### PR TITLE
pygrass.gis: Make Region importable from grass.pygrass.gis

### DIFF
--- a/lib/python/pygrass/gis/__init__.py
+++ b/lib/python/pygrass/gis/__init__.py
@@ -14,6 +14,7 @@ import grass.lib.gis as libgis
 from grass.pygrass.errors import GrassError
 from grass.script.utils import encode, decode
 from grass.pygrass.utils import getenv
+from grass.pygrass.gis.region import Region
 
 test_vector_name = "Gis_test_vector"
 test_raster_name = "Gis_test_raster"


### PR DESCRIPTION
Currently, in order to import the `Region` class you need to import it
from `pygrass.gis.region`. This commit makes it possible to import it
from the `pygrass.gis` package. This way, all `gis` objects can be
imported/used from the same location. E.g.:

    import grass.pygrass.gis as ggis

    ggis.Region
    ggis.Location
    ggis.Mapset

Fixes https://trac.osgeo.org/grass/ticket/3844