### PR TITLE
lib/init/grass.py: Stop clearing the terminal

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1631,17 +1631,6 @@ def close_gui():
             message(_("Unable to close GUI. {0}").format(e))
 
 
-def clear_screen():
-    """Clear terminal"""
-    if windows:
-        pass
-    # TODO: uncomment when PDCurses works.
-    #   cls
-    else:
-        if not is_debug():
-            call(["tput", "clear"])
-
-
 def show_banner():
     """Write GRASS GIS ASCII name to stderr"""
     sys.stderr.write(r"""
@@ -2224,7 +2213,6 @@ def main():
         clean_all()
         sys.exit(0)
     else:
-        clear_screen()
         show_banner()
         say_hello()
         show_info(shellname=shellname,
@@ -2258,7 +2246,6 @@ def main():
         close_gui()
 
         # here we are at the end of grass session
-        clear_screen()
         clean_all()
         if not params.tmp_location:
             writefile(gisrcrc, readfile(gisrc))


### PR DESCRIPTION
Clearing the screen does not offer any real value + doing so using tput
means that depending on the SHELL/terminal emulator used you might also
lose the ability to scroll back.

Fixes https://trac.osgeo.org/grass/ticket/3849#ticket