### PR TITLE
Travis-CI: enable ccache for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 #         Rainer M. Krug, Rainer@krugs.de (osx)
 
 language: c
+cache: ccache
 
 matrix:
    include:
@@ -9,10 +10,15 @@ matrix:
         dist: xenial
         compiler: gcc
         sudo: required
+        env:
+            CC=gcc
+
       - os: linux
         dist: xenial
         compiler: clang
         sudo: required
+        env:
+            CC=clang
 
 env:
   global:

--- a/.travis/linux.install.sh
+++ b/.travis/linux.install.sh
@@ -7,6 +7,7 @@ sudo apt-get install --no-install-recommends \
     autoconf2.13 \
     autotools-dev \
     debhelper \
+    ccache \
     fakeroot \
     flex \
     bison \

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -3,6 +3,7 @@
 
 set -e
 
+export CC="ccache $CC"
 ./configure --host=x86_64-linux-gnu \
             --build=x86_64-linux-gnu \
             --prefix=/usr/lib \


### PR DESCRIPTION
Cold run (cache empty) with gcc: 8 min 55 s
Hot run (cache filled) with gcc: 5 min 58s

Cold run (cache empty) with clang: 9 min 55 sec
Hot run (cache filled) with clang: 6 min 44 sec
