### PR TITLE
libinit: shorten GRASS prompt

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1758,7 +1758,7 @@ def bash_startup(location, location_name, grass_env_file):
         grass_name = "ISIS-GRASS"
     else:
         grass_name = "GRASS"
-    f.write("PS1='{name} {version} ({location}):\\w > '\n".format(
+    f.write("PS1='{name} {version} ({location}):\\W > '\n".format(
         name=grass_name, version=grass_version, location=location_name))
 
     # TODO: have a function and/or module to test this
@@ -1813,7 +1813,7 @@ def default_startup(location, location_name):
         # "$ETC/run" doesn't work at all???
         process = subprocess.Popen([os.getenv('SHELL')])
     else:
-        os.environ['PS1'] = "GRASS %s (%s):\\w > " % (grass_version, location_name)
+        os.environ['PS1'] = "GRASS %s (%s):\\W > " % (grass_version, location_name)
         process = Popen([gpath("etc", "run"), os.getenv('SHELL')])
 
     return process


### PR DESCRIPTION
The GRASS prompt currently shows the full path, e.g.

GRASS 7.7.dev (nc_spm_08):/media/storage/software/GRASS/development/vector/v.in.ogr/gpkg_extents >

while the bash prompt in the same directory shows e.g.
[metz@mylaptop gpkg_extents]$

which I prefer because it does not fill the CLI prompt, which might currently fold into two lines for long paths. I would like to change the GRASS prompt to e.g.

GRASS 7.7.dev (nc_spm_08):gpkg_extents >