### PR TITLE
PyGRASS GridModule silently ignores when module has no output defined

### DIFF
--- a/lib/python/pygrass/modules/grid/grid.py
+++ b/lib/python/pygrass/modules/grid/grid.py
@@ -600,6 +600,7 @@ class GridModule(object):
         loc = Location()
         mset = loc[self.mset.name]
         mset.visible.extend(loc.mapsets())
+        noutputs = 0
         for otmap in self.module.outputs:
             otm = self.module.outputs[otmap]
             if otm.typedesc == 'raster' and otm.value:
@@ -607,6 +608,12 @@ class GridModule(object):
                            self.mset.name, self.msetstr, bboxes,
                            self.module.flags.overwrite,
                            self.start_row, self.start_col, self.out_prefix)
+                noutputs += 1
+        if noutputs < 1:
+            msg = 'No raster output option defined for <{}>'.format(self.module.name)
+            if self.module.name == 'r.mapcalc':
+                msg += '. Use <{}.simple> instead'.format(self.module.name)
+            raise RuntimeError(msg)
 
     def rm_tiles(self):
         """Remove all the tiles."""


### PR DESCRIPTION
See https://trac.osgeo.org/grass/ticket/3852

Now fails

```
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
 100%
Traceback (most recent call last):
  File "/tmp/grid_test.py", line 12, in <module>
    grd.run()
  File "/home/martin/src/grass-p3/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pygrass/modules/grid/grid.py", line 568, in run
    self.patch()
  File "/home/martin/src/grass-p3/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pygrass/modules/grid/grid.py", line 616, in patch
    raise RuntimeError(msg)
RuntimeError: No raster output option defined for <r.mapcalc>. Use <r.mapcalc.simple> instead
```