### PR TITLE
Fix spelling errors.

### DIFF
--- a/general/g.message/g.message.html
+++ b/general/g.message/g.message.html
@@ -42,7 +42,7 @@ While it is known that the interactive Bash instances may treat the
 exclamation mark '<tt>!</tt>' character specifically (making single quoting
 of it necessary), it shouldn't be the case for the non-interactive
 instances of Bash. Nonetheless, to avoid context-based confusion later on
-you are enouraged to single-quote messages that do not require
+you are encouraged to single-quote messages that do not require
 <tt>$VARIABLE</tt> expansion.
 
 <h3>Usage in Python scripts</h3>

--- a/lib/imagery/iscatt_core.c
+++ b/lib/imagery/iscatt_core.c
@@ -438,7 +438,7 @@ static void update_cat_scatt_plts(struct rast_row *bands_rows,
    \brief Computes scatter plots data from bands_rows.
 
    \param scatt_conds pointer to scScatts struct of type SC_SCATT_CONDITIONS, 
-   			       where are selected areas (condtitions) stored
+   			       where are selected areas (conditions) stored
    \param f_cats_rasts_conds file which stores selected areas (conditions) from
                             mapwindow see I_create_cat_rast and I_insert_patch_to_cat_rast
    \param bands_rows data arrays of raster rows from analyzed raster bands 
@@ -511,7 +511,7 @@ static int compute_scatts_from_chunk_row(struct scCats *scatt_conds,
 	else {
 	    scatts_bands = scatts_conds->scatts_bands;
 
-        /* check conditions from category raster condtitions file
+        /* check conditions from category raster conditions file
            (see I_create_cat_rast) */
 	    if (f_cats_rasts_conds[i_cat]) {
 		n_pixs =
@@ -523,7 +523,7 @@ static int compute_scatts_from_chunk_row(struct scCats *scatt_conds,
 		    G_free(rast_pixs);
 		    G_free(belongs_pix);
 		    G_warning(_
-			      ("Unable to read from category raster condtition file."));
+			      ("Unable to read from category raster condition file."));
 		    return -1;
 		}
 		if (n_pixs != n_pixs) {
@@ -800,7 +800,7 @@ int I_compute_scatts(struct Cell_head *region, struct scCats *scatt_conds,
 					 f_cats_rasts_conds,
 					 scatt_conds->n_a_cats);
 		G_warning(_
-			  ("Unable to open category raster condtition file <%s>"),
+			  ("Unable to open category raster condition file <%s>"),
 			  bands[band_id]);
 		return -1;
 	    }

--- a/locale/po/grasslibs_ar.po
+++ b/locale/po/grasslibs_ar.po
@@ -3595,7 +3595,7 @@ msgstr "'%s' لم يمكن فتح ملف التاريخ للفيكتور"
 
 #: ../lib/imagery/iscatt_core.c:526
 #, fuzzy
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr "[%s فى %s]لم يمكن انشاء ملف العنوان الرئيسى"
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3630,7 +3630,7 @@ msgstr " [%s] غير قادر على أنشاء ملف عنوان رئيسى ل"
 
 #: ../lib/imagery/iscatt_core.c:803
 #, fuzzy, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr "datum لم يمكن فتح ملف جدول : %s"
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_bn.po
+++ b/locale/po/grasslibs_bn.po
@@ -3369,7 +3369,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3402,7 +3402,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_cs.po
+++ b/locale/po/grasslibs_cs.po
@@ -3380,7 +3380,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3413,7 +3413,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_de.po
+++ b/locale/po/grasslibs_de.po
@@ -3378,7 +3378,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3411,7 +3411,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_el.po
+++ b/locale/po/grasslibs_el.po
@@ -3373,7 +3373,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_es.po
+++ b/locale/po/grasslibs_es.po
@@ -3417,7 +3417,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr "No ha sido posible escribir en archivo de condiciones de categorías ráster <%s>"
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr "No ha sido posible leer desde archivo de condiciones de categorías ráster."
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3450,7 +3450,7 @@ msgstr "No ha sido posible leer rango de ráster <%s>"
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr "No ha sido posible abrir archivo <%s> de condiciones de categorías"
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_fi.po
+++ b/locale/po/grasslibs_fi.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_fr.po
+++ b/locale/po/grasslibs_fr.po
@@ -3412,7 +3412,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr "impossible d'écrire dans le fichier <%s> de catégories du raster"
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr "Impossible de lire le fichier de catégories du raster."
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3445,7 +3445,7 @@ msgstr "Impossible de lire la plage de valeurs du raster <%s>"
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr "Impossible d'ouvrir le fichier <%s> de catégories du raster"
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_hu.po
+++ b/locale/po/grasslibs_hu.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_id_ID.po
+++ b/locale/po/grasslibs_id_ID.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_it.po
+++ b/locale/po/grasslibs_it.po
@@ -3390,7 +3390,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3423,7 +3423,7 @@ msgstr "Impossibile leggere gli intervalli del raster <%s>"
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_ja.po
+++ b/locale/po/grasslibs_ja.po
@@ -3379,7 +3379,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3412,7 +3412,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_ko.po
+++ b/locale/po/grasslibs_ko.po
@@ -3374,7 +3374,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3407,7 +3407,7 @@ msgstr "래스터 <%s>의 범위를 읽을 수 없습니다"
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_lv.po
+++ b/locale/po/grasslibs_lv.po
@@ -3520,7 +3520,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3555,7 +3555,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_ml.po
+++ b/locale/po/grasslibs_ml.po
@@ -3372,7 +3372,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3405,7 +3405,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_pl.po
+++ b/locale/po/grasslibs_pl.po
@@ -3374,7 +3374,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3407,7 +3407,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_pt.po
+++ b/locale/po/grasslibs_pt.po
@@ -3376,7 +3376,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3409,7 +3409,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_pt_BR.po
+++ b/locale/po/grasslibs_pt_BR.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_ro.po
+++ b/locale/po/grasslibs_ro.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_ru.po
+++ b/locale/po/grasslibs_ru.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_si.po
+++ b/locale/po/grasslibs_si.po
@@ -3370,7 +3370,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3403,7 +3403,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_sl.po
+++ b/locale/po/grasslibs_sl.po
@@ -3616,7 +3616,7 @@ msgstr "ne morem zapisati \"history\" podatkov za [%s]"
 
 #: ../lib/imagery/iscatt_core.c:526
 #, fuzzy
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr "Nezmožen ustvariti datoteko z vzglavjem za [%s v %s]"
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3651,7 +3651,7 @@ msgstr "ne morem spremeniti direktorija v %s"
 
 #: ../lib/imagery/iscatt_core.c:803
 #, fuzzy, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr "Nezmožen odpreti datoteko s tabelo fundamentalne točke: %s"
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_ta.po
+++ b/locale/po/grasslibs_ta.po
@@ -3373,7 +3373,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_th.po
+++ b/locale/po/grasslibs_th.po
@@ -3373,7 +3373,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_tr.po
+++ b/locale/po/grasslibs_tr.po
@@ -3373,7 +3373,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_uk.po
+++ b/locale/po/grasslibs_uk.po
@@ -3371,7 +3371,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_vi.po
+++ b/locale/po/grasslibs_vi.po
@@ -3373,7 +3373,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_zh.po
+++ b/locale/po/grasslibs_zh.po
@@ -3373,7 +3373,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817

--- a/locale/po/grasslibs_zh_CN.po
+++ b/locale/po/grasslibs_zh_CN.po
@@ -410,7 +410,7 @@ msgid "Unable to write into category raster conditions file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:526
-msgid "Unable to read from category raster condtition file."
+msgid "Unable to read from category raster condition file."
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:533
@@ -443,7 +443,7 @@ msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:803
 #, c-format
-msgid "Unable to open category raster condtition file <%s>"
+msgid "Unable to open category raster condition file <%s>"
 msgstr ""
 
 #: ../lib/imagery/iscatt_core.c:817


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the 7.6.1 Debian package build.

 * condtition -> condition
 * enouraged  -> encouraged