### PR TITLE
Some topics contain parentheses

### DIFF
--- a/include/Make/Html.make
+++ b/include/Make/Html.make
@@ -8,7 +8,7 @@ $(HTMLDIR)/%.html: %.html %.tmp.html $(HTMLSRC) $(IMGDST) | $(HTMLDIR)
         $(PYTHON) $(GISBASE)/tools/mkhtml.py $* > $@
 
 $(MANDIR)/%.$(MANSECT): $(HTMLDIR)/%.html
-	$(HTML2MAN) $< $@
+	$(HTML2MAN) "$<" "$@"
 
 %.tmp.html: $(HTMLSRC)
 	if [ "$(HTMLSRC)" != "" ] ; then $(call htmldesc,$<,$@) ; fi

--- a/man/Makefile
+++ b/man/Makefile
@@ -47,8 +47,10 @@ default: $(DSTFILES)
 
 # This must be a separate target so that evaluation of $(MANPAGES)
 # is delayed until the indices have been generated
+left := (
+right := )
 manpages:
-	$(MAKE) $(MANPAGES)
+	$(MAKE) $(subst $(left),\$(left),$(subst $(right),\$(right),$(MANPAGES)))
 
 .PHONY: manpages
 


### PR DESCRIPTION
manpages: Handle filenames with parentheses (e.g., topic_Analytic_Hierarchy_Process_(AHP).html from r.mcda.ahp)