### PR TITLE
python3: shutil.which and subprocess.Popen.__init__ internally use strings (e.g., endswith)

### DIFF
--- a/lib/python/script/core.py
+++ b/lib/python/script/core.py
@@ -1463,8 +1463,7 @@ def find_program(pgm, *args):
     nuldev = open(os.devnull, 'w+')
     try:
         # TODO: the doc or impl is not correct, any return code is accepted
-        cmd = list(map(lambda x: encode(x), [pgm] + list(args)))
-        call(cmd, stdin = nuldev, stdout = nuldev, stderr = nuldev)
+        call([pgm] + list(args), stdin = nuldev, stdout = nuldev, stderr = nuldev)
         found = True
     except:
         found = False


### PR DESCRIPTION
Revert #73945.

Forcing bytes here raises exceptions (well, hidden because we just assign False to found). If we change found = False to raise, the very first g.gisenv call will crash when the GUI starts. Later g.proj when the map display starts. Even the built-in shutil_which crashes with encoding.

The error message from comment 10 in #3731 (https://trac.osgeo.org/grass/ticket/3731) also suggests that we need to pass str or a tuple of str, not bytes to the built-in shutil_which. Now, we use shutil.which for Python 3.