### PR TITLE
Fix spelling errors.

### DIFF
--- a/scripts/r.tileset/r.tileset.html
+++ b/scripts/r.tileset/r.tileset.html
@@ -46,14 +46,14 @@ changing the fs option.
 w=5;s=125;e=45;n=175;cols=80;rows=100;
 </tt></span>
 
-<dd>This is output in a format convinent for setting variables in a shell
+<dd>This is output in a format convenient for setting variables in a shell
 script.
 <dt>
 <span class="code"><tt>
 bbox=5,125,45,175&amp;width=80&amp;height=100
 </tt></span>
 
-<dd>This is output in a format convinent for requesting data from some
+<dd>This is output in a format convenient for requesting data from some
 http services.
 </dl>
 


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the latest GRASS 7.6.1 Debian package build:

 * convinent -> convenient