### PR TITLE
add missing dependencies libgraphite2.dll and libpcre-1.dll

### DIFF
--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -270,6 +270,8 @@ if [ -n "$PACKAGE_PATCH" ]; then
 	/mingw${MINGW_POSTFIX}/bin/libpng16-16.dll \
 	/mingw${MINGW_POSTFIX}/bin/libsystre-0.dll \
 	/mingw${MINGW_POSTFIX}/bin/libtre-5.dll \
+	/mingw${MINGW_POSTFIX}/bin/libgraphite2.dll \
+	/mingw${MINGW_POSTFIX}/bin/libpcre-1.dll \
         /mingw${MINGW_POSTFIX}/bin/zlib1.dll \
         /mingw${MINGW_POSTFIX}/bin/libstdc++-6.dll \
 	apps/grass/grass$POSTFIX/bin


### PR DESCRIPTION
for a working daily winGRASS master build, following dlls should be added to the winGRASS package:

- libgraphite2.dll

- libpcre-1.dll

related trac ticket is https://trac.osgeo.org/grass/ticket/3870