### PR TITLE
Update reference from proj.4 or proj4 to proj (g.version)

### DIFF
--- a/general/g.version/main.c
+++ b/general/g.version/main.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     extended = G_define_flag();
     extended->key = 'e';
     extended->label = _("Print also extended info for additional libraries");
-    extended->description = _("GDAL/OGR, PROJ.4, GEOS");
+    extended->description = _("GDAL/OGR, PROJ, GEOS");
     extended->guisection = _("Additional info");
 
     shell = G_define_flag();
@@ -200,15 +200,15 @@ int main(int argc, char *argv[])
 #endif
         if (strlen(proj) == 3) {
             if (shell->answer)
-                fprintf(stdout, "proj4=%c.%c.%c\n", proj[0], proj[1], proj[2]); 
+                fprintf(stdout, "proj=%c.%c.%c\n", proj[0], proj[1], proj[2]); 
             else
-                fprintf(stdout, "PROJ.4: %c.%c.%c\n", proj[0], proj[1], proj[2]); 
+                fprintf(stdout, "PROJ: %c.%c.%c\n", proj[0], proj[1], proj[2]); 
         }
         else {
             if (shell->answer)
-                fprintf(stdout, "proj4=%s\n", proj);
+                fprintf(stdout, "proj=%s\n", proj);
             else
-                fprintf(stdout, "PROJ.4: %s\n", proj);
+                fprintf(stdout, "PROJ: %s\n", proj);
         }
 #ifdef HAVE_GDAL
         if (shell->answer)


### PR DESCRIPTION
g.version doesn't make sense since proj was update to version 6. Watching reference de proj.4 in g.version is confusing

``` 
> g.version -e
GRASS 7.6.1 (2019)
PROJ.4: 6.1.0
GDAL/OGR: 3.0.0
GEOS: 3.7.2
SQLite: 3.28.0
```

```
g.version -rge
version=7.6.1
date=2019
revision=exported
build_date=2019-07-16
build_platform=x86_64-pc-linux-gnu
build_off_t_size=8
libgis_revision=72327 
libgis_date="2018-03-06 12:12:44 +0100 (Tue, 06 Mar 2018) "
proj4=6.1.0
gdal=3.0.0
geos=3.7.2
sqlite=3.28.0
```