### PR TITLE
grass.py: fix typo in info_text, svn -> dev

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1596,7 +1596,7 @@ def show_banner():
 def say_hello():
     """Write welcome to stderr including Subversion revision if in svn copy"""
     sys.stderr.write(_("Welcome to GRASS GIS %s") % GRASS_VERSION)
-    if GRASS_VERSION.endswith('svn'):
+    if GRASS_VERSION.endswith('dev'):
         try:
             filerev = open(gpath('etc', 'VERSIONNUMBER'))
             linerev = filerev.readline().rstrip('\n')
@@ -1608,7 +1608,7 @@ def say_hello():
             pass
 
 
-INFO_TEXT = r"""\
+INFO_TEXT = r"""
 %-41shttps://grass.osgeo.org
 %-41s%s (%s)
 %-41sg.manual -i

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1594,7 +1594,7 @@ def show_banner():
 
 
 def say_hello():
-    """Write welcome to stderr including Subversion revision if in svn copy"""
+    """Write welcome to stderr including code revision if in git copy"""
     sys.stderr.write(_("Welcome to GRASS GIS %s") % GRASS_VERSION)
     if GRASS_VERSION.endswith('dev'):
         try:


### PR DESCRIPTION
This PR fixes two issues in welcome screen:

* extra backslash character
* show git rev in dev version

Before:

```
Welcome to GRASS GIS 7.9.dev\
```

After:

```
Welcome to GRASS GIS 7.9.dev (b4432f400)
```