### PR TITLE
g.extension: change to python3

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1252,23 +1252,6 @@ def download_source_code(source, url, name, outdev,
     assert os.path.isdir(directory)
 
 
-def get_modules_of_metamodules(name):
-    with open(os.path.join(TMPDIR, name, 'Makefile')) as f:
-        datafile = f.readlines()
-
-    makefile_part = ""
-    next_line = False
-    for line in datafile:
-        if 'SUBDIRS' in line or next_line:
-            makefile_part += line
-            if (line.strip()).endswith('\\'):
-                next_line = True
-            else:
-                next_line = False
-    modules = makefile_part.replace('SUBDIRS', '').replace('=', '').replace('\\', '').strip().split('\n')
-    return [x.strip() for x in modules]
-
-
 def install_extension_std_platforms(name, source, url):
     """Install extension on standard platforms"""
     gisbase = os.getenv('GISBASE')

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -140,8 +140,6 @@ import tempfile
 import xml.etree.ElementTree as etree
 from distutils.dir_util import copy_tree
 
-
-
 from six.moves.urllib.request import urlopen, urlretrieve, ProxyHandler, build_opener, install_opener
 from six.moves.urllib.error import HTTPError, URLError
 
@@ -1042,6 +1040,21 @@ def install_extension_win(name):
     srcdir = os.path.join(TMPDIR, name)
     download_source_code(source=source, url=url, name=name,
                          outdev=outdev, directory=srcdir, tmpdir=TMPDIR)
+
+    # change shebang from python to python3
+    pyfiles = []
+    for r, d, f in os.walk(srcdir):
+        for file in f:
+            if file.endswith('.py'):
+                pyfiles.append(os.path.join(r, file))
+
+    for filename in pyfiles:
+        with fileinput.FileInput(filename, inplace=True) as file:
+            for line in file:
+                print(line.replace(
+                    "#!/usr/bin/env python\n",
+                    "#!/usr/bin/env python3\n"
+                ), end='')
 
     # copy Addons copy tree to destination directory
     move_extracted_files(extract_dir=srcdir, target_dir=options['prefix'],


### PR DESCRIPTION
Motivation: the Addons source code is to be used by multiple GRASS versions. Since 7.8+ Python 3 is expected while older versions need Python 2. Hence a global change in all Addons of shebang to Python 3 would be a problem.

Proposed solution: change shebang during installation.
