### PR TITLE
Rasterize centroids by default

### DIFF
--- a/vector/v.to.rast/main.c
+++ b/vector/v.to.rast/main.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 
     type_opt = G_define_standard_option(G_OPT_V_TYPE);
     type_opt->options = "point,line,boundary,centroid,area";
-    type_opt->answer = "point,line,area";
+    type_opt->answer = "point,line,centroid,area";
     type_opt->guisection = _("Selection");
     
     cats_opt = G_define_standard_option(G_OPT_V_CATS);


### PR DESCRIPTION
Not sure if this should be left for GRASS 8 as it might alter results of existing user scripts, but it would be good to have centroids rasterized e.g. also in v.rast.stats by default. And if areas are rasterized by default, it would make sense to make centroids the default too...