### PR TITLE
Cleanup .swp files too

### DIFF
--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -70,6 +70,7 @@ rm -f locale/po/messages.mo
 rm -f demolocation/PERMANENT/.bash*
 find . -name '*~'     | xargs rm
 find . -name '*.bak'  | xargs rm
+find . -name '*.swp'  | xargs rm
 find . -name '.#*'    | xargs rm
 find . -name '*.orig' | xargs rm
 find . -name '*.rej'  | xargs rm


### PR DESCRIPTION
The 7.8.0RC1 tarball contains a vim swap file for `howto_release.md`