### PR TITLE
db.univar: numerical instability can lead to bug in calculations of stdev, etc

### DIFF
--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -177,14 +177,19 @@ def main():
         sys.stdout.write(
             "Arithmetic mean of absolute values: %.15g\n" %
             (sum3 / N))
-        sys.stdout.write("Variance: %.15g\n" % ((sum2 - sum * sum / N) / N))
-        sys.stdout.write(
-            "Standard deviation: %.15g\n" %
-            (math.sqrt((sum2 - sum * sum / N) / N)))
-        sys.stdout.write(
-            "Coefficient of variation: %.15g\n" %
-            ((math.sqrt((sum2 - sum * sum / N) / N)) /
-             (math.sqrt(sum * sum) / N)))
+        if not ((sum2 - sum * sum / N) / N) < 0:
+            sys.stdout.write("Variance: %.15g\n" % ((sum2 - sum * sum / N) / N))
+            sys.stdout.write(
+                "Standard deviation: %.15g\n" %
+                (math.sqrt((sum2 - sum * sum / N) / N)))
+            sys.stdout.write(
+                "Coefficient of variation: %.15g\n" %
+                ((math.sqrt((sum2 - sum * sum / N) / N)) /
+                 (math.sqrt(sum * sum) / N)))
+        else:
+            sys.stdout.write("Variance: 0\n")
+            sys.stdout.write("Standard deviation: 0\n")
+            sys.stdout.write("Coefficient of variation: 0\n")
         sys.stdout.write("Sum: %.15g\n" % sum)
     else:
         sys.stdout.write("n=%d\n" % N)
@@ -193,15 +198,20 @@ def main():
         sys.stdout.write("range=%.15g\n" % (maxv - minv))
         sys.stdout.write("mean=%.15g\n" % (sum / N))
         sys.stdout.write("mean_abs=%.15g\n" % (sum3 / N))
-        sys.stdout.write("variance=%.15g\n" % ((sum2 - sum * sum / N) / N))
-        sys.stdout.write(
-            "stddev=%.15g\n" %
-            (math.sqrt(
-                (sum2 - sum * sum / N) / N)))
-        sys.stdout.write(
-            "coeff_var=%.15g\n" %
-            ((math.sqrt((sum2 - sum * sum / N) / N)) /
-             (math.sqrt(sum * sum) / N)))
+        if not ((sum2 - sum * sum / N) / N) < 0:
+            sys.stdout.write("variance=%.15g\n" % ((sum2 - sum * sum / N) / N))
+            sys.stdout.write(
+                "stddev=%.15g\n" %
+                (math.sqrt(
+                    (sum2 - sum * sum / N) / N)))
+            sys.stdout.write(
+                "coeff_var=%.15g\n" %
+                ((math.sqrt((sum2 - sum * sum / N) / N)) /
+                 (math.sqrt(sum * sum) / N)))
+        else:
+            sys.stdout.write("variance=0\n")
+            sys.stdout.write("stddev=0\n")
+            sys.stdout.write("coeff_var=0\n")
         sys.stdout.write("sum=%.15g\n" % sum)
 
     if not extend:


### PR DESCRIPTION
Using the NC demo data set:

```
g.copy vect=census_wake2000,mc
v.db.addcolumn mc col="testf double precision"
v.db.update mc col=testf val=-0.14357562916991
```

Then db.univar gives different results, depending on the number of lines selected:

```
db.univar table=mc col=testf driver=sqlite where="cat<5"
Reading column values...
Number of values: 4
Minimum: -0.14357562916991
Maximum: -0.14357562916991
Range: 0
Mean: -0.14357562916991
Arithmetic mean of absolute values: 0.14357562916991
Variance: 0
Standard deviation: 0
Coefficient of variation: 0
Sum: -0.57430251667964
```

but

```
db.univar table=mc col=testf driver=sqlite where="cat<4"
Reading column values...
Number of values: 3
Minimum: -0.14357562916991
Maximum: -0.14357562916991
Range: 0
Mean: -0.14357562916991
Arithmetic mean of absolute values: 0.14357562916991
Variance: -2.31296463463574e-18
Traceback (most recent call last):
  File "/usr/lib/grass76/scripts/db.univar", line 304, in <module>
    main()
  File "/usr/lib/grass76/scripts/db.univar", line 188, in main
    (math.sqrt((sum2 - sum * sum / N) / N)))
ValueError: math domain error
```

and then

```
db.univar table=mc col=testf driver=sqlite where="cat<3"
Reading column values...
Number of values: 2
Minimum: -0.14357562916991
Maximum: -0.14357562916991
Range: 0
Mean: -0.14357562916991
Arithmetic mean of absolute values: 0.14357562916991
Variance: 0
Standard deviation: 0
Coefficient of variation: 0
Sum: -0.28715125833982
```

Variance should never be negative, so this PR adds a check on variance and sets variance, stddev and coeff_var to 0 is variance is negative.