### PR TITLE
 v.in.ascii: include values into the message

### DIFF
--- a/vector/v.in.ascii/local_proto.h
+++ b/vector/v.in.ascii/local_proto.h
@@ -6,7 +6,7 @@
 #include <grass/dbmi.h>
 
 int points_analyse(FILE *, FILE *, char *, char *, int *, int *, int *, int *, int **,
-		   int **, int, int, int, int, int, int, int);
+		   char ***, int **, int, int, int, int, int, int, int);
 
 int points_to_bin(FILE *, int, struct Map_info *, dbDriver *,
 		  char *, char *, char *, int, int *, int, int, int, int, int);

--- a/vector/v.in.ascii/main.c
+++ b/vector/v.in.ascii/main.c
@@ -261,6 +261,7 @@ int main(int argc, char *argv[])
 
     if (format == GV_ASCII_FORMAT_POINT) {
 	int i, rowlen, ncols, minncols, *coltype, *coltype2, *collen, nrows;
+	char **colsample;
 	int n_int = 0, n_double = 0, n_string = 0;
 	char buf[1000];
 	struct field_info *Fi;
@@ -277,7 +278,7 @@ int main(int argc, char *argv[])
 	unlink(tmp);
 
 	points_analyse(ascii, tmpascii, fs, td, &rowlen, &ncols, &minncols,
-		       &nrows, &coltype, &collen, skip_lines, xcol, ycol,
+		       &nrows, &coltype, &colsample, &collen, skip_lines, xcol, ycol,
 		       zcol, catcol, region_flag->answer, ignore_flag->answer);
 
 	G_verbose_message(_("Maximum input row length: %d"), rowlen);
@@ -312,16 +313,20 @@ int main(int argc, char *argv[])
 	}
 
 	if (coltype[xcol] == DB_C_TYPE_STRING) {
-	    G_fatal_error(_("'%s' column is not of number type"), "x");
+	    G_fatal_error(_("'%s' column is not of number type, "
+	                    "encountered: %s"), "x", colsample[xcol]);
 	}
 	if (coltype[ycol] == DB_C_TYPE_STRING) {
-	    G_fatal_error(_("'%s' column is not of number type"), "y");
+	    G_fatal_error(_("'%s' column is not of number type, "
+	                    "encountered: %s"), "y", colsample[ycol]);
 	}
 	if (zcol >= 0 && coltype[zcol] == DB_C_TYPE_STRING) {
-	    G_fatal_error(_("'%s' column is not of number type"), "z");
+	    G_fatal_error(_("'%s' column is not of number type, "
+	                    "encountered: %s"), "z", colsample[zcol]);
 	}
 	if (catcol >= 0 && coltype[catcol] == DB_C_TYPE_STRING) {
-	    G_fatal_error(_("'%s' column is not of number type"), "cat");
+	    G_fatal_error(_("'%s' column is not of number type, "
+	                    "encountered: %s"), "cat", colsample[catcol]);
 	}
 
 	/* Create table */

--- a/vector/v.in.ascii/main.c
+++ b/vector/v.in.ascii/main.c
@@ -472,12 +472,14 @@ int main(int argc, char *argv[])
 
 		    switch (coltype[i]) {
 		    case DB_C_TYPE_INT:
-			if (ctype == DB_C_TYPE_DOUBLE) {
+			/* coltype=int and colsample=NULL indicate,
+			 * an empty column, so we don't report anything. */
+			if (ctype == DB_C_TYPE_DOUBLE && colsample[i]) {
 			    G_warning(_("Column number %d <%s> defined as double "
 				       "has only integer values"), i + 1,
 				      db_get_column_name(column));
 			}
-			else if (ctype == DB_C_TYPE_STRING) {
+			else if (ctype == DB_C_TYPE_STRING && colsample[i]) {
 			    G_warning(_("Column number %d <%s> defined as string "
 				       "has only integer values"), i + 1,
 				      db_get_column_name(column));
@@ -486,8 +488,10 @@ int main(int argc, char *argv[])
 		    case DB_C_TYPE_DOUBLE:
 			if (ctype == DB_C_TYPE_INT) {
 			    G_fatal_error(_("Column number %d <%s> defined as integer "
-					   "has double values"), i + 1,
-					  db_get_column_name(column));
+					    "has double values, encountered: %s"),
+					  i + 1,
+					  db_get_column_name(column),
+					  colsample[i]);
 			}
 			else if (ctype == DB_C_TYPE_STRING) {
 			    G_warning(_("Column number %d <%s> defined as string "
@@ -498,13 +502,16 @@ int main(int argc, char *argv[])
 		    case DB_C_TYPE_STRING:
 			if (ctype == DB_C_TYPE_INT) {
 			    G_fatal_error(_("Column number %d <%s> defined as integer "
-					   "has string values"), i + 1,
-					  db_get_column_name(column));
+					    "has string values, encountered: %s"),
+					  i + 1,
+					  db_get_column_name(column),
+					  colsample[i]);
 			}
 			else if (ctype == DB_C_TYPE_DOUBLE) {
 			    G_fatal_error(_("Column number %d <%s> defined as double "
-					   "has string values"), i + 1,
-					  db_get_column_name(column));
+					    "has string values, encountered: %s"), i + 1,
+					  db_get_column_name(column),
+					  colsample[i]);
 			}
 			if (length < collen[i]) {
 			    G_fatal_error(_("Length of column %d <%s> (%d) is less than "

--- a/vector/v.in.ascii/main.c
+++ b/vector/v.in.ascii/main.c
@@ -314,19 +314,19 @@ int main(int argc, char *argv[])
 
 	if (coltype[xcol] == DB_C_TYPE_STRING) {
 	    G_fatal_error(_("'%s' column is not of number type, "
-	                    "encountered: %s"), "x", colsample[xcol]);
+	                    "encountered: '%s'"), "x", colsample[xcol]);
 	}
 	if (coltype[ycol] == DB_C_TYPE_STRING) {
 	    G_fatal_error(_("'%s' column is not of number type, "
-	                    "encountered: %s"), "y", colsample[ycol]);
+	                    "encountered: '%s'"), "y", colsample[ycol]);
 	}
 	if (zcol >= 0 && coltype[zcol] == DB_C_TYPE_STRING) {
 	    G_fatal_error(_("'%s' column is not of number type, "
-	                    "encountered: %s"), "z", colsample[zcol]);
+	                    "encountered: '%s'"), "z", colsample[zcol]);
 	}
 	if (catcol >= 0 && coltype[catcol] == DB_C_TYPE_STRING) {
 	    G_fatal_error(_("'%s' column is not of number type, "
-	                    "encountered: %s"), "cat", colsample[catcol]);
+	                    "encountered: '%s'"), "cat", colsample[catcol]);
 	}
 
 	/* Create table */
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
 		    case DB_C_TYPE_DOUBLE:
 			if (ctype == DB_C_TYPE_INT) {
 			    G_fatal_error(_("Column number %d <%s> defined as integer "
-					    "has double values, encountered: %s"),
+					    "has double values, encountered: '%s'"),
 					  i + 1,
 					  db_get_column_name(column),
 					  colsample[i]);
@@ -502,15 +502,14 @@ int main(int argc, char *argv[])
 		    case DB_C_TYPE_STRING:
 			if (ctype == DB_C_TYPE_INT) {
 			    G_fatal_error(_("Column number %d <%s> defined as integer "
-					    "has string values, encountered: %s"),
-					  i + 1,
-					  db_get_column_name(column),
+					    "has string values, encountered: '%s'"),
+					  i + 1, db_get_column_name(column),
 					  colsample[i]);
 			}
 			else if (ctype == DB_C_TYPE_DOUBLE) {
 			    G_fatal_error(_("Column number %d <%s> defined as double "
-					    "has string values, encountered: %s"), i + 1,
-					  db_get_column_name(column),
+					    "has string values, encountered: '%s'"),
+					  i + 1, db_get_column_name(column),
 					  colsample[i]);
 			}
 			if (length < collen[i]) {


### PR DESCRIPTION
Stores first encountered value of determined type for each column which is then useful for the messages including avoiding confusing messages about integer-only columns for empty columns.

Before:

```
ERROR: 'x' column is not of number type
ERROR: Column number 4 <col_4326_Lon> defined as double has string values
```

After:

```
ERROR: 'x' column is not of number type, encountered: New York
ERROR: Column number 4 <col_4326_Lon> defined as double has string values,
       encountered: CX-78.69418831
```