### PR TITLE
Show no flags in help

### DIFF
--- a/lib/gis/parser_help.c
+++ b/lib/gis/parser_help.c
@@ -96,7 +96,7 @@ static void usage(FILE *fp, int markers)
                 fprintf(fp, "%s\n", st->module_info.description);
         }
     }
-    if (extensive &&& st->module_info.keywords) {
+    if (extensive && st->module_info.keywords) {
 	fprintf(fp, "\n");
 	if (markers)
 	    fprintf(fp, "{{{KEYWORDS}}}\n");

--- a/lib/gis/parser_help.c
+++ b/lib/gis/parser_help.c
@@ -185,10 +185,18 @@ static void usage(FILE *fp, int markers)
 
     /* Print help info for flags */
 
-    fprintf(fp, "\n");
-    if (markers)
-	fprintf(fp, "{{{FLAGS}}}\n");
-    fprintf(fp, "%s\n", _("Flags:"));
+    /* Show section only when there are flags.
+     * There are always the standard flags if we are printing those.
+     * There is no use case for the markers, so no way to decide if
+     * the marker for flags is mandatory and should be empty if it is
+     * okay for it to be missing like in the current implementation.
+     */
+    if (st->n_flags || standard) {
+	fprintf(fp, "\n");
+	if (markers)
+	    fprintf(fp, "{{{FLAGS}}}\n");
+	fprintf(fp, "%s\n", _("Flags:"));
+    }
 
     if (st->n_flags) {
 	flag = &st->first_flag;


### PR DESCRIPTION
For modules which do not have flags, an empty Flags: section was showed with --help which after 484d43ac31 does not include any of the default flags to safe space. Now, where there are no module-specific flags, the section is completely skipped.

Before:

```
Import a file

Usage:
 v.test.py input=name output=name [--overwrite]
   [--help] [--verbose] [--quiet] [--ui]

Flags:

Parameters:
   input   Name of input file
  output   Name for output vector map
```

After:

```
Import a file

Usage:
 v.test.py input=name output=name [--overwrite]
   [--help] [--verbose] [--quiet] [--ui]

Parameters:
   input   Name of input file
  output   Name for output vector map
```

It changes the behavior of "markers" (if enabled) where `{{{FLAGS}}}` is now optional section, but I don't know about a use case, so I don't know how much it is important.

This also fixes bug/typo from 484d43ac31 (in a currently unused part of code), so perhaps _not_ squashing commits is desirable.