### PR TITLE
v.in.ascii: user likely expectes number of rows used

### DIFF
--- a/vector/v.in.ascii/main.c
+++ b/vector/v.in.ascii/main.c
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
 	   G_message(_("Number of columns: %d"), ncols);
         }
 
-        G_message(_("Number of rows: %d"), nrows);
+        G_message(_("Number of data rows: %d"), nrows - skip_lines);
         
 	/* check column numbers */
 	if (xcol >= minncols) {


### PR DESCRIPTION
I think when you use *v.in.ascii* with skip, you expect to see number of rows without the skip when it reports on rows and columns in the file. For example, I have a file with 100 points with a header. I use `skip=1`. The previous implementation prints:

```
Number of rows: 101
```

The new one prints:

```
Number of data rows: 100
```

Technically, they are the non-ignored rows which is the rows not skipped by skip (including cases when skip is used as an offset rather than skipping a header) and rows not ignored as comments. However, "data rows" seems quite close to what is expected and not misleading at the same time. Let me know if you have other suggestions.