### PR TITLE
v.patch: match map to column (fixes 6616daa)

### DIFF
--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -302,10 +302,10 @@ int main(int argc, char *argv[])
 			      " <%s> from <%s> is <%s> and"
 			      " <%s> from <%s> is <%s>"),
 			    db_get_column_name(column_in),
-			    meta_name,
+			    in_name,
 			    db_sqltype_name(db_get_column_sqltype(column_in)),
 			    db_get_column_name(column_out),
-			    in_name,
+			    meta_name,
 			    db_sqltype_name(db_get_column_sqltype(column_out)));
 		    }
 		    if (ctype_in == DB_C_TYPE_STRING &&


### PR DESCRIPTION
This fixes a bug in the new code from 6616daa.

The order in these messages in the module is "the problematic input" followed by output (where the column names are either derived from first input or from output in append mode).