### PR TITLE
update usage of map() function to Python 3

### DIFF
--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -117,7 +117,7 @@ class ProcessWorkspaceFile:
         if node_lm is not None:
             posAttr = node_lm.get('dim', '')
             if posAttr:
-                posVal = map(int, posAttr.split(','))
+                posVal = list(map(int, posAttr.split(',')))
                 try:
                     self.layerManager['pos'] = (posVal[0], posVal[1])
                     self.layerManager['size'] = (posVal[2], posVal[3])
@@ -137,7 +137,7 @@ class ProcessWorkspaceFile:
             # window position and size
             posAttr = display.get('dim', '')
             if posAttr:
-                posVal = map(int, posAttr.split(','))
+                posVal = list(map(int, posAttr.split(',')))
                 try:
                     pos = (posVal[0], posVal[1])
                     size = (posVal[2], posVal[3])

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1465,7 +1465,7 @@ class GCP(MapFrame, ColumnSorterMixin):
                 if line[0] == '#' or line == '':
                     continue
                 line = line.replace('\n', '').strip()
-                coords = map(float, line.split())
+                coords = list(map(float, line.split()))
                 if coords[4] == 1:
                     check = True
                     self.GCPcount += 1

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -577,7 +577,7 @@ class ModelLoopDialog(ModelItemDialog):
 
         cond = dialog.GetDSeries()
         if not cond:
-            cond = 'map in %s' % map(lambda x: str(x), dialog.GetMapLayers())
+            cond = 'map in {}'.format(list(map(str, dialog.GetMapLayers())))
 
         self.condText.SetValue(cond)
 

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -2018,7 +2018,7 @@ class ProcessModelFile:
         pos = size = None
         posAttr = node.get('pos', None)
         if posAttr:
-            posVal = map(int, posAttr.split(','))
+            posVal = list(map(int, posAttr.split(',')))
             try:
                 pos = (posVal[0], posVal[1])
             except:
@@ -2026,7 +2026,7 @@ class ProcessModelFile:
 
         sizeAttr = node.get('size', None)
         if sizeAttr:
-            sizeVal = map(int, sizeAttr.split(','))
+            sizeVal = list(map(int, sizeAttr.split(',')))
             try:
                 size = (sizeVal[0], sizeVal[1])
             except:

--- a/gui/wxpython/gui_core/wxlibplot.py
+++ b/gui/wxpython/gui_core/wxlibplot.py
@@ -1209,7 +1209,7 @@ class PlotCanvas(wx.Panel):
         else:
             # on Linux, we need to correct the font size by a certain factor if wx.GCDC is used,
             # to make text the same size as if wx.GCDC weren't used
-            screenppi = map(float, wx.ScreenDC().GetPPI())
+            screenppi = list(map(float, wx.ScreenDC().GetPPI()))
             ppi = dc.GetPPI()
             self._fontScale = (screenppi[
                                0] / ppi[0] * self._pointSize[0] + screenppi[1] / ppi[1] * self._pointSize[1]) / 2.0

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -1527,7 +1527,7 @@ class GCP(MapFrame, ColumnSorterMixin):
                 if line[0] == '#' or line == '':
                     continue
                 line = line.replace('\n', '').strip()
-                coords = map(float, line.split())
+                coords = list(map(float, line.split()))
                 if coords[6] == 1:
                     check = True
                     self.GCPcount += 1

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -888,7 +888,7 @@ class GCP(MapFrame, ColumnSorterMixin):
                 if line[0] == '#' or line == '':
                     continue
                 line = line.replace('\n', '').strip()
-                coords = map(float, line.split())
+                coords = list(map(float, line.split()))
                 if coords[4] == 1:
                     check = True
                     self.GCPcount += 1

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -1442,7 +1442,7 @@ class Scalebar(InstructionObject):
                     else:
                         instr['scalebar'] = 'f'
                 elif line.startswith('where'):
-                    instr['where'] = map(float, line.split()[1:3])
+                    instr['where'] = list(map(float, line.split()[1:3]))
                 elif line.startswith('length'):
                     instr['length'] = float(line.split()[1])
                 elif line.startswith('units'):
@@ -1550,7 +1550,7 @@ class RasterLegend(InstructionObject):
         for line in text:
             try:
                 if line.startswith('where'):
-                    instr['where'] = map(float, line.split()[1:3])
+                    instr['where'] = list(map(float, line.split()[1:3]))
                 elif line.startswith('font '):
                     instr['font'] = line.split()[1]
                 elif line.startswith('fontsize'):
@@ -1716,7 +1716,7 @@ class VectorLegend(InstructionObject):
         for line in text:
             try:
                 if line.startswith('where'):
-                    instr['where'] = map(float, line.split()[1:3])
+                    instr['where'] = list(map(float, line.split()[1:3]))
                 elif line.startswith('font '):
                     instr['font'] = line.split()[1]
                 elif line.startswith('fontsize'):


### PR DESCRIPTION
In Python 2 the `map()` function returns a list, but in Python 3 it returns an iterator