### PR TITLE
disable module check since svn keywords are not maintained by git

### DIFF
--- a/lib/gis/gisinit.c
+++ b/lib/gis/gisinit.c
@@ -49,11 +49,13 @@ void G__gisinit(const char *version, const char *pgm)
 
     G_set_program_name(pgm);
 
+    /* temporary disabled since svn keywords are not maintained by git
     if (strcmp(version, GIS_H_VERSION) != 0)
 	G_fatal_error(_("Module built against version %s but "
 			"trying to use version %s. "
 			"You need to rebuild GRASS GIS or untangle multiple installations."),
                         version, GIS_H_VERSION);
+    */
 
     /* Make sure location and mapset are set */
     G_location_path();


### PR DESCRIPTION
Module check is currently broken (see attached screenshot) since svn keywords are not maintained by git. This PR temporary disables this check. It can be re-enabled when svn keywords issue will be solved.

![r-hants](https://user-images.githubusercontent.com/5683186/64133340-b0d52e80-cdd5-11e9-921b-49c1608a4fef.png)
