### PR TITLE
WIP PROJ6 support

### DIFF
--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -83,8 +83,41 @@ int GPJ_init_transform(const struct pj_info *info_in,
                        const struct pj_info *info_out,
 		       struct pj_info *info_trans)
 {
+    char *insrid = NULL, *outsrid = NULL;
+
     if (info_in->pj == NULL)
 	G_fatal_error(_("Input coordinate system is NULL"));
+
+#ifdef HAVE_PROJ_H
+#if PROJ_VERSION_MAJOR >= 6
+    info_trans->pj = NULL;
+    if (info_trans->def) {
+	/* create a pj from user-defined transformation pipeline */
+	info_trans->pj = proj_create(PJ_DEFAULT_CTX, info_trans->def);
+	if (info_trans->pj == NULL) {
+	    G_warning(_("proj_create() failed for '%s'"), info_trans->def);
+	    return -1;
+	}
+	return 1;
+    }
+    info_trans->meters = 1.;
+    info_trans->zone = 0;
+    sprintf(info_trans->proj, "pipeline");
+    
+    /* if no output CRS is defined, 
+     * assume info_out to be ll equivalent of info_in */
+    /* do not use +init=epsg:XXXX, use EPSG:XXXX */
+
+    /* if no output CRS is defined, get the ll equivalent */
+    
+
+
+#else /* PROJ 5 */
+
+#endif
+#else /* PROJ 4 */
+
+#endif
 
 #ifdef HAVE_PROJ_H
     info_trans->pj = NULL;

--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -190,7 +190,7 @@ char *get_pj_type_string(PJ *pj)
 
     switch (proj_get_type(pj)) {
     case PJ_TYPE_UNKNOWN:
-	G_asprintf(&pj_type, "unkown");
+	G_asprintf(&pj_type, "unknown");
 	break;
     case PJ_TYPE_ELLIPSOID:
 	G_asprintf(&pj_type, "ellipsoid");
@@ -244,7 +244,7 @@ char *get_pj_type_string(PJ *pj)
 	G_asprintf(&pj_type, "compound crs");
 	break;
     case PJ_TYPE_TEMPORAL_CRS:
-	G_asprintf(&pj_type, "temporal");
+	G_asprintf(&pj_type, "temporal crs");
 	break;
     case PJ_TYPE_ENGINEERING_CRS:
 	G_asprintf(&pj_type, "engineering crs");
@@ -435,8 +435,8 @@ int GPJ_init_transform(const struct pj_info *info_in,
 
 	/* remove any +towgs84/+nadgrids clause, see above
 	 * does not always remove +towgs84=0.000,0.000,0.000 ??? */
-	G_debug(0, "source proj string: %s", info_in->def);
-	G_debug(0, "source type: %s", get_pj_type_string(info_in->pj));
+	G_debug(1, "source proj string: %s", info_in->def);
+	G_debug(1, "source type: %s", get_pj_type_string(info_in->pj));
 	indefcrs = info_in->def;
 	source_crs = proj_get_source_crs(NULL, info_in->pj);
 	if (source_crs) {
@@ -445,15 +445,15 @@ int GPJ_init_transform(const struct pj_info *info_in,
 	    projstr = proj_as_proj_string(NULL, source_crs, PJ_PROJ_5, NULL);
 	    if (projstr) {
 		indefcrs = G_store(projstr);
-		G_debug(0, "Input CRS definition converted from '%s' to '%s'",
+		G_debug(1, "Input CRS definition converted from '%s' to '%s'",
 		        info_in->def, indefcrs);
 	    }
 	    proj_destroy(source_crs);
 	    source_crs = NULL;
 	}
 
-	G_debug(0, "target proj string: %s", info_out->def);
-	G_debug(0, "target type: %s", get_pj_type_string(info_out->pj));
+	G_debug(1, "target proj string: %s", info_out->def);
+	G_debug(1, "target type: %s", get_pj_type_string(info_out->pj));
 	outdefcrs = info_out->def;
 	target_crs = proj_get_source_crs(NULL, info_out->pj);
 	if (target_crs) {
@@ -462,7 +462,7 @@ int GPJ_init_transform(const struct pj_info *info_in,
 	    projstr = proj_as_proj_string(NULL, target_crs, PJ_PROJ_5, NULL);
 	    if (projstr) {
 		outdefcrs = G_store(projstr);
-		G_debug(0, "Output CRS definition converted from '%s' to '%s'",
+		G_debug(1, "Output CRS definition converted from '%s' to '%s'",
 		        info_out->def, outdefcrs);
 	    }
 	    proj_destroy(target_crs);

--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -400,7 +400,6 @@ int GPJ_init_transform(const struct pj_info *info_in,
 	if (source_crs && target_crs) {
 	    PJ_OPERATION_FACTORY_CONTEXT *operation_ctx;
 	    PJ_OBJ_LIST *op_list;
-	    PJ *op;
 
 	    operation_ctx = proj_create_operation_factory_context(NULL, NULL);
 	    /* constrain by area ? */
@@ -420,8 +419,20 @@ int GPJ_init_transform(const struct pj_info *info_in,
 		    const char *str;
 		    const char *projstr;
 		    PJ_PROJ_INFO pj_info;
+		    PJ *op, *op_norm;
 
 		    op = proj_list_get(NULL, op_list, i);
+		    op_norm = proj_normalize_for_visualization(PJ_DEFAULT_CTX, op);
+
+		    if (!op_norm) {
+			G_warning(_("proj_normalize_for_visualization() failed for operation %d"),
+				  i + 1);
+		    }
+		    else {
+			proj_destroy(op);
+			op = op_norm;
+		    }
+
 		    projstr = proj_as_proj_string(NULL, op,
 				      PJ_PROJ_5, NULL);
 		    pj_info = proj_pj_info(op);

--- a/lib/proj/get_proj.c
+++ b/lib/proj/get_proj.c
@@ -241,6 +241,12 @@ int pj_get_kv(struct pj_info *info, const struct Key_Value *in_proj_keys,
     G_free(datum);
 
 #ifdef HAVE_PROJ_H
+#if PROJ_VERSION_MAJOR >= 6
+    /* without type=crs, PROJ6 does not recognize what this is, 
+     * a crs or some kind of coordinate operation, falling through to
+     * PJ_TYPE_OTHER_COORDINATE_OPERATION */
+    alloc_options("type=crs");
+#endif
     pjc = proj_context_create();
     if (!(pj = proj_create_argv(pjc, nopt, opt_in))) {
 #else
@@ -398,6 +404,12 @@ int pj_get_string(struct pj_info *info, char *str)
     }
 
 #ifdef HAVE_PROJ_H
+#if PROJ_VERSION_MAJOR >= 6
+    /* without type=crs, PROJ6 does not recognize what this is, 
+     * a crs or some kind of coordinate operation, falling through to
+     * PJ_TYPE_OTHER_COORDINATE_OPERATION */
+    alloc_options("type=crs");
+#endif
     pjc = proj_context_create();
     if (!(pj = proj_create_argv(pjc, nopt, opt_in))) {
 	G_warning(_("Unable to initialize pj cause: %s"),


### PR DESCRIPTION
- Convert lowercase epsg to uppercase EPSG

- Axis order of a CRS is no longer always easting, northing, it can also be northing, easting, e.g. EPSG:4326. If source and target CRS are available, axis order is adjusted using proj_normalize_for_visualization() to easting, northing if needed.

- Previously, GRASS did conversions of degress to/from radians and meters from/to map units. Now PROJ6+ might do these conversions itself, or not. GRASS is now doing the conversions only if needed.

- In PROJ6+, there can be several different operations to transform coordinates from one CRS to another CRS. If more than one operation is available, information is provided about these different operations and the user has to provide one of these as pipeline option to r.proj or v.proj. That means that automated reprojection on the fly with r.import or v.import no longer works if more than one operation is available. Further on, the user must take care about axis order and remove any axisswap step from the pipeline if needed.

Example trying to convert from EPSG:2264 to EPSG:4326:
```
WARNING: Found 2 possible transformations
************************
Operation 1:
Description: Inverse of SPCS83 North Carolina zone (US Survey feet) + NAD83
to WGS 84 (55)

Area of use: USA - North Carolina

Accuracy within area of use: 1 m

PROJ string:
+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +z_in=us-ft +xy_out=m
+z_out=m +step +inv +proj=lcc +lat_0=33.75 +lon_0=-79
+lat_1=36.1666666666667 +lat_2=34.3333333333333 +x_0=609601.219202438
+y_0=0 +ellps=GRS80 +step +proj=hgridshift +grids=nchpgn.gsb +step
+proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
************************
Operation 2:
Description: Inverse of SPCS83 North Carolina zone (US Survey feet) + NAD83
to WGS 84 (1)

Area of use: North America - Canada and USA (CONUS, Alaska mainland)

Accuracy within area of use: 4 m

PROJ string:
+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +z_in=us-ft +xy_out=m
+z_out=m +step +inv +proj=lcc +lat_0=33.75 +lon_0=-79
+lat_1=36.1666666666667 +lat_2=34.3333333333333 +x_0=609601.219202438
+y_0=0 +ellps=GRS80 +step +proj=unitconvert +xy_in=rad +xy_out=deg +step
+proj=axisswap +order=2,1
************************
See also output of:
projinfo -o PROJ -s "EPSG:2264" -t "EPSG:4326"
Please provide the appropriate PROJ string with the pipeline option
ERROR: Unable to initialize coordinate transformation
```

The problems here are 1) there is more than one operation available, 2) there is an axisswap that needs to be removed. Both problems need to be resolved by the user. 