### PR TITLE
get rid of wx.insertStringItem deprecation warnings

### DIFF
--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -40,7 +40,7 @@ from gui_core.gselect import Select, ElementSelect
 from gmodeler.model import *
 from lmgr.menudata import LayerManagerMenuData
 from gui_core.wrap import Button, StaticText, StaticBox, TextCtrl, \
-    Menu
+    Menu, ListCtrl
 
 from grass.script import task as gtask
 
@@ -671,7 +671,7 @@ class ModelConditionDialog(ModelItemDialog):
                 'else': self.itemListElse.GetItems()}
 
 
-class ModelListCtrl(wx.ListCtrl,
+class ModelListCtrl(ListCtrl,
                     listmix.ListCtrlAutoWidthMixin,
                     listmix.TextEditMixin):
 
@@ -686,7 +686,7 @@ class ModelListCtrl(wx.ListCtrl,
         self.frame = frame
         self.columnNotEditable = columnsNotEditable
 
-        wx.ListCtrl.__init__(self, parent, id=id, style=style, **kwargs)
+        ListCtrl.__init__(self, parent, id=id, style=style, **kwargs)
         listmix.ListCtrlAutoWidthMixin.__init__(self)
         listmix.TextEditMixin.__init__(self)
 

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -2205,10 +2205,7 @@ class CheckListMapset(
         for mapset in self.parent.all_mapsets_ordered:
             # unclear why this is needed,
             # wrap.ListrCtrl should do the job but it doesn't in this case
-            if wxPythonPhoenix:
-                index = self.InsertItem(self.GetItemCount(), mapset)
-            else:
-                index = self.InsertStringItem(self.GetItemCount(), mapset)
+            index = self.InsertStringItem(self.GetItemCount(), mapset)
             mapsetPath = os.path.join(locationPath,
                                       mapset)
             stat_info = os.stat(mapsetPath)

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -27,18 +27,18 @@ import wx.lib.mixins.listctrl as listmix
 
 from core.gcmd import GMessage, GError, GWarning
 from core.gcmd import RunCommand
-from gui_core.wrap import Button
+from gui_core.wrap import Button, ListCtrl
 
 import grass.script as grass
 from grass.pydispatch.signal import Signal
 
 
-class VectorSelectList(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
+class VectorSelectList(ListCtrl, listmix.ListCtrlAutoWidthMixin):
     """Widget for managing vector features selected from map display
     """
 
     def __init__(self, parent):
-        wx.ListCtrl.__init__(
+        ListCtrl.__init__(
             self,
             parent=parent,
             id=wx.ID_ANY,

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1034,10 +1034,7 @@ class GListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin,
 
         idx = 0
         for item in data:
-            if wxPythonPhoenix:
-                index = self.InsertItem(idx, str(item[0]))
-            else:
-                index = self.InsertStringItem(idx, str(item[0]))
+            index = self.InsertStringItem(idx, str(item[0]))
             for i in range(1, self.GetColumnCount()):
                 self.SetStringItem(index, i, item[i])
             idx += 1

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -73,7 +73,7 @@ from gui_core.gselect import Select
 from core.gcmd import RunCommand, GError, GMessage
 from gui_core.dialogs import SymbolDialog
 from gui_core.wrap import SpinCtrl, Button, TextCtrl, BitmapButton, \
-    StaticText, StaticBox, Rect, EmptyBitmap, TextEntryDialog
+    StaticText, StaticBox, Rect, EmptyBitmap, TextEntryDialog, ListCtrl
 from psmap.utils import *
 from psmap.instructions import *
 
@@ -201,11 +201,11 @@ class PenStyleComboBox(OwnerDrawnComboBox):
         return -1  # default - will be measured from text width
 
 
-class CheckListCtrl(wx.ListCtrl, CheckListCtrlMixin, ListCtrlAutoWidthMixin):
+class CheckListCtrl(ListCtrl, CheckListCtrlMixin, ListCtrlAutoWidthMixin):
     """List control for managing order and labels of vector maps in legend"""
 
     def __init__(self, parent):
-        wx.ListCtrl.__init__(
+        ListCtrl.__init__(
             self, parent, id=wx.ID_ANY, style=wx.LC_REPORT | wx.LC_SINGLE_SEL |
             wx.BORDER_SUNKEN | wx.LC_VRULES | wx.LC_HRULES)
         CheckListCtrlMixin.__init__(self)

--- a/gui/wxpython/vdigit/dialogs.py
+++ b/gui/wxpython/vdigit/dialogs.py
@@ -29,7 +29,7 @@ from core.gcmd import RunCommand, GError
 from core.debug import Debug
 from core.settings import UserSettings
 from gui_core.wrap import SpinCtrl, Button, StaticText, \
-    StaticBox, Menu
+    StaticBox, Menu, ListCtrl
 
 
 class VDigitCategoryDialog(wx.Dialog, listmix.ColumnSorterMixin):
@@ -554,7 +554,7 @@ class VDigitCategoryDialog(wx.Dialog, listmix.ColumnSorterMixin):
         return True
 
 
-class CategoryListCtrl(wx.ListCtrl,
+class CategoryListCtrl(ListCtrl,
                        listmix.ListCtrlAutoWidthMixin,
                        listmix.TextEditMixin):
 
@@ -563,7 +563,7 @@ class CategoryListCtrl(wx.ListCtrl,
         """List of layers/categories"""
         self.parent = parent
 
-        wx.ListCtrl.__init__(self, parent, id, pos, size, style)
+        ListCtrl.__init__(self, parent, id, pos, size, style)
 
         listmix.ListCtrlAutoWidthMixin.__init__(self)
         listmix.TextEditMixin.__init__(self)
@@ -775,7 +775,7 @@ class VDigitDuplicatesDialog(wx.Dialog):
 
 
 class CheckListFeature(
-        wx.ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.CheckListCtrlMixin):
+        ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.CheckListCtrlMixin):
 
     def __init__(self, parent, data,
                  pos=wx.DefaultPosition, log=None):
@@ -784,8 +784,7 @@ class CheckListFeature(
         self.parent = parent
         self.data = data
 
-        wx.ListCtrl.__init__(self, parent, wx.ID_ANY,
-                             style=wx.LC_REPORT)
+        ListCtrl.__init__(self, parent, wx.ID_ANY, style=wx.LC_REPORT)
 
         listmix.CheckListCtrlMixin.__init__(self)
 


### PR DESCRIPTION
In new wxPython, `wx.insertItem()` should be used instead of `wx.insertStringItem()`. This is solving it through a wrapper to support both versions of wxPython. 

PS: Should be backported also to GRASS 7.8, I believe. 