### PR TITLE
fix the renaming of wx.Event variables

### DIFF
--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -707,10 +707,12 @@ class ModelListCtrl(ListCtrl,
 
     def OnBeginEdit(self, event):
         """Editing of item started"""
-        if self.columnNotEditable and event.m_col in self.columnNotEditable:
+        column = event.GetColumn()
+
+        if self.columnNotEditable and column in self.columnNotEditable:
             event.Veto()
             self.SetItemState(
-                event.m_itemIndex,
+                event.GetIndex(),
                 wx.LIST_STATE_SELECTED,
                 wx.LIST_STATE_SELECTED | wx.LIST_STATE_FOCUSED)
         else:

--- a/gui/wxpython/iclass/dialogs.py
+++ b/gui/wxpython/iclass/dialogs.py
@@ -493,8 +493,8 @@ class CategoryListCtrl(wx.ListCtrl,
         return indices
 
     def OnEdit(self, event):
-        currentItem = event.m_itemIndex
-        currentCol = event.m_col
+        currentItem = event.GetIndex()
+        currentCol = event.GetColumn()
         if currentCol == 1:
             col = self.OnGetItemText(currentItem, currentCol)
             col = map(int, col.split(':'))


### PR DESCRIPTION
In new wxPython, `ListCtrl` `Event` does not have the variables `m_col` and `m_itemIndex` anymore. They were renamed to `Column` and `Index`. The usage of getters `GetColumn()` and `GetIndex()` supports the new API of wxPython as well as the old one. 

PS: Should be backported also to GRASS 7.8 as it raises an error even there. 