### PR TITLE
fix band references assignment 

### DIFF
--- a/lib/python/temporal/abstract_map_dataset.py
+++ b/lib/python/temporal/abstract_map_dataset.py
@@ -1054,6 +1054,25 @@ class AbstractMapDataset(AbstractDataset):
 
         return statement
 
+    def read_band_reference_from_grass(self):
+        """Read the band identifier of this map from the map metadata
+           in the GRASS file system based spatial database and
+           set the internal band identifier that should be insert/updated
+           in the temporal database.
+
+           Currently only implemented in RasterDataset. Otherwise
+           silently pass.
+        """
+        pass
+
+    def set_band_reference(self, band_reference):
+        """Set band reference identifier
+
+           Currently only implemented in RasterDataset. Otherwise
+           report a warning.
+        """
+        self.msgr.warning(_("Band references can only be assigned to raster maps"))
+
 ###############################################################################
 
 if __name__ == "__main__":

--- a/lib/python/temporal/register.py
+++ b/lib/python/temporal/register.py
@@ -328,21 +328,15 @@ def register_maps_in_space_time_dataset(
                                      increment=increment, mult=count,
                                      interval=interval)
 
-        # Set band reference (only raster type supported)
-        if type == "rast" or type == "raster":
-            # Set the band reference
-            if band_reference:
-                # Band reference defined in input file
-                # -> update raster metadata
-                # -> write band identifier to GRASS data base
-                map.set_band_reference(band_reference)
-            else:
-                # Try to read band reference from GRASS data base if defined
-                map.read_band_reference_from_grass()
+        # Set the band reference (only raster type supported)
+        if band_reference:
+            # Band reference defined in input file
+            # -> update raster metadata
+            # -> write band identifier to GRASS data base
+            map.set_band_reference(band_reference)
         else:
-            if band_reference:
-                msgr.warning(_("Band references can only be assigned to raster maps"
-                               "Type <%s> is not supported") % (type))
+            # Try to read band reference from GRASS data base if defined
+            map.read_band_reference_from_grass()
 
         if is_in_db:
             #  Gather the SQL update statement

--- a/lib/python/temporal/register.py
+++ b/lib/python/temporal/register.py
@@ -328,15 +328,21 @@ def register_maps_in_space_time_dataset(
                                      increment=increment, mult=count,
                                      interval=interval)
 
-        # Set the band reference
-        if band_reference:
-            # Band reference defined in input file
-            # -> update raster metadata
-            # -> write band identifier to GRASS data base
-            map.set_band_reference(band_reference)
+        # Set band reference (only raster type supported)
+        if type == "rast" or type == "raster":
+            # Set the band reference
+            if band_reference:
+                # Band reference defined in input file
+                # -> update raster metadata
+                # -> write band identifier to GRASS data base
+                map.set_band_reference(band_reference)
+            else:
+                # Try to read band reference from GRASS data base if defined
+                map.read_band_reference_from_grass()
         else:
-            # Try to read band reference from GRASS data base if defined
-            map.read_band_reference_from_grass()
+            if band_reference:
+                msgr.warning(_("Band references can be assigned only to raster maps. "
+                               "Type <%s> is not supported") % (type))
 
         if is_in_db:
             #  Gather the SQL update statement

--- a/lib/python/temporal/register.py
+++ b/lib/python/temporal/register.py
@@ -341,7 +341,7 @@ def register_maps_in_space_time_dataset(
                 map.read_band_reference_from_grass()
         else:
             if band_reference:
-                msgr.warning(_("Band references can be assigned only to raster maps. "
+                msgr.warning(_("Band references can only be assigned to raster maps"
                                "Type <%s> is not supported") % (type))
 
         if is_in_db:


### PR DESCRIPTION
This PR fixes bug introduced by band reference implementation (#63).

## Steps to reproduce

Register vector map into STVDS.

```
t.register inp=test_v maps=x type=vector start=2010-01-01 --o
Gathering map information...
ERROR: 'VectorDataset' object has no attribute
       'read_band_reference_from_grass'
```
