### PR TITLE
fix deprecated wx.NewId()

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -658,7 +658,7 @@ class TaskFrame(wx.Frame):
             flag=wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT,
             border=30)
         # abort key bindings
-        abortId = wx.Window.NewControlId()
+        abortId = wx.NewIdRef()
         self.Bind(wx.EVT_MENU, self.OnAbort, id=abortId)
         accelTableList.append((wx.ACCEL_CTRL, ord('S'), abortId))
         # set accelerator table

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -658,7 +658,7 @@ class TaskFrame(wx.Frame):
             flag=wx.ALIGN_CENTER | wx.LEFT | wx.RIGHT,
             border=30)
         # abort key bindings
-        abortId = wx.NewId()
+        abortId = wx.Window.NewControlId()
         self.Bind(wx.EVT_MENU, self.OnAbort, id=abortId)
         accelTableList.append((wx.ACCEL_CTRL, ord('S'), abortId))
         # set accelerator table


### PR DESCRIPTION
wx.NewId() is superceeded by wx.NewControlId()

```
v.import --ui
/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/forms.py:661: DeprecationWarning: NewId() is deprecated
  abortId = wx.NewId()
```