### PR TITLE
use copy instead of git clone in Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+docker
+!docker/testdata
+.git
+.gitignore
+.github
+.travis
+.travis.yml

--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -6,7 +6,6 @@ LABEL authors="Pietro Zambelli,Markus Neteler"
 LABEL maintainer="peter.zamb@gmail.com,neteler@osgeo.org"
 
 # PACKAGES VERSIONS
-ARG GRASS_VERSION=7.9
 ARG PYTHON_VERSION=3
 ARG PROJ_VERSION=5.2.0
 ARG PROJ_DATUMGRID_VERSION=1.8
@@ -172,16 +171,12 @@ RUN echo "Install main packages";\
     # Checkout and install GRASS GIS
     #
     echo "Install GRASS GIS";\
-    echo "  => Downloading grass-$GRASS_VERSION";\
-    wget -q https://grass.osgeo.org/grass`echo $GRASS_VERSION | tr -d .`/source/snapshot/grass-$GRASS_VERSION.git_src_snapshot_latest.tar.gz && \
-    # unpack source code package and remove tarball archive:
-    mkdir /src/grass_build && \
-    tar xfz grass-$GRASS_VERSION.git_src_snapshot_latest.tar.gz --strip=1 -C /src/grass_build && \
-    rm -f grass-$GRASS_VERSION.git_src_snapshot_latest.tar.gz; \
-    #
-    # Configure compile and install GRASS GIS
-    #
-    echo "  => Configure and compile grass";\
+    echo "  => Downloading grass"
+
+COPY . /src/grass_build/
+
+# Configure compile and install GRASS GIS
+RUN echo "  => Configure and compile grass";\
     cd /src/grass_build && \
     /src/grass_build/configure $GRASS_CONFIG && \
     make -j $NUMTHREADS && \
@@ -235,9 +230,9 @@ ENV GRASSBIN="/usr/local/bin/grass"
 # ===========================
 
 WORKDIR /tmp
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/simple.laz -O simple.laz
+COPY docker/testdata/simple.laz .
 WORKDIR /scripts
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/test_grass_session.py -O test_grass_session.py
+COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 # TODO: fix test
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
@@ -256,6 +251,8 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8"
 
 # show installed version
-RUN $GRASSBIN --tmp-location EPSG:4326 --exec g.version -rge
+RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+    pdal --version && \
+    python3 --version
 
 CMD [$GRASSBIN, "--version"]

--- a/docker/alpine/Dockerfile_alpine_wxgui
+++ b/docker/alpine/Dockerfile_alpine_wxgui
@@ -182,16 +182,12 @@ RUN echo "Install main packages";\
     # Checkout and install GRASS GIS
     #
     echo "Install GRASS GIS";\
-    echo "  => Downloading grass-$GRASS_VERSION";\
-    wget -q https://grass.osgeo.org/grass`echo $GRASS_VERSION | tr -d .`/source/snapshot/grass-$GRASS_VERSION.git_src_snapshot_latest.tar.gz && \
-    # unpack source code package and remove tarball archive:
-    mkdir /src/grass_build && \
-    tar xfz grass-$GRASS_VERSION.git_src_snapshot_latest.tar.gz --strip=1 -C /src/grass_build && \
-    rm -f grass-$GRASS_VERSION.git_src_snapshot_latest.tar.gz; \
-    #
-    # Configure compile and install GRASS GIS
-    #
-    echo "  => Configure and compile grass";\
+    echo "  => Downloading grass"
+
+COPY . /src/grass_build/
+
+# Configure compile and install GRASS GIS
+RUN echo "  => Configure and compile grass";\
     cd /src/grass_build && \
     /src/grass_build/configure $GRASS_CONFIG && \
     make -j $NUMTHREADS && \
@@ -245,9 +241,9 @@ ENV GRASSBIN="/usr/local/bin/grass"
 # ===========================
 
 WORKDIR /tmp
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/simple.laz -O simple.laz
+COPY docker/testdata/simple.laz .
 WORKDIR /scripts
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/test_grass_session.py -O test_grass_session.py
+COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 # TODO: fix test
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
@@ -266,6 +262,8 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8"
 
 # show installed version
-RUN $GRASSBIN --tmp-location EPSG:4326 --exec g.version -rge
+RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+    pdal --version && \
+    python3 --version
 
 CMD [$GRASSBIN, "--version"]

--- a/docker/alpine/README_alpine.md
+++ b/docker/alpine/README_alpine.md
@@ -4,19 +4,42 @@ Dockerfile with an [Alpine Linux](https://www.alpinelinux.org/) image with [GRAS
 
 Download size of this image is only approximately 80 MB.
 
-Build the docker with:
+Clone this repository and change directory:
 
 ```bash
-$ sudo docker build --build-arg GRASS_VERSION=7.9 \
-                    --build-arg PYTHON_VERSION=3  \
-                    --build-arg PROJ_VERSION=5.2.0 \
-                    --build-arg PROJ_DATUMGRID_VERSION=1.8 \
-                    --file Dockerfile_alpine .
+$ git clone https://github.com/OSGeo/grass.git
+$ cd grass
+```
+
+__Build the docker with__:
+
+```bash
+$ docker build \
+         --file docker/alpine/Dockerfile_alpine \
+         --tag grass-py3-pdal:latest-alpine .
 ```
 
 View the images available using `sudo docker images` and open a bash terminal with:
 
 ```bash
-$ sudo docker run -i -t 15550df91610 /bin/bash
+$ docker run -it grass-py3-pdal:latest-alpine /bin/bash
+bash-5.0#
+```
+
+__To build a stable version__:
+
+change to the releasebranch or tag you want to build:
+```bash
+$ git checkout remotes/origin/releasebranch_7_8
+```
+
+and build and enter with:
+
+```bash
+$ docker build \
+         -f docker/alpine/Dockerfile_alpine \
+         -t grass-py3-pdal:stable-alpine .
+
+$ docker run -it grass-py3-pdal:stable-alpine /bin/bash
 bash-5.0#
 ```

--- a/docker/debian/Dockerfile_debian_pdal
+++ b/docker/debian/Dockerfile_debian_pdal
@@ -211,7 +211,7 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
 
 # Create generic GRASS GIS binary name regardless of version number
 RUN ln -sf `find /usr/local/bin -name "grass??" | sort | tail -n 1` /usr/local/bin/grass
-RUN ln -sf `find /usr/local -name "grass??" | sort | tail -n 1` /usr/local/grass
+RUN ln -sf `find /usr/local -type d -name "grass??" | sort | tail -n 1` /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \

--- a/docker/debian/Dockerfile_debian_pdal
+++ b/docker/debian/Dockerfile_debian_pdal
@@ -6,16 +6,10 @@ LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,bettge@mundialis.de
 ENV DEBIAN_FRONTEND noninteractive
 
 # define versions to be used
-ARG GRASS_VERSION=7.9
-ARG GRASS_SHORT_VERSION=79
 ARG PDAL_VERSION=1.8.0
 ARG PROJ_VERSION=5.2.0
 ARG PROJ_DATUMGRID_VERSION=1.8
 ARG LAZ_PERF_VERSION=1.3.0
-ARG SOURCE_GIT_URL=https://github.com
-ARG SOURCE_GIT_REMOTE=OSGeo
-ARG SOURCE_GIT_REPO=grass
-ARG SOURCE_GIT_BRANCH=master
 
 SHELL ["/bin/bash", "-c"]
 
@@ -158,11 +152,9 @@ RUN wget -q \
     make -j $NUMTHREADS && \
     make install
 
-# download grass gis source from git
+# copy grass gis source
 WORKDIR /src
-# TODO change to COPY
-ADD https://api.github.com/repos/$SOURCE_GIT_REMOTE/$SOURCE_GIT_REPO/git/refs/heads/$SOURCE_GIT_BRANCH version.json
-RUN git clone -b ${SOURCE_GIT_BRANCH} --single-branch ${SOURCE_GIT_URL}/${SOURCE_GIT_REMOTE}/${SOURCE_GIT_REPO}.git grass_build
+COPY . /src/grass_build/
 WORKDIR /src/grass_build
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols
@@ -219,9 +211,12 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
 
 # Create generic GRASS GIS binary name regardless of version number
 RUN ln -sf `find /usr/local/bin -name "grass??" | sort | tail -n 1` /usr/local/bin/grass
+RUN ln -sf `find /usr/local -name "grass??" | sort | tail -n 1` /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge
+RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+    pdal --version && \
+    python3 --version
 
 # Reduce the image size
 RUN apt-get autoremove -y
@@ -236,15 +231,15 @@ RUN pip3 install grass-session
 RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal
 
 # add GRASS GIS envs for python usage
-ENV GISBASE "/usr/local/grass${GRASS_SHORT_VERSION}/"
+ENV GISBASE "/usr/local/grass/"
 ENV GRASSBIN "/usr/local/bin/grass"
 ENV PYTHONPATH "${PYTHONPATH}:$GISBASE/etc/python/"
 ENV LD_LIBRARY_PATH "$LD_LIBRARY_PATH:$GISBASE/lib"
 
 WORKDIR /tmp
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/simple.laz -O simple.laz
+COPY docker/testdata/simple.laz .
 WORKDIR /scripts
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/test_grass_session.py -O test_grass_session.py
+COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 RUN /usr/bin/python3 /scripts/test_grass_session.py
 

--- a/docker/debian/README_debian.md
+++ b/docker/debian/README_debian.md
@@ -4,19 +4,42 @@ Dockerfile with an [Debian Linux](https://www.debian.org/) image with [GRASS GIS
 
 Download size of this image is of approximately 2.6 GB.
 
-Build the docker with:
+Clone this repository and change directory:
 
 ```bash
-$ sudo docker build --build-arg GRASS_VERSION=7.9 \
-                    --build-arg PYTHON_VERSION=3  \
-                    --build-arg PROJ_VERSION=5.2.0 \
-                    --build-arg PROJ_DATUMGRID_VERSION=1.8 \
-                    --file Dockerfile_debian_pdal .
+$ git clone https://github.com/OSGeo/grass.git
+$ cd grass
+```
+
+__Build the docker with__:
+
+```bash
+$ docker build \
+         --file docker/debian/Dockerfile_debian_pdal \
+         --tag grass-py3-pdal:latest-debian .
 ```
 
 View the images available using `sudo docker images` and open a bash terminal with:
 
 ```bash
-$ sudo docker run -i -t 15550df91610 /bin/bash
+$ docker run -it grass-py3-pdal:latest-debian /bin/bash
+bash-5.0#
+```
+
+__To build a stable version__:
+
+change to the releasebranch or tag you want to build:
+```bash
+$ git checkout remotes/origin/releasebranch_7_8
+```
+
+and build and enter with:
+
+```bash
+$ docker build \
+         -f docker/debian/Dockerfile_debian_pdal \
+         -t grass-py3-pdal:stable-debian .
+
+$ docker run -it grass-py3-pdal:stable-debian /bin/bash
 bash-5.0#
 ```

--- a/docker/ubuntu/Dockerfile_ubuntu_pdal
+++ b/docker/ubuntu/Dockerfile_ubuntu_pdal
@@ -212,7 +212,7 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
 
 # Create generic GRASS GIS binary name regardless of version number
 RUN ln -sf `find /usr/local/bin -name "grass??" | sort | tail -n 1` /usr/local/bin/grass
-RUN ln -sf `find /usr/local -name "grass??" | sort | tail -n 1` /usr/local/grass
+RUN ln -sf `find /usr/local -type d -name "grass??" | sort | tail -n 1` /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \

--- a/docker/ubuntu/Dockerfile_ubuntu_pdal
+++ b/docker/ubuntu/Dockerfile_ubuntu_pdal
@@ -6,16 +6,10 @@ LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,bettge@mundialis.de
 ENV DEBIAN_FRONTEND noninteractive
 
 # define versions to be used
-ARG GRASS_VERSION=7.9
-ARG GRASS_SHORT_VERSION=79
 ARG PDAL_VERSION=1.8.0
 ARG PROJ_VERSION=4.9.3
 ARG PROJ_DATUMGRID_VERSION=1.8
 ARG LAZ_PERF_VERSION=1.3.0
-ARG SOURCE_GIT_URL=https://github.com
-ARG SOURCE_GIT_REMOTE=OSGeo
-ARG SOURCE_GIT_REPO=grass
-ARG SOURCE_GIT_BRANCH=master
 
 SHELL ["/bin/bash", "-c"]
 
@@ -159,11 +153,9 @@ RUN wget -q \
     make -j $NUMTHREADS && \
     make install
 
-# download grass gis source from git
+# copy grass gis source
 WORKDIR /src
-# TODO change to COPY
-ADD https://api.github.com/repos/$SOURCE_GIT_REMOTE/$SOURCE_GIT_REPO/git/refs/heads/$SOURCE_GIT_BRANCH version.json
-RUN git clone -b ${SOURCE_GIT_BRANCH} --single-branch ${SOURCE_GIT_URL}/${SOURCE_GIT_REMOTE}/${SOURCE_GIT_REPO}.git grass_build
+COPY . /src/grass_build/
 WORKDIR /src/grass_build
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols
@@ -220,9 +212,12 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
 
 # Create generic GRASS GIS binary name regardless of version number
 RUN ln -sf `find /usr/local/bin -name "grass??" | sort | tail -n 1` /usr/local/bin/grass
+RUN ln -sf `find /usr/local -name "grass??" | sort | tail -n 1` /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge
+RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+    pdal --version && \
+    python3 --version
 
 # Reduce the image size
 RUN apt-get autoremove -y
@@ -237,15 +232,15 @@ RUN pip3 install grass-session
 RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal
 
 # add GRASS GIS envs for python usage
-ENV GISBASE "/usr/local/grass${GRASS_SHORT_VERSION}/"
+ENV GISBASE "/usr/local/grass/"
 ENV GRASSBIN "/usr/local/bin/grass"
 ENV PYTHONPATH "${PYTHONPATH}:$GISBASE/etc/python/"
 ENV LD_LIBRARY_PATH "$LD_LIBRARY_PATH:$GISBASE/lib"
 
 WORKDIR /tmp
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/simple.laz -O simple.laz
+COPY docker/testdata/simple.laz .
 WORKDIR /scripts
-RUN wget -q https://raw.githubusercontent.com/OSGeo/grass/master/docker/testdata/test_grass_session.py -O test_grass_session.py
+COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 RUN /usr/bin/python3 /scripts/test_grass_session.py
 

--- a/docker/ubuntu/README_ubuntu.md
+++ b/docker/ubuntu/README_ubuntu.md
@@ -4,19 +4,42 @@ Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with [GRASS GIS](ht
 
 Download size of this image is of approximately 2.6 GB.
 
-Build the docker with:
+Clone this repository and change directory:
 
 ```bash
-$ sudo docker build --build-arg GRASS_VERSION=7.9 \
-                    --build-arg PYTHON_VERSION=3  \
-                    --build-arg PROJ_VERSION=4.9.3 \
-                    --build-arg PROJ_DATUMGRID_VERSION=1.8 \
-                    --file Dockerfile_ubuntu_pdal .
+$ git clone https://github.com/OSGeo/grass.git
+$ cd grass
+```
+
+__Build the docker with__:
+
+```bash
+$ docker build \
+         --file docker/ubuntu/Dockerfile_ubuntu_pdal \
+         --tag grass-py3-pdal:latest-ubuntu .
 ```
 
 View the images available using `sudo docker images` and open a bash terminal with:
 
 ```bash
-$ sudo docker run -i -t 15550df91610 /bin/bash
+$ docker run -it grass-py3-pdal:latest-ubuntu /bin/bash
+bash-5.0#
+```
+
+__To build a stable version__:
+
+change to the releasebranch or tag you want to build:
+```bash
+$ git checkout remotes/origin/releasebranch_7_8
+```
+
+and build and enter with:
+
+```bash
+$ docker build \
+         -f docker/ubuntu/Dockerfile_ubuntu_pdal \
+         -t grass-py3-pdal:stable-ubuntu .
+
+$ docker run -it grass-py3-pdal:stable-ubuntu /bin/bash
 bash-5.0#
 ```


### PR DESCRIPTION
This PR suggests to change the current behaviour of using `git clone` in the Dockerfiles. Before, the GRASS GIS version needed to be configured via `ARG` variables to clone the branch according to the wanted GRASS version. As the source code is here and next to the Dockerfiles already, a simple `COPY` can be used. The GRASS version then corresponds to the branch on which the Dockerimage is build.

Additionally a .dockerignore file was added to not copy the whole context on build time.

An example docker build can be done now with:
```bash
$ docker build \
         --file docker/debian/Dockerfile_debian_pdal \
         --tag grass-py3-pdal:latest-debian .
```
and to build a stable version:
```bash
$ git checkout remotes/origin/releasebranch_7_8
$ docker build \
         -f docker/debian/Dockerfile_debian_pdal \
         -t grass-py3-pdal:stable-debian .
```
Currently, this leads to the following flavours:

master:
- grass-py3-pdal:latest-ubuntu (GRASS GIS 7.9, proj=4.9.3, gdal=2.2.3, geos=3.6.2, sqlite=3.22.0, pdal 1.8.0, Python 3.6.8)
- grass-py3-pdal:latest-debian (GRASS GIS 7.9, proj=5.2.0, gdal=2.4.0, geos=3.7.1, sqlite=3.27.2, pdal 1.8.0, Python 3.7.3)
- grass-py3-pdal:latest-alpine (GRASS GIS 7.9, proj=5.2.0, gdal=2.4.0, geos=3.7.2, sqlite=3.29.0, pdal 1.9.1, Python 3.7.4)

releasebranch_7_8:
- grass-py3-pdal:stable-ubuntu (GRASS GIS 7.8.1, proj=4.9.3, gdal=2.2.3, geos=3.6.2, sqlite=3.22.0, pdal 1.8.0, Python 3.6.8)
- grass-py3-pdal:stable-debian (GRASS GIS 7.8.1, proj=5.2.0, gdal=2.4.0, geos=3.7.1, sqlite=3.27.2, pdal 1.8.0, Python 3.7.3)
- grass-py3-pdal:stable-alpine (GRASS GIS 7.8.1, proj=5.2.0, gdal=2.4.0, geos=3.7.2, sqlite=3.29.0, pdal 1.9.1, Python 3.7.4)
