### PR TITLE
wxGUI: remove legacy initialization of image handlers

### DIFF
--- a/gui/wxpython/animation/g.gui.animation.py
+++ b/gui/wxpython/animation/g.gui.animation.py
@@ -65,7 +65,6 @@ def main():
     from grass.script.setup import set_gui_path
     set_gui_path()
 
-    from core.globalvar import CheckWxVersion
     from core.giface import StandaloneGrassInterface
     from core.layerlist import LayerList
     from animation.frame import AnimationFrame, MAX_COUNT
@@ -124,8 +123,6 @@ def main():
         layerList.AddLayer(layer)
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
 
     frame = AnimationFrame(parent=None, giface=StandaloneGrassInterface())
     frame.CentreOnScreen()

--- a/gui/wxpython/gcp/g.gui.gcp.py
+++ b/gui/wxpython/gcp/g.gui.gcp.py
@@ -52,7 +52,6 @@ def main():
     set_gui_path()
 
     from core.settings import UserSettings
-    from core.globalvar import CheckWxVersion
     from core.giface import StandaloneGrassInterface
     from gcp.manager import GCPWizard
 
@@ -63,8 +62,6 @@ def main():
         os.environ['GRASS_RENDER_IMMEDIATE'] = 'cairo'
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
 
     wizard = GCPWizard(parent=None, giface=StandaloneGrassInterface())
 

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -1147,8 +1147,6 @@ class StartUp(wx.App):
     """Start-up application"""
 
     def OnInit(self):
-        if not globalvar.CheckWxVersion([2, 9]):
-            wx.InitAllImageHandlers()
         StartUp = GRASSStartup()
         StartUp.CenterOnScreen()
         self.SetTopWindow(StartUp)

--- a/gui/wxpython/gmodeler/g.gui.gmodeler.py
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.py
@@ -46,12 +46,9 @@ def main():
     set_gui_path()
 
     from core.giface import StandaloneGrassInterface
-    from core.globalvar import CheckWxVersion
     from gmodeler.frame import ModelFrame
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
     frame = ModelFrame(parent=None, giface=StandaloneGrassInterface())
     if options['file']:
         frame.LoadModelFile(options['file'])

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -706,8 +706,6 @@ class HelpWindow(HtmlWindow):
         in the Panel.
         """
         self.parent = parent
-        if not globalvar.CheckWxVersion([2, 9]):
-            wx.InitAllImageHandlers()
         HtmlWindow.__init__(self, parent=parent, **kwargs)
 
         self.loaded = False

--- a/gui/wxpython/gui_core/wxlibplot.py
+++ b/gui/wxpython/gui_core/wxlibplot.py
@@ -2548,7 +2548,6 @@ def __test():
     class MyApp(wx.App):
 
         def OnInit(self):
-            wx.InitAllImageHandlers()
             frame = TestFrame(None, -1, "PlotCanvas")
             # frame.Show(True)
             self.SetTopWindow(frame)

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -1482,7 +1482,6 @@ def test():
     import core.render as render
 
     app = wx.App()
-    wx.InitAllImageHandlers()
 
     frame = IClassMapFrame()
     frame.Show()

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -63,7 +63,6 @@ def main():
     set_gui_path()
 
     from core.settings import UserSettings
-    from core.globalvar import CheckWxVersion
     from core.giface import StandaloneGrassInterface
     from iclass.frame import IClassMapFrame
 
@@ -106,8 +105,6 @@ def main():
 
     # launch application
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
 
     # show main frame
     giface = StandaloneGrassInterface()

--- a/gui/wxpython/image2target/g.gui.image2target.py
+++ b/gui/wxpython/image2target/g.gui.image2target.py
@@ -118,7 +118,6 @@ def main():
     set_gui_path()
 
     from core.settings import UserSettings
-    from core.globalvar import CheckWxVersion
     from core.giface import StandaloneGrassInterface
     from image2target.ii2t_manager import GCPWizard
 
@@ -170,8 +169,6 @@ def main():
 
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
 
 #    wizard = GCPWizard(parent=None, giface=StandaloneGrassInterface(), 
 #            srcloc=src_loc,srcmpt=src_mpt,srcgrp=src_grp,srcras=src_ras,

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -1153,8 +1153,6 @@ class StartUp(wx.App):
     """Start-up application"""
 
     def OnInit(self):
-        if not globalvar.CheckWxVersion([2, 9]):
-            wx.InitAllImageHandlers()
         StartUp = GRASSStartup()
         StartUp.CenterOnScreen()
         self.SetTopWindow(StartUp)

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -495,9 +495,6 @@ class DMonFrame(MapFrame):
 class MapApp(wx.App):
 
     def OnInit(self):
-        if not globalvar.CheckWxVersion([2, 9]):
-            wx.InitAllImageHandlers()
-
         grass.set_raise_on_error(True)
         # actual use of StandaloneGrassInterface not yet tested
         # needed for adding functionality in future

--- a/gui/wxpython/mapdisp/test_mapdisp.py
+++ b/gui/wxpython/mapdisp/test_mapdisp.py
@@ -59,7 +59,6 @@ from grass.script.setup import set_gui_path
 set_gui_path()
 
 from core.settings import UserSettings
-from core.globalvar import CheckWxVersion
 from core.giface import StandaloneGrassInterface
 from mapwin.base import MapWindowProperties
 from mapwin.buffered import BufferedMapWindow
@@ -302,9 +301,6 @@ def main():
     test = options['test']
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
-
     map_ = Map()
 
     if options['raster']:

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.py
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.py
@@ -57,7 +57,6 @@ def main():
     set_gui_path()
 
     from core.settings import UserSettings
-    from core.globalvar import CheckWxVersion
     from core.giface import StandaloneGrassInterface
     from mapswipe.frame import SwipeMapFrame
 
@@ -78,8 +77,6 @@ def main():
                 gscript.fatal(_("Raster map <%s> not found") % mapName)
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
 
     frame = SwipeMapFrame(parent=None, giface=StandaloneGrassInterface())
 

--- a/gui/wxpython/photo2image/g.gui.photo2image.py
+++ b/gui/wxpython/photo2image/g.gui.photo2image.py
@@ -80,7 +80,6 @@ def main():
     set_gui_path()
 
     from core.settings import UserSettings
-    from core.globalvar import CheckWxVersion
     from core.giface import StandaloneGrassInterface
     from photo2image.ip2i_manager import GCPWizard
 
@@ -116,8 +115,6 @@ def main():
         gscript.fatal(_("Please provive an output files extension (used by i.rectify)"))
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
 
     wizard = GCPWizard(parent=None, giface=StandaloneGrassInterface(), group=group, 
             raster=raster, raster1=raster, camera=camera, order=order, extension=extension)

--- a/gui/wxpython/psmap/g.gui.psmap.py
+++ b/gui/wxpython/psmap/g.gui.psmap.py
@@ -43,12 +43,9 @@ def main():
     from grass.script.setup import set_gui_path
     set_gui_path()
 
-    from core.globalvar import CheckWxVersion
     from psmap.frame import PsMapFrame
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
     frame = PsMapFrame(parent=None)
     frame.Show()
 

--- a/gui/wxpython/rlisetup/g.gui.rlisetup.py
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.py
@@ -38,12 +38,9 @@ def main():
     set_gui_path()
 
     from core.giface import StandaloneGrassInterface
-    from core.globalvar import CheckWxVersion
     from rlisetup.frame import RLiSetupFrame
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
     frame = RLiSetupFrame(parent=None, giface=StandaloneGrassInterface())
     frame.Show()
     frame.CenterOnScreen()

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -50,7 +50,6 @@ def main():
     from grass.script.setup import set_gui_path
     set_gui_path()
 
-    from core.globalvar import CheckWxVersion
     from core.render import Map
     from mapdisp.frame import MapFrame
     from mapdisp.main import DMonGrassInterface
@@ -108,8 +107,6 @@ def main():
         os.environ['GRASS_RENDER_IMMEDIATE'] = 'cairo'
 
     app = wx.App()
-    if not CheckWxVersion([2, 9]):
-        wx.InitAllImageHandlers()
     frame = VDigitMapFrame(options['map'])
     frame.Show()
 

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -32,7 +32,6 @@ from grass.script.core import set_raise_on_error
 from core import globalvar
 from core.utils import registerPid, unregisterPid
 
-
 import wx
 try:
     import wx.lib.agw.advancedsplash as SC
@@ -59,9 +58,6 @@ class GMApp(wx.App):
 
         :return: True
         """
-        if not globalvar.CheckWxVersion([2, 9]):
-            wx.InitAllImageHandlers()
-
         # create splash screen
         introImagePath = os.path.join(globalvar.IMGDIR, "splash_screen.png")
         introImage = wx.Image(introImagePath, wx.BITMAP_TYPE_PNG)


### PR DESCRIPTION
Hoped to get rid of the annoying debug message during start up, but that's coming from elsewhere. Anyway, this is at least clean up.