### PR TITLE
wxGUI: NewIdRef was added only in wxPython 4.0.3. Fix import for <4.0.3

### DIFF
--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     import wx.lib.customtreectrl as CT
 
-from core.globalvar import gtk3, wxPythonPhoenix
+from core.globalvar import gtk3, wxPythonPhoenix, CheckWxVersion
 if wxPythonPhoenix:
     import wx.adv
 
@@ -35,7 +35,7 @@ else:
     ComboPopup = wx.combo.ComboPopup
     wxComboCtrl = wx.combo.ComboCtrl
 
-if wxPythonPhoenix:
+if wxPythonPhoenix and CheckWxVersion([4, 0, 3, 0]):
     from wx import NewIdRef as NewId
 else:
     from wx import NewId


### PR DESCRIPTION
 b5b00f972917e38a6a912f7c385ddbf791889e70 breaks GUI for wxPython (4.0.0, 4.0.3] as NewIdRef was added only in wxPyhton 4.0.3.
Ref: https://wxpython.org/news/wxpython-4.0.3-release/index.html