### PR TITLE
wxGUI: added install notranslation function

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -773,6 +773,9 @@ def GetDefaultEncoding(forceUTF8=False):
     if forceUTF8 and (enc is None or enc == 'UTF8'):
         return 'UTF-8'
 
+    if enc is None:
+        enc = locale.getpreferredencoding()
+
     Debug.msg(1, "GetSystemEncoding(): %s" % enc)
     return enc
 

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1182,6 +1182,14 @@ def load_env(grass_env_file):
         os.environ['LD_LIBRARY_PATH'] = libpath + os.pathsep + isislibpath + os.pathsep + isis3rdparty
 
 
+def install_notranslation():
+    # If locale is not supported, _ function might be missing
+    # This function just installs _ as a pass-through function
+    # See trac #3875 for details
+    import builtins
+    builtins.__dict__['_'] = lambda x: x
+
+
 def set_language(grass_config_dir):
     # This function is used to override system default language and locale
     # Such override can be requested only from wxGUI
@@ -1230,11 +1238,12 @@ def set_language(grass_config_dir):
             # it would be too drastic to exit
             # sys.exit("Fix system locale settings and then try again.")
             locale.setlocale(locale.LC_ALL, 'C')
-            sys.stderr.write("Default locale settings are missing. GRASS running with C locale.")
+            sys.stderr.write("Default locale settings are missing. GRASS running with C locale.\n")
 
         language, encoding = locale.getdefaultlocale()
         if not language:
-            sys.stderr.write("Default locale settings are missing. GRASS running with C locale.")
+            sys.stderr.write("Default locale settings are missing. GRASS running with C locale.\n")
+            install_notranslation()
             return
 
     else:
@@ -1267,6 +1276,7 @@ def set_language(grass_config_dir):
                             " en_US.UTF-8 locale and restart GRASS.\n"
                             "Also consider upgrading your Python version"
                             " to one containing fix for Python Issue 30755.\n")
+                        install_notranslation()
                         return
                     # en_US locale might be missing, still all messages in
                     # GRASS are already in en_US language.
@@ -1293,6 +1303,7 @@ def set_language(grass_config_dir):
                             "If you observe UnicodeError in Python,"
                             " install en_US.UTF-8"
                             " locale and restart GRASS.\n")
+                        install_notranslation()
                         return
                 else:
                     # The last attempt...
@@ -1311,6 +1322,7 @@ def set_language(grass_config_dir):
                         # language
                         os.environ['LANGUAGE'] = language
                         os.environ['LANG'] = language
+                        install_notranslation()
                         return
 
     # Set up environment for subprocesses


### PR DESCRIPTION
_ is needed for startup code itself. In case of error, provide no translation but allow to continue,
 fixes this error:

```
NameError: global name '_' is not defined
```

Fixes trac 3875 (https://trac.osgeo.org/grass/ticket/3875)