### PR TITLE
g.extension: only warn when non-essential files are missing

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1536,14 +1536,16 @@ def remove_extension_xml(modules):
 # check links in CSS
 
 
-def check_style_files(fil):
+def check_style_file(name):
     """Ensures that a specified HTML documentation support file exists
 
     If the file, e.g. a CSS file does not exist, the file is copied from
     the distribution.
+
+    If the files are missing, a warning is issued.
     """
-    dist_file = os.path.join(os.getenv('GISBASE'), 'docs', 'html', fil)
-    addons_file = os.path.join(options['prefix'], 'docs', 'html', fil)
+    dist_file = os.path.join(os.getenv('GISBASE'), 'docs', 'html', name)
+    addons_file = os.path.join(options['prefix'], 'docs', 'html', name)
 
     if os.path.isfile(addons_file):
         return
@@ -1551,7 +1553,12 @@ def check_style_files(fil):
     try:
         shutil.copyfile(dist_file, addons_file)
     except OSError as error:
-        grass.fatal(_("Unable to create '%s': %s") % (addons_file, error))
+        grass.warning(
+            _("Unable to create '{filename}': {error}."
+              " Is the GRASS GIS documentation package installed?"
+              " Installation continues,"
+              " but documentation may not look right.").format(
+              filename=addons_file, error=error))
 
 
 def create_dir(path):
@@ -1575,8 +1582,8 @@ def check_dirs():
     create_dir(os.path.join(options['prefix'], 'bin'))
     create_dir(os.path.join(options['prefix'], 'docs', 'html'))
     create_dir(os.path.join(options['prefix'], 'docs', 'rest'))
-    check_style_files('grass_logo.png')
-    check_style_files('grassdocs.css')
+    check_style_file('grass_logo.png')
+    check_style_file('grassdocs.css')
     create_dir(os.path.join(options['prefix'], 'etc'))
     create_dir(os.path.join(options['prefix'], 'docs', 'man', 'man1'))
     create_dir(os.path.join(options['prefix'], 'scripts'))


### PR DESCRIPTION
Only warn, not fatal error, when CSS and logo files are missing
in the distribution. Tell user about the possibility of
missing a doc pkg. Tell what will happen next.

Also improve function and parameter names.
and switch to format and name vars in now more
complex tr string.

This is particularly useful when you don't have grass-doc package installed and you don't want to install it, but want to install modules using g.extension.