### PR TITLE
wxGUI: Remove python2 specific sys.stderr encoding handling. Fixes #3921

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -48,8 +48,6 @@ from gui_core.widgets import GenericValidator, StaticWrapText
 from gui_core.wrap import Button, ListCtrl, StaticText, StaticBox, \
     TextCtrl
 
-sys.stderr = codecs.getwriter('utf8')(sys.stderr)
-
 
 class GRASSStartup(wx.Frame):
     exit_success = 0

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -42,8 +42,6 @@ from gui_core.widgets import GenericValidator, StaticWrapText
 from gui_core.wrap import Button, ListCtrl, StaticText, \
     StaticBox, TextCtrl
 
-sys.stderr = codecs.getwriter('utf8')(sys.stderr)
-
 
 class GRASSStartup(wx.Frame):
     exit_success = 0


### PR DESCRIPTION
The actual cause of #3921 is printing to stderr: "sys stderr:  write() argument must be str, not bytes", although passed error message is str. Removing this python2 specific workaround fixes the issue.