### PR TITLE
grass.py: Evaluate ^export lines only and expand variables in double/non-quoted values

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1753,6 +1753,8 @@ PROMPT_COMMAND=grass_prompt\n""".format(
             mask2d_test=mask2d_test, mask3d_test=mask3d_test
             ))
 
+    f.write("export HOME=\"%s\"\n" % userhome)  # restore user home path
+
     # read other settings (aliases, ...) since environmental variables
     # have been already set by load_env(), see #3462
     for env_file in [os.path.join(userhome, ".grass.bashrc"),
@@ -1766,7 +1768,6 @@ PROMPT_COMMAND=grass_prompt\n""".format(
                 f.write(line + '\n')
 
     f.write("export PATH=\"%s\"\n" % os.getenv('PATH'))
-    f.write("export HOME=\"%s\"\n" % userhome)  # restore user home path
     f.close()
 
     process = Popen([gpath("etc", "run"), os.getenv('SHELL')])

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1175,7 +1175,7 @@ def load_env(grass_env_file):
         elif v.startswith('"') and v.endswith('"'):
             v = v.strip('"')
         elif v.startswith("'") or v.endswith("'") or v.startswith('"') or v.endswith('"'):
-            # multi-line variable
+            # ignore multi-line variables
             continue
         if expand:
             v = os.path.expanduser(os.path.expandvars(v.replace('\$', '\0')).replace('\0', '$'))

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1160,7 +1160,7 @@ def load_env(grass_env_file):
     if not os.access(grass_env_file, os.R_OK):
         return
 
-    export_re = re.compile('^export[ \t]([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*)$')
+    export_re = re.compile('^export[ \t]+([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*)$')
 
     for line in readfile(grass_env_file).split(os.linesep):
         m = export_re.match(line)

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1179,7 +1179,7 @@ def load_env(grass_env_file):
             debug("Ignore multi-line environmental variable {0}".format(k))
             continue
         if expand:
-            v = os.path.expanduser(os.path.expandvars(v.replace('\$', '\0')).replace('\0', '$'))
+            v = os.path.expanduser(os.path.expandvars(v.replace('\\$', '\0')).replace('\0', '$'))
         debug("Environmental variable set {0}={1}".format(k, v))
         os.environ[k] = v
 

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1160,7 +1160,7 @@ def load_env(grass_env_file):
     if not os.access(grass_env_file, os.R_OK):
         return
 
-    export_re = re.compile('^export[ \t]+([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*)$')
+    export_re = re.compile('^export[ \t]+([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*?)[ \t]*$')
 
     for line in readfile(grass_env_file).split(os.linesep):
         m = export_re.match(line)
@@ -1176,6 +1176,7 @@ def load_env(grass_env_file):
             v = v.strip('"')
         elif v.startswith("'") or v.endswith("'") or v.startswith('"') or v.endswith('"'):
             # ignore multi-line variables
+            debug("Ignore multi-line environmental variable {0}".format(k))
             continue
         if expand:
             v = os.path.expanduser(os.path.expandvars(v.replace('\$', '\0')).replace('\0', '$'))


### PR DESCRIPTION
This PR properly evaluates ^export in single lines in ~/.grass7/bashrc. It will ignore multi-line environment variables. Without this PR,
```
alias vi='vim'
export GDAL_DRIVER_PATH="$HOME/gdalplugins"
#export IGNORE=ME
export HOHO='$HOME'
```
defines
```
vi='vim' # it's not meant to be an environment variable
GDAL_DRIVER_PATH="$HOME/gdalplugins" # not /home/user/gdalplugins
                                     # note double quotes in the definition itself
IGNORE=ME # shouldn't be defined
HOHO='$HOME' # not just $HOME
```
With this PR, the same lines would define
```
GDAL_DRIVER_PATH=/home/user/gdalplugins # $HOME in double quotes expanded
HOHO=$HOME # $HOME in single quotes not expanded
```