### PR TITLE
copy libs into bin directory after running make distclean

### DIFF
--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-# osgeo4w-setup -g -k -a x86_64 -q -P gdal proj geos fftw libjpeg liblas-devel libpng libpq libtiff libxdr pdcurses regex-devel sqlite3 zstd-devel zstd laszip2
+# osgeo4w-setup -g -k -a x86_64 -q -P gdal proj geos fftw libjpeg liblas-devel libpng libpq libtiff libxdr pdcurses regex-devel sqlite3 zstd-devel zstd laszip2 python3-core python3-six
 
 set -e
 
@@ -166,14 +166,6 @@ else
 	conf_opts=
 fi
 
-mkdir -p dist.$conf_host/bin
-cp -uv $DLLS dist.$conf_host/bin
-
-mkdir -p mswindows/osgeo4w/lib
-cp -uv $OSGEO4W_ROOT_MSYS/lib/libpq.lib mswindows/osgeo4w/lib/pq.lib
-cp -uv $OSGEO4W_ROOT_MSYS/lib/proj_i.lib mswindows/osgeo4w/lib/proj.lib
-cp -uv $OSGEO4W_ROOT_MSYS/lib/sqlite3_i.lib mswindows/osgeo4w/lib/sqlite3.lib
-
 if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 	if [ -e include/Make/Platform.make ] ; then
 	    log make distclean
@@ -182,6 +174,14 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 
 	log remove old logs
 	rm -f mswindows/osgeo4w/package.log.*
+
+	mkdir -p dist.$conf_host/bin
+	cp -uv $DLLS dist.$conf_host/bin
+
+	mkdir -p mswindows/osgeo4w/lib
+	cp -uv $OSGEO4W_ROOT_MSYS/lib/libpq.lib mswindows/osgeo4w/lib/pq.lib
+	cp -uv $OSGEO4W_ROOT_MSYS/lib/proj_i.lib mswindows/osgeo4w/lib/proj.lib
+	cp -uv $OSGEO4W_ROOT_MSYS/lib/sqlite3_i.lib mswindows/osgeo4w/lib/sqlite3.lib
 
 	log configure
 	./configure \


### PR DESCRIPTION
`package.sh` copies selected libs into `bin` directory. Than `make distclean` is run (this command removes `bin` directory). As result ongoing compilation can fail due to wrong libs in the path:

```
if [ "/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/bin/d.barscale.exe"
!= "" ] ; then GISRC=/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/demolocation/.grassrc78
GISBASE=C:/msys64/usr/src/grass78/dist.x86_64-w64-mingw32
PATH="/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/bin:/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/bin:/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/scripts:$PATH"
PYTHONPATH="C:/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/etc/python;C:/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/gui/wxpython;$PYTHONPATH"
PATH="/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/bin:/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/bin:/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/scripts:/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/lib:/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/lib:/mingw64/lib/ccache/bin:/C//OS3944~1/apps/Python37:/C//OS3944~1/apps/Python37/Scripts:/C/OS3944~1/bin:/C/Windows/system32:/C/Windows:/C/Windows/system32/WBem:/C/msys64/usr/bin:/C/msys64/mingw64/bin/:/C/msys64/usr/src/grass78/mswindows/osgeo4w/lib:/C/msys64/usr/src/grass78/mswindows/osgeo4w:/C/windows32/system32:/C/windows:/C/windows32/system32:/C/windows:/usr/bin:/mingw64/bin/:/c/msys64/usr/src/grass78/mswindows/osgeo4w/lib:/c/msys64/usr/src/grass78/mswindows/osgeo4w:/c/windows32/system32:/c/windows:/c/windows32/system32:/c/windows"
LC_ALL=C LANG=C LANGUAGE=C
/c/msys64/usr/src/grass78/dist.x86_64-w64-mingw32/bin/d.barscale.exe
--html-description < /dev/null | grep -v '</body>\|</html>' >
d.barscale.tmp.html ; fi
make[3]: *** [../../include/Make/Html.make:14: d.barscale.tmp.html] Error 1
```