### PR TITLE
json parser: change + to @ for URLs

### DIFF
--- a/lib/gis/parser_json.c
+++ b/lib/gis/parser_json.c
@@ -344,7 +344,7 @@ void check_create_import_opts(struct Option *opt, char *element, FILE *fp)
     int has_import = 0;
     char **tokens;
 
-    tokens = G_tokenize(opt->answer, "+");
+    tokens = G_tokenize(opt->answer, "@");
     while (tokens[i]) {
         G_chop(tokens[i]);
         i++;


### PR DESCRIPTION
Since `+` is used in algebraic expressions incl. v.db.update, this char is unsuitable
for the indication of external URL resourcs as used by the importer of
actinia (https://github.com/mundialis/actinia_core/).

This change replaces `+` with `@`, hence this JSON output is now produced correctly (example):

```
GRASS 7.9.dev (utm32N_25832):~ > v.db.update map=antenna_position column="z_antenna" qcolumn="cat + 2.00" --json
{
  "module": "v.db.update",
  "id": "v.db.update_1804289383",
  "inputs":[
     {"param": "map", "value": "antenna_position"},
     {"param": "layer", "value": "1"},
     {"param": "column", "value": "z_antenna"},
     {"param": "query_column", "value": "cat + 2.00"}
   ]}
```

Fixes https://trac.osgeo.org/grass/ticket/3928