### PR TITLE
quick fix of g.extension on MS Windows

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -672,6 +672,8 @@ def install_extension(source, url, xmlurl):
         return
 
     ret = 0
+    installed_modules = []
+    tmp_dir = None
     for module in mlist:
         if sys.platform == "win32":
             ret += install_extension_win(module)
@@ -1026,7 +1028,7 @@ def install_extension_win(name):
                "grass-%(major)s.%(minor)s.%(patch)s" % \
                {'platform': platform,
                 'major': version[0], 'minor': version[1],
-                'patch': 'dev'}
+                'patch': version[2]}
 
     # resolve ZIP URL
     source, url = resolve_source_code(url='{0}/{1}.zip'.format(base_url, name))


### PR DESCRIPTION
g.extension module is currently broken on Windows. This PR fixes two issues:

* hardcoded patch version to '.dev' (will not work for releases)
* not defined variables (installed_modules, tmp_dir) (*)

Getting list of modules (in the case of multi-modules extensions like eg. i.sentinel) from Makefile is not a good idea [1]. It should be solved platform independently.

[1] https://github.com/OSGeo/grass/blob/master/scripts/g.extension/g.extension.py#L1383