### PR TITLE
Remove __pycache__ directories before release.

### DIFF
--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -77,6 +77,7 @@ find . -name '*.rej'  | xargs rm
 find . -name '*.o'    | xargs rm
 find . -name '*.pyc'  | xargs rm
 find . -name 'OBJ.*'  | xargs rm -r
+find . -name '__pycache__' | xargs rm -r
 rm -f gui/wxpython/menustrings.py gui/wxpython/build_ext.pyc gui/wxpython/xml/menudata.xml gui/wxpython/xml/module_tree_menudata.xml
 chmod -R a+r *
 ```


### PR DESCRIPTION
The lintian QA tool reported empty directories in the 7.8.0RC2 tarball:
```
P: grass source: source-contains-empty-directory lib/python/ctypes/ctypesgencore/__pycache__/
P: grass source: source-contains-empty-directory lib/python/ctypes/ctypesgencore/parser/__pycache__/
P: grass source: source-contains-empty-directory lib/python/ctypes/ctypesgencore/printer/__pycache__/
P: grass source: source-contains-empty-directory lib/python/ctypes/ctypesgencore/processor/__pycache__/
P: grass source: source-contains-empty-directory man/__pycache__/
```