### PR TITLE
GUI: do not fail on invalid RC file (empty)

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -285,7 +285,7 @@ class GRASSStartup(wx.Frame):
 
         self.OnSetDatabase(None)
         location = self.GetRCValue("LOCATION_NAME")
-        if location == "<UNKNOWN>":
+        if location == "<UNKNOWN>" or location is None:
             return
         if not os.path.isdir(os.path.join(self.gisdbase, location)):
             location = None


### PR DESCRIPTION
Currently GUI startup screen is not shown on invalid RC file (eg. only one empty line, this situation can happen, recognized especially on Windows platform). 

```
Starting GRASS GIS...
WARNING: Invalid line in RC file (/tmp/grass7-martin-18299/gisrc): '
' (not enough values to unpack (expected 2, got 1))

WARNING: Empty RC file (/tmp/grass7-martin-18299/gisrc)

ERROR: Error in GUI startup. See messages above (if any) and if necessary, please report this error to the GRASS developers.
On systems with package manager, make sure you have the right GUI package, probably named grass-gui, installed.
To run GRASS GIS in text mode use the --text flag.
Use '--help' for further options
     grass79 --help
See also: https://grass.osgeo.org/grass79/manuals/helptext.html
Exiting...
```

This PR allow showing GUI startup screen. So the user can more easily recover the session.