### PR TITLE
r.in.wms: write string not bytes to capabilities file

### DIFF
--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -285,9 +285,8 @@ class WMSBase(object):
         # save to file
         if capfile_output:
             try:
-                temp = open(capfile_output, "w")
-                temp.write(cap.read())
-                temp.close()
+                with open(capfile_output, "w") as temp:
+                    temp.write(grass.decode(cap.read()))
                 return
             except IOError as error:
                 grass.fatal(_("Unabble to open file '%s'.\n%s\n" % (cap_file, error)))

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -261,7 +261,7 @@ class WMSBase(object):
                 grass.fatal(msg)
 
         grass.debug('Fetching capabilities OK')
-        return cap
+        return grass.decode(cap)
 
     def _fetchDataFromServer(self, url, username=None, password=None):
         """!Fetch data from server
@@ -286,7 +286,7 @@ class WMSBase(object):
         if capfile_output:
             try:
                 with open(capfile_output, "w") as temp:
-                    temp.write(grass.decode(cap.read()))
+                    temp.write(cap.read())
                 return
             except IOError as error:
                 grass.fatal(_("Unabble to open file '%s'.\n%s\n" % (cap_file, error)))


### PR DESCRIPTION
Currently, I get an error message, when I try to add WMS in Python3 GRASS 7.8 and 7.9. (In the GUI).
This small commit should fix it.
A backporting candidate for 7.8.2?