### PR TITLE
v.info manual: note on -c flag added

### DIFF
--- a/vector/v.info/v.info.html
+++ b/vector/v.info/v.info.html
@@ -3,9 +3,15 @@
 <em>v.info</em> reports some basic information (metadata) about a
 user-specified vector map and its topology status.
 
-<p>If topology info is not available (i.e., vector map cannot be open on
+<p>
+If topology info is not available (i.e., vector map cannot be opened on
 level 2), vector map extends and number of features need to be counted
 on the fly which may take some time.
+
+<p>
+Note that the flag <b>-c</b> only works when the vector map is connected
+to one or several attribute table(s). This connection can be shown or set
+with <em>v.db.connect</em>.
 
 <h2>EXAMPLE</h2>
 
@@ -146,10 +152,11 @@ gcore.vector_info_topo('geology') # for `v.info shell=topo`
 <em>
 <a href="r.info.html">r.info</a>,
 <a href="r3.info.html">r3.info</a>,
-<a href="t.info.html">t.info</a>
+<a href="t.info.html">t.info</a>,
+<a href="v.db.connect.html">v.db.connect</a>
 </em>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Original author CERL<br>
 Updated to GRASS 6 by Radim Blazek, ITC-Irst, Trento, Italy<br>


### PR DESCRIPTION
Explanation of attribute table connection need for -c flag added.
Fixes https://trac.osgeo.org/grass/ticket/3946