### PR TITLE
grass startup: added support for google-chrome and chromium

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -692,8 +692,8 @@ def set_browser():
         else:
             # the usual suspects
             browsers = ["xdg-open", "x-www-browser", "htmlview", "konqueror", "mozilla",
-                        "mozilla-firefox", "firefox", "iceweasel", "opera",
-                        "netscape", "dillo", "lynx", "links", "w3c"]
+                        "mozilla-firefox", "firefox", "iceweasel", "opera", "google-chrome",
+                        "chromium", "netscape", "dillo", "lynx", "links", "w3c"]
             for b in browsers:
                 if find_exe(b):
                     browser = b


### PR DESCRIPTION
- google-chrome and chromium added
- unsure if `$BROWSER` env variable should be supported, too