### PR TITLE
t.list, t.rast.list: fix missing band_reference

### DIFF
--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -52,7 +52,7 @@
 #% guisection: Formatting
 #% required: no
 #% multiple: yes
-#% options: id,name,creator,mapset,number_of_maps,creation_time,start_time,end_time,interval,north,south,west,east,granularity
+#% options: id,name,band_reference,creator,mapset,number_of_maps,creation_time,start_time,end_time,interval,north,south,west,east,granularity
 #% answer: id
 #%end
 
@@ -64,7 +64,7 @@
 #% guisection: Selection
 #% required: no
 #% multiple: yes
-#% options: id,name,creator,mapset,number_of_maps,creation_time,start_time,end_time,north,south,west,east,granularity,all
+#% options: id,name,band_reference,creator,mapset,number_of_maps,creation_time,start_time,end_time,north,south,west,east,granularity,all
 #% answer: id
 #%end
 

--- a/temporal/t.rast.list/t.rast.list.py
+++ b/temporal/t.rast.list/t.rast.list.py
@@ -39,7 +39,7 @@
 #% guisection: Formatting
 #% required: no
 #% multiple: yes
-#% options: id,name,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
+#% options: id,name,band_reference,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
 #% answer: start_time
 #%end
 
@@ -50,7 +50,7 @@
 #% guisection: Selection
 #% required: no
 #% multiple: yes
-#% options: id,name,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
+#% options: id,name,band_reference,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
 #% answer: name,mapset,start_time,end_time
 #%end
 


### PR DESCRIPTION
This enables output like this:

```
t.rast.list openeo_bolzano_S2 columns=name,band_reference,start_time
name|band_reference|start_time
T32TPS_20180606T102019_B01|S2_1|2018-06-06 10:25:12.692000
T32TPS_20180606T102019_B02|S2_2|2018-06-06 10:25:12.692000
T32TPS_20180606T102019_B03|S2_3|2018-06-06 10:25:12.692000
T32TPS_20180606T102019_B04|S2_4|2018-06-06 10:25:12.692000
...
```