### PR TITLE
replace deprecated time.clock() by time.process_time()

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -2087,14 +2087,14 @@ class GCP(MapFrame, ColumnSorterMixin):
         """Adjust Map Windows after GCP Map Display has been resized
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = time.process_time()
         super(MapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
         """GCP Map Display resized, adjust Map Windows
         """
         if self.GetMapToolbar():
-            if self.resize and self.resize + 0.2 < time.clock():
+            if self.resize and self.resize + 0.2 < time.process_time():
                 srcwidth, srcheight = self.SrcMapWindow.GetSize()
                 tgtwidth, tgtheight = self.TgtMapWindow.GetSize()
                 srcwidth = (srcwidth + tgtwidth) / 2

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -2149,14 +2149,14 @@ class GCP(MapFrame, ColumnSorterMixin):
         """Adjust Map Windows after GCP Map Display has been resized
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = time.process_time()
         super(MapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
         """GCP Map Display resized, adjust Map Windows
         """
         if self.GetMapToolbar():
-            if self.resize and self.resize + 0.2 < time.clock():
+            if self.resize and self.resize + 0.2 < time.process_time():
                 srcwidth, srcheight = self.SrcMapWindow.GetSize()
                 tgtwidth, tgtheight = self.TgtMapWindow.GetSize()
                 srcwidth = (srcwidth + tgtwidth) / 2

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -155,7 +155,7 @@ class Core:
         return self.cat_rast_updater
 
     def UpdateCategoryWithPolygons(self, cat_id, scatts_pols, value):
-        start_time = time.clock()
+        start_time = time.process_time()
 
         if cat_id not in self.scatts_dt.GetCategories():
             raise GException(_("Select category for editing."))

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -253,11 +253,11 @@ class SwipeMapFrame(DoubleMapFrame):
 
     def OnSize(self, event):
         Debug.msg(4, "SwipeMapFrame.OnSize()")
-        self.resize = time.clock()
+        self.resize = time.process_time()
         super(SwipeMapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
-        if self.resize and time.clock() - self.resize > 0.2:
+        if self.resize and time.process_time() - self.resize > 0.2:
             w1 = self.GetFirstWindow()
             w2 = self.GetSecondWindow()
 

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -637,7 +637,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         """Scale map image so that it is the same size as the Window
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = time.process_time()
 
     def OnIdle(self, event):
         """Only re-render a composite map image from GRASS during
@@ -646,7 +646,7 @@ class BufferedMapWindow(MapWindowBase, Window):
 
         # use OnInternalIdle() instead ?
 
-        if self.resize and self.resize + 0.2 < time.clock():
+        if self.resize and self.resize + 0.2 < time.process_time():
             Debug.msg(3, "BufferedWindow.OnSize():")
 
             # set size of the input image

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -1141,7 +1141,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         :param render: re-render map composition
         :type render: bool
         """
-        start = time.clock()
+        start = time.process_time()
 
         self.resize = False
 
@@ -1184,7 +1184,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 self._display.Start2D()
                 self.DrawImages()
 
-        stop = time.clock()
+        stop = time.process_time()
 
         if self.render['quick'] is False:
             if sys.platform != 'darwin':

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1474,14 +1474,14 @@ class GCP(MapFrame, ColumnSorterMixin):
         """Adjust Map Windows after GCP Map Display has been resized
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = time.process_time()
         super(MapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
         """GCP Map Display resized, adjust Map Windows
         """
         if self.GetMapToolbar():
-            if self.resize and self.resize + 0.2 < time.clock():
+            if self.resize and self.resize + 0.2 < time.process_time():
                 srcwidth, srcheight = self.SrcMapWindow.GetSize()
                 tgtwidth, tgtheight = self.TgtMapWindow.GetSize()
                 srcwidth = (srcwidth + tgtwidth) / 2


### PR DESCRIPTION
With the release of Python 3.8 the function time.clock() has been removed, after having been deprecated since Python 3.3:
[What’s New In Python 3.8](https://docs.python.org/3/whatsnew/3.8.html)

Calls to time.clock() should be replaced by calls to either [time.perf_counter()](https://docs.python.org/3/library/time.html#time.perf_counter) or [time.process_time()](https://docs.python.org/3/library/time.html#time.process_time), depending on requirements.

I searched through the code of grass and replaced all occurences of time.clock() with time.process_time().