### PR TITLE
README refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,54 @@
 [![Build Status](https://travis-ci.com/OSGeo/grass.svg?branch=master)](https://travis-ci.com/OSGeo/grass)
 
-GRASS GIS Repository
-====================
+# GRASS GIS Repository
 
-GRASS GIS ([https://grass.osgeo.org/](https://grass.osgeo.org/)) is a Geographic Information System
-used for geospatial data management and analysis, image processing, graphics/map production,
-spatial modeling, and visualization.
+## Description
 
+GRASS GIS ([https://grass.osgeo.org/](https://grass.osgeo.org/)) is
+a Geographic Information System used for geospatial data management and
+analysis, image processing, graphics/map production, spatial modeling, and
+visualization.
 
-How to get write access here?
------------------------------
+## How to get write access here?
 
-In general: you don't really need write access as you can simply open a
-[pull request](https://github.com/OSGeo/grass/pulls) to contribute to GRASS GIS.
+In general: you don't really need write access as you can simply open
+a [pull request](https://github.com/OSGeo/grass/pulls) to contribute to
+GRASS GIS.
 
 Want to become a core developer? See
 [Procedure for gaining Git write access](https://trac.osgeo.org/grass/wiki/HowToContribute#WriteaccesstotheGRASScorerepository)
 
-How to compile GRASS?
----------------------
+## How to compile GRASS?
 
 > See INSTALL file.
 
 Yes, you should really read INSTALL.
 
-How to generate the 'Programmer's Manual'?
-------------------------------------------
+## How to generate the 'Programmer's Manual'?
 
-This needs doxygen (http://www.doxygen.org) and optionally
-Graphviz dot (http://www.research.att.com/sw/tools/graphviz/).
+This needs doxygen (<http://www.doxygen.org>) and optionally
+Graphviz dot (<http://www.research.att.com/sw/tools/graphviz/>).
 
 To build the GRASS programmer's documentation, run
+
 ```
 make htmldocs
 ```
-or to generate documentation as single html file (recommended for simple reading)
+
+or to generate documentation as single html file
+(recommended for simple reading)
+
 ```
 make htmldocs-single
 ```
+
 here. This takes quite some time. The result is in `lib/html/index.html`
 which refers to further document repositories in
+
 ```
-   lib/vector/html/index.html
-   lib/db/html/index.html
-   lib/gis/html/index.html
+lib/vector/html/index.html
+lib/db/html/index.html
+lib/gis/html/index.html
 ```
 
 The master file is: `./grasslib.dox` where all sub-documents have to
@@ -63,7 +68,7 @@ Build using the downloaded source code (in the directory with the
 source code):
 
 ```
-    docker build -t grassgis79 .
+docker build -t grassgis79 .
 ```
 
 A test run (assuming you have existing GRASS GIS location; it can be downloaded from
@@ -85,10 +90,10 @@ Note that the first `grassgis79` is the name of the image while the second
 To run the tests (again assuming local location):
 
 ```
-    docker run -it --rm --user=$(id -u):$(id -g) --volume /your/test/grassdata/:/data --env HOME=/data/ -w /code/grass \
-        grassgis79 grass /data/nc_basic_spm_grass7/PERMANENT --exec \
-            python -m grass.gunittest.main \
-                --location nc_basic_spm_grass7 --location-type nc
+docker run -it --rm --user=$(id -u):$(id -g) --volume /your/test/grassdata/:/data --env HOME=/data/ -w /code/grass \
+    grassgis79 grass /data/nc_basic_spm_grass7/PERMANENT --exec \
+        python -m grass.gunittest.main \
+            --location nc_basic_spm_grass7 --location-type nc
 ```
 
 Note: If you compiled locally before building the Docker image, you may


### PR DESCRIPTION
Follow Markdown recommended style guides in README:

* Do not mix different header styles (minuses and hash marks were used for the same level)
* Line length = 80 characters (I ignored the code excerpts parts)
* Do not use plain URLs (use `<URL>` for them)
* Delete unnecessary indentation
* Surround fenced code blocks by blank lines
* Delete multiple consecutive blank lines