### PR TITLE
py3 fix

### DIFF
--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -261,7 +261,7 @@ class WMSBase(object):
                 grass.fatal(msg)
 
         grass.debug('Fetching capabilities OK')
-        return grass.decode(cap)
+        return grass.decode(cap.read())
 
     def _fetchDataFromServer(self, url, username=None, password=None):
         """!Fetch data from server
@@ -286,15 +286,13 @@ class WMSBase(object):
         if capfile_output:
             try:
                 with open(capfile_output, "w") as temp:
-                    temp.write(cap.read())
+                    temp.write(cap)
                 return
             except IOError as error:
                 grass.fatal(_("Unabble to open file '%s'.\n%s\n" % (cap_file, error)))
 
         # print to output
-        cap_lines = cap.readlines()
-        for line in cap_lines:
-            print(line.rstrip())
+        print(cap)
 
     def _computeBbox(self):
         """!Get region extent for WMS query (bbox)


### PR DESCRIPTION
With this fix, r.in.wms works, but issues in the GUI (add wms to layer tree) remain:

```
Traceback (most recent call last):
  File "/opt/src/grass_ninsbl/dist.x86_64-pc-linux-
gnu/gui/wxpython/web_services/widgets.py", line 548, in
OnCapDownloadDone

self._parseCapFile(self.cap_file)
  File "/opt/src/grass_ninsbl/dist.x86_64-pc-linux-
gnu/gui/wxpython/web_services/widgets.py", line 572, in
_parseCapFile

self._updateFormatRadioBox(self.formats_list)
  File "/opt/src/grass_ninsbl/dist.x86_64-pc-linux-
gnu/gui/wxpython/web_services/widgets.py", line 851, in
_updateFormatRadioBox

border=5)
TypeError
:
Sizer.Insert(): arguments did not match any overloaded call:
  overload 1: 'item' is not a valid keyword argument
  overload 2: 'item' is not a valid keyword argument
  overload 3: 'item' is not a valid keyword argument
  overload 4: 'item' is not a valid keyword argument
  overload 5: 'item' is not a valid keyword argument
  overload 6: 'item' is not a valid keyword argument
  overload 7: 'item' is not a valid keyword argument
  overload 8: 'item' is not a valid keyword argument
  overload 9: 'item' is not a valid keyword argument
Traceback (most recent call last):
  File "/opt/src/grass_ninsbl/dist.x86_64-pc-linux-
gnu/gui/wxpython/web_services/widgets.py", line 548, in
OnCapDownloadDone

self._parseCapFile(self.cap_file)
  File "/opt/src/grass_ninsbl/dist.x86_64-pc-linux-
gnu/gui/wxpython/web_services/widgets.py", line 572, in
_parseCapFile

self._updateFormatRadioBox(self.formats_list)
  File "/opt/src/grass_ninsbl/dist.x86_64-pc-linux-
gnu/gui/wxpython/web_services/widgets.py", line 851, in
_updateFormatRadioBox

border=5)
TypeError
:
Sizer.Insert(): arguments did not match any overloaded call:
  overload 1: 'item' is not a valid keyword argument
  overload 2: 'item' is not a valid keyword argument
  overload 3: 'item' is not a valid keyword argument
  overload 4: 'item' is not a valid keyword argument
  overload 5: 'item' is not a valid keyword argument
  overload 6: 'item' is not a valid keyword argument
  overload 7: 'item' is not a valid keyword argument
  overload 8: 'item' is not a valid keyword argument
  overload 9: 'item' is not a valid keyword argument
```