### PR TITLE
Extend keywords for null and mask modules

### DIFF
--- a/raster/r.null/main.c
+++ b/raster/r.null/main.c
@@ -58,7 +58,9 @@ int main(int argc, char *argv[])
 
     module = G_define_module();
     G_add_keyword(_("raster"));
+    G_add_keyword(_("map management"));
     G_add_keyword(_("null data"));
+    G_add_keyword(_("no-data"));
     module->description = _("Manages NULL-values of given raster map.");
 
     parms.map = G_define_standard_option(G_OPT_R_MAP);

--- a/raster3d/r3.mask/main.c
+++ b/raster3d/r3.mask/main.c
@@ -132,6 +132,8 @@ int main(int argc, char *argv[])
     module = G_define_module();
     G_add_keyword(_("raster3d"));
     G_add_keyword(_("mask"));
+    G_add_keyword(_("null data"));
+    G_add_keyword(_("no-data"));
     G_add_keyword(_("voxel"));
     module->description =
 	_("Establishes the current working 3D raster mask.");

--- a/raster3d/r3.null/main.c
+++ b/raster3d/r3.null/main.c
@@ -178,7 +178,9 @@ int main(int argc, char **argv)
     G_gisinit(argv[0]);
     module = G_define_module();
     G_add_keyword(_("raster3d"));
+    G_add_keyword(_("map management"));
     G_add_keyword(_("null data"));
+    G_add_keyword(_("no-data"));
     G_add_keyword(_("voxel"));
     module->description =
 	_("Explicitly create the 3D NULL-value bitmap file.");

--- a/scripts/r.mask/r.mask.py
+++ b/scripts/r.mask/r.mask.py
@@ -20,6 +20,8 @@
 #% description: Creates a MASK for limiting raster operation.
 #% keyword: raster
 #% keyword: mask
+#% keyword: null data
+#% keyword: no-data
 #% overwrite: yes
 #%end
 #%option G_OPT_R_INPUT


### PR DESCRIPTION
r.null and r3.null are now in *map management* topic and *null data* and *no-data* is shared among r.mask, r.null.all, r.null, r3.mask, and r3.null.