### PR TITLE
Update globalvar.py for wxPython 4.0.7.post2

### DIFF
--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -58,7 +58,7 @@ def CheckWxVersion(version):
     """Check wx version"""
     ver = wx.__version__
     try:
-        split_ver = ver.split('.')
+        split_ver = ver.split('.')[0:3]
         parsed_version = list(map(int, split_ver))
     except ValueError:
         # wxPython 4.0.0aX


### PR DESCRIPTION

For wxPython 4.0.7.post2, the CheckWxVersion will be failed, because it assumes that there only 3 parts in the version string.