### PR TITLE
fix double string encoding with EncodeString()

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -162,9 +162,6 @@ class Popen(subprocess.Popen):
 
     def __init__(self, args, **kwargs):
         if is_mswindows:
-            # encoding not needed for Python3
-            # args = list(map(EncodeString, args))
-
             # The Windows shell (cmd.exe) requires some special characters to
             # be escaped by preceding them with 3 carets (^^^). cmd.exe /?
             # mentions <space> and &()[]{}^=;!'+,`~. A quick test revealed that

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -40,7 +40,7 @@ from grass.exceptions import CalledModuleError
 
 from core import utils
 from core.ws import RenderWMSMgr
-from core.gcmd import GException, GError, RunCommand, EncodeString
+from core.gcmd import GException, GError, RunCommand
 from core.debug import Debug
 from core.settings import UserSettings
 from core.gthread import gThread
@@ -1297,8 +1297,7 @@ class Map(object):
         renderMgr = layer.GetRenderMgr()
         Debug.msg(
             1, "Map.AddLayer(): ltype={0}, command={1}".format(
-                ltype, EncodeString(layer.GetCmd(
-                    string=True))))
+                ltype, layer.GetCmd(string=True)))
         if renderMgr:
             if layer.type == 'wms':
                 renderMgr.dataFetched.connect(self.renderMgr.ReportProgress)
@@ -1360,7 +1359,7 @@ class Map(object):
 
     def SetLayers(self, layers):
         self.layers = layers
-        Debug.msg(5, "Map.SetLayers(): layers={0}".format([EncodeString(layer.GetCmd(string=True)) for layer in layers]))
+        Debug.msg(5, "Map.SetLayers(): layers={0}".format([layer.GetCmd(string=True) for layer in layers]))
 
     def ChangeLayer(self, layer, render=False, **kargs):
         """Change map layer properties
@@ -1510,9 +1509,7 @@ class Map(object):
 
         renderMgr = overlay.GetRenderMgr()
         Debug.msg(
-            1, "Map.AddOverlay(): cmd={0}".format(EncodeString(
-                overlay.GetCmd(
-                    string=True))))
+            1, "Map.AddOverlay(): cmd={0}".format(overlay.GetCmd(string=True)))
         if renderMgr:
             renderMgr.updateProgress.connect(self.renderMgr.ReportProgress)
             renderMgr.renderingFailed.connect(self.renderMgr.RenderingFailed)

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -54,7 +54,7 @@ from core import utils
 from core.render import Map
 from gui_core.gselect import Select, LocationSelect, MapsetSelect
 from gui_core.dialogs import GroupDialog
-from core.gcmd import RunCommand, GMessage, GError, GWarning, EncodeString
+from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from gcp.mapdisplay import MapFrame
 from core.giface import Notification
@@ -296,7 +296,7 @@ class GCPWizard(object):
         self.gisrc_dict['LOCATION_NAME'] = location
         self.gisrc_dict['MAPSET'] = mapset
 
-        self.source_gisrc = EncodeString(utils.GetTempfile())
+        self.source_gisrc = utils.GetTempfile()
 
         try:
             f = open(self.source_gisrc, mode='w')

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -33,7 +33,7 @@ import wx.lib.mixins.listctrl as listmix
 from core import globalvar
 from core import utils
 from gui_core.widgets import SearchModuleWidget, SimpleValidator
-from core.gcmd import GError, EncodeString
+from core.gcmd import GError
 from gui_core.dialogs import SimpleDialog, MapLayersDialogForModeler
 from gui_core.prompt import GPromptSTC
 from gui_core.gselect import Select, ElementSelect
@@ -274,10 +274,7 @@ class ModelSearchDialog(wx.Dialog):
         if len(line) == 0:
             cmd = list()
         else:
-            try:
-                cmd = utils.split(str(line))
-            except UnicodeError:
-                cmd = utils.split(EncodeString((line)))
+            cmd = utils.split(str(line))
         return cmd
 
     def GetCmd(self):

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -46,7 +46,7 @@ from wx.lib import ogl
 
 from core import globalvar
 from core import utils
-from core.gcmd import GMessage, GException, GError, RunCommand, EncodeString, GWarning, GetDefaultEncoding
+from core.gcmd import GMessage, GException, GError, RunCommand, GWarning, GetDefaultEncoding
 from core.settings import UserSettings
 from gui_core.forms import GUI, CmdPanel
 from gui_core.widgets import GNotebook
@@ -2249,22 +2249,19 @@ class WriteModelFile:
                 '%s<name>%s</name>\n' %
                 (' ' *
                  self.indent,
-                 EncodeString(
-                     self.properties['name'])))
+                 self.properties['name']))
         if self.properties['description']:
             self.fd.write(
                 '%s<description>%s</description>\n' %
                 (' ' *
                  self.indent,
-                 EncodeString(
-                     self.properties['description'])))
+                 self.properties['description']))
         if self.properties['author']:
             self.fd.write(
                 '%s<author>%s</author>\n' %
                 (' ' *
                  self.indent,
-                 EncodeString(
-                     self.properties['author'])))
+                 self.properties['author']))
 
         if 'overwrite' in self.properties and \
                 self.properties['overwrite']:
@@ -2283,15 +2280,15 @@ class WriteModelFile:
         for name, values in six.iteritems(self.variables):
             self.fd.write(
                 '%s<variable name="%s" type="%s">\n' %
-                (' ' * self.indent, EncodeString(name), values['type']))
+                (' ' * self.indent, name, values['type']))
             self.indent += 4
             if 'value' in values:
                 self.fd.write('%s<value>%s</value>\n' %
-                              (' ' * self.indent, EncodeString(values['value'])))
+                              (' ' * self.indent, values['value']))
             if 'description' in values:
                 self.fd.write(
                     '%s<description>%s</description>\n' %
-                    (' ' * self.indent, EncodeString(values['description'])))
+                    (' ' * self.indent, values['description']))
             self.indent -= 4
             self.fd.write('%s</variable>\n' % (' ' * self.indent))
         self.indent -= 4
@@ -2313,21 +2310,19 @@ class WriteModelFile:
         """Write actions"""
         self.fd.write(
             '%s<action id="%d" name="%s" pos="%d,%d" size="%d,%d">\n' %
-            (' ' *
-             self.indent,
+            (' ' * self.indent,
              action.GetId(),
-             EncodeString(
-                 action.GetLabel()),
-                action.GetX(),
-                action.GetY(),
-                action.GetWidth(),
-                action.GetHeight()))
+             action.GetLabel(),
+             action.GetX(),
+             action.GetY(),
+             action.GetWidth(),
+             action.GetHeight()))
         self.indent += 4
         comment = action.GetComment()
         if comment:
             self.fd.write(
                 '%s<comment>%s</comment>\n' %
-                (' ' * self.indent, EncodeString(comment)))
+                (' ' * self.indent, comment))
         self.fd.write('%s<task name="%s">\n' %
                       (' ' * self.indent, action.GetLog(string=False)[0]))
         self.indent += 4
@@ -2503,8 +2498,7 @@ class WriteModelFile:
              comment.GetY(),
              comment.GetWidth(),
              comment.GetHeight(),
-             EncodeString(
-                 comment.GetLabel())))
+             comment.GetLabel()))
 
 
 class WritePythonFile:
@@ -2556,10 +2550,9 @@ class WritePythonFile:
 #
 #{header_end}
 """.format(header_begin='#' * 77,
-           module_name=EncodeString(properties['name']),
-           author=EncodeString(properties['author']),
-           purpose=EncodeString(
-               '\n# '.join(properties['description'].splitlines())),
+           module_name=properties['name'],
+           author=properties['author'],
+           purpose='\n# '.join(properties['description'].splitlines()),
            date=time.asctime(),
            header_end='#' * 77))
 
@@ -2569,8 +2562,7 @@ class WritePythonFile:
 #%module
 #% description: {description}
 #%end
-""".format(description=EncodeString(
-                ' '.join(properties['description'].splitlines()))))
+""".format(description=' '.join(properties['description'].splitlines())))
 
         modelItems = self.model.GetItems()
         for item in modelItems:

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -432,7 +432,7 @@ class GConsoleWindow(wx.SplitterWindow):
 
             try:
                 output = open(path, "w")
-                output.write(EncodeString(text))
+                output.write(text)
             except IOError as e:
                 GError(
                     _("Unable to write file '%(path)s'.\n\nDetails: %(error)s") % {

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     from grass.script.setup import set_gui_path
     set_gui_path()
 
-from core.gcmd import EncodeString, GError
+from core.gcmd import GError
 from gui_core.pystc import PyStc
 from core import globalvar
 from core.menutree import MenuTreeModelBuilder
@@ -89,9 +89,9 @@ def module_template():
 #
 #%s
 """ % ('#' * 72,
-            EncodeString(properties['name']),
-            EncodeString(properties['author']),
-            EncodeString('\n# '.join(properties['description'].splitlines())),
+            properties['name'],
+            properties['author'],
+            '\n# '.join(properties['description'].splitlines()),
             time.asctime(),
             '#' * 72))
 
@@ -101,7 +101,7 @@ def module_template():
 #%%module
 #%% description: %s
 #%%end
-""" % (EncodeString(' '.join(properties['description'].splitlines()))))
+""" % (' '.join(properties['description'].splitlines())))
 
     # import modules
     output.write(

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -57,7 +57,7 @@ from core import utils
 from core.render import Map
 from gui_core.gselect import Select, LocationSelect, MapsetSelect
 from gui_core.dialogs import GroupDialog
-from core.gcmd import RunCommand, GMessage, GError, GWarning, EncodeString
+from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from gcp.mapdisplay import MapFrame
 from core.giface import Notification
@@ -323,7 +323,7 @@ class GCPWizard(object):
         self.gisrc_dict['LOCATION_NAME'] = location
         self.gisrc_dict['MAPSET'] = mapset
 
-        self.source_gisrc = EncodeString(utils.GetTempfile())
+        self.source_gisrc = utils.GetTempfile()
 
         try:
             f = open(self.source_gisrc, mode='w')

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -44,7 +44,7 @@ if os.path.join(globalvar.ETCDIR, "python") not in sys.path:
 from grass.script import core as grass
 from grass.script.utils import decode
 
-from core.gcmd import RunCommand, GError, GMessage, EncodeString
+from core.gcmd import RunCommand, GError, GMessage
 from core.settings import UserSettings, GetDisplayVectSettings
 from core.utils import SetAddOnPath, GetLayerNameFromCmd, command2ltype
 from gui_core.preferences import MapsetAccess, PreferencesDialog
@@ -976,15 +976,6 @@ class GMFrame(wx.Frame):
 
         if not filename:
             return False
-        try:
-            filename_encoded = EncodeString(filename)
-        except UnicodeEncodeError:
-            GError(
-                parent=self, message=_(
-                    "Due to the limitations of your operating system, "
-                    "the script path cannot contain certain non-ascii characters. "
-                    "Please rename the script or move it to a different location."))
-            return
 
         if not os.path.exists(filename):
             GError(parent=self,
@@ -1020,7 +1011,7 @@ class GMFrame(wx.Frame):
         addonPath = os.getenv('GRASS_ADDON_PATH', [])
         if addonPath:
             addonPath = addonPath.split(os.pathsep)
-        dirName = os.path.dirname(filename_encoded)
+        dirName = os.path.dirname(filename)
         if dirName not in addonPath:
             addonPath.append(dirName)
             dlg = wx.MessageDialog(

--- a/gui/wxpython/nviz/wxnviz.py
+++ b/gui/wxpython/nviz/wxnviz.py
@@ -59,7 +59,7 @@ except (ImportError, WindowsError) as e:
 
 from core.debug import Debug
 from core.utils import autoCropImageFromFile
-from core.gcmd import EncodeString, DecodeString
+from core.gcmd import DecodeString
 from core.globalvar import wxPythonPhoenix
 from gui_core.wrap import Rect
 import grass.script as grass
@@ -1847,7 +1847,6 @@ class Nviz(object):
         """
         widthOrig = self.width
         heightOrig = self.height
-        filename = EncodeString(filename)
 
         self.ResizeWindow(width, height)
         GS_clear(Nviz_get_bgcolor(self.data))

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -49,7 +49,7 @@ from core import utils
 from core.render import Map
 from gui_core.gselect import Select, LocationSelect, MapsetSelect
 from gui_core.dialogs import GroupDialog
-from core.gcmd import RunCommand, GMessage, GError, GWarning, EncodeString
+from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from photo2image.ip2i_mapdisplay import MapFrame
 from core.giface import Notification
@@ -235,7 +235,7 @@ class GCPWizard(object):
         self.gisrc_dict['LOCATION_NAME'] = location
         self.gisrc_dict['MAPSET'] = mapset
 
-        self.source_gisrc = EncodeString(utils.GetTempfile())
+        self.source_gisrc = utils.GetTempfile()
 
         try:
             f = open(self.source_gisrc, mode='w')


### PR DESCRIPTION
Because the default encoding of strings in Python 3 is Unicode, the usage of `EncodeString()` on them results in "double-encoded" strings like `b'b'intended_string''`. This pull request fixes it where needed: 
* GRASS module template in GRASS Python editor
* exported module output
* broken exported models from gmodeler and generated Python script
* broken georectifiers
* broken save display function for 3D view
* some broken paths
* ...