### PR TITLE
replace obsolete time.clock() in Python 3.3

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -31,7 +31,6 @@ from __future__ import print_function
 import os
 import sys
 import shutil
-import time
 import six
 from copy import copy
 
@@ -2087,14 +2086,14 @@ class GCP(MapFrame, ColumnSorterMixin):
         """Adjust Map Windows after GCP Map Display has been resized
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = grass.clock()
         super(MapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
         """GCP Map Display resized, adjust Map Windows
         """
         if self.GetMapToolbar():
-            if self.resize and self.resize + 0.2 < time.clock():
+            if self.resize and self.resize + 0.2 < grass.clock():
                 srcwidth, srcheight = self.SrcMapWindow.GetSize()
                 tgtwidth, tgtheight = self.TgtMapWindow.GetSize()
                 srcwidth = (srcwidth + tgtwidth) / 2

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -37,7 +37,6 @@ import os
 import sys
 import six
 import shutil
-import time
 from copy import copy
 
 import wx
@@ -2149,14 +2148,14 @@ class GCP(MapFrame, ColumnSorterMixin):
         """Adjust Map Windows after GCP Map Display has been resized
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = grass.clock()
         super(MapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
         """GCP Map Display resized, adjust Map Windows
         """
         if self.GetMapToolbar():
-            if self.resize and self.resize + 0.2 < time.clock():
+            if self.resize and self.resize + 0.2 < grass.clock():
                 srcwidth, srcheight = self.SrcMapWindow.GetSize()
                 tgtwidth, tgtheight = self.TgtMapWindow.GetSize()
                 srcwidth = (srcwidth + tgtwidth) / 2

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -21,8 +21,6 @@ import os
 import sys
 import six
 
-import time
-
 import numpy as np
 
 # used iclass perimeters algorithm instead of convolve2d
@@ -155,8 +153,6 @@ class Core:
         return self.cat_rast_updater
 
     def UpdateCategoryWithPolygons(self, cat_id, scatts_pols, value):
-        start_time = time.clock()
-
         if cat_id not in self.scatts_dt.GetCategories():
             raise GException(_("Select category for editing."))
 

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -17,7 +17,6 @@ This program is free software under the GNU General Public License
 import os
 import sys
 import wx
-import time
 
 import grass.script as grass
 
@@ -253,11 +252,11 @@ class SwipeMapFrame(DoubleMapFrame):
 
     def OnSize(self, event):
         Debug.msg(4, "SwipeMapFrame.OnSize()")
-        self.resize = time.clock()
+        self.resize = grass.clock()
         super(SwipeMapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
-        if self.resize and time.clock() - self.resize > 0.2:
+        if self.resize and grass.clock() - self.resize > 0.2:
             w1 = self.GetFirstWindow()
             w2 = self.GetSecondWindow()
 

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -637,7 +637,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         """Scale map image so that it is the same size as the Window
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = grass.clock()
 
     def OnIdle(self, event):
         """Only re-render a composite map image from GRASS during
@@ -646,7 +646,7 @@ class BufferedMapWindow(MapWindowBase, Window):
 
         # use OnInternalIdle() instead ?
 
-        if self.resize and self.resize + 0.2 < time.clock():
+        if self.resize and self.resize + 0.2 < grass.clock():
             Debug.msg(3, "BufferedWindow.OnSize():")
 
             # set size of the input image

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -1141,7 +1141,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         :param render: re-render map composition
         :type render: bool
         """
-        start = time.clock()
+        start = grass.clock()
 
         self.resize = False
 
@@ -1184,7 +1184,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 self._display.Start2D()
                 self.DrawImages()
 
-        stop = time.clock()
+        stop = grass.clock()
 
         if self.render['quick'] is False:
             if sys.platform != 'darwin':
@@ -1306,7 +1306,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         item = self.tree.GetFirstChild(self.tree.root)[0]
         self._GetDataLayers(item, listOfItems)
 
-        start = time.time()
+        start = grass.clock()
 
         while(len(listOfItems) > 0):
             item = listOfItems.pop()
@@ -1339,7 +1339,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 GError(parent=self,
                        message=e.value)
 
-        stop = time.time()
+        stop = grass.clock()
 
         Debug.msg(1, "GLWindow.LoadDataLayers(): time = %f" % (stop - start))
 
@@ -1356,7 +1356,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             item = self.tree.GetFirstChild(self.tree.root)[0]
             self._GetDataLayers(item, listOfItems)
 
-        start = time.time()
+        start = grass.clock()
 
         update = False
         layersTmp = self.layers[:]
@@ -1389,7 +1389,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             self.lmgr.nviz.UpdateSettings()
             self.UpdateView(None)
 
-        stop = time.time()
+        stop = grass.clock()
 
         Debug.msg(1, "GLWindow.UnloadDataLayers(): time = %f" % (stop - start))
 

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -30,7 +30,6 @@ import os
 import sys
 import six
 import shutil
-import time
 from copy import copy
 
 import wx
@@ -1474,14 +1473,14 @@ class GCP(MapFrame, ColumnSorterMixin):
         """Adjust Map Windows after GCP Map Display has been resized
         """
         # re-render image on idle
-        self.resize = time.clock()
+        self.resize = grass.clock()
         super(MapFrame, self).OnSize(event)
 
     def OnIdle(self, event):
         """GCP Map Display resized, adjust Map Windows
         """
         if self.GetMapToolbar():
-            if self.resize and self.resize + 0.2 < time.clock():
+            if self.resize and self.resize + 0.2 < grass.clock():
                 srcwidth, srcheight = self.SrcMapWindow.GetSize()
                 tgtwidth, tgtheight = self.TgtMapWindow.GetSize()
                 srcwidth = (srcwidth + tgtwidth) / 2

--- a/lib/python/script/utils.py
+++ b/lib/python/script/utils.py
@@ -24,6 +24,7 @@ import shutil
 import locale
 import shlex
 import re
+import time
 
 
 if sys.version_info.major == 3:
@@ -451,3 +452,13 @@ def set_path(modulename, dirname=None, path='.'):
                               "(current dir '%s')." % (pathname, os.getcwd()))
 
         sys.path.insert(0, path)
+
+def clock():
+    """
+    Return time counter to measure performance for chunks of code.
+    Uses time.clock() for Py < 3.3, time.perf_counter() for Py >= 3.3.
+    Should be used only as difference between the calls.
+    """
+    if sys.version_info > (3,2):
+        return time.perf_counter()
+    return time.clock()


### PR DESCRIPTION
Updated PR #225. 
