### PR TITLE
Sort file lists

### DIFF
--- a/locale/grass_po_stats.py
+++ b/locale/grass_po_stats.py
@@ -28,7 +28,7 @@ def read_po_files(inputdirpath):
     originalpath = os.getcwd()
     os.chdir(inputdirpath)
     languages = {}
-    for pofile in glob.glob("*.po"):
+    for pofile in sorted(glob.glob("*.po")):
         lang = pofile.split('_')[1:]
         # check if are two definitions like pt_br
         if len(lang) == 2:

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -195,7 +195,7 @@ def main():
     img_extensions = ['png', 'jpg', 'gif']
     img_patterns = ['*.' + extension for extension in img_extensions]
     imgs = []
-    for filename in os.listdir(html_dir):
+    for filename in sorted(os.listdir(html_dir)):
         if file_matches(filename, img_patterns):
             imgs.append(filename)
 

--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -113,7 +113,7 @@ def file_matches(filename, patterns):
 
 def get_files(directory, patterns, exclude_patterns):
     files = []
-    for filename in os.listdir(directory):
+    for filename in sorted(os.listdir(directory)):
         if file_matches(filename, patterns):
             if not file_matches(filename, exclude_patterns):
                 files.append(filename)
@@ -168,7 +168,7 @@ def main():
                                                "Manual: Manual gallery" % grass_version))
         output.write(header_graphical_index_tmpl)
         output.write('<ul class="img-list">\n')
-        for image, html_file in img_html_files.items():
+        for image, html_file in sorted(img_html_files.items()):
             name = get_module_name(html_file)
             title = title_from_names(name, image)
             output.write(


### PR DESCRIPTION
Sort file lists
to make output reproducible
inspite of nondeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this matters.

Without this patch, some unreproducible files were:
* `vector_graphical.html`
* `translation_status.json`
* `manual_gallery.1`

This PR was done while working on reproducible builds for openSUSE.