### PR TITLE
manual: put module name at first position

### DIFF
--- a/db/drivers/mysql/grass-mesql.html
+++ b/db/drivers/mysql/grass-mesql.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
-<title>GRASS GIS manual: GRASS-MySQL embedded driver</title>
+<title>GRASS-MySQL embedded driver - GRASS GIS manual</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <link rel="stylesheet" href="grassdocs.css" type="text/css">
 </head>

--- a/general/g.setproj/g.setproj.html
+++ b/general/g.setproj/g.setproj.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
-<title>g.setproj</title>
+<title>g.setproj - GRASS GIS manual</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <link rel="stylesheet" href="grassdocs.css" type="text/css">
 </head>
@@ -11,9 +11,9 @@
 
 <h2>NAME</h2>
 
-<em><b>g.setproj</b></em>  - Allows the user to create the PROJ_INFO and the 
-PROJ_UNITS files to record the projection information associated with a 
-current location. 
+<em><b>g.setproj</b></em> allows the user to create the PROJ_INFO and the
+PROJ_UNITS files to record the projection information associated with a
+current location.
 <br>
 
 <h2>SYNOPSIS</h2>
@@ -77,7 +77,7 @@ parallel for the output map.
 <li> <a href="http://www.remotesensing.org/geotiff/proj_list/">Projections Transform List</a> (PROJ4)
 </ul>
 
-<h2>AUTHOR</h2>
+<h2>AUTHORS</h2>
 
 Irina Kosinovsky, 
 U.S. Army Construction Engineering 

--- a/lib/gis/parser_html.c
+++ b/lib/gis/parser_html.c
@@ -43,7 +43,7 @@ void G__usage_html(void)
     fprintf(stdout,
 	    "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n");
     fprintf(stdout, "<html>\n<head>\n");
-    fprintf(stdout, "<title>GRASS GIS manual: %s</title>\n", st->pgm_name);
+    fprintf(stdout, "<title>%s - GRASS GIS manual</title>\n", st->pgm_name);
     fprintf(stdout,
 	    "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=iso-8859-1\">\n");
     fprintf(stdout,

--- a/lib/gis/parser_rest.c
+++ b/lib/gis/parser_rest.c
@@ -46,7 +46,7 @@ void G__usage_rest(void)
         fprintf(stdout, "=");
     }
     fprintf(stdout, "\n");
-    fprintf(stdout, "GRASS GIS manual: %s\n", st->pgm_name);
+    fprintf(stdout, "%s - GRASS GIS manual\n", st->pgm_name);
     fprintf(stdout, "=================");
     for (s = 0; s <= strlen(st->pgm_name); s++) {
         fprintf(stdout, "=");

--- a/raster/r.li/r.li.html
+++ b/raster/r.li/r.li.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
-<title>GRASS GIS manual: r.li</title>
+<title>r.li - GRASS GIS manual</title>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 <link rel="stylesheet" href="grassdocs.css" type="text/css">
 </head>

--- a/tools/g.html2man/ggroff.py
+++ b/tools/g.html2man/ggroff.py
@@ -145,7 +145,7 @@ class Formatter:
                   os.path.basename(self.filename).replace(".html", "") +
                   " 1 \"\" \"GRASS " +
                   version +
-                  "\" \"Grass User's Manual\"")
+                  "\" \"GRASS GIS User's Manual\"")
 
     def pp_tr(self, content):
         content = clean(content)


### PR DESCRIPTION
Show the individual manual page titles with module name at first position to render them visible on a bar of tabs in the browser.
Fixes https://trac.osgeo.org/grass/ticket/3994