### PR TITLE
Error message has appeared in the console tab/cmd after close any module dialog 

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -918,11 +918,11 @@ class TaskFrame(wx.Frame):
                     # happens when closing dialog of a new layer which was
                     # removed from tree
                     pass
-                self.Destroy()
+                self._Destroy()
         else:
             Debug.msg(1, "TaskFrame.OnCancel(): no parent")
             # cancel for non-display commands
-            self.Destroy()
+            self._Destroy()
 
     def OnHelp(self, event):
         """Show manual page (switch to the 'Manual' notebook page)"""
@@ -937,6 +937,12 @@ class TaskFrame(wx.Frame):
         """Create command string (python list)"""
         return self.notebookpanel.createCmd(ignoreErrors=ignoreErrors,
                                             ignoreRequired=ignoreRequired)
+
+    def _Destroy(self):
+        """Destroy Frame"""
+        self.notebookpanel.notebook.Unbind(wx.EVT_NOTEBOOK_PAGE_CHANGED)
+        self.notebookpanel.notebook.widget.Unbind(wx.EVT_NOTEBOOK_PAGE_CHANGED)
+        self.Destroy()
 
 
 class CmdPanel(wx.Panel):


### PR DESCRIPTION
Reproduce bug:

1. Open any module dialog (via menu or cmd)
2. Click on next module dialog tab (Manual)
3. Close this dialog via click on the Close button
4. Error message has appeared in the LayerManager Console tab or in the cmd (depend on the way how to run module)

Error message:

`Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/gui_core/forms.py", line 2543, in OnPageChange
    idx = self.notebook.GetPageIndexByName('manual')
  File "/usr/local/grass79/gui/wxpython/gui_core/widgets.py", line 214, in GetPageIndexByName
    for pageIndex in range(self.classObject.GetPageCount(self.widget)):
RuntimeError: wrapped C/C++ object of type FormNotebook has been deleted`

Error message has appeared in the console tab/cmd depend on module dialog style (basic left, basic top).

