### PR TITLE
use proj 6.2.1 in apline Dockerfile

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -7,8 +7,6 @@ LABEL maintainer="peter.zamb@gmail.com,neteler@osgeo.org"
 
 # PACKAGES VERSIONS
 ARG PYTHON_VERSION=3
-ARG PROJ_VERSION=5.2.0
-ARG PROJ_DATUMGRID_VERSION=1.8
 
 # ================
 # CONFIG VARIABLES
@@ -78,6 +76,8 @@ ENV PACKAGES="\
       py3-pillow \
       py3-six \
       postgresql \
+      proj-datumgrid \
+      proj-util \
       sqlite \
       sqlite-libs \
       tiff \
@@ -105,6 +105,7 @@ ENV PACKAGES="\
       openblas-dev \
       pdal-dev \
       postgresql-dev \
+      proj-dev \
       python3-dev \
       py3-numpy-dev \
       sqlite-dev \
@@ -148,26 +149,6 @@ RUN echo "Install main packages";\
             --virtual .build-deps $GRASS_BUILD_PACKAGES; \
     # echo LANG="en_US.UTF-8" > /etc/default/locale;
     #
-    # install the latest (and compatible) projection library for GRASS GIS
-    #
-    echo "Install PROJ-$PROJ_VERSION";\
-    echo "  => Downloading proj-$PROJ_VERSION";\
-    wget -q http://download.osgeo.org/proj/proj-$PROJ_VERSION.tar.gz && \
-    tar xzvf proj-$PROJ_VERSION.tar.gz && \
-    cd /src/proj-$PROJ_VERSION/ && \
-    echo "  => Downloading datumgrid-$PROJ_DATUMGRID_VERSION" &&\
-    wget -q http://download.osgeo.org/proj/proj-datumgrid-$PROJ_DATUMGRID_VERSION.zip && \
-    cd nad && \
-    unzip ../proj-datumgrid-$PROJ_DATUMGRID_VERSION.zip && \
-    cd .. && \
-    echo "  => configure" &&\
-    ./configure --prefix=/usr/ && \
-    echo "  => compile" &&\
-    make && \
-    echo "  => install" &&\
-    make install && \
-    ldconfig /etc/ld.so.conf.d; \
-    #
     # Checkout and install GRASS GIS
     #
     echo "Install GRASS GIS";\
@@ -195,11 +176,10 @@ RUN echo "  => Configure and compile grass";\
     rm -rf /var/cache/apk/*; \
     rm -rf /root/.cache; \
     # Remove unnecessary grass files
-    rm -rf /usr/local/grass79/demolocation; \
-    rm -rf /usr/local/grass79/docs; \
-    rm -rf /usr/local/grass79/fonts; \
-    rm -rf /usr/local/grass79/gui; \
-    rm -rf /usr/local/grass79/share;
+    rm -rf /usr/local/grass78/demolocation; \
+    rm -rf /usr/local/grass78/fonts; \
+    rm -rf /usr/local/grass78/gui; \
+    rm -rf /usr/local/grass78/share;
 
 
 # Unset environmental variables to avoid later compilation issues


### PR DESCRIPTION
As the alpine image failed to build with gdal 3.0.2 (was updated from 2.4.2 in apline packages) and proj 5.2.0, proj was now updated to use the package version 6.2.1. 

Before:
```
Step 26/27 : RUN grass --tmp-location EPSG:4326 --exec g.version -rge && pdal --version && python3 --version
---> Running in 0b78b4c83e3a
Starting GRASS GIS...
Creating new GRASS GIS location <tmploc>...
ERROR: FileNotFoundError(2, 'No such file or directory')
Exiting...

```
Now:
```
Step 24/25 : RUN grass --tmp-location EPSG:4326 --exec g.version -rge &&     pdal --version &&     python3 --version
 ---> Running in 3f830d4c43d2
Starting GRASS GIS...
Creating new GRASS GIS location <tmploc>...
Cleaning up temporary files...
Executing <g.version -rge> ...
version=7.8.3dev
date=2019
revision=exported
build_date=2019-12-13
build_platform=x86_64-pc-linux-musl
build_off_t_size=8
libgis_revision=00000
libgis_date="?"
proj=6.2.1
gdal=3.0.2
geos=3.8.0
sqlite=3.30.1
Execution of <g.version -rge> finished.
Cleaning up temporary files...
--------------------------------------------------------------------------------
pdal 2.0.1 (git-version: b7a978)
--------------------------------------------------------------------------------

Python 3.8.0

```
Also `/usr/local/grass79/docs` is kept.