### PR TITLE
Do not install config.status

### DIFF
--- a/include/Make/Install.make
+++ b/include/Make/Install.make
@@ -113,7 +113,6 @@ real-install: | $(INST_DIR) $(UNIX_BIN)
 	-rm $(INST_DIR)/$(GRASSMAKE)
 	$(MAKE) $(INST_DIR)/$(GRASSMAKE)
 
-	-$(INSTALL) config.status $(INST_DIR)/config.status
 	-$(CHMOD) -R a+rX $(INST_DIR) 2>/dev/null
 
 ifneq ($(findstring darwin,$(ARCH)),)


### PR DESCRIPTION
Do not install the `config.status` file
because it will contain the build hostname
which makes it hard to reproduce.

See https://reproducible-builds.org/ for why this matters.


Together with #251 and #247 this made the `grass` openSUSE package build reproducibly.
This PR is probably the least important of the 3, because it can easily be implemented with a `rm` in the `grass.spec` file.

This PR was done while working on reproducible builds for openSUSE.