### PR TITLE
Change is/is not to ==/!= for literal comparisons

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -597,7 +597,7 @@ class GConsole(wx.EvtHandler):
                     for line in sfile.readlines():
                         if len(line) < 2:
                             continue
-                        if line[0] is '#' and line[1] is '%':
+                        if line[0] == '#' and line[1] == '%':
                             skipInterface = False
                             break
                     sfile.close()

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -167,7 +167,7 @@ class VectorDBInfo(VectorDBInfoBase):
 
         table = self.layers[layer]["table"]  # get table desc
         # select values (only one record)
-        if where is None or where is '':
+        if where is None or where == '':
             sql = "SELECT %s FROM %s" % (cols, table)
         else:
             sql = "SELECT %s FROM %s WHERE %s" % (cols, table, where)

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -258,7 +258,7 @@ class Model(object):
         for data in self.GetData():
             if prompt == data.GetPrompt():
                 mapName = data.GetValue()
-                if not mapName or mapName[0] is '%':
+                if not mapName or mapName[0] == '%':
                     continue  # skip variables
                 maps.append(mapName)
 

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1865,7 +1865,7 @@ class GdalSelect(wx.Panel):
         self.changingSizer.Show(
             self.protocolPanel, show=(
             sourceType == 'pro'))
-        self.changingSizer.Show(self.dbPanel, show=(sourceType is 'db'))
+        self.changingSizer.Show(self.dbPanel, show=(sourceType == 'db'))
 
         self.changingSizer.Layout()
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1303,7 +1303,7 @@ class EllipsePage(TitledPage):
         try:
             self.ellipse, self.ellipsedesc = self.ellipselist.Search(
                 index=[0, 1], pattern=event.GetString())
-            if self.scope is 'earth':
+            if self.scope == 'earth':
                 self.ellipseparams = self.parent.ellipsoids[self.ellipse][1]
             else:
                 self.ellipseparams = self.parent.planetary_ellipsoids[

--- a/lib/python/pygrass/gis/__init__.py
+++ b/lib/python/pygrass/gis/__init__.py
@@ -72,7 +72,7 @@ def _check_raise(value, path, type):
              if value is empty return environmental variable
     :rtype: str
     """
-    if value is '':
+    if value == '':
         from grass.pygrass.utils import getenv
         return getenv(type)
     if is_valid(value, path, type):

--- a/lib/python/temporal/core.py
+++ b/lib/python/temporal/core.py
@@ -62,7 +62,7 @@ def profile_function(func):
     """Profiling function provided by the temporal framework"""
     do_profiling = os.getenv("GRASS_TGIS_PROFILE")
 
-    if do_profiling is "True" or do_profiling is "1":
+    if do_profiling == "True" or do_profiling == "1":
         import cProfile, pstats
         try:
             import StringIO as io
@@ -579,7 +579,7 @@ def init(raise_fatal_error=False):
             enable_timestamp_write = False
             msgr.warning("TGIS_DISABLE_TIMESTAMP_WRITE is True")
 
-    if driver_string is not None and driver_string is not "":
+    if driver_string is not None and driver_string != "":
         driver_string = decode(driver_string)
         if driver_string == "sqlite":
             tgis_backend = driver_string

--- a/lib/python/temporal/temporal_algebra.py
+++ b/lib/python/temporal/temporal_algebra.py
@@ -2292,7 +2292,7 @@ class TemporalAlgebraParser(object):
                             # Do not register empty maps if not required
                             # In case of a null map continue, do not register null maps
 
-                            if map_i.get_type() is "raster" or map_i.get_type() is "raster3d":
+                            if map_i.get_type() == "raster" or map_i.get_type() == "raster3d":
                                 if map_i.metadata.get_min() is None and \
                                    map_i.metadata.get_max() is None:
                                     if not self.register_null:

--- a/scripts/d.rast.leg/d.rast.leg.py
+++ b/scripts/d.rast.leg/d.rast.leg.py
@@ -141,7 +141,7 @@ def main():
         lmap = map
 
     kv = grass.raster_info(map=lmap)
-    if kv['datatype'] is 'CELL':
+    if kv['datatype'] == 'CELL':
         leg_at = None
     else:
         leg_at = '%f,95,5,10' % VSpacing


### PR DESCRIPTION
This PR fixes ``SyntaxWarning: "is" with a literal. Did you mean "=="?`` warnings (new in Python 3.8?)

https://trac.osgeo.org/grass/ticket/4011

https://bugs.python.org/issue34850 (Python dev discussions)
> using "is" with a literal is always a mistake

Maybe, also ``== None`` => ``is None`` and ``!= None`` => ``is not None`` for better semantics?