### PR TITLE
manual: revert further pages entry addition

### DIFF
--- a/man/build_html.py
+++ b/man/build_html.py
@@ -194,30 +194,32 @@ r"""<!-- the files grass${grass_version_major}.html & helptext.html file live in
 #"
 
 footer_tmpl = string.Template(\
-r"""<a name="wxGUI"></a>
-<h3>wxGUI: Graphical user interface</h3>
-<table><tbody>
-<tr><td valign="top"><a href="wxGUI.html">wxGUI Graphical User Interface</a></td> <td>wxGUI Graphical User Interface</td></tr>
-<tr><td valign="top"><a href="wxGUI.nviz.html">3D visualization suite</a></td>    <td>wxGUI.nviz 3D visualization suite</td></tr>
-</tbody></table>
-<p>
-<a name="further"></a>
-<h3>Further pages</h3>
-<table><tbody>
-<tr><td valign="top"><a href="databaseintro.html">database intro</a></td> <td>database intro</td></tr>
-<tr><td valign="top"><a href="imageryintro.html">imagery intro</a></td> <td>imagery intro</td></tr>
-<tr><td valign="top"><a href="projectionintro.html">projection intro</a></td> <td>projection intro</td></tr>
-<tr><td valign="top"><a href="raster3dintro.html">raster3D intro</a></td> <td>raster3D intro</td></tr>
-<tr><td valign="top"><a href="rasterintro.html">raster intro</a></td> <td>raster intro</td></tr>
-<tr><td valign="top"><a href="temporalintro.html">temporal intro</a></td> <td>temporal intro</td></tr>
-<tr><td valign="top"><a href="vectorintro.html">vector intro</a></td> <td>vector intro</td></tr>
-<tr><td valign="top"> </td> <td> </td></tr>
-<tr><td valign="top"><a href="sql.html">SQL</a></td> <td>SQL</td></tr>
-<tr><td valign="top"><a href="variables.html">Variables</a></td> <td>Variables</td></tr>
-</tbody></table>
-
-<p>
-<hr class="header">
+## TODO: https://trac.osgeo.org/grass/ticket/3987
+#r"""<a name="wxGUI"></a>
+#<h3>wxGUI: Graphical user interface</h3>
+#<table><tbody>
+#<tr><td valign="top"><a href="wxGUI.html">wxGUI Graphical User Interface</a></td> <td>wxGUI Graphical User Interface</td></tr>
+#<tr><td valign="top"><a href="wxGUI.nviz.html">3D visualization suite</a></td>    <td>wxGUI.nviz 3D visualization suite</td></tr>
+#</tbody></table>
+#<p>
+#<a name="further"></a>
+#<h3>Further pages</h3>
+#<table><tbody>
+#<tr><td valign="top"><a href="databaseintro.html">database intro</a></td> <td>database intro</td></tr>
+#<tr><td valign="top"><a href="imageryintro.html">imagery intro</a></td> <td>imagery intro</td></tr>
+#<tr><td valign="top"><a href="projectionintro.html">projection intro</a></td> <td>projection intro</td></tr>
+#<tr><td valign="top"><a href="raster3dintro.html">raster3D intro</a></td> <td>raster3D intro</td></tr>
+#<tr><td valign="top"><a href="rasterintro.html">raster intro</a></td> <td>raster intro</td></tr>
+#<tr><td valign="top"><a href="temporalintro.html">temporal intro</a></td> <td>temporal intro</td></tr>
+#<tr><td valign="top"><a href="vectorintro.html">vector intro</a></td> <td>vector intro</td></tr>
+#<tr><td valign="top"> </td> <td> </td></tr>
+#<tr><td valign="top"><a href="sql.html">SQL</a></td> <td>SQL</td></tr>
+#<tr><td valign="top"><a href="variables.html">Variables</a></td> <td>Variables</td></tr>
+#</tbody></table>
+#
+#<p>
+#<hr class="header">
+r"""<hr class="header">
 <p>
 <a href="${index_url}">Main index</a> |
 <a href="topics.html">Topics index</a> |


### PR DESCRIPTION
The implementation in #258 lead to entries being added on all summary pages and not only in `full_index.html`.
HTML part commented out for now, a different approach is needed how to inject this only in `full_index.html`.

Reopens https://trac.osgeo.org/grass/ticket/3987