### PR TITLE
introduce docker multistage build to alpine image

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:edge as common
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile
@@ -7,6 +7,72 @@ LABEL maintainer="peter.zamb@gmail.com,neteler@osgeo.org"
 
 # PACKAGES VERSIONS
 ARG PYTHON_VERSION=3
+
+# List of packages to be installed
+ENV PACKAGES="\
+      attr \
+      bash \
+      bison \
+      bzip2 \
+      cairo \
+      fftw \
+      flex \
+      freetype \
+      gdal \
+      gettext \
+      geos \
+      gnutls \
+      laszip \
+      libbz2 \
+      libjpeg-turbo \
+      libpng \
+      musl \
+      musl-utils \
+      ncurses \
+      openjpeg \
+      openblas \
+      pdal \
+      py3-numpy \
+      py3-pillow \
+      py3-six \
+      postgresql \
+      proj-datumgrid \
+      proj-util \
+      sqlite \
+      sqlite-libs \
+      subversion \
+      tiff \
+      zstd \
+      zstd-libs \
+    "
+
+# ====================
+# INSTALL DEPENDENCIES
+# ====================
+
+WORKDIR /src
+
+ENV PYTHONBIN=python$PYTHON_VERSION
+
+RUN echo "Install Python";\
+    apk add --no-cache $PYTHONBIN && \
+    $PYTHONBIN -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip$PYTHON_VERSION install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip$PYTHON_VERSION /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
+    rm -r /root/.cache
+
+# Add the packages
+RUN echo "Install main packages";\
+    apk update; \
+    apk add --no-cache \
+            --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+            --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+            $PACKAGES
+
+
+FROM common as build
 
 # ================
 # CONFIG VARIABLES
@@ -47,46 +113,8 @@ ENV MYCFLAGS="-O2 -std=gnu99 -m64" \
     CXXFLAGS="$MYCXXFLAGS" \
     NUMTHREADS=2
 
-
-# List of packages to be installed
-ENV PACKAGES="\
-      attr \
-      bash \
-      bison \
-      bzip2 \
-      cairo \
-      fftw \
-      flex \
-      freetype \
-      gdal \
-      gettext \
-      geos \
-      gnutls \
-      laszip \
-      libbz2 \
-      libjpeg-turbo \
-      libpng \
-      musl \
-      musl-utils \
-      ncurses \
-      openjpeg \
-      openblas \
-      pdal \
-      py3-numpy \
-      py3-pillow \
-      py3-six \
-      postgresql \
-      proj-datumgrid \
-      proj-util \
-      sqlite \
-      sqlite-libs \
-      subversion \
-      tiff \
-      zstd \
-      zstd-libs \
-    " \
-    # These packages are required to compile GRASS GIS.
-    GRASS_BUILD_PACKAGES="\
+# These packages are required to compile GRASS GIS.
+ENV GRASS_BUILD_PACKAGES="\
       build-base \
       bzip2-dev \
       cairo-dev \
@@ -119,42 +147,16 @@ ENV PACKAGES="\
       zstd-dev \
     "
 
-# ====================
-# INSTALL DEPENDENCIES
-# ====================
-
-WORKDIR /src
-
-ENV PYTHONBIN=python$PYTHON_VERSION
-
-RUN echo "Install Python";\
-    apk add --no-cache $PYTHONBIN && \
-    $PYTHONBIN -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip$PYTHON_VERSION install --upgrade pip setuptools && \
-    if [ ! -e /usr/bin/pip ]; then ln -s pip$PYTHON_VERSION /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
-    rm -r /root/.cache
-
 # Add the packages
 RUN echo "Install main packages";\
-    apk update; \
-    apk add --no-cache \
-            --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-            --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-            $PACKAGES; \
     # Add packages just for the GRASS build process
     apk add --no-cache \
             --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
             --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-            --virtual .build-deps $GRASS_BUILD_PACKAGES; \
+            --virtual .build-deps $GRASS_BUILD_PACKAGES
     # echo LANG="en_US.UTF-8" > /etc/default/locale;
-    #
-    # Checkout and install GRASS GIS
-    #
-    echo "Install GRASS GIS";\
-    echo "  => Downloading grass"
 
+# Copy and install GRASS GIS
 COPY . /src/grass_build/
 
 # Configure compile and install GRASS GIS
@@ -163,52 +165,36 @@ RUN echo "  => Configure and compile grass";\
     /src/grass_build/configure $GRASS_CONFIG && \
     make -j $NUMTHREADS && \
     make install && \
-    ldconfig /etc/ld.so.conf.d; \
-    #
-    # enable simple grass command regardless of version number
-    #
-    ln -s `find /usr/local/bin -name "grass*"` /usr/local/bin/grass; \
-    #
-    # Reduce the image size
-    #
-    rm -rf /src/*; \
-    # remove build dependencies and any leftover apk cache
-    apk del --no-cache --purge .build-deps; \
-    rm -rf /var/cache/apk/*; \
-    rm -rf /root/.cache; \
-    # Remove unnecessary grass files
-    rm -rf /usr/local/grass79/demolocation; \
+    ldconfig /etc/ld.so.conf.d
+
+# enable simple grass command regardless of version number
+# also important for COPY cmd later
+RUN ln -s `find /usr/local/bin -name "grass*"` /usr/local/bin/grass
+
+# Reduce the image size - Remove unnecessary grass files
+RUN rm -rf /usr/local/grass79/demolocation; \
     rm -rf /usr/local/grass79/fonts; \
     rm -rf /usr/local/grass79/gui; \
     rm -rf /usr/local/grass79/share;
 
 
-# Unset environmental variables to avoid later compilation issues
-ENV INTEL="" \
-    MYCFLAGS="" \
-    MYLDFLAGS="" \
-    MYCXXFLAGS="" \
-    LD_LIBRARY_PATH="" \
-    LDFLAGS="" \
-    CFLAGS="" \
-    CXXFLAGS="" \
-    # set SHELL var to avoid /bin/sh fallback in interactive GRASS GIS sessions in docker
-    SHELL="/bin/bash"
+
+FROM common as grass
+
+ENV LC_ALL="en_US.UTF-8"
+
+# Copy GRASS GIS from build image
+COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
+COPY --from=build /usr/local/grass* /usr/local/grass
+RUN pip3 install --upgrade pip six grass-session
+RUN ln -s /usr/local/grass /usr/local/grass7
+RUN ln -s /usr/local/grass `grass --config path`
+RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+    pdal --version && \
+    python3 --version
 
 
-# =====================
-# INSTALL GRASS-SESSION
-# =====================
-
-# install external Python API
-RUN pip install grass-session
-
-# set GRASSBIN
-ENV GRASSBIN="/usr/local/bin/grass"
-
-# ===========================
-# TEST grass-session and PDAL
-# ===========================
+FROM grass as test
 
 WORKDIR /tmp
 COPY docker/testdata/simple.laz .
@@ -218,22 +204,23 @@ COPY docker/testdata/test_grass_session.py .
 # TODO: fix test
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
 
-# ========
-# FINALIZE
-# ========
 
-# Data workdir
-WORKDIR /grassdb
-VOLUME /grassdb
+FROM grass as final
 
 # GRASS GIS specific
 # allow work with MAPSETs that are not owned by current user
-ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
-    LC_ALL="en_US.UTF-8"
+ENV GRASSBIN="/usr/local/bin/grass" \
+    GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
+    SHELL="/bin/bash"
+
 
 # show installed version
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
+
+# Data workdir
+WORKDIR /grassdb
+VOLUME /grassdb
 
 CMD [$GRASSBIN, "--version"]

--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -178,7 +178,6 @@ RUN rm -rf /usr/local/grass79/demolocation; \
     rm -rf /usr/local/grass79/share;
 
 
-
 FROM common as grass
 
 ENV LC_ALL="en_US.UTF-8"
@@ -223,4 +222,4 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
 WORKDIR /grassdb
 VOLUME /grassdb
 
-CMD [$GRASSBIN, "--version"]
+CMD $GRASSBIN --version


### PR DESCRIPTION
With this PR, docker [multistage-build ](https://docs.docker.com/develop/develop-images/multistage-build/) is used for the alpine image. The order of the commands in the Dockerfile are only rearranged and a `COPY` statement was added. Additionally the environtment variable resolution for `CMD` was [fixed](https://github.com/moby/moby/issues/5509#issuecomment-42173047).

Now there are the following stages:

- `FROM alpine:edge as common` (includes build- and runtime requirements)
- `FROM common as build` (compiles GRASS GIS)
- `FROM common as grass` (Copies compiled code from `build`)
- `FROM grass as test` (Preprares tests)
- `FROM grass as final` (Finalizes small Dockerimage)

As a result, the Dockerimage is much smaller (local build vs existing one from dockerhub):
```
docker images
grass-py3-pdal             latest-alpine   b2fd2c918c87    8 minutes ago   337MB
mundialis/grass-py3-pdal   latest-alpine   4c371a9c6f84    14 hours ago    900MB
```
