### PR TITLE
Docker alpine image patch to work with py3.8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 docker
 !docker/testdata
+!docker/alpine/alpine-py38-ctypes.patch
+!docker/alpine/alpine-py38-gisinit.patch
 .git
 .gitignore
 .github

--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -158,10 +158,15 @@ RUN echo "Install main packages";\
 
 # Copy and install GRASS GIS
 COPY . /src/grass_build/
+WORKDIR /src/grass_build/
+# PATCH ctypes
+COPY docker/alpine/alpine-py38-ctypes.patch /src/alpine-py38-ctypes.patch
+COPY docker/alpine/alpine-py38-gisinit.patch /src/alpine-py38-gisinit.patch
+RUN patch -p1 < /src/alpine-py38-ctypes.patch
+RUN patch -p1 < /src/alpine-py38-gisinit.patch
 
 # Configure compile and install GRASS GIS
-RUN echo "  => Configure and compile grass";\
-    cd /src/grass_build && \
+RUN echo "  => Configure and compile grass" && \
     /src/grass_build/configure $GRASS_CONFIG && \
     make -j $NUMTHREADS && \
     make install && \
@@ -184,7 +189,7 @@ ENV LC_ALL="en_US.UTF-8"
 
 # Copy GRASS GIS from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
-COPY --from=build /usr/local/grass* /usr/local/grass
+COPY --from=build /usr/local/grass* /usr/local/grass/
 RUN pip3 install --upgrade pip six grass-session
 RUN ln -s /usr/local/grass /usr/local/grass7
 RUN ln -s /usr/local/grass `grass --config path`

--- a/docker/alpine/alpine-py38-ctypes.patch
+++ b/docker/alpine/alpine-py38-ctypes.patch
@@ -1,0 +1,34 @@
+diff --git a/lib/python/ctypes/ctypesgencore/ctypedescs.py b/lib/python/ctypes/ctypesgencore/ctypedescs.py
+index 1b061ea1f..b04fba80e 100644
+--- a/lib/python/ctypes/ctypesgencore/ctypedescs.py
++++ b/lib/python/ctypes/ctypesgencore/ctypedescs.py
+@@ -297,8 +297,16 @@ class CtypesFunction(CtypesType):
+         CtypesType.visit(self, visitor)
+
+     def py_string(self):
++        at = []
++        for a in self.argtypes:
++            if a.py_string() == "String":
++                at.append("POINTER(String)")
++            elif a.py_string()[:5] == "union":
++                at.append("POINTER(%s)" % a.py_string())
++            else:
++                at.append(a.py_string())
+         return 'CFUNCTYPE(UNCHECKED(%s), %s)' % (self.restype.py_string(),
+-                                                 ', '.join([a.py_string() for a in self.argtypes]))
++                                                 ', '.join([a for a in at]))
+
+ last_tagnum = 0
+
+diff --git a/lib/python/ctypes/ctypesgencore/parser/ctypesparser.py b/lib/python/ctypes/ctypesgencore/parser/ctypesparser.py
+index b64d38c9c..0a840acff 100644
+--- a/lib/python/ctypes/ctypesgencore/parser/ctypesparser.py
++++ b/lib/python/ctypes/ctypesgencore/parser/ctypesparser.py
+@@ -183,7 +183,7 @@ class CtypesParser(CParser):
+             isinstance(t.destination, CtypesSimple) and
+             t.destination.name == "char" and
+                 t.destination.signed):
+-            t = CtypesSpecial("String")
++            t = CtypesSpecial("POINTER(String)")
+
+         return t

--- a/docker/alpine/alpine-py38-gisinit.patch
+++ b/docker/alpine/alpine-py38-gisinit.patch
@@ -1,0 +1,33 @@
+diff --git a/lib/gis/gisinit.c b/lib/gis/gisinit.c
+index c45a9eb15..1531d18da 100644
+--- a/lib/gis/gisinit.c
++++ b/lib/gis/gisinit.c
+@@ -49,12 +49,12 @@ void G__gisinit(const char *version, const char *pgm)
+ 
+     G_set_program_name(pgm);
+ 
+-    if (strcmp(version, GIS_H_VERSION) != 0)
++    /*if (strcmp(version, GIS_H_VERSION) != 0)
+ 	G_fatal_error(_("Module built against version %s but "
+ 			"trying to use version %s. "
+ 			"You need to rebuild GRASS GIS or untangle multiple installations."),
+                         version, GIS_H_VERSION);
+-    
++    */
+     /* Make sure location and mapset are set */
+     G_location_path();
+     mapset = G_mapset();
+@@ -83,11 +83,12 @@ void G__no_gisinit(const char *version)
+     if (initialized)
+ 	return;
+ 
+-    if (strcmp(version, GIS_H_VERSION) != 0)
++    /*if (strcmp(version, GIS_H_VERSION) != 0)
+ 	G_fatal_error(_("Module built against version %s but "
+ 			"trying to use version %s. "
+ 			"You need to rebuild GRASS GIS or untangle multiple installations."),
+                         version, GIS_H_VERSION);
++    */
+     gisinit();
+ }
+ 


### PR DESCRIPTION
Currently, some extensions cannot be installed. With these Dockerfile patches for alpine and python3.8, they can be installed again.