### PR TITLE
Lib: Speed up listing a lot of mapsets by 20%.

### DIFF
--- a/lib/gis/mapset_nme.c
+++ b/lib/gis/mapset_nme.c
@@ -143,6 +143,7 @@ void G_reset_mapsets(void)
  */
 char **G_get_available_mapsets(void)
 {
+    char *location;
     char **mapsets = NULL;
     int alloc = 50;
     int n = 0;
@@ -153,15 +154,18 @@ char **G_get_available_mapsets(void)
 
     mapsets = G_calloc(alloc, sizeof(char *));
 
-    dir = opendir(G_location_path());
-    if (!dir)
-	return mapsets;
+    location = G_location_path();
+    dir = opendir(location);
+    if (!dir) {
+        G_free(location);
+        return mapsets;
+    }
 
     while ((ent = readdir(dir))) {
 	char buf[GPATH_MAX];
 	struct stat st;
 
-	sprintf(buf, "%s/%s/WIND", G_location_path(), ent->d_name);
+	sprintf(buf, "%s/%s/WIND", location, ent->d_name);
 
 	if (G_stat(buf, &st) != 0) {
 	    G_debug(4, "%s is not mapset", ent->d_name);
@@ -180,6 +184,7 @@ char **G_get_available_mapsets(void)
     }
 
     closedir(dir);
+    G_free(location);
 
     return mapsets;
 }

--- a/lib/gis/mapset_nme.c
+++ b/lib/gis/mapset_nme.c
@@ -139,7 +139,7 @@ void G_reset_mapsets(void)
 
    List is updated by each call to this function.
 
-   \return pointer to zero terminated array of available mapsets
+   \return pointer to NULL terminated array of available mapsets
  */
 char **G_get_available_mapsets(void)
 {
@@ -180,8 +180,8 @@ char **G_get_available_mapsets(void)
 	}
 
 	mapsets[n++] = G_store(ent->d_name);
-	mapsets[n] = NULL;
     }
+	mapsets[n] = NULL;
 
     closedir(dir);
     G_free(location);


### PR DESCRIPTION
When listing a large list of mapsets (tens of thousands), g.mapsets gets reaaaly slow. This is just one tiny speed up reducing listing time of 100k mapsets on average by 20%.