### PR TITLE
Use gs as alias for grass.script in doc

### DIFF
--- a/display/displaydrivers.html
+++ b/display/displaydrivers.html
@@ -32,7 +32,7 @@ Lets start with simple example of Python script called <i>render.py</i>:
 import os
 import sys
 
-import grass.script as grass
+import grass.script as gs
 from grass.script import task as gtask
 
 os.environ['GRASS_RENDER_IMMEDIATE'] = 'default'
@@ -40,10 +40,10 @@ os.environ['GRASS_RENDER_FILE'] = 'output.png'
 
 cmd, dcmd = gtask.cmdstring_to_tuple(sys.argv[1])
 
-grass.run_command('d.text', text="Test of GRASS_RENDER_COMMAND redirection")
+gs.run_command('d.text', text="Test of GRASS_RENDER_COMMAND redirection")
 
 os.environ['GRASS_RENDER_FILE_READ'] = 'TRUE'
-grass.run_command(cmd, **dcmd)
+gs.run_command(cmd, **dcmd)
 </pre></div>
 
 After defining GRASS_RENDER_COMMAND variable (example for Bash):

--- a/doc/python/README
+++ b/doc/python/README
@@ -2,7 +2,7 @@ There are two ways of using Python to run GRASS commands:
  (or you could mix them together)
 
 - Module scripting using the grass python helper library and g.parser.
-    import grass.script as grass
+    import grass.script as gs
   For examples see scripts/ in the GRASS 7 source code.
 
 

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -46,7 +46,7 @@
 
 import os, sys
 
-import grass.script as grass
+import grass.script as gs
 
 from grass.lib.gis import *
 
@@ -84,7 +84,7 @@ def main():
                 p = None
     
     if len(coords) < 2:
-       grass.fatal("A minimum of two input coordinate pairs are needed")
+       gs.fatal("A minimum of two input coordinate pairs are needed")
     
     # init variables
     overall_distance = 0.0
@@ -141,10 +141,10 @@ def main():
     # we don't need this, but just to have a look
     if proj_type == 1:
         G_database_units_to_meters_factor()
-        grass.message("Location units are %s" % G_database_unit_name(True).lower())
+        gs.message("Location units are %s" % G_database_unit_name(True).lower())
     
     return 0
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/doc/python/script/r.example.py
+++ b/doc/python/script/r.example.py
@@ -14,24 +14,24 @@
 
 import sys
 
-import grass.script as gscript
+import grass.script as gs
 from grass.exceptions import CalledModuleError
 
 
 def main():
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     input_raster = options['input']
     output_raster = options['output']
 
     try:
-        stats = gscript.parse_command('r.univar', map=input_raster, flags='g')
+        stats = gs.parse_command('r.univar', map=input_raster, flags='g')
     except CalledModuleError as e:
-        gscript.fatal('{0}'.format(e))
+        gs.fatal('{0}'.format(e))
     raster_mean = float(stats['mean'])
     raster_stddev = float(stats['stddev'])
     raster_high = raster_mean + raster_stddev
-    gscript.mapcalc('{r} = {i} > {v}'.format(r=output_raster, i=input_raster,
-                                             v=raster_high))
+    gs.mapcalc('{r} = {i} > {v}'.format(r=output_raster, i=input_raster,
+                                        v=raster_high))
     return 0
 
 

--- a/docker/testdata/test_grass_session.py
+++ b/docker/testdata/test_grass_session.py
@@ -1,9 +1,9 @@
 # Import GRASS Python bindings
 from grass_session import Session
-import grass.script as grass
+import grass.script as gs
 
 with Session(gisdb="/grassdata/", location="test", mapset="PERMANENT", create_opts='EPSG:25832'):
     print("Tests for PROJ, GDAL, PDAL, GRASS")
 
     # simple test: just scan the LAZ file
-    grass.run_command('r.in.pdal', input="/tmp/simple.laz", output='count_1', method='n', flags="s", resolution=1, overwrite=True)
+    gs.run_command('r.in.pdal', input="/tmp/simple.laz", output='count_1', method='n', flags="s", resolution=1, overwrite=True)

--- a/general/g.parser/g.parser.html
+++ b/general/g.parser/g.parser.html
@@ -391,7 +391,7 @@ Parameters:
 import os
 import sys
 
-import grass.script as grass
+import grass.script as gs
 
 def main():
     flag_f = flags['f']
@@ -418,7 +418,7 @@ def main():
     return 0
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())
 </pre></div>
 
@@ -646,7 +646,7 @@ v.what.rast --script
 
 import sys
 
-import grass.script as grass
+import grass.script as gs
 
 def main():
     # put code here
@@ -654,7 +654,7 @@ def main():
     return 0
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())
 </pre></div>
 

--- a/general/g.parser/test.py
+++ b/general/g.parser/test.py
@@ -28,11 +28,11 @@
 import sys
 import atexit
 
-import grass.script as grass
+import grass.script as gs
 
 def cleanup():
     # add some cleanup code
-    grass.message(_("Inside cleanup function..."))
+    gs.message(_("Inside cleanup function..."))
 
 def main():
     flag_f = flags['f']
@@ -44,22 +44,22 @@ def main():
     exitcode = 0
 
     if flag_f:
-        grass.message(_("Flag -f set"))
+        gs.message(_("Flag -f set"))
     else:
-        grass.message(_("Flag -f not set"))
+        gs.message(_("Flag -f not set"))
 
     # test if parameter present:
     if option1:
-        grass.message(_("Value of option1 option: '%s'" % option1))
+        gs.message(_("Value of option1 option: '%s'" % option1))
 
-    grass.message(_("Value of raster option: '%s'" % raster))
-    grass.message(_("Value of vector option: '%s'" % vector))
+    gs.message(_("Value of raster option: '%s'" % raster))
+    gs.message(_("Value of vector option: '%s'" % vector))
 
     #### end of your code ####
 
     sys.exit(exitcode)
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     atexit.register(cleanup)
     main()

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -50,11 +50,11 @@ def script_template():
     """The most simple script which runs and gives something"""
     return r"""#!/usr/bin/env python3
 
-import grass.script as gscript
+import grass.script as gs
 
 
 def main():
-    gscript.run_command('g.region', flags='p')
+    gs.run_command('g.region', flags='p')
 
 
 if __name__ == '__main__':
@@ -110,7 +110,7 @@ import sys
 import os
 import atexit
 
-import grass.script as gscript
+import grass.script as gs
 """)
 
     # cleanup()
@@ -121,14 +121,14 @@ RAST_REMOVE = []
 def cleanup():
 """)
     output.write(
-        r"""    gscript.run_command('g.remove', flags='f', type='raster',
+        r"""    gs.run_command('g.remove', flags='f', type='raster',
                           name=RAST_REMOVE)
 """)
     output.write("\ndef main():\n")
     output.write(
-        r"""    options, flags = gscript.parser()
-    gscript.run_command('g.remove', flags='f', type='raster',
-                        name=RAST_REMOVE)
+        r"""    options, flags = gs.parser()
+    gs.run_command('g.remove', flags='f', type='raster',
+                   name=RAST_REMOVE)
 """)
 
     output.write("\n    return 0\n")
@@ -146,16 +146,16 @@ def script_example():
     """Example of a simple script"""
     return r"""#!/usr/bin/env python3
 
-import grass.script as gscript
+import grass.script as gs
 
 def main():
     input_raster = 'elevation'
     output_raster = 'high_areas'
-    stats = gscript.parse_command('r.univar', map='elevation', flags='g')
+    stats = gs.parse_command('r.univar', map='elevation', flags='g')
     raster_mean = float(stats['mean'])
     raster_stddev = float(stats['stddev'])
     raster_high = raster_mean + raster_stddev
-    gscript.mapcalc('{r} = {a} > {m}'.format(r=output_raster, a=input_raster,
+    gs.mapcalc('{r} = {a} > {m}'.format(r=output_raster, a=input_raster,
                                              m=raster_high))
 
 if __name__ == "__main__":
@@ -187,16 +187,16 @@ def module_example():
 
 import sys
 
-import grass.script as gscript
+import grass.script as gs
 
 
 def main():
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     araster = options['araster']
     braster = options['braster']
     output = options['output']
 
-    gscript.mapcalc('{r} = {a} + {b}'.format(r=output, a=araster, b=braster))
+    gs.mapcalc('{r} = {a} + {b}'.format(r=output, a=araster, b=braster))
 
     return 0
 
@@ -224,24 +224,24 @@ def module_error_handling_example():
 
 import sys
 
-import grass.script as gscript
+import grass.script as gs
 from grass.exceptions import CalledModuleError
 
 
 def main():
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     input_raster = options['input']
     output_raster = options['output']
 
     try:
-        stats = gscript.parse_command('r.univar', map=input_raster, flags='g')
+        stats = gs.parse_command('r.univar', map=input_raster, flags='g')
     except CalledModuleError as e:
-        gscript.fatal('{0}'.format(e))
+        gs.fatal('{0}'.format(e))
     raster_mean = float(stats['mean'])
     raster_stddev = float(stats['stddev'])
     raster_high = raster_mean + raster_stddev
-    gscript.mapcalc('{r} = {i} > {v}'.format(r=output_raster, i=input_raster,
-                                             v=raster_high))
+    gs.mapcalc('{r} = {i} > {v}'.format(r=output_raster, i=input_raster,
+                                        v=raster_high))
     return 0
 
 

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -122,7 +122,7 @@ def cleanup():
 """)
     output.write(
         r"""    gs.run_command('g.remove', flags='f', type='raster',
-                          name=RAST_REMOVE)
+                   name=RAST_REMOVE)
 """)
     output.write("\ndef main():\n")
     output.write(
@@ -156,7 +156,7 @@ def main():
     raster_stddev = float(stats['stddev'])
     raster_high = raster_mean + raster_stddev
     gs.mapcalc('{r} = {a} > {m}'.format(r=output_raster, a=input_raster,
-                                             m=raster_high))
+                                        m=raster_high))
 
 if __name__ == "__main__":
     main()

--- a/gui/wxpython/lmgr/pyshell.py
+++ b/gui/wxpython/lmgr/pyshell.py
@@ -42,11 +42,11 @@ class PyShellWindow(wx.Panel):
         wx.Panel.__init__(self, parent=parent, id=id, **kwargs)
 
         self.intro = _("Welcome to wxGUI Interactive Python Shell %s") % VERSION + "\n\n" + \
-            _("Type %s for more GRASS scripting related information.") % "\"help(grass)\"" + "\n" + \
+            _("Type %s for more GRASS scripting related information.") % "\"help(gs)\"" + "\n" + \
             _("Type %s to add raster or vector to the layer tree.") % "\"AddLayer()\"" + "\n\n"
         self.shell = PyShell(parent=self, id=wx.ID_ANY,
                              introText=self.intro,
-                             locals={'grass': grass,
+                             locals={'gs': grass,
                                      'AddLayer': self.AddLayer})
 
         sys.displayhook = self._displayhook

--- a/lib/gis/parser_script.c
+++ b/lib/gis/parser_script.c
@@ -135,11 +135,11 @@ void G__script(void)
     }
 
     fprintf(fp, "\nimport sys\n");
-    fprintf(fp, "\nimport grass.script as grass\n");
+    fprintf(fp, "\nimport grass.script as gs\n");
     fprintf(fp, "\ndef main():");
     fprintf(fp, "\n    # put code here\n");
     fprintf(fp, "\n    return 0\n");
     fprintf(fp, "\nif __name__ == \"__main__\":");
-    fprintf(fp, "\n    options, flags = grass.parser()");
+    fprintf(fp, "\n    options, flags = gs.parser()");
     fprintf(fp, "\n    sys.exit(main())\n");
 }

--- a/lib/init/grass7.html
+++ b/lib/init/grass7.html
@@ -358,18 +358,18 @@ A very simple Python script ("test.py") may look like this:
 #!/usr/bin/env python3
 
 # import GRASS Python bindings (see also pygrass)
-import grass.script as gscript
+import grass.script as gs
 import grass.script.setup as gsetup
 
-gscript.message('Current GRASS GIS 7 environment:')
-print(gscript.gisenv())
+gs.message('Current GRASS GIS 7 environment:')
+print(gs.gisenv())
 
-gscript.message('Available raster maps:')
-for raster in gscript.list_strings(type='raster'):
+gs.message('Available raster maps:')
+for raster in gs.list_strings(type='raster'):
     print(raster)
 
-gscript.message('Available vector maps:')
-for vector in gscript.list_strings(type='vector'):
+gs.message('Available vector maps:')
+for vector in gs.list_strings(type='vector'):
     print(vector)
 </pre></div>
 

--- a/lib/python/docs/src/index.rst
+++ b/lib/python/docs/src/index.rst
@@ -12,7 +12,7 @@ and the GRASS GIS Temporal Framework are entirely written in Python.
 A set of packages is provided to the user in order to provide functionality
 at various levels:
 
-* **script package** provides Python interface to launch GRASS GIS modules in scripts
+* **grass.script package** provides Python interface to launch GRASS GIS modules in scripts
 * **PyGRASS** is an object-oriented Python Application 
   Programming Interface (API) for GRASS GIS which uses the GRASS C API as 
   backend but additionally offers a convenient interface to the GRASS GIS 

--- a/lib/python/docs/src/script_intro.rst
+++ b/lib/python/docs/src/script_intro.rst
@@ -1,5 +1,5 @@
-GRASS GIS Python scripting with script package
-==============================================
+GRASS GIS Python scripting with grass.script package
+====================================================
 
 Parts of the API
 ----------------
@@ -20,10 +20,10 @@ First, try a standard command in Console tab in Layer Manager in GRASS GUI::
 We are running *r.info* with an option ``map`` set to ``elevation`` Now,
 switch to Python tab and type the same command but in Python syntax::
 
-    grass.read_command('r.info', map='elevation', flags='g')
+    gs.read_command('r.info', map='elevation', flags='g')
 
 We used function ``read_command()`` from the ``grass.script`` package
-which is imported under the name ``grass`` in the Python tab in GRASS
+which is imported under the name ``gs`` in the Python tab in GRASS
 GUI. There are also other functions besides ``read_command()`` most
 notably ``run_command()``, ``write_command()`` and ``parse_command()``.
 The first parameter for functions from this group is the name of the
@@ -52,17 +52,17 @@ To launch a Python script from GUI, use File -> Launch Python script.
 
 ::
 
-    import grass.script as gscript
+    import grass.script as gs
 
     def main():
         input_raster = 'elevation'
         output_raster = 'high_areas'
-        stats = gscript.parse_command('r.univar', map='elevation', flags='g')
+        stats = gs.parse_command('r.univar', map='elevation', flags='g')
         raster_mean = float(stats['mean'])
         raster_stddev = float(stats['stddev'])
         raster_high = raster_mean + raster_stddev
-        gscript.mapcalc('{r} = {a} > {m}'.format(r=output_raster, a=input_raster,
-                                                 m=raster_high))
+        gs.mapcalc('{r} = {a} > {m}'.format(r=output_raster, a=input_raster,
+                                            m=raster_high))
 
     if __name__ == "__main__":
         main()
@@ -73,13 +73,13 @@ Processing many maps
 
 ::
 
-    import grass.script as gscript
+    import grass.script as gs
 
     def main():
         rasters = ['lsat7_2002_10', 'lsat7_2002_20', 'lsat7_2002_30', 'lsat7_2002_40']
         max_min = None
         for raster in rasters:
-            stats = gscript.parse_command('r.univar', map=raster, flags='g')
+            stats = gs.parse_command('r.univar', map=raster, flags='g')
             if max_min is None or max_min < stats['min']:
                 max_min = stats['min']
         print max_min
@@ -115,16 +115,16 @@ Providing GRASS module interface to a script
 
     import sys
 
-    import grass.script as gscript
+    import grass.script as gs
 
 
     def main():
-        options, flags = gscript.parser()
+        options, flags = gs.parser()
         araster = options['araster']
         braster = options['braster']
         output = options['output']
 
-        gscript.mapcalc('{r} = {a} + {b}'.format(r=output, a=araster, b=braster))
+        gs.mapcalc('{r} = {a} + {b}'.format(r=output, a=araster, b=braster))
 
         return 0
 

--- a/lib/python/docs/src/script_intro.rst
+++ b/lib/python/docs/src/script_intro.rst
@@ -82,7 +82,7 @@ Processing many maps
             stats = gs.parse_command('r.univar', map=raster, flags='g')
             if max_min is None or max_min < stats['min']:
                 max_min = stats['min']
-        print max_min
+        print(max_min)
 
     if __name__ == "__main__":
         main()

--- a/lib/python/docs/src/temporal_framework.rst
+++ b/lib/python/docs/src/temporal_framework.rst
@@ -273,7 +273,7 @@ to access its registered maps.
     # Lets import the temporal framework and
     # the script framework
     import grass.temporal as tgis
-    import grass.script as grass
+    import grass.script as gs
 
     # Make sure the temporal database exists
     # and set the temporal GIS environment
@@ -292,7 +292,7 @@ to access its registered maps.
     # Check if the space time raster dataset is in the temporal database
     if strds.is_in_db(dbif=dbif) == False:
         dbif.close()
-        grass.fatal(_("Space time %s dataset <%s> not found") % (
+        gs.fatal(_("Space time %s dataset <%s> not found") % (
             strds.get_new_map_instance(None).get_type(), id))
 
     # Fill the object with the content from the temporal database
@@ -330,7 +330,7 @@ for different space time datasets (raster, 3D raster and vector):
     # Lets import the temporal framework and
     # the script framework
     import grass.temporal as tgis
-    import grass.script as grass
+    import grass.script as gs
 
     # The id of the new space time dataset
     id="test@PERMANENT"
@@ -357,15 +357,15 @@ for different space time datasets (raster, 3D raster and vector):
     # First we check if the dataset is already in the database
     if stds.is_in_db(dbif=dbif) and overwrite == False:
         dbif.close()
-        grass.fatal(_("Space time %s dataset <%s> is already in the database. "
-                        "Use the overwrite flag.") %
-                    (stds.get_new_map_instance(None).get_type(), name))
+        gs.fatal(_("Space time %s dataset <%s> is already in the database. "
+                   "Use the overwrite flag.") %
+                 (stds.get_new_map_instance(None).get_type(), name))
 
     # We delete the exiting dataset and create a new one in case we are allowed to overwrite it
     if stds.is_in_db(dbif=dbif) and overwrite == True:
-        grass.warning(_("Overwrite space time %s dataset <%s> "
-                        "and unregister all maps.") %
-                    (stds.get_new_map_instance(None).get_type(), name))
+        gs.warning(_("Overwrite space time %s dataset <%s> "
+                     "and unregister all maps.") %
+                   (stds.get_new_map_instance(None).get_type(), name))
         stds.delete(dbif=dbif)
         stds = stds.get_new_instance(id)
 
@@ -385,7 +385,7 @@ Temporal shifting
 
 .. code-block:: python
 
-    import grass.script as grass
+    import grass.script as gs
     import grass.temporal as tgis
 
     id="test@PERMANENT"
@@ -401,7 +401,7 @@ Temporal shifting
 
     if stds.is_in_db(dbif) == False:
         dbif.close()
-        grass.fatal(_("Space time dataset <%s> not found in temporal database") % (id))
+        gs.fatal(_("Space time dataset <%s> not found in temporal database") % (id))
 
     stds.select(dbif=dbif)
 

--- a/lib/python/script/array.py
+++ b/lib/python/script/array.py
@@ -4,12 +4,12 @@ Functions to use GRASS 2D and 3D rasters with NumPy.
 Usage:
 
 >>> from __future__ import print_function
->>> import grass.script as gscript
+>>> import grass.script as gs
 >>> from grass.script import array as garray
 >>>
 >>> # We create a temporary region that is only valid in this python session
-... gscript.use_temp_region()
->>> gscript.run_command("g.region", n=80, e=120, t=60, s=0, w=0, b=0, res=20, res3=20)
+... gs.use_temp_region()
+>>> gs.run_command("g.region", n=80, e=120, t=60, s=0, w=0, b=0, res=20, res3=20)
 0
 >>>
 >>> # Lets create a raster map numpy array

--- a/lib/python/script/core.py
+++ b/lib/python/script/core.py
@@ -614,7 +614,7 @@ def write_command(*args, **kwargs):
     Passes all arguments to ``feed_command()``, with the string specified
     by the *stdin* argument fed to the process' standard input.
 
-    >>> gscript.write_command(
+    >>> write_command(
     ...    'v.in.ascii', input='-',
     ...    stdin='%s|%s' % (635818.8, 221342.4),
     ...    output='view_point')

--- a/lib/python/script/setup.py
+++ b/lib/python/script/setup.py
@@ -67,21 +67,21 @@ Usage::
 
     # example calls
     gs.message('Current GRASS GIS 7 environment:')
-    print gs.gisenv()
+    print(gs.gisenv())
 
     gs.message('Available raster maps:')
     for rast in gs.list_strings(type='raster'):
-        print rast
+        print(rast)
 
     gs.message('Available vector maps:')
     for vect in gs.list_strings(type='vector'):
-        print vect
+        print(vect)
 
     # clean up at the end
     gsetup.cleanup()
 
 
-(C) 2010-2019 by the GRASS Development Team
+(C) 2010-2020 by the GRASS Development Team
 This program is free software under the GNU General Public
 License (>=v2). Read the file COPYING that comes with GRASS
 for details.

--- a/lib/python/script/setup.py
+++ b/lib/python/script/setup.py
@@ -59,22 +59,22 @@ Usage::
     sys.path.append(grass_pydir)
 
     # import (some) GRASS Python bindings
-    import grass.script as gscript
+    import grass.script as gs
     import grass.script.setup as gsetup
 
     # launch session
     rcfile = gsetup.init(gisbase, gisdb, location, mapset)
 
     # example calls
-    gscript.message('Current GRASS GIS 7 environment:')
-    print gscript.gisenv()
+    gs.message('Current GRASS GIS 7 environment:')
+    print gs.gisenv()
 
-    gscript.message('Available raster maps:')
-    for rast in gscript.list_strings(type='raster'):
+    gs.message('Available raster maps:')
+    for rast in gs.list_strings(type='raster'):
         print rast
 
-    gscript.message('Available vector maps:')
-    for vect in gscript.list_strings(type='vector'):
+    gs.message('Available vector maps:')
+    for vect in gs.list_strings(type='vector'):
         print vect
 
     # clean up at the end
@@ -139,13 +139,13 @@ def init(gisbase, dbase='', location='demolocation', mapset='PERMANENT'):
     Basic usage::
 
         # ... setup GISBASE and PYTHON path before import
-        import grass.script as gscript
-        gisrc = gscript.setup.init("/usr/bin/grass7",
-                                   "/home/john/grassdata",
-                                   "nc_spm_08", "user1")
+        import grass.script as gs
+        gisrc = gs.setup.init("/usr/bin/grass7",
+                              "/home/john/grassdata",
+                              "nc_spm_08", "user1")
         # ... use GRASS modules here
         # end the session
-        gscript.setup.finish()
+        gs.setup.finish()
 
     :param gisbase: path to GRASS installation
     :param dbase: path to GRASS database (default: '')
@@ -258,9 +258,9 @@ def finish():
     called
     
     Basic usage::
-        import grass.script as gscript
+        import grass.script as gs
 
-        gscript.setup.cleanup()
+        gs.setup.cleanup()
     """
 
     clean_default_db()

--- a/lib/python/script/testsuite/test_script_raster.py
+++ b/lib/python/script/testsuite/test_script_raster.py
@@ -32,8 +32,7 @@ class TestRaster(TestCase):
         res = gs.raster_what(self.raster, [self.coords])[0]
         self.assertEquals(int(res[self.raster]['value']), 100)
 
-        res = gs.raster_what(self.raster, [self.coords],
-                                  localized=True)[0]
+        res = gs.raster_what(self.raster, [self.coords], localized=True)[0]
         self.assertEquals(int(res[self.raster][_('value')]), 100)
 
     def test_raster_info(self):

--- a/lib/python/script/testsuite/test_script_raster.py
+++ b/lib/python/script/testsuite/test_script_raster.py
@@ -8,14 +8,14 @@ Created on Thu Feb 18 09:42:23 2016
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-import grass.script as gscript
+import grass.script as gs
 
 
 class TestRaster(TestCase):
     """Test raster functions"""
 
     raster = 'testrasterscript'
-    region = gscript.region()
+    region = gs.region()
     coords = (region['e'] - 1, region['n'] - 1)
 
     @classmethod
@@ -29,15 +29,15 @@ class TestRaster(TestCase):
                       flags='f')
 
     def test_raster_what(self):
-        res = gscript.raster_what(self.raster, [self.coords])[0]
+        res = gs.raster_what(self.raster, [self.coords])[0]
         self.assertEquals(int(res[self.raster]['value']), 100)
 
-        res = gscript.raster_what(self.raster, [self.coords],
+        res = gs.raster_what(self.raster, [self.coords],
                                   localized=True)[0]
         self.assertEquals(int(res[self.raster][_('value')]), 100)
 
     def test_raster_info(self):
-        res = gscript.raster_info(self.raster)
+        res = gs.raster_info(self.raster)
         self.assertEquals(str(res['cols']), str(self.region['cols']))
         self.assertEquals(str(res['north']), str(self.region['n']))
 

--- a/lib/python/temporal/space_time_datasets.py
+++ b/lib/python/temporal/space_time_datasets.py
@@ -39,18 +39,18 @@ class RasterDataset(AbstractMapDataset):
 
         .. code-block:: python
 
-            >>> import grass.script as grass
+            >>> import grass.script as gs
             >>> import grass.temporal as tgis
             >>> init()
-            >>> grass.use_temp_region()
-            >>> grass.run_command("g.region", n=80.0, s=0.0, e=120.0, w=0.0,
+            >>> gs.use_temp_region()
+            >>> gs.run_command("g.region", n=80.0, s=0.0, e=120.0, w=0.0,
             ... t=1.0, b=0.0, res=10.0)
             0
-            >>> grass.run_command("r.mapcalc", overwrite=True, quiet=True,
+            >>> gs.run_command("r.mapcalc", overwrite=True, quiet=True,
             ... expression="strds_map_test_case = 1")
             0
-            >>> grass.run_command("r.timestamp", map="strds_map_test_case",
-            ...                   date="15 jan 1999", quiet=True)
+            >>> gs.run_command("r.timestamp", map="strds_map_test_case",
+            ...                date="15 jan 1999", quiet=True)
             0
             >>> mapset = tgis.get_current_mapset()
             >>> name = "strds_map_test_case"
@@ -87,8 +87,8 @@ class RasterDataset(AbstractMapDataset):
              | Minimum value:.............. 1.0
              | Maximum value:.............. 1.0
 
-            >>> grass.run_command("r.timestamp", map="strds_map_test_case",
-            ...                   date="2 years", quiet=True)
+            >>> gs.run_command("r.timestamp", map="strds_map_test_case",
+            ...                date="2 years", quiet=True)
             0
             >>> rmap.read_timestamp_from_grass()
             True
@@ -129,9 +129,9 @@ class RasterDataset(AbstractMapDataset):
             >>> rmap.is_time_relative()
             False
 
-            >>> grass.run_command("g.remove", flags="f", type="raster", name=name, quiet=True)
+            >>> gs.run_command("g.remove", flags="f", type="raster", name=name, quiet=True)
             0
-            >>> grass.del_temp_region()
+            >>> gs.del_temp_region()
 
     """
     def __init__(self, ident):
@@ -429,17 +429,17 @@ class Raster3DDataset(AbstractMapDataset):
 
         .. code-block:: python
 
-            >>> import grass.script as grass
+            >>> import grass.script as gs
             >>> init()
-            >>> grass.use_temp_region()
-            >>> grass.run_command("g.region", n=80.0, s=0.0, e=120.0, w=0.0,
+            >>> gs.use_temp_region()
+            >>> gs.run_command("g.region", n=80.0, s=0.0, e=120.0, w=0.0,
             ... t=100.0, b=0.0, res=10.0, res3=10.0)
             0
-            >>> grass.run_command("r3.mapcalc", overwrite=True, quiet=True,
-            ...                   expression="str3ds_map_test_case = 1")
+            >>> gs.run_command("r3.mapcalc", overwrite=True, quiet=True,
+            ...                expression="str3ds_map_test_case = 1")
             0
-            >>> grass.run_command("r3.timestamp", map="str3ds_map_test_case",
-            ...                   date="15 jan 1999", quiet=True)
+            >>> gs.run_command("r3.timestamp", map="str3ds_map_test_case",
+            ...                date="15 jan 1999", quiet=True)
             0
             >>> mapset = get_current_mapset()
             >>> name = "str3ds_map_test_case"
@@ -478,8 +478,8 @@ class Raster3DDataset(AbstractMapDataset):
              | Number of depths:........... 10
              | Top-Bottom resolution:...... 10.0
 
-            >>> grass.run_command("r3.timestamp", map="str3ds_map_test_case",
-            ...                   date="2 years", quiet=True)
+            >>> gs.run_command("r3.timestamp", map="str3ds_map_test_case",
+            ...                date="2 years", quiet=True)
             0
             >>> r3map.read_timestamp_from_grass()
             True
@@ -519,9 +519,9 @@ class Raster3DDataset(AbstractMapDataset):
             True
             >>> r3map.is_time_relative()
             False
-            >>> grass.run_command("g.remove", flags="f", type="raster_3d", name=name, quiet=True)
+            >>> gs.run_command("g.remove", flags="f", type="raster_3d", name=name, quiet=True)
             0
-            >>> grass.del_temp_region()
+            >>> gs.del_temp_region()
 
     """
     def __init__(self, ident):
@@ -779,17 +779,17 @@ class VectorDataset(AbstractMapDataset):
 
         .. code-block:: python
 
-            >>> import grass.script as grass
+            >>> import grass.script as gs
             >>> init()
-            >>> grass.use_temp_region()
-            >>> grass.run_command("g.region", n=80.0, s=0.0, e=120.0, w=0.0,
+            >>> gs.use_temp_region()
+            >>> gs.run_command("g.region", n=80.0, s=0.0, e=120.0, w=0.0,
             ... t=1.0, b=0.0, res=10.0)
             0
-            >>> grass.run_command("v.random", overwrite=True, output="stvds_map_test_case",
+            >>> gs.run_command("v.random", overwrite=True, output="stvds_map_test_case",
             ... n=100, zmin=0, zmax=100, flags="z", column="elevation", quiet=True)
             0
-            >>> grass.run_command("v.timestamp", map="stvds_map_test_case",
-            ...                   date="15 jan 1999", quiet=True)
+            >>> gs.run_command("v.timestamp", map="stvds_map_test_case",
+            ...                date="15 jan 1999", quiet=True)
             0
             >>> mapset = get_current_mapset()
             >>> name = "stvds_map_test_case"
@@ -823,8 +823,8 @@ class VectorDataset(AbstractMapDataset):
              | Number of holes ............ 0
              | Number of volumes .......... 0
 
-            >>> grass.run_command("v.timestamp", map="stvds_map_test_case",
-            ...                   date="2 years", quiet=True)
+            >>> gs.run_command("v.timestamp", map="stvds_map_test_case",
+            ...                date="2 years", quiet=True)
             0
             >>> vmap.read_timestamp_from_grass()
             True
@@ -862,9 +862,9 @@ class VectorDataset(AbstractMapDataset):
             True
             >>> vmap.is_time_relative()
             False
-            >>> grass.run_command("g.remove", flags="f", type="vector", name=name, quiet=True)
+            >>> gs.run_command("g.remove", flags="f", type="vector", name=name, quiet=True)
             0
-            >>> grass.del_temp_region()
+            >>> gs.del_temp_region()
 
     """
     def __init__(self, ident):

--- a/raster/r.in.lidar/r.in.lidar.html
+++ b/raster/r.in.lidar/r.in.lidar.html
@@ -537,16 +537,16 @@ Python module:
 
 <div class="code"><pre>
 import glob
-import gscript
+import grass.script as gs
     
 file_list_name = '/home/user/data/filelist.txt'
 with open(, mode='w') as file_list:
     for path in glob.iglob('/home/user/data/lidar/*.las'):
         file_list.write(path + "\n")
 
-gscript.run_command('r.in.lidar', file=file_list_name,
-                    output='mean_height_above_ground',
-                    base_raster='elevation' method='mean')
+gs.run_command('r.in.lidar', file=file_list_name,
+               output='mean_height_above_ground',
+               base_raster='elevation' method='mean')
 </pre></div>
 
 

--- a/raster/r.solute.transport/example.py
+++ b/raster/r.solute.transport/example.py
@@ -1,51 +1,51 @@
 #!/usr/bin/env python3
 # This is an example script how groundwater flow and solute transport are
-# computed within grass
+# computed within GRASS GIS
 import sys
 import os
-import grass.script as grass
+import grass.script as gs
 
 # Overwrite existing maps
-grass.run_command("g.gisenv", set="OVERWRITE=1")
+gs.run_command("g.gisenv", set="OVERWRITE=1")
 
-grass.message("Set the region")
+gs.message("Set the region")
 
 # The area is 200m x 100m with a cell size of 1m x 1m
-grass.run_command("g.region", res=1, res3=1, t=10, b=0, n=100, s=0, w=0, e=200)
-grass.run_command("r.mapcalc", expression="phead=if(col() == 1 , 50, 40)")
-grass.run_command("r.mapcalc", expression="phead=if(col() ==200  , 45 + row()/40, phead)")
-grass.run_command("r.mapcalc", expression="status=if(col() == 1 || col() == 200 , 2, 1)")
-grass.run_command("r.mapcalc", expression="well=if((row() == 50 && col() == 175) || (row() == 10 && col() == 135) , -0.001, 0)")
-grass.run_command("r.mapcalc", expression="hydcond=0.00005")
-grass.run_command("r.mapcalc", expression="recharge=0")
-grass.run_command("r.mapcalc", expression="top_conf=20")
-grass.run_command("r.mapcalc", expression="bottom=0")
-grass.run_command("r.mapcalc", expression="poros=0.17")
-grass.run_command("r.mapcalc", expression="syield=0.0001")
-grass.run_command("r.mapcalc", expression="null=0.0")
+gs.run_command("g.region", res=1, res3=1, t=10, b=0, n=100, s=0, w=0, e=200)
+gs.run_command("r.mapcalc", expression="phead=if(col() == 1 , 50, 40)")
+gs.run_command("r.mapcalc", expression="phead=if(col() ==200  , 45 + row()/40, phead)")
+gs.run_command("r.mapcalc", expression="status=if(col() == 1 || col() == 200 , 2, 1)")
+gs.run_command("r.mapcalc", expression="well=if((row() == 50 && col() == 175) || (row() == 10 && col() == 135) , -0.001, 0)")
+gs.run_command("r.mapcalc", expression="hydcond=0.00005")
+gs.run_command("r.mapcalc", expression="recharge=0")
+gs.run_command("r.mapcalc", expression="top_conf=20")
+gs.run_command("r.mapcalc", expression="bottom=0")
+gs.run_command("r.mapcalc", expression="poros=0.17")
+gs.run_command("r.mapcalc", expression="syield=0.0001")
+gs.run_command("r.mapcalc", expression="null=0.0")
 #
-grass.message(_("Compute a steady state groundwater flow"))
+gs.message(_("Compute a steady state groundwater flow"))
 
-grass.run_command("r.gwflow", solver="cg", top="top_conf", bottom="bottom", phead="phead",\
+gs.run_command("r.gwflow", solver="cg", top="top_conf", bottom="bottom", phead="phead",\
   status="status", hc_x="hydcond", hc_y="hydcond", q="well", s="syield",\
   recharge="recharge", output="gwresult_conf", dt=8640000000000, type="confined")
 
-grass.message(_("generate the transport data"))
-grass.run_command("r.mapcalc", expression="c=if(col() == 15 && row() == 75 , 500.0, 0.0)")
-grass.run_command("r.mapcalc", expression="cs=if(col() == 15 && row() == 75 , 0.0, 0.0)")
-grass.run_command("r.mapcalc", expression="tstatus=if(col() == 1 || col() == 200 , 3, 1)")
-grass.run_command("r.mapcalc", expression="diff=0.0000001")
-grass.run_command("r.mapcalc", expression="R=1.0")
+gs.message(_("generate the transport data"))
+gs.run_command("r.mapcalc", expression="c=if(col() == 15 && row() == 75 , 500.0, 0.0)")
+gs.run_command("r.mapcalc", expression="cs=if(col() == 15 && row() == 75 , 0.0, 0.0)")
+gs.run_command("r.mapcalc", expression="tstatus=if(col() == 1 || col() == 200 , 3, 1)")
+gs.run_command("r.mapcalc", expression="diff=0.0000001")
+gs.run_command("r.mapcalc", expression="R=1.0")
 
 # Compute the initial state
-grass.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
+gs.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
   bottom="bottom", phead="gwresult_conf", status="tstatus", hc_x="hydcond", hc_y="hydcond",\
   rd="R", cs="cs", q="well", nf="poros", output="stresult_conf_0", dt=3600, diff_x="diff",\
   diff_y="diff", c="c", al=0.1, at=0.01)
 
 # Compute the solute transport for 300 days in 10 day steps
 for dt in range(30):
-    grass.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
+    gs.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
     bottom="bottom", phead="gwresult_conf", status="tstatus", hc_x="hydcond", hc_y="hydcond",\
     rd="R", cs="cs", q="well", nf="poros", output="stresult_conf_" + str(dt + 1), dt=864000, diff_x="diff",\
     diff_y="diff", c="stresult_conf_" + str(dt), al=0.1, at=0.01, vx="vx", vy="vy")

--- a/raster/r.solute.transport/r.solute.transport.html
+++ b/raster/r.solute.transport/r.solute.transport.html
@@ -90,52 +90,52 @@ Make sure you are not in a lat/lon projection.
 <div class="code"><pre>
 #!/usr/bin/env python3
 # This is an example script how groundwater flow and solute transport are
-# computed within grass
+# computed within GRASS GIS
 import sys
 import os
-import grass.script as grass
+import grass.script as gs
 
 # Overwrite existing maps
-grass.run_command("g.gisenv", set="OVERWRITE=1")
+gs.run_command("g.gisenv", set="OVERWRITE=1")
 
-grass.message(_("Set the region"))
+gs.message(_("Set the region"))
 
 # The area is 200m x 100m with a cell size of 1m x 1m
-grass.run_command("g.region", res=1, res3=1, t=10, b=0, n=100, s=0, w=0, e=200)
-grass.run_command("r.mapcalc", expression="phead = if(col() == 1 , 50, 40)")
-grass.run_command("r.mapcalc", expression="phead = if(col() ==200  , 45 + row()/40, phead)")
-grass.run_command("r.mapcalc", expression="status = if(col() == 1 || col() == 200 , 2, 1)")
-grass.run_command("r.mapcalc", expression="well = if((row() == 50 && col() == 175) || (row() == 10 && col() == 135) , -0.001, 0)")
-grass.run_command("r.mapcalc", expression="hydcond = 0.00005")
-grass.run_command("r.mapcalc", expression="recharge = 0")
-grass.run_command("r.mapcalc", expression="top_conf = 20")
-grass.run_command("r.mapcalc", expression="bottom = 0")
-grass.run_command("r.mapcalc", expression="poros = 0.17")
-grass.run_command("r.mapcalc", expression="syield = 0.0001")
-grass.run_command("r.mapcalc", expression="null = 0.0")
+gs.run_command("g.region", res=1, res3=1, t=10, b=0, n=100, s=0, w=0, e=200)
+gs.run_command("r.mapcalc", expression="phead = if(col() == 1 , 50, 40)")
+gs.run_command("r.mapcalc", expression="phead = if(col() ==200  , 45 + row()/40, phead)")
+gs.run_command("r.mapcalc", expression="status = if(col() == 1 || col() == 200 , 2, 1)")
+gs.run_command("r.mapcalc", expression="well = if((row() == 50 && col() == 175) || (row() == 10 && col() == 135) , -0.001, 0)")
+gs.run_command("r.mapcalc", expression="hydcond = 0.00005")
+gs.run_command("r.mapcalc", expression="recharge = 0")
+gs.run_command("r.mapcalc", expression="top_conf = 20")
+gs.run_command("r.mapcalc", expression="bottom = 0")
+gs.run_command("r.mapcalc", expression="poros = 0.17")
+gs.run_command("r.mapcalc", expression="syield = 0.0001")
+gs.run_command("r.mapcalc", expression="null = 0.0")
 
-grass.message(_("Compute a steady state groundwater flow"))
+gs.message(_("Compute a steady state groundwater flow"))
 
-grass.run_command("r.gwflow", solver="cg", top="top_conf", bottom="bottom", phead="phead",\
+gs.run_command("r.gwflow", solver="cg", top="top_conf", bottom="bottom", phead="phead",\
   status="status", hc_x="hydcond", hc_y="hydcond", q="well", s="syield",\
   recharge="recharge", output="gwresult_conf", dt=8640000000000, type="confined")
 
-grass.message(_("generate the transport data"))
-grass.run_command("r.mapcalc", expression="c = if(col() == 15 &amp;&amp; row() == 75 , 500.0, 0.0)")
-grass.run_command("r.mapcalc", expression="cs = if(col() == 15 &amp;&amp; row() == 75 , 0.0, 0.0)")
-grass.run_command("r.mapcalc", expression="tstatus = if(col() == 1 || col() == 200 , 3, 1)")
-grass.run_command("r.mapcalc", expression="diff = 0.0000001")
-grass.run_command("r.mapcalc", expression="R = 1.0")
+gs.message(_("generate the transport data"))
+gs.run_command("r.mapcalc", expression="c = if(col() == 15 &amp;&amp; row() == 75 , 500.0, 0.0)")
+gs.run_command("r.mapcalc", expression="cs = if(col() == 15 &amp;&amp; row() == 75 , 0.0, 0.0)")
+gs.run_command("r.mapcalc", expression="tstatus = if(col() == 1 || col() == 200 , 3, 1)")
+gs.run_command("r.mapcalc", expression="diff = 0.0000001")
+gs.run_command("r.mapcalc", expression="R = 1.0")
 
 # Compute the initial state
-grass.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
+gs.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
   bottom="bottom", phead="gwresult_conf", status="tstatus", hc_x="hydcond", hc_y="hydcond",\
   rd="R", cs="cs", q="well", nf="poros", output="stresult_conf_0", dt=3600, diff_x="diff",\
   diff_y="diff", c="c", al=0.1, at=0.01)
 
 # Compute the solute transport for 300 days in 10 day steps
 for dt in range(30):
-    grass.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
+    gs.run_command("r.solute.transport", solver="bicgstab", top="top_conf",\
     bottom="bottom", phead="gwresult_conf", status="tstatus", hc_x="hydcond", hc_y="hydcond",\
     rd="R", cs="cs", q="well", nf="poros", output="stresult_conf_" + str(dt + 1), dt=864000, diff_x="diff",\
     diff_y="diff", c="stresult_conf_" + str(dt), al=0.1, at=0.01)

--- a/scripts/g.extension/testsuite/data/sample_modules/r.plus.example/r.plus.example.py
+++ b/scripts/g.extension/testsuite/data/sample_modules/r.plus.example/r.plus.example.py
@@ -18,16 +18,16 @@
 #%end
 
 
-import grass.script as gscript
+import grass.script as gs
 
 
 def main():
-    options, flags = gscript.parser()
+    options, flags = gs.parser()
     araster = options['araster']
     braster = options['braster']
     output = options['output']
 
-    gscript.mapcalc('{r} = {a} + {b}'.format(r=output, a=araster, b=braster))
+    gs.mapcalc('{r} = {a} + {b}'.format(r=output, a=araster, b=braster))
 
     return 0
 


### PR DESCRIPTION
Both grass and gscript aliases (import grass.script as ...) were replaced by gs
which is shorter but still refering to grass.script.

Changes documentation (.html and .rst), examples (files, wxGUI/pyedit),
grass.script test, and how grass.script is accessible in GUI Python shell (wxGUI/pyshell).
Graphical modeler code generation does not use alias and imports specific objects.
Does not change any of the 'live' source code which still uses mixture of

    import grass.script as grass

and

    import grass.script as gscript

Also touches on couple places to clarify references to grass.script
and to GRASS GIS in general.