### PR TITLE
wxGUI: Show line numbers in the Python editor (pyedit and gmodeler)

### DIFF
--- a/gui/wxpython/gui_core/pystc.py
+++ b/gui/wxpython/gui_core/pystc.py
@@ -70,6 +70,11 @@ class PyStc(stc.StyledTextCtrl):
         self.SetEdgeMode(stc.STC_EDGE_BACKGROUND)
         self.SetEdgeColumn(78)
 
+        # show line numbers
+        self.SetMarginType(1, wx.stc.STC_MARGIN_NUMBER)
+        # supporting only  2 or 3 digit line numbers
+        self.SetMarginWidth(1, 3 * self.faces["size2"])
+
         # setup a margin to hold fold markers
         self.SetMarginType(2, stc.STC_MARGIN_SYMBOL)
         self.SetMarginMask(2, stc.STC_MASK_FOLDERS)


### PR DESCRIPTION
Line numbers are important for error messages/tracebacks and teaching.
Margin size scales with the font size, but only 2 or 3 digit numbers
are supported (users are not expected to write really long files).