### PR TITLE
switch environment: also change mapset

### DIFF
--- a/raster/r.in.gdal/main.c
+++ b/raster/r.in.gdal/main.c
@@ -894,6 +894,7 @@ int main(int argc, char *argv[])
 		G_create_alt_env();
 		G_setenv_nogisrc("LOCATION_NAME", parm.target->answer);
 		sprintf(target_mapset, "PERMANENT");	/* must exist */
+		G_setenv_nogisrc("MAPSET", target_mapset);
 
 		if (G_mapset_permissions(target_mapset) == -1) {
 		    /* create target location later */

--- a/raster/r.proj/main.c
+++ b/raster/r.proj/main.c
@@ -284,6 +284,7 @@ int main(int argc, char **argv)
     G_create_alt_env();
     G_setenv_nogisrc("GISDBASE", indbase->answer ? indbase->answer : G_gisdbase());
     G_setenv_nogisrc("LOCATION_NAME", inlocation->answer);
+    G_setenv_nogisrc("MAPSET", setname);
 
     permissions = G_mapset_permissions(setname);
     if (permissions < 0)	/* can't access mapset       */

--- a/raster/r.proj/main.c
+++ b/raster/r.proj/main.c
@@ -339,6 +339,9 @@ int main(int argc, char **argv)
 	tproj.def = G_store(pipeline->answer);
     }
 #endif
+
+    /* switch back to current location */
+    G_switch_env();
     if (GPJ_init_transform(&iproj, &oproj, &tproj) < 0)
 	G_fatal_error(_("Unable to initialize coordinate transformation"));
 
@@ -348,6 +351,9 @@ int main(int argc, char **argv)
     G_free_key_value(out_unit_info);
     if (G_verbose() > G_verbose_std())
 	pj_print_proj_params(&iproj, &oproj);
+
+    /* switch to input location */
+    G_switch_env();
 
     /* this call causes r.proj to read the entire map into memeory */
     Rast_get_cellhd(inmap->answer, setname, &incellhd);

--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -192,6 +192,7 @@ int main(int argc, char *argv[])
     select_target_env();
     G_setenv_nogisrc("GISDBASE", gbase);
     G_setenv_nogisrc("LOCATION_NAME", iloc_name);
+    G_setenv_nogisrc("MAPSET", iset_name);
     stat = G_mapset_permissions(iset_name);
     
     if (stat >= 0) {		/* yes, we can access the mapset */


### PR DESCRIPTION
WIP because this exposes a bug in r.import: a temp region with WIND_OVERRIDE can not be used with r.proj/v.proj because the location and mapset need to be switched during reprojection, and the env var WIND_OVERRIDE applies only to the location/mapset where it was established -> unable to find the region def given with WIND_OVERRIDE in the source location/mapset.