### PR TITLE
r.kappa: maps[0] is the reference and maps[1] is the classified map

### DIFF
--- a/raster/r.kappa/stats.c
+++ b/raster/r.kappa/stats.c
@@ -27,12 +27,12 @@ int stats(void)
     const char *argv[9];
     int argc = 0;
 
-    strcpy(mname, maps[0]);
+    strcpy(mname, maps[1]);
     mmapset = G_find_raster2(mname, "");
     if (mmapset == NULL)
 	G_fatal_error(_("Raster map <%s> not found"), maps[0]);
 
-    strcpy(rname, maps[1]);
+    strcpy(rname, maps[0]);
     rmapset = G_find_raster2(rname, "");
     if (rmapset == NULL)
 	G_fatal_error(_("Raster map <%s> not found"), maps[1]);


### PR DESCRIPTION
This pull request fixes an old bug which only became apparent through a [recent change in the code](https://github.com/OSGeo/grass/commit/fbd35ebd2faf1f689d9bcae4766b0d36ab6fbbf4#diff-cd0c0347dc0cfb32c9541f122e9b7872).