### PR TITLE
r.import: pass extent to r.in.gdal

### DIFF
--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -210,6 +210,7 @@ def main():
     SRCGISRC = grass.tempfile()
 
     TMPLOC = 'temp_import_location_' + str(os.getpid())
+    TMP_REG_NAME = 'vreg_tmp_' + str(os.getpid())
 
     f = open(SRCGISRC, 'w')
     f.write('MAPSET: PERMANENT\n')
@@ -234,7 +235,7 @@ def main():
 
     # prepare to set region in temp location
     if 'r' in region_flag:
-        tgtregion = "tgtregion_for_" + TMPLOC
+        tgtregion = TMP_REG_NAME
         grass.run_command('v.in.region', **dict(output=tgtregion, flags='d'))
 
     # switch to temp location
@@ -287,6 +288,8 @@ def main():
     if flags['n']:
         rflags = 'n'
 
+    vreg = TMP_REG_NAME
+
     for outfile in outfiles:
 
         n = region['n']
@@ -325,7 +328,6 @@ def main():
             grass.run_command('g.region', n=n, s=s, e=e, w=w)
 
         # v.in.region in tgt
-        vreg = TMP_REG_NAME = 'vreg_tmp_' + str(os.getpid())
         grass.run_command('v.in.region', output=vreg, quiet=True)
 
         grass.del_temp_region()

--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -234,7 +234,7 @@ def main():
 
     # prepare to set region in temp location
     if 'r' in region_flag:
-        tgtregion="tgtregion_for_" + TMPLOC
+        tgtregion = "tgtregion_for_" + TMPLOC
         grass.run_command('v.in.region', **dict(output=tgtregion, flags='d'))
 
     # switch to temp location


### PR DESCRIPTION
This PR enhances the case, when using `r.import` and reprojection is necessary together with the `extent=region` parameter. Before, the region was not limited in `r.in.gdal`. With this PR, `r.import` also limits the import to the current region for `r.in.gdal` leading to a much faster import for large raster data when only a part is needed.