### PR TITLE
Add soname on FreeBSD

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -561,6 +561,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 	    SHLIB_CFLAGS="-fPIC"
 	    #SHLIB_LD="ld -Bshareable -x"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LD_FLAGS="-Wl,-soname,\$(notdir \$[@])"
 	    SHLIB_SUFFIX=".so"
 	    LDFLAGS="-export-dynamic"
 	    #LD_SEARCH_FLAGS='-rpath ${LIB_RUNTIME_DIR}'

--- a/configure
+++ b/configure
@@ -1589,6 +1589,7 @@ EOF
 	    # FreeBSD 3.* and greater have ELF.
 	    SHLIB_CFLAGS="-fPIC"
 	    #SHLIB_LD="ld -Bshareable -x"
+            SHLIB_LD_FLAGS="-Wl,-soname,\$(notdir \$@)"
 	    SHLIB_LD="${CC} -shared"
 	    SHLIB_SUFFIX=".so"
 	    LDFLAGS="-export-dynamic"


### PR DESCRIPTION
GRASS build system does not set sonames of libraries for FreeBSD. it causes problems while packaging grass using our ports/pkg system which uses sonames for dependencies especially to link Grass with QGIS.

cc @rhurlin