### PR TITLE
Remove redundant encode string call in the error message string interpolation

### DIFF
--- a/lib/python/script/task.py
+++ b/lib/python/script/task.py
@@ -201,7 +201,7 @@ class grassTask:
                     if not desc:
                         desc = p['description']
                     errorList.append(_("Parameter '%(name)s' (%(desc)s) is missing.") % \
-                                     {'name': p['name'], 'desc': encode(desc)})
+                                     {'name': p['name'], 'desc': desc})
 
         return errorList
 


### PR DESCRIPTION
Reproduce:

1. Open Add vector map layer
2. Click on the Apply button
3. Error message dialog show

![error_message](https://user-images.githubusercontent.com/50632337/73298584-dd1e9b00-420d-11ea-9a39-41d9c15a4ca0.png)
