### PR TITLE
Fix Cartographic Composer Add graphic tool (Line/Rectangle), Add Image/North Arrow dialog wx FloatSpin widget size

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -226,6 +226,7 @@ class PsmapDialog(wx.Dialog):
         self.objectType = None
         self.unitConv = UnitConversion(self)
         self.spinCtrlSize = (65, -1)
+        self.floatSpinSize = (120, -1)
 
         self.Bind(wx.EVT_CLOSE, self.OnClose)
 
@@ -5865,7 +5866,7 @@ class ImageDialog(PsmapDialog):
         if fs:
             panel.image['scale'] = fs.FloatSpin(
                 panel, id=wx.ID_ANY, min_val=0, max_val=50, increment=0.5,
-                value=1, style=fs.FS_RIGHT, size=self.spinCtrlSize)
+                value=1, style=fs.FS_RIGHT, size=self.floatSpinSize)
             panel.image['scale'].SetFormat("%f")
             panel.image['scale'].SetDigits(1)
         else:
@@ -5900,7 +5901,7 @@ class ImageDialog(PsmapDialog):
         if fs:
             panel.image['rotate'] = fs.FloatSpin(
                 panel, id=wx.ID_ANY, min_val=0, max_val=360, increment=0.5,
-                value=0, style=fs.FS_RIGHT, size=self.spinCtrlSize)
+                value=0, style=fs.FS_RIGHT, size=self.floatSpinSize)
             panel.image['rotate'].SetFormat("%f")
             panel.image['rotate'].SetDigits(1)
         else:
@@ -6824,7 +6825,7 @@ class RectangleDialog(PsmapDialog):
                 increment=1,
                 value=0,
                 style=fs.FS_RIGHT,
-                size=self.spinCtrlSize)
+                size=self.floatSpinSize)
             self.widthCtrl.SetFormat("%f")
             self.widthCtrl.SetDigits(1)
         else:


### PR DESCRIPTION
Fix Cartographic Composer Add graphic tool (Line/Rectangle), Add Image/North Arrow dialog wx FloatSpin widget size.

Default wx FloatSpin widget size:

![floatspin_widget_size_before](https://user-images.githubusercontent.com/50632337/73339696-9797b780-4279-11ea-9624-7cad8b2c8ad6.png)

Resized wx FloatSpin widget:

![floatspin_widget_size_after](https://user-images.githubusercontent.com/50632337/73339749-b138ff00-4279-11ea-8abd-b3f613c31020.png)

Same incorrect widget size in the Add Image/North Arrow dialog.

