### PR TITLE
Add missing Temporal GUI Tools required package in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update \
         python3-six \
         python3-wxgtk4.0 \
         python3-gdal \
+        python3-matplotlib \
         sqlite3 \
         subversion \
         unixodbc-dev \


### PR DESCRIPTION
Add missing `python3-matplotlib` package required for the Temporal GUI Tools.