### PR TITLE
init: Add --tmp-mapset option

### DIFF
--- a/lib/init/grass7.html
+++ b/lib/init/grass7.html
@@ -4,9 +4,11 @@
 
 <b>grass79</b> [<b>-h</b> | <b>-help</b> | <b>--help</b>] [<b>-v</b> | <b>--version</b>] |
 [<b>-c</b> | <b>-c geofile</b> | <b>-c EPSG:code[:datum_trans]</b>] | <b>-e</b> | <b>-f</b> |
-[<b>--text</b> | <b>--gtext</b> | <b>--gui</b>] | <b>--config</b> | <b>--exec EXECUTABLE</b> | <b>--tmp-location</b>
+[<b>--text</b> | <b>--gtext</b> | <b>--gui</b>] | <b>--config</b> |
+[<b>--tmp-location</b> | <b>--tmp-mapset</b>]
     [[[<b>&lt;GISDBASE&gt;/</b>]<b>&lt;LOCATION&gt;/</b>]
     	<b>&lt;MAPSET&gt;</b>]
+[<b>--exec EXECUTABLE</b>]
 
 <h3>Flags:</h3>
 
@@ -55,8 +57,13 @@
 <dt><b>--tmp-location</b>
 <dd> Run using a temporary location which is created based on the given
 coordinate reference system and deleted at the end of the execution
-(use the --exec flag).
-The active mapset will be PERMANENT.
+(use with the --exec flag).
+The active mapset will be the PERMANENT mapset.
+
+<dt><b>--tmp-mapset</b>
+<dd> Run using a temporary mapset which is created in the specified
+location and deleted at the end of the execution
+(use with the --exec flag).
 
 </dl>
 
@@ -389,6 +396,44 @@ help text of a module:
 <div class="code"><pre>
 grass79 --tmp-location XY --exec r.neighbors --help
 </pre></div>
+
+
+<h4>Using temporary mapset</h4>
+
+<p>
+A single command can be executed, e.g., to examine properties of a
+location (here using the NC SPM sample location):
+
+<div class="code"><pre>
+grass79 --tmp-mapset /path/to/grassdata/nc_spm_08/ --exec g.proj -p
+</pre></div>
+
+Computation in a Python script can be executed in the same way:
+
+<div class="code"><pre>
+grass79 --tmp-mapset /path/to/grassdata/nc_spm_08/ --exec processing.py
+</pre></div>
+
+Additional parameters are just passed to the script, so we can run the
+script with different sets of parameters (here 5, 8 and 3, 9) in
+different temporary mapsets which is good for parallel processing.
+
+<div class="code"><pre>
+grass79 --tmp-mapset /path/to/grassdata/nc_spm_08/ --exec processing.py 5 8
+grass79 --tmp-mapset /path/to/grassdata/nc_spm_08/ --exec processing.py 3 9
+</pre></div>
+
+The same applies to Bash scripts (and other scripts supported on you
+platform):
+
+<div class="code"><pre>
+grass79 --tmp-mapset /path/to/grassdata/nc_spm_08/ --exec processing.sh 5 8
+</pre></div>
+
+The temporary mapset is automatically deleted after computation,
+so the script is expected to export, link or otherwise preserve the
+output data before ending.
+
 
 <h4>Troubleshooting</h4>
 Importantly, to avoid an <tt>"[Errno 8] Exec format error"</tt> there must be a 

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+"""
+TEST:      Test of grass --tmp-mapset
+
+AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+
+PURPOSE:   Test that --tmp-mapset option of grass command works
+
+COPYRIGHT: (C) 2020 Vaclav Petras and the GRASS Development Team
+
+This program is free software under the GNU General Public
+License (>=v2). Read the file COPYING that comes with GRASS
+for details.
+"""
+
+import unittest
+import os
+import shutil
+import subprocess
+
+
+# Note that unlike rest of GRASS GIS, here we are using unittest package
+# directly. The grass.gunittest machinery for mapsets is not needed here.
+# How this plays out together with the rest of testing framework is yet to be
+# determined.
+
+
+class TestTmpMapset(unittest.TestCase):
+    """Tests --tmp-mapset option of grass command"""
+
+    # TODO: here we need a name of or path to the main GRASS GIS executable
+    executable = "grass"
+    # an arbitrary, but identifiable and fairly unique name
+    location = "test_tmp_mapset_xy"
+
+    def setUp(self):
+        """Creates a location used in the tests"""
+        subprocess.check_call([self.executable, "-c", "XY", self.location, "-e"])
+        self.subdirs = os.listdir(self.location)
+
+    def tearDown(self):
+        """Deletes the location"""
+        shutil.rmtree(self.location, ignore_errors=True)
+
+    def test_command_runs(self):
+        """Check that correct parameters are accepted"""
+        return_code = subprocess.call(
+            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-g"]
+        )
+        self.assertEqual(
+            return_code,
+            0,
+            msg=(
+                "Non-zero return code from {self.executable}"
+                " when creating mapset".format(**locals())
+            ),
+        )
+
+    def test_command_fails_without_location(self):
+        """Check that the command fails with a nonexistent location"""
+        return_code = subprocess.call(
+            [
+                self.executable,
+                "--tmp-mapset",
+                "does_not_exist",
+                "--exec",
+                "g.proj",
+                "-g",
+            ]
+        )
+        self.assertNotEqual(
+            return_code,
+            0,
+            msg=(
+                "Zero return code from {self.executable},"
+                " but the location directory does not exist".format(**locals())
+            ),
+        )
+
+    def test_mapset_metadata_correct(self):
+        """Check that metadata is readable and have expected value (XY CRS)"""
+        output = subprocess.check_output(
+            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-g"]
+        )
+        self.assertEqual(
+            output.strip(),
+            "name=xy_location_unprojected".encode("ascii"),
+            msg="Mapset metadata are not what was expected, but: {output}".format(
+                **locals()
+            ),
+        )
+
+    def test_mapset_deleted(self):
+        """Check that mapset is deleted at the end of execution"""
+        subprocess.check_call(
+            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-p"]
+        )
+        for directory in os.listdir(self.location):
+            self.assertTrue(
+                directory in self.subdirs,
+                msg="Directory {directory} should have been deleted".format(**locals()),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds --tmp-mapset to the main executable which creates a temporary mapset
in the location specified in the command line. Intended to be used with --exec
and documented that way, but not explicitly checked, so --tmp-mapset without
--exec is possible for experimental purposes (same as --tmp-location).

It handles error states related to common mistakes (and gives suggestions
to user what might be wrong if that info is available).
It also handles errors caused by interaction with -c and --tmp-location.

Documentation (HTML and --help) follows what was already done for --tmp-location
and modifies doc for --tmp-location to make the differences clear, although
providing a set of specific use cases for each might help further.

Test (a first automated test in lib/init) does not fully conform to the current
GRASS GIS standard. It is using the plain Python unittest and not the GRASS GIS extension
of it (grass.gunittest). For this test, the differences in code are minimal,
but the test does not need functions from grass.gunittest nor its setup of
temporary mapset (meant for modules). As a result of using plain unittest,
this test runs outside of the GRASS GIS session. However, it still needs
to know about the tested executable which, if not already available, needs to be put
on PATH as grass (given what is hardcoded in the test now).

A smaller rewrite of some of the code for checking and setting up mapset
was necessary in order to accommodate the new code, specifically the
initial splitting of provided path and diagnostic of invalid location path.
However, adding notes to the code to facilitate further rewrite which is due.