### PR TITLE
wxgui: catch also TypeError when importing ctypes, see #305

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -51,7 +51,7 @@ from core.gthread import gThread
 try:
     import grass.lib.gis as gislib
     haveCtypes = True
-except ImportError:
+except (ImportError, TypeError):
     haveCtypes = False
 
 

--- a/gui/wxpython/nviz/wxnviz.py
+++ b/gui/wxpython/nviz/wxnviz.py
@@ -41,7 +41,10 @@ except ImportError:
 
 import wx
 
-from ctypes import *
+try:
+    from ctypes import *
+except KeyError as e:
+    print("wxnviz.py: {}".format(e), file=sys.stderr)
 
 try:
     WindowsError
@@ -54,7 +57,7 @@ try:
     from grass.lib.ogsf import *
     from grass.lib.nviz import *
     from grass.lib.raster import *
-except (ImportError, WindowsError) as e:
+except (ImportError, WindowsError, TypeError) as e:
     print("wxnviz.py: {}".format(e), file=sys.stderr)
 
 from core.debug import Debug

--- a/gui/wxpython/vdigit/wxdigit.py
+++ b/gui/wxpython/vdigit/wxdigit.py
@@ -47,7 +47,7 @@ try:
     from grass.lib.vector import *
     from grass.lib.vedit import *
     from grass.lib.dbmi import *
-except (ImportError, WindowsError) as e:
+except (ImportError, WindowsError, TypeError) as e:
     print("wxdigit.py: {}".format(e), file=sys.stderr)
 
 class VDigitError:

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -39,7 +39,7 @@ try:
     from grass.lib.gis import *
     from grass.lib.vector import *
     from grass.lib.vedit import *
-except (ImportError, WindowsError) as e:
+except (ImportError, WindowsError, TypeError) as e:
     print("wxdigit.py: {}".format(e), file=sys.stderr)
 
 log = None


### PR DESCRIPTION
This PR allows to start GUI even on TypeError when importing ctypes. See #305 