### PR TITLE
Keep module_items.xml in docker alpine

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -177,10 +177,13 @@ RUN echo "  => Configure and compile grass" && \
 RUN ln -s `find /usr/local/bin -name "grass*"` /usr/local/bin/grass
 
 # Reduce the image size - Remove unnecessary grass files
-RUN rm -rf /usr/local/grass79/demolocation; \
+RUN cp /usr/local/grass79/gui/wxpython/xml/module_items.xml module_items.xml; \
+    rm -rf /usr/local/grass79/demolocation; \
     rm -rf /usr/local/grass79/fonts; \
     rm -rf /usr/local/grass79/gui; \
-    rm -rf /usr/local/grass79/share;
+    rm -rf /usr/local/grass79/share; \
+    mkdir -p /usr/local/grass79/gui/wxpython/xml/; \
+    mv module_items.xml /usr/local/grass79/gui/wxpython/xml/module_items.xml;
 
 
 FROM common as grass


### PR DESCRIPTION
Because this file is needed by g.search.modules.

*Backport needed*