### PR TITLE
run_command(error='status') ignored by python scripting lib

### DIFF
--- a/lib/python/script/core.py
+++ b/lib/python/script/core.py
@@ -372,13 +372,15 @@ def handle_errors(returncode, result, args, kwargs):
         code = ' '.join(args)
         return module, code
 
+    handler = kwargs.get('errors', 'raise')
+    if handler.lower() == 'status':
+        return returncode
+
     if returncode == 0:
         return result
-    handler = kwargs.get('errors', 'raise')
+
     if handler.lower() == 'ignore':
         return result
-    elif handler.lower() == 'status':
-        return returncode
     elif handler.lower() == 'fatal':
         module, code = get_module_and_code(args, kwargs)
         fatal(_("Module {module} ({code}) failed with"


### PR DESCRIPTION
It seems that

```
run_command(error='status')
```
is not working as expected. Discovered (https://github.com/OSGeo/grass/blob/master/scripts/r.import/r.import.py#L183) by running `r.import` which forces reprojection even input data CRS and location matches.

This PR should fix the issue. Only master seems to be affected.