### PR TITLE
wx.Menu.Append: remove text argument

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -456,22 +456,22 @@ class VirtualAttributeList(ListCtrl,
                             'calculator': NewId(),
                             'stats': NewId()}
 
-        popupMenu.Append(self.popupId['sortAsc'], text=_("Sort ascending"))
-        popupMenu.Append(self.popupId['sortDesc'], text=_("Sort descending"))
+        popupMenu.Append(self.popupId['sortAsc'], _("Sort ascending"))
+        popupMenu.Append(self.popupId['sortDesc'], _("Sort descending"))
         popupMenu.AppendSeparator()
         subMenu = Menu()
         popupMenu.AppendMenu(self.popupId['calculate'], _(
             "Calculate (only numeric columns)"), subMenu)
         popupMenu.Append(
             self.popupId['calculator'],
-            text=_("Field calculator"))
+            _("Field calculator"))
         popupMenu.AppendSeparator()
-        popupMenu.Append(self.popupId['stats'], text=_("Statistics"))
+        popupMenu.Append(self.popupId['stats'], _("Statistics"))
 
         if not self.pages['manageTable']:
             popupMenu.AppendSeparator()
             self.popupId['addCol'] = NewId()
-            popupMenu.Append(self.popupId['addCol'], text=_("Add column"))
+            popupMenu.Append(self.popupId['addCol'], _("Add column"))
             if not self.dbMgrData['editable']:
                 popupMenu.Enable(self.popupId['addCol'], False)
 
@@ -483,23 +483,23 @@ class VirtualAttributeList(ListCtrl,
                 types.IntType, types.FloatType):
             popupMenu.Enable(self.popupId['calculate'], False)
 
-        subMenu.Append(self.popupId['area'], text=_("Area size"))
-        subMenu.Append(self.popupId['length'], text=_("Line length"))
+        subMenu.Append(self.popupId['area'], _("Area size"))
+        subMenu.Append(self.popupId['length'], _("Line length"))
         subMenu.Append(
             self.popupId['compact'],
-            text=_("Compactness of an area"))
-        subMenu.Append(self.popupId['fractal'], text=_(
+            _("Compactness of an area"))
+        subMenu.Append(self.popupId['fractal'], _(
             "Fractal dimension of boundary defining a polygon"))
         subMenu.Append(
             self.popupId['perimeter'],
-            text=_("Perimeter length of an area"))
-        subMenu.Append(self.popupId['ncats'], text=_(
+            _("Perimeter length of an area"))
+        subMenu.Append(self.popupId['ncats'], _(
             "Number of features for each category"))
         subMenu.Append(
             self.popupId['slope'],
-            text=_("Slope steepness of 3D line"))
-        subMenu.Append(self.popupId['lsin'], text=_("Line sinuousity"))
-        subMenu.Append(self.popupId['lazimuth'], text=_("Line azimuth"))
+            _("Slope steepness of 3D line"))
+        subMenu.Append(self.popupId['lsin'], _("Line sinuousity"))
+        subMenu.Append(self.popupId['lazimuth'], _("Line azimuth"))
 
         self.Bind(
             wx.EVT_MENU,

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -1500,17 +1500,17 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
         self._onSelectShape(shape)
 
         popupMenu = Menu()
-        popupMenu.Append(self.popupID['remove'], text=_('Remove'))
+        popupMenu.Append(self.popupID['remove'], _('Remove'))
         self.frame.Bind(wx.EVT_MENU, self.OnRemove, id=self.popupID['remove'])
         if isinstance(shape, ModelAction) or isinstance(shape, ModelLoop):
             if shape.IsEnabled():
-                popupMenu.Append(self.popupID['enable'], text=_('Disable'))
+                popupMenu.Append(self.popupID['enable'], _('Disable'))
                 self.frame.Bind(
                     wx.EVT_MENU,
                     self.OnDisable,
                     id=self.popupID['enable'])
             else:
-                popupMenu.Append(self.popupID['enable'], text=_('Enable'))
+                popupMenu.Append(self.popupID['enable'], _('Enable'))
                 self.frame.Bind(
                     wx.EVT_MENU,
                     self.OnEnable,
@@ -1518,13 +1518,13 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
         if isinstance(shape, ModelAction) or isinstance(shape, ModelComment):
             popupMenu.AppendSeparator()
         if isinstance(shape, ModelAction):
-            popupMenu.Append(self.popupID['label'], text=_('Set label'))
+            popupMenu.Append(self.popupID['label'], _('Set label'))
             self.frame.Bind(
                 wx.EVT_MENU,
                 self.OnSetLabel,
                 id=self.popupID['label'])
         if isinstance(shape, ModelAction) or isinstance(shape, ModelComment):
-            popupMenu.Append(self.popupID['comment'], text=_('Set comment'))
+            popupMenu.Append(self.popupID['comment'], _('Set comment'))
             self.frame.Bind(
                 wx.EVT_MENU,
                 self.OnSetComment,
@@ -1534,14 +1534,14 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
             popupMenu.AppendSeparator()
             popupMenu.Append(
                 self.popupID['addPoint'],
-                text=_('Add control point'))
+                _('Add control point'))
             self.frame.Bind(
                 wx.EVT_MENU,
                 self.OnAddPoint,
                 id=self.popupID['addPoint'])
             popupMenu.Append(
                 self.popupID['delPoint'],
-                text=_('Remove control point'))
+                _('Remove control point'))
             self.frame.Bind(
                 wx.EVT_MENU,
                 self.OnRemovePoint,
@@ -1555,7 +1555,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
                len(self.GetShape().GetRelations('from')) > 0:
                 popupMenu.Append(
                     self.popupID['intermediate'],
-                    text=_('Intermediate'),
+                    _('Intermediate'),
                     kind=wx.ITEM_CHECK)
                 if self.GetShape().IsIntermediate():
                     popupMenu.Check(self.popupID['intermediate'], True)
@@ -1568,7 +1568,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
             if self.frame._giface.GetMapDisplay():
                 popupMenu.Append(
                     self.popupID['display'],
-                    text=_('Display'),
+                    _('Display'),
                     kind=wx.ITEM_CHECK)
                 if self.GetShape().HasDisplay():
                     popupMenu.Check(self.popupID['display'], True)
@@ -1585,7 +1585,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
                 isinstance(shape, ModelAction) or \
                 isinstance(shape, ModelLoop):
             popupMenu.AppendSeparator()
-            popupMenu.Append(self.popupID['props'], text=_('Properties'))
+            popupMenu.Append(self.popupID['props'], _('Properties'))
             self.frame.Bind(
                 wx.EVT_MENU,
                 self.OnProperties,

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -575,13 +575,13 @@ class CategoryListCtrl(ListCtrl,
 
         menu = Menu()
 
-        item = menu.Append(wx.ID_ANY, text=_("Rename class"))
+        item = menu.Append(wx.ID_ANY, _("Rename class"))
         self.Bind(wx.EVT_MENU, self.OnRename, item)
 
-        item = menu.Append(wx.ID_ANY, text=_("Set color"))
+        item = menu.Append(wx.ID_ANY, _("Set color"))
         self.Bind(wx.EVT_MENU, self.OnSetColor, item)
 
-        item = menu.Append(item_id, text=_("Change opacity level"))
+        item = menu.Append(item_id, _("Change opacity level"))
         self.Bind(wx.EVT_MENU, self.OnPopupOpacityLevel, item)
 
         if showed:
@@ -589,7 +589,7 @@ class CategoryListCtrl(ListCtrl,
         else:
             text = _("Show")
 
-        item = menu.Append(wx.ID_ANY, text=text)
+        item = menu.Append(wx.ID_ANY, text)
         self.Bind(
             wx.EVT_MENU,
             lambda event: self._setCatAttrs(
@@ -600,31 +600,31 @@ class CategoryListCtrl(ListCtrl,
 
         menu.AppendSeparator()
 
-        item = menu.Append(wx.ID_ANY, text=_("Move to top"))
+        item = menu.Append(wx.ID_ANY, _("Move to top"))
         self.Bind(wx.EVT_MENU, self.OnMoveTop, item)
         if cat_idx == 0:
             menu.Enable(item.GetId(), False)
 
-        item = menu.Append(wx.ID_ANY, text=_("Move to bottom"))
+        item = menu.Append(wx.ID_ANY, _("Move to bottom"))
         self.Bind(wx.EVT_MENU, self.OnMoveBottom, item)
         if cat_idx == len(cats) - 1:
             menu.Enable(item.GetId(), False)
 
         menu.AppendSeparator()
 
-        item = menu.Append(wx.ID_ANY, text=_("Move category up"))
+        item = menu.Append(wx.ID_ANY, _("Move category up"))
         self.Bind(wx.EVT_MENU, self.OnMoveUp, item)
         if cat_idx == 0:
             menu.Enable(item.GetId(), False)
 
-        item = menu.Append(wx.ID_ANY, text=_("Move category down"))
+        item = menu.Append(wx.ID_ANY, _("Move category down"))
         self.Bind(wx.EVT_MENU, self.OnMoveDown, item)
         if cat_idx == len(cats) - 1:
             menu.Enable(item.GetId(), False)
 
         menu.AppendSeparator()
 
-        item = menu.Append(wx.ID_ANY, text=_("Export class raster"))
+        item = menu.Append(wx.ID_ANY, _("Export class raster"))
         self.Bind(wx.EVT_MENU, self.OnExportCatRast, item)
 
         self.PopupMenu(menu)

--- a/gui/wxpython/modules/extensions.py
+++ b/gui/wxpython/modules/extensions.py
@@ -236,12 +236,12 @@ class InstallExtensionWindow(wx.Frame):
         data = node.data
         if data and 'command' in data:
             self.popupMenu = Menu()
-            self.popupMenu.Append(self.popupID['install'], text=_("Install"))
+            self.popupMenu.Append(self.popupID['install'], _("Install"))
             self.Bind(wx.EVT_MENU, self.OnInstall, id=self.popupID['install'])
             self.popupMenu.AppendSeparator()
             self.popupMenu.Append(
                 self.popupID['help'],
-                text=_("Show manual page"))
+                _("Show manual page"))
             self.Bind(wx.EVT_MENU, self.OnItemHelp, id=self.popupID['help'])
 
             self.PopupMenu(self.popupMenu)


### PR DESCRIPTION
On several places wx.Menu.Append() caller is still using `text` named argument (which has been renamed to `item` in wxPython 4). This cases a failure. 

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wx/lib/ogl/canvas.py", line 294, in OnMouseEvent
    nearest_object.GetEventHandler().OnRightClick(x, y, keys, attachment)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/frame.py", line 1503, in OnRightClick
    popupMenu.Append(self.popupID['remove'], text=_('Remove'))
TypeError: Menu.Append(): arguments did not match any overloaded call:
  overload 1: 'text' is not a valid keyword argument
  overload 2: 'text' is not a valid keyword argument
  overload 3: argument 1 has unexpected type 'int'
```

This PR simply removes the named argument in order to quickly fix the issue.

What is preferable solution?

1. remove named argument (we used them quite a lot in the code base)
2. use `item` (since GRASS 7.8+ runs only on wxPython 4)
3. extent wrapper class (this doesn't make sense probably since wxPython2/3 support will be probably removed in future versions)