### PR TITLE
gmodeler: fix python export - main() 

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -2677,7 +2677,7 @@ if __name__ == "__main__":
         if properties.get('overwrite'):
             self.fd.write('    os.environ["GRASS_OVERWRITE"] = "1"\n')
 
-        self.fd.write('    sys.exit(main())\n')
+        self.fd.write('    sys.exit(main(options, flags))\n')
 
     def _writePythonItem(self, item, ignoreBlock=True, variables={}):
         """Write model object to Python file"""


### PR DESCRIPTION
In exported Python script from GRASS modeler the `main()` is assumed to be called with two arguments (options, flags).

```
Traceback (most recent call last):
  File "/home/user/grassdata/jena-
region/PERMANENT/.tmp/b802/30427.0", line 34, in <module>
    sys.exit(main())
TypeError: main() missing 2 required positional arguments:
'options' and 'flags'
```