### PR TITLE
r.grow: Correctly handle shrinking of maps without NULL values

### DIFF
--- a/scripts/r.grow/r.grow.py
+++ b/scripts/r.grow/r.grow.py
@@ -147,7 +147,7 @@ def main():
             grass.fatal(_("Shrinking failed. Removing temporary maps."))
 
         grass.mapcalc(
-            "$output = if($dist < $radius,null(),$old)",
+            "$output = if(isnull($dist), $old, if($dist < $radius,null(),$old))",
             output=output, radius=radius, old=old, dist=temp_dist)
 
     grass.run_command('r.colors', map=output, raster=input)

--- a/scripts/r.grow/testsuite/test_r_grow.py
+++ b/scripts/r.grow/testsuite/test_r_grow.py
@@ -1,7 +1,7 @@
 """
 Created on Sun Jun 07 22:09:41 2018
 
-@author: Sanjeet Bhatti
+@author: Sanjeet Bhatti, Maris Nartiss
 """
 
 from grass.gunittest.case import TestCase
@@ -16,6 +16,8 @@ class TestRGrow(TestCase):
     mapName = 'lakes'
     mapGrownOutput = 'lakes_grown_100m'
     mapShrunkOutput = 'lakes_shrunk_100m'
+    mapNoNULL = 'elevation'
+    mapShrunkNoNULL = 'elevation_shrunk'
 
     @classmethod
     def setUpClass(cls):
@@ -28,7 +30,8 @@ class TestRGrow(TestCase):
         """Remove temporary region"""
         cls.runModule('g.remove', flags='f', type='raster',
                       name=(cls.mapGrownOutput,
-                            cls.mapShrunkOutput))
+                            cls.mapShrunkOutput,
+                            cls.mapShrunkNoNULL))
         cls.del_temp_region()
 
     def test_grow(self):
@@ -44,6 +47,19 @@ class TestRGrow(TestCase):
                               output=self.mapShrunkOutput,
                               radius=-10)
         self.assertModule(module)
+
+    def test_shrink_null(self):
+        """Shrinking of map without NULL values
+        Based on https://github.com/OSGeo/grass/pull/343"""
+        shrinked_string = '56-156'
+        shrinked = SimpleModule('r.grow', input=self.mapNoNULL,
+                              output=self.mapShrunkNoNULL,
+                              radius=-10)
+        self.assertModule(shrinked)
+
+        shrined_range = SimpleModule('r.describe', flags='i', _map=self.mapShrunkNoNULL)
+        self.runModule(shrined_range)
+        self.assertLooksLike(shrinked_string, str(shrined_range.outputs.stdout).strip())
 
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
If r.grow shrinking (negative distance) is performed on a map without NULL values, output is all NULL, although it should be identical to input. With this PR, shrinking of a map without NULL values will produce output equal to input.

Should be applied on top of PR  #277