### PR TITLE
standardization of Markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Compute '....'
@@ -24,11 +25,15 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **System description (please complete the following information):**
- - Operating System: [e.g. Windows, Linux, ... incl. version]
- - GRASS GIS version [e.g. 7.8.1]
+
+- Operating System: [e.g. Windows, Linux, ... incl. version]
+- GRASS GIS version [e.g. 7.8.1]
+
 <!---
+
 - details about further software components
-    - run `g.version -rge` in a GRASS GIS terminal session or check in the GUI menu "Help > About"
+    - run `g.version -rge` in a GRASS GIS terminal session or check in
+      the GUI menu "Help > About"
 --->
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,8 +14,8 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior:
 
 1. Go to '...'
-2. Click on '....'
-3. Compute '....'
+2. Click on '...'
+3. Compute '...'
 4. See error
 
 **Expected behavior**
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 
 **System description (please complete the following information):**
 
-- Operating System: [e.g. Windows, Linux, ... incl. version]
+- Operating System: [e.g. Windows, Linux, ..., incl. version]
 - GRASS GIS version [e.g. 7.8.1]
 
 <!---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,15 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is.
+Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+A clear and concise description of any alternative solutions or features
+you've considered.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Contributions other than code
 
 There is more than one way of contributing, see full list at
-https://grass.osgeo.org/get-involved/.
+<https://grass.osgeo.org/get-involved/>.
 In the rest of this document, we will focus on contributions centered
 around the GRASS GIS source code.
 
@@ -45,7 +45,8 @@ cd grass/
 git remote add upstream https://github.com/OSGeo/grass
 ```
 
-* Your remotes now should be "origin" which is your fork and "upstream" which is this main GRASS GIS repository. You can confirm that using:
+* Your remotes now should be "origin" which is your fork and "upstream" which
+  is this main GRASS GIS repository. You can confirm that using:
 
 ```
 git remote -v
@@ -84,7 +85,8 @@ git rebase upstream/master
 
 ### Update if you have local branches
 
-If `rebase` fails with "error: cannot rebase: You have unstaged changes...", then move your uncommitted local changes to "stash" using:
+If `rebase` fails with "error: cannot rebase: You have unstaged changes...",
+then move your uncommitted local changes to "stash" using:
 
 ```
 git stash
@@ -124,7 +126,7 @@ git checkout -b new-feature
 You can use your favorite tools to change source code or other files
 in the local copy of the code. When make changes, please follow
 Submitting Guidelines at
-http://trac.osgeo.org/grass/wiki/Submitting.
+<http://trac.osgeo.org/grass/wiki/Submitting>.
 
 ### Committing
 
@@ -172,4 +174,4 @@ the maintainers will decide if it is more appropriate to:
 ### Further notes
 
 GRASS GIS maintainers use additional workflows besides the one described
-above. These are detailed at https://trac.osgeo.org/grass/wiki/HowToGit
+above. These are detailed at <https://trac.osgeo.org/grass/wiki/HowToGit>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Want to become a core developer? See
 
 > See INSTALL file.
 
-Yes, you should really read INSTALL.
+Yes, you should really read [INSTALL](INSTALL).
 
 ## How to generate the 'Programmer's Manual'
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a Geographic Information System used for geospatial data management and
 analysis, image processing, graphics/map production, spatial modeling, and
 visualization.
 
-## How to get write access here?
+## How to get write access here
 
 In general: you don't really need write access as you can simply open
 a [pull request](https://github.com/OSGeo/grass/pulls) to contribute to
@@ -18,13 +18,13 @@ GRASS GIS. See [CONTRIBUTING file](CONTRIBUTING.md) for more details.
 Want to become a core developer? See
 [Procedure for gaining Git write access](https://trac.osgeo.org/grass/wiki/HowToContribute#WriteaccesstotheGRASScorerepository)
 
-## How to compile GRASS?
+## How to compile GRASS
 
 > See INSTALL file.
 
 Yes, you should really read INSTALL.
 
-## How to generate the 'Programmer's Manual'?
+## How to generate the 'Programmer's Manual'
 
 This needs doxygen (<http://www.doxygen.org>) and optionally
 Graphviz dot (<http://www.research.att.com/sw/tools/graphviz/>).
@@ -71,17 +71,20 @@ source code):
 docker build -t grassgis79 .
 ```
 
-A test run (assuming you have existing GRASS GIS location; it can be downloaded from
+A test run (assuming you have existing GRASS GIS location; it can be
+downloaded from
 [here](https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip))
 
 ```
 # case 1: launching in the grassdata directory in which the location is stored:
-docker run -it --rm --user=$(id -u):$(id -g) --volume $(pwd):/data --env HOME=/data/ grassgis79 \
-    grass --text nc_basic_spm_grass7/user1 --exec g.region -p
+docker run -it --rm --user=$(id -u):$(id -g) --volume $(pwd):/data \
+    --env HOME=/data/ grassgis79 grass --text nc_basic_spm_grass7/user1 \
+        --exec g.region -p
 
 # case 2: launching anywhere
-docker run -it --rm --user=$(id -u):$(id -g) --volume /your/test/grassdata/:/data --env HOME=/data/ grassgis79 \
-    grass /data/nc_basic_spm_grass7/PERMANENT --exec g.region -p
+docker run -it --rm --user=$(id -u):$(id -g) \
+    --volume /your/test/grassdata/:/data --env HOME=/data/ grassgis79 \
+        grass /data/nc_basic_spm_grass7/PERMANENT --exec g.region -p
 ```
 
 Note that the first `grassgis79` is the name of the image while the second
@@ -90,10 +93,11 @@ Note that the first `grassgis79` is the name of the image while the second
 To run the tests (again assuming local location):
 
 ```
-docker run -it --rm --user=$(id -u):$(id -g) --volume /your/test/grassdata/:/data --env HOME=/data/ -w /code/grass \
-    grassgis79 grass /data/nc_basic_spm_grass7/PERMANENT --exec \
-        python -m grass.gunittest.main \
-            --location nc_basic_spm_grass7 --location-type nc
+docker run -it --rm --user=$(id -u):$(id -g) \
+    --volume /your/test/grassdata/:/data --env HOME=/data/ -w /code/grass \
+        grassgis79 grass /data/nc_basic_spm_grass7/PERMANENT --exec \
+            python -m grass.gunittest.main \
+                --location nc_basic_spm_grass7 --location-type nc
 ```
 
 Note: If you compiled locally before building the Docker image, you may

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -361,9 +361,9 @@ TODO: git tags
 - Our GRASS web site: /announces/
     - Note: DON'T use relative links there
 - Our main mailing lists:
-    - <http://lists.osgeo.org/mailman/listinfo/grass-announce> | <grass-announce@lists.osgeo.org>
-    - <http://lists.osgeo.org/mailman/listinfo/grass-dev> | <grass-dev@lists.osgeo.org>
-    - <http://lists.osgeo.org/mailman/listinfo/grass-user> | <grass-user@lists.osgeo.org>
+    - <https://lists.osgeo.org/mailman/listinfo/grass-announce> | <grass-announce@lists.osgeo.org>
+    - <https://lists.osgeo.org/mailman/listinfo/grass-dev> | <grass-dev@lists.osgeo.org>
+    - <https://lists.osgeo.org/mailman/listinfo/grass-user> | <grass-user@lists.osgeo.org>
 - DebianGIS: <debian-gis@lists.debian.org> - send only small note
 - FreeGIS: <freegis-list@intevation.de>
 - Geowanking: <geowanking@geowanking.org>
@@ -373,14 +373,12 @@ Via Email:
 
 - info@osgeo.org
 - <http://www.gis-news.de/>  (franz-josef.behr@gismngt.de)
-- <http://spatialnews.geocomm.com/submitnews.html> (not free any more, convince editor@geocomm.com)
 - mfeilner@linuxnewmedia.de
 - info@harzer.de
 - editor-geo@geoconnexion.com
 
 Via Web:
 
-- <https://plus.google.com/u/0/communities/111147786674687562495> (G+ GRASS GIS community)
 - <http://linuxtoday.com/contribute.php3>
 - <https://joinup.ec.europa.eu/software/grassgis/home> (submit news, MN)
 - <http://www.macnn.com/contact/newstips/1>

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -1,6 +1,7 @@
 # How to release GRASS GIS binaries and source code
 
-*Note: Some steps in this text are to be done by the development coordinator (currently Markus Neteler, PSC Chair) due to needed logins.*
+*Note: Some steps in this text are to be done by the development coordinator
+(currently Markus Neteler, PSC Chair) due to needed logins.*
 
 ## HOWTO create a release
 
@@ -20,9 +21,11 @@ tools/fix_typos.sh
 ```
 
 ### i18N: sync from Transifex
-See https://www.transifex.com/grass-gis/grass7/dashboard/
 
-Exception Latvian as Latvian is directly edited in git and then sync'ed from master .po files
+See <https://www.transifex.com/grass-gis/grass7/dashboard/>
+
+Exception Latvian as Latvian is directly edited in git and then sync'ed from
+master .po files
 
 ```bash
 cd locale
@@ -42,6 +45,7 @@ make verify
 *Only allowed in RC cycle, not for final release!*
 
 Check that autoconf scripts are up-to-date:
+
 ```bash
 rm -f config.guess config.sub
 wget http://git.savannah.gnu.org/cgit/config.git/plain/config.guess
@@ -49,9 +53,11 @@ wget http://git.savannah.gnu.org/cgit/config.git/plain/config.sub
 git diff config.guess config.sub
 autoconf-2.13
 ```
+
 Now check if configure still works.
 
 If yes, submit to git:
+
 ```bash
 git add config.guess config.sub configure
 git checkout -b config_sub_update_r78
@@ -78,11 +84,13 @@ find . -name '*.o'    | xargs rm
 find . -name '*.pyc'  | xargs rm
 find . -name 'OBJ.*'  | xargs rm -r
 find . -name '__pycache__' | xargs rm -r
-rm -f gui/wxpython/menustrings.py gui/wxpython/build_ext.pyc gui/wxpython/xml/menudata.xml gui/wxpython/xml/module_tree_menudata.xml
+rm -f gui/wxpython/menustrings.py gui/wxpython/build_ext.pyc \
+  gui/wxpython/xml/menudata.xml gui/wxpython/xml/module_tree_menudata.xml
 chmod -R a+r *
 ```
 
 Double check:
+
 ```bash
 git status
 ```
@@ -95,7 +103,7 @@ git status
 
 Directly edit VERSION file in GH interface:
 
-https://github.com/OSGeo/grass/blob/releasebranch_7_8/include/VERSION
+<https://github.com/OSGeo/grass/blob/releasebranch_7_8/include/VERSION>
 
 Example:
 
@@ -113,7 +121,7 @@ Example:
 
 ### Create release tag
 
-(see https://help.github.com/en/articles/creating-releases)
+(see <https://help.github.com/en/articles/creating-releases>)
 
 Preparation:
 
@@ -148,7 +156,7 @@ echo "$VERSION"
 
 To be done in GH interface:
 
-https://github.com/OSGeo/grass/releases/new
+<https://github.com/OSGeo/grass/releases/new>
 
 Tag version | target (examples):
   7.8.1RC1  | releasebranch_7_8
@@ -184,7 +192,6 @@ rmdir ./grass-${VERSION}
 md5sum grass-${VERSION}.tar.gz > grass-${VERSION}.md5sum
 ```
 
-
 Create Changelog file on release branch:
 
 ```bash
@@ -194,11 +201,11 @@ head ChangeLog_$VERSION
 gzip ChangeLog_$VERSION
 ```
 
-### Reset include/VERSION file to git version:
+### Reset include/VERSION file to git version
 
 Directly edit VERSION file in GH interface:
 
-https://github.com/OSGeo/grass/blob/releasebranch_7_8/include/VERSION
+<https://github.com/OSGeo/grass/blob/releasebranch_7_8/include/VERSION>
 
 Example:
 
@@ -212,6 +219,7 @@ Example:
 Commit as "back to dev"
 
 Reset local copy to GH:
+
 ```bash
 # update from GH
 #  assumptions:
@@ -266,65 +274,84 @@ Release is done.
 #### Update CMS web site to show new version
 
 - News section
-- https://grass.osgeo.org/download/software/
-- https://grass.osgeo.org/download/software/sources/
-- https://grass.osgeo.org/download/software/linux/
-- https://grass.osgeo.org/home/history/releases/
+- <https://grass.osgeo.org/download/software/>
+- <https://grass.osgeo.org/download/software/sources/>
+- <https://grass.osgeo.org/download/software/linux/>
+- <https://grass.osgeo.org/home/history/releases/>
 
 TODO: git tags
-- https://grass.osgeo.org/development/svn/svn-tags/ (add tag): echo $RELEASETAG
+
+- <https://grass.osgeo.org/development/svn/svn-tags/> (add tag): echo $RELEASETAG
 
 #### Write announcement and publish it
+
 - store in trac:
-    - https://trac.osgeo.org/grass/wiki/Release/7.8.x-News
-    - https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78  <- add content of major changes only
-- update version in https://grasswiki.osgeo.org/wiki/GRASS-Wiki
-- ~~store in Web as announces/announce_grass$MAJOR$MINOR$RELEASE.html <- how? with protected PHP upload page?~~ (dropped since CMS)
+    - <https://trac.osgeo.org/grass/wiki/Release/7.8.x-News>
+    - <https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78>  <- add content
+      of major changes only
+- update version in <https://grasswiki.osgeo.org/wiki/GRASS-Wiki>
+- ~~store in Web as announces/announce_grass$MAJOR$MINOR$RELEASE.html <- how?
+  with protected PHP upload page?~~ (dropped since CMS)
 
 #### Only when new major release
-- update cronjob 'cron_grass_HEAD_src_snapshot.sh' on grass.osgeo.org to next but one release tag for the differences
+
+- update cronjob 'cron_grass_HEAD_src_snapshot.sh' on grass.osgeo.org to next
+  but one release tag for the differences
 - wiki updates, only when new major release:
-    - {{cmd|xxxx}} macro: https://grasswiki.osgeo.org/wiki/Template:Cmd
+    - {{cmd|xxxx}} macro: <https://grasswiki.osgeo.org/wiki/Template:Cmd>
     - update last version on main page
 - trac updates, only when new major release:
-    - Set "complete" flag in https://trac.osgeo.org/grass/milestone/7.8.x --> Edit Milestone
+    - Set "complete" flag in <https://trac.osgeo.org/grass/milestone/7.8.x> -->
+      Edit Milestone
         - also: Retarget associated open tickets to milestone 7.8.x
-    - Batch modify tickets, set to next milestone (update this query accordingly: two entries to change):
-        - https://trac.osgeo.org/grass/query?status=assigned&status=new&status=reopened&milestone=7.8.0&milestone=7.8.1&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&order=priority
-     - Set max items to 1000, then select all shown tickets via Status: assigned/new/reopened sections
-     - Scroll down to "Batch modify": under the "Comment" section, add Field "Milestone" and set to next version
-     - then use "Change ticket" button, done.
-       - Only in case of new release branch being created:
+    - Batch modify tickets, set to next milestone (update this query
+      accordingly: two entries to change):
+        - <https://trac.osgeo.org/grass/query?status=assigned&status=new&status=reopened&milestone=7.8.0&milestone=7.8.1&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&order=priority>
+    - Set max items to 1000, then select all shown tickets via Status:
+      assigned/new/reopened sections
+    - Scroll down to "Batch modify": under the "Comment" section, add Field
+      "Milestone" and set to next version
+    - then use "Change ticket" button, done.
+        - Only in case of new release branch being created:
 - Add Wiki Macro definitions for manual pages G7X:modulename
-    - Edit: https://trac.osgeo.org/grass/wiki/InterMapTxt
+    - Edit: <https://trac.osgeo.org/grass/wiki/InterMapTxt>
 
 #### WinGRASS notes
+
 - Update grass_packager_release.bat, eg.
+
 ```
      set MAJOR=7
      set MINOR=8
      set PATCH=0RC1
 ```
+
 - Update addons (grass_addons.sh) rules, eg.
+
 ```
      compile $GIT_PATH/grass7 $GISBASE_PATH/grass780RC1   $ADDON_PATH/grass780RC1/addons
 ```
+
 - Modify grass_copy_wwwroot.sh accordingly, eg.
+
 ```
      copy_addon 781RC1 7.8.1RC1
 ```
 
-#### Launchpad notes:
-- Create milestone and release: https://launchpad.net/grass/+series
+#### Launchpad notes
+
+- Create milestone and release: <https://launchpad.net/grass/+series>
 - Upload tarball for created release
-- Update daily recipe contents: https://code.launchpad.net/~grass/+recipe/grass-trunk
+- Update daily recipe contents: <https://code.launchpad.net/~grass/+recipe/grass-trunk>
 
-#### Packaging notes:
-- https://trac.osgeo.org/grass/wiki/BuildHints
-    - https://trac.osgeo.org/grass/wiki/DebianUbuntuPackaging
-    - https://trac.osgeo.org/grass/wiki/CompileOnWindows
+#### Packaging notes
 
-#### Marketing - tell others about release:
+- <https://trac.osgeo.org/grass/wiki/BuildHints>
+    - <https://trac.osgeo.org/grass/wiki/DebianUbuntuPackaging>
+    - <https://trac.osgeo.org/grass/wiki/CompileOnWindows>
+
+#### Marketing - tell others about release
+
 - Notify all packagers (MN has email list)
 - If release candidate:
     - <grass-announce@lists.osgeo.org>
@@ -334,32 +361,36 @@ TODO: git tags
 - Our GRASS web site: /announces/
     - Note: DON'T use relative links there
 - Our main mailing lists:
-    - http://lists.osgeo.org/mailman/listinfo/grass-announce | <grass-announce@lists.osgeo.org>
-    - http://lists.osgeo.org/mailman/listinfo/grass-dev | <grass-dev@lists.osgeo.org>
-    - http://lists.osgeo.org/mailman/listinfo/grass-user | <grass-user@lists.osgeo.org>
-- DebianGIS:          <debian-gis@lists.debian.org> - send only small note
-- FreeGIS:             <freegis-list@intevation.de>
-- Geowanking:       <geowanking@geowanking.org>
--  OSGeo.org:        <news_item@osgeo.org>
+    - <http://lists.osgeo.org/mailman/listinfo/grass-announce> | <grass-announce@lists.osgeo.org>
+    - <http://lists.osgeo.org/mailman/listinfo/grass-dev> | <grass-dev@lists.osgeo.org>
+    - <http://lists.osgeo.org/mailman/listinfo/grass-user> | <grass-user@lists.osgeo.org>
+- DebianGIS: <debian-gis@lists.debian.org> - send only small note
+- FreeGIS: <freegis-list@intevation.de>
+- Geowanking: <geowanking@geowanking.org>
+- OSGeo.org: <news_item@osgeo.org>
 
 Via Email:
+
 - info@osgeo.org
-- http://www.gis-news.de/  (franz-josef.behr@gismngt.de)
-- http://spatialnews.geocomm.com/submitnews.html (not free any more, convince editor@geocomm.com)
+- <http://www.gis-news.de/>  (franz-josef.behr@gismngt.de)
+- <http://spatialnews.geocomm.com/submitnews.html> (not free any more, convince editor@geocomm.com)
 - mfeilner@linuxnewmedia.de
 - info@harzer.de
 - editor-geo@geoconnexion.com
 
 Via Web:
-- https://plus.google.com/u/0/communities/111147786674687562495 (G+ GRASS GIS community)
-- http://linuxtoday.com/contribute.php3
-- https://joinup.ec.europa.eu/software/grassgis/home (submit news, MN)
-- http://www.macnn.com/contact/newstips/1
-- http://www10.giscafe.com/submit_material/submit_options.php#Press (MN)   --> Press releases
-- http://www.directionsmag.com/pressreleases/ (News -> Submit Press Release)
-- http://directory.fsf.org/wiki/GRASS_%28Geographic_Resources_Analysis_Support_System%29
-- https://www.linux-apps.com/p/1128004/edit/ (MN)
-- https://news.eoportal.org/web/eoportal/share-your-news (MN) -> Share your news with the EO community
-- https://www.heise.de/download/product/grass-gis-7105 (update, MN)
-- See also: https://grass.osgeo.org/wiki/Contact_Databases
+
+- <https://plus.google.com/u/0/communities/111147786674687562495> (G+ GRASS GIS community)
+- <http://linuxtoday.com/contribute.php3>
+- <https://joinup.ec.europa.eu/software/grassgis/home> (submit news, MN)
+- <http://www.macnn.com/contact/newstips/1>
+- <http://www10.giscafe.com/submit_material/submit_options.php#Press> (MN) -->
+  Press releases
+- <http://www.directionsmag.com/pressreleases/> (News -> Submit Press Release)
+- <http://directory.fsf.org/wiki/GRASS_%28Geographic_Resources_Analysis_Support_System%29>
+- <https://www.linux-apps.com/p/1128004/edit/> (MN)
+- <https://news.eoportal.org/web/eoportal/share-your-news> (MN) -> Share your
+  news with the EO community
+- <https://www.heise.de/download/product/grass-gis-7105> (update, MN)
+- See also: <https://grass.osgeo.org/wiki/Contact_Databases>
 - ... anywhere else? Please add here.

--- a/docker/alpine/README_alpine.md
+++ b/docker/alpine/README_alpine.md
@@ -1,25 +1,28 @@
 # Docker GRASS GIS (alpine linux)
 
-Dockerfile with an [Alpine Linux](https://www.alpinelinux.org/) image with [GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and [grass-session](https://github.com/zarch/grass-session/).
+Dockerfile with an [Alpine Linux](https://www.alpinelinux.org/) image with
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
+[grass-session](https://github.com/zarch/grass-session/).
 
 Download size of this image is only approximately 80 MB.
 
 Clone this repository and change directory:
 
 ```bash
-$ git clone https://github.com/OSGeo/grass.git
-$ cd grass
+git clone https://github.com/OSGeo/grass.git
+cd grass
 ```
 
 __Build the docker with__:
 
 ```bash
-$ docker build \
+docker build \
          --file docker/alpine/Dockerfile_alpine \
          --tag grass-py3-pdal:latest-alpine .
 ```
 
-View the images available using `sudo docker images` and open a bash terminal with:
+View the images available using `sudo docker images` and open a bash terminal
+with:
 
 ```bash
 $ docker run -it grass-py3-pdal:latest-alpine /bin/bash
@@ -29,8 +32,9 @@ bash-5.0#
 __To build a stable version__:
 
 change to the releasebranch or tag you want to build:
+
 ```bash
-$ git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_7_8
 ```
 
 and build and enter with:

--- a/docker/debian/README_debian.md
+++ b/docker/debian/README_debian.md
@@ -1,20 +1,22 @@
 # Docker GRASS GIS (Debian Linux)
 
-Dockerfile with an [Debian Linux](https://www.debian.org/) image with [GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and [grass-session](https://github.com/zarch/grass-session/).
+Dockerfile with an [Debian Linux](https://www.debian.org/) image with
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
+[grass-session](https://github.com/zarch/grass-session/).
 
 Download size of this image is of approximately 2.6 GB.
 
 Clone this repository and change directory:
 
 ```bash
-$ git clone https://github.com/OSGeo/grass.git
-$ cd grass
+git clone https://github.com/OSGeo/grass.git
+cd grass
 ```
 
 __Build the docker with__:
 
 ```bash
-$ docker build \
+docker build \
          --file docker/debian/Dockerfile_debian_pdal \
          --tag grass-py3-pdal:latest-debian .
 ```
@@ -29,8 +31,9 @@ bash-5.0#
 __To build a stable version__:
 
 change to the releasebranch or tag you want to build:
+
 ```bash
-$ git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_7_8
 ```
 
 and build and enter with:

--- a/docker/testdata/README.md
+++ b/docker/testdata/README.md
@@ -1,1 +1,1 @@
-Data source: https://github.com/PDAL/PDAL/tree/master/test/data/laz/
+Data source: <https://github.com/PDAL/PDAL/tree/master/test/data/laz/>

--- a/docker/ubuntu/README_ubuntu.md
+++ b/docker/ubuntu/README_ubuntu.md
@@ -1,14 +1,16 @@
 # Docker GRASS GIS (Ubuntu Linux)
 
-Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with [GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and [grass-session](https://github.com/zarch/grass-session/).
+Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
+[grass-session](https://github.com/zarch/grass-session/).
 
 Download size of this image is of approximately 2.6 GB.
 
 Clone this repository and change directory:
 
 ```bash
-$ git clone https://github.com/OSGeo/grass.git
-$ cd grass
+git clone https://github.com/OSGeo/grass.git
+cd grass
 ```
 
 ## Ubuntu stable
@@ -16,12 +18,13 @@ $ cd grass
 __Build the docker with__:
 
 ```bash
-$ docker build \
+docker build \
          --file docker/ubuntu/Dockerfile_ubuntu_pdal \
          --tag grass-py3-pdal:stable-ubuntu .
 ```
 
-View the images available using `sudo docker images` and open a bash terminal with:
+View the images available using `sudo docker images` and open a bash terminal
+with:
 
 ```bash
 $ docker run -it grass-py3-pdal:stable-ubuntu /bin/bash
@@ -31,8 +34,9 @@ bash-5.0#
 __To build a stable version__:
 
 change to the releasebranch or tag you want to build:
+
 ```bash
-$ git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_7_8
 ```
 
 and build and enter with:
@@ -46,7 +50,6 @@ $ docker run -it grass-py3-pdal:stable-ubuntu /bin/bash
 bash-5.0#
 ```
 
-
 ## Ubuntu latest
 
 __Build the docker with__:
@@ -57,7 +60,8 @@ $ docker build \
          --tag grass-py3-pdal:latest-ubuntu .
 ```
 
-View the images available using `sudo docker images` and open a bash terminal with:
+View the images available using `sudo docker images` and open a bash terminal
+with:
 
 ```bash
 $ docker run -it grass-py3-pdal:latest-ubuntu /bin/bash
@@ -67,8 +71,9 @@ bash-5.0#
 __To build a latest version__:
 
 change to the releasebranch or tag you want to build:
+
 ```bash
-$ git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_7_8
 ```
 
 and build and enter with:

--- a/mswindows/external/rbatch/batchfiles.md
+++ b/mswindows/external/rbatch/batchfiles.md
@@ -2,7 +2,8 @@
 
 G. Grothendieck
 
-Software and documentation is (c) 2013 GKX Associates Inc. and licensed under [GPL 2.0](http://www.gnu.org/licenses/gpl-2.0.html).
+Software and documentation is (c) 2013 GKX Associates Inc. and licensed
+under [GPL 2.0](http://www.gnu.org/licenses/gpl-2.0.html).
 
 ## Introduction ##
 
@@ -37,13 +38,13 @@ privileges).
 `clip2r.js` copies the current clipboard into a running R instance. It can be
 used with `vim` or other text editor.
 
-`find-miktex.hta` displays a popup window showing where it found MiKTeX. 
+`find-miktex.hta` displays a popup window showing where it found MiKTeX.
 
 ## R.bat ##
 
 ### Purpose ###
 
-The purpose of `R.bat` is to facilitiate the use of R from the Windows `cmd` 
+The purpose of `R.bat` is to facilitiate the use of R from the Windows `cmd`
 line by eliminating the need to make any system changes.  There is no need to
 modify the Windows path or to set any environment variables for standard
 configurations of R.  It will automatically locate R (and Rtools and
@@ -58,7 +59,7 @@ is stored only in the local process.
 such situations where there are minimal permissions.
 
 Like all the other utilities here, `R.bat` is a self contained no-install script
-with no dependencies so just place it anywhere on your Windows path or in the 
+with no dependencies so just place it anywhere on your Windows path or in the
 current directory.
 
 ### Typical Usage ###
@@ -67,23 +68,20 @@ Typical usage of `R.bat` to launch R gui is the following ^[
 If `R.exe` were on the Windows path and before `R.bat` then it would
 have to be written as follows: `R.bat gui`]:
 
-	R gui
-
+```
+R gui
+```
 
 This runs `Rgui.exe`.  If further arguments are specified they are passed on to
-`Rgui.exe`.  For example,
+`Rgui.exe`.  For example, `R gui --help`
 
-	R gui --help
-
-will run: 
-
-	Rgui.exe --help
+will run: `Rgui.exe --help`
 
 ### Subcommands ###
 
 If the first argument is optionally one of `cd`, `cmd`, `dir`, `gui`, `help`,
 `path`, `R`, `script`, `show`, `SetReg`, `tools`, `touch` or the same except
-for upper/lower case then that argument is referred to as the subcommand.  
+for upper/lower case then that argument is referred to as the subcommand.
 
 If no subcommand is provided then the default subcommand is derived from the
 name of the script.
@@ -98,24 +96,28 @@ remainder becomes the default subcommand.  For example, if `R.bat` were renamed
 Other executable files that come with R (`R.exe`, `Rcmd.exe`, `Rscript.exe`)
 can be run in a similar way:
 
-	R --help
-	R cmd --help
-	R script --help
+```
+R --help
+R cmd --help
+R script --help
+```
 
-(`RSetReg.exe` is another executable that comes with R for Windows. It will be 
+(`RSetReg.exe` is another executable that comes with R for Windows. It will be
 discussed later.)
 
 ### Support Subcommands ###
 
 There are also some support commands:
 
-	R cd
-	R dir
-	R ls
-	R help
-	R show
+```
+R cd
+R dir
+R ls
+R help
+R show
+```
 
-`R cd` changes directory to the `R_ROOT` directory (typically 
+`R cd` changes directory to the `R_ROOT` directory (typically
 `C:\Program Files\R`).
 
 `R dir` displays the contents of that directory in chronological order - oldest
@@ -123,23 +125,25 @@ first and most recent last.  `R ls` is the same as `R dir`.
 
 `R show` shows the values of the `R_` environment variables used by `R.bat` .
 Below is a list with typical values.  These values are determined by the script
-heuristically (or the user can set any before running `R.bat` or 
+heuristically (or the user can set any before running `R.bat` or
 `R.bat` itself can be customized by setting any of them near top of the script).
 
-	R_ARCH=x64
-	R_CMD=RShow
-	R_HOME=C:\Program Files\R\R-2.15.3
-	R_MIKTEX_PATH=\Program Files (x86)\MiKTeX 2.9\miktex\bin
-	R_PATH=C:\Program Files\R\R-2.15.3\bin\x64
-	R_REGISTRY=1
-	R_ROOT=C:\Program Files\R
-	R_TOOLS=C:\Rtools
-	R_TOOLS_PATH=C:\Rtools\bin;C:\Rtools\gcc-4.6.3\bin;
-	R_TOOLS_VERSION=3.0.0.1927
-	R_VER=R-2.15.3
+```
+R_ARCH=x64
+R_CMD=RShow
+R_HOME=C:\Program Files\R\R-2.15.3
+R_MIKTEX_PATH=\Program Files (x86)\MiKTeX 2.9\miktex\bin
+R_PATH=C:\Program Files\R\R-2.15.3\bin\x64
+R_REGISTRY=1
+R_ROOT=C:\Program Files\R
+R_TOOLS=C:\Rtools
+R_TOOLS_PATH=C:\Rtools\bin;C:\Rtools\gcc-4.6.3\bin;
+R_TOOLS_VERSION=3.0.0.1927
+R_VER=R-2.15.3
+```
 
 `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS_PATH` are the paths to the directories
-holding the `R`, `MiKTeX` and `Rtools` binaries (i.e. `.exe` files).  
+holding the `R`, `MiKTeX` and `Rtools` binaries (i.e. `.exe` files).
 
 `R_CMD` indicates the subcommand or if no subcommand specified then it is
 derived from the name of the script.  For example if the script were renamed
@@ -155,41 +159,46 @@ values for these variables.
 
 ### Path Setting Subcommands ###
 
-The command 
+The command
 
-	R path
+```
+R path
+```
 
 adds `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS` to the Windows path for the
 current `cmd` line session.  No other `cmd` line sessions are affected and
-there are no permanent changes to the system.  Once this is run 
+there are no permanent changes to the system.  Once this is run
 the R binaries will be on the path so they can be accessed directly without
 `R.bat` within the same Windows cmd line session.
 
 This mode of operation has the advantage that startup will be slightly faster
-since  `R.bat` will not have to run each time that `R` is started. ^[On a 
+since  `R.bat` will not have to run each time that `R` is started. ^[On a
 1.9 GHz Windows 8 machine `R.bat show` runs in 0.75 seconds.]
 
 Note that if both `R.bat` and `R.exe` exist on the Windows path then the first
 on the path will be called if one uses:
 
-	R ...arguments...
+```
+R ...arguments...
+```
 
-thus one may wish to enter `R.bat` or `R.exe` rather than just `R` for clarity. 
+thus one may wish to enter `R.bat` or `R.exe` rather than just `R` for clarity.
 
 Alternately, rename `R.bat` to `Rpath.bat` in which case the command `R path`
 becomes just `Rpath` and `R` becomes unambiguous.
 
-(An alternative to `R path` is the `Rpathset.bat` utility which will be 
+(An alternative to `R path` is the `Rpathset.bat` utility which will be
 described later.)
 
 The command
 
-	R tools
+```
+R tools
+```
 
 is similar to `R path` except only `R_TOOLS_PATH` and `R_MIKTEX_PATH` are
 added to the path (but not `R_PATH`).  This might be useful if you need to use
 those utilities without R.
-
 
 ### Selecting R Version ###
 
@@ -201,13 +210,17 @@ installation in `R_ROOT` which has the most recent date will be used.
 
 If we enter this at the `cmd` line:
 
-	set R_VER=R-2.14.0
+```
+set R_VER=R-2.14.0
+```
 
 then for the remainder of this `cmd` line session that version will be used.
 If one wishes to use two different R versions at once we could spawn a new `cmd`
 line session:
 
-	start
+```
+start
+```
 
 and then enter the same set command into the new window.  Now any use of R in
 the original window will use the default version whereas in the new `cmd` line
@@ -216,9 +229,11 @@ window it will use the specified version.
 One can change the registry entry permanently to refer to a particlar version
 like this:
 
-	cmd /c set R_VER=R-2.14.0 ^& R SetReg
+```
+cmd /c set R_VER=R-2.14.0 ^& R SetReg
+```
 
-This requires Administrator privileges. If not already running as 
+This requires Administrator privileges. If not already running as
 Administrator a window will pop up requesting permission to proceed.
 
 If the registry is empty or `R_REGISTRY=0` then the default version is not
@@ -227,12 +242,14 @@ determined by which R install directory is the most recent.  To make a
 particular R install directory the most recent run the following in a `cmd`
 line session with Administrator privileges:
 
-	R dir
-	el cmd /c set R_VER=R-2.14.0 ^& R touch
+```
+R dir
+el cmd /c set R_VER=R-2.14.0 ^& R touch
+```
 
-The value of `R_VER` in the above line must be one of the directories listed 
-by `R dir`.  The `el.js` command used in the above code comes with these batch 
-files and provides one way to elevate commands to have Administrator 
+The value of `R_VER` in the above line must be one of the directories listed
+by `R dir`.  The `el.js` command used in the above code comes with these batch
+files and provides one way to elevate commands to have Administrator
 privileges.
 
 Note that `R SetReg` and `R touch` make permanent changes to the system
@@ -245,24 +262,24 @@ permanent changes.
 1. If `.\Rgui.exe` exists use implied `R_PATH` and skip remaining points.
 
 2. If `.\{x64,i386}\Rgui.exe` or `.\bin\{x64,i386}\Rgui.exe` exists use implied
-`R_HOME`.
+   `R_HOME`.
 
 3. If `R_HOME` defined then derive any of `R_ROOT` and `R_VER` that are not
-already defined.
+   already defined.
 
-4. If `R_PATH` defined then derive any of `R_ROOT`, `R_HOME`, `R_VER` and 
-`R_ARCH` that are not already defined.
+4. If `R_PATH` defined then derive any of `R_ROOT`, `R_HOME`, `R_VER` and
+   `R_ARCH` that are not already defined.
 
-5. If `R_REGISTRY=1` and R found in registry derive any of `R_HOME`, `R_ROOT` 
-and `R_VER` that are not already defined.
+5. If `R_REGISTRY=1` and R found in registry derive any of `R_HOME`, `R_ROOT`
+   and `R_VER` that are not already defined.
 
 6. If R_ROOT not defined try `%ProgramFiles%\R\*`, `%ProgramFiles(x86)%\R\*`
-    and then `%SystemRoot%\R` else error.
+   and then `%SystemRoot%\R` else error.
 
 7. If `R_VER` not defined use last directory in `cd %R_ROOT% & dir /od`.
 
 8. if `R_ARCH` not defined try `%R_ROOT%\%R_VER%\bin\x64\Rgui.exe` and then
-    `%R_ROOT%\%R_VER%\bin\i386\Rgui.exe`
+   `%R_ROOT%\%R_VER%\bin\i386\Rgui.exe`
 
 9. If `R_ROOT`, `R_VER` and `R_ARCH` defined skip remaining points.
 
@@ -270,19 +287,17 @@ and `R_VER` that are not already defined.
 
 ## #Rscript.bat ##
 
-This is not a separate batch file but is yet another way to call `R.bat`.  
-Its purpose is to turn an R script into a Windows batch file.  
+This is not a separate batch file but is yet another way to call `R.bat`.
+Its purpose is to turn an R script into a Windows batch file.
 
-1.  Copy `R.bat` to a file with the name `#Rscript.bat` like this 
-(from the Windows cmd line):
-
-	copy R.bat #Rscript.bat
+1. Copy `R.bat` to a file with the name `#Rscript.bat` like this
+   (from the Windows cmd line): `copy R.bat #Rscript.bat`
 
 2. Ensure that `#Rscript.bat` is on your windows path.  Then we can turn an
-R script into a `.bat` file by 
-(a) giving the R script a `.bat` extension and 
-(b) putting this line as the 
-first line in the script: `#Rscript %0 %*`
+   R script into a `.bat` file by
+   (a) giving the R script a `.bat` extension and
+   (b) putting this line as the
+   first line in the script: `#Rscript %0 %*`
 
 This makes the script both a Windows batch file and an R script at the same
 time. When run as a batch file it will invoke `#Rscript.bat` which in turn
@@ -292,12 +307,16 @@ be ignored since it would be regarded as a comment by R.)
 
 For example, if we have a file `test.bat` with the following two lines:
 
-	#Rscript %0 %*
-	print(pi)
+```
+#Rscript %0 %*
+print(pi)
+```
 
 then we can invoke it from the Windows cmd line like this:
 
-	test
+```
+test
+```
 
 ## #Rscript2.bat ##
 
@@ -311,25 +330,29 @@ simple to fix since the script itself is simple.
 If you have a 64 bit system then the only part that needs to be changed is
 changing the definition of R_HOME to point to your version of R.  If you
 have a 32 bit system then you will also have to modify the definition of
-R_ARCH on the appropriate line.  
+R_ARCH on the appropriate line.
 
 There is more information on this in the comments at the top of the script.
 
 ## Rpathset.bat ##
 
-The command 
+The command
 
-	Rpathset
+```
+Rpathset
+```
 
 adds `R_PATH`, `R_MIKTEX_PATH` and `R_TOOLS` to the Windows path for the
 current `cmd` line session.  No other `cmd` line sessions are affected and
-there are no permanent changes to the system.  Once this is run 
+there are no permanent changes to the system.  Once this is run
 the R binaries will be on the path so they can be accessed directly without
-`R.bat` .   
+`R.bat`.
 
-`Rpathset` is an alternative to 
+`Rpathset` is an alternative to
 
-	R path 
+```
+R path
+```
 
 but unlike `R.bat`, `Rpathset.bat` does not have any automatic heuristics.
 Instead, it requires that the user manually set the relevant variables in its
@@ -337,19 +360,21 @@ source.  Running `Rpathset.bat` then sets the path accordingly and from then on
 in the session one can access `Rgui.exe`, etc. on the path.  Although
 `Rpathset.bat` involves manual editing it does have the advantage that as a
 consequence it is very simple -- not much more than a collection of Windows
-batch set commands. This makes it easy to customize, less fragile to 
+batch set commands. This makes it easy to customize, less fragile to
 changes in the install procedures of `R` itself and is also more liklely to
 work on untested Windows configurations.
 
 `Rpathset.bat` might be used like this:
 
-	Rpathset
-	Rgui
+```
+Rpathset
+Rgui
+```
 
 where `Rgui` is now directly accessing `Rgui.exe` as `Rpathset.bat` has added
 `R_PATH` to the Windows path.
 
-The set statements are documented in the source of the `Rpathset.bat` file 
+The set statements are documented in the source of the `Rpathset.bat` file
 itself.
 
 ## movedir.bat and copydir.bat ##
@@ -359,27 +384,30 @@ another.  If used to transfer packages from one version of R to another it is
 recommended that the user run `upgrade.packages()` in the target.  For example,
 assuming the default location for the user libraries:
 
-	cd %userprofile%\Documents\win-library
-	copydir 2.15\library 3.0\library
+```
+cd %userprofile%\Documents\win-library
+copydir 2.15\library 3.0\library
 
-	R.bat gui 
-	... now enter update.packages(checkBuilt=TRUE) into R...
+R.bat gui
+... now enter update.packages(checkBuilt=TRUE) into R...
+```
 
 (The `checkBuilt=TRUE` argument forces a rebuild and is normally not required
 when upgrading to another version that differs only in the minor version
 number, e.g. from 2.15.2 to 2.15.3.)
 
-`movedir.bat` and `copydir.bat` will not overwrite any existing package in the 
-target library so they are particularly safe to use.  (If you do wish to 
+`movedir.bat` and `copydir.bat` will not overwrite any existing package in the
+target library so they are particularly safe to use.  (If you do wish to
 overwrite such packages delete them from the target first using the Windows
 `del` command.)
-
 
 ## el.js ##
 
 `el.js` runs its arguments elevated (i.e. with Administrator privileges).  For example,
 
-	el R touch
+```
+el R touch
+```
 
 The user will be prompted to allow elevation to proceed.
 
@@ -392,7 +420,7 @@ with `vim` or other editor.  See the source for additional instructions.
 
 This program displays a window showing where MiKTeX was found. It uses the
 MiKTeX API. This API is not used by `R.bat` .  Instead `R.bat` just looks in
-common places.  (Using this API may be incorporated into the `R.bat` heuristic 
+common places.  (Using this API may be incorporated into the `R.bat` heuristic
 in the future.)
 
 ## make-batchfiles-pdf.bat ##
@@ -402,5 +430,6 @@ This batch file creates a pdf of this documentation from the markdown file
 found [here](https://code.google.com/p/pandoc/downloads/list).  It is run
 without arguments:
 
-	make-batchfiles-pdf
-
+```
+make-batchfiles-pdf
+```

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -1,38 +1,40 @@
 # Singularity GRASS GIS (Debian Linux)
 
-Singularityfile with an [Debian Linux](https://www.debian.org/) image with [GRASS GIS](https://grass.osgeo.org/),
-[PDAL](https://pdal.io) support and [grass-session](https://github.com/zarch/grass-session/).
+Singularityfile with an [Debian Linux](https://www.debian.org/) image with
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
+[grass-session](https://github.com/zarch/grass-session/).
 
 Download size of this image is of approximately 560 MB.
 
 Clone this repository and change directory:
 
 ```bash
-$ git clone https://github.com/OSGeo/grass.git
-$ cd grass
+git clone https://github.com/OSGeo/grass.git
+cd grass
 ```
 
 __Build the singularity with__:
 
 ```bash
-$ sudo singularity build grass_master.simg singularity/debian/singularity_debian
+sudo singularity build grass_master.simg singularity/debian/singularity_debian
 ```
 
 The image can be used as:
 
 ```bash
-$ singularity exec containers/grass_7.8.simg grass --version
+singularity exec containers/grass_7.8.simg grass --version
 ```
 
 __To build a stable version__:
 
 change to the releasebranch or tag you want to build:
+
 ```bash
-$ git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_7_8
 ```
 
 and build and enter with:
 
 ```bash
-$ sudo singularity build grass_7_8.simg singularity/debian/singularity_debian
+sudo singularity build grass_7_8.simg singularity/debian/singularity_debian
 ```


### PR DESCRIPTION
* line length 80 characters
* standardize the number of spaces after list markers (=1)
* standardize code blocks (do not mix triple grave accents with hard tabs)(accents chosen)
* headers surrounded by blank lines
* fenced code blocks surrounded by blank lines
* lists surrounded by blank lines
* avoid trailing punctuation in headers
* avoid trailing spaces
* avoid multiple consecutive blank lines
* avoid dollar signs in code blocks when not needed
* avoid bare links (use `<url>` instead)