### PR TITLE
Fix macOS gui bug for v.proj and r.proj on, addresses #3502

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -1712,7 +1712,9 @@ class CmdPanel(wx.Panel):
                             win = gselect.LocationSelect(parent=which_panel,
                                                          value=value)
                             win.Bind(wx.EVT_TEXT, self.OnUpdateSelection)
+                            win.Bind(wx.EVT_COMBOBOX, self.OnUpdateSelection)
                             win.Bind(wx.EVT_TEXT, self.OnSetValue)
+                            win.Bind(wx.EVT_COMBOBOX, self.OnSetValue)
 
                         elif prompt == 'mapset':
                             if p.get('age', 'old') == 'old':
@@ -1724,7 +1726,9 @@ class CmdPanel(wx.Panel):
                                 parent=which_panel, value=value, new=new,
                                 multiple=p.get('multiple', False))
                             win.Bind(wx.EVT_TEXT, self.OnUpdateSelection)
+                            win.Bind(wx.EVT_COMBOBOX, self.OnUpdateSelection)
                             win.Bind(wx.EVT_TEXT, self.OnSetValue)
+                            win.Bind(wx.EVT_COMBOBOX, self.OnSetValue)
 
                         elif prompt == 'dbase':
                             win = gselect.DbaseSelect(


### PR DESCRIPTION
This addresses issue [#3502](https://trac.osgeo.org/grass/ticket/3502), an old and irritating bug for v.proj and r.proj gui forms on macOS. This is needed because of inconsistencies between platforms with wxpython/wxwidgets event handling for ComboBox.

This "double" event handling (e.g. EVT_COMBOBOX and EVT_TEXT) is nessesary in order to retain field editing (as requested in [#2993](https://trac.osgeo.org/grass/ticket/2993)) as well having a working popup menu selection on __all__ platforms.

This has been tested for mac and win, I see no reason it wouldn't work for linux.

Would be good to backport this fix to 7.8 and perhaps 7.6.

NOTE: credit for this fix to balagates, the reporter of this issue.

Update:
[#3471](https://trac.osgeo.org/grass/ticket/3471) will probably also be solved by this.