### PR TITLE
Fix alpine docker by removing Python3 patch and PDAL

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -31,7 +31,7 @@ ENV PACKAGES="\
       ncurses \
       openjpeg \
       openblas \
-      pdal \
+      #pdal \
       py3-numpy \
       py3-pillow \
       py3-six \
@@ -84,7 +84,7 @@ ENV GRASS_CONFIG="\
       --with-cxx \
       --with-proj --with-proj-share=/usr/share/proj \
       --with-gdal \
-      --with-pdal \
+      #--with-pdal \
       --with-python \
       --with-geos \
       --with-sqlite \
@@ -132,7 +132,7 @@ ENV GRASS_BUILD_PACKAGES="\
       make \
       openjpeg-dev \
       openblas-dev \
-      pdal-dev \
+      #pdal-dev \
       postgresql-dev \
       proj-dev \
       python3-dev \
@@ -159,11 +159,6 @@ RUN echo "Install main packages";\
 # Copy and install GRASS GIS
 COPY . /src/grass_build/
 WORKDIR /src/grass_build/
-
-# Python 3.8.1 patch
-RUN apk add curl
-RUN curl -L https://github.com/mmacata/alpine-python381-patch/releases/download/0.0.0/python3-dev-3.8.1-r1.apk > /src/python3-dev-3.8.1-r1.apk
-RUN apk add --allow-untrusted /src/python3-dev-3.8.1-r1.apk
 
 # Configure compile and install GRASS GIS
 RUN echo "  => Configure and compile grass" && \
@@ -197,7 +192,7 @@ RUN pip3 install --upgrade pip six grass-session
 RUN ln -s /usr/local/grass /usr/local/grass7
 RUN ln -s /usr/local/grass `grass --config path`
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
-    pdal --version && \
+    # pdal --version && \
     python3 --version
 
 # Python 3.8.1 patch again
@@ -231,7 +226,7 @@ ENV GRASSBIN="/usr/local/bin/grass" \
 
 # show installed version
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
-    pdal --version && \
+    #pdal --version && \
     python3 --version
 
 # Data workdir


### PR DESCRIPTION
- Python 3.8.1-rc1 patch removed as Alpine switched to 3.8.1-r3
- PDAL commented out because of PDAL package has been removed from alpine:edge