### PR TITLE
v.patch: Fix line categories when building topology

### DIFF
--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -480,8 +480,7 @@ int main(int argc, char *argv[])
     Vect_set_person(&OutMap, G_whoami());
 
     if (!no_topo->answer) {
-	if (append->answer)
-	    Vect_build_partial(&OutMap, GV_BUILD_NONE);
+	Vect_build_partial(&OutMap, GV_BUILD_BASE);
 
 	if (Vect_get_num_primitives(&OutMap, GV_BOUNDARY) > 0) {
 	    int nmodif;
@@ -489,8 +488,6 @@ int main(int argc, char *argv[])
 	    double xmax, ymax, min_snap, max_snap;
 	    int exp;
 	    char *separator = "-----------------------------------------------------";
-
-	    Vect_build_partial(&OutMap, GV_BUILD_BASE);
 
 	    Vect_get_map_box(&OutMap, &box);
 
@@ -582,8 +579,9 @@ int main(int argc, char *argv[])
 
 	    /* Boundaries are hopefully clean, build areas */
 	    G_message("%s", separator);
-	    Vect_build_partial(&OutMap, GV_BUILD_NONE);
 	}
+
+	Vect_build_partial(&OutMap, GV_BUILD_NONE);
 	Vect_build(&OutMap);
     }
     Vect_close(&OutMap);

--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -483,14 +483,14 @@ int main(int argc, char *argv[])
 	if (append->answer)
 	    Vect_build_partial(&OutMap, GV_BUILD_NONE);
 
-	Vect_build_partial(&OutMap, GV_BUILD_BASE);
-
 	if (Vect_get_num_primitives(&OutMap, GV_BOUNDARY) > 0) {
 	    int nmodif;
 	    struct bound_box box;
 	    double xmax, ymax, min_snap, max_snap;
 	    int exp;
 	    char *separator = "-----------------------------------------------------";
+
+	    Vect_build_partial(&OutMap, GV_BUILD_BASE);
 
 	    Vect_get_map_box(&OutMap, &box);
 


### PR DESCRIPTION
### Issue

Patching line vectors does not add categories to lines when building topology.

### How to reproduce

In nc_spm_08_grass7,
```bash
v.to.db -p map=railroads option=length # print lengths
v.edit --o map=tmp tool=create # create a tmp vector
v.patch --o -a input=railroads output=tmp # patch railroads into tmp
v.to.db -p map=tmp option=length # does NOT print lengths

v.patch --o input=railroads output=tmp # even not appending causes the same issue
v.to.db -p map=tmp option=length # does NOT print lengths
```

### Why?

Currently, `Vect_build_nat()`, which is invoked by `Vect_build_partial()`, adds categories to lines ONLY if it's called with `GV_BUILD_ALL` when the map's built level is `GV_BUILD_NONE` (lines 107-114 in `lib/vector/Vlib/build_nat.c`).
```c
63     if (plus->built < GV_BUILD_BASE) {
...
106             /* Add all categories to category index */
107             if (build == GV_BUILD_ALL) {
108                 for (c = 0; c < Cats->n_cats; c++) {
109                     dig_cidx_add_cat(plus, Cats->field[c], Cats->cat[c],
110                                      line, type);
111                 }
112                 if (Cats->n_cats == 0)  /* add field 0, cat 0 */
113                     dig_cidx_add_cat(plus, 0, 0, line, type);
114             }
...
122     }
```

For example,
```c
/* sets plus->built = GV_BUILD_NONE */
Vect_build_partial(&OutMap, GV_BUILD_NONE);

/* lines 107-114 in build_nat.c are skipped because
 * plus->built = GV_BUILD_NONE < GV_BUILD_BASE
 * (lines 107-114 are inside this if block) */
Vect_build_partial(&OutMap, GV_BUILD_BASE);

/* now, plus->built is already GV_BUILD_BASE,
 * so categories are never added to lines,
 * but they are added to areas */
Vect_build(&OutMap);
```

`Vect_build_partial(&OutMap, GV_BUILD_BASE);` was introduced by [r74206](https://lists.osgeo.org/pipermail/grass-commit/2019-March/045081.html).

### Solution

I'm not sure if `Vect_build_nat()` behaves this way by design, so I decided to fix `v.patch` instead. When there are lines, we don't want to call `Vect_build_partial()` with any other levels between `Vect_build_partial(, GV_BUILD_NONE)` and `Vect_build()`.