### PR TITLE
ctypes: Fix ctypesgencore for Python 3

### DIFF
--- a/lib/python/ctypes/ctypesgencore/parser/yacc.py
+++ b/lib/python/ctypes/ctypesgencore/parser/yacc.py
@@ -2276,7 +2276,7 @@ def yacc(
             raise YaccError("no rules of the form p_rulename are defined.")
 
         # Sort the symbols by line number
-        symbols.sort(lambda x, y: cmp(get_func_code(x).co_firstlineno, get_func_code(y).co_firstlineno))
+        symbols.sort(key=lambda x: get_func_code(x).co_firstlineno)
 
         # Add all of the symbols to the grammar
         for f in symbols:
@@ -2288,7 +2288,7 @@ def yacc(
         # Make a signature of the docstrings
         for f in symbols:
             if f.__doc__:
-                Signature.update(f.__doc__)
+                Signature.update(f.__doc__.encode("utf-8"))
 
         lr_init_vars()
 


### PR DESCRIPTION
Python 3 sort says 'must use keyword argument for key function'
(Python 2 accepts this new syntax).

The parameter of Signature.update() is used as a hash, so any encoding will do,
but using UTF-8 always for consistency.