### PR TITLE
Enable Ctypesgen parsing of non-utf8 files on macOS, fixes trac #3883

### DIFF
--- a/lib/python/ctypes/ctypesgencore/parser/preprocessor.py
+++ b/lib/python/ctypes/ctypesgencore/parser/preprocessor.py
@@ -169,8 +169,25 @@ class PreprocessorParser(object):
                               shell=True,
                               universal_newlines=True,
                               stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
-        ppout, pperr = pp.communicate()
+                              stderr=subprocess.PIPE)        
+        try:
+            ppout, pperr = pp.communicate()
+        except UnicodeError:
+            # Fix for https://trac.osgeo.org/grass/ticket/3883,
+            # handling file(s) encoded with mac_roman
+            if sys.platform == 'darwin':
+                pp = subprocess.Popen(cmd,
+                                      shell=True,
+                                      universal_newlines=False, #read as binary
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE)
+                ppout, pperr = pp.communicate()
+
+                data = ppout.decode('utf8', errors='replace')
+                ppout = data.replace('\r\n', '\n').replace('\r', '\n')
+                pperr = pperr.decode('utf8', errors='replace')
+            else:
+                raise UnicodeError
 
         for line in pperr.split("\n"):
             if line:


### PR DESCRIPTION
This PR addresses the issue [trac#3883](https://trac.osgeo.org/grass/ticket/3883), where system file(s) with mac_roman encoding (in particular containing a bullet character, `0xa5`) causing UnicodeDecodeError and compilation failure on macOS.

This needs to be tested on Windows and Linux.