### PR TITLE
v.import: fix gfs file for GDAL version smaller 2.4.1 by GML import

### DIFF
--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -102,6 +102,7 @@ import os
 import atexit
 import xml.etree.ElementTree as ET # only needed for GDAL version < 2.4.1
 import re # only needed for GDAL version < 2.4.1
+from osgeo import gdal
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError
@@ -130,22 +131,8 @@ def gdal_version():
     return version
 
 
-def version_less_than(actual_version, comparison_version):
-    """Checks actual version if it is less than given comparison version
-
-    :param actual_version: version number to check if it is less than the
-                           comparison version
-    :type actual_version: str
-    :param comparison_version: version number to check if the actual version
-                           is less
-    :type comparison_version: str
-    """
-    comparison_version_tuple = tuple([int(x) for x in comparison_version.split('.')])
-    actual_version_tuple = tuple([int(x) for x in actual_version.split('.')])
-    if actual_version_tuple < comparison_version_tuple:
-        return True
-    else:
-        return False
+def GDAL_COMPUTE_VERSION(maj, min, rev):
+    return ((maj) * 1000000 + (min) * 10000 + (rev) * 100)
 
 
 def fix_gfsfile(input):
@@ -260,7 +247,7 @@ def main():
     # create temp location from input without import
     grass.verbose(_("Creating temporary location for <%s>...") % OGRdatasource)
     try:
-        if version_less_than(gdal_version(), "2.4.1"):
+        if int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 4, 1):
             if OGRdatasource.lower().endswith("gml"):
                 fix_gfsfile(OGRdatasource)
         grass.run_command('v.in.ogr', input=OGRdatasource,
@@ -309,7 +296,7 @@ def main():
     # import into temp location
     grass.message(_("Importing <%s> ...") % OGRdatasource)
     try:
-        if version_less_than(gdal_version(), "2.4.1"):
+        if int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 4, 1):
             if OGRdatasource.lower().endswith("gml"):
                 fix_gfsfile(OGRdatasource)
         grass.run_command('v.in.ogr', input=OGRdatasource,

--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -102,7 +102,10 @@ import os
 import atexit
 import xml.etree.ElementTree as ET # only needed for GDAL version < 2.4.1
 import re # only needed for GDAL version < 2.4.1
-from osgeo import gdal
+try:
+    from osgeo import gdal
+except:
+    grass.fatal(_("Unable to load GDAL Python bindings (requires package 'python-gdal' being installed)"))
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -106,11 +106,6 @@ import re # only needed for GDAL version < 2.4.1
 import grass.script as grass
 from grass.exceptions import CalledModuleError
 
-try:
-    from osgeo import gdal
-except:
-    grass.fatal(_("Unable to load GDAL Python bindings (requires package 'python-gdal' being installed)"))
-
 # initialize global vars
 TMPLOC = None
 SRCGISRC = None
@@ -251,8 +246,12 @@ def main():
     # create temp location from input without import
     grass.verbose(_("Creating temporary location for <%s>...") % OGRdatasource)
     try:
-        if int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 4, 1):
-            if OGRdatasource.lower().endswith("gml"):
+        if OGRdatasource.lower().endswith("gml"):
+            try:
+                from osgeo import gdal
+            except:
+                grass.fatal(_("Unable to load GDAL Python bindings (requires package 'python-gdal' being installed)"))
+            if int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 4, 1):
                 fix_gfsfile(OGRdatasource)
         grass.run_command('v.in.ogr', input=OGRdatasource,
                           location=TMPLOC, flags='i',
@@ -300,8 +299,12 @@ def main():
     # import into temp location
     grass.message(_("Importing <%s> ...") % OGRdatasource)
     try:
-        if int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 4, 1):
-            if OGRdatasource.lower().endswith("gml"):
+        if OGRdatasource.lower().endswith("gml"):
+            try:
+                from osgeo import gdal
+            except:
+                grass.fatal(_("Unable to load GDAL Python bindings (requires package 'python-gdal' being installed)"))
+            if int(gdal.VersionInfo('VERSION_NUM')) < GDAL_COMPUTE_VERSION(2, 4, 1):
                 fix_gfsfile(OGRdatasource)
         grass.run_command('v.in.ogr', input=OGRdatasource,
                           flags=vflags, overwrite=overwrite, **vopts)

--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -102,13 +102,14 @@ import os
 import atexit
 import xml.etree.ElementTree as ET # only needed for GDAL version < 2.4.1
 import re # only needed for GDAL version < 2.4.1
+
+import grass.script as grass
+from grass.exceptions import CalledModuleError
+
 try:
     from osgeo import gdal
 except:
     grass.fatal(_("Unable to load GDAL Python bindings (requires package 'python-gdal' being installed)"))
-
-import grass.script as grass
-from grass.exceptions import CalledModuleError
 
 # initialize global vars
 TMPLOC = None


### PR DESCRIPTION
https://github.com/OSGeo/grass/issues/382 GML import with GDAL version smaller 2.4.1 is broken when gfs file without SRSName.
Fixing by taking the SRSName from the gml file and adding it to the gfs file.