### PR TITLE
os.newline should not be used when writing in text mode

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -1029,6 +1029,7 @@ class Settings:
                 return
 
         try:
+            newline = '\n'
             file = open(self.filePath, "w")
             for group in list(settings.keys()):
                 for key in list(settings[group].keys()):
@@ -1040,7 +1041,7 @@ class Settings:
                             if idx > 0:
                                 file.write(
                                     '%s%s%s%s%s' %
-                                    (os.linesep, group, self.sep, key, self.sep))
+                                    (newline, group, self.sep, key, self.sep))
                             file.write('%s%s' % (subkeys[idx], self.sep))
                             kvalues = list(settings[group][key][subkeys[idx]].keys())
                             srange = range(len(kvalues))
@@ -1059,7 +1060,7 @@ class Settings:
                                     dict):
                                 file.write(
                                     '%s%s%s%s%s' %
-                                    (os.linesep, group, self.sep, key, self.sep))
+                                    (newline, group, self.sep, key, self.sep))
                             value = self._parseValue(
                                 settings[group][key][subkeys[idx]])
                             file.write(
@@ -1069,7 +1070,7 @@ class Settings:
                                     settings[group][key][subkeys[idx + 1]],
                                     dict):
                                 file.write('%s' % self.sep)
-                    file.write(os.linesep)
+                    file.write(newline)
         except IOError as e:
             raise GException(e)
         except Exception as e:

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -983,7 +983,7 @@ class DbMgrNotebookBase(FN.FlatNotebook):
             with open(sqlFilePath, 'w', encoding=enc) as sqlFile:
                 for sql in listOfSQLStatements:
                     sqlFile.write(sql + ';')
-                    sqlFile.write(os.linesep)
+                    sqlFile.write('\n')
 
             driver = self.dbMgrData['mapDBInfo'].layers[
                 self.selLayer]["driver"]
@@ -3881,11 +3881,11 @@ class FieldStatistics(wx.Frame):
             if fn == 'null':
                 sqlFile.write(
                     'select count(*) from %s where %s is null;%s' %
-                    (table, column, os.linesep))
+                    (table, column, '\n'))
             else:
                 sqlFile.write(
                     'select %s(%s) from %s;%s' %
-                    (fn, column, table, os.linesep))
+                    (fn, column, table, '\n'))
         sqlFile.close()
 
         dataStr = RunCommand('db.select',

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -490,9 +490,9 @@ class GConsoleWindow(wx.SplitterWindow):
         try:
             with open(self.cmdFileProtocol, "a") as output:
                 cmds = self.cmdPrompt.GetCommands()
-                output.write(os.linesep.join(cmds))
+                output.write('\n'.join(cmds))
                 if len(cmds) > 0:
-                    output.write(os.linesep)
+                    output.write('\n')
         except IOError as e:
             GError(_("Unable to write file '{filePath}'.\n\nDetails: {error}").format(
                 filePath=self.cmdFileProtocol, error=e))

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -1270,7 +1270,7 @@ class History:
                     removedHistStep = removedHistData[line] = {}
                     continue
                 else:
-                    newHist.write('%s%s%s' % (os.linesep, line, os.linesep))
+                    newHist.write('%s%s%s' % ('\n', line, '\n'))
                     self.histStepsNum = newHistStepsNum
             else:
                 if newHistStepsNum >= self.maxHistSteps:
@@ -1282,7 +1282,7 @@ class History:
 
     def _saveNewHistStep(self, newHist):
         """Save buffer (new step) data into file"""
-        newHist.write('%s%s%s' % (os.linesep, "history step=0", os.linesep))
+        newHist.write('%s%s%s' % ('\n', "history step=0", '\n'))
         for key in list(self.newHistStepData.keys()):
             subkeys = list(self.newHistStepData[key].keys())
             newHist.write('%s%s' % (key, self.sep))
@@ -1290,7 +1290,7 @@ class History:
                 value = self.newHistStepData[key][subkeys[idx]]
                 if isinstance(value, dict):
                     if idx > 0:
-                        newHist.write('%s%s%s' % (os.linesep, key, self.sep))
+                        newHist.write('%s%s%s' % ('\n', key, self.sep))
                     newHist.write('%s%s' % (subkeys[idx], self.sep))
                     kvalues = list(self.newHistStepData[key][subkeys[idx]].keys())
                     srange = range(len(kvalues))
@@ -1308,7 +1308,7 @@ class History:
                     if idx > 0 and isinstance(
                             self.newHistStepData[key][subkeys[idx - 1]],
                             dict):
-                        newHist.write('%s%s%s' % (os.linesep, key, self.sep))
+                        newHist.write('%s%s%s' % ('\n', key, self.sep))
                     value = self._parseValue(
                         self.newHistStepData[key][subkeys[idx]])
                     newHist.write('%s%s%s' % (subkeys[idx], self.sep, value))
@@ -1316,7 +1316,7 @@ class History:
                             self.newHistStepData[key][subkeys[idx + 1]],
                             dict):
                         newHist.write('%s' % self.sep)
-            newHist.write(os.linesep)
+            newHist.write('\n')
         self.histStepsNum = 0
 
     def _parseValue(self, value, read=False):


### PR DESCRIPTION
Causes double newlines on Windows:
https://docs.python.org/3/library/os.html#os.linesep