### PR TITLE
Fix copy-to-clipboard key binding for console (trac#3008)

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -250,6 +250,13 @@ class GMFrame(wx.Frame):
 
         show_menu_errors(menu_errors)
 
+        # Enable copying to clipboard with cmd+c from console and python shell on macOS
+        # (default key binding will clear the console), trac #3008
+        if sys.platform == "darwin":
+            self.Bind(wx.EVT_MENU, self.OnCopyToClipboard, id=wx.ID_COPY)
+            self.accel_tbl = wx.AcceleratorTable([(wx.ACCEL_CTRL, ord("C"), wx.ID_COPY)])
+            self.SetAcceleratorTable(self.accel_tbl)
+
         # start with layer manager on top
         if self.currentPage:
             self.GetMapDisplay().Raise()
@@ -692,6 +699,13 @@ class GMFrame(wx.Frame):
         self.currentPage = None
 
         event.Skip()
+
+    def OnCopyToClipboard(self, event):
+        """Copy selected text in shell to the clipboard"""
+        try:
+            wx.Window.FindFocus().Copy()
+        except:
+            pass
 
     def _switchPageHandler(self, event, notification):
         self._switchPage(notification=notification)

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -21,6 +21,7 @@ This program is free software under the GNU General Public License
 """
 
 import os
+import sys
 
 import wx
 from core import globalvar
@@ -136,6 +137,13 @@ class ImportDialog(wx.Dialog):
                               name='source')
 
         self.createSettingsPage()
+
+        # Enable copying to clipboard with cmd+c from dialog on macOS
+        # (default key binding will close the dialog), trac #3592
+        if sys.platform == "darwin":
+            self.Bind(wx.EVT_MENU, self.OnCopyToClipboard, id=wx.ID_COPY)
+            self.accel_tbl = wx.AcceleratorTable([(wx.ACCEL_CTRL, ord("C"), wx.ID_COPY)])
+            self.SetAcceleratorTable(self.accel_tbl)
 
     def createSettingsPage(self):
 
@@ -309,6 +317,13 @@ class ImportDialog(wx.Dialog):
     def OnCmdDone(self, event):
         """Do what has to be done after importing"""
         pass
+
+    def OnCopyToClipboard(self, event):
+        """Copy selected text in dialog to the clipboard"""
+        try:
+            wx.Window.FindFocus().Copy()
+        except:
+            pass
 
     def _getLayersToReprojetion(self, projMatch_idx, grassName_idx):
         """If there are layers with different projection from loation projection,


### PR DESCRIPTION
This PR addresses the [trac#3008](https://trac.osgeo.org/grass/ticket/3008) issue, where cmd+c  on macOS presently clear the output console instead of the (on macOS) expected outcome: copy-to-clipboard of selected text.

Tested on Windows and Mac.

Update: this also addresses [trac#3592](https://trac.osgeo.org/grass/ticket/3592).