### PR TITLE
[g.gui.image2target] Fix wxPython Phoenix support

### DIFF
--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -45,9 +45,11 @@ import wx.lib.colourselect as csel
 
 from core import globalvar
 if globalvar.wxPythonPhoenix:
-    from wx.adv import Wizard as wiz
+    from wx import adv as wiz
+    from wx.adv import Wizard
 else:
-    import wx.wizard as wiz
+    from wx import wizard as wiz
+    from wx.wizard import Wizard
 
 import grass.script as grass
 

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -36,15 +36,9 @@ import wx
 from wx.lib.mixins.listctrl import CheckListCtrlMixin, ColumnSorterMixin, ListCtrlAutoWidthMixin
 import wx.lib.colourselect as csel
 
-from core import globalvar
-if globalvar.wxPythonPhoenix:
-    from wx.adv import Wizard as wiz
-else:
-    import wx.wizard as wiz
-
 import grass.script as grass
 
-from core import utils
+from core import utils, globalvar
 from core.render import Map
 from gui_core.gselect import Select, LocationSelect, MapsetSelect
 from gui_core.dialogs import GroupDialog


### PR DESCRIPTION
This fix addresses failure on opening `g.gui.image2target` with wxPython Phoenix.

Result with Python 3.8.2 / wxPython 4.0.7.post2:

```
g.gui.image2target                                                              
Traceback (most recent call last):
  File "/Applications/GRASS-7.9.app/Contents/MacOS/scripts/g.gui.image2target", line 181, in <module>
    main()
  File "/Applications/GRASS-7.9.app/Contents/MacOS/scripts/g.gui.image2target", line 177, in main
    wizard = GCPWizard(parent=None, giface=StandaloneGrassInterface())
  File "/Applications/GRASS-7.9.app/Contents/MacOS/gui/wxpython/image2target/ii2t_manager.py", line 176, in __init__
    self.wizard = wiz.Wizard(
AttributeError: type object 'Wizard' has no attribute
'Wizard'
```
