### PR TITLE
Fix show layer inside the layer subgroup

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -550,8 +550,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                     wx.EVT_MENU,
                     self.OnSetCompRegFromMap,
                     id=self.popupID['region'])
-                
-                # raster align 
+
+                # raster align
                 if ltype and ltype == "raster" and len(selected) == 1:
                     item = wx.MenuItem(
                         self.popupMenu,
@@ -1654,8 +1654,10 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                             digitToolbar
                             and digitToolbar.GetLayer() !=
                             mapLayer):
-                        # ignore when map layer is edited
-                        self.Map.ChangeLayerActive(mapLayer, checked)
+                        # layer is maplayer type
+                        if mapLayer:
+                            # ignore when map layer is edited
+                            self.Map.ChangeLayerActive(mapLayer, checked)
                         self.lmgr.WorkspaceChanged()
                     child = self.GetNextSibling(child)
             else:
@@ -2039,15 +2041,15 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                     if mapLayer.type == 'raster':
                         if mapWin.IsLoaded(layer):
                             mapWin.UnloadRaster(layer)
-    
+
                         mapWin.LoadRaster(layer)
-    
+
                     elif mapLayer.type == 'raster_3d':
                         if mapWin.IsLoaded(layer):
                             mapWin.UnloadRaster3d(layer)
-    
+
                         mapWin.LoadRaster3d(layer)
-    
+
                     elif mapLayer.type == 'vector':
                         if mapWin.IsLoaded(layer):
                             mapWin.UnloadVector(layer)
@@ -2056,7 +2058,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                             mapWin.LoadVector(layer, points=True)
                         if (vInfo['lines'] + vInfo['boundaries']) > 0:
                             mapWin.LoadVector(layer, points=False)
-    
+
                     # reset view when first layer loaded
                     nlayers = len(
                         mapWin.Map.GetListOfLayers(


### PR DESCRIPTION
Reproduce:

1. Add first layer group
2. Add second layer group
3. Move second layer group inside first layer group
4. Add vector map layer inside second layer group
5. Check checkbox on the first layer group

This error message appear on the Console tab:

```Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/layertree.py",
line 1660, in OnLayerChecked

self.Map.ChangeLayerActive(mapLayer, checked)
  File "/usr/local/grass79/gui/wxpython/core/render.py",
line 1426, in ChangeLayerActive

layer.active = active
AttributeError
:
'NoneType' object has no attribute 'active'
```


