### PR TITLE
fix NULL values for very small areas address in v.rast.stats

### DIFF
--- a/scripts/v.rast.stats/v.rast.stats.py
+++ b/scripts/v.rast.stats/v.rast.stats.py
@@ -40,6 +40,8 @@
 #%end
 #%option G_OPT_V_FIELD
 #%end
+#%option G_OPT_V_TYPE
+#%end
 #%option G_OPT_DB_WHERE
 #%end
 #%option G_OPT_R_INPUTS
@@ -102,6 +104,7 @@ def main():
     colprefixes = options['column_prefix'].split(',')
     vector = options['map']
     layer = options['layer']
+    vtypes = options['type']
     where = options['where']
     percentile = options['percentile']
     basecols = options['method'].split(',')
@@ -162,7 +165,7 @@ def main():
             kwargs['flags'] = 'd'
 
         grass.run_command('v.to.rast', input=vector, layer=layer, output=rastertmp,
-                          use='cat', quiet=True, **kwargs)
+                          use='cat', type=vtypes, quiet=True, **kwargs)
     except CalledModuleError:
         grass.fatal(_("An error occurred while converting vector to raster"))
 


### PR DESCRIPTION
Rasterizing centroids should fix the issue in tract ticket 2768. If there is more than one area within a pixel NULL values will still occur. But that is probably a different issue...