### PR TITLE
r.import extent=region bug fix

### DIFF
--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -276,8 +276,8 @@ def main():
             grass.fatal(_("Input contains GCPs, rectification is required"))
 
     if 'r' in region_flag:
-        grass.run_command('g.remove', **dict(type="vector", flags="f",
-                          name=tgtregion))
+        grass.run_command('g.remove', type="vector", flags="f",
+                          name=tgtregion)
 
     # switch to target location
     os.environ['GISRC'] = str(TGTGISRC)

--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -275,6 +275,10 @@ def main():
         if os.path.exists(path):
             grass.fatal(_("Input contains GCPs, rectification is required"))
 
+    if 'r' in region_flag:
+        grass.run_command('g.remove', **dict(type="vector", flags="f",
+                          name=tgtregion))
+
     # switch to target location
     os.environ['GISRC'] = str(TGTGISRC)
 


### PR DESCRIPTION
There is an error in `r.import extent=region`. At the temporary location, the region vector map is projected twice, but not deleted in between.

Please test the fix.
Backport to 7.8 is needed.