### PR TITLE
Fix decoding stderr after render layer fail

### DIFF
--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -432,7 +432,7 @@ class RenderLayerMgr(wx.EvtHandler):
         p = grass.start_command(cmd[0], env=env, stderr=grass.PIPE, **cmd[1])
         stdout, stderr = p.communicate()
         if p.returncode:
-            return stderr
+            return grass.decode(stderr)
         else:
             return None
 


### PR DESCRIPTION
Reproduce:

1. In the Layer Manage go to Console tab
2. Run command: `d.vect map=nonexist_layer`
3. Error message  (which isn't decoded) appear:

```
Failed to run command 'd.vect map=nonexist_layer'. Details:                     
b'\nGRASS_INFO_ERROR(7185,1): Vector map <nonexist_layer> not found\nGRASS_INFO_END(7185,1)\n'
```
