### PR TITLE
WIP: Fix failing 'Close GUI' and 'Quit GRASS' on macOS (trac #3009)

### DIFF
--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -111,6 +111,11 @@ class GMApp(wx.App):
 
         return True
 
+    def OnExit(self):
+        """Clean up on exit"""
+        unregisterPid(os.getpid())
+        return super().OnExit()
+
 
 def printHelp():
     """ Print program help"""
@@ -135,10 +140,6 @@ def process_opt(opts, args):
                 workspaceFile = args.pop(0)
 
     return workspaceFile
-
-
-def cleanup():
-    unregisterPid(os.getpid())
 
 
 def main(argv=None):
@@ -169,5 +170,4 @@ def main(argv=None):
     app.MainLoop()
 
 if __name__ == "__main__":
-    atexit.register(cleanup)
     sys.exit(main())

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2155,6 +2155,10 @@ def validate_cmdline(params):
             ).format(params.mapset)
         )
 
+def handleSignal(signum, frame):
+    """Handle signals sent to the this process."""
+    if signum == signal.SIGTERM:
+        sys.exit()
 
 def main():
     """The main function which does the whole setup and run procedure
@@ -2324,6 +2328,9 @@ def main():
     # for first time user because the cost is low and first time user
     # doesn't necessarily mean that the mapset is used for the first time.
     clean_temp()
+    
+    # Make sure terminate signal is caught, apparently not the case for macOS
+    signal.signal(signal.SIGTERM, handleSignal)
 
     # build user fontcap if specified but not present
     make_fontcap()
@@ -2367,6 +2374,10 @@ def main():
         start_gui(grass_gui)
         kv = read_gisrc(gisrc)
         kv['PID'] = str(shell_process.pid)
+        # Make PID for this process on macOS, needed for enable quitting
+        # GRASS, trac #3009.
+        if MACOSX:
+            kv['PID'] = str(os.getpid())
         write_gisrc(kv, gisrc)
         exit_val = shell_process.wait()
         if exit_val != 0:


### PR DESCRIPTION
This addresses the issue [trac#3009](https://trac.osgeo.org/grass/ticket/3009).

Consists of two parts:
* fix for "Quit GRASS"
quitting will not quit the shell on mac, only the grass process
* fix for "Close GUI"
for some reason atexit for `gui/wxpython/wxgui.py` throws error on mac, implementation of cleanup has been altered

Has been tested on mac and win.

