### PR TITLE
Fix set up sampling and analysis framework wizard relative import

### DIFF
--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -42,8 +42,10 @@ from grass.script import raster as grast
 from grass.script import vector as gvect
 from grass.exceptions import CalledModuleError
 
-from functions import SamplingType, sampleAreaVector, convertFeature
-from functions import obtainAreaVector, obtainCategories
+from .functions import (
+    SamplingType, convertFeature, obtainAreaVector, obtainCategories,
+    sampleAreaVector,
+)
 from core.gcmd import GError, GMessage, RunCommand
 
 


### PR DESCRIPTION
Reproduce:

1. In the Layer Manager go to menu Raster -> Landscape patch analysis -> Set up sampling and analysis framework

Error message appear in the Console tab:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
584, in OnRLiSetup

from rlisetup.frame import RLiSetupFrame
  File "/usr/local/grass79/gui/wxpython/rlisetup/frame.py",
line 14, in <module>

from rlisetup.wizard import RLIWizard
  File "/usr/local/grass79/gui/wxpython/rlisetup/wizard.py",
line 45, in <module>

from functions import SamplingType, sampleAreaVector,
convertFeature
ModuleNotFoundError
:
No module named 'functions'
```
