### PR TITLE
Fix wxGUI g.gui.rlisetup config file open mode for write in text mode

### DIFF
--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -144,7 +144,7 @@ class RLIWizard(object):
 
     def _write_confile(self):
         """Write the configuration file"""
-        f = open(os.path.join(self.rlipath, self.startpage.conf_name), 'wb')
+        f = open(os.path.join(self.rlipath, self.startpage.conf_name), 'w')
         self.rasterinfo = grast.raster_info(self.startpage.rast)
         self._write_region(f)
         self._write_area(f)


### PR DESCRIPTION
Reproduce:

1. Run `g.gui.rlisetup`
2. Create config file via gui wizard (any configuration)
3.  After click on Yes button on the last dialog Do you want to create r.li configuration file \<test\>?

Error message appear in the Layer Manager Console tab:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/rlisetup/frame.py",
line 240, in OnNew

RLIWizard(self)
  File "/usr/local/grass79/gui/wxpython/rlisetup/wizard.py",
line 135, in __init__

self._write_confile()
  File "/usr/local/grass79/gui/wxpython/rlisetup/wizard.py",
line 149, in _write_confile

self._write_region(f)
  File "/usr/local/grass79/gui/wxpython/rlisetup/wizard.py",
line 166, in _write_region

fil.write("SAMPLINGFRAME 0|0|1|1\n")
TypeError
:
a bytes-like object is required, not 'str'
```
