### PR TITLE
Fix wxGUI Layer Manager close the Layers NoteBook Display FlatNotebook page

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -688,6 +688,7 @@ class GMFrame(wx.Frame):
 
         self.notebookLayers.GetPage(event.GetSelection()).maptree.Map.Clean()
         self.notebookLayers.GetPage(event.GetSelection()).maptree.Close(True)
+        self.notebookLayers.GetPage(event.GetSelection()).maptree.mapdisplay._mgr.UnInit()
 
         self.currentPage = None
 
@@ -1525,7 +1526,7 @@ class GMFrame(wx.Frame):
                                        lcmd=layer['cmd'],
                                        lgroup=layer['group'],
                                        lnviz=layer['nviz'],
-                                       lvdigit=layer['vdigit'],                                       
+                                       lvdigit=layer['vdigit'],
                                        loadWorkspace=True)
 
             if 'selected' in layer:


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager  -> **Layers**  NoteBook page -> **Display 1** FlatNotebook page, click on the close page x button.

![layers_display_page](https://user-images.githubusercontent.com/50632337/76656121-36991a00-656f-11ea-84d3-5f780b1b3bd5.png)

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-
packages/wx/lib/agw/flatnotebook.py", line 5475, in OnLeftUp

self.DeletePage(self._iActivePage)
  File "/usr/lib/python3/dist-
packages/wx/lib/agw/flatnotebook.py", line 5665, in
DeletePage

book.DeletePage(page)
  File "/usr/lib/python3/dist-
packages/wx/lib/agw/flatnotebook.py", line 4473, in
DeletePage

pageRemoved.Destroy()
wx._core
.
wxAssertionError
:
C++ assertion "GetEventHandler() == this" failed at
../src/common/wincmn.cpp(478) in ~wxWindowBase(): any pushed
event handlers must have been removed
```

