### PR TITLE
postgres: Assign 1000 to TEXT field length

### DIFF
--- a/db/drivers/postgres/describe.c
+++ b/db/drivers/postgres/describe.c
@@ -207,6 +207,7 @@ int get_column_info(PGresult * res, int col, int *pgtype, int *gpgtype,
 
     case PG_TYPE_TEXT:
 	*sqltype = DB_SQL_TYPE_TEXT;
+	*size = 1000;
 	break;
 
     case PG_TYPE_FLOAT4:


### PR DESCRIPTION
# What does this PR do?

Set the length of a TEXT field to 1000 (same as sqlite) for the postgres driver when describing a table.

# Issue

Without this PR, `v.reclass` (or `v.dissolve`) would fail if the actual data length of a TEXT field is greater than whatever its previous column size is. In my case, I had an integer column (size 4) right before a TEXT field and `v.dissolve` using this TEXT field failed with the following error:
```
ERROR:  value too long for type character varying(4)
```

# Why?

`describe_table` in `db/drivers/postgres/describe.c` reuses `fsize` in line 104 if not reset by `get_column_info` in line 210.