### PR TITLE
Fix wxGUI Layer Manager add layer into the empty layer group

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1369,10 +1369,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                                         text='', ct_type=1, wnd=ctrl)
         else:
             if selectedLayer and selectedLayer != self.GetRootItem():
-                if selectedLayer and self.GetLayerInfo(selectedLayer, key='type') == 'group' \
-                        and self.IsExpanded(selectedLayer):
-                    # add to group (first child of self.layer_selected) if group
-                    # expanded
+                if selectedLayer and self.GetLayerInfo(selectedLayer, key='type') == 'group':
+                    # add to group (first child of self.layer_selected)
                     layer = self.PrependItem(parent=selectedLayer,
                                              text='', ct_type=1, wnd=ctrl)
                 else:


### PR DESCRIPTION
Reproduce:

1. Add new empty group layer (select group layer)
2. Add raster/vector etc. map layer (layer isn't inserted into the selected parent group layer)

Default behavior:

![default_behavior1](https://user-images.githubusercontent.com/50632337/76689566-5dbb1e80-6637-11ea-8781-8a6acaf2b9bf.gif)

Customized behavior:

![customized_behavior](https://user-images.githubusercontent.com/50632337/76689590-af63a900-6637-11ea-8137-68077aa235ec.gif)




