### PR TITLE
Fix wxGUI Vector Network Analysis Tool merge dicts

### DIFF
--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -1371,7 +1371,7 @@ class SettingsDialog(wx.Dialog):
         gridSizer = wx.GridBagSizer(vgap=1, hgap=1)
 
         row = 0
-        setts = dict(self.colorsSetts.items() + self.sizeSetts.items())
+        setts = {**self.colorsSetts, **self.sizeSetts}
 
         settsOrder = [
             "selected",


### PR DESCRIPTION
Reproduce:

1.  On the Layer Manager menu go to -> Vector -> Network analysis -> **Vector network analysis tool** (open dialog)
2. On the dialog, click on the **Vector network analysis settings** tool

Error message appear  in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/vnet/dialogs.py",
line 951, in OnSettings

title=_('Settings'), vnet_mgr=self.vnet_mgr)
  File "/usr/local/grass79/gui/wxpython/vnet/dialogs.py",
line 1377, in __init__

setts = dict(self.colorsSetts.items() +
self.sizeSetts.items())
TypeError
:
unsupported operand type(s) for +: 'dict_items' and
'dict_items'
```