### PR TITLE
Fix wxGUI Vector Network Analysis Tool ComboBox widget deprecation warning

### DIFF
--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -1,7 +1,7 @@
 """
 @package gui_core.wrap
 
-@brief Core wrapped wxpython widgets 
+@brief Core wrapped wxpython widgets
 
 Classes:
  - wrap::GSpinCtrl
@@ -619,7 +619,7 @@ class ListBox(wx.ListBox):
     over the widget on different platforms/wxpython versions"""
 
     def __init__(self, *args, **kwargs):
-        wx.ListBox.__init__(self, *args, **kwargs) 
+        wx.ListBox.__init__(self, *args, **kwargs)
 
     def SetToolTip(self, tip):
         if wxPythonPhoenix:
@@ -642,3 +642,17 @@ class HyperlinkCtrl(HyperlinkCtrl_):
             HyperlinkCtrl_.SetToolTip(self, tipString=tip)
         else:
             HyperlinkCtrl_.SetToolTipString(self, tip)
+
+
+class ComboBox(wx.ComboBox):
+    """Wrapper around wx.ComboBox to have more control
+    over the widget on different platforms/wxpython versions"""
+
+    def __init__(self, *args, **kwargs):
+        wx.ComboBox.__init__(self, *args, **kwargs)
+
+    def SetToolTip(self, tip):
+        if wxPythonPhoenix:
+            wx.ComboBox.SetToolTip(self, tipString=tip)
+        else:
+            wx.ComboBox.SetToolTipString(self, tip)

--- a/gui/wxpython/vnet/toolbars.py
+++ b/gui/wxpython/vnet/toolbars.py
@@ -21,6 +21,7 @@ import wx
 
 from icons.icon import MetaIcon
 from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.wrap import ComboBox
 from core.gcmd import RunCommand
 
 
@@ -193,7 +194,7 @@ class AnalysisToolbar(BaseToolbar):
             choices.append(
                 self.vnet_mgr.GetAnalysisProperties(moduleName)['label'])
 
-        self.anChoice = wx.ComboBox(
+        self.anChoice = ComboBox(
             parent=self,
             id=wx.ID_ANY,
             choices=choices,
@@ -201,7 +202,7 @@ class AnalysisToolbar(BaseToolbar):
             size=(
                 350,
                 30))  # FIXME
-        self.anChoice.SetToolTipString(_('Availiable analyses'))
+        self.anChoice.SetToolTip(_('Availiable analyses'))
         self.anChoice.SetSelection(0)
 
         self.anChoiceId = self.AddControl(self.anChoice)

--- a/gui/wxpython/vnet/toolbars.py
+++ b/gui/wxpython/vnet/toolbars.py
@@ -202,7 +202,7 @@ class AnalysisToolbar(BaseToolbar):
             size=(
                 350,
                 30))  # FIXME
-        self.anChoice.SetToolTip(_('Availiable analyses'))
+        self.anChoice.SetToolTip(_('Available analyses'))
         self.anChoice.SetSelection(0)
 
         self.anChoiceId = self.AddControl(self.anChoice)


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager menu go to -> Vector -> Network analysis -> **Vector network analysis tool** (open dialog)

Deprecation warning message appear in the **Console** page:

```
/usr/local/grass79/gui/wxpython/vnet/toolbars.py:204:
wxPyDeprecationWarning: Call to deprecated item. Use
SetToolTip instead.
  self.anChoice.SetToolTipString(_('Availiable analyses'))
```