### PR TITLE
Fix wxGUI Vector Network Analysis Tool close dialog

### DIFF
--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -820,6 +820,7 @@ class VNETDialog(wx.Dialog):
     def OnCloseDialog(self, event):
         """Cancel dialog"""
         self.vnet_mgr.CleanUp()
+        self._mgr.UnInit()
         toolSwitcher = self.giface.GetMapDisplay().GetToolSwitcher()
         toolSwitcher.RemoveToolbarFromGroup(
             'mouseUse', self.toolbars['pointsList'])


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager menu go to -> Vector -> Network analysis -> **Vector network analysis tool** (open dialog)
2. Close dialog via click on the **Quit** toolbar icon tool

Error message appear in the **Console** page:

```
wx._core
.
wxAssertionError
:
C++ assertion "GetEventHandler() == this" failed at
../src/common/wincmn.cpp(478) in ~wxWindowBase(): any pushed
event handlers must have been removed
The above exception was the direct cause of the following
exception:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-
packages/wx/lib/agw/customtreectrl.py", line 7997, in
OnInternalIdle

if not self.HasAGWFlag(TR_MULTIPLE) and not
self.GetSelection():
SystemError
:
PyEval_EvalFrameEx returned a result with an error set
```
Same as #411.
