### PR TITLE
Fix wxGUI Histogramming Tool write log to the stdout

### DIFF
--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -900,7 +900,7 @@ class TextDialog(wx.Dialog):
         UserSettings.ReadSettingsFile(settings=fileSettings)
         fileSettings[self.plottype] = UserSettings.Get(group=self.plottype)
         UserSettings.SaveToFile(fileSettings)
-        self.parent.parent.GetLayerManager().GetLogWindow().WriteLog(
+        self.parent.parent.mapdisplay.GetLayerManager().GetLogWindow().WriteLog(
             _('Plot text sizes saved to file \'%s\'.') % UserSettings.filePath)
         self.EndModal(wx.ID_OK)
 
@@ -1593,7 +1593,7 @@ class OptDialog(wx.Dialog):
         UserSettings.ReadSettingsFile(settings=fileSettings)
         fileSettings[self.plottype] = UserSettings.Get(group=self.plottype)
         UserSettings.SaveToFile(fileSettings)
-        self.parent.parent.GetLayerManager().GetLogWindow().WriteLog(
+        self.parent.parent.mapdislay.GetLayerManager().GetLogWindow().WriteLog(
             _('Plot settings saved to file \'%s\'.') % UserSettings.filePath)
         self.Close()
 

--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -1595,7 +1595,7 @@ class OptDialog(wx.Dialog):
         UserSettings.SaveToFile(fileSettings)
         self.parent.parent.mapdislay.GetLayerManager().GetLogWindow().WriteLog(
             _('Plot settings saved to file \'%s\'.') % UserSettings.filePath)
-        self.Close()
+        self.EndModal(wx.ID_OK)
 
     def OnApply(self, event):
         """Button 'Apply' pressed. Does not close dialog"""
@@ -1611,4 +1611,4 @@ class OptDialog(wx.Dialog):
 
     def OnCancel(self, event):
         """Button 'Cancel' pressed"""
-        self.Close()
+        self.EndModal(wx.ID_OK)


### PR DESCRIPTION
Reproduce:

1. In the Layer Manager toolbar click on the **Add raster map layer** icon tool
2. Right click on the added raster layer to invoke layer menu and click on the **Histogram** menu item
3. On the **Histogramming Tool** frame toolbar click on the **Settings** icon tool menu and choose  **Text settings** (open dialog) or **Plot settings** (open dialog)
4. On the **Text settings** or **Plot settings** dialog click on the **Save** button (save text settings into the file)

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/wxplot/dialogs.py",
line 921, in OnSave

self.parent.parent.GetLayerManager().GetLogWindow().WriteLog
(
AttributeError
:
'LayerTree' object has no attribute 'GetLayerManager'
```

Another error: 
On the open **Plot settings** dialog, try click on the **Cancel** button (dialog doesn't close). 