### PR TITLE
Fix wxGUI Histogramming Tool save text settings (font family/style/weight) into the file

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import os
 import sys
 import copy
+import wx
 
 from core import globalvar
 from core.gcmd import GException, GError
@@ -535,6 +536,10 @@ class Settings:
                     'titleSize': 12,
                     'axisSize': 11,
                     'legendSize': 10,
+                    'defaultSize': 11,
+                    'family': wx.FONTFAMILY_SWISS,
+                    'style': wx.FONTSTYLE_NORMAL,
+                    'weight': wx.FONTWEIGHT_NORMAL,
                 },
                 'grid': {
                     'color': (200, 200, 200, 255),

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -585,6 +585,10 @@ class Settings:
                     'titleSize': 12,
                     'axisSize': 11,
                     'legendSize': 10,
+                    'defaultSize': 11,
+                    'family': wx.FONTFAMILY_SWISS,
+                    'style': wx.FONTSTYLE_NORMAL,
+                    'weight': wx.FONTWEIGHT_NORMAL,
                 },
                 'grid': {
                     'color': (200, 200, 200, 255),

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -497,6 +497,10 @@ class Settings:
                     'titleSize': 12,
                     'axisSize': 11,
                     'legendSize': 10,
+                    'defaultSize': 11,
+                    'family': wx.FONTFAMILY_SWISS,
+                    'style': wx.FONTSTYLE_NORMAL,
+                    'weight': wx.FONTWEIGHT_NORMAL,
                 },
                 'marker': {
                     'color': (0, 0, 0, 255),

--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -146,9 +146,12 @@ class BasePlotFrame(wx.Frame):
         self.properties['font'] = {}
         self.properties['font']['prop'] = UserSettings.Get(
             group=self.plottype, key='font')
-        self.properties['font']['wxfont'] = wx.Font(11, wx.FONTFAMILY_SWISS,
-                                                    wx.FONTSTYLE_NORMAL,
-                                                    wx.FONTWEIGHT_NORMAL)
+        self.wx_font = wx.Font(
+            self.properties['font']['prop']['defaultSize'],
+            self.properties['font']['prop']['family'],
+            self.properties['font']['prop']['style'],
+            self.properties['font']['prop']['weight'],
+        )
 
         self.properties['raster'] = {}
         self.properties['raster'] = UserSettings.Get(
@@ -337,7 +340,7 @@ class BasePlotFrame(wx.Frame):
     def SetGraphStyle(self):
         """Set plot and text options
         """
-        self.client.SetFont(self.properties['font']['wxfont'])
+        self.client.SetFont(self.wx_font)
         self.client.fontSizeTitle = self.properties['font']['prop']['titleSize']
         self.client.fontSizeAxis = self.properties['font']['prop']['axisSize']
 
@@ -562,7 +565,7 @@ class BasePlotFrame(wx.Frame):
     def UpdateLabels(self):
         x, y = self._getPlotLabels()
 
-        self.client.SetFont(self.properties['font']['wxfont'])
+        self.client.SetFont(self.wx_font)
         self.client.fontSizeTitle = self.properties['font']['prop']['titleSize']
         self.client.fontSizeAxis = self.properties['font']['prop']['axisSize']
 

--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -22,15 +22,15 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-import wx.lib.colourselect as csel
-import wx.lib.scrolledpanel as scrolled
 
 from core import globalvar
 from core.settings import UserSettings
 from core.globalvar import ICONDIR
 from gui_core.gselect import Select
-from gui_core.wrap import SpinCtrl, Button, StaticText, \
-    StaticBox, TextCtrl, Choice
+from gui_core.wrap import (
+    ColourSelect, ComboBox, Button, CheckBox, Choice, Panel, RadioButton,
+    ScrolledPanel, SpinCtrl, StaticBox, StaticText, TextCtrl,
+)
 
 from grass.script import core as grass
 
@@ -211,7 +211,7 @@ class ScatterRasterDialog(wx.Dialog):
 #        box.Add(item = label,
 #                flag = wx.ALIGN_CENTER_VERTICAL, pos = (2, 0))
 #        types = ['normal', 'bubble']
-#        scattertype = wx.ComboBox(parent = self, id = wx.ID_ANY, size = (250, -1),
+#        scattertype = ComboBox(parent = self, id = wx.ID_ANY, size = (250, -1),
 #                                choices = types, style = wx.CB_DROPDOWN)
 #        scattertype.SetStringSelection(self.scattertype)
 #        box.Add(item = scattertype,
@@ -296,7 +296,7 @@ class PlotStatsFrame(wx.Frame):
                 wx.BITMAP_TYPE_ICO))
         self.panel = wx.Panel(self)
 
-        sp = scrolled.ScrolledPanel(
+        sp = ScrolledPanel(
             self.panel, -1, size=(400, 400),
             style=wx.TAB_TRAVERSAL | wx.SUNKEN_BORDER, name="Statistics")
 
@@ -516,7 +516,7 @@ class HistRasterDialog(wx.Dialog):
         box.Add(label,
                 flag=wx.ALIGN_CENTER_VERTICAL, pos=(4, 0))
         types = ['count', 'percent', 'area']
-        histtype = wx.ComboBox(parent=self, id=wx.ID_ANY, size=(250, -1),
+        histtype = ComboBox(parent=self, id=wx.ID_ANY, size=(250, -1),
                                choices=types, style=wx.CB_DROPDOWN)
         histtype.SetStringSelection(self.histtype)
         box.Add(histtype,
@@ -761,7 +761,7 @@ class TextDialog(wx.Dialog):
             id=wx.ID_ANY,
             label=_("Font family:"))
         gridSizer.Add(label1, flag=wx.ALIGN_CENTER_VERTICAL, pos=(0, 0))
-        self.ffamilycb = wx.ComboBox(
+        self.ffamilycb = ComboBox(
             parent=self, id=wx.ID_ANY, size=(250, -1),
             choices=list(self.ffamilydict.keys()),
             style=wx.CB_DROPDOWN)
@@ -777,7 +777,7 @@ class TextDialog(wx.Dialog):
         #
         label = StaticText(parent=self, id=wx.ID_ANY, label=_("Style:"))
         gridSizer.Add(label, flag=wx.ALIGN_CENTER_VERTICAL, pos=(1, 0))
-        self.fstylecb = wx.ComboBox(
+        self.fstylecb = ComboBox(
             parent=self, id=wx.ID_ANY, size=(250, -1),
             choices=list(self.fstyledict.keys()),
             style=wx.CB_DROPDOWN)
@@ -793,7 +793,7 @@ class TextDialog(wx.Dialog):
         #
         label = StaticText(parent=self, id=wx.ID_ANY, label=_("Weight:"))
         gridSizer.Add(label, flag=wx.ALIGN_CENTER_VERTICAL, pos=(2, 0))
-        self.fwtcb = wx.ComboBox(
+        self.fwtcb = ComboBox(
             parent=self, size=(250, -1),
             choices=list(self.fwtdict.keys()),
             style=wx.CB_DROPDOWN)
@@ -1041,7 +1041,7 @@ class OptDialog(wx.Dialog):
                 pos=(
                     row,
                     0))
-            color = csel.ColourSelect(
+            color = ColourSelect(
                 parent=self, id=wx.ID_ANY, colour=self.raster[
                     self.map]['pcolor'])
             self.wxId['pcolor'] = color.GetId()
@@ -1113,7 +1113,7 @@ class OptDialog(wx.Dialog):
                 pos=(
                     0,
                     0))
-            ptcolor = csel.ColourSelect(
+            ptcolor = ColourSelect(
                 parent=self,
                 id=wx.ID_ANY,
                 colour=self.properties['marker']['color'])
@@ -1195,7 +1195,7 @@ class OptDialog(wx.Dialog):
                 pos=(
                     0,
                     0))
-            ptcolor = csel.ColourSelect(
+            ptcolor = ColourSelect(
                 parent=self, id=wx.ID_ANY, colour=self.raster[
                     self.map]['pcolor'])
             self.wxId['pcolor'] = ptcolor.GetId()
@@ -1332,7 +1332,7 @@ class OptDialog(wx.Dialog):
             gridSizer.Add(max, pos=(row, 1))
 
             row += 1
-            log = wx.CheckBox(parent=self, id=wx.ID_ANY, label=_("Log scale"))
+            log = CheckBox(parent=self, id=wx.ID_ANY, label=_("Log scale"))
             log.SetValue(prop['log'])
             self.wxId[atype]['log'] = log.GetId()
             gridSizer.Add(log, pos=(row, 0), span=(1, 2))
@@ -1363,7 +1363,7 @@ class OptDialog(wx.Dialog):
         row = 0
         label = StaticText(parent=self, id=wx.ID_ANY, label=_("Grid color"))
         gridSizer.Add(label, flag=wx.ALIGN_CENTER_VERTICAL, pos=(row, 0))
-        gridcolor = csel.ColourSelect(
+        gridcolor = ColourSelect(
             parent=self,
             id=wx.ID_ANY,
             colour=self.properties['grid']['color'])
@@ -1371,7 +1371,7 @@ class OptDialog(wx.Dialog):
         gridSizer.Add(gridcolor, pos=(row, 1))
 
         row += 1
-        gridshow = wx.CheckBox(parent=self, id=wx.ID_ANY, label=_("Show grid"))
+        gridshow = CheckBox(parent=self, id=wx.ID_ANY, label=_("Show grid"))
         gridshow.SetValue(self.properties['grid']['enabled'])
         self.wxId['grid']['enabled'] = gridshow.GetId()
         gridSizer.Add(gridshow, pos=(row, 0), span=(1, 2))
@@ -1391,7 +1391,7 @@ class OptDialog(wx.Dialog):
         gridSizer.Add(legendfontsize, pos=(row, 1))
 
         row += 1
-        legendshow = wx.CheckBox(
+        legendshow = CheckBox(
             parent=self,
             id=wx.ID_ANY,
             label=_("Show legend"))

--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -650,9 +650,9 @@ class TextDialog(wx.Dialog):
         self.properties = self.parent.properties  # read-only
 
         # font size
-        self.fontfamily = self.properties['font']['wxfont'].GetFamily()
-        self.fontstyle = self.properties['font']['wxfont'].GetStyle()
-        self.fontweight = self.properties['font']['wxfont'].GetWeight()
+        self.fontfamily = self.parent.wx_font.GetFamily()
+        self.fontstyle = self.parent.wx_font.GetStyle()
+        self.fontweight = self.parent.wx_font.GetWeight()
 
         self._do_layout()
 
@@ -887,11 +887,14 @@ class TextDialog(wx.Dialog):
             'axisSize'] = self.axislabelsize.GetValue()
 
         family = self.ffamilydict[self.ffamilycb.GetStringSelection()]
-        self.properties['font']['wxfont'].SetFamily(family)
+        self.properties['font']['prop']['family'] = family
+        self.parent.wx_font.SetFamily(family)
         style = self.fstyledict[self.fstylecb.GetStringSelection()]
-        self.properties['font']['wxfont'].SetStyle(style)
+        self.properties['font']['prop']['style'] = style
+        self.parent.wx_font.SetStyle(style)
         weight = self.fwtdict[self.fwtcb.GetStringSelection()]
-        self.properties['font']['wxfont'].SetWeight(weight)
+        self.properties['font']['prop']['weight'] = weight
+        self.parent.wx_font.SetWeight(weight)
 
     def OnSave(self, event):
         """Button 'Save' pressed"""


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager toolbar click on the **Add raster map layer** icon tool
2. Right click on the added raster layer to invoke layer menu and click on the **Histogram** menu item
3. On the **Histogramming Tool** frame toolbar click on the **Settings** icon tool menu and choose **Text settings** (open dialog)
4. Change **font family** settings to the modern, **font style** to the italic, **font weight** to the bold
5. On the **Text settings** dialog click on the **Save** button (save text settings into the file)
6. Font family, style, weight changed on the **histogram** (title, axis label...)
7. Check content of the saved histogram settings file `cat  ~/.grass7/wx`

```
histogram;raster;pcolor;0:0:255;pwidth;1;pstyle;solid;datatype;cell
histogram;font;titleSize;12;axisSize;11;legendSize;10
histogram;grid;color;200:200:200;enabled;True
histogram;x-axis;type;auto;min;0;max;0;log;False
histogram;y-axis;type;auto;min;0;max;0;log;False
histogram;legend;enabled;True
```
Histogram font family, style, weight setting  is missing.