### PR TITLE
Fix wxGUI Histogramming Tool Plot xSpec, ySpec property value

### DIFF
--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -191,15 +191,15 @@ class BasePlotFrame(wx.Frame):
 
         # x and y axis set to normal (non-log)
         self.client.logScale = (False, False)
-        if self.properties['x-axis']['prop']['type']:
+        if self.properties['x-axis']['prop']['type'] == 'custom':
+            self.client.xSpec = 'min'
+        else:
             self.client.xSpec = self.properties['x-axis']['prop']['type']
-        else:
-            self.client.xSpec = 'auto'
 
-        if self.properties['y-axis']['prop']['type']:
-            self.client.ySpec = self.properties['y-axis']['prop']['type']
+        if self.properties['y-axis']['prop']['type'] == 'custom':
+            self.client.ySpec = 'min'
         else:
-            self.client.ySpec = 'auto'
+            self.client.ySpec = self.properties['y-axis']['prop']['type']
 
     def InitRasterOpts(self, rasterList, plottype):
         """Initialize or update raster dictionary for plotting


### PR DESCRIPTION
Reproduce:

1. In the Layer Manager toolbar click on the **Add raster map layer** icon tool
2. Right click on the added raster layer to invoke layer menu and click on the **Histogram** menu item
3. On the **Histogramming Tool** frame toolbar click on the **Settings** icon tool menu and choose   **Plot settings** (open dialog)
4. On the **Plot settings** dialog, change X-Axis Scale option to the **custom** type, and set **Custom min** and **max** value, and change Y-Axis Scale same too
5.  On the **Plot settings** dialog click on the **Ok** button
6.  Close  **Histogramming Tool** frame 
7. Reopen  **Histogramming Tool** frame 

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/layertree.py",
line 1130, in OnHistogram

win = HistogramPlotFrame(parent=self, rasterList=rasterList)
  File
"/usr/local/grass79/gui/wxpython/wxplot/histogram.py", line
73, in __init__

self._initOpts()
  File
"/usr/local/grass79/gui/wxpython/wxplot/histogram.py", line
85, in _initOpts

self.InitPlotOpts('histogram')
  File "/usr/local/grass79/gui/wxpython/wxplot/base.py",
line 199, in InitPlotOpts

self.client.xSpec =
self.properties['x-axis']['prop']['type']
  File "/usr/lib/python3/dist-
packages/wx/lib/plot/plotcanvas.py", line 1564, in xSpec

if not isinstance(value, (list, tuple)) and len(value != 2):
TypeError
:
object of type 'bool' has no len()
```