### PR TITLE
Fix wxGUI Map Display Window close frame

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -688,7 +688,8 @@ class GMFrame(wx.Frame):
 
         self.notebookLayers.GetPage(event.GetSelection()).maptree.Map.Clean()
         self.notebookLayers.GetPage(event.GetSelection()).maptree.Close(True)
-        self.notebookLayers.GetPage(event.GetSelection()).maptree.mapdisplay._mgr.UnInit()
+        self.notebookLayers.GetPage(event.GetSelection()).maptree. \
+            mapdisplay._mgr._UnInit()
 
         self.currentPage = None
 

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -741,7 +741,7 @@ class MapFrame(SingleMapFrame):
                 self._giface.WriteError(_('Failed to run d.to.rast:\n') + messages)
                 grass.try_remove(pngFile)
                 return
-    
+
             # alignExtent changes only region variable
             oldRegion = self.GetMap().GetCurrentRegion().copy()
             self.GetMap().AlignExtentFromDisplay()
@@ -774,7 +774,7 @@ class MapFrame(SingleMapFrame):
         pngFile = grass.tempfile(create=False) + '.png'
         dOutFileCmd = ['d.out.file', 'output=' + pngFile, 'format=png']
         self.DOutFile(dOutFileCmd, callback=_DToRastDone)
-        
+
 
 
     def DToRastOptData(self, dcmd, layer, params, propwin):
@@ -1561,3 +1561,8 @@ class MapFrame(SingleMapFrame):
 
         self.RemoveToolbar('rdigit', destroy=True)
         self.rdigit = None
+
+    def _UnInit(self):
+        """Uninitializarion"""
+        if not self._layerManager:
+            self._mgr.UnInit()


### PR DESCRIPTION
Reproduce:

1. Run wxGUI (`g.gui`)
2. Close only Map Display Window frame

Error message appear iin the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
696, in OnCBPageClosed

self.notebookLayers.GetPage(event.GetSelection()).maptree.ma
pdisplay._mgr.UnInit()
wx._core
.
wxAssertionError
:
C++ assertion "Assert failure" failed at
../src/common/wincmn.cpp(1517) in RemoveEventHandler():
where has the event handler gone?
```
Error related with the changes in the PR #411.
