### PR TITLE
Fix wxGUI Manage color rules interactively (vector map) frame

### DIFF
--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -1560,7 +1560,7 @@ class VectorColorTable(ColorTable):
 
         sep = ';'
         if self.inmap:
-            outFile = tempfile.NamedTemporaryFile(mode='w+b')
+            outFile = tempfile.NamedTemporaryFile(mode='w+')
             ret = RunCommand('v.db.select',
                              quiet=True,
                              flags='c',

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -1199,7 +1199,7 @@ class VectorColorTable(ColorTable):
             self.cp = wx.CollapsiblePane(
                 scrollPanel,
                 label=_("Import or export color table"),
-                winid=wx.ID_ANY,
+                id=wx.ID_ANY,
                 style=wx.CP_DEFAULT_STYLE | wx.CP_NO_TLW_RESIZE)
             self.Bind(
                 wx.EVT_COLLAPSIBLEPANE_CHANGED,

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -82,8 +82,8 @@ class RulesPanel:
         # clear button
         self.clearAll = Button(parent, id=wx.ID_ANY, label=_("Clear all"))
         #  determines how many rules should be added
-        self.numRules = SpinCtrl(parent, id=wx.ID_ANY,
-                                 min=1, max=1e6, initial=1)
+        self.numRules = SpinCtrl(parent, id=wx.ID_ANY, min=1, max=1e6,
+                                 initial=1, size=(150, -1))
         # add rules
         self.btnAdd = Button(parent, id=wx.ID_ADD)
 


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager menu go to -> Vector -> Manage colors -> **Manage color rules interactively** (open frame)

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
1780, in OnVectorRules

attributeType='color')
  File
"/usr/local/grass79/gui/wxpython/modules/colorrules.py",
line 1090, in __init__

'Create new color rules for vector map'), **kwargs)
  File
"/usr/local/grass79/gui/wxpython/modules/colorrules.py",
line 375, in __init__

self._doLayout()
  File
"/usr/local/grass79/gui/wxpython/modules/colorrules.py",
line 1212, in _doLayout

style=wx.CP_DEFAULT_STYLE | wx.CP_NO_TLW_RESIZE)
TypeError
:
CollapsiblePane(): arguments did not match any overloaded
call:
  overload 1: too many arguments
  overload 2: 'winid' is not a valid keyword argument
```

Another error:

1. On the Manage color rules interactively frame select vector map via **Select vector map** ComboBox widget
2. Check **Use color column instead of color table** checkbox wdiget:

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File
"/usr/local/grass79/gui/wxpython/modules/colorrules.py",
line 1304, in OnCheckColumn

self.LoadTable()
  File
"/usr/local/grass79/gui/wxpython/modules/colorrules.py",
line 1557, in LoadTable

self.LoadRulesFromColumn()
  File
"/usr/local/grass79/gui/wxpython/modules/colorrules.py",
line 1603, in LoadRulesFromColumn

record = outFile.readline().replace('\n', '')
TypeError
:
a bytes-like object is required, not 'str'
```

Another fix:

Fix wx SpinCtrl widget size
