### PR TITLE
Fix destroy open wxGUI Vector Network Analysis Tool dialog when wxGUI is closed

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -106,6 +106,9 @@ class MapFrame(SingleMapFrame):
         # Emitted when closing display by closing its window.
         self.closingDisplay = Signal("MapFrame.closingDisplay")
 
+        # Emitted when closing display by closing its window.
+        self.closingVNETDialog = Signal("MapFrame.closingVNETDialog")
+
         # properties are shared in other objects, so defining here
         self.mapWindowProperties = MapWindowProperties()
         self.mapWindowProperties.setValuesFromUserSettings()
@@ -744,7 +747,7 @@ class MapFrame(SingleMapFrame):
                 self._giface.WriteError(_('Failed to run d.to.rast:\n') + messages)
                 grass.try_remove(pngFile)
                 return
-    
+
             # alignExtent changes only region variable
             oldRegion = self.GetMap().GetCurrentRegion().copy()
             self.GetMap().AlignExtentFromDisplay()
@@ -777,7 +780,7 @@ class MapFrame(SingleMapFrame):
         pngFile = grass.tempfile(create=False) + '.png'
         dOutFileCmd = ['d.out.file', 'output=' + pngFile, 'format=png']
         self.DOutFile(dOutFileCmd, callback=_DToRastDone)
-        
+
 
 
     def DToRastOptData(self, dcmd, layer, params, propwin):
@@ -843,6 +846,8 @@ class MapFrame(SingleMapFrame):
             self.RemoveNviz()
         if hasattr(self, 'rdigit') and self.rdigit:
             self.rdigit.CleanUp()
+        if self.dialogs['vnet']:
+            self.closingVNETDialog.emit()
         self._mgr.UnInit()
 
     def OnCloseWindow(self, event):
@@ -1484,6 +1489,7 @@ class MapFrame(SingleMapFrame):
 
         from vnet.dialogs import VNETDialog
         self.dialogs['vnet'] = VNETDialog(parent=self, giface=self._giface)
+        self.closingVNETDialog.connect(self.dialogs['vnet'].OnCloseDialog)
         self.dialogs['vnet'].CenterOnScreen()
         self.dialogs['vnet'].Show()
 

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -67,8 +67,6 @@ from vnet.vnet_utils import DegreesToRadians, RadiansToDegrees, GetNearestNodeCa
 # - when layer tree of is changed, tmp result map is removed from render list
 # - optimization of map drawing
 # - tmp maps - add number of process
-# - destructor problem - when GRASS GIS is closed with open VNETDialog,
-#   it's destructor is not called
 
 
 class VNETDialog(wx.Dialog):
@@ -817,7 +815,7 @@ class VNETDialog(wx.Dialog):
 
         return mapName, mapSet
 
-    def OnCloseDialog(self, event):
+    def OnCloseDialog(self, event=None):
         """Cancel dialog"""
         self.vnet_mgr.CleanUp()
         self._mgr.UnInit()


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager menu go to -> Vector -> Network analysis -> **Vector network analysis tool** (open dialog)
2. Close wxGUI, on the Layer Manager menu go to -> File -> Close GUI

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
2540, in OnCloseWindow

self._closeWindow(event)
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
2608, in _closeWindow

self.notebookLayers.DeleteAllPages()
  File "/usr/lib/python3/dist-
packages/wx/lib/agw/flatnotebook.py", line 4501, in
DeleteAllPages

page.Destroy()
wx._core
.
wxAssertionError
:
C++ assertion "GetEventHandler() == this" failed at
../src/common/wincmn.cpp(478) in ~wxWindowBase(): any pushed
event handlers must have been removed

```