### PR TITLE
OSGeo4W BAT files review

### DIFF
--- a/mswindows/osgeo4w/env.bat.tmpl
+++ b/mswindows/osgeo4w/env.bat.tmpl
@@ -18,7 +18,6 @@ set FONTCONFIG_FILE=%GISBASE%\etc\fonts.conf
 REM
 REM GDAL-related
 REM
-set GDAL_DATA=%OSGEO4W_ROOT%\share\gdal
 set GEOTIFF_CSV=%OSGEO4W_ROOT%\share\epsg_csv
 
 REM

--- a/mswindows/osgeo4w/env.bat.tmpl
+++ b/mswindows/osgeo4w/env.bat.tmpl
@@ -16,11 +16,6 @@ set GRASS_PROJSHARE=%OSGEO4W_ROOT%\share\proj
 set FONTCONFIG_FILE=%GISBASE%\etc\fonts.conf
 
 REM
-REM GDAL-related
-REM
-set GEOTIFF_CSV=%OSGEO4W_ROOT%\share\epsg_csv
-
-REM
 REM RStudio-related
 REM
 REM set RStudio temporarily to %PATH% if it exists

--- a/mswindows/osgeo4w/env.bat.tmpl
+++ b/mswindows/osgeo4w/env.bat.tmpl
@@ -11,19 +11,21 @@ REM Note that msys package must be also installed
 REM set GRASS_SH=%OSGEO4W_ROOT%\apps\msys\bin\sh.exe
 
 set GRASS_PYTHON=%OSGEO4W_ROOT%\bin\python3.exe
-set PYTHONHOME=%OSGEO4W_ROOT%\apps\Python37
-
 set GRASS_PROJSHARE=%OSGEO4W_ROOT%\share\proj
 
+set FONTCONFIG_FILE=%GISBASE%\etc\fonts.conf
+
+REM
+REM GDAL-related
+REM
 set PROJ_LIB=%OSGEO4W_ROOT%\share\proj
 set GDAL_DATA=%OSGEO4W_ROOT%\share\gdal
 set GEOTIFF_CSV=%OSGEO4W_ROOT%\share\epsg_csv
 
-set FONTCONFIG_FILE=%GISBASE%\etc\fonts.conf
-
+REM
+REM RStudio-related
+REM
 REM set RStudio temporarily to %PATH% if it exists
-
 IF EXIST "%ProgramFiles%\RStudio\bin\rstudio.exe" set PATH=%PATH%;%ProgramFiles%\RStudio\bin
-
 REM set R_USER if %USERPROFILE%\Documents\R\ exists to catch most common cases of private R libraries
 IF EXIST "%USERPROFILE%\Documents\R\" set R_USER=%USERPROFILE%\Documents\

--- a/mswindows/osgeo4w/env.bat.tmpl
+++ b/mswindows/osgeo4w/env.bat.tmpl
@@ -18,7 +18,6 @@ set FONTCONFIG_FILE=%GISBASE%\etc\fonts.conf
 REM
 REM GDAL-related
 REM
-set PROJ_LIB=%OSGEO4W_ROOT%\share\proj
 set GDAL_DATA=%OSGEO4W_ROOT%\share\gdal
 set GEOTIFF_CSV=%OSGEO4W_ROOT%\share\epsg_csv
 

--- a/mswindows/osgeo4w/grass.bat.tmpl
+++ b/mswindows/osgeo4w/grass.bat.tmpl
@@ -9,7 +9,6 @@ rem
 rem Set environmental variables
 rem
 call "%~dp0\o4w_env.bat"
-call py3_env.bat
 call "%OSGEO4W_ROOT%\apps\grass\grass@POSTFIX@\etc\env.bat"
 @echo off
 

--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -113,11 +113,7 @@ read PATCH <&3
 export VERSION=${MAJOR}.${MINOR}.${PATCH}
 export POSTFIX=${MAJOR}${MINOR}
 
-if [[ "$PATCH" == *svn* ]] ; then
-    GRASS_EXECUTABLE=grass${MAJOR}${MINOR}svn
-else
-    GRASS_EXECUTABLE=grass${MAJOR}${MINOR}
-fi
+GRASS_EXECUTABLE=grass${MAJOR}${MINOR}
 
 if [ -f mswindows/osgeo4w/package.log ]; then
     i=0

--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -113,7 +113,11 @@ read PATCH <&3
 export VERSION=${MAJOR}.${MINOR}.${PATCH}
 export POSTFIX=${MAJOR}${MINOR}
 
-GRASS_EXECUTABLE=grass${MAJOR}${MINOR}
+if [[ "$PATCH" == *svn* ]] ; then
+    GRASS_EXECUTABLE=grass${MAJOR}${MINOR}svn
+else
+    GRASS_EXECUTABLE=grass${MAJOR}${MINOR}
+fi
 
 if [ -f mswindows/osgeo4w/package.log ]; then
     i=0


### PR DESCRIPTION
List of issues:

* `env.bat` doesn't need to define `PYTHONHOME` since it's already defined by `py3_env.bat`
* `py3_env.bat` doesn't need to be called from `grass.bat` since it's called by `env.bat`
* `package.sh`: development versions executable do not use any postfix, currently eg. `grass79`