### PR TITLE
Fix wxGUI Vector Network Analysis Tool execute analysis

### DIFF
--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -694,7 +694,7 @@ class VNETAnalysisParameters:
                 vectMaps = grass.list_grouped('vector')[mapSet]
 
         if not params["input"] or mapName not in vectMaps:
-            invParams = params.keys()[:]
+            invParams = list(params.keys())[:]
             return invParams
 
         # check arc/node layer


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager menu go to -> Vector -> Network analysis -> **Vector network analysis tool** (open dialog)
2. Click on the **Execute analysis** toolbar icon tool

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/vnet/dialogs.py",
line 899, in OnAnalyze

ret = self.vnet_mgr.RunAnalysis()
  File "/usr/local/grass79/gui/wxpython/vnet/vnet_core.py",
line 109, in RunAnalysis

params, err_params, flags = self.vnet_data.GetParams()
  File "/usr/local/grass79/gui/wxpython/vnet/vnet_data.py",
line 97, in GetParams

return self.an_params.GetParams()
  File "/usr/local/grass79/gui/wxpython/vnet/vnet_data.py",
line 681, in GetParams

invParams = self._getInvalidParams(self.params)
  File "/usr/local/grass79/gui/wxpython/vnet/vnet_data.py",
line 697, in _getInvalidParams

invParams = params.keys()[:]
TypeError
:
'dict_keys' object is not subscriptable
```

