### PR TITLE
wxGUI/gcpmanager: fix #430

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1747,6 +1747,7 @@ class GCP(MapFrame, ColumnSorterMixin):
             self.TgtMap.Clean()
 
             self.grwiz.Cleanup()
+            self._mgr.UnInit()
 
             self.Destroy()
 


### PR DESCRIPTION
Aui manger needs to be uninitialized.