### PR TITLE
Fix wxGUI Manage color rules interactively (vector map) wx.CollapsiblePane widget layout

### DIFF
--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -1251,7 +1251,7 @@ class VectorColorTable(ColorTable):
 
     def OnPaneChanged(self, event=None):
         # redo the layout
-        self.Layout()
+        self.panel.Layout()
         # and also change the labels
         if self.cp.IsExpanded():
             self.cp.SetLabel('')


### PR DESCRIPTION
Reproduce:

1. On the Layer Manager menu go to -> Vector -> Manage colors -> **Manage color rules interactively** (open frame)
2. Try expand/collapse **Import or export color table** panel

Default behavior:
![default_behavior](https://user-images.githubusercontent.com/50632337/77298972-0890a400-6cec-11ea-80d1-f7fe3c7fca5d.gif)

Fixed behavior:
![fixed_behavior](https://user-images.githubusercontent.com/50632337/77299016-1ba37400-6cec-11ea-9519-29edeea9dc6c.gif)

