### PR TITLE
Fix wxGUI Set vector output format load profile settings

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1891,7 +1891,7 @@ class GdalSelect(wx.Panel):
         # data list: [type, dsn, format, options]
         if len(data) == 3:
             data.append('')
-        elif len < 3:
+        elif len(data) < 3:
             return
 
         self.source.SetSelection(self.sourceMap[data[0]])
@@ -2747,7 +2747,7 @@ class SqlWhereSelect(wx.Panel):
             win.Show()
         except GException as e:
             GMessage(parent=self.parent, message='{}'.format(e))
-        
+
     def SetData(self, vector, layer):
         self.vector_map = vector
         self.vector_layer = int(layer) # TODO: support layer names


### PR DESCRIPTION
Reproduce:

1. Open Set vector output format dialog
1.1. Set Output type: Directory
1.2. Set Format: GeoPackage
1.3. Set Directory: /tmp/output_data
2. Save profile as test and close dialog
3. Open dialog choose test profile

Error message appear in the **Console** page:

```
Traceback (most recent call last):
  File
"/usr/local/grass79/gui/wxpython/gui_core/widgets.py", line
1286, in OnSettingsChanged

self.settingsChanged.emit(data=data)
  File
"/usr/local/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/local/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 349, in send

**named
  File "/usr/local/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File
"/usr/local/grass79/gui/wxpython/gui_core/gselect.py", line
1898, in OnSettingsChanged

elif data < 3:
TypeError
:
'<' not supported between instances of 'list' and 'int'
```