### PR TITLE
Fix wxGUI Set vector output format wx.Choice widget width

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1515,7 +1515,7 @@ class GdalSelect(wx.Panel):
         browse.GetChildren()[1].SetName('GdalSelectDataSource')
 
         self.dirWidgets['browse'] = browse
-        formatSelect = wx.Choice(parent=self.dirPanel, size=(300, -1))
+        formatSelect = wx.Choice(parent=self.dirPanel)
         self.dirWidgets['format'] = formatSelect
         fileFormats = GetFormats(writableOnly=dest)[fType]['file']
         formatSelect.SetItems(sorted(list(fileFormats)))
@@ -2747,7 +2747,7 @@ class SqlWhereSelect(wx.Panel):
             win.Show()
         except GException as e:
             GMessage(parent=self.parent, message='{}'.format(e))
-        
+
     def SetData(self, vector, layer):
         self.vector_map = vector
         self.vector_layer = int(layer) # TODO: support layer names

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -707,7 +707,7 @@ class GdalOutputDialog(wx.Dialog):
         dialogSizer.Fit(self.panel)
 
         size = wx.Size(
-            globalvar.DIALOG_GSELECT_SIZE[0] + 225,
+            globalvar.DIALOG_GSELECT_SIZE[0] + 320,
             self.GetBestSize()[1] + 35)
         self.SetMinSize(size)
         self.SetSize((size.width, size.height))


### PR DESCRIPTION
1. Open Set vector output format dialog

Default Format wx.Choice widget width:

![default_choice_widget_width](https://user-images.githubusercontent.com/50632337/77351561-3acaf180-6d3e-11ea-9881-251be0a0af3b.jpeg)

Customized widget width:

![customized_choice_widget_width](https://user-images.githubusercontent.com/50632337/77351719-72d23480-6d3e-11ea-892f-47dc75e1e66b.jpeg)




