### PR TITLE
Alpine dockerfile: removed PDAL

### DIFF
--- a/docker/alpine/Dockerfile_alpine_wxgui
+++ b/docker/alpine/Dockerfile_alpine_wxgui
@@ -18,7 +18,6 @@ ENV GRASS_CONFIG="\
       --with-cxx \
       --with-proj --with-proj-share=/usr/share/proj \
       --with-gdal \
-      --with-pdal \
       --with-python \
       --with-geos \
       --with-sqlite \
@@ -29,6 +28,7 @@ ENV GRASS_CONFIG="\
       --with-wxwidgets \
       --with-postgres --with-postgres-includes='/usr/include/postgresql' \
       --without-freetype \
+      --without-pdal \
       --without-openmp \
       --without-opengl \
       --without-nls \
@@ -64,7 +64,6 @@ ENV PACKAGES="\
       geos \
       gnutls \
       gtk+3.0 \
-      laszip \
       libbz2 \
       libjpeg-turbo \
       libpng \
@@ -73,7 +72,6 @@ ENV PACKAGES="\
       ncurses \
       openjpeg \
       openblas \
-      pdal \
       py3-numpy \
       py3-pillow \
       py3-six \
@@ -102,14 +100,12 @@ ENV PACKAGES="\
       geos-dev \
       gnutls-dev \
       gtk+3.0-dev \
-      laszip-dev \
       libc6-compat \
       libjpeg-turbo-dev \
       libpng-dev \
       make \
       openjpeg-dev \
       openblas-dev \
-      pdal-dev \
       postgresql-dev \
       proj-dev \
       python3-dev \
@@ -216,15 +212,12 @@ RUN pip install grass-session
 # set GRASSBIN
 ENV GRASSBIN="/usr/local/bin/grass"
 
-# ===========================
-# TEST grass-session and PDAL
-# ===========================
+# ==================
+# TEST grass-session
+# ==================
 
-WORKDIR /tmp
-COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## just scan the LAZ file
 # TODO: fix test
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
 
@@ -243,7 +236,6 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
 
 # show installed version
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
-    pdal --version && \
     python3 --version
 
 CMD [$GRASSBIN, "--version"]


### PR DESCRIPTION
Removed PDAL as it has been removed from Alpine Linux

(mainly sync with Dockerfile_alpine_latest)