### PR TITLE
Fix failing vector digitizer on mac, trac#3487

### DIFF
--- a/lib/python/ctypes/Makefile
+++ b/lib/python/ctypes/Makefile
@@ -56,9 +56,14 @@ proj_INC        = $(PROJINC)
 vector_INC      = $(VECT_INC) $(VECT_CFLAGS)
 vedit_INC       = $(VECT_INC) $(VECT_CFLAGS)
 
+MAC_FLAGS = ""
+ifneq ($(findstring darwin,$(ARCH)),)
+MAC_FLAGS  = "-D_Nullable="
+endif
+
 SED = sed
 CTYPESGEN = ./ctypesgen.py
-CTYPESFLAGS = --cpp "$(CC) -E $(CPPFLAGS) $(LFS_CFLAGS) $(EXTRA_CFLAGS) $(NLS_CFLAGS) $(DEFS) $(EXTRA_INC) $(INC) -D__GLIBC_HAVE_LONG_LONG"
+CTYPESFLAGS = --cpp "$(CC) -E $(CPPFLAGS) $(LFS_CFLAGS) $(MAC_FLAGS) $(EXTRA_CFLAGS) $(NLS_CFLAGS) $(DEFS) $(EXTRA_INC) $(INC) -D__GLIBC_HAVE_LONG_LONG"
 EXTRA_CLEAN_FILES := $(wildcard ctypesgencore/*.pyc) $(wildcard ctypesgencore/*/*.pyc)
 
 ifneq ($(MINGW),)


### PR DESCRIPTION
This fixes the [trac#3487](https://trac.osgeo.org/grass/ticket/3487) issue with failing (segfault) vector digitizing on mac.

It is actually a fix for two independent issues:
1. ctypes related. Ctypesgen generates incomplete py files. Addressed by adding compiler flag.
2. render related. On mac a render cycle has already started when the toolbar is inserted. Addressed by temporarily suspend rendering.

The second fix affects all platforms, so should be tested on linux and windows.

Important fix, should be backported to 7.8.3 if accepted.

Update: the second issue was reported separately: [trac#3652](https://trac.osgeo.org/grass/ticket/3652).
The issue [trac#3472](https://trac.osgeo.org/grass/ticket/3472) is probably also addressed by the ctypesgen fix.

Update 2: the second issue, was probably caused by my personally built debug version of python. Reverting to standard python build, this is no longer an issue. The [trac#3652](https://trac.osgeo.org/grass/ticket/3652) doesn't seem to be an issue anymore.