### PR TITLE
libraster

### DIFF
--- a/lib/raster/init.c
+++ b/lib/raster/init.c
@@ -93,6 +93,9 @@ static int init(void)
 
     R__.nbytes = sizeof(CELL);
 
+    R__.fileinfo_count = 0;
+    R__.fileinfo = NULL;
+
     R__.compression_type = G_default_compressor();
 
     cname = getenv("GRASS_COMPRESSOR");

--- a/lib/raster/open.c
+++ b/lib/raster/open.c
@@ -648,6 +648,7 @@ static int open_raster_new(const char *name, int open_mode,
     fcb->map_type = map_type;
     fcb->open_mode = -1;
     fcb->gdal = NULL;
+    fcb->vrt = NULL;
 
     /* for writing fcb->data is allocated to be R__.wr_window.cols * 
        sizeof(CELL or DCELL or FCELL)  */

--- a/lib/raster/vrt.c
+++ b/lib/raster/vrt.c
@@ -198,7 +198,8 @@ int Rast_get_vrt_row(int fd, void *buf, int row, RASTER_MAP_TYPE data_type)
 	     * a mask is applied to the collected data 
 	     * after this function returns */
 	    Rast_set_null_value(tmpbuf, rd_window->cols, data_type);
-	    tfd = Rast_open_old(p->name, p->mapset);
+	    /* avoid Rast__check_for_auto_masking() */
+	    tfd = Rast__open_old(p->name, p->mapset);
 	    Rast_get_row_nomask(tfd, tmpbuf, row, data_type);
 	    Rast_unopen(tfd);
 	    


### PR DESCRIPTION
Rast_get_vrt_row(): avoid free'ing of current vrt struct with Rast__check_for_auto_masking(), this causes a segmentation fault