### PR TITLE
datum.table: added SIRGAS 1995

### DIFF
--- a/lib/gis/datum.table
+++ b/lib/gis/datum.table
@@ -99,3 +99,5 @@ itrf92   "ITRF92"    grs80 dx=0   dy=0    dz=0
 S_JTSK	"System_Jednotne_Trigonometricke_Site_Katastralni"	bessel	dx=589	dy=76	dz=480
 # http://spatialreference.org/ref/epsg/4674/
 sirgas2000 "Sistema_de_Referencia_Geocentrico_para_las_AmericaS_2000"   grs80       dx=0        dy=0       dz=0
+# https://epsg.io/4170, sirgas1995 in degree
+sirgas1995 "Sistema_de_Referencia_Geocentrico_para_las_AmericaS_1995"   grs80       dx=0        dy=0       dz=0


### PR DESCRIPTION
Adds support for datum: Sistema de Referencia Geocentrico para America del Sur 1995

Fixes #452

Source: https://epsg.io/4170