### PR TITLE
Fix wxGUI g.gui.vdigit update available vector maps after the frame is show

### DIFF
--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -55,6 +55,9 @@ class VDigitToolbar(BaseToolbar):
             self.editingStopped.connect(layerTree.StopEditing)
             self.editingBgMap.connect(layerTree.SetBgMapForEditing)
 
+        # bind events
+        self.Bind(wx.EVT_SHOW, self.OnShow)
+
         # currently selected map layer for editing (reference to MapLayer
         # instance)
         self.mapLayer = None
@@ -1116,3 +1119,8 @@ class VDigitToolbar(BaseToolbar):
     def GetLayer(self):
         """Get selected layer for editing -- MapLayer instance"""
         return self.mapLayer
+
+    def OnShow(self, event):
+        """Show frame event"""
+        # list of available vector maps
+        self.UpdateListOfLayers(updateTool=True)


### PR DESCRIPTION
To reproduce:

1. On the Layer Manager add some vector map layer
2. On the Map Display window toolbar choose Vector digitizer (start editing)
3. On the Vector digitizer toolbar combobox widget choose vector map layer item (added in the first step)
4. Quit Vector digitizer (click on the Quit digitizer toolbar tool icon)
5. On the Layer Manager, double left click on added vector map layer, and choose another vector map layer
6. Repeat step number no. 2 
7. On the Vector digitizer toolbar combobox widget choose vector map layer item (added in step no. 5)
8. Vector maps layers list (step no. 7) doesn't contain actual layer name (contain previous layer name from step no. 1)

Default behavior:

![vdigit_layer_list](https://user-images.githubusercontent.com/50632337/77888538-b65ffd80-726c-11ea-83be-e71367bbbdcc.gif)

