### PR TITLE
Fix wxGUI Layer Manager add vector map layer Set color table interactively menu item

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -641,6 +641,14 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                 self.OnVectorColorTable,
                 id=self.popupID['color'])
 
+            self.popupMenu.Append(
+                self.popupID['colori'],
+                _("Set color table interactively"))
+            self.Bind(
+                wx.EVT_MENU,
+                self.lmgr.OnVectorRules,
+                id=self.popupID['colori'])
+
             item = wx.MenuItem(
                 self.popupMenu,
                 id=self.popupID['attr'],


### PR DESCRIPTION

![set_color_table_interactively_vector_map_menu_item](https://user-images.githubusercontent.com/50632337/78061354-69277d00-738d-11ea-9119-c0c306c28b45.jpeg)


