### PR TITLE
v.report: Fix newline issue

### DIFF
--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -100,7 +100,7 @@ def main():
     # NOTE: we suppress -1 cat and 0 cat
     if isConnection:
         f = grass.vector_db(map=mapname)[int(layer)]
-        p = grass.pipe_command('v.db.select', quiet=True, map=mapname, layer=layer)
+        p = grass.pipe_command('v.db.select', flags='n', quiet=True, map=mapname, layer=layer)
         records1 = []
         catcol = -1
         ncols = 0

--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -100,7 +100,7 @@ def main():
     # NOTE: we suppress -1 cat and 0 cat
     if isConnection:
         f = grass.vector_db(map=mapname)[int(layer)]
-        p = grass.pipe_command('v.db.select', flags='n', quiet=True, map=mapname, layer=layer)
+        p = grass.pipe_command('v.db.select', flags='e', quiet=True, map=mapname, layer=layer)
         records1 = []
         catcol = -1
         ncols = 0


### PR DESCRIPTION
# Issue

If there are newline characters in a column, `v.report` will fail. I found this issue in the GADM 3.6 dataset.

# How to reproduce it in the NC sample dataset

```
g.copy --o vect=boundary_county,tmp
db.execute sql="update tmp set name='BREAK' || char(10) || 'ME' where cat=1"
v.report map=tmp option=area
```
will fail.

# What does this PR do?

It uses the new `-e` flag of `v.db.select` from #476.