### PR TITLE
v.to.db: Require --overwrite flag to overwrite existing columns

### DIFF
--- a/vector/v.to.db/main.c
+++ b/vector/v.to.db/main.c
@@ -206,8 +206,12 @@ int main(int argc, char *argv[])
 			}
 		    }
 
-		    G_warning(_("Values in column <%s> will be overwritten"),
-			      options.col[col]);
+		    if (G_get_overwrite())
+			G_warning(_("Values in column <%s> will be overwritten"),
+				  options.col[col]);
+		    else
+			G_fatal_error(_("Column <%s> exists. To overwrite, use the --overwrite flag"),
+				      options.col[col]);
 
 		    break;
 		}

--- a/vector/v.to.db/v.to.db.html
+++ b/vector/v.to.db/v.to.db.html
@@ -36,11 +36,10 @@ a given input vector <em>layer</em>. The <b>print only</b> (<b>-p</b>) mode
 doesn't require a table. Use <em><a href="db.execute.html">db.execute</a></em>
 or <em><a href="v.db.addtable.html">v.db.addtable</a></em> to create a table if
 needed.
-<p>Updating the table has to be done column-wise. The <em>column</em> must be
-present in the table, except when using the <b>print only</b> (<b>-p</b>)
-mode. Use <em><a href="db.execute.html">db.execute</a></em> or
-<em><a href="v.db.addcolumn.html">v.db.addcolumn</a></em> to add new columns if
-needed.
+<p>Updating the table has to be done column-wise. The <em>column</em> will be
+created in the table if it doesn't already exist, except when using the
+<b>print only</b> (<b>-p</b>) mode. If the <em>column</em> exists, the
+<b>--overwrite</b> flag is required to overwrite it.
 
 <h2>EXAMPLES</h2>
 


### PR DESCRIPTION
This PR implements the `--overwrite` flag as discussed in https://trac.osgeo.org/grass/ticket/3466 and updates the manual. It requires the `--overwrite` flag to overwrite existing columns.