### PR TITLE
Fix wxGUI Import vector/raster dialog min width

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1687,7 +1687,7 @@ class GdalSelect(wx.Panel):
         sizer = wx.GridBagSizer(vgap=5, hgap=10)
         paddingSizer.Add(self.fileWidgets['browse'],
                          flag=wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND,
-                         border=30)
+                         border=35)
         sizer.Add(paddingSizer, flag=wx.EXPAND, pos=(0, 0), span=(1, 2))
         sizer.AddGrowableCol(0)
         if self.dest:

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -222,7 +222,7 @@ class ImportDialog(wx.Dialog):
         dialogSizer.Fit(self.panel)
 
         # auto-layout seems not work here - FIXME
-        size = wx.Size(globalvar.DIALOG_GSELECT_SIZE[0] + 225, 550)
+        size = wx.Size(globalvar.DIALOG_GSELECT_SIZE[0] + 322, 550)
         self.SetMinSize(size)
         self.SetSize((size.width, size.height + 100))
         # width = self.GetSize()[0]


### PR DESCRIPTION
Default min width:

![vector_import_dialog](https://user-images.githubusercontent.com/50632337/78649018-213cb480-78bd-11ea-9b00-5537ddc595aa.png)

Fix border size:

![vector_import_dialog_browse_widget_border](https://user-images.githubusercontent.com/50632337/78649231-74166c00-78bd-11ea-82db-5f84e1a57472.png)

