### PR TITLE
Fix bug introduced in the issue #466

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -909,8 +909,6 @@ class BufferedMapWindow(MapWindowBase, Window):
         Debug.msg(1, "BufferedWindow.UpdateMap(): started "
                   "(render=%s, renderVector=%s)" % (render, renderVector))
 
-        self.resize = False
-
         # was if self.Map.cmdfile and ...
         if self.IsAlwaysRenderEnabled() and self.img is None:
             render = True


### PR DESCRIPTION
I confirm this bug #466. The solution is set the correct empty bitmap buffer size. 