### PR TITLE
wxGUI: delete also lmgr notebook pages when closing workspace

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1752,6 +1752,8 @@ class GMFrame(wx.Frame):
             self.workspaceFile)
 
         self.OnDisplayCloseAll()
+        self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
+        self.notebookLayers.DeleteAllPages()
         self.workspaceFile = None
         self.workspaceChanged = False
         self._setTitle()


### PR DESCRIPTION
The bug was introduced in #427.