### PR TITLE
wxGUI Layer Manager: Fix close all open map display windows via menu item

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1768,8 +1768,7 @@ class GMFrame(wx.Frame):
         """Close all open map display windows
         """
         for display in self.GetMapDisplay(onlyCurrent=False):
-            display.CleanUp()
-            display.Destroy()
+            display.OnCloseWindow(event)
 
     def OnRenderAllMapDisplays(self, event=None):
         for display in self.GetAllMapDisplays():


### PR DESCRIPTION
To reproduce:

1. Open another Map Display Window (via toolbar item icon Start new map display)
1. On Layer Manager go to menu File -> Map display -> Close all open map display windows
2. Corresponding Layer Manager Display tab doesn' t close
