### PR TITLE
wxGUI Module dialog: Fix enable scrolling for the Basic top module style (fix bug introduced in the issue #480)

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -1344,7 +1344,7 @@ class CmdPanel(wx.Panel):
                                        flag=style, border=5)
                         font_sizer.Add(font_btn, proportion=0,
                                        flag=style, border=5)
-                        
+
                         which_sizer.Add(font_sizer, proportion=0,
                                         flag=style, border=5)
                         p['wxId'].append(font_btn.GetId())
@@ -2082,7 +2082,7 @@ class CmdPanel(wx.Panel):
                             self.OnUpdateValues()  # TODO: replace by signal
 
                         self.win1.OnCheckItem = OnCheckItem
-                        
+
                 elif prompt == 'sql_query':
                     win = gselect.SqlWhereSelect(
                         parent=which_panel, param=p)
@@ -2207,7 +2207,7 @@ class CmdPanel(wx.Panel):
         pSqlWhereIds = []
         for p in pSqlWhere:
             pSqlWhereIds += p['wxId']
-        
+
         # set wxId-bindings
         if pMap:
             pMap['wxId-bind'] = []
@@ -2253,7 +2253,7 @@ class CmdPanel(wx.Panel):
         maxsizes = (0, 0)
         for section in sections:
             tab[section].SetSizer(tabsizer[section])
-            tabsizer[section].Fit(tab[section])
+            tab[section].SetupScrolling(True, True, 10, 10)
             tab[section].Layout()
             minsecsizes = tabsizer[section].GetSize()
             maxsizes = list(map(lambda x: max(maxsizes[x], minsecsizes[x]), (0, 1)))


### PR DESCRIPTION
I confirm this bug #480.

How to reproduce:

Bug related with module dialog Basic top style, another style has vertical and horizontal scrollbar.

1. On the Layer Manager Window menu go to Settings -> Preferences -> Appearance page (tab)
2. Change Module dialog style to Basic top
3. Open `r.sun` module

Default behavior:

![r_sun_module_dialog](https://user-images.githubusercontent.com/50632337/79129612-d253bb00-7da5-11ea-8323-7363e7c8f4ba.png)

Expected, fixed behavior:

![fixed_r_sun_module_dialog](https://user-images.githubusercontent.com/50632337/79130726-c0731780-7da7-11ea-9f39-7d96988015fe.png)

