### PR TITLE
g.gui.vdigit Snap selected lines/boundaries tool: Fix checking SnapLine function return value

### DIFF
--- a/gui/wxpython/vdigit/wxdigit.py
+++ b/gui/wxpython/vdigit/wxdigit.py
@@ -1165,7 +1165,7 @@ class IVDigit:
     def SnapLine(self):
         """Snap selected lines/boundaries
 
-        :return: on success
+        :return: 0 on success
         :return: -1 on error
         """
         if not self._checkMap():
@@ -1180,6 +1180,8 @@ class IVDigit:
         if nlines < Vect_get_num_lines(self.poMapInfo):
             self._addChangeset()
             self.toolbar.EnableUndo()
+
+        return 0
 
     def ConnectLine(self):
         """Connect selected lines/boundaries


### PR DESCRIPTION
To reproduce.

1. Start editing new vector map
2. Digitize new line
3. Digitize new line near to first line
4. Set suitable snapping treshold value
5. Chose Additional tool -> Snap selected lines/boundaries (only to nodes) tool
6. Apply tool

Error message:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 1397, in MouseActions

self.OnRightUp(event)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 1643, in OnRightUp

self._onRightUp(event)
  File
"/usr/lib64/grass79/gui/wxpython/vdigit/mapwindow.py", line
1071, in _onRightUp

if self.digit.SnapLine() < 0:
TypeError
:
'<' not supported between instances of 'NoneType' and 'int'
```