### PR TITLE
[WIP] Fix ctypes bsd

### DIFF
--- a/lib/python/ctypes/Makefile
+++ b/lib/python/ctypes/Makefile
@@ -63,7 +63,7 @@ endif
 
 SED = sed
 CTYPESGEN = ./ctypesgen.py
-CTYPESFLAGS = --cpp "$(CC) -E $(CPPFLAGS) $(LFS_CFLAGS) $(MAC_FLAGS) $(EXTRA_CFLAGS) $(NLS_CFLAGS) $(DEFS) $(EXTRA_INC) $(INC) -D__GLIBC_HAVE_LONG_LONG"
+CTYPESFLAGS = --cpp "$(CC) -E $(CPPFLAGS) $(LFS_CFLAGS) $(MAC_FLAGS) $(EXTRA_CFLAGS) $(NLS_CFLAGS) $(DEFS) $(EXTRA_INC) $(INC) -D__GLIBC_HAVE_LONG_LONG -D__GNUCLIKE_BUILTIN_VARARGS"
 EXTRA_CLEAN_FILES := $(wildcard ctypesgencore/*.pyc) $(wildcard ctypesgencore/*/*.pyc)
 
 ifneq ($(MINGW),)

--- a/lib/python/ctypes/ctypesgencore/parser/preprocessor.py
+++ b/lib/python/ctypes/ctypesgencore/parser/preprocessor.py
@@ -123,7 +123,8 @@ class PreprocessorParser(object):
     def __init__(self, options, cparser):
         self.defines = ["inline=", "__inline__=", "__extension__=",
                         "_Bool=uint8_t", "__const=const", "__asm__(x)=",
-                        "__asm(x)=", "CTYPESGEN=1"]
+                        "__asm(x)=", "CTYPESGEN=1",
+			"__attribute__(x)=", "__aligned(x)=", "_Noreturn="]
 
         # On OSX, explicitly add these defines to keep from getting syntax
         # errors in the OSX standard headers.


### PR DESCRIPTION
This PR reduces error messages on BSD-like systems (FreeBSD and MacOs).
I am still stuck on xxintrin.h.

Only tested on my local machine (FreeBSD 12 amd64).

Still as a WIP for now.