### PR TITLE
Lazy imports and work without import numpy

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -43,7 +43,6 @@ from core.settings import UserSettings, GetDisplayVectSettings
 from vdigit.main import haveVDigit
 from core.gcmd import GWarning, GError, RunCommand
 from icons.icon import MetaIcon
-from web_services.dialogs import SaveWMSLayerDialog
 from gui_core.widgets import MapValidator
 from gui_core.wrap import Menu, GenBitmapButton, TextCtrl, NewId
 from lmgr.giface import LayerManagerGrassInterfaceForMapDisplay
@@ -897,6 +896,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
     def OnSaveWs(self, event):
         """Show dialog for saving web service layer into GRASS vector/raster layer"""
         mapLayer = self.GetLayerInfo(self.layer_selected, key='maplayer')
+        from web_services.dialogs import SaveWMSLayerDialog
         dlg = SaveWMSLayerDialog(parent=self, layer=mapLayer,
                                  giface=self._gifaceForDisplay)
         dlg.CentreOnScreen()

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -37,7 +37,6 @@ from gui_core.dialogs import SqlQueryFrame, SetOpacityDialog, TextEntryDialog
 from gui_core.forms import GUI
 from mapdisp.frame import MapFrame
 from core.render import Map
-from wxplot.histogram import HistogramPlotFrame
 from core.utils import GetLayerNameFromCmd, ltype2command
 from core.debug import Debug
 from core.settings import UserSettings, GetDisplayVectSettings
@@ -1136,6 +1135,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                              "raster map. No map name defined."))
             return
 
+        # lazy import to reduce dependecies and startup
+        from wxplot.histogram import HistogramPlotFrame
         win = HistogramPlotFrame(parent=self, giface=self._giface, rasterList=rasterList)
         win.CentreOnScreen()
         win.Show()

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -46,7 +46,7 @@ from icons.icon import MetaIcon
 from gui_core.widgets import MapValidator
 from gui_core.wrap import Menu, GenBitmapButton, TextCtrl, NewId
 from lmgr.giface import LayerManagerGrassInterfaceForMapDisplay
-from core.giface import Notification
+
 
 TREE_ITEM_HEIGHT = 25
 


### PR DESCRIPTION
This follows other lazy imports in lmgr.frame and potentially speeds up GUI startup,
but more importantly, it avoids numpy import in wx.lib.plot.plotcanvas
used by wxplot.histogram.

Now GUI starts without numpy installed with message in terminal from wxnviz
which should be the only place requiring numpy on startup and thus proving
a message about the missing dependency.

Additionally, web_services.dialogs.SaveWMSLayerDialog is lazy imported and unused core.giface.Notification is removed.

I tested the histogram and save WMS from layer tree with numpy present. Without this PR, wxGUI won't start when numpy is missing, although I did not test if it really does.