### PR TITLE
Fix grass-session installation in alpine docker

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -193,12 +193,8 @@ COPY --from=build /usr/local/grass* /usr/local/grass/
 # pip 20.0.0 fix
 RUN apk add curl && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py pip==20.0.2 && rm get-pip.py
 #RUN pip3 install --upgrade pip six grass-session
-RUN pip3 install --upgrade pip six
 RUN apk add git
-RUN git clone https://github.com/zarch/grass-session.git
-WORKDIR grass-session
-RUN git checkout 0b8414c1 && python3 setup.py install
-
+RUN pip3 install --upgrade pip six git+git://github.com/zarch/grass-session.git@0b8414c1
 RUN ln -s /usr/local/grass /usr/local/grass7
 RUN ln -s /usr/local/grass `grass --config path`
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \

--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -192,7 +192,13 @@ COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
 # pip 20.0.0 fix
 RUN apk add curl && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py pip==20.0.2 && rm get-pip.py
-RUN pip3 install --upgrade pip six grass-session
+#RUN pip3 install --upgrade pip six grass-session
+RUN pip3 install --upgrade pip six
+RUN apk add git
+RUN git clone https://github.com/zarch/grass-session.git
+WORKDIR grass-session
+RUN git checkout 0b8414c1 && python3 setup.py install
+
 RUN ln -s /usr/local/grass /usr/local/grass7
 RUN ln -s /usr/local/grass `grass --config path`
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \


### PR DESCRIPTION
WARNING: fixed by using an old version of grass-session
This PR uses an old version in the alpine Dockerfile until https://github.com/zarch/grass-session/issues/16 is fixed to remain operational.

*backport needed*