### PR TITLE
Fix grass-session installation in docker files

### DIFF
--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -195,7 +195,10 @@ ENV INTEL="" \
 # =====================
 
 # install external Python API
-RUN pip install grass-session
+#RUN pip install grass-session
+# ugly workaround for https://github.com/zarch/grass-session/issues/16
+RUN apk add git
+RUN pip3 install --upgrade pip six git+git://github.com/zarch/grass-session.git@0b8414c1
 
 # set GRASSBIN
 ENV GRASSBIN="/usr/local/bin/grass"

--- a/docker/alpine/Dockerfile_alpine_wxgui
+++ b/docker/alpine/Dockerfile_alpine_wxgui
@@ -207,7 +207,10 @@ ENV INTEL="" \
 # =====================
 
 # install external Python API
-RUN pip install grass-session
+#RUN pip install grass-session
+# ugly workaround for https://github.com/zarch/grass-session/issues/16
+RUN apk add git
+RUN pip3 install --upgrade pip six git+git://github.com/zarch/grass-session.git@0b8414c1
 
 # set GRASSBIN
 ENV GRASSBIN="/usr/local/bin/grass"

--- a/docker/debian/Dockerfile_debian_pdal
+++ b/docker/debian/Dockerfile_debian_pdal
@@ -225,7 +225,10 @@ RUN apt-get clean -y
 WORKDIR /scripts
 
 # install external GRASS GIS session Python API
-RUN pip3 install grass-session
+#RUN pip3 install grass-session
+# ugly workaround for https://github.com/zarch/grass-session/issues/16
+RUN apt-get install git
+RUN pip3 install --upgrade pip3 git+git://github.com/zarch/grass-session.git@0b8414c1
 
 # install GRASS GIS extensions
 RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal

--- a/docker/ubuntu/Dockerfile_ubuntu_latest_pdal
+++ b/docker/ubuntu/Dockerfile_ubuntu_latest_pdal
@@ -171,7 +171,10 @@ RUN apt-get clean -y
 WORKDIR /scripts
 
 # install external GRASS GIS session Python API
-RUN pip3 install grass-session
+#RUN pip3 install grass-session
+# ugly workaround for https://github.com/zarch/grass-session/issues/16
+RUN apt-get install git
+RUN pip3 install --upgrade pip3 git+git://github.com/zarch/grass-session.git@0b8414c1
 
 # install GRASS GIS extensions
 RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal

--- a/docker/ubuntu/Dockerfile_ubuntu_pdal
+++ b/docker/ubuntu/Dockerfile_ubuntu_pdal
@@ -226,7 +226,10 @@ RUN apt-get clean -y
 WORKDIR /scripts
 
 # install external GRASS GIS session Python API
-RUN pip3 install grass-session
+#RUN pip3 install grass-session
+# ugly workaround for https://github.com/zarch/grass-session/issues/16
+RUN apt-get install git
+RUN pip3 install --upgrade pip3 git+git://github.com/zarch/grass-session.git@0b8414c1
 
 # install GRASS GIS extensions
 RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal


### PR DESCRIPTION
Due to https://github.com/zarch/grass-session/issues/16 all docker builds are currently broken.

This workaround pins the last working version by applying the workaround used in https://github.com/OSGeo/grass/pull/516

To be removed once `grass-session` is back functional.