### PR TITLE
Fix fixed-width CJK formatting

### DIFF
--- a/include/defs/gis.h
+++ b/include/defs/gis.h
@@ -161,15 +161,15 @@ int G_asprintf(char **, const char *, ...)
 int G_rasprintf(char **, size_t *,const char *, ...)
     __attribute__ ((format(printf, 3, 4)));
 
-/* printa.c */
-int G_printa(const char *, ...);
-int G_fprinta(FILE *, const char *, ...);
-int G_sprinta(char *, const char *, ...);
-int G_snprinta(char *, size_t, const char *, ...);
-int G_vprinta(const char *, va_list);
-int G_vfprinta(FILE *, const char *, va_list);
-int G_vsprinta(char *, const char *, va_list);
-int G_vsnprinta(char *, size_t, const char *, va_list);
+/* aprintf.c */
+int G_aprintf(const char *, ...);
+int G_faprintf(FILE *, const char *, ...);
+int G_saprintf(char *, const char *, ...);
+int G_snaprintf(char *, size_t, const char *, ...);
+int G_vaprintf(const char *, va_list);
+int G_vfaprintf(FILE *, const char *, va_list);
+int G_vsaprintf(char *, const char *, va_list);
+int G_vsnaprintf(char *, size_t, const char *, va_list);
 
 /* bands.c */
 int G__read_band_reference(FILE *, struct Key_Value **);

--- a/include/defs/gis.h
+++ b/include/defs/gis.h
@@ -161,6 +161,16 @@ int G_asprintf(char **, const char *, ...)
 int G_rasprintf(char **, size_t *,const char *, ...)
     __attribute__ ((format(printf, 3, 4)));
 
+/* printa.c */
+int G_printa(const char *, ...);
+int G_fprinta(FILE *, const char *, ...);
+int G_sprinta(char *, const char *, ...);
+int G_snprinta(char *, size_t, const char *, ...);
+int G_vprinta(const char *, va_list);
+int G_vfprinta(FILE *, const char *, va_list);
+int G_vsprinta(char *, const char *, va_list);
+int G_vsnprinta(char *, size_t, const char *, va_list);
+
 /* bands.c */
 int G__read_band_reference(FILE *, struct Key_Value **);
 int G__write_band_reference(FILE *, const char *, const char *);

--- a/lib/gis/aprintf.c
+++ b/lib/gis/aprintf.c
@@ -389,7 +389,7 @@ int G_vsnaprintf(char *str, size_t size, const char *format, va_list ap)
 }
 
 /*!
- * \brief Adjust the width of string specifiers to the display space intead of
+ * \brief Adjust the width of string specifiers to the display space instead of
  * the number of bytes for wide characters and print them formatted using the
  * adjusted display width.
  *

--- a/lib/gis/aprintf.c
+++ b/lib/gis/aprintf.c
@@ -27,7 +27,7 @@
 /* printf(3) man page */
 #define CONVS "diouxXeEfFgGaAcsCSpnm%"
 
-/* % + flags + width + precision + length + conversoin + NULL */
+/* % + flags + width + precision + length + conversion + NULL */
 #define SPEC_BUF_SIZE 16
 
 struct options

--- a/lib/gis/aprintf.c
+++ b/lib/gis/aprintf.c
@@ -1,9 +1,9 @@
 /*!
- * \file lib/gis/printa.c
+ * \file lib/gis/aprintf.c
  *
  * \brief GIS Library - Print functions for aligning wide characters.
  *
- * Extracted from the print-aligned C library (libprinta under GPL v3+) by
+ * Extracted from the aligned printf C library (libaprintf under GPL v3+) by
  * Huidae Cho.
  *
  * (C) 2020 by the GRASS Development Team
@@ -42,7 +42,7 @@ static int count_wide_chars_in_cols(const char *, int);
 static int count_bytes_in_cols(const char *, int);
 static int ovprintf(struct options *, const char *, va_list);
 static int oprintf(struct options *, const char *, ...);
-static int oprinta(struct options *, const char *, va_list);
+static int oaprintf(struct options *, const char *, va_list);
 
 /*!
  * \brief Count the number of wide characters in a string.
@@ -176,7 +176,7 @@ static int oprintf(struct options *opts, const char *format, ...)
 
 /*!
  * \brief Core function for aligning wide characters with Latin characters
- * using %s specifiers. G_printa(), G_fprinta(), and G_sprinta() wrap around
+ * using %s specifiers. G_aprintf(), G_faprintf(), and G_saprintf() wrap around
  * this function to implement printf(), fprintf(), and sprintf() counterparts,
  * respectively.
  *
@@ -185,7 +185,7 @@ static int oprintf(struct options *opts, const char *format, ...)
  * \param[in] ap variable argument list for the format string
  * \return number of bytes printed or fatal error on error
  */
-static int oprinta(struct options *opts, const char *format, va_list ap)
+static int oaprintf(struct options *opts, const char *format, va_list ap)
 {
     char *fmt, *asis, *p, spec[SPEC_BUF_SIZE];
     int nbytes = 0;
@@ -329,26 +329,26 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 }
 
 /*!
- * \brief vprintf() version of G_printa(). See G_printa() for more details.
+ * \brief vprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] format string format
  * \param[in] ap variable argument list for the format string
  * \return number of bytes printed or fatal error on error
  */
-int G_vprinta(const char *format, va_list ap)
+int G_vaprintf(const char *format, va_list ap)
 {
-    return oprinta(NULL, format, ap);
+    return oaprintf(NULL, format, ap);
 }
 
 /*!
- * \brief vfprintf() version of G_printa(). See G_printa() for more details.
+ * \brief vfprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] stream file pointer
  * \param[in] format string format
  * \param[in] ap variable argument list for the format string
  * \return number of bytes printed or fatal error on error
  */
-int G_vfprinta(FILE *stream, const char *format, va_list ap)
+int G_vfaprintf(FILE *stream, const char *format, va_list ap)
 {
     struct options opts;
 
@@ -356,18 +356,18 @@ int G_vfprinta(FILE *stream, const char *format, va_list ap)
     opts.str = NULL;
     opts.size = -1;
 
-    return oprinta(&opts, format, ap);
+    return oaprintf(&opts, format, ap);
 }
 
 /*!
- * \brief vsprintf() version of G_printa(). See G_printa() for more details.
+ * \brief vsprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] str string buffer
  * \param[in] format string format
  * \param[in] ap variable argument list for the format string
  * \return number of bytes printed or fatal error on error
  */
-int G_vsprinta(char *str, const char *format, va_list ap)
+int G_vsaprintf(char *str, const char *format, va_list ap)
 {
     struct options opts;
 
@@ -375,11 +375,11 @@ int G_vsprinta(char *str, const char *format, va_list ap)
     opts.str = opts._str = str;
     opts.size = -1;
 
-    return oprinta(&opts, format, ap);
+    return oaprintf(&opts, format, ap);
 }
 
 /*!
- * \brief vsnprintf() version of G_printa(). See G_printa() for more details.
+ * \brief vsnprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] str string buffer
  * \param[in] size string buffer size
@@ -388,7 +388,7 @@ int G_vsprinta(char *str, const char *format, va_list ap)
  * \return number of bytes that would be printed if size was big enough or
  *	   fatal error on error
  */
-int G_vsnprinta(char *str, size_t size, const char *format, va_list ap)
+int G_vsnaprintf(char *str, size_t size, const char *format, va_list ap)
 {
     struct options opts;
 
@@ -396,7 +396,7 @@ int G_vsnprinta(char *str, size_t size, const char *format, va_list ap)
     opts.str = opts._str = str;
     opts.size = opts._size = size;
 
-    return oprinta(&opts, format, ap);
+    return oaprintf(&opts, format, ap);
 }
 
 /*!
@@ -411,7 +411,7 @@ int G_vsnprinta(char *str, size_t size, const char *format, va_list ap)
     가나|
 -----------
  * and
- *	G_printa("%10s|\n%10s|\n", "ABCD", "가나");
+ *	G_aprintf("%10s|\n%10s|\n", "ABCD", "가나");
 -----------
       ABCD|
       가나|
@@ -421,60 +421,60 @@ int G_vsnprinta(char *str, size_t size, const char *format, va_list ap)
  * \param[in] ... arguments for the format string
  * \return number of bytes printed or fatal error on error
  */
-int G_printa(const char *format, ...)
+int G_aprintf(const char *format, ...)
 {
     va_list ap;
     int nbytes;
 
     va_start(ap, format);
-    nbytes = G_vprinta(format, ap);
+    nbytes = G_vaprintf(format, ap);
     va_end(ap);
 
     return nbytes;
 }
 
 /*!
- * \brief fprintf() version of G_printa(). See G_printa() for more details.
+ * \brief fprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] stream file pointer
  * \param[in] format string format
  * \param[in] ... arguments for the format string
  * \return number of bytes printed or fatal error on error
  */
-int G_fprinta(FILE *stream, const char *format, ...)
+int G_faprintf(FILE *stream, const char *format, ...)
 {
     va_list ap;
     int nbytes;
 
     va_start(ap, format);
-    nbytes = G_vfprinta(stream, format, ap);
+    nbytes = G_vfaprintf(stream, format, ap);
     va_end(ap);
 
     return nbytes;
 }
 
 /*!
- * \brief sprintf() version of G_printa(). See G_printa() for more details.
+ * \brief sprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] str string buffer
  * \param[in] format string format
  * \param[in] ... arguments for the format string
  * \return number of bytes printed or fatal error on error
  */
-int G_sprinta(char *str, const char *format, ...)
+int G_saprintf(char *str, const char *format, ...)
 {
     va_list ap;
     int nbytes;
 
     va_start(ap, format);
-    nbytes = G_vsprinta(str, format, ap);
+    nbytes = G_vsaprintf(str, format, ap);
     va_end(ap);
 
     return nbytes;
 }
 
 /*!
- * \brief snprintf() version of G_printa(). See G_printa() for more details.
+ * \brief snprintf() version of G_aprintf(). See G_aprintf() for more details.
  *
  * \param[in] str string buffer
  * \param[in] size string buffer size
@@ -483,13 +483,13 @@ int G_sprinta(char *str, const char *format, ...)
  * \return number of bytes that would be printed if size was big enough or
  *	   fatal error on error
  */
-int G_snprinta(char *str, size_t size, const char *format, ...)
+int G_snaprintf(char *str, size_t size, const char *format, ...)
 {
     va_list ap;
     int nbytes;
 
     va_start(ap, format);
-    nbytes = G_vsnprinta(str, size, format, ap);
+    nbytes = G_vsnaprintf(str, size, format, ap);
     va_end(ap);
 
     return nbytes;

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -80,17 +80,17 @@ static int count_wide_chars_in_cols(const char *str, int ncols)
     int count = 0, lead = 0;
 
     str--;
-    while(ncols >= 0 && *++str){
-	if((*str & 0xc0) != 0x80){
+    while (ncols >= 0 && *++str) {
+	if ((*str & 0xc0) != 0x80) {
 	    lead = 1;
 	    ncols--;
-	}else if(lead){
+	} else if (lead) {
 	    lead = 0;
 	    ncols--;
 	    count++;
 	}
     }
-    if((*str & 0xc0) == 0x80)
+    if ((*str & 0xc0) == 0x80)
 	count--;
 
     return count;
@@ -108,11 +108,11 @@ static int count_bytes_in_cols(const char *str, int ncols)
     const char *p = str - 1;
     int lead = 0;
 
-    while(ncols >= 0 && *++p){
-	if((*p & 0xc0) != 0x80){
+    while (ncols >= 0 && *++p) {
+	if ((*p & 0xc0) != 0x80) {
 	    lead = 1;
 	    ncols--;
-	}else if(lead){
+	} else if (lead) {
 	    lead = 0;
 	    ncols--;
 	}

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -82,7 +82,7 @@ static int _vprintf(struct options *opts, const char *format, va_list ap)
 	nbytes = vfprintf(opts->stream, format, ap);
     else {
 	if ((long int)opts->size >= 0) {
-	    /* snprintf(str, 0, ...) prints garbage */
+	    /* snprintf(str, 0, ...) does not alter str */
 	    nbytes = vsnprintf(opts->_str, opts->_size, format, ap);
 	    opts->_size -= nbytes;
 	} else

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -156,6 +156,7 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 		    char tmp;
 		    /* found a conversion specifier */
 		    if (*c == 's') {
+			/* if this is a string specifier */
 			int width = -1, prec = -1, use_ovprintf = 1;
 			char *p_tmp, *s;
 			va_list ap_copy;
@@ -164,15 +165,17 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 			 * characters */
 			va_copy(ap_copy, ap);
 
-			/* if string */
 			*p_spec = 0;
 			p_spec = spec;
 			if (*p_spec == '-')
+			    /* alignment */
 			    p_spec++;
 			if (*p_spec == '*') {
+			    /* read width from next argument */
 			    width = va_arg(ap, int);
 			    p_spec++;
 			} else if (*p_spec >= '0' && *p_spec <= '9') {
+			    /* read width */
 			    p_tmp = p_spec;
 			    while (*p_spec >= '0' && *p_spec <= '9')
 				p_spec++;
@@ -182,11 +185,14 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 			    *p_spec = tmp;
 			}
 			if (*p_spec == '.') {
+			    /* precision */
 			    p_spec++;
 			    if (*p_spec == '*') {
+				/* read precision from next argument */
 				prec = va_arg(ap, int);
 				p_spec++;
 			    } else if (*p_spec >= '0' && *p_spec <= '9') {
+				/* read precision */
 				p_tmp = p_spec;
 				while (*p_spec >= '0' && *p_spec <= '9')
 				    p_spec++;
@@ -197,7 +203,7 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 			    }
 			}
 			if (*p_spec) {
-			    /* really? */
+			    /* illegal string specifier? */
 			    va_end(ap_copy);
 			    *(q + 1) = 0;
 			    G_fatal_error(_("Failed to parse string specifier: %s"), p);
@@ -205,9 +211,11 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 
 			s = va_arg(ap, char *);
 			if (width > 0) {
+			    /* if width is specified */
 			    int wcount = wide_count(s);
 
 			    if (wcount) {
+				/* if there are wide characters */
 				width += wcount;
 				prec += prec > 0 ? wcount : 0;
 				p_spec = spec;
@@ -220,7 +228,9 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 				nbytes += oprintf(opts, spec, s);
 				use_ovprintf = 0;
 			    }
+			    /* else use ovprintf() as much as possible */
 			}
+			/* else use ovprintf() as much as possible */
 			if (use_ovprintf) {
 			    tmp = *(q + 1);
 			    *(q + 1) = 0;
@@ -230,7 +240,7 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 
 			va_end(ap_copy);
 		    } else {
-			/* else use ovprintf() */
+			/* else use ovprintf() for non-string specifiers */
 			tmp = *(q + 1);
 			*(q + 1) = 0;
 			nbytes += ovprintf(opts, p, ap);

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -205,6 +205,7 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
 			s = va_arg(ap, char *);
 			if (width > 0) {
 			    int wcount = wide_count(s);
+
 			    if (wcount) {
 				width += wcount;
 				prec += prec > 0 ? wcount : 0;

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -80,7 +80,7 @@ static int count_wide_chars_in_cols(const char *str, int ncols)
     int count = 0, lead = 0;
 
     str--;
-    while (ncols >= 0 && *++str) {
+    while (ncols >= 0 && *++str)
 	if ((*str & 0xc0) != 0x80) {
 	    lead = 1;
 	    ncols--;
@@ -89,7 +89,6 @@ static int count_wide_chars_in_cols(const char *str, int ncols)
 	    ncols--;
 	    count++;
 	}
-    }
     if ((*str & 0xc0) == 0x80)
 	count--;
 
@@ -108,7 +107,7 @@ static int count_bytes_in_cols(const char *str, int ncols)
     const char *p = str - 1;
     int lead = 0;
 
-    while (ncols >= 0 && *++p) {
+    while (ncols >= 0 && *++p)
 	if ((*p & 0xc0) != 0x80) {
 	    lead = 1;
 	    ncols--;
@@ -116,7 +115,6 @@ static int count_bytes_in_cols(const char *str, int ncols)
 	    lead = 0;
 	    ncols--;
 	}
-    }
 
     return p - str;
 }

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -135,7 +135,7 @@ static int oprinta(struct options *opts, const char *format, va_list ap)
     int nbytes = 0;
 
     /* make a copy so we can temporarily change the format string */
-    p = asis = fmt = (char *)malloc(strlen(format) + 1);
+    p = asis = fmt = (char *)G_malloc(strlen(format) + 1);
     strcpy(fmt, format);
 
     while (*p) {

--- a/lib/gis/printa.c
+++ b/lib/gis/printa.c
@@ -1,0 +1,419 @@
+/*!
+ * \file lib/gis/printa.c
+ *
+ * \brief GIS Library - Print functions for aligning wide characters.
+ *
+ * Extracted from the print-aligned C library (libprinta under GPL v3+) by
+ * Huidae Cho.
+ *
+ * (C) 2020 by the GRASS Development Team
+ *
+ * This program is free software under the GNU General Public License
+ * (>=v2). Read the file COPYING that comes with GRASS for details.
+ *
+ * \author Huidae Cho
+ *
+ * \date 2020
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include <grass/gis.h>
+#include <grass/glocale.h>
+
+/* printf(3) man page */
+#define CONVERSIONS "diouxXeEfFgGaAcsCSpnm%"
+
+struct options
+{
+    FILE *stream;
+    char *str, *_str;
+    size_t size, _size;
+};
+
+static int wide_count(const char *);
+static int _vprintf(struct options *, const char *, va_list);
+static int _printf(struct options *, const char *, ...);
+static int oprinta(struct options *, const char *, va_list);
+
+/*!
+ * \brief Count the number of wide characters in a string.
+ *
+ * \param[in] str input string
+ * \return number of wide characters in str
+ */
+static int wide_count(const char *str)
+{
+    int count = 0, lead = 0;
+
+    while (*str)
+	/* if the first two bits are 10 (0x80 = 1000 0000), this byte is
+	 * following a previous multi-byte character; only count the leading
+	 * byte */
+	if ((*str++ & 0xc0) != 0x80)
+	    lead = 1;
+	else if (lead) {
+	    lead = 0;
+	    count++;
+	}
+
+    return count;
+}
+
+/*!
+ * \brief Branch into vprintf(), vfprintf(), or vsprintf() depending on passed
+ * options.
+ *
+ * \param[in] opts options for branching
+ * \param[in] format string format
+ * \param[in] ap variable argument list for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+static int _vprintf(struct options *opts, const char *format, va_list ap)
+{
+    int nbytes;
+
+    if (opts == NULL || (opts->stream == NULL && opts->_str == NULL))
+	nbytes = vprintf(format, ap);
+    else if (opts->stream)
+	nbytes = vfprintf(opts->stream, format, ap);
+    else {
+	if ((long int)opts->size >= 0) {
+	    /* snprintf(str, 0, ...) prints garbage */
+	    nbytes = vsnprintf(opts->_str, opts->_size, format, ap);
+	    opts->_size -= nbytes;
+	} else
+	    /* snprintf(str, negative, ...) is equivalent to snprintf(str, ...)
+	     * because size_t is unsigned */
+	    nbytes = vsprintf(opts->_str, format, ap);
+	opts->_str += nbytes;
+    }
+
+    if (nbytes < 0)
+	G_fatal_error(_("_vprintf() failed"));
+
+    return nbytes;
+}
+
+/*!
+ * \brief Invoke _vprintf() for branching into different *printf() functions.
+ *
+ * \param[in] opts options for branching
+ * \param[in] format string format
+ * \param[in] ... arguments for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+static int _printf(struct options *opts, const char *format, ...)
+{
+    va_list ap;
+    int nbytes;
+
+    va_start(ap, format);
+    nbytes = _vprintf(opts, format, ap);
+    va_end(ap);
+
+    return nbytes;
+}
+
+/*!
+ * \brief Core function for aligning wide characters with Latin characters
+ * using %s specifiers. G_printa(), G_fprinta(), and G_sprinta() wrap around
+ * this function to implement printf(), fprintf(), and sprintf() counterparts,
+ * respectively.
+ *
+ * \param[in] opts options for branching
+ * \param[in] format string format
+ * \param[in] ap variable argument list for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+static int oprinta(struct options *opts, const char *format, va_list ap)
+{
+    char *fmt, *asis, *p, spec[10];
+    int nbytes = 0;
+
+    /* make a copy so we can temporarily change the format string */
+    p = asis = fmt = (char *)malloc(strlen(format) + 1);
+    strcpy(fmt, format);
+
+    while (*p) {
+	if (*p == '%') {
+	    char *q = p, *p_spec = spec;
+
+	    /* print the string before this specifier */
+	    *p = 0;
+	    nbytes += _printf(opts, asis);
+	    *p = '%';
+
+	    /* skip % */
+	    while (*++q) {
+		char *c = CONVERSIONS - 1;
+
+		while (*++c && *q != *c);
+		if (*c) {
+		    char tmp;
+		    /* found a conversion specifier */
+		    if (*c == 's') {
+			int width = -1, prec = -1, use_printf = 1;
+			char *p_tmp, *s;
+			va_list ap_copy;
+
+			/* save this ap and use _vprintf() for non-wide
+			 * characters */
+			va_copy(ap_copy, ap);
+
+			/* if string */
+			*p_spec = 0;
+			p_spec = spec;
+			if (*p_spec == '-')
+			    p_spec++;
+			if (*p_spec == '*') {
+			    width = va_arg(ap, int);
+			    p_spec++;
+			} else if (*p_spec >= '0' && *p_spec <= '9') {
+			    p_tmp = p_spec;
+			    while (*p_spec >= '0' && *p_spec <= '9')
+				p_spec++;
+			    tmp = *p_spec;
+			    *p_spec = 0;
+			    width = atoi(p_tmp);
+			    *p_spec = tmp;
+			}
+			if (*p_spec == '.') {
+			    p_spec++;
+			    if (*p_spec == '*') {
+				prec = va_arg(ap, int);
+				p_spec++;
+			    } else if (*p_spec >= '0' && *p_spec <= '9') {
+				p_tmp = p_spec;
+				while (*p_spec >= '0' && *p_spec <= '9')
+				    p_spec++;
+				tmp = *p_spec;
+				*p_spec = 0;
+				prec = atoi(p_tmp);
+				*p_spec = tmp;
+			    }
+			}
+			if (*p_spec) {
+			    /* really? */
+			    va_end(ap_copy);
+			    G_fatal_error(_("G_printa() failed"));
+			}
+
+			s = va_arg(ap, char *);
+			if (width > 0) {
+			    int wcount = wide_count(s);
+			    if (wcount) {
+				width += wcount;
+				prec += prec > 0 ? wcount : 0;
+				p_spec = spec;
+				p_spec += sprintf(p_spec, "%%%s%d",
+					spec[0] == '-' ? "-" : "", width);
+				if (prec >= 0)
+				    p_spec += sprintf(p_spec, ".%d", prec);
+				*p_spec++ = 's';
+				*p_spec = 0;
+				nbytes += _printf(opts, spec, s);
+				use_printf = 0;
+			    }
+			}
+			if (use_printf) {
+			    tmp = *(q + 1);
+			    *(q + 1) = 0;
+			    nbytes += _vprintf(opts, p, ap_copy);
+			    *(q + 1) = tmp;
+			}
+
+			va_end(ap_copy);
+		    } else {
+			/* else use _vprintf() */
+			tmp = *(q + 1);
+			*(q + 1) = 0;
+			nbytes += _vprintf(opts, p, ap);
+			*(q + 1) = tmp;
+		    }
+		    break;
+		} else
+		    *p_spec++ = *q;
+	    }
+	    asis = (p = q) + 1;
+	}
+	p++;
+    }
+
+    /* print the remaining string */
+    *p = 0;
+    nbytes += _printf(opts, asis);
+    *p = '%';
+
+    return nbytes;
+}
+
+/*!
+ * \brief vprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] format string format
+ * \param[in] ap variable argument list for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+int G_vprinta(const char *format, va_list ap)
+{
+    return oprinta(NULL, format, ap);
+}
+
+/*!
+ * \brief vfprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] stream file pointer
+ * \param[in] format string format
+ * \param[in] ap variable argument list for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+int G_vfprinta(FILE *stream, const char *format, va_list ap)
+{
+    struct options opts;
+
+    opts.stream = stream;
+    opts.str = NULL;
+    opts.size = -1;
+
+    return oprinta(&opts, format, ap);
+}
+
+/*!
+ * \brief vsprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] str string buffer
+ * \param[in] format string format
+ * \param[in] ap variable argument list for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+int G_vsprinta(char *str, const char *format, va_list ap)
+{
+    struct options opts;
+
+    opts.stream = NULL;
+    opts.str = opts._str = str;
+    opts.size = -1;
+
+    return oprinta(&opts, format, ap);
+}
+
+/*!
+ * \brief vsnprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] str string buffer
+ * \param[in] size string buffer size
+ * \param[in] format string format
+ * \param[in] ap variable argument list for the format string
+ * \return number of bytes that would be printed if size was big enough or
+ *	   fatal error on error
+ */
+int G_vsnprinta(char *str, size_t size, const char *format, va_list ap)
+{
+    struct options opts;
+
+    opts.stream = NULL;
+    opts.str = opts._str = str;
+    opts.size = opts._size = size;
+
+    return oprinta(&opts, format, ap);
+}
+
+/*!
+ * \brief Adjust the width of string specifiers to the display space intead of
+ * the number of bytes for wide characters and print them formatted using the
+ * adjusted display width.
+ *
+ * compare
+ *	printf("%10s|\n%10s|\n", "ABCD", "가나");
+-----------
+      ABCD|
+    가나|
+-----------
+ * and
+ *	G_printa("%10s|\n%10s|\n", "ABCD", "가나");
+-----------
+      ABCD|
+      가나|
+-----------
+ *
+ * \param[in] format string format
+ * \param[in] ... arguments for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+int G_printa(const char *format, ...)
+{
+    va_list ap;
+    int nbytes;
+
+    va_start(ap, format);
+    nbytes = G_vprinta(format, ap);
+    va_end(ap);
+
+    return nbytes;
+}
+
+/*!
+ * \brief fprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] stream file pointer
+ * \param[in] format string format
+ * \param[in] ... arguments for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+int G_fprinta(FILE *stream, const char *format, ...)
+{
+    va_list ap;
+    int nbytes;
+
+    va_start(ap, format);
+    nbytes = G_vfprinta(stream, format, ap);
+    va_end(ap);
+
+    return nbytes;
+}
+
+/*!
+ * \brief sprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] str string buffer
+ * \param[in] format string format
+ * \param[in] ... arguments for the format string
+ * \return number of bytes printed or fatal error on error
+ */
+int G_sprinta(char *str, const char *format, ...)
+{
+    va_list ap;
+    int nbytes;
+
+    va_start(ap, format);
+    nbytes = G_vsprinta(str, format, ap);
+    va_end(ap);
+
+    return nbytes;
+}
+
+/*!
+ * \brief snprintf() version of G_printa(). See G_printa() for more details.
+ *
+ * \param[in] str string buffer
+ * \param[in] size string buffer size
+ * \param[in] format string format
+ * \param[in] ... arguments for the format string
+ * \return number of bytes that would be printed if size was big enough or
+ *	   fatal error on error
+ */
+int G_snprinta(char *str, size_t size, const char *format, ...)
+{
+    va_list ap;
+    int nbytes;
+
+    va_start(ap, format);
+    nbytes = G_vsnprinta(str, size, format, ap);
+    va_end(ap);
+
+    return nbytes;
+}

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -266,30 +266,20 @@ def wxpath(*args):
 
 
 def wide_count(s):
-    '''
-    Returns the number of wide CJK characters in a string.
+    """Returns the number of wide CJK characters in a string.
 
-    Arguments:
-        s (str): string
-
-    Returns:
-        Number of wide CJK characters (int)
-    '''
+    :param str s: string
+    """
     return sum(unicodedata.east_asian_width(c) in 'WF' for c in s)
 
 
 def f(fmt, *args):
-    '''
-    Adjusts fixed-width string specifiers for wide CJK characters and returns a
+    """Adjusts fixed-width string specifiers for wide CJK characters and returns a
     formatted string.
 
-    Arguments:
-        fmt (str): format string
-        *args: arguments for the format string
-
-    Returns:
-        Formatted string (str)
-    '''
+    :param str fmt: format string
+    :param *args: arguments for the format string
+    """
     matches = []
     # https://docs.python.org/3/library/stdtypes.html#old-string-formatting
     for m in re.finditer('%([#0 +-]*)([0-9]*)(\.[0-9]*)?([hlL]?[diouxXeEfFgGcrsa%])', fmt):
@@ -309,21 +299,6 @@ def f(fmt, *args):
             fmt = ''.join((fmt[:m.start()], '%', f, w, p, c, fmt[m.end():]))
         i -= 1
     return fmt % args
-
-
-def printf(fmt, *args):
-    '''
-    Prints the formatted string of print(fmt % args, end='') similar to
-    printf() in C. Note that this function does not add a newline.
-
-    Arguments:
-        fmt (str): format string
-        *args: arguments for the format string
-
-    Returns:
-        None
-    '''
-    print(f(fmt, *args), end='')
 
 
 # using format for most but leaving usage of template for the dynamic ones

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -265,7 +265,7 @@ def wxpath(*args):
     return os.path.join(_WXPYTHON_BASE, *args)
 
 
-def wide_count(s):
+def count_wide_chars(s):
     """Returns the number of wide CJK characters in a string.
 
     :param str s: string
@@ -296,7 +296,7 @@ def f(fmt, *args):
         p = m.group(3) or ''
         c = m.group(4)
         if c == 's' and w:
-            w = str(int(w) - wide_count(args[i]))
+            w = str(int(w) - count_wide_chars(args[i]))
             fmt = ''.join((fmt[:m.start()], '%', f, w, p, c, fmt[m.end():]))
         i -= 1
     return fmt % args

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -54,6 +54,7 @@ import platform
 import tempfile
 import locale
 import uuid
+import unicodedata
 
 
 # mechanism meant for debugging this script (only)
@@ -262,6 +263,67 @@ def wxpath(*args):
         # this can be called only after GISBASE was set
         _WXPYTHON_BASE = gpath("gui", "wxpython")
     return os.path.join(_WXPYTHON_BASE, *args)
+
+
+def wide_count(s):
+    '''
+    Returns the number of wide CJK characters in a string.
+
+    Arguments:
+        s (str): string
+
+    Returns:
+        Number of wide CJK characters (int)
+    '''
+    return sum(unicodedata.east_asian_width(c) in 'WF' for c in s)
+
+
+def f(fmt, *args):
+    '''
+    Adjusts fixed-width string specifiers for wide CJK characters and returns a
+    formatted string.
+
+    Arguments:
+        fmt (str): format string
+        *args: arguments for the format string
+
+    Returns:
+        Formatted string (str)
+    '''
+    matches = []
+    # https://docs.python.org/3/library/stdtypes.html#old-string-formatting
+    for m in re.finditer('%([#0 +-]*)([0-9]*)(\.[0-9]*)?([hlL]?[diouxXeEfFgGcrsa%])', fmt):
+        matches.append(m)
+
+    if len(matches) != len(args):
+        raise Exception('The numbers of format specifiers and arguments do not match')
+
+    i = len(args) - 1
+    for m in reversed(matches):
+        f = m.group(1)
+        w = m.group(2)
+        p = m.group(3) or ''
+        c = m.group(4)
+        if c == 's' and w:
+            w = str(int(w) - wide_count(args[i]))
+            fmt = ''.join((fmt[:m.start()], '%', f, w, p, c, fmt[m.end():]))
+        i -= 1
+    return fmt % args
+
+
+def printf(fmt, *args):
+    '''
+    Prints the formatted string of print(fmt % args, end='') similar to
+    printf() in C. Note that this function does not add a newline.
+
+    Arguments:
+        fmt (str): format string
+        *args: arguments for the format string
+
+    Returns:
+        None
+    '''
+    print(f(fmt, *args), end='')
 
 
 # using format for most but leaving usage of template for the dynamic ones
@@ -1794,7 +1856,7 @@ INFO_TEXT = r"""
 
 def show_info(shellname, grass_gui, default_gui):
     """Write basic info about GRASS GIS and GRASS session to stderr"""
-    sys.stderr.write(INFO_TEXT % (
+    sys.stderr.write(f(INFO_TEXT,
         _("GRASS GIS homepage:"),
         # GTC Running through: SHELL NAME
         _("This version running through:"),
@@ -1804,11 +1866,11 @@ def show_info(shellname, grass_gui, default_gui):
         _("See citation options with:")))
 
     if grass_gui == 'wxpython':
-        message("%-41sg.gui wxpython" % _("If required, restart the GUI with:"))
+        message(f("%-41sg.gui wxpython", _("If required, restart the GUI with:")))
     else:
-        message("%-41sg.gui %s" % (_("Start the GUI with:"), default_gui))
+        message(f("%-41sg.gui %s", _("Start the GUI with:"), default_gui))
 
-    message("%-41sexit" % _("When ready to quit enter:"))
+    message(f("%-41sexit", _("When ready to quit enter:")))
     message("")
 
 

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -275,8 +275,8 @@ def wide_count(s):
 
 
 def f(fmt, *args):
-    """Adjusts fixed-width string specifiers for wide CJK characters and returns a
-    formatted string.
+    """Adjusts fixed-width string specifiers for wide CJK characters and
+    returns a formatted string. Does not support named arguments yet.
 
     :param str fmt: format string
     :param *args: arguments for the format string

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -270,7 +270,8 @@ def wide_count(s):
 
     :param str s: string
     """
-    return sum(unicodedata.east_asian_width(c) in 'WF' for c in s)
+    return sum(unicodedata.east_asian_width(c) in 'WF' for c in
+            (s if sys.version_info.major >= 3 else unicode(s)))
 
 
 def f(fmt, *args):

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -7,7 +7,7 @@
 
 #include "local_proto.h"
 
-#define printline(x) G_fprinta (stdout, " | %-74.74s |\n", x)
+#define printline(x) G_faprintf (stdout, " | %-74.74s |\n", x)
 #define divider(x) \
         fprintf (stdout, " %c", x); \
         for (i = 0; i < 76; i++ ) \
@@ -314,41 +314,41 @@ void print_info(const struct Map_info *Map)
     }
 
     divider('+');
-    G_sprinta(line, "%-17s%s", _("Name:"),
+    G_saprintf(line, "%-17s%s", _("Name:"),
             Vect_get_name(Map));
     printline(line);
-    G_sprinta(line, "%-17s%s", _("Mapset:"),
+    G_saprintf(line, "%-17s%s", _("Mapset:"),
             Vect_get_mapset(Map));
     printline(line);
     
-    G_sprinta(line, "%-17s%s", _("Location:"),
+    G_saprintf(line, "%-17s%s", _("Location:"),
             G_location());
     printline(line);
-    G_sprinta(line, "%-17s%s", _("Database:"),
+    G_saprintf(line, "%-17s%s", _("Database:"),
             G_gisdbase());
     printline(line);
 
-    G_sprinta(line, "%-17s%s", _("Title:"),
+    G_saprintf(line, "%-17s%s", _("Title:"),
             Vect_get_map_name(Map));
     printline(line);
-    G_sprinta(line, "%-17s1:%d", _("Map scale:"),
+    G_saprintf(line, "%-17s1:%d", _("Map scale:"),
             Vect_get_scale(Map));
     printline(line);
 
-    G_sprinta(line, "%-17s%s", _("Name of creator:"),
+    G_saprintf(line, "%-17s%s", _("Name of creator:"),
             Vect_get_person(Map));
     printline(line);
-    G_sprinta(line, "%-17s%s", _("Organization:"),
+    G_saprintf(line, "%-17s%s", _("Organization:"),
             Vect_get_organization(Map));
     printline(line);
-    G_sprinta(line, "%-17s%s", _("Source date:"),
+    G_saprintf(line, "%-17s%s", _("Source date:"),
             Vect_get_map_date(Map));
     printline(line);
 
     /* This shows the TimeStamp (if present) */
     if (time_ok  == TRUE && (first_time_ok || second_time_ok)) {
         G_format_timestamp(&ts, timebuff);
-        G_sprinta(line, "%-17s%s", _("Timestamp (first layer): "), timebuff);
+        G_saprintf(line, "%-17s%s", _("Timestamp (first layer): "), timebuff);
         printline(line);
     }
     else {
@@ -360,18 +360,18 @@ void print_info(const struct Map_info *Map)
     
     if (map_type == GV_FORMAT_OGR ||
         map_type == GV_FORMAT_OGR_DIRECT) {
-        G_sprinta(line, "%-17s%s (%s)", _("Map format:"),
+        G_saprintf(line, "%-17s%s (%s)", _("Map format:"),
                 Vect_maptype_info(Map), Vect_get_finfo_format_info(Map));
         printline(line);
         
         /* for OGR format print also datasource and layer */
-        G_sprinta(line, "%-17s%s", _("OGR layer:"),
+        G_saprintf(line, "%-17s%s", _("OGR layer:"),
                 Vect_get_finfo_layer_name(Map));
         printline(line);
-        G_sprinta(line, "%-17s%s", _("OGR datasource:"),
+        G_saprintf(line, "%-17s%s", _("OGR datasource:"),
                 Vect_get_finfo_dsn_name(Map));
         printline(line);
-        G_sprinta(line, "%-17s%s", _("Feature type:"),
+        G_saprintf(line, "%-17s%s", _("Feature type:"),
                 Vect_get_finfo_geometry_type(Map));
         printline(line);
     }
@@ -384,23 +384,23 @@ void print_info(const struct Map_info *Map)
 
         finfo = Vect_get_finfo(Map);
         
-        G_sprinta(line, "%-17s%s (%s)", _("Map format:"),
+        G_saprintf(line, "%-17s%s (%s)", _("Map format:"),
                 Vect_maptype_info(Map), Vect_get_finfo_format_info(Map));
         printline(line);
         
         /* for PostGIS format print also datasource and layer */
-        G_sprinta(line, "%-17s%s", _("DB table:"),
+        G_saprintf(line, "%-17s%s", _("DB table:"),
                 Vect_get_finfo_layer_name(Map));
         printline(line);
-        G_sprinta(line, "%-17s%s", _("DB name:"),
+        G_saprintf(line, "%-17s%s", _("DB name:"),
                 Vect_get_finfo_dsn_name(Map));
         printline(line);
 
-        G_sprinta(line, "%-17s%s", _("Geometry column:"),
+        G_saprintf(line, "%-17s%s", _("Geometry column:"),
                 finfo->pg.geom_column);
         printline(line);
 
-        G_sprinta(line, "%-17s%s", _("Feature type:"),
+        G_saprintf(line, "%-17s%s", _("Feature type:"),
                 Vect_get_finfo_geometry_type(Map));
         printline(line);
 
@@ -410,21 +410,21 @@ void print_info(const struct Map_info *Map)
                                                    &toposchema_name, &topogeom_column,
                                                    &topo_geo_only);
         if (topo_format == GV_TOPO_POSTGIS) {
-            G_sprinta(line, "%-17s%s (%s %s%s)", _("Topology:"), "PostGIS",
+            G_saprintf(line, "%-17s%s (%s %s%s)", _("Topology:"), "PostGIS",
                     _("schema:"), toposchema_name,
                     topo_geo_only ? ", topo-geo-only: yes" : "");
             printline(line);
 
-            G_sprinta(line, "%-17s%s", _("Topology column:"),
+            G_saprintf(line, "%-17s%s", _("Topology column:"),
                     topogeom_column);
         }
         else
-            G_sprinta(line, "%-17s%s", _("Topology:"), "pseudo (simple features)");
+            G_saprintf(line, "%-17s%s", _("Topology:"), "pseudo (simple features)");
         
         printline(line);
     }
     else {
-        G_sprinta(line, "%-17s%s", _("Map format:"),
+        G_saprintf(line, "%-17s%s", _("Map format:"),
                 Vect_maptype_info(Map));
         printline(line);
     }
@@ -432,27 +432,27 @@ void print_info(const struct Map_info *Map)
 
     divider('|');
     
-    G_sprinta(line, "  %s: %s (%s: %i)",
+    G_saprintf(line, "  %s: %s (%s: %i)",
             _("Type of map"), _("vector"), _("level"), Vect_level(Map));
     printline(line);
     
     if (Vect_level(Map) > 0) {
         printline("");
-        G_sprinta(line,
+        G_saprintf(line,
                 "  %-24s%-9d       %-22s%-9d",
                 _("Number of points:"), 
                 Vect_get_num_primitives(Map, GV_POINT),
                 _("Number of centroids:"),
                 Vect_get_num_primitives(Map, GV_CENTROID));
         printline(line);
-        G_sprinta(line,
+        G_saprintf(line,
                 "  %-24s%-9d       %-22s%-9d",
                 _("Number of lines:"),
                 Vect_get_num_primitives(Map, GV_LINE),
                 _("Number of boundaries:"),
                 Vect_get_num_primitives(Map, GV_BOUNDARY));
         printline(line);
-        G_sprinta(line,
+        G_saprintf(line,
                 "  %-24s%-9d       %-22s%-9d",
                 _("Number of areas:"),
                 Vect_get_num_areas(Map),
@@ -460,14 +460,14 @@ void print_info(const struct Map_info *Map)
                 Vect_get_num_islands(Map));
         printline(line);
         if (Vect_is_3d(Map)) {
-            G_sprinta(line,
+            G_saprintf(line,
                     "  %-24s%-9d       %-22s%-9d",
                     _("Number of faces:"),
                     Vect_get_num_primitives(Map, GV_FACE),
                     _("Number of kernels:"),
                     Vect_get_num_primitives(Map, GV_KERNEL));
             printline(line);
-            G_sprinta(line,
+            G_saprintf(line,
                     "  %-24s%-9d       %-22s%-9d",
                     _("Number of volumes:"),
                     Vect_get_num_volumes(Map),
@@ -477,11 +477,11 @@ void print_info(const struct Map_info *Map)
         }
         printline("");
 
-        G_sprinta(line, "  %-24s%s",
+        G_saprintf(line, "  %-24s%s",
                 _("Map is 3D:"),
                 Vect_is_3d(Map) ? _("Yes") : _("No"));
         printline(line);
-        G_sprinta(line, "  %-24s%-9d",
+        G_saprintf(line, "  %-24s%-9d",
                 _("Number of dblinks:"),
                 Vect_get_num_dblinks(Map));
         printline(line);
@@ -501,12 +501,12 @@ void print_info(const struct Map_info *Map)
         else
             sprintf(tmp1, "%d", utm_zone);
 
-        G_sprinta(line, "  %s: %s (%s %s)",
+        G_saprintf(line, "  %s: %s (%s %s)",
                 _("Projection"), Vect_get_proj_name(Map),
                 _("zone"), tmp1);
     }
     else
-        G_sprinta(line, "  %s: %s",
+        G_saprintf(line, "  %s: %s",
                 _("Projection"), Vect_get_proj_name(Map));
 
     printline(line);
@@ -536,9 +536,9 @@ void print_info(const struct Map_info *Map)
     printline("");
 
     format_double(Vect_get_thresh(Map), tmp1);
-    G_sprinta(line, "  %s: %s", _("Digitization threshold"), tmp1);
+    G_saprintf(line, "  %s: %s", _("Digitization threshold"), tmp1);
     printline(line);
-    G_sprinta(line, "  %s:", _("Comment"));
+    G_saprintf(line, "  %s:", _("Comment"));
     printline(line);
     sprintf(line, "    %s", Vect_get_comment(Map));
     printline(line);

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -7,7 +7,7 @@
 
 #include "local_proto.h"
 
-#define printline(x) fprintf (stdout, " | %-74.74s |\n", x)
+#define printline(x) G_fprinta (stdout, " | %-74.74s |\n", x)
 #define divider(x) \
         fprintf (stdout, " %c", x); \
         for (i = 0; i < 76; i++ ) \
@@ -314,41 +314,41 @@ void print_info(const struct Map_info *Map)
     }
 
     divider('+');
-    sprintf(line, "%-17s%s", _("Name:"),
+    G_sprinta(line, "%-17s%s", _("Name:"),
             Vect_get_name(Map));
     printline(line);
-    sprintf(line, "%-17s%s", _("Mapset:"),
+    G_sprinta(line, "%-17s%s", _("Mapset:"),
             Vect_get_mapset(Map));
     printline(line);
     
-    sprintf(line, "%-17s%s", _("Location:"),
+    G_sprinta(line, "%-17s%s", _("Location:"),
             G_location());
     printline(line);
-    sprintf(line, "%-17s%s", _("Database:"),
+    G_sprinta(line, "%-17s%s", _("Database:"),
             G_gisdbase());
     printline(line);
 
-    sprintf(line, "%-17s%s", _("Title:"),
+    G_sprinta(line, "%-17s%s", _("Title:"),
             Vect_get_map_name(Map));
     printline(line);
-    sprintf(line, "%-17s1:%d", _("Map scale:"),
+    G_sprinta(line, "%-17s1:%d", _("Map scale:"),
             Vect_get_scale(Map));
     printline(line);
 
-    sprintf(line, "%-17s%s", _("Name of creator:"),
+    G_sprinta(line, "%-17s%s", _("Name of creator:"),
             Vect_get_person(Map));
     printline(line);
-    sprintf(line, "%-17s%s", _("Organization:"),
+    G_sprinta(line, "%-17s%s", _("Organization:"),
             Vect_get_organization(Map));
     printline(line);
-    sprintf(line, "%-17s%s", _("Source date:"),
+    G_sprinta(line, "%-17s%s", _("Source date:"),
             Vect_get_map_date(Map));
     printline(line);
 
     /* This shows the TimeStamp (if present) */
     if (time_ok  == TRUE && (first_time_ok || second_time_ok)) {
         G_format_timestamp(&ts, timebuff);
-        sprintf(line, "%-17s%s", _("Timestamp (first layer): "), timebuff);
+        G_sprinta(line, "%-17s%s", _("Timestamp (first layer): "), timebuff);
         printline(line);
     }
     else {
@@ -360,18 +360,18 @@ void print_info(const struct Map_info *Map)
     
     if (map_type == GV_FORMAT_OGR ||
         map_type == GV_FORMAT_OGR_DIRECT) {
-        sprintf(line, "%-17s%s (%s)", _("Map format:"),
+        G_sprinta(line, "%-17s%s (%s)", _("Map format:"),
                 Vect_maptype_info(Map), Vect_get_finfo_format_info(Map));
         printline(line);
         
         /* for OGR format print also datasource and layer */
-        sprintf(line, "%-17s%s", _("OGR layer:"),
+        G_sprinta(line, "%-17s%s", _("OGR layer:"),
                 Vect_get_finfo_layer_name(Map));
         printline(line);
-        sprintf(line, "%-17s%s", _("OGR datasource:"),
+        G_sprinta(line, "%-17s%s", _("OGR datasource:"),
                 Vect_get_finfo_dsn_name(Map));
         printline(line);
-        sprintf(line, "%-17s%s", _("Feature type:"),
+        G_sprinta(line, "%-17s%s", _("Feature type:"),
                 Vect_get_finfo_geometry_type(Map));
         printline(line);
     }
@@ -384,23 +384,23 @@ void print_info(const struct Map_info *Map)
 
         finfo = Vect_get_finfo(Map);
         
-        sprintf(line, "%-17s%s (%s)", _("Map format:"),
+        G_sprinta(line, "%-17s%s (%s)", _("Map format:"),
                 Vect_maptype_info(Map), Vect_get_finfo_format_info(Map));
         printline(line);
         
         /* for PostGIS format print also datasource and layer */
-        sprintf(line, "%-17s%s", _("DB table:"),
+        G_sprinta(line, "%-17s%s", _("DB table:"),
                 Vect_get_finfo_layer_name(Map));
         printline(line);
-        sprintf(line, "%-17s%s", _("DB name:"),
+        G_sprinta(line, "%-17s%s", _("DB name:"),
                 Vect_get_finfo_dsn_name(Map));
         printline(line);
 
-        sprintf(line, "%-17s%s", _("Geometry column:"),
+        G_sprinta(line, "%-17s%s", _("Geometry column:"),
                 finfo->pg.geom_column);
         printline(line);
 
-        sprintf(line, "%-17s%s", _("Feature type:"),
+        G_sprinta(line, "%-17s%s", _("Feature type:"),
                 Vect_get_finfo_geometry_type(Map));
         printline(line);
 
@@ -410,21 +410,21 @@ void print_info(const struct Map_info *Map)
                                                    &toposchema_name, &topogeom_column,
                                                    &topo_geo_only);
         if (topo_format == GV_TOPO_POSTGIS) {
-            sprintf(line, "%-17s%s (%s %s%s)", _("Topology:"), "PostGIS",
+            G_sprinta(line, "%-17s%s (%s %s%s)", _("Topology:"), "PostGIS",
                     _("schema:"), toposchema_name,
                     topo_geo_only ? ", topo-geo-only: yes" : "");
             printline(line);
 
-            sprintf(line, "%-17s%s", _("Topology column:"),
+            G_sprinta(line, "%-17s%s", _("Topology column:"),
                     topogeom_column);
         }
         else
-            sprintf(line, "%-17s%s", _("Topology:"), "pseudo (simple features)");
+            G_sprinta(line, "%-17s%s", _("Topology:"), "pseudo (simple features)");
         
         printline(line);
     }
     else {
-        sprintf(line, "%-17s%s", _("Map format:"),
+        G_sprinta(line, "%-17s%s", _("Map format:"),
                 Vect_maptype_info(Map));
         printline(line);
     }
@@ -432,27 +432,27 @@ void print_info(const struct Map_info *Map)
 
     divider('|');
     
-    sprintf(line, "  %s: %s (%s: %i)",
+    G_sprinta(line, "  %s: %s (%s: %i)",
             _("Type of map"), _("vector"), _("level"), Vect_level(Map));
     printline(line);
     
     if (Vect_level(Map) > 0) {
         printline("");
-        sprintf(line,
+        G_sprinta(line,
                 "  %-24s%-9d       %-22s%-9d",
                 _("Number of points:"), 
                 Vect_get_num_primitives(Map, GV_POINT),
                 _("Number of centroids:"),
                 Vect_get_num_primitives(Map, GV_CENTROID));
         printline(line);
-        sprintf(line,
+        G_sprinta(line,
                 "  %-24s%-9d       %-22s%-9d",
                 _("Number of lines:"),
                 Vect_get_num_primitives(Map, GV_LINE),
                 _("Number of boundaries:"),
                 Vect_get_num_primitives(Map, GV_BOUNDARY));
         printline(line);
-        sprintf(line,
+        G_sprinta(line,
                 "  %-24s%-9d       %-22s%-9d",
                 _("Number of areas:"),
                 Vect_get_num_areas(Map),
@@ -460,14 +460,14 @@ void print_info(const struct Map_info *Map)
                 Vect_get_num_islands(Map));
         printline(line);
         if (Vect_is_3d(Map)) {
-            sprintf(line,
+            G_sprinta(line,
                     "  %-24s%-9d       %-22s%-9d",
                     _("Number of faces:"),
                     Vect_get_num_primitives(Map, GV_FACE),
                     _("Number of kernels:"),
                     Vect_get_num_primitives(Map, GV_KERNEL));
             printline(line);
-            sprintf(line,
+            G_sprinta(line,
                     "  %-24s%-9d       %-22s%-9d",
                     _("Number of volumes:"),
                     Vect_get_num_volumes(Map),
@@ -477,11 +477,11 @@ void print_info(const struct Map_info *Map)
         }
         printline("");
 
-        sprintf(line, "  %-24s%s",
+        G_sprinta(line, "  %-24s%s",
                 _("Map is 3D:"),
                 Vect_is_3d(Map) ? _("Yes") : _("No"));
         printline(line);
-        sprintf(line, "  %-24s%-9d",
+        G_sprinta(line, "  %-24s%-9d",
                 _("Number of dblinks:"),
                 Vect_get_num_dblinks(Map));
         printline(line);
@@ -501,12 +501,12 @@ void print_info(const struct Map_info *Map)
         else
             sprintf(tmp1, "%d", utm_zone);
 
-        sprintf(line, "  %s: %s (%s %s)",
+        G_sprinta(line, "  %s: %s (%s %s)",
                 _("Projection"), Vect_get_proj_name(Map),
                 _("zone"), tmp1);
     }
     else
-        sprintf(line, "  %s: %s",
+        G_sprinta(line, "  %s: %s",
                 _("Projection"), Vect_get_proj_name(Map));
 
     printline(line);
@@ -536,9 +536,9 @@ void print_info(const struct Map_info *Map)
     printline("");
 
     format_double(Vect_get_thresh(Map), tmp1);
-    sprintf(line, "  %s: %s", _("Digitization threshold"), tmp1);
+    G_sprinta(line, "  %s: %s", _("Digitization threshold"), tmp1);
     printline(line);
-    sprintf(line, "  %s:", _("Comment"));
+    G_sprinta(line, "  %s:", _("Comment"));
     printline(line);
     sprintf(line, "    %s", Vect_get_comment(Map));
     printline(line);


### PR DESCRIPTION
# CJK characters' counts/bytes vs. display widths

This PR fixes horizontally misaligned welcome messages for CJK locales. Python 3's string specifier (`%{width}s`) counts a double-column-wide CJK character as one even though they take up two columns in the terminal. This behavior can easily break horizontal alignments when there are CJK characters in translated messages. For more details, visit [CJK Format](https://github.com/HuidaeCho/cjkformat) and [libaprintf](https://github.com/HuidaeCho/libaprintf).

![misaligned](https://user-images.githubusercontent.com/7456117/79534772-7b6e1000-8049-11ea-9e52-2397c2f65ecc.png)

vs.

![aligned](https://user-images.githubusercontent.com/7456117/79534780-82951e00-8049-11ea-976d-01ab919418c8.png)

## `v.info`

![v info-misaligned](https://user-images.githubusercontent.com/7456117/79534783-87f26880-8049-11ea-95d0-5352d64e9a25.png)

vs.

![v info-aligned](https://user-images.githubusercontent.com/7456117/79697230-85616000-824f-11ea-99a4-52b79f1a2259.png)

## `r.info`

The main table output from `r.info` is not translated.