### PR TITLE
Add label to new GitHub issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[Bug]"
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: "[Feat]"
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
This adds automatically a label to a newly opened issue on GitHub.

And removes default prepending [***] title part (e.g. [Bug]).

Partly a solution to #526.