### PR TITLE
wxGUI mapwin: Fix Pointer tool double left click on a map canvas

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -1615,7 +1615,7 @@ class BufferedMapWindow(MapWindowBase, Window):
                 screenCoords[0],
                 screenCoords[1],
                 self.hitradius)
-            if idlist:
+            if idlist and idlist[0] != 99:
                 self.dragid = idlist[0]
                 self.overlayActivated.emit(overlayId=self.dragid)
 


### PR DESCRIPTION
To reproduce:

1. Start gui `g.gui`
2. Add some vector or raster map layer
3. On map Window Display choose Pointer tool
4. Double left click on map canvas

Error message:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 1381, in MouseActions

self.OnButtonDClick(event)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 1621, in OnButtonDClick

self.overlayActivated.emit(overlayId=self.dragid)
  File
"/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 349, in send

**named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File "/usr/lib64/grass79/gui/wxpython/mapdisp/frame.py",
line 1209, in _activateOverlay

dlg = self.decorations[overlayId].dialog
KeyError
:
99