### PR TITLE
grass7 manual: document --config parameters

### DIFF
--- a/lib/init/grass7.html
+++ b/lib/init/grass7.html
@@ -49,7 +49,7 @@
 (<em><a href="wxGUI.html">wxGUI</a></em>) should be used
 
 <dt><b>--config</b>
-<dd> Prints GRASS configuration parameters (options: arch, build, compiler, path, revision)
+<dd> Prints GRASS configuration parameters (options: arch, build, compiler, date, path, revision, svn_revision, version)
 
 <dt><b>--exec EXECUTABLE</b>
 <dd> Execute GRASS module or script. The provided executable will be executed in a GRASS GIS non-interactive session.
@@ -109,6 +109,23 @@ the <em>grass79</em> program will try to verify that the system you
 specified exists and that you can access it successfully. If any of
 these checks fail then <em>grass79</em> will automatically switch back
 to the text user interface mode.
+
+<h2>FLAGS</h2>
+
+The flag <b>--config option</b> prints GRASS GIS configuration and
+version parameters, with the options:
+
+<ul>
+<li><b>arch</b>: system architecture (e.g., <tt>x86_64-pc-linux-gnu</tt>)</li>
+<li><b>build</b>:  (e.g., <tt>./configure  --with-cxx --enable-largefile --with-proj [...]</tt>)</li>
+<li><b>compiler</b>:  (e.g., <tt>gcc</tt>)</li>
+<li><b>date</b>:  (e.g., <tt>Tue Mar 31 20:34:57 2020 +0200</tt>)</li>
+<li><b>path</b>:  (e.g., <tt>/usr/lib64/grass78</tt>)</li>
+<li><b>revision</b>:  (e.g., <tt>745ee7ec9</tt>)</li>
+<li><b>svn_revision</b>:  (e.g., <tt>062bffc8</tt>)</li>
+<li><b>version</b>:  (e.g., <tt>7.9.dev</tt>)</li>
+</ul>
+
 
 <h2>SAMPLE DATA</h2>
 
@@ -461,11 +478,10 @@ GRASS_PYTHON environmental variable.
 List of <a href="variables.html">GRASS environment variables</a>
 
 <p>
-<a href="http://grass.osgeo.org">GRASS GIS Web site</a><br>
-<a href="http://grass.osgeo.org/wiki/">GRASS GIS User Wiki</a><br>
-<a href="http://trac.osgeo.org/grass/">GRASS GIS Bug Tracker</a><br>
-<a href="http://grass.osgeo.org/programming7/">GRASS GIS 7 Programmer's
-  Manual</a>
+<a href="https://grass.osgeo.org">GRASS GIS Web site</a><br>
+<a href="https://grasswiki.osgeo.org/wiki/">GRASS GIS User Wiki</a><br>
+<a href="https://github.com/OSGeo/grass/issues">GRASS GIS Bug Tracker</a><br>
+<a href="https://grass.osgeo.org/programming7/">GRASS GIS 7 Programmer's Manual</a>
 
 <h2>AUTHORS (of this page)</h2>
 

--- a/lib/init/grass7.html
+++ b/lib/init/grass7.html
@@ -117,13 +117,13 @@ version parameters, with the options:
 
 <ul>
 <li><b>arch</b>: system architecture (e.g., <tt>x86_64-pc-linux-gnu</tt>)</li>
-<li><b>build</b>:  (e.g., <tt>./configure  --with-cxx --enable-largefile --with-proj [...]</tt>)</li>
-<li><b>compiler</b>:  (e.g., <tt>gcc</tt>)</li>
-<li><b>date</b>:  (e.g., <tt>Tue Mar 31 20:34:57 2020 +0200</tt>)</li>
-<li><b>path</b>:  (e.g., <tt>/usr/lib64/grass78</tt>)</li>
-<li><b>revision</b>:  (e.g., <tt>745ee7ec9</tt>)</li>
-<li><b>svn_revision</b>:  (e.g., <tt>062bffc8</tt>)</li>
-<li><b>version</b>:  (e.g., <tt>7.9.dev</tt>)</li>
+<li><b>build</b>: (e.g., <tt>./configure --with-cxx --enable-largefile --with-proj [...]</tt>)</li>
+<li><b>compiler</b>: (e.g., <tt>gcc</tt>)</li>
+<li><b>date</b>: (e.g., <tt>Tue Mar 31 20:34:57 2020 +0200</tt>)</li>
+<li><b>path</b>: (e.g., <tt>/usr/lib64/grass78</tt>)</li>
+<li><b>revision</b>: (e.g., <tt>745ee7ec9</tt>)</li>
+<li><b>svn_revision</b>: (e.g., <tt>062bffc8</tt>)</li>
+<li><b>version</b>: (e.g., <tt>7.9.dev</tt>)</li>
 </ul>
 
 

--- a/lib/init/grass7.html
+++ b/lib/init/grass7.html
@@ -120,7 +120,7 @@ version parameters, with the options:
 <li><b>build</b>: (e.g., <tt>./configure --with-cxx --enable-largefile --with-proj [...]</tt>)</li>
 <li><b>compiler</b>: (e.g., <tt>gcc</tt>)</li>
 <li><b>date</b>: (e.g., <tt>Tue Mar 31 20:34:57 2020 +0200</tt>)</li>
-<li><b>path</b>: (e.g., <tt>/usr/lib64/grass78</tt>)</li>
+<li><b>path</b>: (e.g., <tt>/usr/lib64/grass79</tt>)</li>
 <li><b>revision</b>: (e.g., <tt>745ee7ec9</tt>)</li>
 <li><b>svn_revision</b>: (e.g., <tt>062bffc8</tt>)</li>
 <li><b>version</b>: (e.g., <tt>7.9.dev</tt>)</li>


### PR DESCRIPTION
Adding missing `grass --config <option>` documentation

Adresses https://github.com/OSGeo/grass/pull/405#pullrequestreview-396590898