### PR TITLE
Ignore current errors from wxGUI, scripts, temporal

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run Flake8
       run: |
         cd lib/python
-        flake8 --count --statistics --show-source .
+        flake8 --count --statistics --show-source --jobs=$(nproc) .
 
   flake8-wxgui:
 
@@ -42,7 +42,7 @@ jobs:
     - name: Run Flake8
       run: |
         cd gui/wxpython
-        flake8 --count --statistics --show-source .
+        flake8 --count --statistics --show-source --jobs=$(nproc) .
 
   flake8-scripts:
 
@@ -62,7 +62,7 @@ jobs:
     - name: Run Flake8
       run: |
         cd scripts
-        flake8 --count --statistics --show-source .
+        flake8 --count --statistics --show-source --jobs=$(nproc) .
 
   flake8-temporal-modules:
 
@@ -82,4 +82,4 @@ jobs:
     - name: Run Flake8
       run: |
         cd temporal
-        flake8 --count --statistics --show-source .
+        flake8 --count --statistics --show-source --jobs=$(nproc) .

--- a/gui/wxpython/.flake8
+++ b/gui/wxpython/.flake8
@@ -1,44 +1,26 @@
 [flake8]
 ignore =
-    E101, # indentation contains mixed spaces and tabs
-    W191, # indentation contains tabs
-    E111, # indentation is not a multiple of four
     E114, # indentation is not a multiple of four (comment)
-    E116, # unexpected indentation (comment)
-    E242, # tab after ','
-    E251, # unexpected spaces around keyword / parameter equals
+    E115, # expected an indented block (comment)
     E262, # inline comment should start with '# '
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment
+    W605, # invalid escape sequence '\.'
     E402, # module level import not at top of file
-    E501, # line too long (183 > 150 characters)
     E502, # the backslash is redundant between brackets
-    E701, # multiple statements on one line (colon)
-    E702, # multiple statements on one line (semicolon)
-    E703, # statement ends with a semicolon
-    E711, # comparison to None should be 'if cond is None:'
-    E712, # comparison to True should be 'if cond is True:' or 'if cond:'
+    E712, # comparison to False should be 'if cond is False:' or 'if not cond:'
     E713, # test for membership should be 'not in'
-    E721, # do not compare types, use 'isinstance()'
     E722, # do not use bare 'except'
     E731, # do not assign a lambda expression, use a def
     E741, # ambiguous variable name 'l'
-    F401, # '.reader.BandReferenceReader' imported but unused
-    F403, # 'from ctypes import *' used; unable to detect undefined names
-    F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
-    F811, # redefinition of unused 'utils' from line 26
+    E999, # SyntaxError: EOL while scanning string literal
+    F401, # 'animation.utils.getCpuCount' imported but unused
+    F403, # 'from gmodeler.model import *' used; unable to detect undefined names
+    F405, # '_' may be undefined, or defined from star imports: gmodeler.model
+    F811, # redefinition of unused 'wx' from line 106
     F821, # undefined name '_'
-    F841, # local variable 't0' is assigned to but never used
-    F901, # 'raise NotImplemented' should be 'raise NotImplementedError'
-    W605, # invalid escape sequence '\_'
-    W291, # trailing whitespace
-    W292, # no newline at end of file
-    W293, # blank line contains whitespace
-    W391, # blank line at end of file
-    W503, # line break before binary operator
-    W504, # line break after binary operator
+    F841, # local variable 'dc' is assigned to but never used
     E117, # over-indented
-    E121, # continuation line under-indented for hanging indent
     E122, # continuation line missing indentation or outdented
     E123, # closing bracket does not match indentation of opening bracket's line
     E124, # closing bracket does not match visual indentation
@@ -46,17 +28,14 @@ ignore =
     E126, # continuation line over-indented for hanging indent
     E127, # continuation line over-indented for visual indent
     E128, # continuation line under-indented for visual indent
-    E129, # visually indented line with same indent as next logical line
-    E201, # whitespace after '{'
-    E202, # whitespace before ')'
+    E131, # continuation line unaligned for hanging indent
+    E202, # whitespace before '}'
     E203, # whitespace before ':'
     E211, # whitespace before '('
-    E221, # multiple spaces before operator
     E222, # multiple spaces after operator
     E225, # missing whitespace around operator
     E226, # missing whitespace around arithmetic operator
-    E228, # missing whitespace around modulo operator
-    E231, # missing whitespace after ':'
+    E231, # missing whitespace after ','
     E241, # multiple spaces after ','
     E261, # at least two spaces before inline comment
     E271, # multiple spaces after keyword
@@ -65,7 +44,13 @@ ignore =
     E302, # expected 2 blank lines, found 1
     E303, # too many blank lines (3)
     E305, # expected 2 blank lines after class or function definition, found 1
+    E306, # expected 1 blank line before a nested definition, found 0
     E401, # multiple imports on one line
+    E501, # line too long (96 > 79 characters)
+    W291, # trailing whitespace
+    W293, # blank line contains whitespace
+    W503, # line break before binary operator
+    W504, # line break after binary operator
 
 max-line-length = 88
 exclude =

--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -1,0 +1,60 @@
+[flake8]
+ignore =
+    E265, # block comment should start with '# '
+    E266, # too many leading '#' for block comment
+    E402, # module level import not at top of file
+    E711, # comparison to None should be 'if cond is None:'
+    E712, # comparison to False should be 'if cond is False:' or 'if not cond:'
+    E713, # test for membership should be 'not in'
+    E722, # do not use bare 'except'
+    E731, # do not assign a lambda expression, use a def
+    E741, # ambiguous variable name 'l'
+    F401, # 'grass.script.core.gisenv' imported but unused
+    F632, # use ==/!= to compare str, bytes, and int literals
+    F821, # undefined name '_'
+    F841, # local variable 'center' is assigned to but never used
+    E111, # indentation is not a multiple of four
+    E711, # comparison to None should be 'if cond is None:'
+    F632, # use ==/!= to compare str, bytes, and int literals
+    W391, # blank line at end of file
+    E111, # indentation is not a multiple of four
+    E121, # continuation line under-indented for hanging indent
+    E125, # continuation line with same indent as next logical line
+    E127, # continuation line over-indented for visual indent
+    E128, # continuation line under-indented for visual indent
+    E202, # whitespace before ')'
+    E211, # whitespace before '['
+    E221, # multiple spaces before operator
+    E225, # missing whitespace around operator
+    E226, # missing whitespace around arithmetic operator
+    E231, # missing whitespace after ','
+    E251, # unexpected spaces around keyword / parameter equals
+    E261, # at least two spaces before inline comment
+    E271, # multiple spaces after keyword
+    E272, # multiple spaces before keyword
+    E302, # expected 2 blank lines, found 1
+    E303, # too many blank lines (2)
+    E305, # expected 2 blank lines after class or function definition, found 1
+    E501, # line too long (161 > 150 characters)
+    W293, # blank line contains whitespace
+    W391, # blank line at end of file
+    W503, # line break before binary operator
+    W504, # line break after binary operator
+    E121, # continuation line under-indented for hanging indent
+    E221, # multiple spaces before operator
+    E251, # unexpected spaces around keyword / parameter equals
+
+max-line-length = 88
+exclude =
+    .git,
+    __pycache__,
+    .env,
+    .venv,
+    env,
+    venv,
+    ENV,
+    env.bak,
+    venv.bak,
+    ctypes,
+    pydispatch,
+    testsuite,

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -1,0 +1,48 @@
+[flake8]
+ignore =
+    E265, # block comment should start with '# '
+    E266, # too many leading '#' for block comment
+    E502, # the backslash is redundant between brackets
+    E711, # comparison to None should be 'if cond is not None:'
+    E712, # comparison to False should be 'if cond is False:' or 'if not cond:'
+    E722, # do not use bare 'except'
+    F401, # 'ply.lex' imported but unused
+    F821, # undefined name '_'
+    F841, # local variable 'column' is assigned to but never used
+    W291, # trailing whitespace
+    W293, # blank line contains whitespace
+    W391, # blank line at end of file
+    W504, # line break after binary operator
+    E117, # over-indented
+    E125, # continuation line with same indent as next logical line
+    E126, # continuation line over-indented for hanging indent
+    E127, # continuation line over-indented for visual indent
+    E128, # continuation line under-indented for visual indent
+    E129, # visually indented line with same indent as next logical line
+    E222, # multiple spaces after operator
+    E225, # missing whitespace around operator
+    E226, # missing whitespace around arithmetic operator
+    E228, # missing whitespace around modulo operator
+    E231, # missing whitespace after ','
+    E241, # multiple spaces after ','
+    E251, # unexpected spaces around keyword / parameter equals
+    E271, # multiple spaces after keyword
+    E302, # expected 2 blank lines, found 1
+    E303, # too many blank lines (2)
+    E305, # expected 2 blank lines after class or function definition, found 1
+    E501, # line too long (179 > 150 characters)
+  
+max-line-length = 88
+exclude =
+    .git,
+    __pycache__,
+    .env,
+    .venv,
+    env,
+    venv,
+    ENV,
+    env.bak,
+    venv.bak,
+    ctypes,
+    pydispatch,
+    testsuite,


### PR DESCRIPTION
Python code errors from Flake8 are now ignored gui/wxpython, scripts, and temporal
in the same way as in lib/python. Unique set of errors is used for each directory
to keep ignored errors at minimum.

Serious errors are sorted at the top. Whitespace at the bottom.
Line length is set to 88, but ignored.