### PR TITLE
Fix some Flake8 warnings in grass package

### DIFF
--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -1,7 +1,5 @@
 [flake8]
 ignore =
-    E114, # indentation is not a multiple of four (comment)
-    E116, # unexpected indentation (comment)
     E251, # unexpected spaces around keyword / parameter equals
     E262, # inline comment should start with '# '
     E265, # block comment should start with '# '

--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -7,7 +7,6 @@ ignore =
     E502, # the backslash is redundant between brackets
     E711, # comparison to None should be 'if cond is None:'
     E712, # comparison to True should be 'if cond is True:' or 'if cond:'
-    E713, # test for membership should be 'not in'
     E721, # do not compare types, use 'isinstance()'
     E722, # do not use bare 'except'
     E731, # do not assign a lambda expression, use a def

--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -1,11 +1,9 @@
 [flake8]
 ignore =
-    E251, # unexpected spaces around keyword / parameter equals
     E262, # inline comment should start with '# '
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment
     E402, # module level import not at top of file
-    E501, # line too long (183 > 150 characters)
     E502, # the backslash is redundant between brackets
     E703, # statement ends with a semicolon
     E711, # comparison to None should be 'if cond is None:'
@@ -50,9 +48,11 @@ ignore =
     E228, # missing whitespace around modulo operator
     E231, # missing whitespace after ':'
     E241, # multiple spaces after ','
+    E251, # unexpected spaces around keyword / parameter equals
     E261, # at least two spaces before inline comment
     E271, # multiple spaces after keyword
     E272, # multiple spaces before keyword
+    E501, # line too long (183 > 150 characters)
     E301, # expected 1 blank line, found 0
     E302, # expected 2 blank lines, found 1
     E303, # too many blank lines (3)

--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -7,8 +7,6 @@ ignore =
     E402, # module level import not at top of file
     E501, # line too long (183 > 150 characters)
     E502, # the backslash is redundant between brackets
-    E701, # multiple statements on one line (colon)
-    E702, # multiple statements on one line (semicolon)
     E703, # statement ends with a semicolon
     E711, # comparison to None should be 'if cond is None:'
     E712, # comparison to True should be 'if cond is True:' or 'if cond:'

--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -1,11 +1,8 @@
 [flake8]
 ignore =
-    E101, # indentation contains mixed spaces and tabs
-    W191, # indentation contains tabs
     E111, # indentation is not a multiple of four
     E114, # indentation is not a multiple of four (comment)
     E116, # unexpected indentation (comment)
-    E242, # tab after ','
     E251, # unexpected spaces around keyword / parameter equals
     E262, # inline comment should start with '# '
     E265, # block comment should start with '# '

--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -1,6 +1,5 @@
 [flake8]
 ignore =
-    E111, # indentation is not a multiple of four
     E114, # indentation is not a multiple of four (comment)
     E116, # unexpected indentation (comment)
     E251, # unexpected spaces around keyword / parameter equals

--- a/lib/python/.flake8
+++ b/lib/python/.flake8
@@ -5,7 +5,6 @@ ignore =
     E266, # too many leading '#' for block comment
     E402, # module level import not at top of file
     E502, # the backslash is redundant between brackets
-    E703, # statement ends with a semicolon
     E711, # comparison to None should be 'if cond is None:'
     E712, # comparison to True should be 'if cond is True:' or 'if cond:'
     E713, # test for membership should be 'not in'

--- a/lib/python/gunittest/main.py
+++ b/lib/python/gunittest/main.py
@@ -86,7 +86,7 @@ def test():
     #    cov.start()
     #except ImportError:
     #    pass
-        # TODO: add some message somewhere
+    # TODO: add some message somewhere
 
     # TODO: enable passing omit to exclude also gunittest or nothing
     program = GrassTestProgram(module='__main__', exit_at_end=False, grass_location='all')

--- a/lib/python/imaging/images2gif.py
+++ b/lib/python/imaging/images2gif.py
@@ -209,10 +209,11 @@ class GifWriter:
 
         if loops == 0 or loops == float('inf'):
             loops = 2 ** 16 - 1
-            #bb = "" # application extension should not be used
-                    # (the extension interprets zero loops
-                    # to mean an infinite number of loops)
-                    # Mmm, does not seem to work
+            # bb = ""
+            # application extension should not be used
+            # (the extension interprets zero loops
+            # to mean an infinite number of loops)
+            # Mmm, does not seem to work
         if True:
             bb = "\x21\xFF\x0B"  # application extension
             bb += "NETSCAPE2.0"

--- a/lib/python/imaging/images2swf.py
+++ b/lib/python/imaging/images2swf.py
@@ -876,10 +876,14 @@ def _readPixels(bb, i, tagType, L1):
         raise RuntimeError("Need Numpy to read an SWF file.")
 
     # Get info
-    charId = bb[i:i + 2]; i += 2
-    format = ord(bb[i:i + 1]); i += 1
-    width = bitsToInt(bb[i:i + 2], 16); i += 2
-    height = bitsToInt(bb[i:i + 2], 16); i += 2
+    charId = bb[i:i + 2]
+    i += 2
+    format = ord(bb[i:i + 1])
+    i += 1
+    width = bitsToInt(bb[i:i + 2], 16)
+    i += 2
+    height = bitsToInt(bb[i:i + 2], 16)
+    i += 2
 
     # If we can, get pixeldata and make nunmpy array
     if format != 5:

--- a/lib/python/pygrass/rpc/base.py
+++ b/lib/python/pygrass/rpc/base.py
@@ -168,7 +168,7 @@ class RPCServerBase(object):
         try:
             ret = self.client_conn.recv()
             if isinstance(ret,  FatalError):
-               raise ret
+                raise ret
             return ret
         except (EOFError,  IOError,  FatalError) as e:
             # The pipe was closed by the checker thread because

--- a/lib/python/script/core.py
+++ b/lib/python/script/core.py
@@ -191,7 +191,7 @@ def shutil_which(cmd, mode=os.F_OK | os.X_OK, path=None):
 
     if sys.platform == "win32":
         # The current directory takes precedence on Windows.
-        if not os.curdir in path:
+        if os.curdir not in path:
             path.insert(0, os.curdir)
 
         # PATHEXT is necessary to check on Windows (force lowercase)
@@ -216,7 +216,7 @@ def shutil_which(cmd, mode=os.F_OK | os.X_OK, path=None):
     seen = set()
     for dir in path:
         normdir = os.path.normcase(dir)
-        if not normdir in seen:
+        if normdir not in seen:
             seen.add(normdir)
             for thefile in files:
                 name = os.path.join(dir, thefile)

--- a/lib/python/script/setup.py
+++ b/lib/python/script/setup.py
@@ -228,7 +228,7 @@ def clean_default_db():
         if os.path.exists(database):
             gcore.message(_("Cleaning up default sqlite database ..."))
             gcore.start_command('db.execute', sql = 'VACUUM')
-	    # give it some time to start
+            # give it some time to start
             import time
             time.sleep(0.1)
 

--- a/lib/python/temporal/core.py
+++ b/lib/python/temporal/core.py
@@ -927,7 +927,7 @@ def _create_tgis_metadata_table(content, dbif=None):
        :param dbif: The database interface to be used
     """
     dbif, connected = init_dbif(dbif)
-    statement = "CREATE TABLE tgis_metadata (key VARCHAR NOT NULL, value VARCHAR);\n";
+    statement = "CREATE TABLE tgis_metadata (key VARCHAR NOT NULL, value VARCHAR);\n"
     dbif.execute_transaction(statement)
 
     for key in content.keys():

--- a/lib/python/temporal/core.py
+++ b/lib/python/temporal/core.py
@@ -1109,12 +1109,12 @@ class SQLDatabaseInterfaceConnection(object):
 
     def _create_mapset_error_message(self, mapset):
 
-          return("You have no permission to "
-                 "access mapset <%(mapset)s>, or "
-                 "mapset <%(mapset)s> has no temporal database. "
-                 "Accessible mapsets are: <%(mapsets)s>" % \
-                 {"mapset": decode(mapset),
-                  "mapsets":','.join(self.tgis_mapsets.keys())})
+        return("You have no permission to "
+               "access mapset <%(mapset)s>, or "
+               "mapset <%(mapset)s> has no temporal database. "
+               "Accessible mapsets are: <%(mapsets)s>" % \
+               {"mapset": decode(mapset),
+                "mapsets":','.join(self.tgis_mapsets.keys())})
 
 ###############################################################################
 

--- a/lib/python/temporal/core.py
+++ b/lib/python/temporal/core.py
@@ -563,7 +563,6 @@ def init(raise_fatal_error=False, skip_db_version_check=False):
     _init_tgis_c_library_interface()
     msgr = get_tgis_message_interface()
     msgr.debug(1, "Initiate the temporal database")
-                  #"\n  traceback:%s"%(str("  \n".join(traceback.format_stack()))))
 
     msgr.debug(1, ("Raise on error id: %s"%str(raise_on_error)))
 
@@ -1158,8 +1157,6 @@ class DBConnection(object):
         self.msgr.debug(1, "DBConnection constructor:"\
                            "\n  backend: %s"\
                            "\n  dbstring: %s"%(backend, self.dbstring))
-                           #"\n  traceback:%s"%(backend, self.dbstring,
-                           #str("  \n".join(traceback.format_stack()))))
 
     def __del__(self):
         if self.connected is True:

--- a/lib/python/temporal/metadata.py
+++ b/lib/python/temporal/metadata.py
@@ -429,7 +429,7 @@ class Raster3DMetadata(RasterMetadataBase):
 
         RasterMetadataBase.__init__(self, "raster3d_metadata", ident,
                                     datatype, cols, rows, number_of_cells,
-                                    nsres,	ewres, min, max)
+                                    nsres, ewres, min, max)
 
         self.set_tbres(tbres)
         self.set_depths(depths)

--- a/lib/python/temporal/temporal_algebra.py
+++ b/lib/python/temporal/temporal_algebra.py
@@ -1930,8 +1930,8 @@ class TemporalAlgebraParser(object):
             tvardict["END_DATE"]       = end.date()
             tvardict["END_DATETIME"]   = end
             tvardict["END_TIME"]       = end.time()
-            #core.fatal(_("The temporal functions for map <%s> only supported for absolute"\
-                #          "time." % (str(map.get_id()))))
+            # core.fatal(_("The temporal functions for map <%s> only "
+            #              "supported for absolute time." % (str(map.get_id()))))
         return(tvardict)
 
     def eval_datetime_str(self, tfuncval, comp, value):

--- a/lib/python/temporal/temporal_algebra.py
+++ b/lib/python/temporal/temporal_algebra.py
@@ -837,7 +837,8 @@ class TemporalAlgebraParser(object):
         count = 0
         while True:
             tok = l.lexer.token()
-            if not tok: break
+            if not tok:
+                break
 
             # Ignore map layer
             tokens.append(tok.type)

--- a/lib/python/temporal/temporal_algebra.py
+++ b/lib/python/temporal/temporal_algebra.py
@@ -683,9 +683,10 @@ class TemporalAlgebraLexer(object):
         print(data)
         self.lexer.input(data)
         while True:
-             tok = self.lexer.token()
-             if not tok: break
-             print(tok)
+            tok = self.lexer.token()
+            if not tok:
+                break
+            print(tok)
 
 ###############################################################################
 
@@ -1776,8 +1777,8 @@ class TemporalAlgebraParser(object):
                         "FINISHED"]
 
         for topo in topolist:
-          if topo.upper() not in topologylist:
-              raise SyntaxError("Unpermitted temporal relation name '" + topo + "'")
+            if topo.upper() not in topologylist:
+                raise SyntaxError("Unpermitted temporal relation name '" + topo + "'")
 
         # Create temporal topology for maplistA to maplistB.
         tb = SpatioTemporalTopologyBuilder()

--- a/lib/python/temporal/temporal_granularity.py
+++ b/lib/python/temporal/temporal_granularity.py
@@ -508,7 +508,7 @@ def compute_absolute_time_granularity(maps):
 ###############################################################################
 
 def compute_common_relative_time_granularity(gran_list):
-	"""Compute the greatest common granule from a list of relative time granules
+    """Compute the greatest common granule from a list of relative time granules
 
         .. code-block:: python
 
@@ -524,7 +524,7 @@ def compute_common_relative_time_granularity(gran_list):
             >>> tgis.compute_common_relative_time_granularity(grans)
             10
     """
-	return gcd_list(gran_list)
+    return gcd_list(gran_list)
 
 ###############################################################################
 

--- a/lib/python/temporal/temporal_operator.py
+++ b/lib/python/temporal/temporal_operator.py
@@ -277,9 +277,10 @@ class TemporalOperatorLexer(object):
         print(data)
         self.lexer.input(data)
         while True:
-             tok = self.lexer.token()
-             if not tok: break
-             print(tok)
+            tok = self.lexer.token()
+            if not tok:
+                break
+            print(tok)
 
 ###############################################################################
 

--- a/lib/python/temporal/temporal_raster3d_algebra.py
+++ b/lib/python/temporal/temporal_raster3d_algebra.py
@@ -47,7 +47,8 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
 
         while True:
             tok = l.lexer.token()
-            if not tok: break
+            if not tok:
+                break
 
             if tok.type == "STVDS" or tok.type == "STRDS" or tok.type == "STR3DS":
                 raise SyntaxError("Syntax error near '%s'" %(tok.type))

--- a/lib/python/temporal/temporal_raster_algebra.py
+++ b/lib/python/temporal/temporal_raster_algebra.py
@@ -91,7 +91,8 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
 
         while True:
             tok = l.lexer.token()
-            if not tok: break
+            if not tok:
+                break
 
             if tok.type == "STVDS" or tok.type == "STRDS" or tok.type == "STR3DS":
                 raise SyntaxError("Syntax error near '%s'" %(tok.type))

--- a/lib/python/temporal/temporal_raster_base_algebra.py
+++ b/lib/python/temporal/temporal_raster_base_algebra.py
@@ -1865,7 +1865,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                 mapinput = map_i.get_id()
                 # Create r.mapcalc expression string for the operation.
                 cmdstring = "(%s)" %(n_maps)
-                 # Append module command.
+                # Append module command.
                 map_i.cmd_list = cmdstring
                 # Append map to result map list.
                 resultlist.append(map_i)

--- a/lib/python/temporal/temporal_vector_algebra.py
+++ b/lib/python/temporal/temporal_vector_algebra.py
@@ -142,7 +142,8 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
 
         while True:
             tok = l.lexer.token()
-            if not tok: break
+            if not tok:
+                break
 
             if tok.type == "STVDS" or tok.type == "STRDS" or tok.type == "STR3DS":
                 raise SyntaxError("Syntax error near '%s'" %(tok.type))

--- a/lib/python/temporal/temporal_vector_algebra.py
+++ b/lib/python/temporal/temporal_vector_algebra.py
@@ -204,8 +204,8 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         resultdict = {}
         # Check if given temporal relation are valid.
         for topo in topolist:
-          if topo.upper() not in topologylist:
-              raise SyntaxError("Unpermitted temporal relation name '" + topo + "'")
+            if topo.upper() not in topologylist:
+                raise SyntaxError("Unpermitted temporal relation name '" + topo + "'")
 
         # Create temporal topology for maplistA to maplistB.
         tb = SpatioTemporalTopologyBuilder()


### PR DESCRIPTION
Fix some Flake8 errrors/warnings in the lib/python directory (grass.script, ...). Mostly indentation in grass.temporal and grass.imaging.

Stats for non-whitespace errors after applying this PR, i.e., what still needs to be fixed, is:

```
3     E262 inline comment should start with '# '
168   E265 block comment should start with '# '
14    E266 too many leading '#' for block comment
54    E402 module level import not at top of file
73    E502 the backslash is redundant between brackets
18    E711 comparison to None should be 'if cond is None:'
11    E712 comparison to True should be 'if cond is True:' or 'if cond:'
1     E721 do not compare types, use 'isinstance()'
69    E722 do not use bare 'except'
3     E731 do not assign a lambda expression, use a def
22    E741 ambiguous variable name 'l'
115   F401 '.reader.BandReferenceReader' imported but unused
54    F403 'from ctypes import *' used; unable to detect undefined names
388   F405 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
4     F811 redefinition of unused 'utils' from line 26
368   F821 undefined name '_'
24    F841 local variable 't0' is assigned to but never used
1     F901 'raise NotImplemented' should be 'raise NotImplementedError'
42    W605 invalid escape sequence '\_'
```