### PR TITLE
wxGUI: fix menustrings generation and adjust flake8

### DIFF
--- a/gui/wxpython/.flake8
+++ b/gui/wxpython/.flake8
@@ -13,7 +13,6 @@ ignore =
     E722, # do not use bare 'except'
     E731, # do not assign a lambda expression, use a def
     E741, # ambiguous variable name 'l'
-    E999, # SyntaxError: EOL while scanning string literal
     F401, # 'animation.utils.getCpuCount' imported but unused
     F403, # 'from gmodeler.model import *' used; unable to detect undefined names
     F405, # '_' may be undefined, or defined from star imports: gmodeler.model

--- a/gui/wxpython/core/menutree.py
+++ b/gui/wxpython/core/menutree.py
@@ -171,7 +171,7 @@ class MenuTreeModelBuilder:
 
         :param fh: file descriptor
         """
-        className = str(self.__class__).split('.', 1)[1]
+        className = self.__class__.__name__
         fh.write('menustrings_%s = [\n' % className)
         for child in self.model.root.children:
             printStrings(child, fh)


### PR DESCRIPTION
The previous code generated invalid menustrings.py Python code in Python 3.  This should work in both Pythons but it changes slightly how the class name looks like. I am not sure if that matters for any translation tools, but so far no one complaint about malformed menustrings.py in 7.8.