### PR TITLE
wxGUI preferences: Fix load epsg codes

### DIFF
--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -981,7 +981,7 @@ class PreferencesDialog(PreferencesBaseDialog):
 
         gridSizer.Add(showCompExtent,
                       pos=(row, 0), span=(1, 2))
-        
+
         #
         # mouse wheel zoom
         #
@@ -1418,7 +1418,7 @@ class PreferencesDialog(PreferencesBaseDialog):
             hlWidth, pos=(row, col + 1),
             span=(1, 2),
             flag=wx.ALIGN_RIGHT)
-        
+
         # random colors
         row +=1
         randomColors = wx.CheckBox(parent=panel, id=wx.ID_ANY, label=_(
@@ -1926,7 +1926,7 @@ class PreferencesDialog(PreferencesBaseDialog):
             wx.EndBusyCursor()
             return
 
-        choices = map(str, sorted(self.epsgCodeDict.keys()))
+        choices = list(map(str, sorted(self.epsgCodeDict.keys())))
 
         epsgCombo.SetItems(choices)
         wx.EndBusyCursor()


### PR DESCRIPTION
To reproduce:

1. On the Layer Manager menu go to Settings -> Preferences
2. On the Preferences (GUI Settings) dialog go to Projection page (tab)
3. Click on the Load EPSG codes button

Error message:

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/preferences.py",
line 1931, in OnLoadEpsgCodes

epsgCombo.SetItems(choices)
  File "/usr/lib64/python3.6/site-packages/wx/core.py", line
2491, in _ItemContainer_SetItems

self.Set(items)
TypeError
:
ItemContainer.Set(): argument 1 has unexpected type 'map'
```


