### PR TITLE
Startup: Avoid a race condition

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -18,7 +18,7 @@
 #               command line options for setting the GISDBASE, LOCATION,
 #               and/or MAPSET. Finally it starts GRASS with the appropriate
 #               user interface and cleans up after it is finished.
-# COPYRIGHT:    (C) 2000-2019 by the GRASS Development Team
+# COPYRIGHT:    (C) 2000-2020 by the GRASS Development Team
 #
 #               This program is free software under the GNU General
 #               Public License (>=v2). Read the file COPYING that

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -518,15 +518,8 @@ def read_env_file(path):
     return kv
 
 
-def write_gisrc(kv, filename):
-    f = open(filename, 'w')
-    for k, v in kv.items():
-        f.write("%s: %s\n" % (k, v))
-    f.close()
-
-
-def append_to_gisrc(kv, filename):
-    f = open(filename, 'a')
+def write_gisrc(kv, filename, append=False):
+    f = open(filename, 'a' if append else 'w')
     for k, v in kv.items():
         f.write("%s: %s\n" % (k, v))
     f.close()
@@ -2383,7 +2376,7 @@ def main():
         start_gui(grass_gui)
         kv = {}
         kv['PID'] = str(shell_process.pid)
-        append_to_gisrc(kv, gisrc)
+        write_gisrc(kv, gisrc, True)
         exit_val = shell_process.wait()
         if exit_val != 0:
             warning(_("Failed to start shell '%s'") % os.getenv('SHELL'))

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -525,6 +525,13 @@ def write_gisrc(kv, filename):
     f.close()
 
 
+def append_to_gisrc(kv, filename):
+    f = open(filename, 'a')
+    for k, v in kv.items():
+        f.write("%s: %s\n" % (k, v))
+    f.close()
+
+
 def read_gui(gisrc, default_gui):
     grass_gui = None
     # At this point the GRASS user interface variable has been set from the
@@ -2374,9 +2381,9 @@ def main():
 
         # start GUI and register shell PID in rc file
         start_gui(grass_gui)
-        kv = read_gisrc(gisrc)
+        kv = {}
         kv['PID'] = str(shell_process.pid)
-        write_gisrc(kv, gisrc)
+        append_to_gisrc(kv, gisrc)
         exit_val = shell_process.wait()
         if exit_val != 0:
             warning(_("Failed to start shell '%s'") % os.getenv('SHELL'))


### PR DESCRIPTION
About 20-40%? I'm getting this error message on startup:
```
Starting GRASS GIS...
Cleaning up temporary files...

          __________  ___   __________    _______________
         / ____/ __ \/   | / ___/ ___/   / ____/  _/ ___/
        / / __/ /_/ / /| | \__ \\_  \   / / __ / / \__ \
       / /_/ / _, _/ ___ |___/ /__/ /  / /_/ // / ___/ /
       \____/_/ |_/_/  |_/____/____/   \____/___//____/

Welcome to GRASS GIS 7.9.dev (252b45abb)
GRASS GIS homepage:                      https://grass.osgeo.org
This version running through:            Bash Shell (/bin/bash)
Help is available with the command:      g.manual -i
See the licence terms with:              g.version -c
See citation options with:               g.version -x
Start the GUI with:                      g.gui wxpython
When ready to quit enter:                exit

ERROR: Variable 'GISDBASE' not set
ERROR: Variable 'LOCATION_NAME' not set
ERROR: Variable 'MAPSET' not set
ERROR: Variable 'LOCATION_NAME' not set
```

It randomly happens and variable names are also random, but those variables are all part of `grass_prompt()` in `bash_startup()`.

Why does it happen? `bash_startup()` starts a bash process and almost immediately after that, `gisrc`, from which `grass_prompt()` pulls those variables, gets *fully* rewritten by `write_gisrc()` to append `PID`. `gisrc` gets truncated by `open(filename, 'w')` in `write_gisrc()` and `grass_prompt()` tries to read this file. If these two events happen almost at the same time, `grass_prompt()` can fail to read some or all variables with the above message.

This PR *appends* `PID` instead of fully rewriting `gisrc` to resolve this race condition.