### PR TITLE
Fix spelling errors.

### DIFF
--- a/imagery/i.ortho.photo/i.ortho.camera/i.ortho.camera.html
+++ b/imagery/i.ortho.photo/i.ortho.camera/i.ortho.camera.html
@@ -54,7 +54,7 @@ fiducial marks. In the ideal case of no deviations in the camera (see camera
 calibration certificate) the center is the origin and the values are 0 for
 both X and Y of Point of Symmetry. But usually the principal point does not
 fall on the intersection of the radii at the center of the picture. This
-excentricity is usually of the order of a few micrometers. <p>
+eccentricity is usually of the order of a few micrometers. <p>
 
 You are then asked to enter the X and Y photo coordinates of each fiducial
 as follows.

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -474,7 +474,7 @@ int region_growing(struct globals *globals)
 				pathflag = FALSE;
 
 			    if (Rk_bestn.id < 0) {
-				G_debug(4, "Rk's best neighour is negative");
+				G_debug(4, "Rk's best neighbour is negative");
 				pathflag = FALSE;
 			    }
 

--- a/lib/vector/Vlib/remove_areas.c
+++ b/lib/vector/Vlib/remove_areas.c
@@ -119,7 +119,7 @@ Vect_remove_small_areas_ext(struct Map_info *Map, double thresh,
 	}
 	G_debug(3, "num neighbours = %d", AList->n_values);
 
-	/* Go through the list of neighours and find that with the longest boundary */
+	/* Go through the list of neighbours and find that with the longest boundary */
 	dissolve_neighbour = 0;
 	length = -1.0;
 	for (i = 0; i < AList->n_values; i++) {


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build of 7.8.3-rc1:

 * neighour     -> neighbour
 * excentricity -> eccentricity