### PR TITLE
Drop wx.ALIGN_CENTER_HORIZONTAL, wx.ALIGN_CENTER_VERTICAL and wx.ALIGN_RIGHT when wxEXPAND is used

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -372,7 +372,7 @@ class GRASSStartup(wx.Frame):
                            flag=wx.EXPAND | wx.ALL,
                            border=1)
             main_sizer.Add(buttons_sizer, proportion=0,
-                           flag=wx.ALIGN_CENTER_HORIZONTAL | wx.ALL,
+                           flag=wx.ALL,
                            border=1)
             for button in buttons:
                 buttons_sizer.Add(button, proportion=0,
@@ -438,15 +438,13 @@ class GRASSStartup(wx.Frame):
                   wx.ALL,
                   border=3)  # image
         sizer.Add(gisdbase_boxsizer, proportion=0,
-                  flag=wx.ALIGN_CENTER_HORIZONTAL |
-                  wx.RIGHT | wx.LEFT | wx.TOP | wx.EXPAND,
+                  flag=wx.RIGHT | wx.LEFT | wx.TOP | wx.EXPAND,
                   border=3)  # GISDBASE setting
 
         # warning/error message
         sizer.Add(self.lmessage,
                   proportion=0,
-                  flag=wx.ALIGN_CENTER_VERTICAL |
-                  wx.ALIGN_LEFT | wx.ALL | wx.EXPAND, border=5)
+                  flag=wx.ALIGN_LEFT | wx.ALL | wx.EXPAND, border=5)
         sizer.Add(location_mapset_sizer, proportion=1,
                   flag=wx.RIGHT | wx.LEFT | wx.EXPAND,
                   border=1)

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -341,11 +341,10 @@ class LocationDownloadPanel(wx.Panel):
         button_sizer.Add(self.download_button, proportion=0)
 
         vertical.Add(button_sizer, proportion=0,
-                     flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT | wx.ALIGN_RIGHT, border=10)
+                     flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10)
         vertical.AddStretchSpacer()
         vertical.Add(self.message, proportion=0,
-                     flag=wx.ALIGN_CENTER_VERTICAL |
-                     wx.ALIGN_LEFT | wx.ALL | wx.EXPAND, border=10)
+                     flag=wx.ALIGN_LEFT | wx.ALL | wx.EXPAND, border=10)
 
         self.SetSizer(vertical)
         vertical.Fit(self)


### PR DESCRIPTION
This will fix https://github.com/OSGeo/grass/issues/564
