### PR TITLE
v.db.addtable: Overwrite newly created cat column (Fix #567)

### DIFF
--- a/scripts/v.db.addtable/v.db.addtable.py
+++ b/scripts/v.db.addtable/v.db.addtable.py
@@ -148,7 +148,7 @@ def main():
     # modules such as v.what.rast happy: (creates new row for each
     # vector line):
     try:
-        grass.run_command('v.to.db', map=map_name, layer=layer,
+        grass.run_command('v.to.db', overwrite=True, map=map_name, layer=layer,
                           option='cat', column=key, qlayer=layer)
     except CalledModuleError:
         # remove link

--- a/scripts/v.to.lines/v.to.lines.py
+++ b/scripts/v.to.lines/v.to.lines.py
@@ -102,7 +102,6 @@ def main():
         grass.fatal(_("Error creating layer 2"))
     try:
         grass.run_command('v.db.addtable', map=input_tmp, layer="2",
-                          columns="left integer,right integer",
                           quiet=quiet)
     except CalledModuleError:
         grass.run_command('g.remove', flags='f', type='vector',


### PR DESCRIPTION
This PR adds the `overwrite` flag to `v.to.db` (Fix #567).