### PR TITLE
Fix Flake8 errors in temporal modules

### DIFF
--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -3,7 +3,6 @@ ignore =
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment
     E502, # the backslash is redundant between brackets
-    E711, # comparison to None should be 'if cond is not None:'
     E712, # comparison to False should be 'if cond is False:' or 'if not cond:'
     E722, # do not use bare 'except'
     F401, # 'ply.lex' imported but unused

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -1,10 +1,10 @@
 [flake8]
 ignore =
+    F841, # local variable 'column' is assigned to but never used
+    F821, # undefined name '_'
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment
     E502, # the backslash is redundant between brackets
-    F821, # undefined name '_'
-    F841, # local variable 'column' is assigned to but never used
     W291, # trailing whitespace
     W293, # blank line contains whitespace
     W391, # blank line at end of file

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -4,7 +4,6 @@ ignore =
     E266, # too many leading '#' for block comment
     E502, # the backslash is redundant between brackets
     E722, # do not use bare 'except'
-    F401, # 'ply.lex' imported but unused
     F821, # undefined name '_'
     F841, # local variable 'column' is assigned to but never used
     W291, # trailing whitespace

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -3,7 +3,6 @@ ignore =
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment
     E502, # the backslash is redundant between brackets
-    E722, # do not use bare 'except'
     F821, # undefined name '_'
     F841, # local variable 'column' is assigned to but never used
     W291, # trailing whitespace

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -3,7 +3,6 @@ ignore =
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment
     E502, # the backslash is redundant between brackets
-    E712, # comparison to False should be 'if cond is False:' or 'if not cond:'
     E722, # do not use bare 'except'
     F401, # 'ply.lex' imported but unused
     F821, # undefined name '_'

--- a/temporal/t.info/t.info.py
+++ b/temporal/t.info/t.info.py
@@ -109,16 +109,16 @@ def main():
 
     dataset = tgis.dataset_factory(type_, id_)
 
-    if dataset.is_in_db(dbif) == False:
+    if not dataset.is_in_db(dbif):
         grass.fatal(_("Dataset <%s> not found in temporal database") % (id_))
 
     dataset.select(dbif)
 
-    if history == True and type_ in ["strds", "stvds", "str3ds"]:
+    if history and type_ in ["strds", "stvds", "str3ds"]:
         dataset.print_history()
         return
 
-    if shellstyle == True:
+    if shellstyle:
         dataset.print_shell_info()
     else:
         dataset.print_info()

--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -149,7 +149,7 @@ def main():
                                                      (sp.get_new_map_instance(None).get_type(),  time,  key))
 
                     # Print the column names if requested
-                    if colhead == True and first == True:
+                    if colhead and first:
                         output = ""
                         count = 0
                         for key in rows[0].keys():

--- a/temporal/t.merge/t.merge.py
+++ b/temporal/t.merge/t.merge.py
@@ -103,7 +103,7 @@ def main():
     output_stds = tgis.dataset_factory(type, output_id)
     output_exists = output_stds.is_in_db(dbif=dbif)
 
-    if output_exists == True and grass.overwrite() == False:
+    if output_exists and not grass.overwrite():
         dbif.close()
         grass.fatal(_("Unable to merge maps into space time %s dataset <%s> "\
                       "please use the overwrite flag.") % \
@@ -121,7 +121,7 @@ def main():
     registered_output_maps = {}
     # Maps that are already registered in an existing dataset 
     # are not registered again
-    if output_exists == True:
+    if output_exists:
         rows = output_stds.get_registered_maps(columns="id", dbif=dbif)
         if rows:
             for row in rows:
@@ -145,7 +145,7 @@ def main():
 
     output_stds.update_from_registered_maps(dbif=dbif)
 
-    if output_exists == True:
+    if output_exists:
         output_stds.update_command_string(dbif=dbif)
 
 if __name__ == "__main__":

--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -180,7 +180,7 @@ def main():
 
     input_strds = tgis.SpaceTimeRasterDataset(id)
 
-    if input_strds.is_in_db() == False:
+    if not input_strds.is_in_db():
         dbif.close()
         grass.fatal(_("Space time %s dataset <%s> not found") % (
             input_strds.get_output_map_instance(None).get_type(), id))
@@ -243,7 +243,7 @@ def main():
             minimum_id = minimum + "@" + mapset
 
         minimum_strds = tgis.SpaceTimeRasterDataset(minimum_id)
-        if minimum_strds.is_in_db() == False:
+        if not minimum_strds.is_in_db():
             dbif.close()
             grass.fatal(_("Space time raster dataset <%s> not found") % (minimum_strds.get_id()))
 
@@ -262,7 +262,7 @@ def main():
             maximum_id = maximum + "@" + mapset
 
         maximum_strds = tgis.SpaceTimeRasterDataset(maximum_id)
-        if maximum_strds.is_in_db() == False:
+        if not maximum_strds.is_in_db():
             dbif.close()
             grass.fatal(_("Space time raster dataset <%s> not found") % (maximum_strds.get_id()))
 

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -199,7 +199,7 @@ def main():
 
     input_strds = tgis.SpaceTimeRasterDataset(id)
 
-    if input_strds.is_in_db() == False:
+    if not input_strds.is_in_db():
         dbif.close()
         grass.fatal(_("Space time raster dataset <%s> not found") % (id))
 
@@ -219,18 +219,18 @@ def main():
                           "database, use overwrite flag to overwrite") % out_id)
 
     if tgis.check_granularity_string(granularity,
-                                     input_strds.get_temporal_type()) == False:
+                                     input_strds.get_temporal_type()) is False:
             dbif.close()
             grass.fatal(_("Invalid granularity"))
 
     if tgis.check_granularity_string(cycle,
-                                     input_strds.get_temporal_type()) == False:
+                                     input_strds.get_temporal_type()) is False:
             dbif.close()
             grass.fatal(_("Invalid cycle"))
 
     if offset:
         if tgis.check_granularity_string(offset,
-                                         input_strds.get_temporal_type()) == False:
+                                         input_strds.get_temporal_type()) is False:
                 dbif.close()
                 grass.fatal(_("Invalid offset"))
 
@@ -247,7 +247,7 @@ def main():
             lower_id = lower + "@" + mapset
 
         lower_strds = tgis.SpaceTimeRasterDataset(lower_id)
-        if lower_strds.is_in_db() == False:
+        if not lower_strds.is_in_db():
             dbif.close()
             grass.fatal(_("Space time raster dataset <%s> not found") % (lower_strds.get_id()))
 
@@ -269,7 +269,7 @@ def main():
             upper_id = upper + "@" + mapset
 
         upper_strds = tgis.SpaceTimeRasterDataset(upper_id)
-        if upper_strds.is_in_db() == False:
+        if not upper_strds.is_in_db():
             dbif.close()
             grass.fatal(_("Space time raster dataset <%s> not found") % (upper_strds.get_id()))
 

--- a/temporal/t.rast.algebra/t.rast.algebra.py
+++ b/temporal/t.rast.algebra/t.rast.algebra.py
@@ -105,7 +105,7 @@ def main():
         # Intentionally unused imports
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
-    except:
+    except ImportError:
         grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
                              "You can use t.rast.mapcalc that provides a limited but useful alternative to "
                              "t.rast.algebra without PLY requirement."))

--- a/temporal/t.rast.algebra/t.rast.algebra.py
+++ b/temporal/t.rast.algebra/t.rast.algebra.py
@@ -102,8 +102,9 @@ def main():
 
     # Check for PLY istallation
     try:
-        import ply.lex as lex
-        import ply.yacc as yacc
+        # Intentionally unused imports
+        import ply.lex as lex  # noqa: F401
+        import ply.yacc as yacc  # noqa: F401
     except:
         grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
                              "You can use t.rast.mapcalc that provides a limited but useful alternative to "

--- a/temporal/t.rast.gapfill/t.rast.gapfill.py
+++ b/temporal/t.rast.gapfill/t.rast.gapfill.py
@@ -70,9 +70,7 @@
 
 import sys
 import copy
-from multiprocessing import Process
 import grass.script as grass
-from grass.exceptions import FatalError
 
 ############################################################################
 

--- a/temporal/t.rast.gapfill/t.rast.gapfill.py
+++ b/temporal/t.rast.gapfill/t.rast.gapfill.py
@@ -216,7 +216,7 @@ def main():
     # Insert new interpolated maps in temporal database and dataset
     for _map in result_list:
         id = _map.get_id()
-        if overwrite_flags[id] == True:
+        if overwrite_flags[id]:
             if _map.is_time_absolute():
                 start, end = _map.get_absolute_time()
                 if _map.is_in_db():

--- a/temporal/t.rast.what/t.rast.what.py
+++ b/temporal/t.rast.what/t.rast.what.py
@@ -123,7 +123,6 @@ import sys
 import copy
 import grass.script as gscript
 
-import pdb
 
 ############################################################################
 

--- a/temporal/t.rast3d.algebra/t.rast3d.algebra.py
+++ b/temporal/t.rast3d.algebra/t.rast3d.algebra.py
@@ -88,8 +88,9 @@ def main():
 
     # Check for PLY istallation
     try:
-        import ply.lex as lex
-        import ply.yacc as yacc
+        # Intentionally unused imports
+        import ply.lex as lex  # noqa: F401
+        import ply.yacc as yacc  # noqa: F401
     except:
         grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
                              "You can use t.rast3d.mapcalc that provides a limited but useful alternative to "

--- a/temporal/t.rast3d.algebra/t.rast3d.algebra.py
+++ b/temporal/t.rast3d.algebra/t.rast3d.algebra.py
@@ -91,7 +91,7 @@ def main():
         # Intentionally unused imports
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
-    except:
+    except ImportError:
         grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
                              "You can use t.rast3d.mapcalc that provides a limited but useful alternative to "
                              "t.rast3d.mapcalc2 without PLY requirement."))

--- a/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
+++ b/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
@@ -77,8 +77,6 @@
 #% description: Check the spatial topology of temporally related maps and process only spatially related maps
 #%end
 
-from multiprocessing import Process
-import copy
 import grass.script as grass
 
 

--- a/temporal/t.rename/t.rename.py
+++ b/temporal/t.rename/t.rename.py
@@ -85,7 +85,7 @@ def main():
                       "mapset.") % (stds.get_new_map_instance(None).get_type(), 
                                     old_id))
         
-    if stds.is_in_db(dbif=dbif) == False:
+    if not stds.is_in_db(dbif=dbif):
         dbif.close()
         grass.fatal(_("Space time %s dataset <%s> not found") % (
             stds.get_new_map_instance(None).get_type(), old_id))
@@ -93,14 +93,14 @@ def main():
     # Check if the new id is in the database
     new_stds = tgis.dataset_factory(type, new_id)
 
-    if new_stds.is_in_db(dbif=dbif) == True and grass.overwrite() == False:
+    if new_stds.is_in_db(dbif=dbif) and not grass.overwrite():
         dbif.close()
         grass.fatal(_("Unable to rename Space time %s dataset <%s>. Name <%s> "
                       "is in use, please use the overwrite flag.") % (
             stds.get_new_map_instance(None).get_type(), old_id, new_id))
     
     # Remove an already existing space time dataset
-    if new_stds.is_in_db(dbif=dbif) == True:
+    if new_stds.is_in_db(dbif=dbif):
         new_stds.delete(dbif=dbif)
         
     stds.select(dbif=dbif)

--- a/temporal/t.select/t.select.py
+++ b/temporal/t.select/t.select.py
@@ -71,7 +71,7 @@ def main():
         # Intentionally unused imports
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
-    except:
+    except ImportError:
         grass.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."))
 
     tgis.init(True)

--- a/temporal/t.select/t.select.py
+++ b/temporal/t.select/t.select.py
@@ -68,8 +68,9 @@ def main():
 
     # Check for PLY istallation
     try:
-        import ply.lex as lex
-        import ply.yacc as yacc
+        # Intentionally unused imports
+        import ply.lex as lex  # noqa: F401
+        import ply.yacc as yacc  # noqa: F401
     except:
         grass.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."))
 

--- a/temporal/t.shift/t.shift.py
+++ b/temporal/t.shift/t.shift.py
@@ -69,7 +69,7 @@ def main():
     stds = tgis.open_old_stds(name, type, dbif)
     check = stds.shift(gran=gran, dbif=dbif)
 
-    if check == False:
+    if check is False:
         dbif.close()
         grass.fatal(_("Unable to temporally shift the space time %s dataset <%s>") % \
                      (stds.get_new_map_instance(None).get_type(), id))

--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -128,7 +128,7 @@ def main():
         map = tgis.dataset_factory(type, mapid)
 
         # Unregister map if in database
-        if map.is_in_db(dbif) == True:
+        if map.is_in_db(dbif):
             # Unregister from a single dataset
             if input:
                 # Collect SQL statements

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -69,7 +69,7 @@ def main():
         # Intentionally unused imports
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
-    except:
+    except ImportError:
         grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."))
 
     tgis.init(True)

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -66,8 +66,9 @@ def main():
 
     # Check for PLY istallation
     try:
-        import ply.lex as lex
-        import ply.yacc as yacc
+        # Intentionally unused imports
+        import ply.lex as lex  # noqa: F401
+        import ply.yacc as yacc  # noqa: F401
     except:
         grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."))
 

--- a/temporal/t.vect.observe.strds/t.vect.observe.strds.py
+++ b/temporal/t.vect.observe.strds/t.vect.observe.strds.py
@@ -55,7 +55,6 @@
 #%end
 
 import grass.script as grass
-import grass.script.raster as raster
 from grass.exceptions import CalledModuleError
 
 ############################################################################

--- a/temporal/t.vect.observe.strds/t.vect.observe.strds.py
+++ b/temporal/t.vect.observe.strds/t.vect.observe.strds.py
@@ -64,7 +64,7 @@ class Sample(object):
     def __init__(self, start = None, end = None, raster_names = None):
         self.start = start
         self.end = end
-        if raster_names != None:
+        if raster_names is not None:
             self.raster_names = raster_names
         else:
             self.raster_names = []


### PR DESCRIPTION
This solves or individually ignores:

* E711 comparison to None should be 'if cond is not None:'
* E712 comparison to False should be 'if cond is False:' or 'if not cond:'
* E722 do not use bare 'except'
* F401 'ply.lex' imported but unused

The ply imports are just for testing its presence, so they are expected to be unused, so I'm ignoring the error for the given lines.

You can see the changes for the individual errors in the individual commits.