### PR TITLE
[rv].unpack: sys.stdout.write() cannot print bytes; convert f.read() to str

### DIFF
--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -82,7 +82,7 @@ def main():
         try:
             for fname in ['PROJ_INFO', 'PROJ_UNITS']:
                 f = tar.extractfile('{}/{}'.format(data_name, fname))
-                sys.stdout.write(f.read())
+                sys.stdout.write(f.read().decode())
         except KeyError:
             grass.fatal(_("Pack file unreadable: file '{}' missing".format(fname)))
         tar.close()

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -85,7 +85,7 @@ def main():
         try:
             for fname in ['PROJ_INFO', 'PROJ_UNITS']:
                 f = tar.extractfile(fname)
-                sys.stdout.write(f.read())
+                sys.stdout.write(f.read().decode())
         except KeyError:
             grass.fatal(_("Pack file unreadable: file '{}' missing".format(fname)))
         tar.close()


### PR DESCRIPTION
This PR fixes the `-p` flag of `[rv].unpack`.
```
TypeError: write() argument must be str, not bytes
```