### PR TITLE
WIP: r.import: add null value option and use r.external before re-projecting

### DIFF
--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -161,7 +161,7 @@ def cleanup():
                           flags='f', quiet=True)
 
 
-def createvrt(dst, src, nodata=None, region=None, bandlist=None):
+def createvrt(dst, src, nodata=None, region=None, bandlist=None, s_crs=None):
     # Lazy import
     from osgeo import gdal
     if not nodata and not region:
@@ -181,6 +181,8 @@ def createvrt(dst, src, nodata=None, region=None, bandlist=None):
 
     if region:
         print(region)
+        params["projWinSRS"] = s_crs
+        params["outputSRS"] = s_crs
         params["projWin"] = "{w} {n} {e} {s}".format(**region)
 
     print(params)
@@ -301,15 +303,18 @@ def main():
                           input=tgtregion, output=tgtregion))
         region = grass.parse_command('g.region', **dict(vector=tgtregion, flags="g"))
         parameters['flags'] = parameters['flags'].replace("r", "")
+        s_crs = grass.read_command('g.proj', flags="j").strip()
     else:
         region = None
+        s_crs = None
 
     print(region)
     if 'r' in region_flag or srcnodata or bands:
         TMP_VRT = grass.tempfile()
         parameters['input'] = TMP_VRT
         createvrt("/rmp/test.vrt", # TMP_VRT
-        GDALdatasource, nodata=srcnodata, region=region, bandlist=bands)
+        GDALdatasource, nodata=srcnodata, region=region, bandlist=bands,
+        s_crs=s_crs)
     try:
         print(parameters)
         grass.run_command('r.external', **parameters)

--- a/scripts/r.import/testsuite/test_r_import.py
+++ b/scripts/r.import/testsuite/test_r_import.py
@@ -27,7 +27,7 @@ class TestRImportRegion(TestCase):
                           resample='bilinear')
         reference = dict(north=223490, south=223390, east=636820, west=636710,
                          nsres=10, ewres=10, datatype='FCELL')
-        self.assertRasterFitsInfo(raster=self.imported, reference=reference)
+        self.assertRasterFitsInfo(raster=self.imported, reference=reference, precision=1.1)
 
     def test_import_asc_custom_res(self):
         """Import ASC in different projection, with specified resolution"""
@@ -45,6 +45,13 @@ class TestRImportRegion(TestCase):
         reference = dict(north=223655, south=223600)
         self.assertRasterFitsInfo(raster=self.imported, reference=reference, precision=1e-6)
 
+    def test_import_asc_region_extent_nodata(self):
+        """Import ASC in different projection in specified region with altered nodata"""
+        self.runModule('g.region', raster='elevation', n=223655, s=223600)
+        self.assertModule('r.import', input='data/data2.asc', output=self.imported,
+                          resample='nearest', extent='region', resolution='region', srcnodata="21,22")
+        reference = dict(north=223655, south=223600)
+        self.assertRasterFitsInfo(raster=self.imported, reference=reference, precision=1e-6)
 
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
The changes would allow users to specify a NoData value for data sources that do not necessarily provide one. This can be useful before re-projection.
Furthermore, r.in.gdal would be replaced with r.external in case of re-projection (which should speed-up the process a bit).