### PR TITLE
v.what.rast: fix writing of map history

### DIFF
--- a/vector/v.what.rast/main.c
+++ b/vector/v.what.rast/main.c
@@ -259,13 +259,16 @@ int main(int argc, char *argv[])
 	point_cnt++;
     }
     G_progress(1, 1);
+    Vect_close(&Map);
     
     if (!print_flag->answer) {
+	if (Vect_open_update_head(&Map, opt.vect->answer, "") < 0)
+	    G_warning(_("Unable to write history for vector map <%s>"),
+		      opt.vect->answer);
 	Vect_set_db_updated(&Map);
 	Vect_hist_command(&Map);
-	Vect_set_db_updated(&Map); /* again? */
+	Vect_close(&Map);
     }
-    Vect_close(&Map);
 
     if (point_cnt < 1) {
         G_important_message(_("No features of type (%s) found in vector map <%s>"),


### PR DESCRIPTION
`Vect_open_old*()` does not allow history writing. History wasn't working. This PR uses `Vect_open_update_head()` to write history.