### PR TITLE
wxGUI vdigit: Fix Undo/Redo tool event 

### DIFF
--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -495,13 +495,15 @@ class VDigitToolbar(BaseToolbar):
 
     def OnUndo(self, event):
         """Undo previous changes"""
-        self.digit.Undo()
+        if self.digit:
+            self.digit.Undo()
 
         event.Skip()
 
     def OnRedo(self, event):
         """Undo previous changes"""
-        self.digit.Undo(level=1)
+        if self.digit:
+            self.digit.Undo(level=1)
 
         event.Skip()
 


### PR DESCRIPTION
To reproduce:

1. Start gui `g.gui`
2. On the Map Display Window go to ComboBox widget and choose **Vector digitizer** item
3. Don't choose vector map layer in the ComboBox widget in the vdigit toolbar
4. Click on the **Undo/Redo** tool icon

Error message (switch to Console page):

Undo tool:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/vdigit/toolbars.py",
line 501, in OnUndo

self.digit.Undo()
AttributeError
:
'NoneType' object has no attribute 'Undo'
```

Redo tool:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/vdigit/toolbars.py",
line 508, in OnRedo

self.digit.Undo(level=1)
AttributeError
:
'NoneType' object has no attribute 'Undo'
```

 