### PR TITLE
wxGUI rdigit: Fix show save dialog

### DIFF
--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -300,16 +300,19 @@ class RDigitController(wx.EvtHandler):
 
     def Stop(self):
         """Before stopping digitizer, asks to save edits"""
-        dlg = wx.MessageDialog(
-            self._mapWindow,
-            _("Do you want to save changes?"),
-            _("Save raster map changes"),
-            wx.YES_NO)
-        if dlg.ShowModal() == wx.ID_YES:
-            if self._drawing:
-                self._finish()
-            self._thread.Run(callable=self._exportRaster,
-                             ondone=lambda event: self._updateAndQuit())
+        if self._editedRaster:
+            dlg = wx.MessageDialog(
+                self._mapWindow,
+                _("Do you want to save changes?"),
+                _("Save raster map changes"),
+                wx.YES_NO)
+            if dlg.ShowModal() == wx.ID_YES:
+                if self._drawing:
+                    self._finish()
+                self._thread.Run(callable=self._exportRaster,
+                                 ondone=lambda event: self._updateAndQuit())
+            else:
+                self.quitDigitizer.emit()
         else:
             self.quitDigitizer.emit()
 

--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -341,12 +341,13 @@ class RDigitController(wx.EvtHandler):
         :param restore: if restore previous cursor, mouse['use']
         """
         try:
-            gcore.run_command(
-                'g.remove',
-                type='raster',
-                flags='f',
-                name=self._backupRasterName,
-                quiet=True)
+            if self._backupRasterName:
+                gcore.run_command(
+                    'g.remove',
+                    type='raster',
+                    flags='f',
+                    name=self._backupRasterName,
+                    quiet=True)
         except CalledModuleError:
             pass
 


### PR DESCRIPTION
Actual behavior:

![rdigit_save_diaog_actual](https://user-images.githubusercontent.com/50632337/81215820-33a03000-8fda-11ea-9114-56dd389023cc.gif)

1. It isn't necessary to show the save dialog If I quit raster digitizer and I don't choose raster map layer in the ComboBox widget (rdigit toolbar)

2.  If I don't choose raster map layer in the ComboBox widget (rdigit toolbar) and I quit raster digitizer,  during call `CleanUp` method error message appear in the terminal emulator:

Error message:

`ERROR: At least one of the following options is required: <pattern> and <name>`

Error message is raised by calling `g.remove` if `name` param is `None`

```
--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -341,12 +341,13 @@ class RDigitController(wx.EvtHandler):
         :param restore: if restore previous cursor, mouse['use']
         """
         try:
-            gcore.run_command(
-                'g.remove',
-                type='raster',
-                flags='f',
-                name=self._backupRasterName,
-                quiet=True)
+            if self._backupRasterName:
+                gcore.run_command(
+                    'g.remove',
+                    type='raster',
+                    flags='f',
+                    name=self._backupRasterName,
+                    quiet=True)
         except CalledModuleError:
             pass
```

Expected behavior:

![rdigit_save_dialog_expected](https://user-images.githubusercontent.com/50632337/81218104-f2aa1a80-8fdd-11ea-97f5-704f97365cd1.gif)


