### PR TITLE
r.neighbors: add option for exponential weighting

### DIFF
--- a/raster/r.neighbors/local_proto.h
+++ b/raster/r.neighbors/local_proto.h
@@ -23,3 +23,4 @@ extern int null_cats(const char *);
 /* read_weights.c */
 extern void read_weights(const char *);
 extern void gaussian_weights(double);
+extern void exponential_weights(double);

--- a/raster/r.neighbors/local_proto.h
+++ b/raster/r.neighbors/local_proto.h
@@ -22,4 +22,6 @@ extern int null_cats(const char *);
 
 /* read_weights.c */
 extern void read_weights(const char *);
+extern double gaussian(double, double);
+extern double exponential(double, double);
 extern void compute_weights(const char *, double);

--- a/raster/r.neighbors/local_proto.h
+++ b/raster/r.neighbors/local_proto.h
@@ -22,5 +22,4 @@ extern int null_cats(const char *);
 
 /* read_weights.c */
 extern void read_weights(const char *);
-extern void gaussian_weights(double);
-extern void exponential_weights(double);
+extern void compute_weights(const char *, double);

--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
 	G_fatal_error(_("Neighborhood size must be odd"));
     ncb.dist = ncb.nsize / 2;
 
-    if (strcmp(parm.weighting_function->answer, "none") == 1 && flag.circle->answer)
+    if (strcmp(parm.weighting_function->answer, "none") && flag.circle->answer)
 	G_fatal_error(_("-%c and %s= are mutually exclusive"),
 			flag.circle->key, parm.weighting_function->answer);
 
@@ -314,8 +314,8 @@ int main(int argc, char *argv[])
 	G_fatal_error(_("File with weighting matrix is missing."));
 
     /* Check if weighting factor is given for all other weighting functions*/
-    if (strcmp(parm.weighting_function->answer, "none") != 0 &&
-        strcmp(parm.weighting_function->answer, "file") != 0 &&
+    if (strcmp(parm.weighting_function->answer, "none") &&
+        strcmp(parm.weighting_function->answer, "file") &&
         !parm.weighting_factor->answer)
 	G_fatal_error(_("Weighting function '%s' requires a %s."),
 			parm.weighting_function->answer, parm.weighting_factor->key);
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
 	read_weights(parm.weight->answer);
 	weights = 1;
     }
-    else if (strcmp(parm.weighting_function->answer, "none") != 0) {
+    else if (strcmp(parm.weighting_function->answer, "none")) {
 	G_verbose_message(_("Computing %s weights..."),
 			      parm.weighting_function->answer);
 	compute_weights(parm.weighting_function->answer,
@@ -382,7 +382,7 @@ int main(int argc, char *argv[])
 		out->method_fn_w = menu[method].method_w;
 	    }
 	    else {
-		if (strcmp(parm.weighting_function->answer,"none") == 1) {
+		if (strcmp(parm.weighting_function->answer,"none")) {
 		    G_warning(_("Method %s not compatible with weighing window, using weight mask instead"),
 			      method_name);
 		    if (!have_weights_mask) {

--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -81,15 +81,6 @@ static struct menu menu[] = {
     {0, 0, 0, 0, 0, 0, 0, 0}
 };
 
-/* modify this table to add new methods */
-static struct weight_functions weight_functions[] = {
-    {"none", "No weighting"},
-    {"gaussian", "Gaussian weighting function"},
-    {"exponential", "Exponential weighting function"},
-    {"file", "File with a custom weighting matrix"},
-    {0, 0}
-};
-
 struct ncb ncb;
 
 struct output
@@ -115,19 +106,6 @@ static int find_method(const char *method_name)
 	    return i;
 
     G_fatal_error(_("Unknown method <%s>"), method_name);
-
-    return -1;
-}
-
-static int find_weight_function(const char *weight_function)
-{
-    int i;
-
-    for (i = 0; weight_functions[i].name; i++)
-	if (strcmp(weight_functions[i].name, weight_function) == 0)
-	    return i;
-
-    G_fatal_error(_("Unknown weight type <%s>"), weight_function);
 
     return -1;
 }
@@ -247,15 +225,16 @@ int main(int argc, char *argv[])
     parm.weighting_function->type = TYPE_STRING;
     parm.weighting_function->required = NO;
     parm.weighting_function->answer = "none";
-    p = G_malloc(1024);
-    for (n = 0; weight_functions[n].name; n++) {
-	if (n)
-	    strcat(p, ",");
-	else
-	    *p = 0;
-	strcat(p, weight_functions[n].name);
-    }
-    parm.weighting_function->options = p;
+    parm.weighting_function->options = "none,gaussian,exponential,file";
+    G_asprintf((char **)&(parm.weighting_function->descriptions),
+               "none;%s;"
+               "gaussian;%s;"
+               "exponential;%s;"
+               "file;%s;",
+               _("No weighting"),
+               _("Gaussian weighting function"),
+               _("Exponential weighting function"),
+               _("File with a custom weighting matrix"));
     parm.weighting_function->description = _("Weighting function");
     parm.weighting_function->multiple = NO;
 

--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -149,6 +149,7 @@ int main(int argc, char *argv[])
 	struct Option *title;
 	struct Option *weight;
 	struct Option *gauss;
+	struct Option *exp;
 	struct Option *quantile;
     } parm;
     struct
@@ -231,6 +232,12 @@ int main(int argc, char *argv[])
     parm.gauss->required = NO;
     parm.gauss->description = _("Sigma (in cells) for Gaussian filter");
 
+    parm.exp = G_define_option();
+    parm.exp->key = "exponent";
+    parm.exp->type = TYPE_DOUBLE;
+    parm.exp->required = NO;
+    parm.exp->description = _("Factor for an exponential kernel");
+
     parm.quantile = G_define_option();
     parm.quantile->key = "quantile";
     parm.quantile->type = TYPE_DOUBLE;
@@ -265,6 +272,14 @@ int main(int argc, char *argv[])
     if (parm.weight->answer && parm.gauss->answer)
 	G_fatal_error(_("%s= and %s= are mutually exclusive"),
 			parm.weight->key, parm.gauss->key);
+
+    if (parm.exp->answer && parm.gauss->answer)
+	G_fatal_error(_("%s= and %s= are mutually exclusive"),
+			parm.exp->key, parm.gauss->key);
+
+    if (parm.weight->answer && parm.exp->answer)
+	G_fatal_error(_("%s= and %s= are mutually exclusive"),
+			parm.weight->key, parm.exp->key);
 
     ncb.oldcell = parm.input->answer;
 
@@ -307,6 +322,10 @@ int main(int argc, char *argv[])
 	gaussian_weights(atof(parm.gauss->answer));
 	weights = 1;
     }
+    else if (parm.exp->answer) {
+	exponential_weights(atof(parm.exp->answer));
+	weights = 1;
+    }
     
     copycolr = 0;
     have_weights_mask = 0;
@@ -335,6 +354,10 @@ int main(int argc, char *argv[])
 		}
 		else if (parm.gauss->answer) {
 		    G_warning(_("Method %s not compatible with Gaussian filter, using unweighed version instead"),
+			      method_name);
+		}
+		else if (parm.exp->answer) {
+		    G_warning(_("Method %s not compatible with exponential kernel, using unweighed version instead"),
 			      method_name);
 		}
 		

--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -83,7 +83,7 @@ static struct menu menu[] = {
 
 /* modify this table to add new methods */
 static struct weight_functions weight_functions[] = {
-    {"None", "No weighting"},
+    {"none", "No weighting"},
     {"gaussian", "Gaussian weighting function"},
     {"exponential", "Exponential weighting function"},
     {"file", "File with a custom weighting matrix"},
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
     parm.weighting_function->key = "weighting_function";
     parm.weighting_function->type = TYPE_STRING;
     parm.weighting_function->required = NO;
-    parm.weighting_function->answer = "None";
+    parm.weighting_function->answer = "none";
     p = G_malloc(1024);
     for (n = 0; weight_functions[n].name; n++) {
 	if (n)
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
     parm.weighting_factor->type = TYPE_DOUBLE;
     parm.weighting_factor->required = NO;
     parm.weighting_factor->multiple = NO;
-    parm.weighting_factor->description = _("Factor used in the selected weighting function (ignored for None and file)");
+    parm.weighting_factor->description = _("Factor used in the selected weighting function (ignored for none and file)");
 
     parm.weight = G_define_standard_option(G_OPT_F_INPUT);
     parm.weight->key = "weight";
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
 	G_fatal_error(_("Neighborhood size must be odd"));
     ncb.dist = ncb.nsize / 2;
 
-    if (strcmp(parm.weighting_function->answer, "None") == 1 && flag.circle->answer)
+    if (strcmp(parm.weighting_function->answer, "none") == 1 && flag.circle->answer)
 	G_fatal_error(_("-%c and %s= are mutually exclusive"),
 			flag.circle->key, parm.weighting_function->answer);
 
@@ -314,7 +314,7 @@ int main(int argc, char *argv[])
 	G_fatal_error(_("File with weighting matrix is missing."));
 
     /* Check if weighting factor is given for all other weighting functions*/
-    if (strcmp(parm.weighting_function->answer, "None") != 0 &&
+    if (strcmp(parm.weighting_function->answer, "none") != 0 &&
         strcmp(parm.weighting_function->answer, "file") != 0 &&
         !parm.weighting_factor->answer)
 	G_fatal_error(_("Weighting function '%s' requires a %s."),
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
 	read_weights(parm.weight->answer);
 	weights = 1;
     }
-    else if (strcmp(parm.weighting_function->answer, "None") != 0) {
+    else if (strcmp(parm.weighting_function->answer, "none") != 0) {
 	G_verbose_message(_("Computing %s weights..."),
 			      parm.weighting_function->answer);
 	compute_weights(parm.weighting_function->answer,
@@ -382,7 +382,7 @@ int main(int argc, char *argv[])
 		out->method_fn_w = menu[method].method_w;
 	    }
 	    else {
-		if (strcmp(parm.weighting_function->answer,"None") == 1) {
+		if (strcmp(parm.weighting_function->answer,"none") == 1) {
 		    G_warning(_("Method %s not compatible with weighing window, using weight mask instead"),
 			      method_name);
 		    if (!have_weights_mask) {

--- a/raster/r.neighbors/r.neighbors.html
+++ b/raster/r.neighbors/r.neighbors.html
@@ -1,11 +1,11 @@
 <h2>DESCRIPTION</h2>
 
 <em><b>r.neighbors</b></em> looks at each cell in a raster input
-file, and examines the values assigned to the
-cells in some user-defined "neighborhood" around it.  It
+map, and examines the values assigned to the
+cells in some user-defined "neighborhood" around it. It
 outputs a new raster map layer in which each cell is
 assigned a value that is some (user-specified)
-function of the values in that cell's neighborhood.  For
+function of the values in that cell's neighborhood. For
 example, each cell in the output layer might be assigned a
 value equal to the average of the values
 appearing in its 3 x 3 cell "neighborhood" in the input
@@ -59,20 +59,31 @@ Without using the selection map, the output map would look like this:
 </pre></div>
 
 <p>It is also possible to weigh cells within the neighborhood. This can
-be either done with a custom weights matrix with the <em><b>weight</b></em> option
-or by giving factors for mathematical functions in the <em><b>gauss</b></em> or
-<em><b>exponent</b></em> option.
-<p>In the <em><b>gauss</b></em> option, the user specifies the sigma value (&sigma;)
-for the gauss filter, that represents the standard deviation of the gaussian
-distribution. The weighting formula for the gaussian filter is defined as follows:
+be either done with a custom weights matrix or by specifying a weighting
+function.
+
+<p>In order to use a custom weights matrix, <i>file</i> needs to be
+specified as a <b>weighting_function</b> and a path to a text file
+containing the weights needs to be given in the <b>weight</b> option.
+
+<p>Alternatively, <i>gaussian</i> and <i>exponential</i> weighting
+functions can be selected as weighting function.
+
+<p>For the <i>gaussian</i> weighting function, the user specifies the
+sigma value (&sigma;) for the gauss filter in the <b>weighting_factor</b>
+option. The sigma value represents the standard deviation of the gaussian
+distribution, where the weighting formula for the gaussian filter is
+defined as follows:
 <p>exp(-(x&#42;x+y&#42;y)/(2&#42;&sigma;&#94;2))/(2&#42;&pi;&#42;&sigma;&#94;2)
 <p>Lower values for sigma result in a steeper curve, so that more weight
 is put on cells close to the center of the moving window with a steeper
 decrease in weights with distance from the center.
-<p>In the <em><b>exponent</b></em> option, the user specifies a factor for an
-exponential kernel. Negative factors result in negative exponential
-decrease in weights from the center cell. The weighting formula for the
-exponential kernel is defined as follows:
+
+<p>For the <i>exponential</i> weighting function, the user specifies a
+factor for an exponential kernel in the <b>weighting_factor</b>.
+Negative factors result in negative exponential decrease in weights from
+the center cell. The weighting formula for the exponential kernel is
+defined as follows:
 <p>exp(factor*sqrt(x&#42;x+y&#42;y))
 <p>Stronger negative values for the factor result in a steeper curve,
 so that more weight is put on cells close to the center of the moving
@@ -86,7 +97,7 @@ These options are described further below.
 
 <p>
 <em>Neighborhood Operation Methods:</em>
-The <b>neighborhood</b> operators determine what new 
+The <b>neighborhood</b> operators determine what new
 value a center cell in a neighborhood will have after examining
 values inside its neighboring cells.
 Each cell in a raster map layer becomes the center cell of a neighborhood 
@@ -208,13 +219,15 @@ For example, a size value of 3 will result in
 <p>
 <em>Matrix weights:</em>
 A custom matrix can be used if none of the neighborhood operation
-methods are desirable by using the <b>weight</b>.  This option must
+methods are desirable by using the <b>weight</b>. This option must
 be used in conjunction with the <b>size</b> option to specify the
-matrix size.  The weights desired are to be entered into a text file.
-For example, to calculate the focal mean with a matrix <b>size</b> of
-3,
+matrix size and <i>file</i> needs to be specified as
+<b>weighting_function</b>. The weights desired are to be entered into a
+text file. For example, to calculate the focal mean with a matrix
+<b>size</b> of 3,
 <div class="code"><pre>
-r.neigbors in=input.map out=output.map size=3 weight=weights.txt
+r.neigbors in=input.map out=output.map size=3 weighting_function=file \
+weight=weights.txt
 </pre></div>
 
 The contents of the weight.txt file:
@@ -235,7 +248,7 @@ This corresponds to the following 3x3 matrix:
 +-+-+-+
 </pre></div>
 
-To calculate an annulus shaped neighborhood the contents of weight.txt file 
+To calculate an annulus shaped neighborhood the contents of weight.txt file
 may be e.g. for size=5:
 <div class="code"><pre>
  0 1 1 1 0
@@ -421,7 +434,7 @@ r.neighbors input=random_cells output=counts method=count
 
 Optionally - exclude centre cell from the count (= only look around)
 <div class="code"><pre>
-r.mapcalc "cound_around = if( isnull(random_cells), counts, counts - 1)"
+r.mapcalc "count_around = if( isnull(random_cells), counts, counts - 1)"
 </pre></div>
 
 

--- a/raster/r.neighbors/r.neighbors.html
+++ b/raster/r.neighbors/r.neighbors.html
@@ -58,12 +58,32 @@ Without using the selection map, the output map would look like this:
 1 1 1 1 1
 </pre></div>
 
-<p>Optionally, the user can also specify the <b>TITLE</b> to
-be assigned to the raster map layer <b>output</b>, elect
-to not align the resolution of the output with that of the
-input (the <b>-a</b> option), and run <em><b>r.neighbors</b></em>
-with a custom matrix weights with the <em>weight</em> option.
+<p>It is also possible to weigh cells within the neighborhood. This can
+be either done with a custom weights matrix with the <em><b>weight</b></em> option
+or by giving factors for mathematical functions in the <em><b>gauss</b></em> or
+<em><b>exponent</b></em> option.
+<p>In the <em><b>gauss</b></em> option, the user specifies the sigma value (&sigma;)
+for the gauss filter, that represents the standard deviation of the gaussian
+distribution. The weighting formula for the gaussian filter is defined as follows:
+<p>exp(-(x&#42;x+y&#42;y)/(2&#42;&sigma;&#94;2))/(2&#42;&pi;&#42;&sigma;&#94;2)
+<p>Lower values for sigma result in a steeper curve, so that more weight
+is put on cells close to the center of the moving window with a steeper
+decrease in weights with distance from the center.
+<p>In the <em><b>exponent</b></em> option, the user specifies a factor for an
+exponential kernel. Negative factors result in negative exponential
+decrease in weights from the center cell. The weighting formula for the
+exponential kernel is defined as follows:
+<p>exp(factor*sqrt(x&#42;x+y&#42;y))
+<p>Stronger negative values for the factor result in a steeper curve,
+so that more weight is put on cells close to the center of the moving
+window with a steeper decrease in weights with distance from the center.
+
+<p>Optionally, the user can also run <em><b>r.neighbors</b></em> specify
+the <b>TITLE</b> to be assigned to the raster map layer <b>output</b>,
+select to not align the resolution of the output with that of the
+input (the <b>-a</b> option).
 These options are described further below.
+
 <p>
 <em>Neighborhood Operation Methods:</em>
 The <b>neighborhood</b> operators determine what new 

--- a/raster/r.neighbors/readweights.c
+++ b/raster/r.neighbors/readweights.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <stdio.h>
 #include <math.h>
 #include <grass/gis.h>
@@ -25,37 +26,24 @@ void read_weights(const char *filename)
     fclose(fp);
 }
 
-void gaussian_weights(double sigma)
+void compute_weights(const char * function_type, double factor)
 {
-    double sigma2 = sigma * sigma;
-    int i, j;
+		int i, j;
 
-    ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
-    for (i = 0; i < ncb.nsize; i++)
-	ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
+        ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
+        for (i = 0; i < ncb.nsize; i++)
+		ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
 
-    for (i = 0; i < ncb.nsize; i++) {
-	double y = i - ncb.dist;
-	for (j = 0; j < ncb.nsize; j++) {
-	    double x = j - ncb.dist;
-	    ncb.weights[i][j] = exp(-(x*x+y*y)/(2*sigma2))/(2*M_PI*sigma2);
+        for (i = 0; i < ncb.nsize; i++) {
+		double y = i - ncb.dist;
+		for (j = 0; j < ncb.nsize; j++) {
+	        double x = j - ncb.dist;
+            if (strcmp(function_type, "gaussian") == 0) {
+		        double sigma2 = factor * factor;
+	            ncb.weights[i][j] = exp(-(x*x+y*y)/(2*sigma2))/(2*M_PI*sigma2);
+	        } else if (strcmp(function_type, "exponential") == 0) {
+                ncb.weights[i][j] = exp(factor*sqrt(x*x+y*y));
+        }
 	}
-    }
-}
-
-void exponential_weights(double factor)
-{
-    int i, j;
-
-    ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
-    for (i = 0; i < ncb.nsize; i++)
-	ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
-
-    for (i = 0; i < ncb.nsize; i++) {
-	double y = i - ncb.dist;
-	for (j = 0; j < ncb.nsize; j++) {
-	    double x = j - ncb.dist;
-	    ncb.weights[i][j] = exp(factor*sqrt(x*x+y*y));
 	}
-    }
 }

--- a/raster/r.neighbors/readweights.c
+++ b/raster/r.neighbors/readweights.c
@@ -13,15 +13,15 @@ void read_weights(const char *filename)
 
     ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
     for (i = 0; i < ncb.nsize; i++)
-	ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
+        ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
 
     if (!fp)
-	G_fatal_error(_("Unable to open weights file %s"), filename);
+        G_fatal_error(_("Unable to open weights file %s"), filename);
 
     for (i = 0; i < ncb.nsize; i++)
-	for (j = 0; j < ncb.nsize; j++)
-	    if (fscanf(fp, "%lf", &ncb.weights[i][j]) != 1)
-		G_fatal_error(_("Error reading weights file %s"), filename);
+        for (j = 0; j < ncb.nsize; j++)
+            if (fscanf(fp, "%lf", &ncb.weights[i][j]) != 1)
+                G_fatal_error(_("Error reading weights file %s"), filename);
 
     fclose(fp);
 }
@@ -29,38 +29,39 @@ void read_weights(const char *filename)
 double gaussian(double factor, double squared_distance)
 {
     double sigma2 = factor * factor;
-	return exp(-squared_distance/(2*sigma2))/(2*M_PI*sigma2);
+
+    return exp(-squared_distance / (2 * sigma2)) / (2 * M_PI * sigma2);
 }
 
 double exponential(double factor, double squared_distance)
 {
-	return exp(factor*sqrt(squared_distance));
+    return exp(factor * sqrt(squared_distance));
 }
 
-void compute_weights(const char * function_type, double factor)
+void compute_weights(const char *function_type, double factor)
 {
-		int i, j;
-		double (*weight)(double, double);
+    int i, j;
+    double (*weight) (double, double);
 
-        if(!strcmp(function_type, "gaussian"))
-        {
-                weight = gaussian;
-         }
-         else if (!strcmp(function_type, "exponential"))
-         {
-                weight = exponential;
+    if (!strcmp(function_type, "gaussian")) {
+        weight = gaussian;
+    }
+    else if (!strcmp(function_type, "exponential")) {
+        weight = exponential;
+    }
+
+
+    ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
+    for (i = 0; i < ncb.nsize; i++)
+        ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
+
+    for (i = 0; i < ncb.nsize; i++) {
+        double y = i - ncb.dist;
+
+        for (j = 0; j < ncb.nsize; j++) {
+            double x = j - ncb.dist;
+
+            ncb.weights[i][j] = weight(factor, x * x + y * y);
         }
-
-
-        ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
-        for (i = 0; i < ncb.nsize; i++)
-		ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
-
-        for (i = 0; i < ncb.nsize; i++) {
-		double y = i - ncb.dist;
-		for (j = 0; j < ncb.nsize; j++) {
-	        double x = j - ncb.dist;
-            ncb.weights[i][j] = weight(factor, x*x+y*y);
-	    }
-	    }
+    }
 }

--- a/raster/r.neighbors/readweights.c
+++ b/raster/r.neighbors/readweights.c
@@ -26,9 +26,31 @@ void read_weights(const char *filename)
     fclose(fp);
 }
 
+double gaussian(double factor, double squared_distance)
+{
+    double sigma2 = factor * factor;
+	return exp(-squared_distance/(2*sigma2))/(2*M_PI*sigma2);
+}
+
+double exponential(double factor, double squared_distance)
+{
+	return exp(factor*sqrt(squared_distance));
+}
+
 void compute_weights(const char * function_type, double factor)
 {
 		int i, j;
+		double (*weight)(double, double);
+
+        if(!strcmp(function_type, "gaussian"))
+        {
+                weight = gaussian;
+         }
+         else if (!strcmp(function_type, "exponential"))
+         {
+                weight = exponential;
+        }
+
 
         ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
         for (i = 0; i < ncb.nsize; i++)
@@ -38,12 +60,7 @@ void compute_weights(const char * function_type, double factor)
 		double y = i - ncb.dist;
 		for (j = 0; j < ncb.nsize; j++) {
 	        double x = j - ncb.dist;
-            if (strcmp(function_type, "gaussian") == 0) {
-		        double sigma2 = factor * factor;
-	            ncb.weights[i][j] = exp(-(x*x+y*y)/(2*sigma2))/(2*M_PI*sigma2);
-	        } else if (strcmp(function_type, "exponential") == 0) {
-                ncb.weights[i][j] = exp(factor*sqrt(x*x+y*y));
-        }
-	}
-	}
+            ncb.weights[i][j] = weight(factor, x*x+y*y);
+	    }
+	    }
 }

--- a/raster/r.neighbors/readweights.c
+++ b/raster/r.neighbors/readweights.c
@@ -42,3 +42,20 @@ void gaussian_weights(double sigma)
 	}
     }
 }
+
+void exponential_weights(double factor)
+{
+    int i, j;
+
+    ncb.weights = G_malloc(ncb.nsize * sizeof(DCELL *));
+    for (i = 0; i < ncb.nsize; i++)
+	ncb.weights[i] = G_malloc(ncb.nsize * sizeof(DCELL));
+
+    for (i = 0; i < ncb.nsize; i++) {
+	double y = i - ncb.dist;
+	for (j = 0; j < ncb.nsize; j++) {
+	    double x = j - ncb.dist;
+	    ncb.weights[i][j] = exp(factor*sqrt(x*x+y*y));
+	}
+    }
+}

--- a/raster/r.neighbors/testsuite/test_r_neighbors.py
+++ b/raster/r.neighbors/testsuite/test_r_neighbors.py
@@ -530,10 +530,10 @@ class TestNeighbors(TestCase):
         self.to_remove.extend(outputs)
         self.assertModule(
             "r.neighbors",
-            flags="c",
             input="elevation",
             size=7,
-            gauss=2.0,
+            weighting_function="gaussian",
+            weighting_factor=2.0,
             output=",".join(outputs),
             method=list(self.test_options[test_case].keys()),
         )
@@ -557,6 +557,7 @@ class TestNeighbors(TestCase):
             "r.neighbors",
             input="elevation",
             size=5,
+            weighting_function="file",
             output=",".join(outputs),
             method=list(self.test_options[test_case].keys()),
             weight=weights,
@@ -569,6 +570,7 @@ class TestNeighbors(TestCase):
             input="elevation",
             flags="c",
             size=5,
+            weighting_function="file",
             output="{}_fails".format(test_case),
             method="sum",
             weight=weights,


### PR DESCRIPTION
r.neighbors has already a nice option to weigh cells within the neighborhood using a mathematical function (2D gaussian distribution).

This PR adds an option for exponential weighting, that has applications e.g. in spatial ecology. This is a rather simple implementation with some copy and paste from the gaussian function.

It would probably be preferable to have a more generic approach that allows also for other distribution functions (see e.g. en.wikipedia.org/wiki/List_of_probability_distributions) to be added without increasing the number of options too much?

The PR also addresses #593 (but that can be easily separated out from this PR if preferable)