### PR TITLE
g.proj: fix segfault when reading proj info from georef file

### DIFF
--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -247,6 +247,7 @@ int input_georef(char *geofile)
     G_debug(1, "Trying to open <%s> with OGR...", geofile);
     OGRRegisterAll();
 
+    ogr_ds = NULL;
     hSRS = NULL;
     if ((ogr_ds = OGROpen(geofile, FALSE, NULL))
 	&& (OGR_DS_GetLayerCount(ogr_ds) > 0)) {

--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -258,8 +258,6 @@ int input_georef(char *geofile)
 	hSRS = OGR_L_GetSpatialRef(ogr_layer);
 	ret = GPJ_osr_to_grass(&cellhd, &projinfo, &projunits, hSRS, 0);
 	set_default_region();
-
-	OGR_DS_Destroy(ogr_ds);
     }
     else {
 	/* Try opening with GDAL */
@@ -322,6 +320,8 @@ int input_georef(char *geofile)
 	    }
 	}
     }
+    if (ogr_ds)
+	OGR_DS_Destroy(ogr_ds);
 
     return ret;
 


### PR DESCRIPTION
This should fix segmentation fault I was getting when trying to create a new location based on georeferenced file. E.g. this caused in some cases segfault:

    g.proj -p georef=test.shp

Valgrind showed the OGR data source was destroyed before the OGRSpatialReferenceH hSRS was accessed.