### PR TITLE
Optionally disable mapset locking and cleaning

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2414,10 +2414,10 @@ def main():
             # to user config dir (aka last used rc file).
             copy_general_gis_env(gisrc, gisrcrc)
 
-        # After this point no more grass modules may be called
-        # done message at last: no atexit.register()
-        # or register done_message()
         done_message()
+        # After this point no more grass modules may be called
+        # except what was registered using atexit in a proper order.
+
 
 if __name__ == '__main__':
     main()

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2406,7 +2406,10 @@ def main():
         # close GUI if running
         close_gui()
 
-        if not params.tmp_location:
+        # Saving only here in an interactive session and only if not using
+        # tmp location or mapset. (Not saving anything although just l/m
+        # could be ignored.)
+        if not params.tmp_location and not params.tmp_mapset:
             # Save general (not session-specific) gis env variables
             # to user config dir (aka last used rc file).
             copy_general_gis_env(gisrc, gisrcrc)

--- a/lib/init/grass7.html
+++ b/lib/init/grass7.html
@@ -5,6 +5,7 @@
 <b>grass79</b> [<b>-h</b> | <b>-help</b> | <b>--help</b>] [<b>-v</b> | <b>--version</b>] |
 [<b>-c</b> | <b>-c geofile</b> | <b>-c EPSG:code[:datum_trans]</b>] | <b>-e</b> | <b>-f</b> |
 [<b>--text</b> | <b>--gtext</b> | <b>--gui</b>] | <b>--config</b> |
+[<b>--no-lock</b>] | [<b>--no-clean</b>] | [<b>--clean-only</b>] |
 [<b>--tmp-location</b> | <b>--tmp-mapset</b>]
     [[[<b>&lt;GISDBASE&gt;/</b>]<b>&lt;LOCATION&gt;/</b>]
     	<b>&lt;MAPSET&gt;</b>]
@@ -64,6 +65,19 @@ The active mapset will be the PERMANENT mapset.
 <dd> Run using a temporary mapset which is created in the specified
 location and deleted at the end of the execution
 (use with the --exec flag).
+
+<dt><b>--no-lock</b>
+<dd> Do not lock the mapset and leave the responsibility for handling
+concurrent sessions on the user.
+(Use with the <b>--exec</b> flag. See also <b>--no-clean</b>.)
+
+<dt><b>--no-clean</b>
+<dd> Do not clean the mapset when starting and ending a session.
+(Use with the <b>--exec</b> flag.
+See also <b>--no-lock</b> and <b>--clean-only</b>.)
+
+<dt><b>--clean-only</b>
+<dd> Do only the cleanup of the mapset and exit.
 
 </dl>
 
@@ -451,6 +465,61 @@ The temporary mapset is automatically deleted after computation,
 so the script is expected to export, link or otherwise preserve the
 output data before ending.
 
+<h4>Multiple sessions in one mapset</h4>
+
+Multiple processes in GRASS GIS can run parallel in two basic ways.
+First, the processes can run in multiple sessions each using its own
+mapset (a mapset created by the user or on-the-fly by
+<b>--tmp-mapset</b>). This option often requires management of mapsets
+and collection of data from multiple mapsets, but it is the most robust
+one. Second, some processes, for example most of the raster operations,
+can run in parallel in one mapset. Although this typically means
+running in one session connected to one mapset, this can be also done
+by starting multiple sessions using <b>--exec</b> connected to one
+mapset. In this case, the standard mapset locking and cleaning needs to
+be disabled using <b>--no-lock</b> and <b>--no-clean</b>. This is
+advantageous when it is not possible to have all the parallel processes
+started within one session, for example, when each process is running
+on a different machine.
+
+<p>
+In the following example, let's assume that a Python script called
+<code>run.py</code> was prepared, so that it can run multiple times in
+parallel and it takes one parameter which makes each run unique.
+Another script called <code>post_process_all_runs.py</code> will do
+the post-processing using results from all runs of <code>run.py</code>
+within one mapset.
+
+<p>
+In the first step, let's create a new mapset to be used in the next
+steps:
+
+<div class="code"><pre>
+grass79 -e -c /path/to/mapset
+</pre></div>
+
+This is the list of commands to be executed in parallel. The actual
+parallel execution is beyond this example, but let's assume that
+something like GNU parallel or Python multiprocessing package executes
+the following commands in parallel.
+
+<div class="code"><pre>
+grass79 /path/to/mapset --no-lock --no-clean --exec run.py 1
+grass79 /path/to/mapset --no-lock --no-clean --exec run.py 2
+grass79 /path/to/mapset --no-lock --no-clean --exec run.py 3
+grass79 /path/to/mapset --no-lock --no-clean --exec run.py 4
+</pre></div>
+
+In a final step, assuming the above processes finished, the other script
+does the post-processing of what is now the mapset.
+
+<div class="code"><pre>
+grass79 /path/to/mapset --exec post_process_all_runs.py
+</pre></div>
+
+The above command is not using <b>--no-clean</b>, so the standard
+cleaning procedure omitted above happens here, so no extra cleaning step
+is needed.
 
 <h4>Troubleshooting</h4>
 Importantly, to avoid an <tt>"[Errno 8] Exec format error"</tt> there must be a 

--- a/lib/init/testsuite/test_grass_clean_lock.py
+++ b/lib/init/testsuite/test_grass_clean_lock.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+"""
+TEST:      Test of grass --tmp-mapset
+
+AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+
+PURPOSE:   Test that --tmp-mapset option of grass command works
+
+COPYRIGHT: (C) 2020 Vaclav Petras and the GRASS Development Team
+
+This program is free software under the GNU General Public
+License (>=v2). Read the file COPYING that comes with GRASS
+for details.
+"""
+
+import unittest
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+
+# Note that unlike rest of GRASS GIS, here we are using unittest package
+# directly. The grass.gunittest machinery for mapsets is not needed here.
+# How this plays out together with the rest of testing framework is yet to be
+# determined.
+
+
+class TestCleanLock(unittest.TestCase):
+    """Tests --no-clean --no-lock options of grass command"""
+
+    # TODO: here we need a name of or path to the main GRASS GIS executable
+    executable = "grass"
+    # an arbitrary, but identifiable and fairly unique name
+    location = "test_tmp_mapset_xy"
+    mapset = os.path.join(location, "PERMANENT")
+
+    def setUp(self):
+        """Creates a location used in the tests"""
+        subprocess.check_call([self.executable, "-c", "XY", self.location, "-e"])
+        self.subdirs = os.listdir(self.location)
+
+    def tearDown(self):
+        """Deletes the location"""
+        shutil.rmtree(self.location, ignore_errors=True)
+
+    def test_command_runs(self):
+        """Check that correct parameters are accepted"""
+        return_code = subprocess.call(
+            [self.executable, self.mapset, "--no-clean", "--exec", "g.proj", "-g"]
+        )
+        self.assertEqual(
+            return_code,
+            0,
+            msg=(
+                "Non-zero return code from {self.executable}"
+                " with --no-clean".format(**locals())
+            ),
+        )
+
+        return_code = subprocess.call(
+            [self.executable, self.mapset, "--no-lock", "--exec", "g.proj", "-g"]
+        )
+        self.assertEqual(
+            return_code,
+            0,
+            msg=(
+                "Non-zero return code from {self.executable}"
+                " with --no-lock".format(**locals())
+            ),
+        )
+
+        return_code = subprocess.call(
+            [
+                self.executable,
+                self.mapset,
+                "--no-clean",
+                "--no-lock",
+                "--exec",
+                "g.proj",
+                "-g",
+            ]
+        )
+        self.assertEqual(
+            return_code,
+            0,
+            msg=(
+                "Non-zero return code from {self.executable}"
+                " with --no-clean and --no-lock".format(**locals())
+            ),
+        )
+
+        return_code = subprocess.call([self.executable, self.mapset, "--clean-only"])
+        self.assertEqual(
+            return_code,
+            0,
+            msg=(
+                "Non-zero return code from {self.executable}"
+                " with --clean-only".format(**locals())
+            ),
+        )
+
+    def test_clean_only_fails_with_exec(self):
+        """Check that using --clean-only fails when --exec is provided"""
+        return_code = subprocess.call(
+            [self.executable, self.mapset, "--clean-only", "--exec", "g.proj", "-g"]
+        )
+        self.assertNotEqual(
+            return_code,
+            0,
+            msg=("Zero retrun code from {self.executable}".format(**locals())),
+        )
+
+    def test_cleaning_fake_tmp_file(self):
+        """Check that --no-clean does not delete existing temp files.
+
+        Then it checks that the file is deleted without --no-clean.
+
+        Assumes that clean_temp for cleaning tmp files in mapsets would delete
+        file with name xxx.yyy when there is no process with PID xxx.
+        It further assumes that there is no process with the PID we used,
+        so clean_temp would delete the file.
+        Finally, it assumes the naming and nesting of the tmp dir.
+        """
+        common_unix_max = 32768  # common max of unix PIDs
+        fake_pid = common_unix_max + 1
+        mapset_tmp_dir_name = Path(self.mapset) / ".tmp" / platform.node()
+        mapset_tmp_dir_name.mkdir(parents=True, exist_ok=True)
+        name = "{}.1".format(fake_pid)
+        fake_tmp_file = mapset_tmp_dir_name / name
+        fake_tmp_file.touch()
+        subprocess.check_call(
+            [self.executable, "--no-clean", self.mapset, "--exec", "g.proj", "-g"]
+        )
+        self.assertTrue(fake_tmp_file.exists(), msg="File should still exist")
+        subprocess.check_call([self.executable, self.mapset, "--exec", "g.proj", "-g"])
+        self.assertFalse(fake_tmp_file.exists(), msg="File should have been deleted")
+
+    def test_cleaning_g_tempfile(self):
+        """Check that --no-clean does not delete existing temp files.
+
+        Then it checks that the file is deleted without --no-clean.
+
+        This makes no assumptions about inner workings of tmp file cleaning,
+        but it relies on g.tempfile to work correctly and that there no
+        other files in the tmp dir.
+        It still needs to assume that there is no process with the PID we used,
+        so clean_temp would delete the file.
+        """
+        common_unix_max = 32768  # common max of unix PIDs
+        fake_pid = common_unix_max + 1
+        mapset_tmp_dir_name = Path(self.mapset) / ".tmp" / platform.node()
+        # we need --no-clean even here otherwise we delete the file at exit
+        subprocess.check_call(
+            [
+                self.executable,
+                self.mapset,
+                "--no-clean",
+                "--exec",
+                "g.tempfile",
+                "pid={}".format(fake_pid),
+            ]
+        )
+        # another process
+        subprocess.check_call(
+            [self.executable, "--no-clean", self.mapset, "--exec", "g.proj", "-g"]
+        )
+        self.assertTrue(
+            os.listdir(str(mapset_tmp_dir_name)), msg="File should still exist"
+        )
+        subprocess.check_call([self.executable, self.mapset, "--exec", "g.proj", "-g"])
+        self.assertFalse(
+            os.listdir(str(mapset_tmp_dir_name)), msg="File should have been deleted"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/init/testsuite/test_grass_lock.sh
+++ b/lib/init/testsuite/test_grass_lock.sh
@@ -71,7 +71,7 @@ wait
 
 PARAM="--no-clean"
 # To check that it fails as expected, uncomment the following line.
-PARAM=""
+# PARAM=""
 
 for i in `seq 1 ${NPROC}`
 do
@@ -80,6 +80,8 @@ do
 done
 
 wait
+
+"${GRASS}" "${MAPSET_PATH}" --clean-only
 
 # Evaluate the computation
 # See how many raster maps are in the mapset

--- a/lib/init/testsuite/test_grass_lock.sh
+++ b/lib/init/testsuite/test_grass_lock.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+GRASS="grass"
+LOCATION="test_tmp_mapset_xy"
+MAPSET_PATH="${LOCATION}/PERMANENT"
+
+cleanup () {
+    rm -r "${LOCATION}"
+}
+
+trap cleanup EXIT
+
+# Setup
+
+"${GRASS}" -e -c XY "${LOCATION}"
+
+"${GRASS}" "${MAPSET_PATH}" --exec g.region rows=200 cols=200
+
+# Test using sleep
+# This shows that --no-lock works.
+
+"${GRASS}" "${MAPSET_PATH}" --no-lock --exec sleep 10 &
+
+for i in `seq 1 5`
+do
+    "${GRASS}" "${MAPSET_PATH}" --no-lock --exec sleep 10 &
+done
+
+wait
+
+# Test with computation
+# When this works, there should be no warnings about "No such file..."
+# Increasing number of processes and size of the region increases chance
+# of warnings and errors, but it is too much to have it in test
+# (1000 processes and rows=10000 cols=10000).
+
+for i in `seq 1 50`
+do
+    "${GRASS}" "${MAPSET_PATH}" --no-lock --no-clean --exec \
+        r.mapcalc "a_$i = sqrt(sin(rand(0, 100)))" -s &
+done
+
+wait
+
+# Evaluate the computation
+# See how many raster maps are in the mapset
+
+EXPECTED=50
+NUM=$("${GRASS}" "${MAPSET_PATH}" --exec g.list type=raster pattern="*" | wc -l)
+
+if [ "$NUM" -ne "$EXPECTED" ]
+then
+    echo "Got $NUM but expected $EXPECTED maps"
+    exit 1
+fi


### PR DESCRIPTION
This allows to skip locking of a mapset which in combination with no cleaning of a mapset allows for multiple jobs to be executed in one mapset using --exec. This should be the same as running multiple jobs together right in a single session (having the same limitations, but also not touching any general files).

To account for the use case when the mapset is not used for any interactive session, a separate flag for cleaning is provided for convenience (same as something like --exec g.region -p).

Similarly to --tmp-location and --tmp-mapset, usage of --no-lock and --no-clean without --exec is not disallowed, but it is not documented either before its usefulness is evaluated. One use case is starting an interactive session with --no-lock --no-clean to examine results of jobs running with these.

The combining the new flags with the old ones and between each other is not limited except for few cases which clearly exclude each other (--clean-only means only cleaning and no cleaning and cleaning only don't make sense either). Although --no-lock and --no-clean are meant to be used together, saying what is the correct or allowed use is hard because the purpose of these flags is to disable the standard session behavior.

Additional changes:

- Using atexit to call mapset cleaning functions to make more organized and thus easier to disable
- Rename and document related functions.
- Extract gis env (rc) saving from the clean up code because it is not related (the old function was called clean_env, so it seemed related).
- If --tmp-mapset is used with --gui or --text (allowed but undocumented combination), do not store last used gis env vars (gisrc). This was missing from 9da94b70eab8313f2a1e70752609f7b2caa2e741 (#313).
 
This is a much better version of (no closed) [Trac 2685](https://trac.osgeo.org/grass/ticket/2685) which suggested flag to ignore the lock. This achieves the same more formally by not creating the unwanted lock in the first place which is a standard situation on Windows and when managing the session manually directly through environmental variables. Additionally, this provides an important addition to avoid removal temporary files of another session during a clean up and a convenient way to do that afterwards.

As for the importance of --no-clean, as far as I understand, clean_temp program responsible for removing the files looks at pid of a process which supposedly created the file based on the file name and if the process is still running, it does not remove the file. (For other files it looks at the date and it works within the machine's/node's subdirectory.) However, in my test I do get some problems (maps not created) and warnings from clean_temp: `WARNING: Can't stat file ...: No such file or directory,skipping`. Additionally current clean up at the end of the session is vacuuming SQLite, so multiple vacuums are requested. (Perhaps this is a moderate issue because parallel jobs running in one mapset can practically use a single SQLite database only for reading.) The test follows.
```
grass ~/grassdata/nc_spm/test1 -c -e
for i in `seq 1 1000`
do
    grass ~/grassdata/nc_spm/test1/ --no-lock --exec r.mapcalc "e$i = sin(rand(0, 100))" -s &
done
wait
grass ~/grassdata/nc_spm/test1/ --exec g.list type=raster mapset=. | wc

grass ~/grassdata/nc_spm/test2/ -c -e
for i in `seq 1 1000`
do
    grass ~/grassdata/nc_spm/test2/ --no-lock --no-clean --exec r.mapcalc "e$i = sin(rand(0, 100))" -s &
done
wait
grass ~/grassdata/nc_spm/test2/ --exec g.list type=raster mapset=. | wc
```

This should improve parallel workflows, e.g. with GNU parallel or on HPC. Expected usage:

```
# prepare data
grass ~/grassdata/nc_spm/landsat/ ...
# somehow get these running in parallel
grass ~/grassdata/nc_spm/landsat/ --no-lock --no-clean --exec g.long.computation ...
grass ~/grassdata/nc_spm/landsat/ --no-lock --no-clean --exec g.long.computation ...
grass ~/grassdata/nc_spm/landsat/ --clean-only
# evaluate the results
# ...
```