### PR TITLE
CI: Use a specific Flake8 version

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,10 +1,11 @@
-name: Code quality check
+name: Python code quality check
 
 on:
 - push
 - pull_request
 
 jobs:
+
   flake8-lib-python:
 
     runs-on: ubuntu-18.04
@@ -18,7 +19,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
+        pip install flake8==3.8.0
     - name: Run Flake8
       run: |
         cd lib/python
@@ -26,7 +27,6 @@ jobs:
 
   flake8-wxgui:
 
-    continue-on-error: true
     runs-on: ubuntu-18.04
 
     steps:
@@ -38,7 +38,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
+        pip install flake8==3.8.0
     - name: Run Flake8
       run: |
         cd gui/wxpython
@@ -46,7 +46,6 @@ jobs:
 
   flake8-scripts:
 
-    continue-on-error: true
     runs-on: ubuntu-18.04
 
     steps:
@@ -58,7 +57,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
+        pip install flake8==3.8.0
     - name: Run Flake8
       run: |
         cd scripts
@@ -66,7 +65,6 @@ jobs:
 
   flake8-temporal-modules:
 
-    continue-on-error: true
     runs-on: ubuntu-18.04
 
     steps:
@@ -78,7 +76,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
+        pip install flake8==3.8.0
     - name: Run Flake8
       run: |
         cd temporal

--- a/lib/python/pygrass/tests/benchmark.py
+++ b/lib/python/pygrass/tests/benchmark.py
@@ -374,7 +374,7 @@ class OptionParser(optparse.OptionParser):
         for option in self.option_list:
             if hasattr(option, strREQUIRED) and option.required:
                 if not getattr(values, option.dest):
-                    self.error("option %s is required".format(str(option)))
+                    self.error("option {} is required".format(str(option)))
         return optparse.OptionParser.check_values(self, values, args)
 
 


### PR DESCRIPTION
This adds a version specification to the Flake8 install in CI,
namely 3.8.0, the latest release.

It fixes string formatting issue (F523) in one file.
This fixes #619.

This also does some polish in the CI config file to tell that this is Python
and it removes the now unused continue-on-error lines.