### PR TITLE
wxGUI Add web service layer: Fix dialog layout

### DIFF
--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -147,6 +147,8 @@ class WSPanel(wx.Panel):
         self.Bind(EVT_CMD_DONE, self.OnCapDownloadDone)
         self.Bind(EVT_CMD_OUTPUT, self.OnCmdOutput)
 
+        self.SetMinSize((-1, 300))
+
     def __del__(self):
         self.cmd_thread.abort(abortall=True)
         grass.try_remove(self.cap_file)

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -46,8 +46,8 @@ from web_services.cap_interface import WMSCapabilities, WMTSCapabilities, OnEart
 
 from gui_core.widgets import GNotebook
 from gui_core.widgets import ManageSettingsWidget
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, \
-    TextCtrl, TreeCtrl
+from gui_core.wrap import Button, ScrolledPanel, SpinCtrl, StaticBox, \
+    StaticText, TextCtrl, TreeCtrl
 
 import grass.script as grass
 
@@ -241,7 +241,8 @@ class WSPanel(wx.Panel):
         """
         # TODO parse maxcol, maxrow, settings from d.wms module?
         # TODO OnEarth driver - add selection of time
-        adv_setts_panel = wx.Panel(parent=self, id=wx.ID_ANY)
+        adv_setts_panel = ScrolledPanel(parent=self, id=wx.ID_ANY,
+                                        style=wx.TAB_TRAVERSAL | wx.SUNKEN_BORDER)
         self.notebook.AddPage(page=adv_setts_panel,
                               text=_('Advanced request settings'),
                               name='adv_req_setts')
@@ -411,6 +412,8 @@ class WSPanel(wx.Panel):
                        border=5)
 
         adv_setts_panel.SetSizer(border)
+        adv_setts_panel.SetAutoLayout(True)
+        adv_setts_panel.SetupScrolling()
 
     def OnUp(self, event):
         """Move selected layer up


### PR DESCRIPTION
**1.** Set Request page BoxSizer widget min size

To reproduce:

1. Click on the **Add web service layer (WMS, WMTS, NASA OnEarth)** toolbar icon tool
2. Choose existed predefinned profile **NASA GIBS WMTS** item in the Load ComboBox widget
3. Click on the **Connect** button

Default dialog (Request page) layout:

![web_services_dialog_default](https://user-images.githubusercontent.com/50632337/81704635-56b16080-946e-11ea-995f-02671db3ca80.png)

Expected dialog (Request page) layout:

![web_services_dialog_expected](https://user-images.githubusercontent.com/50632337/81738403-f2a49180-9499-11ea-956a-14fcf7c2c3af.png)


**2.** Set Advanced request settings page ScrolledPanel widget

To reproduce:

1. Click on the **Add web service layer (WMS, WMTS, NASA OnEarth)** toolbar icon tool
2. Set this url `http://gis.nature.cz/arcgis/services/Aplikace/Opendata/MapServer/WmsServer` in the Server TextCtrl widget 
3. Click on the **Connect** button
4. In the **List of layers** choose **USES - koncepcni vymezeni nadregionalnich biocenter** (long layer name)
4. Switch to the **Advanced request settings** page

Default dialog (Advanced request settings page) layout:

![web_services_dialog_default](https://user-images.githubusercontent.com/50632337/81705545-72693680-946f-11ea-918a-936fa060dec7.png)

Expected dialog (Advanced request settings page) layout:

![web_services_dialog_expected](https://user-images.githubusercontent.com/50632337/81705931-e0156280-946f-11ea-9235-3a9151ff424d.png)


