### PR TITLE
wxGUI lmgr: Fix cancel save workspace dialog

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -668,6 +668,7 @@ class GMFrame(wx.Frame):
         caption = _("Close Map Display {}").format(name)
         if not self.CanClosePage(caption):
             event.Veto()
+            return
 
         maptree = self.notebookLayers.GetPage(event.GetSelection()).maptree
         maptree.GetMapDisplay().CleanUp()


### PR DESCRIPTION
To reproduce:

1. Start gui `g.gui`
2. Add some vector map layer
3. On the Layer Manager click on the x button next to arrows
4. On the save workspace dialog click on the cancel button
5. Try re-render map, click on the Render map Map Display Window toolbar icon (map canvas is empty, because map display `CleanUp()` method is called during `OnCBPageClosing` event)

```
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -668,6 +668,7 @@ class GMFrame(wx.Frame):
         caption = _("Close Map Display {}").format(name)
         if not self.CanClosePage(caption):
             event.Veto()
+            return
 
         maptree = self.notebookLayers.GetPage(event.GetSelection()).maptree
         maptree.GetMapDisplay().CleanUp()
```





