### PR TITLE
wxGUI r.li.setup: Show message dialog if removed config file isn't selected from the list

### DIFF
--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -220,7 +220,7 @@ class RLiSetupFrame(wx.Frame):
         """Remove configuration file from path and update the list"""
         try:
             confile = self.listfiles[self.listfileBox.GetSelections()[0]]
-        except:
+        except IndexError:
             gcmd.GMessage(parent=self,
                           message=_("You have to select a configuration file"))
             return
@@ -251,7 +251,7 @@ class RLiSetupFrame(wx.Frame):
         """Rename an existing configuration file"""
         try:
             confile = self.listfiles[self.listfileBox.GetSelections()[0]]
-        except:
+        except IndexError:
             gcmd.GMessage(parent=self,
                           message=_("You have to select a configuration file"))
             return
@@ -271,7 +271,7 @@ class RLiSetupFrame(wx.Frame):
         """Show and edit a configuration file"""
         try:
             confile = self.listfiles[self.listfileBox.GetSelections()[0]]
-        except:
+        except IndexError:
             gcmd.GMessage(parent=self,
                           message=_("You have to select a configuration file"))
             return

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -218,7 +218,12 @@ class RLiSetupFrame(wx.Frame):
 
     def OnRemove(self, event):
         """Remove configuration file from path and update the list"""
-        confile = self.listfiles[self.listfileBox.GetSelections()[0]]
+        try:
+            confile = self.listfiles[self.listfileBox.GetSelections()[0]]
+        except:
+            gcmd.GMessage(parent=self,
+                          message=_("You have to select a configuration file"))
+            return
         dlg = wx.MessageDialog(
             parent=self.parent,
             message=_(


### PR DESCRIPTION
To reproduce:

1. On Layer Manager Window go to menu Raster -> Landscape patch analysis -> Set up sampling and analysis framework (or run `g.gui.rlisetup`), open rlisetup dialog
2. Don't select config file from the list (or don't have created any config file -> empty list)
3. Click on the Remove button

Error message (Console page):

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/rlisetup/frame.py",
line 221, in OnRemove

confile =
self.listfiles[self.listfileBox.GetSelections()[0]]
IndexError
:
list index out of range
```