### PR TITLE
wxGUI g.gui.rlisetup: Fix get rectangle sample units size

### DIFF
--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -362,8 +362,8 @@ class RLIWizard(object):
                 cl = float(self.CIR_CL) / float(self.rasterinfo['cols'])
                 rl = float(self.CIR_RL) / float(self.rasterinfo['rows'])
             else:
-                cl = float(self.moving.width) / float(self.rasterinfo['cols'])
-                rl = float(self.moving.height) / float(self.rasterinfo['rows'])
+                cl = float(self.units.width) / float(self.rasterinfo['cols'])
+                rl = float(self.units.height) / float(self.rasterinfo['rows'])
 
             fil.write("SAMPLEAREA -1|-1|%r|%r\n" % (rl, cl))
             if self.units.distrtype == 'non_overlapping':


### PR DESCRIPTION
To reproduce:

![rlisetup_sampling_units](https://user-images.githubusercontent.com/50632337/81833362-e5da7900-953f-11ea-8b16-63200736a401.gif)

Error message:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/rlisetup/frame.py",
line 245, in OnNew

RLIWizard(self)
  File "/usr/lib64/grass79/gui/wxpython/rlisetup/wizard.py",
line 135, in __init__

self._write_confile()
  File "/usr/lib64/grass79/gui/wxpython/rlisetup/wizard.py",
line 150, in _write_confile

self._write_area(f)
  File "/usr/lib64/grass79/gui/wxpython/rlisetup/wizard.py",
line 367, in _write_area

cl = float(self.moving.width) /
float(self.rasterinfo['cols'])
ValueError
:
could not convert string to float:
```