### PR TITLE
wxGUI locdownload: Fix missing flush method

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -90,13 +90,16 @@ class DownloadError(Exception):
 class RedirectText(object):
     def __init__(self, window):
         self.out = window
- 
+
     def write(self, string):
         try:
             wx.CallAfter(self.out.SetLabel, string)
         except:
             # window closed -> PyDeadObjectError
             pass
+
+    def flush(self):
+        pass
 
 # copy from g.extension, potentially move to library
 def move_extracted_files(extract_dir, target_dir, files):
@@ -185,7 +188,7 @@ def reporthook(count, block_size, total_size):
     sys.stdout.write("Download in progress, wait until it is finished\n{0}%, {1} MB, {2} KB/s, {3:.0f} seconds passed".format(
         percent, progress_size / (1024 * 1024), speed, duration
     ))
-    
+
 # based on g.extension, potentially move to library
 def download_and_extract(source):
     """Download a file (archive) from URL and uncompress it"""
@@ -490,14 +493,14 @@ class LocationDownloadDialog(wx.Dialog):
                                    caption=_("Abort download"),
                                    style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION | wx.CENTRE
             )
-            
+
             ret = dlg.ShowModal()
             dlg.Destroy()
 
             # TODO: terminate download process on wx.ID_YES
             if ret == wx.ID_NO:
                 return
-    
+
         self.Close()
 
 def main():


### PR DESCRIPTION
To reproduce:

1. Start GRASS GIS `grass79`
2. On the Startup window click on the Download button
3. Choose Basic NC location item in the ComboBox widget
4. Click on the Download button
5. After download is completed close the Download dialog
6. Choose nc_basic_spm_grass7 location from listbox
7. Click on the Start GRASS session button

Error message:

```
Starting GRASS GIS...
05:32:21 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
Exception ignored in: <startup.locdownload.RedirectText object at 0x7fd95e9494e0>
AttributeError: 'RedirectText' object has no attribute 'flush'
ERROR: Invalid return code from GUI startup script.
Please advise GRASS developers of this error.
Exiting...
```
