### PR TITLE
wxGUI dbmgr: Fix dbmgr widgets layout on the wxMSW

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1210,7 +1210,7 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
             name='wherePanel')
         sqlWhereColumn = wx.ComboBox(
             parent=whereSimpleSqlPanel, id=wx.ID_ANY, size=(150, -1),
-            style=wx.CB_SIMPLE | wx.CB_READONLY,
+            style=wx.CB_READONLY,
             choices=self.dbMgrData['mapDBInfo'].GetColumns(
                 self.dbMgrData['mapDBInfo'].layers[layer]['table']))
         sqlWhereColumn.SetSelection(0)
@@ -1262,16 +1262,16 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         sqlSimpleWhereSizer.Add(
             sqlWhereColumn,
-            flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             border=3)
         sqlSimpleWhereSizer.Add(
             sqlWhereCond,
-            flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             border=3)
         sqlSimpleWhereSizer.Add(
             sqlWhereValue,
             proportion=1,
-            flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            flag=wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             border=3)
         whereSimpleSqlPanel.SetSizer(sqlSimpleWhereSizer)
         simpleSqlSizer.Add(sqlLabel, border=5, pos=(0, 0),

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -61,8 +61,8 @@ from dbmgr.vinfo import VectorDBInfo, GetUnicodeValue, CreateDbInfoDesc, GetDbEn
 from core.debug import Debug
 from dbmgr.dialogs import ModifyTableRecord, AddColumnDialog
 from core.settings import UserSettings
-from gui_core.wrap import SpinCtrl, Button, TextCtrl, ListCtrl, CheckBox, \
-    StaticText, StaticBox, Menu, NewId
+from gui_core.wrap import Button, CheckBox, ComboBox, ListCtrl, Menu, \
+    NewId, SpinCtrl, StaticBox, StaticText, TextCtrl
 from core.utils import cmp
 
 if sys.version_info.major >= 3:
@@ -1208,7 +1208,7 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
             parent=simpleSqlPanel,
             id=wx.ID_ANY,
             name='wherePanel')
-        sqlWhereColumn = wx.ComboBox(
+        sqlWhereColumn = ComboBox(
             parent=whereSimpleSqlPanel, id=wx.ID_ANY, size=(150, -1),
             style=wx.CB_READONLY,
             choices=self.dbMgrData['mapDBInfo'].GetColumns(
@@ -2384,9 +2384,9 @@ class DbMgrTablesPage(DbMgrNotebookBase):
                               label=" %s " % _("Rename column"))
         renameSizer = wx.StaticBoxSizer(renameBox, wx.HORIZONTAL)
 
-        columnFrom = wx.ComboBox(
+        columnFrom = ComboBox(
             parent=panel, id=wx.ID_ANY, size=(150, -1),
-            style=wx.CB_SIMPLE | wx.CB_READONLY,
+            style=wx.CB_READONLY,
             choices=self.dbMgrData['mapDBInfo'].GetColumns(table))
         columnFrom.SetSelection(0)
         self.layerPage[layer]['renameCol'] = columnFrom.GetId()
@@ -3276,9 +3276,9 @@ class LayerBook(wx.Notebook):
         label = StaticText(parent=self.deletePanel, id=wx.ID_ANY,
                            label='%s:' % _("Layer to remove"))
 
-        self.deleteLayer = wx.ComboBox(
+        self.deleteLayer = ComboBox(
             parent=self.deletePanel, id=wx.ID_ANY, size=(100, -1),
-            style=wx.CB_SIMPLE | wx.CB_READONLY,
+            style=wx.CB_READONLY,
             choices=list(map(str, self.mapDBInfo.layers.keys())))
         self.deleteLayer.SetSelection(0)
         self.deleteLayer.Bind(wx.EVT_COMBOBOX, self.OnChangeLayer)
@@ -3351,9 +3351,9 @@ class LayerBook(wx.Notebook):
         self.modifyLayerWidgets = {'layer':
                                    (StaticText(parent=self.modifyPanel, id=wx.ID_ANY,
                                                label='%s:' % _("Layer")),
-                                    wx.ComboBox(parent=self.modifyPanel, id=wx.ID_ANY,
+                                    ComboBox(parent=self.modifyPanel, id=wx.ID_ANY,
                                                 size=(100, -1),
-                                                style=wx.CB_SIMPLE | wx.CB_READONLY,
+                                                style=wx.CB_READONLY,
                                                 choices=list(map(str,
                                                             self.mapDBInfo.layers.keys())))),
                                    'driver':


### PR DESCRIPTION
Default layout (wxMSW only):

- Browse data page:

![dbmgr_browse_page_default](https://user-images.githubusercontent.com/50632337/81904574-c127e500-95c3-11ea-8d86-4850d9f0f9e8.png)

Expected layout:

- Browse data page:

![dbmgr_browse_page_expected](https://user-images.githubusercontent.com/50632337/81904683-e288d100-95c3-11ea-955d-57d0d07385da.png)

Default layout (wxMSW only):

 - Manage tables page:

![dbmgr_manage_table_default](https://user-images.githubusercontent.com/50632337/81904773-064c1700-95c4-11ea-92a5-c9bae8a04893.png)

Expected layout:

- Manage tables page:

![dbmgr_manage_tables_expected](https://user-images.githubusercontent.com/50632337/81904817-16fc8d00-95c4-11ea-9173-fa98501b306c.png)

Default layout (wxMSW only):

- Manage layers page:

![dbmgr_manage_layers_1_default](https://user-images.githubusercontent.com/50632337/81904863-309dd480-95c4-11ea-9f3e-c673098eeb93.png)

![dbmgr_manage_layers_2_default](https://user-images.githubusercontent.com/50632337/81904872-3398c500-95c4-11ea-9c26-01f7c64d84a9.png)


Expected layout:

- Manage layers page:

![dbmgr_manage_layers_1_expected](https://user-images.githubusercontent.com/50632337/81904914-47dcc200-95c4-11ea-8a8e-72e37eec4717.png)

![dbmgr_manage_layers_2_expected](https://user-images.githubusercontent.com/50632337/81904926-4a3f1c00-95c4-11ea-9532-b4b541da70cd.png)

