### PR TITLE
wxGUI AddWSDialog RenderWMSMgr: Fix render WMS jpeg source format

### DIFF
--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -170,14 +170,21 @@ class RenderWMSMgr(wx.EvtHandler):
         self.mapMerger.AddRasterBands(self.tempMap, {1: 1, 2: 2, 3: 3})
         del self.mapMerger
 
+        add_alpha_channel = True
+        mask_fill_value = 0
+        if self.fetching_cmd[1]['format'] == 'jpeg':
+            mask_fill_value = 255 # white color, g.pnmcomp doesn't apply mask (alpha channel)
+            add_alpha_channel = False
+
         self.maskMerger = GDALRasterMerger(
             targetFile=self.layer.maskfile,
             region=self.renderedRegion,
             bandsNum=1,
             gdalDriver='PNM',
-            fillValue=0)
-        #{4 : 1} alpha channel (4) to first and only channel (1) in mask
-        self.maskMerger.AddRasterBands(self.tempMap, {4: 1})
+            fillValue=mask_fill_value)
+        if add_alpha_channel:
+            #{4 : 1} alpha channel (4) to first and only channel (1) in mask
+            self.maskMerger.AddRasterBands(self.tempMap, {4: 1})
         del self.maskMerger
 
         self.fetched_data_cmd = self.fetching_cmd


### PR DESCRIPTION
To reproduce:

1. Click on the **Add web service layer (WMS, WMTS, NASA OnEarth)** toolbar icon tool
2. Set this url `http://ows.mundialis.de/services/service?` in the Server TextCtrl widget 
3. Click on the **Connect** button
4. In the **List of layers** choose **OpenStreetMap WMS - by terrestris** -> **default**
5. On the **Source image format** RadioBox widget check **jpeg**
6. Choose proper **Source projection** CheckBox widget item (EPSG: 4326) 
7. Click on the **Add layer** button

Error message (Console page):

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/core/gthread.py",
line 121, in OnDone

event.ondone(event)
  File "/usr/lib64/grass79/gui/wxpython/core/ws.py", line
200, in OnRenderDone

self.maskMerger.AddRasterBands(self.tempMap, {4: 1})
  File "/usr/lib64/grass79/gui/wxpython/core/ws.py", line
392, in AddRasterBands

bandData = sDataset.GetRasterBand(sBandNnum).ReadRaster(
AttributeError
:
'NoneType' object has no attribute 'ReadRaster'
```

Error message (Terminal emulator):

```
ERROR 5: /home/user/grassdata/osm/PERMANENT/.tmp/gnu-linux/12160.4: GDALDataset::GetRasterBand(4) - Illegal band #
```