### PR TITLE
wxGUI/composer: use integers instead of wx id to fix pickle error

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -61,7 +61,7 @@ from gui_core.wrap import (
     BitmapButton, BitmapComboBox, BitmapFromImage, Button,
     CheckBox, Choice, ClientDC, ColourPickerCtrl, Dialog, DirBrowseButton,
     EmptyBitmap, ExpandoTextCtrl, FileBrowseButton, FloatSpin, ListBox,
-    ListCtrl, NewId, Notebook, OwnerDrawnComboBox, Panel, RadioButton,
+    ListCtrl, Notebook, OwnerDrawnComboBox, Panel, RadioButton,
     Rect, ScrolledPanel, SpinCtrl, StaticBox, StaticText, TextCtrl,
     TextEntryDialog, EmptyImage, CheckListCtrlMixin
 )

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -42,7 +42,7 @@ from core.utils import PilImageToWxImage
 from gui_core.forms import GUI
 from gui_core.dialogs import HyperlinkDialog
 from gui_core.ghelp import ShowAboutDialog
-from gui_core.wrap import ClientDC, PseudoDC, Rect, StockCursor, EmptyBitmap, NewId
+from gui_core.wrap import ClientDC, PseudoDC, Rect, StockCursor, EmptyBitmap
 from psmap.menudata import PsMapMenuData
 from gui_core.toolbars import ToolSwitcher
 
@@ -1009,7 +1009,7 @@ class PsMapFrame(wx.Frame):
 
     def DialogDataChanged(self, id):
         ids = id
-        if isinstance(id, int) or isinstance(id, wx.WindowIDRef):
+        if isinstance(id, int):
             ids = [id]
         for id in ids:
             itype = self.instruction[id].type

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -46,8 +46,12 @@ from grass.script.task import cmdlist_to_tuple
 from core.gcmd import RunCommand, GError, GMessage, GWarning
 from core.utils import GetCmdString
 from dbmgr.vinfo import VectorDBInfo
-from gui_core.wrap import NewId
+from gui_core.wrap import NewId as wxNewId
 from psmap.utils import *
+
+
+def NewId():
+    return int(wxNewId())
 
 
 class Instruction:


### PR DESCRIPTION
wx IDs can't be pickled and cause error in composer. This was working before, perhaps some wx change.