### PR TITLE
wxGUI lmgr: Fix remove both selected parent/children group layer

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -2525,7 +2525,11 @@ class GMFrame(wx.Frame):
         for layer in self.GetLayerTree().GetSelections():
             if self.GetLayerTree().GetLayerInfo(layer, key='type') == 'group':
                 self.GetLayerTree().DeleteChildren(layer)
-            self.GetLayerTree().Delete(layer)
+            # nested children group layer in the parent group layer (both selected)
+            try:
+                self.GetLayerTree().Delete(layer)
+            except ValueError:
+                pass
 
     def OnKeyDown(self, event):
         """Key pressed"""


### PR DESCRIPTION
To reproduce:

![lmgr](https://user-images.githubusercontent.com/50632337/82137145-b49acb00-9815-11ea-81d6-2036b5b7c5f4.gif)

Error message (Console page):

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
2531, in OnDeleteLayer

self.GetLayerTree().Delete(layer)
  File "/usr/lib/python3/dist-
packages/wx/lib/agw/customtreectrl.py", line 5310, in Delete

parent.GetChildren().remove(item)  # remove by value
ValueError
:
list.remove(x): x not in list
```