### PR TITLE
g.gui.iclass: replace removed dist_point_to_segment()

### DIFF
--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -24,6 +24,7 @@ from multiprocessing import Process, Queue
 from copy import deepcopy
 from iscatt.core_c import MergeArrays, ApplyColormap
 from iscatt.dialogs import ManageBusyCursorMixin
+from iscatt.utils import dist_point_to_segment
 from core.settings import UserSettings
 from gui_core.wrap import Menu, NewId
 
@@ -35,7 +36,6 @@ try:
         FigureCanvasWxAgg as FigCanvas
     from matplotlib.lines import Line2D
     from matplotlib.artist import Artist
-    from matplotlib.mlab import dist_point_to_segment
     from matplotlib.patches import Polygon, Ellipse, Rectangle
     import matplotlib.image as mi
     import matplotlib.colors as mcolors

--- a/gui/wxpython/iscatt/utils.py
+++ b/gui/wxpython/iscatt/utils.py
@@ -1,0 +1,52 @@
+"""
+@package iscatt.utils
+
+@brief Misc utilities for iscatt
+
+(C) 2020 by the GRASS Development Team
+
+This program is free software under the GNU General Public License
+(>=v2). Read the file COPYING that comes with GRASS for details.
+
+@author Nicklas Larsson <n_larsson yahoo com>
+"""
+
+import numpy as np
+
+# Code originate from matplotlib
+# https://matplotlib.org/3.0.0/_modules/matplotlib/mlab.html#dist
+def dist(x, y):
+    """
+    Return the distance between two points.
+    """
+    d = x - y
+    return np.sqrt(np.dot(d, d))
+
+# Code originate from matplotlib
+# https://matplotlib.org/3.0.0/_modules/matplotlib/mlab.html#dist_point_to_segment
+def dist_point_to_segment(p, s0, s1):
+    """
+    Get the distance of a point to a segment.
+
+      *p*, *s0*, *s1* are *xy* sequences
+
+    This algorithm from
+    http://geomalgorithms.com/a02-_lines.html
+    """
+    p = np.asarray(p, float)
+    s0 = np.asarray(s0, float)
+    s1 = np.asarray(s1, float)
+    v = s1 - s0
+    w = p - s0
+
+    c1 = np.dot(w, v)
+    if c1 <= 0:
+        return dist(p, s0)
+
+    c2 = np.dot(v, v)
+    if c2 <= c1:
+        return dist(p, s1)
+
+    b = c1 / c2
+    pb = s0 + b * v
+    return dist(p, pb)


### PR DESCRIPTION
This replaces dist_point_to_segment() from matplotlib, which was disabled for matplotlib 3.1.0+.

Addresses: https://github.com/OSGeo/grass/issues/461.


To test the algorithm [updated]:
```python
#!/usr/bin/env python3

import numpy as np

# from https://matplotlib.org/3.0.0/_modules/matplotlib/mlab.html#dist 
def dist(x, y):
    """
    Return the distance between two points.
    """
    d = x-y
    return np.sqrt(np.dot(d, d))

# from https://matplotlib.org/3.0.0/_modules/matplotlib/mlab.html#dist_point_to_segment
def dist_point_to_segment(p, s0, s1):
    """
    Get the distance of a point to a segment.

      *p*, *s0*, *s1* are *xy* sequences

    This algorithm from
    http://geomalgorithms.com/a02-_lines.html
    """
    p = np.asarray(p, float)
    s0 = np.asarray(s0, float)
    s1 = np.asarray(s1, float)
    v = s1 - s0
    w = p - s0

    c1 = np.dot(w, v)
    if c1 <= 0:
        return dist(p, s0)

    c2 = np.dot(v, v)
    if c2 <= c1:
        return dist(p, s1)

    b = c1 / c2
    pb = s0 + b * v
    return dist(p, pb)

# -------------------------------------------------------------------

def dist_jts(a, b):
    a_x, a_y = a
    b_x, b_y = b

    dx = a_x - b_x
    dy = a_y - b_y

    return np.sqrt(dx * dx + dy * dy)

# function ported from jts https://github.com/locationtech/jts/blob/e5e52b64b5be06ad73932a49a7303a04d89d923a/modules/core/src/main/java/org/locationtech/jts/algorithm/Distance.java#L147
def dist_point_to_segment_jts(p, s0, s1):
    p_x, p_y = p
    s0_x, s0_y = s0
    s1_x, s1_y = s1

    if s0_x == s1_x and s0_y == s1_y:
        return dist_jts(p, s1)

    len2 = (s1_x - s0_x) * (s1_x - s0_x) + (s1_y - s0_y) * (s1_y - s0_y)
    
    r = ((p_x - s0_x) * (s1_x - s0_x) + (p_y - s0_y) * (s1_y - s0_y)) / len2

    if r <= 0.0:
        return dist_jts(p, s0)

    if r >= 1.0:
        return dist_jts(p, s1)

    s = ((s0_y - p_y) * (s1_x - s0_x) - (s0_x - p_x) * (s1_y - s0_y)) / len2

    return np.fabs(s) * np.sqrt(len2)

# -------------------------------------------------------------------

# new function based on https://stackoverflow.com/questions/39840030/distance-between-point-and-a-line-from-two-points/39840218
def dist_point_to_segment_new1(p, s0, s1):
    p = np.asarray(p, float)
    s0 = np.asarray(s0, float)
    s1 = np.asarray(s1, float)

    if (s0 == s1).all():
        d = p - s0
        return np.sqrt(np.dot(d, d))

    d = np.cross(s1 - s0, p - s0) / np.linalg.norm(s1 - s0)

    return np.fabs(d)

# -------------------------------------------------------------------

# new function based on http://www.fundza.com/vectors/point2line/index.html
def dist_point_to_segment_new2(p, s0, s1):
    p = np.asarray(p, float)
    s0 = np.asarray(s0, float)
    s1 = np.asarray(s1, float)

    if (s0 == s1).all():
        d = p - s0
        return np.sqrt(np.dot(d, d))

    line_vec = s1 - s0
    p_vec = p - s0
    line_len = np.sqrt(np.dot(line_vec, line_vec))
    line_unitvec = (line_vec[0]/line_len, line_vec[1]/line_len)
    p_vec_scaled = (p_vec[0] * 1.0/line_len, p_vec[1] * 1.0/line_len)
    t = np.dot(line_unitvec, p_vec_scaled)
    if t < 0.0:
        t = 0.0
    elif t > 1.0:
        t = 1.0

    nearest = (line_vec[0] * t, line_vec[1] * t)
    d = p_vec - nearest
    dist = np.sqrt(np.dot(d, d))

    return dist

# ===================================================================

def main():
    p = -5, 40
    s0 = 0, 0
    s1 = 0, 10

    d = dist_point_to_segment(p, s0, s1)
    print("org  d: %s" %d)

    d2 = dist_point_to_segment_jts(p, s0, s1)
    print("jts  d: %s" % d2)

    d3 = dist_point_to_segment_new1(p, s0, s1)
    print("new  d: %s" %d3)

    d4 = dist_point_to_segment_new2(p, s0, s1)
    print("new2 d: %s" % d4)

if __name__ == "__main__":
    main()

```
