### PR TITLE
wxGUI location wizard: First page

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2121,7 +2121,7 @@ class SummaryPage(TitledPage):
         self.sizer.Add(self.llocation,
                        flag=wx.ALIGN_LEFT | wx.ALL,
                        border=5, pos=(2, 1))
-        self.sizer.Add(self.MakeLabel(_("Location Description:")),
+        self.sizer.Add(self.MakeLabel(_("Description:")),
                        flag=wx.ALIGN_LEFT | wx.ALL,
                        border=5, pos=(3, 0))
         self.sizer.Add(self.panelTitle,

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -179,6 +179,11 @@ class DatabasePage(TitledPage):
                 grass.legal_name,
                 self._nameValidationFailed))
         self.tlocTitle = self.MakeTextCtrl(size=(400, -1))
+        
+        # text for required options
+        self.required_txt = self.MakeStaticText(text = "*", size=(-1, -1))
+        self.required_txt.SetForegroundColour(wx.RED)
+        self.required_txt.SetToolTip(_("This option is required"))
 
         # checkbox
         self.tlocRegion = self.MakeCheckBox(_("Set default region extent and resolution"),
@@ -209,7 +214,7 @@ class DatabasePage(TitledPage):
         self.sizer.Add(
             self.MakeLabel(
                 "%s:" %
-                _("Project Location"),
+                _("Location Name"),
                 tooltip=_("Name of location directory in GIS Data Directory")),
             flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
             border=5,
@@ -220,6 +225,11 @@ class DatabasePage(TitledPage):
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
                        pos=(2, 2))
+        self.sizer.Add(self.required_txt,
+                       flag=wx.ALIGN_LEFT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=5,
+                       pos=(2, 3))
 
         self.sizer.Add(
             self.MakeLabel(

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2404,8 +2404,6 @@ class LocationWizard(wx.Object):
                 self.location = self.startpage.location
                 self.grassdatabase = self.startpage.grassdatabase
                 self.georeffile = self.filepage.georeffile
-                self.default_region = self.startpage.tlocRegion.IsChecked()
-                self.user_mapset = self.startpage.tlocUserMapset.IsChecked()
                 # FIXME here was code for setting default region, what for is this if:
                 # if self.altdb == False:
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -88,7 +88,7 @@ class TitledPage(WizardPageSimple):
         self.pagesizer = wx.BoxSizer(wx.VERTICAL)
         self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
         self.sizer.SetCols(5)
-        self.sizer.SetRows(6)
+        self.sizer.SetRows(8)
 
     def DoLayout(self):
         """Do page layout"""
@@ -127,15 +127,6 @@ class TitledPage(WizardPageSimple):
             textCtrl.SetToolTip(tooltip)
         return textCtrl
 
-    def MakeStaticText(self, text='', size=(100, -1),
-                     style=0, parent=None):
-        """Generic static text control"""
-        if not parent:
-            parent = self
-        staticText = StaticText(parent=parent, id=wx.ID_ANY, label=text,
-                               size=size, style=style)
-        return staticText
-
     def MakeButton(self, text, id=wx.ID_ANY, size=(-1, -1),
                    parent=None, tooltip=None):
         """Generic button"""
@@ -171,7 +162,7 @@ class DatabasePage(TitledPage):
         self.locTitle = ''
 
         # text controls
-        self.tgisdbase = self.MakeStaticText(grassdatabase, size=(-1, -1))
+        self.tgisdbase = self.MakeTextCtrl(grassdatabase, size=(400, -1), style = wx.TE_READONLY | wx.TRANSPARENT_WINDOW)       
         self.tlocation = self.MakeTextCtrl("newLocation", size=(400, -1))
         self.tlocation.SetFocus()
         self.tlocation.SetValidator(
@@ -181,9 +172,16 @@ class DatabasePage(TitledPage):
         self.tlocTitle = self.MakeTextCtrl(size=(400, -1))
         
         # text for required options
-        self.required_txt = self.MakeStaticText("*", size=(-1, -1))
+        self.required_txt = self.MakeLabel("*")
         self.required_txt.SetForegroundColour(wx.RED)
         self.required_txt.SetToolTip(_("This option is required"))
+        
+        # text for optional options
+        self.optional_txt = self.MakeLabel("(optional)")
+        italics = wx.Font(10, wx.DEFAULT, wx.ITALIC, wx.NORMAL)
+        self.optional_txt.SetFont(italics)
+        self.optional_txt.SetForegroundColour("gray")
+        self.optional_txt.SetToolTip(_("This option is optional"))
 
         # checkbox
         self.tlocRegion = self.MakeCheckBox(_("Set default region extent and resolution"),
@@ -201,62 +199,67 @@ class DatabasePage(TitledPage):
 
         # layout
         self.sizer.Add(self.MakeLabel(_("GIS Data Directory:")),
-                       flag=wx.ALIGN_RIGHT |
+                       flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5,
+                       wx.ALL, border=2,
                        pos=(1, 1))
         self.sizer.Add(self.tgisdbase,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(1, 3))
+                       pos=(2, 1))
 
         self.sizer.Add(
             self.MakeLabel(
                 "%s:" %
                 _("Location Name"),
                 tooltip=_("Name of location directory in GIS Data Directory")),
-            flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
             border=5,
-            pos=(2, 1)
+            pos=(3, 1)
         )
-        self.sizer.Add(self.required_txt,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5,
-                       pos=(2, 2))
         self.sizer.Add(self.tlocation,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(2, 3))
+                       pos=(4, 1))
+        self.sizer.Add(self.required_txt,
+                       flag=wx.ALIGN_LEFT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=5,
+                       pos=(4, 2))
 
         self.sizer.Add(
             self.MakeLabel(
                 "%s:" %
-                _("Location Title"),
+                _("Description"),
                 tooltip=_(
-                    "Optional location title, "
-                    "you can leave this field blank.")),
-            flag=wx.ALIGN_RIGHT | wx.ALIGN_TOP | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+                    "Description of location directory in GIS Data Directory")),
+            flag=wx.ALIGN_LEFT | wx.ALIGN_TOP | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
             border=5,
-            pos=(3, 1)
+            pos=(5, 1)
         )
         self.sizer.Add(self.tlocTitle,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(3, 3), span=(1, 2))
+                       pos=(6, 1))
+        self.sizer.Add(self.optional_txt,
+                       flag=wx.ALIGN_LEFT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=5,
+                       pos=(6, 2))
+        
         self.sizer.Add(self.tlocRegion,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(4, 3), span=(1, 2))
+                       pos=(7, 1), span=(1, 2))
         self.sizer.Add(self.tlocUserMapset,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(5, 3), span=(1, 2))
+                       pos=(8, 1), span=(1, 2))
         self.sizer.AddGrowableCol(3)
 
         # bindings

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -174,15 +174,15 @@ class DatabasePage(TitledPage):
         self.tlocTitle = self.MakeTextCtrl(size=(400, -1))
         
         # text for required options
-        self.required_txt = self.MakeLabel("*")
-        self.required_txt.SetForegroundColour(wx.RED)
-        self.required_txt.SetToolTip(_("This option is required"))
+        required_txt = self.MakeLabel("*")
+        required_txt.SetForegroundColour(wx.RED)
+        required_txt.SetToolTip(_("This option is required"))
         
         # text for optional options
-        self.optional_txt = self.MakeLabel(_("(optional)"))
+        optional_txt = self.MakeLabel(_("(optional)"))
         italics = wx.Font(10, wx.DEFAULT, wx.ITALIC, wx.NORMAL)
-        self.optional_txt.SetFont(italics)
-        self.optional_txt.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        optional_txt.SetFont(italics)
+        optional_txt.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
 
         # layout
         self.sizer.Add(
@@ -199,7 +199,7 @@ class DatabasePage(TitledPage):
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
                        pos=(2, 1))
-        self.sizer.Add(self.required_txt,
+        self.sizer.Add(required_txt,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
@@ -220,7 +220,7 @@ class DatabasePage(TitledPage):
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
                        pos=(4, 1))
-        self.sizer.Add(self.optional_txt,
+        self.sizer.Add(optional_txt,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -164,7 +164,7 @@ class DatabasePage(TitledPage):
         self.bbrowse = self.MakeButton(_("Change"))
 
         # text controls
-        self.tgisdbase = self.MakeTextCtrl(grassdatabase, size=(400, -1))    
+        self.tgisdbase = self.MakeLabel(grassdatabase)    
         self.tlocation = self.MakeTextCtrl("newLocation", size=(400, -1))
         self.tlocation.SetFocus()
         self.tlocation.SetValidator(
@@ -277,7 +277,7 @@ class DatabasePage(TitledPage):
                            os.getcwd(), wx.DD_DEFAULT_STYLE)
         if dlg.ShowModal() == wx.ID_OK:
             self.grassdatabase = dlg.GetPath()
-            self.tgisdbase.SetValue(self.grassdatabase)
+            self.tgisdbase.SetLabel(self.grassdatabase)
 
         dlg.Destroy()
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -179,10 +179,10 @@ class DatabasePage(TitledPage):
         self.required_txt.SetToolTip(_("This option is required"))
         
         # text for optional options
-        self.optional_txt = self.MakeLabel("(optional)")
+        self.optional_txt = self.MakeLabel(_("(optional)"))
         italics = wx.Font(10, wx.DEFAULT, wx.ITALIC, wx.NORMAL)
         self.optional_txt.SetFont(italics)
-        self.optional_txt.SetForegroundColour("gray")
+        self.optional_txt.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
 
         # layout
         self.sizer.Add(

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -181,7 +181,7 @@ class DatabasePage(TitledPage):
         self.tlocTitle = self.MakeTextCtrl(size=(400, -1))
         
         # text for required options
-        self.required_txt = self.MakeStaticText(text = "*", size=(-1, -1))
+        self.required_txt = self.MakeStaticText("*", size=(-1, -1))
         self.required_txt.SetForegroundColour(wx.RED)
         self.required_txt.SetToolTip(_("This option is required"))
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -172,7 +172,7 @@ class DatabasePage(TitledPage):
 
         # text controls
         self.tgisdbase = self.MakeStaticText(grassdatabase, size=(-1, -1))
-        self.tlocation = self.MakeTextCtrl("newLocation", size=(300, -1))
+        self.tlocation = self.MakeTextCtrl("newLocation", size=(400, -1))
         self.tlocation.SetFocus()
         self.tlocation.SetValidator(
             GenericValidator(
@@ -209,7 +209,7 @@ class DatabasePage(TitledPage):
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(1, 2))
+                       pos=(1, 3))
 
         self.sizer.Add(
             self.MakeLabel(
@@ -220,12 +220,12 @@ class DatabasePage(TitledPage):
             border=5,
             pos=(2, 1)
         )
-        self.sizer.Add(self.tlocation,
+        self.sizer.Add(self.required_txt,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
                        pos=(2, 2))
-        self.sizer.Add(self.required_txt,
+        self.sizer.Add(self.tlocation,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
@@ -246,17 +246,17 @@ class DatabasePage(TitledPage):
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(3, 2), span=(1, 2))
+                       pos=(3, 3), span=(1, 2))
         self.sizer.Add(self.tlocRegion,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(4, 2), span=(1, 2))
+                       pos=(4, 3), span=(1, 2))
         self.sizer.Add(self.tlocUserMapset,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(5, 2), span=(1, 2))
+                       pos=(5, 3), span=(1, 2))
         self.sizer.AddGrowableCol(3)
 
         # bindings

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2121,7 +2121,7 @@ class SummaryPage(TitledPage):
         self.sizer.Add(self.llocation,
                        flag=wx.ALIGN_LEFT | wx.ALL,
                        border=5, pos=(2, 1))
-        self.sizer.Add(self.MakeLabel(_("Location Title:")),
+        self.sizer.Add(self.MakeLabel(_("Location Description:")),
                        flag=wx.ALIGN_LEFT | wx.ALL,
                        border=5, pos=(3, 0))
         self.sizer.Add(self.panelTitle,

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -155,14 +155,16 @@ class DatabasePage(TitledPage):
 
     def __init__(self, wizard, parent, grassdatabase):
         TitledPage.__init__(self, wizard, _(
-            "Define GRASS Database and Location Name"))
+            "Define new GRASS Location"))
 
         self.grassdatabase = grassdatabase
         self.location = ''
         self.locTitle = ''
+        
+        self.bbrowse = self.MakeButton(_("Change"))
 
         # text controls
-        self.tgisdbase = self.MakeTextCtrl(grassdatabase, size=(400, -1), style = wx.TE_READONLY | wx.TRANSPARENT_WINDOW)       
+        self.tgisdbase = self.MakeTextCtrl(grassdatabase, size=(400, -1))    
         self.tlocation = self.MakeTextCtrl("newLocation", size=(400, -1))
         self.tlocation.SetFocus()
         self.tlocation.SetValidator(
@@ -181,53 +183,27 @@ class DatabasePage(TitledPage):
         italics = wx.Font(10, wx.DEFAULT, wx.ITALIC, wx.NORMAL)
         self.optional_txt.SetFont(italics)
         self.optional_txt.SetForegroundColour("gray")
-        self.optional_txt.SetToolTip(_("This option is optional"))
-
-        # checkbox
-        self.tlocRegion = self.MakeCheckBox(_("Set default region extent and resolution"),
-                                            tooltip=_("This option allows setting default "
-                                                      "computation region immediately after "
-                                                      "new location is created. Default "
-                                                      "computation region can be defined later "
-                                                      "using g.region based on imported data."))
-
-        self.tlocUserMapset = self.MakeCheckBox(_("Create user mapset"),
-                                                tooltip=_("This option allows creating user "
-                                                          "mapset immediately after new location "
-                                                          "is created. Note that GRASS always creates "
-                                                          "PERMANENT mapset."))
 
         # layout
-        self.sizer.Add(self.MakeLabel(_("GIS Data Directory:")),
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=2,
-                       pos=(1, 1))
-        self.sizer.Add(self.tgisdbase,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5,
-                       pos=(2, 1))
-
         self.sizer.Add(
             self.MakeLabel(
                 "%s:" %
-                _("Location Name"),
+                _("Name"),
                 tooltip=_("Name of location directory in GIS Data Directory")),
             flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
             border=5,
-            pos=(3, 1)
+            pos=(1, 1)
         )
         self.sizer.Add(self.tlocation,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(4, 1))
+                       pos=(2, 1))
         self.sizer.Add(self.required_txt,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(4, 2))
+                       pos=(2, 2))
 
         self.sizer.Add(
             self.MakeLabel(
@@ -237,35 +213,40 @@ class DatabasePage(TitledPage):
                     "Description of location directory in GIS Data Directory")),
             flag=wx.ALIGN_LEFT | wx.ALIGN_TOP | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
             border=5,
-            pos=(5, 1)
+            pos=(3, 1)
         )
         self.sizer.Add(self.tlocTitle,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(6, 1))
+                       pos=(4, 1))
         self.sizer.Add(self.optional_txt,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(6, 2))
+                       pos=(4, 2))
         
-        self.sizer.Add(self.tlocRegion,
+        self.sizer.Add(self.MakeLabel(_("Location will be created in GRASS database:")),
+                       flag=wx.ALIGN_LEFT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=2,
+                       pos=(5, 1))
+        self.sizer.Add(self.tgisdbase,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(7, 1), span=(1, 2))
-        self.sizer.Add(self.tlocUserMapset,
+                       pos=(6, 1))
+        self.sizer.Add(self.bbrowse,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5,
-                       pos=(8, 1), span=(1, 2))
-        self.sizer.AddGrowableCol(3)
+                       pos=(6, 2))
 
         # bindings
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.tgisdbase.Bind(wx.EVT_TEXT, self.OnChangeName)
         self.tlocation.Bind(wx.EVT_TEXT, self.OnChangeName)
+        self.Bind(wx.EVT_BUTTON, self.OnBrowse, self.bbrowse)
 
     def _nameValidationFailed(self, ctrl):
         message = _(
@@ -289,6 +270,16 @@ class DatabasePage(TitledPage):
             nextButton.Disable()
 
         event.Skip()
+        
+    def OnBrowse(self, event):
+        """Choose GRASS data directory"""
+        dlg = wx.DirDialog(self, _("Choose GRASS data directory:"),
+                           os.getcwd(), wx.DD_DEFAULT_STYLE)
+        if dlg.ShowModal() == wx.ID_OK:
+            self.grassdatabase = dlg.GetPath()
+            self.tgisdbase.SetValue(self.grassdatabase)
+
+        dlg.Destroy()
 
     def OnPageChanging(self, event=None):
         error = None


### PR DESCRIPTION
Location wizard location name marked as required and the Project Location renamed to Location Name.

> @lindakladivova Please provide screenshots before and after. It's self-explanatory description :-)

Sorry I do not have before. I have the one after :-) :
![Screenshot from 2020-05-18 15-28-09](https://user-images.githubusercontent.com/49241681/82257184-388baa80-991d-11ea-8fc2-20fdf30dd7bd.png)




> I would say the asterisk should go right after the label. Since there is GridBagSizer used, you may need to shift the edit fields one column to the right to get the asterisk there so that everything is aligned. Alternatively, the edit fields could be moved below the label like we have in forms.

Here's the screenshot of the second version:
![Screenshot from 2020-05-19 10-06-21](https://user-images.githubusercontent.com/49241681/82344664-f2d0ef80-99b9-11ea-81d8-bef65cfba872.png)

Here's the screenshot of the third version:
(The layout was a bit changed and also the Description was marked as optional. GIS data directory is still non-editable but made through wx.TE_READONLY method.)
![Screenshot from 2020-05-19 15-04-43](https://user-images.githubusercontent.com/49241681/82373246-edd46600-99e2-11ea-8b23-3b165ee8f4de.png)

Here's the screenshot of the fourth version:
![Screenshot from 2020-05-20 11-08-53](https://user-images.githubusercontent.com/49241681/82470901-8f16f700-9a8b-11ea-8f33-45be60470ca6.png)
I more like the TextCtrl than StaticText for Location Database. I find it more logical because the window is editable. What do you think?

The fifth version with StaticText:
![Screenshot from 2020-05-20 12-09-40](https://user-images.githubusercontent.com/49241681/82476212-4e22e080-9a93-11ea-8662-c4f79d700415.png)


