### PR TITLE
wxGUI gcp GroupDialog: Fix StaticText widget existence check

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -49,7 +49,7 @@ from gui_core.widgets import SingleSymbolPanel, GListCtrl, SimpleValidator, \
 from core.settings import UserSettings
 from core.debug import Debug
 from gui_core.wrap import Button, CheckListBox, EmptyBitmap, HyperlinkCtrl, \
-    Menu, NewId, SpinCtrl, StaticBox, StaticText, TextCtrl 
+    Menu, NewId, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 
 class SimpleDialog(wx.Dialog):
@@ -1329,7 +1329,8 @@ class GroupDialog(wx.Dialog):
 
     def ClearNotification(self):
         """Clear notification string"""
-        self.infoLabel.SetLabel("")
+        if self.infoLabel:
+            self.infoLabel.SetLabel("")
 
     def ApplyChanges(self):
         """Create or edit group"""


### PR DESCRIPTION
To reproduce:

![gcp_group_dialog](https://user-images.githubusercontent.com/50632337/82254670-920ecc00-9953-11ea-8a0b-71724e36578b.gif)

After click on the Ok button (Group dialog), `ClearNotification()` method is called with delay `wx.CallLater(4000, self.ClearNotification)`, when dialog instance is destroyed.

Error message (Console page):

```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-packages/wx/core.py", line
2254, in Notify

self.notify()
  File "/usr/lib64/python3.6/site-packages/wx/core.py", line
3410, in Notify

self.result = self.callable(*self.args, **self.kwargs)
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/dialogs.py", line
1336, in ClearNotification

self.infoLabel.SetLabel("")
RuntimeError
:
wrapped C/C++ object of type StaticText has been deleted
```