### PR TITLE
wxGUI animation: allow to use saved region instead of comp region

### DIFF
--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -355,8 +355,7 @@ class AnimationController(wx.EvtHandler):
                     continue
                 anim = [anim for anim in self.animationData
                         if anim.windowIndex == i][0]
-                w, h = self.mapwindows[i].GetClientSize()
-                regions = anim.GetRegions(w, h)
+                regions = anim.GetRegions()
                 self.animations[i].SetFrames(
                     [HashCmds(cmdList, region) for cmdList,
                      region in zip(anim.cmdMatrix, regions)])
@@ -368,8 +367,7 @@ class AnimationController(wx.EvtHandler):
                     continue
                 anim = [anim for anim in self.animationData
                         if anim.windowIndex == i][0]
-                w, h = self.mapwindows[i].GetClientSize()
-                regions = anim.GetRegions(w, h)
+                regions = anim.GetRegions()
                 identifiers = sampleCmdMatrixAndCreateNames(
                     anim.cmdMatrix, mapNamesDict[
                         anim.firstStdsNameType[0]], regions)
@@ -413,8 +411,8 @@ class AnimationController(wx.EvtHandler):
         opacities = [
             layer.opacity for layer in animationData.layerList
             if layer.active]
-        w, h = self.mapwindows[animationData.GetWindowIndex()].GetClientSize()
-        regions = animationData.GetRegions(w, h)
+        #w, h = self.mapwindows[animationData.GetWindowIndex()].GetClientSize()
+        regions = animationData.GetRegions()
         self.bitmapProvider.SetCmds(
             animationData.cmdMatrix, opacities, regions)
 

--- a/gui/wxpython/animation/utils.py
+++ b/gui/wxpython/animation/utils.py
@@ -384,9 +384,12 @@ def interpolate(start, end, count):
         while start < end:
             values.append(start)
             start += step
-    else:
+    elif end < start:
         while end < start:
             values.append(start)
             start += step
+    else:
+        values = [start] * (count - 1)
     values.append(end)
+
     return values


### PR DESCRIPTION
Adds the ability to select a saved region for animation instead of using current computational region.