### PR TITLE
CI: Remove notifications comming from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,4 @@ after_success:
   - bash < (curl -s https://codecov.io/bash)
 
 notifications:
-        email:
-            recipients:
-                - grass-dev@lists.osgeo.org
-                - landa.martin@gmail.com
-                - wenzeslaus@gmail.com
-            on_success: change
-            on_failure: always
         irc: "chat.freenode.net#grass"
-


### PR DESCRIPTION
With enough people using GitHub directly, there is no need to send the emails to the mailing
list or developers. Travis status shows right next each commit and PR and together with GitHub Actions.
