### PR TITLE
wxgui: startup GUI automatic detection of grassdata: make case independent #644

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,7 +38,7 @@ import wx.lib.mixins.listctrl as listmix
 from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
-    get_lockfile_if_present, get_possible_database_path, create_mapset)
+    get_lockfile_if_present, get_or_create_possible_database_path, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog
 import startup.guiutils as sgui
@@ -506,7 +506,7 @@ class GRASSStartup(wx.Frame):
         # only if nothing is set (<UNKNOWN> comes from init script)
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
-        path = get_possible_database_path()
+        path = get_or_create_possible_database_path()
         if path:
             try:
                 self.tgisdbase.SetValue(path)

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,7 +38,8 @@ import wx.lib.mixins.listctrl as listmix
 from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
-    get_lockfile_if_present, get_or_create_possible_database_path, create_mapset)
+    get_lockfile_if_present, get_possible_database_path, \
+    create_possible_database_path, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog
 import startup.guiutils as sgui
@@ -506,29 +507,22 @@ class GRASSStartup(wx.Frame):
         # only if nothing is set (<UNKNOWN> comes from init script)
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
-        path = get_or_create_possible_database_path()
+        path = get_possible_database_path()
+        # If nothing found, create GRASS directory
+        if path is None:
+            path = create_possible_database_path()
+        try:
+            self.tgisdbase.SetValue(path)
+        except UnicodeDecodeError:
+            # restore previous state
+            # wizard gives error in this case, we just ignore
+            path = None
+            self.tgisdbase.SetValue(self.gisdbase)
+        # if we still have path
         if path:
-            try:
-                self.tgisdbase.SetValue(path)
-            except UnicodeDecodeError:
-                # restore previous state
-                # wizard gives error in this case, we just ignore
-                path = None
-                self.tgisdbase.SetValue(self.gisdbase)
-            # if we still have path
-            if path:
-                self.gisdbase = path
-                self.OnSetDatabase(None)
-        else:
-            # nothing found
-            # TODO: should it be warning, hint or message?
-            self._showWarning(_(
-                'GRASS needs a directory (GRASS database) '
-                'in which to store its data. '
-                'Create one now if you have not already done so. '
-                'A popular choice is "grassdata", located in '
-                'your home directory. '
-                'Press Browse button to select the directory.'))
+            self.gisdbase = path
+            self.OnSetDatabase(None)
+
 
     def OnWizard(self, event):
         """Location wizard started"""

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,8 +38,7 @@ import wx.lib.mixins.listctrl as listmix
 from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
-    get_lockfile_if_present, get_possible_database_path,
-    create_possible_database_path, create_mapset)
+    get_lockfile_if_present, get_possible_database_path, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog
 import startup.guiutils as sgui
@@ -508,21 +507,28 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
-        # If nothing found, create GRASS directory
-        if path is None:
-            path = create_possible_database_path()
-        try:
-            self.tgisdbase.SetValue(path)
-        except UnicodeDecodeError:
-            # restore previous state
-            # wizard gives error in this case, we just ignore
-            path = None
-            self.tgisdbase.SetValue(self.gisdbase)
-        # if we still have path
         if path:
-            self.gisdbase = path
-            self.OnSetDatabase(None)
-
+            try:
+                self.tgisdbase.SetValue(path)
+            except UnicodeDecodeError:
+                # restore previous state
+                # wizard gives error in this case, we just ignore
+                path = None
+                self.tgisdbase.SetValue(self.gisdbase)
+            # if we still have path
+            if path:
+                self.gisdbase = path
+                self.OnSetDatabase(None)
+        else:
+            # nothing found
+            # TODO: should it be warning, hint or message?
+            self._showWarning(_(
+                'GRASS needs a directory (GRASS database) '
+                'in which to store its data. '
+                'Create one now if you have not already done so. '
+                'A popular choice is "grassdata", located in '
+                'your home directory. '
+                'Press Browse button to select the directory.'))
 
     def OnWizard(self, event):
         """Location wizard started"""

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,7 +38,7 @@ import wx.lib.mixins.listctrl as listmix
 from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
-    get_lockfile_if_present, get_possible_database_path, \
+    get_lockfile_if_present, get_possible_database_path,
     create_possible_database_path, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -35,24 +35,29 @@ def get_possible_database_path():
     # potential translations (old Windows and some Linux)
     # but ~ and ~/Documents should cover most of the cases
     # ordered by preference and then likelihood
-    candidates = [
-        os.path.join(home, "grassdata"),
-        os.path.join(home, "Documents", "grassdata"),
-        os.path.join(home, "My Documents", "grassdata"),
-    ]
-    try:
-        # here goes everything which has potential unicode issues
-        candidates.append(os.path.join(home, _("Documents"), "grassdata"))
-        candidates.append(os.path.join(home, _("My Documents"), "grassdata"))
-    except UnicodeDecodeError:
-        # just ignore the errors if it doesn't work
-        pass
-    path = None
-    for candidate in candidates:
-        if os.path.exists(candidate):
-            path = candidate
-            break  # get the first match
-    return path
+    
+    options = ["grassdata","GRASSDATA","Grassdata","GrassData"]
+    
+    for option in options:
+    
+        candidates = [
+            os.path.join(home, option),
+            os.path.join(home, "Documents", option),
+            os.path.join(home, "My Documents", option),
+        ]
+        try:
+            # here goes everything which has potential unicode issues
+            candidates.append(os.path.join(home, _("Documents"), option))
+            candidates.append(os.path.join(home, _("My Documents"), option))
+        except UnicodeDecodeError:
+            # just ignore the errors if it doesn't work
+            pass
+        path = None
+        for candidate in candidates:
+            if os.path.exists(candidate):
+                path = candidate
+                return path
+
 
 
 def get_lockfile_if_present(database, location, mapset):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -39,39 +39,28 @@ def get_possible_database_path():
     # Documents and My Documents for Windows
     # potential translations (old Windows and some Linux)
     # but ~ and ~/Documents should cover most of the cases
-    # ordered by platform preference
-    
-    # Search or create independent "grassdata" in the home Linux dir
-    if sys.platform.startswith('linux'):
-        
-        # Search for independent "grassdata" dir
-        for dir in next(os.walk(home))[1]:            
-            if 'grassdata' in dir.lower():
-                path = os.path.join(home, dir)
-                break         
+    # ordered by platform preference      
             
-    # Search independent "grassdata" in other dirs (Windows and Mac)
-    else:        
-        candidates = [
-            os.path.join(home, "Documents"),
-            os.path.join(home, "My Documents"),
-            os.path.join(tempfile.gettempdir()) # temp dir
-        ]
-        
-        try:
-            # here goes everything which has potential unicode issues
-            candidates.append(os.path.join(home, _("Documents")))
-            candidates.append(os.path.join(home, _("My Documents")))
-        except UnicodeDecodeError:
-            # just ignore the errors if it doesn't work
-            pass
+    # Search independent "grassdata" directories      
+    candidates = [
+        os.path.join(home),
+        os.path.join(home, "Documents"),
+    ]
+    
+    try:
+        # here goes everything which has potential unicode issues
+        candidates.append(os.path.join(home, _("Documents")))
+    except UnicodeDecodeError:
+        # just ignore the errors if it doesn't work
+        pass
 
-        for candidate in candidates:         
-            if os.path.exists(candidate):
-                for subdir in next(os.walk(candidate))[1]:
-                    if 'grassdata' in subdir.lower():
-                        path = os.path.join(candidate, subdir)
-                        break                
+    # Find possible database path
+    for candidate in candidates:         
+        if os.path.exists(candidate):
+            for subdir in next(os.walk(candidate))[1]:
+                if 'grassdata' in subdir.lower():
+                    path = os.path.join(candidate, subdir)
+                    break                
     return path    
 
 

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -18,42 +18,43 @@ solve the errors etc. in a general manner).
 
 import os
 import shutil
-import tempfile
-import sys
 
 
 def get_possible_database_path():
     """Finds the directory for possible GRASS Database.
-
     It automatically detects independent directory named grassdata 
     in the usual locations. 
-
-    Returns the path as a string or None. If nothing was found, the return 
-    value can be used to test if the directory was found.  
+    
+    Returns the path as a string or None. If nothing was found, 
+    the return value can be used to test if the directory was found.  
     """
-    home = os.path.expanduser('~')            
+    home = os.path.expanduser('~')       
     # try some common directories for grassdata
-    # grassdata (lowercase) in home for Linux (first choice)
+    # case independent grassdata in home for Linux (first choice)
     # Documents for Windows
     # potential translations (old Windows and some Linux)
     # but ~ and ~/Documents should cover most of the cases
-    # case independent  
             
-    # Search independent "grassdata" directories      
+    # Independent "grassdata" directories      
     candidates = [
         home,
-        os.path.join(home, "Documents")
-    ]    
-    
-    tr_documents = os.path.join(home,_("Documents"))
-    if tr_documents not in candidates:
-        try:
-            # here goes everything which has potential unicode issues
-            candidates.append(tr_documents)
-        except UnicodeDecodeError:
-            # just ignore the errors if it doesn't work
-            pass
-
+        os.path.join(home, "Documents"),
+        os.path.join(home, "My Documents")
+    ] 
+    # Potential translations (old Windows and some Linux)
+    tr_documents = [
+        os.path.join(home,_("Documents")),
+        os.path.join(home,_("My Documents"))
+    ]
+    # Add potential translations to the list of candidates
+    for tr_document in tr_documents: 
+        if tr_document not in candidates:
+            try:
+                # here goes everything which has potential unicode issues
+                candidates.append(tr_document)
+            except UnicodeDecodeError:
+                # just ignore the errors if it doesn't work
+                pass
     # Find possible database path
     for candidate in candidates:         
         if os.path.exists(candidate):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -28,9 +28,7 @@ def get_possible_database_path():
     Looks for directory named grassdata in the usual locations.
 
     Returns the path as a string or None if nothing was found, so the return 
-    value can be used to test if the directory was found.
-    
-    Returns the path as a string.   
+    value can be used to test if the directory was found.  
     """
     home = os.path.expanduser('~')           
     path = None     
@@ -44,7 +42,7 @@ def get_possible_database_path():
     # Search independent "grassdata" directories      
     candidates = [
         os.path.join(home),
-        os.path.join(home, "Documents"),
+        os.path.join(home, "Documents")
     ]
     
     try:

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -26,25 +26,21 @@ def get_possible_database_path():
     
     Returns the path as a string or None if nothing was found.
     """
-    home = os.path.expanduser('~')  
+    home = os.path.expanduser('~')
+
     # try some common directories for grassdata
-    # case independent grassdata in home for Linux (first choice)
-    # Documents for Windows
-            
-    # Independent "grassdata" directories      
     candidates = [
         home,
         os.path.join(home, "Documents"),
-        os.path.join(home, "My Documents")
-    ] 
+    ]
 
-    # Find possible database path
-    for candidate in candidates:         
+    # find possible database path
+    for candidate in candidates:
         if os.path.exists(candidate):
             for subdir in next(os.walk(candidate))[1]:
                 if 'grassdata' in subdir.lower():
-                    return os.path.join(candidate,subdir)             
-    return None    
+                    return os.path.join(candidate,subdir)
+    return None
 
 
 def get_lockfile_if_present(database, location, mapset):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -23,43 +23,44 @@ import sys
 
 
 def get_possible_database_path():
-    """Finds the directory to what is possibly a GRASS Database.
+    """Finds the directory for possible GRASS Database.
 
-    Looks for directory named grassdata in the usual locations.
+    It automatically detects independent directory named grassdata 
+    in the usual locations. 
 
-    Returns the path as a string or None if nothing was found, so the return 
+    Returns the path as a string or None. If nothing was found, the return 
     value can be used to test if the directory was found.  
     """
-    home = os.path.expanduser('~')           
-    path = None     
+    home = os.path.expanduser('~')            
     # try some common directories for grassdata
     # grassdata (lowercase) in home for Linux (first choice)
-    # Documents and My Documents for Windows
+    # Documents for Windows
     # potential translations (old Windows and some Linux)
     # but ~ and ~/Documents should cover most of the cases
-    # ordered by platform preference      
+    # case independent  
             
     # Search independent "grassdata" directories      
     candidates = [
-        os.path.join(home),
+        home,
         os.path.join(home, "Documents")
-    ]
+    ]    
     
-    try:
-        # here goes everything which has potential unicode issues
-        candidates.append(os.path.join(home, _("Documents")))
-    except UnicodeDecodeError:
-        # just ignore the errors if it doesn't work
-        pass
+    tr_documents = os.path.join(home,_("Documents"))
+    if tr_documents not in candidates:
+        try:
+            # here goes everything which has potential unicode issues
+            candidates.append(tr_documents)
+        except UnicodeDecodeError:
+            # just ignore the errors if it doesn't work
+            pass
 
     # Find possible database path
     for candidate in candidates:         
         if os.path.exists(candidate):
             for subdir in next(os.walk(candidate))[1]:
                 if 'grassdata' in subdir.lower():
-                    path = os.path.join(candidate, subdir)
-                    break                
-    return path    
+                    return os.path.join(candidate,subdir)             
+    return None    
 
 
 def get_lockfile_if_present(database, location, mapset):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -36,7 +36,7 @@ def get_possible_database_path():
     # but ~ and ~/Documents should cover most of the cases
     # ordered by preference and then likelihood
     
-    options = ["grassdata","GRASSDATA","Grassdata","GrassData"]
+    options = ["grassdata", "GRASSDATA", "Grassdata", "GrassData"]
     
     for option in options:
     

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -19,7 +19,6 @@ solve the errors etc. in a general manner).
 import os
 import shutil
 import tempfile
-import getpass
 import sys
 
 
@@ -63,7 +62,7 @@ def get_possible_database_path():
             # here goes everything which has potential unicode issues
             candidates.append(os.path.join(home, _("Documents")))
             candidates.append(os.path.join(home, _("My Documents")))
-        except:
+        except UnicodeDecodeError:
             # just ignore the errors if it doesn't work
             pass
 
@@ -74,54 +73,6 @@ def get_possible_database_path():
                         path = os.path.join(candidate, subdir)
                         break                
     return path    
-
-
-def create_possible_database_path():
-    """Create the directory to what is possibly a GRASS Database.
-
-    Create directory named grassdata in the usual locations.   
-    
-    Returns the new path as a string.  
-    """
-    home = os.path.expanduser('~') 
-    tmp = os.path.join(tempfile.gettempdir(),
-                               "grassdata_{}".format(getpass.getuser()))           
-    
-    # Create independent "grassdata" in the home Linux dir
-    if sys.platform.startswith('linux'):
-        try:
-            path = os.path.join(home, "grassdata")
-            os.mkdir(path)
-        except OSError: 
-            print ("Creation of the directory {} failed".format(path))
-    
-    # Create independent "grassdata" in other dirs (Windows and Mac)
-    else:  
-        candidates = [
-            os.path.join(home, "Documents", "grassdata"),
-            os.path.join(home, "My Documents", "grassdata")
-        ]
-        
-        try:
-            # here goes everything which has potential unicode issues
-            candidates.append(os.path.join(home, _("Documents"), "grassdata"))
-            candidates.append(os.path.join(home, _("My Documents"), "grassdata"))
-        except:
-            # just ignore the errors if it doesn't work
-            pass
-                
-            for candidate in candidates:                
-                try:
-                    os.mkdir(candidate)
-                    path = candidate
-                except OSError:
-                    print ("Creation of the directory {} failed".format(candidate))
-                        
-    # If still doesn't exist, create "grassdata_username" dir in temp           
-    if path is None:        
-            os.mkdir(tmp)
-            path = tmp            
-    return path
 
 
 def get_lockfile_if_present(database, location, mapset):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -21,19 +21,15 @@ import shutil
 
 
 def get_possible_database_path():
-    """Finds the directory for possible GRASS Database.
-    It automatically detects independent directory named grassdata 
-    in the usual locations. 
+    """Looks for directory 'grassdata' (case-insensitive) in standard 
+    locations to detect existing GRASS Database.
     
-    Returns the path as a string or None. If nothing was found, 
-    the return value can be used to test if the directory was found.  
+    Returns the path as a string or None if nothing was found.
     """
-    home = os.path.expanduser('~')       
+    home = os.path.expanduser('~')  
     # try some common directories for grassdata
     # case independent grassdata in home for Linux (first choice)
     # Documents for Windows
-    # potential translations (old Windows and some Linux)
-    # but ~ and ~/Documents should cover most of the cases
             
     # Independent "grassdata" directories      
     candidates = [
@@ -41,20 +37,7 @@ def get_possible_database_path():
         os.path.join(home, "Documents"),
         os.path.join(home, "My Documents")
     ] 
-    # Potential translations (old Windows and some Linux)
-    tr_documents = [
-        os.path.join(home,_("Documents")),
-        os.path.join(home,_("My Documents"))
-    ]
-    # Add potential translations to the list of candidates
-    for tr_document in tr_documents: 
-        if tr_document not in candidates:
-            try:
-                # here goes everything which has potential unicode issues
-                candidates.append(tr_document)
-            except UnicodeDecodeError:
-                # just ignore the errors if it doesn't work
-                pass
+
     # Find possible database path
     for candidate in candidates:         
         if os.path.exists(candidate):


### PR DESCRIPTION
After starting GRASS GIS with GUI, the GUI now searches for existing grassdata (e.g., dac6d4a and #644 with #664). 

This platfrom-dependent directory would be:

    - $HOME (os.path.expanduser('~')) on Linux and the like,
    - User's Documents on Windows (see dac6d4a for code trying to identify that dir),
    - One of the above on macOS - macOS users, please share your ideas.

This function does not address temporary directory. No platform specific code.
