### PR TITLE
wxGUI WSPropertiesDialog: Fix show web service map layer properties dialog

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -489,9 +489,10 @@ class WSDialogBase(wx.Dialog):
             self.active_ws_panel.Hide()
 
         self.active_ws_panel = self.ws_panels[ws]['panel']
-        self.active_ws_panel.Show()
-        self.SetMaxSize((-1, -1))
-        self.active_ws_panel.GetContainingSizer().Layout()
+        if not self.active_ws_panel.IsShown():
+            self.active_ws_panel.Show()
+            self.SetMaxSize((-1, -1))
+            self.active_ws_panel.GetContainingSizer().Layout()
 
     def OnAdvConnPaneChanged(self, event):
         """Collapse search module box
@@ -810,9 +811,9 @@ class WSPropertiesDialog(WSDialogBase):
 
         ws = self._getWSfromCmd(cmd)
         if self.ws_panels[ws]['panel'].IsConnected():
-            self.ws_panels[ws]['panel'].UpdateWidgetsByCmd(cmd)
             self.choose_ws_rb.SetStringSelection(self.ws_panels[ws]['label'])
             self._showWsPanel(ws)
+            self.ws_panels[ws]['panel'].UpdateWidgetsByCmd(cmd)
 
     def _getWSfromCmd(self, cmd):
         driver = cmd[1]['driver']


### PR DESCRIPTION
To reproduce:

web service url: `http://ows.mundialis.de/services/service?`

1. Add some web service map layer via wxGUI Add web service layer dialog
2. Choose another available web service than default WMS 1.1.1 item (RadioButton widget), check WMS 1.3.0 item
3. Click on the Add layer button
4. Open web service map layer properties dialog (double click on the added web service map layer)

Default behavior:

![ws_props_dialog_def](https://user-images.githubusercontent.com/50632337/82748851-605b9200-9da5-11ea-9676-0542e060d8aa.gif)
(* **choose WMS 1.3.0**)

After double click on the web service layer, `d.wms` module dialog is open

Expected behavior:

Open web service map layer properties wxGUI dialog, not `d.wms` module dialog

Error message (Console page):

```
Traceback (most recent call last):
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 551, in _parseCapFile

self.cap = self.ws_drvs[self.ws]['cap_parser'](cap_file)
  File "/usr/local/grass79/gui/wxpython/web_services/cap_int
erface.py", line 343, in __init__

OnEarthCapabilitiesTree.__init__(self, cap_file)
  File "/usr/local/grass79/etc/r.in.wms/wms_cap_parsers.py",
line 520, in __init__

self._checkLayerTree(self.getroot())
  File "/usr/local/grass79/etc/r.in.wms/wms_cap_parsers.py",
line 528, in _checkLayerTree

tiled_patterns = self._find(parent_layer, 'TiledPatterns')
  File "/usr/local/grass79/etc/r.in.wms/wms_cap_parsers.py",
line 551, in _find

Tag <%s> was not found.") % tag)
xml.etree.ElementTree
.
ParseError
:
Unable to parse tile service file.
                                 Tag <TiledPatterns> was not
found.
During handling of the above exception, another exception
occurred:
Traceback (most recent call last):
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 608, in OnAddLayer

cmd=cmd)
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 661, in __init__

self.LoadCapFiles(ws_cap_files=self.revert_ws_cap_files,
cmd=cmd)
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 737, in LoadCapFiles

cap_file=cap_file)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 588, in ParseCapFile

self._parseCapFile(self.cap_file)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 560, in _parseCapFile

self._postCapParsedEvt(error_msg=error_msg)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 671, in _postCapParsedEvt

self.capParsed.emit(error_msg=error_msg)
  File
"/usr/local/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/local/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 349, in send

**named
  File "/usr/local/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 804, in OnPanelCapParsed

self._updateWsPanelWidgetsByCmd(self.cmd_to_set)
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 813, in _updateWsPanelWidgetsByCmd

self.ws_panels[ws]['panel'].UpdateWidgetsByCmd(cmd)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 625, in UpdateWidgetsByCmd

self.list.SelectLayers(l_st_list)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 1117, in SelectLayers

checknext(root_item, l_st_list, items_to_sel)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 1106, in checknext

item = self.GetNextVisible(item)
wx._core
.
wxAssertionError
:
C++ assertion "IsVisible(item)" failed at
../src/generic/treectlg.cpp(1528) in GetNextVisible(): this
item itself should be visible
```