### PR TITLE
wxGUI AddWSDialog: Fix setting output layer name, after selecting another layer

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -160,9 +160,7 @@ class WSDialogBase(wx.Dialog):
         self.settsManager.settingsSaving.connect(self.OnSettingsSaving)
 
     def OnLayerSelected(self, title):
-
-        if not self.layerName.GetValue().strip():
-            self.layerName.SetValue(title)
+        self.layerName.SetValue(title)
 
     def _doLayout(self):
 


### PR DESCRIPTION
To reproduce:

web service url: `http://ows.mundialis.de/services/service?`

1. Add some web service map layer via wxGUI Add web service layer dialog
2. Open web service map layer properties dialog (double click on the added web service map layer)
3. Select another layer from List of layers widget, and Output layer name has not changed


Default behavior (to reproduce):

![ws_prop_dialog_def](https://user-images.githubusercontent.com/50632337/82749790-e1b62300-9dab-11ea-9b49-8a706d96c678.gif)

![ws_prop_dialog_def](https://user-images.githubusercontent.com/50632337/82750015-ac123980-9dad-11ea-8ca1-2474bc377488.png)


Expected behavior:

![ws_prop_dialog_exp](https://user-images.githubusercontent.com/50632337/82749839-470a1400-9dac-11ea-982d-d02966e87348.gif)

![ws_prop_dialog_exp](https://user-images.githubusercontent.com/50632337/82750151-7a4da280-9dae-11ea-9f61-d3b7d04dd81e.png)






