### PR TITLE
wxGUI WSPropertiesDialog: Fix render new selected web service map layer in the map canvas

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -758,7 +758,7 @@ class WSPropertiesDialog(WSDialogBase):
 
         self.giface.GetLayerTree().GetOptData(dcmd=lcmd,
                                               layer=self.layer,
-                                              params=None,
+                                              params=True,
                                               propwin=self)
 
         # TODO use just list or tuple


### PR DESCRIPTION
To reproduce:

web service url: `http://ows.mundialis.de/services/service?`

1. Add some web service map layer via wxGUI Add web service layer dialog
2. Open web service map layer properties dialog (double click on the added web service map layer)
3. Select another layer from List of layers widget, and click on the Apply button

Default behavior:

New selected map layer from web service properties dialog has not rendered in the map canvas

Expected behavior:

Render new selected map  in the map canvas

