### PR TITLE
wxGUI lmgr: Fix position of bitmap image button overlaid web service map layer name 

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -2004,6 +2004,9 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             mapName, found = GetLayerNameFromCmd(dcmd)
             mapLayer = self.GetLayerInfo(layer, key='maplayer')
             self.SetItemText(layer, mapName)
+            # calculates all the positions of the visible items
+            # fix length from item to next non-toplevel window position
+            self.CalculatePositions()
 
             if not mapText or not found:
                 propwin.Hide()


### PR DESCRIPTION
To reproduce:

web service url: `http://ows.mundialis.de/services/service?`

1. Add some web service map layer via wxGUI Add web service layer dialog (for example 'OSM Overlay WMS - by terrestris') *
2. Open web service map layer properties dialog (double click on the added web service map layer)
3. Select another layer from List of layers widget (select layer which name is longer than previous map layer name for example: 'SRTM30 Colored Hillshade - by terrestris'), and click on the Apply button

(* layer manager must contain only one added map layer -> actually added web service map layer)

Default behavior:

![lmgr_ws_layer_name_overlaid_def](https://user-images.githubusercontent.com/50632337/82750706-2d6bcb00-9db2-11ea-9492-0f7d35e27f48.gif)

![lmgr_layer_name_overlaid_def](https://user-images.githubusercontent.com/50632337/82751105-517cdb80-9db5-11ea-9fdc-527f7744327a.png)

Expected behavior:

![lmgr_ws_layer_name_overlaid_exp](https://user-images.githubusercontent.com/50632337/82751119-6e191380-9db5-11ea-98a3-dc5635b65219.gif)

![lmgr_layer_name_overlaid_exp](https://user-images.githubusercontent.com/50632337/82751157-ab7da100-9db5-11ea-9a34-115baec473b3.png)

