### PR TITLE
wxGUI location wizard: EPSG page

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1540,9 +1540,8 @@ class EPSGPage(TitledPage):
             style=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
 
         # search box
-        self.searchb = SearchCtrl(self, size=(200, 30),
-                                  style=wx.TE_PROCESS_ENTER)
-        
+        self.searchb = SearchCtrl(self, size=(-1, 30),
+                                  style=wx.TE_PROCESS_ENTER)        
         self.epsglist = ItemList(
             self,
             data=None,
@@ -1554,8 +1553,8 @@ class EPSGPage(TitledPage):
         # epsg.io hyperlink
         self.tlink = HyperlinkCtrl(
             self, id=wx.ID_ANY, 
-            label="https://epsg.io/?q=",
-            url="https://epsg.io/?q=")
+            label="epsg.io",
+            url="https://epsg.io/")
         self.tlink.SetNormalColour(
             wx.SystemSettings.GetColour(
                 wx.SYS_COLOUR_GRAYTEXT))
@@ -1568,21 +1567,23 @@ class EPSGPage(TitledPage):
                        flag=wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5)
         searchBoxSizer.Add(self.searchb, proportion=1,
-                       flag=wx.ALL, border=5)
+                       flag=wx.ALL |
+                       wx.EXPAND, border=5)
         epsglistBoxSizer.Add(self.epsglist, proportion=1,
-                       flag=wx.EXPAND |
-                       wx.ALL, border=5)
+                       flag= wx.ALL |
+                       wx.EXPAND, border=5)
         informationBoxSizer.AddStretchSpacer(1) 
         informationBoxSizer.Add(self.llink,  proportion=0,
                        flag=wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5)
-        informationBoxSizer.Add(self.tlink, proportion=1,
-                       flag=wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5)
+                       wx.RIGHT, border=5)
+        informationBoxSizer.Add(self.tlink, proportion=0,
+                       flag=wx.ALIGN_CENTER_VERTICAL)
+
         
         self.sizer.Add(searchBoxSizer, proportion=0, flag=wx.EXPAND)
         self.sizer.Add(epsglistBoxSizer, proportion=1, flag=wx.EXPAND)
-        self.sizer.Add(informationBoxSizer, proportion=0, flag=wx.EXPAND)
+        self.sizer.Add(informationBoxSizer, proportion=0,
+                       flag=wx.EXPAND | wx.TOP, border=5)
         
         # events
         self.searchb.Bind(wx.EVT_TEXT, self.OnTextChange)
@@ -1642,8 +1643,7 @@ class EPSGPage(TitledPage):
             
         try:
             self.epsgcode = int(self.epsgcode)
-        except:
-            
+        except:          
             self.epsgcode = None
 
         nextButton = wx.FindWindowById(wx.ID_FORWARD)
@@ -1661,19 +1661,17 @@ class EPSGPage(TitledPage):
             self.epsgdesc = self.epsgparams = ''           
             
         value = self.searchb.GetValue()
-        self.tlink.SetURL(str("https://epsg.io/?q={0}".format(value)))
-        self.tlink.SetLabel(str("https://epsg.io/?q={0}".format(value)))
 
         if value == '':
             self.epsgcode = None
             self.epsgdesc = self.epsgparams = ''
             self.OnBrowseCodes(None)
+            self.tlink.SetURL(str("https://epsg.io/".format(value)))  
         else:
             try:
-                
                 self.epsgcode, self.epsgdesc, self.epsgparams = \
                 self.epsglist.Search(index=[0, 1, 2], pattern=value)
-                
+                self.tlink.SetURL(str("https://epsg.io/?q={0}".format(value)))             
             except (IndexError, ValueError):  # -> no item found
                 self.epsgcode = None
                 self.epsgdesc = self.epsgparams = ''
@@ -1688,7 +1686,6 @@ class EPSGPage(TitledPage):
         self.epsgdesc = self.epsglist.GetItem(index, 1).GetText()
         self.searchb.SetValue(str(self.epsgcode))
         self.tlink.SetURL(str("https://epsg.io/?q={0}".format(self.epsgcode)))
-        self.tlink.SetLabel(str("https://epsg.io/?q={0}".format(self.epsgcode)))
 
         event.Skip()
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -55,7 +55,7 @@ from core.utils import cmp
 from core.gcmd import RunCommand, GError, GMessage, GWarning
 from gui_core.widgets import GenericValidator
 from gui_core.wrap import SpinCtrl, SearchCtrl, StaticText, \
-    TextCtrl, Button, CheckBox, StaticBox, NewId, ListCtrl
+    TextCtrl, Button, CheckBox, StaticBox, NewId, ListCtrl, HyperlinkCtrl
 from location_wizard.base import BaseClass
 from location_wizard.dialogs import SelectTransformDialog
 
@@ -1496,25 +1496,17 @@ class EPSGPage(TitledPage):
         self.epsgparams = ''
 
         # labels
-        self.lfile = self.MakeLabel(
-            _("Path to the EPSG-codes file:"),
-            style=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
         self.lcode = self.MakeLabel(
             _("EPSG code:"),
             style=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
-        # text input
-        epsgdir = utils.PathJoin(os.environ["GRASS_PROJSHARE"], 'epsg')
-        self.tfile = self.MakeTextCtrl(text=epsgdir, size=(200, -1),
-                                       style=wx.TE_PROCESS_ENTER)
-        self.tcode = self.MakeTextCtrl(size=(200, -1))
-
-        # buttons
-        self.bbrowse = self.MakeButton(_("Browse"))
+        self.llink = self.MakeLabel(
+            _("Link to epsg.io:"),
+            style=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
 
         # search box
         self.searchb = SearchCtrl(self, size=(200, -1),
                                   style=wx.TE_PROCESS_ENTER)
-
+        
         self.epsglist = ItemList(
             self,
             data=None,
@@ -1523,42 +1515,44 @@ class EPSGPage(TitledPage):
                 _('Description'),
                 _('Parameters')])
 
+        # epsg.io hyperlink
+        self.tlink = HyperlinkCtrl(
+            self, id=wx.ID_ANY, 
+            size=(200, -1),
+            label="epsg.io",
+            url="epsg.io")
+        self.tlink.SetNormalColour(
+            wx.SystemSettings.GetColour(
+                wx.SYS_COLOUR_GRAYTEXT))
+        self.tlink.SetVisitedColour(
+            wx.SystemSettings.GetColour(
+                wx.SYS_COLOUR_GRAYTEXT))
+        
         # layout
-        self.sizer.Add(self.lfile,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(1, 1), span=(1, 2))
-        self.sizer.Add(self.tfile,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(1, 3))
-        self.sizer.Add(self.bbrowse,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(1, 4))
         self.sizer.Add(self.lcode,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(2, 1), span=(1, 2))
-        self.sizer.Add(self.tcode,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(2, 3))
+                       wx.ALL, border=5, pos=(1, 1), span=(1, 2))
         self.sizer.Add(self.searchb,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(3, 3))
-
+                       wx.ALL, border=5, pos=(1, 3))
+        self.sizer.Add(self.llink,
+                       flag=wx.ALIGN_LEFT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=5, pos=(2, 1), span=(1, 2))
+        self.sizer.Add(self.tlink,
+                       flag=wx.ALIGN_LEFT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=5, pos=(2, 3), span=(1, 2))
         self.sizer.Add(self.epsglist,
-                       flag=wx.ALIGN_LEFT | wx.EXPAND, pos=(4, 1),
+                       flag=wx.ALIGN_LEFT | wx.EXPAND, pos=(3, 1),
                        span=(1, 4))
         self.sizer.AddGrowableCol(3)
         self.sizer.AddGrowableRow(4)
 
         # events
-        self.bbrowse.Bind(wx.EVT_BUTTON, self.OnBrowse)
-        self.tfile.Bind(wx.EVT_TEXT_ENTER, self.OnBrowseCodes)
-        self.tcode.Bind(wx.EVT_TEXT, self.OnText)
+        self.searchb.Bind(wx.EVT_TEXT, self.OnText)
         self.epsglist.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnItemSelected)
         self.searchb.Bind(wx.EVT_TEXT_ENTER, self.OnSearch)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
@@ -1678,11 +1672,12 @@ class EPSGPage(TitledPage):
     def OnItemSelected(self, event):
         """EPSG code selected from the list"""
         index = event.GetIndex()
-        item = event.GetItem()
 
         self.epsgcode = int(self.epsglist.GetItem(index, 0).GetText())
         self.epsgdesc = self.epsglist.GetItem(index, 1).GetText()
-        self.tcode.SetValue(str(self.epsgcode))
+        self.searchb.SetValue(str(self.epsgcode))
+        self.tlink.SetURL(str("https://epsg.io/{0}".format(self.epsgcode)))
+        self.tlink.SetLabel(str("epsg.io:{0}".format(self.epsgcode)))
 
         event.Skip()
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1570,7 +1570,7 @@ class EPSGPage(TitledPage):
                        flag=wx.ALL |
                        wx.EXPAND, border=5)
         epsglistBoxSizer.Add(self.epsglist, proportion=1,
-                       flag= wx.ALL |
+                       flag=wx.ALL |
                        wx.EXPAND, border=5)
         informationBoxSizer.AddStretchSpacer(1) 
         informationBoxSizer.Add(self.llink,  proportion=0,
@@ -1666,7 +1666,7 @@ class EPSGPage(TitledPage):
             self.epsgcode = None
             self.epsgdesc = self.epsgparams = ''
             self.OnBrowseCodes(None)
-            self.tlink.SetURL(str("https://epsg.io/".format(value)))  
+            self.tlink.SetURL(str("https://epsg.io/"))  
         else:
             try:
                 self.epsgcode, self.epsgdesc, self.epsgparams = \

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -87,12 +87,10 @@ class TitledPage(WizardPageSimple):
         self.title.SetFont(wx.Font(13, wx.SWISS, wx.NORMAL, wx.BOLD))
         # main sizers
         self.pagesizer = wx.BoxSizer(wx.VERTICAL)
-        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
-        self.sizer.SetCols(5)
-        self.sizer.SetRows(8)
 
     def DoLayout(self):
         """Do page layout"""
+        
         self.pagesizer.Add(self.title, proportion=0,
                            flag=wx.EXPAND | wx.ALL,
                            border=5)
@@ -158,6 +156,10 @@ class DatabasePage(TitledPage):
         TitledPage.__init__(self, wizard, _(
             "Define new GRASS Location"))
 
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.grassdatabase = grassdatabase
         self.location = ''
         self.locTitle = ''
@@ -317,13 +319,17 @@ class CoordinateSystemPage(TitledPage):
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _(
             "Choose method for creating a new location"))
-
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.parent = parent
         global coordsys
 
         # toggles
         self.radioEpsg = wx.RadioButton(parent=self, id=wx.ID_ANY, label=_(
-            "Select EPSG code of spatial reference system"), style=wx.RB_GROUP)
+            "Select coordinate reference system by EPSG"), style=wx.RB_GROUP)
         #self.radioIau = wx.RadioButton(
         #    parent=self, id=wx.ID_ANY,
         #    label=_("Select IAU code of spatial reference system"))
@@ -462,7 +468,11 @@ class ProjectionsPage(TitledPage):
 
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Choose projection"))
-
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.parent = parent
         self.proj = ''
         self.projdesc = ''
@@ -782,6 +792,10 @@ class ProjParamsPage(TitledPage):
         TitledPage.__init__(self, wizard, _("Choose projection parameters"))
         global coordsys
 
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.parent = parent
         self.panel = None
         self.prjParamSizer = None
@@ -989,6 +1003,10 @@ class DatumPage(TitledPage):
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Specify geodetic datum"))
 
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.parent = parent
         self.datum = ''
         self.datumdesc = ''
@@ -1162,7 +1180,11 @@ class EllipsePage(TitledPage):
 
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Specify ellipsoid"))
-
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.parent = parent
 
         self.ellipse = ''
@@ -1337,7 +1359,11 @@ class GeoreferencedFilePage(TitledPage):
 
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Select georeferenced file"))
-
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.georeffile = ''
 
         # create controls
@@ -1413,7 +1439,11 @@ class WKTPage(TitledPage):
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _(
             "Select Well Known Text (WKT) .prj file"))
-
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.wktfile = ''
 
         # create controls
@@ -1489,6 +1519,12 @@ class EPSGPage(TitledPage):
 
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Choose EPSG Code"))
+        
+        self.sizer = wx.BoxSizer(wx.VERTICAL)  
+        searchBoxSizer = wx.BoxSizer(wx.HORIZONTAL)
+        epsglistBoxSizer = wx.BoxSizer(wx.HORIZONTAL)
+        informationBoxSizer = wx.BoxSizer(wx.HORIZONTAL)
+        
         self.parent = parent
         self.epsgCodeDict = {}
         self.epsgcode = None
@@ -1497,14 +1533,14 @@ class EPSGPage(TitledPage):
 
         # labels
         self.lcode = self.MakeLabel(
-            _("EPSG code:"),
+            _("Filter by EPSG code or description:"),
             style=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
         self.llink = self.MakeLabel(
-            _("Link to epsg.io:"),
+            _("Find more information at:"),
             style=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL)
 
         # search box
-        self.searchb = SearchCtrl(self, size=(200, -1),
+        self.searchb = SearchCtrl(self, size=(200, 30),
                                   style=wx.TE_PROCESS_ENTER)
         
         self.epsglist = ItemList(
@@ -1528,33 +1564,38 @@ class EPSGPage(TitledPage):
             wx.SystemSettings.GetColour(
                 wx.SYS_COLOUR_GRAYTEXT))
         
-        # layout
-        self.sizer.Add(self.lcode,
+        # layout       
+        searchBoxSizer.Add(self.lcode, proportion=0,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(1, 1), span=(1, 2))
-        self.sizer.Add(self.searchb,
+                       wx.ALL, border=5)
+        searchBoxSizer.Add(self.searchb, proportion=1,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(1, 3))
-        self.sizer.Add(self.llink,
+                       wx.ALL, border=5)
+        epsglistBoxSizer.Add(self.epsglist, proportion=1,
                        flag=wx.ALIGN_LEFT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(2, 1), span=(1, 2))
-        self.sizer.Add(self.tlink,
-                       flag=wx.ALIGN_LEFT |
+                       wx.EXPAND |
+                       wx.ALL, border=5)
+        informationBoxSizer.AddStretchSpacer(10) 
+        informationBoxSizer.Add(self.llink,  proportion=0,
+                       flag=wx.ALIGN_RIGHT |
                        wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5, pos=(2, 3), span=(1, 2))
-        self.sizer.Add(self.epsglist,
-                       flag=wx.ALIGN_LEFT | wx.EXPAND, pos=(3, 1),
-                       span=(1, 4))
-        self.sizer.AddGrowableCol(3)
-        self.sizer.AddGrowableRow(4)
-
+                       wx.ALL, border=5)
+        informationBoxSizer.Add(self.tlink, proportion=1,
+                       flag=wx.ALIGN_RIGHT |
+                       wx.ALIGN_CENTER_VERTICAL |
+                       wx.ALL, border=5)
+        
+        self.sizer.Add(searchBoxSizer, proportion=0, flag=wx.EXPAND)
+        self.sizer.Add(epsglistBoxSizer, proportion=1, flag=wx.EXPAND)
+        self.sizer.Add(informationBoxSizer, proportion=0, flag=wx.EXPAND)
+        
         # events
         self.searchb.Bind(wx.EVT_TEXT, self.OnText)
+        self.searchb.Bind(wx.EVT_TEXT, self.OnSearch)
         self.epsglist.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnItemSelected)
-        self.searchb.Bind(wx.EVT_TEXT_ENTER, self.OnSearch)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
@@ -1632,7 +1673,6 @@ class EPSGPage(TitledPage):
         if value == '':
             self.epsgcode = None
             self.epsgdesc = self.epsgparams = ''
-            self.tcode.SetValue('')
             self.searchb.SetValue('')
             self.OnBrowseCodes(None)
         else:
@@ -1642,30 +1682,6 @@ class EPSGPage(TitledPage):
             except (IndexError, ValueError):  # -> no item found
                 self.epsgcode = None
                 self.epsgdesc = self.epsgparams = ''
-                self.tcode.SetValue('')
-
-        event.Skip()
-
-    def OnBrowse(self, event):
-        """Define path for EPSG code file"""
-        path = os.path.dirname(self.tfile.GetValue())
-        if not path:
-            path = os.getcwd()
-
-        dlg = wx.FileDialog(
-            parent=self,
-            message=_("Choose EPSG codes file"),
-            defaultDir=path,
-            defaultFile="",
-            wildcard="*",
-            style=wx.FD_OPEN)
-
-        if dlg.ShowModal() == wx.ID_OK:
-            path = dlg.GetPath()
-            self.tfile.SetValue(path)
-            self.OnBrowseCodes(None)
-
-        dlg.Destroy()
 
         event.Skip()
 
@@ -1707,6 +1723,11 @@ class IAUPage(TitledPage):
 
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Choose IAU Code"))
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.parent = parent
         self.epsgCodeDict = {}
         self.epsgcode = None
@@ -1956,6 +1977,11 @@ class CustomPage(TitledPage):
             self, wizard,
             _("Choose method of specifying georeferencing parameters"))
         global coordsys
+        
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
         self.customstring = ''
         self.parent = parent
 
@@ -2064,8 +2090,13 @@ class SummaryPage(TitledPage):
 
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Summary"))
-        self.parent = parent
 
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
+        
+        self.parent = parent
+        
         self.panelTitle = scrolled.ScrolledPanel(parent=self, id=wx.ID_ANY)
         self.panelProj4string = scrolled.ScrolledPanel(
             parent=self, id=wx.ID_ANY)

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1554,9 +1554,8 @@ class EPSGPage(TitledPage):
         # epsg.io hyperlink
         self.tlink = HyperlinkCtrl(
             self, id=wx.ID_ANY, 
-            size=(200, -1),
-            label="epsg.io",
-            url="epsg.io")
+            label="https://epsg.io/?q=",
+            url="https://epsg.io/?q=")
         self.tlink.SetNormalColour(
             wx.SystemSettings.GetColour(
                 wx.SYS_COLOUR_GRAYTEXT))
@@ -1566,26 +1565,19 @@ class EPSGPage(TitledPage):
         
         # layout       
         searchBoxSizer.Add(self.lcode, proportion=0,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
+                       flag=wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5)
         searchBoxSizer.Add(self.searchb, proportion=1,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.ALL, border=5)
+                       flag=wx.ALL, border=5)
         epsglistBoxSizer.Add(self.epsglist, proportion=1,
-                       flag=wx.ALIGN_LEFT |
-                       wx.ALIGN_CENTER_VERTICAL |
-                       wx.EXPAND |
+                       flag=wx.EXPAND |
                        wx.ALL, border=5)
-        informationBoxSizer.AddStretchSpacer(10) 
+        informationBoxSizer.AddStretchSpacer(1) 
         informationBoxSizer.Add(self.llink,  proportion=0,
-                       flag=wx.ALIGN_RIGHT |
-                       wx.ALIGN_CENTER_VERTICAL |
+                       flag=wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5)
         informationBoxSizer.Add(self.tlink, proportion=1,
-                       flag=wx.ALIGN_RIGHT |
-                       wx.ALIGN_CENTER_VERTICAL |
+                       flag=wx.ALIGN_CENTER_VERTICAL |
                        wx.ALL, border=5)
         
         self.sizer.Add(searchBoxSizer, proportion=0, flag=wx.EXPAND)
@@ -1593,8 +1585,7 @@ class EPSGPage(TitledPage):
         self.sizer.Add(informationBoxSizer, proportion=0, flag=wx.EXPAND)
         
         # events
-        self.searchb.Bind(wx.EVT_TEXT, self.OnText)
-        self.searchb.Bind(wx.EVT_TEXT, self.OnSearch)
+        self.searchb.Bind(wx.EVT_TEXT, self.OnTextChange)
         self.epsglist.Bind(wx.EVT_LIST_ITEM_SELECTED, self.OnItemSelected)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
@@ -1646,11 +1637,13 @@ class EPSGPage(TitledPage):
                     self.parent.datum_trans = dtrans
             self.GetNext().SetPrev(self)
 
-    def OnText(self, event):
+    def OnTextChange(self, event):
         self.epsgcode = event.GetString()
+            
         try:
             self.epsgcode = int(self.epsgcode)
         except:
+            
             self.epsgcode = None
 
         nextButton = wx.FindWindowById(wx.ID_FORWARD)
@@ -1665,20 +1658,22 @@ class EPSGPage(TitledPage):
             self.epsgcode = None  # not found
             if nextButton.IsEnabled():
                 nextButton.Enable(False)
-            self.epsgdesc = self.epsgparams = ''
-
-    def OnSearch(self, event):
+            self.epsgdesc = self.epsgparams = ''           
+            
         value = self.searchb.GetValue()
+        self.tlink.SetURL(str("https://epsg.io/?q={0}".format(value)))
+        self.tlink.SetLabel(str("https://epsg.io/?q={0}".format(value)))
 
         if value == '':
             self.epsgcode = None
             self.epsgdesc = self.epsgparams = ''
-            self.searchb.SetValue('')
             self.OnBrowseCodes(None)
         else:
             try:
+                
                 self.epsgcode, self.epsgdesc, self.epsgparams = \
-                    self.epsglist.Search(index=[0, 1, 2], pattern=value)
+                self.epsglist.Search(index=[0, 1, 2], pattern=value)
+                
             except (IndexError, ValueError):  # -> no item found
                 self.epsgcode = None
                 self.epsgdesc = self.epsgparams = ''
@@ -1692,8 +1687,8 @@ class EPSGPage(TitledPage):
         self.epsgcode = int(self.epsglist.GetItem(index, 0).GetText())
         self.epsgdesc = self.epsglist.GetItem(index, 1).GetText()
         self.searchb.SetValue(str(self.epsgcode))
-        self.tlink.SetURL(str("https://epsg.io/{0}".format(self.epsgcode)))
-        self.tlink.SetLabel(str("epsg.io:{0}".format(self.epsgcode)))
+        self.tlink.SetURL(str("https://epsg.io/?q={0}".format(self.epsgcode)))
+        self.tlink.SetLabel(str("https://epsg.io/?q={0}".format(self.epsgcode)))
 
         event.Skip()
 


### PR DESCRIPTION
Path to usr/share/proj/epsg was removed. Search and EPSG code text inputs were merged into one search input. Link to epsg.io was added. The layout was adapted using several box sizers instead of grid sizer.

Before: 
![Screenshot from 2020-05-24 13-46-49](https://user-images.githubusercontent.com/49241681/82762159-0ff42c80-9dc5-11ea-8130-4bd7097a51f0.png)

Version 1:
![Screenshot from 2020-06-05 07-26-31](https://user-images.githubusercontent.com/49241681/83877497-ee872f00-a73a-11ea-9386-ce5ca8640255.png)

The motion of events is following (unincorporated yet in Version 1):
- searching in a list on the fly
- choose automatically the first row and permit "next" button
- if epsg code is empty, nothing is selected and "next" button is not active
- change informative URL according to a query string

Version 2:
![Screenshot from 2020-06-06 05-24-32](https://user-images.githubusercontent.com/49241681/83942387-39647d80-a7f3-11ea-8dc0-33b0da88051f.png)

Already incorporated:
- searching in a list on the fly
- if epsg code is empty, nothing is selected and "next" button is not active
- change informative URL according to a query string

I have a problem that when selecting epsg code from a table, it sometimes happens that neither the query string nor the final epsg code mentioned in the summary page changes. Also I am not sure how to incorporate choosing the automatically the first row in the list.

Version 3 (Layout enhancement):
![Screenshot from 2020-06-07 05-10-50](https://user-images.githubusercontent.com/49241681/83966145-bf96c780-a8b8-11ea-9bcf-a6fb1e448bf9.png)


