### PR TITLE
r.univar: support large regions with more than 2 billion cells for extended stats

### DIFF
--- a/raster/r.univar/globals.h
+++ b/raster/r.univar/globals.h
@@ -34,8 +34,8 @@ typedef struct
     unsigned int n_perc;
     double *perc;
     double sum_abs;
-    unsigned long n;
-    unsigned long size;
+    size_t n;
+    size_t size;
     DCELL *dcell_array;
     FCELL *fcell_array;
     CELL *cell_array;
@@ -63,9 +63,9 @@ extern param_type param;
 extern zone_type zone_info;
 
 /* fn prototypes */
-void heapsort_double(double *data, int n);
-void heapsort_float(float *data, int n);
-void heapsort_int(int *data, int n);
+void heapsort_double(double *data, size_t n);
+void heapsort_float(float *data, size_t n);
+void heapsort_int(int *data, size_t n);
 int print_stats(univar_stat * stats);
 int print_stats_table(univar_stat * stats);
 univar_stat *create_univar_stat_struct(int map_type, int n_perc);

--- a/raster/r.univar/sort.c
+++ b/raster/r.univar/sort.c
@@ -10,16 +10,17 @@
  */
 
 #include "globals.h"
-static void downheap_int(int *array, int n, int k);
-static void downheap_float(float *array, int n, int k);
-static void downheap_double(double *array, int n, int k);
+static void downheap_int(int *array, size_t n, size_t k);
+static void downheap_float(float *array, size_t n, size_t k);
+static void downheap_double(double *array, size_t n, size_t k);
 
 /* *************************************************************** */
 /* *************************************************************** */
 /* *************************************************************** */
-void downheap_int(int *array, int n, int k)
+void downheap_int(int *array, size_t n, size_t k)
 {
-    int j, v;
+    size_t j;
+    int v;
 
     v = array[k];
     while (k <= n / 2) {
@@ -40,9 +41,9 @@ void downheap_int(int *array, int n, int k)
 /* *************************************************************** */
 /* *************************************************************** */
 /* *************************************************************** */
-void downheap_float(float *array, int n, int k)
+void downheap_float(float *array, size_t n, size_t k)
 {
-    int j;
+    size_t j;
     float v;
 
     v = array[k];
@@ -64,9 +65,9 @@ void downheap_float(float *array, int n, int k)
 /* *************************************************************** */
 /* *************************************************************** */
 /* *************************************************************** */
-void downheap_double(double *array, int n, int k)
+void downheap_double(double *array, size_t n, size_t k)
 {
-    int j;
+    size_t j;
     double v;
 
     v = array[k];
@@ -88,9 +89,10 @@ void downheap_double(double *array, int n, int k)
 /* *************************************************************** */
 /* ****** heapsort for int arrays of size n ********************** */
 /* *************************************************************** */
-void heapsort_int(int *array, int n)
+void heapsort_int(int *array, size_t n)
 {
-    int k, t;
+    ssize_t k;
+    int t;
 
     --n;
 
@@ -110,9 +112,9 @@ void heapsort_int(int *array, int n)
 /* *************************************************************** */
 /* ****** heapsort for float arrays of size n ******************** */
 /* *************************************************************** */
-void heapsort_float(float *array, int n)
+void heapsort_float(float *array, size_t n)
 {
-    int k;
+    ssize_t k;
     float t;
 
     --n;
@@ -132,9 +134,9 @@ void heapsort_float(float *array, int n)
 /* *************************************************************** */
 /* ****** heapsort for double arrays of size n ******************* */
 /* *************************************************************** */
-void heapsort_double(double *array, int n)
+void heapsort_double(double *array, size_t n)
 {
-    int k;
+    ssize_t k;
     double t;
 
     --n;

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -117,7 +117,7 @@ int print_stats(univar_stat * stats)
 	double quartile_25 = 0.0, quartile_75 = 0.0, *quartile_perc;
 	double median = 0.0;
 	unsigned int i;
-	int qpos_25, qpos_75, *qpos_perc;
+	size_t qpos_25, qpos_75, *qpos_perc;
 
 	/* all these calculations get promoted to doubles, so any DIV0 becomes nan */
 	mean = stats[z].sum / stats[z].n;
@@ -178,7 +178,7 @@ int print_stats(univar_stat * stats)
 
 	/* TODO: mode, skewness, kurtosis */
 	if (param.extended->answer) {
-	    qpos_perc = (int *)G_calloc(stats[z].n_perc, sizeof(int));
+	    qpos_perc = (size_t *)G_calloc(stats[z].n_perc, sizeof(size_t));
 	    quartile_perc = (double *)G_calloc(stats[z].n_perc, sizeof(double));
 
 	    if (stats[z].n == 0) {
@@ -188,10 +188,10 @@ int print_stats(univar_stat * stats)
 	    }
 	    else {
 		for (i = 0; i < stats[z].n_perc; i++) {
-		    qpos_perc[i] = (int)(stats[z].n * 1e-2 * stats[z].perc[i] - 0.5);
+		    qpos_perc[i] = (size_t)(stats[z].n * 1e-2 * stats[z].perc[i] - 0.5);
 		}
-		qpos_25 = (int)(stats[z].n * 0.25 - 0.5);
-		qpos_75 = (int)(stats[z].n * 0.75 - 0.5);
+		qpos_25 = (size_t)(stats[z].n * 0.25 - 0.5);
+		qpos_75 = (size_t)(stats[z].n * 0.75 - 0.5);
 
 		switch (stats[z].map_type) {
 		case CELL_TYPE:


### PR DESCRIPTION
r.univar -e fails with a segmentation fault caused by integer overflow with regions larger than 2 billion cells. This PR fixes this bug.