### PR TITLE
wxGUI AddWSDialog: Fix render WMTS layer with OGC:CRS84 coor system

### DIFF
--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -16,6 +16,7 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz>
 """
 
+import re
 import os
 import sys
 import six
@@ -709,7 +710,9 @@ class WSPanel(wx.Panel):
 
         if 'srs' not in self.drv_props['ignored_params']:
             i_srs = self.params['srs'].GetSelection()
-            epsg_num = int(self.projs_list[i_srs].split(':')[-1])
+            srs = self.projs_list[i_srs].split(':')[-1]
+            epsg_num = int(''.join(re.findall(r'\d+', srs)))
+
             lcmd.append("srs=%s" % epsg_num)
 
         for k in ['maxcols', 'maxrows', 'urlparams']:
@@ -774,11 +777,8 @@ class WSPanel(wx.Panel):
                 proj_code = Srs(proj.strip()).getcode()
                 proj_spl = proj_code.split(':')
                 if proj_spl[0].strip().lower() in self.drv_info.GetSrs():
-                    try:
-                        int(proj_spl[1])
-                        self.projs_list.append(proj_code)
-                    except ValueError as IndexError:
-                        continue
+                    # accept ogc:crs code
+                    self.projs_list.append(proj_code)
 
             cur_sel = self.params['srs'].GetStringSelection()
 

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -612,7 +612,7 @@ class WMSDriversInfo:
             "image/gif",
             "image/png8"]
 
-        self.srs = ("epsg", "crs")
+        self.srs = ("epsg", "ogc")
 
     def GetDrvProperties(self, driver):
         """!Get information about driver parameters.
@@ -692,9 +692,9 @@ def GetSRSParamVal(srs):
     """
 
     if srs in [84, 83, 27]:
-        return "CRS:%d" % srs
+        return "OGC:CRS{}".format(srs)
     else:
-        return "EPSG:%d" % srs
+        return "EPSG:{}".format(srs)
 
 
 def GetEpsg(srs):

--- a/scripts/r.in.wms/wms_drv.py
+++ b/scripts/r.in.wms/wms_drv.py
@@ -44,7 +44,7 @@ try:
 except ImportError:  # < Python 2.7
     from xml.parsers.expat import ExpatError as ParseError
 
-from wms_base import WMSBase, GetSRSParamVal
+from wms_base import GetEpsg, GetSRSParamVal, WMSBase
 
 from wms_cap_parsers import WMTSCapabilitiesTree, OnEarthCapabilitiesTree
 from srs import Srs
@@ -225,7 +225,7 @@ class WMSDrv(WMSBase):
         # georeferencing and setting projection of temp_map
         projection = grass.read_command('g.proj',
                                         flags='wf',
-                                        epsg=self.params['srs'])
+                                        epsg=GetEpsg(self.params['srs']))
         projection = projection.rstrip('\n')
         temp_map_dataset.SetProjection(projection)
 


### PR DESCRIPTION
To reproduce:

1. Open wxGUI Add web service layer dialog
2. From default profiles choose NASA GIBS WMTS item
3. Select some layer from the list
4. Choose source projection

Default behavior:

![add_ws_dialog_wmts_src_proj_def](https://user-images.githubusercontent.com/50632337/82987276-9001d880-9ff7-11ea-81e4-ece333947e17.png)

Missing source projection (Chooice widget items) for every layer in the list

Expected behavior:

![add_ws_dialog_wmts_src_proj_exp](https://user-images.githubusercontent.com/50632337/82987287-93955f80-9ff7-11ea-9cde-e4a61f2a2dad.png)

Chooice source projection widget has correct source projection item OGC:CRS84





