### PR TITLE
pythonlib: add env variables to all relevant functions in script lib

### DIFF
--- a/lib/python/script/array.py
+++ b/lib/python/script/array.py
@@ -124,8 +124,8 @@ from grass.exceptions import CalledModuleError
 ###############################################################################
 
 class _tempfile(object):
-    def __init__(self):
-        self.filename = gcore.tempfile()
+    def __init__(self, env=None):
+        self.filename = gcore.tempfile(env=env)
 
     def __del__(self):
         try_remove(self.filename)
@@ -133,18 +133,19 @@ class _tempfile(object):
 ###############################################################################
 
 class array(numpy.memmap):
-    def __new__(cls, mapname=None, null=None, dtype=numpy.double):
+    def __new__(cls, mapname=None, null=None, dtype=numpy.double, env=None):
         """Define new numpy array
 
         :param cls:
         :param dtype: data type (default: numpy.double)
+        :param env: environment
         """
-        reg = gcore.region()
+        reg = gcore.region(env=env)
         r = reg['rows']
         c = reg['cols']
         shape = (r, c)
 
-        tempfile = _tempfile()
+        tempfile = _tempfile(env)
         if mapname:
             kind = numpy.dtype(dtype).kind
             size = numpy.dtype(dtype).itemsize
@@ -167,7 +168,8 @@ class array(numpy.memmap):
                 bytes=size,
                 null=null,
                 quiet=True,
-                overwrite=True)
+                overwrite=True,
+                env=env)
 
         self = numpy.memmap.__new__(
             cls,
@@ -178,6 +180,7 @@ class array(numpy.memmap):
 
         self.tempfile = tempfile
         self.filename = tempfile.filename
+        self._env = env
         return self
 
     def read(self, mapname, null=None):
@@ -253,7 +256,7 @@ class array(numpy.memmap):
         else:
             raise ValueError(_('Invalid kind <%s>') % kind)
 
-        reg = gcore.region()
+        reg = gcore.region(env=self._env)
 
         try:
             gcore.run_command(
@@ -271,7 +274,8 @@ class array(numpy.memmap):
                 east=reg['e'],
                 west=reg['w'],
                 rows=reg['rows'],
-                cols=reg['cols'])
+                cols=reg['cols'],
+                env=self._env)
         except CalledModuleError:
             return 1
         else:
@@ -281,11 +285,12 @@ class array(numpy.memmap):
 
 
 class array3d(numpy.memmap):
-    def __new__(cls, mapname=None, null=None, dtype=numpy.double):
+    def __new__(cls, mapname=None, null=None, dtype=numpy.double, env=None):
         """Define new 3d numpy array
 
         :param cls:
         :param dtype: data type (default: numpy.double)
+        :param env: environment
         """
         reg = gcore.region(True)
         r = reg['rows3']
@@ -316,7 +321,8 @@ class array3d(numpy.memmap):
                 bytes=size,
                 null=null,
                 quiet=True,
-                overwrite=True)
+                overwrite=True,
+                env=env)
 
         self = numpy.memmap.__new__(
             cls,
@@ -327,6 +333,7 @@ class array3d(numpy.memmap):
 
         self.tempfile = tempfile
         self.filename = tempfile.filename
+        self._env = env
 
         return self
 
@@ -398,7 +405,7 @@ class array3d(numpy.memmap):
         else:
             raise ValueError(_('Invalid kind <%s>') % kind)
 
-        reg = gcore.region(True)
+        reg = gcore.region(True, env=self._env)
 
         try:
             gcore.run_command(
@@ -418,7 +425,8 @@ class array3d(numpy.memmap):
                 west=reg['w'],
                 depths=reg['depths'],
                 rows=reg['rows3'],
-                cols=reg['cols3'])
+                cols=reg['cols3'],
+                env=self._env)
 
         except CalledModuleError:
             return 1

--- a/lib/python/script/raster.py
+++ b/lib/python/script/raster.py
@@ -33,27 +33,28 @@ if sys.version_info.major >= 3:
     unicode = str
 
 
-def raster_history(map, overwrite=False):
+def raster_history(map, overwrite=False, env=None):
     """Set the command history for a raster map to the command used to
     invoke the script (interface to `r.support`).
 
     :param str map: map name
+    :param env: environment
 
     :return: True on success
     :return: False on failure
 
     """
-    current_mapset = gisenv()['MAPSET']
-    if find_file(name=map)['mapset'] == current_mapset:
+    current_mapset = gisenv(env)['MAPSET']
+    if find_file(name=map, env=env)['mapset'] == current_mapset:
         if overwrite == True:
-            historyfile = tempfile()
+            historyfile = tempfile(env=env)
             f = open(historyfile, 'w')
             f.write(os.environ['CMDLINE'])
             f.close()
-            run_command('r.support', map=map, loadhistory=historyfile)
+            run_command('r.support', map=map, loadhistory=historyfile, env=env)
             try_remove(historyfile)
         else:
-            run_command('r.support', map=map, history=os.environ['CMDLINE'])
+            run_command('r.support', map=map, history=os.environ['CMDLINE'], env=env)
         return True
 
     warning(_("Unable to write history for <%(map)s>. "
@@ -61,7 +62,7 @@ def raster_history(map, overwrite=False):
     return False
 
 
-def raster_info(map):
+def raster_info(map, env=None):
     """Return information about a raster map (interface to
     `r.info -gre`). Example:
 
@@ -69,6 +70,7 @@ def raster_info(map):
     {'creator': '"helena"', 'cols': '1500' ... 'south': 215000.0}
 
     :param str map: map name
+    :param env: environment
 
     :return: parsed raster info
 
@@ -80,7 +82,7 @@ def raster_info(map):
         else:
             return float(s)
 
-    s = read_command('r.info', flags='gre', map=map)
+    s = read_command('r.info', flags='gre', map=map, env=env)
     kv = parse_key_val(s)
     for k in ['min', 'max']:
         kv[k] = float_or_null(kv[k])

--- a/lib/python/script/raster3d.py
+++ b/lib/python/script/raster3d.py
@@ -27,7 +27,7 @@ from .utils import float_or_dms, parse_key_val
 from grass.exceptions import CalledModuleError
 
 
-def raster3d_info(map):
+def raster3d_info(map, env=None):
     """Return information about a raster3d map (interface to `r3.info`).
     Example:
 
@@ -38,6 +38,7 @@ def raster3d_info(map):
     0
 
     :param str map: map name
+    :param env: environment
 
     :return: parsed raster3d info
     """
@@ -48,7 +49,7 @@ def raster3d_info(map):
         else:
             return float(s)
 
-    s = read_command('r3.info', flags='rg', map=map)
+    s = read_command('r3.info', flags='rg', map=map, env=env)
     kv = parse_key_val(s)
     for k in ['min', 'max']:
         kv[k] = float_or_null(kv[k])

--- a/lib/python/script/vector.py
+++ b/lib/python/script/vector.py
@@ -33,7 +33,7 @@ from .core import *
 from grass.exceptions import CalledModuleError
 
 
-def vector_db(map, **args):
+def vector_db(map, env=None, **kwargs):
     """Return the database connection details for a vector map
     (interface to `v.db.connect -g`). Example:
 
@@ -41,12 +41,13 @@ def vector_db(map, **args):
     {1: {'layer': 1, ... 'table': 'geology'}}
 
     :param str map: vector map
-    :param args: other v.db.connect's arguments
+    :param kwargs: other v.db.connect's arguments
+    :param env: environment
 
     :return: dictionary
     """
     s = read_command('v.db.connect', quiet=True, flags='g', map=map, sep=';',
-                     **args)
+                     env=env, **kwargs)
     result = {}
 
     for l in s.splitlines():
@@ -73,17 +74,18 @@ def vector_db(map, **args):
     return result
 
 
-def vector_layer_db(map, layer):
+def vector_layer_db(map, layer, env=None):
     """Return the database connection details for a vector map layer.
     If db connection for given layer is not defined, fatal() is called.
 
     :param str map: map name
     :param layer: layer number
+    :param env: environment
 
     :return: parsed output
     """
     try:
-        f = vector_db(map)[int(layer)]
+        f = vector_db(map, env=env)[int(layer)]
     except KeyError:
         fatal(_("Database connection not defined for layer %s") % layer)
 
@@ -92,7 +94,7 @@ def vector_layer_db(map, layer):
 # run "v.info -c ..." and parse output
 
 
-def vector_columns(map, layer=None, getDict=True, **args):
+def vector_columns(map, layer=None, getDict=True, env=None, **kwargs):
     """Return a dictionary (or a list) of the columns for the
     database table connected to a vector map (interface to `v.info -c`).
 
@@ -118,12 +120,13 @@ def vector_columns(map, layer=None, getDict=True, **args):
     :param layer: layer number or name (None for all layers)
     :param bool getDict: True to return dictionary of columns otherwise list
                          of column names is returned
-    :param args: (v.info's arguments)
+    :param kwargs: (v.info's arguments)
+    :param env: environment
 
     :return: dictionary/list of columns
     """
     s = read_command('v.info', flags='c', map=map, layer=layer, quiet=True,
-                     **args)
+                     env=env, **kwargs)
     if getDict:
         result = dict()
     else:
@@ -140,20 +143,21 @@ def vector_columns(map, layer=None, getDict=True, **args):
     return result
 
 
-def vector_history(map, replace=False):
+def vector_history(map, replace=False, env=None):
     """Set the command history for a vector map to the command used to
     invoke the script (interface to `v.support`).
 
     :param str map: mapname
     :param bool replace: Replace command line instead of appending it
+    :param env: environment
 
     :return: v.support output
     """
     run_command('v.support', map=map, cmdhist=os.environ['CMDLINE'],
-                flags='h' if replace else None)
+                flags='h' if replace else None, env=env)
 
 
-def vector_info_topo(map, layer=1):
+def vector_info_topo(map, layer=1, env=None):
     """Return information about a vector map (interface to `v.info -t`).
     Example:
 
@@ -164,10 +168,12 @@ def vector_info_topo(map, layer=1):
 
     :param str map: map name
     :param int layer: layer number
+    :param env: environment
 
     :return: parsed output
     """
-    s = read_command('v.info', flags='t', layer=layer, map=map)
+    s = read_command('v.info', flags='t', layer=layer, map=map,
+                     env=env)
     ret = parse_key_val(s, val_type=int)
     if 'map3d' in ret:
         ret['map3d'] = bool(ret['map3d'])
@@ -175,7 +181,7 @@ def vector_info_topo(map, layer=1):
     return ret
 
 
-def vector_info(map, layer=1):
+def vector_info(map, layer=1, env=None):
     """Return information about a vector map (interface to
     `v.info`). Example:
 
@@ -184,11 +190,13 @@ def vector_info(map, layer=1):
 
     :param str map: map name
     :param int layer: layer number
+    :param env: environment
 
     :return: parsed vector info
     """
 
-    s = read_command('v.info', flags='get', layer=layer, map=map)
+    s = read_command('v.info', flags='get', layer=layer, map=map,
+                     env=env)
 
     kv = parse_key_val(s)
     for k in ['north', 'south', 'east', 'west', 'top', 'bottom']:
@@ -207,7 +215,7 @@ def vector_info(map, layer=1):
     return kv
 
 
-def vector_db_select(map, layer=1, **kwargs):
+def vector_db_select(map, layer=1, env=None, **kwargs):
     """Get attribute data of selected vector map layer.
 
     Function returns list of columns and dictionary of values ordered by
@@ -223,11 +231,12 @@ def vector_db_select(map, layer=1, **kwargs):
     :param str map: map name
     :param int layer: layer number
     :param kwargs: v.db.select options
+    :param env: environment
 
     :return: dictionary ('columns' and 'values')
     """
     try:
-        key = vector_db(map=map)[layer]['key']
+        key = vector_db(map=map, env=env)[layer]['key']
     except KeyError:
         error(_('Missing layer %(layer)d in vector map <%(map)s>') % \
               {'layer': layer, 'map': map})
@@ -241,7 +250,8 @@ def vector_db_select(map, layer=1, **kwargs):
             debug("Adding key column to the output")
             kwargs['columns'] += ',' + key
 
-    ret = read_command('v.db.select', map=map, layer=layer, **kwargs)
+    ret = read_command('v.db.select', map=map, layer=layer,
+                       env=env, **kwargs)
 
     if not ret:
         error(_('vector_db_select() failed'))
@@ -273,7 +283,9 @@ json = None
 orderedDict = None
 
 
-def vector_what(map, coord, distance=0.0, ttype=None, encoding=None, skip_attributes=False, layer=None, multiple=False):
+def vector_what(map, coord, distance=0.0, ttype=None,
+                encoding=None, skip_attributes=False,
+                layer=None, multiple=False, env=None):
     """Query vector map at given locations
 
     To query one vector map at one location
@@ -334,12 +346,14 @@ def vector_what(map, coord, distance=0.0, ttype=None, encoding=None, skip_attrib
     :param layer: layer number or list of layers (one for each vector),
                   if None, all layers (-1) are used
     :param multiple: find multiple features within threshold distance
+    :param env: environment
 
     :return: parsed list
     """
-    if "LC_ALL" in os.environ:
-        locale = os.environ["LC_ALL"]
-        os.environ["LC_ALL"] = "C"
+    if not env:
+        env = os.environ.copy()
+    if "LC_ALL" in env:
+        env["LC_ALL"] = "C"
 
     if isinstance(map, (bytes, unicode)):
         map_list = [map]
@@ -380,13 +394,10 @@ def vector_what(map, coord, distance=0.0, ttype=None, encoding=None, skip_attrib
         cmdParams['type'] = ','.join(ttype)
 
     try:
-        ret = read_command('v.what',
+        ret = read_command('v.what', env=env,
                            **cmdParams).strip()
     except CalledModuleError as e:
         raise ScriptError(e.msg)
-
-    if "LC_ALL" in os.environ:
-        os.environ["LC_ALL"] = locale
 
     data = list()
     if not ret:


### PR DESCRIPTION
Passing environment is needed for certain functions for fixes of r.import in #676 .
The rest of the functions get it for consistency and proper use in the future.