### PR TITLE
wxGUI d.mon: Fix launch light-weight wx monitor without toolbars and statusbar

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1436,12 +1436,13 @@ class MapFrame(SingleMapFrame):
                       constrainRes=False, projection=False, alignExtent=True):
         """Set properies of map display window"""
         self.mapWindowProperties.autoRender = render
-        self.statusbarManager.SetMode(mode)
-        self.StatusbarUpdate()
+        if self.statusbarManager:
+            self.statusbarManager.SetMode(mode)
+            self.StatusbarUpdate()
+            self.SetProperty('projection', projection)
         self.mapWindowProperties.showRegion = showCompExtent
         self.mapWindowProperties.alignExtent = alignExtent
         self.mapWindowProperties.resolution = constrainRes
-        self.SetProperty('projection', projection)
 
     def IsStandalone(self):
         """Check if Map display is standalone

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -457,7 +457,7 @@ class DMonGrassInterface(StandaloneGrassInterface):
             action = self._mapframe.RemoveToolbar
         else:
             action = self._mapframe.AddToolbar
-        toolbars = self._mapframe.GetToolbarNames()
+        toolbars = list(self._mapframe.GetToolbarNames())
         if not toolbars:
             toolbars.append('map')
         for toolbar in toolbars:


### PR DESCRIPTION
Fix launch light-weight wx monitor without toolbars and statusbar  `-x` flag.

To reproduce:

1. `d.mon -x start=wx0`

Error message:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/mapdisp/main.py", line 635, in <module>
    mapFrame = gmMap.CreateMapFrame(monName, monDecor)
  File "/usr/local/grass79/gui/wxpython/mapdisp/main.py", line 547, in CreateMapFrame
    group='display', key='showCompExtent', subkey='enabled'))
  File "/usr/local/grass79/gui/wxpython/mapdisp/frame.py", line 1440, in SetProperties
    self.statusbarManager.SetMode(mode)
AttributeError: 'NoneType' object has no attribute 'SetMode'
Error in atexit._run_exitfuncs:
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at ../src/common/wincmn.cpp(478) in ~wxWindowBase(): any pushed event handlers must have been removed
```