### PR TITLE
wxGUI/gcp: fix checking vector map existence in the group

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -885,22 +885,25 @@ class DispMapPage(TitledPage):
                                     self.parent.grouppage.xygroup,
                                     'VREF')
 
-            f = open(vgrpfile)
+            error_message = _(
+                'No maps in selected group <%s>.\n'
+                'Please edit group or select another group.') % \
+                self.parent.grouppage.xygroup
+
             try:
-                for vect in f.readlines():
-                    vect = vect.strip('\n')
-                    if len(vect) < 1:
-                        continue
-                    self.parent.src_maps.append(vect)
-            finally:
-                f.close()
+                with open(vgrpfile) as f:
+                    for vect in f.readlines():
+                        vect = vect.strip('\n')
+                        if len(vect) < 1:
+                            continue
+                        self.parent.src_maps.append(vect)
+            except FileNotFoundError:
+                GError(parent=self, message=error_message,
+                       showTraceback=False)
+                return
 
             if len(self.parent.src_maps) < 1:
-                GError(
-                    parent=self, message=_(
-                        'No maps in selected group <%s>.\n'
-                        'Please edit group or select another group.') %
-                    self.parent.grouppage.xygroup)
+                GError(parent=self, message=error_message)
                 return
 
         # filter out all maps not in group


### PR DESCRIPTION
To reproduce:

1. Georectify vector map

Default behavior:

![gcp_def](https://user-images.githubusercontent.com/50632337/83279559-96e64200-a1d5-11ea-9773-d9ed12d47953.gif)
(* test group is empty no vector map)

Error message (Console page):

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/gcp/manager.py",
line 888, in OnEnterPage

f = open(vgrpfile)
FileNotFoundError
:
[Errno 2] No such file or directory:
```

Expected behavior:

![gcp_exp](https://user-images.githubusercontent.com/50632337/83279900-1b38c500-a1d6-11ea-997d-7054f50bdcbe.gif)

