### PR TITLE
wxGUI WSPropertiesDialog: Fix close dialog

### DIFF
--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -802,7 +802,7 @@ class WSPanel(wx.Panel):
             self.formats_list = []
             cur_sel = None
 
-            if self.params['format'] is not None:
+            if self.params['format']:
                 cur_sel = self.params['format'].GetStringSelection()
 
             if len(curr_sel_ls) > 0:
@@ -812,7 +812,8 @@ class WSPanel(wx.Panel):
                 self._updateFormatRadioBox(self.formats_list)
 
                 if cur_sel:
-                    self.params['format'].SetStringSelection(cur_sel)
+                    if self.params['format']:
+                        self.params['format'].SetStringSelection(cur_sel)
                 else:
                     self._setDefaultFormatVal()
 
@@ -830,7 +831,7 @@ class WSPanel(wx.Panel):
     def _updateFormatRadioBox(self, formats_list):
         """Helper function
         """
-        if self.params['format'] is not None:
+        if self.params['format']:
             self.req_page_sizer.Detach(self.params['format'])
             self.params['format'].Destroy()
         if len(self.formats_list) > 0:


### PR DESCRIPTION
To reproduce:

1. Open wxGUI Add web service layer dialog
2. Set server url: `https://demospectrum.koremuat.com/rest/Spatial/WMTS` (bug appear if  the server provide only one type of the available web services WMTS (one RadioButton widget)). If you choose another ws server url `http://ows.mundialis.de/services/service?` which provide  two type of the available web services WMS 1.1.1 and WMS 1.3.0 (two RadioButton widgets), the error will not appear.
3. Select some layer from the list
4. Click on the Add layer button
5. Close dialog
6. Double left click on the added ws layer -> open ws properties dialog
7. Click on the Close button

Error message:

```
Traceback (most recent call last):
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 789, in OnClose

self._close()
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 794, in _close

ws_cap_files=self.revert_ws_cap_files)
  File
"/usr/local/grass79/gui/wxpython/web_services/dialogs.py",
line 737, in LoadCapFiles

cap_file=cap_file)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 589, in ParseCapFile

self._parseCapFile(self.cap_file)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 573, in _parseCapFile

self.OnListSelChanged(event=None)
  File
"/usr/local/grass79/gui/wxpython/web_services/widgets.py",
line 826, in OnListSelChanged

self.params['format'].SetStringSelection(cur_sel)
RuntimeError
:
wrapped C/C++ object of type RadioBox has been deleted
```
