### PR TITLE
wxGUI gcp: Fix show add vector map to group dialog

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -613,18 +613,26 @@ class GroupPage(TitledPage):
         if self.xygroup == '':
             self.xygroup = self.cb_group.GetValue()
 
-        dlg = VectGroup(parent=self,
-                        id=wx.ID_ANY,
-                        grassdb=self.grassdatabase,
-                        location=self.xylocation,
-                        mapset=self.xymapset,
-                        group=self.xygroup)
+        vector_dir = os.path.join(self.grassdatabase,
+                                  self.xylocation,
+                                  self.xymapset,
+                                  'vector')
 
-        if dlg.ShowModal() != wx.ID_OK:
-            return
+        if os.path.exists(vector_dir):
+            dlg = VectGroup(parent=self,
+                            id=wx.ID_ANY,
+                            grassdb=self.grassdatabase,
+                            location=self.xylocation,
+                            mapset=self.xymapset,
+                            group=self.xygroup)
 
-        dlg.MakeVGroup()
-        self.OnEnterPage()
+            if dlg.ShowModal() != wx.ID_OK:
+                return
+
+            dlg.MakeVGroup()
+            self.OnEnterPage()
+        else:
+            GError(parent=self, message=_('No vector maps.'))
 
     def OnExtension(self, event):
         self.extension = self.ext_txt.GetValue()


### PR DESCRIPTION
Default behavior:

Dialog for adding vector maps into group isn't open after click on the Add vector map to group button (location xy, PERMANENT mapset doesn't contain any vector maps)

![gcp_def](https://user-images.githubusercontent.com/50632337/83406265-8f5dad80-a40e-11ea-806e-1f7e46a12cb2.gif)

Error message:

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/gcp/manager.py",
line 621, in OnVGroup

group=self.xygroup)
  File "/usr/local/grass79/gui/wxpython/gcp/manager.py",
line 2372, in __init__

'vector'))
FileNotFoundError
:
[Errno 2] No such file or directory:
'/data/xy/PERMANENT/vector'
```

Expected behavior:

When location xy, PERMANENT mapset doesn't contain any vector maps, show error message dialog 'No vector maps.' after click on the Add vector map to group button.

![gcp_exp](https://user-images.githubusercontent.com/50632337/83407184-75bd6580-a410-11ea-9ffd-010000b00a44.gif)





