### PR TITLE
wxGUI vnet: Fix ctypes c_char_p arg type (bytes object)

### DIFF
--- a/gui/wxpython/vnet/vnet_utils.py
+++ b/gui/wxpython/vnet/vnet_utils.py
@@ -20,6 +20,7 @@ This program is free software under the GNU General Public License
 
 import math
 from grass.script import core as grass
+from grass.script.utils import encode
 
 try:
     import grass.lib.vector as vectlib
@@ -58,8 +59,8 @@ def SnapToNode(e, n, tresh, vectMap):
 
     openedMap = pointer(vectlib.Map_info())
     ret = vectlib.Vect_open_old(openedMap,
-                                c_char_p(vectMap),
-                                c_char_p(mapSet))
+                                c_char_p(encode(vectMap)),
+                                c_char_p(encode(mapSet)))
     if ret == 1:
         vectlib.Vect_close(openedMap)
     if ret != 2:
@@ -98,8 +99,8 @@ def GetNearestNodeCat(e, n, layer, tresh, vectMap):
 
     openedMap = pointer(vectlib.Map_info())
     ret = vectlib.Vect_open_old(openedMap,
-                                c_char_p(vectMapName),
-                                c_char_p(mapSet))
+                                c_char_p(encode(vectMapName)),
+                                c_char_p(encode(mapSet)))
     if ret == 1:
         vectlib.Vect_close(openedMap)
     if ret != 2:


### PR DESCRIPTION
To reproduce:

1. Launch GRASS GIS with **nc_basic_spm_grass7** location, PERMANENT mapset
1. Add **railroads** vector map
2. Open **Vector network analysis tool dialog**
3. Choose vnet tool (**Shortest path (v.net.path)** item from the ComboBox widget)
4. Switch to the **Points page** (tab)
5. Click on the toolbar icon **Activate snapping to nodes** (right arrow icon)
6. Select point **Start point** item from the list (click on the item)
7. Click on the toolbar icon **Insert point from Map Display** (mouse pointer icon)
8. On the Map Display window left click near to the line

![vnet_def](https://user-images.githubusercontent.com/50632337/83490466-5d048c80-a4b0-11ea-96ed-751497d3024a.gif)


Error message:

![vnet_error_message](https://user-images.githubusercontent.com/50632337/83490844-09467300-a4b1-11ea-95ca-5be51c713a95.jpeg)
