### PR TITLE
Fix an error when exporting csv file from g.gui.tplot

### DIFF
--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -651,7 +651,7 @@ class TplotFrame(wx.Frame):
             zipped = list(zip(x, *y))
         else:
             zipped = list(zip(x, y))
-        with open(self.csvpath, "w") as fi:
+        with open(self.csvpath, "w", newline='') as fi:
             writer = csv.writer(fi)
             if self.header:
                 head = ["Time"]

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -272,7 +272,7 @@ class TplotFrame(wx.Frame):
         self.controlPanelSizerVector.Fit(self)
         self.ntb.AddPage(page=self.controlPanelVector, text=_('STVDS'),
                          name='STVDS')
-        
+
         # ------------ITEMS IN NOTEBOOK PAGE (LABELS)------------------------
         self.controlPanelLabels = wx.Panel(parent=self.ntb, id=wx.ID_ANY)
         self.titleLabel = StaticText(parent=self.controlPanelLabels,
@@ -651,14 +651,14 @@ class TplotFrame(wx.Frame):
             zipped = list(zip(x, *y))
         else:
             zipped = list(zip(x, y))
-        with open(self.csvpath, "wb") as fi:
+        with open(self.csvpath, "w") as fi:
             writer = csv.writer(fi)
             if self.header:
                 head = ["Time"]
                 head.extend(self.yticksNames)
                 writer.writerow(head)
             writer.writerows(zipped)
-        
+
     def drawR(self):
         ycsv = []
         xcsv = []
@@ -799,7 +799,7 @@ class TplotFrame(wx.Frame):
         if (os.path.exists(self.csvpath) and not self.overwrite):
             dlg = wx.MessageDialog(self, _("{pa} already exists, do you want "
                                    "to overwrite?".format(pa=self.csvpath)),
-                                   _("File exists"), 
+                                   _("File exists"),
                                    wx.OK | wx.CANCEL | wx.ICON_QUESTION)
             if dlg.ShowModal() != wx.ID_OK:
                 dlg.Destroy()


### PR DESCRIPTION
I got this error when I use csv option:

```
env LC_ALL=en_US.UTF-8 g.gui.tplot strds=beam coordinates=1979128,5189251 csv=/tmp/out.csv --quiet --overwrite
21:05:07: Debug: Adding duplicate image handler for 'Windows bitmap file'
Traceback (most recent call last):
  File "/usr/local/grass78/scripts/g.gui.tplot", line 174, in <module>
    main()
  File "/usr/local/grass78/scripts/g.gui.tplot", line 161, in main
    ylabel, csvfile, flags['h'], gscript .overwrite)
  File "/usr/local/grass78/gui/wxpython/tplot/frame.py", line 1018, in SetDatasets
    self._redraw()
  File "/usr/local/grass78/gui/wxpython/tplot/frame.py", line 898, in _redraw
    self._drawFigure()
  File "/usr/local/grass78/gui/wxpython/tplot/frame.py", line 621, in _drawFigure
    self.drawR()
  File "/usr/local/grass78/gui/wxpython/tplot/frame.py", line 695, in drawR
    self._writeCSV(xcsv, ycsv)
  File "/usr/local/grass78/gui/wxpython/tplot/frame.py", line 660, in _writeCSV
    writer.writerows(zipped)
TypeError: a bytes-like object is required, not 'str'
```

Replace "wb" by "w" fix the issue.
Maybe, it's forgetfulness in the conversion of the code to python3.
