### PR TITLE
render: Fix .legrow file existence check

### DIFF
--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -1375,7 +1375,8 @@ class Map(object):
                     os.remove(f)
 
             if layer.GetType() in ('vector', 'thememap'):
-                os.remove(layer._legrow)
+                if os.path.isfile(layer._legrow):
+                    os.remove(layer._legrow)
 
             list.remove(layer)
 


### PR DESCRIPTION
To reproduce:

1. Launch GRASS GIS with **nc_basic_spm_grass7** location, PERMANENT mapset
1. Add **railroads** vector map
2. Open **Vector network analysis tool dialog**
3. Choose vnet tool (**Shortest path (v.net.path)** item from the ComboBox widget)
4. Switch to the **Points page** (tab)
5. Click on the toolbar icon **Activate snapping to nodes** (right arrow icon)
6. Select point **Start point** item from the list (click on the item)
7. Click on the toolbar icon **Insert point from Map Display** (mouse pointer icon)
8. On the Map Display window, left click near to the line (find line which is not connected to the network (**Start point**)). Snap **End point** to the line which is connected to the network (according points on the image bellow) 
9. Execute analysis (play button) 

![vnet_points](https://user-images.githubusercontent.com/50632337/83609440-9a375000-a57e-11ea-8e14-e3151684ca42.png)

Error message:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/vnet/dialogs.py",
line 908, in OnAnalyze

ret = self.vnet_mgr.RunAnalysis()
  File "/usr/lib64/grass79/gui/wxpython/vnet/vnet_core.py",
line 121, in RunAnalysis

self.results["vect_map"].DeleteRenderLayer()
  File "/usr/lib64/grass79/gui/wxpython/vnet/vnet_data.py",
line 1102, in DeleteRenderLayer

self.mapWin.Map.DeleteLayer(self.renderLayer)
  File "/usr/lib64/grass79/gui/wxpython/core/render.py",
line 1379, in DeleteLayer

os.remove(layer._legrow)
FileNotFoundError
:
[Errno 2] No such file or directory:
'/tmp/grass7-tomas-4282/tmp1wcvy_0h.legrow'
```
