### PR TITLE
wxGUI d.histogram: Set default font

### DIFF
--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -241,7 +241,7 @@ class BufferedWindow(wx.Window):
         if "GRASS_ENCODING" in os.environ:
             self._oldencoding = os.environ["GRASS_ENCODING"]
         if self.parent.encoding is not None and self.parent.encoding != "ISO-8859-1":
-            os.environ[GRASS_ENCODING] = self.parent.encoding
+            os.environ["GRASS_ENCODING"] = self.parent.encoding
 
         # using active comp region
         self.Map.GetRegion(update=True)

--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -24,6 +24,7 @@ import wx
 
 from core import globalvar
 from core.render import Map
+from core.settings import UserSettings
 from gui_core.forms import GUI
 from mapdisp.gprint import PrintOptions
 from core.utils import GetLayerNameFromCmd
@@ -227,10 +228,10 @@ class BufferedWindow(wx.Window):
         Debug.msg(
             2, "BufferedWindow.UpdateHist(%s): render=%s" %
             (img, self.render))
-        
+
         if not self.render:
             return
-        
+
         # render new map images
         # set default font and encoding environmental variables
         if "GRASS_FONT" in os.environ:
@@ -318,7 +319,15 @@ class HistogramFrame(wx.Frame):
         self.params = {}  # previously set histogram parameters
         self.propwin = ''  # ID of properties dialog
 
-        self.font = ""
+        # Default font
+        font_properties = UserSettings.Get(
+            group='histogram', key='font', settings_type='default')
+        self.font = wx.Font(
+            font_properties['defaultSize'],
+            font_properties['family'],
+            font_properties['style'],
+            font_properties['weight'],
+        ).GetFaceName().lower()
         self.encoding = 'ISO-8859-1'  # default encoding for display fonts
 
         self.toolbar = HistogramToolbar(parent=self)


### PR DESCRIPTION
Default behavior (requires select font):

![d_histogram_def](https://user-images.githubusercontent.com/50632337/83870859-4455da00-a72f-11ea-9dde-8b02697b2a17.png)

Expected (with default font):

![d_histogram_exp](https://user-images.githubusercontent.com/50632337/83870903-546db980-a72f-11ea-93aa-83bffc29dbf7.png)

Another fix:

1. On the wxGUI d.histogram dialog,  click on the select font toolbar icon
2. From the font settings select another font and click on the Ok button

Error message:

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/modules/histogram.py", line
474, in SetHistFont

self.HistWindow.UpdateHist()
  File
"/usr/lib64/grass79/gui/wxpython/modules/histogram.py", line
251, in UpdateHist

os.environ[GRASS_ENCODING] = self.parent.encoding
NameError
:
name 'GRASS_ENCODING' is not defined
```