### PR TITLE
wxGUI: fix RunCommand to decode also empty string to return unicode

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -716,7 +716,9 @@ def RunCommand(prog, flags="", overwrite=False, quiet=False,
         ps.stdin.close()
         ps.stdin = None
 
-    stdout, stderr = [decode(out) for out in ps.communicate()]
+    stdout, stderr = ps.communicate()
+    stderr = decode(stderr)
+    stdout = decode(stdout) if read else stdout
 
     if parent:  # restore previous settings
         os.environ['GRASS_MESSAGE_FORMAT'] = messageFormat

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -716,7 +716,7 @@ def RunCommand(prog, flags="", overwrite=False, quiet=False,
         ps.stdin.close()
         ps.stdin = None
 
-    stdout, stderr = list(map(DecodeString, ps.communicate()))
+    stdout, stderr = [decode(out) for out in ps.communicate()]
 
     if parent:  # restore previous settings
         os.environ['GRASS_MESSAGE_FORMAT'] = messageFormat


### PR DESCRIPTION
* use decode from python scripting library
* fixes TypeError generated in loc wizard when changing page from epsg code to summary