### PR TITLE
wxgui: Create grassdata automatically on the first GUI startup 

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -39,7 +39,7 @@ from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
     get_lockfile_if_present, get_possible_database_path, 
-    create_possible_database_path, create_mapset)
+    create_database_directory, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog
 import startup.guiutils as sgui
@@ -508,9 +508,9 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
-        # If nothing found, create GRASS directory
+        # If nothing found, try to create GRASS directory
         if path is None:
-            path = create_possible_database_path()
+            path = create_database_directory()
 
         if path:
             try:
@@ -534,7 +534,6 @@ class GRASSStartup(wx.Frame):
                 'A popular choice is "grassdata", located in '
                 'your home directory. '
                 'Press Browse button to select the directory.'))
-
 
     def OnWizard(self, event):
         """Location wizard started"""

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -511,17 +511,30 @@ class GRASSStartup(wx.Frame):
         # If nothing found, create GRASS directory
         if path is None:
             path = create_possible_database_path()
-        try:
-            self.tgisdbase.SetValue(path)
-        except UnicodeDecodeError:
-            # restore previous state
-            # wizard gives error in this case, we just ignore
-            path = None
-            self.tgisdbase.SetValue(self.gisdbase)
-        # if we still have path
+
         if path:
-            self.gisdbase = path
-            self.OnSetDatabase(None)
+            try:
+                self.tgisdbase.SetValue(path)
+            except UnicodeDecodeError:
+                # restore previous state
+                # wizard gives error in this case, we just ignore
+                path = None
+                self.tgisdbase.SetValue(self.gisdbase)
+            # if we still have path
+            if path:
+                self.gisdbase = path
+                self.OnSetDatabase(None)
+        else:
+            # nothing found
+            # TODO: should it be warning, hint or message?
+            self._showWarning(_(
+                'GRASS needs a directory (GRASS database) '
+                'in which to store its data. '
+                'Create one now if you have not already done so. '
+                'A popular choice is "grassdata", located in '
+                'your home directory. '
+                'Press Browse button to select the directory.'))
+
 
     def OnWizard(self, event):
         """Location wizard started"""

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,7 +38,8 @@ import wx.lib.mixins.listctrl as listmix
 from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
-    get_lockfile_if_present, get_possible_database_path, create_mapset)
+    get_lockfile_if_present, get_possible_database_path, 
+    create_possible_database_path, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog
 import startup.guiutils as sgui
@@ -507,28 +508,20 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
+        # If nothing found, create GRASS directory
+        if path is None:
+            path = create_possible_database_path()
+        try:
+            self.tgisdbase.SetValue(path)
+        except UnicodeDecodeError:
+            # restore previous state
+            # wizard gives error in this case, we just ignore
+            path = None
+            self.tgisdbase.SetValue(self.gisdbase)
+        # if we still have path
         if path:
-            try:
-                self.tgisdbase.SetValue(path)
-            except UnicodeDecodeError:
-                # restore previous state
-                # wizard gives error in this case, we just ignore
-                path = None
-                self.tgisdbase.SetValue(self.gisdbase)
-            # if we still have path
-            if path:
-                self.gisdbase = path
-                self.OnSetDatabase(None)
-        else:
-            # nothing found
-            # TODO: should it be warning, hint or message?
-            self._showWarning(_(
-                'GRASS needs a directory (GRASS database) '
-                'in which to store its data. '
-                'Create one now if you have not already done so. '
-                'A popular choice is "grassdata", located in '
-                'your home directory. '
-                'Press Browse button to select the directory.'))
+            self.gisdbase = path
+            self.OnSetDatabase(None)
 
     def OnWizard(self, event):
         """Location wizard started"""

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,7 +38,7 @@ import wx.lib.mixins.listctrl as listmix
 from core.gcmd import GMessage, GError, DecodeString, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
-    get_lockfile_if_present, get_possible_database_path, 
+    get_lockfile_if_present, get_possible_database_path,
     create_database_directory, create_mapset)
 import startup.utils as sutils
 from startup.guiutils import SetSessionMapset, NewMapsetDialog

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -58,57 +58,49 @@ def get_possible_database_path():
     return path
 
 
-def create_possible_database_path():
-    """Create the standard GRASS GIS directory.
+def create_database_directory():
+    """Creates the standard GRASS GIS directory.
 
-    Create directory named grassdata in the standard location according to the platform.  
+    Creates database directory named grassdata in the standard location 
+    according to the platform.  
     
     Returns the new path as a string or None if nothing was found or created.
     """
     home = os.path.expanduser('~')   
     candidates = []       
-    
-    # Candidate for independent "grassdata" in for Linux and macOS
+   
+    # Candidate for case independent "grassdata" for Linux and macOS
     if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-        candidates.append(os.path.join(home, "grassdata"))
-    
-    # Candidates for independent "grassdata" in other dirs (Windows)
+        candidates.append(os.path.join(home, "grassdata"))   
+    # Candidates for case independent "grassdata" in other dirs (Windows)
     else:  
         candidates.append(os.path.join(home, "Documents", "grassdata"))
         
-        try:
-            # here goes everything which has potential unicode issues
-            candidates.append(os.path.join(home, _("Documents"), "grassdata"))
-        except UnicodeDecodeError:
-            # just ignore the errors if it doesn't work
-            pass
-    
     # Create "grassdata" directory           
     for candidate in candidates:                
         try:
             os.mkdir(candidate)
-            path = candidate
-            return path
+            return candidate
         except OSError:
             pass
     
-    # Temporary "grassdata" directory       
-    tmp = os.path.join(tempfile.gettempdir(),
-                               "grassdata_{}".format(getpass.getuser())) 
+    # Temporary "grassdata" directory     
+    tmp = os.path.join(
+        tempfile.gettempdir(),
+        "grassdata_{}".format(getpass.getuser())
+    ) 
     
-    # Control if exists, if does not, create it
+    # Check if exists, if does not, create it
     if os.path.exists(tmp):
-        path = tmp
-        return path
+        return tmp
     else:
         try:
             os.mkdir(tmp)
-            path = tmp
+            return tmp
         except OSError:
             pass
         
-    return path                
-
+    return None
 
 def get_lockfile_if_present(database, location, mapset):
     """Return path to lock if present, None otherwise

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -66,25 +66,23 @@ def create_database_directory():
     
     Returns the new path as a string or None if nothing was found or created.
     """
-    home = os.path.expanduser('~')   
-    candidates = []       
+    home = os.path.expanduser('~')
    
     # Candidate for case independent "grassdata" for Linux and macOS
     if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-        candidates.append(os.path.join(home, "grassdata"))   
+        candidate = os.path.join(home, "grassdata")
     # Candidates for case independent "grassdata" in other dirs (Windows)
     else:  
-        candidates.append(os.path.join(home, "Documents", "grassdata"))
+        candidate = os.path.join(home, "Documents", "grassdata")
         
-    # Create "grassdata" directory           
-    for candidate in candidates:                
-        try:
-            os.mkdir(candidate)
-            return candidate
-        except OSError:
-            pass
+    # Create "grassdata" directory   
+    try:
+        os.mkdir(candidate)
+        return candidate
+    except OSError:
+        pass
     
-    # Temporary "grassdata" directory     
+    # Temporary "grassdata" directory   
     tmp = os.path.join(
         tempfile.gettempdir(),
         "grassdata_{}".format(getpass.getuser())
@@ -92,13 +90,12 @@ def create_database_directory():
     
     # Check if exists, if does not, create it
     if os.path.exists(tmp):
+        return tmp       
+    try:
+        os.mkdir(tmp)
         return tmp
-    else:
-        try:
-            os.mkdir(tmp)
-            return tmp
-        except OSError:
-            pass
+    except OSError:
+        pass
         
     return None
 

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -66,23 +66,25 @@ def create_database_directory():
     
     Returns the new path as a string or None if nothing was found or created.
     """
-    home = os.path.expanduser('~')
+    home = os.path.expanduser('~')   
+    candidates = []       
    
     # Candidate for case independent "grassdata" for Linux and macOS
     if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-        candidate = os.path.join(home, "grassdata")
+        candidates.append(os.path.join(home, "grassdata"))   
     # Candidates for case independent "grassdata" in other dirs (Windows)
     else:  
-        candidate = os.path.join(home, "Documents", "grassdata")
+        candidates.append(os.path.join(home, "Documents", "grassdata"))
         
-    # Create "grassdata" directory   
-    try:
-        os.mkdir(candidate)
-        return candidate
-    except OSError:
-        pass
+    # Create "grassdata" directory           
+    for candidate in candidates:                
+        try:
+            os.mkdir(candidate)
+            return candidate
+        except OSError:
+            pass
     
-    # Temporary "grassdata" directory   
+    # Temporary "grassdata" directory     
     tmp = os.path.join(
         tempfile.gettempdir(),
         "grassdata_{}".format(getpass.getuser())
@@ -90,12 +92,13 @@ def create_database_directory():
     
     # Check if exists, if does not, create it
     if os.path.exists(tmp):
-        return tmp       
-    try:
-        os.mkdir(tmp)
         return tmp
-    except OSError:
-        pass
+    else:
+        try:
+            os.mkdir(tmp)
+            return tmp
+        except OSError:
+            pass
         
     return None
 

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -18,6 +18,9 @@ solve the errors etc. in a general manner).
 
 import os
 import shutil
+import tempfile
+import getpass
+import sys
 
 
 def get_possible_database_path():
@@ -52,6 +55,54 @@ def get_possible_database_path():
         if os.path.exists(candidate):
             path = candidate
             break  # get the first match
+    return path
+
+
+def create_possible_database_path():
+    """Create the directory to what is possibly a GRASS Database.
+
+    Create directory named grassdata in the usual locations.   
+    
+    Returns the new path as a string.  
+    """
+    home = os.path.expanduser('~') 
+    tmp = os.path.join(tempfile.gettempdir(),
+                               "grassdata_{}".format(getpass.getuser()))           
+    
+    # Create independent "grassdata" in the home Linux dir
+    if sys.platform.startswith('linux'):
+        try:
+            path = os.path.join(home, "grassdata")
+            os.mkdir(path)
+        except OSError: 
+            print ("Creation of the directory {} failed".format(path))
+    
+    # Create independent "grassdata" in other dirs (Windows and Mac)
+    else:  
+        candidates = [
+            os.path.join(home, "Documents", "grassdata"),
+            os.path.join(home, "My Documents", "grassdata")
+        ]
+        
+        try:
+            # here goes everything which has potential unicode issues
+            candidates.append(os.path.join(home, _("Documents"), "grassdata"))
+            candidates.append(os.path.join(home, _("My Documents"), "grassdata"))
+        except:
+            # just ignore the errors if it doesn't work
+            pass
+                
+            for candidate in candidates:                
+                try:
+                    os.mkdir(candidate)
+                    path = candidate
+                except OSError:
+                    print ("Creation of the directory {} failed".format(candidate))
+                        
+    # If still doesn't exist, create "grassdata_username" dir in temp           
+    if path is None:        
+            os.mkdir(tmp)
+            path = tmp            
     return path
 
 

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -66,24 +66,22 @@ def create_database_directory():
     
     Returns the new path as a string or None if nothing was found or created.
     """
-    home = os.path.expanduser('~')   
-    candidates = []       
+    home = os.path.expanduser('~')     
    
     # Candidate for case independent "grassdata" for Linux and macOS
     if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-        candidates.append(os.path.join(home, "grassdata"))   
+        candidate = os.path.join(home, "grassdata")
     # Candidates for case independent "grassdata" in other dirs (Windows)
     else:  
-        candidates.append(os.path.join(home, "Documents", "grassdata"))
+        candidate = os.path.join(home, "Documents", "grassdata")
         
-    # Create "grassdata" directory           
-    for candidate in candidates:                
-        try:
-            os.mkdir(candidate)
-            return candidate
-        except OSError:
-            pass
-    
+    # Create "grassdata" directory                          
+    try:
+        os.mkdir(candidate)
+        return candidate
+    except OSError:
+        pass
+
     # Temporary "grassdata" directory     
     tmp = os.path.join(
         tempfile.gettempdir(),
@@ -93,12 +91,11 @@ def create_database_directory():
     # Check if exists, if does not, create it
     if os.path.exists(tmp):
         return tmp
-    else:
-        try:
-            os.mkdir(tmp)
-            return tmp
-        except OSError:
-            pass
+    try:
+        os.mkdir(tmp)
+        return tmp
+    except OSError:
+        pass
         
     return None
 

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -69,10 +69,10 @@ def create_database_directory():
     home = os.path.expanduser('~')
 
     # Determine the standard path according to the platform
-    if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-        path = os.path.join(home, "grassdata")
-    else:
+    if sys.platform == 'win32':
         path = os.path.join(home, "Documents", "grassdata")
+    else:
+        path = os.path.join(home, "grassdata")
 
     # Create "grassdata" directory
     try:

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -62,41 +62,47 @@ def create_database_directory():
     """Creates the standard GRASS GIS directory.
 
     Creates database directory named grassdata in the standard location 
-    according to the platform.  
-    
+    according to the platform.
+
     Returns the new path as a string or None if nothing was found or created.
     """
-    home = os.path.expanduser('~')     
-   
-    # Candidate for case independent "grassdata" for Linux and macOS
+    home = os.path.expanduser('~')
+
+    # Determine the standard path according to the platform
     if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
-        candidate = os.path.join(home, "grassdata")
-    # Candidates for case independent "grassdata" in other dirs (Windows)
-    else:  
-        candidate = os.path.join(home, "Documents", "grassdata")
-        
-    # Create "grassdata" directory                          
+        path = os.path.join(home, "grassdata")
+    else:
+        path = os.path.join(home, "Documents", "grassdata")
+
+    # Create "grassdata" directory
     try:
-        os.mkdir(candidate)
-        return candidate
+        os.mkdir(path)
+        return path
     except OSError:
         pass
 
-    # Temporary "grassdata" directory     
-    tmp = os.path.join(
+    # Create a temporary "grassdata" directory if GRASS is running
+    # in some special environment and the standard directories
+    # cannot be created which might be the case in some "try out GRASS"
+    # use cases.
+    path = os.path.join(
         tempfile.gettempdir(),
         "grassdata_{}".format(getpass.getuser())
-    ) 
-    
-    # Check if exists, if does not, create it
-    if os.path.exists(tmp):
-        return tmp
+    )
+
+    # The created tmp is not cleaned by GRASS, so we are relying on
+    # the system to do it at some point. The positive outcome is that
+    # another GRASS instance will find the data created by the first
+    # one which is desired in the "try out GRASS" use case we are
+    # aiming towards."
+    if os.path.exists(path):
+        return path
     try:
-        os.mkdir(tmp)
-        return tmp
+        os.mkdir(path)
+        return path
     except OSError:
         pass
-        
+
     return None
 
 def get_lockfile_if_present(database, location, mapset):


### PR DESCRIPTION
After starting GRASS GIS with GUI, the GUI now searches for existing grassdata (e.g., dac6d4a and #644 with #664). If nothing is found, GRASS GIS (GUI) should automatically create directory named grassdata as a subdirectory of a platfrom-dependent directory. This platfrom-dependent directory would be:

- $HOME (os.path.expanduser('~')) on Linux and the like,
- User's Documents on Windows (see dac6d4a for code trying to identify that dir),
 - One of the above on macOS - macOS users, please share your ideas.

If that fails (GRASS is running in some special environment and the standard directories cannot be created which might be the case in some "try out GRASS" use cases) it should use a temporary directory (/tmp/... etc.) as a fallback. 
The created tmp is not cleaned by GRASS, so we are relying on the system to do it at some point. 