### PR TITLE
wxGUI rdigit: Update list of available raster map layers, when map layers tree changed

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -2154,11 +2154,21 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         self.SetLayerInfo(item, key='maplayer', value=maplayer)
 
-        # if digitization tool enabled -> update list of available vector map
-        # layers
+        # if vector digitization tool enabled -> update list of
+        # available vector map layers
         if self.mapdisplay.GetToolbar('vdigit'):
             self.mapdisplay.GetToolbar(
                 'vdigit').UpdateListOfLayers(updateTool=True)
+
+        # if raster digitization tool enabled -> update list of
+        # available raster map layers
+        if self.mapdisplay.GetToolbar('rdigit'):
+            rasters = self.GetMap().GetListOfLayers(
+                ltype='raster', mapset=grass.gisenv()['MAPSET'])
+            self.mapdisplay.GetToolbar(
+                'rdigit').UpdateRasterLayers(rasters)
+            self.mapdisplay.GetToolbar(
+                'rdigit').SelectDefault()
 
         self.Map.SetLayers(self.GetVisibleLayers())
 


### PR DESCRIPTION
Default behavior:

![rdigit_def](https://user-images.githubusercontent.com/50632337/84626097-cfc82b80-aee4-11ea-8f49-129a2e119392.gif)

Expected behavior:

![rdigit_exp](https://user-images.githubusercontent.com/50632337/84626335-2e8da500-aee5-11ea-983b-dd8df1f68989.gif)

Additional info:

Add raster map layer via calling `d.vect map=elevation` from wxGUI Console page, update list of available raster map layers.