### PR TITLE
wxGUI vdigit: Update list of available vector map layers, when map layers tree changed

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -315,6 +315,7 @@ class MapFrame(SingleMapFrame):
                 MapWindow=self.MapWindow, digitClass=VDigit,
                 giface=self._giface)
             self.toolbars['vdigit'].quitDigitizer.connect(self.QuitVDigit)
+            self.Map.layerAdded.connect(self._updateVDigitLayers)
         self.MapWindowVDigit.SetToolbar(self.toolbars['vdigit'])
 
         self._mgr.AddPane(self.toolbars['vdigit'],
@@ -331,6 +332,11 @@ class MapFrame(SingleMapFrame):
         self.MapWindow.pen = wx.Pen(colour='red', width=2, style=wx.SOLID)
         self.MapWindow.polypen = wx.Pen(
             colour='green', width=2, style=wx.SOLID)
+
+    def _updateVDigitLayers(self, layer):
+        """Update vdigit layers"""
+        if 'vdigit' in self.toolbars:
+            self.toolbars['vdigit'].UpdateListOfLayers(updateTool=True)
 
     def AddNviz(self):
         """Add 3D view mode window


### PR DESCRIPTION
Update list of available vector map layers, when map layers tree changed (launch 
`d.vect map=mapname` from wxGUI Layer manager Console page).

Default behavior:

![vdigit_def](https://user-images.githubusercontent.com/50632337/84658512-4b8e9c00-af16-11ea-8544-31298e408c5e.gif)

Expected behavior:

![vdigit_exp](https://user-images.githubusercontent.com/50632337/84655155-b937c980-af10-11ea-8149-3d4804e4e0e0.gif)

Additional info:

Add vector map layer via `d.vect` wxGUI module dialog, update list of available vector map layers.