### PR TITLE
change alpine docker to alpine version 3.12

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -1,5 +1,5 @@
-FROM mundialis/docker-pdal:1.8.0 as pdal
-FROM alpine:3.11 as common
+FROM mundialis/docker-pdal:2.1.0 as pdal
+FROM alpine:3.12 as common
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile
@@ -71,7 +71,6 @@ RUN echo "Install main packages";\
     apk add --no-cache $PACKAGES
 
 COPY --from=pdal /usr/bin/pdal* /usr/bin/
-COPY --from=pdal /usr/lib/pdal /usr/lib/pdal
 COPY --from=pdal /usr/lib/libpdal* /usr/lib/
 COPY --from=pdal /usr/lib/pkgconfig/pdal.pc /usr/lib/pkgconfig/pdal.pc
 COPY --from=pdal /usr/include/pdal /usr/include/pdal


### PR DESCRIPTION
There is a new alpine version 3.12 (https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases).
Depends on https://github.com/mundialis/docker-pdal/pull/2.