### PR TITLE
d.rast.edit: Remove 'wxversion' module

### DIFF
--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -34,6 +34,8 @@ from grass.script.core import get_commands
 
 from core.debug import Debug
 
+WXPY3_MIN_VERSION = [4, 0, 0, 0]
+
 
 def parse_version_string(version):
     """Parse version number, return three numbers as list
@@ -88,43 +90,23 @@ def CheckWxVersion(version):
     return True
 
 
-def CheckForWx(forceVersion=os.getenv('GRASS_WXVERSION', None)):
-    """Try to import wx module and check its version
-
-    :param forceVersion: force wxPython version, eg. '2.8'
-    """
+def CheckForWx():
+    """Try to import wx module"""
     if 'wx' in sys.modules.keys():
         return
 
-    minVersion = [2, 8, 10, 1]
     try:
-        try:
-            # Note that Phoenix doesn't have wxversion anymore
-            import wxversion
-        except ImportError as e:
-            # if there is no wx raises ImportError
-            import wx
-            return
-        if forceVersion:
-            wxversion.select(forceVersion)
-        wxversion.ensureMinimal(str(minVersion[0]) + '.' + str(minVersion[1]))
-        import wx  # noqa: F811
+        import wx
         version = parse_version_string(wx.__version__)
-
-        if version < minVersion:
+        if version < WXPY3_MIN_VERSION:
             raise ValueError(
                 "Your wxPython version is {}".format(wx.__version__))
-
+        return
     except ImportError as e:
-        print('ERROR: wxGUI requires wxPython. %s' % str(e),
+        print('ERROR: wxGUI requires wxPython. {}'.format(e),
               file=sys.stderr)
         print('You can still use GRASS GIS modules in'
               ' the command line or in Python.', file=sys.stderr)
-        sys.exit(1)
-    except (ValueError, wxversion.VersionError) as e:
-        message = "ERROR: wxGUI requires wxPython >= {version}: {error}".format(
-            version=version_as_string(minVersion), error=e)
-        print(message, file=sys.stderr)
         sys.exit(1)
     except locale.Error as e:
         print("Unable to set locale:", e, file=sys.stderr)
@@ -263,7 +245,7 @@ toolbarSize = (24, 24)
 
 """@Check version of wxPython, use agwStyle for 2.8.11+"""
 hasAgw = CheckWxVersion([2, 8, 11, 0])
-wxPython3 = CheckWxVersion([3, 0, 0, 0])
+wxPython3 = CheckWxVersion(WXPY3_MIN_VERSION)
 wxPythonPhoenix = CheckWxPhoenix()
 
 gtk3 = True if 'gtk3' in wx.PlatformInfo else False

--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -245,7 +245,6 @@ toolbarSize = (24, 24)
 
 """@Check version of wxPython, use agwStyle for 2.8.11+"""
 hasAgw = CheckWxVersion([2, 8, 11, 0])
-wxPython3 = CheckWxVersion(WXPY3_MIN_VERSION)
 wxPythonPhoenix = CheckWxPhoenix()
 
 gtk3 = True if 'gtk3' in wx.PlatformInfo else False

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -226,8 +226,7 @@ class MapFrame(SingleMapFrame):
 
         # create statusbar and its manager
         statusbar = self.CreateStatusBar(number=4, style=0)
-        if globalvar.wxPython3:
-            statusbar.SetMinHeight(24)
+        statusbar.SetMinHeight(24)
         statusbar.SetStatusWidths([-5, -2, -1, -1])
         self.statusbarManager = sb.SbManager(
             mapframe=self, statusbar=statusbar)

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -23,7 +23,6 @@ import grass.script as grass
 from gui_core.mapdisp import DoubleMapFrame
 from gui_core.dialogs import GetImageHandlers
 from mapwin.base import MapWindowProperties
-from core import globalvar
 from core.render import Map
 from mapdisp import statusbar as sb
 from core.debug import Debug
@@ -170,8 +169,7 @@ class SwipeMapFrame(DoubleMapFrame):
 
         # create statusbar and its manager
         statusbar = self.CreateStatusBar(number=4, style=0)
-        if globalvar.wxPython3:
-            statusbar.SetMinHeight(24)
+        statusbar.SetMinHeight(24)
         statusbar.SetStatusWidths([-5, -2, -1, -1])
         self.statusbarManager = sb.SbManager(
             mapframe=self, statusbar=statusbar)

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -80,10 +80,8 @@ import atexit
 import grass.script as grass
 
 try:
-    import wxversion
-    wxversion.select(['3.0', '2.8', '2.6'])
     import wx
-except Exception:
+except ImportError:
     # ensure that --help, --interface-description etc work even without wx
     if __name__ == "__main__":
         if len(sys.argv) == 2:

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -42,8 +42,6 @@ import numpy
 import time
 import signal
 
-import wxversion
-wxversion.select('2.8')
 import wx
 
 


### PR DESCRIPTION
To reproduce:

1. Launch `d.rast.edit` from terminal emulator.

Error message:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/scripts/d.rast.edit", line 83, in <module>
    import wxversion
ModuleNotFoundError: No module named 'wxversion
```
Additional info:

wxPython [wxversion module](https://docs.wxpython.org/MigrationGuide.html#the-wxversion-module)