### PR TITLE
wxGUI g.gui.animation: Fix wx.CheckBox widget deprecation warning

### DIFF
--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -42,8 +42,8 @@ from gui_core.forms import GUI
 from core.settings import UserSettings
 from gui_core.gselect import Select
 from gui_core.widgets import FloatValidator
-from gui_core.wrap import SpinCtrl, CheckBox, TextCtrl, Button, \
-    BitmapButton, StaticText, StaticBox, Choice, RadioButton, EmptyImage
+from gui_core.wrap import BitmapButton, Button, CheckBox, Choice, \
+    ComboBox, EmptyImage, RadioButton, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 from animation.utils import TemporalMode, getRegisteredMaps, getNameAndLayer, getCpuCount
 from animation.data import AnimationData, AnimLayer
@@ -2017,7 +2017,7 @@ class PreferencesDialog(PreferencesBaseDialog):
             pos=(
                 row,
                 0))
-        self.tempFormat = wx.ComboBox(parent=panel, name='GetValue')
+        self.tempFormat = ComboBox(parent=panel, name='GetValue')
         self.tempFormat.SetItems(self._timeFormats)
         self.tempFormat.SetValue(self._initFormat)
         self.winId['animation:temporal:format'] = self.tempFormat.GetId()


### PR DESCRIPTION
Warning message:

```
/usr/lib64/grass79/gui/wxpython/animation/dialogs.py:2035:
wxPyDeprecationWarning: Call to deprecated item. Use
SetToolTip instead.
  "Click and then press key up or down to preview "
```
