### PR TITLE
Add zsh terminal prompt support

### DIFF
--- a/general/g.mapset/main.c
+++ b/general/g.mapset/main.c
@@ -216,6 +216,11 @@ int main(int argc, char *argv[])
 				  "history -S; history -L %s/.history; setenv histfile=%s/.history"),
 				mapset_new_path, mapset_new_path);
 	}
+	else if (strstr(shell, "zsh")) {
+	    G_important_message(_("You can switch the history by commands:\n"
+				  "fc -W; fc -R %s/.zsh_history; HISTFILE=%s/.zsh_history"),
+				mapset_new_path, mapset_new_path);
+	}
     }
 
     G_verbose_message(_("Your current mapset is <%s>"), mapset_new);

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1900,10 +1900,21 @@ def csh_startup(location, location_name, mapset, grass_env_file):
     os.environ['HOME'] = userhome
     return process
 
+def shell_startup(location, location_name, grass_env_file, shell_name):
+    if shell_name not in ['bash', 'zsh']:
+        raise ValueError('Only bash and zsh are supported by shell_startup()')
 
-def bash_startup(location, location_name, grass_env_file):
+    if shell_name == 'zsh':
+        sh_history = ".zsh_history"
+        shrc = ".zshrc"
+        grass_shrc = ".grass.zshrc"
+    else:
+        sh_history = ".bash_history"
+        shrc = ".bashrc"
+        grass_shrc = ".grass.bashrc"
+
     # save command history in mapset dir and remember more
-    os.environ['HISTFILE'] = os.path.join(location, ".bash_history")
+    os.environ['HISTFILE'] = os.path.join(location, sh_history)
     if not os.getenv('HISTSIZE') and not os.getenv('HISTFILESIZE'):
         os.environ['HISTSIZE'] = "3000"
 
@@ -1915,23 +1926,42 @@ def bash_startup(location, location_name, grass_env_file):
     home = location                   # save .bashrc in $LOCATION
     os.environ['HOME'] = home
 
-    bashrc = os.path.join(home, ".bashrc")
-    try_remove(bashrc)
+    shell_rc_file = os.path.join(home, shrc)
+    try_remove(shell_rc_file)
 
-    f = open(bashrc, 'w')
-    f.write("test -r ~/.alias && . ~/.alias\n")
+    f = open(shell_rc_file, 'w')
+    
+    if shell_name == 'zsh':
+        f.write('test -r {home}/.alias && source {home}/.alias\n'.format(
+            home=userhome))
+    else:
+        f.write("test -r ~/.alias && . ~/.alias\n")
 
     if os.getenv('ISISROOT'):
         # GRASS GIS and ISIS blend
         grass_name = "ISIS-GRASS"
     else:
         grass_name = "GRASS"
-    f.write("PS1='{name} {version} ({location}):\\w > '\n".format(
-        name=grass_name, version=GRASS_VERSION, location=location_name))
+        
+    if shell_name == 'zsh':
+        f.write("setopt PROMPT_SUBST\n")
+        f.write("PS1='{name} {version} : %1~ > '\n".format(
+            name=grass_name, version=GRASS_VERSION))
+    else:
+        f.write("PS1='{name} {version} ({location}):\\w > '\n".format(
+            name=grass_name, version=GRASS_VERSION, location=location_name))
 
     # TODO: have a function and/or module to test this
     mask2d_test = 'test -f "$MAPSET_PATH/cell/MASK"'
     mask3d_test = 'test -d "$MAPSET_PATH/grid3/RASTER3D_MASK"'
+
+    zsh_addition = ""
+    if shell_name == 'zsh':
+        zsh_addition = """
+    local z_lo=`g.gisenv get=LOCATION_NAME`
+    local z_ms=`g.gisenv get=MAPSET`
+    ZLOC="Mapset <$z_ms> in <$z_lo>"
+    """
 
     # double curly brackets means single one for format function
     # setting LOCATION for backwards compatibility
@@ -1939,20 +1969,26 @@ def bash_startup(location, location_name, grass_env_file):
         """grass_prompt() {{
     MAPSET_PATH="`g.gisenv get=GISDBASE,LOCATION_NAME,MAPSET separator='/'`"
     LOCATION="$MAPSET_PATH"
+    {zsh_addition}
     if {mask2d_test} && {mask3d_test} ; then
-        echo [{both_masks}]
+        echo "[{both_masks}]"
     elif {mask2d_test} ; then
-        echo [{mask2d}]
+        echo "[{mask2d}]"
     elif {mask3d_test} ; then
-        echo [{mask3d}]
+        echo "[{mask3d}]"
     fi
 }}
 PROMPT_COMMAND=grass_prompt\n""".format(
             both_masks=_("2D and 3D raster MASKs present"),
             mask2d=_("Raster MASK present"),
             mask3d=_("3D raster MASK present"),
-            mask2d_test=mask2d_test, mask3d_test=mask3d_test
+            mask2d_test=mask2d_test, mask3d_test=mask3d_test,
+            zsh_addition=zsh_addition
             ))
+
+    if shell_name == 'zsh':
+        f.write('precmd() { eval "$PROMPT_COMMAND" }\n')
+        f.write('RPROMPT=\'${ZLOC}\'\n')
 
     # this line was moved here from below .grass.bashrc to allow ~ and $HOME in
     # .grass.bashrc
@@ -1960,7 +1996,7 @@ PROMPT_COMMAND=grass_prompt\n""".format(
 
     # read other settings (aliases, ...) since environmental variables
     # have been already set by load_env(), see #3462
-    for env_file in [os.path.join(userhome, ".grass.bashrc"),
+    for env_file in [os.path.join(userhome, grass_shrc),
                      grass_env_file]:
         if not os.access(env_file, os.R_OK):
             continue
@@ -1971,12 +2007,14 @@ PROMPT_COMMAND=grass_prompt\n""".format(
                 f.write(line + '\n')
 
     f.write("export PATH=\"%s\"\n" % os.getenv('PATH'))
+    # fix trac issue #3009 https://trac.osgeo.org/grass/ticket/3009
+    # re: failure to "Quit GRASS" from GUI
+    f.write("trap \"exit\" TERM\n")
     f.close()
 
     process = Popen([gpath("etc", "run"), os.getenv('SHELL')])
     os.environ['HOME'] = userhome
     return process
-
 
 def default_startup(location, location_name):
     if WINDOWS:
@@ -2404,10 +2442,16 @@ def main():
                                         mapset_settings.location,
                                         mapset_settings.mapset,
                                         grass_env_file)
+        elif sh in ['zsh']:
+            shell_process = shell_startup(mapset_settings.full_mapset,
+                                          mapset_settings.location,
+                                          grass_env_file,
+                                          "zsh")
         elif sh in ['bash', 'msh', 'cygwin']:
-            shell_process = bash_startup(mapset_settings.full_mapset,
-                                         mapset_settings.location,
-                                         grass_env_file)
+            shell_process = shell_startup(mapset_settings.full_mapset,
+                                          mapset_settings.location,
+                                          grass_env_file,
+                                          "bash")
         else:
             shell_process = default_startup(mapset_settings.full_mapset,
                                             mapset_settings.location)


### PR DESCRIPTION
This addresses https://github.com/OSGeo/grass/issues/719, regarding missing GRASS specific terminal prompt with zsh.

The code is more-or-less a copy of `bash_startup()` with `bash` replaced with `zsh` at appropriate places and adopted `PS1` to zsh.

This seems to work as is, but `zsh_startup()` might be merged with `bash_startup()` using variables and I'm not familiar with every part of the code (and how to test it) – I therefore leave this as WIP.

For testing this PR : do `chsh -s $(which zsh)` and open new terminal.
