### PR TITLE
grass.script.utils.set_path: Fix parse two paths from string, and insert them in the sys.path separately (used by g.extension compilation process)

### DIFF
--- a/lib/python/script/utils.py
+++ b/lib/python/script/utils.py
@@ -455,8 +455,14 @@ def set_path(modulename, dirname=None, path='.'):
             pathname = os.path.join(modulename, dirname) if dirname else modulename
             raise ImportError("Not able to find the path '%s' directory "
                               "(current dir '%s')." % (pathname, os.getcwd()))
-
-        sys.path.insert(0, path)
+        # Two paths in one string 'module path:module libname path'
+        # Used by g.extension compilation process
+        if os.pathsep in path:
+            paths = path.split(os.pathsep)
+            sys.path.insert(0, paths[0])
+            sys.path.insert(0, paths[1])
+        else:
+            sys.path.insert(0, path)
 
 def clock():
     """


### PR DESCRIPTION
To reproduce:

1. `mkdir /tmp/test; cd /tmp/test`

2. `git clone -b fix_g_gui_metadata --single-branch https://github.com/tmszi/grass-addons.git`, check [PR](https://github.com/OSGeo/grass-addons/pull/222).

3. Install (fresh installation) `wx.metadata` addon but from local dir (downloaded in the previous step in `/tmp/test` dir): `g.extension operation=add extension=wx.metadata url=/tmp/test/grass-addons/grass7/gui/wxpython/wx.metadata`

Error message:

```
</home/tomas/grass-addons/grass7/gui/wxpython/wx.metadata> (be patient)...
Compiling...
Traceback (most recent call last):
  File "/tmp/grass7-tomas-18402/tmpkyio8kpk/wx.metadata/scripts/db.csw.admin", line 248, in <module>
    from mdlib.cswutil import *
ModuleNotFoundError: No module named 'mdlib'
make[1]: *** [/usr/lib64/grass79/include/Make/Html.make:14: db.csw.admin.tmp.html] Error 1
Traceback (most recent call last):
  File "/tmp/grass7-tomas-18402/tmpkyio8kpk/wx.metadata/scripts/g.gui.cswbrowser", line 22, in <module>
    from mdlib.cswlib import CSWBrowserPanel, CSWConnectionPanel
ModuleNotFoundError: No module named 'mdlib'
make[1]: *** [/usr/lib64/grass79/include/Make/Html.make:14: g.gui.cswbrowser.tmp.html] Error 1
Traceback (most recent call last):
  File "/tmp/grass7-tomas-18402/tmpkyio8kpk/wx.metadata/scripts/g.gui.metadata", line 44, in <module>
    from mdlib import mdgrass
ModuleNotFoundError: No module named 'mdlib'
```

`db.csw.admin.py` file:

```
from grass.script.utils import set_path

set_path(modulename='wx.metadata', dirname='mdlib')
from mdlib.cswutil import *
```

Debug info:

Inside [`set_path`](https://grass.osgeo.org/grass78/manuals/libpython/_modules/script/utils.html#set_path) function is called function [`get_lib_path(modname, libname=None)`](https://grass.osgeo.org/grass78/manuals/libpython/_modules/script/utils.html#get_lib_path), which return not single path string (in the case if `modulename='wx.metadata', libname='mdlib'`, but two paths separate with separator `os.pathsep`  -> `:` string).

'**module path:module libname path**'

`/tmp/grass7-tomas-23958/tmpluxbsogl/wx.metadata/etc/wx.metadata:/tmp/grass7-tomas-23958/tmpluxbsogl/wx.metadata/etc/wx.metadata/mdlib`

Call `sys.path.insert(0, path)` didn't  insert two paths (we need parse string first, and insert them separately)