### PR TITLE
fix Iterable import in pygrass/vector

### DIFF
--- a/lib/python/pygrass/vector/basic.py
+++ b/lib/python/pygrass/vector/basic.py
@@ -6,7 +6,7 @@ Created on Tue Jul 31 13:06:20 2012
 """
 import ctypes
 import grass.lib.vector as libvect
-from collections import Iterable
+from collections.abc import Iterable
 
 from grass.pygrass.shell.conversion import dict2html
 


### PR DESCRIPTION
Fix #733.
It seems that this import is only in vector/basic.py