### PR TITLE
Remove colouring of standard buttons

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -259,7 +259,6 @@ class GRASSStartup(wx.Frame):
         self.SetIcon(wx.Icon(os.path.join(globalvar.ICONDIR, "grass.ico"),
                              wx.BITMAP_TYPE_ICO))
 
-        self.bstart.SetForegroundColour(wx.Colour(35, 142, 35))
         self.bstart.SetToolTip(_("Enter GRASS session"))
         self.bstart.Enable(False)
         self.bmapset.Enable(False)

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -2368,7 +2368,6 @@ class QuitDialog(wx.Dialog):
         self.btnClose.SetFocus()
         self.btnQuit = Button(parent=self.panel, id=wx.ID_YES,
                                  label=_("Quit GRASS GIS"))
-        self.btnQuit.SetForegroundColour(wx.Colour(35, 142, 35))
 
         self.btnClose.Bind(wx.EVT_BUTTON, self.OnClose)
         self.btnQuit.Bind(wx.EVT_BUTTON, self.OnQuit)

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -611,7 +611,6 @@ class TaskFrame(wx.Frame):
                 parent=self.panel, id=wx.ID_OK, label=_("&Run"))
             self.btn_run.SetToolTip(_("Run the command (Ctrl+R)"))
             self.btn_run.SetDefault()
-            self.btn_run.SetForegroundColour(wx.Colour(35, 142, 35))
 
             btnsizer.Add(self.btn_run, proportion=0,
                          flag=wx.ALL | wx.ALIGN_CENTER,

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -250,7 +250,6 @@ class GRASSStartup(wx.Frame):
         self.SetIcon(wx.Icon(os.path.join(globalvar.ICONDIR, "grass.ico"),
                              wx.BITMAP_TYPE_ICO))
 
-        self.bstart.SetForegroundColour(wx.Colour(35, 142, 35))
         self.bstart.SetToolTip(_("Enter GRASS session"))
         self.bstart.Enable(False)
         self.bmapset.Enable(False)

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -156,7 +156,6 @@ class MapCalcFrame(wx.Frame):
             parent=self.panel,
             id=wx.ID_ANY,
             label=_("&Run"))
-        self.btn_run.SetForegroundColour(wx.Colour(35, 142, 35))
         self.btn_run.SetDefault()
         self.btn_close = Button(parent=self.panel, id=wx.ID_CLOSE)
         self.btn_save = Button(parent=self.panel, id=wx.ID_SAVE)


### PR DESCRIPTION
This PR removes the (green) colouring of standard buttons, which as of wxPython 4.1.0 has become a critical readability problem on macOS.

It is preferable to let the OS handle look and behaviour of standard buttons.

Fixes #743