### PR TITLE
wxGUI: Use system colours to enable dark mode support

### DIFF
--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -196,7 +196,8 @@ class CTreeView(AbstractTreeViewMixin, CustomTreeCtrl):
             kw[style] = CT.TR_HIDE_ROOT | CT.TR_FULL_ROW_HIGHLIGHT |\
                 CT.TR_HAS_BUTTONS | CT.TR_LINES_AT_ROOT | CT.TR_SINGLE
         super(CTreeView, self).__init__(parent=parent, model=model, **kw)
-        self.SetBackgroundColour("white")
+        self.SetBackgroundColour(
+            wx.SystemSettings().GetColour(wx.SYS_COLOUR_WINDOW))
         self.RefreshItems()
 
 

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -176,7 +176,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                 style=ctstyle,
                 **kwargs)
         self.SetName("LayerTree")
-        self.SetBackgroundColour("white")
+        self.SetBackgroundColour(
+            wx.SystemSettings().GetColour(wx.SYS_COLOUR_WINDOW))
 
         # SetAutoLayout() causes that no vertical scrollbar is displayed
         # when some layers are not visible in layer tree

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -600,13 +600,8 @@ class ItemList(ListCtrl,
         for column in columns:
             self.InsertColumn(i, column)
             i += 1
-        #
-        # add some attributes
-        #
-        self.attr1 = wx.ListItemAttr()
-        self.attr1.SetBackgroundColour(wx.Colour(238, 238, 238))
-        self.attr2 = wx.ListItemAttr()
-        self.attr2.SetBackgroundColour("white")
+        
+        self.EnableAlternateRowColours()
 
         if self.sourceData:
             self.Populate()
@@ -705,14 +700,6 @@ class ItemList(ListCtrl,
 
     def OnGetItemImage(self, item):
         return -1
-
-    def OnGetItemAttr(self, item):
-        """Get item attributes"""
-        index = self.itemIndexMap[item]
-        if (index % 2) == 0:
-            return self.attr2
-        else:
-            return self.attr1
 
     def SortItems(self, sorter=cmp):
         """Sort items"""


### PR DESCRIPTION
This PR enables dark mode support in the following places:

* Layer Manager > Layer Tree tab
* Layer Manager > Modules tab
* Location wizard

tested with `Python 3.8.3 + wxPython 4.0.7.post2` and `Python 3.7.3 + wxPython 4.1.0` under macOS.

(Update: dark mode is supported on mac starting only with wxPython 4.1, updated description above to reflect this.)