### PR TITLE
CI: Add GH Super Linter for a subset of secondary files

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,12 @@
+# GitHub Actions Workflows
+
+## GitHub Super Linter
+
+Run locally using Docker:
+
+```
+docker run --rm -e RUN_LOCAL=true -e VALIDATE_PERL=true -v $PWD:/tmp/lint github/super-linter
+```
+
+Note that you need to enable each validation separately or not specify
+any to enable all.

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,34 @@
+name: General linting
+
+on:
+- push
+- pull_request
+
+jobs:
+
+  super-linter:
+
+    name: GitHub Super Linter
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    -  name: Lint code base
+       uses: docker://github/super-linter:v2.2.2
+       env:
+         # Listed but disabled linters would be nice to have.
+         # Python (supported using Pylint) and C/C++ (not supported) are
+         # handled separately due to the complexity of the settings.
+         # (The rest is simply disabled automatically as of v2.)
+         VALIDATE_BASH: false
+         VALIDATE_CSS: false
+         VALIDATE_DOCKER: false
+         VALIDATE_JAVASCRIPT_ES: true
+         VALIDATE_JAVASCRIPT_STANDARD: false
+         VALIDATE_JSON: true
+         VALIDATE_MD: false
+         VALIDATE_PERL: false
+         VALIDATE_POWERSHELL: true
+         VALIDATE_XML: true
+         VALIDATE_YAML: true


### PR DESCRIPTION
This runs GitHub Super Linter for JSON, XML, and YAML. It also runs a basic JavaScript check

and PowerShell lint (for any future .ps1 files).

Bash, CSS, Docker, better JavaScript check, Markdown, and Perl are
included as disabled to be enabled later.
