### PR TITLE
wxGUI: use default output font dialog for macOS and wxPython >=4.0.6

### DIFF
--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -47,7 +47,7 @@ from core import globalvar
 from core.gcmd import RunCommand, GError
 from core.utils import ListOfMapsets, GetColorTables, ReadEpsgCodes
 from core.settings import UserSettings
-from core.globalvar import wxPythonPhoenix
+from core.globalvar import wxPythonPhoenix, CheckWxVersion
 from gui_core.dialogs import SymbolDialog, DefaultFontDialog
 from gui_core.widgets import IntegerValidator, ColorTablesComboBox
 from core.debug import Debug
@@ -758,7 +758,7 @@ class PreferencesDialog(PreferencesBaseDialog):
         panel.SetSizer(border)
 
         # bindings
-        if sys.platform == 'darwin':
+        if sys.platform == 'darwin' and not CheckWxVersion([4, 0, 6]):
             outfontButton.Bind(wx.EVT_BUTTON, self.OnSetOutputFontCustomDialog)
         else:
             outfontButton.Bind(wx.EVT_BUTTON, self.OnSetOutputFont)


### PR DESCRIPTION
The default font dialog works on mac from at least wxPython 4.0.6 (tested with Michael's binary).