### PR TITLE
init: Start in last used mapset with --gui like --text

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1182,6 +1182,24 @@ def load_gisrc(gisrc, gisrcrc):
     return mapset_settings
 
 
+def can_start_in_mapset(gisrc, force_lock_removal=False):
+    """Check if a mapset from a gisrc file is usable for new session"""
+    mapset_settings = MapsetSettings()
+    kv = read_gisrc(gisrc)
+    mapset_settings.gisdbase = kv.get('GISDBASE')
+    mapset_settings.location = kv.get('LOCATION_NAME')
+    mapset_settings.mapset = kv.get('MAPSET')
+    if not mapset_settings.is_valid():
+        return False
+    if not is_mapset_valid(mapset_settings.full_mapset):
+        return False
+    if not is_mapset_users(mapset_settings.full_mapset):
+        return False
+    if not force_lock_removal and is_mapset_locked(mapset_settings.full_mapset):
+        return False
+    return True
+
+
 # load environmental variables from grass_env_file
 def load_env(grass_env_file):
     if not os.access(grass_env_file, os.R_OK):
@@ -1426,6 +1444,24 @@ def set_language(grass_config_dir):
         gettext.install('grasslibs', gpath('locale'), codeset=encoding)
     else:
         gettext.install('grasslibs', gpath('locale'))
+
+
+def is_mapset_users(mapset_path):
+    """Check if the mapset belongs to the user"""
+    if os.environ.get("GRASS_SKIP_MAPSET_OWNER_CHECK", None):
+        # Mapset just needs to be accessible for writting.
+        return os.access(mapset_path, os.W_OK)
+    # Mapset needs to be owned by user.
+    stat_info = os.stat(mapset_path)
+    mapset_uid = stat_info.st_uid
+    return mapset_uid == os.getuid()
+
+
+def is_mapset_locked(mapset_path):
+    """Check if the mapset is locked"""
+    lock_name = '.gislock'
+    lockfile = os.path.join(mapset_path, lock_name)
+    return os.path.exists(lockfile)
 
 
 # TODO: grass_gui parameter is a hack and should be removed, see below
@@ -2286,9 +2322,10 @@ def main():
 
     # Parsing argument to get LOCATION
     if not params.mapset and not params.tmp_location:
+        last_mapset_usable = can_start_in_mapset(gisrc, params.force_gislock_removal)
         # Try interactive startup
         # User selects LOCATION and MAPSET if not set
-        if not set_mapset_interactive(grass_gui):
+        if not last_mapset_usable and not set_mapset_interactive(grass_gui):
             # No GUI available, update gisrc file
             fatal(_("<{0}> requested, but not available. Run GRASS in text "
                     "mode (--text) or install missing package (usually "


### PR DESCRIPTION
When the grass executable is started with --text, it uses the last used mapset.
Now also grass --gui behaves the same way and starts the main GUI without using the startup
window first to ask about the mapset.

The checks for starting in mapset are different because --text assumes it is interactive
and can just fail and give options to the user while --gui needs to provide a GUI way.
As a result, --gui shows the startup window when the mapset is not usable for starting
(both use the ask-for-permission paradigm, i.e., check before trying to perform the action).

This now makes more sense than ever before because the Data tab is now the default one in GUI (#756) and there is more functionality in Data tab which was mostly in Startup and File menu and not readily available in the Data tab (e.g., switch mapset or #731 - adding new mapset).

List of further functionality to make the experience smooth:

* [x] Download new location (#747)
* [x] Rename and delete of locations and mapsets (#771)
* [x] Check lock/active session and permissions/ownership when switching to mapset
* [x] Allow to force remove lock (#898)

Optional:

* [x] Add/change GRASS databases (#761)
* [x] Create new location (#747)
* [x] Distinguish mapset by lock and ownership (#714)

**Additional context**

This was discussed at [GRASS GIS Community Sprint Autumn 2017](https://grasswiki.osgeo.org/wiki/Talk:GRASS_GIS_Community_Sprint_Autumn_2017#Markus_Neteler):

> ...location wizard prevents new-users to actually see the software and creates confusion
> Solution: Startup into main menu with Lat-Long predefined, then show import wizard || switch projection || change location
> Alternative: _start GRASS in last location+mapset_, then ask if GRASSDB/location/mapset should be changed.

This was discussed on [Next steps in GSoC and beyond video call, July 15, 2020](https://trac.osgeo.org/grass/wiki/wxGUIDevelopment/New_Startup#NextstepsinGSoCandbeyondvideocallJuly152020):

> _Starting GUI in the last used mapset_ (--text starts in the last used mapset)?
> _Yes_, at least experimentally. 
> Always start in some mapset (demo, _last_, temporary)?
> _Start in the last used_ and use the demolocation as a fallback when locked or deleted...