### PR TITLE
init: Start shell only with TTY

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -2620,8 +2620,11 @@ class GMFrame(wx.Frame):
         """Quit GRASS terminal"""
         try:
             shellPid = int(grass.gisenv()['PID'])
-        except:
-            grass.warning(_("Unable to exit GRASS shell: unknown PID"))
+        except (KeyError, ValueError) as error:
+            Debug.msg(
+                1,
+                "No PID for GRASS shell (assuming no shell running): {}".format(error)
+            )
             return
 
         Debug.msg(1, "Exiting shell with pid={0}".format(shellPid))

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2461,8 +2461,6 @@ def main():
                         % grass_gui)
             if sh in ['csh', 'tcsh']:
                 shell_process = csh_startup(mapset_settings.full_mapset,
-                                            mapset_settings.location,
-                                            mapset_settings.mapset,
                                             grass_env_file)
             elif sh in ['zsh']:
                 shell_process = sh_like_startup(mapset_settings.full_mapset,


### PR DESCRIPTION
Start the (sub-)shell only when running in an interactive terminal (TTY).
Without checking this, the start fails in contexts when terminal is not available,
for example, running command from Alt+F2 dialog on many Linux distributions.
The same situation can be created using the nohup command.

A failure to retrieve shell PID from gisenv is no longer considered an error
for cases when shell was not started.

The interactive shell can be forced regadless of the TTY by using --text in the command line.

This solves [Trac ticket 3295](https://trac.osgeo.org/grass/ticket/3295) (GRASS GIS fails to start without terminal).