### PR TITLE
wxGUI: fix atexit error in debug mode

### DIFF
--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 import os
 import sys
 import getopt
-import atexit
 
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
@@ -111,6 +110,11 @@ class GMApp(wx.App):
 
         return True
 
+        def OnExit(self):
+            """Clean up on exit"""
+            unregisterPid(os.getpid())
+            return super().OnExit()
+
 
 def printHelp():
     """ Print program help"""
@@ -135,10 +139,6 @@ def process_opt(opts, args):
                 workspaceFile = args.pop(0)
 
     return workspaceFile
-
-
-def cleanup():
-    unregisterPid(os.getpid())
 
 
 def main(argv=None):
@@ -169,5 +169,4 @@ def main(argv=None):
     app.MainLoop()
 
 if __name__ == "__main__":
-    atexit.register(cleanup)
     sys.exit(main())


### PR DESCRIPTION
This addresses an atexit error `Error in atexit._run_exitfuncs:`on closing GRASS GUI if `DEBUG` has been set to >=1.


This fix has been lifted from #408, which key issue will (most probably) be redundant with #722.