### PR TITLE
wxGUI/g.gui.mapswipe: Fix wx.CheckListBox widget wxPyDeprecationWarning

### DIFF
--- a/gui/wxpython/gui_core/simplelmgr.py
+++ b/gui/wxpython/gui_core/simplelmgr.py
@@ -177,7 +177,7 @@ class SimpleLayerManager(wx.Panel):
 
     def OnLayerChecked(self, event):
         """Layer was (un)checked, update layer's info."""
-        checkedIdxs = self._checkList.GetChecked()
+        checkedIdxs = self._checkList.GetCheckedItems()
         for i, layer in enumerate(self._layerList):
             if i in checkedIdxs and not layer.IsActive():
                 layer.Activate()


### PR DESCRIPTION
Depcrecation warning message:

```
/usr/lib64/grass79/gui/wxpython/gui_core/simplelmgr.py:180:
wxPyDeprecationWarning: Call to deprecated item. Use
GetCheckedItems instead.
  checkedIdxs = self._checkList.GetChecked()
```