### PR TITLE
d.rast.arrow: Fix negative drainage directions

### DIFF
--- a/display/d.rast.arrow/main.c
+++ b/display/d.rast.arrow/main.c
@@ -380,6 +380,8 @@ int main(int argc, char **argv)
 	    if (map_type == 2 || map_type == 3 || map_type == 5) {
 		if (Rast_is_null_value(ptr, raster_type))
 		    aspect_c = 0;
+		else if (map_type == 5 && aspect_f < 0)
+		    aspect_c = (int)(0.5 - aspect_f);
 		else
 		    aspect_c = (int)(aspect_f + 0.5);
 	    }
@@ -514,7 +516,7 @@ int main(int argc, char **argv)
 	    /* case switch for r.watershed drainage type aspect map */
 	    else if (map_type == 5) {
 		D_use_color(arrow_color);
-		switch (aspect_c >= 0 ? aspect_c : -aspect_c) {
+		switch (aspect_c) {
 		case 0:
 		    /* only draw if x_color is not none (transparent) */
 		    if (x_color > 0) {


### PR DESCRIPTION
`r.watershed`'s `drainage=` output generates negative values for cells that leave the current computational region. The absolute value of those negative values represents drainage directions. For example, both "6" and "-6" mean "towards south". Originally, `d.rast.arrow` used to convert "-6" to "-5" using:
```c
aspect_c = (int)(aspect_f + 0.5); // (int)(-6 + 0.5) = (int)-5.5 = -5
```
Now, "-5" is not south anymore. It turned into south-west! This PR does
```c
aspect_c = (int)(0.5 - aspect_f); // (int)(0.5 - (-6)) = (int)6.5 = 6 in this specific example.
```
to fix negative `drainage` directions.