### PR TITLE
wxGUI: fix bad indentation

### DIFF
--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -110,10 +110,10 @@ class GMApp(wx.App):
 
         return True
 
-        def OnExit(self):
-            """Clean up on exit"""
-            unregisterPid(os.getpid())
-            return super().OnExit()
+    def OnExit(self):
+        """Clean up on exit"""
+        unregisterPid(os.getpid())
+        return super().OnExit()
 
 
 def printHelp():


### PR DESCRIPTION
Accidentally the PR #772 introduced a bad indentation causing `OnExit` *not* to be called on `Close GUI` , this PR corrects this.
Needs to be backported as well.