### PR TITLE
wxGUI: Do not reload the tree after canceled Delete in data catalog

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -942,10 +942,11 @@ class DataCatalogTree(TreeView):
         Delete selected mapset
         """
         try:
-            if (delete_mapset_interactively(self,
-                                        self.selected_grassdb[0].label,
-                                        self.selected_location[0].label,
-                                        self.selected_mapset[0].label)):
+            if (delete_mapset_interactively(
+                    self,
+                    self.selected_grassdb[0].label,
+                    self.selected_location[0].label,
+                    self.selected_mapset[0].label)):
                 self.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,
@@ -957,9 +958,10 @@ class DataCatalogTree(TreeView):
         Delete selected location
         """
         try:
-            if (delete_location_interactively(self,
-                                          self.selected_grassdb[0].label,
-                                          self.selected_location[0].label)):
+            if (delete_location_interactively(
+                    self,
+                    self.selected_grassdb[0].label,
+                    self.selected_location[0].label)):
                 self.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -942,29 +942,29 @@ class DataCatalogTree(TreeView):
         Delete selected mapset
         """
         try:
-            delete_mapset_interactively(self,
+            if (delete_mapset_interactively(self,
                                         self.selected_grassdb[0].label,
                                         self.selected_location[0].label,
-                                        self.selected_mapset[0].label)
+                                        self.selected_mapset[0].label)):
+                self.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,
                    message=_("Unable to delete mapset: %s") % e,
                    showTraceback=False)
-        self.ReloadTreeItems()
 
     def OnDeleteLocation(self, event):
         """
         Delete selected location
         """
         try:
-            delete_location_interactively(self,
+            if (delete_location_interactively(self,
                                           self.selected_grassdb[0].label,
-                                          self.selected_location[0].label)
+                                          self.selected_location[0].label)):
+                self.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,
                    message=_("Unable to delete location: %s") % e,
                    showTraceback=False)
-        self.ReloadTreeItems()
 
     def OnDisplayLayer(self, event):
         """Display layer in current graphics view"""

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -606,7 +606,6 @@ class GRASSStartup(wx.Frame):
                     'name': filePath},
                 parent=self)
 
-
     # the event can be refactored out by using lambda in bind
     def OnRenameMapset(self, event):
         """Rename selected mapset
@@ -649,9 +648,10 @@ class GRASSStartup(wx.Frame):
         location = self.listOfLocations[self.lblocations.GetSelection()]
         mapset = self.listOfMapsets[self.lbmapsets.GetSelection()]
         try:
-            delete_mapset_interactively(self, self.gisdbase, location, mapset)
-            self.OnSelectLocation(None)
-            self.lbmapsets.SetSelection(0)
+            if (delete_mapset_interactively(self, self.gisdbase,
+                                            location, mapset)):
+                self.OnSelectLocation(None)
+                self.lbmapsets.SetSelection(0)
         except Exception as e:
             GError(parent=self,
                    message=_("Unable to delete mapset: %s") % e,
@@ -663,11 +663,11 @@ class GRASSStartup(wx.Frame):
         """
         location = self.listOfLocations[self.lblocations.GetSelection()]
         try:
-            delete_location_interactively(self, self.gisdbase, location)
-            self.UpdateLocations(self.gisdbase)
-            self.lblocations.SetSelection(0)
-            self.OnSelectLocation(None)
-            self.lbmapsets.SetSelection(0)
+            if (delete_location_interactively(self, self.gisdbase, location)):
+                self.UpdateLocations(self.gisdbase)
+                self.lblocations.SetSelection(0)
+                self.OnSelectLocation(None)
+                self.lbmapsets.SetSelection(0)
         except Exception as e:
             GError(parent=self,
                    message=_("Unable to delete location: %s") % e,
@@ -980,7 +980,7 @@ class GListBox(ListCtrl, listmix.ListCtrlAutoWidthMixin):
         self._LoadData(choices, disabled)
 
     def SetSelection(self, item, force=False):
-        if item !=  wx.NOT_FOUND and \
+        if item != wx.NOT_FOUND and \
                 (platform.system() != 'Windows' or force):
             # Windows -> FIXME
             self.SetItemState(
@@ -1005,6 +1005,7 @@ class StartUp(wx.App):
         StartUp.SuggestDatabase()
 
         return 1
+
 
 if __name__ == "__main__":
     if os.getenv("GISBASE") is None:

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -309,6 +309,7 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
     if dlg.ShowModal() == wx.ID_YES:
         try:
             delete_mapset(grassdb, location, mapset)
+            dlg.Destroy()
             return True
         except OSError as err:
             wx.MessageBox(
@@ -317,9 +318,8 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
                 message=_("Unable to delete mapset.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
+        dlg.Destroy()
         return False
-
-    dlg.Destroy()
 
 
 def delete_location_interactively(guiparent, grassdb, location):
@@ -342,6 +342,7 @@ def delete_location_interactively(guiparent, grassdb, location):
     if dlg.ShowModal() == wx.ID_YES:
         try:
             delete_location(grassdb, location)
+            dlg.Destroy()
             return True
         except OSError as err:
             wx.MessageBox(
@@ -350,6 +351,5 @@ def delete_location_interactively(guiparent, grassdb, location):
                 message=_("Unable to delete location.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
-            return False
-
-    dlg.Destroy()
+        dlg.Destroy()
+        return False

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -215,6 +215,7 @@ def rename_mapset_interactively(guiparent, grassdb, location, mapset):
     """
     Rename selected mapset
     """
+    newmapset = None
     if mapset == "PERMANENT":
         GMessage(
             parent=guiparent,
@@ -223,7 +224,8 @@ def rename_mapset_interactively(guiparent, grassdb, location, mapset):
                 "This mapset cannot be renamed."
             ),
         )
-        return
+        return newmapset
+
     dlg = MapsetDialog(
         parent=guiparent,
         default=mapset,
@@ -244,8 +246,6 @@ def rename_mapset_interactively(guiparent, grassdb, location, mapset):
                 message=_("Unable to rename mapset.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
-    else:
-        newmapset = None
     dlg.Destroy()
     return newmapset
 
@@ -291,7 +291,7 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
                 "This mapset cannot be deleted."
             ),
         )
-        return
+        return False
 
     dlg = wx.MessageDialog(
         parent=guiparent,
@@ -318,7 +318,7 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
                 message=_("Unable to delete mapset.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
-        dlg.Destroy()
+    dlg.Destroy()
     return False
 
 
@@ -351,5 +351,5 @@ def delete_location_interactively(guiparent, grassdb, location):
                 message=_("Unable to delete location.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
-        dlg.Destroy()
+    dlg.Destroy()
     return False

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -319,7 +319,7 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
         dlg.Destroy()
-        return False
+    return False
 
 
 def delete_location_interactively(guiparent, grassdb, location):
@@ -352,4 +352,4 @@ def delete_location_interactively(guiparent, grassdb, location):
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
         dlg.Destroy()
-        return False
+    return False

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -309,6 +309,7 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
     if dlg.ShowModal() == wx.ID_YES:
         try:
             delete_mapset(grassdb, location, mapset)
+            return True
         except OSError as err:
             wx.MessageBox(
                 parent=guiparent,
@@ -316,6 +317,7 @@ def delete_mapset_interactively(guiparent, grassdb, location, mapset):
                 message=_("Unable to delete mapset.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
+        return False
 
     dlg.Destroy()
 
@@ -340,6 +342,7 @@ def delete_location_interactively(guiparent, grassdb, location):
     if dlg.ShowModal() == wx.ID_YES:
         try:
             delete_location(grassdb, location)
+            return True
         except OSError as err:
             wx.MessageBox(
                 parent=guiparent,
@@ -347,5 +350,6 @@ def delete_location_interactively(guiparent, grassdb, location):
                 message=_("Unable to delete location.\n\n%s") % err,
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
+            return False
 
     dlg.Destroy()

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -240,6 +240,7 @@ def rename_mapset_interactively(guiparent, grassdb, location, mapset):
         try:
             rename_mapset(grassdb, location, mapset, newmapset)
         except OSError as err:
+            newmapset = None
             wx.MessageBox(
                 parent=guiparent,
                 caption=_("Error"),
@@ -267,6 +268,7 @@ def rename_location_interactively(guiparent, grassdb, location):
         try:
             rename_location(grassdb, location, newlocation)
         except OSError as err:
+            newlocation = None
             wx.MessageBox(
                 parent=guiparent,
                 caption=_("Error"),


### PR DESCRIPTION
wxGUI/datacatalog: Reloading and updating is made only if Delete operation is not cancelled.