### PR TITLE
wxGUI/mac: fix cmd+c key bindings for text copying

### DIFF
--- a/gui/wxpython/dbmgr/manager.py
+++ b/gui/wxpython/dbmgr/manager.py
@@ -136,12 +136,24 @@ class AttributeManager(wx.Frame, DbMgrBase):
             wx.CallAfter(self.notebook.SetSelection, 0)  # select browse tab
 
         # buttons
-        self.btnClose = Button(parent=self.panel, id=wx.ID_CLOSE)
+        if sys.platform == "darwin":
+            self.ID_CLEAR = wx.NewIdRef()
+            self.ID_CLOSE = wx.NewIdRef()
+            self.Bind(wx.EVT_MENU, self.OnCloseWindow, id=self.ID_CLOSE)
+            self.accel_tbl = wx.AcceleratorTable(
+                [(wx.ACCEL_NORMAL, wx.WXK_ESCAPE, self.ID_CLOSE)])
+            self.SetAcceleratorTable(self.accel_tbl)
+        else:
+            self.ID_CLEAR = wx.ID_CLEAR
+            self.ID_CLOSE = wx.ID_CLOSE
+        self.btnClose = Button(
+            parent=self.panel, id=self.ID_CLOSE, label=_("Close"))
         self.btnClose.SetToolTip(_("Close Attribute Table Manager"))
         self.btnReload = Button(parent=self.panel, id=wx.ID_REFRESH)
         self.btnReload.SetToolTip(
             _("Reload currently selected attribute data"))
-        self.btnReset = Button(parent=self.panel, id=wx.ID_CLEAR)
+        self.btnReset = Button(
+            parent=self.panel, id=self.ID_CLEAR, label=_("Clear"))
         self.btnReset.SetToolTip(
             _("Reload all attribute data (drop current selection)"))
 

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -128,11 +128,23 @@ class SQLBuilder(wx.Frame):
         #
         # buttons
         #
-        self.btn_clear = Button(parent=self.panel, id=wx.ID_CLEAR)
+        if sys.platform == "darwin":
+            self.ID_CLEAR = wx.NewIdRef()
+            self.ID_CLOSE = wx.NewIdRef()
+            self.Bind(wx.EVT_MENU, self.OnClose, id=self.ID_CLOSE)
+            self.accel_tbl = wx.AcceleratorTable(
+                [(wx.ACCEL_NORMAL, wx.WXK_ESCAPE, self.ID_CLOSE)])
+            self.SetAcceleratorTable(self.accel_tbl)
+        else:
+            self.ID_CLEAR = wx.ID_CLEAR
+            self.ID_CLOSE = wx.ID_CLOSE
+        self.btn_clear = Button(
+            parent=self.panel, id=self.ID_CLEAR, label=_("Clear"))
         self.btn_clear.SetToolTip(_("Set SQL statement to default"))
         self.btn_apply = Button(parent=self.panel, id=wx.ID_APPLY)
         self.btn_apply.SetToolTip(_("Apply SQL statement"))
-        self.btn_close = Button(parent=self.panel, id=wx.ID_CLOSE)
+        self.btn_close = Button(
+            parent=self.panel, id=self.ID_CLOSE, label=_("Close"))
         self.btn_close.SetToolTip(_("Close the dialog"))
 
         self.btn_logic = {'is': ['=', ],

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -20,6 +20,7 @@ This program is free software under the GNU General Public License
 """
 
 import os
+import sys
 import textwrap
 
 import wx
@@ -156,10 +157,15 @@ class GConsoleWindow(wx.SplitterWindow):
                                     label=" %s " % cmdLabel)
 
         # buttons
+        if sys.platform == "darwin":
+            self.ID_CLEAR = wx.NewIdRef()
+        else:
+            self.ID_CLEAR = wx.ID_CLEAR
         self.btnOutputClear = Button(
-            parent=self.panelOutput, id=wx.ID_CLEAR)
+            parent=self.panelOutput, id=self.ID_CLEAR, label=_("Clear"))
         self.btnOutputClear.SetToolTip(_("Clear output window content"))
-        self.btnCmdClear = Button(parent=self.panelOutput, id=wx.ID_CLEAR)
+        self.btnCmdClear = Button(
+            parent=self.panelOutput, id=self.ID_CLEAR, label=_("Clear"))
         self.btnCmdClear.SetToolTip(_("Clear command prompt content"))
         self.btnOutputSave = Button(parent=self.panelOutput, id=wx.ID_SAVE)
         self.btnOutputSave.SetToolTip(

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -246,13 +246,6 @@ class GMFrame(wx.Frame):
 
         show_menu_errors(menu_errors)
 
-        # Enable copying to clipboard with cmd+c from console and python shell on macOS
-        # (default key binding will clear the console), trac #3008
-        if sys.platform == "darwin":
-            self.Bind(wx.EVT_MENU, self.OnCopyToClipboard, id=wx.ID_COPY)
-            self.accel_tbl = wx.AcceleratorTable([(wx.ACCEL_CTRL, ord("C"), wx.ID_COPY)])
-            self.SetAcceleratorTable(self.accel_tbl)
-
         # start with layer manager on top
         if self.currentPage:
             self.GetMapDisplay().Raise()
@@ -716,13 +709,6 @@ class GMFrame(wx.Frame):
                 elif ret == wx.ID_CANCEL:
                     return False
         return True
-
-    def OnCopyToClipboard(self, event):
-        """Copy selected text in shell to the clipboard"""
-        try:
-            wx.Window.FindFocus().Copy()
-        except:
-            pass
 
     def _switchPageHandler(self, event, notification):
         self._switchPage(notification=notification)

--- a/gui/wxpython/lmgr/pyshell.py
+++ b/gui/wxpython/lmgr/pyshell.py
@@ -44,14 +44,20 @@ class PyShellWindow(wx.Panel):
         self.intro = _("Welcome to wxGUI Interactive Python Shell %s") % VERSION + "\n\n" + \
             _("Type %s for more GRASS scripting related information.") % "\"help(grass)\"" + "\n" + \
             _("Type %s to add raster or vector to the layer tree.") % "\"AddLayer()\"" + "\n\n"
+        use_stock_id = (sys.platform != "darwin")  # Should be False on macOS
         self.shell = PyShell(parent=self, id=wx.ID_ANY,
                              introText=self.intro,
                              locals={'grass': grass,
-                                     'AddLayer': self.AddLayer})
+                                     'AddLayer': self.AddLayer},
+                             useStockId=use_stock_id)
 
         sys.displayhook = self._displayhook
 
-        self.btnClear = Button(self, wx.ID_CLEAR)
+        if sys.platform == "darwin":
+            self.ID_CLEAR = wx.NewIdRef()
+        else:
+            self.ID_CLEAR = wx.ID_CLEAR
+        self.btnClear = Button(self, self.ID_CLEAR, _("Clear"))
         self.btnClear.Bind(wx.EVT_BUTTON, self.OnClear)
         self.btnClear.SetToolTip(_("Delete all text from the shell"))
 

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -116,14 +116,25 @@ class ImportDialog(wx.Dialog):
         # buttons
         #
         # cancel
-        self.btn_close = Button(parent=self.panel, id=wx.ID_CLOSE)
-        self.btn_close.SetToolTip(_("Close dialog"))
+        if sys.platform == "darwin":
+            self.ID_CLOSE = wx.NewIdRef()
+            self.Bind(wx.EVT_MENU, self.OnClose, id=self.ID_CLOSE)
+            self.accel_tbl = wx.AcceleratorTable(
+                [(wx.ACCEL_NORMAL, wx.WXK_ESCAPE, self.ID_CLOSE)])
+            self.SetAcceleratorTable(self.accel_tbl)
+        else:
+            self.ID_CLOSE = wx.ID_CLOSE
+        self.btn_close = Button(
+            parent=self.panel, id=self.ID_CLOSE, label=_("Close"))
         self.btn_close.Bind(wx.EVT_BUTTON, self.OnClose)
+        self.btn_close.SetToolTip(_("Close dialog"))
         # run
+        if sys.platform == "darwin":
+            self.OK_ID = wx.NewIdRef()
+        else:
+            self.OK_ID = wx.OK_ID
         self.btn_run = Button(
-            parent=self.panel,
-            id=wx.ID_OK,
-            label=_("&Import"))
+            parent=self.panel, id=self.OK_ID, label=_("&Import"))
         self.btn_run.SetToolTip(_("Import selected layers"))
         self.btn_run.SetDefault()
         self.btn_run.Bind(wx.EVT_BUTTON, self.OnRun)
@@ -139,13 +150,6 @@ class ImportDialog(wx.Dialog):
                               name='source')
 
         self.createSettingsPage()
-
-        # Enable copying to clipboard with cmd+c from dialog on macOS
-        # (default key binding will close the dialog), trac #3592
-        if sys.platform == "darwin":
-            self.Bind(wx.EVT_MENU, self.OnCopyToClipboard, id=wx.ID_COPY)
-            self.accel_tbl = wx.AcceleratorTable([(wx.ACCEL_CTRL, ord("C"), wx.ID_COPY)])
-            self.SetAcceleratorTable(self.accel_tbl)
 
     def createSettingsPage(self):
 

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -17,6 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import os
+import sys
 import re
 
 import wx
@@ -150,7 +151,20 @@ class MapCalcFrame(wx.Frame):
         #
         # Buttons
         #
-        self.btn_clear = Button(parent=self.panel, id=wx.ID_CLEAR)
+        if sys.platform == "darwin":
+            self.ID_CLEAR = wx.NewIdRef()
+            self.ID_CLOSE = wx.NewIdRef()
+            self.ID_COPY = wx.NewIdRef()
+            self.Bind(wx.EVT_MENU, self.OnClose, id=self.ID_CLOSE)
+            self.accel_tbl = wx.AcceleratorTable(
+                [(wx.ACCEL_NORMAL, wx.WXK_ESCAPE, self.ID_CLOSE)])
+            self.SetAcceleratorTable(self.accel_tbl)
+        else:
+            self.ID_CLEAR = wx.ID_CLEAR
+            self.ID_CLOSE = wx.ID_CLOSE
+            self.ID_COPY = wx.ID_COPY
+        self.btn_clear = Button(
+            parent=self.panel, id=self.ID_CLEAR, label=_("Clear"))
         self.btn_help = Button(parent=self.panel, id=wx.ID_HELP)
         self.btn_run = Button(
             parent=self.panel,
@@ -158,13 +172,15 @@ class MapCalcFrame(wx.Frame):
             label=_("&Run"))
         self.btn_run.SetForegroundColour(wx.Colour(35, 142, 35))
         self.btn_run.SetDefault()
-        self.btn_close = Button(parent=self.panel, id=wx.ID_CLOSE)
+        self.btn_close = Button(
+            parent=self.panel, id=self.ID_CLOSE, label=_("Close"))
         self.btn_save = Button(parent=self.panel, id=wx.ID_SAVE)
         self.btn_save.SetToolTip(_('Save expression to file'))
         self.btn_load = Button(parent=self.panel, id=wx.ID_ANY,
                                label=_("&Load"))
         self.btn_load.SetToolTip(_('Load expression from file'))
-        self.btn_copy = Button(parent=self.panel, id=wx.ID_COPY)
+        self.btn_copy = Button(
+            parent=self.panel, id=self.ID_COPY, label=_("Copy"))
         self.btn_copy.SetToolTip(
             _("Copy the current command string to the clipboard"))
 


### PR DESCRIPTION
With wxPython 4.1.0 previous fixes (#393) turned insufficient. This is a workaround for a still unresolved wxWidgets issue. It also reinstates the ESCAPE key as a way to close the window/dialog (where appropriate).

Fixes #785

This is indeed a workaround, which works fine for the places it addresses (but is not a general fix or future proof). I've been tearing my hair on this and I'd be more than happy for suggestions for improvement.

(This has been tested on wxPython 4.1.0 and 4.0.7.post2, so it should be safe to backport).