### PR TITLE
wxGUI/datacatalog: Fix bad flag in reprojection dialog

### DIFF
--- a/gui/wxpython/datacatalog/dialogs.py
+++ b/gui/wxpython/datacatalog/dialogs.py
@@ -93,7 +93,7 @@ class CatalogReprojectionDialog(wx.Dialog):
         label = _("Map layer <{ml}> needs to be reprojected.\n"
                   "Please review and modify reprojection parameters:").format(ml=self.iLayer)
         dialogSizer.Add(StaticText(self.panel, label=label),
-                        flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, border=10)
+                        flag=wx.ALL | wx.EXPAND, border=10)
         if self.etype == 'raster':
             optionsSizer.Add(StaticText(self.panel, label=_("Estimated resolution:")),
                              pos=(0, 0), flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL)


### PR DESCRIPTION
Reprojection dialog in datacatalog fails with wxPython 4.1.0 with following error message:

```
Traceback (most recent call last):
  File "/Volumes/dev/grass/dist.x86_64-apple-
darwin19.5.0/gui/wxpython/datacatalog/tree.py", line 860, in
OnPasteMap

env, callback)
  File "/Volumes/dev/grass/dist.x86_64-apple-
darwin19.5.0/gui/wxpython/datacatalog/dialogs.py", line 57,
in __init__

self._doLayout()
  File "/Volumes/dev/grass/dist.x86_64-apple-
darwin19.5.0/gui/wxpython/datacatalog/dialogs.py", line 96,
in _doLayout

flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND,
border=10)
wx._core
.
wxAssertionError
:
C++ assertion "!(flags & wxALIGN_CENTRE_VERTICAL)" failed at
/Users/robind/projects/bb2/dist-osx-
py37/build/ext/wxWidgets/src/common/sizer.cpp(2077) in
DoInsert(): Vertical alignment flags are ignored in vertical
sizers
```

This PR addresses this issue.