### PR TITLE
wxGUI/datacatalog: show warning message dialog if drag map them to the target location node in the tree

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1008,15 +1008,23 @@ class DataCatalogTree(TreeView):
         self.copy_mode = wx.GetMouseState().ControlDown()
         if node:
             self.DefineItems([node])
-            if self._restricted and gisenv()['MAPSET'] != self.selected_mapset[0].data['name']:
-                GMessage(_("To move or copy maps to other mapsets, unlock editing of other mapsets"),
+            if None not in self.selected_mapset:
+                if self._restricted and gisenv()['MAPSET'] != self.selected_mapset[0].data['name']:
+                    GMessage(_("To move or copy maps to other mapsets, unlock editing of other mapsets"),
+                             parent=self)
+                    event.Veto()
+                    return
+
+                event.Allow()
+                Debug.msg(1, "DROP DONE")
+                self.OnPasteMap(event)
+            else:
+                GMessage(_("To move or copy maps to other location, "
+                           "please drag them to a mapset in the "
+                           "destination location"),
                          parent=self)
                 event.Veto()
                 return
-
-            event.Allow()
-            Debug.msg(1, "DROP DONE")
-            self.OnPasteMap(event)
 
     def OnSwitchDbLocationMapset(self, event):
         """Switch to location and mapset"""


### PR DESCRIPTION
To reproduce:

1. Try to move map from one mapset node into another location node in the tree

Default behavior:

![output_def](https://user-images.githubusercontent.com/50632337/87936935-0c62e600-ca94-11ea-84fd-1b451964e9c4.gif)

Error message:

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
289, in <lambda>

self._emitSignal(evt.GetItem(), self.endDrag, event=evt))
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/treeview.py", line
175, in _emitSignal

signal.emit(node=node, **kwargs)
  File
"/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 349, in send

**named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
886, in OnEndDrag

if self._restricted and gisenv()['MAPSET'] !=
self.selected_mapset[0].label:
AttributeError
:
'NoneType' object has no attribute 'label'
```

Expected behavior (show warning message dialog):

![output_exp](https://user-images.githubusercontent.com/50632337/87937095-53e97200-ca94-11ea-9683-d979a873df39.gif)

![show_warn_message_dialog](https://user-images.githubusercontent.com/50632337/87937352-dc681280-ca94-11ea-8bf6-8973944eaff6.png)



