### PR TITLE
wxGUI: Add new icons to data catalog for actions avaliable in context menu

### DIFF
--- a/gui/icons/grass/location-add.svg
+++ b/gui/icons/grass/location-add.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="96"
+   inkscape:export-xdpi="96"
+   inkscape:export-filename="C:\Users\kladivoval\Desktop\location-add.png"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 6.3499999 6.3499999"
+   height="24"
+   width="24"
+   sodipodi:docname="location-add.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     id="namedview23"
+     showgrid="false"
+     inkscape:zoom="18.863213"
+     inkscape:cx="6.1128494"
+     inkscape:cy="12"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g108"
+     transform="matrix(0.26458333,0,0,0.26458333,0.01182026,-2.0310632)"
+     fill="none">
+    <g
+       id="g104"
+       stroke-width="0.8"
+       stroke="#5489c4">
+      <path
+         id="path94"
+         d="m 12.000001,10.286844 c 7.115911,3.532057 6.099353,16.777269 0,19.426312" />
+      <path
+         id="path96"
+         d="M 0.81785277,20.000001 H 23.182148" />
+      <path
+         id="path98"
+         d="m 2.1902082,14.688719 c 5.6927292,0.758755 13.8252008,0.758755 19.5179298,0" />
+      <path
+         id="path100"
+         d="m 2.1902082,25.311281 c 5.6927292,-0.758754 13.8252008,-0.758754 19.5179298,0" />
+      <path
+         id="path102"
+         d="m 12.000001,10.286844 c -6.0993537,2.649043 -7.1159126,15.894256 0,19.426312" />
+    </g>
+    <path
+       id="path106"
+       transform="matrix(0.94418617,0,0,0.8171557,16.859375,8.715626)"
+       stroke-width="1.28353"
+       stroke="#3e74b2"
+       d="m 6.9656949,13.809332 a 12.112323,12.156691 0 1 1 -24.2246459,0 12.112323,12.156691 0 1 1 24.2246459,0 z"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+  </g>
+  <g
+     id="g844"
+     transform="matrix(0.21452698,0,0,0.21452698,-0.48540003,-0.51719001)">
+    <rect
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       id="rect836"
+       y="19"
+       x="19"
+       width="13"
+       ry="2.6149368"
+       rx="2.6149371"
+       height="13"
+       style="fill:#5a8c5a" />
+    <path
+       id="path838"
+       style="overflow:visible;fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round"
+       d="m 21.6,25.499999 h 7.8" />
+    <path
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       id="path840"
+       style="overflow:visible;fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.6;stroke-linecap:round;stroke-linejoin:round"
+       d="M 25.5,29.399999 V 21.6" />
+    <path
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       id="path842"
+       d="m 20.3,25.499999 h 10.4 c 0,0 0,0 0,-2.6 C 30.7,20.3 30.05,20.3 25.5,20.3 c -4.55,0 -5.2,0 -5.2,2.599999 0,2.6 0,2.6 0,2.6 z"
+       style="opacity:0.3;fill:#fcffff;fill-rule:evenodd" />
+  </g>
+</svg>

--- a/gui/icons/grass/location-download.svg
+++ b/gui/icons/grass/location-download.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="location-download.svg"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.3499999"
+   version="1.1"
+   id="svg8"
+   inkscape:export-filename="C:\Users\kladivoval\Desktop\location-download.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <sodipodi:namedview
+     inkscape:current-layer="svg8"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="12"
+     inkscape:cx="12.929979"
+     inkscape:zoom="30.625"
+     showgrid="false"
+     id="namedview23"
+     inkscape:window-height="1137"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     fill="none"
+     transform="matrix(0.26458333,0,0,0.26458333,0.01182026,-2.0310632)"
+     id="g108">
+    <g
+       stroke="#5489c4"
+       stroke-width="0.8"
+       id="g104">
+      <path
+         d="m 12.000001,10.286844 c 7.115911,3.532057 6.099353,16.777269 0,19.426312"
+         id="path94" />
+      <path
+         d="M 0.81785277,20.000001 H 23.182148"
+         id="path96" />
+      <path
+         d="m 2.1902082,14.688719 c 5.6927292,0.758755 13.8252008,0.758755 19.5179298,0"
+         id="path98" />
+      <path
+         d="m 2.1902082,25.311281 c 5.6927292,-0.758754 13.8252008,-0.758754 19.5179298,0"
+         id="path100" />
+      <path
+         d="m 12.000001,10.286844 c -6.0993537,2.649043 -7.1159126,15.894256 0,19.426312"
+         id="path102" />
+    </g>
+    <path
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       d="m 6.9656949,13.809332 a 12.112323,12.156691 0 1 1 -24.2246459,0 12.112323,12.156691 0 1 1 24.2246459,0 z"
+       stroke="#3e74b2"
+       stroke-width="1.28353"
+       transform="matrix(0.94418617,0,0,0.8171557,16.859375,8.715626)"
+       id="path106" />
+  </g>
+  <rect
+     inkscape:export-ydpi="96"
+     inkscape:export-xdpi="96"
+     fill="#3c5a6e"
+     height="2.7721853"
+     rx="0.50655389"
+     width="2.7721853"
+     x="3.5956585"
+     y="3.5754879"
+     id="rect171"
+     style="stroke-width:0.252016" />
+  <path
+     inkscape:export-ydpi="96"
+     inkscape:export-xdpi="96"
+     d="m 3.7758801,5.0554289 2.4745562,-0.00276 v -0.549895 c 0,-0.8221024 -0.2749506,-0.8221024 -1.2372781,-0.8221024 -0.9623273,0 -1.2372781,0 -1.2372781,0.824852 z"
+     fill="#fcffff"
+     fill-rule="evenodd"
+     opacity="0.3"
+     id="path173"
+     style="stroke-width:0.27495" />
+  <g
+     fill="none"
+     stroke="#ffffff"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g179"
+     transform="matrix(0.29150493,0,0,0.29150493,-0.43979886,-0.40841962)">
+    <path
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       d="m 17.7,15.75 h -2.5 v 5.5 h 2.5"
+       stroke-width="1.5"
+       id="path175" />
+    <path
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       d="m 19.493,20.48 -1.5,-1.99 1.5,-1.99 m 3.007,1.98 h -3.397"
+       id="path177" />
+  </g>
+</svg>

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -20,8 +20,11 @@ import os
 
 from core.gthread import gThread
 from core.debug import Debug
+from core.gcmd import GError
 from datacatalog.tree import DataCatalogTree
 from datacatalog.toolbars import DataCatalogToolbar
+from startup.guiutils import create_mapset_interactively
+from grass.script import gisenv
 
 from grass.pydispatch.signal import Signal
 
@@ -101,6 +104,24 @@ class DataCatalog(wx.Panel):
             self.tree.InsertGrassDb(name=grassdatabase)
 
         dlg.Destroy()
+
+    def OnCreateMapset(self, event):
+        """Create new mapset in current location"""
+        genv = gisenv()
+        gisdbase = genv['GISDBASE']
+        location = genv['LOCATION_NAME']
+        try:
+            mapset = create_mapset_interactively(self, gisdbase, location)
+            if mapset:
+                item = self.tree._model.SearchNodes(name=location,
+                                                    type='location')
+                self.tree.InsertMapset(name=mapset,
+                                  location_node=item)
+                self.tree.ReloadTreeItems()
+        except Exception as e:
+            GError(parent=self,
+                   message=_("Unable to create new mapset: %s") % e,
+                   showTraceback=False)
 
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -108,23 +108,7 @@ class DataCatalog(wx.Panel):
     def OnCreateMapset(self, event):
         """Create new mapset in current location"""
         genv = gisenv()
-        gisdbase = genv['GISDBASE']
-        location = genv['LOCATION_NAME']
-        try:
-            mapset = create_mapset_interactively(self, gisdbase, location)
-            if mapset:
-                db = self.tree._model.SearchNodes(name=gisdbase,
-                                                  type='grassdb')
-                loc = self.tree._model.SearchNodes(parent=db[0],
-                                                   name=location,
-                                                   type='location')
-                self.tree.InsertMapset(name=mapset,
-                                       location_node=loc[0])
-                self.tree.ReloadTreeItems()
-        except Exception as e:
-            GError(parent=self,
-                   message=_("Unable to create new mapset: %s") % e,
-                   showTraceback=False)
+        self.tree.CreateMapset(genv['GISDBASE'], genv['LOCATION_NAME'])
 
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -113,10 +113,13 @@ class DataCatalog(wx.Panel):
         try:
             mapset = create_mapset_interactively(self, gisdbase, location)
             if mapset:
-                item = self.tree._model.SearchNodes(name=location,
-                                                    type='location')
+                db = self.tree._model.SearchNodes(name=gisdbase,
+                                                  type='grassdb')
+                loc = self.tree._model.SearchNodes(parent=db[0],
+                                                   name=location,
+                                                   type='location')
                 self.tree.InsertMapset(name=mapset,
-                                  location_node=item)
+                                       location_node=loc[0])
                 self.tree.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -20,11 +20,8 @@ import os
 
 from core.gthread import gThread
 from core.debug import Debug
-from core.gcmd import GError
 from datacatalog.tree import DataCatalogTree
 from datacatalog.toolbars import DataCatalogToolbar
-from startup.guiutils import create_mapset_interactively
-from grass.script import gisenv
 
 from grass.pydispatch.signal import Signal
 
@@ -107,8 +104,8 @@ class DataCatalog(wx.Panel):
 
     def OnCreateMapset(self, event):
         """Create new mapset in current location"""
-        genv = gisenv()
-        self.tree.CreateMapset(genv['GISDBASE'], genv['LOCATION_NAME'])
+        db_node, loc_node, mapset_node = self.tree.GetCurrentDbLocationMapsetNode()
+        self.tree.CreateMapset(db_node, loc_node)
 
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -124,23 +124,7 @@ class DataCatalogFrame(wx.Frame):
     def OnCreateMapset(self, event):
         """Create new mapset in current location"""
         genv = gisenv()
-        gisdbase = genv['GISDBASE']
-        location = genv['LOCATION_NAME']
-        try:
-            mapset = create_mapset_interactively(self, gisdbase, location)
-            if mapset:
-                db = self.tree._model.SearchNodes(name=gisdbase,
-                                                  type='grassdb')
-                loc = self.tree._model.SearchNodes(parent=db[0],
-                                                   name=location,
-                                                   type='location')
-                self.tree.InsertMapset(name=mapset,
-                                       location_node=loc[0])
-                self.tree.ReloadTreeItems()
-        except Exception as e:
-            GError(parent=self,
-                   message=_("Unable to create new mapset: %s") % e,
-                   showTraceback=False)
+        self.tree.CreateMapset(genv['GISDBASE'], genv['LOCATION_NAME'])
 
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -129,10 +129,13 @@ class DataCatalogFrame(wx.Frame):
         try:
             mapset = create_mapset_interactively(self, gisdbase, location)
             if mapset:
-                item = self.tree._model.SearchNodes(name=location,
-                                                    type='location')
+                db = self.tree._model.SearchNodes(name=gisdbase,
+                                                  type='grassdb')
+                loc = self.tree._model.SearchNodes(parent=db[0],
+                                                   name=location,
+                                                   type='location')
                 self.tree.InsertMapset(name=mapset,
-                                  location_node=item)
+                                       location_node=loc[0])
                 self.tree.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -22,12 +22,10 @@ import sys
 import wx
 
 from core.globalvar import ICONDIR
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import RunCommand, GMessage
 from datacatalog.tree import DataCatalogTree
 from datacatalog.toolbars import DataCatalogToolbar
 from gui_core.wrap import Button
-from grass.script import gisenv
-from startup.guiutils import create_mapset_interactively
 
 
 class DataCatalogFrame(wx.Frame):
@@ -123,8 +121,8 @@ class DataCatalogFrame(wx.Frame):
 
     def OnCreateMapset(self, event):
         """Create new mapset in current location"""
-        genv = gisenv()
-        self.tree.CreateMapset(genv['GISDBASE'], genv['LOCATION_NAME'])
+        db_node, loc_node, mapset_node = self.tree.GetCurrentDbLocationMapsetNode()
+        self.tree.CreateMapset(db_node, loc_node)
 
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -22,10 +22,12 @@ import sys
 import wx
 
 from core.globalvar import ICONDIR
-from core.gcmd import RunCommand, GMessage
+from core.gcmd import RunCommand, GError, GMessage
 from datacatalog.tree import DataCatalogTree
 from datacatalog.toolbars import DataCatalogToolbar
 from gui_core.wrap import Button
+from grass.script import gisenv
+from startup.guiutils import create_mapset_interactively
 
 
 class DataCatalogFrame(wx.Frame):
@@ -118,6 +120,24 @@ class DataCatalogFrame(wx.Frame):
             self.tree.InsertGrassDb(name=grassdatabase)
 
         dlg.Destroy()
+
+    def OnCreateMapset(self, event):
+        """Create new mapset in current location"""
+        genv = gisenv()
+        gisdbase = genv['GISDBASE']
+        location = genv['LOCATION_NAME']
+        try:
+            mapset = create_mapset_interactively(self, gisdbase, location)
+            if mapset:
+                item = self.tree._model.SearchNodes(name=location,
+                                                    type='location')
+                self.tree.InsertMapset(name=mapset,
+                                  location_node=item)
+                self.tree.ReloadTreeItems()
+        except Exception as e:
+            GError(parent=self,
+                   message=_("Unable to create new mapset: %s") % e,
+                   showTraceback=False)
 
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""

--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -37,13 +37,7 @@ icons = {
         label=_("Click to add new GRASS database")),
     'addMapset': MetaIcon(
         img='mapset-add',
-        label=_("Click to add new mapset in current location")),
-    'addLocation': MetaIcon(
-        img='location-add',
-        label=_("Click to add new location in current database")),
-    'downloadLocation': MetaIcon(
-        img='location-download',
-        label=_("Click to download location to current database"))
+        label=_("Click to add new mapset in current location"))
 }
 
 
@@ -86,10 +80,6 @@ class DataCatalogToolbar(BaseToolbar):
                                      ("addGrassDB", icons['addGrassDB'],
                                       self.parent.OnAddGrassDB),
                                      ("addMapset", icons['addMapset'],
-                                      self.parent.OnCreateMapset),
-                                     ("addLocation", icons['addLocation'],
-                                      self.parent.OnCreateMapset),
-                                     ("downloadLocation", icons['downloadLocation'],
                                       self.parent.OnCreateMapset)
                                      ))
 

--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -34,7 +34,16 @@ icons = {
         label=_("Click to allow editing other mapsets")),
     'addGrassDB': MetaIcon(
         img='grassdb-add',
-        label=_("Click to add new GRASS database"))
+        label=_("Click to add new GRASS database")),
+#    'addMapset': MetaIcon(
+#        img='grass_mapset',
+#        label=_("Click to add new mapset in current location")),
+#    'addLocation': MetaIcon(
+#        img='grass_location',
+#        label=_("Click to add new location in current database")),
+#    'downloadLocation': MetaIcon(
+#        img='downloading_svg',
+#        label=_("Click to download location to current database"))
 }
 
 
@@ -75,7 +84,9 @@ class DataCatalogToolbar(BaseToolbar):
                                      ("lock", icons['locked'],
                                       self.OnSetRestriction, wx.ITEM_CHECK),
                                      ("addGrassDB", icons['addGrassDB'],
-                                      self.parent.OnAddGrassDB)
+                                      self.parent.OnAddGrassDB),
+                                     ("addMapset", icons['addGrassDB'],
+                                      self.parent.OnCreateMapset)
                                      ))
 
     def OnSetRestriction(self, event):

--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -38,12 +38,12 @@ icons = {
     'addMapset': MetaIcon(
         img='mapset-add',
         label=_("Click to add new mapset in current location")),
-#    'addLocation': MetaIcon(
-#        img='grass_location',
-#        label=_("Click to add new location in current database")),
-#    'downloadLocation': MetaIcon(
-#        img='downloading_svg',
-#        label=_("Click to download location to current database"))
+    'addLocation': MetaIcon(
+        img='location-add',
+        label=_("Click to add new location in current database")),
+    'downloadLocation': MetaIcon(
+        img='location-download',
+        label=_("Click to download location to current database"))
 }
 
 
@@ -86,6 +86,10 @@ class DataCatalogToolbar(BaseToolbar):
                                      ("addGrassDB", icons['addGrassDB'],
                                       self.parent.OnAddGrassDB),
                                      ("addMapset", icons['addMapset'],
+                                      self.parent.OnCreateMapset),
+                                     ("addLocation", icons['addLocation'],
+                                      self.parent.OnCreateMapset),
+                                     ("downloadLocation", icons['downloadLocation'],
                                       self.parent.OnCreateMapset)
                                      ))
 

--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -35,9 +35,9 @@ icons = {
     'addGrassDB': MetaIcon(
         img='grassdb-add',
         label=_("Click to add new GRASS database")),
-#    'addMapset': MetaIcon(
-#        img='grass_mapset',
-#        label=_("Click to add new mapset in current location")),
+    'addMapset': MetaIcon(
+        img='mapset-add',
+        label=_("Click to add new mapset in current location")),
 #    'addLocation': MetaIcon(
 #        img='grass_location',
 #        label=_("Click to add new location in current database")),
@@ -85,7 +85,7 @@ class DataCatalogToolbar(BaseToolbar):
                                       self.OnSetRestriction, wx.ITEM_CHECK),
                                      ("addGrassDB", icons['addGrassDB'],
                                       self.parent.OnAddGrassDB),
-                                     ("addMapset", icons['addGrassDB'],
+                                     ("addMapset", icons['addMapset'],
                                       self.parent.OnCreateMapset)
                                      ))
 

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -669,30 +669,18 @@ class DataCatalogTree(TreeView):
             self.Rename(old_name, new_name)
             self.ReloadTreeItems()
 
-    def CreateMapset(self, grassdb, location):
-        """General function for creating new mapset"""
-        try:
-            mapset = create_mapset_interactively(self, grassdb, location)
-            if mapset:
-                db = self._model.SearchNodes(name=grassdb,
-                                                  type='grassdb')
-                loc = self._model.SearchNodes(parent=db[0],
-                                                   name=location,
-                                                   type='location')
-                self.InsertMapset(name=mapset,
-                                       location_node=loc[0])
-                self.ReloadTreeItems()
-        except Exception as e:
-            GError(parent=self,
-                   message=_("Unable to create new mapset: {}").format(e),
-                   showTraceback=False)
+    def CreateMapset(self, grassdb_node, location_node):
+        """Creates new mapset interactively and adds it to the tree."""
+        mapset = create_mapset_interactively(self, grassdb_node.data["name"],
+                                             location_node.data["name"])
+        if mapset:
+            self.InsertMapset(name=mapset,
+                              location_node=location_node)
+            self.ReloadTreeItems()
 
     def OnCreateMapset(self, event):
         """Create new mapset"""
-        self.CreateMapset(
-            self.selected_grassdb[0].data['name'],
-            self.selected_location[0].data['name']
-        )
+        self.CreateMapset(self.selected_grassdb[0], self.selected_location[0])
 
     def OnRenameMapset(self, event):
         """

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -669,22 +669,30 @@ class DataCatalogTree(TreeView):
             self.Rename(old_name, new_name)
             self.ReloadTreeItems()
 
-    def OnCreateMapset(self, event):
-        """Create new mapset"""
-        gisdbase = self.selected_grassdb[0]
-        location = self.selected_location[0]
+    def CreateMapset(self, grassdb, location):
+        """General function for creating new mapset"""
         try:
-            mapset = create_mapset_interactively(self,
-                                        gisdbase.data['name'],
-                                        location.data['name'],)
+            mapset = create_mapset_interactively(self, grassdb, location)
             if mapset:
+                db = self._model.SearchNodes(name=grassdb,
+                                                  type='grassdb')
+                loc = self._model.SearchNodes(parent=db[0],
+                                                   name=location,
+                                                   type='location')
                 self.InsertMapset(name=mapset,
-                                  location_node=location)
+                                       location_node=loc[0])
                 self.ReloadTreeItems()
         except Exception as e:
             GError(parent=self,
-                   message=_("Unable to create new mapset: %s") % e,
+                   message=_("Unable to create new mapset: {}").format(e),
                    showTraceback=False)
+
+    def OnCreateMapset(self, event):
+        """Create new mapset"""
+        self.CreateMapset(
+            self.selected_grassdb[0].data['name'],
+            self.selected_location[0].data['name']
+        )
 
     def OnRenameMapset(self, event):
         """

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -195,18 +195,18 @@ def create_mapset_interactively(guiparent, grassdb, location):
         location=location,
     )
 
+    mapset = None
     if dlg.ShowModal() == wx.ID_OK:
         mapset = dlg.GetValue()
         try:
             create_mapset(grassdb, location, mapset)
         except OSError as err:
+            mapset = None
             GError(
                 parent=guiparent,
                 message=_("Unable to create new mapset: %s") % err,
                 showTraceback=False,
             )
-    else:
-        mapset = None
     dlg.Destroy()
     return mapset
 


### PR DESCRIPTION
Certain actions that are currently available (and will be available in the future) in the context menus of data catalog need to be exposed as toolbar icons. This is a suggested list of actions, to be edited based on discussion and feature availability:

- [x] add new database (already created)
- [x] create new mapset (now created)

Other:
- [ ] download sample location
- [ ] create new location
- [ ] import into current mapset

