### PR TITLE
wxGUI/lmgr: fix return 'Layer' class str value if map layer name is None

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -1460,7 +1460,8 @@ class CmdPanel(wx.Panel):
                                     for layer in layers:
                                         if layer.type != p.get('prompt'):
                                             continue
-                                        mapList.append(str(layer))
+                                        if str(layer):
+                                            mapList.append(str(layer))
                         selection = gselect.Select(
                             parent=which_panel, id=wx.ID_ANY,
                             size=globalvar.DIALOG_GSELECT_SIZE, type=elem,

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -44,7 +44,7 @@ class Layer(object):
         return self._pydata[0].keys()
 
     def __str__(self):
-        return self.maplayer.name
+        return '' if self.maplayer.name is None else self.maplayer.name
 
 
 class LayerList(object):


### PR DESCRIPTION
Fix bug introduced in the issue #814.