### PR TITLE
wxGUI/datacatalog: move or copy location/mapset isn't allowed, show warning message dialog

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -995,6 +995,18 @@ class DataCatalogTree(TreeView):
     def OnBeginDrag(self, node, event):
         """Just copy necessary data"""
         self.DefineItems(self.GetSelected())
+
+        if self.selected_location and None in self.selected_mapset and \
+           None in self.selected_layer:
+            GMessage(_("Move or copy location isn't allowed"))
+            event.Veto()
+            return
+        elif self.selected_location and self.selected_mapset and \
+             None in self.selected_layer:
+            GMessage(_("Move or copy mapset isn't allowed"))
+            event.Veto()
+            return
+
         if self.selected_layer and not (self._restricted and gisenv()[
                                         'LOCATION_NAME'] != self.selected_location[0].data['name']):
             event.Allow()


### PR DESCRIPTION
To reproduce:

1. Try to move location node to another location mapset node (drag and drop).

2. Try to move mapset node from one location to another location mapset node (drag and drop).

Error message:

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
298, in <lambda>

self._emitSignal(evt.GetItem(), self.beginDrag, event=evt))
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/treeview.py", line
175, in _emitSignal

signal.emit(node=node, **kwargs)
  File
"/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 349, in send

**named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
1011, in OnBeginDrag

self.OnCopyMap(event)
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
650, in OnCopyMap

label = _("Map <{layer}> marked for
copying.").format(layer=self.copy_layer[0].data['name'])
AttributeError
:
'NoneType' object has no attribute 'data'
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
300, in <lambda>

self._emitSignal(evt.GetItem(), self.endDrag, event=evt))
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/treeview.py", line
175, in _emitSignal

signal.emit(node=node, **kwargs)
  File
"/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 349, in send

**named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
1030, in OnEndDrag

self.OnPasteMap(event)
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
779, in OnPasteMap

new_name = self.copy_layer[i].data['name']
AttributeError
:
'NoneType' object has no attribute 'data'
```

Expected behavior:

Move mapset or location to another mapset location node isn't allowed, show warning message dialog.