### PR TITLE
wxGUI/datacatalog: don't expand the location tree node if the transformation dialog is closed

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -861,7 +861,8 @@ class DataCatalogTree(TreeView):
                                                 new_name,
                                                 self.copy_layer[i].data['type'],
                                                 env, callback)
-                dlg.ShowModal()
+                if dlg.ShowModal() == wx.ID_CANCEL:
+                    return
         self.ExpandNode(self.selected_mapset[0], recursive=True)
         self._initVariablesCatalog()
 


### PR DESCRIPTION
To reproduce:

1. Try to move map from one mapset location node into another location mapset node in the tree (drag and drop)

2. Close transformation dialog

Default behavior (target location mapset tree node is expanded, after close transformation dialog):

![expand_tree_def](https://user-images.githubusercontent.com/50632337/88140286-b7d57d00-cbf1-11ea-950a-8d0281046399.gif)

Expected behavior (it isn't necessary expand target location mapset tree node, after close transformation dialog):

![expand_tree_exp](https://user-images.githubusercontent.com/50632337/88140428-0420bd00-cbf2-11ea-8d39-d89d7ef93b5f.gif)
