### PR TITLE
wxGUI/g.gui.gcp: fix launch g.gui.gcp

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -60,7 +60,7 @@ from core.giface import Notification
 from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, \
     CheckListBox, TextCtrl, Menu, ListCtrl, BitmapFromImage, CheckListCtrlMixin
 
-from location_wizard.wizard import TitledPage as TitledPage
+from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 
 #
 # global variables

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -24,11 +24,11 @@ This program is free software under the GNU General Public License
 @author Original version improved by Martin Landa <landa.martin gmail.com>
 @author Rewritten by Markus Metz redesign georectfier -> GCP Manage
 @author Support for GraphicsSet added by Stepan Turek <stepan.turek seznam.cz> (2012)
-@author port i.image.2target (v6) to version 7 in 2017 by Yann 
+@author port i.image.2target (v6) to version 7 in 2017 by Yann
 """
 
 #TODO: i.ortho.transform has 6 appearances, check each of them and configure
-#TODO: i.ortho.transform looks for REF_POINTS/CONTROL_POINTS and not POINTS 
+#TODO: i.ortho.transform looks for REF_POINTS/CONTROL_POINTS and not POINTS
 #TODO: CHECK CONTROL_POINTS format and create it for i.ortho.transform to use.
 
 from __future__ import print_function
@@ -65,7 +65,7 @@ from core.giface import Notification
 from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, \
     CheckListBox, TextCtrl, Menu, ListCtrl, BitmapFromImage, CheckListCtrlMixin
 
-from location_wizard.wizard import TitledPage as TitledPage
+from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 
 #
 # global variables
@@ -122,7 +122,7 @@ class GCPWizard(object):
     #    self.extension = extension
     #    self.src_maps = self.src_map
     #    # location for xy map to georectify
-    #    self.newlocation = self.srcloc 
+    #    self.newlocation = self.srcloc
     #    # mapset for xy map to georectify
     #    self.newmapset = self.srcmpt
     def __init__(self, parent, giface):

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -6,6 +6,7 @@ from multiple methods.
 
 Classes:
  - wizard::TitledPage
+ - wizard::GridBagSizerTitledPage
  - wizard::DatabasePage
  - wizard::CoordinateSystemPage
  - wizard::ProjectionsPage
@@ -70,7 +71,6 @@ global west
 global resolution
 global wizerror
 global translist
-
 
 class TitledPage(WizardPageSimple):
     """Class to make wizard pages. Generic methods to make labels,
@@ -145,6 +145,16 @@ class TitledPage(WizardPageSimple):
         if tooltip:
             chbox.SetToolTip(tooltip)
         return chbox
+
+
+class GridBagSizerTitledPage(TitledPage):
+    """GridBagSizer declaration for TitledPage class"""
+    def __init__(self, parent, title):
+        super().__init__(parent, title)
+
+        self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
+        self.sizer.SetCols(5)
+        self.sizer.SetRows(8)
 
 
 class DatabasePage(TitledPage):
@@ -600,7 +610,7 @@ class ItemList(ListCtrl,
         for column in columns:
             self.InsertColumn(i, column)
             i += 1
-        
+
         self.EnableAlternateRowColours()
 
         if self.sourceData:
@@ -1489,7 +1499,7 @@ class EPSGPage(TitledPage):
     def __init__(self, wizard, parent):
         TitledPage.__init__(self, wizard, _("Select CRS from a list"))
 
-        self.sizer = wx.BoxSizer(wx.VERTICAL)  
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
         searchBoxSizer = wx.BoxSizer(wx.HORIZONTAL)
         epsglistBoxSizer = wx.BoxSizer(wx.HORIZONTAL)
         informationBoxSizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -1982,7 +1992,7 @@ class CustomPage(TitledPage):
                 return
 
             # check for datum tranforms
-            # FIXME: -t flag is a hack-around for trac bug #1849          
+            # FIXME: -t flag is a hack-around for trac bug #1849
             ret, out, err = RunCommand('g.proj',
                                        read=True, getErrorMsg=True,
                                        proj4=self.customstring,

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1,8 +1,8 @@
 """
 @package photo2image.ip2i_manager
 
-@brief Scanning distortion correction of a photo for GRASS GIS. 
-Includes ground control point management and interactive point 
+@brief Scanning distortion correction of a photo for GRASS GIS.
+Includes ground control point management and interactive point
 and click GCP creation
 
 Classes:
@@ -49,7 +49,7 @@ from core.giface import Notification
 from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, \
     TextCtrl, Menu, ListCtrl, BitmapFromImage, CheckListCtrlMixin
 
-from location_wizard.wizard import TitledPage as TitledPage
+from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 
 #
 # global variables
@@ -151,7 +151,7 @@ class GCPWizard(object):
 
         #
         # add layer to source map
-        #        
+        #
         try:
             # set computational region to match selected map and zoom display
             # to region
@@ -279,7 +279,7 @@ class GCP(MapFrame, ColumnSorterMixin):
             self.show_target = False
         else:
             self.show_target = True
-        
+
         self.camera = camera
 
         #wx.Frame.__init__(self, parent, id, title, size = size, name = "GCPFrame")
@@ -394,7 +394,7 @@ class GCP(MapFrame, ColumnSorterMixin):
                 if fc_count > storeLine :
                     dataFiducialX.append(line.split()[1])
                     dataFiducialY.append(line.split()[2])
-                    
+
         except IOError as err:
             GError(
                 parent=self,

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -34,7 +34,7 @@ import wx.lib.scrolledpanel as scrolled
 
 from gui_core import gselect
 from gui_core.wrap import Button, StaticText, TextCtrl
-from location_wizard.wizard import TitledPage as TitledPage
+from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 from rlisetup.functions import checkValue, retRLiPath
 from rlisetup.sampling_frame import RLiSetupMapPanel
 from grass.script import core as grass


### PR DESCRIPTION
Move back `wx.GridBagSizer` sizer declaration into `TitledPage` base class, also required for wxGUI `g.gui.gcp` wizard pages.

To reproduce:

1. Launch `g.gui.gcp`

Error message:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/scripts/g.gui.gcp", line 71, in <module>
    main()
  File "/usr/lib64/grass79/scripts/g.gui.gcp", line 66, in main
    wizard = GCPWizard(parent=None, giface=StandaloneGrassInterface())
  File "/usr/lib64/grass79/gui/wxpython/gcp/manager.py", line 153, in __init__
    self.startpage = LocationPage(self.wizard, self)
  File "/usr/lib64/grass79/gui/wxpython/gcp/manager.py", line 370, in __init__
    self.sizer.Add(self.rb_maptype,
AttributeError: 'LocationPage' object has no attribute 'sizer'
```

This [commit](https://github.com/OSGeo/grass/commit/19ea788f9219e9ec7b19cb27420d31ba9cfcf514#diff-300368203de7a2fc283ce684faca60c6) remove `wx.GridBagSizer` sizer declaration from base class `TitledPage`.


