### PR TITLE
v.kernel: fix inconsistent msg

### DIFF
--- a/locale/po/grassmods_ar.po
+++ b/locale/po/grassmods_ar.po
@@ -43287,7 +43287,7 @@ msgstr ""
 #: ../vector/v.kernel/main.c:218
 msgid ""
 "In network mode, normalize values by sum of density multiplied by length of "
-"each segment. Integral over the output map then gives 1.0 * mult"
+"each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_bn.po
+++ b/locale/po/grassmods_bn.po
@@ -38490,7 +38490,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_cs.po
+++ b/locale/po/grassmods_cs.po
@@ -38772,7 +38772,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_de.po
+++ b/locale/po/grassmods_de.po
@@ -38642,8 +38642,8 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
-msgstr "Im Netzwerk-Modus: normalisiere Werte durch die Summe der Dichte multipliziert mit der Länge der Segmente. Integral über die Ausgabekarte ergibt 1.0 * mult."
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
+msgstr "Im Netzwerk-Modus: normalisiere Werte durch die Summe der Dichte multipliziert mit der Länge der Segmente. Integral über die Ausgabekarte ergibt 1.0 * multiplier."
 
 #: ../vector/v.kernel/main.c:224
 msgid "In network mode, multiply the result by number of input points"

--- a/locale/po/grassmods_el.po
+++ b/locale/po/grassmods_el.po
@@ -38499,7 +38499,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_es.po
+++ b/locale/po/grassmods_es.po
@@ -38675,8 +38675,8 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr "Solamente calcular radio óptimo y salir (no se escribe ningún mapa)"
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
-msgstr "En el modo de red, normalizar valores por la suma de densidades multiplicada por la longitud de cada segmento. Entonces la integral sobre el mapa de salida da 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
+msgstr "En el modo de red, normalizar valores por la suma de densidades multiplicada por la longitud de cada segmento. Entonces la integral sobre el mapa de salida da 1.0 * multiplier"
 
 #: ../vector/v.kernel/main.c:224
 msgid "In network mode, multiply the result by number of input points"

--- a/locale/po/grassmods_fi.po
+++ b/locale/po/grassmods_fi.po
@@ -38492,7 +38492,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_fr.po
+++ b/locale/po/grassmods_fr.po
@@ -38570,7 +38570,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_hu.po
+++ b/locale/po/grassmods_hu.po
@@ -38491,7 +38491,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_id_ID.po
+++ b/locale/po/grassmods_id_ID.po
@@ -38416,7 +38416,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_it.po
+++ b/locale/po/grassmods_it.po
@@ -38613,7 +38613,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_ja.po
+++ b/locale/po/grassmods_ja.po
@@ -38544,7 +38544,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_ko.po
+++ b/locale/po/grassmods_ko.po
@@ -38432,7 +38432,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_lv.po
+++ b/locale/po/grassmods_lv.po
@@ -40151,7 +40151,7 @@ msgstr ""
 #: ../vector/v.kernel/main.c:218
 msgid ""
 "In network mode, normalize values by sum of density multiplied by length of "
-"each segment. Integral over the output map then gives 1.0 * mult"
+"each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_ml.po
+++ b/locale/po/grassmods_ml.po
@@ -38490,7 +38490,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_pl.po
+++ b/locale/po/grassmods_pl.po
@@ -38681,7 +38681,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_pt.po
+++ b/locale/po/grassmods_pt.po
@@ -38516,7 +38516,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_pt_BR.po
+++ b/locale/po/grassmods_pt_BR.po
@@ -38518,7 +38518,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_ro.po
+++ b/locale/po/grassmods_ro.po
@@ -38602,7 +38602,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_ru.po
+++ b/locale/po/grassmods_ru.po
@@ -38639,7 +38639,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_si.po
+++ b/locale/po/grassmods_si.po
@@ -38490,7 +38490,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_sl.po
+++ b/locale/po/grassmods_sl.po
@@ -43590,7 +43590,7 @@ msgstr ""
 #: ../vector/v.kernel/main.c:218
 msgid ""
 "In network mode, normalize values by sum of density multiplied by length of "
-"each segment. Integral over the output map then gives 1.0 * mult"
+"each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_ta.po
+++ b/locale/po/grassmods_ta.po
@@ -38493,7 +38493,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_th.po
+++ b/locale/po/grassmods_th.po
@@ -38420,7 +38420,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_tr.po
+++ b/locale/po/grassmods_tr.po
@@ -38531,7 +38531,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_uk.po
+++ b/locale/po/grassmods_uk.po
@@ -38638,7 +38638,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_vi.po
+++ b/locale/po/grassmods_vi.po
@@ -38420,7 +38420,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_zh.po
+++ b/locale/po/grassmods_zh.po
@@ -38426,7 +38426,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/locale/po/grassmods_zh_CN.po
+++ b/locale/po/grassmods_zh_CN.po
@@ -25946,7 +25946,7 @@ msgid "Only calculate optimal radius and exit (no map is written)"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:218
-msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult"
+msgid "In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier"
 msgstr ""
 
 #: ../vector/v.kernel/main.c:224

--- a/vector/v.kernel/main.c
+++ b/vector/v.kernel/main.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
     flag_normalize = G_define_flag();
     flag_normalize->key = 'n';
     flag_normalize->description =
-	_("In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * mult");
+	_("In network mode, normalize values by sum of density multiplied by length of each segment. Integral over the output map then gives 1.0 * multiplier");
     flag_normalize->guisection = _("Network");
 
     flag_multiply = G_define_flag();
@@ -227,7 +227,7 @@ int main(int argc, char **argv)
 
     G_option_required(out_opt, net_out_opt, NULL);
     G_option_exclusive(out_opt, net_out_opt, NULL);
-    /* this should be activated for GRASS 8
+    /* TODO: this should be activated for GRASS 8
     G_option_requires(net_opt, net_out_opt, NULL);
     */
     if (G_parser(argc, argv))


### PR DESCRIPTION
do not use abbreviated parameter names in parameter descriptions

(overlooked in https://github.com/OSGeo/grass/commit/a5161d8ebd230a3b4003006d2075f8739f9a8e2a)