### PR TITLE
wxGUI/animation: add export output animation file validation, before export file

### DIFF
--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -1503,12 +1503,25 @@ class ExportDialog(wx.Dialog):
                         "Export directory is missing."))
                 return
         elif self.formatChoice.GetSelection() == 1:
-            if not self.gifBrowse.GetValue():
-                GError(parent=self, message=_("Export file is missing."))
+            if not self._export_file_validation(
+                    filebrowsebtn=self.gifBrowse,
+                    file_path=self.gifBrowse.GetValue(),
+                    file_postfix='.gif',
+            ):
                 return
         elif self.formatChoice.GetSelection() == 2:
-            if not self.swfBrowse.GetValue():
-                GError(parent=self, message=_("Export file is missing."))
+            if not self._export_file_validation(
+                    filebrowsebtn=self.swfBrowse,
+                    file_path=self.swfBrowse.GetValue(),
+                    file_postfix='.swf',
+            ):
+                return
+        elif self.formatChoice.GetSelection() == 3:
+            if not self._export_file_validation(
+                    filebrowsebtn=self.aviBrowse,
+                    file_path=self.aviBrowse.GetValue(),
+                    file_postfix='.avi',
+            ):
                 return
 
         # hide only to keep previous values
@@ -1559,6 +1572,59 @@ class ExportDialog(wx.Dialog):
         self.hidevbox.Show(self.posBox, False)
         self.hidevbox.Show(self.informBox, True)
         self.hidevbox.Layout()
+
+    def _export_file_validation(self, filebrowsebtn, file_path,
+                                file_postfix):
+        """File validation before export
+
+        :param obj filebrowsebutton: filebrowsebutton widget
+        :param str file_path: exported file path
+        :param str file_postfix: exported file postfix
+        (.gif, .swf, .avi)
+
+        :return bool: True if validation is ok
+        """
+
+        file_path_does_not_exist_err_message = _(
+            "Exported file directory '{base_dir}' "
+            "does not exist."
+        )
+        if not file_path:
+            GError(parent=self, message=_("Export file is missing."))
+            return False
+        else:
+            if file_path.endswith(file_postfix):
+                filebrowsebtn.SetValue(file_path + file_postfix)
+                file_path += file_postfix
+
+            base_dir = os.path.dirname(file_path)
+            if not os.path.exists(base_dir):
+                GError(
+                    parent=self,
+                    message=file_path_does_not_exist_err_message.format(
+                        base_dir=base_dir,
+                    ),
+                )
+                return False
+
+            if os.path.exists(file_path):
+                overwrite_dlg = wx.MessageDialog(
+                    self.GetParent(),
+                    message=_(
+                        "Exported animation file <{file}> exists. "
+                        "Do you want to overwrite it?".format(
+                            file=file_path,
+                        ),
+                    ),
+                    caption=_("Overwrite?"),
+                    style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
+                )
+                if not overwrite_dlg.ShowModal() == wx.ID_YES:
+                    overwrite_dlg.Destroy()
+                    return False
+                overwrite_dlg.Destroy()
+
+        return True
 
 
 class AnimSimpleLayerManager(SimpleLayerManager):


### PR DESCRIPTION
**To Reproduce**

1. Create an animation
2. Go to export
3. Choose export to animated GIF
4. Set output GIF file `/tmp/test` (but without postfix '.gif')
5. Hit Export button

**Error message:**

![g_gui_anim_export_error](https://user-images.githubusercontent.com/50632337/88515943-c86c6580-cfec-11ea-8e2e-ee53ee16dbf8.png)

**Expected behavior:**

Validate exported output animation file name/path.
