### PR TITLE
wxGUI/datacatalog: change ReloadTreeItems to use node-specific reloads

### DIFF
--- a/gui/wxpython/core/treemodel.py
+++ b/gui/wxpython/core/treemodel.py
@@ -117,7 +117,7 @@ class TreeModel(object):
     def GetIndexOfNode(self, node):
         """Method used for communication between view (VirtualTree) and model."""
         index = []
-        return self._getIndex(node, index)
+        return tuple(self._getIndex(node, index))
 
     def _getIndex(self, node, index):
         if node.parent:

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -75,7 +75,7 @@ class DataCatalog(wx.Panel):
         if self._loaded:
             return
 
-        self.thread.Run(callable=self.tree.InitTreeItems,
+        self.thread.Run(callable=self.tree.ReloadTreeItems,
                         ondone=lambda event: self.LoadItemsDone())
 
     def LoadItemsDone(self):

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -52,7 +52,7 @@ class DataCatalogFrame(wx.Frame):
 
         # tree
         self.tree = DataCatalogTree(parent=self.panel, giface=self._giface)
-        self.tree.InitTreeItems()
+        self.tree.ReloadTreeItems()
         self.tree.UpdateCurrentDbLocationMapsetNode()
         self.tree.ExpandCurrentMapset()
         self.tree.changeMapset.connect(lambda mapset:

--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -158,9 +158,14 @@ class AbstractTreeViewMixin(VirtualTree):
     def RefreshNode(self, node, recursive=False):
         """Refreshes node."""
         index = self._model.GetIndexOfNode(node)
-        self.RefreshItem(index)
         if recursive:
-            self.RefreshChildrenRecursively(self.GetItemByIndex(index))
+            try:
+                item = self.GetItemByIndex(index)
+            except IndexError:
+                return
+            self.RefreshItemRecursively(item, index)
+        else:
+            self.RefreshItem(index)
 
     def _emitSignal(self, item, signal, **kwargs):
         """Helper method for emitting signals.


### PR DESCRIPTION
The change is done in order to reload only nodes that are needed to be reloaded, e.g. when mapset is deleted, we don't need to reload entire tree including all dbs.

Includes fixes in treeview and treemodel.