### PR TITLE
gitignore: Add testreport directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ raster/r.mapcalc/mapcalc.output
 raster/r.mapcalc/mapcalc.tab.c
 raster/r.mapcalc/mapcalc.tab.h
 raster/r.mapcalc/mapcalc.yy.c
+testreport/*
 testsuite/examples/testreports/
 mswindows/GRASS-Installer.nsi
 mswindows/GRASS-Packager.bat


### PR DESCRIPTION
This PR adds the resulting directory of  `python3 -m grass.gunittest.main ...` to .gitignore.