### PR TITLE
wxGUI/animation: fix wxPyDeprecationWarning

### DIFF
--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -2031,7 +2031,7 @@ class PreferencesDialog(PreferencesBaseDialog):
         self.tempFormat.Bind(
             wx.EVT_TEXT, lambda evt: self._setTimeFormat(
                 self.tempFormat.GetValue()))
-        self.tempFormat.SetToolTipString(
+        self.tempFormat.SetToolTip(
             _(
                 "Click and then press key up or down to preview "
                 "different date and time formats. "


### PR DESCRIPTION
Fix `wxPyDeprecationWarning`.


**Warning message**:

```
wxPyDeprecationWarning: Call to deprecated item. Use SetToolTip instead.
```