### PR TITLE
wxGUI: update wxPython 4.1.0 support for FlatNotebook

### DIFF
--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -134,13 +134,14 @@ Deleted automatically on re-render action
 QUERYLAYER = 'qlayer'
 
 """Style definition for FlatNotebook pages"""
-FNPageStyle = FN.FNB_VC8 | \
+FNPageStyle = FN.FNB_FF2 | \
     FN.FNB_BACKGROUND_GRADIENT | \
     FN.FNB_NODRAG | \
     FN.FNB_TABS_BORDER_SIMPLE
 
 FNPageDStyle = FN.FNB_FANCY_TABS | \
     FN.FNB_BOTTOM | \
+    FN.FNB_NODRAG | \
     FN.FNB_NO_NAV_BUTTONS | \
     FN.FNB_NO_X_BUTTON
 

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1173,7 +1173,7 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         # sql statement box
         FNPageStyle = FN.FNB_NO_NAV_BUTTONS | \
-            FN.FNB_NO_X_BUTTON
+            FN.FNB_NO_X_BUTTON | FN.FNB_NODRAG | FN.FNB_FANCY_TABS
         if globalvar.hasAgw:
             dbmStyle = {'agwStyle': FNPageStyle}
         else:

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -124,11 +124,11 @@ class ModelFrame(wx.Frame):
         self.statusbar = self.CreateStatusBar(number=1)
 
         self.notebook = GNotebook(parent=self,
-                                  style=FN.FNB_FANCY_TABS | FN.FNB_BOTTOM |
-                                  FN.FNB_NO_NAV_BUTTONS | FN.FNB_NO_X_BUTTON)
+                                  style=globalvar.FNPageDStyle)
 
         self.canvas = ModelCanvas(self)
-        self.canvas.SetBackgroundColour(wx.WHITE)
+        self.canvas.SetBackgroundColour(
+            wx.SystemSettings().GetColour(wx.SYS_COLOUR_WINDOW))
         self.canvas.SetCursor(self.cursors["default"])
 
         self.model = Model(self.canvas)

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -328,13 +328,8 @@ class GMFrame(wx.Frame):
             name='catalog')
 
         # create displays notebook widget
-        cbStyle = globalvar.FNPageStyle
-        if globalvar.hasAgw:
-            self.notebookLayers = FN.FlatNotebook(
-                self.notebook, id=wx.ID_ANY, agwStyle=cbStyle)
-        else:
-            self.notebookLayers = FN.FlatNotebook(
-                self.notebook, id=wx.ID_ANY, style=cbStyle)
+        self.notebookLayers = GNotebook(parent=self.notebook,
+                                        style=globalvar.FNPageStyle)
         self.notebookLayers.SetTabAreaColour(globalvar.FNPageColor)
         menu = self._createTabMenu()
         self.notebookLayers.SetRightClickMenu(menu)
@@ -2133,7 +2128,8 @@ class GMFrame(wx.Frame):
             dispName = name
         else:
             dispName = "Display " + str(self.displayIndex + 1)
-        self.notebookLayers.AddPage(self.pg_panel, text=dispName, select=True)
+        self.notebookLayers.AddPage(
+            page=self.pg_panel, text=dispName, select=True)
         self.currentPage = self.notebookLayers.GetCurrentPage()
 
         # create layer tree (tree control for managing GIS layers)  and put on

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -131,8 +131,7 @@ class ImportDialog(wx.Dialog):
         self.Bind(wx.EVT_CLOSE, lambda evt: self.Destroy())
 
         self.notebook = GNotebook(parent=self,
-                                  style=FN.FNB_FANCY_TABS | FN.FNB_BOTTOM |
-                                  FN.FNB_NO_X_BUTTON)
+                                  style=globalvar.FNPageDStyle)
 
         self.notebook.AddPage(page=self.panel,
                               text=_('Source settings'),

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -223,14 +223,14 @@ class PsMapFrame(wx.Frame):
         """
         mainSizer = wx.BoxSizer(wx.VERTICAL)
         if globalvar.hasAgw:
-            self.book = fnb.FlatNotebook(parent=self, id=wx.ID_ANY,
-                                         agwStyle=fnb.FNB_FANCY_TABS | fnb.FNB_BOTTOM |
-                                         fnb.FNB_NO_NAV_BUTTONS | fnb.FNB_NO_X_BUTTON)
+            self.book = fnb.FlatNotebook(parent=self,
+                                         id=wx.ID_ANY,
+                                         agwStyle=globalvar.FNPageDStyle)
         else:
-            self.book = fnb.FlatNotebook(parent=self, id=wx.ID_ANY,
-                                         style=fnb.FNB_FANCY_TABS | fnb.FNB_BOTTOM |
-                                         fnb.FNB_NO_NAV_BUTTONS | fnb.FNB_NO_X_BUTTON)
-        #self.book = fnb.FlatNotebook(self, wx.ID_ANY, style = fnb.FNB_BOTTOM)
+            self.book = fnb.FlatNotebook(parent=self,
+                                         id=wx.ID_ANY,
+                                         style=globalvar.FNPageDStyle)
+
         self.book.AddPage(self.canvas, "Draft mode")
         self.book.AddPage(self.previewCanvas, "Preview")
         self.book.SetSelection(0)

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -172,7 +172,8 @@ class TplotFrame(wx.Frame):
         # self.vbox.AddSpacer(10)
 
         # ------------ADD NOTEBOOK------------
-        self.ntb = GNotebook(parent=self.mainPanel, style=FN.FNB_FANCY_TABS)
+        self.ntb = GNotebook(parent=self.mainPanel,
+                             style=FN.FNB_FANCY_TABS | FN.FNB_NODRAG)
 
         # ------------ITEMS IN NOTEBOOK PAGE (RASTER)------------------------
 

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -128,8 +128,7 @@ class VNETDialog(wx.Dialog):
 
         self.mainPanel = Panel(parent=self)
         self.notebook = GNotebook(parent=self.mainPanel,
-                                  style=FN.FNB_FANCY_TABS | FN.FNB_BOTTOM |
-                                  FN.FNB_NO_X_BUTTON)
+                                  style=globalvar.FNPageDStyle)
 
         # statusbar
         self.stPriorities = {'important': 5, 'iformation': 1}

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -135,8 +135,9 @@ class WSPanel(wx.Panel):
         reqDataBox = StaticBox(
             parent=self, label=_(" Requested data settings "))
         self._nb_sizer = wx.StaticBoxSizer(reqDataBox, wx.VERTICAL)
-        self.notebook = GNotebook(parent=self,
-                                  style=FN.FNB_FANCY_TABS | FN.FNB_NO_X_BUTTON)
+        self.notebook = GNotebook(
+            parent=self,
+            style=FN.FNB_FANCY_TABS | FN.FNB_NO_X_BUTTON | FN.FNB_NODRAG)
 
         self._requestPage()
         self._advancedSettsPage()


### PR DESCRIPTION
This addresses two separate, but interlinked issues:

1. addition of flatnotebook.FNB_NODRAG window style flag to prevent macOS GUI crash on switching tabs
2. dark mode support

FlatNotebook with window style  flatnotebook.FNB_VC8 or default style will now render unreadable tabs in dark mode:

*default (label colour changes, but not the background):*
<img width="131" alt="notebooktab-default" src="https://user-images.githubusercontent.com/14186207/88929600-a4be4f00-d27a-11ea-9e4c-f3ac5afe53ae.png">
*dark mode:*
<img width="131" alt="notebooktab-darkmode" src="https://user-images.githubusercontent.com/14186207/88929609-a851d600-d27a-11ea-8062-1ce5a22e7ba5.png">

this has been addressed by using flatnotebook.FNB_FANCY_TABS or flatnotebook.FNB_FF2.

In addition, the canvas colour of Graphical Modeler has been set to system colour.

The first issue – crash on Mac – is a wxPython (or rather wxWidgets) issue. I intend to report this.

❗  This should be backported if accepted.