### PR TITLE
G78 init: ensure zsh environment variable SAVEHIST is set

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1766,6 +1766,8 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
     f = open(shell_rc_file, 'w')
 
     if sh == 'zsh':
+        if not os.getenv('SAVEHIST'):
+            os.environ['SAVEHIST'] = os.getenv('HISTSIZE')
         f.write('test -r {home}/.alias && source {home}/.alias\n'.format(
             home=userhome))
     else:


### PR DESCRIPTION
Some set-ups with zsh may on GRASS initiation create a session without $SAVEHIST being set, leaving the terminal history not working. This PR addresses this case.


Mirror of #805 for the 7.8 branch.
