### PR TITLE
changed natural earth dataset archive from zip to tarball

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -82,7 +82,7 @@ LOCATIONS = [
     },
     {
         "label": "Natural Earth Dataset in WGS84",
-        "url": "https://github.com/baharmon/natural-earth-dataset/archive/natural-earth.zip",
+        "url": "https://zenodo.org/record/3968936/files/natural-earth-dataset.tar.gz",
         "size": "207 MB",
         "epsg": "4326",
         "license": "ODC Public Domain Dedication and License 1.0",


### PR DESCRIPTION
Changed the natural earth dataset download in the startup menu from a zip archive on GitHub to a tarball on Zenodo. Tested on a local installation of GRASS 7.9.
Issue #509 
PR #544 