### PR TITLE
Start in a demo/startup location

### DIFF
--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -39,8 +39,7 @@ from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
     get_possible_database_path,
     create_database_directory,
-    get_startup_location,
-    copy_startup_location)
+    get_startup_location)
 from startup.guiutils import (SetSessionMapset,
                               create_mapset_interactively,
                               create_location_interactively,
@@ -512,14 +511,11 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
-        print(path)
 
         # If nothing found, try to create GRASS directory and copy startup loc
         if path is None:
             path = create_database_directory()
-            location = get_startup_location()
-            if location:
-                copy_startup_location(path, location)
+            location = get_startup_location(path)
 
         if path:
             try:

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -38,7 +38,9 @@ from core.gcmd import GError, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
     get_possible_database_path,
-    create_database_directory)
+    create_database_directory,
+    startup_location_exists,
+    copy_startup_location)
 from startup.guiutils import (SetSessionMapset,
                               create_mapset_interactively,
                               create_location_interactively,
@@ -510,9 +512,11 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
-        # If nothing found, try to create GRASS directory
+        # If nothing found, try to create GRASS directory and copy startup loc
         if path is None:
             path = create_database_directory()
+            if startup_location_exists:
+                copy_startup_location(path)
 
         if path:
             try:

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -39,7 +39,7 @@ from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
     get_possible_database_path,
     create_database_directory,
-    get_startup_location)
+    create_startup_location_in_grassdb)
 from startup.guiutils import (SetSessionMapset,
                               create_mapset_interactively,
                               create_location_interactively,
@@ -514,8 +514,13 @@ class GRASSStartup(wx.Frame):
 
         # If nothing found, try to create GRASS directory and copy startup loc
         if path is None:
-            path = create_database_directory()
-            grassdatabase, location, mapset_name = get_startup_location(path)
+            grassdb = create_database_directory()
+            location = "world_latlong_wgs84"
+            mapset_name = create_startup_location_in_grassdb(grassdb,
+                                                             location)
+            if mapset_name:
+                self.SetLocation(grassdb, location, mapset_name)
+                self.ExitSuccessfully()
 
         if path:
             try:
@@ -540,9 +545,6 @@ class GRASSStartup(wx.Frame):
                 'your home directory. '
                 'Press Browse button to select the directory.'))
 
-        self.SetLocation(grassdatabase, location, mapset_name)
-        self.ExitSuccessfully()
-
     def OnCreateLocation(self, event):
         """Location wizard started"""
         grassdatabase, location, mapset = (
@@ -559,7 +561,6 @@ class GRASSStartup(wx.Frame):
                 self.listOfLocations.index(location))
             self.lbmapsets.SetSelection(0)
             self.SetLocation(grassdatabase, location, mapset)
-
 
     # the event can be refactored out by using lambda in bind
     def OnRenameMapset(self, event):

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -512,6 +512,7 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
+        print(path)
 
         # If nothing found, try to create GRASS directory and copy startup loc
         if path is None:

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -39,7 +39,7 @@ from core.utils import GetListOfLocations, GetListOfMapsets
 from startup.utils import (
     get_possible_database_path,
     create_database_directory,
-    startup_location_exists,
+    get_startup_location,
     copy_startup_location)
 from startup.guiutils import (SetSessionMapset,
                               create_mapset_interactively,
@@ -512,11 +512,13 @@ class GRASSStartup(wx.Frame):
         if self.GetRCValue("LOCATION_NAME") != "<UNKNOWN>":
             return
         path = get_possible_database_path()
+
         # If nothing found, try to create GRASS directory and copy startup loc
         if path is None:
             path = create_database_directory()
-            if startup_location_exists:
-                copy_startup_location(path)
+            location = get_startup_location()
+            if location:
+                copy_startup_location(path, location)
 
         if path:
             try:

--- a/gui/wxpython/gis_set.py
+++ b/gui/wxpython/gis_set.py
@@ -515,7 +515,7 @@ class GRASSStartup(wx.Frame):
         # If nothing found, try to create GRASS directory and copy startup loc
         if path is None:
             path = create_database_directory()
-            location = get_startup_location(path)
+            grassdatabase, location, mapset_name = get_startup_location(path)
 
         if path:
             try:
@@ -539,6 +539,9 @@ class GRASSStartup(wx.Frame):
                 'A popular choice is "grassdata", located in '
                 'your home directory. '
                 'Press Browse button to select the directory.'))
+
+        self.SetLocation(grassdatabase, location, mapset_name)
+        self.ExitSuccessfully()
 
     def OnCreateLocation(self, event):
         """Location wizard started"""

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -90,30 +90,29 @@ def create_database_directory():
 
 
 def startup_location_exists():
-    """Check for demolocation directory in distribution.
+    """Check for startup location directory in distribution.
 
-    Returns True if found or False if nothing was found.
+    Returns startup location if found or None if nothing was found.
     """
     home = os.path.expanduser("~")
-    demolocation = os.path.join(home, "grass", "demolocation"),
-    print(demolocation)
+    startup_location = os.path.join(home, "grass", "demolocation"),
 
-    # Find out if demolocation exists
-    if os.path.exists(demolocation):
-        return True
-    return False
+    # Find out if startup location exists
+    if os.path.exists(startup_location):
+        return startup_location
+    return None
 
 
-def copy_startup_location(grassdatabase):
-    """Copy the simple demolocation with some data to GRASS database.
+def copy_startup_location(grassdatabase, startup_location):
+    """Copy the simple startup_location with some data to GRASS database.
     Returns True if successfully copied or False when an error was encountered.
     """
-    home = os.path.expanduser("~")
-    demolocation = os.path.join(home, "grass", "demolocation")
+    src = startup_location
+    dst = os.path.join(grassdatabase, "demolocation")
 
-    # Copy source demolocation into GRASS database
+    # Copy source startup location into GRASS database
     try:
-        copytree(demolocation, grassdatabase, ignore=ignore_patterns('*.tmpl','Makefile*'))
+        copytree(src, dst, ignore=ignore_patterns('*.tmpl','Makefile*'))
         return True
     except (IOError, OSError) as why:
         pass

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -130,13 +130,6 @@ def _create_startup_mapset(location_path):
     """
     mapset_name = default_name = get_default_mapset_name()
     mapset_path = os.path.join(location_path, mapset_name)
-    counter = 2
-
-    while os.path.exists(mapset_path):
-        mapset_name = _("{name}_{counter}").format(name=default_name,
-                                                   counter=str(counter))
-        mapset_path = os.path.join(location_path, mapset_name)
-        counter += 1
 
     # Create new startup mapset
     try:

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -149,10 +149,11 @@ def _create_startup_mapset(location_path):
 
 
 def create_startup_location_in_grassdb(grassdatabase, startup_location_name):
-    """Wrapping function for creating whole new startup location in grassdb.
+    """Create a new startup location in the given GRASS database.
 
-    Returns the newly created mapset on success. Returns None If no location
-    to copy or copying failed."""
+    Returns the newly created mapset name on success. Returns None if there is
+    no location to copy in the installation or copying failed.
+    """
 
     # Find out if startup location exists
     startup_location = _get_startup_location_in_distribution()

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -89,13 +89,13 @@ def create_database_directory():
     return None
 
 
-def startup_location_exists():
+def get_startup_location():
     """Check for startup location directory in distribution.
 
     Returns startup location if found or None if nothing was found.
     """
-    home = os.path.expanduser("~")
-    startup_location = os.path.join(home, "grass", "demolocation"),
+    gisbase = os.getenv("GISBASE")
+    startup_location = os.path.join(gisbase, "demolocation"),
 
     # Find out if startup location exists
     if os.path.exists(startup_location):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -20,7 +20,7 @@ import os
 import tempfile
 import getpass
 import sys
-
+from shutil import copytree, ignore_patterns
 
 def get_possible_database_path():
     """Looks for directory 'grassdata' (case-insensitive) in standard
@@ -87,3 +87,34 @@ def create_database_directory():
         pass
 
     return None
+
+
+def startup_location_exists():
+    """Check for demolocation directory in distribution.
+
+    Returns True if found or False if nothing was found.
+    """
+    home = os.path.expanduser("~")
+    demolocation = os.path.join(home, "grass", "demolocation"),
+    print(demolocation)
+
+    # Find out if demolocation exists
+    if os.path.exists(demolocation):
+        return True
+    return False
+
+
+def copy_startup_location(grassdatabase):
+    """Copy the simple demolocation with some data to GRASS database.
+    Returns True if successfully copied or False when an error was encountered.
+    """
+    home = os.path.expanduser("~")
+    demolocation = os.path.join(home, "grass", "demolocation")
+
+    # Copy source demolocation into GRASS database
+    try:
+        copytree(demolocation, grassdatabase, ignore=ignore_patterns('*.tmpl','Makefile*'))
+        return True
+    except (IOError, OSError) as why:
+        pass
+    return False

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -21,6 +21,7 @@ import tempfile
 import getpass
 import sys
 from shutil import copytree, ignore_patterns
+from grass.grassdb.create import create_mapset, get_default_mapset_name
 
 def get_possible_database_path():
     """Looks for directory 'grassdata' (case-insensitive) in standard
@@ -120,6 +121,28 @@ def _copy_startup_location(grassdatabase, startup_location):
     return False
 
 
+def _create_startup_mapset(grassdatabase, startup_location):
+    """Create the new empty startup mapset named after user.
+
+    Returns True if successfully created or False when an error was encountered.
+    """
+    name = get_default_mapset_name()
+    mapset_path = os.path.join(grassdatabase, startup_location, name)
+    counter = 1
+
+    while os.path.exists(mapset_path):
+        name = name + "_" + str(counter)
+        mapset_path = os.path.join(grassdatabase, startup_location, name)
+
+    # Create new startup mapset
+    try:
+        create_mapset(grassdatabase, startup_location, name)
+        return True
+    except (IOError, OSError):
+        pass
+    return False
+
+
 def get_startup_location(grassdatabase):
     """Wrapping function for managing startup location.
 
@@ -130,6 +153,7 @@ def get_startup_location(grassdatabase):
     # Find out if startup location exists
     location = _get_startup_location_in_distribution()
     if location:
-            if _copy_startup_location(grassdatabase, location):
+        if _copy_startup_location(grassdatabase, location):
+            if _create_startup_mapset(grassdatabase, location):
                 return location
     return None

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -89,7 +89,7 @@ def create_database_directory():
     return None
 
 
-def get_startup_location():
+def _get_startup_location_in_distribution():
     """Check for startup location directory in distribution.
 
     Returns startup location if found or None if nothing was found.
@@ -103,8 +103,9 @@ def get_startup_location():
     return None
 
 
-def copy_startup_location(grassdatabase, startup_location):
+def _copy_startup_location(grassdatabase, startup_location):
     """Copy the simple startup_location with some data to GRASS database.
+
     Returns True if successfully copied or False when an error was encountered.
     """
     src = startup_location
@@ -114,6 +115,21 @@ def copy_startup_location(grassdatabase, startup_location):
     try:
         copytree(src, dst, ignore=ignore_patterns('*.tmpl','Makefile*'))
         return True
-    except (IOError, OSError) as why:
+    except (IOError, OSError):
         pass
     return False
+
+
+def get_startup_location(grassdatabase):
+    """Wrapping function for managing startup location.
+
+    Returns the location on success and None otherwise.
+    Internally resolves all the cases (no location to copy, copying failed
+    and an existing user's copy of the location)."""
+
+    # Find out if startup location exists
+    location = _get_startup_location_in_distribution()
+    if location:
+            if _copy_startup_location(grassdatabase, location):
+                return location
+    return None

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -95,7 +95,7 @@ def get_startup_location():
     Returns startup location if found or None if nothing was found.
     """
     gisbase = os.getenv("GISBASE")
-    startup_location = os.path.join(gisbase, "demolocation"),
+    startup_location = os.path.join(gisbase, "demolocation")
 
     # Find out if startup location exists
     if os.path.exists(startup_location):

--- a/gui/wxpython/startup/utils.py
+++ b/gui/wxpython/startup/utils.py
@@ -9,6 +9,7 @@ This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
 
 @author Vaclav Petras <wenzeslaus gmail com>
+@author Linda Kladivova <l.kladivova@seznam.cz>
 
 This file should not use (import) anything from GUI code (wx or wxGUI).
 This can potentially be part of the Python library (i.e. it needs to
@@ -22,6 +23,7 @@ import getpass
 import sys
 from shutil import copytree, ignore_patterns
 from grass.grassdb.create import create_mapset, get_default_mapset_name
+
 
 def get_possible_database_path():
     """Looks for directory 'grassdata' (case-insensitive) in standard
@@ -107,53 +109,58 @@ def _get_startup_location_in_distribution():
 def _copy_startup_location(grassdatabase, startup_location):
     """Copy the simple startup_location with some data to GRASS database.
 
-    Returns True if successfully copied or False when an error was encountered.
+    Returns path to startup location if successfully copied or None
+    when an error was encountered.
     """
     src = startup_location
-    dst = os.path.join(grassdatabase, "demolocation")
+    dst = os.path.join(grassdatabase, "world_latlong_wgs84")
 
     # Copy source startup location into GRASS database
     try:
         copytree(src, dst, ignore=ignore_patterns('*.tmpl','Makefile*'))
-        return True
+        return dst
     except (IOError, OSError):
         pass
-    return False
+    return None
 
 
-def _create_startup_mapset(grassdatabase, startup_location):
+def _create_startup_mapset(location_path):
     """Create the new empty startup mapset named after user.
 
     Returns True if successfully created or False when an error was encountered.
     """
     name = get_default_mapset_name()
-    mapset_path = os.path.join(grassdatabase, startup_location, name)
-    counter = 1
+    mapset_path = os.path.join(location_path, name)
+    counter = 2
 
     while os.path.exists(mapset_path):
-        name = name + "_" + str(counter)
-        mapset_path = os.path.join(grassdatabase, startup_location, name)
+        mapset_name = _("{name}_{counter}").format(name=name,
+                                                   counter=str(counter))
+        mapset_path = os.path.join(location_path, mapset_name)
+        counter += 1
 
     # Create new startup mapset
     try:
-        create_mapset(grassdatabase, startup_location, name)
-        return True
+        grassdatabase, location = os.path.split(location_path)
+        create_mapset(grassdatabase, location, mapset_name)
+        return grassdatabase, location, mapset_name
     except (IOError, OSError):
         pass
-    return False
+    return None
 
 
 def get_startup_location(grassdatabase):
     """Wrapping function for managing startup location.
 
-    Returns the location on success and None otherwise.
+    Returns the copied location on success and None otherwise.
     Internally resolves all the cases (no location to copy, copying failed
     and an existing user's copy of the location)."""
 
     # Find out if startup location exists
     location = _get_startup_location_in_distribution()
     if location:
-        if _copy_startup_location(grassdatabase, location):
-            if _create_startup_mapset(grassdatabase, location):
-                return location
+        location_path =_copy_startup_location(grassdatabase, location)
+        if location_path:
+            grassdatabase, location, mapset_name = _create_startup_mapset(location_path)
+            return grassdatabase, location, mapset_name
     return None


### PR DESCRIPTION
After creating this directory, follow with another function to create a simple location with some data.

The location demolocation in distribution (GISBASE) can be used for that. If it does not exist and thus cannot be copied, the startup should continue as usual.

I think the name should be startup or startup_location. It is more descriptive than demolocation but still clearly conveying it is not meant for normal use.

The startup mechanism for the first-time user should make use the mapset concept because it will both ensure preserving the data in PERMANENT intact and, at the same time, it will show how to use the mapset concept at least in the relation to the PERMANENT mapset.

When the startup/demo location is created/copied, a new mapset should be created there and used for starting, not the PERMANENT.

It will be only one mapset, but eventually there will be more than one, so probably some name_1, name_2, ... will be needed. 