### PR TITLE
Fix spelling errors.

### DIFF
--- a/scripts/r.mask/r.mask.html
+++ b/scripts/r.mask/r.mask.html
@@ -9,7 +9,7 @@ for example when used in a module as an input map.
 
 The MASK will block out certain areas of a raster map from analysis and/or
 display, by "hiding" them from sight of other GRASS modules. Data falling
-within the bounaries of the MASK can be modified and operated upon by other
+within the boundaries of the MASK can be modified and operated upon by other
 GRASS raster modules; data falling outside the MASK is treated as if it were NULL.
 <p>
 Because the MASK is actually only a reclass map named "MASK", it can be


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * bounaries -> boundaries