### PR TITLE
wxGUI/mapdisp: fix double click on the overlays in the 3D view

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1215,12 +1215,13 @@ class MapFrame(SingleMapFrame):
 
         :param overlayId: id of overlay
         """
-        dlg = self.decorations[overlayId].dialog
-        if dlg.IsShown():
-            dlg.SetFocus()
-            dlg.Raise()
-        else:
-            dlg.Show()
+        if self.decorations:
+            dlg = self.decorations[overlayId].dialog
+            if dlg.IsShown():
+                dlg.SetFocus()
+                dlg.Raise()
+            else:
+                dlg.Show()
 
     def RemoveOverlay(self, overlayId):
         """Hide overlay.

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1215,7 +1215,7 @@ class MapFrame(SingleMapFrame):
 
         :param overlayId: id of overlay
         """
-        if self.decorations:
+        if overlayId in self.decorations:
             dlg = self.decorations[overlayId].dialog
             if dlg.IsShown():
                 dlg.SetFocus()


### PR DESCRIPTION
**To Reproduce**

1. Add raster map `d.rast elevation`
2. Switch to 3D view
3. Add north arrow via map display window toolbar icon (Add map elements menu)
4. Double click on the added north arrow overlay

**Error message**:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/nviz/mapwindow.py",
line 633, in OnMouseAction

self.OnDClick(event)
  File "/usr/lib64/grass79/gui/wxpython/nviz/mapwindow.py",
line 859, in OnDClick

self.overlayActivated.emit(overlayId=self.dragid)
  File
"/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py",
line 229, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 344, in send

response = robustapply.robustApply(
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File "/usr/lib64/grass79/gui/wxpython/mapdisp/frame.py",
line 1220, in _activateOverlay

dlg = self.decorations[overlayId].dialog
KeyError
:
-1
```
