### PR TITLE
init: Do not try to set system as a GRASS session locale

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1284,7 +1284,7 @@ def set_language(grass_config_dir):
     if language == 'C':
         language = 'en'
 
-    if language == 'None' or language == '' or not language:
+    if language == 'None' or language == '' or language == 'system' or not language:
         # Language override is disabled (system language specified)
         # As by default program runs with C locale, but users expect to
         # have their default locale, we'll just set default locale


### PR DESCRIPTION
Observed in the wild by Linda Kladivova https://github.com/OSGeo/grass/pull/858#issuecomment-668455497
It's easier to handle special case than figure out what went wrong.