### PR TITLE
wxGUI/nviz: fix set surface 'object' key, after GLWindow class init

### DIFF
--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -125,6 +125,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         self.mapQueried = Signal('GLWindow.mapQueried')
 
         self.init = False
+        self.call = False
         self.initView = False
         self.context = None
         if CheckWxVersion(version=[2, 9]):
@@ -464,6 +465,16 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 win.SetItems(self.GetLayerNames('raster'))
 
             self.init = True
+        else:
+            if not self.call:
+                layer = self.tree.GetSelectedLayer(
+                    multi=False, checkedOnly=True)
+                if layer:
+                    layer = self.tree.GetLayerInfo(layer, key='maplayer')
+                    if layer.type == 'raster':
+                        self.lmgr.nviz.UpdatePage('surface')
+                        self.lmgr.nviz.UpdateSettings()
+                self.call = True
 
         self.UpdateMap()
 
@@ -1668,6 +1679,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
 
         :param item: layer item
         """
+        self.call = False
         layer = self.tree.GetLayerInfo(item, key='maplayer')
 
         if layer.type not in ('raster', 'raster_3d'):

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -3238,7 +3238,8 @@ class NvizToolWindow(FN.FlatNotebook):
         try:
             data = self._getLayerPropertiesByName(
                 name, mapType='raster')['surface']
-        except TypeError as e:
+            data['object']
+        except (KeyError, TypeError) as e:
             self.EnablePage('surface', False)
             return
 


### PR DESCRIPTION
**To Reproduce:**

1. `d.rast map=elevation`
2. Switch 2D view -> 3D view
3. Switch 3D view -> 2D view
4. Switch 2D view -> 3D view again

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/nviz/tools.py", line
3247, in OnSetRaster

self.UpdateSurfacePage(layer, data, updateName=False)
  File "/usr/lib64/grass79/gui/wxpython/nviz/tools.py", line
5370, in UpdateSurfacePage

self.OnSurfaceAxis(None)
  File "/usr/lib64/grass79/gui/wxpython/nviz/tools.py", line
3784, in OnSurfaceAxis

id = data['surface']['object']['id']
KeyError
:
'object
```

**Debug info:**

We need setting `data['surface']['object']` key again (step no. 4), after [popped](https://github.com/OSGeo/grass/blob/64527a73f29b745de89758ce7fc6462235f6da30/gui/wxpython/nviz/mapwindow.py#L1701) from data dict, during unload raster map (step no. 3).