### PR TITLE
wxGUI/nviz: fix update list of surface in vector page during delete constant surface

### DIFF
--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -2714,7 +2714,9 @@ class NvizToolWindow(FN.FlatNotebook):
         for vtype in ('points', 'lines'):
             checklist = self.FindWindowById(
                 self.win['vector'][vtype]['surface'])
-            checklist.Delete(checklist.FindString(name))
+            item = checklist.FindString(name)
+            if item > wx.NOT_FOUND:
+                checklist.Delete(item)
 
         if self.mapDisplay.IsAutoRendered():
             self.mapWindow.Refresh(False)


### PR DESCRIPTION
**To Reproduce:**

1. `d.rast map=elevation`
2. Switch 2D view -> 3D view
3. On the 3D view page go to Data page -> Constant surface collapsible panel -> New button (add constant surface)
4. Switch 3D view -> 2D view
5. Switch 2D view -> 3D view again
6. On the 3D view page go to Data page -> Constant surface collapsible panel -> Delete button (delete constant surface)

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/nviz/tools.py", line
2720, in OnDeleteConstant

checklist.Delete(item)
wx._core
.
wxAssertionError
:
C++ assertion "pos < GetCount()" failed at /var/tmp/portage/
x11-libs/wxGTK-3.0.4-r302/work/wxWidgets-3.0.4/src/common/ct
rlsub.cpp(111) in Delete(): invalid index
```