### PR TITLE
Data catalog: double click on map from different location fails

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -573,6 +573,7 @@ class DataCatalogTree(TreeView):
         if not isinstance(self._giface, StandaloneGrassInterface):
             self.DefineItems([node])
             selected_layer = self.selected_layer[0]
+            selected_mapset = self.selected_mapset[0]
             selected_loc = self.selected_location[0]
 
             if selected_layer is not None:
@@ -583,10 +584,12 @@ class DataCatalogTree(TreeView):
                     dlg = wx.MessageDialog(
                         parent=self,
                         message=_(
-                            "The map is not in the current location and cannot be displayed."
+                            "Map {0}@{1} is not in the current location"
+                            " and therefore cannot be displayed."
                             "\n\n"
-                            "To view this map, switch to the selected mapset."
-                        ),
+                            "To displey this map switch to mapset first."
+                        ).format(selected_layer.data['name'],
+                                 selected_mapset.data['name']),
                         caption=_("Unable to display the map"),
                         style=wx.OK | wx.ICON_WARNING
                     )

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -572,10 +572,33 @@ class DataCatalogTree(TreeView):
         """
         if not isinstance(self._giface, StandaloneGrassInterface):
             self.DefineItems([node])
-            if self.selected_layer[0] is not None:
-                # display selected layer and return
-                self.DisplayLayer()
-                return
+            selected_layer = self.selected_layer[0]
+            selected_loc = self.selected_location[0]
+
+            if selected_layer is not None:
+                genv = gisenv()
+
+                # Check if the layer is in different location
+                if selected_loc.data['name'] != genv['LOCATION_NAME']:
+                    dlg = wx.MessageDialog(
+                        parent=self,
+                        message=_("The map {0} is in the mapset in"
+                                  " the different location {1}."
+                                  " Do you want to switch to this"
+                                  " mapset?").format(selected_layer.data['name'],
+                                                     selected_loc.data['name']),
+                        caption=_("Switch to mapset in different location"),
+                        style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION
+                        )
+                    if dlg.ShowModal() == wx.ID_YES:
+                        self._SwitchDbLocationMapset()
+                        self.DisplayLayer()
+                        dlg.Destroy()
+                        return
+                    dlg.Destroy()
+                else:
+                     self.DisplayLayer()
+                     return
 
         # expand/collapse location/mapset...
         if self.IsNodeExpanded(node):

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -582,19 +582,15 @@ class DataCatalogTree(TreeView):
                 if selected_loc.data['name'] != genv['LOCATION_NAME']:
                     dlg = wx.MessageDialog(
                         parent=self,
-                        message=_("The map {0} is in the mapset in"
-                                  " the different location {1}."
-                                  " Do you want to switch to this"
-                                  " mapset?").format(selected_layer.data['name'],
-                                                     selected_loc.data['name']),
-                        caption=_("Switch to mapset in different location"),
-                        style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION
+                        message=_(
+                            "The map is not in the current location and cannot be displayed."
+                            "\n\n"
+                            "To view this map, switch to the selected mapset."
+                        ),
+                        caption=_("Unable to display the map"),
+                        style=wx.OK | wx.ICON_WARNING
                     )
-                    if dlg.ShowModal() == wx.ID_YES:
-                        self._SwitchDbLocationMapset()
-                        self.DisplayLayer()
-                        dlg.Destroy()
-                        return
+                    dlg.ShowModal()
                     dlg.Destroy()
                 else:
                     self.DisplayLayer()

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -584,10 +584,10 @@ class DataCatalogTree(TreeView):
                     dlg = wx.MessageDialog(
                         parent=self,
                         message=_(
-                            "Map {0}@{1} is not in the current location"
+                            "Map <{0}@{1}> is not in the current location"
                             " and therefore cannot be displayed."
                             "\n\n"
-                            "To displey this map switch to mapset first."
+                            "To display this map switch to mapset <{1}> first."
                         ).format(selected_layer.data['name'],
                                  selected_mapset.data['name']),
                         caption=_("Unable to display the map"),

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -589,7 +589,7 @@ class DataCatalogTree(TreeView):
                                                      selected_loc.data['name']),
                         caption=_("Switch to mapset in different location"),
                         style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION
-                        )
+                    )
                     if dlg.ShowModal() == wx.ID_YES:
                         self._SwitchDbLocationMapset()
                         self.DisplayLayer()
@@ -597,8 +597,8 @@ class DataCatalogTree(TreeView):
                         return
                     dlg.Destroy()
                 else:
-                     self.DisplayLayer()
-                     return
+                    self.DisplayLayer()
+                    return
 
         # expand/collapse location/mapset...
         if self.IsNodeExpanded(node):


### PR DESCRIPTION
**Describe the bug**
Double click on map from different than current location adds the layer into layer tree but the layer does not exist in current location so it fails to display it.

**Expected behavior**
I suppose it should inform user that the map is in different location and ask if they want to switch to that mapset.