### PR TITLE
wxGUI/nviz: fix relative import from 'wxnviz' module

### DIFF
--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -55,12 +55,9 @@ from gui_core.gselect import Select
 from gui_core.wrap import Window, SpinCtrl, PseudoDC, ToggleButton, Button, \
     TextCtrl, StaticText, StaticBox, CheckListBox, ColourSelect
 from core.debug import Debug
-try:
-    from nviz.mapwindow import wxUpdateProperties, wxUpdateView,\
-        wxUpdateLight, wxUpdateCPlane
-    import wxnviz
-except ImportError:
-    pass
+from nviz.mapwindow import wxUpdateProperties, wxUpdateView,\
+    wxUpdateLight, wxUpdateCPlane
+from .wxnviz import DM_FLAT, DM_GOURAUD, MAX_ISOSURFS
 
 
 class NvizToolWindow(FN.FlatNotebook):
@@ -4242,7 +4239,7 @@ class NvizToolWindow(FN.FlatNotebook):
         delete = self.FindWindowById(self.win['volume']['btnDelete'])
         moveDown = self.FindWindowById(self.win['volume']['btnMoveDown'])
         moveUp = self.FindWindowById(self.win['volume']['btnMoveUp'])
-        if nitems >= wxnviz.MAX_ISOSURFS:
+        if nitems >= MAX_ISOSURFS:
             # disable add button on max
             add.Enable(False)
         else:
@@ -4319,9 +4316,9 @@ class NvizToolWindow(FN.FlatNotebook):
 
         mode = 0
         if selection == 0:
-            mode |= wxnviz.DM_FLAT
+            mode |= DM_FLAT
         else:
-            mode |= wxnviz.DM_GOURAUD
+            mode |= DM_GOURAUD
 
         if self.FindWindowById(self.win['volume']['draw'][
                                'mode']).GetSelection() == 0:


### PR DESCRIPTION
**To Reproduce**:

Location: **slovakia3d_grass7**

1. `d.rast map=dem500`
2. `d.rast3d map=precip3d.500z50`
3. Switch 2D view -> 3D view
4. Go to 3D view page -> Data page -> 3D Raster collapsible panel -> choose **precip3d.500z50** 3D raster map -> click on the Add button (Add isosurface)

**Error message**:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/nviz/tools.py", line
4533, in OnVolumeAdd

self.UpdateIsosurfButtons(list)
  File "/usr/lib64/grass79/gui/wxpython/nviz/tools.py", line
4251, in UpdateIsosurfButtons

if nitems >= wxnviz.MAX_ISOSURFS:
NameError
:
name 'wxnviz' is not defined

```