### PR TITLE
wxGUI/datacatalog: fix display 3D raster

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1100,7 +1100,7 @@ class DataCatalogTree(TreeView):
     def DisplayLayer(self):
         """Display selected layer in current graphics view"""
         all_names = []
-        names = {'raster': [], 'vector': [], 'raster3d': []}
+        names = {'raster': [], 'vector': [], 'raster_3d': []}
         for i in range(len(self.selected_layer)):
             name = self.selected_layer[i].data['name'] + '@' + self.selected_mapset[i].data['name']
             names[self.selected_layer[i].data['type']].append(name)


### PR DESCRIPTION
**To Reproduce**:

Location: **slovakia3d_grass7**

1. On the Layer Manager **Data page** find raster map **precip3d.500z50** in the PERMANENT mapset, and via menu click on the **Display layer**

**Error message**:

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
1018, in OnDisplayLayer

self.DisplayLayer()
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
1027, in DisplayLayer

names[self.selected_layer[i].data['type']].append(name)
KeyError
:
'raster_3d'
```