### PR TITLE
New color table: percentage of forest cover

### DIFF
--- a/lib/gis/colors.desc
+++ b/lib/gis/colors.desc
@@ -13,6 +13,7 @@ elevation: maps relative ranges of raster values to elevation color ramp
 etopo2: colors for ETOPO2 worldwide bathymetry/topography
 evi: enhanced vegetative index colors
 fahrenheit: blue to red for Fahrenheit temperature
+forest_cover: percentage of forest cover
 gdd: accumulated growing degree days
 grass: GRASS GIS green (perceptually uniform)
 greens: white to green

--- a/lib/gis/colors/forest_cover
+++ b/lib/gis/colors/forest_cover
@@ -1,0 +1,13 @@
+# Percentage of forest cover, derived from
+# https://catalog.data.gov/dataset/modis-terra-vegetation-continuous-fields-yearly-l3-global-250m-sin-grid-v006
+0 255:250:250
+10 242:238:191
+20 242:233:126
+30 214:214:54
+40 175:214:0
+50 137:186:0
+60 99:156:0
+70 68:128:0
+80 43:99:0
+90 21:71:0
+100 10:56:0


### PR DESCRIPTION
Percentage of forest cover, color values derived from
https://catalog.data.gov/dataset/modis-terra-vegetation-continuous-fields-yearly-l3-global-250m-sin-grid-v006
and
https://lcluc.umd.edu/metadata/global-30m-landsat-tree-canopy-version-4

Example:

![image](https://user-images.githubusercontent.com/1295172/89917032-9c5e0080-dbf8-11ea-80fc-d645a6dce0ee.png)
