### PR TITLE
wxGUI/nviz: fix failed map centring on mac with pre-wx4.1

### DIFF
--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -247,6 +247,11 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                         "and restart GUI.")
             GMessage(message)
 
+    def GetContentScaleFactor(self):
+            if sys.platform == "darwin" and not CheckWxVersion(version=[4, 1, 0]):
+                return 1
+            return super().GetContentScaleFactor()
+
     def InitFly(self):
         """Initialize fly through dictionary"""
         fly = {'interval': 10,             # interval for timerFly

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -248,9 +248,9 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             GMessage(message)
 
     def GetContentScaleFactor(self):
-            if sys.platform == "darwin" and not CheckWxVersion(version=[4, 1, 0]):
-                return 1
-            return super().GetContentScaleFactor()
+        if sys.platform == "darwin" and not CheckWxVersion(version=[4, 1, 0]):
+            return 1
+        return super().GetContentScaleFactor()
 
     def InitFly(self):
         """Initialize fly through dictionary"""


### PR DESCRIPTION
Fixes #590

Seems that the #590 issue with problem centring the map in nviz 3D-mode on hi-res displays, is an issue only for Mac with wxPython <4.1.0.