### PR TITLE
wxGUI: fix wxPython 4.1.0 support for "About GRASS GIS" dialog

### DIFF
--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -105,9 +105,7 @@ class AboutWindow(wx.Frame):
 
     def _doLayout(self):
         btnSizer = wx.BoxSizer(wx.HORIZONTAL)
-        btnSizer.Add(self.btnClose, proportion=0,
-                     flag=wx.ALL | wx.ALIGN_RIGHT,
-                     border=5)
+        btnSizer.Add(self.btnClose, proportion=0, flag=wx.ALL, border=5)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.aboutNotebook, proportion=1,
@@ -226,10 +224,7 @@ class AboutWindow(wx.Frame):
 
         infoGridSizer.AddGrowableCol(0)
         infoGridSizer.AddGrowableCol(1)
-        infoSizer.Add(
-            infoGridSizer,
-            proportion=1,
-            flag=wx.EXPAND | wx.ALIGN_CENTER | wx.ALIGN_CENTER_VERTICAL)
+        infoSizer.Add(infoGridSizer, proportion=1, flag=wx.EXPAND)
 
         row += 2
         infoGridSizer.Add(StaticText(parent=infoTxt, id=wx.ID_ANY,


### PR DESCRIPTION
Open the "About GRASS GIS" dialog using wxPython 4.1 fails with flag asserts.
This PR addresses that.