### PR TITLE
Check for gislock and other issues when deleting/renaming/editing mapset and location in catalog

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1493,7 +1493,7 @@ class DataCatalogTree(TreeView):
         item = wx.MenuItem(menu, wx.ID_ANY, _("&Remove GRASS database from data catalog"))
         menu.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.OnRemoveGrassDb, item)
-        if self._restricted or self.selected_grassdb[0].data['name'] == genv['GISDBASE']:
+        if self.selected_grassdb[0].data['name'] == genv['GISDBASE']:
             item.Enable(False)
 
         item = wx.MenuItem(menu, wx.ID_ANY, _("&Delete GRASS database from disk"))

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1493,13 +1493,13 @@ class DataCatalogTree(TreeView):
         item = wx.MenuItem(menu, wx.ID_ANY, _("&Remove GRASS database from data catalog"))
         menu.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.OnRemoveGrassDb, item)
-        if currentGrassDb:
+        if self._restricted or self.selected_grassdb[0].data['name'] == genv['GISDBASE']:
             item.Enable(False)
 
         item = wx.MenuItem(menu, wx.ID_ANY, _("&Delete GRASS database from disk"))
         menu.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.OnDeleteGrassDb, item)
-        if currentGrassDb:
+        if self._restricted:
             item.Enable(False)
 
         self.PopupMenu(menu)

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -173,7 +173,7 @@ def get_reason_mapset_not_removable(grassdb, location, mapset, check_permanent):
     Parameter *check_permanent* is True of False. It depends on whether
     we want to check for permanent mapset or not.
 
-    Returns message as string if there was failed check or empty string whether not.
+    Returns message as string if there was failed check, otherwise None.
     """
     message = None
     mapset_path = os.path.join(grassdb, location, mapset)

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -20,7 +20,6 @@ import sys
 import wx
 
 import grass.script as gs
-from grass.script import core as grass
 from grass.script import gisenv
 from grass.grassdb.checks import (
     mapset_exists,
@@ -161,7 +160,7 @@ def check_mapsets_interactively(mapsets, check_permanent):
     Parameter *mapsets* is a list of tuples (database, location, mapset)
     Parameter *check_permanent* is True of False. It depends on whether
     we want to perform this check or not.
-    
+
     Returns messages as list if there was an exception or None whether not.
     """
     messages = []
@@ -170,7 +169,7 @@ def check_mapsets_interactively(mapsets, check_permanent):
 
         # Check if mapset is permanent
         if mapset == "PERMANENT":
-            if check_permanent == True:
+            if check_permanent is True:
                 messages.append(_("Mapset <{}> is required for a valid location.").format(mapset_path))
         # Check if mapset is current
         elif is_mapset_current(grassdb, location, mapset):
@@ -691,14 +690,14 @@ def delete_grassdb_interactively(guiparent, grassdb):
 
     if issue:
         dlg = wx.MessageDialog(
-        parent=guiparent,
-        message=_(
-            "Cannot delete GRASS database from disk for the following reason:\n\n"
-            "{}\n\n"
-            "GRASS database will not be deleted."
-        ).format(issue),
-        caption=_("Unable to delete selected GRASS database"),
-        style=wx.OK | wx.ICON_WARNING
+            parent=guiparent,
+            message=_(
+                "Cannot delete GRASS database from disk for the following reason:\n\n"
+                "{}\n\n"
+                "GRASS database will not be deleted."
+            ).format(issue),
+            caption=_("Unable to delete selected GRASS database"),
+            style=wx.OK | wx.ICON_WARNING
         )
         dlg.ShowModal()
     else:

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -159,7 +159,7 @@ def get_reasons_mapsets_not_removable(mapsets, check_permanent):
     messages = []
     for grassdb, location, mapset in mapsets:
         messages += get_reasons_mapset_not_removable(grassdb, location,
-                                                    mapset, check_permanent)
+                                                     mapset, check_permanent)
     return messages
 
 
@@ -176,19 +176,19 @@ def get_reasons_mapset_not_removable(grassdb, location, mapset, check_permanent)
     # Check if mapset is permanent
     if check_permanent and mapset == "PERMANENT":
         messages.append(_("Mapset <{mapset}> is required for a valid location.").format(
-                mapset=mapset_path))
+            mapset=mapset_path))
     # Check if mapset is current
     elif is_mapset_current(grassdb, location, mapset):
         messages.append(_("Mapset <{mapset}> is the current mapset.").format(
-                mapset=mapset_path))
+            mapset=mapset_path))
     # Check whether mapset is in use
     elif is_mapset_locked(mapset_path):
         messages.append(_("Mapset <{mapset}> is in use.").format(
-                mapset=mapset_path))
+            mapset=mapset_path))
     # Check whether mapset is owned by different user
     elif is_different_mapset_owner(mapset_path):
         messages.append(_("Mapset <{mapset}> is owned by a different user.").format(
-                mapset=mapset_path))
+            mapset=mapset_path))
 
     return messages
 
@@ -215,7 +215,7 @@ def get_reasons_location_not_removable(grassdb, location):
     # Check if location is current
     if is_location_current(grassdb, location):
         messages.append(_("Location <{location}> is the current location.").format(
-                location=location_path))
+            location=location_path))
         return messages
 
     # Find mapsets in particular location
@@ -397,7 +397,7 @@ def rename_mapset_interactively(guiparent, grassdb, location, mapset):
 
     # Check selected mapset
     message = get_reasons_mapset_not_removable(grassdb, location, mapset,
-                                         check_permanent=True)
+                                               check_permanent=True)
     if message:
         dlg = wx.MessageDialog(
             parent=guiparent,

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -46,7 +46,6 @@ from location_wizard.dialogs import RegionDef
 from gui_core.widgets import GenericMultiValidator
 
 
-
 def SetSessionMapset(database, location, mapset):
     """Sets database, location and mapset for the current session"""
     RunCommand("g.gisenv", set="GISDBASE=%s" % database)

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -154,7 +154,7 @@ def get_reasons_mapsets_not_removable(mapsets, check_permanent):
     Parameter *check_permanent* is True of False. It depends on whether
     we want to check for permanent mapset or not.
 
-    Returns messages as list if there were any failed checks or None whether not.
+    Returns messages as list if there were any failed checks, otherwise empty list.
     """
     messages = []
     for grassdb, location, mapset in mapsets:
@@ -201,7 +201,7 @@ def get_reasons_locations_not_removable(locations):
 
     Parameter *locations* is a list of tuples (database, location).
 
-    Returns messages as list if there were any failed checks or None whether not.
+    Returns messages as list if there were any failed checks, otherwise empty list.
     """
     messages = []
     for grassdb, location in locations:
@@ -212,7 +212,7 @@ def get_reasons_locations_not_removable(locations):
 def get_reasons_location_not_removable(grassdb, location):
     """Get reasons why one location cannot be removed.
 
-    Returns messages as list if there were any failed checks or None whether not.
+    Returns messages as list if there were any failed checks, otherwise empty list.
     """
     messages = []
     location_path = os.path.join(grassdb, location)
@@ -249,7 +249,7 @@ def get_reasons_location_not_removable(grassdb, location):
 def get_reasons_grassdb_not_removable(grassdb):
     """Get reasons why one grassdb cannot be removed.
 
-    Returns messages as list if there were any failed checks or None whether not.
+    Returns messages as list if there were any failed checks, otherwise empty list.
     """
     messages = []
     genv = gisenv()
@@ -730,7 +730,7 @@ def delete_grassdb_interactively(guiparent, grassdb):
                 "{reasons}\n\n"
                 "GRASS database will not be deleted."
             ).format(reasons="\n".join(messages)),
-            caption=_("Unable to delete selected locations"),
+            caption=_("Unable to delete selected GRASS database"),
             style=wx.OK | wx.ICON_WARNING
         )
         dlg.ShowModal()

--- a/lib/python/grassdb/checks.py
+++ b/lib/python/grassdb/checks.py
@@ -12,6 +12,7 @@ for details.
 
 import os
 from pathlib import Path
+from grass.script import gisenv
 
 
 def mapset_exists(database, location, mapset):
@@ -56,6 +57,23 @@ def is_location_valid(database, location):
     return os.access(
         os.path.join(database, location, "PERMANENT", "DEFAULT_WIND"), os.F_OK
     )
+
+
+def is_mapset_current(grassdb, location, mapset):
+    genv = gisenv()
+    if (grassdb == genv['GISDBASE'] and
+        location == genv['LOCATION_NAME'] and
+        mapset == genv['MAPSET']):
+        return True
+    return False
+
+
+def is_location_current(grassdb, location):
+    genv = gisenv()
+    if (grassdb == genv['GISDBASE'] and
+        location == genv['LOCATION_NAME']):
+        return True
+    return False
 
 
 def is_current_user_mapset_owner(mapset_path):


### PR DESCRIPTION
Currently we don't have mechanism in data catalog to check for gislock and if mapset belongs to different user, so that we prevent user from actions including deleting or renaming mapset, and editing layers. The same applies to location deleting/renaming, it needs to check whether all mapsets can be edited.