### PR TITLE
wxGUI/animation: fix 'RuntimeError: dictionary changed size during iteration'

### DIFF
--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -695,7 +695,7 @@ class DictRefCounter:
     def Clear(self):
         """Clears items which are not needed any more."""
         Debug.msg(4, 'DictRefCounter.Clear')
-        for key in self.dictionary.keys():
+        for key in self.dictionary.copy().keys():
             if key is not None:
                 if self.referenceCount[key] <= 0:
                     del self.dictionary[key]


### PR DESCRIPTION
**To Reproduce:**

1. Launch Animation tool `g.gui.animation`

2. Hit Add new animation toolbar tool -> Add space-time datasets or series of map layers -> Open Select raster/vector maps dialog -> Choose basins, elevation, landuse raster map -> Hit Ok button -> Hit  Ok buton -> Hit Ok button

3. Hit Add, edit or remove animation toolbar tool -> Choose Animation 1 -> Hit Edit button -> Edit layer properties -> Open Select raster/vector maps dialog -> Choose basins, elevation raster map -> Hit Ok button -> Hit  Ok buton -> Hit Ok button

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/animation/frame.py", line 204, in OnEditAnimation
    self.controller.EditAnimations()
  File "/usr/lib64/grass79/gui/wxpython/animation/controller.py", line 220, in EditAnimations
    self._setAnimations()
  File "/usr/lib64/grass79/gui/wxpython/animation/controller.py", line 328, in _setAnimations
    self._updateBitmapData()
  File "/usr/lib64/grass79/gui/wxpython/animation/controller.py", line 407, in _updateBitmapData
    self.bitmapPool.Clear()
  File "/usr/lib64/grass79/gui/wxpython/animation/provider.py", line 698, in Clear
    for key in self.dictionary.keys():
RuntimeError: dictionary changed size during iteration
```
