### PR TITLE
wxGUI/datacatalog: multiple grass databases context menu shows Delete locations

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -622,6 +622,8 @@ class DataCatalogTree(TreeView):
             self._popupMenuLocation()
         elif self.selected_grassdb[0] and not self.selected_location[0] and len(self.selected_grassdb) == 1:
             self._popupMenuGrassDb()
+        elif len(self.selected_grassdb) > 1 and not self.selected_location[0]:
+            self._popupMenuEmpty()
         elif len(self.selected_location) > 1 and not self.selected_mapset[0]:
             self._popupMenuMultipleLocations()
         elif len(self.selected_mapset) > 1:


### PR DESCRIPTION
**Describe the bug**
When you select multiple GRASS databases in datacatalog and right click you get "Delete locations", which is obviously a mistake. This is in latest master.

**Expected behavior**
If there is no action implemented for multiple databases, it should show "No available options".