### PR TITLE
Reflect changes when mapset/location is created from menu

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1072,9 +1072,8 @@ class GMFrame(wx.Frame):
 
     def OnLocationWizard(self, event):
         """Create new location"""
-        grassdb_node, loc_node, mapset_node = self.datacatalog.tree.GetCurrentDbLocationMapsetNode()
         grassdatabase, location, mapset = (
-            create_location_interactively(self, grassdb_node.data['name'])
+            create_location_interactively(self, grass.gisenv()['GISDBASE'])
         )
         if location:
             self.datacatalog.tree.ReloadTreeItems()

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1068,9 +1068,7 @@ class GMFrame(wx.Frame):
         mapset = create_mapset_interactively(self, db_node.data['name'],
                                              loc_node.data['name'])
         if mapset:
-            self.datacatalog.tree.InsertMapset(name=mapset,
-                              location_node=loc_node)
-        self.datacatalog.tree.ReloadTreeItems()
+            self.datacatalog.tree.ReloadTreeItems()
 
     def OnLocationWizard(self, event):
         """Create new location"""

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1077,12 +1077,7 @@ class GMFrame(wx.Frame):
             create_location_interactively(self, grassdb_node.data['name'])
         )
         if location:
-            grassdb_nodes = self.datacatalog.tree._model.SearchNodes(name=grassdatabase,
-                                                                     type='grassdb')
-            if not grassdb_nodes:
-                grassdb_node = self.datacatalog.tree.InsertGrassDb(name=grassdatabase)
-            self.datacatalog.tree.InsertLocation(location, grassdb_node)
-        self.datacatalog.tree.ReloadTreeItems()
+            self.datacatalog.tree.ReloadTreeItems()
 
     def OnChangeMapset(self, event):
         """Change current mapset"""

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1062,7 +1062,7 @@ class GMFrame(wx.Frame):
 
     def OnCreateMapset(self, event):
         """Create new mapset"""
-        db_node, loc_node, mapset_node  = self.datacatalog.tree.GetCurrentDbLocationMapsetNode()
+        db_node, loc_node, mapset_node = self.datacatalog.tree.GetCurrentDbLocationMapsetNode()
         self.datacatalog.tree.CreateMapset(db_node, loc_node)
 
     def OnLocationWizard(self, event):

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1064,9 +1064,9 @@ class GMFrame(wx.Frame):
 
     def OnCreateMapset(self, event):
         """Create new mapset"""
-        db_node, loc_node, mapset_node = self.datacatalog.tree.GetCurrentDbLocationMapsetNode()
-        mapset = create_mapset_interactively(self, db_node.data['name'],
-                                             loc_node.data['name'])
+        gisenv = grass.gisenv()
+        mapset = create_mapset_interactively(self, gisenv['GISDBASE'],
+                                             gisenv['LOCATION_NAME'])
         if mapset:
             self.datacatalog.tree.ReloadTreeItems()
 


### PR DESCRIPTION
There are several actions that need to be synced in GUI and datacatalog. This PR solves the case when the mapset/location is created from menu.