### PR TITLE
wxGUI: refactor changing mapset through file menu and catalog with signals

### DIFF
--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -212,6 +212,8 @@ class StandaloneGrassInterface():
         # add: if map should be added to layer tree (questionable attribute)
         self.mapCreated = Signal('StandaloneGrassInterface.mapCreated')
 
+        self.mapsetChanged = Signal('LayerManagerGrassInterface.mapsetChanged')
+
         # Signal emitted to request updating of map
         self.updateMap = Signal('StandaloneGrassInterface.updateMap')
 

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -50,8 +50,6 @@ class DataCatalog(wx.Panel):
         self.thread = gThread()
         self._loaded = False
         self.tree.showNotification.connect(self.showNotification)
-        self.tree.changeMapset.connect(self.changeMapset)
-        self.tree.changeLocation.connect(self.changeLocation)
 
         # some layout
         self._layout()

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -55,15 +55,6 @@ class DataCatalogFrame(wx.Frame):
         self.tree.ReloadTreeItems()
         self.tree.UpdateCurrentDbLocationMapsetNode()
         self.tree.ExpandCurrentMapset()
-        self.tree.changeMapset.connect(lambda mapset:
-                                       self.ChangeDbLocationMapset(
-                                               location=None,
-                                               mapset=mapset))
-        self.tree.changeLocation.connect(lambda mapset, location, dbase:
-                                         self.ChangeDbLocationMapset(
-                                                 dbase=dbase,
-                                                 location=location,
-                                                 mapset=mapset))
 
         # buttons
         self.btnClose = Button(parent=self.panel, id=wx.ID_CLOSE)
@@ -136,34 +127,6 @@ class DataCatalogFrame(wx.Frame):
     def SetRestriction(self, restrict):
         """Allow editing other mapsets or restrict editing to current mapset"""
         self.tree.SetRestriction(restrict)
-
-    def ChangeDbLocationMapset(self, mapset, location=None, dbase=None):
-        """Change mapset, location or db"""
-        if dbase:
-            if RunCommand('g.mapset', parent=self,
-                          location=location,
-                          mapset=mapset,
-                          dbase=dbase) == 0:
-                GMessage(parent=self,
-                         message=_("Current GRASS database is <%(dbase)s>.\n"
-                                   "Current location is <%(loc)s>.\n"
-                                   "Current mapset is <%(mapset)s>."
-                                   ) %
-                         {'dbase': dbase, 'loc': location, 'mapset': mapset})
-        elif location:
-            if RunCommand('g.mapset', parent=self,
-                          location=location,
-                          mapset=mapset) == 0:
-                GMessage(parent=self,
-                         message=_("Current location is <%(loc)s>.\n"
-                                   "Current mapset is <%(mapset)s>.") %
-                         {'loc': location, 'mapset': mapset})
-        else:
-            if RunCommand('g.mapset',
-                          parent=self,
-                          mapset=mapset) == 0:
-                GMessage(parent=self,
-                         message=_("Current mapset is <%s>.") % mapset)
 
     def Filter(self, text):
         self.tree.Filter(text=text)

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -45,7 +45,8 @@ from startup.guiutils import (
     delete_locations_interactively,
     download_location_interactively,
     delete_grassdb_interactively,
-    can_switch_mapset_interactive
+    can_switch_mapset_interactive,
+    change_mapset_interactively
 )
 
 from grass.pydispatch.signal import Signal
@@ -262,11 +263,10 @@ class DataCatalogTree(TreeView):
         self._restricted = True
 
         self.showNotification = Signal('Tree.showNotification')
-        self.changeMapset = Signal('Tree.changeMapset')
-        self.changeLocation = Signal('Tree.changeLocation')
         self.parent = parent
         self.contextMenu.connect(self.OnRightClick)
         self.itemActivated.connect(self.OnDoubleClick)
+        self._giface.mapsetChanged.connect(self._updateAfterMapsetChanged)
         self._iconTypes = ['grassdb', 'location', 'mapset', 'raster',
                            'vector', 'raster_3d']
         self._initImages()
@@ -1272,20 +1272,18 @@ class DataCatalogTree(TreeView):
         if can_switch_mapset_interactive(self, grassdb, location, mapset):
             # Switch to mapset in the same location
             if (grassdb == genv['GISDBASE'] and location == genv['LOCATION_NAME']):
-                self.changeMapset.emit(mapset=mapset)
+                change_mapset_interactively(self, self._giface, None, None, mapset)
             # Switch to mapset in the same grassdb
             elif grassdb == genv['GISDBASE']:
-                self.changeLocation.emit(mapset=mapset,
-                                         location=location,
-                                         dbase=None)
+                change_mapset_interactively(self, self._giface, None, location, mapset)
             # Switch to mapset in a different grassdb
             else:
-                self.changeLocation.emit(mapset=mapset,
-                                         location=location,
-                                         dbase=grassdb)
-            self.UpdateCurrentDbLocationMapsetNode()
-            self.ExpandCurrentMapset()
-            self.RefreshItems()
+                change_mapset_interactively(self, self._giface, grassdb, location, mapset)
+
+    def _updateAfterMapsetChanged(self):
+        self.UpdateCurrentDbLocationMapsetNode()
+        self.ExpandCurrentMapset()
+        self.RefreshItems()
 
     def OnMetadata(self, event):
         """Show metadata of any raster/vector/3draster"""

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -188,6 +188,8 @@ class LayerManagerGrassInterface(object):
         # add: if map should be added to layer tree (questionable attribute)
         self.mapCreated = Signal('LayerManagerGrassInterface.mapCreated')
 
+        self.mapsetChanged = Signal('LayerManagerGrassInterface.mapsetChanged')
+
         # Signal emitted to request updating of map
         self.updateMap = Signal('LayerManagerGrassInterface.updateMap')
 

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -865,3 +865,35 @@ def import_file(guiparent, filePath):
                 "this imported map.") % {
                 'name': filePath},
             parent=guiparent)
+
+
+def change_mapset_interactively(guiparent, giface, dbase, location, mapset):
+    """Change mapset, location or db"""
+    if dbase:
+        if RunCommand('g.mapset', parent=guiparent,
+                      location=location,
+                      mapset=mapset,
+                      dbase=dbase) == 0:
+            GMessage(parent=guiparent,
+                     message=_("Current GRASS database is <%(dbase)s>.\n"
+                               "Current location is <%(loc)s>.\n"
+                               "Current mapset is <%(mapset)s>."
+                               ) %
+                     {'dbase': dbase, 'loc': location, 'mapset': mapset})
+            giface.mapsetChanged.emit(dbase, location, mapset)
+    elif location:
+        if RunCommand('g.mapset', parent=guiparent,
+                      location=location,
+                      mapset=mapset) == 0:
+            GMessage(parent=guiparent,
+                     message=_("Current location is <%(loc)s>.\n"
+                               "Current mapset is <%(mapset)s>.") %
+                     {'loc': location, 'mapset': mapset})
+            giface.mapsetChanged.emit(dbase=None, location=location, mapset=mapset)
+    else:
+        if RunCommand('g.mapset',
+                      parent=guiparent,
+                      mapset=mapset) == 0:
+            GMessage(parent=guiparent,
+                     message=_("Current mapset is <%s>.") % mapset)
+            giface.mapsetChanged.emit(dbase=None, location=None, mapset=mapset)


### PR DESCRIPTION
This creates a new signal in grass interface that informs subscribers that current mapset has been changed. The actual switching of mapset is moved to a separate function in startup/guiutils.py (to be renamed to something else eventually).