### PR TITLE
wxGUI datacatalog: add direct editing of mapset and location name

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -890,20 +890,22 @@ class DataCatalogTree(TreeView):
                                                           mapset,
                                                           check_permanent=True)
                 if message:
-                    label = _("Cannot rename mapset <{mapset}> for the "
-                              "following reason: {reason}").format(
-                              mapset=mapset, reason=message)
+                    label = _(
+                        "Cannot rename mapset <{mapset}> for the "
+                        "following reason: {reason}").format(
+                        mapset=mapset, reason=message)
                     self.showNotification.emit(message=label)
                     event.Veto()
                     return
             elif node.data['type'] == 'location':
                 location = self.selected_location[0].data['name']
                 messages = get_reasons_location_not_removable(self.selected_grassdb[0].data['name'],
-                                                            location)
+                                                              location)
                 if messages:
-                    label = _("Cannot rename location <{location}> for the "
-                              "following reasons: {reasons}").format(
-                              location=location, reasons="\n".join(messages))
+                    label = _(
+                        "Cannot rename location <{location}> for the "
+                        "following reasons: {reasons}").format(
+                        location=location, reasons="\n".join(messages))
                     self.showNotification.emit(message=label)
                     event.Veto()
                     return
@@ -929,9 +931,10 @@ class DataCatalogTree(TreeView):
                                         self.selected_location[0].data['name'],
                                         new_name)
             if message:
-                label = _("Cannot rename mapset <{mapset}> for the "
-                          "following reason: {reason}").format(
-                          mapset=old_name, reason=message)
+                label = _(
+                    "Cannot rename mapset <{mapset}> for the "
+                    "following reason: {reason}").format(
+                    mapset=old_name, reason=message)
                 self.showNotification.emit(message=label)
                 event.Veto()
                 return
@@ -940,17 +943,19 @@ class DataCatalogTree(TreeView):
                           self.selected_mapset[0].data['name'],
                           new_name)
             self._renameNode(self.selected_mapset[0], new_name)
-            label = _("Renaming mapset <{oldmapset}> to <{newmapset}> completed").format(
-                        oldmapset=old_name, newmapset=new_name)
+            label = _(
+                "Renaming mapset <{oldmapset}> to <{newmapset}> completed").format(
+                oldmapset=old_name, newmapset=new_name)
             self.showNotification.emit(message=label)
 
         elif node.data['type'] == 'location':
             message = check_location_name(self.selected_grassdb[0].data['name'],
                                           new_name)
             if message:
-                label = _("Cannot rename location <{location}> for the "
-                          "following reason: {reason}").format(
-                          location=new_name, reason=message)
+                label = _(
+                    "Cannot rename location <{location}> for the "
+                    "following reason: {reason}").format(
+                    location=new_name, reason=message)
                 self.showNotification.emit(message=label)
                 event.Veto()
                 return
@@ -958,8 +963,9 @@ class DataCatalogTree(TreeView):
                             self.selected_location[0].data['name'],
                             new_name)
             self._renameNode(self.selected_location[0], new_name)
-            label = _("Renaming location <{oldlocation}> to <{newlocation}> completed").format(
-                    oldlocation=old_name, newlocation=new_name)
+            label = _(
+                "Renaming location <{oldlocation}> to <{newlocation}> completed").format(
+                oldlocation=old_name, newlocation=new_name)
             self.showNotification.emit(message=label)
 
     def Rename(self, old, new):

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -869,13 +869,10 @@ class DataCatalogTree(TreeView):
             return
         # Check selected mapset
         elif node.data['type'] == 'mapset':
-            mapset = self.selected_mapset[0].data['name']
-            message = get_reason_mapset_not_removable(self.selected_grassdb[0].data['name'],
-                                                      self.selected_location[0].data['name'],
-                                                      mapset,
-                                                      check_permanent=True)
-            if message:
-                self.showNotification.emit(message="")
+            if get_reason_mapset_not_removable(self.selected_grassdb[0].data['name'],
+                                               self.selected_location[0].data['name'],
+                                               self.selected_mapset[0].data['name']
+                                               check_permanent=True)
                 event.Veto()
                 return
         # Check selected location

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -866,32 +866,28 @@ class DataCatalogTree(TreeView):
         # Not allowed for grassdb node
         if node.data['type'] == 'grassdb':
             event.Veto()
-            return
         # Check selected mapset
         elif node.data['type'] == 'mapset':
-            if get_reason_mapset_not_removable(self.selected_grassdb[0].data['name'],
-                                               self.selected_location[0].data['name'],
-                                               self.selected_mapset[0].data['name'],
-                                               check_permanent=True):
+            if (
+                self._restricted
+                or get_reason_mapset_not_removable(self.selected_grassdb[0].data['name'],
+                                                   self.selected_location[0].data['name'],
+                                                   self.selected_mapset[0].data['name'],
+                                                   check_permanent=True)
+            ):
                 event.Veto()
-                return
         # Check selected location
         elif node.data['type'] == 'location':
-            if get_reasons_location_not_removable(self.selected_grassdb[0].data['name'],
-                                                  self.selected_location[0].data['name']):
+            if (
+                self._restricted
+                or get_reasons_location_not_removable(self.selected_grassdb[0].data['name'],
+                                                      self.selected_location[0].data['name'])
+            ):
                 event.Veto()
-                return
-
-        # When restricted mode is on, only editing a layer in the current mapset is enabled
-        genv = gisenv()
-        currentGrassDb, currentLocation, currentMapset = self._isCurrent(genv)
-        if self._restricted and node.data['type'] in ('raster', 'raster_3d', 'vector') and \
-                currentMapset and len(self.selected_layer) == 1:
-            return
-        # Otherwise when restricted mode is on, editing is not allowed at all
-        if self._restricted:
-            event.Veto()
-            return
+        elif node.data['type'] in ('raster', 'raster_3d', 'vector'):
+            currentGrassDb, currentLocation, currentMapset = self._isCurrent(gisenv())
+            if not currentMapset:
+                event.Veto()
 
     def OnEditLabel(self, node, event):
         """End label editing"""

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -871,31 +871,25 @@ class DataCatalogTree(TreeView):
         elif node.data['type'] == 'mapset':
             if get_reason_mapset_not_removable(self.selected_grassdb[0].data['name'],
                                                self.selected_location[0].data['name'],
-                                               self.selected_mapset[0].data['name']
-                                               check_permanent=True)
+                                               self.selected_mapset[0].data['name'],
+                                               check_permanent=True):
                 event.Veto()
                 return
         # Check selected location
         elif node.data['type'] == 'location':
-            location = self.selected_location[0].data['name']
-            messages = get_reasons_location_not_removable(self.selected_grassdb[0].data['name'],
-                                                          location)
-            if messages:
-                self.showNotification.emit(message="")
+            if get_reasons_location_not_removable(self.selected_grassdb[0].data['name'],
+                                                  self.selected_location[0].data['name']):
                 event.Veto()
                 return
 
         # When restricted mode is on, only editing a layer in the current mapset is enabled
         genv = gisenv()
         currentGrassDb, currentLocation, currentMapset = self._isCurrent(genv)
-        if not self._restricted or \
-                (self._restricted and node.data['type'] in ('raster', 'raster_3d', 'vector') and
-                currentMapset and len(self.selected_layer) == 1):
-            Debug.msg(1, "Start label edit {name}".format(name=node.data['name']))
-            label = _("Editing {name}").format(name=node.data['name'])
-            self.showNotification.emit(message=label)
-        else:
-            self.showNotification.emit(message="")
+        if self._restricted and node.data['type'] in ('raster', 'raster_3d', 'vector') and \
+                currentMapset and len(self.selected_layer) == 1:
+            return
+        # Otherwise when restricted mode is on, editing is not allowed at all
+        if self._restricted:
             event.Veto()
             return
 

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -273,6 +273,56 @@ def get_reasons_grassdb_not_removable(grassdb):
     return messages
 
 
+def check_mapset_name(grassdb, location, mapset_name):
+    """Check mapset name.
+
+    Returns message as string if there was failed check, otherwise None.
+    """
+    message = None
+    mapset_path = os.path.join(grassdb, location, mapset_name)
+
+    # Check if mapset name is valid
+    if not gs.legal_name(mapset_name):
+        message = _(
+            "Name '{}' is not a valid name for location or mapset. "
+            "Please use only ASCII characters excluding characters {} "
+            "and space.").format(mapset_name, '/"\'@,=*~')
+    # Check reserved mapset name
+    elif mapset_name.lower() == 'ogr':
+        message = _(
+            "Name '{}' is reserved for direct "
+            "read access to OGR layers. Please use "
+            "another name for your mapset.").format(mapset_name)
+    # Check whether mapset exists
+    elif mapset_exists(grassdb, location, mapset_name):
+        message = _("Mapset  <{mapset}> already exists. Please consider using "
+                    "another name for your mapset.").format(
+                    mapset=mapset_path)
+    return message
+
+
+def check_location_name(grassdb, location_name):
+    """Check location name.
+
+    Returns message as string if there was failed check, otherwise None.
+    """
+    message = None
+    location_path = os.path.join(grassdb, location_name)
+
+    # Check if mapset name is valid
+    if not gs.legal_name(location_name):
+        message = _(
+            "Name '{}' is not a valid name for location or mapset. "
+            "Please use only ASCII characters excluding characters {} "
+            "and space.").format(location_name, '/"\'@,=*~')
+    # Check whether location exists
+    elif location_exists(grassdb, location_name):
+        message = _("Location  <{location}> already exists. Please consider using "
+                    "another name for your location.").format(
+                    location=location_path)
+    return message
+
+
 # TODO: similar to (but not the same as) read_gisrc function in grass.py
 def read_gisrc():
     """Read variables from a current GISRC file

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -29,7 +29,8 @@ from grass.grassdb.checks import (
     get_reason_mapset_not_removable,
     get_reasons_mapsets_not_removable,
     get_reasons_location_not_removable,
-    get_reasons_locations_not_removable
+    get_reasons_locations_not_removable,
+    get_reasons_grassdb_not_removable
 )
 
 from grass.grassdb.create import create_mapset, get_default_mapset_name
@@ -46,8 +47,6 @@ from core.gcmd import GError, GMessage, DecodeString, RunCommand
 from gui_core.dialogs import TextEntryDialog
 from location_wizard.dialogs import RegionDef
 from gui_core.widgets import GenericValidator
-from core.utils import GetListOfLocations
-from grass.script import gisenv
 
 
 def SetSessionMapset(database, location, mapset):
@@ -160,31 +159,6 @@ def GetVersion():
         grassVersion = versionLine
         grassRevisionStr = ''
     return (grassVersion, grassRevisionStr)
-
-
-def get_reasons_grassdb_not_removable(grassdb):
-    """Get reasons why one grassdb cannot be removed.
-
-    Returns messages as list if there were any failed checks, otherwise empty list.
-    """
-    messages = []
-    genv = gisenv()
-
-    # Check if grassdb is current
-    if grassdb == genv['GISDBASE']:
-        messages.append(_("GRASS database <{grassdb}> is the current database.").format(
-            grassdb=grassdb))
-        return messages
-
-    g_locations = GetListOfLocations(grassdb)
-
-    # Append to the list of tuples
-    locations = []
-    for g_location in g_locations:
-        locations.append((grassdb, g_location))
-    messages = get_reasons_locations_not_removable(locations)
-
-    return messages
 
 
 def create_mapset_interactively(guiparent, grassdb, location):

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -19,16 +19,17 @@ import os
 import sys
 import wx
 
-import grass.script as gs
-from grass.script import gisenv
 from grass.grassdb.checks import (
-    mapset_exists,
-    location_exists,
     is_mapset_locked,
     get_mapset_lock_info,
-    is_different_mapset_owner,
-    is_mapset_current,
-    is_location_current
+    is_mapset_name_valid,
+    is_location_name_valid,
+    get_mapset_name_invalid_reason,
+    get_location_name_invalid_reason,
+    get_reason_mapset_not_removable,
+    get_reasons_mapsets_not_removable,
+    get_reasons_location_not_removable,
+    get_reasons_locations_not_removable
 )
 
 from grass.grassdb.create import create_mapset, get_default_mapset_name
@@ -40,12 +41,13 @@ from grass.grassdb.manage import (
     rename_location,
 )
 
-from core.utils import GetListOfLocations
 from core import globalvar
 from core.gcmd import GError, GMessage, DecodeString, RunCommand
 from gui_core.dialogs import TextEntryDialog
 from location_wizard.dialogs import RegionDef
-from gui_core.widgets import GenericMultiValidator
+from gui_core.widgets import GenericValidator
+from core.utils import GetListOfLocations
+from grass.script import gisenv
 
 
 def SetSessionMapset(database, location, mapset):
@@ -61,11 +63,8 @@ class MapsetDialog(TextEntryDialog):
         self.database = database
         self.location = location
 
-        # list of tuples consisting of conditions and callbacks
-        checks = [(gs.legal_name, self._nameValidationFailed),
-                  (self._checkMapsetNotExists, self._mapsetAlreadyExists),
-                  (self._checkOGR, self._reservedMapsetName)]
-        validator = GenericMultiValidator(checks)
+        validator = GenericValidator(self._isMapsetNameValid,
+                                     self._getMapsetNameInvalidReason)
 
         TextEntryDialog.__init__(
             self, parent=parent,
@@ -75,39 +74,17 @@ class MapsetDialog(TextEntryDialog):
             validator=validator,
         )
 
-    def _nameValidationFailed(self, ctrl):
-        message = _(
-            "Name '{}' is not a valid name for location or mapset. "
-            "Please use only ASCII characters excluding characters {} "
-            "and space.").format(ctrl.GetValue(), '/"\'@,=*~')
-        GError(parent=self, message=message, caption=_("Invalid name"))
+    def _getMapsetNameInvalidReason(self, ctrl):
+        message = get_mapset_name_invalid_reason(self.database,
+                                                 self.location,
+                                                 ctrl.GetValue())
+        GError(parent=self, message=message, caption=_("Invalid mapset name"))
 
-    def _checkOGR(self, text):
-        """Check user's input for reserved mapset name."""
-        if text.lower() == 'ogr':
-            return False
-        return True
-
-    def _reservedMapsetName(self, ctrl):
-        message = _(
-            "Name '{}' is reserved for direct "
-            "read access to OGR layers. Please use "
-            "another name for your mapset.").format(ctrl.GetValue())
-        GError(parent=self, message=message,
-               caption=_("Reserved mapset name"))
-
-    def _checkMapsetNotExists(self, text):
-        """Check whether user's input mapset exists or not."""
-        if mapset_exists(self.database, self.location, text):
-            return False
-        return True
-
-    def _mapsetAlreadyExists(self, ctrl):
-        message = _(
-            "Mapset '{}' already exists. Please consider using "
-            "another name for your mapset.").format(ctrl.GetValue())
-        GError(parent=self, message=message,
-               caption=_("Existing mapset path"))
+    def _isMapsetNameValid(self, text):
+        """Check whether user's input location is valid or not."""
+        if is_mapset_name_valid(self.database, self.location, text):
+            return True
+        return False
 
 
 class LocationDialog(TextEntryDialog):
@@ -115,10 +92,8 @@ class LocationDialog(TextEntryDialog):
                  database=None):
         self.database = database
 
-        # list of tuples consisting of conditions and callbacks
-        checks = [(gs.legal_name, self._nameValidationFailed),
-                  (self._checkLocationNotExists, self._locationAlreadyExists)]
-        validator = GenericMultiValidator(checks)
+        validator = GenericValidator(self._isLocationNameValid,
+                                     self._getLocationNameInvalidReason)
 
         TextEntryDialog.__init__(
             self, parent=parent,
@@ -128,201 +103,16 @@ class LocationDialog(TextEntryDialog):
             validator=validator,
         )
 
-    def _nameValidationFailed(self, ctrl):
-        message = _(
-            "Name '{}' is not a valid name for location or mapset. "
-            "Please use only ASCII characters excluding characters {} "
-            "and space.").format(ctrl.GetValue(), '/"\'@,=*~')
-        GError(parent=self, message=message, caption=_("Invalid name"))
+    def _getLocationNameInvalidReason(self, ctrl):
+        message = get_location_name_invalid_reason(self.database,
+                                                   ctrl.GetValue())
+        GError(parent=self, message=message, caption=_("Invalid location name"))
 
-    def _checkLocationNotExists(self, text):
-        """Check whether user's input location exists or not."""
-        if location_exists(self.database, text):
-            return False
-        return True
-
-    def _locationAlreadyExists(self, ctrl):
-        message = _(
-            "Location '{}' already exists. Please consider using "
-            "another name for your location.").format(ctrl.GetValue())
-        GError(parent=self, message=message,
-               caption=_("Existing location path"))
-
-
-def get_reasons_mapsets_not_removable(mapsets, check_permanent):
-    """Get reasons why mapsets cannot be removed.
-
-    Parameter *mapsets* is a list of tuples (database, location, mapset).
-    Parameter *check_permanent* is True of False. It depends on whether
-    we want to check for permanent mapset or not.
-
-    Returns messages as list if there were any failed checks, otherwise empty list.
-    """
-    messages = []
-    for grassdb, location, mapset in mapsets:
-        message = get_reason_mapset_not_removable(grassdb, location,
-                                                  mapset, check_permanent)
-        if message:
-            messages.append(message)
-    return messages
-
-
-def get_reason_mapset_not_removable(grassdb, location, mapset, check_permanent):
-    """Get reason why one mapset cannot be removed.
-
-    Parameter *check_permanent* is True of False. It depends on whether
-    we want to check for permanent mapset or not.
-
-    Returns message as string if there was failed check, otherwise None.
-    """
-    message = None
-    mapset_path = os.path.join(grassdb, location, mapset)
-
-    # Check if mapset is permanent
-    if check_permanent and mapset == "PERMANENT":
-        message = _("Mapset <{mapset}> is required for a valid location.").format(
-            mapset=mapset_path)
-    # Check if mapset is current
-    elif is_mapset_current(grassdb, location, mapset):
-        message = _("Mapset <{mapset}> is the current mapset.").format(
-            mapset=mapset_path)
-    # Check whether mapset is in use
-    elif is_mapset_locked(mapset_path):
-        message = _("Mapset <{mapset}> is in use.").format(
-            mapset=mapset_path)
-    # Check whether mapset is owned by different user
-    elif is_different_mapset_owner(mapset_path):
-        message = _("Mapset <{mapset}> is owned by a different user.").format(
-            mapset=mapset_path)
-
-    return message
-
-
-def get_reasons_locations_not_removable(locations):
-    """Get reasons why locations cannot be removed.
-
-    Parameter *locations* is a list of tuples (database, location).
-
-    Returns messages as list if there were any failed checks, otherwise empty list.
-    """
-    messages = []
-    for grassdb, location in locations:
-        messages += get_reasons_location_not_removable(grassdb, location)
-    return messages
-
-
-def get_reasons_location_not_removable(grassdb, location):
-    """Get reasons why one location cannot be removed.
-
-    Returns messages as list if there were any failed checks, otherwise empty list.
-    """
-    messages = []
-    location_path = os.path.join(grassdb, location)
-
-    # Check if location is current
-    if is_location_current(grassdb, location):
-        messages.append(_("Location <{location}> is the current location.").format(
-            location=location_path))
-        return messages
-
-    # Find mapsets in particular location
-    tmp_gisrc_file, env = gs.create_environment(grassdb, location, 'PERMANENT')
-    env['GRASS_SKIP_MAPSET_OWNER_CHECK'] = '1'
-
-    g_mapsets = gs.read_command(
-        'g.mapsets',
-        flags='l',
-        separator='comma',
-        quiet=True,
-        env=env).strip().split(',')
-
-    # Append to the list of tuples
-    mapsets = []
-    for g_mapset in g_mapsets:
-        mapsets.append((grassdb, location, g_mapset))
-
-    # Concentenate both checks
-    messages += get_reasons_mapsets_not_removable(mapsets, check_permanent=False)
-
-    gs.try_remove(tmp_gisrc_file)
-    return messages
-
-
-def get_reasons_grassdb_not_removable(grassdb):
-    """Get reasons why one grassdb cannot be removed.
-
-    Returns messages as list if there were any failed checks, otherwise empty list.
-    """
-    messages = []
-    genv = gisenv()
-
-    # Check if grassdb is current
-    if grassdb == genv['GISDBASE']:
-        messages.append(_("GRASS database <{grassdb}> is the current database.").format(
-            grassdb=grassdb))
-        return messages
-
-    g_locations = GetListOfLocations(grassdb)
-
-    # Append to the list of tuples
-    locations = []
-    for g_location in g_locations:
-        locations.append((grassdb, g_location))
-    messages = get_reasons_locations_not_removable(locations)
-
-    return messages
-
-
-def check_mapset_name(grassdb, location, mapset_name):
-    """Check mapset name.
-
-    Returns message as string if there was failed check, otherwise None.
-    """
-    message = None
-    mapset_path = os.path.join(grassdb, location, mapset_name)
-
-    # Check if mapset name is valid
-    if not gs.legal_name(mapset_name):
-        message = _(
-            "Name '{}' is not a valid name for location or mapset. "
-            "Please use only ASCII characters excluding characters {} "
-            "and space.").format(mapset_name, '/"\'@,=*~')
-    # Check reserved mapset name
-    elif mapset_name.lower() == 'ogr':
-        message = _(
-            "Name '{}' is reserved for direct "
-            "read access to OGR layers. Please use "
-            "another name for your mapset.").format(mapset_name)
-    # Check whether mapset exists
-    elif mapset_exists(grassdb, location, mapset_name):
-        message = _(
-            "Mapset  <{mapset}> already exists. Please consider using "
-            "another name for your mapset.").format(mapset=mapset_path)
-
-    return message
-
-
-def check_location_name(grassdb, location_name):
-    """Check location name.
-
-    Returns message as string if there was failed check, otherwise None.
-    """
-    message = None
-    location_path = os.path.join(grassdb, location_name)
-
-    # Check if mapset name is valid
-    if not gs.legal_name(location_name):
-        message = _(
-            "Name '{}' is not a valid name for location or mapset. "
-            "Please use only ASCII characters excluding characters {} "
-            "and space.").format(location_name, '/"\'@,=*~')
-    # Check whether location exists
-    elif location_exists(grassdb, location_name):
-        message = _(
-            "Location  <{location}> already exists. Please consider using "
-            "another name for your location.").format(location=location_path)
-
-    return message
+    def _isLocationNameValid(self, text):
+        """Check whether user's input location is valid or not."""
+        if is_location_name_valid(self.database, text):
+            return True
+        return False
 
 
 # TODO: similar to (but not the same as) read_gisrc function in grass.py
@@ -374,6 +164,31 @@ def GetVersion():
         grassVersion = versionLine
         grassRevisionStr = ''
     return (grassVersion, grassRevisionStr)
+
+
+def get_reasons_grassdb_not_removable(grassdb):
+    """Get reasons why one grassdb cannot be removed.
+
+    Returns messages as list if there were any failed checks, otherwise empty list.
+    """
+    messages = []
+    genv = gisenv()
+
+    # Check if grassdb is current
+    if grassdb == genv['GISDBASE']:
+        messages.append(_("GRASS database <{grassdb}> is the current database.").format(
+            grassdb=grassdb))
+        return messages
+
+    g_locations = GetListOfLocations(grassdb)
+
+    # Append to the list of tuples
+    locations = []
+    for g_location in g_locations:
+        locations.append((grassdb, g_location))
+    messages = get_reasons_locations_not_removable(locations)
+
+    return messages
 
 
 def create_mapset_interactively(guiparent, grassdb, location):

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -295,9 +295,10 @@ def check_mapset_name(grassdb, location, mapset_name):
             "another name for your mapset.").format(mapset_name)
     # Check whether mapset exists
     elif mapset_exists(grassdb, location, mapset_name):
-        message = _("Mapset  <{mapset}> already exists. Please consider using "
-                    "another name for your mapset.").format(
-                    mapset=mapset_path)
+        message = _(
+            "Mapset  <{mapset}> already exists. Please consider using "
+            "another name for your mapset.").format(mapset=mapset_path)
+
     return message
 
 
@@ -317,9 +318,10 @@ def check_location_name(grassdb, location_name):
             "and space.").format(location_name, '/"\'@,=*~')
     # Check whether location exists
     elif location_exists(grassdb, location_name):
-        message = _("Location  <{location}> already exists. Please consider using "
-                    "another name for your location.").format(
-                    location=location_path)
+        message = _(
+            "Location  <{location}> already exists. Please consider using "
+            "another name for your location.").format(location=location_path)
+
     return message
 
 

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -64,7 +64,7 @@ class MapsetDialog(TextEntryDialog):
         self.location = location
 
         validator = GenericValidator(self._isMapsetNameValid,
-                                     self._getMapsetNameInvalidReason)
+                                     self._showMapsetNameInvalidReason)
 
         TextEntryDialog.__init__(
             self, parent=parent,
@@ -74,7 +74,7 @@ class MapsetDialog(TextEntryDialog):
             validator=validator,
         )
 
-    def _getMapsetNameInvalidReason(self, ctrl):
+    def _showMapsetNameInvalidReason(self, ctrl):
         message = get_mapset_name_invalid_reason(self.database,
                                                  self.location,
                                                  ctrl.GetValue())
@@ -82,9 +82,7 @@ class MapsetDialog(TextEntryDialog):
 
     def _isMapsetNameValid(self, text):
         """Check whether user's input location is valid or not."""
-        if is_mapset_name_valid(self.database, self.location, text):
-            return True
-        return False
+        return is_mapset_name_valid(self.database, self.location, text)
 
 
 class LocationDialog(TextEntryDialog):
@@ -93,7 +91,7 @@ class LocationDialog(TextEntryDialog):
         self.database = database
 
         validator = GenericValidator(self._isLocationNameValid,
-                                     self._getLocationNameInvalidReason)
+                                     self._showLocationNameInvalidReason)
 
         TextEntryDialog.__init__(
             self, parent=parent,
@@ -103,16 +101,14 @@ class LocationDialog(TextEntryDialog):
             validator=validator,
         )
 
-    def _getLocationNameInvalidReason(self, ctrl):
+    def _showLocationNameInvalidReason(self, ctrl):
         message = get_location_name_invalid_reason(self.database,
                                                    ctrl.GetValue())
         GError(parent=self, message=message, caption=_("Invalid location name"))
 
     def _isLocationNameValid(self, text):
         """Check whether user's input location is valid or not."""
-        if is_location_name_valid(self.database, text):
-            return True
-        return False
+        return is_location_name_valid(self.database, text)
 
 
 # TODO: similar to (but not the same as) read_gisrc function in grass.py

--- a/lib/python/grassdb/checks.py
+++ b/lib/python/grassdb/checks.py
@@ -375,7 +375,7 @@ def is_mapset_name_valid(database, location, mapset_name):
 
     Returns True if mapset name is valid, otherwise False.
     """
-    return gs.legal_name(mapset_name) and mapset_name.lower != "ogr" and not \
+    return gs.legal_name(mapset_name) and mapset_name.lower() != "ogr" and not \
         mapset_exists(database, location, mapset_name)
 
 

--- a/lib/python/grassdb/checks.py
+++ b/lib/python/grassdb/checks.py
@@ -519,20 +519,13 @@ def get_list_of_locations(dbase):
 
     :return: list of locations (sorted)
     """
-    listOfLocations = list()
+    locations = list()
+    for location in glob.glob(os.path.join(dbase, "*")):
+        if os.path.join(
+                location, "PERMANENT") in glob.glob(
+                os.path.join(location, "*")):
+            locations.append(os.path.basename(location))
 
-    try:
-        for location in glob.glob(os.path.join(dbase, "*")):
-            try:
-                if os.path.join(
-                        location, "PERMANENT") in glob.glob(
-                        os.path.join(location, "*")):
-                    listOfLocations.append(os.path.basename(location))
-            except:
-                pass
-    except (UnicodeEncodeError, UnicodeDecodeError) as e:
-        raise e
+    locations.sort(key=lambda x: x.lower())
 
-    listOfLocations.sort(key=lambda x: x.lower())
-
-    return listOfLocations
+    return locations

--- a/lib/python/grassdb/checks.py
+++ b/lib/python/grassdb/checks.py
@@ -14,6 +14,7 @@ import os
 import datetime
 from pathlib import Path
 from grass.script import gisenv
+import grass.script as gs
 
 
 def mapset_exists(database, location, mapset):
@@ -60,19 +61,19 @@ def is_location_valid(database, location):
     )
 
 
-def is_mapset_current(grassdb, location, mapset):
+def is_mapset_current(database, location, mapset):
     genv = gisenv()
-    if (grassdb == genv['GISDBASE'] and
-        location == genv['LOCATION_NAME'] and
-        mapset == genv['MAPSET']):
+    if (database == genv['GISDBASE'] and
+            location == genv['LOCATION_NAME'] and
+            mapset == genv['MAPSET']):
         return True
     return False
 
 
-def is_location_current(grassdb, location):
+def is_location_current(database, location):
     genv = gisenv()
-    if (grassdb == genv['GISDBASE'] and
-        location == genv['LOCATION_NAME']):
+    if (database == genv['GISDBASE'] and
+            location == genv['LOCATION_NAME']):
         return True
     return False
 
@@ -305,3 +306,181 @@ def get_location_invalid_suggestion(database, location):
             " Did you mean to specify one of them?"
         ).format(location=location)
     return None
+
+
+def get_mapset_name_invalid_reason(database, location, mapset_name):
+    """Get reasons why mapset name is not valid.
+
+    It gets reasons when:
+     * Name is not valid.
+     * Name is reserved for OGR layers.
+     * Mapset in the same path already exists.
+
+    Returns message as string if there was a reason, otherwise None.
+    """
+    message = None
+    mapset_path = os.path.join(database, location, mapset_name)
+
+    # Check if mapset name is valid
+    if not gs.legal_name(mapset_name):
+        message = _(
+            "Name '{}' is not a valid name for location or mapset. "
+            "Please use only ASCII characters excluding characters {} "
+            "and space.").format(mapset_name, '/"\'@,=*~')
+    # Check reserved mapset name
+    elif mapset_name.lower() == 'ogr':
+        message = _(
+            "Name '{}' is reserved for direct "
+            "read access to OGR layers. Please use "
+            "another name for your mapset.").format(mapset_name)
+    # Check whether mapset exists
+    elif mapset_exists(database, location, mapset_name):
+        message = _(
+            "Mapset  <{mapset}> already exists. Please consider using "
+            "another name for your mapset.").format(mapset=mapset_path)
+
+    return message
+
+
+def get_location_name_invalid_reason(grassdb, location_name):
+    """Get reasons why location name is not valid.
+
+    It gets reasons when:
+     * Name is not valid.
+     * Location in the same path already exists.
+
+    Returns message as string if there was a reason, otherwise None.
+    """
+    message = None
+    location_path = os.path.join(grassdb, location_name)
+
+    # Check if mapset name is valid
+    if not gs.legal_name(location_name):
+        message = _(
+            "Name '{}' is not a valid name for location or mapset. "
+            "Please use only ASCII characters excluding characters {} "
+            "and space.").format(location_name, '/"\'@,=*~')
+    # Check whether location exists
+    elif location_exists(grassdb, location_name):
+        message = _(
+            "Location  <{location}> already exists. Please consider using "
+            "another name for your location.").format(location=location_path)
+
+    return message
+
+
+def is_mapset_name_valid(database, location, mapset_name):
+    """Check if mapset name is valid.
+
+    Returns True if mapset name is valid, otherwise False.
+    """
+    return gs.legal_name(mapset_name) and mapset_name.lower != "ogr" and not \
+        mapset_exists(database, location, mapset_name)
+
+
+def is_location_name_valid(database, location_name):
+    """Check if location name is valid.
+
+    Returns True if location name is valid, otherwise False.
+    """
+    return gs.legal_name(location_name) and not \
+        mapset_exists(database, location_name)
+
+
+def get_reasons_mapsets_not_removable(mapsets, check_permanent):
+    """Get reasons why mapsets cannot be removed.
+
+    Parameter *mapsets* is a list of tuples (database, location, mapset).
+    Parameter *check_permanent* is True of False. It depends on whether
+    we want to check for permanent mapset or not.
+
+    Returns messages as list if there were any failed checks, otherwise empty list.
+    """
+    messages = []
+    for grassdb, location, mapset in mapsets:
+        message = get_reason_mapset_not_removable(grassdb, location,
+                                                  mapset, check_permanent)
+        if message:
+            messages.append(message)
+    return messages
+
+
+def get_reason_mapset_not_removable(grassdb, location, mapset, check_permanent):
+    """Get reason why one mapset cannot be removed.
+
+    Parameter *check_permanent* is True of False. It depends on whether
+    we want to check for permanent mapset or not.
+
+    Returns message as string if there was failed check, otherwise None.
+    """
+    message = None
+    mapset_path = os.path.join(grassdb, location, mapset)
+
+    # Check if mapset is permanent
+    if check_permanent and mapset == "PERMANENT":
+        message = _("Mapset <{mapset}> is required for a valid location.").format(
+            mapset=mapset_path)
+    # Check if mapset is current
+    elif is_mapset_current(grassdb, location, mapset):
+        message = _("Mapset <{mapset}> is the current mapset.").format(
+            mapset=mapset_path)
+    # Check whether mapset is in use
+    elif is_mapset_locked(mapset_path):
+        message = _("Mapset <{mapset}> is in use.").format(
+            mapset=mapset_path)
+    # Check whether mapset is owned by different user
+    elif is_different_mapset_owner(mapset_path):
+        message = _("Mapset <{mapset}> is owned by a different user.").format(
+            mapset=mapset_path)
+
+    return message
+
+
+def get_reasons_locations_not_removable(locations):
+    """Get reasons why locations cannot be removed.
+
+    Parameter *locations* is a list of tuples (database, location).
+
+    Returns messages as list if there were any failed checks, otherwise empty list.
+    """
+    messages = []
+    for grassdb, location in locations:
+        messages += get_reasons_location_not_removable(grassdb, location)
+    return messages
+
+
+def get_reasons_location_not_removable(grassdb, location):
+    """Get reasons why one location cannot be removed.
+
+    Returns messages as list if there were any failed checks, otherwise empty list.
+    """
+    messages = []
+    location_path = os.path.join(grassdb, location)
+
+    # Check if location is current
+    if is_location_current(grassdb, location):
+        messages.append(_("Location <{location}> is the current location.").format(
+            location=location_path))
+        return messages
+
+    # Find mapsets in particular location
+    tmp_gisrc_file, env = gs.create_environment(grassdb, location, 'PERMANENT')
+    env['GRASS_SKIP_MAPSET_OWNER_CHECK'] = '1'
+
+    g_mapsets = gs.read_command(
+        'g.mapsets',
+        flags='l',
+        separator='comma',
+        quiet=True,
+        env=env).strip().split(',')
+
+    # Append to the list of tuples
+    mapsets = []
+    for g_mapset in g_mapsets:
+        mapsets.append((grassdb, location, g_mapset))
+
+    # Concentenate both checks
+    messages += get_reasons_mapsets_not_removable(mapsets, check_permanent=False)
+
+    gs.try_remove(tmp_gisrc_file)
+    return messages

--- a/lib/python/grassdb/checks.py
+++ b/lib/python/grassdb/checks.py
@@ -384,7 +384,7 @@ def is_location_name_valid(database, location_name):
     Returns True if location name is valid, otherwise False.
     """
     return gs.legal_name(location_name) and not \
-        mapset_exists(database, location_name)
+        location_exists(database, location_name)
 
 
 def get_reasons_mapsets_not_removable(mapsets, check_permanent):


### PR DESCRIPTION
Addresses both #917, #918.

**https://github.com/OSGeo/grass/issues/918:**
Currently we can rename map by selecting it and clicking at it again, which opens an editing window (like in any file manager). This should work also for **mapsets and locations**. It should take into account if the restricted mode is on or off.

**https://github.com/OSGeo/grass/issues/917:**
In datacatalog when we select a map in other mapset and click on it second time to open editing window, you can rename it even when restricted mode is on. This should not be permitted.