### PR TITLE
wxGUI/gcp: fix launch add vector map to group dialog

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -2477,7 +2477,7 @@ class VectGroup(wx.Dialog):
                     line = line.replace('\n', '')
                     if len(line) < 1:
                         continue
-                    checked.append(line)
+                    checked.append(line.split('@')[0])
                 self.listMap.SetCheckedStrings(checked)
             finally:
                 f.close()


### PR DESCRIPTION
**To Reproduce:**

1. Launch Georectifier wizard setup
2. Select **vector** map type to georectify
3. Choose source location and source mapset
4. Hit **Add vector map to group** button

![gcp_wizard_vect_group_dialog](https://user-images.githubusercontent.com/50632337/90850825-1ae23d00-e373-11ea-92da-2f2173b08cfa.png)

**Error message**:

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/gcp/manager.py",
line 649, in OnVGroup

group=self.xygroup)
  File "/usr/lib64/grass79/gui/wxpython/gcp/manager.py",
line 2483, in __init__

self.listMap.SetCheckedStrings(checked)
  File "/usr/lib64/python3.6/site-packages/wx/core.py", line
2590, in _CheckListBox_SetCheckedStrings

assert s in self.GetStrings(), "String ('%s') not found" % s
AssertionError
:
String ('bd_new@PERMANENT') not found
```
