### PR TITLE
rasterlib: Explain missing header file in get_cellhd

### DIFF
--- a/lib/raster/get_cellhd.c
+++ b/lib/raster/get_cellhd.c
@@ -3,7 +3,7 @@
 
    \brief Raster library - Read raster map header
 
-   (C) 2001-2009 by the GRASS Development Team
+   (C) 2001-2020 by the GRASS Development Team
 
    This program is free software under the GNU General Public License
    (>=v2).  Read the file COPYING that comes with GRASS for details.
@@ -23,10 +23,7 @@
 
    The raster header for the raster map <i>name</i> in the specified
    <i>mapset</i> is read into the <i>cellhd</i> structure. If there is
-   an error reading the raster header file, a diagnostic message is
-   printed and -1 is returned. Otherwise, 0 is returned.
-
-   <b>Note</b>:a warning message for errors encountered.
+   an error reading the raster header file, G_fatal_error() is called.
 
    Cell header files may contain either grid cell header information or
    reclass information. If it is a reclass file, it will specify the
@@ -42,11 +39,12 @@
    \return void
  */
 void Rast_get_cellhd(const char *name, const char *mapset,
-		     struct Cell_head *cellhd)
+                     struct Cell_head *cellhd)
 {
     FILE *fp;
     int is_reclass;
     char real_name[GNAME_MAX], real_mapset[GMAPSET_MAX];
+    const char *detail;
 
     /*
        is_reclass = Rast_is_reclass (name, mapset, real_name, real_mapset);
@@ -61,20 +59,26 @@ void Rast_get_cellhd(const char *name, const char *mapset,
      */
     is_reclass = (Rast_is_reclass(name, mapset, real_name, real_mapset) > 0);
     if (is_reclass) {
-	fp = G_fopen_old("cellhd", real_name, real_mapset);
-	if (!fp)
-	    G_fatal_error(_("Unable to read header file for raster map <%s@%s>. "
-			    "It is a reclass of raster map <%s@%s> %s"),
-			  name, mapset, real_name, real_mapset,
-			  !G_find_raster(real_name, real_mapset)
-			  ? _("which is missing.")
-			  : _("whose header file can't be opened."));
+        fp = G_fopen_old("cellhd", real_name, real_mapset);
+        if (!fp) {
+            detail = !G_find_raster(real_name, real_mapset)
+                ? _("However, that raster map is missing."
+                    " Perhaps, it was deleted by mistake.")
+                : _("However, header file of that raster map can't be"
+                    " opened. It seems that it was corrupted after"
+                    " creating the reclass raster map.");
+            G_fatal_error(_("Unable to read header file for raster map <%s@%s>. "
+                           "It is a reclass of raster map <%s@%s>. %s"), name,
+                          mapset, real_name, real_mapset, detail);
+        }
     }
     else {
-	fp = G_fopen_old("cellhd", name, mapset);
-	if (!fp)
-	    G_fatal_error(_("Unable to open header file for raster map <%s@%s>"),
-			  name, mapset);
+        fp = G_fopen_old("cellhd", name, mapset);
+        if (!fp)
+            G_fatal_error(_("Unable to open header file for raster map <%s@%s>."
+                           " It seems that some previous step failed and"
+                           " created an incomplete raster map."), name,
+                          mapset);
     }
 
     G__read_Cell_head(fp, cellhd, 1);


### PR DESCRIPTION
When header file is missing, the user is presented with 'Unable to open header file for raster map'.
Clearly not the same as unable to open map, but it is not clear what is wrong as it is not clear
what actually is the relation ship of the header file to the raster map or why this error occurred
and not the map not found one.

This adds some hints on what may have happened, so the user can start investigation (or recomputation) being
more informed on what might be the problem. At the same time, this keeps the original (core of the) message there
so that there is no doubt about what was the immediate cause of the error.

This PR also fixes the construction of an English sentence in the translatable string and replaces that by
adding another sentence.

The normal case and the two reclass cases each give a different info as the context is likely different.
In all cases 'It seems' and 'Perhaps' are used to indicate uncertainty of the message.

The documentation of the function was outdated mentioning return codes and warnings, now updated with G_fatal_error().

Since most of the lines in this file change, the indent script was applied.
