### PR TITLE
gunittest docs: fix broken links

### DIFF
--- a/lib/python/docs/conf.py
+++ b/lib/python/docs/conf.py
@@ -46,7 +46,7 @@ grass_version = core.version()['version']
 today = date.today()
 
 copy("_templates/layout.html.template", "_templates/layout.html")
-with open("_templates/layout.html", "a+b") as f:
+with open("_templates/layout.html", "a") as f:
     f.write(footer_tmpl.substitute(grass_version=grass_version, year=today.year))
     f.close()
 

--- a/lib/python/docs/src/gunittest_testing.rst
+++ b/lib/python/docs/src/gunittest_testing.rst
@@ -668,9 +668,26 @@ Analyzing quality of source code
 Besides testing, you can also use some tools to check the quality of your code
 according to various standards and occurrence of certain code patterns.
 
-For C/C++ code use third party solution `Coverity Scan`_ where GRASS GIS
-is registered as project number `1038`_. Also you can use `Cppcheck`_
-which will show a lot of errors which compilers do not check.
+GRASS GIS source code analysis is performed with `GitHub Actions`_ to build
+(compile), test, and run Python static code analysis, in order to improve
+the overall quality, maintainability and standard compliance of our code.
+
+The C and C++ source code is checked with GCC C/C++ tests including
+GNU C11 and C++11. For Python code, an initial static code analysis/code
+quality check/linting using `Flake8`_ has been implemented. The workflow
+builds and tests GRASS GIS on different Ubuntu versions, Centos as well as
+OSGeo4W. Success, errors and warnings are reported accordingly in the
+GitHub Actions interface for each `pull request`_. This code analysis
+has been set up as a continuous integration (CI) workflow, i.e. after each
+source code change - when submitting a code pull request - it is triggered
+automatically.
+
+Besides core GRASS GIS (`master`_ and `release_branch_7_8`_) also the
+`addons`_ repository has a minimalistic set of source code analysis enabled.
+
+For C/C++ code we additionally use the third party solution `Coverity Scan`_
+where GRASS GIS is registered as project number `1038`_. Also you can use
+`Cppcheck`_ which will show a lot of errors which compilers do not check.
 In any case, set your compiler to high error and warning levels,
 check them and fix them in your code. Furthermore, `Travis-CI`_ is used
 to check if the source code can still be compiled after submitting changes
@@ -717,9 +734,15 @@ Further reading
 
 .. _unittest: https://docs.python.org/2/library/unittest.html
 .. _doctest: https://docs.python.org/2/library/doctest.html
+.. _GitHub Actions: https://github.com/OSGeo/grass/actions
+.. _Flake8: https://pypi.org/project/flake8/
+.. _pull request: https://github.com/OSGeo/grass/pulls
+.. _master: https://github.com/OSGeo/grass/
+.. _release_branch_7_8: https://github.com/OSGeo/grass/tree/releasebranch_7_8
+.. _addons: https://github.com/OSGeo/grass-addons/actions
 .. _Coverity Scan: https://scan.coverity.com/
-.. _Travis-CI: https://travis-ci.org/GRASS-GIS/grass-ci
+.. _Travis-CI: https://travis-ci.org/github/OSGeo/grass
 .. _1038: https://scan.coverity.com/projects/1038
 .. _Cppcheck: http://cppcheck.sourceforge.net/
 .. _sandbox: https://svn.osgeo.org/grass/sandbox/wenzeslaus/grass_py_static_check.py
-.. _GRASS GIS sample data: https://grass.osgeo.org/download/sample-data and http://fatra.cnr.ncsu.edu/data/ (nc_spm_full_v2alpha)
+.. _GRASS GIS sample data: https://grass.osgeo.org/download/data/ and http://fatra.cnr.ncsu.edu/data/ (nc_spm_full_v2alpha)

--- a/lib/python/docs/src/gunittest_testing.rst
+++ b/lib/python/docs/src/gunittest_testing.rst
@@ -668,23 +668,6 @@ Analyzing quality of source code
 Besides testing, you can also use some tools to check the quality of your code
 according to various standards and occurrence of certain code patterns.
 
-GRASS GIS source code analysis is performed with `GitHub Actions`_ to build
-(compile), test, and run Python static code analysis, in order to improve
-the overall quality, maintainability and standard compliance of our code.
-
-The C and C++ source code is checked with GCC C/C++ tests including
-GNU C11 and C++11. For Python code, an initial static code analysis/code
-quality check/linting using `Flake8`_ has been implemented. The workflow
-builds and tests GRASS GIS on different Ubuntu versions, Centos as well as
-OSGeo4W. Success, errors and warnings are reported accordingly in the
-GitHub Actions interface for each `pull request`_. This code analysis
-has been set up as a continuous integration (CI) workflow, i.e. after each
-source code change - when submitting a code pull request - it is triggered
-automatically.
-
-Besides core GRASS GIS (`master`_ and `release_branch_7_8`_) also the
-`addons`_ repository has a minimalistic set of source code analysis enabled.
-
 For C/C++ code we additionally use the third party solution `Coverity Scan`_
 where GRASS GIS is registered as project number `1038`_. Also you can use
 `Cppcheck`_ which will show a lot of errors which compilers do not check.
@@ -734,12 +717,6 @@ Further reading
 
 .. _unittest: https://docs.python.org/2/library/unittest.html
 .. _doctest: https://docs.python.org/2/library/doctest.html
-.. _GitHub Actions: https://github.com/OSGeo/grass/actions
-.. _Flake8: https://pypi.org/project/flake8/
-.. _pull request: https://github.com/OSGeo/grass/pulls
-.. _master: https://github.com/OSGeo/grass/
-.. _release_branch_7_8: https://github.com/OSGeo/grass/tree/releasebranch_7_8
-.. _addons: https://github.com/OSGeo/grass-addons/actions
 .. _Coverity Scan: https://scan.coverity.com/
 .. _Travis-CI: https://travis-ci.org/github/OSGeo/grass
 .. _1038: https://scan.coverity.com/projects/1038


### PR DESCRIPTION
<strike>This PR expands the "[Analyzing quality of source code](https://grass.osgeo.org/grass79/manuals/libpython/gunittest_testing.html#analyzing-quality-of-source-code)" section in "Testing GRASS GIS source code and modules" document with information about our new [GitHub Actions](https://grass.osgeo.org/news/2020_06_28_github_actions/).</strike>

In addition, I fixed some outdated links.

Note that related to this, I got this Python error:

```
make sphinxdoclib
...
make[1]: Entering directory '/home/mneteler/software/grass_master/lib/python/docs'
SPHINXBUILD: Found <sphinx-build>
SPHINXAPIDOC: Found <sphinx-apidoc>
SPHINXBUILD: Using <sphinx-build>
GISRC=/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/demolocation/.grassrc79 GISBASE=/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu PATH="/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/scripts:$PATH" PYTHONPATH="/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/etc/python:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/gui/wxpython:$PYTHONPATH" LD_LIBRARY_PATH="/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/scripts:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/lib:/home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/lib:" LC_ALL=C LANG=C LANGUAGE=C sphinx-build -b html -d _build/doctrees   -c . src/ /home/mneteler/software/grass_master/dist.x86_64-pc-linux-gnu/docs/html/libpython
Running Sphinx v2.2.2

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/sphinx/config.py", line 361, in eval_config_file
    execfile_(filename, namespace)
  File "/usr/lib/python3.8/site-packages/sphinx/util/pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "/home/mneteler/software/grass_master/lib/python/docs/conf.py", line 50, in <module>
    f.write(footer_tmpl.substitute(grass_version=grass_version, year=today.year))
TypeError: a bytes-like object is required, not 'str'

make[1]: *** [Makefile:72: libpythonhtml] Error 2
make[1]: Leaving directory '/home/mneteler/software/grass_master/lib/python/docs'
make: *** [include/Make/Sphinx.make:48: sphinxdoclib] Error 2
```