### PR TITLE
lib/gis: allow setting vector/raster processing custom tmp directory via shell env variable

### DIFF
--- a/include/defs/gis.h
+++ b/include/defs/gis.h
@@ -352,7 +352,8 @@ void G_init_logging(void);
 char *G_file_name(char *, const char *, const char *, const char *);
 char *G_file_name_misc(char *, const char *, const char *, const char *,
 		       const char *);
-char *G_file_name_tmp(char *, const char *, const char *, const char *);
+char *G_file_name_tmp(char *, const char *, const char *, const char *, 
+						const char *);
 
 /* find_file.c */
 const char *G_find_file(const char *, char *, const char *);
@@ -538,7 +539,7 @@ char *G_mapset_path(void);
 
 /* mapset_msc.c */
 int G_make_mapset_element(const char *);
-int G_make_mapset_element_tmp(const char *);
+int G_make_mapset_element_tmp(const char *, const char*);
 int G__make_mapset_element_misc(const char *, const char *);
 int G_mapset_permissions(const char *);
 int G_mapset_permissions2(const char *, const char *, const char *);

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -53,11 +53,11 @@ int G_make_mapset_element(const char *p_element)
    \return 0 no element defined
    \return 1 on success
  */
-int G_make_mapset_element_tmp(const char *p_element)
+int G_make_mapset_element_tmp(const char *p_element, const char *type)
 {
     char path[GPATH_MAX];
     
-    G_file_name_tmp(path, NULL, NULL, G_mapset());
+    G_file_name_tmp(path, NULL, NULL, G_mapset(), type);
     return make_mapset_element(path, p_element);
 }
 

--- a/lib/gis/open.c
+++ b/lib/gis/open.c
@@ -21,6 +21,7 @@
 
 #include <grass/gis.h>
 #include <grass/glocale.h>
+#include <grass/vect/dig_defines.h>
 
 #include "gis_local_proto.h"
 
@@ -56,10 +57,21 @@ static int G__open(const char *element,
     int is_tmp;
     char path[GPATH_MAX];
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
+    const char *type = NULL;
     
     G__check_gisinit();
 
     is_tmp = (element && strncmp(element, ".tmp", 3) == 0);
+    if (strcmp(name, GV_FRMT_ELEMENT) == 0 ||
+        strcmp(name, GV_COOR_ELEMENT) == 0 ||
+        strcmp(name, GV_HEAD_ELEMENT) == 0 ||
+        strcmp(name, GV_DBLN_ELEMENT) == 0 ||
+        strcmp(name, GV_HIST_ELEMENT) == 0 ||
+        strcmp(name, GV_TOPO_ELEMENT) == 0 ||
+        strcmp(name, GV_SIDX_ELEMENT) == 0 ||
+        strcmp(name, GV_CIDX_ELEMENT) == 0) {
+      type = "vector";
+    }
 
     /* READ */
     if (mode == 0) {
@@ -82,7 +94,7 @@ static int G__open(const char *element,
             G_file_name(path, element, name, mapset);
         }
         else {
-            G_file_name_tmp(path, element, name, mapset);
+            G_file_name_tmp(path, element, name, mapset, type);
         }
         
 	if ((fd = open(path, 0)) < 0)
@@ -108,11 +120,11 @@ static int G__open(const char *element,
         if (!is_tmp)
             G_file_name(path, element, name, mapset);
         else
-            G_file_name_tmp(path, element, name, mapset);
+            G_file_name_tmp(path, element, name, mapset, type);
         
 	if (mode == 1 || access(path, 0) != 0) {
             if (is_tmp)
-                G_make_mapset_element_tmp(element);
+                G_make_mapset_element_tmp(element, type);
             else
                 G_make_mapset_element(element);
 	    close(open(path, O_WRONLY | O_CREAT | O_TRUNC, 0666));

--- a/lib/gis/tempfile.c
+++ b/lib/gis/tempfile.c
@@ -85,7 +85,7 @@ char *G_tempfile_pid(int pid)
     do {
 	int uniq = G_counter_next(&unique);
 	sprintf(name, "%d.%d", pid, uniq);
-	G_file_name(path, element, name, G_mapset());
+	G_file_name_tmp(path, element, name, G_mapset(), NULL);
     }
     while (access(path, F_OK) == 0);
 
@@ -101,7 +101,7 @@ char *G_tempfile_pid(int pid)
  */
 void G_temp_element(char *element)
 {
-    G__temp_element(element, FALSE);
+    G__temp_element(element, TRUE);
 }
 
 /*!
@@ -124,7 +124,7 @@ void G__temp_element(char *element, int tmp)
     if (!tmp)
         G_make_mapset_element(element);
     else
-        G_make_mapset_element_tmp(element);
+        G_make_mapset_element_tmp(element, NULL);
     
     G_debug(2, "G__temp_element(): %s (tmp=%d)", element, tmp);
 }

--- a/lib/init/variables.html
+++ b/lib/init/variables.html
@@ -77,19 +77,19 @@ PERMANENT
 </blockquote>
 
 <dl>
-  
+
   <dt>GISBASE</dt>
   <dd>directory where GRASS lives. This is set automatically by the
     startup script.</dd>
-  
+
   <dt>GISRC</dt>
   <dd>name of <tt>$HOME/.grass7/rc</tt> file. Defines the system wide value
     when starting a GRASS session. Within a GRASS session, a temporary copy
     of this file will be used.</dd>
-  
+
   <dt>GRASS_ADDON_PATH</dt>
   <dd>[grass startup script, g.extension]<br>
-    specifies additional path(s) containing local and/or custom GRASS 
+    specifies additional path(s) containing local and/or custom GRASS
     modules extra to the standard distribution.</dd>
 
   <dt>GRASS_ADDON_BASE</dt>
@@ -99,12 +99,12 @@ PERMANENT
     distribution. The default on GNU/Linux
     is <tt>$HOME/.grass7/addons</tt>, on MS
     Windows <tt>$APPDATA\GRASS7\addons</tt>.</dd>
-  
+
   <dt>GRASS_ADDON_ETC</dt>
   <dd>[libgis, g.findetc]<br>
     specify paths where support files (etc/) may be found external to
     standard distribution.</dd>
-  
+
   <dt>GRASS_BATCH_JOB</dt>
   <dd>defines the name (path) of a shell script to be processed as
   batch job.</dd>
@@ -112,18 +112,18 @@ PERMANENT
   <dt>GRASS_COMPRESSOR</dt>
   <dd>[libraster]<br>
     the compression method for new raster maps can be set with the
-    environment variable GRASS_COMPRESSOR. Supported methods are RLE, 
-    ZLIB, LZ4, BZIP2, and ZSTD. The default is ZSTD if available, 
-    otherwise ZLIB, which can be changed with e.g. 
-    <tt>GRASS_COMPRESSOR=ZSTD</tt></dd>, granted that GRASS has been 
-    compiled with the requested compressor. Compressors that are always 
-    available are RLE, ZLIB, and LZ4. The compressors BZIP2 and ZSTD 
+    environment variable GRASS_COMPRESSOR. Supported methods are RLE,
+    ZLIB, LZ4, BZIP2, and ZSTD. The default is ZSTD if available,
+    otherwise ZLIB, which can be changed with e.g.
+    <tt>GRASS_COMPRESSOR=ZSTD</tt></dd>, granted that GRASS has been
+    compiled with the requested compressor. Compressors that are always
+    available are RLE, ZLIB, and LZ4. The compressors BZIP2 and ZSTD
     must be enabled when configuring GRASS for compilation.
 
   <dt>GRASS_DB_ENCODING</dt>
   <dd>[various modules, wxGUI]<br>
     encoding for vector attribute data (utf-8, ascii, iso8859-1, koi8-r)</dd>
-  
+
   <dt>GIS_ERROR_LOG</dt>
   <dd>If set, GIS_ERROR_LOG should be the absolute path to the log
    file (a relative path will be interpreted relative to the process'
@@ -132,16 +132,16 @@ PERMANENT
    only be used if it already exists.</dd>
 
   <dt>GRASS_ERROR_MAIL</dt>
-  <dd>set to any value to send user mail on an error or warning that 
+  <dd>set to any value to send user mail on an error or warning that
     happens while stderr is being redirected.</dd>
-  
+
   <dt>GRASS_FONT</dt>
   <dd>[display drivers]<br>
     specifies the font as either the name of a font from
     <tt>$GISBASE/etc/fontcap</tt> (or alternative fontcap file
     specified by GRASS_FONT_CAP), or alternatively the full path to a
     FreeType font file.</dd>
-  
+
   <dt>GRASS_ENCODING</dt>
   <dd>[display drivers]<br>
     the encoding to be assumed for text which is drawn using a
@@ -149,14 +149,14 @@ PERMANENT
 
   <dt>GRASS_FONT_CAP</dt>
   <dd>[g.mkfontcap, d.font, display drivers]<br>
-    specifies an alternative location (to <tt>$GISBASE/etc/fontcap</tt>) for 
+    specifies an alternative location (to <tt>$GISBASE/etc/fontcap</tt>) for
     the font configuration file.</dd>
-  
+
   <dt>GRASS_FULL_OPTION_NAMES</dt>
   <dd>[parser]<br>
     Generates a warning if GRASS_FULL_OPTION_NAMES is set (to anything) and
     a found string is not an exact match for the given string.</dd>
-  
+
   <dt>GRASS_GUI</dt>
   <dd>either <tt>text</tt> (text user interface), <tt>gtext</tt> (text
   user interface with GUI welcome screen), or <tt>gui</tt> (graphical
@@ -166,7 +166,7 @@ PERMANENT
   gisenv variable (see below). If this shell variable exists at GRASS
   startup, it will determine the GUI used. If it is not defined
   startup will default to the last GUI used.</dd>
-    
+
   <dt>GRASS_HTML_BROWSER</dt>
   <dd>[init.sh, wxgui]<br> defines name of HTML browser. For most
     platforms this should be an executable in your PATH, or the full
@@ -196,7 +196,7 @@ PERMANENT
   <dt>GRASS_ZLIB_LEVEL</dt>
   <dd>[libgis]<br> if the environment variable GRASS_ZLIB_LEVEL exists and its value can
     be parsed as an integer, it determines the compression level used when new compressed
-    raster maps are compressed using zlib compression. This applies to all 
+    raster maps are compressed using zlib compression. This applies to all
     raster map types (CELL, FCELL, DCELL).
     <br><br>
     Valid zlib compression levels are -1 to 9. The <tt>GRASS_ZLIB_LEVEL=-1</tt> corresponds
@@ -205,22 +205,22 @@ PERMANENT
     <br><br>
     If the variable doesn't exist, or the value cannot be parsed as an
     integer, zlib's default compression level 6 will be used.</dd>
-  
+
   <dt>GRASS_MESSAGE_FORMAT</dt>
   <dd>[various modules, wxGUI]<br>
     it may be set to either
     <ul>
       <li><tt>standard</tt> - sets percentage output and message
-	formatting style to standard formatting,</li>
+    formatting style to standard formatting,</li>
       <li><tt>gui</tt> - sets percentage output and message formatting
-	style to GUI formatting,</li>
+    style to GUI formatting,</li>
       <li><tt>silent</tt> - disables percentage output and error
-	messages,</li>
+    messages,</li>
       <li><tt>plain</tt> - sets percentage output and message
-	formatting style to ASCII output without rewinding control
-	characters.</li>
+    formatting style to ASCII output without rewinding control
+    characters.</li>
   </ul></dd>
-  
+
   <dt>GRASS_MOUSE_BUTTON</dt>
   <dd>[various modules]<br> swaps mouse buttons for two-button or
     left-handed mice. Its value has three digits 1, 2, and 3, which
@@ -229,15 +229,15 @@ PERMANENT
     buttons. Note that this variable should be set before a display
     driver is initialized (e.g.,
     <tt>d.mon x0</tt>).</dd>
-  
+
   <dt>GRASS_PAGER</dt>
   <dd>[various modules]<br>
     it may be set to either <tt>less</tt>, <tt>more</tt>, or <tt>cat</tt>.</dd>
-  
+
   <dt>GRASS_PERL</dt>
   <dd>[used during install process for generating man pages]<br>
     set Perl with path.</dd>
-  
+
   <dt>GRASS_SKIP_MAPSET_OWNER_CHECK</dt>
   <dd>By default it is not possible to work with MAPSETs that are
     not owned by current user. Setting this variable to any non-empty value
@@ -258,7 +258,7 @@ PERMANENT
     set to override Python executable.<br>
     On Mac OS X this should be the <tt>pythonw</tt> executable for the
     wxGUI to work.</dd>
-  
+
   <dt>GRASS_VECTOR_LOWMEM</dt>
   <dd>[vectorlib]<br>
     If the environment variable GRASS_VECTOR_LOWMEM exists, memory
@@ -306,7 +306,7 @@ PERMANENT
       <li><tt>delete</tt> - the temporary vector map is deleted when
       closing the map.
       </li>
-    </ul>    
+    </ul>
     Default value is <tt>keep</tt>.
 
     Note that temporary vector maps are not visible to the user
@@ -320,10 +320,19 @@ PERMANENT
   <tt>$LOCATION/$MAPSET/.tmp/$HOSTNAME</tt>. If GRASS_VECTOR_TMPDIR_MAPSET is
   set to '0', the temporary directory is located in TMPDIR
   (environmental variable defined by the user or GRASS initialization
-  script if not given).<br>
+  script if not given). Or you can set any other directory.<br>
   Important note: This variable is currently used only in vector
   library. In other words the variable is ignored by raster or
   raster3d library.</dd>
+
+  <dt>GRASS_RASTER_TMPDIR_MAPSET</dt>
+  <dd>[rasterlib]<br> By default GRASS temporary directory is located in
+  <tt>$LOCATION/$MAPSET/.tmp/$HOSTNAME</tt>. If GRASS_RASTER_TMPDIR_MAPSET is
+  set to '0', the temporary directory is located in TMPDIR
+  (environmental variable defined by the user or GRASS initialization
+  script if not given). Or you can set any other directory.<br>
+  Important note: This variable is currently used only in raster
+  library.</dd>
 
   <dt>GRASS_VECTOR_TOPO_DEBUG</dt>
   <dd>[vectorlib, v.generalize]<br> If the environment variable
@@ -352,18 +361,18 @@ PERMANENT
     startup defaults to an internal '$GISBASE/etc/grass-xterm-mac',
     which emulates the necessary xterm functionality in
     Terminal.app.</dd>
-  
+
   <dt>GRASS_UI_TERM</dt>
   <dd>set to any value to use the terminal based parser.</dd>
 
   <dt>GRASS_VERSION</dt>
   <dd>reports the current version number (used by R-stats interface etc);
     should not be changed by user.</dd>
-    
+
   <dt>GRASS_NO_GLX_PBUFFERS</dt>
   <dd>[nviz]<br>
     set to any value to disable the use of GLX Pbuffers.</dd>
-  
+
   <dt>GRASS_NO_GLX_PIXMAPS</dt>
   <dd>[nviz]<br>
     Set to any value to disable the use of GLX Pixmaps.</dd>
@@ -377,11 +386,11 @@ PERMANENT
   <dt>TMPDIR, TEMP, TMP</dt>
   <dd>[Various GRASS GIS commands and wxGUI]<br>
   <!-- what about Windows %TEMP% and http://trac.osgeo.org/grass/ticket/560#comment:21 ? -->
-	The default wxGUI temporary directory is chosen from a 
-	platform-dependent list, but the user can control the selection of
-	this directory by setting one of the TMPDIR, TEMP or TMP
-	environment variables Hence the wxGUI uses $TMPDIR if it is set,
-	then $TEMP, otherwise /tmp.</dd>
+    The default wxGUI temporary directory is chosen from a
+    platform-dependent list, but the user can control the selection of
+    this directory by setting one of the TMPDIR, TEMP or TMP
+    environment variables Hence the wxGUI uses $TMPDIR if it is set,
+    then $TEMP, otherwise /tmp.</dd>
 </dl>
 
 <h3>List of selected GRASS environment variables for rendering</h3>
@@ -400,13 +409,13 @@ PERMANENT
     is <em><a href="cairodriver.html">cairo</a></em> (if available)
     otherwise <em><a href="pngdriver.html">png</a></em>.
   </dd>
-  
+
   <dt>GRASS_RENDER_WIDTH</dt>
   <dd>defines the width of output image (default is 640).</dd>
-  
+
   <dt>GRASS_RENDER_HEIGHT</dt>
   <dd>defines the height of output image (default is 480).</dd>
-  
+
   <dt>GRASS_RENDER_FILE</dt>
   <dd>the name of the resulting image file.</dd>
 
@@ -417,7 +426,7 @@ PERMANENT
 
   <dt>GRASS_RENDER_LINE_WIDTH</dt>
   <dd>defines default line width.</dd>
-  
+
   <dt>GRASS_RENDER_TEXT_SIZE</dt>
   <dd>defines default text size.</dd>
 
@@ -443,7 +452,7 @@ For specific driver-related variables see:
   [ These variables are intended <b>for internal use only</b> by the GRASS
   software to facilitate communication between the GIS engine, GRASS scripts,
   and the GUI.
-  
+
   The user should not set these in a GRASS session. They are meant to be set
   locally for specific commands. ]
 </blockquote>
@@ -462,7 +471,7 @@ For specific driver-related variables see:
     be inherited by dependent modules as the script runs. Setting either the
     GRASS_OVERWRITE environment variable or the OVERWRITE gisenv variable detailed
     below will cause maps with identical names to be overwritten.</dd>
-  
+
   <dt>GRASS_VERBOSE</dt>
   <dd>[all modules]<br>
     toggles verbosity level
@@ -476,13 +485,13 @@ For specific driver-related variables see:
     This variable is automatically created by <em><a href="g.parser.html">g.parser</a></em>
     so that the <tt>--verbose</tt> or <tt>--quiet</tt> flags will be inherited
     by dependent modules as the script runs.</dd>
-  
+
   <dt>GRASS_REGION</dt>
   <dd>[libgis]<br>
     override region settings, separate parameters with a ";". Format
     is the same as in the WIND region settings file. Otherwise use is the same as
     WIND_OVERRIDE.</dd>
-  
+
   <dt>WIND_OVERRIDE</dt>
   <dd>[libgis]<br>
     it causes programs to use the specified named region (created with
@@ -500,7 +509,7 @@ For specific driver-related variables see:
 </blockquote>
 
 <dl>
-  
+
   <dt>DEBUG</dt>
   <dd>[entire GRASS]<br>
     sets level of debug message output (0: no debug messages)
@@ -511,26 +520,26 @@ g.gisenv set=DEBUG=0
   <dt>WX_DEBUG</dt>
   <dd>[wxGUI]<br>
     sets level of debug message output for <em><a href="wxGUI.html">wxGUI</a></em> (0: no debug messages, 1-5 debug levels)
-  
+
   <dt>GISDBASE</dt>
   <dd>initial database</dd>
 
   <dt>GIS_LOCK</dt>
   <dd>lock ID to prevent parallel GRASS use,
     <br>process id of the start-up shell script</dd>
-  
+
   <dt>GUI</dt>
   <dd>See <tt>GRASS_GUI</tt> environmental variable for details.</dd>
-  
+
   <dt>LOCATION</dt>
   <dd>full path to location directory</dd>
-  
+
   <dt>LOCATION_NAME</dt>
   <dd>initial location name</dd>
-  
+
   <dt>MAPSET</dt>
   <dd>initial mapset</dd>
-  
+
   <dt>MEMORYMB</dt>
   <dd>[entire GRASS with focus on raster related data processing]<br>
     sets the maximum memory to be used (in MB), i.e. the cache size for raster rows
@@ -565,13 +574,13 @@ g.gisenv set="MEMORYMB=6000"
 
   <dt><tt>$HOME/.grass7/env.bat</tt></dt>
   <dd>stores the shell environment variables (MS Windows only)</dd>
-  
+
   <dt><tt>$HOME/.grass7/login</tt></dt>
   <dd>stores the DBMI passwords in this hidden file.
     Only the file owner can access this file.</dd>
 
   <dt><tt>$HOME/GIS_ERROR_LOG</tt></dt>
-  <dd>if this file exists then all GRASS error and warning messages are 
+  <dd>if this file exists then all GRASS error and warning messages are
     logged here. Applies to current user. To generate the file, use:
     <tt>touch $HOME/GIS_ERROR_LOG</tt><br>
    See also GIS_ERROR_LOG variable.</dd>

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -1483,7 +1483,7 @@ char *Vect__get_element_path(char *file_path,
     
     Vect__get_path(path, Map);
     if (Map->temporary)
-        G_file_name_tmp(file_path, path, element, Map->mapset);
+        G_file_name_tmp(file_path, path, element, Map->mapset, "vector");
     else
         G_file_name(file_path, path, element, Map->mapset);
 

--- a/temporal/t.rast.export/t.rast.export.py
+++ b/temporal/t.rast.export/t.rast.export.py
@@ -37,7 +37,7 @@
 
 #%option G_OPT_M_DIR
 #% key: directory
-#% description: Path to the work directory, default is /tmp
+#% description: Path to the work directory, default is /tmp, respect 'GRASS_RASTER_TMPDIR_MAPSET' shell env var
 #% required: no
 #% answer: /tmp
 #%end
@@ -102,6 +102,8 @@
 #%option G_OPT_T_WHERE
 #%end
 
+import os
+
 import grass.script as grass
 
 
@@ -128,6 +130,33 @@ def main():
             grass.warning(_("Createopt, metaopt and nodata options are not "
                             "working with pack and AAIGrid formats, "
                             "they will be skipped"))
+
+    tmp_dir_env = os.getenv('GRASS_RASTER_TMPDIR_MAPSET')
+    if tmp_dir_env:
+        if os.path.isdir(tmp_dir_env):
+            directory = tmp_dir_env
+            grass.warning(
+                _(
+                    "'GRASS_RASTER_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "exist and will be used.".format(
+                        new_tmp_dir=tmp_dir_env,
+                    ),
+                )
+            )
+        else:
+            grass.warning(
+                _(
+                    "'GRASS_RASTER_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "doesn't exist. The default directory "
+                    "will be used <'{def_tmp_dir}'>.".format(
+                        new_tmp_dir=tmp_dir_env,
+                        def_tmp_dir=directory,
+                    ),
+                )
+            )
+
     # Make sure the temporal database exists
     tgis.init()
     # Export the space time raster dataset

--- a/temporal/t.rast.import/t.rast.import.py
+++ b/temporal/t.rast.import/t.rast.import.py
@@ -47,7 +47,7 @@
 
 #%option G_OPT_M_DIR
 #% key: directory
-#% description: Path to the extraction directory
+#% description: Path to the extraction directory, default is /tmp, respect 'GRASS_RASTER_TMPDIR_MAPSET' shell env var
 #% answer: /tmp
 #%end
 
@@ -104,6 +104,8 @@
 #% description: Create the location specified by the "location" parameter and exit. Do not import the space time raster datasets.
 #%end
 
+import os
+
 import grass.script as grass
 
 
@@ -126,10 +128,36 @@ def main():
     overr = flags["o"]
     create = flags["c"]
 
+    tmp_dir_env = os.getenv('GRASS_RASTER_TMPDIR_MAPSET')
+    if tmp_dir_env:
+        if os.path.isdir(tmp_dir_env):
+            directory = tmp_dir_env
+            grass.warning(
+                _(
+                    "'GRASS_RASTER_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "exist and will be used.".format(
+                        new_tmp_dir=tmp_dir_env,
+                    ),
+                )
+            )
+        else:
+            grass.warning(
+                _(
+                    "'GRASS_RASTER_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "doesn't exist. The default directory "
+                    "will be used <'{def_tmp_dir}'>.".format(
+                        new_tmp_dir=tmp_dir_env,
+                        def_tmp_dir=directory,
+                    ),
+                )
+            )
+
     tgis.init()
 
     tgis.import_stds(input, output, directory, title, descr, location,
-                     link, exp, overr, create, "strds", base, 
+                     link, exp, overr, create, "strds", base,
                      set_current_region, memory)
 
 if __name__ == "__main__":

--- a/temporal/t.vect.export/t.vect.export.py
+++ b/temporal/t.vect.export/t.vect.export.py
@@ -37,7 +37,7 @@
 
 #%option G_OPT_M_DIR
 #% key: directory
-#% description: Path to the work directory, default is /tmp
+#% description: Path to the work directory, default is /tmp, respect 'GRASS_VECTOR_TMPDIR_MAPSET' shell env var
 #% required: no
 #% answer: /tmp
 #%end
@@ -81,6 +81,32 @@ def main():
     directory = options["directory"]
     where = options["where"]
     _format = options["format"]
+
+    tmp_dir_env = os.getenv('GRASS_VECTOR_TMPDIR_MAPSET')
+    if tmp_dir_env:
+        if os.path.isdir(tmp_dir_env):
+            directory = tmp_dir_env
+            grass.warning(
+                _(
+                    "'GRASS_VECTOR_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "exist and will be used.".format(
+                        new_tmp_dir=tmp_dir_env,
+                    ),
+                )
+            )
+        else:
+            grass.warning(
+                _(
+                    "'GRASS_VECTOR_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "doesn't exist. The default directory "
+                    "will be used <'{def_tmp_dir}'>.".format(
+                        new_tmp_dir=tmp_dir_env,
+                        def_tmp_dir=directory,
+                    ),
+                )
+            )
 
     # Make sure the temporal database exists
     tgis.init()

--- a/temporal/t.vect.import/t.vect.import.py
+++ b/temporal/t.vect.import/t.vect.import.py
@@ -46,7 +46,8 @@
 
 #%option G_OPT_M_DIR
 #% key: directory
-#% description: Path to the extraction directory
+#% description: Path to the extraction directory, default is /tmp, respect 'GRASS_VECTOR_TMPDIR_MAPSET' shell env var
+#% answer: /tmp
 #%end
 
 #%option
@@ -89,6 +90,8 @@
 #% description: Create the location specified by the "location" parameter and exit. Do not import the space time vector datasets.
 #%end
 
+import os
+
 import grass.script as grass
 
 
@@ -107,6 +110,32 @@ def main():
     exp = flags["e"]
     overr = flags["o"]
     create = flags["c"]
+
+    tmp_dir_env = os.getenv('GRASS_VECTOR_TMPDIR_MAPSET')
+    if tmp_dir_env:
+        if os.path.isdir(tmp_dir_env):
+            directory = tmp_dir_env
+            grass.warning(
+                _(
+                    "'GRASS_VECTOR_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "exist and will be used.".format(
+                        new_tmp_dir=tmp_dir_env,
+                    ),
+                )
+            )
+        else:
+            grass.warning(
+                _(
+                    "'GRASS_VECTOR_TMPDIR_MAPSET' shell env "
+                    "variable value (directory path) <'{new_tmp_dir}'> "
+                    "doesn't exist. The default directory "
+                    "will be used <'{def_tmp_dir}'>.".format(
+                        new_tmp_dir=tmp_dir_env,
+                        def_tmp_dir=directory,
+                    ),
+                )
+            )
 
     tgis.init()
 


### PR DESCRIPTION
With this small patch it is possible set 'GRASS_RASTER_TMPDIR_MAPSET' shell env variable (zero value or any directory) issue #893, and 'GRASS_VECTOR_TMPDIR_MAPSET' (originally only [zero value ](https://grass.osgeo.org/grass79/manuals/variables.html) could be set) to any other directory. A subdirectory (`.tmp/hostname/`) of files is always created in the setted directory. Could @neteler test it, please?

**Simple test** (nc_basic_spm_grass7 location):

Raster process:
```
g.region rast=elevation

v.random output=elev_pts npoints=10000 column=z
v.what.rast map=elev_pts raster=elevation column=z

# make custom raster tmp dir
mkdir /tmp/gg_raster_tmp

export GRASS_RASTER_TMPDIR_MAPSET=/tmp/gg_raster_tmp

# start another virtual terminal tab
watch ls -la "/tmp/gg_raster_tmp/.tmp/`hostname`/"

# check directory content, previous step
v.surf.rst input=elev_pts zcolumn=z elevation=elev_test slope=slope_test aspect=aspect_test
```

Vector process:

```
# make custom raster tmp dir
mkdir /tmp/gg_vector_tmp

export GRASS_VECTOR_TMPDIR_MAPSET=/tmp/gg_vector_tmp

# start another virtual terminal tab
watch ls -la "/tmp/gg_vector_tmp/.tmp/`hostname`/vector"

# elev_pts vector map is from previous raster process example
# check directory content, previous step
v.buffer input=elev_pts output=elev_pts_buffer distance=5
```
