### PR TITLE
wxGUI datacatalog: Adapt tooltip 'Add new grass database' button

### DIFF
--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -34,7 +34,7 @@ icons = {
         label=_("Allow edits outside of the current mapset")),
     'addGrassDB': MetaIcon(
         img='grassdb-add',
-        label=_("Add new GRASS database")),
+        label=_("Add existing or create new database")),
     'addMapset': MetaIcon(
         img='mapset-add',
         label=_("Create new mapset in current location")),


### PR DESCRIPTION
The wording of the tooltip of the button Add new grass database changed to "Add existing or create new database"