### PR TITLE
install: check lowercased prefix

### DIFF
--- a/include/Make/Install.make
+++ b/include/Make/Install.make
@@ -71,7 +71,7 @@ install-check-writable:
 	fi
 
 install-check-prefix:
-	@ result=`echo "$(INST_DIR)" | awk '{ if ($$1 ~ /grass/) print $$1 }'`; \
+	@ result=`echo "$(INST_DIR)" | awk '{ if (tolower($$1) ~ /grass/) print $$1 }'`; \
 	if [ "$$result" = "" ] ; then \
 		echo "WARNING: Your install directory $(INST_DIR)" >&2 ; \
 		echo "  does not contain the word 'grass'." >&2 ; \


### PR DESCRIPTION
At present there is an installation directory check for `grass`. This is too exclusive and will cause a warning and unnecessary interaction for cases where GRASS is written in uppercase.

E.g. a conda based mac install will go to: `/Applications/GRASS-7.9.app/Contents/Resources`.

This PR will make the check against a lowercased install directory path.