### PR TITLE
libgis parser: an empty string is not an answer

### DIFF
--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1089,6 +1089,10 @@ void set_option(const char *string)
     *ptr = '\0';
     string++;
 
+    /* an empty string is not a valid answer, skip */
+    if (! *string)
+	return;
+
     /* Find option with best keyword match */
     key_len = strlen(the_key);
     for (at_opt = &st->first_option; at_opt; at_opt = at_opt->next_opt) {


### PR DESCRIPTION
Skip zero length answers
Options are typically set with `option=answer`. Somtetimes, e.g. in modules calling other modules, it can happen that an answer is not set, and `option=` is passed instead of `option=answer`, but `option=`  does not provide an answer. This PR fixes this, making it easier for modules to construct optional answers for other modules, and makes debugging easier if a required answer is not provided.

Easy test: `r.info map=`