### PR TITLE
r.carve manual: fix example for stream vector

### DIFF
--- a/raster/r.carve/r.carve.html
+++ b/raster/r.carve/r.carve.html
@@ -24,13 +24,20 @@ North Carolina sample dataset:
 # set computational region
 g.region raster=elev_lid792_1m -p
 
+# digitize a ditch for the farm pond
+echo "L  3 1
+ 638692.93595422 220198.90026383
+ 638737.42270627 220149.74706926
+ 638984.43306379 220148.19158842
+ 1     1" | v.in.ascii -n input=- output=ditch format=standard
+
 # visualize original data
 d.mon wx0
 d.rast elev_lid792_1m
-d.vect streams
+d.vect ditch
 
 # carve
-r.carve rast=elev_lid792_1m vect=streams out=carved_dem width=3 depth=0.5
+r.carve raster=elev_lid792_1m vector=ditch output=carved_dem width=3 depth=0.5
 
 # visualize resulting carved DEM map
 d.rast carved_dem
@@ -48,6 +55,12 @@ r.watershed elevation=carved_dem accumulation=carved_dem_accum
 d.rast elev_lid792_1m_accum
 d.erase
 d.rast carved_dem_accum
+
+# differences
+r.mapcalc "accum_diff = elev_lid792_1m_accum - carved_dem_accum"
+r.colors accum_diff color=differences
+d.erase
+d.rast accum_diff
 </pre></div>
 
 <center>


### PR DESCRIPTION
The example used the `streams` map which is not in the extent of the elevation map `elev_lid792_1m` at all.
The updated example uses a newly digitized line.

New addition: compute differences accumulation map.

BTW: the NC farm area is [here](https://en.mapy.cz/zakladni?x=-78.6773289&y=35.7349805&z=17&base=ophoto&source=coor&id=-78.67885774%2C35.73616052).