### PR TITLE
wxGUI/forms: Add giface to standalone forms and fix history in giface

### DIFF
--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -201,8 +201,17 @@ class GrassInterface:
         """
         raise NotImplementedError()
 
+    def UpdateCmdHistory(self, cmd):
+        """Add the command to the current history list shown to the user
 
-class StandaloneGrassInterface():
+        .. note::
+
+            Some implementations may not implement this method or do nothing.
+        """
+        raise NotImplementedError()
+
+
+class StandaloneGrassInterface(GrassInterface):
     """@implements GrassInterface"""
 
     def __init__(self):
@@ -311,4 +320,5 @@ class StandaloneGrassInterface():
         raise NotImplementedError()
 
     def UpdateCmdHistory(self, cmd):
-        raise NotImplementedError()
+        """There is no history displayed to the user, doing nothing"""
+        pass

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -103,7 +103,7 @@ from core import gcmd
 from core import utils
 from core.settings import UserSettings
 from gui_core.widgets import FloatValidator, GNotebook, FormNotebook, FormListbook
-from core.giface import Notification
+from core.giface import Notification, StandaloneGrassInterface
 from gui_core.widgets import LayersList
 from gui_core.wrap import BitmapFromImage, Button, StaticText, StaticBox, SpinCtrl, \
     CheckBox, BitmapButton, TextCtrl, NewId
@@ -3004,7 +3004,7 @@ class GrassGUIApp(wx.App):
 
         self.mf = TaskFrame(
             parent=None,
-            giface=None,
+            giface=StandaloneGrassInterface(),
             task_description=self.grass_task)
         self.mf.CentreOnScreen()
         self.mf.Show(True)


### PR DESCRIPTION
The standalone forms were not using giface, None was passed instead which caused some parts relying on giface
to be there to fail, specifically, the disabled prompt since 2d24a42cd4b6c66ab81348aa61240e784df39032 (#930).
The prompt is not used in forms, but it is not decoupled from GConsoleWindow, so disabling it, only hides it.

This required to correctly handle implementation of StandaloneGrassInterface::UpdateCmdHistory() which was not
called previosly because the code relied to giface to not be there in the standalone case instead of dealing
with the implementation differences through the interface. Now the StandaloneGrassInterface implements this
function as no-op since there is nothing to do here. No interactive prompt to update.

The giface function UpdateCmdHistory() was not previously not defined in terms of what it does.
This is now fixed and the new implementation in StandaloneGrassInterface makes sense in light of this definition
(which is based on the implemenation of this method in lmgr).

The function was missing from the abstract interface class which served so far mainly as the general interface documentation.
This is now fixed and StandaloneGrassInterface now newly inherits from this class. The inheritance is optional,
but here it can provide useful default implementations for the functions which are not supported by (and should not with)
the StandaloneGrassInterface instances.

This fixes the standalone forms not starting (from command line) after 2d24a42cd4b6c66ab81348aa61240e784df39032.
