### PR TITLE
CRS management

### DIFF
--- a/general/g.proj/create.c
+++ b/general/g.proj/create.c
@@ -10,8 +10,8 @@ void create_location(const char *location)
 {
     int ret;
 
-    ret = G_make_location_epsg(location, &cellhd, projinfo, projunits,
-                               projepsg);
+    ret = G_make_location_crs(location, &cellhd, projinfo, projunits,
+                               projepsg, projwkt, projsrid);
     if (ret == 0)
 	G_message(_("Location <%s> created"), location);
     else if (ret == -1)
@@ -57,6 +57,14 @@ void modify_projinfo()
     if (projepsg != NULL) {
 	G_file_name(path, "", "PROJ_EPSG", "PERMANENT");
 	G_write_key_value_file(path, projepsg);
+    }
+
+    if (projwkt != NULL) {
+	G_write_projwkt(NULL, projwkt);
+    }
+
+    if (projsrid != NULL) {
+	G_write_projsrid(NULL, projsrid);
     }
 
     if ((old_cellhd.zone != cellhd.zone) ||

--- a/general/g.proj/local_proto.h
+++ b/general/g.proj/local_proto.h
@@ -1,12 +1,14 @@
 #include <grass/config.h>
 
 extern struct Key_Value *projinfo, *projunits, *projepsg;
+extern char *projsrid, *projwkt;
 extern struct Cell_head cellhd;
 
 /* input.c */
 void input_currloc(void);
 #ifdef HAVE_OGR
 int input_wkt(char *);
+int input_srid(char *);
 int input_proj4(char *);
 int input_epsg(int);
 int input_georef(char *);

--- a/general/g.proj/output.c
+++ b/general/g.proj/output.c
@@ -27,7 +27,8 @@
 
 static int check_xy(int shell);
 
-/* print projection information gathered from one of the possible inputs */
+/* print projection information gathered from one of the possible inputs
+ * in GRASS format */
 void print_projinfo(int shell)
 {
     int i;
@@ -123,43 +124,75 @@ void print_datuminfo(void)
     return;
 }
 
+/* print input projection information in PROJ format */
 void print_proj4(int dontprettify)
 {
     struct pj_info pjinfo;
-    char *proj4, *proj4mod, *i;
+    char *i, *projstrmod;
+    const char *projstr;
     const char *unfact;
 
     if (check_xy(FALSE))
 	return;
 
-    if (pj_get_kv(&pjinfo, projinfo, projunits) == -1)
-        G_fatal_error(_("Unable to convert projection information to PROJ format"));
-    proj4 = pjinfo.def;
-#ifdef HAVE_PROJ_H
-    proj_destroy(pjinfo.pj);
-#else
-    pj_free(pjinfo.pj);
-#endif
-    /* GRASS-style PROJ.4 strings don't include a unit factor as this is
-     * handled separately in GRASS - must include it here though */
-    unfact = G_find_key_value("meters", projunits);
-    if (unfact != NULL && (strcmp(pjinfo.proj, "ll") != 0))
-	G_asprintf(&proj4mod, "%s +to_meter=%s", proj4, unfact);
-    else
-	proj4mod = G_store(proj4);
+    projstr = NULL;
+    projstrmod = NULL;
 
-    for (i = proj4mod; *i; i++) {
+#if PROJ_VERSION_MAJOR >= 6
+    /* PROJ6+: create a PJ object from wkt or srid,
+     * then get PROJ string using PROJ API */
+    {
+	PJ *obj = NULL;
+
+	if (projwkt) {
+	    obj = proj_create_from_wkt(NULL, projwkt, NULL, NULL, NULL);
+	}
+	if (!obj && projsrid) {
+	    obj = proj_create(NULL, projsrid);
+	}
+	if (obj) {
+	    projstr = proj_as_proj_string(NULL, obj, PJ_PROJ_5, NULL);
+
+	    if (projstr)
+		projstr = G_store(projstr);
+	    proj_destroy(obj);
+	}
+    }
+#endif
+
+    if (!projstr) {
+	if (pj_get_kv(&pjinfo, projinfo, projunits) == -1)
+	    G_fatal_error(_("Unable to convert projection information to PROJ format"));
+	projstr = pjinfo.def;
+#if PROJ_VERSION_MAJOR >= 5
+	proj_destroy(pjinfo.pj);
+#else
+	pj_free(pjinfo.pj);
+#endif
+
+	/* GRASS-style PROJ.4 strings don't include a unit factor as this is
+	 * handled separately in GRASS - must include it here though */
+	unfact = G_find_key_value("meters", projunits);
+	if (unfact != NULL && (strcmp(pjinfo.proj, "ll") != 0))
+	    G_asprintf(&projstrmod, "%s +to_meter=%s", projstr, unfact);
+	else
+	    projstrmod = G_store(projstr);
+    }
+    if (!projstrmod)
+	projstrmod = G_store(projstr);
+
+    for (i = projstrmod; *i; i++) {
 	/* Don't print the first space */
-	if (i == proj4mod && *i == ' ')
+	if (i == projstrmod && *i == ' ')
 	    continue;
 
-	if (*i == ' ' && *(i+1) == '+' && !(dontprettify))
+	if (*i == ' ' && *(i + 1) == '+' && !(dontprettify))
 	    fputc('\n', stdout);
 	else
 	    fputc(*i, stdout);
     }
     fputc('\n', stdout);
-    G_free(proj4mod);
+    G_free(projstrmod);
 
     return;
 }
@@ -172,8 +205,65 @@ void print_wkt(int esristyle, int dontprettify)
     if (check_xy(FALSE))
 	return;
 
+    outwkt = NULL;
+
+#if PROJ_VERSION_MAJOR >= 6
+    /* print WKT2 using GDAL OSR interface */
+    {
+	OGRSpatialReferenceH hSRS;
+	const char *tmpwkt;
+	const char **papszOptions = NULL;
+
+	papszOptions = G_calloc(3, sizeof(char *));
+	if (dontprettify)
+	    papszOptions[0] = G_store("MULTILINE=NO");
+	else
+	    papszOptions[0] = G_store("MULTILINE=YES");
+	if (esristyle)
+	    papszOptions[1] = G_store("FORMAT=WKT1_ESRI");
+	else
+	    papszOptions[1] = G_store("FORMAT=WKT2");
+	papszOptions[2] = NULL;
+
+	hSRS = NULL;
+
+	if (projsrid) {
+	    PJ *obj;
+
+	    obj = proj_create(NULL, projsrid);
+	    if (!obj)
+		G_fatal_error(_("Unable to create PROJ definition from srid <%s>"), projsrid);
+	    tmpwkt = proj_as_wkt(NULL, obj, PJ_WKT2_2019, NULL);
+	    hSRS = OSRNewSpatialReference(tmpwkt);
+	    OSRExportToWktEx(hSRS, &outwkt, papszOptions);
+	}
+	if (!outwkt && projwkt) {
+	    hSRS = OSRNewSpatialReference(projwkt);
+	    OSRExportToWktEx(hSRS, &outwkt, papszOptions);
+	}
+	if (!outwkt && projepsg) {
+	    int epsg_num;
+
+	    epsg_num = atoi(G_find_key_value("epsg", projepsg));
+
+	    OSRImportFromEPSG(hSRS, epsg_num);
+	    OSRExportToWktEx(hSRS, &outwkt, papszOptions);
+	}
+	if (!outwkt) {
+	    /* use GRASS proj info + units */
+	    projwkt = GPJ_grass_to_wkt2(projinfo, projunits, projepsg, esristyle,
+				      !(dontprettify));
+	    hSRS = OSRNewSpatialReference(projwkt);
+	    OSRExportToWktEx(hSRS, &outwkt, papszOptions);
+	}
+	if (hSRS)
+	    OSRDestroySpatialReference(hSRS);
+    }
+#else
     outwkt = GPJ_grass_to_wkt2(projinfo, projunits, projepsg, esristyle,
 			      !(dontprettify));
+#endif
+
     if (outwkt != NULL) {
 	fprintf(stdout, "%s\n", outwkt);
 	G_free(outwkt);

--- a/include/defs/gis.h
+++ b/include/defs/gis.h
@@ -398,6 +398,8 @@ int G_read_ellipsoid_table(int);
 struct Key_Value *G_get_projunits(void);
 struct Key_Value *G_get_projinfo(void);
 struct Key_Value *G_get_projepsg(void);
+char *G_get_projwkt(void);
+char *G_get_projsrid(void);
 
 /* get_window.c */
 void G_get_window(struct Cell_head *);
@@ -522,6 +524,11 @@ int G_make_location(const char *, struct Cell_head *, const struct Key_Value *,
 		    const struct Key_Value *);
 int G_make_location_epsg(const char *, struct Cell_head *, const struct Key_Value *,
 			 const struct Key_Value *, const struct Key_Value *);
+int G_make_location_crs(const char *, struct Cell_head *, const struct Key_Value *,
+			const struct Key_Value *, const struct Key_Value *,
+			const char *, const char *);
+int G_write_projsrid(const char *, const char *);
+int G_write_projwkt(const char *, const char *);
 int G_compare_projections(const struct Key_Value *, const struct Key_Value *,
 			  const struct Key_Value *, const struct Key_Value *);
 

--- a/include/gis.h
+++ b/include/gis.h
@@ -117,6 +117,8 @@ static const char *GRASS_copyright __attribute__ ((unused))
 #define PROJECTION_FILE "PROJ_INFO"
 #define UNIT_FILE       "PROJ_UNITS"
 #define EPSG_FILE       "PROJ_EPSG"
+#define WKT_FILE        "PROJ_WKT"
+#define SRID_FILE       "PROJ_SRID"
 
 #ifdef __MINGW32__
 #define CONFIG_DIR "GRASS7"

--- a/include/gprojects.h
+++ b/include/gprojects.h
@@ -27,9 +27,14 @@
 #include <proj_api.h>
 #define PJ_FWD 	 1
 #define PJ_INV 	-1
+/* PROJ_VERSION_MAJOR is not set in the old PROJ API */
+#define PROJ_VERSION_MAJOR 4
 #endif
 #ifdef HAVE_OGR
 #    include <ogr_srs_api.h>
+#    if PROJ_VERSION_MAJOR >= 6 && GDAL_VERSION_MAJOR < 3
+#        error "PROJ 6+ requires GDAL 3+"
+#    endif
 #endif
 
 /* Data Files */
@@ -60,6 +65,7 @@ struct gpj_datum
     double dx, dy, dz;
 };
 
+/* no longer needed with PROJ6+ */
 struct gpj_datum_transform_list
 {
 

--- a/lib/gis/get_projinfo.c
+++ b/lib/gis/get_projinfo.c
@@ -9,6 +9,8 @@
   (>=v2). Read the file COPYING that comes with GRASS for details.
 */
 
+#include <string.h>
+#include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <grass/gis.h>
@@ -93,6 +95,8 @@ struct Key_Value *G_get_projinfo(void)
   \return pointer to Key_Value structure with key/value pairs
   \return NULL when EPSG code is not defined for location
 */
+
+/* superseded by G_get_projsrid(), keep for backwards compatibility */ 
 struct Key_Value *G_get_projepsg(void)
 {
     struct Key_Value *in_epsg_keys;
@@ -109,4 +113,157 @@ struct Key_Value *G_get_projepsg(void)
     in_epsg_keys = G_read_key_value_file(path);
 
     return in_epsg_keys;
+}
+
+/*!
+  \brief Get WKT information for the current location
+
+  \return pointer to WKT string
+  \return NULL when WKT is not available for the current location
+*/
+
+char *G_get_projwkt(void)
+{
+    char *wktstring = NULL;
+    char path[GPATH_MAX];
+    FILE *fp;
+    int n, nalloc;
+    int c;
+
+    G_file_name(path, "", WKT_FILE, "PERMANENT");
+    if (access(path, 0) != 0) {
+	if (G_projection() != PROJECTION_XY) {
+	    G_warning(_("<%s> file not found for location <%s>"),
+		      WKT_FILE, G_location());
+	}
+	return NULL;
+    }
+
+    fp = fopen(path, "r");
+    if (!fp)
+	G_fatal_error(_("Unable to open output file <%s>: %s"), path, strerror(errno));
+
+    wktstring = G_malloc(1024 * sizeof(char));
+    nalloc = 1024;
+
+    n = 0;
+    while (1) {
+	c = fgetc(fp);
+
+	if (c == EOF) {
+	    break;
+	}
+
+	if (c == '\r') {	/* DOS or MacOS9 */
+	    c = fgetc(fp);
+	    if (c != EOF) {
+		if (c != '\n') {	/* MacOS9 - we have to return the char to stream */
+		    ungetc(c, fp);
+		    c = '\n';
+		}
+	    }
+	    else {	/* MacOS9 - we have to return the char to stream */
+		ungetc(c, fp);
+		c = '\n';
+	    }
+
+	}
+
+	if (n == nalloc) {
+	    wktstring = G_realloc(wktstring, nalloc + 1024);
+	    nalloc += 1024;
+	}
+
+	wktstring[n] = c;
+
+	n++;
+    }
+
+    if (n > 0) {
+	if (n == nalloc) {
+	    wktstring = G_realloc(wktstring, nalloc + 1);
+	    nalloc += 1;
+	}
+	wktstring[n] = '\0';
+    }
+    else {
+	G_free(wktstring);
+	wktstring = NULL;
+    }
+
+    if (fclose(fp) != 0)
+	G_fatal_error(_("Error closing output file <%s>: %s"), path, strerror(errno));
+
+    return wktstring;
+}
+
+/*!
+  \brief Get srid (spatial reference id) for the current location
+
+  \return pointer to srid string
+  \return NULL when srid is not available for the current location
+*/
+
+char *G_get_projsrid(void)
+{
+    char *sridstring = NULL;
+    char path[GPATH_MAX];
+    FILE *fp;
+    int n, nalloc;
+    int c;
+
+    G_file_name(path, "", WKT_FILE, "PERMANENT");
+    if (access(path, 0) != 0) {
+	if (G_projection() != PROJECTION_XY) {
+	    G_warning(_("<%s> file not found for location <%s>"),
+		      WKT_FILE, G_location());
+	}
+	return NULL;
+    }
+
+    fp = fopen(path, "r");
+    if (!fp)
+	G_fatal_error(_("Unable to open output file <%s>: %s"), path, strerror(errno));
+
+    sridstring = G_malloc(1024 * sizeof(char));
+    nalloc = 1024;
+
+    n = 0;
+    while (1) {
+	c = fgetc(fp);
+
+	if (c == EOF) {
+	    break;
+	}
+
+	/* srid must be the first line */
+	if (c == '\r' || c == '\n')
+	    break;
+
+	if (n == nalloc) {
+	    sridstring = G_realloc(sridstring, nalloc + 1024);
+	    nalloc += 1024;
+	}
+
+	sridstring[n] = c;
+
+	n++;
+    }
+
+    if (n > 0) {
+	if (n == nalloc) {
+	    sridstring = G_realloc(sridstring, nalloc + 1);
+	    nalloc += 1;
+	}
+	sridstring[n] = '\0';
+    }
+    else {
+	G_free(sridstring);
+	sridstring = NULL;
+    }
+
+    if (fclose(fp) != 0)
+	G_fatal_error(_("Error closing output file <%s>: %s"), path, strerror(errno));
+
+    return sridstring;
 }

--- a/lib/gis/make_loc.c
+++ b/lib/gis/make_loc.c
@@ -540,11 +540,11 @@ int G_write_projwkt(const char *location_name, const char *wktstring)
     err = 0;
     n = strlen(wktstring);
     if (wktstring[n - 1] != '\n') {
-	if (EOF == fprintf(fp, "%s\n", wktstring))
+	if (n != fprintf(fp, "%s\n", wktstring))
 	    err = -1;
     }
     else {
-	if (EOF == fprintf(fp, "%s", wktstring))
+	if (n != fprintf(fp, "%s", wktstring))
 	    err = -1;
     }
 
@@ -590,11 +590,11 @@ int G_write_projsrid(const char *location_name, const char *sridstring)
     err = 0;
     n = strlen(sridstring);
     if (sridstring[n - 1] != '\n') {
-	if (EOF == fprintf(fp, "%s\n", sridstring))
+	if (n != fprintf(fp, "%s\n", sridstring))
 	    err = -1;
     }
     else {
-	if (EOF == fprintf(fp, "%s", sridstring))
+	if (n != fprintf(fp, "%s", sridstring))
 	    err = -1;
     }
 

--- a/lib/gis/make_loc.c
+++ b/lib/gis/make_loc.c
@@ -18,9 +18,11 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <math.h>
+#include <grass/glocale.h>
 
 /*!
  * \brief Create a new location
@@ -140,6 +142,77 @@ int G_make_location_epsg(const char *location_name,
     if (proj_epsg != NULL) {
 	G_file_name(path, "", "PROJ_EPSG", "PERMANENT");
 	G_write_key_value_file(path, proj_epsg);
+    }
+
+    return 0;
+}
+
+/*!
+ * \brief Create a new location
+ * 
+ * This function creates a new location in the current database,
+ * initializes the projection, default window and current window,
+ * and sets WKT, srid, and EPSG code if present
+ *
+ * \param location_name Name of the new location. Should not include
+ *                      the full path, the location will be created within
+ *                      the current database.
+ * \param wind          default window setting for the new location.
+ *                      All fields should be set in this
+ *                      structure, and care should be taken to ensure that
+ *                      the proj/zone fields match the definition in the
+ *                      proj_info parameter(see G_set_cellhd_from_projinfo()).
+ *
+ * \param proj_info     projection definition suitable to write to the
+ *                      PROJ_INFO file, or NULL for PROJECTION_XY.
+ *
+ * \param proj_units    projection units suitable to write to the PROJ_UNITS
+ *                      file, or NULL.
+ * 
+ * \param proj_epsg     EPSG code suitable to write to the PROJ_EPSG
+ *                      file, or NULL.
+ *
+ * \param proj_wkt      WKT defintion suitable to write to the PROJ_WKT
+ *                      file, or NULL.
+ *
+ * \param proj_srid     Spatial reference ID suitable to write to the PROJ_SRID
+ *                      file, or NULL.
+ *
+ * \return 0 on success
+ * \return -1 to indicate a system error (check errno).
+ * \return -2 failed to create projection file (currently not used)
+ * \return -3 illegal name 
+ */
+int G_make_location_crs(const char *location_name,
+			struct Cell_head *wind,
+			const struct Key_Value *proj_info,
+			const struct Key_Value *proj_units,
+			const struct Key_Value *proj_epsg,
+			const char *proj_wkt,
+			const char *proj_srid)
+{
+    int ret;
+    char path[GPATH_MAX];
+
+    ret = G_make_location(location_name, wind, proj_info, proj_units);
+
+    if (ret != 0)
+	return ret;
+
+    /* Write out PROJ_EPSG if epsg code is available. */
+    if (proj_epsg != NULL) {
+	G_file_name(path, "", "PROJ_EPSG", "PERMANENT");
+	G_write_key_value_file(path, proj_epsg);
+    }
+
+    /* Write out PROJ_WKT if WKT is available. */
+    if (proj_wkt != NULL) {
+	G_write_projwkt(location_name, proj_wkt);
+    }
+
+    /* Write out PROJ_SRID if srid is available. */
+    if (proj_srid != NULL) {
+	G_write_projsrid(location_name, proj_srid);
     }
 
     return 0;
@@ -431,4 +504,102 @@ int G_compare_projections(const struct Key_Value *proj_info1,
     /* -------------------------------------------------------------------- */
 
     return 1;
+}
+
+/*!
+   \brief Write WKT definition to file
+   
+   Any WKT string and version recognized by PROJ is supported.
+
+   \param location_name name of the location to write the WKT definition
+   \param wktstring pointer to WKT string
+
+   \return 0 success
+   \return -1 error writing
+ */
+
+int G_write_projwkt(const char *location_name, const char *wktstring)
+{
+    FILE *fp;
+    char path[GPATH_MAX];
+    int err, n;
+
+    if (!wktstring)
+	return 0;
+
+    if (location_name && *location_name)
+	sprintf(path, "%s/%s/%s/%s", G_gisdbase(), location_name, "PERMANENT", WKT_FILE);
+    else
+	G_file_name(path, "", WKT_FILE, "PERMANENT");
+
+    fp = fopen(path, "w");
+
+    if (!fp)
+	G_fatal_error(_("Unable to open output file <%s>: %s"), path, strerror(errno));
+
+    err = 0;
+    n = strlen(wktstring);
+    if (wktstring[n - 1] != '\n') {
+	if (EOF == fprintf(fp, "%s\n", wktstring))
+	    err = -1;
+    }
+    else {
+	if (EOF == fprintf(fp, "%s", wktstring))
+	    err = -1;
+    }
+
+    if (fclose(fp) != 0)
+	G_fatal_error(_("Error closing output file <%s>: %s"), path, strerror(errno));
+
+    return err;
+}
+
+
+/*!
+   \brief Write srid (spatial reference id) to file
+
+    A srid consists of an authority name and code and must be known to
+    PROJ.
+
+   \param location_name name of the location to write the srid
+   \param sridstring pointer to srid string
+
+   \return 0 success
+   \return -1 error writing
+ */
+
+int G_write_projsrid(const char *location_name, const char *sridstring)
+{
+    FILE *fp;
+    char path[GPATH_MAX];
+    int err, n;
+
+    if (!sridstring)
+	return 0;
+
+    if (location_name && *location_name)
+	sprintf(path, "%s/%s/%s/%s", G_gisdbase(), location_name, "PERMANENT", SRID_FILE);
+    else
+	G_file_name(path, "", SRID_FILE, "PERMANENT");
+
+    fp = fopen(path, "w");
+
+    if (!fp)
+	G_fatal_error(_("Unable to open output file <%s>: %s"), path, strerror(errno));
+
+    err = 0;
+    n = strlen(sridstring);
+    if (sridstring[n - 1] != '\n') {
+	if (EOF == fprintf(fp, "%s\n", sridstring))
+	    err = -1;
+    }
+    else {
+	if (EOF == fprintf(fp, "%s", sridstring))
+	    err = -1;
+    }
+
+    if (fclose(fp) != 0)
+	G_fatal_error(_("Error closing output file <%s>: %s"), path, strerror(errno));
+
+    return err;
 }

--- a/lib/gis/proj3.c
+++ b/lib/gis/proj3.c
@@ -11,6 +11,9 @@
   \author Original author CERL
  */
 
+/* TODO: the G_database_*() functions should be renamed to G_location_*()
+ * because they apply to a GRASS location, not to a GRASS database */
+
 #include <string.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>


### PR DESCRIPTION
first steps to use WKT as main CRS definition and leave datum transformation parameters to PROJ: store WKT and spatail reference id (authority code) if available.
Test command with CRS authority name "IGNF" and code "WALL78UTM1S.WALLIS96":
`g.proj -w srid=IGNF:WALL78UTM1S.WALLIS96` 
See also issue #961 