### PR TITLE
macOS: use @rpath as dynamic linker

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -507,12 +507,13 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
             LDFLAGS="-Wl,--export-dynamic,--enable-runtime-pseudo-reloc"
             LD_LIBRARY_PATH_VAR="PATH"
             ;;
-	*-apple-darwin*)
-	    SHLIB_CFLAGS="-fno-common"
-	    SHLIB_SUFFIX=".dylib"
-	    SHLIB_LD="${CC} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name \${INST_DIR}/lib/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
-	    LD_LIBRARY_PATH_VAR="DYLD_LIBRARY_PATH"
-	    ;;
+        *-apple-darwin*)
+            SHLIB_CFLAGS="-fno-common"
+            SHLIB_SUFFIX=".dylib"
+            SHLIB_LD="${CC} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name @rpath/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
+            LDFLAGS="-Wl,-rpath,${INSTDIR}/lib,-rpath,\${GISBASE}/lib"
+            LD_LIBRARY_PATH_VAR="LD_RUN_PATH"
+            ;;
 	*-sun-solaris*)
 	    # Note: If _REENTRANT isn't defined, then Solaris
 	    # won't define thread-safe library routines.

--- a/configure
+++ b/configure
@@ -1551,12 +1551,13 @@ ac_save_ldflags="$LDFLAGS"
             LDFLAGS="-Wl,--export-dynamic,--enable-runtime-pseudo-reloc"
             LD_LIBRARY_PATH_VAR="PATH"
             ;;
-	*-apple-darwin*)
-	    SHLIB_CFLAGS="-fno-common"
-	    SHLIB_SUFFIX=".dylib"
-	    SHLIB_LD="${CC} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name \${INST_DIR}/lib/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
-	    LD_LIBRARY_PATH_VAR="DYLD_LIBRARY_PATH"
-	    ;;
+        *-apple-darwin*)
+            SHLIB_CFLAGS="-fno-common"
+            SHLIB_SUFFIX=".dylib"
+            SHLIB_LD="${CC} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name @rpath/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
+            LDFLAGS="-Wl,-rpath,${INSTDIR}/lib,-rpath,\${GISBASE}/lib"
+            LD_LIBRARY_PATH_VAR="LD_RUN_PATH"
+            ;;
 	*-sun-solaris*)
 	    # Note: If _REENTRANT isn't defined, then Solaris
 	    # won't define thread-safe library routines.

--- a/lib/python/ctypes/loader.py
+++ b/lib/python/ctypes/loader.py
@@ -124,7 +124,9 @@ class DarwinLibraryLoader(LibraryLoader):
         dyld_fallback_library_path = _environ_path("DYLD_FALLBACK_LIBRARY_PATH")
         if not dyld_fallback_library_path:
             dyld_fallback_library_path = [os.path.expanduser('~/lib'),
-                                          '/usr/local/lib', '/usr/lib']
+                                          '/usr/local/lib', '/usr/lib',
+                                          os.path.join(sys.prefix, 'lib')]
+        dyld_fallback_library_path.extend(_environ_path('LD_RUN_PATH'))
 
         dirs = []
 


### PR DESCRIPTION
Fixes #980 

With this PR, building GRASS on Mac will use `@rpath` instead of `DYLD_LIBRARY_PATH` for dynamic linking.

I have tested this as standard unix-like build, with MacPorts, as well as with the semi-official conda based mac-bundle build (https://github.com/nilason/grass-conda).

