### PR TITLE
g.search.modules: add keyword='' for all modules

### DIFF
--- a/scripts/g.search.modules/g.search.modules.py
+++ b/scripts/g.search.modules/g.search.modules.py
@@ -94,6 +94,8 @@ def main():
 
     if exact_keywords:
         keywords = options['keyword'].split(',')
+    elif options['keyword'] == '*':
+        keywords = ['']
     else:
         keywords = options['keyword'].lower().split(',')
 

--- a/scripts/g.search.modules/g.search.modules.py
+++ b/scripts/g.search.modules/g.search.modules.py
@@ -23,7 +23,7 @@
 #% multiple: yes
 #% type: string
 #% description: Keyword to be searched
-#% required : yes
+#% required : no
 #%end
 #%flag
 #% key: a
@@ -94,7 +94,7 @@ def main():
 
     if exact_keywords:
         keywords = options['keyword'].split(',')
-    elif options['keyword'] == '*':
+    elif not options['keyword']:
         keywords = ['']
     else:
         keywords = options['keyword'].lower().split(',')


### PR DESCRIPTION
Since the commit https://github.com/OSGeo/grass/commit/b339724848a8c881f636a4dca297cb7adfa29502 does not allow `keyword=""` with this change you can list all GRASS GIS modules if `keyword` is not set at all.

Developed with @griembauer.