### PR TITLE
Dockerfiles: install git before build

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -130,6 +130,7 @@ ENV GRASS_BUILD_PACKAGES="\
       gcc \
       gdal-dev \
       geos-dev \
+      git \
       gnutls-dev \
       libc6-compat \
       libjpeg-turbo-dev \

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -94,6 +94,7 @@ ENV PACKAGES="\
       gcc \
       gdal-dev \
       geos-dev \
+      git \
       gnutls-dev \
       libc6-compat \
       libjpeg-turbo-dev \

--- a/docker/alpine/Dockerfile_alpine_wxgui
+++ b/docker/alpine/Dockerfile_alpine_wxgui
@@ -98,6 +98,7 @@ ENV PACKAGES="\
       gcc \
       gdal-dev \
       geos-dev \
+      git \
       gnutls-dev \
       gtk+3.0-dev \
       libc6-compat \


### PR DESCRIPTION
Currently, running `g.version` in a docker container based on the alpine images does not reveal the git commit hash, e.g.
```
version=7.8.4dev
date=2020
revision=exported
build_date=2020-09-25
build_platform=x86_64-pc-linux-musl
build_off_t_size=8
libgis_revision=2020-09-25T08:27:21+00:00
libgis_date=2020-09-25T08:27:21+00:00
proj=7.0.1
gdal=3.1.2
geos=3.8.1
sqlite=3.32.1
```
Because `git` needs to be installed to reveal the revision.
This PR adds `git` before build time to reveal the commit hash.