### PR TITLE
Reflect grassdb changes in catalog 

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -737,6 +737,13 @@ class GConsole(wx.EvtHandler):
                                 'fullname']:
                             self.mapCreated.emit(
                                 name=lname, ltype=prompt, add=event.addLayer)
+                            gisenv = grass.gisenv()
+                            self._giface.grassdbChanged.emit(grassdb=gisenv['GISDBASE'],
+                                                             location=gisenv['LOCATION_NAME'],
+                                                             mapset=gisenv['MAPSET'],
+                                                             action='new',
+                                                             newname=lname.split('@')[0],
+                                                             element=prompt)
         if name == 'r.mask':
             self.updateMap.emit()
 

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -742,7 +742,7 @@ class GConsole(wx.EvtHandler):
                                                              location=gisenv['LOCATION_NAME'],
                                                              mapset=gisenv['MAPSET'],
                                                              action='new',
-                                                             newname=lname.split('@')[0],
+                                                             map=lname.split('@')[0],
                                                              element=prompt)
         if name == 'r.mask':
             self.updateMap.emit()

--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -221,7 +221,9 @@ class StandaloneGrassInterface(GrassInterface):
         # add: if map should be added to layer tree (questionable attribute)
         self.mapCreated = Signal('StandaloneGrassInterface.mapCreated')
 
-        self.currentMapsetChanged = Signal('LayerManagerGrassInterface.currentMapsetChanged')
+        self.currentMapsetChanged = Signal('StandaloneGrassInterface.currentMapsetChanged')
+
+        self.grassdbChanged = Signal('StandaloneGrassInterface.grassdbChanged')
 
         # Signal emitted to request updating of map
         self.updateMap = Signal('StandaloneGrassInterface.updateMap')

--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -217,12 +217,23 @@ class StandaloneGrassInterface(GrassInterface):
     def __init__(self):
 
         # Signal when some map is created or updated by a module.
+        # Used for adding/refreshing displayed layers.
         # attributes: name: map name, ltype: map type,
         # add: if map should be added to layer tree (questionable attribute)
         self.mapCreated = Signal('StandaloneGrassInterface.mapCreated')
 
+        # Signal for communicating current mapset has been switched
         self.currentMapsetChanged = Signal('StandaloneGrassInterface.currentMapsetChanged')
 
+        # Signal for communicating something in current grassdb has changed.
+        # Parameters:
+        # action: required, is one of 'new', 'rename', 'delete'
+        # element: required, can be one of 'grassdb', 'location', 'mapset', 'raster', 'vector' and 'raster_3d'
+        # grassdb: path to grass db, required
+        # location: location name, required
+        # mapset: mapset name, required when element is 'mapset', 'raster', 'vector' or 'raster_3d'
+        # map: map name, required when element is 'raster', 'vector' or 'raster_3d'
+        # newname: new name (of mapset, map), required with action='rename'
         self.grassdbChanged = Signal('StandaloneGrassInterface.grassdbChanged')
 
         # Signal emitted to request updating of map

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -645,7 +645,6 @@ class DataCatalogTree(TreeView):
         """Rename node (map, mapset, location), sort and refresh.
         Should be called after actual renaming of a map, mapset, location."""
         node.data['name'] = name
-        print('rename')
         self._model.SortChildren(node.parent)
         self.RefreshNode(node.parent, recursive=True)
 

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -187,6 +187,13 @@ def getLocationTree(gisdbase, location, queue, mapsets=None):
 
 
 class MapWatch(PatternMatchingEventHandler):
+    """Monitors file events (create, delete, move files) using watchdog
+    to inform about changes in current mapset. One instance monitors
+    only one element (raster, vector, raster_3d).
+    Patterns are not used/needed in this case, use just '*' for matching
+    everything. When file/directory change is detected, wx event is dispatched
+    to event handler (can't use Signals because this is different thread),
+    containing info about the change."""
     def __init__(self, patterns, element, event_handler):
         PatternMatchingEventHandler.__init__(self, patterns=patterns)
         self.element = element

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1531,6 +1531,7 @@ class DataCatalogTree(TreeView):
                                       location=location)
                 if node:
                     self._reloadLocationNode(node)
+                    self.UpdateCurrentDbLocationMapsetNode()
                     self.RefreshNode(node, recursive=True)
             elif action == 'rename':
                 node = self.GetDbNode(grassdb=grassdb,

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -69,7 +69,11 @@ from lmgr.giface import LayerManagerGrassInterface
 from datacatalog.catalog import DataCatalog
 from gui_core.forms import GUI
 from gui_core.wrap import Menu, TextEntryDialog
-from startup.guiutils import switch_mapset_interactively
+from startup.guiutils import (
+    switch_mapset_interactively,
+    create_mapset_interactively,
+    create_location_interactively
+)
 
 
 class GMFrame(wx.Frame):
@@ -479,56 +483,15 @@ class GMFrame(wx.Frame):
 
     def OnLocationWizard(self, event):
         """Launch location wizard"""
-        from location_wizard.wizard import LocationWizard
-        from location_wizard.dialogs import RegionDef
-
-        gWizard = LocationWizard(parent=self,
-                                 grassdatabase=grass.gisenv()['GISDBASE'])
-        location = gWizard.location
-
-        if location is not None:
-            dlg = wx.MessageDialog(parent=self,
-                                   message=_('Location <%s> created.\n\n'
-                                             'Do you want to switch to the '
-                                             'new location?') % location,
-                                   caption=_("Switch to new location?"),
-                                   style=wx.YES_NO | wx.NO_DEFAULT |
-                                   wx.ICON_QUESTION | wx.CENTRE)
-
-            ret = dlg.ShowModal()
-            dlg.Destroy()
-            if ret == wx.ID_YES:
-                if RunCommand('g.mapset', parent=self,
-                              location=location,
-                              mapset='PERMANENT') != 0:
-                    return
-
-                # close current workspace and create new one
-                self.OnWorkspaceClose()
-                self.OnWorkspaceNew()
-                GMessage(parent=self,
-                         message=_("Current location is <%(loc)s>.\n"
-                                   "Current mapset is <%(mapset)s>.") %
-                         {'loc': location, 'mapset': 'PERMANENT'})
-
-                # code duplication with gis_set.py
-                dlg = wx.MessageDialog(
-                    parent=self,
-                    message=_(
-                        "Do you want to set the default "
-                        "region extents and resolution now?"),
-                    caption=_("Location <%s> created") %
-                    location,
-                    style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION)
-                dlg.CenterOnScreen()
-                if dlg.ShowModal() == wx.ID_YES:
-                    dlg.Destroy()
-                    defineRegion = RegionDef(self, location=location)
-                    defineRegion.CenterOnScreen()
-                    defineRegion.ShowModal()
-                    defineRegion.Destroy()
-                else:
-                    dlg.Destroy()
+        gisenv = grass.gisenv()
+        grassdb, location, mapset = (
+            create_location_interactively(self, gisenv['GISDBASE'])
+        )
+        if location:
+            self._giface.grassdbChanged.emit(grassdb=gisenv['GISDBASE'],
+                                             location=location,
+                                             action='new',
+                                             element='location')
 
     def OnSettingsChanged(self):
         """Here can be functions which have to be called
@@ -1082,28 +1045,15 @@ class GMFrame(wx.Frame):
 
     def OnCreateMapset(self, event):
         """Create new mapset"""
-        dlg = wx.TextEntryDialog(parent=self,
-                                 message=_('Enter name for new mapset:'),
-                                 caption=_('Create new mapset'))
-
-        if dlg.ShowModal() == wx.ID_OK:
-            mapset = dlg.GetValue()
-            if not mapset:
-                GError(parent=self,
-                       message=_("No mapset provided. Operation canceled."))
-                return
-
-            ret = RunCommand('g.mapset',
-                             parent=self,
-                             flags='c',
-                             mapset=mapset)
-            # ensure that DB connection is defined
-            ret += RunCommand('db.connect',
-                              parent=self,
-                              flags='c')
-            if ret == 0:
-                GMessage(parent=self,
-                         message=_("Current mapset is <%s>.") % mapset)
+        gisenv = grass.gisenv()
+        mapset = create_mapset_interactively(self, gisenv['GISDBASE'],
+                                             gisenv['LOCATION_NAME'])
+        if mapset:
+            self._giface.grassdbChanged.emit(grassdb=gisenv['GISDBASE'],
+                                             location=gisenv['LOCATION_NAME'],
+                                             mapset=mapset,
+                                             action='new',
+                                             element='mapset')
 
     def OnChangeMapset(self, event):
         """Change current mapset"""

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -189,6 +189,7 @@ class LayerManagerGrassInterface(object):
         self.mapCreated = Signal('LayerManagerGrassInterface.mapCreated')
 
         self.currentMapsetChanged = Signal('LayerManagerGrassInterface.currentMapsetChanged')
+        self.grassdbChanged = Signal('LayerManagerGrassInterface.grassdbChanged')
 
         # Signal emitted to request updating of map
         self.updateMap = Signal('LayerManagerGrassInterface.updateMap')

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -184,11 +184,23 @@ class LayerManagerGrassInterface(object):
         self.lmgr = lmgr
 
         # Signal when some map is created or updated by a module.
+        # Used for adding/refreshing displayed layers.
         # attributes: name: map name, ltype: map type,
         # add: if map should be added to layer tree (questionable attribute)
         self.mapCreated = Signal('LayerManagerGrassInterface.mapCreated')
 
+        # Signal for communicating current mapset has been switched
         self.currentMapsetChanged = Signal('LayerManagerGrassInterface.currentMapsetChanged')
+
+        # Signal for communicating something in current grassdb has changed.
+        # Parameters:
+        # action: required, is one of 'new', 'rename', 'delete'
+        # element: required, can be one of 'grassdb', 'location', 'mapset', 'raster', 'vector' and 'raster_3d'
+        # grassdb: path to grass db, required
+        # location: location name, required
+        # mapset: mapset name, required when element is 'mapset', 'raster', 'vector' or 'raster_3d'
+        # map: map name, required when element is 'raster', 'vector' or 'raster_3d'
+        # newname: new name (of mapset, map), required with action='rename'
         self.grassdbChanged = Signal('LayerManagerGrassInterface.grassdbChanged')
 
         # Signal emitted to request updating of map

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -238,6 +238,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         self.Bind(wx.EVT_IDLE, self.OnIdle)
         self.Bind(wx.EVT_MOTION, self.OnMotion)
 
+        self._giface.grassdbChanged.connect(self.OnGrassDBChanged)
+
     def _setIcons(self, il):
         self._icon = {}
         for iconName in ("layerRaster", "layerRaster_3d", "layerRgb",
@@ -1313,6 +1315,60 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         self.SetItemText(item, self._getLayerName(item))
 
         event.Skip()
+
+    def OnGrassDBChanged(self, grassdb, location, mapset,
+                         element, action, map=None, newname=None):
+        """Handler of giface.grassDbChanged signal, updates layers in tree.
+         Covers cases when map or mapset is deleted or renamed."""
+        gisenv = grass.gisenv()
+        if not (gisenv['GISDBASE'] == grassdb
+                and gisenv['LOCATION_NAME'] == location):
+            return
+        if action not in ('delete', 'rename'):
+            return
+        if element in ('raster', 'vector', 'raster_3d'):
+            name = map + '@' + mapset if '@' not in map else map
+            items = self.FindItemByData(key='name', value=name)
+            if items:
+                for item in reversed(items):
+                    if action == 'delete':
+                        self.Delete(item)
+                    elif action == 'rename':
+                        # rename in command
+                        cmd = self.GetLayerInfo(item, key='cmd')
+                        for i in range(1, len(cmd)):
+                            if map in cmd[i].split('=')[-1]:
+                                cmd[i] = cmd[i].replace(map, newname)
+                        self.SetLayerInfo(item, key='cmd', value=cmd)
+                        self.ChangeLayer(item)
+                        # change label if not edited
+                        label = self.GetLayerInfo(item, key='label')
+                        if not label:
+                            newlabel = self.GetItemText(item).replace(map, newname)
+                            self.SetItemText(item, newlabel)
+        elif element == 'mapset':
+            items = []
+            item = self.GetFirstChild(self.root)[0]
+            while item and item.IsOk():
+                cmd = self.GetLayerInfo(item, key='cmd')
+                for each in cmd:
+                    if '@' + mapset in each:
+                        items.append(item)
+                        break
+                item = self.GetNextItem(item)
+            for item in reversed(items):
+                if action == 'delete':
+                    self.Delete(item)
+                elif action == 'rename':
+                    # rename in command
+                    cmd = self.GetLayerInfo(item, key='cmd')
+                    for i in range(1, len(cmd)):
+                        if mapset in cmd[i].split('=')[-1]:
+                            cmd[i] = cmd[i].replace(mapset, newname)
+                    self.SetLayerInfo(item, key='cmd', value=cmd)
+                    self.ChangeLayer(item)
+                    newlabel = self.GetItemText(item).replace('@' + mapset, '@' + newname)
+                    self.SetItemText(item, newlabel)
 
     def AddLayer(self, ltype, lname=None, lchecked=None, lopacity=1.0,
                  lcmd=None, lgroup=None, lvdigit=None, lnviz=None,

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1316,7 +1316,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         event.Skip()
 
-    def OnGrassDBChanged(self, action, element, grassdb, location=None,
+    def OnGrassDBChanged(self, action, element, grassdb, location,
                          mapset=None, map=None, newname=None):
         """Handler of giface.grassDbChanged signal, updates layers in tree.
          Covers cases when map or mapset is deleted or renamed."""

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1316,8 +1316,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         event.Skip()
 
-    def OnGrassDBChanged(self, grassdb, location, mapset,
-                         element, action, map=None, newname=None):
+    def OnGrassDBChanged(self, action, element, grassdb, location=None,
+                         mapset=None, map=None, newname=None):
         """Handler of giface.grassDbChanged signal, updates layers in tree.
          Covers cases when map or mapset is deleted or renamed."""
         gisenv = grass.gisenv()

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -721,7 +721,7 @@ class MapCalcFrame(wx.Frame):
                                          location=gisenv['LOCATION_NAME'],
                                          mapset=gisenv['MAPSET'],
                                          action='new',
-                                         newname=name.split('@')[0],
+                                         map=name.split('@')[0],
                                          element=ltype)
 
     def OnSaveExpression(self, event):

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -716,6 +716,13 @@ class MapCalcFrame(wx.Frame):
             ltype = 'raster_3d'
         self._giface.mapCreated.emit(
             name=name, ltype=ltype, add=self.addbox.IsChecked())
+        gisenv = grass.gisenv()
+        self._giface.grassdbChanged.emit(grassdb=gisenv['GISDBASE'],
+                                         location=gisenv['LOCATION_NAME'],
+                                         mapset=gisenv['MAPSET'],
+                                         action='new',
+                                         newname=name.split('@')[0],
+                                         element=ltype)
 
     def OnSaveExpression(self, event):
         """Saves expression to file

--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -452,6 +452,13 @@ class RDigitController(wx.EvtHandler):
         self._editedRaster = name
         self._mapType = mapType
         self.newRasterCreated.emit(name=name)
+        gisenv = gcore.gisenv()
+        self._giface.grassdbChanged.emit(grassdb=gisenv['GISDBASE'],
+                                         location=gisenv['LOCATION_NAME'],
+                                         mapset=gisenv['MAPSET'],
+                                         action='new',
+                                         newname=name.split('@')[0],
+                                         element='raster')
 
     def _backupRaster(self, name):
         """Creates a temporary backup raster necessary for undo behavior.

--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -457,7 +457,7 @@ class RDigitController(wx.EvtHandler):
                                          location=gisenv['LOCATION_NAME'],
                                          mapset=gisenv['MAPSET'],
                                          action='new',
-                                         newname=name.split('@')[0],
+                                         map=name.split('@')[0],
                                          element='raster')
 
     def _backupRaster(self, name):

--- a/raster/rasterintro.html
+++ b/raster/rasterintro.html
@@ -201,7 +201,7 @@ Univariate statistics (<a href="r.univar.html">r.univar</a>) and
 reports are also available (<a href="r.report.html">r.report</a>,<a
 href="r.stats.html">r.stats</a>, <a href="r.volume.html">r.volume</a>).
 
-Since <a href="r.univar.html">r.univar</a> may be slow for extented
+Since <a href="r.univar.html">r.univar</a> may be slow for extended
 statistics these can be calculated using
 <a href="r.stats.quantile.html">r.stats.quantile</a>. Without a zones input
 raster, the <a href="r.quantile.html">r.quantile</a> module will be significantly


### PR DESCRIPTION
This PR introduces new signal to update catalog tree when a change in grass database happened.
So far it covers cases when a new map is created through running a module (from command line or dialog), imports, mapcalc.

Also updates tree when new mapset/location is created from menu. Here it changes behavior, it doesn't automatically switch to the new mapset. Supersedes/incorporates #916.

Additionally it uses python watchdog library to observe current mapset to reflect changes from terminal or other sources not covered by mechanism above. Only current mapset is observed because there is a low default limit on how many files can be watched. Watchdog is not part of standard Python lib but can be installed through pip, the PR should work without it, missing changes done externally.

Fixes #885.

![demo](https://user-images.githubusercontent.com/7494312/94449413-0c5d2180-017a-11eb-978c-411e053681fc.gif)