### PR TITLE
i.image.mosaic: fix TypeError

### DIFF
--- a/scripts/i.image.mosaic/i.image.mosaic.py
+++ b/scripts/i.image.mosaic/i.image.mosaic.py
@@ -45,7 +45,7 @@ def copy_colors(fh, map, offset):
             if f[0] in ['nv', 'default']:
                 continue
             f[0] = str(float(f[0]) + offset)
-        out = ' '.join(f) + '\n' 
+        out = ' '.join(f) + '\n'
         fh.write(out.encode('utf-8'))
     p.wait()
 

--- a/scripts/i.image.mosaic/i.image.mosaic.py
+++ b/scripts/i.image.mosaic/i.image.mosaic.py
@@ -40,12 +40,13 @@ import grass.script as gscript
 def copy_colors(fh, map, offset):
     p = gscript.pipe_command('r.colors.out', map=map)
     for line in p.stdout:
-        f = line.rstrip('\r\n').split(' ')
+        f = line.decode('utf-8').rstrip('\r\n').split(' ')
         if offset:
             if f[0] in ['nv', 'default']:
                 continue
             f[0] = str(float(f[0]) + offset)
-        fh.write(' '.join(f) + '\n')
+        out = ' '.join(f) + '\n' 
+        fh.write(out.encode('utf-8'))
     p.wait()
 
 


### PR DESCRIPTION
Fix python TypeError: a bytes-like object is required, not 'str' . (python 3.8.5)