### PR TITLE
manuals and docs: update broken URLS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,7 +60,7 @@ INSTITUTIONAL SUPPORT
  - The Open Source Geospatial Foundation (http://www.osgeo.org)
 
 FURTHER CONTRIBUTORS
- - See: http://grass.osgeo.org/home/credits/
+ - See: https://grass.osgeo.org/about/credits/
 
 [please complete and correct as needed !]
 
@@ -271,7 +271,7 @@ GRASS GIS 5.4 Author List
 -------------------------
 
 Please check additionally the GRASS 1.x-5.0 credits list at:
- http://grass.osgeo.org/home/credits/
+ https://grass.osgeo.org/about/credits/
 
 While it is impossible for us to give credit to everyone (past 
 and present) who has contributed to GRASS, the following is the 
@@ -359,7 +359,7 @@ Former GRASS 4.2.0 development:
 Former GRASS 4 development (1984 to 1995):
    U.S. Army Construction Engineering Research Laboratories  (CERL)
    Jim Westervelt, Michael Shapiro, Chris Rewerts, Robert Lozar, David Gerdes, ...
-   See: http://grass.osgeo.org/home/credits/
+   See: https://grass.osgeo.org/about/credits/
 
 Former Institutions
  - University of Illinois at Urbana-Champaign, USA

--- a/CITING
+++ b/CITING
@@ -12,10 +12,10 @@ number X.Y accordingly):
 
 * GRASS Development Team, YEAR. Geographic Resources Analysis Support
   System (GRASS) Software, Version X.Y. Open Source Geospatial
-  Foundation. http://grass.osgeo.org
+  Foundation. https://grass.osgeo.org
 * GRASS Development Team, YEAR. Geographic Resources Analysis Support
   System (GRASS) Programmer's Manual. Open Source Geospatial Foundation.
-  Electronic document: http://grass.osgeo.org/programming7
+  Electronic document: https://grass.osgeo.org/programming7
 
 Citing a GRASS GIS Addon (update AUTHOR(S), YEAR, Addon-NAME, and
 version number X.Y accordingly):
@@ -37,5 +37,5 @@ A BibTeX entry for LaTeX users is:
   organization = {Open Source Geospatial Foundation},
   address = {USA},
   year = {YEAR},
-  url = {http://grass.osgeo.org},
+  url = {https://grass.osgeo.org},
 }

--- a/COPYING
+++ b/COPYING
@@ -36,4 +36,4 @@ GRASS Development Team at the following address:
  53111 Bonn, Germany
  neteler AT osgeo.org
 
-Internet:  http://grass.osgeo.org
+Internet:  https://grass.osgeo.org

--- a/INSTALL
+++ b/INSTALL
@@ -293,7 +293,7 @@ https://grasswiki.osgeo.org/wiki/Software_requirements_specification
 
 Note that this code is still actively being developed and errors inevitably
 turn up. If you find a bug, please report it to the GRASS bug tracking system
-so we can fix it. See https://grass.osgeo.org/development/bug-tracking/
+so we can fix it. See https://grass.osgeo.org/contribute/
 
 If you are interested in helping to develop GRASS, please join the GRASS
 developers mailing list. See https://grass.osgeo.org/development/

--- a/NEWS
+++ b/NEWS
@@ -2,10 +2,14 @@ NEWS
 
 GRASS GIS 7
 
+ o https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78
+ o https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures76
+ o https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures74
+ o https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures72
  o https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures
 
  List of releases
  o https://trac.osgeo.org/grass/wiki/Release
 
 GRASS GIS 1-6
- o List of older releases, starting in 1984 (!), see http://grass.osgeo.org/home/history/releases/ 
+ o List of older releases, starting in 1984 (!), see https://grass.osgeo.org/about/history/releases/

--- a/REQUIREMENTS.html
+++ b/REQUIREMENTS.html
@@ -235,7 +235,7 @@ MacOSX users may go here to download precompiled libraries etc.:
 <hr width="100%">
 <i>&copy; GRASS Development Team 1997-2020</i>
 <p>Please report bugs here:
-<br><a href="https://grass.osgeo.org/development/bug-tracking/">https://grass.osgeo.org/development/bug-tracking/</a>
+<br><a href="https://grass.osgeo.org/contribute/">https://grass.osgeo.org/contribute/</a>
 
 <!--
 <p>

--- a/TODO
+++ b/TODO
@@ -27,7 +27,7 @@ Imagery
                    the ortho lib. Seems to provide also ortho rectification for
                    satellite data (i.points3, i.rectify3)
 - See
-  http://grasswiki.osgeo.org/wiki/Image_processing#Ideas_collection_for_improving_GRASS.27_Image_processing_capabilities
+  https://grasswiki.osgeo.org/wiki/Image_processing#Ideas_collection_for_improving_GRASS.27_Image_processing_capabilities
 - image modules:
     - merge of i.rectify and i.rectify3
     - addition of new resampling algorithms such as bilinear, cubic convolution

--- a/db/databaseintro.html
+++ b/db/databaseintro.html
@@ -36,7 +36,7 @@ copy a a full table or selectively parts of it, use <a href="db.copy.html">db.co
 Further conversion tools:
 <ul>
 <li><a href="http://sourceforge.net/projects/mdbtools">MDB Tools</a>: Convert MS-Access data to SQL, DBF, etc.</li>
-<li><a href="http://grasswiki.osgeo.org/wiki/Openoffice.org_with_SQL_Databases">Using OpenOffice.org with SQL Databases</a>
+<li><a href="https://grasswiki.osgeo.org/wiki/Openoffice.org_with_SQL_Databases">Using OpenOffice.org with SQL Databases</a>
 </ul>
 
 

--- a/display/d.northarrow/d.northarrow.html
+++ b/display/d.northarrow/d.northarrow.html
@@ -4,7 +4,7 @@
 the given screen coordinates. If no coordinates are given it will draw the
 north arrow in the bottom right of the display. It can draw the north arrow
 in a number of styles (see the
- <a href="http://grasswiki.osgeo.org/wiki/Cartography#Display_monitors">wiki
+ <a href="https://grasswiki.osgeo.org/wiki/Cartography#Display_monitors">wiki
 page</a> for details).
 With certain styles of north arrow label 'N' is displayed by default,
 and can be changed with option <b>label</b>, for example for different languages.

--- a/doc/debugging.txt
+++ b/doc/debugging.txt
@@ -1,7 +1,7 @@
 GRASS GIS Debugging:
 
 See also
-http://grasswiki.osgeo.org/wiki/GRASS_Debugging
+https://grasswiki.osgeo.org/wiki/GRASS_Debugging
 
 ----------------------------------------------------
 At user level:
@@ -75,7 +75,7 @@ C Code debugging Software:
         Python debugger. )
 
     See mini tutorial here:
-    http://grass.osgeo.org/wiki/GRASS_Debugging
+    https://grasswiki.osgeo.org/wiki/GRASS_Debugging
 
 2b) Graphical front-end for command-line debugger: kdbg
       Use the menus

--- a/doc/grass_database.html
+++ b/doc/grass_database.html
@@ -282,7 +282,7 @@ the <em>File</em> menu in <em>Layer Manager</em> or
 <br>
 <a href="grass7.html">GRASS GIS 7 startup program manual page</a>
 <br>
-<a href="http://grasswiki.osgeo.org/wiki/Importing_data">Importing data on GRASS Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Importing_data">Importing data on GRASS Wiki</a>
 <br>
 <a href="r.import.html">r.import</a>,
 <a href="v.import.html">v.import</a>,

--- a/doc/gui/wxpython/example/g.gui.example.html
+++ b/doc/gui/wxpython/example/g.gui.example.html
@@ -60,7 +60,7 @@ Put screenshot here
 Create wiki page and put the link here:
 <p>
 See also
-user <a href="http://grasswiki.osgeo.org/wiki/WxGUI_...">wiki</a> page.
+user <a href="https://grasswiki.osgeo.org/wiki/WxGUI_...">wiki</a> page.
 </p>
 -->
 

--- a/doc/python/script/r.example.html
+++ b/doc/python/script/r.example.html
@@ -27,7 +27,7 @@ r.info elevation_mean_stddev
 <a href="v.example.html">v.example</a>
 </em>
 
-<a href="http://grass.osgeo.org/programming7/">GRASS Programmer's Manual</a>
+<a href="https://grass.osgeo.org/programming7/">GRASS Programmer's Manual</a>
 
 <h2>AUTHORS</h2>
 

--- a/general/g.gui/g.gui.html
+++ b/general/g.gui/g.gui.html
@@ -25,13 +25,6 @@ internal variables are not the shell environment variables and the
 <tt>rc</tt> file is not a classic UNIX run command file, it just
 contains persistent GRASS variables.
 
-<p>
-The
-old <em><a href="http://grass.osgeo.org/grass64/manuals/gis.m.html">gis.m</a></em>
-and <em><a href="http://grass.osgeo.org/grass64/manuals/d.m.html">d.m</a></em>
-Tcl/Tk-based GUIs known from GRASS GIS 6 have been dropped in GRASS
-GIS 7.
-
 <h2>EXAMPLES</h2>
 
 Set default user interface setting to command line, text-based UI:
@@ -62,7 +55,7 @@ g.gui -dn ui=wxpython
 </em>
 
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/WxPython-based_GUI_for_GRASS">wxGUI wiki page</a>
+<a href="https://grasswiki.osgeo.org/wiki/WxPython-based_GUI_for_GRASS">wxGUI wiki page</a>
 
 <h2>AUTHORS</h2>
 

--- a/general/g.parser/g.parser.html
+++ b/general/g.parser/g.parser.html
@@ -80,7 +80,7 @@ or <tt>label</tt>.
 <p>
 The parsers allows using predefined <em>standardized options and
 flags</em>, see the list
-of <a href="http://grass.osgeo.org/programming7/parser__standard__options_8c.html#a1a5da9db1229a9bbc59d16ae84540bb8">options</a> and <a href="http://grass.osgeo.org/programming7/parser__standard__options_8c.html#ad081e95e5d4dc3daab9c820d962e6902">flags</a>
+of <a href="https://grass.osgeo.org/programming7/parser__standard__options_8c.html#a1a5da9db1229a9bbc59d16ae84540bb8">options</a> and <a href="https://grass.osgeo.org/programming7/parser__standard__options_8c.html#ad081e95e5d4dc3daab9c820d962e6902">flags</a>
 in the programmer manual. Eg. the option
 
 <div class="code"><pre>
@@ -195,7 +195,7 @@ The parser has the ability to specify option relationships.
 
 <p>
 For C, the relevant functions are those in
-<a href="http://grass.osgeo.org/programming7/parser__dependencies_8c.html">lib/gis/parser_dependencies.c</a>.
+<a href="https://grass.osgeo.org/programming7/parser__dependencies_8c.html">lib/gis/parser_dependencies.c</a>.
 
 <p>
 For scripts, relationships are specified using a "rules" section, e.g.
@@ -674,7 +674,7 @@ Overview table: <a href="parser_standard_options.html">Parser standard options</
 
 <p>
 Related Wiki pages:
-<a href="http://grasswiki.osgeo.org/wiki/Category:Linking_to_other_languages">Using GRASS GIS with other programming languages</a>
+<a href="https://grasswiki.osgeo.org/wiki/Category:Linking_to_other_languages">Using GRASS GIS with other programming languages</a>
 
 <h2>AUTHOR</h2>
 

--- a/grasslib.dox
+++ b/grasslib.dox
@@ -18,7 +18,7 @@ Analysis Support System</i> from the programming perspective. Design
 theory, system support libraries, system maintenance, and system
 enhancement are all presented. This work is part of ongoing research
 being performed by the <a
-href="http://grasswiki.osgeo.org/wiki/Team">GRASS Development
+href="https://grasswiki.osgeo.org/wiki/Team">GRASS Development
 Team</a>, an international team of programmers, GRASS module authors
 are cited within their module's source code and the contributed manual
 pages.

--- a/gui/icons/grass.appdata.xml
+++ b/gui/icons/grass.appdata.xml
@@ -33,26 +33,22 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>http://grass.osgeo.org/uploads/images/Gallery/gui/wxgui_histogram.png</image>
+      <image>https://grass.osgeo.org//images/gallery/gui/wxgui_histogram.png</image>
       <caption/>
     </screenshot>
     <screenshot>
-      <image>http://grass.osgeo.org/uploads/images/Gallery/platforms/grass7_RaspberryPI.png</image>
+      <image>https://grass.osgeo.org/images/gallery/lidar/jockeyposter1.jpg</image>
       <caption/>
     </screenshot>
     <screenshot>
-      <image>http://grass.osgeo.org/uploads/images/Gallery/LiDAR/jockeyposter1.jpg</image>
-      <caption/>
-    </screenshot>
-    <screenshot>
-      <image>http://grass.osgeo.org/uploads/images/Gallery/gui/grass7_wxNviz_volume_slices_1.png</image>
+      <image>https://grass.osgeo.org//images/gallery/gui/grass7_wxNviz_volume_slices_1.png</image>
       <caption/>
     </screenshot>
   </screenshots>
   <url type="homepage">https://grass.osgeo.org/</url>
-  <url type="translate">https://grass.osgeo.org/development/translations/</url>
-  <url type="donation">https://grass.osgeo.org/donations/</url>
-  <url type="bugtracker">https://grass.osgeo.org/development/bug-tracking/</url>
+  <url type="translate">https://grasswiki.osgeo.org/wiki/GRASS_messages_translation</url>
+  <url type="donation">https://grass.osgeo.org/contribute/donations/</url>
+  <url type="bugtracker">https://grass.osgeo.org/contribute/</url>
   <url type="help">https://grass.osgeo.org/documentation/</url>
   <update_contact>grass-web@lists.osgeo.org</update_contact>
   <developer_name>GRASS Development Team</developer_name>

--- a/gui/wxpython/animation/g.gui.animation.html
+++ b/gui/wxpython/animation/g.gui.animation.html
@@ -93,7 +93,7 @@ g.gui.animation raster=`g.list -e type=raster mapset=. separator=comma pattern="
 </em>
 
 <p>
-See also related <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Animation_Tool">wiki page</a>.
+See also related <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Animation_Tool">wiki page</a>.
 
 <h2>AUTHOR</h2>
 

--- a/gui/wxpython/dbmgr/g.gui.dbmgr.html
+++ b/gui/wxpython/dbmgr/g.gui.dbmgr.html
@@ -67,9 +67,9 @@ module <em>g.gui.dbmgr</em>.
 
 <p>
 See
-also <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Attribute_Table_Manager">wiki</a>
+also <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Attribute_Table_Manager">wiki</a>
 page
-including <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Attribute_Table_Manager#Video_tutorials">video
+including <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Attribute_Table_Manager#Video_tutorials">video
 tutorials</a>.
 
 <h2>AUTHORS</h2>

--- a/gui/wxpython/docs/wxGUI.iscatt.html
+++ b/gui/wxpython/docs/wxGUI.iscatt.html
@@ -76,13 +76,13 @@ Selection of areas in mapwindow is currently supported only if the tool was laun
 
 <p>
 See also the
-user <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Interactive_Scatter_Plot_Tool">wiki</a>
+user <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Interactive_Scatter_Plot_Tool">wiki</a>
 page.
 
 <h2>AUTHOR</h2>
 
 Stepan
-Turek, <a href="http://grasswiki.osgeo.org/wiki/GRASS_GSoC_2013_GRASS_GIS_Interactive_Scatter_Plot_Tool">Google
+Turek, <a href="https://grasswiki.osgeo.org/wiki/GRASS_GSoC_2013_GRASS_GIS_Interactive_Scatter_Plot_Tool">Google
 Summer of Code 2013</a> (mentor: Martin Landa)
 
 <!--

--- a/gui/wxpython/docs/wxGUI.nviz.html
+++ b/gui/wxpython/docs/wxGUI.nviz.html
@@ -394,8 +394,8 @@ computer.
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/WxNVIZ">wiki</a> page
-(especially various <a href="http://grasswiki.osgeo.org/wiki/WxNVIZ#Video_tutorials">video
+See also <a href="https://grasswiki.osgeo.org/wiki/WxNVIZ">wiki</a> page
+(especially various <a href="https://grasswiki.osgeo.org/wiki/WxNVIZ#Video_tutorials">video
 tutorials</a>).
 
 <br><br>
@@ -409,10 +409,10 @@ Command-line module <em><a href="m.nviz.image.html">m.nviz.image</a></em>.
 <b>The wxNviz GUI</b>
 <p>
 <a href="http://geo.fsv.cvut.cz/gwiki/Landa">Martin
-Landa</a>, <a href="http://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2008">Google
+Landa</a>, <a href="https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2008">Google
 Summer of Code 2008</a> (mentor: Michael Barton)
-and <a href="http://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2010">2010</a> (mentor: Helena Mitasova)<br>
-Anna Kratochvilova, <a href="http://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2011">Google
+and <a href="https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2010">2010</a> (mentor: Helena Mitasova)<br>
+Anna Kratochvilova, <a href="https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2011">Google
 Summer of Code 2011</a> (mentor: Martin Landa)
 
 <p>

--- a/gui/wxpython/docs/wxGUI.vnet.html
+++ b/gui/wxpython/docs/wxGUI.vnet.html
@@ -98,13 +98,13 @@ See list of <a href="topic_network.html">vector network modules</a>.
 
 <p>
 See also the
-user <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Vector_Network_Analysis_Tool">wiki</a>
-page including <a href="http://grasswiki.osgeo.org/wiki/WxGUI Vector Network Analysis Tool#Video tutorial">video tutorial</a>.
+user <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Vector_Network_Analysis_Tool">wiki</a>
+page including <a href="https://grasswiki.osgeo.org/wiki/WxGUI Vector Network Analysis Tool#Video tutorial">video tutorial</a>.
 
 <h2>AUTHOR</h2>
 
 Stepan
-Turek, <a href="http://grasswiki.osgeo.org/wiki/GRASS_GSoC_2012_WxGUI_front_end_for_vector_analysis_modules">Google
+Turek, <a href="https://grasswiki.osgeo.org/wiki/GRASS_GSoC_2012_WxGUI_front_end_for_vector_analysis_modules">Google
 Summer of Code 2012</a> (mentor: Martin Landa)
 
 <!--

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -38,7 +38,7 @@ footer_tmpl = string.Template(
     r"""
 {% block footer %}<hr class="header">
 <p><a href="../index.html">Help Index</a> | <a href="../topics.html">Topics Index</a> | <a href="../keywords.html">Keywords Index</a> | <a href="../full_index.html">Full Index</a></p>
-<p>&copy; 2003-${year} <a href="http://grass.osgeo.org">GRASS Development Team</a>, GRASS GIS ${grass_version} Reference Manual</p>
+<p>&copy; 2003-${year} <a href="https://grass.osgeo.org">GRASS Development Team</a>, GRASS GIS ${grass_version} Reference Manual</p>
 {% endblock %}
 """)
 

--- a/gui/wxpython/gcp/g.gui.gcp.html
+++ b/gui/wxpython/gcp/g.gui.gcp.html
@@ -305,7 +305,7 @@ error is displayed.
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/WxGUI/Video_tutorials#Georectifier">video
+See also <a href="https://grasswiki.osgeo.org/wiki/WxGUI/Video_tutorials#Georectifier">video
 tutorials</a> on GRASS Wiki.
 
 <h2>AUTHORS</h2>

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -904,7 +904,7 @@ def ShowAboutDialog(prgName, startYear):
                 'grass.ico'),
             wx.BITMAP_TYPE_ICO))
     info.SetName(prgName)
-    info.SetWebSite('http://grass.osgeo.org')
+    info.SetWebSite('https://grass.osgeo.org')
     info.SetDescription(
         _grassDevTeam(startYear) +
         '\n\n' +

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -488,7 +488,7 @@ class PyEditController(object):
         # not using g.manual because it does not show
         entry = 'libpython/script_intro.html'
         major, minor, patch = gscript.version()['version'].split('.')
-        url = 'http://grass.osgeo.org/grass%s%s/manuals/%s' % (
+        url = 'https://grass.osgeo.org/grass%s%s/manuals/%s' % (
             major, minor, entry)
         open_url(url)
 

--- a/gui/wxpython/iclass/g.gui.iclass.html
+++ b/gui/wxpython/iclass/g.gui.iclass.html
@@ -83,7 +83,7 @@ used for seed means for the clusters in
 
 <p>
 See also
-user <a href="http://grasswiki.osgeo.org/wiki/WxIClass">wiki</a> page
+user <a href="https://grasswiki.osgeo.org/wiki/WxIClass">wiki</a> page
 and <a href="http://trac.osgeo.org/grass/wiki/wxGUIDevelopment/wxIClass">development</a> page.
 
 <h2>AUTHOR</h2>

--- a/gui/wxpython/image2target/g.gui.image2target.html
+++ b/gui/wxpython/image2target/g.gui.image2target.html
@@ -305,7 +305,7 @@ error is displayed.
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/WxGUI/Video_tutorials#Georectifier">video
+See also <a href="https://grasswiki.osgeo.org/wiki/WxGUI/Video_tutorials#Georectifier">video
 tutorials</a> on GRASS Wiki.
 
 <h2>AUTHORS</h2>

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.html
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.html
@@ -45,7 +45,7 @@ Source: <a href="http://earthobservatory.nasa.gov/NaturalHazards/view.php?id=496
 </em>
 
 <p>
-See also the user <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Map_Swipe">wiki</a> page.
+See also the user <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Map_Swipe">wiki</a> page.
 
 
 <h2>AUTHOR</h2>

--- a/gui/wxpython/photo2image/g.gui.photo2image.html
+++ b/gui/wxpython/photo2image/g.gui.photo2image.html
@@ -44,7 +44,7 @@ g.gui.photo2image group=aerial@PERMANENT raster=gs13.1@PERMANENT camera=gscamera
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/WxGUI/Video_tutorials#Georectifier">video
+See also <a href="https://grasswiki.osgeo.org/wiki/WxGUI/Video_tutorials#Georectifier">video
 tutorials</a> on GRASS Wiki.
 
 <h2>SEE ALSO</h2>

--- a/gui/wxpython/psmap/g.gui.psmap.html
+++ b/gui/wxpython/psmap/g.gui.psmap.html
@@ -210,7 +210,7 @@ Currently supported <em><a href="ps.map.html">ps.map</a></em> instructions:
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Cartographic_Composer">wiki</a> page.
+See also <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Cartographic_Composer">wiki</a> page.
 
 <h2>AUTHOR</h2>
 

--- a/gui/wxpython/rlisetup/g.gui.rlisetup.html
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.html
@@ -331,7 +331,7 @@ See the respective modules for further examples.
 </em>
 <p>
 <em>
-<a href="http://grass.osgeo.org/gdp/landscape/r_le_manual5.pdf">Old r.le suite manual</a> (1992)
+<a href="https://grass.osgeo.org/gdp/landscape/r_le_manual5.pdf">Old r.le suite manual</a> (1992)
 </em>
 <p>
 <em>

--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -277,8 +277,8 @@ boundaries are automatically attached to the chosen points.
 <h2>REFERENCES</h2>
 
 <ul>
-  <li><a href="http://grass.osgeo.org/programming7/veditlib.html">GRASS Vedit Library</a></li>
-  <li><a href="http://grasswiki.osgeo.org/wiki/Vector_Database_Management">Vector Database Management</a> (Wiki page)</li>
+  <li><a href="https://grass.osgeo.org/programming7/veditlib.html">GRASS Vedit Library</a></li>
+  <li><a href="https://grasswiki.osgeo.org/wiki/Vector_Database_Management">Vector Database Management</a> (Wiki page)</li>
 </ul>
 
 <h2>SEE ALSO</h2>
@@ -297,8 +297,8 @@ boundaries are automatically attached to the chosen points.
 </em>
 
 <p>
-See also the <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Vector_Digitizer">WxGUI Vector Digitizer Wiki page</a>
-including <a href="http://grasswiki.osgeo.org/wiki/WxGUI_Vector_Digitizer#Vector_tutorials">video
+See also the <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Vector_Digitizer">WxGUI Vector Digitizer Wiki page</a>
+including <a href="https://grasswiki.osgeo.org/wiki/WxGUI_Vector_Digitizer#Vector_tutorials">video
 tutorials</a>.
 
 <h2>AUTHOR</h2>

--- a/imagery/i.atcorr/i.atcorr.html
+++ b/imagery/i.atcorr/i.atcorr.html
@@ -1064,7 +1064,7 @@ optical depth at 550nm.
 
 <h2>SEE ALSO</h2>
 
-GRASS Wiki page about <a href="http://grasswiki.osgeo.org/wiki/Atmospheric_correction">Atmospheric correction</a>
+GRASS Wiki page about <a href="https://grasswiki.osgeo.org/wiki/Atmospheric_correction">Atmospheric correction</a>
 <p>
 <em>
 <a href="i.aster.toar.html">i.aster.toar</a>,

--- a/imagery/i.cluster/i.cluster.html
+++ b/imagery/i.cluster/i.cluster.html
@@ -280,9 +280,9 @@ See example in its manual page.
 <h2>SEE ALSO</h2>
 
 <ul>
-<li> <a href="http://grasswiki.osgeo.org/wiki/Image_classification">Image classification</a> wiki page</li>
+<li> <a href="https://grasswiki.osgeo.org/wiki/Image_classification">Image classification</a> wiki page</li>
 <li> Historical reference also the GRASS GIS 4 
-     <a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image Processing manual</a> (PDF)</li>
+     <a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image Processing manual</a> (PDF)</li>
 <li> <a href="https://en.wikipedia.org/wiki/K-means_clustering">Wikipedia article on <i>k</i>-means clustering</a>
      (note that <em>i.cluster</em> uses a modification of the <i>k</i>-means clustering algorithm)</li>
 </ul>

--- a/imagery/i.group/i.group.html
+++ b/imagery/i.group/i.group.html
@@ -35,7 +35,7 @@ i.group group=vis_bands subgroup=vis_bands input=lsat7_2000_10,lsat7_2000_20,lsa
 <h2>SEE ALSO</h2>
 
 The GRASS 4 <em>
-<a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
+<a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
 Processing manual</a></em>
 
 <p><em>

--- a/imagery/i.maxlik/i.maxlik.html
+++ b/imagery/i.maxlik/i.maxlik.html
@@ -122,12 +122,12 @@ Output raster map with rejection probability values (pixel classification confid
 
 <h2>SEE ALSO</h2>
 
-<a href="http://grasswiki.osgeo.org/wiki/Image_processing">Image processing</a>
+<a href="https://grasswiki.osgeo.org/wiki/Image_processing">Image processing</a>
 and
-<a href="http://grasswiki.osgeo.org/wiki/Image_classification">Image classification</a>
+<a href="https://grasswiki.osgeo.org/wiki/Image_classification">Image classification</a>
 wiki pages and for historical reference also
 the GRASS GIS 4<em>
-<a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
+<a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
 Processing manual</a></em>
 
 <p>

--- a/imagery/i.ortho.photo/lib/TODO
+++ b/imagery/i.ortho.photo/lib/TODO
@@ -18,7 +18,7 @@ Subject: Re: Re: i.ortho.photo
 Possibly a lot is already done in lib/image3/ ?
 
 - See
-  http://grasswiki.osgeo.org/wiki/Image_processing#Ideas_collection_for_improving_GRASS.27_Image_processing_capabilities
+  https://grasswiki.osgeo.org/wiki/Image_processing#Ideas_collection_for_improving_GRASS.27_Image_processing_capabilities
 - image modules:
     - merge of i.rectify and i.rectify3
     - addition of new resampling algorithms such as bilinear, cubic convolution

--- a/imagery/i.pca/i.pca.html
+++ b/imagery/i.pca/i.pca.html
@@ -103,7 +103,7 @@ Space Research Center, University of Texas, Austin, 1990.
 <a href="r.mapcalc.html">r.mapcalc</a>
 <p>
 <em>
-<a href="http://grasswiki.osgeo.org/wiki/Principal_Components_Analysis">Principal Components Analysis article</a>
+<a href="https://grasswiki.osgeo.org/wiki/Principal_Components_Analysis">Principal Components Analysis article</a>
 (GRASS Wiki)
 </em>
 

--- a/imagery/i.rectify/i.rectify.html
+++ b/imagery/i.rectify/i.rectify.html
@@ -171,7 +171,7 @@ on the hard drive.
 <h2>SEE ALSO</h2>
 
 The GRASS 4 <em>
-<a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
+<a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
 Processing manual</a></em>
 
 <p><em>

--- a/imagery/i.segment/i.segment.html
+++ b/imagery/i.segment/i.segment.html
@@ -265,10 +265,10 @@ existing classification functionality.</li>
 <h2>REFERENCES</h2>
 This project was first developed during GSoC 2012. Project documentation, 
 Image Segmentation references, and other information is at the 
-<a href="http://grasswiki.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation">project wiki</a>.
+<a href="https://grasswiki.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation">project wiki</a>.
 <p>
 Information about 
-<a href="http://grasswiki.osgeo.org/wiki/Image_classification">classification in GRASS</a> 
+<a href="https://grasswiki.osgeo.org/wiki/Image_classification">classification in GRASS</a> 
 is at available on the wiki.
 
 <h2>SEE ALSO</h2>

--- a/imagery/i.segment/outline
+++ b/imagery/i.segment/outline
@@ -1,5 +1,5 @@
 This is the draft pseudocode for the region growing segmentation algorithm.  More information, references, requirements, etc are at the wiki:
-http://grass.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation
+https://grass.osgeo.org/wiki/GRASS_GSoC_2012_Image_Segmentation
 
 For anyone interested in background discussion, Rev 51907 includes original comments and discussion between EM, MM, and ML.  All comments were combined (and new threads started!) after that revision.
 

--- a/imagery/i.target/i.target.html
+++ b/imagery/i.target/i.target.html
@@ -27,7 +27,7 @@ group will be displayed.
 <h2>SEE ALSO</h2>
 
 The GRASS 4 <em>
-<a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image Processing manual</a></em>
+<a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image Processing manual</a></em>
 
 <p>
 <em>

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -238,9 +238,9 @@ Several modules support the calculation of the energy balance:
 <h3>See also</h3>
 
 <ul>
-<li> GRASS GIS Wiki page: <a href="http://grasswiki.osgeo.org/wiki/Image_processing">Image processing</a></li>
+<li> GRASS GIS Wiki page: <a href="https://grasswiki.osgeo.org/wiki/Image_processing">Image processing</a></li>
 <li>The GRASS 4 
-    <em><a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
+    <em><a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
      Processing manual</a></em></li>
   <li><a href="rasterintro.html">Introduction into raster data processing</a></li>
   <li><a href="raster3dintro.html">Introduction into 3D raster data (voxel) processing</a></li>

--- a/include/Make/Doxyfile_arch_html.in
+++ b/include/Make/Doxyfile_arch_html.in
@@ -193,7 +193,7 @@ TAB_SIZE               = 8
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES += gmod{1}="<a href='http://grass.osgeo.org/grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@/manuals/\1.html'><tt>\1</tt></a>"
+ALIASES += gmod{1}="<a href='https://grass.osgeo.org/grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@/manuals/\1.html'><tt>\1</tt></a>"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding

--- a/include/Make/Doxyfile_arch_latex.in
+++ b/include/Make/Doxyfile_arch_latex.in
@@ -193,7 +193,7 @@ TAB_SIZE               = 8
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES += gmod{1}="<a href='http://grass.osgeo.org/grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@/manuals/\1.html'><tt>\1</tt></a>"
+ALIASES += gmod{1}="<a href='https://grass.osgeo.org/grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@/manuals/\1.html'><tt>\1</tt></a>"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding

--- a/lib/arraystats/arraystatslib.dox
+++ b/lib/arraystats/arraystatslib.dox
@@ -1,6 +1,6 @@
 /*! \page arraystatslib GRASS Array Statistics Library
 
-by Jean-Pierre Grimmeau, and GRASS Development Team (http://grass.osgeo.org)
+by Jean-Pierre Grimmeau, and GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/cairodriver/cairodriver.dox
+++ b/lib/cairodriver/cairodriver.dox
@@ -1,6 +1,6 @@
 /*! \page cairodriver GRASS Cairo Display Driver
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \section cairointro Introduction to Cairo display driver
 

--- a/lib/cdhc/cdhclib.dox
+++ b/lib/cdhc/cdhclib.dox
@@ -1,6 +1,6 @@
 /*! \page cdhclib GRASS testing normality & exponentiality Library
 
-by Darrell McCauley and  GRASS Development Team (http://grass.osgeo.org)
+by Darrell McCauley and  GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/cluster/clusterlib.dox
+++ b/lib/cluster/clusterlib.dox
@@ -1,6 +1,6 @@
 /*! \page clusterlib GRASS Cluster analysis statistics Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \section clusterintro Introduction
 

--- a/lib/db/dbmilib.dox
+++ b/lib/db/dbmilib.dox
@@ -2,7 +2,7 @@
 
 by GRASS Development Team
 
-http://grass.osgeo.org
+https://grass.osgeo.org
 
 \section dbmiIntro Introduction
 

--- a/lib/display/displaylib.dox
+++ b/lib/display/displaylib.dox
@@ -1,6 +1,6 @@
 /*! \page displaylib GRASS Display Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 This library provides a wide assortment of higher level graphics
 commands which in turn use the graphics library primitives. It is

--- a/lib/gis/gislib.dox
+++ b/lib/gis/gislib.dox
@@ -3,7 +3,7 @@
      by M. Neteler 2/2004, 2005, 2006
   -->
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/init/helptext.html
+++ b/lib/init/helptext.html
@@ -140,7 +140,7 @@ To create the GRASS database:
 <p>
 Sample data such as the &quot;North Carolina&quot; or the
 &quot;Spearfish&quot; sample datasets may be downloaded from
-<a href="http://grass.osgeo.org/download/sample-data/">http://grass.osgeo.org/download/sample-data/</a>
+<a href="https://grass.osgeo.org/download/data/">https://grass.osgeo.org/download/data/</a>
 and the compressed data package(s) extracted into this new database
 directory.
 <p>
@@ -193,7 +193,7 @@ For a first time startup, the following steps have to be followed:
 <h2>Further Reading</h2>
 
 Please have a look at the GRASS GIS web site for tutorials and books:
-<a href="http://grass.osgeo.org/documentation/">http://grass.osgeo.org/documentation/</a>.
+<a href="https://grass.osgeo.org/learn/">https://grass.osgeo.org/learn/</a>.
 
 <h2>See also</h2>
 

--- a/lib/manage/managelib.dox
+++ b/lib/manage/managelib.dox
@@ -1,6 +1,6 @@
 /*! \page managelib GRASS Data Elements Manage Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \section manageintro Introduction
 

--- a/lib/nviz/nvizlib.dox
+++ b/lib/nviz/nvizlib.dox
@@ -1,6 +1,6 @@
 /*! \page nvizlib GRASS Nviz Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \section nvizintro Introduction to Nviz Library
 

--- a/lib/ogsf/ogsflib.dox
+++ b/lib/ogsf/ogsflib.dox
@@ -4,7 +4,7 @@
      Updated by Martin Landa <landa.martin gmail.com> in 6/2011
   -->
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \section ogsfintro OGSF Library for OpenGL programming
 

--- a/lib/pngdriver/pngdriverlib.dox
+++ b/lib/pngdriver/pngdriverlib.dox
@@ -1,6 +1,6 @@
 /*! \page pngdriverlib GRASS GIS PNG Display Driver Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 This library defines PNG Display Driver.
 

--- a/lib/proj/projlib.dox
+++ b/lib/proj/projlib.dox
@@ -5,7 +5,7 @@
 
 by GRASS Development Team
 
-http://grass.osgeo.org
+https://grass.osgeo.org
 
 \section projintro GRASS GIS and the PROJ4 projection library
 

--- a/lib/psdriver/psdriverlib.dox
+++ b/lib/psdriver/psdriverlib.dox
@@ -1,6 +1,6 @@
 /*! \page psdriverlib GRASS Postscript Display Driver Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 This library defines Postscript Display Driver.
 

--- a/lib/python/docs/conf.py
+++ b/lib/python/docs/conf.py
@@ -39,7 +39,7 @@ footer_tmpl = string.Template(
     r"""
 {% block footer %}<hr class="header">
 <p><a href="../index.html">Help Index</a> | <a href="../topics.html">Topics Index</a> | <a href="../keywords.html">Keywords Index</a> | <a href="../full_index.html">Full Index</a></p>
-<p>&copy; 2003-${year} <a href="http://grass.osgeo.org">GRASS Development Team</a>, GRASS GIS ${grass_version} Reference Manual</p>
+<p>&copy; 2003-${year} <a href="https://grass.osgeo.org">GRASS Development Team</a>, GRASS GIS ${grass_version} Reference Manual</p>
 {% endblock %}
 """)
 

--- a/lib/python/docs/src/pygrass_index.rst
+++ b/lib/python/docs/src/pygrass_index.rst
@@ -48,9 +48,9 @@ References
   Geo-Information. 2(1):201-219. `doi:10.3390/ijgi2010201
   <http://dx.doi.org/10.3390/ijgi2010201>`_
 * `Python related articles in the GRASS GIS Wiki
-  <http://grasswiki.osgeo.org/wiki/Category:Python>`_
+  <https://grasswiki.osgeo.org/wiki/Category:Python>`_
 * `GRASS GIS 7 Programmer's Manual
-  <http://grass.osgeo.org/programming7/>`_
+  <https://grass.osgeo.org/programming7/>`_
 
 This project has been funded with support from the `Google Summer of
 Code 2012

--- a/lib/python/docs/src/pygrass_messages.rst
+++ b/lib/python/docs/src/pygrass_messages.rst
@@ -3,7 +3,7 @@ PyGRASS message interface
 
 The PyGRASS message interface is a fast and exit-safe interface to the
 `GRASS C-library message functions
-<http://grass.osgeo.org/programming7/gis_2error_8c.html>`_.
+<https://grass.osgeo.org/programming7/gis_2error_8c.html>`_.
 
 The :class:`~pygrass.messages.Messenger` class implements a fast and
 exit-safe interface to the GRASS C-library message functions like:

--- a/lib/python/docs/src/pygrass_raster.rst
+++ b/lib/python/docs/src/pygrass_raster.rst
@@ -5,7 +5,7 @@ Introduction to Raster classes
 
 Details about the GRASS GIS raster architecture can be found in the
 `GRASS GIS 7 Programmer's Manual: GRASS Raster Library
-<http://grass.osgeo.org/programming7/rasterlib.html>`_.
+<https://grass.osgeo.org/programming7/rasterlib.html>`_.
 
 PyGRASS uses 3 different raster classes, that respect the 3 different
 approaches of GRASS-C API. The classes use a standardized interface to
@@ -225,6 +225,6 @@ Similarly, writing to a map uses two methods: ``put_row()`` to write a row and
     >>> elev.remove()
 
 
-.. _Raster library: http://grass.osgeo.org/programming7/rasterlib.html
-.. _RowIO library: http://grass.osgeo.org/programming7/rowiolib.html
-.. _Segmentation library: http://grass.osgeo.org/programming7/segmentlib.html
+.. _Raster library: https://grass.osgeo.org/programming7/rasterlib.html
+.. _RowIO library: https://grass.osgeo.org/programming7/rowiolib.html
+.. _Segmentation library: https://grass.osgeo.org/programming7/segmentlib.html

--- a/lib/python/docs/src/pygrass_vector.rst
+++ b/lib/python/docs/src/pygrass_vector.rst
@@ -3,12 +3,12 @@ Introduction to Vector classes
 
 Details about the GRASS GIS vector architecture can be found in the
 `GRASS GIS 7 Programmer's Manual: GRASS Vector Library
-<http://grass.osgeo.org/programming7/vectorlib.html>`_.
+<https://grass.osgeo.org/programming7/vectorlib.html>`_.
 
 PyGRASS has two classes for vector maps: :ref:`Vector-label` and
 :ref:`VectorTopo-label`.  As the names suggest, the Vector class is
 for vector maps, while VectorTopo opens vector maps with `GRASS GIS
-topology <http://grass.osgeo.org/programming7/vlibTopology.html>`_.
+topology <https://grass.osgeo.org/programming7/vlibTopology.html>`_.
 VectorTopo is an extension of the Vector class, so supports all the
 Vector class methods, with additions. The classes are part of the
 :mod:`~pygrass.vector` module.
@@ -345,4 +345,4 @@ Now, find an area with an island inside... ::
     >>> isle.bbox()
     Bbox(199947.296494, 199280.969494, 754920.623987, 754351.812986)
 
-.. _Vector library: http://grass.osgeo.org/programming7/vectorlib.html
+.. _Vector library: https://grass.osgeo.org/programming7/vectorlib.html

--- a/lib/python/docs/src/script_intro.rst
+++ b/lib/python/docs/src/script_intro.rst
@@ -156,4 +156,4 @@ the code due to the dynamic nature of Python, there is a large number
 of tools such as *pep8* or *pylint* which can help you to identify problems
 in you Python code.
 
-.. _C API documentation: http://grass.osgeo.org/programming7/gis_8h.html
+.. _C API documentation: https://grass.osgeo.org/programming7/gis_8h.html

--- a/lib/python/docs/src/temporal_framework.rst
+++ b/lib/python/docs/src/temporal_framework.rst
@@ -415,7 +415,7 @@ References
 ----------
 
 * Gebbert, S., Pebesma, E., 2014. *TGRASS: A temporal GIS for field based environmental modeling*. Environmental Modelling & Software. 2(1):201-219. `doi:10.1016/j.envsoft.2013.11.001 <http://dx.doi.org/10.1016/j.envsoft.2013.11.001>`_
-* `TGRASS related articles in the GRASS GIS Wiki <http://grasswiki.osgeo.org/wiki/Temporal_data_processing>`_
+* `TGRASS related articles in the GRASS GIS Wiki <https://grasswiki.osgeo.org/wiki/Temporal_data_processing>`_
 * Supplementary material of the publication *The GRASS GIS Temporal Framework*
   to be published in
   *International Journal of Geographical Information Science* in 2017, Download  

--- a/lib/raster/rasterlib.dox
+++ b/lib/raster/rasterlib.dox
@@ -4,7 +4,7 @@
      * updated to GRASS 7 by Martin Landa
   -->
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/rowio/rowiolib.dox
+++ b/lib/rowio/rowiolib.dox
@@ -1,6 +1,6 @@
 /*! \page rowiolib GRASS Row Input/Output Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 This library is used for reading/writing raster rows.
 

--- a/lib/vector/dglib/dglib.dox
+++ b/lib/vector/dglib/dglib.dox
@@ -1,6 +1,6 @@
 /*! \page dglib GRASS Directed Graph Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/neta/netalib.dox
+++ b/lib/vector/neta/netalib.dox
@@ -1,6 +1,6 @@
 /*! \page netalib GRASS Network Analysis Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib.dox
+++ b/lib/vector/vectorlib.dox
@@ -1,6 +1,6 @@
 /*! \page vectorlib GRASS Vector Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 
@@ -294,7 +294,7 @@ Information about categories holds \ref line_cats data structure.
 \section vlibAttributes Attributes
 
 For a user-centric view about attribute management, see the explanations
-in the <a href="http://grasswiki.osgeo.org/wiki/Vector_Database_Management">GRASS GIS Wiki</a>.
+in the <a href="https://grasswiki.osgeo.org/wiki/Vector_Database_Management">GRASS GIS Wiki</a>.
 
 The attribute data are stored in external database. Connection with the
 database is done through drivers based on \ref dbmilib. Records in a

--- a/lib/vector/vectorlib_ascii.dox
+++ b/lib/vector/vectorlib_ascii.dox
@@ -1,6 +1,6 @@
 /*! \page vlibAscii Vector ASCII Format
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_faq.dox
+++ b/lib/vector/vectorlib_faq.dox
@@ -1,6 +1,6 @@
 /*! \page vlibFAQ Vector FAQ
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 <dl>
 

--- a/lib/vector/vectorlib_files.dox
+++ b/lib/vector/vectorlib_files.dox
@@ -1,6 +1,6 @@
 /*! \page vlibFormat Vector format description
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_indices.dox
+++ b/lib/vector/vectorlib_indices.dox
@@ -1,6 +1,6 @@
 /*! \page vlibIndices Spatial and category indices
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_libraries.dox
+++ b/lib/vector/vectorlib_libraries.dox
@@ -1,6 +1,6 @@
 /*! \page vlibDescription Vector libraries
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_lists.dox
+++ b/lib/vector/vectorlib_lists.dox
@@ -1,6 +1,6 @@
 /*! \page vlibLists Vector Library Structures and Functions
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_ogr.dox
+++ b/lib/vector/vectorlib_ogr.dox
@@ -1,6 +1,6 @@
 /*! \page vlibOgr GRASS-OGR data provider
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_pg.dox
+++ b/lib/vector/vectorlib_pg.dox
@@ -1,6 +1,6 @@
 /*! \page vlibPg GRASS-PostGIS data provider
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_tin.dox
+++ b/lib/vector/vectorlib_tin.dox
@@ -1,6 +1,6 @@
 /*! \page vlibTin Vector TINs
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vectorlib_topology.dox
+++ b/lib/vector/vectorlib_topology.dox
@@ -1,6 +1,6 @@
 /*! \page vlibTopology Topology
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/lib/vector/vedit/veditlib.dox
+++ b/lib/vector/vedit/veditlib.dox
@@ -1,6 +1,6 @@
 /*! \page veditlib GRASS Vedit Library
 
-by GRASS Development Team (http://grass.osgeo.org)
+by GRASS Development Team (https://grass.osgeo.org)
 
 \tableofcontents
 

--- a/macosx/app/build_html_user_index.sh
+++ b/macosx/app/build_html_user_index.sh
@@ -55,7 +55,7 @@ echo " <link rel=\"stylesheet\" href=\"grassdocs.css\" type=\"text/css\">
 <h2>GRASS GIS $GRASSVERSION Reference Manual</h2>
 
 <p>Geographic Resources Analysis Support System, commonly referred to as
-<a href=\"http://grass.osgeo.org\">GRASS</a>, 
+<a href=\"https://grass.osgeo.org\">GRASS</a>, 
 is a Geographic Information System (GIS) used for geospatial data management
 and analysis, image processing, graphics/maps production, spatial modeling,
 and visualization. GRASS is currently used in academic and commercial settings
@@ -74,7 +74,7 @@ write_html_footer()
 # $1: filename
 echo "<hr class=\"header\">" >> $1
 echo "<p><a href=\"$GISBASE/docs/html/index.html\">Help Index</a> | <a href=\"$GISBASE/docs/html/full_index.html\">Full Index</a> | <a href=\"$HTMLDIR/addon_index.html\">Addon Index</a><br>" >> $1
-echo "&copy; 2003-2008 <a href=\"http://grass.osgeo.org\">GRASS Development Team</a></p>" >> $1
+echo "&copy; 2003-2008 <a href=\"https://grass.osgeo.org\">GRASS Development Team</a></p>" >> $1
 echo "</body>" >> $1   
 echo "</html>" >> $1
 }

--- a/macosx/pkg/resources/License.rtf
+++ b/macosx/pkg/resources/License.rtf
@@ -35,7 +35,7 @@ Questions regarding GRASS GIS should be directed to the GRASS Development Team a
  {\field{\*\fldinst{HYPERLINK "mailto:neteler@itc.it"}}{\fldrslt neteler@itc.it}}\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\ri1440\ql\qnatural
 \cf0 \
-Internet:  {\field{\*\fldinst{HYPERLINK "http://grass.osgeo.org"}}{\fldrslt http://grass.osgeo.org}}\
+Internet:  {\field{\*\fldinst{HYPERLINK "https://grass.osgeo.org"}}{\fldrslt https://grass.osgeo.org}}\
 \
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\ri1456\ql\qnatural

--- a/misc/m.nviz.image/m.nviz.image.html
+++ b/misc/m.nviz.image/m.nviz.image.html
@@ -24,11 +24,11 @@ m.nviz.image elevation_map=elevation output=elev perspective=15
 <h2>AUTHOR</h2>
 
 <a href="http://geo.fsv.cvut.cz/gwiki/Landa">Martin
-Landa</a>, <a href="http://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2008">Google
+Landa</a>, <a href="https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2008">Google
 Summer of Code 2008</a> (mentor: Michael Barton)
-and <a href="http://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2010">Google
+and <a href="https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2010">Google
 Summer of Code 2010</a> (mentor: Helena Mitasova)<br>
-Anna Kratochvilova, <a href="http://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2011">Google
+Anna Kratochvilova, <a href="https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2011">Google
 Summer of Code 2011</a> (mentor: Martin Landa)
 
 <!--

--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -86,8 +86,8 @@ SetCompressorDictSize 128
 ;Publisher variables
 
 !define PUBLISHER "GRASS Development Team"
-!define WEB_SITE "http://grass.osgeo.org"
-!define WIKI_PAGE "http://grass.osgeo.org/wiki"
+!define WEB_SITE "https://grass.osgeo.org"
+!define WIKI_PAGE "https://grass.osgeo.org/wiki"
 
 ;----------------------------------------------------------------------------------------------------------------------------
 
@@ -979,7 +979,7 @@ Section /O "North Carolina (Wake County) Data Set" SecNorthCarolinaSDB
 	;Set the size (in KB) of the unpacked archive file
 	AddSize 254521
   
-  	StrCpy $HTTP_PATH "http://grass.osgeo.org/sampledata/north_carolina/"
+  	StrCpy $HTTP_PATH "https://grass.osgeo.org/sampledata/north_carolina/"
 	StrCpy $ARCHIVE_NAME "nc_spm_08_grass7.tar.gz"
 	StrCpy $EXTENDED_ARCHIVE_NAME "North Carolina (Wake County)"
 	StrCpy $ORIGINAL_UNTAR_FOLDER "nc_spm_08_grass7"
@@ -997,7 +997,7 @@ Section /O "South Dakota (Spearfish County) Data Set" SecSpearfishSDB
 	;Set the size (in KB) of the unpacked archive file
 	AddSize 42171
 	
-	StrCpy $HTTP_PATH "http://grass.osgeo.org/sampledata"
+	StrCpy $HTTP_PATH "https://grass.osgeo.org/sampledata"
 	StrCpy $ARCHIVE_NAME "spearfish_grass70data-0.3.tar.gz"
 	StrCpy $EXTENDED_ARCHIVE_NAME "South Dakota (Spearfish County)"
 	StrCpy $ORIGINAL_UNTAR_FOLDER "spearfish60_grass7"

--- a/mswindows/Installer-Files/GRASS-WebSite.url
+++ b/mswindows/Installer-Files/GRASS-WebSite.url
@@ -1,5 +1,5 @@
 [InternetShortcut]
-URL=http://grass.osgeo.org/
+URL=https://grass.osgeo.org/
 IDList=
 [{000214A0-0000-0000-C000-000000000046}]
 Prop3=19,2

--- a/mswindows/Installer-Files/WinGRASS-README.url
+++ b/mswindows/Installer-Files/WinGRASS-README.url
@@ -1,7 +1,7 @@
 [InternetShortcut]
 URL=https://grass.osgeo.org/grass79/binary/mswindows/native/README.html
 IDList=
-IconFile=http://grass.osgeo.org/favicon.ico
+IconFile=https://grass.osgeo.org/images/favicon/favicon.ico
 IconIndex=1
 [{000214A0-0000-0000-C000-000000000046}]
 Prop3=19,2

--- a/ps/ps.map/ps.map.html
+++ b/ps/ps.map/ps.map.html
@@ -1250,7 +1250,7 @@ by the <b>color</b> instruction.
 Pattern may be scaled with the <b>scale</b> command. Several standard hatching
 patterns are provided in <tt>$GISBASE/etc/paint/patterns/</tt>.
 Demonstrative images can be found on the
-<a href="http://grasswiki.osgeo.org/wiki/AreaFillPatterns">GRASS Wiki site</a>.
+<a href="https://grasswiki.osgeo.org/wiki/AreaFillPatterns">GRASS Wiki site</a>.
 
 You can also create your own custom pattern files in a text editor. 
 Example of pattern file:
@@ -1618,7 +1618,7 @@ outline
 -->
 
 <p>More examples can be found on the
-<a href="http://grasswiki.osgeo.org/wiki/Ps.map_scripts">GRASS Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Ps.map_scripts">GRASS Wiki</a>
 help site.
 <p>
 

--- a/raster/r.basins.fill/r.basins.fill.html
+++ b/raster/r.basins.fill/r.basins.fill.html
@@ -34,7 +34,7 @@ map layer is used.
 <h2>SEE ALSO</h2>
 
 See Appendix A of the <b>GRASS</b> <a
-href="http://grass.osgeo.org/gdp/raster/r.watershed.ps">Tutorial:
+href="https://grass.osgeo.org/gdp/raster/r.watershed.ps">Tutorial:
 r.watershed</a> for further details on the combined use of
 <em>r.basins.fill</em> and <em>r.watershed</em>.
 

--- a/raster/r.colors/r.colors.html
+++ b/raster/r.colors/r.colors.html
@@ -306,7 +306,7 @@ r.colors map=current_raster -n rast=current_raster
 </em>
 
 <p>See also wiki
-page <a href="http://grasswiki.osgeo.org/wiki/Color_tables">Color
+page <a href="https://grasswiki.osgeo.org/wiki/Color_tables">Color
 tables</a> (from GRASS User Wiki)
 
 <p><a href="http://colorbrewer.org">ColorBrewer</a> is an online tool designed to

--- a/raster/r.colors/r3.colors.html
+++ b/raster/r.colors/r3.colors.html
@@ -21,7 +21,7 @@ r3.colors map=volume_1 color=gyr
 </em>
 
 <p>See also wiki
-page <a href="http://grasswiki.osgeo.org/wiki/Color_tables">Color
+page <a href="https://grasswiki.osgeo.org/wiki/Color_tables">Color
 tables</a> (from GRASS User Wiki)
 
 <p><a href="http://colorbrewer.org">ColorBrewer</a> is an online tool designed to

--- a/raster/r.cost/test_suite/profile.sh
+++ b/raster/r.cost/test_suite/profile.sh
@@ -1,4 +1,4 @@
-# NC dataset, http://grass.osgeo.org/download/sample-data/
+# NC dataset, https://grass.osgeo.org/download/data/
 
 OUTFILE=callgrind.out.1196
 MAP=elevation

--- a/raster/r.covar/r.covar.html
+++ b/raster/r.covar/r.covar.html
@@ -17,8 +17,8 @@ eigen values and eigen vectors. An NxN covariance matrix would result in
 N real eigen values and N eigen vectors (each composed of N real numbers). 
 
 <p>
-The module <em><a href="http://grasswiki.osgeo.org/wiki/AddOns/GRASS_7/misc#m.eigensystem">m.eigensystem</a></em>
-in <a href="http://grass.osgeo.org/download/addons/">GRASS GIS Addons</a>
+The module <em><a href="https://grasswiki.osgeo.org/wiki/AddOns/GRASS_7/misc#m.eigensystem">m.eigensystem</a></em>
+in <a href="https://grass.osgeo.org/download/addons/">GRASS GIS Addons</a>
 can be compiled and used to generate the eigen values and vectors.
 
 <h2>EXAMPLE</h2>

--- a/raster/r.in.gdal/r.in.gdal.html
+++ b/raster/r.in.gdal/r.in.gdal.html
@@ -430,7 +430,7 @@ r.in.gdal HDF4_EOS:EOS_GRID:"MOD15A2.A2003153.h18v04.004.2003171141042.hdf":MOD_
 </em>
 
 <p>
-GRASS GIS Wiki page: Import of <a href="http://grasswiki.osgeo.org/wiki/Global_datasets">Global datasets</a>
+GRASS GIS Wiki page: Import of <a href="https://grasswiki.osgeo.org/wiki/Global_datasets">Global datasets</a>
 
 <h2>REFERENCES</h2>
 

--- a/raster/r.in.lidar/r.in.lidar.html
+++ b/raster/r.in.lidar/r.in.lidar.html
@@ -454,7 +454,7 @@ g.region -e
 <h3>Serpent Mound dataset</h3>
 
 This example is analogous to the example used in the GRASS wiki page for
-<a href="http://grasswiki.osgeo.org/wiki/LIDAR#Import_LAS_as_raster_DEM">importing LAS as raster DEM</a>.
+<a href="https://grasswiki.osgeo.org/wiki/LIDAR#Import_LAS_as_raster_DEM">importing LAS as raster DEM</a>.
 <p>The sample LAS data are in the file "Serpent Mound Model LAS Data.las", 
 available at 
 <a href="http://www.appliedimagery.com/downloads/sampledata/Serpent%20Mound%20Model%20LAS%20Data.las">appliedimagery.com</a>:

--- a/raster/r.li/r.li.daemon/r.li.daemon.html
+++ b/raster/r.li/r.li.daemon/r.li.daemon.html
@@ -75,7 +75,7 @@ The documentation is in doxygen files.
 
 <h2>SEE ALSO</h2>
 
-<em><a href="http://grass.osgeo.org/gdp/landscape/r_le_manual5.pdf">old r.le manual</a></em><br>
+<em><a href="https://grass.osgeo.org/gdp/landscape/r_le_manual5.pdf">old r.le manual</a></em><br>
 <em><a href="r.li.html">r.li</a></em> - package overview <br>
 <em><a href="g.gui.rlisetup.html">g.gui.rlisetup</a></em>
 

--- a/raster/r.mapcalc/r.mapcalc.html
+++ b/raster/r.mapcalc/r.mapcalc.html
@@ -815,11 +815,11 @@ NULL cells. It is left to the user to utilize the <tt>isnull()</tt> function.
 
 <h2>REFERENCES</h2>
 
-<b><a href="http://grass.osgeo.org/uploads/grass/history_docs/mapcalc-algebra.pdf">r.mapcalc: An Algebra for GIS and Image
+<b><a href="https://grass.osgeo.org/gdp/raster/mapcalc-algebra.pdf">r.mapcalc: An Algebra for GIS and Image
 Processing</a></b>, by Michael Shapiro and Jim Westervelt, U.S. Army
 Construction Engineering Research Laboratory (March/1991).
 <p>
-<b><a href="http://grass.osgeo.org/uploads/grass/history_docs/mapcalc.pdf">Performing Map Calculations on GRASS Data:
+<b><a href="https://grass.osgeo.org/history_docs/mapcalc.pdf">Performing Map Calculations on GRASS Data:
 r.mapcalc Program Tutorial</a></b>, by Marji Larson, Michael Shapiro and Scott
 Tweddale, U.S. Army Construction Engineering Research Laboratory (December
 1991)

--- a/raster/r.mapcalc/r3.mapcalc.html
+++ b/raster/r.mapcalc/r3.mapcalc.html
@@ -604,11 +604,11 @@ NULL cells. It is left to the user to utilize the <tt>isnull()</tt> function.
 
 <h2>REFERENCES</h2>
 
-<b><a href="http://grass.osgeo.org/uploads/grass/history_docs/mapcalc-algebra.pdf">r.mapcalc: An Algebra for GIS and Image
+<b><a href="https://grass.osgeo.org/gdp/raster/mapcalc-algebra.pdf">r.mapcalc: An Algebra for GIS and Image
 Processing</a></b>, by Michael Shapiro and Jim Westervelt, U.S. Army
 Construction Engineering Research Laboratory (March/1991).
 <p> 
-<b><a href="http://grass.osgeo.org/uploads/grass/history_docs/mapcalc.pdf">Performing Map Calculations on GRASS Data:
+<b><a href="https://grass.osgeo.org/history_docs/mapcalc.pdf">Performing Map Calculations on GRASS Data:
 r.mapcalc Program Tutorial</a></b>, by Marji Larson, Michael Shapiro and Scott
 Tweddale, U.S. Army Construction Engineering Research Laboratory (December
 1991)

--- a/raster/r.out.vtk/r.out.vtk.html
+++ b/raster/r.out.vtk/r.out.vtk.html
@@ -124,7 +124,7 @@ To achieve proper RGB overlay:
 </em>
 
 <br>
-<a href="http://grasswiki.osgeo.org/wiki/GRASS_and_Paraview">GRASS and Paraview Wiki page</a>
+<a href="https://grasswiki.osgeo.org/wiki/GRASS_and_Paraview">GRASS and Paraview Wiki page</a>
 
 <h2>AUTHOR</h2>
 Soeren Gebbert

--- a/raster/r.patch/r.patch.html
+++ b/raster/r.patch/r.patch.html
@@ -153,7 +153,7 @@ your_username  hard    nofile          1500
 
 This would raise the hard limit to 1500 file. Be warned that more
 files open need more RAM. See also the Wiki page
-<a href="http://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>.
+<a href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>.
 
 <p>
 Operating systems usually limit the length of the command line
@@ -205,7 +205,7 @@ r.patch input=$MAPS output=maps_mosaic
 <a href="v.mkgrid.html">v.mkgrid</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
+<a href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.ros/r.ros.html
+++ b/raster/r.ros/r.ros.html
@@ -139,7 +139,7 @@ r.ros -s model=fire_model moisture_1h=1hour_moisture moisture_live=live_moisture
 <a href="r.spreadpath.html">r.spreadpath</a>
 </em>
 
-Sample data download: <a href="http://grass.osgeo.org/download/sample-data/">firedemo.sh</a>
+Sample data download: <a href="https://grass.osgeo.org/download/data/">firedemo.sh</a>
 (run this script within the "Fire simulation data set" location.
 
 <h2> AUTHOR</h2>

--- a/raster/r.series.accumulate/r.series.accumulate.html
+++ b/raster/r.series.accumulate/r.series.accumulate.html
@@ -141,7 +141,7 @@ r.series.accumulate in=MOD11A1.Day,MOD11A1.Night,MYD11A1.Day,MYD11A1.Night out=M
 <a href="r.series.interp.html">r.series.interp</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
+<a href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
 
 <h2>REFERENCES</h2>
 

--- a/raster/r.series.interp/r.series.interp.html
+++ b/raster/r.series.interp/r.series.interp.html
@@ -56,7 +56,7 @@ The resulting maps will have the values 200, 300 and 400.
 <a href="r.series.accumulate.html">r.series.accumulate</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
+<a href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.series/r.series.html
+++ b/raster/r.series/r.series.html
@@ -220,7 +220,7 @@ r.series file=mapnames.txt \
 <a href="r.univar.html">r.univar</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
+<a href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing">Hints for large raster data processing</a>
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.spread/r.spread.html
+++ b/raster/r.spread/r.spread.html
@@ -131,7 +131,7 @@ Rutgers University, New Brunswick, New Jersey
 <a href="r.spreadpath.html">r.spreadpath</a>
 </em>
 
-Sample data download: <a href="http://grass.osgeo.org/download/sample-data/">firedemo.sh</a>
+Sample data download: <a href="https://grass.osgeo.org/download/data/">firedemo.sh</a>
 (run this script within the "Fire simulation data set" location.
 
 <h2>AUTHOR</h2>

--- a/raster/r.spreadpath/r.spreadpath.html
+++ b/raster/r.spreadpath/r.spreadpath.html
@@ -57,7 +57,7 @@ Rutgers University, New Brunswick, New Jersey
 <a href="r.ros.html">r.ros</a>
 </em>
 
-Sample data download: <a href="http://grass.osgeo.org/download/sample-data/">firedemo.sh</a>
+Sample data download: <a href="https://grass.osgeo.org/download/data/">firedemo.sh</a>
 (run this script within the "Fire simulation data set" location.
 
 <h2>AUTHOR</h2>

--- a/raster/r.stats/test_suite/profile.sh
+++ b/raster/r.stats/test_suite/profile.sh
@@ -1,4 +1,4 @@
-# NC dataset, http://grass.osgeo.org/download/sample-data/
+# NC dataset, https://grass.osgeo.org/download/data/
 
 OUTFILE=callgrind.out.1196
 MAP=elevation

--- a/raster/r.stream.extract/r.stream.extract.html
+++ b/raster/r.stream.extract/r.stream.extract.html
@@ -283,7 +283,7 @@ representation using digital elevation models.</i>
 
 <p>
 See
-also <a href="http://grasswiki.osgeo.org/wiki/R.stream.*_modules">r.streams.*
+also <a href="https://grasswiki.osgeo.org/wiki/R.stream.*_modules">r.streams.*
 modules</a> wiki page.
 
 <h2>AUTHOR</h2>

--- a/raster/r.sun/TODO
+++ b/raster/r.sun/TODO
@@ -13,7 +13,7 @@ MN 4/2001
 
 #### 
 Update
-  http://grasswiki.osgeo.org/wiki/R.sun
+  https://grasswiki.osgeo.org/wiki/R.sun
 
 ####
 Fix http://trac.osgeo.org/grass/ticket/498

--- a/raster/r.water.outlet/r.water.outlet.html
+++ b/raster/r.water.outlet/r.water.outlet.html
@@ -28,7 +28,7 @@ representing the overland slope uphill of the point.
 <h2>EXAMPLE</h2>
 
 A watershed in
-the <a href="http://grass.osgeo.org/download/sample-data/">North
+the <a href="https://grass.osgeo.org/download/data/">North
 Carolina sample dataset</a> region:
 
 <div class="code"><pre>

--- a/scripts/g.extension.all/g.extension.all.html
+++ b/scripts/g.extension.all/g.extension.all.html
@@ -29,7 +29,7 @@ g.extension.rebuild.all -f
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/GRASS_AddOns">GRASS Addons</a> wiki page.
+See also <a href="https://grasswiki.osgeo.org/wiki/GRASS_AddOns">GRASS Addons</a> wiki page.
 
 <h2>AUTHOR</h2>
 

--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -255,7 +255,7 @@ with the version number) must be installed.
 <p>
 <a href="https://grass.osgeo.org/grass7/manuals/addons/">GRASS GIS 7 Addons Manual pages</a>
 <br>
-<a href="http://grasswiki.osgeo.org/wiki/GRASS_AddOns">GRASS Addons</a> wiki page.
+<a href="https://grasswiki.osgeo.org/wiki/GRASS_AddOns">GRASS Addons</a> wiki page.
 
 <h2>AUTHORS</h2>
 

--- a/scripts/g.manual/g.manual.py
+++ b/scripts/g.manual/g.manual.py
@@ -37,7 +37,7 @@
 #%flag
 #% key: o
 #% label: Display online manuals instead of locally installed
-#% description: Use online manuals available at http://grass.osgeo.org website. This flag has no effect when displaying MAN text pages.
+#% description: Use online manuals available at https://grass.osgeo.org website. This flag has no effect when displaying MAN text pages.
 #%end
 #%option
 #% key: entry
@@ -69,9 +69,9 @@ def start_browser(entry):
 
     if flags['o']:
         major, minor, patch = grass.version()['version'].split('.')
-        url_path = 'http://grass.osgeo.org/grass%s%s/manuals/%s.html' % (major, minor, entry)
+        url_path = 'https://grass.osgeo.org/grass%s%s/manuals/%s.html' % (major, minor, entry)
         if urlopen(url_path).getcode() != 200:
-            url_path = 'http://grass.osgeo.org/grass%s%s/manuals/addons/%s.html' % (
+            url_path = 'https://grass.osgeo.org/grass%s%s/manuals/addons/%s.html' % (
                 major, minor, entry)
     else:
         path = os.path.join(gisbase, 'docs', 'html', entry + '.html')

--- a/scripts/r.in.srtm/r.in.srtm.html
+++ b/scripts/r.in.srtm/r.in.srtm.html
@@ -38,7 +38,7 @@ The <a href="http://pub7.bravenet.com/forum/537683448/">SRTM Web Forum</a>
 
 <h2>REFERENCES</h2>
 
-M. Neteler, 2005. <a href="http://grass.osgeo.org/newsletter/GRASSNews_vol3.pdf">SRTM and VMAP0 data in OGR and GRASS.</a> <i><a href="http://grass.osgeo.org/newsletter/">GRASS Newsletter</a></i>, Vol.3, pp. 2-6, June 2005. ISSN 1614-8746.
+M. Neteler, 2005. <a href="https://grass.osgeo.org/newsletter/GRASSNews_vol3.pdf">SRTM and VMAP0 data in OGR and GRASS.</a> <i><a href="https://grass.osgeo.org/newsletter/">GRASS Newsletter</a></i>, Vol.3, pp. 2-6, June 2005. ISSN 1614-8746.
 
 
 <h2>AUTHORS</h2>

--- a/scripts/r.out.xyz/r.out.xyz.html
+++ b/scripts/r.out.xyz/r.out.xyz.html
@@ -35,7 +35,7 @@ r.out.xyz input=elev_lid792_1m output=elev_lid792_1m.csv separator=","
 In this example, elevation data from the North Carolina dataset are
 exported along with R,G,B triplet of the related orthophoto into a
 combined file (requires the import of the supplementary high-resolution
-<a href="http://grass.osgeo.org/sampledata/north_carolina/ortho2010_t792_subset_20cm.tif">color orthophoto</a>, here called "ortho2010_t792"):
+<a href="https://grass.osgeo.org/sampledata/north_carolina/ortho2010_t792_subset_20cm.tif">color orthophoto</a>, here called "ortho2010_t792"):
 
 <div class="code"><pre>
 g.region raster=elev_lid792_1m res=1 -a -p

--- a/scripts/r3.in.xyz/r3.in.xyz.html
+++ b/scripts/r3.in.xyz/r3.in.xyz.html
@@ -43,7 +43,7 @@ written in C.
 <h2>EXAMPLE</h2>
 
 Using the Serpent Mound dataset. (see the
- <a href="http://grasswiki.osgeo.org/wiki/LIDAR">GRASS LiDAR wiki page</a>)
+ <a href="https://grasswiki.osgeo.org/wiki/LIDAR">GRASS LiDAR wiki page</a>)
 
 <div class="code"><pre>
   #scan dataset for extent:

--- a/temporal/t.rast.aggregate/t.rast.aggregate.html
+++ b/temporal/t.rast.aggregate/t.rast.aggregate.html
@@ -206,7 +206,7 @@ yearly_avg_temp_2004|climate|2004-01-01 00:00:00|2005-01-01 00:00:00
 <a href="r.mask.html">r.mask</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
 
 <h2>AUTHOR</h2>

--- a/temporal/t.rast.algebra/t.rast.algebra.html
+++ b/temporal/t.rast.algebra/t.rast.algebra.html
@@ -573,7 +573,7 @@ C = if({equal}, B {#,contain} A > 1, (B {+,contain,l} A {-,equal,l} B) {equal,=/
 <a href="t.rast.mapcalc.html">t.rast.mapcalc</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
 <h2>REFERENCES</h2>
 

--- a/temporal/t.rast.list/t.rast.list.html
+++ b/temporal/t.rast.list/t.rast.list.html
@@ -221,7 +221,7 @@ current limitations.
 <a href="t.vect.list.html">t.vect.list</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
 
 <h2>AUTHOR</h2>

--- a/temporal/t.rast.mapcalc/t.rast.mapcalc.html
+++ b/temporal/t.rast.mapcalc/t.rast.mapcalc.html
@@ -176,7 +176,7 @@ see <em><a href="g.bands.html">g.bands</a></em> module.
 <a href="t.info.html">t.info</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
 <h2>AUTHOR</h2>
 

--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -79,7 +79,7 @@ done
 <a href="t.info.html">t.info</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal data processing Wiki</a>
 
 <h2>AUTHOR</h2>
 

--- a/temporal/temporalintro.html
+++ b/temporal/temporalintro.html
@@ -253,7 +253,7 @@ their raster pendants, but with 3D raster map layers:
 <li> Gebbert, S., Leppelt, T., Pebesma, E., 2019. <i>A topology based spatio-temporal map algebra for big data analysis</i>.
      Data 4, 86. (<a href="https://doi.org/10.3390/data4020086">DOI</a>)</li>
 
-<li> <a href="http://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal
+<li> <a href="https://grasswiki.osgeo.org/wiki/Temporal_data_processing">Temporal
 	data processing</a> (Wiki)</li>
 
 <li> Vaclav Petras, Anna Petrasova, Helena Mitasova, Markus Neteler,

--- a/tools/grass_indent.sh
+++ b/tools/grass_indent.sh
@@ -4,7 +4,7 @@
 
 # Should be in sync with:
 #     https://trac.osgeo.org/grass/wiki/Submitting/C
-#     http://grasswiki.osgeo.org/wiki/Development#Explanation_of_C_indentation_rules
+#     https://grasswiki.osgeo.org/wiki/Development#Explanation_of_C_indentation_rules
 
 # Dependencies:
 #     indent

--- a/tools/mkrest.py
+++ b/tools/mkrest.py
@@ -36,14 +36,14 @@ footer_index = string.Template(\
 """
 
 :doc:`Main Page <index>` - :doc:`${INDEXNAMECAP} index <${INDEXNAME}>` - :doc:`Full index <full_index>` 
-2003-${YEAR} `GRASS Development Team <http://grass.osgeo.org>`_
+2003-${YEAR} `GRASS Development Team <https://grass.osgeo.org>`_
 """)
 
 footer_noindex = string.Template(\
 """
 
 :doc:`Main Page <index>`  - :doc:`Full index <full_index>` 
-2003-${YEAR} `GRASS Development Team <http://grass.osgeo.org>`_
+2003-${YEAR} `GRASS Development Team <https://grass.osgeo.org>`_
 """)
 
 

--- a/tools/module_synopsis.sh
+++ b/tools/module_synopsis.sh
@@ -324,7 +324,7 @@ cat << EOF >> "${TMP}.html"
 <hr class="header">
 <p>
 <a href="index.html">Help Index</a><br>
-&copy; 2007-2010 <a href="http://grass.osgeo.org">GRASS Development Team</a>
+&copy; 2007-2010 <a href="https://grass.osgeo.org">GRASS Development Team</a>
 </p>
 
 </BODY>

--- a/tools/ppmrotate.py
+++ b/tools/ppmrotate.py
@@ -5,7 +5,7 @@
 #  AUTHOR: Glynn Clements (Python version)
 #          Vaclav Petras (separate script)
 #      Earlier Bourne script version by Hamish Bowman,
-#      http://grasswiki.osgeo.org/wiki/Talk:Color_tables
+#      https://grasswiki.osgeo.org/wiki/Talk:Color_tables
 #
 #   (C) 2009-2017 by the GRASS Development Team
 #       This program is free software under the GNU General Public

--- a/tools/thumbnails.py
+++ b/tools/thumbnails.py
@@ -5,7 +5,7 @@
 #  AUTHOR: Vaclav Petras (non-PPM version using r.mapcalc)
 #          Glynn Clements (Python version)
 #      Earlier Bourne script version by Hamish Bowman,
-#      http://grasswiki.osgeo.org/wiki/Talk:Color_tables
+#      https://grasswiki.osgeo.org/wiki/Talk:Color_tables
 #
 #   (C) 2009-2017 by the GRASS Development Team
 #       This program is free software under the GNU General Public

--- a/vector/v.build/v.build.html
+++ b/vector/v.build/v.build.html
@@ -63,7 +63,7 @@ current mapset.
 Dump options print topology, spatial, category or feature index to
 standard output. Such information can be printed also for vector maps
 from other mapsets. A description of the vector topology is available in
-the <a href="http://grass.osgeo.org/programming7/vlibTopology.html">GRASS GIS 7 Programmer's Manual</a>,
+the <a href="https://grass.osgeo.org/programming7/vlibTopology.html">GRASS GIS 7 Programmer's Manual</a>,
 section "Vector library topology management".
 
 <div class="code"><pre>

--- a/vector/v.colors/v.colors.html
+++ b/vector/v.colors/v.colors.html
@@ -123,7 +123,7 @@ v.db.dropcolumn map=soils_general column=GRASSRGB
 </em>
 
 <p>See also wiki
-page <a href="http://grasswiki.osgeo.org/wiki/Color_tables">Color
+page <a href="https://grasswiki.osgeo.org/wiki/Color_tables">Color
 tables</a> (from GRASS User Wiki)
 
 <p><a href="http://colorbrewer.org">ColorBrewer</a> is an online tool designed to

--- a/vector/v.external.out/v.external.out.html
+++ b/vector/v.external.out/v.external.out.html
@@ -52,7 +52,7 @@ compared to PostgreSQL/PostGIS driver from OGR library:
   <li><tt>SRID=&lt;value&gt;</tt> - spatial reference identifier,
   default: not defined</li>
   <li><tt>TOPOLOGY=YES|NO</tt> - enable/disable
-  native <a href="http://grasswiki.osgeo.org/wiki/PostGIS_Topology">PostGIS
+  native <a href="https://grasswiki.osgeo.org/wiki/PostGIS_Topology">PostGIS
   topology</a>, default: NO</li>
 </ul>
 
@@ -197,7 +197,7 @@ v.external.out loadsettings=gisdb_topo.txt
 
 <p>
 See
-also GRASS <a href="http://grasswiki.osgeo.org/wiki/Working_with_external_data_in_GRASS_7">user wiki page</a> for more examples.
+also GRASS <a href="https://grasswiki.osgeo.org/wiki/Working_with_external_data_in_GRASS_7">user wiki page</a> for more examples.
 
 <h2>AUTHOR</h2>
 

--- a/vector/v.external/v.external.html
+++ b/vector/v.external/v.external.html
@@ -146,7 +146,7 @@ API</a> documentation
 
 <p>
 See
-also GRASS <a href="http://grasswiki.osgeo.org/wiki/Working_with_external_data_in_GRASS_7">user wiki page</a> for more examples.
+also GRASS <a href="https://grasswiki.osgeo.org/wiki/Working_with_external_data_in_GRASS_7">user wiki page</a> for more examples.
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.generalize/v.generalize.html
+++ b/vector/v.generalize/v.generalize.html
@@ -356,7 +356,7 @@ v.generalize input=xxx output=xxx_yyy method=... \
   <a href="v.dissolve.html">v.dissolve</a>
 </em>
 <p>
-<a href="http://grasswiki.osgeo.org/wiki/V.generalize_tutorial">v.generalize Tutorial</a> (GRASS-Wiki)
+<a href="https://grasswiki.osgeo.org/wiki/V.generalize_tutorial">v.generalize Tutorial</a> (GRASS-Wiki)
 
 
 <h2>AUTHORS</h2>

--- a/vector/v.in.dxf/v.in.dxf.html
+++ b/vector/v.in.dxf/v.in.dxf.html
@@ -57,7 +57,7 @@ output map. Neither the "handle" nor "label" column is mandatory.
 </em>
 
 <p><em>
-  <a href="http://grasswiki.osgeo.org/wiki/Import_DXF">How-to import DXF files in wxGUI</a> (from GRASS User Wiki)
+  <a href="https://grasswiki.osgeo.org/wiki/Import_DXF">How-to import DXF files in wxGUI</a> (from GRASS User Wiki)
 </em>
 
 <h2>AUTHORS</h2>

--- a/vector/v.in.lidar/v.in.lidar.html
+++ b/vector/v.in.lidar/v.in.lidar.html
@@ -105,7 +105,7 @@ needed to test for matching projections.
 <h2>EXAMPLE</h2>
 
 This example is analogous to the example used in the GRASS wiki page for
-<a href="http://grasswiki.osgeo.org/wiki/LIDAR#Import_LAS_as_vector_points">importing LAS as vector points</a>.
+<a href="https://grasswiki.osgeo.org/wiki/LIDAR#Import_LAS_as_vector_points">importing LAS as vector points</a>.
 <p>The sample LAS data are in the file "Serpent Mound Model LAS Data.las", 
 available at 
 <a href="http://www.appliedimagery.com/downloads/sampledata/Serpent%20Mound%20Model%20LAS%20Data.las">appliedimagery.com</a>

--- a/vector/v.in.ogr/v.in.ogr.html
+++ b/vector/v.in.ogr/v.in.ogr.html
@@ -481,7 +481,7 @@ with <em><a href="v.proj.html">v.proj</a></em>.
 </em>
 
 <p>
-GRASS GIS Wiki page: Import of <a href="http://grasswiki.osgeo.org/wiki/Global_datasets">Global datasets</a>
+GRASS GIS Wiki page: Import of <a href="https://grasswiki.osgeo.org/wiki/Global_datasets">Global datasets</a>
 
 <h2>AUTHORS</h2>
 

--- a/vector/v.net.alloc/v.net.alloc.html
+++ b/vector/v.net.alloc/v.net.alloc.html
@@ -41,7 +41,7 @@ possible turn on any possible node (intersection) in both directions.
 Turntable can be created by the <em><a href="v.net.html">v.net</a></em> 
 module. For more information about turns in the vector network analyses 
 see
-<a href="http://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
+<a href="https://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
 
 <h2>NOTES</h2>
 

--- a/vector/v.net.iso/v.net.iso.html
+++ b/vector/v.net.iso/v.net.iso.html
@@ -41,7 +41,7 @@ possible turn on any possible node (intersection) in both directions.
 Turntable can be created by the <em><a href="v.net.html">v.net</a></em> 
 module. For more information about turns in the vector network analyses 
 see
-<a href="http://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
+<a href="https://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
 
 <h2>NOTES</h2>
 

--- a/vector/v.net.path/v.net.path.html
+++ b/vector/v.net.path/v.net.path.html
@@ -80,7 +80,7 @@ turntable with costs of every possible turn on any possible node
  Turntable can be created by 
  the <em><a href="v.net.html">v.net</a></em> module. 
 For more information about turns in the vector network analyses see
-<a href="http://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
+<a href="https://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
 
 
 <h2>NOTES</h2>

--- a/vector/v.net.salesman/v.net.salesman.html
+++ b/vector/v.net.salesman/v.net.salesman.html
@@ -31,7 +31,7 @@ turntable with costs of every possible turn on any possible node
  Turntable can be created by 
  the <em><a href="v.net.html">v.net</a></em> module. 
 For more information about turns in the vector network analyses see
-<a href="http://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
+<a href="https://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
 
 <h2>NOTES</h2>
 Arcs can be closed using cost = -1. 

--- a/vector/v.net/v.net.html
+++ b/vector/v.net/v.net.html
@@ -102,7 +102,7 @@ Turntable name consists of output vector map name + "_turntable_" + "t" + "_" + 
 <!--<em><a href="v.net.steiner.html">v.net.steiner</a></em>.-->
 
 For more information about turns in the vector network analyses see 
-<a href="http://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
+<a href="https://grasswiki.osgeo.org/wiki/Turns_in_the_vector_network_analysis">wiki page</a>.
 
 <p>
 Once a vector network has been created, it can be analyzed in a 

--- a/vector/v.out.postgis/v.out.postgis.html
+++ b/vector/v.out.postgis/v.out.postgis.html
@@ -241,7 +241,7 @@ v.out.postgis -l input=busroutesall output="PG:dbname=grass"
 </pre></div>
 
 For more info about PostGIS Topology implementation in GRASS see
-the <a href="http://grasswiki.osgeo.org/wiki/PostGIS_Topology">wiki
+the <a href="https://grasswiki.osgeo.org/wiki/PostGIS_Topology">wiki
 page</a>.
 
 <h2>TODO</h2>
@@ -266,7 +266,7 @@ page</a>.
 <ul>
   <li><a href="http://www.opengeospatial.org/standards/sfa">OGC Simple Feature Access</a> specification</li>
   <li><a href="http://postgis.net/docs/Topology.html">PostGIS Topology</a> documentation</li>
-  <li><a href="http://grass.osgeo.org/programming7/vlibPg.html">GRASS-PostGIS data provider</a></li>
+  <li><a href="https://grass.osgeo.org/programming7/vlibPg.html">GRASS-PostGIS data provider</a></li>
 </ul>
 
 <h2>SEE ALSO</h2>
@@ -279,8 +279,8 @@ page</a>.
 </em>
 
 <p>
-See also <a href="http://grasswiki.osgeo.org/wiki/PostGIS">PostGIS</a>
-and <a href="http://grasswiki.osgeo.org/wiki/PostGIS_Topology">PostGIS
+See also <a href="https://grasswiki.osgeo.org/wiki/PostGIS">PostGIS</a>
+and <a href="https://grasswiki.osgeo.org/wiki/PostGIS_Topology">PostGIS
 Topology</a> wiki page from GRASS User Wiki.
 
 <h2>AUTHOR</h2>

--- a/vector/v.qcount/v.qcount.html
+++ b/vector/v.qcount/v.qcount.html
@@ -109,7 +109,7 @@ Biology</em>, 2:215-235, 1959.
 -->
 
 <p>[8] James Darrell McCauley 1993. Complete Spatial Randomness and Quadrat Methods - 
-<a href="https://grass.osgeo.org/uploads/grass/history_docs/v_qcount_tutorial.pdf">GRASS Tutorial on v.qcount</a>
+<a href="https://grass.osgeo.org/history_docs/v_qcount_tutorial.pdf">GRASS Tutorial on v.qcount</a>
 
 
 

--- a/vector/v.rectify/v.rectify.html
+++ b/vector/v.rectify/v.rectify.html
@@ -99,7 +99,7 @@ determined using a modified Gaussian elimination method.
 <h2>SEE ALSO</h2>
 
 The GRASS 4 <em>
-<a href="http://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
+<a href="https://grass.osgeo.org/gdp/imagery/grass4_image_processing.pdf">Image
 Processing manual</a></em>
 
 <p>

--- a/vector/v.sample/v.sample.html
+++ b/vector/v.sample/v.sample.html
@@ -66,7 +66,7 @@ sample dataset elevation models at random positions:
 
 <em>Image Sampling Methods</em> - GRASS Tutorial on <em>s.sample</em>
 (available as 
-<a href="http://grass.osgeo.org/gdp/sites/">s.sample-tutorial.ps.gz</a>) 
+<a href="https://grass.osgeo.org/gdp/sites/">s.sample-tutorial.ps.gz</a>) 
 
 
 <h2>AUTHOR</h2>

--- a/vector/v.surf.rst/v.surf.rst.html
+++ b/vector/v.surf.rst/v.surf.rst.html
@@ -197,7 +197,7 @@ pattern perpendicular to the previous example. Please note that
 anisotropy option has not been extensively tested and may include bugs
 (for example, topographic parameters may not be computed correctly) -
 if there are problems, please report to GRASS bugtracker (accessible
-from <a href="http://grass.osgeo.org/">http://grass.osgeo.org/</a>).<br>
+from <a href="https://grass.osgeo.org/">https://grass.osgeo.org/</a>).<br>
 
 <!--
 <p>The program gives warning when significant overshoots appear and higher


### PR DESCRIPTION
- fix outdated and broken links to pages and documents on https://grass.osgeo.org
- change from http to https