### PR TITLE
g.extension: add '-j' flag which generates JSON file containing the download URLs of the official Addons

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -167,8 +167,7 @@ HTTP_STATUS_CODES = list(http.HTTPStatus)
 
 
 def download_addons_paths_file(
-        url, response_format, headers={}, *args, **kwargs,
-):
+        url, response_format, headers={}, *args, **kwargs):
     """Download Add-Ons paths json file
 
     :param str url: url address

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -118,9 +118,16 @@
 #% description: Operate on toolboxes instead of single modules (experimental)
 #% suppress_required: yes
 #%end
+#%flag
+#% key: j
+#% description: Generates JSON file containing the download URLs of the official Addons
+#% guisection: Install
+#% suppress_required: yes
+#%end
+
 
 #%rules
-#% required: extension, -l, -c, -g, -a
+#% required: extension, -l, -c, -g, -a, -j
 #% exclusive: extension, -l, -c, -g
 #% exclusive: extension, -l, -c, -a
 #%end
@@ -168,7 +175,8 @@ HTTP_STATUS_CODES = list(http.HTTPStatus)
 
 def download_addons_paths_file(
         url, response_format, headers={}, *args, **kwargs):
-    """Download Add-Ons paths json file
+    """Generates JSON file containing the download URLs of the official
+    Addons
 
     :param str url: url address
     :param str response_format: content type
@@ -2217,6 +2225,11 @@ def main():
     # define path
     options['prefix'] = resolve_install_prefix(path=options['prefix'],
                                                to_system=flags['s'])
+
+    if flags['j']:
+        get_addons_paths(gg_addons_base_dir=options['prefix'])
+        return 0
+
     # list available extensions
     if flags['l'] or flags['c'] or (flags['g'] and not flags['a']):
         # using dummy extension, we don't need any extension URL now,

--- a/tools/mkhtml.py
+++ b/tools/mkhtml.py
@@ -35,7 +35,6 @@ try:
 except:
     import urllib.parse as urlparse
 
-
 if sys.version_info[0] == 2:
     PY2 = True
 else:
@@ -283,7 +282,9 @@ def get_addon_path(pgm):
             with open(addons_paths, 'r') as f:
                 addons_paths = json.load(f)
             for addon in addons_paths['tree']:
-                if pgm in addon['path']:
+                split_path = addon['path'].split('/')
+                root_dir, module_dir = split_path[0], split_path[-1]
+                if 'grass7' == root_dir and pgm == module_dir:
                     return True, addon['path']
     return None, None
 


### PR DESCRIPTION
Add '-j' flag which generates JSON file containing the download URLs of the official Addons independently (needed for [Add-Ons build script](https://github.com/OSGeo/grass-addons/pull/307/commits/8a0844b9ef47bcdb71f36221a1647c709b39fa91#diff-26fec5cb1bc02e1a45f9839f31067986)).

Plus fix find correct Addon URL path.