### PR TITLE
catalog: use natural sort

### DIFF
--- a/gui/wxpython/core/treemodel.py
+++ b/gui/wxpython/core/treemodel.py
@@ -18,6 +18,8 @@ This program is free software under the GNU General Public License
 import six
 import weakref
 
+from grass.script.utils import naturally_sort
+
 
 class TreeModel(object):
     """Class represents a tree structure with hidden root.
@@ -147,9 +149,9 @@ class TreeModel(object):
             del node.children[:]
 
     def SortChildren(self, node):
-        """Sorts children alphabetically based on label."""
+        """Sorts children with 'natural sort' based on label."""
         if node.children:
-            node.children.sort(key=lambda node: node.label)
+            naturally_sort(node.children, key=lambda node: node.label)
 
     def __str__(self):
         """Print tree."""

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -36,7 +36,7 @@ import six
 import wx
 
 from grass.script import core as grass
-from grass.script.utils import natural_sort, try_remove
+from grass.script.utils import naturally_sorted, try_remove
 
 from grass.pydispatch.signal import Signal
 
@@ -1562,7 +1562,7 @@ class MapLayersDialogBase(wx.Dialog):
         :param str mapset: mapset name
         """
         self.map_layers = grass.list_grouped(type=type)[mapset]
-        self.layers.Set(natural_sort(self.map_layers))
+        self.layers.Set(naturally_sorted(self.map_layers))
 
         # check all items by default
         for item in range(self.layers.GetCount()):
@@ -1628,7 +1628,7 @@ class MapLayersDialogBase(wx.Dialog):
                     list.append(layer)
             except:
                 pass
-        list = natural_sort(list)
+        list = naturally_sorted(list)
 
         self.layers.Set(list)
         self.OnSelectAll(None)
@@ -2587,7 +2587,7 @@ class DefaultFontDialog(wx.Dialog):
             fontlist.append(longname)
             fontdict[longname] = shortname
             fontdict_reverse[shortname] = longname
-        fontlist = natural_sort(list(set(fontlist)))
+        fontlist = naturally_sorted(list(set(fontlist)))
 
         return fontdict, fontdict_reverse, fontlist
 

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -607,7 +607,7 @@ class TreeCtrlComboPopup(ListCtrlComboPopup):
         :param exclude: True to exclude, False for forcing the list
         :param node: parent node
         """
-        elist = grass.natural_sort(elist)
+        elist = grass.naturally_sorted(elist)
         for elem in elist:
             if elem != '':
                 fullqElem = elem + '@' + mapset

--- a/lib/python/script/utils.py
+++ b/lib/python/script/utils.py
@@ -332,16 +332,35 @@ def split(s):
 #    http://stackoverflow.com/questions/4836710/
 #    does-python-have-a-built-in-function-for-string-natural-sort/4836734#4836734
 def natural_sort(l):
-    """Returns sorted strings using natural sort
+    """Returns sorted list using natural sort
+    (deprecated, use naturally_sorted)
+    """
+    return naturally_sorted(l)
+
+
+def naturally_sorted(l, key=None):
+    """Returns sorted list using natural sort
+    """
+    copy_l = l[:]
+    naturally_sort(copy_l, key)
+    return copy_l
+
+
+def naturally_sort(l, key=None):
+    """Sorts lists using natural sort
     """
 
     def convert(text):
         return int(text) if text.isdigit() else text.lower()
 
-    def alphanum_key(key):
-        return [convert(c) for c in re.split('([0-9]+)', key)]
+    def alphanum_key(actual_key):
+        if key:
+            sort_key = key(actual_key)
+        else:
+            sort_key = actual_key
+        return [convert(c) for c in re.split('([0-9]+)', sort_key)]
 
-    return sorted(l, key=alphanum_key)
+    l.sort(key=alphanum_key)
 
 
 def get_lib_path(modname, libname=None):


### PR DESCRIPTION
Data catalog uses 'natural sort' now:

Before:
![Selection_048](https://user-images.githubusercontent.com/7494312/95280348-c7dd2000-0822-11eb-8a40-d6083727a073.png)

With this PR:
![Selection_047](https://user-images.githubusercontent.com/7494312/95280352-ca3f7a00-0822-11eb-8098-e331f765bf28.png)
