### PR TITLE
wxGUI/g.gui.iclass: fix copy vector features from vector map

### DIFF
--- a/gui/wxpython/iclass/digit.py
+++ b/gui/wxpython/iclass/digit.py
@@ -129,13 +129,15 @@ class IClassVDigit(IVDigit):
         for cat in cats:
             Vedit_delete_areas_cat(self.poMapInfo, 1, cat)
 
-    def CopyMap(self, name, tmp=False):
+    def CopyMap(self, name, tmp=False, update=False):
         """Make a copy of open vector map
 
         Note: Attributes are not copied
 
         :param name: name for a copy
         :param tmp: True for temporary map
+        :param bool update: True if copy target vector map (poMapInfoNew)
+        exist
 
         :return: number of copied features
         :return: -1 on error
@@ -147,13 +149,23 @@ class IClassVDigit(IVDigit):
         poMapInfoNew = pointer(Map_info())
 
         if not tmp:
-            open_fn = Vect_open_new
+            if update:
+                open_fn = Vect_open_update
+            else:
+                open_fn = Vect_open_new
         else:
-            open_fn = Vect_open_tmp_new
+            if update:
+                open_fn = Vect_open_tmp_update
+            else:
+                open_fn = Vect_open_tmp_new
 
-        is3D = bool(Vect_is_3d(self.poMapInfo))
-        if open_fn(poMapInfoNew, name, is3D) == -1:
-            return -1
+        if update:
+            if open_fn(poMapInfoNew, name, '') == -1:
+                return -1
+        else:
+            is3D = bool(Vect_is_3d(self.poMapInfo))
+            if open_fn(poMapInfoNew, name, is3D) == -1:
+                return -1
 
         verbose = G_verbose()
         G_set_verbose(-1)      # be silent

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -614,7 +614,7 @@ class IClassMapFrame(DoubleMapFrame):
         vname = self._getTempVectorName()
         # avoid deleting temporary map
         os.environ['GRASS_VECTOR_TEMPORARY'] = '1'
-        if digitClass.CopyMap(vname, tmp=True) == -1:
+        if digitClass.CopyMap(vname, tmp=True, update=True) == -1:
             GError(
                 parent=self,
                 message=_("Unable to copy vector features from <%s>") %


### PR DESCRIPTION
Fix bug reported in the issue #1019.

Target empty [vector map exists in the tmp dir ](https://github.com/OSGeo/grass/blob/master/gui/wxpython/iclass/frame.py#L253)(before copy vector features). We need call proper [Vect_open_tmp_update()](https://github.com/OSGeo/grass/compare/master...tmszi:fix-g-gui-iclass-copy-vector-map-feats?expand=1#diff-28797fd0de70f39b0a0f0674d7c14693b22a533223922e929e6bca203e86a97fR158) function instead of [Vect_open_tmp_new()](https://github.com/OSGeo/grass/blob/master/gui/wxpython/iclass/digit.py#L152) for opening target vector map, before [copy vector features ](https://github.com/OSGeo/grass/blob/master/gui/wxpython/iclass/frame.py#L617)from source to target vector map.

It is solving this error message:

```
Segmentation fault (core dumped)
```