### PR TITLE
v.random: Fix segfault as per bug #1024

### DIFF
--- a/vector/v.random/main.c
+++ b/vector/v.random/main.c
@@ -667,7 +667,7 @@ int main(int argc, char *argv[])
             cat = i + 1;
             
             if (!notable) {
-                if (parm.input->answer) {
+                if (parm.input->answer && field > 0) {
                     Vect_cat_get(Cats, field, &cat_area);
 
                     cats_array[i].cat = cat;


### PR DESCRIPTION
cats_array memory is allocated only when fields for parm.input->answer are > 0

Needs backport to 7.8.