### PR TITLE
wxGUI/import_export: fix output map overwriting if global overwrite setting is allowed

### DIFF
--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -264,7 +264,7 @@ class ImportDialog(wx.Dialog):
     def _validateOutputMapName(self):
         """Enable/disable output map name validation according the
         overwrite state"""
-        if not self.overwrite.IsChecked() or \
+        if not self.overwrite.IsChecked() or not \
            UserSettings.Get(group='cmd', key='overwrite',
                             subkey='enabled'):
             if not self.list.GetValidator().\


### PR DESCRIPTION
**To Reproduce** (nc_spm_08_grass7 location, PERMANENT mapset):

1. Launch GRASS GIS
2. Make backup of firestations vector map
2. On the Layer Manager menu go to Settings -> Preferences -> Modules tab -> Check Allow output files to overwrite existing files checkbox -> Save settings
3. Launch Import vector data wxGUI dialog
4. Try import some vector map -> as output map name choose firestations -> Hit Import button
5. Validation process complain that firestations vector map exist (it is True), whereas overwrite checkbox is checked, validation must pass.

