### PR TITLE
wxGUI/g.gui.psmap: fix move line object error message

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -1979,10 +1979,10 @@ class PsMapBufferedWindow(wx.Window):
                 yDiff = newRect[1] - oldRect[1]
                 self.instruction[id]['rect'] = newRect
 
-                point1 = wx.Point2D(
-                    xDiff, yDiff) + self.instruction[id]['where'][0]
-                point2 = wx.Point2D(
-                    xDiff, yDiff) + self.instruction[id]['where'][1]
+                point1 = wx.Point2D(*self.instruction[id]['where'][0])
+                point2 = wx.Point2D(*self.instruction[id]['where'][1])
+                point1 += wx.Point2D(xDiff, yDiff)
+                point2 += wx.Point2D(xDiff, yDiff)
                 self.instruction[id]['where'] = [point1, point2]
 
                 self.RecalculateEN()


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. Choose Add simple graphics tool - Line from toolbar
3. Draw line
4. Move line with Pointer tool

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1493, in MouseActions
    self.OnLeftUp(event)
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1720, in OnLeftUp
    self.RecalculatePosition(ids=[self.dragId])
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1999, in RecalculatePosition
    xDiff, yDiff) + self.instruction[id]['where'][0]
TypeError: unsupported operand type(s) for +: 'Point2D' and 'tuple'
```