### PR TITLE
wxGUI/g.gui.psmap: fix resize line object

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -1914,7 +1914,7 @@ class PsMapBufferedWindow(wx.Window):
                         pPaper = points[0]
                     pCanvas = self.CanvasPaperCoordinates(
                         rect=Rect2DPS(pPaper, (0, 0)), canvasToPaper=False)[:2]
-                    bounds = wx.RectPP(pCanvas, pos)
+                    bounds = wx.Rect(pCanvas, pos)
                     self.DrawGraphics(
                         drawid=self.dragId,
                         shape='line',


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. Choose Add simple graphics tool - Line from toolbar
3. Draw line
4. Resize line with Pointer tool

![g_gui_psmap_resize_line_object](https://user-images.githubusercontent.com/50632337/96445648-8d0abd00-1210-11eb-9b7a-c7184f360382.png)



**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1497, in MouseActions
    self.OnDragging(event)
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1917, in OnDragging
    bounds = wx.RectPP(pCanvas, pos)
AttributeError: module 'wx' has no attribute 'RectPP'
```
