### PR TITLE
wxGUI/g.gui.psmap: fix move point object error message

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -1965,7 +1965,9 @@ class PsMapBufferedWindow(wx.Window):
                 rect = self.pdcObj.GetIdBounds(id)
                 self.instruction[id]['rect'] = self.CanvasPaperCoordinates(
                     rect=rect, canvasToPaper=True)
-                rect.OffsetXY(rect.GetWidth() / 2, rect.GetHeight() / 2)
+                rect.Offset(
+                    dx=rect.GetWidth() / 2, dy=rect.GetHeight() / 2,
+                )
                 self.instruction[id]['where'] = self.CanvasPaperCoordinates(
                     rect=rect, canvasToPaper=True)[: 2]
                 self.RecalculateEN()


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. Choose Add simple graphics tool - Point from toolbar
3. Draw point
4. Move point with Pointer tool

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1493, in MouseActions
    self.OnLeftUp(event)
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1720, in OnLeftUp
    self.RecalculatePosition(ids=[self.dragId])
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1968, in RecalculatePosition
    rect.OffsetXY(rect.GetWidth() / 2, rect.GetHeight() / 2)
AttributeError: 'Rect' object has no attribute 'OffsetXY'
```