### PR TITLE
imagery/i.image.mosaic: fix encode, decode string

### DIFF
--- a/scripts/i.image.mosaic/i.image.mosaic.py
+++ b/scripts/i.image.mosaic/i.image.mosaic.py
@@ -40,12 +40,12 @@ import grass.script as gscript
 def copy_colors(fh, map, offset):
     p = gscript.pipe_command('r.colors.out', map=map)
     for line in p.stdout:
-        f = line.rstrip('\r\n').split(' ')
+        f = gscript.decode(line).rstrip('\r\n').split(' ')
         if offset:
             if f[0] in ['nv', 'default']:
                 continue
             f[0] = str(float(f[0]) + offset)
-        fh.write(' '.join(f) + '\n')
+        fh.write(gscript.encode(' '.join(f) + '\n'))
     p.wait()
 
 


### PR DESCRIPTION
Fix bug reported in the issue #1028.

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/scripts/i.image.mosaic", line
101, in <module>
    main()
  File "/usr/lib64/grass79/scripts/i.image.mosaic", line 90,
in main
    copy_colors(p.stdin, img, offset)
  File "/usr/lib64/grass79/scripts/i.image.mosaic", line 43,
in copy_colors
    f = line.rstrip('\r\n').split(' ')
TypeError: a bytes-like object is required, not 'str'
```

