### PR TITLE
wxGUI/g.gui.image2target: fix show Settings dialog

### DIFF
--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -238,7 +238,7 @@ class StaticText(wx.StaticText):
 
     def SetToolTip(self, tip):
         if wxPythonPhoenix:
-            wx.StaticText.SetToolTip(self, tipString=tip)
+            wx.StaticText.SetToolTip(self, tip)
         else:
             wx.StaticText.SetToolTipString(self, tip)
 
@@ -327,7 +327,7 @@ class ListCtrl(wx.ListCtrl):
         else:
             return super(ListCtrl, self).IsChecked(item)
 
-           
+
 if CheckWxVersion([4, 1, 0]):
     class CheckListCtrlMixin():
         """This class pretends to be deprecated CheckListCtrlMixin mixin and

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -2755,11 +2755,10 @@ class GrSettingsDialog(wx.Dialog):
             parent=panel, id=wx.ID_ANY,
             label=_("Highlight RMS error > M + SD * factor:"))
         rmslabel.SetToolTip(
-            wx.ToolTip(
-                _(
-                    "Highlight GCPs with an RMS error larger than \n"
-                    "mean + standard deviation * given factor. \n"
-                    "Recommended values for this factor are between 1 and 2.")))
+            _(
+                "Highlight GCPs with an RMS error larger than \n"
+                "mean + standard deviation * given factor. \n"
+                "Recommended values for this factor are between 1 and 2."))
         rmsgridSizer.Add(
             rmslabel,
             flag=wx.ALIGN_CENTER_VERTICAL,


### PR DESCRIPTION
**To Reproduce:**

1. Launch Manage Ground Control Points `g.gui.image2target`
2. Hit Georectifier settings tool from toolbar

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/image2target/ii2t_manager.py", line 1751, in OnSettings
    id=wx.ID_ANY, title=_('GCP Manager settings'))
  File "/usr/lib64/grass79/gui/wxpython/image2target/ii2t_manager.py", line 2692, in __init__
    self.__CreateSymbologyPage(notebook)
  File "/usr/lib64/grass79/gui/wxpython/image2target/ii2t_manager.py", line 2760, in __CreateSymbologyPage
    "Highlight GCPs with an RMS error larger than \n"
  File "/usr/lib64/grass79/gui/wxpython/gui_core/wrap.py", line 242, in SetToolTip
    wx.StaticText.SetToolTip(self, tipString=tip)
TypeError: Window.SetToolTip(): arguments did not match any overloaded call:
  overload 1: argument 'tipString' has unexpected type 'ToolTip'
  overload 2: 'tipString' is not a valid keyword argument
```

