### PR TITLE
wxGUI/g.gui.image2target: fix close window (dissociate the managed window from the AuiManager)

### DIFF
--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -1814,6 +1814,7 @@ class GCP(MapFrame, ColumnSorterMixin):
             self.TgtMap.Clean()
 
             self.grwiz.Cleanup()
+            self._mgr.UnInit()
 
             self.Destroy()
 


### PR DESCRIPTION
**To Reproduce:**

1. Launch Manage Ground Control Points `g.gui.image2target`
2. Close window

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/scripts/g.gui.image2target", line 182, in <module>
    main()
  File "/usr/lib64/grass79/scripts/g.gui.image2target", line 179, in main
    app.MainLoop()
  File "/usr/lib64/python3.6/site-packages/wx/core.py", line 2167, in MainLoop
    rv = wx.PyApp.MainLoop(self)
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /var/tmp/portage/x11-libs/wxGTK-3.0.4-r302/work/wxWidgets-3.0.4/src/common/wincmn.cpp(477) in ~wxWindowBase(): any pushed event handlers must have been removed
Segmentation fault
```