### PR TITLE
wxGUI/g.gui.psmap: fix add legend error message

### DIFF
--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -402,7 +402,7 @@ def getRasterType(map):
     if map is None:
         map = ''
     file = grass.find_file(name=map, element='cell')
-    if file['file']:
+    if file.get('file'):
         rasterType = grass.raster_info(map)['datatype']
         return rasterType
     else:


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. Choose Add maps elements - Legend from tool menu on the toolbar

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 731, in OnAddLegend
    settings=self.instruction, page=page)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py", line 3352, in __init__
    self.panelRaster = self._rasterLegend(self.notebook)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py", line 3408, in _rasterLegend
    rasterType = getRasterType(map=self.currRaster)
  File "/usr/lib64/grass79/gui/wxpython/psmap/utils.py", line 405, in getRasterType
    if file['file']:
KeyError: 'file'
```