### PR TITLE
wxGUI/g.gui.mapswipe: fix hit Apply button if first and second raster aren't choosed

### DIFF
--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -398,14 +398,15 @@ class SwipeMapFrame(DoubleMapFrame):
             self.rasters['first'], self.rasters['second'] = first, second
             res1 = self.SetFirstRaster(name=self.rasters['first'])
             res2 = self.SetSecondRaster(name=self.rasters['second'])
-            if not (res1 and res2) and first and second:
+            if not (res1 and res2) and (first or second):
                 message = ''
-                if not res1:
+                if first and not res1:
                     message += _("Map <%s> not found. ") % self.rasters[
                         'first']
-                if not res2:
+                if second and not res2:
                     message += _("Map <%s> not found.") % self.rasters[
                         'second']
+                if message:
                     GError(parent=self, message=message)
                     return
             self.ZoomToMap()
@@ -420,25 +421,27 @@ class SwipeMapFrame(DoubleMapFrame):
 
     def SetFirstRaster(self, name):
         """Set raster map to first Map"""
-        raster = grass.find_file(name=name, element='cell')
-        if raster['fullname']:
-            self.rasters['first'] = raster['fullname']
-            self.SetLayer(
-                name=raster['fullname'],
-                mapInstance=self.GetFirstMap())
-            return True
+        if name:
+            raster = grass.find_file(name=name, element='cell')
+            if raster.get('fullname'):
+                self.rasters['first'] = raster['fullname']
+                self.SetLayer(
+                    name=raster['fullname'],
+                    mapInstance=self.GetFirstMap())
+                return True
 
         return False
 
     def SetSecondRaster(self, name):
         """Set raster map to second Map"""
-        raster = grass.find_file(name=name, element='cell')
-        if raster['fullname']:
-            self.rasters['second'] = raster['fullname']
-            self.SetLayer(
-                name=raster['fullname'],
-                mapInstance=self.GetSecondMap())
-            return True
+        if name:
+            raster = grass.find_file(name=name, element='cell')
+            if raster.get('fullname'):
+                self.rasters['second'] = raster['fullname']
+                self.SetLayer(
+                    name=raster['fullname'],
+                    mapInstance=self.GetSecondMap())
+                return True
 
         return False
 


### PR DESCRIPTION
**To Reproduce:**

1. Launch Map Swipe window `g.gui.mapswipe`
2. On the Select raster maps dialog (don't choose any first and second raster map)
3. Hit Apply button

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapswipe/dialogs.py", line 69, in <lambda>
    self.btnApply.Bind(wx.EVT_BUTTON, lambda evt: self._apply())
  File "/usr/lib64/grass79/gui/wxpython/mapswipe/dialogs.py", line 231, in _apply
    self.applyChanges.emit()
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py", line 230, in emit
    dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispatcher.py", line 350, in send
    **named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/usr/lib64/grass79/gui/wxpython/mapswipe/frame.py", line 399, in OnApplyInputChanges
    res1 = self.SetFirstRaster(name=self.rasters['first'])
  File "/usr/lib64/grass79/gui/wxpython/mapswipe/frame.py", line 424, in SetFirstRaster
    if raster['fullname']:
KeyError: 'fullname'
```

~Show error message dialog if you don't choose first and second raster map:~

![g_gui_mapswipe_error_message_dialog](https://user-images.githubusercontent.com/50632337/96907915-2f8aa080-149c-11eb-96e3-856e68b99280.png)
