### PR TITLE
wxGUI/g.gui.psmap: add checking map frame exists if you add labels

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -6451,7 +6451,7 @@ class PointDialog(PsmapDialog):
             style=fs.FS_RIGHT)
         self.rotCtrl.SetFormat("%f")
         self.rotCtrl.SetDigits(1)
-        
+
         self.rotCtrl.SetToolTip(
             _("Counterclockwise rotation in degrees"))
         self.rotCtrl.SetValue(float(self.pointDict['rotate']))
@@ -6880,7 +6880,7 @@ class LabelsDialog(PsmapDialog):
         self.select = Select(
             parent=panel,
             multiple=True,
-            type='labels',
+            type='label',
             fullyQualified=False)
         self.select.SetValue(','.join(self.labelsDict['labels']))
         self.select.SetFocus()

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -240,6 +240,24 @@ class PsMapFrame(wx.Frame):
         self.SetSizer(mainSizer)
         mainSizer.Fit(self)
 
+    def _checkMapFrameExists(self, type_id):
+        """Check if map frame exists
+
+        :param int type_id: type id (raster, vector,...)
+
+        :return bool: False if map frame doesn't exists
+        """
+        if self.instruction.FindInstructionByType('map'):
+            mapId = self.instruction.FindInstructionByType('map').id
+        else:
+            mapId = None
+
+        if not type_id:
+            if not mapId:
+                GMessage(message=_("Please, create map frame first."))
+                return False
+        return True
+
     def InstructionFile(self):
         """Creates mapping instructions"""
 
@@ -653,15 +671,9 @@ class PsMapFrame(wx.Frame):
             id = self.instruction.FindInstructionByType('raster').id
         else:
             id = None
-        if self.instruction.FindInstructionByType('map'):
-            mapId = self.instruction.FindInstructionByType('map').id
-        else:
-            mapId = None
 
-        if not id:
-            if not mapId:
-                GMessage(message=_("Please, create map frame first."))
-                return
+        if not self._checkMapFrameExists(type_id=id):
+            return
 
 ##        dlg = RasterDialog(self, id = id, settings = self.instruction)
 # dlg.ShowModal()
@@ -679,14 +691,9 @@ class PsMapFrame(wx.Frame):
             id = self.instruction.FindInstructionByType('vector').id
         else:
             id = None
-        if self.instruction.FindInstructionByType('map'):
-            mapId = self.instruction.FindInstructionByType('map').id
-        else:
-            mapId = None
-        if not id:
-            if not mapId:
-                GMessage(message=_("Please, create map frame first."))
-                return
+
+        if not self._checkMapFrameExists(type_id=id):
+            return
 
 ##        dlg = MainVectorDialog(self, id = id, settings = self.instruction)
 # dlg.ShowModal()
@@ -864,6 +871,9 @@ class PsMapFrame(wx.Frame):
             id = self.instruction.FindInstructionByType('labels').id
         else:
             id = None
+
+        if not self._checkMapFrameExists(type_id=id):
+            return
 
         if 'labels' not in self.openDialogs:
             dlg = LabelsDialog(self, id=id, settings=self.instruction)

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -97,12 +97,13 @@ class Instruction:
         for each in self.instruction:
             if each.id == id:
                 if each.type == 'map':
-                    # must remove raster, vector layers too
+                    # must remove raster, vector layers, labels too
                     vektor = self.FindInstructionByType('vector', list=True)
                     vProperties = self.FindInstructionByType(
                         'vProperties', list=True)
                     raster = self.FindInstructionByType('raster', list=True)
-                    for item in vektor + vProperties + raster:
+                    labels = self.FindInstructionByType('labels', list=True)
+                    for item in vektor + vProperties + raster + labels:
                         if item in self.instruction:
                             self.instruction.remove(item)
 
@@ -120,7 +121,9 @@ class Instruction:
             self.instruction.append(instruction)
         # add to drawable objects
         if instruction.type not in (
-                'page', 'raster', 'vector', 'vProperties', 'initMap'):
+                'page', 'raster', 'vector', 'vProperties', 'initMap',
+                'labels',
+        ):
             if instruction.type == 'map':
                 self.objectsToDraw.insert(0, instruction.id)
             else:


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. On the toolbar tool click on Add overlays tool and choose/click on Add labels menu item
3. On Add labels dialog hit Apply button

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py", line 436, in OnApply
    self.parent.DialogDataChanged(id=self.id)
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1142, in DialogDataChanged
    id = self.instruction.FindInstructionByType('map').id
AttributeError: 'list' object has no attribute 'id'
```

My opinion is that add labels should be allowed if a map frame is added (same as in the case Add raster/vector map layer tool), because they relate to vector map layer.

Another bug in the Add vector labels dialog is missing list of available labels in the current MAPSET:

Default behavior:

![g_gui_psmap_add_vector_labels_dialog_def](https://user-images.githubusercontent.com/50632337/97161904-b67e9800-177e-11eb-9747-95e8eeed5f1e.png)

Expected behavior:

![g_gui_psmap_add_vector_labels_dialog_exp](https://user-images.githubusercontent.com/50632337/97161920-c0080000-177e-11eb-82ba-516f5ff4f6d3.png)

