### PR TITLE
wxGUI/g.gui.psmap: fix double click on the map frame with vector map

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -1161,7 +1161,6 @@ class MapFramePanel(Panel):
 
         # bindings
         self.scaleChoice.Bind(wx.EVT_CHOICE, self.OnScaleChoice)
-        self.select.GetTextCtrl().Bind(wx.EVT_TEXT, self.OnMap)
         self.Bind(wx.EVT_RADIOBUTTON, self.OnElementType, self.vectorTypeRadio)
         self.Bind(wx.EVT_RADIOBUTTON, self.OnElementType, self.rasterTypeRadio)
         self.Bind(wx.EVT_CHECKBOX, self.OnBorder, self.borderCheck)


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. From toolbar choose Map frame tool, on the opened dialog window choose some vector map and hit OK button
3. Double click on the added Map frame

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py", line 1186, in OnMap
    rect=self.mapFrameDict['rect'])
  File "/usr/lib64/grass79/gui/wxpython/psmap/utils.py", line 233, in AutoAdjust
    res = grass.read_command("g.region", flags='gu', raster=map)
  File "/usr/lib64/grass79/etc/python/grass/script/core.py", line 566, in read_command
    return handle_errors(returncode, stdout, args, kwargs)
  File "/usr/lib64/grass79/etc/python/grass/script/core.py", line 394, in handle_errors
    returncode=returncode)
grass.exceptions.CalledModuleError: Module run g.region g.region -gu raster=bridges@PERMANENT ended with error
Process ended with non-zero return code 1. See errors in the (error) output.
```