### PR TITLE
wxGUI/g.gui.psmap: fix preview orientation if page orientation is landscape

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -433,7 +433,9 @@ class PsMapFrame(wx.Frame):
             try:
                 im = PILImage.open(event.userData['filename'])
                 if self.instruction[self.pageId]['Orientation'] == 'Landscape':
-                    im = im.rotate(270)
+                    import numpy as np
+                    im_array = np.array(im)
+                    im = PILImage.fromarray(np.rot90(im_array, 3))
 
                 # hack for Windows, change method for loading EPS
                 if sys.platform == 'win32':


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. From toolbar choose Page setup and on dialog window change page orientation from Portrait to Landscape
3. Add Map frame and choose raster map (example elevation)
4. Show Preview

**Default behavior:**

![g_gui_psmap_landscape_preview_def](https://user-images.githubusercontent.com/50632337/97751732-1b295200-1af3-11eb-8942-7c61b1f854bf.png)

**Expected behavior:**

![g_gui_psmap_landscape_preview_exp](https://user-images.githubusercontent.com/50632337/97751758-25e3e700-1af3-11eb-9bbc-8bfad550c63c.png)


