### PR TITLE
wxGUI/g.gui.psmap: disable draw graphics tool on the preview page

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -202,7 +202,6 @@ class PsMapFrame(wx.Frame):
         # workaround for http://trac.wxwidgets.org/ticket/13628
         self.SetSize(self.GetBestSize())
 
-        self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGED, self.OnPageChanged)
         self.Bind(wx.EVT_CLOSE, self.OnCloseWindow)
         self.Bind(EVT_CMD_DONE, self.OnCmdDone)
@@ -1219,13 +1218,6 @@ class PsMapFrame(wx.Frame):
         else:
             self.SetStatusText('')
 
-    def OnPageChanging(self, event):
-        """Flatnotebook page is changing"""
-        if self.currentPage == 0 and self.mouse['use'] in [
-                'addMap', 'addPoint', 'addLine', 'addRectangle'
-        ]:
-            event.Veto()
-
     def OnHelp(self, event):
         """Show help"""
         if self.parent and self.parent.GetName() == 'LayerManager':
@@ -1503,24 +1495,27 @@ class PsMapBufferedWindow(wx.Window):
     def MouseActions(self, event):
         """Mouse motion and button click notifier
         """
+        disable = self.preview and self.mouse['use'] in ('pointer', 'resize',
+                                                         'addMap', 'addPoint',
+                                                         'addLine', 'addRectangle')
         # zoom with mouse wheel
         if event.GetWheelRotation() != 0:
             self.OnMouseWheel(event)
 
         # left mouse button pressed
-        elif event.LeftDown():
+        elif event.LeftDown() and not disable:
             self.OnLeftDown(event)
 
         # left mouse button released
-        elif event.LeftUp():
+        elif event.LeftUp() and not disable:
             self.OnLeftUp(event)
 
         # dragging
-        elif event.Dragging():
+        elif event.Dragging() and not disable:
             self.OnDragging(event)
 
         # double click
-        elif event.ButtonDClick():
+        elif event.ButtonDClick() and not disable:
             self.OnButtonDClick(event)
 
         # middle mouse button pressed

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -258,6 +258,14 @@ class PsMapFrame(wx.Frame):
                 return False
         return True
 
+    def _switchToPage(self, page_index=0):
+        """Switch to page (default to Draft page)
+
+        :param int page_index: page index where you want to switch
+        """
+        self.book.SetSelection(page_index)
+        self.currentPage = page_index
+
     def InstructionFile(self):
         """Creates mapping instructions"""
 
@@ -794,6 +802,7 @@ class PsMapFrame(wx.Frame):
         """Add point action selected"""
         self.mouse["use"] = "addPoint"
         self.canvas.SetCursor(self.cursors["cross"])
+        self._switchToPage()
 
     def AddPoint(self, id=None, coordinates=None):
         """Add point and open property dialog.
@@ -819,6 +828,7 @@ class PsMapFrame(wx.Frame):
         """Add line action selected"""
         self.mouse["use"] = "addLine"
         self.canvas.SetCursor(self.cursors["cross"])
+        self._switchToPage()
 
     def AddLine(self, id=None, coordinates=None):
         """Add line and open property dialog.
@@ -844,6 +854,7 @@ class PsMapFrame(wx.Frame):
         """Add rectangle action selected"""
         self.mouse["use"] = "addRectangle"
         self.canvas.SetCursor(self.cursors["cross"])
+        self._switchToPage()
 
     def AddRectangle(self, id=None, coordinates=None):
         """Add rectangle and open property dialog.
@@ -1210,7 +1221,9 @@ class PsMapFrame(wx.Frame):
 
     def OnPageChanging(self, event):
         """Flatnotebook page is changing"""
-        if self.currentPage == 0 and self.mouse['use'] == 'addMap':
+        if self.currentPage == 0 and self.mouse['use'] in [
+                'addMap', 'addPoint', 'addLine', 'addRectangle'
+        ]:
             event.Veto()
 
     def OnHelp(self, event):


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. Switch to Preview page
2. From toolbar choose Add simple graphics: points
3. Draw (add) some points

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1538, in MouseActions
    self.OnLeftUp(event)
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1774, in OnLeftUp
    event.GetX(), event.GetY(), 0, 0), canvasToPaper=True)[:2]
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 1385, in CanvasPaperCoordinates
    pRect = self.pdcPaper.GetIdBounds(self.pageId)
AttributeError: 'PsMapBufferedWindow' object has no attribute 'pageId'
```

**Default behavior:**

![g_gui_psmap_preview_page_def](https://user-images.githubusercontent.com/50632337/97796888-b3205c00-1c17-11eb-8e71-f58417b53bc7.png)

**Expected behavior:**

![g_gui_psmap_preview_page_exp](https://user-images.githubusercontent.com/50632337/97796891-bc112d80-1c17-11eb-9437-cb1fab6e1247.png)
