### PR TITLE
wxGUI/g.gui.psmap: fix launch ps.map module dialog from the File menu

### DIFF
--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -64,7 +64,8 @@ class GPrompt(object):
         self.cmdDesc = None
 
         self._loadHistory()
-        giface.currentMapsetChanged.connect(self._loadHistory)
+        if giface:
+            giface.currentMapsetChanged.connect(self._loadHistory)
 
         # list of traced commands
         self.commands = list()


### PR DESCRIPTION
**To Reproduce:**

1. Launch Cartographic Composer `g.gui.psmap`
2. On the dialog menu go to File -> Launch ps.map dialog

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py", line 318, in OnPsMapDialog
    GUI(parent=self).ParseCommand(cmd=['ps.map'])
  File "/usr/lib64/grass79/gui/wxpython/gui_core/forms.py", line 2935, in ParseCommand
    get_dcmd=get_dcmd, layer=layer)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/forms.py", line 550, in __init__
    frame=self)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/forms.py", line 2291, in __init__
    margin=False)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/goutput.py", line 120, in __init__
    parent=self, giface=giface, menuModel=self._menuModel
  File "/usr/lib64/grass79/gui/wxpython/gui_core/prompt.py", line 143, in __init__
    GPrompt.__init__(self, parent=parent, giface=giface, menuModel=menuModel)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/prompt.py", line 67, in __init__
    giface.currentMapsetChanged.connect(self._loadHistory)
AttributeError: 'NoneType' object has no attribute 'currentMapsetChanged'
```
