### PR TITLE
wxGUI/vselect: fix show error message if selected map layer type is raster

### DIFF
--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -272,11 +272,7 @@ class VectorSelectBase():
             if layerSelected.type != 'vector':
                 mapName = None
                 self.UnregisterMapEvtHandler()
-                GError(
-                    _(
-                        "No vector map layer selected. Operation canceled."
-                    ),
-                )
+                GError(_("No vector map layer selected. Operation canceled."))
             else:
                 mapName = str(layerSelected)
                 if self.mapName is not None:

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -274,9 +274,7 @@ class VectorSelectBase():
                 self.UnregisterMapEvtHandler()
                 GError(
                     _(
-                        "Selected raster map layer <{}> "
-                        "isn't supported. Please select vector map layer. "
-                        "Operation canceled.".format(layerSelected),
+                        "No vector map layer selected. Operation canceled."
                     ),
                 )
             else:

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -269,10 +269,21 @@ class VectorSelectBase():
             return None
 
         if layerSelected:
-            mapName = str(layerSelected)
-            if self.mapName is not None:
-                if self.mapName != mapName:
-                    self.Reset()
+            if layerSelected.type != 'vector':
+                mapName = None
+                self.UnregisterMapEvtHandler()
+                GError(
+                    _(
+                        "Selected raster map layer <{}> "
+                        "isn't supported. Please select vector map layer. "
+                        "Operation canceled.".format(layerSelected),
+                    ),
+                )
+            else:
+                mapName = str(layerSelected)
+                if self.mapName is not None:
+                    if self.mapName != mapName:
+                        self.Reset()
         else:
             mapName = None
             self.UnregisterMapEvtHandler()


### PR DESCRIPTION
**To Reproduce:**

1. Start wxGUI `g.gui`
2. Display some raster map (and select this map layer in the Layer Manager map tree if it isn't selected)
3. On the Map Display window from toolbar choose Select vector feature(s) tool
4. Left click on the aspect raster map to select feature

**Default behavior:**

You get error message which isn't understandable for user.

![wxgui_vselect_error_message_def](https://user-images.githubusercontent.com/50632337/97806590-affb8f00-1c5c-11eb-85ec-2dd0c410ec47.png)

**Expected behavior:**

Select vector feature(s) tool support vector map layer type only and you get understandable error message.

![wxgui_vselect_error_message_exp](https://user-images.githubusercontent.com/50632337/97806631-f0f3a380-1c5c-11eb-9d82-767643d0b942.png)
