### PR TITLE
Use the full string length in strncmp() calls.

### DIFF
--- a/lib/gis/open.c
+++ b/lib/gis/open.c
@@ -59,7 +59,7 @@ static int G__open(const char *element,
     
     G__check_gisinit();
 
-    is_tmp = (element && strncmp(element, ".tmp", 3) == 0);
+    is_tmp = (element && strncmp(element, ".tmp", 4) == 0);
 
     /* READ */
     if (mode == 0) {

--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -275,7 +275,7 @@ int Vect_read_ascii_head(FILE *dascii, struct Map_info *Map)
 	while (*ptr == ' ')
 	    ptr++;
 
-	if (strncmp(buff, "ORGANIZATION:", 12) == 0)
+	if (strncmp(buff, "ORGANIZATION:", 13) == 0)
 	    Vect_set_organization(Map, ptr);
 	else if (strncmp(buff, "DIGIT DATE:", 11) == 0)
 	    Vect_set_date(Map, ptr);

--- a/lib/vector/Vlib/header.c
+++ b/lib/vector/Vlib/header.c
@@ -142,7 +142,7 @@ int Vect__read_head(struct Map_info *Map)
 	while (*ptr == ' ')
 	    ptr++;
 
-	if (strncmp(buff, "ORGANIZATION:", sizeof(char) * 12) == 0)
+	if (strncmp(buff, "ORGANIZATION:", sizeof(char) * 13) == 0)
 	    Vect_set_organization(Map, ptr);
 	else if (strncmp(buff, "DIGIT DATE:", sizeof(char) * 11) == 0)
 	    Vect_set_date(Map, ptr);


### PR DESCRIPTION
Here is a trivial bugfix, you might want to backport it too.