### PR TITLE
wxGUI/d.mon: fix rendered image size according actual map display size

### DIFF
--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -529,6 +529,10 @@ class RenderMapMgr(wx.EvtHandler):
                 # is rendered but its size differes from current env
                 if not layer.forceRender and (size[0] != w or size[1] != h):
                     layer.forceRender = True
+            # Force render cmd (e.g. d.mon start=wx0 && d.rast elevation)
+            # mapfile size is default d.mon size 720 x 480
+            elif not size and layer.IsRendered():
+                layer.forceRender = True
 
     def UpdateRenderEnv(self, env):
         self._render_env.update(env)

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -507,7 +507,7 @@ class MapApp(wx.App):
             toolbars.append('map')
 
         if __name__ == "__main__":
-            self.cmdTimeStamp = os.path.getmtime(monFile['cmd'])
+            self.cmdTimeStamp = 0 # fake initial timestamp
             self.Map = DMonMap(giface=self._giface, cmdfile=monFile['cmd'],
                                mapfile=monFile['map'])
 

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -869,7 +869,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         updTime = time.time()
         self.lastUpdateMapReq = updTime
 
-        if self.updDelay <= 0.0:
+        if self.updDelay < 0.0:
             self._runUpdateMap()
         else:
             self.timerRunId = self.renderTimingThr.GetId()


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. `d.mon start=wx0 && d.rast elevation`
2. `d.redraw`

**Error message:**

![d_mon_error_message_def](https://user-images.githubusercontent.com/50632337/98020327-2803b980-1e03-11eb-8266-14703b5edab8.png)

**Expected behavior:**

![d_mon_exp](https://user-images.githubusercontent.com/50632337/98020598-803abb80-1e03-11eb-8572-de31c9ab0114.png)
