### PR TITLE
wxGUI/lmgr: fix get layer name

### DIFF
--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -44,7 +44,7 @@ class Layer(object):
         return self._pydata[0].keys()
 
     def __str__(self):
-        return '' if self.maplayer is None else self.maplayer.name
+        return '' if (self.maplayer is None or self.maplayer.name is None) else self.maplayer.name
 
 
 class LayerList(object):

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -44,7 +44,7 @@ class Layer(object):
         return self._pydata[0].keys()
 
     def __str__(self):
-        return '' if self.maplayer.name is None else self.maplayer.name
+        return '' if self.maplayer is None else self.maplayer.name
 
 
 class LayerList(object):


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. On the Layer manager switch to Display tab and add new group, Add group tool from toolbar (select new group from the tree if it isn't selected)
3. On the Layer manager switch to Modules tab and from GUI tools toolbox double click on the Correct scanning distortions [g.gui.photo2image] item

**Error message:**

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/treeview.py", line
70, in <lambda>

self._emitSignal(evt.GetItem(), self.itemActivated))
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/treeview.py", line
180, in _emitSignal

signal.emit(node=node, **kwargs)
  File
"/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py",
line 230, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispa
tcher.py", line 350, in send

**named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/menu.py",
line 190, in <lambda>

self._tree.itemActivated.connect(lambda node:
self.Run(node))
  File "/usr/lib64/grass79/gui/wxpython/gui_core/menu.py",
line 258, in Run

eval(handler)(event=None, cmd=data['command'].split())
  File "/usr/lib64/grass79/gui/wxpython/lmgr/frame.py", line
934, in RunMenuCmd

self._gconsole.RunCmd(cmd)
  File "/usr/lib64/grass79/gui/wxpython/core/gconsole.py",
line 555, in RunCmd

giface=self._giface).ParseCommand(command)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/forms.py",
line 2935, in ParseCommand

get_dcmd=get_dcmd, layer=layer)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/forms.py",
line 550, in __init__

frame=self)
  File "/usr/lib64/grass79/gui/wxpython/gui_core/forms.py",
line 1462, in __init__

if str(layer):
  File "/usr/lib64/grass79/gui/wxpython/lmgr/giface.py",
line 47, in __str__

return '' if self.maplayer.name is None else
self.maplayer.name
AttributeError
:
'NoneType' object has no attribute 'name'
```
 

