### PR TITLE
wxGUI/mapwin: add map overlays 'at' parameter arg validation

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -102,7 +102,10 @@ from gui_core import gselect
 from core import gcmd
 from core import utils
 from core.settings import UserSettings
-from gui_core.widgets import FloatValidator, GNotebook, FormNotebook, FormListbook
+from gui_core.widgets import (
+    FloatValidator, FormListbook, FormNotebook, GNotebook,
+    PlacementValidator,
+)
 from core.giface import Notification, StandaloneGrassInterface
 from gui_core.widgets import LayersList
 from gui_core.wrap import BitmapFromImage, Button, CloseButton, StaticText, \
@@ -1240,9 +1243,16 @@ class CmdPanel(wx.Panel):
                                 max=maxValue)
                             style = wx.BOTTOM | wx.LEFT
                         else:
-                            txt2 = TextCtrl(
-                                parent=which_panel, value=p.get(
-                                    'default', ''))
+                            if p['name'] in ('at'):
+                                txt2 = TextCtrl(
+                                    parent=which_panel, value=p.get(
+                                        'default', ''),
+                                    validator=PlacementValidator(
+                                        num_of_params=len(p['key_desc'])))
+                            else:
+                                txt2 = TextCtrl(
+                                    parent=which_panel, value=p.get(
+                                        'default', ''))
                             style = wx.EXPAND | wx.BOTTOM | wx.LEFT
 
                         value = self._getValue(p)
@@ -1317,9 +1327,16 @@ class CmdPanel(wx.Panel):
                 if p.get('multiple', False) or \
                         p.get('type', 'string') == 'string' or \
                         len(p.get('key_desc', [])) > 1:
-                    win = TextCtrl(
-                        parent=which_panel, value=p.get(
-                            'default', ''))
+                    if p['name'] in ('at'):
+                        win = TextCtrl(
+                            parent=which_panel, value=p.get(
+                                'default', ''),
+                            validator=PlacementValidator(
+                                num_of_params=len(p['key_desc'])))
+                    else:
+                        win = TextCtrl(
+                            parent=which_panel, value=p.get(
+                                'default', ''))
 
                     value = self._getValue(p)
                     if value:

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -583,14 +583,13 @@ class BaseValidator(Validator):
 
     def OnText(self, event):
         """Do validation"""
-        self.Validate()
+        self.Validate(win=event.GetEventObject())
 
         event.Skip()
 
-    def Validate(self):
+    def Validate(self, win):
         """Validate input"""
-        textCtrl = self.GetWindow()
-        text = textCtrl.GetValue()
+        text = win.GetValue()
 
         if text:
             try:
@@ -630,11 +629,9 @@ class CoordinatesValidator(BaseValidator):
     def __init__(self):
         BaseValidator.__init__(self)
 
-    def Validate(self):
+    def Validate(self, win):
         """Validate input"""
-
-        textCtrl = self.GetWindow()
-        text = textCtrl.GetValue()
+        text = win.GetValue()
         if text:
             try:
                 text = text.split(',')
@@ -687,10 +684,9 @@ class EmailValidator(BaseValidator):
     def __init__(self):
         BaseValidator.__init__(self)
 
-    def Validate(self):
+    def Validate(self, win):
         """Validate input"""
-        textCtrl = self.GetWindow()
-        text = textCtrl.GetValue()
+        text = win.GetValue()
         if text:
             if re.match(r'\b[\w.-]+@[\w.-]+.\w{2,4}\b', text) is None:
                 self._notvalid()
@@ -710,10 +706,9 @@ class TimeISOValidator(BaseValidator):
     def __init__(self):
         BaseValidator.__init__(self)
 
-    def Validate(self):
+    def Validate(self, win):
         """Validate input"""
-        textCtrl = self.GetWindow()
-        text = textCtrl.GetValue()
+        text = win.GetValue()
         if text:
             try:
                 datetime.strptime(text, '%Y-%m-%d')
@@ -1057,9 +1052,8 @@ class PlacementValidator(BaseValidator):
         super()._notvalid()
         self._enableDisableBtn(enable=False)
 
-    def Validate(self):
+    def Validate(self, win):
         """Validate input"""
-        win = self.GetWindow()
         text = win.GetValue()
         if text:
             try:

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1036,7 +1036,7 @@ class PlacementValidator(BaseValidator):
     def _enableDisableBtn(self, enable):
         """Enable/Disable buttomn
 
-        :param str enable: Enable/Disable btn
+        :param bool enable: Enable/Disable btn
         """
         win = self.GetWindow().GetTopLevelParent()
         for btn_id in (wx.ID_OK, wx.ID_APPLY):

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -606,7 +606,6 @@ class BaseValidator(Validator):
         textCtrl = self.GetWindow()
 
         textCtrl.SetBackgroundColour("grey")
-        textCtrl.SetFocus()
         textCtrl.Refresh()
 
     def _valid(self):
@@ -1039,27 +1038,28 @@ class PlacementValidator(BaseValidator):
         self._num_of_params = num_of_params
         super().__init__()
 
-    def _enableDisableBtn(self, mode='Enable'):
+    def _enableDisableBtn(self, enable):
         """Enable/Disable buttomn
 
-        :param str mode: Enable/Disable btn
+        :param str enable: Enable/Disable btn
         """
         win = self.GetWindow().GetTopLevelParent()
         for btn_id in (wx.ID_OK, wx.ID_APPLY):
             btn = win.FindWindow(id=btn_id)
             if btn:
-                getattr(btn, mode)()
+                btn.Enable(enable)
 
     def _valid(self):
         super()._valid()
-        self._enableDisableBtn()
+        self._enableDisableBtn(enable=True)
 
     def _notvalid(self):
         super()._notvalid()
-        self._enableDisableBtn(mode='Disable')
+        self._enableDisableBtn(enable=False)
 
-    def Validate(self, win):
+    def Validate(self):
         """Validate input"""
+        win = self.GetWindow()
         text = win.GetValue()
         if text:
             try:

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -22,6 +22,7 @@ Classes:
  - widgets::GenericValidator
  - widgets::GenericMultiValidator
  - widgets::LayersListValidator
+ - widgets::PlacementValidator
  - widgets::GListCtrl
  - widgets::SearchModuleWidget
  - widgets::ManageSettingsWidget
@@ -44,6 +45,8 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (Google SoC 2011)
 @author Stepan Turek <stepan.turek seznam.cz> (ManageSettingsWidget - created from GdalSelect)
 @author Matej Krejci <matejkrejci gmail.com> (Google GSoC 2014; EmailValidator, TimeISOValidator)
+@author Tomas Zigo <tomas.zigo slovanet.sk> (LayersListValidator,
+PlacementValidator)
 """
 
 import os
@@ -1027,6 +1030,59 @@ class LayersListValidator(GenericValidator):
                 self._callback(layers_list=win)
                 return False
         return True
+
+
+class PlacementValidator(BaseValidator):
+    """Validator for placement input (list of floats separated by comma)"""
+
+    def __init__(self, num_of_params):
+        self._num_of_params = num_of_params
+        super().__init__()
+
+    def _enableDisableBtn(self, mode='Enable'):
+        """Enable/Disable buttomn
+
+        :param str mode: Enable/Disable btn
+        """
+        win = self.GetWindow().GetTopLevelParent()
+        for btn_id in (wx.ID_OK, wx.ID_APPLY):
+            btn = win.FindWindow(id=btn_id)
+            if btn:
+                getattr(btn, mode)()
+
+    def _valid(self):
+        super()._valid()
+        self._enableDisableBtn()
+
+    def _notvalid(self):
+        super()._notvalid()
+        self._enableDisableBtn(mode='Disable')
+
+    def Validate(self):
+        """Validate input"""
+        textCtrl = self.GetWindow()
+        text = textCtrl.GetValue()
+        if text:
+            try:
+                text = text.split(',')
+
+                for t in text:
+                    float(t)
+
+                if len(text) % self._num_of_params != 0:
+                    self._notvalid()
+                    return False
+
+            except ValueError:
+                self._notvalid()
+                return False
+
+        self._valid()
+        return True
+
+    def Clone(self):
+        """Clone validator"""
+        return PlacementValidator(num_of_params=self._num_of_params)
 
 
 class GListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin,

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1058,10 +1058,9 @@ class PlacementValidator(BaseValidator):
         super()._notvalid()
         self._enableDisableBtn(mode='Disable')
 
-    def Validate(self):
+    def Validate(self, win):
         """Validate input"""
-        textCtrl = self.GetWindow()
-        text = textCtrl.GetValue()
+        text = win.GetValue()
         if text:
             try:
                 text = text.split(',')


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Display elevation raster map
3. Add elevation raster map legend
4. On the Map display window double click on the added elevation raster map legend
5. On the d.legend dialog go to Optional tab (page)
6. Set 'at' parameter argument (which required four number at=bottom,top,left,right) but set only one number e.g. 5
7. Hit Apply or OK button

**Error message:**

```
ERROR: Failed to run command 'd.legend raster=elevation at=5'. Details:

       ERROR: Option <at> must be provided in multiples of 4
       You provided 1 item(s): 5
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/core/gthread.py", line 137, in OnDone
    event.ondone(event)
  File "/usr/lib64/grass79/gui/wxpython/core/render.py", line 483, in OnRenderDone
    self.updateProgress.emit(env=event.userdata['env'], layer=self.layer)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py", line 230, in emit
    dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispatcher.py", line 350, in send
    **named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/usr/lib64/grass79/gui/wxpython/core/render.py", line 774, in ReportProgress
    self.renderDone.emit(env=env)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/signal.py", line 230, in emit
    dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/dispatcher.py", line 350, in send
    **named
  File "/usr/lib64/grass79/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 967, in _updateMFinished
    coords=self.overlays[id].coords)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/decorations.py", line 105, in GetCoords
    (self._renderer.width, self._renderer.height))
  File "/usr/lib64/grass79/gui/wxpython/mapwin/decorations.py", line 304, in GetPlacement
    '=')[1].split(',')]  # pylint: disable-msg=W0612
ValueError: not enough values to unpack (expected 4, got 1)
```
**Expected behavior:**

![wxgui_mapwin_overlays_at_param_arg_validation_exp](https://user-images.githubusercontent.com/50632337/98230450-6f9d5900-1f5b-11eb-992e-713cd487dc5e.png)