### PR TITLE
wxGUI/gconsole: fix saving command param arg with quotation marks to history file 

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -495,10 +495,10 @@ class GConsole(wx.EvtHandler):
         :param userData: data defined for the command
         """
         if isinstance(command, dict):
-            cmd_save_to_history = command['cmdString']
-            command = command['cmd']
+            cmd_save_to_history = command["cmdString"]
+            command = command["cmd"]
         else:
-            cmd_save_to_history = ' '.join(command)
+            cmd_save_to_history = " ".join(command)
 
         if len(command) == 0:
             Debug.msg(2, "GPrompt:RunCmd(): empty command")

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -480,6 +480,10 @@ class GConsole(wx.EvtHandler):
         For example, see layer manager which handles d.* on its own.
 
         :param command: command given as a list (produced e.g. by utils.split())
+        or dict with key 'cmd' with list value (command list produced
+        e.g. by utils.split()) and key 'cmdString' with original cmd
+        string with preserved quotation marks (for sql param arg, where
+        param arg, r.mapcalc...) to save to a history file
         :param compReg: True use computation region
         :param notification: form of notification
         :param bool skipInterface: True to do not launch GRASS interface
@@ -490,12 +494,18 @@ class GConsole(wx.EvtHandler):
         :param addLayer: to be passed in the mapCreated signal
         :param userData: data defined for the command
         """
+        if isinstance(command, dict):
+            cmd_save_to_history = command['cmdString']
+            command = command['cmd']
+        else:
+            cmd_save_to_history = ' '.join(command)
+
         if len(command) == 0:
             Debug.msg(2, "GPrompt:RunCmd(): empty command")
             return
 
         # update history file
-        self.UpdateHistoryFile(" ".join(command))
+        self.UpdateHistoryFile(cmd_save_to_history)
 
         if command[0] in globalvar.grassCmd:
             # send GRASS command without arguments to GUI command interface

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -134,8 +134,9 @@ class GPrompt(object):
         except UnicodeError:
             cmd = utils.split(EncodeString((cmdString)))
         cmd = list(map(DecodeString, cmd))
+        _cmd = {'cmd': cmd, 'cmdString': str(cmdString)}
 
-        self.promptRunCmd.emit(cmd=cmd)
+        self.promptRunCmd.emit(cmd=_cmd)
 
         self.CmdErase()
         self.ShowStatusText("")

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -134,9 +134,8 @@ class GPrompt(object):
         except UnicodeError:
             cmd = utils.split(EncodeString((cmdString)))
         cmd = list(map(DecodeString, cmd))
-        _cmd = {"cmd": cmd, "cmdString": str(cmdString)}
 
-        self.promptRunCmd.emit(cmd=_cmd)
+        self.promptRunCmd.emit(cmd={"cmd": cmd, "cmdString": str(cmdString)})
 
         self.CmdErase()
         self.ShowStatusText("")

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -134,7 +134,7 @@ class GPrompt(object):
         except UnicodeError:
             cmd = utils.split(EncodeString((cmdString)))
         cmd = list(map(DecodeString, cmd))
-        _cmd = {'cmd': cmd, 'cmdString': str(cmdString)}
+        _cmd = {"cmd": cmd, "cmdString": str(cmdString)}
 
         self.promptRunCmd.emit(cmd=_cmd)
 


### PR DESCRIPTION
Fixes #974.

**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. On the Layer Manager windows switch to the Console page (tab)
3. Run this command e.g. `db.select sql="SELECT * FROM census WHERE cat < 5"`
4. Find this command (from step no. 3) in the console history up arrow keyboard
5. You got this command  `db.select sql=SELECT * FROM census WHERE cat < 5`, but sql param arg is without quotation marks
6. Check commands history file `tail -n 1 grassdata/nc_basic_spm_grass7/PERMANENT/.bash_history` (adjust path according your nc_basic_spm_grass7 LOCATION PERMANENT mapset path), and you got
`db.select sql=SELECT * FROM census WHERE cat < 10`
7. If you rerun this command from history (step no. 5) in the wxGUI Console you got error message

**Error message:**

![gconsole_error_message](https://user-images.githubusercontent.com/50632337/98462795-0ade3a80-21b7-11eb-9a04-b7a389bced52.png)


**Expected behavior:**

Runed  command  e.g. `db.select sql="SELECT * FROM census WHERE cat < 5"` from wxGUI Console must be same (sql param arg must have quotation marks) as command  saved to history file.
