### PR TITLE
Small code fixes for d.legend and Cairo_Text

### DIFF
--- a/display/d.legend/draw.c
+++ b/display/d.legend/draw.c
@@ -67,7 +67,7 @@ void draw(const char *map_name, int maptype, int color, int thin, int lines,
     double coef;
     double ppl;
     double bb,bt,bl,br;
-    char MaxLabel[512];
+    char MaxLabel[513];
     double num;
     int MaxLabelW, LabelW;
 
@@ -594,7 +594,7 @@ void draw(const char *map_name, int maptype, int color, int thin, int lines,
                         }
                         if (color)
                             D_use_color(color);
-                            D_text(buff);
+                        D_text(buff);
                     }
                 }
             }                   /* for */
@@ -1360,5 +1360,4 @@ void draw(const char *map_name, int maptype, int color, int thin, int lines,
         }
 
     }
-    D_save_command(G_recreate_command());
 }

--- a/display/d.legend/main.c
+++ b/display/d.legend/main.c
@@ -486,6 +486,7 @@ int main(int argc, char **argv)
          opt_at, opt_fontsize, opt_tstep, opt_range, histo,
          hidestr, log_scale, 1, digits, units);
 
+    D_save_command(G_recreate_command());
     D_close_driver();
 
     exit(EXIT_SUCCESS);

--- a/lib/cairodriver/text.c
+++ b/lib/cairodriver/text.c
@@ -8,7 +8,7 @@
   This program is free software under the GNU General Public License
   (>=v2). Read the file COPYING that comes with GRASS for details.
   
-  \author Lars Ahlzen <lars ahlzen.com> (original contibutor)
+  \author Lars Ahlzen <lars ahlzen.com> (original contributor)
   \author Glynn Clements  
 */
 
@@ -42,7 +42,7 @@ static char *convert(const char *in)
 	size_t ret;
 	iconv_t cd;
 
-	if ((cd = iconv_open("UTF-8", encoding)) < 0)
+	if ((cd = iconv_open("UTF-8", encoding)) == (iconv_t) -1)
 	    G_fatal_error(_("Unable to convert from <%s> to UTF-8"),
 			  encoding);
 
@@ -340,4 +340,3 @@ void Cairo_font_info(char ***list, int *count)
     font_list_fc(list, count, 1);
 #endif
 }
-


### PR DESCRIPTION
MaxLabel needs to hold buff plus one (e.g. for a space) to avoid several
warnings: sprintf may write a terminating nul past the end of the destination
[-Wformat-overflow=] with GCC.

D_save_command needs to be called only one per standard module call
(although should be removed in the future). draw() is called twice with bg drawing.

D_text call seems to be badly indented, but in a correct branch, so fixing
warning: this if clause does not guard... [-Wmisleading-indentation].

Various iconv documetations specify the retun value on error as (iconv_t) -1
for iconv_open, so test specifically for that and avoid
warning: ordered comparison of pointer with integer zero [-Wextra].

Fix also a typo and empty line at the end of file.
