### PR TITLE
wxGUI/mapdisp: Overlay properties in context menu

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -290,7 +290,7 @@ class BufferedMapWindow(MapWindowBase, Window):
                 self.Bind(wx.EVT_MENU,
                           lambda evt: self.overlays[idlist[0]].StartResizing(),
                           id=resizeLegendId)
-                menu.Append(resizeLegendId, _("Resize and reposition legend"))
+                menu.Append(resizeLegendId, _("Resize and move legend"))
 
             activateId = NewId()
             self.Bind(wx.EVT_MENU,

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -284,12 +284,19 @@ class BufferedMapWindow(MapWindowBase, Window):
                       id=removeId)
             menu.Append(removeId, self.overlays[idlist[0]].removeLabel)
 
+            # raster legend can be resized
             if self.overlays[idlist[0]].name == 'legend':
                 resizeLegendId = NewId()
                 self.Bind(wx.EVT_MENU,
                           lambda evt: self.overlays[idlist[0]].StartResizing(),
                           id=resizeLegendId)
-                menu.Append(resizeLegendId, _("Resize legend"))
+                menu.Append(resizeLegendId, _("Resize and reposition legend"))
+
+            activateId = NewId()
+            self.Bind(wx.EVT_MENU,
+                      lambda evt: self.overlayActivated.emit(overlayId=idlist[0]),
+                      id=activateId)
+            menu.Append(removeId, self.overlays[idlist[0]].activateLabel)
         self.PopupMenu(menu)
         menu.Destroy()
 
@@ -1688,8 +1695,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         pos = event.GetPosition()
         idlist = self.pdc.FindObjects(pos[0], pos[1], self.hitradius)
         if self.overlays and idlist and [i for i in idlist if i in list(self.overlays.keys())]:  # legend, scale bar, north arrow, dtext
-            self.SetToolTip("Double click in Pointer mode to set object"
-                            " properties,\nright click to remove")
+            self.SetToolTip("Right click to modify or remove")
         else:
             self.SetToolTip(None)
         event.Skip()

--- a/gui/wxpython/mapwin/decorations.py
+++ b/gui/wxpython/mapwin/decorations.py
@@ -46,6 +46,7 @@ class OverlayController(object):
         self._cmd = None   # to be set by user
         self._name = None  # to be defined by subclass
         self._removeLabel = None  # to be defined by subclass
+        self._activateLabel = None  # to be defined by subclass
         self._id = NewId()
         self._dialog = None
 
@@ -95,6 +96,11 @@ class OverlayController(object):
         return self._removeLabel
 
     removeLabel = property(fget=GetRemoveLabel)
+
+    def GetActivateLabel(self):
+        return self._activateLabel
+
+    activateLabel = property(fget=GetActivateLabel)
 
     def GetId(self):
         return self._id
@@ -195,6 +201,7 @@ class DtextController(OverlayController):
         OverlayController.__init__(self, renderer, giface)
         self._name = 'text'
         self._removeLabel = _("Remove text")
+        self._activateLabel = _("Text properties")
         self._defaultAt = 'at=50,50'
         self._cmd = ['d.text', self._defaultAt]
 
@@ -218,6 +225,7 @@ class BarscaleController(OverlayController):
         OverlayController.__init__(self, renderer, giface)
         self._name = 'barscale'
         self._removeLabel = _("Remove scale bar")
+        self._activateLabel = _("Scale bar properties")
         # different from default because the reference point is not in the
         # middle
         self._defaultAt = 'at=0,98'
@@ -230,6 +238,7 @@ class ArrowController(OverlayController):
         OverlayController.__init__(self, renderer, giface)
         self._name = 'arrow'
         self._removeLabel = _("Remove north arrow")
+        self._activateLabel = _("North arrow properties")
         # different from default because the reference point is not in the
         # middle
         self._defaultAt = 'at=85.0,25.0'
@@ -241,7 +250,8 @@ class LegendVectController(OverlayController):
     def __init__(self, renderer, giface):
         OverlayController.__init__(self, renderer, giface)
         self._name = 'vectleg'
-        self._removeLabel = _("Remove vector legend")
+        self._removeLabel = _("Remove legend")
+        self._activateLabel = _("Vector legend properties")
         # different from default because the reference point is not in the
         # middle
         self._defaultAt = 'at=20.0,80.0'
@@ -254,6 +264,7 @@ class LegendController(OverlayController):
         OverlayController.__init__(self, renderer, giface)
         self._name = 'legend'
         self._removeLabel = _("Remove legend")
+        self._activateLabel = _("Raster legend properties")
         # default is in the center to avoid trimmed legend on the edge
         self._defaultAt = 'at=5,50,47,50'
         self._cmd = ['d.legend', self._defaultAt]


### PR DESCRIPTION
Properties of legends and other overlays are now also available from the context
menu on right click.

Tooltip is simplified, more general, and does not advertise the double click anymore.

Raster legend resize is renamed to resize and reposition because that's what it is.

Remove vector legend now says only _Remove legend_ like for removing raster legend (and for resizing raster legend).

New state of tooltip and context menu (example for raster legend):

![Screenshot from 2020-11-09 20-14-44](https://user-images.githubusercontent.com/5449060/98615469-bf1bb600-22c8-11eb-8aa0-f1b5cf5d6b6e.png)
![Screenshot from 2020-11-09 20-16-45](https://user-images.githubusercontent.com/5449060/98615471-c0e57980-22c8-11eb-80a4-8084f6552171.png)