### PR TITLE
wxGUI/mapwin: fix showing overlays module properties dialog from the map display context menu

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -296,7 +296,7 @@ class BufferedMapWindow(MapWindowBase, Window):
             self.Bind(wx.EVT_MENU,
                       lambda evt: self.overlayActivated.emit(overlayId=idlist[0]),
                       id=activateId)
-            menu.Append(removeId, self.overlays[idlist[0]].activateLabel)
+            menu.Append(activateId, self.overlays[idlist[0]].activateLabel)
         self.PopupMenu(menu)
         menu.Destroy()
 


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Display raster map e.g. elevation
3. Add legend for elevation raster map
4. Click with right mouse button on added legend to display the context menu and click on the Raster legend properties
5. Legend will be removed

**Expected behavior:**

After click on the Raster legend properties menu item show legend module properties dialog, instead of remove the legend.

