### PR TITLE
wxGUI/mapwin: fix correct horizontal raster legend position after apply new legend setting

### DIFF
--- a/gui/wxpython/mapwin/decorations.py
+++ b/gui/wxpython/mapwin/decorations.py
@@ -267,7 +267,29 @@ class LegendController(OverlayController):
         self._activateLabel = _("Raster legend properties")
         # default is in the center to avoid trimmed legend on the edge
         self._defaultAt = 'at=5,50,47,50'
+        self._actualAt = self._defaultAt
         self._cmd = ['d.legend', self._defaultAt]
+
+    def SetCmd(self, cmd):
+        """Overriden method
+
+        Required for setting default or actual raster legend position.
+        """
+        hasAt = False
+        for i in cmd:
+            if i.startswith("at="):
+                hasAt = True
+                # reset coordinates, 'at' values will be used, see GetCoords
+                self._coords = None
+                break
+        if not hasAt:
+            if self._actualAt != self._defaultAt:
+                cmd.append(self._actualAt)
+            else:
+                cmd.append(self._defaultAt)
+        self._cmd = cmd
+
+    cmd = property(fset=SetCmd, fget=OverlayController.GetCmd)
 
     def GetPlacement(self, screensize):
         if not hasPIL:
@@ -330,6 +352,7 @@ class LegendController(OverlayController):
                 break
 
         self._coords = None
+        self._actualAt = atStr
         self.Show()
 
     def StartResizing(self):


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Display raster map e.g. elevation `d.rast elevation`
3. Add legend for elevation raster map `d.legend -b raster=elevation title=Legend title_fontsize=18 font=DejaVuSans-Bold`
4. Resize legend from vertical orientation to the horizontal orientation
5. Open legend module dialog properties (double click) and hit OK button
6. Legend position change back (doesn't retain orientation) from new horizontal orientation to the previous vertical orientation

**Default behavior:**

![d_legend_def](https://user-images.githubusercontent.com/50632337/98946594-5e70c100-24f4-11eb-80d8-635596e7a776.gif)


**Expected behavior:**

![d_legend_exp](https://user-images.githubusercontent.com/50632337/98946756-94ae4080-24f4-11eb-987c-bfabd18e4430.gif)

If raster legend has horizontal orientation, than after apply new legend setting (hit Apply or OK button on the legend module settings dialog) the orientation of legend must not change.