### PR TITLE
temporal: Unused variables in temporal modules

### DIFF
--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -1,6 +1,5 @@
 [flake8]
 ignore =
-    F841, # local variable 'column' is assigned to but never used
     F821, # undefined name '_'
     E265, # block comment should start with '# '
     E266, # too many leading '#' for block comment

--- a/temporal/t.rast.algebra/testsuite/test_raster_algebra.py
+++ b/temporal/t.rast.algebra/testsuite/test_raster_algebra.py
@@ -392,7 +392,6 @@ class TestTRastAlgebra(TestCase):
 
         D = tgis.open_old_stds("R", type="strds")
         
-        maplist = D.get_registered_maps_as_objects()
         self.assertEqual(D.metadata.get_number_of_maps(), 1)
         self.assertEqual(D.metadata.get_min_min(), 99) 
         self.assertEqual(D.metadata.get_max_max(), 99) 
@@ -409,7 +408,6 @@ class TestTRastAlgebra(TestCase):
 
         D = tgis.open_old_stds("R", type="strds")
         
-        maplist = D.get_registered_maps_as_objects()
         self.assertEqual(D.metadata.get_number_of_maps(), 1)
         self.assertEqual(D.metadata.get_min_min(), 100) 
         self.assertEqual(D.metadata.get_max_max(), 100) 
@@ -426,7 +424,6 @@ class TestTRastAlgebra(TestCase):
 
         D = tgis.open_old_stds("R", type="strds")
         
-        maplist = D.get_registered_maps_as_objects()
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
         self.assertEqual(D.metadata.get_min_min(), 101) 
         self.assertEqual(D.metadata.get_max_max(), 104) 
@@ -443,7 +440,6 @@ class TestTRastAlgebra(TestCase):
 
         D = tgis.open_old_stds("R", type="strds")
         
-        maplist = D.get_registered_maps_as_objects()
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
         self.assertEqual(D.metadata.get_min_min(), 100) 
         self.assertEqual(D.metadata.get_max_max(), 400) 

--- a/temporal/t.rast.to.vect/t.rast.to.vect.py
+++ b/temporal/t.rast.to.vect/t.rast.to.vect.py
@@ -183,6 +183,7 @@ def main(options, flags):
                                    output="dummy", run_=False,
                                    finish_=False, flags=flags,
                                    type=method, overwrite=overwrite,
+                                   column=column,
                                    quiet=True)
 
     # The module queue for parallel execution, except if attribute tables should

--- a/temporal/t.rast.what/t.rast.what.py
+++ b/temporal/t.rast.what/t.rast.what.py
@@ -383,7 +383,6 @@ def one_point_per_col_output(separator, output_files, output_time_list,
     for count in range(len(output_files)):
         file_name = output_files[count]
         gscript.verbose(_("Transforming r.what output file %s"%(file_name)))
-        map_list = output_time_list[count]
         in_file = open(file_name, "r")
         lines = in_file.readlines()
 

--- a/temporal/t.rast3d.algebra/testsuite/test_raster3d_algebra.py
+++ b/temporal/t.rast3d.algebra/testsuite/test_raster3d_algebra.py
@@ -25,8 +25,7 @@ class TestTRast3dAlgebra(TestCase):
         os.putenv("GRASS_OVERWRITE",  "1")
         tgis.init(True) # Raise on error instead of exit(1)
         cls.use_temp_region()
-        ret = grass.script.run_command("g.region", n=80.0, s=0.0, e=120.0,
-                                       w=0.0, t=100.0, b=0.0, res=10.0)
+
 
         cls.runModule("r3.mapcalc", overwrite=True, quiet=True, expression="a1 = 1")
         cls.runModule("r3.mapcalc", overwrite=True, quiet=True, expression="a2 = 2")

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -62,7 +62,6 @@ def main():
     expression = options['expression']
     basename = options['basename']
     spatial = flags["s"]
-    stdstype = "stvds"
 
     # Check for PLY istallation
     try:


### PR DESCRIPTION
Remove unused variables from temporal module.
removed   F841, # local variable... from temporal/.flake8