### PR TITLE
t.vect.algebra: modified html doc

### DIFF
--- a/temporal/t.vect.algebra/t.vect.algebra.html
+++ b/temporal/t.vect.algebra/t.vect.algebra.html
@@ -31,10 +31,6 @@ of year, time differences or number of maps per time interval to build
 up conditions. These operations can be assigned to space time datasets 
 or to the results of operations between space time datasets.
 
-<p>
-The type of the input space time datasets must be defined 
-with the input parameter <b>type</b>. Possible options are STRDS, STVDS 
-or STR3DS. The default is set to space time raster datasets (STRDS). 
 <p> As default, topological relationships between space time datasets 
 will be evaluated only temporal. Use the <b>s</b> flag to activate the 
 additionally spatial topology evaluation. <p> The expression option 


### PR DESCRIPTION
 removed a paragraph talking about raster dataset types, which is not an option in this module