### PR TITLE
ci: Update setting env vars, use 20.04, C gnu17

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -30,8 +30,8 @@ jobs:
         ./Anaconda3-2020.02-Linux-x86_64.sh -b
     - name: Set variables with conda executable and activate
       run: |
-        echo "::set-env name=CONDA::/github/home/anaconda3/bin/conda"
-        echo "::set-env name=CONDA_ACTIVATE::/github/home/anaconda3/bin/activate"
+        echo "CONDA=/github/home/anaconda3/bin/conda" >> $GITHUB_ENV
+        echo "CONDA_ACTIVATE=/github/home/anaconda3/bin/activate" >> $GITHUB_ENV
     - name: Get GRASS GIS runtime conda dependencies
       run: |
         source $CONDA_ACTIVATE
@@ -41,17 +41,17 @@ jobs:
         mkdir $HOME/install
     - name: Set number of cores for compilation
       run: |
-        echo "::set-env name=MAKEFLAGS::-j$(nproc)"
+        echo "MAKEFLAGS=-j1" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "::set-env name=LD_LIBRARY_PATH::$HOME/install/lib"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
     - name: Build
       run: |
         source $CONDA_ACTIVATE
         .github/workflows/build_centos.sh $HOME/install
     - name: Add the bin directory to PATH
       run: |
-        echo "::add-path::$HOME/install/bin"
+        echo "$HOME/install/bin" >> $GITHUB_PATH
     - name: Test executing of the grass command
       run: |
         source $CONDA_ACTIVATE

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -41,7 +41,7 @@ jobs:
         mkdir $HOME/install
     - name: Set number of cores for compilation
       run: |
-        echo "MAKEFLAGS=-j1" >> $GITHUB_ENV
+        echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
         echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         os:
         - ubuntu-16.04
         - ubuntu-18.04
+        - ubuntu-20.04
       fail-fast: false
 
     steps:
@@ -29,10 +30,10 @@ jobs:
         mkdir $HOME/install
     - name: Ensure one core for compilation
       run: |
-        echo "::set-env name=MAKEFLAGS::-j1"
+        echo "MAKEFLAGS=-j1" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "::set-env name=LD_LIBRARY_PATH::$HOME/install/lib"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
     - name: Build
       run: .github/workflows/build.sh $HOME/install
 
@@ -43,8 +44,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-16.04
         - ubuntu-18.04
+        - ubuntu-20.04
       fail-fast: false
 
     steps:
@@ -60,15 +61,15 @@ jobs:
         mkdir $HOME/install
     - name: Set number of cores for compilation
       run: |
-        echo "::set-env name=MAKEFLAGS::-j$(nproc)"
+        echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "::set-env name=LD_LIBRARY_PATH::$HOME/install/lib"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
     - name: Build
       run: .github/workflows/build.sh $HOME/install
     - name: Add the bin directory to PATH
       run: |
-        echo "::add-path::$HOME/install/bin"
+        echo "$HOME/install/bin" >> $GITHUB_PATH
     - name: Test executing of the grass command
       run: .github/workflows/test_simple.sh
     - name: Run tests

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -8,13 +8,13 @@ jobs:
   build:
     name: ${{ matrix.c }} & ${{ matrix.cpp }}
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         c:
         - gnu99
         - gnu11
-        # - gnu17  # not available in Ubuntu 18.04
+        - gnu17
         cpp:
         - c++11
         - c++14
@@ -34,10 +34,10 @@ jobs:
         mkdir $HOME/install
     - name: Ensure one core for compilation
       run: |
-        echo "::set-env name=MAKEFLAGS::-j1"
+        echo "MAKEFLAGS=-j1" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "::set-env name=LD_LIBRARY_PATH::$HOME/install/lib"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
     - name: Build
       env:
         # TODO: -pedantic-errors here won't go through ./configure (with GNU C)


### PR DESCRIPTION
Update how env vars and path var are set in GitHub Actions after change in the API (fixes #1090).

Compile also on Ubuntu 20.04. Test on 20.04, but no longer on 16.04.

Use Ubuntu 20.04 for GCC to get the GNU 17 C standard.
