### PR TITLE
simwe: fix r.sim.sediment segfault, memory freeing was in wrong place

### DIFF
--- a/raster/r.sim/r.sim.sediment/main.c
+++ b/raster/r.sim/r.sim.sediment/main.c
@@ -434,6 +434,7 @@ int main(int argc, char *argv[])
 	if (ii != 1)
 	    G_fatal_error(_("Cannot write raster maps"));
     }
+    free_walkers();
 
     /* Exit with Success */
     exit(EXIT_SUCCESS);

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -533,6 +533,7 @@ int main(int argc, char *argv[])
 
     grad_check();
     main_loop();
+    free_walkers();
 
     /* Exit with Success */
     exit(EXIT_SUCCESS);

--- a/raster/r.sim/simlib/output.c
+++ b/raster/r.sim/simlib/output.c
@@ -767,7 +767,6 @@ int output_et()
 	Rast_free_colors(&colors);
 	/*  } */
     }
-    free_walkers();
 
     return 1;
 }


### PR DESCRIPTION
Needs to be eventually backported after backporting f5adfb6 and e2d6fdd.