### PR TITLE
ci: Update setting env vars, Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
     - name: Build
       run: .github/workflows/build.sh $HOME/install
     - name: Add the bin directory to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         os:
         - ubuntu-16.04
         - ubuntu-18.04
+        - ubuntu-20.04
       fail-fast: false
 
     steps:
@@ -29,10 +30,10 @@ jobs:
         mkdir $HOME/install
     - name: Ensure one core for compilation
       run: |
-        echo "::set-env name=MAKEFLAGS::-j1"
+        echo "MAKEFLAGS=-j1" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "::set-env name=LD_LIBRARY_PATH::$HOME/install/lib"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
     - name: Build
       run: .github/workflows/build.sh $HOME/install
 
@@ -45,6 +46,7 @@ jobs:
         os:
         - ubuntu-16.04
         - ubuntu-18.04
+        - ubuntu-20.04
       fail-fast: false
 
     steps:
@@ -60,15 +62,15 @@ jobs:
         mkdir $HOME/install
     - name: Set number of cores for compilation
       run: |
-        echo "::set-env name=MAKEFLAGS::-j$(nproc)"
+        echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
     - name: Set LD_LIBRARY_PATH for compilation
       run: |
-        echo "::set-env name=LD_LIBRARY_PATH::$HOME/install/lib"
+        echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV"
     - name: Build
       run: .github/workflows/build.sh $HOME/install
     - name: Add the bin directory to PATH
       run: |
-        echo "::add-path::$HOME/install/bin"
+        echo "$HOME/install/bin" >> $GITHUB_PATH
     - name: Test executing of the grass command
       run: .github/workflows/test_simple.sh
     - name: Run tests

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -8,7 +8,7 @@ jobs:
 
   flake8-lib-python:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -27,7 +27,7 @@ jobs:
 
   flake8-wxgui:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -46,7 +46,7 @@ jobs:
 
   flake8-scripts:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -65,7 +65,7 @@ jobs:
 
   flake8-temporal-modules:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Update how env vars and path var are set in GitHub Actions after change in the API (fixes #1090).

Compile and test also on Ubuntu 20.04.

Use Ubuntu 20.04 for Flake8 tests (ubuntu-20.04 will become ubuntu-latest on GH Actions soon).