### PR TITLE
g.extension: for local urls do not do get_addons_paths

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2277,7 +2277,7 @@ def main():
 
     if options['operation'] == 'add':
         check_dirs()
-        # check if extension is from official github
+        # query GitHub API only if extension will be downloaded from official GRASS GIS addon repository
         if original_url == '':
             get_addons_paths(gg_addons_base_dir=options['prefix'])
         source, url = resolve_source_code(name=options['extension'],

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2277,8 +2277,8 @@ def main():
 
     if options['operation'] == 'add':
         check_dirs()
-        # check if extension is from official github or other http/https sources
-        if original_url == '' or original_url.startswith('http'):
+        # check if extension is from official github
+        if original_url == '':
             get_addons_paths(gg_addons_base_dir=options['prefix'])
         source, url = resolve_source_code(name=options['extension'],
                                           url=original_url)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2277,7 +2277,9 @@ def main():
 
     if options['operation'] == 'add':
         check_dirs()
-        get_addons_paths(gg_addons_base_dir=options['prefix'])
+        # check if extension is from official github or other http/https sources
+        if original_url == '' or original_url.startswith('http'):
+            get_addons_paths(gg_addons_base_dir=options['prefix'])
         source, url = resolve_source_code(name=options['extension'],
                                           url=original_url)
         xmlurl = resolve_xmlurl_prefix(original_url, source=source)


### PR DESCRIPTION
If many GRASS GIS addons are installed in a loop the following error message appears:
```
g.extension url=/src/grass_plugins/v.surf.mass extension=v.surf.mass
Starting GRASS GIS...
Creating new GRASS GIS location <tmploc>...
Cleaning up temporary files...
Executing <g.extension url=/src/grass_plugins/v.surf.mass extension=v.surf.mass> ...
ERROR: Download file from
       <https://api.github.com/repos/OSGeo/grass-addons/git/trees/master?recursive=1>,
       return status code HTTP Error 403: rate limit exceeded,
Execution of <g.extension url=/src/grass_plugins/v.surf.mass extension=v.surf.mass> finished.
Cleaning up temporary files...
```
To reduce this error not all installations of addons should use `get_addons_paths`. Only information of official addons are in `https://api.github.com/repos/OSGeo/grass-addons/git/trees/master?recursive=1` because of that it should only be requested for official addons.