### PR TITLE
wxGUI/lmgr: fix add group layer during vector map editing

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1841,7 +1841,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
             if digitToolbar.GetLayer() == mapLayer:
                 self._setGradient('vdigit')
-            elif bgmap == mapLayer.GetName():
+            elif mapLayer and bgmap == mapLayer.GetName():
                 self._setGradient('bgmap')
             else:
                 self._setGradient()


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI
2. Display vector map e.g. `d.vect census`
3. Start editing census vector map
4. Add group layer

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/lmgr/layertree.py",
line 1844, in OnChangeSel

elif bgmap == mapLayer.GetName():
AttributeError
:
'NoneType' object has no attribute 'GetName'
```