### PR TITLE
Accept more numeric types in Python modules

### DIFF
--- a/lib/python/script/db.py
+++ b/lib/python/script/db.py
@@ -231,3 +231,52 @@ def db_commit_transaction(driver):
     if driver in ('sqlite', 'pg', 'mysql'):
         return 'COMMIT'
     return ''
+
+
+_SQL_INT_TYPES = [
+    "INT",
+    "INTEGER",
+    "TINYINT",
+    "SMALLINT",
+    "MEDIUMINT",
+    "BIGINT",
+    "UNSIGNED BIG INT",
+    "INT2",
+    "INT8",
+]
+
+
+_SQL_FLOAT_TYPES = [
+    "REAL",
+    "DOUBLE",
+    "DOUBLE PRECISION",
+    "FLOAT",
+    "FLOATING POINT",
+]
+
+
+_SQL_NUMERIC_TYPES = _SQL_INT_TYPES + _SQL_FLOAT_TYPES
+
+
+def sql_type_is_int(sql_type):
+    """Return True if SQL type is integral
+
+    Returns True for known integral types, False otherwise.
+    """
+    return sql_type.upper() in _SQL_INT_TYPES
+
+
+def sql_type_is_float(sql_type):
+    """Return True if SQL type is floating point
+
+    Returns True for known floating point types, False otherwise.
+    """
+    return sql_type.upper() in _SQL_FLOAT_TYPES
+
+
+def sql_type_is_numeric(sql_type):
+    """Return True if SQL type is numeric
+
+    Returns True for known integral and floating point types, False otherwise.
+    """
+    return sql_type.upper() in _SQL_NUMERIC_TYPES

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -115,7 +115,7 @@ def main():
                                 " but column <{column_name}> is {column_type}."
                                 " Use a column which is an integer"
                                 " or floating point number.").format(
-                                    column_name=cname, column_type=ctype)
+                                    column_name=cname, column_type=ctype))
     if not found:
         gscript.fatal(_("Column <%s> not found in table <%s>") % (column, table))
 

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -87,6 +87,25 @@ def sortfile(infile, outfile):
     outf.close()
 
 
+SQL_INT_TYPES = [
+    "INT",
+    "INTEGER",
+    "TINYINT",
+    "SMALLINT",
+    "MEDIUMINT",
+    "BIGINT",
+    "UNSIGNED BIG INT",
+    "INT2",
+    "INT8",
+]
+SQL_FLOAT_TYPES = [
+    "REAL",
+    "DOUBLE",
+    "DOUBLE PRECISION",
+    "FLOAT",
+    "FLOATING POINT",
+]
+
 def main():
     global tmp
     tmp = gscript.tempfile()
@@ -102,6 +121,8 @@ def main():
 
     perc = [float(p) for p in perc.split(',')]
 
+    numeric_types = SQL_INT_TYPES + SQL_FLOAT_TYPES
+
     desc_table = gscript.db_describe(table, database=database, driver=driver)
     if not desc_table:
         gscript.fatal(_("Unable to describe table <%s>") % table)
@@ -109,7 +130,7 @@ def main():
     for cname, ctype, cwidth in desc_table['cols']:
         if cname == column:
             found = True
-            if ctype not in ('INTEGER', 'DOUBLE PRECISION'):
+            if ctype not in numeric_types:
                 gscript.fatal(_("Column <%s> is not numeric") % cname)
     if not found:
         gscript.fatal(_("Column <%s> not found in table <%s>") % (column, table))

--- a/scripts/v.db.update/v.db.update.py
+++ b/scripts/v.db.update/v.db.update.py
@@ -55,6 +55,7 @@
 import sys
 import os
 import grass.script as grass
+from grass.script import sql_type_is_numeric
 
 
 def main():
@@ -104,7 +105,7 @@ def main():
         if not value:
             grass.fatal(_('Either <value> or <qcolumn> must be given'))
         # we insert a value
-        if coltype.upper() not in ["INTEGER", "DOUBLE PRECISION"]:
+        if not sql_type_is_numeric(coltype):
             value = "'%s'" % value
 
     cmd = "UPDATE %s SET %s=%s" % (table, column, value)

--- a/scripts/v.db.update/v.db.update.py
+++ b/scripts/v.db.update/v.db.update.py
@@ -118,7 +118,10 @@ def main():
         cmd = sqliteload + cmd
 
     grass.verbose("SQL: \"%s\"" % cmd)
-    grass.write_command('db.execute', input='-', database=database, driver=driver, stdin=cmd)
+    grass.write_command('db.execute', input='-',
+                        database=database, driver=driver,
+                        stdin=cmd,
+                        errors="exit")
 
     # write cmd history:
     grass.vector_history(vector)

--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -39,6 +39,7 @@ import atexit
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError
+from grass.script import sql_type_is_float
 
 
 def cleanup():
@@ -76,12 +77,15 @@ def main():
                           (int(layer), 'column'))
             layer = '1'
         try:
-            coltype = grass.vector_columns(input, layer)[column]
+            column_type = grass.vector_columns(input, layer)[column]['type']
         except KeyError:
             grass.fatal(_('Column <%s> not found') % column)
 
-        if coltype['type'] not in ('INTEGER', 'SMALLINT', 'CHARACTER', 'TEXT'):
-            grass.fatal(_("Key column must be of type integer or string"))
+        if sql_type_is_float(column_type):
+            grass.fatal(_("Column <{column}> is {column_type} and floating point"
+                          " types cannot be used for dissolving."
+                          " Use a column which is an integer or text.").format(
+                              column=column, column_type=column_type)
 
         f = grass.vector_layer_db(input, layer)
 

--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -85,7 +85,7 @@ def main():
             grass.fatal(_("Column <{column}> is {column_type} and floating point"
                           " types cannot be used for dissolving."
                           " Use a column which is an integer or text.").format(
-                              column=column, column_type=column_type)
+                              column=column, column_type=column_type))
 
         f = grass.vector_layer_db(input, layer)
 
@@ -93,15 +93,15 @@ def main():
 
         tmpfile = '%s_%s' % (output, tmp)
 
+        grass.run_command('v.reclass', input=input, output=tmpfile,
+                              layer=layer, column=column, errors="exit")
+
         try:
-            grass.run_command('v.reclass', input=input, output=tmpfile,
-                              layer=layer, column=column)
             grass.run_command('v.extract', flags='d', input=tmpfile,
-                              output=output, type='area', layer=layer)
-        except CalledModuleError as e:
-            grass.fatal(_("Final extraction steps failed."
-                          " Check above error messages and"
-                          " see following details:\n%s") % e)
+                              output=output, type='area', layer=layer, errors="exit")
+        except CalledModuleError:
+            grass.fatal(_("The final extraction step with v.extract failed."
+                          " Check above error messages."))
 
     # write cmd history:
     grass.vector_history(output)


### PR DESCRIPTION
There is more numeric types in SQL than just INTEGER and DOUBLE PRECISION, for example, typical one in SQLite is REAL, so db.univar (and v.db.univar) need to accept those too as numeric types. Currently, db.univar errors when column has type REAL, although it should just work. This PR fixes that.

v.db.update allows user to pass invalid numbers because it does apply quoting even for some numeric types such as REAL. This causes zeros being recorded in the table without any warning with SQLite backend. The new version in this PR skips quoting for more types and causes SQL syntax error when the value provided is not a number (e.g. when user puts an expression into `value` instead of `query_column`).

v.dissolve does not seem to have issues with SQLite unlike the other two (three), but it seems to me that a similar fix is needed. I reused the functions created for the other cases, but the v.dissolve case is little more complex since string types are involved too. If someone can test this with PostgreSQL or comment on it, that would be great. _The question is if v.dissolve accepts all data types it should accept?_ Maybe the best course of action is to solely rely on v.reclass for this test (and an informative error message!) or drop v.dissolve from this PR completely. Let me know what you think.

Anyway, the functionality needed for db.univar and v.db.update seems general enough, so I added the utility functions to the library (grass.script.db). (In fact, the initial implementation of this is in v.db.pyupdate, so that's another use for them.) An alternative would be to somehow mimic the `db_sqltype_to_Ctype()` from the C library or somehow wrap that in Python, but I'm not sure about the cost/benefit ratio there.

There is some more info in the individual commit messages.