### PR TITLE
wxGUI: Remove calls of unicode function which don't work in Python 3

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -493,7 +493,7 @@ class GConsole(wx.EvtHandler):
                     task = GUI(show=None).ParseCommand(command)
                 except GException as e:
                     GError(parent=self._guiparent,
-                           message=unicode(e),
+                           message=str(e),
                            showTraceback=False)
                     return
 

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -802,7 +802,7 @@ class SQLBuilderUpdate(SQLBuilder):
                     colstr = sqlstr[idx1:].strip()
 
                 cols = [col.split('=')[0].strip() for col in colstr.split(',')]
-                if unicode(value) in cols:
+                if value in cols:
                     self.text_sql.SetInsertionPoint(curspos)
                     wx.CallAfter(self.text_sql.SetFocus)
                     return

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -474,9 +474,9 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
                                     self.toComplete['cmd']).count('.')
                                 self.autoCompList.append(
                                     command.split('.', dotNumber)[-1])
-                        except UnicodeDecodeError as e:  # TODO: fix it
+                        except UnicodeDecodeError as error:
                             sys.stderr.write(
-                                DecodeString(command) + ": " + unicode(e))
+                                DecodeString(command) + ": " + str(error))
 
             except (KeyError, TypeError):
                 return

--- a/gui/wxpython/modules/extensions.py
+++ b/gui/wxpython/modules/extensions.py
@@ -215,9 +215,9 @@ class InstallExtensionWindow(wx.Frame):
                 callable=self.modelBuilder.Load,
                 url='', # self.repo.GetValue().strip(),
                 ondone=lambda event: self._fetchDone())
-        except GException as e:
+        except GException as error:
             self._fetchDone()
-            GError(unicode(e), parent=self, showTraceback=False)
+            GError(str(error), parent=self, showTraceback=False)
 
     def _fetchDone(self):
         self.tree.RefreshItems()

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -397,8 +397,8 @@ class TimelineFrame(wx.Frame):
             datasets = self._checkDatasets(datasets)
             if not datasets:
                 return
-        except GException as e:
-            GError(parent=self, message=unicode(e), showTraceback=False)
+        except GException as error:
+            GError(parent=self, message=str(error), showTraceback=False)
             return
 
         self.datasets = datasets
@@ -509,8 +509,8 @@ class TimelineFrame(wx.Frame):
             datasets = self._checkDatasets(datasets)
             if not datasets:
                 return
-        except GException as e:
-            GError(parent=self, message=unicode(e), showTraceback=False)
+        except GException as error:
+            GError(parent=self, message=str(error), showTraceback=False)
             return
         self.datasets = datasets
         self.datasetSelect.SetValue(


### PR DESCRIPTION
This removes all direct calls of unicode() function which is not
present in Python 3.

The str() function is used instead to convert from exceptions/errors to strings.
The column iteration works without any conversion in Python 3.

Additionaly, this renames variables e to error and removes a todo note to
fix exceptional case in a better way (not clear enough to be useful).
