### PR TITLE
wxGUI/dbmgr: Show proper error when table parsing failed

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -287,12 +287,24 @@ class VirtualAttributeList(ListCtrl,
 
             record = record.split(fs)
             if len(columns) != len(record):
-                GError(parent=self,
-                       message=_("Inconsistent number of columns "
-                                 "in the table <%(table)s>.") %
-                       {'table': tableName})
+                # Assuming there will be always at least one.
+                last = record[-1]
+                show_max = 3
+                if len(record) > show_max:
+                    record = record[:show_max]
+                # TODO: The real fix here is to use JSON output from v.db.select or
+                # proper CSV output and real CSV reader here (Python csv and json packages).
+                raise GException(
+                    _(
+                        "Unable to read the table <{table}> from the database due"
+                        " to seemingly inconsistent number of columns in the data transfer."
+                        " Check row: {row}..."
+                        " Likely, a newline character is present in the attribute value starting with: '{value}'"
+                        " Use the v.db.select module to investigate."
+                    ).format(table=tableName, row=" | ".join(record), value=last)
+                )
                 self.columns = {}  # because of IsEmpty method
-                return
+                return None
 
             self.AddDataRow(i, record, columns, keyId)
 


### PR DESCRIPTION
When parsing of a row fails, instead of trying to show error message
(and getting the GUI in a partially frozen state), raise exception
which the caller code expects and shows the message in a window
and allows user to continue working (although no table content is displayed).

The message also contains more details and suggests most likely cause (and fix).

This is a quick-fix. The real fix would be to use real CSV or JSON format and
parser as noted in the comment.
