### PR TITLE
r.stats.zonal and v.vect.stats: Improve documentation and interface

### DIFF
--- a/raster/r.stats.quantile/main.c
+++ b/raster/r.stats.quantile/main.c
@@ -515,6 +515,7 @@ int main(int argc, char *argv[])
     module = G_define_module();
     G_add_keyword(_("raster"));
     G_add_keyword(_("statistics"));
+    G_add_keyword(_("zonal statistics"));
     G_add_keyword(_("percentile"));
     G_add_keyword(_("quantile"));
     module->description = _("Compute category quantiles using two passes.");

--- a/raster/r.stats.zonal/r.stats.zonal.html
+++ b/raster/r.stats.zonal/r.stats.zonal.html
@@ -4,8 +4,8 @@
 floating-point "cover layer" according to how it intersects with objects
 in a "base layer". A variety of standard statistical measures are possible.
 This type of analysis is often called <em>zonal statistics</em>.
-The the zones are specified as the <b>base</b> raster map and
-the statistical are computed from cells in the <b>cover</b> raster map.
+The zones are specified as the <b>base</b> raster map and
+the statistics are computed from cells in the <b>cover</b> raster map.
 Notably, the output of this module is spatial:
 The resulting values are recorded as cell values in the <b>output</b> raster map.
 

--- a/raster/r.stats.zonal/r.stats.zonal.html
+++ b/raster/r.stats.zonal/r.stats.zonal.html
@@ -2,8 +2,12 @@
 
 <em>r.stats.zonal</em> is a tool to analyse exploratory statistics of a 
 floating-point "cover layer" according to how it intersects with objects
-in a "base layer". A variety of standard statistical measures are possible
-(called "zonal statistics" in some GIS).
+in a "base layer". A variety of standard statistical measures are possible.
+This type of analysis is often called <em>zonal statistics</em>.
+The the zones are specified as the <b>base</b> raster map and
+the statistical are computed from cells in the <b>cover</b> raster map.
+Notably, the output of this module is spatial:
+The resulting values are recorded as cell values in the <b>output</b> raster map.
 
 <h2>NOTES</H2>
 
@@ -31,11 +35,29 @@ r.colors zipcodes_elev_avg color=elevation -g
 </pre></div>
 
 <h2>SEE ALSO</h2>
-<em>
-<a href="r.quantile.html">r.quantile</a>,
-<a href="r.stats.quantile.html">r.stats.quantile</a>,
-<a href="r.statistics.html">r.statistics</a>
-</em>
+
+<ul>
+    <li>
+        <em><a href="r.stats.quantile.html">r.stats.quantile</a></em>
+        for computing quantiles in zones (objects in base raster map),
+    </li>
+    <li>
+        <em><a href="r.quantile.html">r.quantile</a></em>
+        for computing quantiles of a whole raster map,
+    </li>
+    <li>
+        <em><a href="r.statistics.html">r.statistics</a></em>
+        for categorical (integer) zonal statistics,
+    </li>
+    <li>
+        <em><a href="r.univar.html">r.univar</a></em>
+        for zonal statistics with textual (non-spatial) output,
+    </li>
+    <li>
+        <em><a href="v.vect.stats.html">v.vect.stats</a></em>
+        for statistics of vector points in vector areas.
+    </li>
+</ul>
 
 <h2>AUTHOR</h2>
 Glynn Clements

--- a/vector/v.vect.stats/main.c
+++ b/vector/v.vect.stats/main.c
@@ -200,12 +200,14 @@ int main(int argc, char *argv[])
     }
     method_opt->options = p;
     method_opt->description = _("Method for aggregate statistics");
+    method_opt->guisection = _("Statistics");
 
     point_column_opt = G_define_standard_option(G_OPT_DB_COLUMN);
     point_column_opt->key = "points_column";
     point_column_opt->label =
 	_("Column name of points map to use for statistics");
     point_column_opt->description = _("Column of points map must be numeric");
+    point_column_opt->guisection = _("Statistics");
 
     count_column_opt = G_define_standard_option(G_OPT_DB_COLUMN);
     count_column_opt->key = "count_column";
@@ -213,12 +215,14 @@ int main(int argc, char *argv[])
     count_column_opt->label = _("Column name to upload points count");
     count_column_opt->description =
 	_("Column to hold points count, must be of type integer, will be created if not existing");
+    count_column_opt->guisection = _("Statistics");
 
     stats_column_opt = G_define_standard_option(G_OPT_DB_COLUMN);
     stats_column_opt->key = "stats_column";
     stats_column_opt->label = _("Column name to upload statistics");
     stats_column_opt->description =
 	_("Column to hold statistics, must be of type double, will be created if not existing");
+    stats_column_opt->guisection = _("Statistics");
 
     fs_opt = G_define_standard_option(G_OPT_F_SEP);
     fs_opt->guisection = _("Print");

--- a/vector/v.vect.stats/v.vect.stats.html
+++ b/vector/v.vect.stats/v.vect.stats.html
@@ -240,13 +240,34 @@ associated with point, standard deviation)
 
 <h2>SEE ALSO</h2>
 
-<em>
-<a href="v.distance.html">v.distance</a>,
-<a href="r.distance.html">r.distance</a>,
-<a href="v.rast.stats.html">v.rast.stats</a>,
-<a href="v.what.vect.html">v.what.vect</a>,
-<a href="v.mkgrid.html">v.mkgrid</a>
-</em>
+<ul>
+    <li>
+        <em><a href="v.rast.stats.html">v.rast.stats</a></em>
+        for zonal statistics of raster maps using vector zones
+        (univariate statistics of a raster map),
+    </li>
+    <li>
+        <em><a href="r.stats.zonal.html">r.stats.zonal</a></em>
+        for zonal statistics of raster map using raster zones
+        (univariate statistics using two raster maps),
+    </li>
+    <li>
+        <em><a href="v.what.vect.html">v.what.vect</a></em>
+        for querying one vector map by another,
+    </li>
+    <li>
+        <em><a href="v.distance.html">v.distance</a></em>
+        for finding nearest features,
+    </li>
+    <li>
+        <em><a href="r.distance.html">r.distance</a></em>
+        for computing distances between objects in raster maps,
+    </li>
+    <li>
+        <em><a href="v.mkgrid.html">v.mkgrid</a></em>
+        for creating vector grids to aggregate point data.
+    </li>
+</ul>
 
 
 <h2>AUTHOR</h2>


### PR DESCRIPTION
Link the r.stats.zonal and v.vect.stats in doc through See also to help users
find the other one.

Extended the See also sections by adding the "see it for this and that" info.

A new Statistics guisection for v.vect.stats avoids the important options
for column names ending up in Optional.

Remove sentence _called "zonal statistics" in some GIS_ from a module which has zonal in its name. Replace by explanation of options with the zonal/zones terminology.

r.stats.quantile missed the zonal statistics keyword the others have.
