### PR TITLE
wxGUI: Replace getchildren and getiterator from ElementTree

### DIFF
--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -413,7 +413,7 @@ def _expandToolboxes(node, toolboxes):
             continue
         for subtoolbox in n.findall('./items/subtoolbox'):
             items = n.find('./items')
-            idx = items.getchildren().index(subtoolbox)
+            idx = list(items).index(subtoolbox)
 
             if has_xpath:
                 toolbox = toolboxes.find(
@@ -450,7 +450,7 @@ def _expandUserToolboxesItem(node, toolboxes):
 
     for n in node.findall('./items/user-toolboxes-list'):
         items = node.find('./items')
-        idx = items.getchildren().index(n)
+        idx = list(items).index(n)
         el = etree.Element(
             'toolbox', attrib={
                 'name': 'GeneratedUserToolboxesList'})
@@ -531,7 +531,7 @@ def _expandAddonsItem(node):
     for n in addonsTags:
         # find parent is not possible with implementation of etree (in 2.7)
         items = node.find('./menubar')
-        idx = items.getchildren().index(n)
+        idx = list(items).index(n)
         # do not set name since it is already in menudata file
         # attib={'name': 'AddonsList'}
         el = etree.Element('menu')
@@ -570,9 +570,8 @@ def _expandItems(node, items, itemTag):
 
         if moduleNode is None:  # module not available in dist
             continue
-        mItemChildren = moduleItem.getchildren()
-        tagList = [n.tag for n in mItemChildren]
-        for node in moduleNode.getchildren():
+        tagList = [n.tag for n in moduleItem]
+        for node in moduleNode:
             if node.tag not in tagList:
                 moduleItem.append(node)
 

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -209,7 +209,7 @@ class ProcessWorkspaceFile:
         :param node: display tree node
         :param inGroup: in group -> index of group item otherwise -1
         """
-        for item in node.getchildren():
+        for item in node:
             if item.tag == 'group':
                 # -> group
                 self.layers.append({

--- a/gui/wxpython/tools/update_menudata.py
+++ b/gui/wxpython/tools/update_menudata.py
@@ -73,12 +73,12 @@ def updateData(data, modules):
               'vcolors']
 
     menu_modules = list()
-    for node in data.tree.getiterator():
+    for node in data.tree.iter():
         if node.tag != 'menuitem':
             continue
 
         item = dict()
-        for child in node.getchildren():
+        for child in node:
             item[child.tag] = child.text
 
         if 'command' not in item:


### PR DESCRIPTION
Element.getchildren() and getiterator() are deprecated since Python
version 3.2 and removed in version 3.9.

Using simpler replacements list(), in, and iter().

Fixes #1119.
