### PR TITLE
g.extension: add branch option

### DIFF
--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -185,7 +185,13 @@ g.extension extension=r.stream.distance operation=remove
 Simple URL to GitHub, GitLab, Bitbucket repositories:
 
 <div class="code"><pre>
-g.extension r.example url=github.com/johnsmith/r.example
+g.extension r.example.plus url="https://github.com/wenzeslaus/r.example.plus"
+</pre></div>
+
+Simple URL to GitHub, GitLab, Bitbucket repositories from a specific (e.g. development) branch:
+
+<div class="code"><pre>
+g.extension r.example.plus url="https://github.com/wenzeslaus/r.example.plus" branch=master
 </pre></div>
 
 Simple URL to OSGeo Trac (downloads a ZIP file, requires download to be enabled in Trac):

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1464,7 +1464,11 @@ def download_source_code(source, url, name, outdev,
         try:
             response = urlopen(url)
         except URLError:
-            grass.fatal(_("Extension <%s> not found") % name)
+            # Try download add-on from 'master' branch
+            try:
+                response = urlopen(url.replace('main', 'master'))
+            except URLError:
+                grass.fatal(_("Extension <%s> not found") % name)
         with open(zip_name, 'wb') as out_file:
             shutil.copyfileobj(response, out_file)
         extract_zip(name=zip_name, directory=directory, tmpdir=tmpdir)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -255,14 +255,9 @@ def download_addons_paths_file(
                 ),
             )
         else:
-            gscript.fatal(
-                _(
-                    "Download file from <{url}>, "
-                    "return status code {code}, ".format(
-                        url=url,
-                        code=err,
-                    ),
-                ),
+            return download_addons_paths_file(
+                url=url.replace('main', 'master'),
+                response_format=response_format,
             )
     except URLError:
         gscript.fatal(
@@ -2241,7 +2236,7 @@ def get_addons_paths(gg_addons_base_dir):
     get_addons_paths.json_file = 'addons_paths.json'
 
     url = 'https://api.github.com/repos/OSGeo/grass-addons/git/trees/'\
-        'master?recursive=1'
+        'main?recursive=1'
 
     response = download_addons_paths_file(
         url=url, response_format='application/json',

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1469,7 +1469,7 @@ def download_source_code(source, url, name, outdev,
             if branch == "main":
                 try:
                     url = url.replace('main', 'master')
-                    gscript.message(_("Failed with default branch. "
+                    gscript.message(_("Expected default branch not found. "
                                     "Trying again from <{url}>...")
                                     .format(url=url))
                     response = urlopen(url)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -75,7 +75,7 @@
 #% description: Specific branch to fetch addon from (only used when fetching from git)
 #% required: no
 #% multiple: no
-#% answer: master
+#% answer: main
 #%end
 
 #%flag
@@ -1497,7 +1497,7 @@ def download_source_code(source, url, name, outdev,
 def install_extension_std_platforms(name, source, url, branch):
     """Install extension on standard platforms"""
     gisbase = os.getenv('GISBASE')
-    source_url = 'https://github.com/OSGeo/grass-addons/tree/{branch}/grass7/'.format(branch=branch)
+    source_url = 'https://github.com/OSGeo/grass-addons/tree/master/grass7/'
 
     if source == 'official':
         gscript.message(_("Fetching <%s> from "
@@ -2229,7 +2229,7 @@ def resolve_source_code(url=None, name=None, branch=None):
         return 'svn', url
 
 
-def get_addons_paths(gg_addons_base_dir, branch):
+def get_addons_paths(gg_addons_base_dir):
     """Get and save extensions paths as 'extensions_paths.json' json file
     in the $GRASS_ADDON_BASE dir. The file serves as a list of all addons,
     and their paths (mkhmtl.py tool)
@@ -2237,7 +2237,7 @@ def get_addons_paths(gg_addons_base_dir, branch):
     get_addons_paths.json_file = 'addons_paths.json'
 
     url = 'https://api.github.com/repos/OSGeo/grass-addons/git/trees/'\
-        '{branch}?recursive=1'
+        'master?recursive=1'
 
     response = download_addons_paths_file(
         url=url, response_format='application/json',

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1475,7 +1475,7 @@ def download_source_code(source, url, name, outdev,
                     response = urlopen(url)
                 except URLError:
                     grass.fatal(_("Extension <{name}> not found. Please check "
-                                  "'url' and 'branch' options".format(name)))
+                                  "'url' and 'branch' options".format(name=name)))
             else:
                 grass.fatal(_("Extension <%s> not found") % name)
 

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1474,7 +1474,7 @@ def download_source_code(source, url, name, outdev,
                                     .format(url=url))
                     response = urlopen(url)
                 except URLError:
-                    grass.fatal(_("Extension <%s> not found. Please check "
+                    grass.fatal(_("Extension <{name}> not found. Please check "
                                   "'url' and 'branch' options".format(name)))
             else:
                 grass.fatal(_("Extension <%s> not found") % name)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1470,7 +1470,7 @@ def download_source_code(source, url, name, outdev,
                 try:
                     url = url.replace('main', 'master')
                     gscript.message(_("Failed with default branch. "
-                                    "Try again from <{url}>...")
+                                    "Trying again from <{url}>...")
                                     .format(url=url))
                     response = urlopen(url)
                 except URLError:


### PR DESCRIPTION
Address #1128 and #625 by adding a 'branch' optionthat is only used when fetcing from online repos tht support branches...

Tests pass locally, and also e.g. this:
`g.extension operation=add url=https://github.com/mundialis/t.rast.mosaic branch=main extension=t.rast.mosaic`
works.

Please review.

Maybe I should add an example to the documentation? Anything else?

It is sort of a new feature, but maybe we can view lack of support for branches as a bug, after the move to git?
