### PR TITLE
wxGUI: drop show preferences dialog as modal

### DIFF
--- a/gui/wxpython/animation/frame.py
+++ b/gui/wxpython/animation/frame.py
@@ -314,7 +314,7 @@ class AnimationFrame(wx.Frame):
                 lambda: self.controller.UpdateAnimations())
             dlg.CenterOnParent()
 
-        self.dialogs['preferences'].ShowModal()
+        self.dialogs['preferences'].Show()
 
     def OnHelp(self, event):
         RunCommand('g.manual',

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -375,7 +375,7 @@ class ModelFrame(wx.Frame):
         dlg = PreferencesDialog(parent=self, giface=self._giface)
         dlg.CenterOnParent()
 
-        dlg.ShowModal()
+        dlg.Show()
         self.canvas.Refresh()
 
     def OnHelp(self, event):

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -751,7 +751,7 @@ class SwipeMapFrame(DoubleMapFrame):
             self._preferencesDialog = dlg
             self._preferencesDialog.CenterOnParent()
 
-        self._preferencesDialog.ShowModal()
+        self._preferencesDialog.Show()
 
     def OnCloseWindow(self, event):
         self.GetFirstMap().Clean()


### PR DESCRIPTION
This PR addresses an irrecoverable modal state, only to be "solved" with "force quit", on closing Preference dialog with Cancel for each of Animation Tool, Map Swipe and Graphical Modeler.

This is an issue confirmed for Mac, for 7.8.4 as well as master.

#### Steps to reproduce:

1. Open "Graphical Modeler"
2. Open "Modelers settings" in toolbar
3.  Try close "Modelers settings" dialog window with "Cancel" or with "x" button in window title bar

... the setting dialog window closes but the GUI is still in a modal state with no way out.


#### Some background

The settings dialogs concerned are all based on `PreferencesBaseDialog` (gui/wxpython/gui_core/preferences.py) and are called with `ShowModal()`. The "GUI Settings" and "NVIZ Settings" are similarly based on the same PreferencesBaseDialog class. The latter two are, however, called with `Show()` and closing with Cancel works as expected.
