### PR TITLE
g.region: Add more detail into error messages

### DIFF
--- a/lib/gis/adj_cellhd.c
+++ b/lib/gis/adj_cellhd.c
@@ -59,7 +59,9 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
     }
     else {
 	if (cellhd->rows <= 0)
-	    G_fatal_error(_("Illegal number of rows: %d"), cellhd->rows);
+	    G_fatal_error(_("Illegal number of rows: %d"
+			    " (resolution is %f)"),
+			  cellhd->rows, cellhd->ns_res);
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
@@ -68,7 +70,9 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
     }
     else {
 	if (cellhd->cols <= 0)
-	    G_fatal_error(_("Illegal number of columns: %d"), cellhd->cols);
+	    G_fatal_error(_("Illegal number of columns: %d"
+			    " (resolution is %f)"),
+			  cellhd->cols, cellhd->ew_res);
     }
 
     /* check the edge values */
@@ -173,9 +177,13 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
     }
     else {
 	if (cellhd->rows <= 0)
-	    G_fatal_error(_("Illegal number of rows: %d"), cellhd->rows);
+	    G_fatal_error(_("Illegal number of rows: %d"
+			    " (resolution is %f)"),
+			  cellhd->rows, cellhd->ns_res);
 	if (cellhd->rows3 <= 0)
-	    G_fatal_error(_("Illegal number of rows for 3D: %d"), cellhd->rows3);
+	    G_fatal_error(_("Illegal number of rows for 3D: %d"
+			    " (resolution is %f)"),
+			  cellhd->rows3, cellhd->ns_res3);
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
@@ -187,10 +195,13 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
     }
     else {
 	if (cellhd->cols <= 0)
-	    G_fatal_error(_("Illegal number of columns: %d"), cellhd->cols);
+	    G_fatal_error(_("Illegal number of columns: %d"
+			    " (resolution is %f)"),
+			  cellhd->cols, cellhd->ew_res);
 	if (cellhd->cols3 <= 0)
-	    G_fatal_error(_("Illegal number of columns for 3D: %d"),
-			  cellhd->cols);
+	    G_fatal_error(_("Illegal number of columns for 3D: %d"
+			    " (resolution is %f)"),
+			  cellhd->cols3, cellhd->ew_res3);
     }
     if (!depth_flag) {
 	if (cellhd->tb_res <= 0)

--- a/lib/gis/adj_cellhd.c
+++ b/lib/gis/adj_cellhd.c
@@ -54,33 +54,39 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
 
     if (!row_flag) {
 	if (cellhd->ns_res <= 0)
-	    G_fatal_error(_("Illegal n-s resolution value <%lf>"), cellhd->ns_res);
+	    G_fatal_error(_("Illegal n-s resolution value: %lf"), cellhd->ns_res);
     }
     else {
 	if (cellhd->rows <= 0)
-	    G_fatal_error(_("Illegal row value"));
+	    G_fatal_error(_("Illegal number of rows: %d"), cellhd->rows);
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
-	    G_fatal_error(_("Illegal e-w resolution value"));
+	    G_fatal_error(_("Illegal e-w resolution value: %lf"), cellhd->ew_res);
     }
     else {
 	if (cellhd->cols <= 0)
-	    G_fatal_error(_("Illegal col value"));
+	    G_fatal_error(_("Illegal number of columns: %d"), cellhd->cols);
     }
 
     /* check the edge values */
     if (cellhd->north <= cellhd->south) {
 	if (cellhd->proj == PROJECTION_LL)
-	    G_fatal_error(_("North must be north of South"));
+	    G_fatal_error(_("North must be north of South,"
+			    " but %lf (north) <= %lf (south"),
+			  cellhd->north, cellhd->south);
 	else
-	    G_fatal_error(_("North must be larger than South"));
+	    G_fatal_error(_("North must be larger than South,"
+			    " but %lf (north) <= %lf (south"),
+		          cellhd->north, cellhd->south);
     }
 
     ll_wrap(cellhd);
 
     if (cellhd->east <= cellhd->west)
-	G_fatal_error(_("East must be larger than West"));
+	G_fatal_error(_("East must be larger than West,"
+			" but %lf (east) <= %lf (west)"),
+		      cellhd->east, cellhd->west);
 
     /* compute rows and columns, if not set */
     if (!row_flag) {
@@ -98,8 +104,12 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
 	    cellhd->cols = 1;
     }
 
-    if (cellhd->cols < 0 || cellhd->rows < 0) {
-	G_fatal_error(_("Invalid coordinates"));
+    if (cellhd->cols < 0) {
+	G_fatal_error(_("Invalid coordinates: negative number of columns"));
+    }
+
+    if (cellhd->rows < 0) {
+	G_fatal_error(_("Invalid coordinates: negative number of rows"));
     }
 
     /* (re)compute the resolutions */

--- a/lib/gis/adj_cellhd.c
+++ b/lib/gis/adj_cellhd.c
@@ -54,24 +54,24 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
 
     if (!row_flag) {
 	if (cellhd->ns_res <= 0)
-	    G_fatal_error(_("Illegal n-s resolution value: %lf"),
+	    G_fatal_error(_("Illegal n-s resolution value: %g"),
 			  cellhd->ns_res);
     }
     else {
 	if (cellhd->rows <= 0)
 	    G_fatal_error(_("Illegal number of rows: %d"
-			    " (resolution is %f)"),
+			    " (resolution is %g)"),
 			  cellhd->rows, cellhd->ns_res);
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
-	    G_fatal_error(_("Illegal e-w resolution value: %lf"),
+	    G_fatal_error(_("Illegal e-w resolution value: %g"),
 			  cellhd->ew_res);
     }
     else {
 	if (cellhd->cols <= 0)
 	    G_fatal_error(_("Illegal number of columns: %d"
-			    " (resolution is %f)"),
+			    " (resolution is %g)"),
 			  cellhd->cols, cellhd->ew_res);
     }
 
@@ -79,11 +79,11 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
     if (cellhd->north <= cellhd->south) {
 	if (cellhd->proj == PROJECTION_LL)
 	    G_fatal_error(_("North must be north of South,"
-			    " but %lf (north) <= %lf (south"),
+			    " but %g (north) <= %g (south"),
 			  cellhd->north, cellhd->south);
 	else
 	    G_fatal_error(_("North must be larger than South,"
-			    " but %lf (north) <= %lf (south"),
+			    " but %g (north) <= %g (south"),
 		          cellhd->north, cellhd->south);
     }
 
@@ -91,7 +91,7 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
 
     if (cellhd->east <= cellhd->west)
 	G_fatal_error(_("East must be larger than West,"
-			" but %lf (east) <= %lf (west)"),
+			" but %g (east) <= %g (west)"),
 		      cellhd->east, cellhd->west);
 
     /* compute rows and columns, if not set */
@@ -169,43 +169,43 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
 
     if (!row_flag) {
 	if (cellhd->ns_res <= 0)
-	    G_fatal_error(_("Illegal n-s resolution value: %lf"),
+	    G_fatal_error(_("Illegal n-s resolution value: %g"),
 			  cellhd->ns_res);
 	if (cellhd->ns_res3 <= 0)
-	    G_fatal_error(_("Illegal n-s resolution value for 3D: %lf"),
+	    G_fatal_error(_("Illegal n-s resolution value for 3D: %g"),
 			  cellhd->ns_res3);
     }
     else {
 	if (cellhd->rows <= 0)
 	    G_fatal_error(_("Illegal number of rows: %d"
-			    " (resolution is %f)"),
+			    " (resolution is %g)"),
 			  cellhd->rows, cellhd->ns_res);
 	if (cellhd->rows3 <= 0)
 	    G_fatal_error(_("Illegal number of rows for 3D: %d"
-			    " (resolution is %f)"),
+			    " (resolution is %g)"),
 			  cellhd->rows3, cellhd->ns_res3);
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
-	    G_fatal_error(_("Illegal e-w resolution value: %lf"),
+	    G_fatal_error(_("Illegal e-w resolution value: %g"),
 			  cellhd->ew_res);
 	if (cellhd->ew_res3 <= 0)
-	    G_fatal_error(_("Illegal e-w resolution value for 3D: %lf"),
-			  cellhd->ew_res);
+	    G_fatal_error(_("Illegal e-w resolution value for 3D: %g"),
+			  cellhd->ew_res3);
     }
     else {
 	if (cellhd->cols <= 0)
 	    G_fatal_error(_("Illegal number of columns: %d"
-			    " (resolution is %f)"),
+			    " (resolution is %g)"),
 			  cellhd->cols, cellhd->ew_res);
 	if (cellhd->cols3 <= 0)
 	    G_fatal_error(_("Illegal number of columns for 3D: %d"
-			    " (resolution is %f)"),
+			    " (resolution is %g)"),
 			  cellhd->cols3, cellhd->ew_res3);
     }
     if (!depth_flag) {
 	if (cellhd->tb_res <= 0)
-	    G_fatal_error(_("Illegal t-b resolution value: %lf"),
+	    G_fatal_error(_("Illegal t-b resolution value: %g"),
 			  cellhd->tb_res);
     }
     else {
@@ -217,11 +217,11 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
     if (cellhd->north <= cellhd->south) {
 	if (cellhd->proj == PROJECTION_LL)
 	    G_fatal_error(_("North must be north of South,"
-			    " but %lf (north) <= %lf (south"),
+			    " but %g (north) <= %g (south"),
 			  cellhd->north, cellhd->south);
 	else
 	    G_fatal_error(_("North must be larger than South,"
-			    " but %lf (north) <= %lf (south"),
+			    " but %g (north) <= %g (south"),
 		          cellhd->north, cellhd->south);
     }
 
@@ -229,12 +229,12 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
 
     if (cellhd->east <= cellhd->west)
 	G_fatal_error(_("East must be larger than West,"
-			" but %lf (east) <= %lf (west)"),
+			" but %g (east) <= %g (west)"),
 		      cellhd->east, cellhd->west);
 
     if (cellhd->top <= cellhd->bottom)
 	G_fatal_error(_("Top must be larger than Bottom,"
-			" but %lf (top) <= %lf (bottom)"),
+			" but %g (top) <= %g (bottom)"),
 		      cellhd->top, cellhd->bottom);
 
     /* compute rows and columns, if not set */

--- a/lib/gis/adj_cellhd.c
+++ b/lib/gis/adj_cellhd.c
@@ -54,7 +54,8 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
 
     if (!row_flag) {
 	if (cellhd->ns_res <= 0)
-	    G_fatal_error(_("Illegal n-s resolution value: %lf"), cellhd->ns_res);
+	    G_fatal_error(_("Illegal n-s resolution value: %lf"),
+			  cellhd->ns_res);
     }
     else {
 	if (cellhd->rows <= 0)
@@ -62,7 +63,8 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
-	    G_fatal_error(_("Illegal e-w resolution value: %lf"), cellhd->ew_res);
+	    G_fatal_error(_("Illegal e-w resolution value: %lf"),
+			  cellhd->ew_res);
     }
     else {
 	if (cellhd->cols <= 0)
@@ -107,7 +109,6 @@ void G_adjust_Cell_head(struct Cell_head *cellhd, int row_flag, int col_flag)
     if (cellhd->cols < 0) {
 	G_fatal_error(_("Invalid coordinates: negative number of columns"));
     }
-
     if (cellhd->rows < 0) {
 	G_fatal_error(_("Invalid coordinates: negative number of rows"));
     }
@@ -164,52 +165,66 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
 
     if (!row_flag) {
 	if (cellhd->ns_res <= 0)
-	    G_fatal_error(_("Illegal n-s resolution value"));
+	    G_fatal_error(_("Illegal n-s resolution value: %lf"),
+			  cellhd->ns_res);
 	if (cellhd->ns_res3 <= 0)
-	    G_fatal_error(_("Illegal n-s3 resolution value"));
+	    G_fatal_error(_("Illegal n-s resolution value for 3D: %lf"),
+			  cellhd->ns_res3);
     }
     else {
 	if (cellhd->rows <= 0)
-	    G_fatal_error(_("Illegal row value"));
+	    G_fatal_error(_("Illegal number of rows: %d"), cellhd->rows);
 	if (cellhd->rows3 <= 0)
-	    G_fatal_error(_("Illegal row3 value"));
+	    G_fatal_error(_("Illegal number of rows for 3D: %d"), cellhd->rows3);
     }
     if (!col_flag) {
 	if (cellhd->ew_res <= 0)
-	    G_fatal_error(_("Illegal e-w resolution value"));
+	    G_fatal_error(_("Illegal e-w resolution value: %lf"),
+			  cellhd->ew_res);
 	if (cellhd->ew_res3 <= 0)
-	    G_fatal_error(_("Illegal e-w3 resolution value"));
+	    G_fatal_error(_("Illegal e-w resolution value for 3D: %lf"),
+			  cellhd->ew_res);
     }
     else {
 	if (cellhd->cols <= 0)
-	    G_fatal_error(_("Illegal col value"));
+	    G_fatal_error(_("Illegal number of columns: %d"), cellhd->cols);
 	if (cellhd->cols3 <= 0)
-	    G_fatal_error(_("Illegal col3 value"));
+	    G_fatal_error(_("Illegal number of columns for 3D: %d"),
+			  cellhd->cols);
     }
     if (!depth_flag) {
 	if (cellhd->tb_res <= 0)
-	    G_fatal_error(_("Illegal t-b3 resolution value"));
+	    G_fatal_error(_("Illegal t-b resolution value: %lf"),
+			  cellhd->tb_res);
     }
     else {
 	if (cellhd->depths <= 0)
-	    G_fatal_error(_("Illegal depths value"));
+	    G_fatal_error(_("Illegal depths value: %d"), cellhd->depths);
     }
 
     /* check the edge values */
     if (cellhd->north <= cellhd->south) {
 	if (cellhd->proj == PROJECTION_LL)
-	    G_fatal_error(_("North must be north of South"));
+	    G_fatal_error(_("North must be north of South,"
+			    " but %lf (north) <= %lf (south"),
+			  cellhd->north, cellhd->south);
 	else
-	    G_fatal_error(_("North must be larger than South"));
+	    G_fatal_error(_("North must be larger than South,"
+			    " but %lf (north) <= %lf (south"),
+		          cellhd->north, cellhd->south);
     }
 
     ll_wrap(cellhd);
 
     if (cellhd->east <= cellhd->west)
-	G_fatal_error(_("East must be larger than West"));
+	G_fatal_error(_("East must be larger than West,"
+			" but %lf (east) <= %lf (west)"),
+		      cellhd->east, cellhd->west);
 
     if (cellhd->top <= cellhd->bottom)
-	G_fatal_error(_("Top must be larger than Bottom"));
+	G_fatal_error(_("Top must be larger than Bottom,"
+			" but %lf (top) <= %lf (bottom)"),
+		      cellhd->top, cellhd->bottom);
 
     /* compute rows and columns, if not set */
     if (!row_flag) {
@@ -247,9 +262,14 @@ void G_adjust_Cell_head3(struct Cell_head *cellhd, int row_flag,
 	    cellhd->depths = 1;
     }
 
-    if (cellhd->cols < 0 || cellhd->rows < 0 || cellhd->cols3 < 0 ||
-	cellhd->rows3 < 0 || cellhd->depths < 0) {
-	G_fatal_error(_("Invalid coordinates"));
+    if (cellhd->cols < 0 || cellhd->cols3 < 0) {
+	G_fatal_error(_("Invalid coordinates: negative number of columns"));
+    }
+    if (cellhd->rows < 0 || cellhd->rows3 < 0) {
+	G_fatal_error(_("Invalid coordinates: negative number of rows"));
+    }
+    if (cellhd->depths < 0) {
+	G_fatal_error(_("Invalid coordinates: negative number of depths"));
     }
 
     /* (re)compute the resolutions */


### PR DESCRIPTION
Messages such as 'Illegal col value' might be sufficient for a simple g.region call,
but g.region is called at many different places indirectly and G_adjust_Cell_head, too,
so col does not make much sense anymore.

* This uses general terms (number of columns) instead of g.region options (col value).
  G_adjust_Cell_head and G_adjust_Cell_head3 are library functions after all.
* Uses message colon value syntax where possible.
* Explains why the error was triggered or shows the offending value.
