### PR TITLE
g.extension: improve way how to parse module name from makefile

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1509,6 +1509,8 @@ def install_extension_std_platforms(name, source, url):
                          outdev=outdev, directory=srcdir, tmpdir=TMPDIR)
     os.chdir(srcdir)
 
+    pgm_not_found_message = _('Module name not found.'
+                              ' Check module Makefile syntax (PGM variable).')
     # collect module names
     module_list = list()
     for r, d, f in os.walk(srcdir):
@@ -1517,9 +1519,15 @@ def install_extension_std_platforms(name, source, url):
                 # get the module name: PGM = <module name>
                 with open(os.path.join(r, 'Makefile')) as fp:
                     for line in fp.readlines():
-                        if "PGM =" in line:
-                            modulename = line.split('=')[1].strip()
-                            module_list.append(modulename)
+                        if "PGM" in line:
+                            try:
+                                modulename = line.split('=')[1].strip()
+                                if modulename:
+                                    module_list.append(modulename)
+                                else:
+                                    grass.error(pgm_not_found_message)
+                            except IndexError:
+                                grass.error(pgm_not_found_message)
 
     # change shebang from python to python3
     pyfiles = []


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. `g.extension r.sample.category`
2. Check if module is registred
 ```
GRASS nc_basic_spm_grass7/PERMANENT:~ > g.extension -a
No extension (module) installed
```
Problematic are Add-Ons which has defined PGM variable without space around '=' in the makefile. 

```
MODULE_TOPDIR = ../..

PGM=r.sample.category

include $(MODULE_TOPDIR)/include/Make/Script.make

default: script
```

List of problematic Add-Ons:

```
general/g.isis3mt/Makefile:3:PGM=g.isis3mt
general/g.copyall/Makefile:3:PGM=g.copyall
raster3d/r3.what/Makefile:3:PGM=r3.what
raster/r.green/r.green.hydro/Makefile:3:PGM=r.green.hydro
raster/r.green/r.green.biomassfor/Makefile:3:PGM=r.green.biomassfor
raster/r.green/Makefile:3:PGM=r.green
raster/r.green/r.green.gshp/Makefile:3:PGM=r.green.gshp
raster/r.vect.stats/Makefile:3:PGM=r.vect.stats
raster/r.bioclim/Makefile:3:PGM=r.bioclim
raster/r.sun.hourly/Makefile:3:PGM=r.sun.hourly
raster/r.landscape.evol/Makefile:3:PGM=r.landscape.evol
raster/r.stream.watersheds/Makefile:3:PGM=r.stream.watersheds
raster/r.surf.nnbathy/Makefile:3:PGM=r.surf.nnbathy
raster/r.out.kde/Makefile:3:PGM=r.out.kde
raster/r.landscape.evol.old/Makefile:3:PGM=r.landscape.evol.old
raster/r.out.ntv2/Makefile:3:PGM=r.out.ntv2
raster/r.lake.series/Makefile:3:PGM=r.lake.series
raster/r.local.relief/Makefile:3:PGM=r.local.relief
raster/r.stream.variables/Makefile:3:PGM=r.stream.variables
raster/r.sample.category/Makefile:3:PGM=r.sample.category
raster/r.shaded.pca/Makefile:3:PGM=r.shaded.pca
raster/r.connectivity/Makefile:3:PGM=r.connectivity
raster/r.slope.direction/Makefile:3:PGM=r.slope.direction
raster/r.sun.daily/Makefile:3:PGM=r.sun.daily
raster/r.sim.water.mp/Makefile:4:PGM=r.sim.water.mp
gui/wxpython/wx.mwprecip/Makefile:3:PGM= g.gui.mwprecip
gui/wxpython/wx.metadata/g.gui.cswbrowser/Makefile:3:PGM= g.gui.cswbrowser
gui/wxpython/wx.metadata/g.gui.metadata/Makefile:3:PGM= g.gui.metadata
display/d.vect.thematic2/Makefile:3:PGM=d.vect.thematic2
display/d.explanation.plot/Makefile:3:PGM=d.explanation.plot
vector/v.in.redwg/Makefile:3:PGM=v.in.redwg
vector/v.area.stats/Makefile:4:PGM=v.area.stats
vector/v.tin.to.rast/Makefile:3:PGM=v.tin.to.rast
vector/v.area.weigh/Makefile:3:PGM=v.area.weigh
vector/v.convert/Makefile:4:PGM=v.convert
vector/v.surf.nnbathy/Makefile:3:PGM=v.surf.nnbathy
vector/v.concave.hull/Makefile:3:PGM=v.concave.hull
imagery/i.fusion.brovey/Makefile:3:PGM=i.fusion.brovey
```

Fixes #1136.