### PR TITLE
d.vect: Apply variable color only to area fill

### DIFF
--- a/display/d.vect/area.c
+++ b/display/d.vect/area.c
@@ -216,13 +216,8 @@ int display_area(struct Map_info *Map, struct cat_list *Clist, const struct Cell
 
 	/* boundary */
 	if (bcolor) {
-	    if (custom_rgb) {
-		D_RGB_color((unsigned char)red, (unsigned char)grn,
-			    (unsigned char)blu);
-	    }
-	    else {
-		D_RGB_color(bcolor->r, bcolor->g, bcolor->b);
-	    }
+	    /* Use the boundary color regardless of color table, RGB col... */
+	    D_RGB_color(bcolor->r, bcolor->g, bcolor->b);
 	    /* use different user defined render methods */
 	    D_polyline_abs(APoints->x, APoints->y, APoints->n_points);
 	    for (i = 0; i < n_isles; i++) {


### PR DESCRIPTION
Always use (respect) the color option for the area boundary and apply color table
and other variable color options only to the area fill (as fill_color).
