### PR TITLE
g.extension: remove branch from Windows-function

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1231,8 +1231,7 @@ def install_extension_win(name):
     os.chdir(TMPDIR)  # this is just to not leave something behind
     srcdir = os.path.join(TMPDIR, name)
     download_source_code(source=source, url=url, name=name,
-                         outdev=outdev, directory=srcdir, tmpdir=TMPDIR,
-                         branch=branch)
+                         outdev=outdev, directory=srcdir, tmpdir=TMPDIR)
 
     # collect module names and file names
     module_list = list()


### PR DESCRIPTION
fix #1150

Unfortunately, I have no Windows box available for testing. So I tested the function i Python like this:

```
import imp
g_extension = imp.load_source('g.extension', '/opt/src/grass_ninsbl_git/scripts/g.extension/g.extension.py'
g_extension.options = {"extension":"r.in.gbif","operation": "add", "prefix": "/tmp/"}         
g_extension.build_platform = 'x86_64'   
g_extension.version = "784"     
g_extension.TMPDIR = "/tmp/" 
g_extension.install_extension_win("v.in.gbif")
```

Tests for downloading from online repos should be added. See also: #625 