### PR TITLE
g.extension: add tests for download from various sources

### DIFF
--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -121,6 +121,29 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             self.assertFileExists(file)
 
     @unittest.skipIf(skip, "Skipping as chosen...")
+    def test_github_install_official_multimodule(self):
+        """Test installing multi-module extension from official addons repository"""
+        i_sentinel_files = [
+            os.path.join(
+                self.install_prefix, "scripts", "i.sentinel.parallel.download"
+            ),
+            os.path.join(
+                self.install_prefix, "docs", "html", "i.sentinel.parallel.download.html"
+            ),
+            os.path.join(self.install_prefix, "scripts", "i.sentinel.import"),
+            os.path.join(self.install_prefix, "docs", "html", "i.sentinel.import.html"),
+        ]
+        self.assertModule(
+            "g.extension", extension="i.sentinel", url=None, prefix=self.install_prefix
+        )
+
+        for file in i_sentinel_files:
+            self.assertFileExists(file)
+            if not file.endswith("html"):
+                print(file)
+                self.assertModule(file, **{"help": True})
+
+    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_windows_install(self):
         """Test function for installing extension on MS Windows"""
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -59,7 +59,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         self.assertModule(
             "g.extension",
-            extension="r.plus.example",
+            extension="r.example.plus",
             url="https://github.com/wenzeslaus/r.example.plus",
             prefix=self.install_prefix,
         )
@@ -67,7 +67,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         # Modules with non-standard branch would be good for testing...
         self.assertModule(
             "g.extension",
-            extension="r.plus.example",
+            extension="r.example.plus",
             url="https://github.com/wenzeslaus/r.example.plus",
             prefix=self.install_prefix,
             branch="main",
@@ -81,7 +81,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         """Test installing extension from gitlab"""
         self.assertModule(
             "g.extension",
-            extension="r.plus.example",
+            extension="r.example.plus",
             url="https://gitlab.com/vpetras/r.example.plus",
             prefix=self.install_prefix,
         )
@@ -114,7 +114,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             os.path.join(self.install_prefix, "docs", "html", "r.clip.html"),
         ]
         self.assertModule(
-            "g.extension", extension="r.clip", url=None, prefix=self.install_prefix
+            "g.extension", extension="v.in.gbif", url=None, prefix=self.install_prefix
         )
 
         for file in r_clip_files:
@@ -165,7 +165,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             "prefix": self.install_prefix,
         }
         g_extension.build_platform = "x86_64"
-        g_extension.version = "784"
+        g_extension.version = "785"
         g_extension.TMPDIR = self.install_prefix
         g_extension.install_extension_win("v.in.gbif")
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -1,5 +1,5 @@
 """
-TEST:      test_addons_modules.py
+TEST:      test_addons_download.py
 
 AUTHOR(S): Stefan Blumentrath <stefan dot blumentrath at nina dot no)
            based on test_addons_modules.py by

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -1,0 +1,156 @@
+"""
+TEST:      test_addons_modules.py
+
+AUTHOR(S): Stefan Blumentrath <stefan dot blumentrath at nina dot no)
+           based on test_addons_modules.py by
+           Vaclav Petras <wenzeslaus gmail com>
+
+PURPOSE:   Test for g.extension individual modules/extensions download
+
+COPYRIGHT: (C) 2020 Stefan Blumentrath, Vaclav Petras,
+           and by the GRASS Development Team
+
+           This program is free software under the GNU General Public
+           License (>=v2). Read the file COPYING that comes with GRASS
+           for details.
+"""
+
+import os
+import imp
+from distutils.spawn import find_executable
+import unittest
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+from grass.gunittest.utils import silent_rmtree
+
+# Set to True if test is supposed to run
+skip = False
+
+
+class TestModuleDownloadFromDifferentSources(TestCase):
+
+    url = "https://github.com/wenzeslaus/r.example.plus"
+    path = os.path.join("data", "sample_modules")
+    # MS Windows install function requires absolute paths
+    install_prefix = os.path.abspath("gextension_test_install_path")
+
+    files = [
+        os.path.join(install_prefix, "scripts", "r.example.plus"),
+        os.path.join(install_prefix, "docs", "html", "r.example.plus.html"),
+    ]
+
+    def setUp(self):
+        """Make sure we are not dealing with some old files"""
+        if os.path.exists(self.install_prefix):
+            files = os.listdir(self.install_prefix)
+            if files:
+                RuntimeError(
+                    "Install prefix path '{}' contains files {}".format(
+                        self.install_prefix, files
+                    )
+                )
+
+    def tearDown(self):
+        """Remove created files"""
+        silent_rmtree(self.install_prefix)
+
+    @unittest.skipIf(skip, "Skipping as chosen...")
+    def test_github_install(self):
+        """Test installing extension from github"""
+
+        self.assertModule(
+            "g.extension",
+            extension="r.plus.example",
+            url="https://github.com/wenzeslaus/r.example.plus",
+            prefix=self.install_prefix,
+        )
+
+        # Modules with non-standard branch would be good for testing...
+        self.assertModule(
+            "g.extension",
+            extension="r.plus.example",
+            url="https://github.com/wenzeslaus/r.example.plus",
+            prefix=self.install_prefix,
+            branch="main",
+        )
+
+        for file in self.files:
+            self.assertFileExists(file)
+
+    @unittest.skipIf(skip, "Skipping as chosen...")
+    def test_gitlab_install(self):
+        """Test installing extension from gitlab"""
+        self.assertModule(
+            "g.extension",
+            extension="r.plus.example",
+            url="https://gitlab.com/vpetras/r.example.plus",
+            prefix=self.install_prefix,
+        )
+
+        for file in self.files:
+            self.assertFileExists(file)
+
+    @unittest.skipIf(skip, "Skipping as chosen...")
+    def test_bitbucket_install(self):
+        """Test installing extension from bitbucket"""
+        d_rast_files = [
+            os.path.join(self.install_prefix, "scripts", "r.sim.stats"),
+            os.path.join(self.install_prefix, "docs", "html", "r.sim.stats.html"),
+        ]
+        self.assertModule(
+            "g.extension",
+            extension="r.sim.stats",
+            url="https://bitbucket.org/lrntct/r.sim.stats",
+            prefix=self.install_prefix,
+        )
+
+        for file in d_rast_files:
+            self.assertFileExists(file)
+
+    @unittest.skipIf(skip, "Skipping as chosen...")
+    def test_github_install_official(self):
+        """Test installing extension from official addons repository"""
+        r_clip_files = [
+            os.path.join(self.install_prefix, "scripts", "r.clip"),
+            os.path.join(self.install_prefix, "docs", "html", "r.clip.html"),
+        ]
+        self.assertModule(
+            "g.extension", extension="r.clip", url=None, prefix=self.install_prefix
+        )
+
+        for file in r_clip_files:
+            self.assertFileExists(file)
+
+    @unittest.skipIf(skip, "Skipping as chosen...")
+    def test_windows_install(self):
+        """Test function for installing extension on MS Windows"""
+
+        if not os.path.exists(self.install_prefix):
+            os.mkdir(self.install_prefix)
+
+        v_in_gbif_files = [
+            os.path.join(self.install_prefix, "v.in.gbif", "bin", "v.in.gbif.bat"),
+            os.path.join(self.install_prefix, "v.in.gbif", "scripts", "v.in.gbif.py"),
+            os.path.join(
+                self.install_prefix, "v.in.gbif", "docs", "html", "v.in.gbif.html"
+            ),
+        ]
+        g_extension_path = find_executable("g.extension")
+        g_extension = imp.load_source("g.extension", g_extension_path)
+        g_extension.options = {
+            "extension": "v.in.gbif",
+            "operation": "add",
+            "prefix": self.install_prefix,
+        }
+        g_extension.build_platform = "x86_64"
+        g_extension.version = "784"
+        g_extension.TMPDIR = self.install_prefix
+        g_extension.install_extension_win("v.in.gbif")
+
+        for file in v_in_gbif_files:
+            self.assertFileExists(file)
+
+
+if __name__ == "__main__":
+    test()

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -24,8 +24,8 @@ from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.utils import silent_rmtree
 
-# Set to True if test is supposed to run
-skip = False
+# Set to False if test is supposed to run
+skip = True
 
 
 class TestModuleDownloadFromDifferentSources(TestCase):

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -30,8 +30,6 @@ skip = True
 
 class TestModuleDownloadFromDifferentSources(TestCase):
 
-    url = "https://github.com/wenzeslaus/r.example.plus"
-    path = os.path.join("data", "sample_modules")
     # MS Windows install function requires absolute paths
     install_prefix = os.path.abspath("gextension_test_install_path")
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -16,16 +16,12 @@ COPYRIGHT: (C) 2020 Stefan Blumentrath, Vaclav Petras,
 """
 
 import os
-import imp
+from importlib.machinery import SourceFileLoader
 from distutils.spawn import find_executable
-import unittest
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.utils import silent_rmtree
-
-# Set to False if test is supposed to run
-skip = True
 
 
 class TestModuleDownloadFromDifferentSources(TestCase):
@@ -53,7 +49,6 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         """Remove created files"""
         silent_rmtree(self.install_prefix)
 
-    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_github_install(self):
         """Test installing extension from github"""
 
@@ -70,13 +65,11 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             extension="r.example.plus",
             url="https://github.com/wenzeslaus/r.example.plus",
             prefix=self.install_prefix,
-            branch="main",
         )
 
         for file in self.files:
             self.assertFileExists(file)
 
-    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_gitlab_install(self):
         """Test installing extension from gitlab"""
         self.assertModule(
@@ -89,7 +82,6 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in self.files:
             self.assertFileExists(file)
 
-    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_bitbucket_install(self):
         """Test installing extension from bitbucket"""
         d_rast_files = [
@@ -106,21 +98,17 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in d_rast_files:
             self.assertFileExists(file)
 
-    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_github_install_official(self):
-        """Test installing extension from official addons repository"""
-        r_clip_files = [
-            os.path.join(self.install_prefix, "scripts", "r.clip"),
-            os.path.join(self.install_prefix, "docs", "html", "r.clip.html"),
+        """Test installing C-extension from official addons repository"""
+        r_gdd_files = [
+            os.path.join(self.install_prefix, "bin", "r.gdd"),
+            os.path.join(self.install_prefix, "docs", "html", "r.gdd.html"),
         ]
-        self.assertModule(
-            "g.extension", extension="v.in.gbif", url=None, prefix=self.install_prefix
-        )
+        self.assertModule("g.extension", extension="r.gdd", prefix=self.install_prefix)
 
-        for file in r_clip_files:
+        for file in r_gdd_files:
             self.assertFileExists(file)
 
-    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_github_install_official_multimodule(self):
         """Test installing multi-module extension from official addons repository"""
         i_sentinel_files = [
@@ -134,7 +122,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             os.path.join(self.install_prefix, "docs", "html", "i.sentinel.import.html"),
         ]
         self.assertModule(
-            "g.extension", extension="i.sentinel", url=None, prefix=self.install_prefix
+            "g.extension", extension="i.sentinel", prefix=self.install_prefix
         )
 
         for file in i_sentinel_files:
@@ -143,7 +131,6 @@ class TestModuleDownloadFromDifferentSources(TestCase):
                 print(file)
                 self.assertModule(file, **{"help": True})
 
-    @unittest.skipIf(skip, "Skipping as chosen...")
     def test_windows_install(self):
         """Test function for installing extension on MS Windows"""
 
@@ -158,7 +145,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             ),
         ]
         g_extension_path = find_executable("g.extension")
-        g_extension = imp.load_source("g.extension", g_extension_path)
+        g_extension = SourceFileLoader("g.extension", g_extension_path).load_module()
         g_extension.options = {
             "extension": "v.in.gbif",
             "operation": "add",

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -133,7 +133,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in files:
             self.assertFileExists(file)
-            if not str(file).endswith("html"):
+            if not file.suffix == "html":
                 self.assertModule(str(file), help=True)
 
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -131,39 +131,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in files:
             self.assertFileExists(file)
             if not str(file).endswith("html"):
-                print(file)
-                self.assertModule(file, help=True)
-
-    def test_windows_install(self):
-        """Test function for installing extension on MS Windows
-
-        The purpose of this function is to enable tests for
-        downloads of addons on MS Windows, even when developing
-        on other platforms. It loads g.extension as a module and
-        finally executes the install_extension_win() function."""
-
-        if not self.install_prefix.exists():
-            self.install_prefix.mkdir(parents=False)
-
-        files = [
-            self.install_prefix.joinpath("v.in.gbif", "bin", "v.in.gbif.bat"),
-            self.install_prefix.joinpath("v.in.gbif", "scripts", "v.in.gbif.py"),
-            self.install_prefix.joinpath("v.in.gbif", "docs", "html", "v.in.gbif.html"),
-        ]
-        g_extension_path = shutil.which("g.extension")
-        g_extension = SourceFileLoader("g.extension", g_extension_path).load_module()
-        g_extension.options = {
-            "extension": "v.in.gbif",
-            "operation": "add",
-            "prefix": str(self.install_prefix),
-        }
-        g_extension.build_platform = "x86_64"
-        g_extension.version = gscript.version()["version"].replace(".", "")
-        g_extension.TMPDIR = str(self.install_prefix)
-        g_extension.install_extension_win("v.in.gbif")
-
-        for file in files:
-            self.assertFileExists(file)
+                self.assertModule(str(file), help=True)
 
 
 if __name__ == "__main__":

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -104,7 +104,9 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             os.path.join(self.install_prefix, "bin", "r.gdd"),
             os.path.join(self.install_prefix, "docs", "html", "r.gdd.html"),
         ]
-        self.assertModule("g.extension", extension="r.gdd", prefix=self.install_prefix)
+        self.assertModule(
+            "g.extension", extension="r.clip", prefix=self.install_prefix
+        )
 
         for file in r_gdd_files:
             self.assertFileExists(file)

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -104,9 +104,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             os.path.join(self.install_prefix, "bin", "r.gdd"),
             os.path.join(self.install_prefix, "docs", "html", "r.gdd.html"),
         ]
-        self.assertModule(
-            "g.extension", extension="r.clip", prefix=self.install_prefix
-        )
+        self.assertModule("g.extension", extension="r.clip", prefix=self.install_prefix)
 
         for file in r_gdd_files:
             self.assertFileExists(file)

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -52,7 +52,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         """Remove created files"""
         silent_rmtree(str(self.install_prefix))
 
-    @unittest.skipIf(ms_windows)
+    @unittest.skipIf(ms_windows, "currently not supported on MS Windows")
     def test_github_install(self):
         """Test installing extension from github"""
 
@@ -74,7 +74,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in self.files:
             self.assertFileExists(file)
 
-    @unittest.skipIf(ms_windows)
+    @unittest.skipIf(ms_windows, "currently not supported on MS Windows")
     def test_gitlab_install(self):
         """Test installing extension from gitlab"""
         self.assertModule(
@@ -87,7 +87,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in self.files:
             self.assertFileExists(file)
 
-    @unittest.skipIf(ms_windows)
+    @unittest.skipIf(ms_windows, "currently not supported on MS Windows")
     def test_bitbucket_install(self):
         """Test installing extension from bitbucket"""
         files = [

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -7,7 +7,7 @@ AUTHOR(S): Stefan Blumentrath <stefan dot blumentrath at nina dot no)
 
 PURPOSE:   Test for g.extension individual modules/extensions download
 
-COPYRIGHT: (C) 2020 Stefan Blumentrath, Vaclav Petras,
+COPYRIGHT: (C) 2022 Stefan Blumentrath, Vaclav Petras,
            and by the GRASS Development Team
 
            This program is free software under the GNU General Public
@@ -33,8 +33,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
     install_prefix = Path("gextension_test_install_path").absolute()
 
     files = [
-        install_prefix.joinpath("scripts", "r.example.plus"),
-        install_prefix.joinpath("docs", "html", "r.example.plus.html"),
+        install_prefix / "scripts" / "r.example.plus",
+        install_prefix / "docs" / "html" / "r.example.plus.html",
     ]
 
     def setUp(self):
@@ -43,9 +43,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             files = list(path.name for path in self.install_prefix.iterdir())
             if files:
                 RuntimeError(
-                    "Install prefix path '{}' contains files {}".format(
-                        str(self.install_prefix), files
-                    )
+                    f"Install prefix path '{self.install_prefix}' \
+                    contains files {','.join(files)}"
                 )
 
     def tearDown(self):
@@ -55,13 +54,6 @@ class TestModuleDownloadFromDifferentSources(TestCase):
     @unittest.skipIf(ms_windows, "currently not supported on MS Windows")
     def test_github_install(self):
         """Test installing extension from github"""
-
-        self.assertModule(
-            "g.extension",
-            extension="r.example.plus",
-            url="https://github.com/wenzeslaus/r.example.plus",
-            prefix=str(self.install_prefix),
-        )
 
         # Modules with non-standard branch would be good for testing...
         self.assertModule(
@@ -91,8 +83,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
     def test_bitbucket_install(self):
         """Test installing extension from bitbucket"""
         files = [
-            self.install_prefix.joinpath("scripts", "r.sim.stats"),
-            self.install_prefix.joinpath("docs", "html", "r.sim.stats.html"),
+            self.install_prefix / "scripts" / "r.sim.stats",
+            self.install_prefix / "docs" / "html" / "r.sim.stats.html",
         ]
         self.assertModule(
             "g.extension",
@@ -107,8 +99,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
     def test_github_install_official(self):
         """Test installing C-extension from official addons repository"""
         files = [
-            self.install_prefix.joinpath("bin", "r.gdd"),
-            self.install_prefix.joinpath("docs", "html", "r.gdd.html"),
+            self.install_prefix / "bin" / "r.gdd",
+            self.install_prefix / "docs" / "html" / "r.gdd.html",
         ]
         self.assertModule(
             "g.extension", extension="r.gdd", prefix=str(self.install_prefix)
@@ -120,12 +112,10 @@ class TestModuleDownloadFromDifferentSources(TestCase):
     def test_github_install_official_multimodule(self):
         """Test installing multi-module extension from official addons repository"""
         files = [
-            self.install_prefix.joinpath("scripts", "i.sentinel.parallel.download"),
-            self.install_prefix.joinpath(
-                "docs", "html", "i.sentinel.parallel.download.html"
-            ),
-            self.install_prefix.joinpath("scripts", "i.sentinel.import"),
-            self.install_prefix.joinpath("docs", "html", "i.sentinel.import.html"),
+            self.install_prefix / "scripts" / "i.sentinel.parallel.download",
+            self.install_prefix / "docs" / "html" / "i.sentinel.parallel.download.html",
+            self.install_prefix / "scripts" / "i.sentinel.import",
+            self.install_prefix / "docs" / "html" / "i.sentinel.import.html",
         ]
         self.assertModule(
             "g.extension", extension="i.sentinel", prefix=str(self.install_prefix)
@@ -133,7 +123,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in files:
             self.assertFileExists(file)
-            if not file.suffix == "html":
+            if not file.suffix == ".html":
                 self.assertModule(str(file), help=True)
 
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -15,16 +15,16 @@ COPYRIGHT: (C) 2020 Stefan Blumentrath, Vaclav Petras,
            for details.
 """
 
-import shutil
+import sys
+import unittest
 
 from pathlib import Path
-from importlib.machinery import SourceFileLoader
-
-import grass.script as gscript
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.utils import silent_rmtree
+
+ms_windows = sys.platform == "win32"
 
 
 class TestModuleDownloadFromDifferentSources(TestCase):
@@ -52,6 +52,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         """Remove created files"""
         silent_rmtree(str(self.install_prefix))
 
+    @unittest.skipIf(ms_windows)
     def test_github_install(self):
         """Test installing extension from github"""
 
@@ -73,6 +74,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in self.files:
             self.assertFileExists(file)
 
+    @unittest.skipIf(ms_windows)
     def test_gitlab_install(self):
         """Test installing extension from gitlab"""
         self.assertModule(
@@ -85,6 +87,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         for file in self.files:
             self.assertFileExists(file)
 
+    @unittest.skipIf(ms_windows)
     def test_bitbucket_install(self):
         """Test installing extension from bitbucket"""
         files = [

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -21,7 +21,7 @@ from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.utils import silent_rmtree
 
-ms_windows = sys.platform == "win32"
+ms_windows = sys.platform == "win32" or sys.platform == "cygwin"
 
 
 class TestModuleDownloadFromDifferentSources(TestCase):
@@ -107,7 +107,6 @@ class TestModuleDownloadFromDifferentSources(TestCase):
     def test_github_install_official(self):
         """Test installing C-extension from official addons repository"""
         files = [
-            self.install_prefix / "bin" / "r.gdd",
             self.install_prefix / "docs" / "html" / "r.gdd.html",
         ]
         if ms_windows:

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -27,6 +27,7 @@ ms_windows = sys.platform == "win32"
 class TestModuleDownloadFromDifferentSources(TestCase):
     """Tests if addons are downloaded and installed successfully
     by checking that respective files are present in the prefix directory
+    and that the addon starts (help is printed)
     Based on test_addons_modules.py bym Vaclav Petras <wenzeslaus gmail com>
     """
 
@@ -66,6 +67,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in self.files:
             self.assertFileExists(file)
+            if file.suffix != ".html":
+                self.assertModule(str(file), help=True)
 
     @unittest.skipIf(ms_windows, "currently not supported on MS Windows")
     def test_gitlab_install(self):
@@ -79,6 +82,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in self.files:
             self.assertFileExists(file)
+            if file.suffix != ".html":
+                self.assertModule(str(file), help=True)
 
     @unittest.skipIf(ms_windows, "currently not supported on MS Windows")
     def test_bitbucket_install(self):
@@ -96,6 +101,8 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in files:
             self.assertFileExists(file)
+            if file.suffix != ".html":
+                self.assertModule(str(file), help=True)
 
     def test_github_install_official(self):
         """Test installing C-extension from official addons repository"""
@@ -103,28 +110,50 @@ class TestModuleDownloadFromDifferentSources(TestCase):
             self.install_prefix / "bin" / "r.gdd",
             self.install_prefix / "docs" / "html" / "r.gdd.html",
         ]
+        if ms_windows:
+            files.append(self.install_prefix / "bin" / "r.gdd.exe")
+        else:
+            files.append(self.install_prefix / "bin" / "r.gdd")
+
         self.assertModule(
             "g.extension", extension="r.gdd", prefix=str(self.install_prefix)
         )
 
         for file in files:
             self.assertFileExists(file)
+            if file.suffix != ".html":
+                self.assertModule(str(file), help=True)
 
     def test_github_install_official_multimodule(self):
         """Test installing multi-module extension from official addons repository"""
         files = [
-            self.install_prefix / "scripts" / "i.sentinel.parallel.download",
             self.install_prefix / "docs" / "html" / "i.sentinel.parallel.download.html",
-            self.install_prefix / "scripts" / "i.sentinel.import",
             self.install_prefix / "docs" / "html" / "i.sentinel.import.html",
         ]
+        if ms_windows:
+            files.extend(
+                [
+                    self.install_prefix / "scripts" / "i.sentinel.parallel.download.py",
+                    self.install_prefix / "scripts" / "i.sentinel.import.py",
+                    self.install_prefix / "bin" / "i.sentinel.parallel.download.bat",
+                    self.install_prefix / "bin" / "i.sentinel.import.bat",
+                ]
+            )
+        else:
+            files.extend(
+                [
+                    self.install_prefix / "scripts" / "i.sentinel.parallel.download",
+                    self.install_prefix / "scripts" / "i.sentinel.import",
+                ]
+            )
+
         self.assertModule(
             "g.extension", extension="i.sentinel", prefix=str(self.install_prefix)
         )
 
         for file in files:
             self.assertFileExists(file)
-            if not file.suffix == ".html":
+            if file.suffix != ".html" and file.suffix != ".py":
                 self.assertModule(str(file), help=True)
 
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -2,13 +2,10 @@
 TEST:      test_addons_download.py
 
 AUTHOR(S): Stefan Blumentrath <stefan dot blumentrath at nina dot no)
-           based on test_addons_modules.py by
-           Vaclav Petras <wenzeslaus gmail com>
 
 PURPOSE:   Test for g.extension individual modules/extensions download
 
-COPYRIGHT: (C) 2022 Stefan Blumentrath, Vaclav Petras,
-           and by the GRASS Development Team
+COPYRIGHT: (C) 2022 Stefan Blumentrath and by the GRASS Development Team
 
            This program is free software under the GNU General Public
            License (>=v2). Read the file COPYING that comes with GRASS
@@ -28,6 +25,10 @@ ms_windows = sys.platform == "win32"
 
 
 class TestModuleDownloadFromDifferentSources(TestCase):
+    """Tests if addons are downloaded and installed successfully
+    by checking that respective files are present in the prefix directory
+    Based on test_addons_modules.py bym Vaclav Petras <wenzeslaus gmail com>
+    """
 
     # MS Windows install function requires absolute paths
     install_prefix = Path("gextension_test_install_path").absolute()


### PR DESCRIPTION
This PR adds test for downloading addons from:
- github
- gitlab
- bitbucket and
- the official addon repository as well as
- for MS Windows

Cause I was not sure if tests that download content from the internet are acceptable I deactivated tests by default. So devs would have to activate them by setting skip to False.
