### PR TITLE
wxGUI/PyShell: check for wxPython version

### DIFF
--- a/gui/wxpython/lmgr/pyshell.py
+++ b/gui/wxpython/lmgr/pyshell.py
@@ -45,17 +45,17 @@ class PyShellWindow(wx.Panel):
         self.intro = _("Welcome to wxGUI Interactive Python Shell %s") % VERSION + "\n\n" + \
             _("Type %s for more GRASS scripting related information.") % "\"help(gs)\"" + "\n" + \
             _("Type %s to add raster or vector to the layer tree.") % "\"AddLayer()\"" + "\n\n"
+
+        shellargs = dict(
+            parent=self,
+            id=wx.ID_ANY,
+            introText=self.intro,
+            locals={"gs": grass, "AddLayer": self.AddLayer},
+        )
+        # useStockId (available since wxPython 4.0.2) should be False on macOS
         if sys.platform == "darwin" and CheckWxVersion([4, 0, 2]):
-            self.shell = PyShell(parent=self, id=wx.ID_ANY,
-                                 introText=self.intro,
-                                 locals={'gs': grass,
-                                         'AddLayer': self.AddLayer},
-                                 useStockId=False)
-        else:
-            self.shell = PyShell(parent=self, id=wx.ID_ANY,
-                                 introText=self.intro,
-                                 locals={'gs': grass,
-                                         'AddLayer': self.AddLayer})
+            shellargs["useStockId"] = False
+        self.shell = PyShell(**shellargs)
 
         sys.displayhook = self._displayhook
 

--- a/gui/wxpython/lmgr/pyshell.py
+++ b/gui/wxpython/lmgr/pyshell.py
@@ -30,6 +30,7 @@ import grass.script as grass
 from grass.script.utils import try_remove
 
 from gui_core.wrap import Button, ClearButton
+from core.globalvar import CheckWxVersion
 
 
 class PyShellWindow(wx.Panel):
@@ -44,12 +45,17 @@ class PyShellWindow(wx.Panel):
         self.intro = _("Welcome to wxGUI Interactive Python Shell %s") % VERSION + "\n\n" + \
             _("Type %s for more GRASS scripting related information.") % "\"help(gs)\"" + "\n" + \
             _("Type %s to add raster or vector to the layer tree.") % "\"AddLayer()\"" + "\n\n"
-        # useStockId should be False on macOS
-        self.shell = PyShell(parent=self, id=wx.ID_ANY,
-                             introText=self.intro,
-                             locals={'gs': grass,
-                                     'AddLayer': self.AddLayer},
-                             useStockId=(sys.platform != "darwin"))
+        if sys.platform == "darwin" and CheckWxVersion([4, 0, 2]):
+            self.shell = PyShell(parent=self, id=wx.ID_ANY,
+                                 introText=self.intro,
+                                 locals={'gs': grass,
+                                         'AddLayer': self.AddLayer},
+                                 useStockId=False)
+        else:
+            self.shell = PyShell(parent=self, id=wx.ID_ANY,
+                                 introText=self.intro,
+                                 locals={'gs': grass,
+                                         'AddLayer': self.AddLayer})
 
         sys.displayhook = self._displayhook
 


### PR DESCRIPTION
Add a wxPython version check on using `useStockId` parameter on (Py)Shell init call.

Fixes #1156