### PR TITLE
wxGUI: fix wxPython 4.1 support

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -368,8 +368,7 @@ class NewVectorDialog(VectorDialog):
                 proportion=0,
                 flag=wx.ALIGN_CENTER_VERTICAL)
             keySizer.AddSpacer(10)
-            keySizer.Add(self.keycol, proportion=0,
-                         flag=wx.ALIGN_RIGHT)
+            keySizer.Add(self.keycol, proportion=0)
             self.dataSizer.Add(keySizer, proportion=1,
                                flag=wx.EXPAND | wx.ALL, border=1)
 

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -756,7 +756,7 @@ class GdalOutputDialog(wx.Dialog):
         dialogSizer.Add(
             btnSizer,
             proportion=0,
-            flag=wx.ALIGN_CENTER_VERTICAL | wx.BOTTOM | wx.TOP | wx.ALIGN_RIGHT,
+            flag=wx.BOTTOM | wx.TOP | wx.ALIGN_RIGHT,
             border=10)
 
         self.panel.SetAutoLayout(True)


### PR DESCRIPTION
The "Create new vector map" dialog collapses with wxPython 4.1 because of bad alignment flag. This PR addresses this.

Failure using Python:
```
3.8.2 (default, Sep 24 2020, 19:37:08) 
[Clang 12.0.0 (clang-1200.0.32.21)]
4.1.0 osx-cocoa (phoenix) wxWidgets 3.1.4
```

<img width="415" alt="Screenshot" src="https://user-images.githubusercontent.com/14186207/101461008-9b38a800-393a-11eb-9c25-046ba855ab3c.png">

```
Traceback (most recent call last):
  File "/Library/Python/3.8/site-packages/wx/core.py", line
3383, in <lambda>

lambda event: event.callable(*event.args, **event.kw) )
  File
"/usr/local/grass79/gui/wxpython/gui_core/dialogs.py", line
371, in _layout

keySizer.Add(self.keycol, proportion=0,
wx._core
.
wxAssertionError
:
C++ assertion "!(flags & wxALIGN_RIGHT)" failed at
/Users/robind/projects/bb2/dist-osx-
py38/build/ext/wxWidgets/src/common/sizer.cpp(2098) in
DoInsert(): Horizontal alignment flags are ignored in
horizontal sizers
```


**Update:**
I stumbled on another similar issue on:

`"Import/link raster or vector data" > "Set vector output format"`

```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/lmgr/frame.py", line
1930, in OnVectorOutputFormat

dlg = GdalOutputDialog(parent=self, ogr=True)
  File
"/usr/local/grass79/gui/wxpython/modules/import_export.py",
line 740, in __init__

self._layout()
  File
"/usr/local/grass79/gui/wxpython/modules/import_export.py",
line 756, in _layout

dialogSizer.Add(
wx._core
.
wxAssertionError
:
C++ assertion "!(flags & wxALIGN_CENTRE_VERTICAL)" failed at
/Users/robind/projects/bb2/dist-osx-
py38/build/ext/wxWidgets/src/common/sizer.cpp(2077) in
DoInsert(): Vertical alignment flags are ignored in vertical
sizers
```

... updated PR with fix for this one too.