### PR TITLE
g.extension: support token authentication for gitlab/hub

### DIFF
--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -88,11 +88,22 @@ For well known general hosting services, namely GitHub, GitLab and Bitbucket,
 <em>g.extension</em> supports the download of a repository as a ZIP file.
 Here the user only needs to provide a base URL to the repository web page
 (with or without the <tt>https://</tt> part).
-For GitLab and Bitbucket, the latest source code in the default branch is 
-downloaded, for GitHub, the latest source code in the master branch is downloaded.
-Of course, a user can still specify the full URL of a ZIP file
-and install a specific branch or release in this way (ZIP file mechanism
-will be applied).
+If not otherwise specified in the <b>branch</b> option, the default branch 
+(main or master) is downloaded. Of course, a user can still specify the full 
+URL of a ZIP file and install a specific branch, commit or release in this way 
+(ZIP file mechanism will be applied).
+
+<p>
+For GitHub and GitLab authentication with a Personal Access Token (PAT) 
+is supported in order to access private repositories. For PAT authentication, 
+first a Personal Access Token needs to be acquired from either
+<a href="https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html">
+GitLab</a> or <a href="https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token">
+GitHub</a>. For security reasons it is recommended to pass PATs either 
+through environment variables or files to the command. <em>g.extension</em> 
+will automatically check for an environment variable named
+PERSONAL_ACCESS_TOKEN and use it for authentication, unless a PAT is 
+provided through the <b>token</b> option.
 
 <p>
 For the official repository, <em>g.extension</em> supports listing available
@@ -192,6 +203,13 @@ Simple URL to GitHub, GitLab, Bitbucket repositories from a specific (e.g. devel
 
 <div class="code"><pre>
 g.extension r.example.plus url="https://github.com/wenzeslaus/r.example.plus" branch=master
+</pre></div>
+
+Private GitHub or GitLab repository with token authentication:
+
+<div class="code"><pre>
+export PERSONAL_ACCESS_TOKEN=my_personal_access_token
+g.extension my_private_repo url="https://github.com/my_user/my_private_repo"
 </pre></div>
 
 Simple URL to OSGeo Trac (downloads a ZIP file, requires download to be enabled in Trac):

--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -102,7 +102,7 @@ GitLab</a> or <a href="https://docs.github.com/en/free-pro-team@latest/github/au
 GitHub</a>. For security reasons it is recommended to pass PATs either 
 through environment variables or files to the command. <em>g.extension</em> 
 will automatically check for an environment variable named
-PERSONAL_ACCESS_TOKEN and use it for authentication, unless a PAT is 
+<code>PERSONAL_ACCESS_TOKEN</code> and use it for authentication, unless a PAT is 
 provided through the <b>token</b> option.
 
 <p>

--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -88,7 +88,7 @@ For well known general hosting services, namely GitHub, GitLab and Bitbucket,
 <em>g.extension</em> supports the download of a repository as a ZIP file.
 Here the user only needs to provide a base URL to the repository web page
 (with or without the <tt>https://</tt> part).
-If not otherwise specified in the <b>branch</b> option, the default branch 
+If not specified otherwise in the <b>branch</b> option, the default branch 
 (main or master) is downloaded. Of course, a user can still specify the full 
 URL of a ZIP file and install a specific branch, commit or release in this way 
 (ZIP file mechanism will be applied).

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2202,6 +2202,17 @@ def resolve_source_code(url=None, name=None, branch=None):
                 pass
             # Test if github repo exists (need to use API)
             try:
+                # Check token scopes (permission)
+                open_url = urlopen("https://api.github.com/users/{}".format(
+                    *url.split('/')[-2:-1]))
+                scopes = open_url.getheader('X-OAuth-Scopes')
+                if 'repo' not in scopes:
+                    grass.fatal(
+                        _("Your access token don't have permission to "
+                          "read private repository info. Add 'repo' "
+                          "scope which define the access for personal token "
+                          "on the url <https://github.com/settings/tokens>")
+                    )
                 open_url = urlopen('https://api.github.com/repos/{}/{}'.format(*url.split("/")[-2:]))
                 open_url.close()
                 url_validated = True

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2334,17 +2334,16 @@ def main():
     if token and hosting:
         HEADERS['Authorization'] = "{} {}".format(hosting[0], token)
 
-
     # Get token from input option
     token_input = False
     if options['token']:
         if options['token'] == "-":
-            token_input = sys.stdin.read().rstrip()
+            token_input = sys.stdin.readline().rstrip()
             if not token_input:
                 grass.fatal(_('No token specified. Please try again.'))
         else:
             try:
-                with open(options['token'], 'r') as tokenfile:
+                with open(options['token']) as tokenfile:
                     token_input = tokenfile.readline().rstrip()
                     if not token_input:
                         grass.fatal(

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2216,6 +2216,10 @@ def resolve_source_code(url=None, name=None, branch=None):
                 open_url = urlopen('https://api.github.com/repos/{}/{}'.format(*url.split("/")[-2:]))
                 open_url.close()
                 url_validated = True
+            except HTTPError as err:
+                if (err.code == 403 and
+                    err.msg == 'rate limit exceeded'):
+                    gscript.warning(_('GitHub API rate limit exceeded.'))
             except:
                 pass
             # Test if gitlab repo exists (need to use API)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2200,6 +2200,20 @@ def resolve_source_code(url=None, name=None, branch=None):
                 url_validated = True
             except:
                 pass
+            # Test if github repo exists (need to use API)
+            try:
+                open_url = urlopen('https://api.github.com/repos/{}/{}'.format(*url.split("/")[-2:]))
+                open_url.close()
+                url_validated = True
+            except:
+                pass
+            # Test if gitlab repo exists (need to use API)
+            try:
+                open_url = urlopen('https://gitlab.com/api/v4/projects/{}%2F{}'.format(*url.split("/")[-2:]))
+                open_url.close()
+                url_validated = True
+            except:
+                pass
         else:
             try:
                 open_url = urlopen('http://' + url)
@@ -2280,6 +2294,18 @@ def main():
         proxy = urlrequest.ProxyHandler(PROXIES)
         opener = urlrequest.build_opener(proxy)
         urlrequest.install_opener(opener)
+
+    token_tags = {
+        "gitlab": "Bearer",
+        "github": "token"
+        }
+
+    hosting = [token_tags[key] for key in token_tags if key in original_url]
+    token = os.getenv('PRIVATE_ACCESS_TOKEN')
+
+    if token and hosting:
+        global HEADERS
+        HEADERS["Authorization"] = "{} {}".format(hosting[0], token)
 
     # define path
     options['prefix'] = resolve_install_prefix(path=options['prefix'],

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2247,7 +2247,7 @@ def resolve_source_code(url=None, name=None, branch=None):
                 open_url.close()
                 url_validated = True
             except HTTPError as err:
-                if (err.code == 403 and err.msg == 'rate limit exceeded'):
+                if (err.code == 403 and err.msg == 'Forbidden'):
                     gscript.warning(_('GitHub API rate limit exceeded.'))
             except:
                 pass

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2298,7 +2298,7 @@ def main():
     token_tags = {
         "gitlab": "Bearer",
         "github": "token"
-        }
+    }
 
     hosting = [token_tags[key] for key in token_tags if key in original_url]
     token = os.getenv('PRIVATE_ACCESS_TOKEN')

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -81,7 +81,7 @@
 #% key: token
 #% type: string
 #% key_desc: token
-#% description: Private Access Token (PAT) for authentication to private git repositories
+#% description: Personal Access Token (PAT) for authentication to private git repositories
 #% required: no
 #% multiple: no
 #%end
@@ -2327,7 +2327,7 @@ def main():
     hosting = [token_tags[key] for key in token_tags if key in original_url]
 
     # Get token from hardcoded environment variable
-    token = os.getenv('PRIVATE_ACCESS_TOKEN')
+    token = os.getenv('PERSONAL_ACCESS_TOKEN')
 
     global HEADERS
     # Set authorization method according to supported hosting service
@@ -2336,16 +2336,21 @@ def main():
 
 
     # Get token from input option
-    token_input = options['token']
+    if options['token']:
+        if options['token'] == "-":
+            token_input = sys.stdin.read().rstrip()
+        else:
+            with open(options['token'], 'r') as tokenfile:
+                token_input = tokenfile.readlines()[0].rstrip()
 
     if token and token_input:
-        gscript.warning(_("Private Access Token provided both via input \
+        gscript.warning(_("Personal Access Token provided both via input \
                            option and environment variable. Using the \
                            token from the input option."))
 
     # Let input option override environment variable
     if token_input:
-        HEADERS['Authorization'] = "{} {}".format(hosting[0], token)
+        HEADERS['Authorization'] = "{} {}".format(hosting[0], token_input)
 
     # define path
     options['prefix'] = resolve_install_prefix(path=options['prefix'],

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2336,6 +2336,7 @@ def main():
 
 
     # Get token from input option
+    token_input = False
     if options['token']:
         if options['token'] == "-":
             token_input = sys.stdin.read().rstrip()

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2217,8 +2217,7 @@ def resolve_source_code(url=None, name=None, branch=None):
                 open_url.close()
                 url_validated = True
             except HTTPError as err:
-                if (err.code == 403 and
-                    err.msg == 'rate limit exceeded'):
+                if (err.code == 403 and err.msg == 'rate limit exceeded'):
                     gscript.warning(_('GitHub API rate limit exceeded.'))
             except:
                 pass

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2257,6 +2257,9 @@ def resolve_source_code(url=None, name=None, branch=None):
                 gitlab_private_repo_id = json.loads(open_url.read())['id']
                 open_url.close()
                 url_validated = True
+            except HTTPError as err:
+                if (err.code == 429 and err.msg == 'Too Many Requests'):
+                    gscript.warning(_('GitLab API rate limit exceeded.'))
             except:
                 pass
         else:

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2044,7 +2044,7 @@ KNOWN_HOST_SERVICES_INFO = {
         'url_end': '?format=zip',
     },
     'GitHub': {
-        'url': 'https://api.github.com/repos/{owner}/test/zipball/{branch}',
+        'url': 'https://api.github.com/repos/{owner}/{repository}/zipball/{branch}',
     },
     'GitLab': {
         'url': 'https://gitlab.com/api/v4/projects/{project_id}/repository/archive.zip?sha={branch}',
@@ -2079,7 +2079,8 @@ def resolve_known_host_service(
     if github_repo_owner:
         return 'remote_zip', KNOWN_HOST_SERVICES_INFO\
             ['GitHub']['url'].format(
-                owner=github_repo_owner, branch=branch,
+                owner=github_repo_owner, repository= url.split('/')[-1],
+                branch=branch,
             )
 
     if gitlab_repo_id:

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2340,9 +2340,34 @@ def main():
     if options['token']:
         if options['token'] == "-":
             token_input = sys.stdin.read().rstrip()
+            if not token_input:
+                grass.fatal(_('No token specified. Please try again.'))
         else:
-            with open(options['token'], 'r') as tokenfile:
-                token_input = tokenfile.readlines()[0].rstrip()
+            try:
+                with open(options['token'], 'r') as tokenfile:
+                    token_input = tokenfile.readline().rstrip()
+                    if not token_input:
+                        grass.fatal(
+                            _("Token file is empty <{}>. "
+                              "Please check token file content.".format(
+                                  options['token']))
+                        )
+            except FileNotFoundError:
+                grass.fatal(
+                    _("No such file or directory <{}>. "
+                      "Please check token file path.".format(
+                          options['token']))
+                )
+            except PermissionError:
+                grass.fatal(
+                    _("Permission denied <{}>. Please change token file "
+                      "permission for reading.".format(options['token']))
+                )
+            except IOError:
+                grass.fatal(
+                    _("Couldn't read token file <{}>.".format(
+                        options['token']))
+                )
 
     if token and token_input:
         gscript.warning(_("Personal Access Token provided both via input \

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2241,7 +2241,7 @@ def resolve_source_code(url=None, name=None, branch=None):
                         _("Your access token don't have permission to "
                           "read private repository info. Add 'repo' "
                           "scope which define the access for personal token "
-                          "on the url <https://github.com/settings/tokens>")
+                          "on the url <https://github.com/settings/tokens>.")
                     )
                 open_url = urlopen('https://api.github.com/repos/{}/{}'.format(*url.split("/")[-2:]))
                 open_url.close()


### PR DESCRIPTION
It seems gitlab and github only support token authentication for private repos. This PR implements such authentication to private github/gitlab repositories, so they can be accessed by g.extension.

My main question (and reason this is WIP) however is: How to we access the users Private Access Token (PAT) in a reliable and appropriate way. Current implementation assumes the token is stored in an environment variable named "PRIVATE_ACCESS_TOKEN" as environment variables are recommended for tokens. Would it be better to read from a file with the token or stdin?

See also: #625