### PR TITLE
Change default color for rendering vectors (gray->blue) [news]

### DIFF
--- a/display/d.vect/main.c
+++ b/display/d.vect/main.c
@@ -118,11 +118,12 @@ int main(int argc, char **argv)
     /* Colors */
     color_opt = G_define_standard_option(G_OPT_CN);
     color_opt->label = _("Feature color");
+    color_opt->answer = "0:29:57";
     color_opt->guisection = _("Colors");
     
     fcolor_opt = G_define_standard_option(G_OPT_CN);
     fcolor_opt->key = "fill_color";
-    fcolor_opt->answer = "200:200:200";
+    fcolor_opt->answer = "0:103:204";
     fcolor_opt->label = _("Area fill color");
     fcolor_opt->guisection = _("Colors");
 

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -339,13 +339,13 @@ class Settings:
             #
             'vectorLayer': {
                 'featureColor': {
-                    'color': (0, 0, 0),
+                    'color': (0, 29, 57),
                     'transparent': {
                         'enabled': False
                     }
                 },
                 'areaFillColor': {
-                    'color': (200, 200, 200),
+                    'color': (0, 103, 204),
                     'transparent': {
                         'enabled': False
                     }


### PR DESCRIPTION
Use light and dark blue as defaults in d.vect and in the default GUI settings
for rendering vector maps.

The d.vect values are applied in d.mon and with direct rendering,
the GUI values when user does not have user settings yet and
when user settings is saved for the first time (since then it is driven
by value there, so this needs settings to not exists to take its effect).

## Points (default marker x)

![points_only_x](https://user-images.githubusercontent.com/5449060/101720222-05ecff00-3a73-11eb-841c-30147199549a.png)

## Lines (default width 0/1)

![lines](https://user-images.githubusercontent.com/5449060/101720232-0ab1b300-3a73-11eb-857c-74a7051c833a.png)

## Areas (default border 0/1)

![areas](https://user-images.githubusercontent.com/5449060/101720234-0c7b7680-3a73-11eb-97a3-9fdd65060c8a.png)

## Points with marker point (small circle)

![points_only_o](https://user-images.githubusercontent.com/5449060/101720316-48aed700-3a73-11eb-8503-bbc368f659ef.png)

## Lines with widths 1 and 3

![lines_wide](https://user-images.githubusercontent.com/5449060/101720317-49e00400-3a73-11eb-9f7a-39d18bd08b1b.png)

## Comparison of old and new in action

![Screenshot from 2020-12-09 23-01-23](https://user-images.githubusercontent.com/5449060/101720367-6ed47700-3a73-11eb-949f-a3e2554da219.png)


