### PR TITLE
wxGUI/mapdisp: Always respect user-set background color in Map Display

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -80,7 +80,11 @@ class BufferedMapWindow(MapWindowBase, Window):
         """
         MapWindowBase.__init__(self, parent=parent, giface=giface, Map=Map)
         wx.Window.__init__(self, parent=parent, id=id, style=style, **kwargs)
-        self.SetBackgroundColour("white")
+        # This is applied when no layers are rendered and thus the background
+        # color is not applied in rendering itself (it would be applied always
+        # if rendering would use transparent background).
+        self.SetBackgroundColour(wx.Colour(*UserSettings.Get(
+            group='display', key='bgcolor', subkey='color')))
 
         self._properties = properties
         # this class should not ask for digit, this is a hack


### PR DESCRIPTION
The background color from user settings was applied only when actual rendering happened. So with no layers at the start and when all unchecked the color was the hardcoded white.

Now the color is always the same although it comes from different sources (background by default and g.pnmcomp result when displaying data).

This creates consistent behavior and it is a plus for the dark theme support because when user manually the dark background to fit with the dark theme, the big empty white area is no longer displayed when no data is there.

This applies to all components which use mapwin.BufferedMapWindow,
e.g., Map Swipe.

State before and after right after starting GUI (background color manually set to gray):

![Screenshot from 2020-12-09 23-49-44](https://user-images.githubusercontent.com/5449060/101722971-510a1080-3a79-11eb-9906-c4aa5d8bbeb5.png)