### PR TITLE
wxGUI/Save display to file dialog: add wxPython 4.1 support

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1973,7 +1973,7 @@ class ImageSizeDialog(wx.Dialog):
         btnsizer.Realize()
 
         sizer.Add(btnsizer, proportion=0,
-                  flag=wx.EXPAND | wx.ALIGN_RIGHT | wx.ALL, border=5)
+                  flag=wx.EXPAND | wx.ALL, border=5)
 
         self.panel.SetSizer(sizer)
         sizer.Fit(self.panel)


### PR DESCRIPTION
The dialog `Save display to file` fails with wxPython 4.1 because of bad use of flags (see also e.g. #1161). This PR addresses this.


Using:
```
3.8.2 (default, Sep 24 2020, 19:37:08) 
[Clang 12.0.0 (clang-1200.0.32.21)]
4.1.0 osx-cocoa (phoenix) wxWidgets 3.1.4
```

results in:
```
Traceback (most recent call last):
  File "/usr/local/grass79/gui/wxpython/mapdisp/frame.py",
line 650, in SaveToFile

dlg = ImageSizeDialog(self)
  File
"/usr/local/grass79/gui/wxpython/gui_core/dialogs.py", line
1945, in __init__

self._layout()
  File
"/usr/local/grass79/gui/wxpython/gui_core/dialogs.py", line
1979, in _layout

sizer.Add(btnsizer, proportion=0,
wx._core
.
wxAssertionError
:
C++ assertion "!(flags & (wxALIGN_RIGHT |
wxALIGN_CENTRE_HORIZONTAL))" failed at
/Users/robind/projects/bb2/dist-osx-
py39/build/ext/wxWidgets/src/common/sizer.cpp(2159) in
DoInsert(): Horizontal alignment flags are ignored with
wxEXPAND
```

Suggested changes has also been tested and passed on:
- Windows / GRASS 7.8.1 (!) / Python 3.7.0 / wxPython 4.0.7 msw (phoenix) wxWidgets 3.0.5
- Mac / GRASS 7.8.5RC1 / Python 3.8.6 / 4.0.7.post2 osx-cocoa (phoenix) wxWidgets 3.0.5