### PR TITLE
wxGUI/mapdisp: it is also possible to remove the MASK interactively

### DIFF
--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -37,7 +37,7 @@ import wx
 from core import utils
 from core.gcmd import RunCommand
 from core.settings import UserSettings
-from gui_core.wrap import StaticText, TextCtrl
+from gui_core.wrap import Button, TextCtrl
 
 from grass.script import core as grass
 
@@ -283,7 +283,6 @@ class SbManager:
                     wWin = rect.width - 6
                 if idx == 2:  # mask
                     x += 5
-                    y += 4
                 elif idx == 3:  # render
                     x += 5
             win.SetPosition((x, y))
@@ -894,14 +893,21 @@ class SbProjection(SbItem):
 
 
 class SbMask(SbItem):
-    """StaticText to show whether mask is activated."""
+    """Button to show whether mask is activated and remove mask with
+    left mouse click
+    """
 
     def __init__(self, mapframe, statusbar, position=0):
         SbItem.__init__(self, mapframe, statusbar, position)
+        self._mapframe = mapframe
         self.name = "mask"
 
-        self.widget = StaticText(parent=self.statusbar, id=wx.ID_ANY, label=_("MASK"))
+        self.widget = Button(
+            parent=self.statusbar, id=wx.ID_ANY, label=_("MASK"), style=wx.NO_BORDER
+        )
+        self.widget.Bind(wx.EVT_BUTTON, self.OnRemoveMask)
         self.widget.SetForegroundColour(wx.Colour(255, 0, 0))
+        self.widget.SetToolTip(tip=_("Left mouse click to remove the MASK"))
         self.widget.Hide()
 
     def Update(self):
@@ -911,6 +917,24 @@ class SbMask(SbItem):
             self.Show()
         else:
             self.Hide()
+
+    def OnRemoveMask(self, event):
+        if grass.find_file(
+            name="MASK", element="cell", mapset=grass.gisenv()["MAPSET"]
+        )["name"]:
+
+            dlg = wx.MessageDialog(
+                self._mapframe,
+                message=_("Are you sure that you want to remove the MASK?"),
+                caption=_("Remove MASK"),
+                style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
+            )
+            if dlg.ShowModal() != wx.ID_YES:
+                dlg.Destroy()
+                return
+            RunCommand("r.mask", flags="r")
+            self.Hide()
+            self._mapframe.OnRender(event=None)
 
 
 class SbTextItem(SbItem):

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -923,7 +923,7 @@ class SbMask(SbItem):
         )["name"]:
 
             dlg = wx.MessageDialog(
-                self._mapframe,
+                self.mapFrame,
                 message=_("Are you sure that you want to remove the MASK?"),
                 caption=_("Remove MASK"),
                 style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
@@ -933,7 +933,7 @@ class SbMask(SbItem):
                 return
             RunCommand("r.mask", flags="r")
             self.Hide()
-            self._mapframe.OnRender(event=None)
+            self.mapFrame.OnRender(event=None)
 
 
 class SbTextItem(SbItem):

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -899,7 +899,6 @@ class SbMask(SbItem):
 
     def __init__(self, mapframe, statusbar, position=0):
         SbItem.__init__(self, mapframe, statusbar, position)
-        self._mapframe = mapframe
         self.name = "mask"
 
         self.widget = Button(


### PR DESCRIPTION
It is also possible to remove the MASK interactively (left mouse click on the button MASK widget inside statusbar).

**Current behavior:**

![wxgui_mapdisp_mask_def](https://user-images.githubusercontent.com/50632337/102122388-b24d2d80-3e45-11eb-8a09-c5bba5e519aa.png)

**Suggested behavior:**

![wxgui_mapdisp_mask_exp](https://user-images.githubusercontent.com/50632337/102122399-b7aa7800-3e45-11eb-8fe5-54b8b3f0028e.png)
