### PR TITLE
Stop ignoring .git folder for docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ docker
 .travis.yml
 
 # The following git files are needed by GRASS GIS to extract the revision
-# during compilation. If you are not using one of the Dockerimgages from this
+# during compilation. If you are not using one of the Dockerimages from this
 # repository, delete the .git folder in your Dockerfile after compilation.
 .git
 !.git/HEAD

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@ docker
 !docker/testdata
 !docker/alpine/alpine-py38-ctypes.patch
 !docker/alpine/alpine-py38-gisinit.patch
-.git
+!.git
 .gitignore
 .github
 .travis

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,15 @@
 docker
 !docker/testdata
-!docker/alpine/alpine-py38-ctypes.patch
-!docker/alpine/alpine-py38-gisinit.patch
-!.git
 .gitignore
 .github
 .travis
 .travis.yml
+
+# The following git files are needed by GRASS GIS to extract the revision
+# during compilation. If you are not using one of the Dockerimgages from this
+# repository, delete the .git folder in your Dockerfile after compilation.
+.git
+!.git/HEAD
+!.git/refs/heads
+!.git/objects
+.git/objects/*

--- a/docker/debian/Dockerfile_debian_pdal
+++ b/docker/debian/Dockerfile_debian_pdal
@@ -222,6 +222,7 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
 # Reduce the image size
 RUN apt-get autoremove -y
 RUN apt-get clean -y
+RUN rm -r /src/grass_build/.git
 
 WORKDIR /scripts
 

--- a/docker/ubuntu/Dockerfile_ubuntu_pdal
+++ b/docker/ubuntu/Dockerfile_ubuntu_pdal
@@ -214,6 +214,7 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
 # Reduce the image size
 RUN apt-get autoremove -y
 RUN apt-get clean -y
+RUN rm -r /src/grass_build/.git
 
 WORKDIR /scripts
 


### PR DESCRIPTION
Currently the `.git` folder is ignored during docker builds. This masks the revision in the GRASS GIS version:
```
/src/actinia_core # grass --tmp-location epsg:4326 --exec g.version -rge
Starting GRASS GIS...
Creating new GRASS GIS location <tmploc>...
Cleaning up temporary files...
Executing <g.version -rge> ...
version=7.9.dev
date=2020
revision=exported
build_date=2020-12-16
build_platform=x86_64-pc-linux-musl
build_off_t_size=8
libgis_revision=2020-12-16T00:36:32+00:00
libgis_date=2020-12-16T00:36:32+00:00
proj=7.0.1
gdal=3.1.4
geos=3.8.1
sqlite=3.32.1
Execution of <g.version -rge> finished.
Cleaning up temporary files...
```
Looking for the cause, it behaves like this when no `.git` folder is present: https://github.com/OSGeo/grass/blob/master/configure.in#L149. Therefore this PR suggests to no longer ignore the `.git` folder during docker builds. Local test was successful.