### PR TITLE
tplot/frame.py: fixes for Matplotlib 3.3+

### DIFF
--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -35,7 +35,6 @@ try:
         FigureCanvasWxAgg as FigCanvas, \
         NavigationToolbar2WxAgg as NavigationToolbar
     import matplotlib.dates as mdates
-    from matplotlib import cbook
 except ImportError as e:
     raise ImportError(_('The Timeline Tool needs the "matplotlib" '
                         '(python-matplotlib and on some systems also python-matplotlib-wx) package(s) to be installed. {0}').format(e))
@@ -615,7 +614,7 @@ class DataCursor(object):
         self.formatFunction = formatFunction
         self.offsets = offsets
         self.display_all = display_all
-        if not cbook.iterable(artists):
+        if not np.iterable(artists):
             artists = [artists]
         self.artists = artists
 
@@ -626,7 +625,7 @@ class DataCursor(object):
         for ax in self.axes:
             self.annotations[ax] = self.annotate(ax)
         for artist in self.artists:
-            artist.set_picker(tolerance)
+            artist.set_pickradius(tolerance)
         for fig in self.figures:
             fig.canvas.mpl_connect('pick_event', self)
             fig.canvas.mpl_connect('key_press_event', self.keyPressed)

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -39,7 +39,6 @@ try:
         FigureCanvasWxAgg as FigCanvas, \
         NavigationToolbar2WxAgg as NavigationToolbar
     import matplotlib.dates as mdates
-    from matplotlib import cbook
 except ImportError as e:
     raise ImportError(_('The Temporal Plot Tool needs the "matplotlib" '
                         '(python-matplotlib) package to be installed. {0}').format(e))

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -1125,7 +1125,7 @@ class DataCursor(object):
         self.formatFunction = formatFunction
         self.offsets = offsets
         self.display_all = display_all
-        if not cbook.iterable(artists):
+        if not np.iterable(artists):
             artists = [artists]
         self.artists = artists
         self.convert = convert

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -1136,7 +1136,7 @@ class DataCursor(object):
         for ax in self.axes:
             self.annotations[ax] = self.annotate(ax)
         for artist in self.artists:
-            artist.set_picker(tolerance)
+            artist.set_pickradius(tolerance)
         for fig in self.figures:
             fig.canvas.mpl_connect('pick_event', self)
             fig.canvas.mpl_connect('key_press_event', self.keyPressed)


### PR DESCRIPTION
The PR fixes the following error (occurs on recent Ubuntu, Fedora):

```
GRASS 7.8.5dev (dwd_gauss_krueger_z3):/mnt/data/geodata/dwd_raster_germany/annual_air_temp_mean > g.gui.tplot strds=germany_annual_air_temp_mean coordinates=3363642,5621244 title="Mean air temp (Deg * 10) in Bonn Lengsdorf"
22:49:50: Debug: Adding duplicate image handler for 'Windows bitmap file'
Traceback (most recent call last):
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/scripts/g.gui.tplot", line 175, in <module>
    main()
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/scripts/g.gui.tplot", line 161, in main
    frame.SetDatasets(rasters, vectors, coords, cats, attr, title, xlabel,
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/gui/wxpython/tplot/frame.py", line 1019, in SetDatasets
    self._redraw()
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/gui/wxpython/tplot/frame.py", line 899, in _redraw
    self._drawFigure()
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/gui/wxpython/tplot/frame.py", line 630, in _drawFigure
    DataCursor(self.plots, self.lookUp, InfoFormat, self.convert)
  File "/home/mundialis/software/grass78_git/dist.x86_64-pc-linux-gnu/gui/wxpython/tplot/frame.py", line 1128, in __init__
    if not cbook.iterable(artists):
AttributeError: module 'matplotlib.cbook' has no attribute 'iterable'
```

I found the reason: _The iterable function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use np.iterable instead._

Fix inspired by https://github.com/stonebig/plotnine/commit/2044a91c37ba2e732fcd823fddb07cb7f5f06977