### PR TITLE
wxGUI/gselect: fix select widget for wxGUI 'd.vect' module

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2559,7 +2559,10 @@ class VectorCategorySelect(wx.Panel):
         if self._isMapSelected():
             layerList = self.giface.GetLayerList()
             layerSelected = layerList.GetSelectedLayer()
-            inputName = self.task.get_param('input')
+            # d.vect module
+            inputName = self.task.get_param(value='map', raiseError=False)
+            if not inputName:
+                inputName = self.task.get_param('input')
             if inputName['value'] != str(layerSelected):
                 if inputName['value'] == '' or inputName['value'] is None:
                     GWarning(_("Input vector map is not selected"))


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Display railroads vector map `d.vect railroads`
3. Open railroads vector map display properties wxGUI dialog (double click on railroads vector map layer on Display tab layers tree)
4. On the vector layer display properties wxGUI dialog switch to the Selection page (tab)
5. Go to Category values parameter and try activate selection widget (left click on the selection button)
6.  You get error message

**Error message:**

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/gselect.py", line
2580, in _onClick

if not self._chckMap():
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/gselect.py", line
2564, in _chckMap

inputName = self.task.get_param('input')
  File "/usr/lib64/grass79/etc/python/grass/script/task.py",
line 176, in get_param

{'element': element, 'value': value })
ValueError
:
Parameter element 'name' not found: 'input'
```