### PR TITLE
wxGUI/rlisetup: dissociate the managed window from the manager ('wx.aui.AuiManager' instance) before destroy wizard window

### DIFF
--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -136,11 +136,11 @@ class RLIWizard(object):
                 self._cleanup()
             dlg.Destroy()
         else:
+            self._cleanup()
             self.wizard.Destroy()
             GMessage(parent=self.parent,
                      message=_("r.li.setup wizard canceled. "
                                "Configuration file not created."))
-            self._cleanup()
 
     def _write_confile(self):
         """Write the configuration file"""
@@ -476,6 +476,12 @@ class RLIWizard(object):
         self.moving.width = ''
         self.moving.height = ''
         self.moving.boxtype = ''
+        for page in (self.drawsampleframepage,
+                     self.regions,
+                     self.drawsampleunitspage,
+                     self.vectorareas):
+            if page.mapPanel:
+                page.mapPanel._mgr.UnInit()
 
 
 class FirstPage(TitledPage):


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch 'Set up sampling and analysis framework' `g.gui.rlisetup`
2. Hit Create button on 'Setup for r.li modules' wxGUI dialog
3. On the first page 'Select maps and define name' of 'Create new configuration file for r.li modules' wizard fill out the form as follows
![g_gui_rlisetup_first_wizard_page](https://user-images.githubusercontent.com/50632337/102718057-5f142880-42e6-11eb-90eb-48599186eef3.png)
4. Hit Next button
5. On the next wizard page 'Draw sampling frame', draw rectangle (holding down left mouse click and moving down or up) and hit Next button
6. On the next wizard page 'Insert sampling areas' hit Cancel button
7. You get error message

**Error message:**

```
wx._core
.
wxAssertionError
:
C++ assertion "GetEventHandler() == this" failed at /var/tmp
/portage/x11-libs/wxGTK-3.0.4-r302/work/wxWidgets-3.0.4/src/
common/wincmn.cpp(477) in ~wxWindowBase(): any pushed event
handlers must have been removed
The above exception was the direct cause of the following
exception:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-
packages/wx/lib/agw/customtreectrl.py", line 8183, in
OnInternalIdle

if not self.HasAGWFlag(TR_MULTIPLE) and not
self.GetSelection():
  File "/usr/lib64/python3.6/site-
packages/wx/lib/agw/customtreectrl.py", line 3534, in
HasAGWFlag

return bool(self._agwStyle & flag)
SystemError
:
<class 'bool'> returned a result with an error set
```