### PR TITLE
wxGUI/mapdisp: fix select tool combobox widget text after change tool selection (e.g. Vector digitizer -> 3D view)

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -558,7 +558,11 @@ class MapFrame(SingleMapFrame):
             self._mgr.GetPane('2d').Show()
             self._switchMapWindow(self.MapWindow2D)
 
-        self.toolbars['map'].Enable2D(True)
+        map = self.toolbars['map']
+        map.Enable2D(True)
+        map._setComboBoxValue(
+            value=map._mode_label['2d'],
+        )
 
         self._mgr.Update()
 

--- a/gui/wxpython/mapdisp/toolbars.py
+++ b/gui/wxpython/mapdisp/toolbars.py
@@ -93,14 +93,14 @@ class MapToolbar(BaseToolbar):
 
         # optional tools
         toolNum = 0
-        choices = [_('2D view'), ]
+        self._mode_label = {'2d': _('2D view')}
         self.toolId = {'2d': toolNum}
         toolNum += 1
         if self.parent.GetLayerManager():
             log = self.parent.GetLayerManager().GetLogWindow()
 
         if haveNviz:
-            choices.append(_('3D view'))
+            self._mode_label['3d'] = _('3D view')
             self.toolId['3d'] = toolNum
             toolNum += 1
         else:
@@ -112,7 +112,7 @@ class MapToolbar(BaseToolbar):
             self.toolId['3d'] = -1
 
         if haveVDigit:
-            choices.append(_("Vector digitizer"))
+            self._mode_label['vdigit'] = _("Vector digitizer")
             self.toolId['vdigit'] = toolNum
             toolNum += 1
         else:
@@ -129,11 +129,11 @@ class MapToolbar(BaseToolbar):
                     wrap=60)
 
             self.toolId['vdigit'] = -1
-        choices.append(_("Raster digitizer"))
+        self._mode_label['rdigit'] = _("Raster digitizer")
         self.toolId['rdigit'] = toolNum
 
         self.combo = wx.ComboBox(parent=self, id=wx.ID_ANY,
-                                 choices=choices,
+                                 choices=tuple(self._mode_label.values()),
                                  style=wx.CB_READONLY, size=(110, -1))
         self.combo.SetSelection(0)
 
@@ -237,20 +237,24 @@ class MapToolbar(BaseToolbar):
         if tool == self.toolId['2d']:
             self.ExitToolbars()
             self.Enable2D(True)
+            self._setComboBoxValue(value=self._mode_label['2d'])
 
         elif tool == self.toolId['3d'] and \
                 not (self.parent.MapWindow3D and self.parent.IsPaneShown('3d')):
             self.ExitToolbars()
+            self._setComboBoxValue(value=self._mode_label['3d'])
             self.parent.AddNviz()
 
         elif tool == self.toolId['vdigit'] and \
                 not self.parent.GetToolbar('vdigit'):
             self.ExitToolbars()
+            self._setComboBoxValue(value=self._mode_label['vdigit'])
             self.parent.AddToolbar("vdigit")
             self.parent.MapWindow.SetFocus()
 
         elif tool == self.toolId['rdigit']:
             self.ExitToolbars()
+            self._setComboBoxValue(value=self._mode_label['rdigit'])
             self.parent.AddRDigit()
 
     def OnAnalyze(self, event):
@@ -296,5 +300,7 @@ class MapToolbar(BaseToolbar):
                      self.select):
             self.EnableTool(tool, enabled)
         self.ChangeToolsDesc(enabled)
-        if enabled:
-            self.combo.SetValue(_("2D view"))
+
+    def _setComboBoxValue(self, value):
+        """Set ComboBox widget value"""
+        self.combo.SetValue(value)


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Display raster map e.g. elevation `d.rast elevation`
3. On the Map Window change select tool combobox widget tool 2D view -> Vector digitizer
4. On the Map Window change select tool combobox widget tool Vector digitizer -> 3D view (don't quit Vector digitizer via Quit digitizer button) 
5.  Check select tool combobox widget selected tool text, which is 2D view and the 3D view should be correct.

**Expected behavior:**

 After change tool selection (e.g. Vector digitizer -> 3D view) combobox widget should have correct selected tool text.

