### PR TITLE
wxGUI/tplot: fix x, y coordinates validation

### DIFF
--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -831,8 +831,12 @@ class TplotFrame(wx.Frame):
                     coordx, coordy = self.coorval.GetValue().split(',')
                     coordx, coordy = float(coordx), float(coordy)
                 except (ValueError, AttributeError):
-                    GMessage(message=_("Incorrect coordinates format, should "
-                                       "be: x,y"), parent=self)
+                    GError(
+                        parent=self,
+                        message=_("Incorrect coordinates format, should be: x,y"),
+                        showTraceback=False,
+                    )
+                    return
             coors = [coordx, coordy]
             if coors:
                 try:


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch Temporal Plot Tool `g.gui.tplot`
2. Choose Raster temporal dataset (strds)
3. Fill X and Y coordinates separated by comma with text
4.  Hit Draw button
5. On the emulator terminal you get error message

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/tplot/frame.py", line 837, in OnRedraw
    coors = [coordx, coordy]
UnboundLocalError: local variable 'coordx' referenced before assignment
```