### PR TITLE
wxGUI/tplot: fix export csv file

### DIFF
--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -794,6 +794,7 @@ class TplotFrame(wx.Frame):
 
     def OnRedraw(self, event=None):
         """Required redrawing."""
+        self.init()
         self.csvpath = self.csvButton.GetValue()
         self.header = self.headerCheck.IsChecked()
         if (os.path.exists(self.csvpath) and not self.overwrite):
@@ -807,7 +808,6 @@ class TplotFrame(wx.Frame):
                        message=_("Please change name of output CSV file or "))
                 return
             dlg.Destroy()
-        self.init()
         datasetsR = self.datasetSelectR.GetValue().strip()
         datasetsV = self.datasetSelectV.GetValue().strip()
 


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch Temporal Plot Tool `g.gui.tplot`
2. Load some raster temporal dataset e.g. tempmean
3. On the Export page (tab) choose CSV file path
3. Hit Draw button
4. Check if CSV file was created

Note:

If you launch Launch Temporal Plot Tool from module `g.gui.tplot --ui` with filled 'Name for output CSV file' option, export plot data to CSV file work correctly.

**Expected behavior:**

Exporting data to a CSV file should work after pressing the Draw button from `g.gui.tplot` dialog.


