### PR TITLE
 wxGUI/import_export: fix validation input map name (overwrite flag)

### DIFF
--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -102,6 +102,9 @@ class ImportDialog(wx.Dialog):
                 key='overwrite',
                 subkey='enabled'))
         self.overwrite.Bind(wx.EVT_CHECKBOX, self.OnCheckOverwrite)
+        if UserSettings.Get(group='cmd', key='overwrite',
+                            subkey='enabled'):
+            self.list.validate = False
 
         self.add = wx.CheckBox(parent=self.panel, id=wx.ID_ANY)
         self.closeOnFinish = wx.CheckBox(parent=self.panel, id=wx.ID_ANY,
@@ -255,9 +258,7 @@ class ImportDialog(wx.Dialog):
     def _validateOutputMapName(self):
         """Enable/disable output map name validation according the
         overwrite state"""
-        if not self.overwrite.IsChecked() or not \
-           UserSettings.Get(group='cmd', key='overwrite',
-                            subkey='enabled'):
+        if not self.overwrite.IsChecked():
             if not self.list.GetValidator().\
                Validate(win=self.list, validate_all=True):
                 return False


### PR DESCRIPTION
Fix validation input map name (overwrite flag).

**To Reproduce:**

Steps to reproduce the behavior:

1. Set Allow output files to overwrite existing files globally
2. Launch wxGUI Import raster data dialog
3. File source type
4. Choose file
5. On the List of raster layers, try change layer name for output GRASS map to name which exists e.g. elevation (press the Enter key)
6. Message dialog inform you that map name exists

**Expected behavior:**

If Allow output files to overwrite existing files setting is globally True, you should not see a message dialog box (validation) that the map exists (step no. 6.).

