### PR TITLE
wxGUI: New, simplified, unified window titles

### DIFF
--- a/gui/wxpython/animation/frame.py
+++ b/gui/wxpython/animation/frame.py
@@ -48,7 +48,7 @@ gcore.set_raise_on_error(True)
 
 class AnimationFrame(wx.Frame):
 
-    def __init__(self, parent, giface, title=_("GRASS GIS Animation tool"),
+    def __init__(self, parent, giface, title=_("Animation Tool"),
                  rasters=None, timeseries=None):
         wx.Frame.__init__(self, parent, title=title,
                           style=wx.DEFAULT_FRAME_STYLE, size=(800, 600))

--- a/gui/wxpython/animation/g.gui.animation.py
+++ b/gui/wxpython/animation/g.gui.animation.py
@@ -128,7 +128,11 @@ def main():
 
     app = wx.App()
 
-    frame = AnimationFrame(parent=None, giface=StandaloneGrassInterface())
+    frame = AnimationFrame(
+        parent=None,
+        giface=StandaloneGrassInterface(),
+        title=_("Animation Tool - GRASS GIS"),
+    )
     frame.CentreOnScreen()
     frame.Show()
     if len(layerList) >= 1:

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -30,7 +30,7 @@ class DataCatalogFrame(wx.Frame):
 
     def __init__(self, parent, giface=None):
         wx.Frame.__init__(self, parent=parent,
-                          title=_('GRASS GIS Data Catalog'))
+                          title=_('Data Catalog'))
         self.SetName("DataCatalog")
         self.SetIcon(
             wx.Icon(

--- a/gui/wxpython/datacatalog/g.gui.datacatalog.py
+++ b/gui/wxpython/datacatalog/g.gui.datacatalog.py
@@ -43,7 +43,11 @@ def main():
 
     app = wx.App()
 
-    frame = DataCatalogFrame(parent=None, giface=StandaloneGrassInterface())
+    frame = DataCatalogFrame(
+        parent=None,
+        giface=StandaloneGrassInterface(),
+        title=_("Data Catalog - GRASS GIS"),
+    )
     frame.CentreOnScreen()
     frame.Show()
     app.MainLoop()

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1151,7 +1151,7 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         label = _("Table")
         if not self.dbMgrData['editable']:
-            label += _(" (readonly)")
+            label += _(" (read-only)")
 
         if pos == -1:
             pos = self.GetPageCount()
@@ -2274,7 +2274,7 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         self.layerPage[layer]['tablePage'] = panel.GetId()
         label = _("Table")
         if not self.dbMgrData['editable']:
-            label += _(" (readonly)")
+            label += _(" (read-only)")
 
         if pos == -1:
             pos = self.GetPageCount()

--- a/gui/wxpython/dbmgr/g.gui.dbmgr.py
+++ b/gui/wxpython/dbmgr/g.gui.dbmgr.py
@@ -51,9 +51,12 @@ def main():
         _("Loading attribute data for vector map <%s>...") %
         mapName)
     f = AttributeManager(
-        parent=None, id=wx.ID_ANY, title="%s - <%s>" %
-        (_("GRASS GIS Attribute Table Manager"), mapName), size=(
-            900, 600), vectorName=mapName)
+        parent=None,
+        id=wx.ID_ANY,
+        base_title=_("Attribute Table Manager - GRASS GIS"),
+        size=(900, 600),
+        vectorName=mapName,
+    )
     f.Show()
 
     app.MainLoop()

--- a/gui/wxpython/dbmgr/manager.py
+++ b/gui/wxpython/dbmgr/manager.py
@@ -48,13 +48,16 @@ from gui_core.wrap import Button, ClearButton, CloseButton
 class AttributeManager(wx.Frame, DbMgrBase):
 
     def __init__(self, parent, id=wx.ID_ANY,
-                 title=None, vectorName=None, item=None, log=None,
+                 title=None,
+                 base_title=None,
+                 vectorName=None, item=None, log=None,
                  selection=None, **kwargs):
         """GRASS Attribute Table Manager window
 
         :param parent: parent window
         :param id: window id
-        :param title: window title or None for default title
+        :param title: full window title or None for default title
+        :param base_title: the document independent part of title or None for default
         :param vectorName: name of vector map
         :param item: item from Layer Tree
         :param log: log window
@@ -76,11 +79,14 @@ class AttributeManager(wx.Frame, DbMgrBase):
 
         # title
         if not title:
-            title = "%s" % _("GRASS GIS Attribute Table Manager - ")
+            if not base_title:
+                base_title = _("Attribute Table Manager")
+            document = self.dbMgrData['vectName']
             if not self.dbMgrData['editable']:
-                title += _("READONLY - ")
-            title += "<%s>" % (self.dbMgrData['vectName'])
-
+                document = _("{document} (read-only)").format(document=document)
+            title = "{document} - {tool_name}".format(
+                document=document, tool_name=base_title
+            )
         self.SetTitle(title)
 
         # icon

--- a/gui/wxpython/gcp/mapdisplay.py
+++ b/gui/wxpython/gcp/mapdisplay.py
@@ -47,7 +47,7 @@ class MapFrame(SingleMapFrame):
     """
 
     def __init__(self, parent, giface,
-                 title=_("GRASS GIS Manage Ground Control Points"),
+                 title=_("Manage Ground Control Points"),
                  toolbars=["gcpdisp"], Map=None, auimgr=None,
                  name='GCPMapWindow', **kwargs):
         """Main map display window with toolbars, statusbar and

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -78,7 +78,7 @@ from grass.script import core as grass
 class ModelFrame(wx.Frame):
 
     def __init__(self, parent, giface, id=wx.ID_ANY,
-                 title=_("GRASS GIS Graphical Modeler"), **kwargs):
+                 title=_("Graphical Modeler"), **kwargs):
         """Graphical modeler main window
 
         :param parent: parent window

--- a/gui/wxpython/gmodeler/g.gui.gmodeler.py
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.py
@@ -49,7 +49,11 @@ def main():
     from gmodeler.frame import ModelFrame
 
     app = wx.App()
-    frame = ModelFrame(parent=None, giface=StandaloneGrassInterface())
+    frame = ModelFrame(
+        parent=None,
+        giface=StandaloneGrassInterface(),
+        title=_("Graphical Modeler - GRASS GIS"),
+    )
     if options['file']:
         frame.LoadModelFile(options['file'])
     frame.Show()

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1997,7 +1997,7 @@ class ImageSizeDialog(wx.Dialog):
 class SqlQueryFrame(wx.Frame):
 
     def __init__(self, parent, id=wx.ID_ANY,
-                 title=_("GRASS GIS SQL Query Utility"),
+                 title=_("SQL Query Utility"),
                  *kwargs):
         """SQL Query Utility window
         """

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -469,6 +469,7 @@ class TaskFrame(wx.Frame):
 
     def __init__(self, parent, giface, task_description, id=wx.ID_ANY,
                  get_dcmd=None, layer=None,
+                 title=None,
                  style=wx.DEFAULT_FRAME_STYLE | wx.TAB_TRAVERSAL, **kwargs):
         self.get_dcmd = get_dcmd
         self.layer = layer
@@ -478,13 +479,9 @@ class TaskFrame(wx.Frame):
 
         self.dialogClosing = Signal('TaskFrame.dialogClosing')
 
-        # module name + keywords
-        title = self.task.get_name()
-        try:
-            if self.task.keywords != ['']:
-                title += " [" + ', '.join(self.task.keywords) + "]"
-        except ValueError:
-            pass
+        # Module name as title by default
+        if not title:
+            title = self.task.get_name()
 
         wx.Frame.__init__(self, parent=parent, id=id, title=title,
                           name="MainFrame", style=style, **kwargs)

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -687,7 +687,7 @@ class PyEditFrame(wx.Frame):
     # pylint: disable=invalid-name
 
     def __init__(self, parent, giface, id=wx.ID_ANY,
-                 title=_("GRASS GIS Simple Python Editor"),
+                 title=_("Simple Python Editor"),
                  **kwargs):
         wx.Frame.__init__(self, parent=parent, id=id, title=title, **kwargs)
         self.parent = parent

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -76,7 +76,7 @@ class IClassMapFrame(DoubleMapFrame):
 
     def __init__(
             self, parent=None, giface=None,
-            title=_("GRASS GIS Supervised Classification Tool"),
+            title=_("Supervised Classification Tool"),
             toolbars=["iClassMisc", "iClassMap", "vdigit", "iClass"],
             size=(875, 600),
             name='IClassWindow', **kwargs):

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -108,7 +108,11 @@ def main():
 
     # show main frame
     giface = StandaloneGrassInterface()
-    frame = IClassMapFrame(parent=None, giface=giface)
+    frame = IClassMapFrame(
+        parent=None,
+        giface=giface,
+        title=_("Supervised Classification Tool - GRASS GIS"),
+    )
     if not flags['m']:
         frame.CenterOnScreen()
     if group_name:

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -168,7 +168,7 @@ class IScattDialog(wx.Dialog):
 
     def __init__(
             self, parent, giface,
-            title=_("GRASS GIS Interactive Scatter Plot Tool"),
+            title=_("Interactive Scatter Plot Tool"),
             id=wx.ID_ANY, style=wx.DEFAULT_FRAME_STYLE, **kwargs):
         wx.Dialog.__init__(
             self,

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -91,12 +91,7 @@ class GMFrame(wx.Frame):
         if title:
             self.baseTitle = title
         else:
-            try:
-                grassVersion = grass.version()['version']
-            except KeyError:
-                sys.stderr.write(_("Unable to get GRASS version\n"))
-                grassVersion = "?"
-            self.baseTitle = _("GRASS GIS %s Layer Manager") % grassVersion
+            self.baseTitle = _("GRASS GIS")
 
         self.iconsize = (16, 16)
 
@@ -265,15 +260,27 @@ class GMFrame(wx.Frame):
 
     def _setTitle(self):
         """Set frame title"""
+        gisenv = grass.gisenv()
+        location = gisenv["LOCATION_NAME"]
+        mapset = gisenv["MAPSET"]
         if self.workspaceFile:
+            filename = os.path.splitext(os.path.basename(self.workspaceFile))[0]
             self.SetTitle(
-                self.baseTitle +
-                " - " +
-                os.path.splitext(
-                    os.path.basename(
-                        self.workspaceFile))[0])
+                "{workspace} - {location}/{mapset} - {program}".format(
+                    location=location,
+                    mapset=mapset,
+                    workspace=filename,
+                    program=self.baseTitle
+                )
+            )
         else:
-            self.SetTitle(self.baseTitle)
+            self.SetTitle(
+                "{location}/{mapset} - {program}".format(
+                    location=location,
+                    mapset=mapset,
+                    program=self.baseTitle
+                )
+            )
 
     def _createMenuBar(self):
         """Creates menu bar"""
@@ -290,7 +297,7 @@ class GMFrame(wx.Frame):
         Used to rename display.
         """
         menu = Menu()
-        item = wx.MenuItem(menu, id=wx.ID_ANY, text=_("Rename Map Display"))
+        item = wx.MenuItem(menu, id=wx.ID_ANY, text=_("Rename current Map Display"))
         menu.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.OnRenameDisplay, item)
 
@@ -1102,12 +1109,7 @@ class GMFrame(wx.Frame):
         If location is None, mapset changed within location.
         """
         if not location:
-            # TODO: this does not use the actual names if they were
-            # renamed (it just uses the numbers)
-            dispId = 1
-            for display in self.GetMapDisplay(onlyCurrent=False):
-                display.SetTitleWithName(str(dispId))  # TODO: signal ?
-                dispId += 1
+            self._setTitle()
         else:
             # close current workspace and create new one
             self.OnWorkspaceClose()
@@ -1766,12 +1768,7 @@ class GMFrame(wx.Frame):
             self.notebookLayers.SetPageText(
                 page=self.currentPageNum, text=name)
             mapdisplay = self.GetMapDisplay()
-            # There is a slight inconsistency: When creating the display
-            # we use just the number, but when user renames it,
-            # we use the full name. Both cases make sense and each
-            # separately gives expected result, so we keep this
-            # behavior.
-            mapdisplay.SetTitleWithName(name)
+            mapdisplay.SetTitle(name)
         dlg.Destroy()
 
     def OnRasterRules(self, event):
@@ -2087,7 +2084,7 @@ class GMFrame(wx.Frame):
         if name:
             dispName = name
         else:
-            dispName = "Display " + str(self.displayIndex + 1)
+            dispName = _("Map Display {number}").format(number=self.displayIndex + 1)
         self.notebookLayers.AddPage(
             page=self.pg_panel, text=dispName, select=True)
         self.currentPage = self.notebookLayers.GetCurrentPage()
@@ -2100,7 +2097,9 @@ class GMFrame(wx.Frame):
             style=wx.TR_HAS_BUTTONS | wx.TR_LINES_AT_ROOT | wx.TR_HIDE_ROOT | wx.
             TR_DEFAULT_STYLE | wx.NO_BORDER | wx.FULL_REPAINT_ON_RESIZE,
             idx=self.displayIndex, lmgr=self, notebook=self.notebookLayers,
-            showMapDisplay=show)
+            showMapDisplay=show,
+            title=dispName,
+        )
 
         # layout for controls
         cb_boxsizer = wx.BoxSizer(wx.VERTICAL)

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -121,7 +121,9 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                  id=wx.ID_ANY, style=wx.SUNKEN_BORDER,
                  ctstyle=CT.TR_HAS_BUTTONS | CT.TR_HAS_VARIABLE_ROW_HEIGHT |
                  CT.TR_HIDE_ROOT | CT.TR_ROW_LINES | CT.TR_FULL_ROW_HIGHLIGHT |
-                 CT.TR_MULTIPLE, **kwargs):
+                 CT.TR_MULTIPLE,
+                 title=None,
+                 **kwargs):
 
         if 'style' in kwargs:
             ctstyle |= kwargs['style']
@@ -198,11 +200,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                                    style=wx.DEFAULT_FRAME_STYLE,
                                    tree=self, notebook=self.notebook,
                                    lmgr=self.lmgr, page=self.treepg,
-                                   Map=self.Map)
-
-        # here (with initial auto-generated names) we use just the
-        # number, not the whole name for simplicity
-        self.mapdisplay.SetTitleWithName(str(self.displayIndex + 1))
+                                   Map=self.Map,
+                                   title=title)
 
         # show new display
         if showMapDisplay is True:

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -61,7 +61,7 @@ class MapFrame(SingleMapFrame):
     child double buffered drawing window.
     """
 
-    def __init__(self, parent, giface, title=_("GRASS GIS - Map display"),
+    def __init__(self, parent, giface, title=_("Map Display"),
                  toolbars=["map"], statusbar=True,
                  tree=None, notebook=None, lmgr=None,
                  page=None, Map=None, auimgr=None, name='MapWindow', **kwargs):
@@ -248,25 +248,6 @@ class MapFrame(SingleMapFrame):
 
     def GetMapWindow(self):
         return self.MapWindow
-
-    def SetTitleWithName(self, name):
-        """Set map display title its name
-
-        This function should be used when there are multiple map
-        displays.
-
-        Sets also other dynamically determined parts of the title
-        specific for GRASS GIS map display,
-        while the standard (inherited) ``SetTitle()`` function sets the
-        raw title and doesn't add or modify anything.
-        """
-        gisenv = grass.gisenv()
-        title = _("GRASS GIS Map Display: %(name)s - %(loc)s/%(mapset)s") % {
-            'name': name,
-            'loc': gisenv["LOCATION_NAME"],
-            'mapset': gisenv["MAPSET"]}
-
-        self.SetTitle(title)
 
     def _addToolbarVDigit(self):
         """Add vector digitizer toolbar

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -38,7 +38,7 @@ from mapswipe.dialogs import SwipeMapDialog, PreferencesDialog
 class SwipeMapFrame(DoubleMapFrame):
 
     def __init__(self, parent=None, giface=None,
-                 title=_("GRASS GIS Map Swipe"), name="swipe", **kwargs):
+                 title=_("Map Swipe"), name="swipe", **kwargs):
         DoubleMapFrame.__init__(self, parent=parent, title=title, name=name,
                                 firstMap=Map(), secondMap=Map(), **kwargs)
         Debug.msg(1, "SwipeMapFrame.__init__()")

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.py
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.py
@@ -78,7 +78,11 @@ def main():
 
     app = wx.App()
 
-    frame = SwipeMapFrame(parent=None, giface=StandaloneGrassInterface())
+    frame = SwipeMapFrame(
+        parent=None,
+        giface=StandaloneGrassInterface(),
+        title=_("Temporal Plot Tool - GRASS GIS"),
+    )
 
     if first:
         frame.SetFirstRaster(first)

--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -293,7 +293,7 @@ class HistogramFrame(wx.Frame):
     """
 
     def __init__(self, parent, giface, id=wx.ID_ANY,
-                 title=_("GRASS GIS Histogramming Tool (d.histogram)"),
+                 title=_("Histogramming Tool (d.histogram)"),
                  size=wx.Size(500, 350),
                  style=wx.DEFAULT_FRAME_STYLE, **kwargs):
         wx.Frame.__init__(

--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -293,7 +293,7 @@ class HistogramFrame(wx.Frame):
     """
 
     def __init__(self, parent, giface, id=wx.ID_ANY,
-                 title=_("Histogramming Tool (d.histogram)"),
+                 title=_("Histogram Tool  [d.histogram]"),
                  size=wx.Size(500, 350),
                  style=wx.DEFAULT_FRAME_STYLE, **kwargs):
         wx.Frame.__init__(

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -53,10 +53,10 @@ class MapCalcFrame(wx.Frame):
 
         if self.cmd == 'r.mapcalc':
             self.rast3d = False
-            title = _('GRASS GIS Raster Map Calculator')
+            title = _('Raster Map Calculator')
         if self.cmd == 'r3.mapcalc':
             self.rast3d = True
-            title = _('GRASS GIS 3D Raster Map Calculator')
+            title = _('3D Raster Map Calculator')
 
         wx.Frame.__init__(self, parent, id=id, title=title, **kwargs)
         self.SetIcon(

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -54,7 +54,7 @@ from psmap.utils import *
 class PsMapFrame(wx.Frame):
 
     def __init__(self, parent=None, id=wx.ID_ANY,
-                 title=_("GRASS GIS Cartographic Composer"), **kwargs):
+                 title=_("Cartographic Composer"), **kwargs):
         """Main window of ps.map GUI
 
         :param parent: parent window

--- a/gui/wxpython/psmap/g.gui.psmap.py
+++ b/gui/wxpython/psmap/g.gui.psmap.py
@@ -46,7 +46,10 @@ def main():
     from psmap.frame import PsMapFrame
 
     app = wx.App()
-    frame = PsMapFrame(parent=None)
+    frame = PsMapFrame(
+        parent=None,
+        title=_("Cartographic Composer - GRASS GIS"),
+    )
     frame.Show()
 
     if options['file']:

--- a/gui/wxpython/rdigit/g.gui.rdigit.py
+++ b/gui/wxpython/rdigit/g.gui.rdigit.py
@@ -88,9 +88,10 @@ def main():
             MapFrame.__init__(
                 self, parent=None, Map=Map(),
                 giface=DMonGrassInterface(None),
-                title=_("GRASS GIS Raster Digitizer"), size=(850, 600),
+                title=_("Raster Digitizer - GRASS GIS"),
+                size=(850, 600),
             )
-            # this giface issue not solved yet, we must set mapframe aferwards
+            # this giface issue not solved yet, we must set mapframe afterwards
             self._giface._mapframe = self
             self._giface.mapCreated.connect(self.OnMapCreated)
             self._mapObj = self.GetMap()

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -111,8 +111,7 @@ class RLiSetupFrame(wx.Frame):
 
     def __init__(
             self, parent, giface=None, id=wx.ID_ANY,
-            title=_("GRASS"
-                    " GIS Setup for r.li modules"),
+            title=_("Setup for r.li modules"),
             style=wx.DEFAULT_FRAME_STYLE | wx.RESIZE_BORDER, **kwargs):
         # VARIABLES
         self.parent = parent

--- a/gui/wxpython/rlisetup/g.gui.rlisetup.py
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.py
@@ -41,7 +41,11 @@ def main():
     from rlisetup.frame import RLiSetupFrame
 
     app = wx.App()
-    frame = RLiSetupFrame(parent=None, giface=StandaloneGrassInterface())
+    frame = RLiSetupFrame(
+        parent=None,
+        giface=StandaloneGrassInterface(),
+        title=_("Setup for r.li modules - GRASS GIS"),
+    )
     frame.Show()
     frame.CenterOnScreen()
 

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -558,7 +558,7 @@ class LocationDownloadDialog(wx.Dialog):
     Contains the panel and Cancel button.
     """
     def __init__(self, parent, database,
-                 title=_("GRASS GIS Location Download")):
+                 title=_("Location Download")):
         """
         :param database: database to download the location to
         :param title: window title if the default is not appropriate

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -74,7 +74,7 @@ class TimelineFrame(wx.Frame):
             self,
             parent,
             id=wx.ID_ANY,
-            title=_("GRASS GIS Timeline Tool"))
+            title=_("Timeline Tool"))
 
         tgis.init(True)
         self.datasets = []

--- a/gui/wxpython/timeline/g.gui.timeline.py
+++ b/gui/wxpython/timeline/g.gui.timeline.py
@@ -58,7 +58,10 @@ def main():
     view3d = flags['3']
 
     app = wx.App()
-    frame = TimelineFrame(None)
+    frame = TimelineFrame(
+        parent=None,
+        title=_("Timeline Tool - GRASS GIS"),
+    )
     frame.SetDatasets(datasets)
     frame.Show3D(view3d)
     frame.Show()

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -97,7 +97,7 @@ class TplotFrame(wx.Frame):
 
     def __init__(self, parent, giface):
         wx.Frame.__init__(self, parent, id=wx.ID_ANY,
-                          title=_("GRASS GIS Temporal Plot Tool"))
+                          title=_("Temporal Plot Tool"))
 
         tgis.init(True)
         self._giface = giface

--- a/gui/wxpython/tplot/g.gui.tplot.py
+++ b/gui/wxpython/tplot/g.gui.tplot.py
@@ -162,7 +162,11 @@ def main():
     if options['csv']:
         csvfile = options['csv']
     app = wx.App()
-    frame = TplotFrame(parent=None, giface=StandaloneGrassInterface())
+    frame = TplotFrame(
+        parent=None,
+        giface=StandaloneGrassInterface(),
+        title=_("Temporal Plot Tool - GRASS GIS"),
+    )
     if flags['l']:
         frame.linRegRaster.SetValue(state=True)
         frame.linRegVector.SetValue(state=True)

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -64,7 +64,7 @@ def main():
         def __init__(self, vectorMap):
             MapFrame.__init__(
                 self, parent=None, Map=Map(), giface=DMonGrassInterface(None),
-                title=_("GRASS GIS Vector Digitizer"), size=(850, 600))
+                title=_("Vector Digitizer - GRASS GIS"), size=(850, 600))
             # this giface issue not solved yet, we must set mapframe aferwards
             self._giface._mapframe = self
             # load vector map

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -74,7 +74,7 @@ from vnet.vnet_utils import DegreesToRadians, RadiansToDegrees, GetNearestNodeCa
 class VNETDialog(wx.Dialog):
 
     def __init__(self, parent, giface, id=wx.ID_ANY,
-                 title=_("GRASS GIS Vector Network Analysis Tool"),
+                 title=_("Vector Network Analysis Tool"),
                  style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER, **kwargs):
         """Dialog for vector network analysis"""
 

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -62,6 +62,10 @@ class GMApp(wx.App):
 
         :return: True
         """
+        # Internal and display name of the app (if supported by/on platform)
+        self.SetAppName("GRASS GIS")
+        self.SetVendorName("The GRASS Development Team")
+
         # create splash screen
         introImagePath = os.path.join(globalvar.IMGDIR, "splash_screen.png")
         introImage = wx.Image(introImagePath, wx.BITMAP_TYPE_PNG)

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -40,7 +40,7 @@ class HistogramPlotFrame(BasePlotFrame):
         # workaround for http://trac.wxwidgets.org/ticket/13888
         if sys.platform != 'darwin':
             self.SetToolBar(self.toolbar)
-        self.SetTitle(_("Histogramming Tool"))
+        self.SetTitle(_("Histogram Tool"))
 
         #
         # Init variables

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -40,7 +40,7 @@ class HistogramPlotFrame(BasePlotFrame):
         # workaround for http://trac.wxwidgets.org/ticket/13888
         if sys.platform != 'darwin':
             self.SetToolBar(self.toolbar)
-        self.SetTitle(_("GRASS GIS Histogramming Tool"))
+        self.SetTitle(_("Histogramming Tool"))
 
         #
         # Init variables


### PR DESCRIPTION
The 'lmgr' window is considered the main one, so it is no longer
called (GRASS GIS) Layer Manager, but just GRASS GIS. This fits well with this
window being the main GRASS GIS component for many users, although it is not
technically completely precise.

The lmgr window title previously included only workspace name after its base title.
Now it includes workspace name (if applicable), followed by
mapset/location (previously in map display title) and that is followed by the base title,
separated by dashes. This follows common practice of document before application name,
or from most specific information to most general. This also brings the titles closer
to what a single window interface would use. It also may improve the situation reported by a beginner:
*Once I open the GRASS GIS console...it opens another application called Layer Manager*, reported in
[Trac Ticket 3474](https://trac.osgeo.org/grass/ticket/3474).

The version number of is no longer included in the title. This is again a common practice
and it makes making release screenshots easier. Bug reports need a more complete info anyway.
Users which have multiple installations are likely advanced anyway and can always check if needed.

Map display does not include mapset/location at the end as before,
nor GRASS GIS as prefix. Titles of tabs in the Display tab are fully synchronized
with the titles regardless of the title being the default or custom,
so the tabs now say Map Display, not just Display. This simplifies the code
significantly and clarifies the interface. (Small change to rename item
in menu is included for further clarification.)

Database manager which includes vector name in the title follows the same practice
as the main window lmgr, i.e., document before tool/app name.
The read-only info is included with more common spelling and standard case
(applied in the table tab title).

Dialogs started from main GUI don't show GRASS GIS as first part of the title.
This basic title is usually set as default in the frame.
The corresponding g.gui.* tools (if any) set their own title using
a tool - program name syntax and are considered to be somewhat standalone,
so they include GRASS GIS after a dash.

The GUI forms/dialogs for modules no longer include keywords in (square) brackets.
Module name is therefore more highlighted as the actual tool name.
Keywords are not meant to be used this way. (A useful title might be menu item
label, but that's not readily available.)

wxgui.py now sets the application name and vendor which improves how the program
is titled on some platforms. (Making no distinction between internal and display
name because there is no current use case for that.)

![Screenshot from 2020-12-29 00-37-08](https://user-images.githubusercontent.com/5449060/103261076-1277bf80-496e-11eb-969b-627edbac6286.png)