### PR TITLE
init: Do not ask for a terminal in the freedesktop entry

### DIFF
--- a/gui/icons/grass.desktop
+++ b/gui/icons/grass.desktop
@@ -49,6 +49,6 @@ GenericName[uz]=Geografik axborot tizimi
 Icon=grass
 TryExec=/usr/bin/grass79
 Exec=grass79
-Terminal=true
+Terminal=false
 Keywords=gis;spatial;geospatial;database;remote sensing;hydrology;vector;raster;visualization;maps;wms;wfs;ogc;osgeo;
 Categories=Education;Science;Geoscience;Geography;


### PR DESCRIPTION
This PR specifies that the GRASS GIS desktop application _should not start with a terminal_ in the Freedesktop Desktop Entry (`.desktop` file).

Based on the discussion in [Make terminal window optional? (grass-dev, Sep 5-12, 2020)](https://lists.osgeo.org/pipermail/grass-dev/2020-September/094601.html) we are going with (option 2):

*Remove the terminal from desktop launchers so that GRASS GIS starts without the terminal when started in the GUI way. When a user starts GRASS GIS using a command from an existing terminal, there is no change from the current behavior: a (sub-)shell is started and possibly GUI launches.*

In other words, the terminal experience with an interactive shell is now opt-in with this PR. 

The correct behavior (i.e., not a failure) without an interactive terminal is enabled by 171db2e53ff3e6e3dc524be19ee54bd021aa0d35 (#768). The GUI will provide a clear application main window title after #1216 and a smooth quit experience after #1219.

This PR only changes the `.desktop` file provided with GRASS GIS. It does not change any actual installers or packages, especially no change is done for Windows and macOS.

Package/installer maintainers, please take an action for your platform. Open separate PRs if applicable.