### PR TITLE
remove deprecated py 'PIL' module 'fromstring', 'tostring' method call

### DIFF
--- a/gui/wxpython/animation/utils.py
+++ b/gui/wxpython/animation/utils.py
@@ -265,8 +265,7 @@ def RenderText(text, font, bgcolor, fgcolor):
 def WxImageToPil(image):
     """Converts wx.Image to PIL image"""
     pilImage = Image.new('RGB', (image.GetWidth(), image.GetHeight()))
-    getattr(pilImage, "frombytes", getattr(pilImage, "fromstring"))(
-        bytes(image.GetData()))
+    pilImage.frombytes(bytes(image.GetData()))
     return pilImage
 
 

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -1044,39 +1044,19 @@ def PilImageToWxImage(pilImage, copyAlpha=True):
         wxImage = EmptyImage(*pilImage.size)
         pilImageCopyRGBA = pilImage.copy()
         pilImageCopyRGB = pilImageCopyRGBA.convert('RGB')    # RGBA --> RGB
-        fn = getattr(
-            pilImageCopyRGB,
-            "tobytes",
-            getattr(
-                pilImageCopyRGB,
-                "tostring"))
-        pilImageRgbData = fn()
-        wxImage.SetData(pilImageRgbData)
-        fn = getattr(
-            pilImageCopyRGBA,
-            "tobytes",
-            getattr(
-                pilImageCopyRGBA,
-                "tostring"))
+        wxImage.SetData(pilImageCopyRGB.tobytes())
         # Create layer and insert alpha values.
         if wxPythonPhoenix:
-            wxImage.SetAlpha(fn()[3::4])
+            wxImage.SetAlpha(pilImageCopyRGBA.tobytes()[3::4])
         else:
-            wxImage.SetAlphaData(fn()[3::4])
+            wxImage.SetAlphaData(pilImageCopyRGBA.tobytes()[3::4])
 
     else:    # The resulting image will not have alpha.
         wxImage = EmptyImage(*pilImage.size)
         pilImageCopy = pilImage.copy()
         # Discard any alpha from the PIL image.
         pilImageCopyRGB = pilImageCopy.convert('RGB')
-        fn = getattr(
-            pilImageCopyRGB,
-            "tobytes",
-            getattr(
-                pilImageCopyRGB,
-                "tostring"))
-        pilImageRgbData = fn()
-        wxImage.SetData(pilImageRgbData)
+        wxImage.SetData(pilImageCopyRGB.tobytes())
 
     return wxImage
 

--- a/lib/python/imaging/images2gif.py
+++ b/lib/python/imaging/images2gif.py
@@ -792,7 +792,7 @@ class NeuQuant:
 
         # Initialize
         self.setconstants(samplefac, colors)
-        self.pixels = np.fromstring(getattr(image, "tobytes", getattr(image, "tostring"))(), np.uint32)
+        self.pixels = np.fromstring(image.tobytes(), np.uint32)
         self.setUpArrays()
 
         self.learn()

--- a/lib/python/imaging/images2swf.py
+++ b/lib/python/imaging/images2swf.py
@@ -169,8 +169,7 @@ class BitArray:
         return self._len  # self.data.shape[0]
 
     def __repr__(self):
-        fn = getattr(self.data[:self._len], "tobytes", getattr(self.data[:self._len], "tostring"))
-        return fn().decode('ascii')
+        return self.data[:self._len].tobytes()
 
     def _checkSize(self):
         # check length... grow if necessary


### PR DESCRIPTION
Remove deprecated py 'PIL' module 'fromstring', 'tostring' method call (removed from 'PIL' module version >= 8.0.0).

**To Reproduce:**

Steps to reproduce the behavior:

1. Install python Pillow module version >= 8.0.0.
2. Launch Cartographic Composer `g.gui.psmap`
3. Try insert Image or North Arrow
4. You get error message

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-
packages/wx/lib/filebrowsebutton.py", line 140, in OnChanged

self.changeCallback(evt)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 5996, in OnDirChanged

self.OnImageSelectionChanged(None)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 6042, in OnImageSelectionChanged

img = PilImageToWxImage(pImg)
  File "/usr/lib64/grass79/gui/wxpython/core/utils.py", line
1077, in PilImageToWxImage

"tostring"))
AttributeError
:
'Image' object has no attribute 'tostring'
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py",
line 778, in OnAddImage

dlg = ImageDialog(self, id=id, settings=self.instruction,
env=self.env)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 5765, in __init__

self.OnDirChanged(None)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 5996, in OnDirChanged

self.OnImageSelectionChanged(None)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 6042, in OnImageSelectionChanged

img = PilImageToWxImage(pImg)
  File "/usr/lib64/grass79/gui/wxpython/core/utils.py", line
1077, in PilImageToWxImage

"tostring"))
AttributeError
:
'Image' object has no attribute 'tostring'
```

