### PR TITLE
fix parsing GDAL/OGR formats which contains a colon in a description

### DIFF
--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -671,7 +671,7 @@ def _parseFormats(output, writableOnly=False):
         patt = re.compile('\(rw\+?\)$', re.IGNORECASE)
 
     for line in output.splitlines():
-        key, name = map(lambda x: x.strip(), line.strip().rsplit(':', -1))
+        key, name = map(lambda x: x.strip(), line.strip().split(':', 1))
 
         if writableOnly and not patt.search(key):
             continue


### PR DESCRIPTION
Steps to reproduce:

1. Open GUI
2. Go to `File -> Import raster data -> Simplified import ...`

Import dialog can fail due to problem parsing supported GDAL/OGR formats. Parsing formats such

```
HEIF (ro): ISO/IEC 23008-12:2017 High Efficiency Image File Format
```

will fail with

```python
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/lmgr/frame.py", line 1980, in OnImportGdalLayers
    dlg = GdalImportDialog(parent=self, giface=self._giface)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/modules/import_export.py", line 424, in __init__
    self.dsnInput = GdalSelect(parent=self, panel=self.panel,
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/gselect.py", line 1520, in __init__
    fileFormats = GetFormats(writableOnly=dest)[fType]['file']
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/core/utils.py", line 713, in GetFormats
    ogrAll, ogrWritable = _getOGRFormats()
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/core/utils.py", line 644, in _getGDALFormats
    return _parseFormats(ret), _parseFormats(ret, writableOnly=True)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/core/utils.py", line 675, in _parseFormats
    
ValueError: too many values to unpack (expected 2)
```