### PR TITLE
wxGUI: add option for start-up without Terminal

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -159,6 +159,12 @@ class Settings:
                         'enabled' : False
                     },
                 },
+                # init
+                'init': {
+                    'startWithoutShellIfPossible': {
+                        'enabled' : True
+                    },
+                },
             },
             #
             # datacatalog

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -481,6 +481,47 @@ class PreferencesDialog(PreferencesBaseDialog):
             border=5)
         border.Add(sizer, proportion=0, flag=wx.ALL | wx.EXPAND, border=3)
 
+        #
+        # init
+        #
+        box = StaticBox(
+            parent=panel, id=wx.ID_ANY, label=" %s " % _("Start-up settings")
+        )
+        sizer = wx.StaticBoxSizer(box, wx.VERTICAL)
+
+        gridSizer = wx.GridBagSizer(hgap=3, vgap=3)
+
+        row = 0
+        startWithoutShell = wx.CheckBox(
+            parent=panel,
+            id=wx.ID_ANY,
+            label=_(
+                "Start-up GRASS GIS without Terminal if possible (requires restart)"
+            ),
+            name="IsChecked",
+        )
+        startWithoutShell.SetValue(
+            self.settings.Get(
+                group="general",
+                key="init",
+                subkey=["startWithoutShellIfPossible", "enabled"],
+            )
+        )
+        self.winId[
+            "general:init:startWithoutShellIfPossible:enabled"
+        ] = startWithoutShell.GetId()
+
+        gridSizer.Add(startWithoutShell,
+                      pos=(row, 0), span=(1, 2))
+
+        gridSizer.AddGrowableCol(0)
+        sizer.Add(
+            gridSizer,
+            proportion=1,
+            flag=wx.ALL | wx.EXPAND,
+            border=5)
+        border.Add(sizer, proportion=0, flag=wx.ALL | wx.EXPAND, border=3)
+
         panel.SetSizer(border)
 
         return panel


### PR DESCRIPTION
This adds to the Preferences the possibility to set a flag whether a terminal (shell) should not (if possible) be started with GRASS. Packagers need to implement the reading of this setting in the start-up process.

Related to: #1219 and #1221.
