### PR TITLE
wxGUI/vselect: fix delete row from selected features list

### DIFF
--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -147,6 +147,8 @@ class VectorSelectBase():
         """Delete row in widget
         """
         index = self.slist.GetFocusedItem()
+        if index < 0:
+            return
         category = self.slist.GetItemText(index)
         for item in self.selectedFeatures:
             if int(item['Category']) == int(category):


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Dispaly vector map e.g. `d.vect census`
3. On the Map Display window activate Select vector feature(s) tool from toolbar
4. Select some vector feature (3 features)
5. Move mouse pointer on the Select vector feature(s) tool dialog
6. Delete some selected features from the dialog list (right mouse click, click four times)
7. See error message

**Error message:**

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/gui_core/vselect.py", line
152, in OnDeleteRow

category = self.slist.GetItemText(index)
wx._core
.
wxAssertionError
:
C++ assertion "item.m_itemId >= 0 && (size_t)item.m_itemId <
GetItemCount()" failed at /var/tmp/portage/x11-libs/wxGTK-3.
0.4-r302/work/wxWidgets-3.0.4/src/generic/listctrl.cpp(3531)
in GetItem(): invalid item index in GetItem
```