### PR TITLE
make: Add support for Makefile variable DESTDIR

### DIFF
--- a/include/Make/Install.make
+++ b/include/Make/Install.make
@@ -49,7 +49,7 @@ install-check-built:
 		exit; \
 	fi
 
-install-check-parent:
+install-check-parent: | $(DESTDIR)
 	@ INST_PATH=`dirname $(DESTDIR)$(INST_DIR)`; \
 	while [ ! -d "$(DESTDIR)$$INST_PATH" ]; do \
 		INST_PATH=`dirname $$INST_PATH`; \
@@ -119,6 +119,9 @@ ifneq ($(findstring darwin,$(ARCH)),)
 	@# enable OSX Help Viewer
 	@/bin/ln -sfh "$(INST_DIR)/docs/html" /Library/Documentation/Help/GRASS-$(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR)
 endif
+
+$(DESTDIR):
+	$(MAKE_DIR_CMD) -p $@
 
 $(DESTDIR)$(INST_DIR) $(DESTDIR)$(UNIX_BIN):
 	$(MAKE_DIR_CMD) $@

--- a/include/Make/Install.make
+++ b/include/Make/Install.make
@@ -50,11 +50,11 @@ install-check-built:
 	fi
 
 install-check-parent:
-	@ INST_PATH=`dirname $(INST_DIR)`; \
-	while [ ! -d "$$INST_PATH" ]; do \
+	@ INST_PATH=`dirname $(DESTDIR)$(INST_DIR)`; \
+	while [ ! -d "$(DESTDIR)$$INST_PATH" ]; do \
 		INST_PATH=`dirname $$INST_PATH`; \
 	done; \
-	if [ ! -d "$(INST_DIR)" -a ! -w "$$INST_PATH" ] ; then \
+	if [ ! -d "$(DESTDIR)$(INST_DIR)" -a ! -w "$(DESTDIR)$$INST_PATH" ] ; then \
 		echo "ERROR: Directory $$INST_PATH is a parent directory of your" >&2 ; \
 		echo "  install directory $(INST_DIR) and is not writable." >&2 ; \
 		echo "  Perhaps you need root access." >&2 ; \
@@ -63,7 +63,7 @@ install-check-parent:
 	fi
 
 install-check-writable:
-	@ if [ -d "$(INST_DIR)" -a ! -w "$(INST_DIR)" ] ; then \
+	@ if [ -d "$(DESTDIR)$(INST_DIR)" -a ! -w "$(DESTDIR)$(INST_DIR)" ] ; then \
 		echo "ERROR: Your install directory $(INST_DIR) is not writable." >&2 ; \
 		echo "  Perhaps you need root access." >&2 ; \
 		echo "  Installation aborted, exiting Make." >&2 ; \
@@ -71,7 +71,7 @@ install-check-writable:
 	fi
 
 install-check-prefix:
-	@ result=`echo "$(INST_DIR)" | awk '{ if (tolower($$1) ~ /grass/) print $$1 }'`; \
+	@ result=`echo "$(DESTDIR)$(INST_DIR)" | awk '{ if (tolower($$1) ~ /grass/) print $$1 }'`; \
 	if [ "$$result" = "" ] ; then \
 		echo "WARNING: Your install directory $(INST_DIR)" >&2 ; \
 		echo "  does not contain the word 'grass'." >&2 ; \
@@ -88,7 +88,7 @@ install-check-prefix:
 ifneq ($(strip $(MINGW)),)
 STARTUP = $(INST_DIR)/etc/$(GRASS_NAME).py
 else
-STARTUP = $(UNIX_BIN)/$(GRASS_NAME)
+STARTUP = $(DESTDIR)$(UNIX_BIN)/$(GRASS_NAME)
 endif
 
 FONTCAP = etc/fontcap
@@ -96,31 +96,31 @@ TMPGISRC = demolocation/.grassrc$(GRASS_VERSION_MAJOR)$(GRASS_VERSION_MINOR)
 PLATMAKE = include/Make/Platform.make
 GRASSMAKE = include/Make/Grass.make
 
-real-install: | $(INST_DIR) $(UNIX_BIN)
-	-tar cBCf $(GISBASE) - . | tar xBCf $(INST_DIR) - 2>/dev/null
-	-rm $(INST_DIR)/$(GRASS_NAME).tmp
+real-install: | $(DESTDIR) $(DESTDIR)$(INST_DIR) $(DESTDIR)$(UNIX_BIN)
+	-tar cBCf $(GISBASE) - . | tar xBCf $(DESTDIR)$(INST_DIR) - 2>/dev/null
+	-rm $(DESTDIR)$(INST_DIR)/$(GRASS_NAME).tmp
 	$(MAKE) $(STARTUP)
 
-	-rm $(INST_DIR)/$(FONTCAP)
-	$(MAKE) $(INST_DIR)/$(FONTCAP)
+	-rm $(DESTDIR)$(INST_DIR)/$(FONTCAP)
+	$(MAKE) $(DESTDIR)$(INST_DIR)/$(FONTCAP)
 
-	-rm $(INST_DIR)/$(TMPGISRC)
-	$(MAKE) $(INST_DIR)/$(TMPGISRC)
+	-rm $(DESTDIR)$(INST_DIR)/$(TMPGISRC)
+	$(MAKE) $(DESTDIR)$(INST_DIR)/$(TMPGISRC)
 
-	-rm $(INST_DIR)/$(PLATMAKE)
-	$(MAKE) $(INST_DIR)/$(PLATMAKE)
+	-rm $(DESTDIR)$(INST_DIR)/$(PLATMAKE)
+	$(MAKE) $(DESTDIR)$(INST_DIR)/$(PLATMAKE)
 
-	-rm $(INST_DIR)/$(GRASSMAKE)
-	$(MAKE) $(INST_DIR)/$(GRASSMAKE)
+	-rm $(DESTDIR)$(INST_DIR)/$(GRASSMAKE)
+	$(MAKE) $(DESTDIR)$(INST_DIR)/$(GRASSMAKE)
 
-	-$(CHMOD) -R a+rX $(INST_DIR) 2>/dev/null
+	-$(CHMOD) -R a+rX $(DESTDIR)$(INST_DIR) 2>/dev/null
 
 ifneq ($(findstring darwin,$(ARCH)),)
 	@# enable OSX Help Viewer
 	@/bin/ln -sfh "$(INST_DIR)/docs/html" /Library/Documentation/Help/GRASS-$(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR)
 endif
 
-$(INST_DIR) $(UNIX_BIN):
+$(DESTDIR)$(INST_DIR) $(DESTDIR)$(UNIX_BIN):
 	$(MAKE_DIR_CMD) $@
 
 $(STARTUP): $(ARCH_DISTDIR)/$(GRASS_NAME).tmp
@@ -144,16 +144,16 @@ sed -e 's#^\(ARCH_DISTDIR.[^=]*\).*#\1= $(INST_DIR)#g' \
     -e 's#^\(ARCH_BINDIR.[^=]*\).*#\1= $(UNIX_BIN)#g' $< > $@
 endef
 
-$(INST_DIR)/$(FONTCAP): $(GISBASE)/$(FONTCAP)
+$(DESTDIR)$(INST_DIR)/$(FONTCAP): $(GISBASE)/$(FONTCAP)
 	$(call fix_gisbase)
 
-$(INST_DIR)/$(TMPGISRC): $(GISBASE)/$(TMPGISRC)
+$(DESTDIR)$(INST_DIR)/$(TMPGISRC): $(GISBASE)/$(TMPGISRC)
 	$(call fix_gisbase)
 
-$(INST_DIR)/$(PLATMAKE): $(GISBASE)/$(PLATMAKE)
+$(DESTDIR)$(INST_DIR)/$(PLATMAKE): $(GISBASE)/$(PLATMAKE)
 	$(call fix_grass_home)
 
-$(INST_DIR)/$(GRASSMAKE): $(GISBASE)/$(GRASSMAKE)
+$(DESTDIR)$(INST_DIR)/$(GRASSMAKE): $(GISBASE)/$(GRASSMAKE)
 	$(call fix_grass_arch)
 
 install-macosx:


### PR DESCRIPTION
This PR adds support for staged installs with the addition of the Makefile variable `DESTDIR`.

Support of `DESTDIR` is "strongly recommended"  for packages support  by [GNU Coding Standards](https://www.gnu.org/prep/standards/html_node/DESTDIR.html). See also automake documentation [2.2.10 Building Binary Packages Using DESTDIR](https://www.gnu.org/software/automake/manual/html_node/DESTDIR.html) and [12.4 Staged Installs](https://www.gnu.org/software/automake/manual/html_node/Staged-Installs.html).

This addresses [trac ticket 764 (open)](https://trac.osgeo.org/grass/ticket/764) and [trac ticket 1839 (closed)](https://trac.osgeo.org/grass/ticket/1839), regarding issues with MacPorts build of GRASS GIS.

The problem with missing `DESTDIR` support was also discussed in [Red Hat Bugzilla – Bug 1739908](https://bugzilla.redhat.com/show_bug.cgi?id=1739908).

Using `DESTDIR` in packaging systems is mentioned in e.g. [MacPorts Documentation: 5.3. Port Phases](https://guide.macports.org/chunked/reference.phases.html) and Fedora Packaging Guidelines [here](https://docs.fedoraproject.org/en-US/packaging-guidelines/RPMMacros/) and [here](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_why_the_makeinstall_macro_should_not_be_used).

This is a modification of https://github.com/macports/macports-ports/blob/4e2a26e42de94067ac78b3f26dbb54d5931158e0/gis/grass7/files/patch-Install_make.diff
originally created by @Veence.

I have successfully tested this locally with an ordinary `./configure | make | make install` kind of build, as well as a MacPorts port on Mac.

#### How to use and test `DESTDIR`

In short: e.g. `make DESTDIR=/home/stagedir install` will install GRASS GIS into `/home/stagedir`, not into `$prefix`. Compiling and linking will not be affected, the files will only be "copied" into `DESTDIR` in the end.
:exclamation: If `DESTDIR` is **not** defined as in `make install`, installation will proceed as expected to `$prefix`.

Test:
```sh
# given default prefix=/usr/local
./configure [...]
make
make install                              # should not give (unexpected) errors 
make DESTDIR=/home/stagedir install       # should not give (unexpected) errors and similar log as previous command
diff -rq /usr/local/grass79 /home/stagedir/usr/local/grass79     # should show no difference
diff /usr/local/bin/grass79 /home/stagedir/usr/local/bin/grass79 # should show no difference

# remove installed
rm /usr/local/bin/grass79
rm -rf /usr/local/grass79

# undo this PR, i.e. revert the `include/Make/Install.make` file
# then install again and diff against previous staged version
make install
diff -rq /usr/local/grass79 /home/stagedir/usr/local/grass79     # should show no difference
diff /usr/local/bin/grass79 /home/stagedir/usr/local/bin/grass79 # should show no difference
```
