### PR TITLE
Fix compiler warnings, part 1

### DIFF
--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 
     /* For some strange reason infd[0] cannot be used later */
     /* So nfiles is initialized with nfiles = 1 */
-    int nfiles = 1;
+    int nfiles = 0;
     int i = 0, j = 0;
     int radiance = 0;
     void *inrast[MAXFILES];
@@ -227,23 +227,20 @@ int main(int argc, char *argv[])
 
     /********************/
     for (; *ptr != NULL; ptr++) {
-        if (nfiles > MAXFILES)
+        if (nfiles == MAXFILES)
             G_fatal_error(_("Too many input maps. Only %d allowed."),
                           MAXFILES);
         name = *ptr;
         /* Allocate input buffer */
-        in_data_type[nfiles - 1] = Rast_map_type(name, "");
-        /* For some strange reason infd[0] cannot be used later */
-        /* So nfiles is initialized with nfiles = 1 */
+        in_data_type[nfiles] = Rast_map_type(name, "");
         infd[nfiles] = Rast_open_old(name, "");
 
         Rast_get_cellhd(name, "", &cellhd);
-        inrast[nfiles - 1] = Rast_allocate_buf(in_data_type[nfiles - 1]);
+        inrast[nfiles] = Rast_allocate_buf(in_data_type[nfiles]);
         nfiles++;
     }
-    nfiles--;
     if (nfiles < MAXFILES)
-        G_fatal_error(_("The input band number should be 15"));
+        G_fatal_error(_("The input band number should be %d"), MAXFILES);
 
     /***************************************************/
     /* Allocate output buffer, use input map data_type */
@@ -253,21 +250,21 @@ int main(int argc, char *argv[])
     for (i = 0; i < MAXFILES; i++)
         outrast[i] = Rast_allocate_buf(out_data_type);
 
-    outfd[1] = Rast_open_new(result0, 1);
-    outfd[2] = Rast_open_new(result1, 1);
-    outfd[3] = Rast_open_new(result2, 1);
-    outfd[4] = Rast_open_new(result3, 1);
-    outfd[5] = Rast_open_new(result4, 1);
-    outfd[6] = Rast_open_new(result5, 1);
-    outfd[7] = Rast_open_new(result6, 1);
-    outfd[8] = Rast_open_new(result7, 1);
-    outfd[9] = Rast_open_new(result8, 1);
-    outfd[10] = Rast_open_new(result9, 1);
-    outfd[11] = Rast_open_new(result10, 1);
-    outfd[12] = Rast_open_new(result11, 1);
-    outfd[13] = Rast_open_new(result12, 1);
-    outfd[14] = Rast_open_new(result13, 1);
-    outfd[15] = Rast_open_new(result14, 1);
+    outfd[0] = Rast_open_new(result0, 1);
+    outfd[1] = Rast_open_new(result1, 1);
+    outfd[2] = Rast_open_new(result2, 1);
+    outfd[3] = Rast_open_new(result3, 1);
+    outfd[4] = Rast_open_new(result4, 1);
+    outfd[5] = Rast_open_new(result5, 1);
+    outfd[6] = Rast_open_new(result6, 1);
+    outfd[7] = Rast_open_new(result7, 1);
+    outfd[8] = Rast_open_new(result8, 1);
+    outfd[9] = Rast_open_new(result9, 1);
+    outfd[10] = Rast_open_new(result10, 1);
+    outfd[11] = Rast_open_new(result11, 1);
+    outfd[12] = Rast_open_new(result12, 1);
+    outfd[13] = Rast_open_new(result13, 1);
+    outfd[14] = Rast_open_new(result14, 1);
     /* Process pixels */
 
     DCELL dout[MAXFILES];
@@ -276,8 +273,8 @@ int main(int argc, char *argv[])
     for (row = 0; row < nrows; row++) {
         G_percent(row, nrows, 2);
         /* read input map */
-        for (i = 1; i <= MAXFILES; i++)
-            Rast_get_row(infd[i], inrast[i - 1], row, in_data_type[i - 1]);
+        for (i = 0; i < MAXFILES; i++)
+            Rast_get_row(infd[i], inrast[i], row, in_data_type[i]);
 
         /*process the data */
         for (col = 0; col < ncols; col++) {
@@ -306,13 +303,13 @@ int main(int argc, char *argv[])
                 outrast[i][col] = dout[i];
             }
         }
-        for (i = 1; i <= MAXFILES; i++)
-            Rast_put_row(outfd[i], outrast[i - 1], out_data_type);
+        for (i = 0; i < MAXFILES; i++)
+            Rast_put_row(outfd[i], outrast[i], out_data_type);
     }
-    for (i = 1; i <= MAXFILES; i++) {
-        G_free(inrast[i - 1]);
+    for (i = 0; i < MAXFILES; i++) {
+        G_free(inrast[i]);
         Rast_close(infd[i]);
-        G_free(outrast[i - 1]);
+        G_free(outrast[i]);
         Rast_close(outfd[i]);
     }
     exit(EXIT_SUCCESS);

--- a/imagery/i.evapo.time/main.c
+++ b/imagery/i.evapo.time/main.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
     module->description =_("Computes temporal integration of satellite "
 			   "ET actual (ETa) following the daily ET reference "
 			   "(ETo) from meteorological station(s).");
-    
+
     /* Define the different options */
     input = G_define_standard_option(G_OPT_R_INPUTS);
     input->key = "eta";
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
     input3->type = TYPE_DOUBLE;
     input3->required = YES;
     input3->description = _("Value of DOY for ETo first day");
-    
+
     input4 = G_define_option();
     input4->key = "start_period";
     input4->type = TYPE_DOUBLE;
@@ -114,11 +114,11 @@ int main(int argc, char *argv[])
     input5->description = _("Value of DOY for the last day of the period studied");
 
     output = G_define_standard_option(G_OPT_R_OUTPUT);
-    
+
     /* init nfiles */
-    nfiles = 1;
-    nfiles1 = 1;
-    nfiles2 = 1;
+    nfiles = 0;
+    nfiles1 = 0;
+    nfiles2 = 0;
 
     /********************/
 
@@ -157,13 +157,13 @@ int main(int argc, char *argv[])
 	inrast[nfiles] = Rast_allocate_d_buf();
 	nfiles++;
     }
-    nfiles--;
-    if (nfiles <= 1)
+
+    if (nfiles < 2)
 	G_fatal_error(_("The min specified input map is two"));
-	
+
 	/****************************************/
     for (; *ptr1 != NULL; ptr1++) {
-	if (nfiles1 > MAXFILES)
+	if (nfiles1 == MAXFILES)
 	    G_fatal_error(_("Too many ETa_doy files. Only %d allowed."),
 			  MAXFILES);
 	name1 = *ptr1;
@@ -173,8 +173,8 @@ int main(int argc, char *argv[])
 	inrast1[nfiles1] = Rast_allocate_d_buf();
 	nfiles1++;
     }
-    nfiles1--;
-    if (nfiles1 <= 1)
+
+    if (nfiles1 < 2)
 	G_fatal_error(_("The min specified input map is two"));
 
 
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
 	/****************************************/
 
     for (; *ptr2 != NULL; ptr2++) {
-	if (nfiles > MAXFILES)
+	if (nfiles2 == MAXFILES)
 	    G_fatal_error(_("Too many ETo files. Only %d allowed."),
 			  MAXFILES);
 	name2 = *ptr2;
@@ -195,8 +195,8 @@ int main(int argc, char *argv[])
 	inrast2[nfiles2] = Rast_allocate_d_buf();
 	nfiles2++;
     }
-    nfiles2--;
-    if (nfiles2 <= 1)
+
+    if (nfiles2 < 2)
 	G_fatal_error(_("The min specified input map is two"));
 
     /* Allocate output buffer, use input map data_type */
@@ -222,13 +222,13 @@ int main(int argc, char *argv[])
 	G_percent(row, nrows, 2);
 
 	/* read input map */
-	for (i = 1; i <= nfiles; i++) 
+	for (i = 0; i < nfiles; i++)
 	    Rast_get_d_row(infd[i], inrast[i], row);
-	
-	for (i = 1; i <= nfiles1; i++) 
+
+	for (i = 0; i < nfiles1; i++)
 	    Rast_get_d_row(infd1[i], inrast1[i], row);
 
-	for (i = 1; i <= nfiles2; i++) 
+	for (i = 0; i < nfiles2; i++)
 	    Rast_get_d_row (infd2[i], inrast2[i], row);
 
 	/*process the data */
@@ -236,14 +236,14 @@ int main(int argc, char *argv[])
         {
             int	d1_null=0;
             int	d_null=0;
-	    for (i = 1; i <= nfiles; i++) 
+	    for (i = 0; i < nfiles; i++)
             {
 		    if (Rast_is_d_null_value(&((DCELL *) inrast[i])[col]))
 		    	d_null=1;
 		    else
 	                d[i] = ((DCELL *) inrast[i])[col];
 	    }
-	    for (i = 1; i <= nfiles1; i++) 
+	    for (i = 0; i < nfiles1; i++)
             {
 		    if (Rast_is_d_null_value(&((DCELL *) inrast1[i])[col]))
 			d1_null=1;
@@ -251,14 +251,14 @@ int main(int argc, char *argv[])
 	                d1[i] = ((DCELL *) inrast1[i])[col];
 	    }
 
-	    for (i = 1; i <= nfiles2; i++) 
+	    for (i = 0; i < nfiles2; i++)
 		    d2[i] = ((DCELL *) inrast2[i])[col];
 
 	    /* Find out the DOY of the eto image    */
-	    for (i = 1; i <= nfiles1; i++) 
+	    for (i = 0; i < nfiles1; i++)
             {
 		if ( d_null==1 || d1_null==1 )
-			Rast_set_d_null_value(&outrast[col],1);	
+			Rast_set_d_null_value(&outrast[col],1);
 		else
 		{
 			doy[i] = d1[i] - etodoy+1;
@@ -266,10 +266,10 @@ int main(int argc, char *argv[])
 				Rast_set_d_null_value(&outrast[col],1);
 			else
 				d_ETrF[i] = d[i] / d2[(int)doy[i]];
-		} 
+		}
 	    }
 
-	    for (i = 1; i <= nfiles1; i++) 
+	    for (i = 0; i < nfiles1; i++)
             {
 		/* do nothing	*/
 		if ( d_null==1 || d1_null==1)
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
 		else
 		{
 			DOYbeforeETa[i]=0; DOYafterETa[i]=0;
-			if (i == 1)   
+			if (i == 0)
 				DOYbeforeETa[i] = startperiod;
 			else
 			{
@@ -287,17 +287,17 @@ int main(int argc, char *argv[])
 				while (d1[k]>=startperiod )
 				{
 					if (d1[k]<0)	 /* case were d1[k] is null */
-						k=k-1;					
+						k=k-1;
 					else
 					{
 						DOYbeforeETa[i] = 1+((d1[i] + d1[k])/2.0);
 						break;
-					}			
+					}
 				}
 
 			}
-	
-			if (i == nfiles1)  
+
+			if (i == (nfiles1-1))
 				DOYafterETa[i] = endperiod;
 			else
 			{
@@ -310,22 +310,22 @@ int main(int argc, char *argv[])
 					{
 						DOYafterETa[i] = (d1[i] + d1[k]) / 2.0;
 						break;
-	   				}					
+					}
 				}
 			}
 		}	
 	    }
 
-	    sum[MAXFILES] = 0.0;
-	    for (i = 1; i <= nfiles1; i++) 
+	    /* sum[MAXFILES] = 0.0; */
+	    for (i = 0; i < nfiles1; i++)
             {
 		if(d_null==1 || d1_null==1)
                 {
 		    /* do nothing	 */
-		} 
+		}
                 else
                 {
-			if (DOYbeforeETa[i]==0 || DOYbeforeETa[i]==0 ) 	
+			if (DOYbeforeETa[i]==0 || DOYbeforeETa[i]==0 )
                             Rast_set_d_null_value(&outrast[col],1);
 			else 
                         {
@@ -337,31 +337,31 @@ int main(int argc, char *argv[])
 			}
 		}
 	    }
-	
+
 	    d_out = 0.0;
-	    for (i = 1; i <= nfiles1; i++)
+	    for (i = 0; i < nfiles1; i++)
             {
 		if(d_null==1 || d_null==1)
 			Rast_set_d_null_value(&outrast[col],1);
 		else
-                {	
+                {
 			d_out += d_ETrF[i] * sum[i];
 		     	outrast[col] = d_out;
-		}	
+		}
 	    }
 	}
 	Rast_put_row(outfd, outrast, out_data_type);
     }
 
-    for (i = 1; i <= nfiles; i++) {
+    for (i = 0; i < nfiles; i++) {
 	G_free(inrast[i]);
 	Rast_close(infd[i]);
     }
-    for (i = 1; i <= nfiles1; i++) {
+    for (i = 0; i < nfiles1; i++) {
 	G_free(inrast1[i]);
 	Rast_close(infd1[i]);
     }
-    for (i = 1; i <= nfiles2; i++) {
+    for (i = 0; i < nfiles2; i++) {
 	G_free(inrast2[i]);
 	Rast_close(infd2[i]);
     }

--- a/lib/gmath/blas_level_1.c
+++ b/lib/gmath/blas_level_1.c
@@ -551,7 +551,7 @@ void G_math_i_asum_norm(int *x, double *value, int rows)
 
 #pragma omp parallel for schedule (static) reduction(+:s)
     for (i = rows - 1; i >= 0; i--) {
-	s += fabs(x[i]);
+	s += (double)abs(x[i]);
     }
 #pragma omp single
     {
@@ -579,10 +579,10 @@ void G_math_i_max_norm(int *x, int *value, int rows)
 
     int max = 0.0;
 
-    max = fabs(x[rows - 1]);
+    max = abs(x[rows - 1]);
     for (i = rows - 2; i >= 0; i--) {
-	if (max < fabs(x[i]))
-	    max = fabs(x[i]);
+	if (max < abs(x[i]))
+	    max = abs(x[i]);
     }
 
     *value = max;

--- a/lib/imagery/iscatt_core.c
+++ b/lib/imagery/iscatt_core.c
@@ -181,14 +181,14 @@ static int get_rows_and_cols_bounds(struct Cell_head *A, struct Cell_head *B,
     struct Cell_head intersec;
 
     /* TODO is it right check? */
-    if (abs(A->ns_res - B->ns_res) > GRASS_EPSILON) {
+    if (fabs(A->ns_res - B->ns_res) > GRASS_EPSILON) {
 	G_warning(
 		"'get_rows_and_cols_bounds' ns_res does not fit, A->ns_res: %f B->ns_res: %f",
 		A->ns_res, B->ns_res);
 	return -2;
     }
 
-    if (abs(A->ew_res - B->ew_res) > GRASS_EPSILON) {
+    if (fabs(A->ew_res - B->ew_res) > GRASS_EPSILON) {
 	G_warning(
 		"'get_rows_and_cols_bounds' ew_res does not fit, A->ew_res: %f B->ew_res: %f",
 		A->ew_res, B->ew_res);

--- a/lib/raster3d/test/test_put_get_value_large_file.c
+++ b/lib/raster3d/test/test_put_get_value_large_file.c
@@ -130,7 +130,7 @@ int test_large_file(int depths, int rows, int cols, int tile_size)
             for(x = 0; x < region.cols; x++) {
                 /* Check the counter as cell value */
                 Rast3d_get_value(map, x, y, z, &value, DCELL_TYPE);
-                if(fabs(value - (double)(count) > EPSILON)) {
+                if(fabs(value - (double)(count)) > EPSILON) {
                     G_message("At: z %i y %i x %i -- value %.14lf != %.14lf\n",
                     		z, y, x, value, (double)(count));
 			sum++;

--- a/lib/vector/neta/bridge.c
+++ b/lib/vector/neta/bridge.c
@@ -102,7 +102,7 @@ int NetA_compute_bridges(dglGraph_s * graph, struct ilist *bridge_list)
 			dglEdgeGet_Tail(graph, current_edge[node_id]);
 		    dglInt32_t edge_id =
 			dglEdgeGet_Id(graph, current_edge[node_id]);
-		    if (abs(edge_id) == parent[node_id])
+		    if (labs(edge_id) == parent[node_id])
 			continue;	/*skip edge we used to travel to this node */
 		    int to_id = dglNodeGet_Id(graph, to);
 
@@ -111,7 +111,7 @@ int NetA_compute_bridges(dglGraph_s * graph, struct ilist *bridge_list)
 			    min_tin[node_id] = tin[to_id];
 		    }
 		    else {	/*forward edge */
-			parent[to_id] = abs(edge_id);
+			parent[to_id] = labs(edge_id);
 			stack[stack_size++] = to;
 			break;
 		    }

--- a/lib/vector/neta/flow.c
+++ b/lib/vector/neta/flow.c
@@ -103,7 +103,7 @@ int NetA_flow(dglGraph_s * graph, struct ilist *source_list,
 		dglInt32_t to =
 		    dglNodeGet_Id(graph, dglEdgeGet_Tail(graph, edge));
 		if (!is_source[to] && prev[to] == NULL &&
-		    cap > sign(id) * flow[abs(id)]) {
+		    cap > sign(id) * flow[labs(id)]) {
 		    prev[to] = edge;
 		    if (is_sink[to]) {
 			found = to;
@@ -127,7 +127,7 @@ int NetA_flow(dglGraph_s * graph, struct ilist *source_list,
 	edge_id = dglEdgeGet_Id(graph, prev[node]);
 	min_residue =
 	    dglEdgeGet_Cost(graph,
-			    prev[node]) - sign(edge_id) * flow[abs(edge_id)];
+			    prev[node]) - sign(edge_id) * flow[labs(edge_id)];
 	while (!is_source[node]) {
 	    dglInt32_t residue;
 
@@ -135,7 +135,7 @@ int NetA_flow(dglGraph_s * graph, struct ilist *source_list,
 	    residue =
 		dglEdgeGet_Cost(graph,
 				prev[node]) -
-		sign(edge_id) * flow[abs(edge_id)];
+		sign(edge_id) * flow[labs(edge_id)];
 	    if (residue < min_residue)
 		min_residue = residue;
 	    node = dglNodeGet_Id(graph, dglEdgeGet_Head(graph, prev[node]));
@@ -145,7 +145,7 @@ int NetA_flow(dglGraph_s * graph, struct ilist *source_list,
 	node = found;
 	while (!is_source[node]) {
 	    edge_id = dglEdgeGet_Id(graph, prev[node]);
-	    flow[abs(edge_id)] += sign(edge_id) * min_residue;
+	    flow[labs(edge_id)] += sign(edge_id) * min_residue;
 	    node = dglNodeGet_Id(graph, dglEdgeGet_Head(graph, prev[node]));
 	}
     }
@@ -214,7 +214,7 @@ int NetA_min_cut(dglGraph_s * graph, struct ilist *source_list,
 	    dglInt32_t id = dglEdgeGet_Id(graph, edge);
 	    dglInt32_t to =
 		dglNodeGet_Id(graph, dglEdgeGet_Tail(graph, edge));
-	    if (!visited[to] && cap > sign(id) * flow[abs(id)]) {
+	    if (!visited[to] && cap > sign(id) * flow[labs(id)]) {
 		visited[to] = 1;
 		queue[end++] = to;
 	    }
@@ -236,10 +236,10 @@ int NetA_min_cut(dglGraph_s * graph, struct ilist *source_list,
 	    dglInt32_t to, edge_id;
 
 	    to = dglNodeGet_Id(graph, dglEdgeGet_Tail(graph, edge));
-	    edge_id = abs(dglEdgeGet_Id(graph, edge));
+	    edge_id = labs(dglEdgeGet_Id(graph, edge));
 	    if (!visited[to] && flow[edge_id] != 0) {
 		Vect_list_append(cut, edge_id);
-		total_flow += abs(flow[abs(edge_id)]);
+		total_flow += abs(flow[labs(edge_id)]);
 	    }
 	}
 	dglEdgeset_T_Release(&et);

--- a/lib/vector/neta/path.c
+++ b/lib/vector/neta/path.c
@@ -293,7 +293,7 @@ int NetA_find_path(dglGraph_s * graph, int from, int to, int *edges,
 				dglNodeGet_OutEdgeset(graph, node));
 	for (edge = dglEdgeset_T_First(&et); edge;
 	     edge = dglEdgeset_T_Next(&et)) {
-	    dglInt32_t edge_id = abs(dglEdgeGet_Id(graph, edge));
+	    dglInt32_t edge_id = labs(dglEdgeGet_Id(graph, edge));
 	    dglInt32_t node_id =
 		dglNodeGet_Id(graph, dglEdgeGet_Tail(graph, edge));
 	    if (edges[edge_id] && !vis[node_id]) {
@@ -313,7 +313,7 @@ int NetA_find_path(dglGraph_s * graph, int from, int to, int *edges,
 
     cur = to;
     while (prev[cur] != NULL) {
-	Vect_list_append(list, abs(dglEdgeGet_Id(graph, prev[cur])));
+	Vect_list_append(list, labs(dglEdgeGet_Id(graph, prev[cur])));
 	cur = dglNodeGet_Id(graph, dglEdgeGet_Head(graph, prev[cur]));
     }
 

--- a/raster/r.grow.distance/main.c
+++ b/raster/r.grow.distance/main.c
@@ -47,12 +47,12 @@ static double distance_euclidean_squared(double dx, double dy)
 
 static double distance_maximum(double dx, double dy)
 {
-    return MAX(abs(dx), abs(dy));
+    return MAX(fabs(dx), fabs(dy));
 }
 
 static double distance_manhattan(double dx, double dy)
 {
-    return abs(dx) + abs(dy);
+    return fabs(dx) + fabs(dy);
 }
 
 static double geodesic_distance(int x1, int y1, int x2, int y2)

--- a/raster/r.latlong/main.c
+++ b/raster/r.latlong/main.c
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
     ymax = cellhd.north;
     nrows = Rast_window_rows();
     ncols = Rast_window_cols();
-    stepx = abs(xmax-xmin)/(double)ncols;
-    stepy = abs(ymax-ymin)/(double)nrows;
+    stepx = fabs(xmax-xmin)/(double)ncols;
+    stepy = fabs(ymax-ymin)/(double)nrows;
     
     /*Stolen from r.sun */ 
     /* Set up parameters for projection to lat/long if necessary */ 

--- a/raster/r.stream.extract/streams.c
+++ b/raster/r.stream.extract/streams.c
@@ -597,14 +597,6 @@ int extract_streams(double threshold, double mont_exp, int internal_acc)
 	    G_fatal_error("np_side < 0");
 	    
 	/* set main drainage direction to A* path if possible */
-	if (mfd_cells > 0 && max_side != np_side) {
-	    if (fabs(wat_nbr[np_side] >= max_acc)) {
-		max_acc = fabs(wat_nbr[np_side]);
-		r_max = dr;
-		c_max = dc;
-		max_side = np_side;
-	    }
-	}
 	if (mfd_cells == 0) {
 	    flat = 0;
 	    r_max = dr;

--- a/raster/r.surf.idw/ll.c
+++ b/raster/r.surf.idw/ll.c
@@ -66,11 +66,12 @@ int find_neighbors_LL(EW * ewptr, NEIGHBOR * nbr_head, SHORT row, SHORT col,
 	    else if (!replace_neighbor(Mptr, nbr_head, distance))
 		*active = FALSE;	/* curtail search in this direction */
 
-	    if (*active)
+	    if (*active) {
 		if (westward)
 		    extend_west(ewptr);
 		else
 		    extend_east(ewptr);
+	    }
 	}
 
 	active = &ewptr->ealive;

--- a/raster/r.viewshed/main.cpp
+++ b/raster/r.viewshed/main.cpp
@@ -501,7 +501,7 @@ parse_args(int argc, char *argv[], int *vpRow, int *vpCol,
     obsElevOpt->required = NO;
     obsElevOpt->key_desc = "value";
     obsElevOpt->description = _("Viewing elevation above the ground");
-    obsElevOpt->answer = "1.75";
+    obsElevOpt->answer = G_store("1.75");
     obsElevOpt->guisection = _("Settings");
 
     /* target elevation offset */
@@ -513,7 +513,7 @@ parse_args(int argc, char *argv[], int *vpRow, int *vpCol,
     tgtElevOpt->required = NO;
     tgtElevOpt->key_desc = "value";
     tgtElevOpt->description = _("Offset for target elevation above the ground");
-    tgtElevOpt->answer = "0.0";
+    tgtElevOpt->answer = G_store("0.0");
     tgtElevOpt->guisection = _("Settings");
 
     /* max distance */
@@ -569,7 +569,7 @@ parse_args(int argc, char *argv[], int *vpRow, int *vpCol,
     refrCoeffOpt->description = _("Refraction coefficient");
     refrCoeffOpt->type = TYPE_DOUBLE;
     refrCoeffOpt->required = NO;
-    refrCoeffOpt->answer = "0.14286";
+    refrCoeffOpt->answer = G_store("0.14286");
     refrCoeffOpt->options = "0.0-1.0";
     refrCoeffOpt->guisection = _("Refraction");
     
@@ -583,7 +583,7 @@ parse_args(int argc, char *argv[], int *vpRow, int *vpCol,
     memAmountOpt->key_desc = "value";
     memAmountOpt->description =
 	_("Amount of memory to use in MB");
-    memAmountOpt->answer = "500";
+    memAmountOpt->answer = G_store("500");
 
     /* temporary STREAM path */
     struct Option *streamdirOpt;

--- a/vector/v.generalize/network.c
+++ b/vector/v.generalize/network.c
@@ -120,7 +120,7 @@ int graph_generalization(struct Map_info *In, struct Map_info *Out,
 
 	    to_degree = dglNodeGet_OutDegree(gr, to);
 	    from_degree = dglNodeGet_OutDegree(gr, from);
-	    id = abs(dglEdgeGet_Id(gr, edge));
+	    id = labs(dglEdgeGet_Id(gr, edge));
 
 	    /* allocate memory, if it has not been not allocated already */
 	    if (!g.edge[id]) {
@@ -135,7 +135,7 @@ int graph_generalization(struct Map_info *In, struct Map_info *Out,
 
 	    for (to_edge = dglEdgeset_T_First(&to_et); to_edge;
 		 to_edge = dglEdgeset_T_Next(&to_et)) {
-		int id2 = abs(dglEdgeGet_Id(gr, to_edge));
+		int id2 = labs(dglEdgeGet_Id(gr, to_edge));
 
 		g.edge[id][g.degree[id]++] = id2;
 	    }

--- a/vector/v.label.sa/labels.c
+++ b/vector/v.label.sa/labels.c
@@ -1029,8 +1029,8 @@ static double label_lineover(label_t * label, label_candidate_t * candidate,
 	    candidate->point.x, candidate->point.y);
     /*    trsk = skyline_trans_rot(label->skyline, &candidate->point,
        candidate->rotation); */
-    b.x = abs((label->bb.E - label->bb.W) * cos(candidate->rotation));
-    b.y = abs((label->bb.E - label->bb.W) * sin(candidate->rotation));
+    b.x = fabs((label->bb.E - label->bb.W) * cos(candidate->rotation));
+    b.y = fabs((label->bb.E - label->bb.W) * sin(candidate->rotation));
 
     trbb = box_trans_rot(&label->bb, &candidate->point, candidate->rotation);
     n = Vect_select_lines_by_polygon(&Map, trbb, 0, NULL, linetype, il);
@@ -1083,8 +1083,8 @@ static double label_lineover(label_t * label, label_candidate_t * candidate,
 	if (found > 1) {
 	    double cosvb;
 
-	    v.x = abs(v2.x - v1.x);
-	    v.y = abs(v2.y - v1.y);
+	    v.x = fabs(v2.x - v1.x);
+	    v.y = fabs(v2.y - v1.y);
 	    cosvb = ((b.x * v.x + b.y * v.y) /
 		     (sqrt(b.x * b.x + b.y * b.y) *
 		      sqrt(v.x * v.x + v.y * v.y)));

--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -491,14 +491,14 @@ int main(int argc, char *argv[])
 
 	    Vect_get_map_box(&OutMap, &box);
 
-	    if (abs(box.E) > abs(box.W))
-		xmax = abs(box.E);
+	    if (fabs(box.E) > fabs(box.W))
+		xmax = fabs(box.E);
 	    else
-		xmax = abs(box.W);
-	    if (abs(box.N) > abs(box.S))
-		ymax = abs(box.N);
+		xmax = fabs(box.W);
+	    if (fabs(box.N) > fabs(box.S))
+		ymax = fabs(box.N);
 	    else
-		ymax = abs(box.S);
+		ymax = fabs(box.S);
 
 	    if (xmax < ymax)
 		xmax = ymax;


### PR DESCRIPTION
Fixes compiler warnings:
- -Wabsolute-value
- -Warray-bounds
- -Wc++11-compat-deprecated-writable-strings
- -Wdangling-else

First part addressing #1247.

There are a couple of ambivalent cases and I'm not sure how to correctly address them.
I hope for input from experienced C programmers and leave this open as a draft.

Update:

Modules / code parts directly affected:

- imagery/i.aster.toar (partly rewritten)
- imagery/i.evapo.time (partly rewritten)
- lib/gmath
- lib/imagery
- lib/vector/neta
- raster/r.grow.distance
- raster/r.latlong
- raster/r.stream.extract (commented out a part)
- raster/r.surf.idw
- raster/r.viewshed
- vector/v.generalize
- vector/v.label.sa
- vector/v.patch