### PR TITLE
GitHub action CI: drop ubuntu-16.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-16.04
         - ubuntu-18.04
         - ubuntu-20.04
       fail-fast: false


### PR DESCRIPTION
Since ubuntu-16.04 is rather dated, drop it in GitHub action CI.