### PR TITLE
Fix compiler warnings, part 2

### DIFF
--- a/db/drivers/ogr/execute.c
+++ b/db/drivers/ogr/execute.c
@@ -88,7 +88,7 @@ int db__driver_execute_immediate(dbString * sql)
 	hFeature = OGR_L_GetNextFeature(hLayer);
 	if (!hFeature)
 	    break;
-	G_debug(5, "\tfid=%ld", OGR_F_GetFID(hFeature));
+	G_debug(5, "\tfid=%lld", OGR_F_GetFID(hFeature));
 	
 	for (i = 0; i < ncols; i++) {
 	    if (cols[i].qindex > -1) {
@@ -110,7 +110,7 @@ int db__driver_execute_immediate(dbString * sql)
 	    OGR_F_SetFieldString(hFeature, cols[i].index, value);
 	}
 	if (OGR_L_SetFeature(hLayer, hFeature) != OGRERR_NONE)
-	    G_warning(_("\tOGR failed to write feature fid=%ld to layer <%s>"),
+	    G_warning(_("\tOGR failed to write feature fid=%lld to layer <%s>"),
 		      OGR_F_GetFID(hFeature), OGR_L_GetName(hLayer));
 	OGR_F_Destroy(hFeature);
     }

--- a/include/gis.h
+++ b/include/gis.h
@@ -60,7 +60,7 @@ static const char *GRASS_copyright __attribute__ ((unused))
 #define FALSE 0
 #endif
 
-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
+#if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) || (__APPLE__ && __LP64__)
 #define PRI_OFF_T	"lld"
 #else
 #define PRI_OFF_T	"ld"

--- a/lib/vector/Vlib/open_nat.c
+++ b/lib/vector/Vlib/open_nat.c
@@ -150,11 +150,11 @@ int check_coor(struct Map_info *Map)
 
     if (dif > 0) {
 	G_warning(_("Coor file of vector map <%s@%s> is larger than it should be "
-		   "(%ld bytes excess)"), Map->name, Map->mapset, dif);
+		   "(%" PRI_OFF_T " bytes excess)"), Map->name, Map->mapset, dif);
     }
     else if (dif < 0) {
 	G_warning(_("Coor file of vector <%s@%s> is shorter than it should be "
-		   "(%ld bytes missing)."), Map->name, Map->mapset, -dif);
+		   "(%" PRI_OFF_T " bytes missing)."), Map->name, Map->mapset, -dif);
     }
     return 1;
 }

--- a/lib/vector/Vlib/write.c
+++ b/lib/vector/Vlib/write.c
@@ -222,7 +222,7 @@ off_t Vect_rewrite_line(struct Map_info *Map, off_t line, int type,
 {
     off_t ret;
 
-    G_debug(3, "Vect_rewrite_line(): name = %s, format = %d, level = %d, line/offset = %"PRI_OFF_T,
+    G_debug(3, "Vect_rewrite_line(): name = %s, format = %d, level = %d, line/offset = %" PRI_OFF_T,
 	    Map->name, Map->format, Map->level, line);
 
     if (!check_map(Map))
@@ -231,7 +231,7 @@ off_t Vect_rewrite_line(struct Map_info *Map, off_t line, int type,
     ret = (*Vect_rewrite_line_array[Map->format][Map->level]) (Map, line, type,
 							       points, cats);
     if (ret == -1)
-        G_warning(_("Unable to rewrite feature/offset %lu in vector map <%s>"),
+        G_warning(_("Unable to rewrite feature/offset %" PRI_OFF_T " in vector map <%s>"),
 	          line, Vect_get_name(Map));
 
     return ret;
@@ -254,7 +254,7 @@ int Vect_delete_line(struct Map_info *Map, off_t line)
 {
     int ret;
 
-    G_debug(3, "Vect_delete_line(): name = %s, line/offset = %"PRI_OFF_T,
+    G_debug(3, "Vect_delete_line(): name = %s, line/offset = %" PRI_OFF_T,
             Map->name, line);
 
     if (!check_map(Map))
@@ -263,7 +263,7 @@ int Vect_delete_line(struct Map_info *Map, off_t line)
     ret = (*Vect_delete_line_array[Map->format][Map->level]) (Map, line);
 
     if (ret == -1)
-	G_warning(_("Unable to delete feature/offset %lu from vector map <%s>"),
+	G_warning(_("Unable to delete feature/offset %" PRI_OFF_T " from vector map <%s>"),
                   line, Vect_get_name(Map));
 
     return ret;
@@ -287,7 +287,7 @@ int Vect_restore_line(struct Map_info *Map, off_t offset, off_t line)
 {
     int ret;
 
-    G_debug(3, "Vect_restore_line(): name = %s, level = %d, offset = %"PRI_OFF_T", line = %"PRI_OFF_T,
+    G_debug(3, "Vect_restore_line(): name = %s, level = %d, offset = %" PRI_OFF_T ", line = %" PRI_OFF_T,
             Map->name, Map->level, offset, line);
 
     if (!check_map(Map))
@@ -296,7 +296,7 @@ int Vect_restore_line(struct Map_info *Map, off_t offset, off_t line)
     ret = (*Vect_restore_line_array[Map->format][Map->level]) (Map, offset, line);
 
     if (ret == -1)
-	G_warning(_("Unable to restore feature/offset %"PRI_OFF_T" in vector map <%s>"),
+	G_warning(_("Unable to restore feature/offset %" PRI_OFF_T " in vector map <%s>"),
                   offset, Vect_get_name(Map));
 
     return ret;

--- a/lib/vector/Vlib/write_nat.c
+++ b/lib/vector/Vlib/write_nat.c
@@ -105,7 +105,7 @@ off_t V1_rewrite_line_nat(struct Map_info *Map, off_t offset, int type,
     static struct line_pnts *old_points = NULL;
     static struct line_cats *old_cats = NULL;
 
-    G_debug(3, "V1_rewrite_line_nat(): offset = %"PRI_OFF_T,
+    G_debug(3, "V1_rewrite_line_nat(): offset = %" PRI_OFF_T,
 	    offset);
 
     /* First compare numbers of points and cats with tha old one */
@@ -241,7 +241,7 @@ int V1_delete_line_nat(struct Map_info *Map, off_t offset)
     char rhead;
     struct gvfile *dig_fp;
 
-    G_debug(3, "V1_delete_line_nat(): offset = %"PRI_OFF_T, offset);
+    G_debug(3, "V1_delete_line_nat(): offset = %" PRI_OFF_T, offset);
 
     dig_set_cur_port(&(Map->head.port));
     dig_fp = &(Map->dig_fp);
@@ -342,7 +342,7 @@ int V1_restore_line_nat(struct Map_info *Map, off_t offset, off_t line)
     char rhead;
     struct gvfile *dig_fp;
     
-    G_debug(3, "V1_restore_line_nat(): offset = %"PRI_OFF_T", line (not used) = %"PRI_OFF_T, offset, line);
+    G_debug(3, "V1_restore_line_nat(): offset = %" PRI_OFF_T ", line (not used) = %" PRI_OFF_T, offset, line);
     
     dig_set_cur_port(&(Map->head.port));
     dig_fp = &(Map->dig_fp);
@@ -392,10 +392,10 @@ int V2_restore_line_nat(struct Map_info *Map, off_t offset, off_t line)
     
     plus = &(Map->plus);
 
-    G_debug(3, "V2_restore_line_nat(): offset = %"PRI_OFF_T", line = %"PRI_OFF_T, offset, line);
+    G_debug(3, "V2_restore_line_nat(): offset = %" PRI_OFF_T ", line = %" PRI_OFF_T, offset, line);
 
     if (line < 1 || line > plus->n_lines) {
-        G_warning(_("Attempt to access feature with invalid id (%"PRI_OFF_T")"), line);
+        G_warning(_("Attempt to access feature with invalid id (%" PRI_OFF_T ")"), line);
         return -1;
     }
     
@@ -463,7 +463,7 @@ off_t V1__write_line_nat(struct Map_info *Map, off_t offset, int type,
 	    return -1;
 
 	offset = dig_ftell(&(Map->dig_fp));
-	G_debug(3, "V1__rewrite_line_nat(): offset = %lu", offset);
+	G_debug(3, "V1__rewrite_line_nat(): offset = %" PRI_OFF_T, offset);
 	if (offset == -1)
 	    return -1;
     }
@@ -885,7 +885,7 @@ int V2__add_line_to_topo_nat(struct Map_info *Map, off_t offset, int type,
 
     plus = &(Map->plus);
     
-    G_debug(3, "V2__add_line_to_topo_nat(): offset = %ld (build level = %d)", offset, plus->built);
+    G_debug(3, "V2__add_line_to_topo_nat(): offset = %" PRI_OFF_T " (build level = %d)", offset, plus->built);
 
     if (plus->built < GV_BUILD_BASE) /* nothing to build */
         return 0;

--- a/lib/vector/Vlib/write_ogr.c
+++ b/lib/vector/Vlib/write_ogr.c
@@ -89,7 +89,7 @@ off_t V1_rewrite_line_ogr(struct Map_info *Map,
 			  off_t offset, int type,
 			  const struct line_pnts *points, const struct line_cats *cats)
 {
-    G_debug(3, "V1_rewrite_line_ogr(): type=%d offset=%"PRI_OFF_T,
+    G_debug(3, "V1_rewrite_line_ogr(): type=%d offset=%" PRI_OFF_T,
 	    type, offset);
 #ifdef HAVE_OGR
     if (type != V1_read_line_ogr(Map, NULL, NULL, offset)) {
@@ -131,7 +131,7 @@ int V1_delete_line_ogr(struct Map_info *Map, off_t offset)
     }
     
     if (offset >= ogr_info->offset.array_num) {
-	G_warning(_("Invalid offset (%ld)"), offset);
+	G_warning(_("Invalid offset (%" PRI_OFF_T ")"), offset);
 	return -1;
     }
     

--- a/lib/vector/Vlib/write_pg.c
+++ b/lib/vector/Vlib/write_pg.c
@@ -181,7 +181,7 @@ off_t V1_rewrite_line_pg(struct Map_info * Map,
                          const struct line_pnts * points,
                          const struct line_cats * cats)
 {
-    G_debug(3, "V1_rewrite_line_pg(): type=%d offset=%"PRI_OFF_T,
+    G_debug(3, "V1_rewrite_line_pg(): type=%d offset=%" PRI_OFF_T,
             type, offset);
 #ifdef HAVE_POSTGRES
     if (type != V1_read_line_pg(Map, NULL, NULL, offset)) {
@@ -278,7 +278,7 @@ off_t V2_rewrite_line_pg(struct Map_info *Map, off_t line, int type,
     }
     
     geom_data = line_to_wkb(pg_info, &points, 1, type, Map->head.with_z);
-    G_asprintf(&stmt, "UPDATE \"%s\".\"%s\" SET geom = '%s'::GEOMETRY WHERE %s_id = %ld",
+    G_asprintf(&stmt, "UPDATE \"%s\".\"%s\" SET geom = '%s'::GEOMETRY WHERE %s_id = %" PRI_OFF_T,
                schema_name, table_name, geom_data, keycolumn, line);
     G_free(geom_data);
 
@@ -324,7 +324,7 @@ int V1_delete_line_pg(struct Map_info *Map, off_t offset)
     }
 
     if (offset >= pg_info->offset.array_num) {
-        G_warning(_("Invalid offset (%ld)"), offset);
+        G_warning(_("Invalid offset (%" PRI_OFF_T ")"), offset);
         return -1;
     }
 

--- a/raster/r.compress/main.c
+++ b/raster/r.compress/main.c
@@ -216,13 +216,13 @@ static int process(char *name, int uncompress)
 
     if (newsize < oldsize)
 	G_message(uncompress
-		  ? _("DONE: uncompressed file is %lu %s (%.2f%) smaller")
-		  : _("DONE: compressed file is %lu %s (%.2f%) smaller"),
+		  ? _("DONE: uncompressed file is %lu %s (%.2f%%) smaller")
+		  : _("DONE: compressed file is %lu %s (%.2f%%) smaller"),
 		  (unsigned long)diff, sizestr, (double) 100.0 - 100.0 * newsize / oldsize);
     else if (newsize > oldsize)
 	G_message(uncompress
-		  ? _("DONE: uncompressed file is %lu %s (%.2f%) larger")
-		  : _("DONE: compressed file is %lu %s (%.2f%) larger"),
+		  ? _("DONE: uncompressed file is %lu %s (%.2f%%) larger")
+		  : _("DONE: compressed file is %lu %s (%.2f%%) larger"),
 		  (unsigned long)diff, sizestr, (double) 100.0 * newsize / oldsize - 100.0);
     else
 	G_message(_("same size"));

--- a/raster/r.terraflow/main.cpp
+++ b/raster/r.terraflow/main.cpp
@@ -413,13 +413,13 @@ printMaxSortSize(long nodata_count) {
   off_t maxneed = (fillmaxsize > flowmaxsize) ? fillmaxsize: flowmaxsize;
   maxneed =  2*maxneed; /* need 2*N to sort */
 
-  G_debug(1, "total elements=%lld, nodata elements=%ld",
+  G_debug(1, "total elements=%" PRI_OFF_T ", nodata elements=%ld",
           (off_t)nrows * ncols, nodata_count);
   G_debug(1, "largest temporary files: ");
-  G_debug(1, "\t\t FILL: %s [%lld elements, %ldB each]",
+  G_debug(1, "\t\t FILL: %s [%" PRI_OFF_T " elements, %ldB each]",
           formatNumber(buf, fillmaxsize),
           (off_t)nrows * ncols, sizeof(waterWindowType));
-  G_debug(1, "\t\t FLOW: %s [%lld elements, %ldB each]",
+  G_debug(1, "\t\t FLOW: %s [%" PRI_OFF_T " elements, %ldB each]",
           formatNumber(buf, flowmaxsize),
           (off_t)nrows * ncols - nodata_count, sizeof(sweepItem));
   G_debug(1, "Will need at least %s space available in %s",

--- a/raster/r.terraflow/stats.cpp
+++ b/raster/r.terraflow/stats.cpp
@@ -171,25 +171,16 @@ statsRecorder::comment(const int n) {
 
 
 
-#if __FreeBSD__ &&  __i386__
-#define LDFMT "%qd"
-#else
-#if __linux__
-#define LDFMT "%lld"
-#else
-#define LDFMT "%ld"
-#endif
-#endif
 char *
 formatNumber(char *buf, off_t val) {
   if(val > (1<<30)) {
-	sprintf(buf, "%.2fG (" LDFMT ")", (double)val/(1<<30), val);
+	sprintf(buf, "%.2fG (%" PRI_OFF_T ")", (double)val/(1<<30), val);
   } else if(val > (1<<20)) {
-	sprintf(buf, "%.2fM (" LDFMT ")", (double)val/(1<<20), val);
+	sprintf(buf, "%.2fM (%" PRI_OFF_T ")", (double)val/(1<<20), val);
   } else if(val > (1<<10)) {
-	sprintf(buf, "%.2fK (" LDFMT ")", (double)val/(1<<10), val);
+	sprintf(buf, "%.2fK (%" PRI_OFF_T ")", (double)val/(1<<10), val);
   } else {
-	sprintf(buf, LDFMT, val);
+	sprintf(buf, "%" PRI_OFF_T, val);
   }
   return buf;
 }

--- a/raster/r.terraflow/sweep.cpp
+++ b/raster/r.terraflow/sweep.cpp
@@ -207,7 +207,7 @@ sweep(AMI_STREAM<sweepItem> *sweepstr, const flowaccumulation_type D8CUT,
     /* read next sweepItem = (prio, elevwin, topoRankwin, dir) */
     ae = sweepstr->read_item(&crtpoint);
     if (ae != AMI_ERROR_NO_ERROR) {
-      fprintf(stderr, "sweep: k=%ld: cannot read next item..\n", k);
+      fprintf(stderr, "sweep: k=%" PRI_OFF_T ": cannot read next item..\n", k);
       exit(1);
     }
     /* cout << "k=" << k << " prio =" << crtpoint->getPriority() << "\n"; */

--- a/raster/r.viewshed/main.cpp
+++ b/raster/r.viewshed/main.cpp
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
        requires some changes. To do. */
     if (!(vp.row < hd->nrows && vp.col < hd->ncols)) {
 	/* unfortunately, we don't know the point coordinates now */
-	G_warning(_("Region extent: north=%d, south=%d, east=%d, west=%d"),
+	G_warning(_("Region extent: north=%f, south=%f, east=%f, west=%f"),
 	    hd->window.north, hd->window.south, hd->window.east, hd->window.west);
 	G_warning(_("Region extent: rows=%d, cols=%d"), hd->nrows, hd->ncols);
 	G_warning(_("Viewpoint: row=%d, col=%d"), vp.row, vp.col);

--- a/raster3d/r3.stats/support.c
+++ b/raster3d/r3.stats/support.c
@@ -271,10 +271,10 @@ void print_stat_table(stat_table *stats, int counts_only)
     }
     else if (counts_only) {
 	for (i = 0; i < stats->nsteps; i++) {
-	    fprintf(stdout, "%d %ld\n",
+	    fprintf(stdout, "%d %d\n",
 		    stats->table[i]->num, stats->table[i]->count);
 	}
-	fprintf(stdout, "* %ld\n", stats->null->count);
+	fprintf(stdout, "* %d\n", stats->null->count);
     }
     else {
 	/*       1234567   012345678901234567   012345678901234567   0123456789012   0123456   0123456789 */

--- a/tools/timer/main.c
+++ b/tools/timer/main.c
@@ -25,7 +25,7 @@ int main()
 	fprintf(stderr, "gettimeofday error");
 	return 1;
     }
-    fprintf(stdout, "%li.%li\n", t.tv_sec, t.tv_usec);
+    fprintf(stdout, "%li.%li\n", t.tv_sec, (long)t.tv_usec);
     fflush(stdout);
 
     return 0;

--- a/vector/v.in.ascii/points.c
+++ b/vector/v.in.ascii/points.c
@@ -148,7 +148,7 @@ int points_analyse(FILE * ascii_in, FILE * ascii, char *fs, char *td,
 		continue;
 	    }
 	    else {
-		G_warning(_("ntokens: %d, xcol: %d, ycol: %d, zcol: %d"), xcol, ycol, zcol);
+		G_warning(_("ntokens: %d, xcol: %d, ycol: %d, zcol: %d"), ntokens, xcol, ycol, zcol);
 		G_fatal_error(_("Broken row %d: '%s'"), row, buf);
 	    }
 	}

--- a/vector/v.lrs/v.lrs.create/main.c
+++ b/vector/v.lrs/v.lrs.create/main.c
@@ -732,7 +732,7 @@ int main(int argc, char **argv)
 						 mposts[k + 1].end_off);
 			    if (ret > -1) {	/* start >= end */
 				G_warning(_("Start of 1. MP >= end of 2. MP for points' "
-					   "cats %[d], [%d]"), mposts[k].cat,
+					   "cats [%d], [%d]"), mposts[k].cat,
 					  mposts[k + 1].cat);
 				mposts[k].err = ERR_END_GT_START;
 				order = 0;


### PR DESCRIPTION
Fixes `-Wformat` compiler warnings.

One important culprit to these warnings was caused by bad detection of `off_t` print format with PRI_OFF_T.
Suggested solution works for me. I'm curious if it bears in general.

Second part addressing #1247.

Update:

The `PRI_OFF_T` problem seems to be Mac-only, updated accordingly.

Modules / code parts directly affected:
- db/drivers/ogr
- lib/vector/Vlib
- raster/r.compress
- raster/r.info
- raster/t.terraflow
- raster/r.viewshed
- raster3d/r3.out.vtk
- raster3d/r3.stats
- tools/timer
- vector/v.in.ascii
- vector/v.lrs/v.lrs.create
