### PR TITLE
Fix compiler warnings, part 3

### DIFF
--- a/db/db.select/main.c
+++ b/db/db.select/main.c
@@ -276,7 +276,7 @@ void parse_command_line(int argc, char **argv)
     parms.table = table->answer;
     parms.sql = sql->answer;
     parms.fs = G_option_to_separator(fs);
-    parms.vs = '\0';
+    parms.vs = NULL;
     if (vs->answer)
 	parms.vs = G_option_to_separator(vs);
     parms.nv = nv->answer;

--- a/display/d.mon/list.c
+++ b/display/d.mon/list.c
@@ -52,7 +52,7 @@ void list_mon(char ***list, int *n)
     while ((dp = readdir(dirp)) != NULL) {
 	int ret;
 
-        if (!dp->d_name || dp->d_name[0] == '.')
+	if (!dp->d_name[0] || dp->d_name[0] == '.')
 	    continue;
 
 	mon_path = get_path(dp->d_name, TRUE);
@@ -145,7 +145,7 @@ void list_files(const char *name, FILE *fd_out)
         G_fatal_error(_("No support files found for monitor <%s>"), name);
 
     while ((dp = readdir(dirp)) != NULL) {
-        if (!dp->d_name || dp->d_name[0] == '.')
+        if (!dp->d_name[0] || dp->d_name[0] == '.')
             continue;
         
         p = strrchr(dp->d_name, '.');

--- a/display/d.mon/stop.c
+++ b/display/d.mon/stop.c
@@ -34,7 +34,7 @@ int stop(const char *name)
     dirp = opendir(mon_path);
 
     while ((dp = readdir(dirp)) != NULL) {
-        if (!dp->d_name || dp->d_name[0] == '.')
+        if (!*dp->d_name || dp->d_name[0] == '.')
             continue;
         sprintf(file_path, "%s/%s", mon_path, dp->d_name);
         if (unlink(file_path) == -1)

--- a/imagery/i.landsat.toar/landsat_set.c
+++ b/imagery/i.landsat.toar/landsat_set.c
@@ -45,8 +45,7 @@ void sensor_TM(lsat_data * lsat)
     double wmax[] = { 0.52, 0.60, 0.69, 0.90, 1.75, 12.50, 2.35 };
     /* 30, 30, 30, 30, 30, 120 original, 60 resamples before Feb 25, 2010 and 30 after, 30 */
 
-    if (!lsat->sensor)
-	strcpy(lsat->sensor, "TM");
+    strcpy(lsat->sensor, "TM");
 
     lsat->bands = 7;
     for (i = 0; i < lsat->bands; i++) {

--- a/imagery/i.landsat.toar/main.c
+++ b/imagery/i.landsat.toar/main.c
@@ -319,7 +319,7 @@ int main(int argc, char *argv[])
 	G_debug(1, "lsat.number = %d, lsat.sensor = [%s]",
 		lsat.number, lsat.sensor);
 
-	if (!lsat.sensor || lsat.number > 8 || lsat.number < 1)
+	if (!lsat.sensor[0] || lsat.number > 8 || lsat.number < 1)
 	    G_fatal_error(_("Failed to identify satellite"));
 
 	G_debug(1, "Landsat-%d %s with data set in metadata file [%s]",

--- a/include/iostream/ami_stream.h
+++ b/include/iostream/ami_stream.h
@@ -613,7 +613,7 @@ AMI_err AMI_STREAM<T>::write_item(const T &elt) {
   } else {
     if (fwrite((char*)(&elt), sizeof(T), 1,fp) < 1) {
       cerr << "ERROR: AMI_STREAM::write_item failed.\n";
-      if (path && *path)
+      if (*path)
 	perror(path);
       else
 	perror("AMI_STREAM::write_item: ");
@@ -640,7 +640,7 @@ AMI_err AMI_STREAM<T>::write_array(const T *data, off_t len) {
     nobj = fwrite(data, sizeof(T), len, fp);
     if (nobj  < len) {
       cerr << "ERROR: AMI_STREAM::write_array failed.\n";
-      if (path && *path)
+      if (*path)
 	perror(path);
       else
 	perror("AMI_STREAM::write_array: ");

--- a/lib/db/dbmi_base/dbmscap.c
+++ b/lib/db/dbmi_base/dbmscap.c
@@ -210,7 +210,7 @@ dbDbmscap *db_read_dbmscap(void)
 }
 
 static int cmp_entry(dbDbmscap *a, dbDbmscap *b) {
-  return( a->driverName && b->driverName ? strcmp(a->driverName,b->driverName) : 0 );
+    return( *a->driverName && *b->driverName ? strcmp(a->driverName,b->driverName) : 0 );
 }
 
 static void add_entry(dbDbmscap ** list, char *name, char *startup, char *comment)

--- a/lib/db/dbmi_base/dirent.c
+++ b/lib/db/dbmi_base/dirent.c
@@ -17,9 +17,15 @@
 #include <unistd.h>
 #include <grass/dbmi.h>
 /* NOTE: these should come from <unistd.h> or from <sys/file.h> */
+#ifndef R_OK
 #define R_OK 4
+#endif
+#ifndef W_OK
 #define W_OK 2
+#endif
+#ifndef X_OK
 #define X_OK 1
+#endif
 
 #include <sys/types.h>
 #ifdef USE_DIRECT

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -297,11 +297,11 @@ static int get_login(const char *driver, const char *database, const char **user
 
     G_debug(3, "db_get_login(): drv=[%s] db=[%s]", driver, database);
 
-    user[0] = '\0';
-    password[0] = '\0';
-    host[0] = '\0';
-    port[0] = '\0';
-    
+    *user = NULL;
+    *password = NULL;
+    *host = NULL;
+    *port = NULL;
+
     init_login(&login);
 
     if (read_file(&login) == -1)

--- a/vector/v.category/main.c
+++ b/vector/v.category/main.c
@@ -537,7 +537,7 @@ int main(int argc, char *argv[])
 			freps[fld]->table = G_store(Fi->table);
 		    }
 		    else {
-			freps[fld]->table = '\0';
+			freps[fld]->table = NULL;
 		    }
 		}
 
@@ -601,7 +601,7 @@ int main(int argc, char *argv[])
 			    freps[fld]->table = G_store(Fi->table);
 			}
 			else {
-			    freps[fld]->table = '\0';
+			    freps[fld]->table = NULL;
 			}
 		    }
 


### PR DESCRIPTION
Fixes compiler warnings:

- -Wnon-literal-null-conversion
- -Wmacro-redefined
- -Wpointer-bool-conversion

Third part addressing #1247.

Please see comments in code for fixes of `-Wpointer-bool-conversion`warnings.

Modules / code parts directly affected:

- db/db.select
- lib/db/dbmi_base
- vector/v.category
- display/d.mon
- imagery/i.landsat.toar
- include/iostream
