### PR TITLE
wxGUI: remove Version and copyright from menu as redundant

### DIFF
--- a/gui/wxpython/xml/toolboxes.xml
+++ b/gui/wxpython/xml/toolboxes.xml
@@ -609,8 +609,6 @@
       <separator/>
       <wxgui-item name="CreateNewLocation"/>
       <wxgui-item name="CreateNewMapset"/>
-      <separator/>
-      <wxgui-item name="VersionAndCopyright"/>
     </items>
   </toolbox>
   <toolbox name="MapProjections">

--- a/gui/wxpython/xml/wxgui_items.xml
+++ b/gui/wxpython/xml/wxgui_items.xml
@@ -311,12 +311,6 @@
     <description>Creates new mapset in the current location, changes current mapset.</description>
     <keywords>general,mapset,create</keywords>
   </wxgui-item>
-  <wxgui-item name="VersionAndCopyright">
-    <label>Version and copyright</label>
-    <command>g.version -c</command>
-    <description>Displays version and copyright information.</description>
-    <keywords>general,version</keywords>
-  </wxgui-item>
   <wxgui-item name="DisplayMapProjection">
     <label>Display map projection</label>
     <command>g.proj -p</command>


### PR DESCRIPTION
Menu item Version and copyright was in Settings -> GRASS working environment, which doesn't seem to make sense, I would expect it to be in Help menu. Given both version and copyright can be found in Help ->About GRASS GIS, I decided to remove it completely. Alternatively it could be moved to Help menu.