### PR TITLE
Fix compiler warnings, part 4

### DIFF
--- a/lib/cairodriver/read_bmp.c
+++ b/lib/cairodriver/read_bmp.c
@@ -80,7 +80,7 @@ static int read_bmp_header(const unsigned char *p)
 
 void cairo_read_bmp(void)
 {
-    char header[HEADER_SIZE];
+    unsigned char header[HEADER_SIZE];
     FILE *input;
 
     input = fopen(ca.file_name, "rb");

--- a/lib/cairodriver/text.c
+++ b/lib/cairodriver/text.c
@@ -195,7 +195,7 @@ static void set_font_fc(const char *name)
 	face = NULL;
     }
 
-    pattern = FcNameParse(name);
+    pattern = FcNameParse((FcChar8 *)name);
     FcDefaultSubstitute(pattern);
     FcConfigSubstitute(FcConfigGetCurrent(), pattern, FcMatchPattern);
     pattern = FcFontMatch(FcConfigGetCurrent(), pattern, &result);
@@ -223,7 +223,7 @@ static void font_list_fc(char ***list, int *count, int verbose)
     for (i = 0; i < fontset->nfont; i++) {
 	char buf[1024];
 	FcPattern *pat = fontset->fonts[i];
-	FcChar8 *family = "", *style = "";
+	FcChar8 *family = (FcChar8 *)"", *style = (FcChar8 *)"";
 
 	FcPatternGetString(pat, FC_FAMILY, 0, &family);
 	FcPatternGetString(pat, FC_STYLE , 0, &style );

--- a/lib/cairodriver/write_bmp.c
+++ b/lib/cairodriver/write_bmp.c
@@ -64,7 +64,7 @@ static void make_bmp_header(unsigned char *p)
 
 void cairo_write_bmp(void)
 {
-    char header[HEADER_SIZE];
+    unsigned char header[HEADER_SIZE];
     FILE *output;
 
     output = fopen(ca.file_name, "wb");

--- a/lib/db/dbmi_client/c_list_drivers.c
+++ b/lib/db/dbmi_client/c_list_drivers.c
@@ -32,7 +32,7 @@ const char *db_list_drivers(void)
     else {
 	/* build the comma separated string of existing drivers */
 	for (cur = list; cur; cur = cur->next) {
-	    if (cur->driverName == '\0')
+	    if (cur->driverName[0] == '\0')
 		break;
 	    else {
 		if (cur != list)

--- a/lib/db/dbmi_client/start.c
+++ b/lib/db/dbmi_client/start.c
@@ -94,7 +94,7 @@ dbDriver *db_start_driver(const char *name)
 	return (dbDriver *) NULL;
 
     /* if name is empty use connection.driverName, added by RB 4/2000 */
-    if (name == '\0') {
+    if (name[0] == '\0') {
 	db_get_connection(&connection);
 	if (NULL == (name = connection.driverName))
 	    return (dbDriver *) NULL;

--- a/lib/dspf/cube_io.c
+++ b/lib/dspf/cube_io.c
@@ -137,7 +137,7 @@ int read_cube(Cube_data * Cube, file_info * headfax)
     int t_cnt;
     int ret;
     int i, j, size;
-    unsigned char inchar;
+    char inchar;
     poly_info *Poly_info;
     static int first = 1;
     FILE *fp;
@@ -193,7 +193,7 @@ int read_cube(Cube_data * Cube, file_info * headfax)
     my_fread(&inchar, 1, 1, fp);
     size |= inchar;
 
-    if (0 >= (ret = my_fread(Buffer, 1, size, fp))) {
+    if (0 >= (ret = my_fread((char *)Buffer, 1, size, fp))) {
 	fprintf(stderr, "Error reading display file offset %"PRI_OFF_T"\n", G_ftell(fp));
 	return (-1);
     }

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1207,7 +1207,7 @@ void check_opts(void)
 		check_an_opt(opt->key, opt->type,
 			     opt->options, opt->opts, &opt->answer);
 	    else {
-		for (ans = 0; opt->answers[ans] != '\0'; ans++)
+		for (ans = 0; opt->answers[ans] != NULL; ans++)
 		    check_an_opt(opt->key, opt->type,
 				 opt->options, opt->opts, &opt->answers[ans]);
 	    }
@@ -1529,7 +1529,7 @@ void check_multiple_opts(void)
 		if (*ptr == ',')
 		    n_commas++;
 	    /* count items */
-	    for (n = 0; opt->answers[n] != '\0'; n++) ;
+	    for (n = 0; opt->answers[n] != NULL; n++) ;
 	    /* if not correct multiple of items */
 	    if (n % n_commas) {
 		G_asprintf(&err,

--- a/lib/ogsf/gvl_calc.c
+++ b/lib/ogsf/gvl_calc.c
@@ -738,9 +738,9 @@ void gvl_write_char(int pos, unsigned char **data, unsigned char c)
 {
     /* check to need allocation memory */
     if ((pos % BUFFER_SIZE) == 0) {
-	*data = (char *)G_realloc(*data,
-				  sizeof(char) * ((pos / BUFFER_SIZE) +
-						  1) * BUFFER_SIZE);
+	*data = G_realloc(*data,
+			  sizeof(char) * ((pos / BUFFER_SIZE) +
+					  1) * BUFFER_SIZE);
 	if (!(*data)) {
 	    return;
 	}

--- a/lib/pngdriver/draw_bitmap.c
+++ b/lib/pngdriver/draw_bitmap.c
@@ -67,7 +67,7 @@ void PNG_draw_bitmap(int ncols, int nrows, int threshold,
 		int x = cur_x + i;
 		unsigned int k = buf[j * ncols + i];
 		unsigned int *p = &png.grid[y * png.width + x];
-		unsigned int a0, r0, g0, b0;
+		int a0, r0, g0, b0;
 		unsigned int a, r, g, b;
 
 		png_get_pixel(*p, &r0, &g0, &b0, &a0);

--- a/lib/pngdriver/read_bmp.c
+++ b/lib/pngdriver/read_bmp.c
@@ -78,7 +78,7 @@ static int read_bmp_header(const unsigned char *p)
 
 void read_bmp(void)
 {
-    char header[HEADER_SIZE];
+    unsigned char header[HEADER_SIZE];
     FILE *input;
     int x, y;
     unsigned int *p;

--- a/lib/pngdriver/write_bmp.c
+++ b/lib/pngdriver/write_bmp.c
@@ -62,7 +62,7 @@ static void make_bmp_header(unsigned char *p)
 
 void write_bmp(void)
 {
-    char header[HEADER_SIZE];
+    unsigned char header[HEADER_SIZE];
     FILE *output;
     int x, y;
     unsigned int *p;

--- a/lib/raster3d/index.c
+++ b/lib/raster3d/index.c
@@ -59,7 +59,7 @@ static int Rast3d_readIndex(RASTER3D_Map * map)
 	    return 0;
 	}
 
-	Rast3d_rle_decode(tmp2, tmp, map->indexLongNbytes * map->nTiles, 1,
+	Rast3d_rle_decode((char *)tmp2, (char *)tmp, map->indexLongNbytes * map->nTiles, 1,
 		     &dummy1, &dummy2);
 
 	if (indexLength > sizeof(long) * map->nTiles)

--- a/lib/raster3d/open.c
+++ b/lib/raster3d/open.c
@@ -83,7 +83,8 @@ void *Rast3d_open_cell_old(const char *name, const char *mapset,
     int rows, cols, depths, precision;
     double ew_res, ns_res, tb_res;
     int nofHeaderBytes, dataOffset, useXdr, hasIndex;
-    char *ltmp, *unit;
+    char *unit;
+    unsigned char *ltmp;
     int vertical_unit;
     int version;
     double north, south, east, west, top, bottom;


### PR DESCRIPTION
Fixes compiler warnings:

- -Wpointer-compare
- -Wpointer-sign
- -Wtautological-pointer-compare

Fourth part addressing #1247.


Modules / code parts directly affected:

- lib/cairodriver
- lib/db/dbmi_client
- lib/dspf
- lib/gis
- lib/pngdriver
- lib/raster3d
