### PR TITLE
wxGUI/datacatalog: fix incorrect entry invalid (broken) regular expression

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -151,7 +151,7 @@ class MapWatch(PatternMatchingEventHandler):
         PatternMatchingEventHandler.__init__(self, patterns=patterns)
         self.element = element
         self.event_handler = event_handler
-        
+
     def on_created(self, event):
         if (self.element == 'vector' or self.element == 'raster_3d') and not event.is_directory:
             return
@@ -171,7 +171,7 @@ class MapWatch(PatternMatchingEventHandler):
             return
         evt = updateMapset(src_path=event.src_path, event_type=event.event_type,
                            is_directory=event.is_directory, dest_path=event.dest_path)
-        wx.PostEvent(self.event_handler, evt)  
+        wx.PostEvent(self.event_handler, evt)
 
 
 class NameEntryDialog(TextEntryDialog):
@@ -250,7 +250,7 @@ class DataCatalogNode(DictNode):
                 if not (key in self.data and self.data[key] == value):
                     return False
             return True
-        # for filtering            
+        # for filtering
         if (
             'type' in kwargs and 'type' in self.data
             and kwargs['type'] != self.data['type']
@@ -339,7 +339,7 @@ class DataCatalogTree(TreeView):
         self.startEdit.connect(self.OnStartEditLabel)
         self.endEdit.connect(self.OnEditLabel)
         self.Bind(EVT_UPDATE_MAPSET, self.OnWatchdogMapsetReload)
-        
+
         self.observer = None
 
     def _resetSelectVariables(self):
@@ -1656,10 +1656,13 @@ class DataCatalogTree(TreeView):
         if not name:
             self._model = self._orig_model
         else:
-            if element:
-                self._model = self._orig_model.Filtered(method='filtering', name=re.compile(name), type=element)
-            else:
-                self._model = self._orig_model.Filtered(method='filtering', name=re.compile(name))
+            try:
+                if element:
+                    self._model = self._orig_model.Filtered(method='filtering', name=re.compile(name), type=element)
+                else:
+                    self._model = self._orig_model.Filtered(method='filtering', name=re.compile(name))
+            except re.error:
+                return
         self.UpdateCurrentDbLocationMapsetNode()
         self.RefreshItems()
         self.ExpandCurrentMapset()

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1657,12 +1657,14 @@ class DataCatalogTree(TreeView):
             self._model = self._orig_model
         else:
             try:
-                if element:
-                    self._model = self._orig_model.Filtered(method='filtering', name=re.compile(name), type=element)
-                else:
-                    self._model = self._orig_model.Filtered(method='filtering', name=re.compile(name))
+                compiled = re.compile(name)
             except re.error:
                 return
+            if element:
+                self._model = self._orig_model.Filtered(method='filtering', name=compiled, type=element)
+            else:
+                self._model = self._orig_model.Filtered(method='filtering', name=compiled)
+
         self.UpdateCurrentDbLocationMapsetNode()
         self.RefreshItems()
         self.ExpandCurrentMapset()


### PR DESCRIPTION
**To Reproduce:**

Steps to reproduce the behavior:

1. Launch wxGUI
2. On the Data page (tab) write e.g. asterisk symbol in the search widget 
3. See error message

```
Traceback (most recent call last):
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/toolbars.py",
line 68, in <lambda>

self.filter.GetValue(), self.filter_element))
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/catalog.py",
line 142, in Filter

self.tree.Filter(text=text, element=element)
  File
"/usr/lib64/grass79/gui/wxpython/datacatalog/tree.py", line
1663, in Filter

self._model = self._orig_model.Filtered(method='filtering',
name=re.compile(name))
  File "/usr/lib64/python3.6/re.py", line 233, in compile

return _compile(pattern, flags)
  File "/usr/lib64/python3.6/re.py", line 301, in _compile

p = sre_compile.compile(pattern, flags)
  File "/usr/lib64/python3.6/sre_compile.py", line 562, in
compile

p = sre_parse.parse(p, flags)
  File "/usr/lib64/python3.6/sre_parse.py", line 855, in
parse

p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib64/python3.6/sre_parse.py", line 416, in
_parse_sub

not nested and not items))
  File "/usr/lib64/python3.6/sre_parse.py", line 616, in
_parse

source.tell() - here + len(this))
sre_constants
.
error
:
nothing to repeat at position 0
```

