### PR TITLE
attempt to fix #1218 windows does not start

### DIFF
--- a/mswindows/env.bat
+++ b/mswindows/env.bat
@@ -13,7 +13,7 @@ set GEOTIFF_CSV=%GISBASE%\share\epsg_csv
 
 set FONTCONFIG_FILE=%GISBASE%\etc\fonts.conf
 
-set PATH=%GISBASE%\extrabin;%GISBASE%\bin;%PATH%
+set PATH=%GISBASE%\extrabin;%GISBASE%\bin;%PYTHONHOME%;%PATH%
 
 REM set RStudio temporarily to %PATH% if it exists
 


### PR DESCRIPTION
add %PYTHONHOME% to %PATH% in order for a working pywin32