### PR TITLE
Fix compiler warnings, part 5 (rst/interpfl lib & v.surf.rst)

### DIFF
--- a/lib/rst/interp_float/init2d.c
+++ b/lib/rst/interp_float/init2d.c
@@ -54,7 +54,7 @@ void IL_init_params_2d(struct interp_params *params,
                        double scl,  /*!< anisotropy scaling factor */
                        FILE * t1, FILE * t2, FILE * t3, FILE * t4, FILE * t5,
                        FILE * t6,  /*!< temp files for writing interp. values (t1-t6) */
-                       FILE * dev,  /*!< pointer to deviations file */
+                       bool create_devi,  /*!< create deviations file? */
                        struct TimeStamp *ts,
                        int c,  /*!< cross validation */
                        const char *wheresql     /*!< SQL WHERE statement */
@@ -99,7 +99,7 @@ void IL_init_params_2d(struct interp_params *params,
     params->Tmp_fd_xx = t4;
     params->Tmp_fd_yy = t5;
     params->Tmp_fd_xy = t6;
-    params->fddevi = dev;
+    params->create_devi = create_devi;
     params->ts = ts;
     params->cv = c;
     params->wheresql = wheresql;

--- a/lib/rst/interp_float/interpf.h
+++ b/lib/rst/interp_float/interpf.h
@@ -92,7 +92,7 @@ struct interp_params
     FILE *Tmp_fd_z, *Tmp_fd_dx,
 	*Tmp_fd_dy, *Tmp_fd_xx,
 	*Tmp_fd_yy, *Tmp_fd_xy;	/**< temp files for writing interp. values */
-    FILE *fddevi;		/**< pointer to deviations file */
+    bool create_devi;		/**< create deviations file? */
 
     grid_calc_fn *grid_calc;	/**< calculates grid for given segm */
     matrix_create_fn *matrix_create;	/**< creates matrix for a given segm */
@@ -118,7 +118,7 @@ void IL_init_params_2d(struct interp_params *, FILE *, int, int, double,
 		       double, int, int, int, int, double,
 		       char *, char *, char *, char *, char *, char *,
 		       double, double, double, int, double, double,
-		       FILE *, FILE *, FILE *, FILE *, FILE *, FILE *, FILE *,
+		       FILE *, FILE *, FILE *, FILE *, FILE *, FILE *, bool,
 		       struct TimeStamp *, int, const char *);
 
 void IL_init_func_2d(struct interp_params *, grid_calc_fn *,

--- a/lib/rst/interp_float/point2d.c
+++ b/lib/rst/interp_float/point2d.c
@@ -110,7 +110,7 @@ int IL_check_at_points_2d(struct interp_params *params,
 	else
 	    inside = 0;
 
-	if (params->fddevi != NULL) {
+	if (params->create_devi) {
 
 	    if (inside) {	/* if the point is inside the region */
 		Vect_reset_line(Pnts);

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -451,7 +451,7 @@ int main(int argc, char *argv[])
 		      fi, MAXPOINTS, SCIK1, SCIK2, SCIK3, smc, elev, slope,
 		      aspect, pcurv, tcurv, mcurv, dmin, inp_x_orig,
 		      inp_y_orig, deriv, theta, scalex, Tmp_fd_z, Tmp_fd_dx,
-		      Tmp_fd_dy, Tmp_fd_xx, Tmp_fd_yy, Tmp_fd_xy, NULL, NULL,
+		      Tmp_fd_dy, Tmp_fd_xx, Tmp_fd_yy, Tmp_fd_xy, false, NULL,
 		      0, NULL);
 
     /*  In the above line, the penultimate argument is supposed to be a 

--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -88,6 +88,7 @@ static char *tcurv = NULL;
 static char *mcurv = NULL;
 static char *maskmap = NULL;
 static char *devi = NULL;
+static bool create_devi = false;
 static char *cvdev = NULL;
 static int sdisk, disk, ddisk, sddisk;
 static FILE *Tmp_fd_z = NULL;
@@ -631,6 +632,7 @@ int main(int argc, char *argv[])
 	}
 	db_begin_transaction(driver2);
 	count = 1;
+	create_devi = true;
 
     }
 
@@ -643,7 +645,7 @@ int main(int argc, char *argv[])
 		      SCIK1, SCIK2, SCIK3, rsm, elev, slope, aspect, pcurv,
 		      tcurv, mcurv, dmin, x_orig, y_orig, deriv, theta,
 		      scalex, Tmp_fd_z, Tmp_fd_dx, Tmp_fd_dy, Tmp_fd_xx,
-		      Tmp_fd_yy, Tmp_fd_xy, devi, NULL, cv,
+		      Tmp_fd_yy, Tmp_fd_xy, create_devi, NULL, cv,
 		      parm.wheresql->answer);
 
     IL_init_func_2d(&params, IL_grid_calc_2d, IL_matrix_create,


### PR DESCRIPTION
Output deviation argument to `IL_init_params_2d()` and in the `interp_params` struct (lib/rst/interp_float), was defined as FILE*. In practice a char* of the file path was given to the function in 'v.surf.rst/main.c' and this pointer's only use was to check whether it was NULL or not. It was used as a flag (and this is the reason it worked at all). This changes the argument to be ~~an integer, representing a boolean value~~ a `bool`.


Addresses one -Wincompatible-pointer-types compiler warning.

```
/usr/bin/clang  -g -pipe -arch x86_64 -DGL_SILENCE_DEPRECATION    -I/Volumes/grass/dist.x86_64-apple-darwin19.6.0/include -I/Volumes/grass/dist.x86_64-apple-darwin19.6.0/include   -I/opt/local/include -I/opt/local/include  -DPACKAGE=\""grassmods"\"  -I/opt/local/include/postgresql12  -I/Volumes/grass/dist.x86_64-apple-darwin19.6.0/include -I/Volumes/grass/dist.x86_64-apple-darwin19.6.0/include -DRELDIR=\"vector/v.surf.rst\" -o OBJ.x86_64-apple-darwin19.6.0/main.o -c main.c
main.c:646:31: warning: incompatible pointer types passing 'char *' to parameter of type 'FILE *' (aka 'struct __sFILE *') [-Wincompatible-pointer-types]
                      Tmp_fd_yy, Tmp_fd_xy, devi, NULL, cv,
                                            ^~~~
```

```
gcc  -std=gnu11   -I/home/runner/work/grass/grass/dist.x86_64-pc-linux-gnu/include -I/home/runner/work/grass/grass/dist.x86_64-pc-linux-gnu/include   -I/usr/include/gdal -I/usr/include -fopenmp -DPACKAGE=\""grassmods"\"    -I/home/runner/work/grass/grass/dist.x86_64-pc-linux-gnu/include -I/home/runner/work/grass/grass/dist.x86_64-pc-linux-gnu/include -DRELDIR=\"vector/v.surf.rst\" -o OBJ.x86_64-pc-linux-gnu/main.o -c main.c
main.c: In function ‘main’:
main.c:646:31: warning: passing argument 41 of ‘IL_init_params_2d’ from incompatible pointer type [-Wincompatible-pointer-types]
  646 |         Tmp_fd_yy, Tmp_fd_xy, devi, NULL, cv,
      |                               ^~~~
      |                               |
      |                               char *
In file included from main.c:40:
/home/runner/work/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/interpf.h:121:58: note: expected ‘FILE *’ {aka ‘struct _IO_FILE *’} but argument is of type ‘char *’
  121 |          FILE *, FILE *, FILE *, FILE *, FILE *, FILE *, FILE *,
      |                                                          ^~~~~~
```

This is a suggestion of how to address this warning (and wrongful code). I'm aware it breaks API.
I'm looking forward, as always, for input, comments...

Fifth part addressing #1247.

