### PR TITLE
Fix compiler warnings, part 6

### DIFF
--- a/display/d.vect.thematic/display.c
+++ b/display/d.vect.thematic/display.c
@@ -74,7 +74,7 @@ int display_lines(struct Map_info *Map, struct cat_list *Clist,
             if (ltype == -1) {
                 G_fatal_error(_("Unable to read vector map"));
             }
-            else if ((ltype == -2)) {   /* EOF */
+            else if (ltype == -2) {   /* EOF */
                 break;
             }
         }

--- a/lib/dspf/cube_io.c
+++ b/lib/dspf/cube_io.c
@@ -171,7 +171,7 @@ int read_cube(Cube_data * Cube, file_info * headfax)
 	    break;
 	}
 
-	for (i = 0; ret = fread(fptr + i, 1, 10240, fp); i += ret) ;
+	for (i = 0; (ret = fread(fptr + i, 1, 10240, fp)); i += ret) ;
     }
 
     if (zeros_left) {

--- a/lib/imagery/iscatt_core.c
+++ b/lib/imagery/iscatt_core.c
@@ -526,7 +526,7 @@ static int compute_scatts_from_chunk_row(struct scCats *scatt_conds,
 			      ("Unable to read from category raster condition file."));
 		    return -1;
 		}
-		if (n_pixs != n_pixs) {
+		if (n_pixs != (row_size) / sizeof(unsigned char)) {
 		    G_free(rast_pixs);
 		    G_free(belongs_pix);
 		    G_warning(_

--- a/lib/vector/Vlib/merge_lines.c
+++ b/lib/vector/Vlib/merge_lines.c
@@ -138,7 +138,7 @@ int Vect_merge_lines(struct Map_info *Map, int type, int *new_lines,
 		curr_line = Vect_get_node_line(Map, next_node, i);
 		if ((Plus->Line[abs(curr_line)]->type & GV_LINES))
 		    lines_type++;
-		if ((Plus->Line[abs(curr_line)]->type == ltype)) {
+		if (Plus->Line[abs(curr_line)]->type == ltype) {
 		    if (abs(curr_line) != abs(first)) {
 			Vect_read_line(Map, NULL, Cats, abs(curr_line));
 			
@@ -186,7 +186,7 @@ int Vect_merge_lines(struct Map_info *Map, int type, int *new_lines,
 		curr_line = Vect_get_node_line(Map, next_node, i);
 		if ((Plus->Line[abs(curr_line)]->type & GV_LINES))
 		    lines_type++;
-		if ((Plus->Line[abs(curr_line)]->type == ltype)) {
+		if (Plus->Line[abs(curr_line)]->type == ltype) {
 		    if (abs(curr_line) != abs(last)) {
 			Vect_read_line(Map, NULL, Cats, abs(curr_line));
 			

--- a/raster/r.compress/main.c
+++ b/raster/r.compress/main.c
@@ -216,13 +216,13 @@ static int process(char *name, int uncompress)
 
     if (newsize < oldsize)
 	G_message(uncompress
-		  ? _("DONE: uncompressed file is %lu %s (%.2f%) smaller")
-		  : _("DONE: compressed file is %lu %s (%.2f%) smaller"),
+		  ? _("DONE: uncompressed file is %lu %s (%.2f%%) smaller")
+		  : _("DONE: compressed file is %lu %s (%.2f%%) smaller"),
 		  (unsigned long)diff, sizestr, (double) 100.0 - 100.0 * newsize / oldsize);
     else if (newsize > oldsize)
 	G_message(uncompress
-		  ? _("DONE: uncompressed file is %lu %s (%.2f%) larger")
-		  : _("DONE: compressed file is %lu %s (%.2f%) larger"),
+		  ? _("DONE: uncompressed file is %lu %s (%.2f%%) larger")
+		  : _("DONE: compressed file is %lu %s (%.2f%%) larger"),
 		  (unsigned long)diff, sizestr, (double) 100.0 * newsize / oldsize - 100.0);
     else
 	G_message(_("same size"));

--- a/raster/r.in.gridatb/file_io.c
+++ b/raster/r.in.gridatb/file_io.c
@@ -28,7 +28,7 @@ void rdwr_gridatb(void)
     cellhd.format = -1;
     cellhd.compressed = 1;
 
-    if (retval = adjcellhd(&cellhd)) {
+    if ((retval = adjcellhd(&cellhd))) {
 	fclose(fp);
 	switch (retval) {
 	case 1:

--- a/raster3d/r3.info/main.c
+++ b/raster3d/r3.info/main.c
@@ -482,7 +482,7 @@ int main(int argc, char *argv[])
 		fprintf(out, "description=");
 		fprintf(out, "\"%s\"\n", Rast_get_history(&hist, HIST_KEYWRD));
 		if (Rast_history_length(&hist)) {
-                    fprintf(out, "comments=\"", i);
+                    fprintf(out, "comments=\"");
 		    for (i = 0; i < Rast_history_length(&hist); i++)
 			fprintf(out, "%s", Rast_history_line(&hist, i));
                     fprintf(out, "\"\n");


### PR DESCRIPTION
Fixes compiler warnings:

- -Wformat-extra-args
- -Wformat-invalid-specifier
- -Wparentheses
- -Wparentheses-equality
- -Wtautological-compare

Sixth part addressing #1247.

There are a couple of ambivalent cases and I'm not sure how to correctly address them. See comments.

Modules / code parts directly affected:
- lib/dspf
- lib/imagery/
- lib/vector/Vlib/
- display/d.vect.thematic
- raster/r.compress
- raster/r.fill.stats
- raster/r.in.gridatb
- raster3d/r3.info

