### PR TITLE
Fix compiler warnings, part 7

### DIFF
--- a/imagery/i.evapo.pm/main.c
+++ b/imagery/i.evapo.pm/main.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     input_hc->description = _("Name of input crop height raster map [m]");
 
     output = G_define_standard_option(G_OPT_R_OUTPUT);
-	_("Name for output raster map [mm/h]");
+    output->description = _("Name for output raster map [mm/h]");
 
     zero = G_define_flag();
     zero->key = 'z';

--- a/lib/display/draw2.c
+++ b/lib/display/draw2.c
@@ -126,7 +126,7 @@ static void reduce_path(struct path *dst, const struct path *src, double eps)
 
 	if (fabs(v1->x - v0->x) < eps && fabs(v1->y - v0->y) < eps &&
 	    fabs(v1->x - v2->x) < eps && fabs(v1->y - v2->y) < eps &&
-	    v0->mode != P_MOVE && v1->mode != P_MOVE && !v2->mode != P_MOVE)
+	    v0->mode != P_MOVE && v1->mode != P_MOVE && (!v2->mode) != P_MOVE)
 	    continue;
 
 	path_append(dst, v1->x, v1->y, v1->mode);

--- a/lib/imagery/list_subgp.c
+++ b/lib/imagery/list_subgp.c
@@ -34,7 +34,7 @@ char **list_subgroups(char *group, const char *mapset, int *subgs_num)
     sprintf(buf, "group/%s/subgroup", group);
     G_file_name(path, buf, "", mapset);
 
-    if (!G_lstat(path, &sb) == 0 || !S_ISDIR(sb.st_mode))
+    if (G_lstat(path, &sb) || !S_ISDIR(sb.st_mode))
 	return NULL;
 
     subgs = G_ls2(path, subgs_num);

--- a/lib/raster3d/close.c
+++ b/lib/raster3d/close.c
@@ -106,7 +106,7 @@ static int close_cell_new(RASTER3D_Map * map)
 	return 0;
     }
 
-    if (!close_new(map) != 0) {
+    if (!close_new(map)) {
 	G_warning(_("Unable to create 3D raster map <%s>"), map->fileName);
 	return 0;
     }
@@ -126,7 +126,7 @@ static int close_old(RASTER3D_Map * map)
 
 static int close_cell_old(RASTER3D_Map * map)
 {
-    if (!close_old(map) != 0) {
+    if (!close_old(map)) {
 	G_warning(_("Unable to close 3D raster map <%s>"), map->fileName);
 	return 0;
     }
@@ -155,7 +155,7 @@ int Rast3d_close(RASTER3D_Map * map)
 	}
     }
     else {
-	if (!close_cell_old(map) != 0) {
+	if (!close_cell_old(map)) {
 	    G_warning(_("Unable to close 3D raster map <%s>"), map->fileName);
 	    return 0;
 	}

--- a/raster/r.viewshed/viewshed.cpp
+++ b/raster/r.viewshed/viewshed.cpp
@@ -151,9 +151,10 @@ AEvent *allocate_eventlist(GridHeader * hd)
     }
     else {
 	/* this is the max value of size_t */
-	long long maxsizet = ((long long)1 << (sizeof(size_t) * 8 - 1)) - 1;
+	long long m = ((long long)1 << (sizeof(size_t) * 8 - 1)),
+		  maxsizet = m - 1;
 
-	maxsizet += ((long long)1 << (sizeof(size_t) * 8 - 1));
+	maxsizet += m;
 
 	G_debug(1, "max size_t is %lld", maxsizet);
 

--- a/vector/v.generalize/point.h
+++ b/vector/v.generalize/point.h
@@ -34,44 +34,44 @@ typedef struct Point_list
 } POINT_LIST;
 
 /* res = a - b */
-extern inline void point_subtract(POINT a, POINT b, POINT * res);
+extern void point_subtract(POINT a, POINT b, POINT * res);
 
 /* res = a + b */
-extern inline void point_add(POINT a, POINT b, POINT * res);
+extern void point_add(POINT a, POINT b, POINT * res);
 
 /* dot product of two vectors: ax * bx + ay * by + az * bz */
 extern double point_dot(POINT a, POINT b);
 
 /* squared distance from the origin */
-extern inline double point_dist2(POINT a);
+extern double point_dist2(POINT a);
 
 /* assign point Points[index] to the res
  * if with z = 0 then res.z = 0  
  */
-extern inline void point_assign(struct line_pnts *Points, int index,
-				int with_z, POINT * res, int is_loop);
+extern void point_assign(struct line_pnts *Points, int index,
+                                int with_z, POINT * res, int is_loop);
 /* assign point Points[index] to the res
  * if with z = 0 then res.z = 0  
  * loop to infinite
  */
 
 /* res = k * a */
-extern inline void point_scalar(POINT a, double k, POINT * res);
+extern void point_scalar(POINT a, double k, POINT * res);
 
 /* copy the last point of Points to Points[pos] */
-extern inline void points_copy_last(struct line_pnts *Points, int pos);
+extern void points_copy_last(struct line_pnts *Points, int pos);
 
 /* distance between two points */
-extern inline double point_dist(POINT a, POINT b);
+extern double point_dist(POINT a, POINT b);
 
 /* squared distance between two points */
-extern inline double point_dist_square(POINT a, POINT b);
+extern double point_dist_square(POINT a, POINT b);
 
 /* angle in radians between vectors ab and bc */
-extern inline double point_angle_between(POINT a, POINT b, POINT c);
+extern double point_angle_between(POINT a, POINT b, POINT c);
 
 /* distance squared between a and segment bc */
-extern inline double point_dist_segment_square(POINT a, POINT b, POINT c,
+extern double point_dist_segment_square(POINT a, POINT b, POINT c,
 					       int with_z);
 /* creates empty list of points */
 extern POINT_LIST *point_list_new(POINT p);

--- a/vector/v.in.pdal/main.cpp
+++ b/vector/v.in.pdal/main.cpp
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
     max_ground_window_opt->key = "max_ground_window_size";
     max_ground_window_opt->type = TYPE_DOUBLE;
     max_ground_window_opt->required = NO;
-    max_ground_window_opt->answer = "33";
+    max_ground_window_opt->answer = G_store("33");
     max_ground_window_opt->description =
         _("Maximum window size for ground filter");
     max_ground_window_opt->guisection = _("Ground filter");
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
     ground_slope_opt->key = "ground_slope";
     ground_slope_opt->type = TYPE_DOUBLE;
     ground_slope_opt->required = NO;
-    ground_slope_opt->answer = "1.0";
+    ground_slope_opt->answer = G_store("1.0");
     ground_slope_opt->description = _("Slope for ground filter");
     ground_slope_opt->guisection = _("Ground filter");
 
@@ -255,7 +255,7 @@ int main(int argc, char *argv[])
     max_ground_distance_opt->key = "max_ground_distance";
     max_ground_distance_opt->type = TYPE_DOUBLE;
     max_ground_distance_opt->required = NO;
-    max_ground_distance_opt->answer = "2.5";
+    max_ground_distance_opt->answer = G_store("2.5");
     max_ground_distance_opt->description =
         _("Maximum distance for ground filter");
     max_ground_distance_opt->guisection = _("Ground filter");
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
     init_ground_distance_opt->key = "initial_ground_distance";
     init_ground_distance_opt->type = TYPE_DOUBLE;
     init_ground_distance_opt->required = NO;
-    init_ground_distance_opt->answer = "0.15";
+    init_ground_distance_opt->answer = G_store("0.15");
     init_ground_distance_opt->description =
         _("Initial distance for ground filter");
     init_ground_distance_opt->guisection = _("Ground filter");
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
     ground_cell_size_opt->key = "ground_cell_size";
     ground_cell_size_opt->type = TYPE_DOUBLE;
     ground_cell_size_opt->required = NO;
-    ground_cell_size_opt->answer = "1";
+    ground_cell_size_opt->answer = G_store("1");
     ground_cell_size_opt->description =
         _("Initial distance for ground filter");
     ground_cell_size_opt->guisection = _("Ground filter");


### PR DESCRIPTION
Fixes compiler warnings:

- -Winteger-overflow
- -Wlogical-not-parentheses
- -Wunused-value
- -Wwritable-strings
- -Wundefined-inline

Seventh part addressing #1247.

There are a couple of `-Wlogical-not-parentheses` warnings and I'm not absolutely sure how to correctly address them. See comments in code.

Modules / code parts directly affected:

- lib/display
- lib/imagery
- lib/raster3d
- imagery/i.evapo.pm
- raster/r.viewshed
- vector/v.generalize
- vector/v.in.pdal
