### PR TITLE
Fix compiler warnings, part 8

### DIFF
--- a/db/drivers/ogr/execute.c
+++ b/db/drivers/ogr/execute.c
@@ -109,7 +109,9 @@ int db__driver_execute_immediate(dbString * sql)
 	    }
 	    OGR_F_SetFieldString(hFeature, cols[i].index, value);
 	}
-	OGR_L_SetFeature(hLayer, hFeature);
+	if (OGR_L_SetFeature(hLayer, hFeature) != OGRERR_NONE)
+	    G_warning(_("\tOGR failed to write feature fid=%ld to layer <%s>"),
+		      OGR_F_GetFID(hFeature), OGR_L_GetName(hLayer));
 	OGR_F_Destroy(hFeature);
     }
     

--- a/general/g.parser/translate.c
+++ b/general/g.parser/translate.c
@@ -12,7 +12,7 @@ char *translate(const char *arg)
     static const char *domain;
 
     if (arg == NULL)
-	return arg;
+	return (char *) arg;
 
     if (strlen(arg) == 0)
         return NULL; /* unset */
@@ -33,6 +33,6 @@ char *translate(const char *arg)
 
     return G_gettext(domain, arg);
 #else
-    return arg;
+    return (char *) arg;
 #endif
 }

--- a/include/defs/nviz.h
+++ b/include/defs/nviz.h
@@ -35,9 +35,9 @@ int Nviz_set_cplane_here(nv_data *, int, float, float);
 
 /* draw.c */
 int Nviz_draw_all_surf(nv_data *);
-int Nviz_draw_all_vect();
-int Nviz_draw_all_site();
-int Nviz_draw_all_vol();
+int Nviz_draw_all_vect(void);
+int Nviz_draw_all_site(void);
+int Nviz_draw_all_vol(void);
 int Nviz_draw_all(nv_data *);
 int Nviz_draw_quick(nv_data *, int);
 int Nviz_load_image(GLubyte *, int, int, int);

--- a/lib/imagery/list_subgp.c
+++ b/lib/imagery/list_subgp.c
@@ -15,7 +15,7 @@
 #include <grass/imagery.h>
 #include <grass/glocale.h>
 
-char **list_subgroups(char *group, const char *mapset, int *subgs_num)
+char **list_subgroups(const char *group, const char *mapset, int *subgs_num)
 {
     /* Unlike I_list_subgroup and I_list_subgroup_simple this function 
        returns array of subgroup names, it does not use fprintf. 

--- a/lib/nviz/draw.c
+++ b/lib/nviz/draw.c
@@ -118,7 +118,7 @@ int sort_surfs_max(int *surf, int *id_sort, int *indices, int num)
 
    \return 1
  */
-int Nviz_draw_all_vect()
+int Nviz_draw_all_vect(void)
 {
     /* GS_set_cancel(0); */
 
@@ -143,7 +143,7 @@ int Nviz_draw_all_vect()
 
    \return 1
  */
-int Nviz_draw_all_site()
+int Nviz_draw_all_site(void)
 {
     int i;
     int *site_list, nsites;
@@ -172,7 +172,7 @@ int Nviz_draw_all_site()
 
    \return 1
  */
-int Nviz_draw_all_vol()
+int Nviz_draw_all_vol(void)
 {
     int *vol_list, nvols, i;
 
@@ -230,13 +230,13 @@ int Nviz_draw_all(nv_data * data)
 	Nviz_draw_all_surf(data);
 
     if (draw_vect)
-	Nviz_draw_all_vect(data);
+	Nviz_draw_all_vect();
 
     if (draw_site)
-	Nviz_draw_all_site(data);
+	Nviz_draw_all_site();
 
     if (draw_vol)
-	Nviz_draw_all_vol(data);
+	Nviz_draw_all_vol();
 	
     for(i = 0; i < data->num_fringes; i++) {
 	struct fringe_data * f = data->fringe[i];

--- a/lib/raster/put_row.c
+++ b/lib/raster/put_row.c
@@ -514,7 +514,7 @@ static void write_null_bits_compressed(const unsigned char *flags,
     compressed_buf = G_malloc(cmax);
 
     /* compress null bits file with LZ4, see lib/gis/compress.h */
-    nwrite = G_compress(flags, size, compressed_buf, cmax, 3);
+    nwrite = G_compress((unsigned char *)flags, size, compressed_buf, cmax, 3);
 
     if (nwrite > 0 && nwrite < size) {
 	if (write(fcb->null_fd, compressed_buf, nwrite) != nwrite)

--- a/lib/vector/Vlib/open_ogr.c
+++ b/lib/vector/Vlib/open_ogr.c
@@ -100,8 +100,13 @@ int V1_open_old_ogr(struct Map_info *Map, int update)
     G_debug(2, "OGR layer %d opened", layer);
 
     ogr_info->layer = Ogr_layer;
-    if (update && OGR_L_TestCapability(ogr_info->layer, OLCTransactions))
-	OGR_L_StartTransaction(ogr_info->layer);
+    if (update && OGR_L_TestCapability(ogr_info->layer, OLCTransactions) &&
+	(OGR_L_StartTransaction(ogr_info->layer) != OGRERR_NONE)) {
+	OGR_DS_Destroy(Ogr_ds);
+	G_warning(_("OGR transaction with layer <%s> failed to start"),
+		  ogr_info->layer_name);
+	return -1;
+    }
     
     switch(Ogr_geom_type) {
     case wkbPoint25D: case wkbLineString25D: case wkbPolygon25D:

--- a/lib/vector/Vlib/write_ogr.c
+++ b/lib/vector/Vlib/write_ogr.c
@@ -347,8 +347,12 @@ int create_ogr_layer(struct Map_info *Map, int type)
 		      "Unable to write attributes."));
     }
     
-    if (OGR_L_TestCapability(ogr_info->layer, OLCTransactions))
-	OGR_L_StartTransaction(ogr_info->layer);
+    if (OGR_L_TestCapability(ogr_info->layer, OLCTransactions) &&
+	(OGR_L_StartTransaction(ogr_info->layer) != OGRERR_NONE)) {
+	G_warning(_("OGR transaction with layer <%s> failed to start"),
+		  ogr_info->layer_name);
+	return -1;
+    }
 
     return 0;
 }

--- a/raster/r.fill.stats/main.c
+++ b/raster/r.fill.stats/main.c
@@ -743,7 +743,7 @@ int main(int argc, char *argv[])
     /* program settings */
     char *input;
     char *output;
-    char *mapset;
+    const char *mapset;
     double radius = 1.0;
     unsigned long min_cells = 12;
     double power = 2.0;

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -129,7 +129,7 @@ double TOLER;
 const char *str_step;
 
 int mode;
-int isMode()
+int isMode(void)
 {
     return mode;
 }
@@ -393,7 +393,7 @@ int main(int argc, char *argv[])
 	sscanf(parm.direction->answer, "%lf", &single_direction);
 
 
-    if (isMode(WHOLE_RASTER)) {
+    if (WHOLE_RASTER == isMode()) {
 	if ((parm.direction->answer == NULL) && (parm.step->answer == NULL)) {
 	    G_fatal_error(
 		_("You didn't specify a direction value or step size. Aborting."));

--- a/raster/r.random/local_proto.h
+++ b/raster/r.random/local_proto.h
@@ -1,5 +1,5 @@
 #ifndef __LOCAL_PROTO_H__
-#define __LOCAL_PHOTO_H__
+#define __LOCAL_PROTO_H__
 
 #include <grass/raster.h>
 

--- a/raster3d/r3.retile/main.c
+++ b/raster3d/r3.retile/main.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     struct GModule *module;
     RASTER3D_Map *map = NULL;
     int tileX, tileY, tileZ;
-    char *mapset;
+    const char *mapset;
 
     /* Initialize GRASS */
     G_gisinit(argv[0]);

--- a/vector/v.lrs/v.lrs.create/main.c
+++ b/vector/v.lrs/v.lrs.create/main.c
@@ -206,14 +206,14 @@ int main(int argc, char **argv)
     driver_opt->required = NO;
     driver_opt->description = _("Driver name for reference system table");
     driver_opt->options = db_list_drivers();
-    driver_opt->answer = db_get_default_driver_name();
+    driver_opt->answer = (char *) db_get_default_driver_name();
 
     database_opt = G_define_option();
     database_opt->key = "rsdatabase";
     database_opt->type = TYPE_STRING;
     database_opt->required = NO;
     database_opt->description = _("Database name for reference system table");
-    database_opt->answer = db_get_default_database_name();
+    database_opt->answer = (char *) db_get_default_database_name();
 
     table_opt = G_define_option();
     table_opt->key = "rstable";

--- a/vector/v.lrs/v.lrs.label/main.c
+++ b/vector/v.lrs/v.lrs.label/main.c
@@ -123,14 +123,14 @@ int main(int argc, char **argv)
     driver_opt->required = NO;
     driver_opt->description = _("Driver name for reference system table");
     driver_opt->options = db_list_drivers();
-    driver_opt->answer = db_get_default_driver_name();
+    driver_opt->answer = (char *) db_get_default_driver_name();
 
     database_opt = G_define_option();
     database_opt->key = "rsdatabase";
     database_opt->type = TYPE_STRING;
     database_opt->required = NO;
     database_opt->description = _("Database name for reference system table");
-    database_opt->answer = db_get_default_database_name();
+    database_opt->answer = (char *) db_get_default_database_name();
 
     table_opt = G_define_option();
     table_opt->key = "rstable";

--- a/vector/v.lrs/v.lrs.segment/main.c
+++ b/vector/v.lrs/v.lrs.segment/main.c
@@ -93,14 +93,14 @@ int main(int argc, char **argv)
     driver_opt->required = NO;
     driver_opt->description = _("Driver name for reference system table");
     driver_opt->options = db_list_drivers();
-    driver_opt->answer = db_get_default_driver_name();
+    driver_opt->answer = (char *) db_get_default_driver_name();
 
     database_opt = G_define_option();
     database_opt->key = "rsdatabase";
     database_opt->type = TYPE_STRING;
     database_opt->required = NO;
     database_opt->description = _("Database name for reference system table");
-    database_opt->answer = db_get_default_database_name();
+    database_opt->answer = (char *) db_get_default_database_name();
 
     table_opt = G_define_option();
     table_opt->key = "rstable";

--- a/vector/v.lrs/v.lrs.where/main.c
+++ b/vector/v.lrs/v.lrs.where/main.c
@@ -85,14 +85,14 @@ int main(int argc, char **argv)
     driver_opt->required = NO;
     driver_opt->description = _("Driver name for reference system table");
     driver_opt->options = db_list_drivers();
-    driver_opt->answer = db_get_default_driver_name();
+    driver_opt->answer = (char *) db_get_default_driver_name();
 
     database_opt = G_define_option();
     database_opt->key = "rsdatabase";
     database_opt->type = TYPE_STRING;
     database_opt->required = NO;
     database_opt->description = _("Database name for reference system table");
-    database_opt->answer = db_get_default_database_name();
+    database_opt->answer = (char *) db_get_default_database_name();
 
     table_opt = G_define_option();
     table_opt->key = "rstable";

--- a/vector/v.rectify/crs.h
+++ b/vector/v.rectify/crs.h
@@ -1,5 +1,5 @@
 
-#ifndef CRS3D_H
+#ifndef CRS3D_H_
 #define CRS3D_H_
 
 #define MAXORDER 3


### PR DESCRIPTION
Fixes compiler warnings:

- -Wincompatible-pointer-types-discards-qualifiers
- -Wunused-result
- -Wheader-guard
- "too many arguments in call to function"

Eighth part addressing #1247.

Note: there are a few cases of OGR error handling added, please do pay special attention to them and their implementation.

Modules / code parts directly affected:

- lib/raster
- lib/imagery
- lib/nviz
- lib/vector/Vlib
- db/drivers/ogr
- general/g.parser
- raster/r.fill.stats
- raster3d/r3.retile
- raster/r.horizon
- raster/r.random
- vector/v.lrs/v.lrs.create
- vector/v.lrs/v.lrs.label
- vector/v.lrs/v.lrs.segment
- vector/v.lrs/v.lrs.where
- vector/v.rectify
