### PR TITLE
parser: Use #-space-% to allow writing PEP8-compliant Python code

### DIFF
--- a/doc/gui/wxpython/example/g.gui.example.py
+++ b/doc/gui/wxpython/example/g.gui.example.py
@@ -18,16 +18,16 @@
 #
 ############################################################################
 
-#%module
-#% description: Example GUI application which displays raster map and further information
-#% keyword: example
-#% keyword: GUI
-#% keyword: raster
-#%end
-#%option G_OPT_R_INPUT
-#% description: Name of raster map to load
-#% required: no
-#%end
+# %module
+# % description: Example GUI application which displays raster map and further information
+# % keyword: example
+# % keyword: GUI
+# % keyword: raster
+# %end
+# %option G_OPT_R_INPUT
+# % description: Name of raster map to load
+# % required: no
+# %end
 
 import os
 import sys

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -23,26 +23,26 @@
 # Requires Numeric module (NumPy) from  http://numpy.scipy.org/
 #
 
-#%module
-#% label: Finds the distance between two or more points.
-#% description: If the projection is latitude-longitude, this distance is measured along the geodesic.
-#% keyword: miscellaneous
-#% keyword: distance
-#% keyword: measure
-#%end
-#%option
-#% key: coord
-#% type: string
-#% required: yes
-#% multiple: yes
-#% key_desc: easting,northing
-#% description: Comma separated list of coordinate pairs
-#%end
-#%flag
-#% key: i
-#% description: Read coordinate pairs from stdin
-#% suppress_required: yes
-#%end
+# %module
+# % label: Finds the distance between two or more points.
+# % description: If the projection is latitude-longitude, this distance is measured along the geodesic.
+# % keyword: miscellaneous
+# % keyword: distance
+# % keyword: measure
+# %end
+# %option
+# % key: coord
+# % type: string
+# % required: yes
+# % multiple: yes
+# % key_desc: easting,northing
+# % description: Comma separated list of coordinate pairs
+# %end
+# %flag
+# % key: i
+# % description: Read coordinate pairs from stdin
+# % suppress_required: yes
+# %end
 
 import os, sys
 

--- a/doc/python/script/r.example.py
+++ b/doc/python/script/r.example.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-#%module
-#% description: Selects values from raster above value of mean plus standard deviation
-#% keyword: raster
-#% keyword: select
-#% keyword: standard deviation
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
+# %module
+# % description: Selects values from raster above value of mean plus standard deviation
+# % keyword: raster
+# % keyword: select
+# % keyword: standard deviation
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
 
 
 import sys

--- a/general/g.parser/g.parser.html
+++ b/general/g.parser/g.parser.html
@@ -58,20 +58,20 @@ are separated by null characters.
 Typical header definitions are as follows:
 
 <div class="code"><pre>
-#%module
-#% description: g.parser test script   
-#%end
-#%flag
-#% key: f
-#% description: A flag
-#%end
-#%option
-#% key: raster
-#% type: string
-#% gisprompt: old,cell,raster
-#% description: Raster input map
-#% required: yes
-#%end
+# %module
+# % description: g.parser test script
+# %end
+# %flag
+# % key: f
+# % description: A flag
+# %end
+# %option
+# % key: raster
+# % type: string
+# % gisprompt: old,cell,raster
+# % description: Raster input map
+# % required: yes
+# %end
 </pre></div>
 
 With <tt>{NULL}</tt> it is possible to suppress a predefined <tt>description</tt>
@@ -84,21 +84,21 @@ of <a href="https://grass.osgeo.org/programming7/parser__standard__options_8c.ht
 in the programmer manual. Eg. the option
 
 <div class="code"><pre>
-#%option
-#% key: raster
-#% type: string
-#% gisprompt: old,cell,raster
-#% description: Raster input map
-#% required: yes
-#%end
+# %option
+# % key: raster
+# % type: string
+# % gisprompt: old,cell,raster
+# % description: Raster input map
+# % required: yes
+# %end
 </pre></div>
 
 can be easily defined as
 
 <div class="code"><pre>
-#%option G_OPT_R_MAP
-#% key: raster
-#%end
+# %option G_OPT_R_MAP
+# % key: raster
+# %end
 </pre></div>
 
 The parser allows defining predefined <em>rules</em>
@@ -107,26 +107,26 @@ for used options.
 The syntax of the rules section is following:
 
 <div class="code"><pre>
-#%rules
-#% exclusive: capfile_output, capfile
-#%end
+# %rules
+# % exclusive: capfile_output, capfile
+# %end
 </pre></div>
 
 The parser also allows defining "OR" conditions, e.g. requiring raster
 OR vector (for details, see below), e.g.for options:
 
 <div class="code"><pre>
-#%rules
-#% required: raster, vector
-#%end
+# %rules
+# % required: raster, vector
+# %end
 </pre></div>
 
 and e.g., for flags:
 
 <div class="code"><pre>
-#%rules
-#% required: -i,-d,-c
-#%end
+# %rules
+# % required: -i,-d,-c
+# %end
 </pre></div>
 
 <h2>NOTES</h2>
@@ -134,7 +134,7 @@ and e.g., for flags:
 An option can be instructed to allow multiple inputs by adding the
 following line:
 <div class="code"><pre>
-#% multiple: yes
+# % multiple: yes
 </pre></div>
 
 While this will only directly change the <i>Usage</i> section of the help
@@ -154,7 +154,7 @@ specify that the options should appear in multiple tabs in the
 auto-generated GUI.  Any options without a <tt>guisection</tt> field
 go into the "Required" or "Options" tab.  For example:
 <div class="code"><pre>
-#% guisection: tabname
+# % guisection: tabname
 </pre></div>
 would put that option in a tab named <i>tabname</i>.
 
@@ -162,7 +162,7 @@ would put that option in a tab named <i>tabname</i>.
 A "<tt>key_desc</tt>" field may be added to each option to specify the text that
 appears in the module's usage help section. For example:
 <div class="code"><pre>
-#% key_desc: filename
+# % key_desc: filename
 </pre></div>
 added to an <b>input</b> option would create the usage summary
 <tt>[input=filename]</tt>.
@@ -179,6 +179,12 @@ were used, you should be checking <tt>GRASS_OVERWRITE</tt> and/or
 should behave the same way regardless of whether they were set
 by <b>--o</b>, <b>--q</b> or <b>--v</b> being passed to the script or
 set by other means.
+
+<p>
+For backwards compatibility reasons, the header definitions can use
+<code>#%</code> instead of <code># %</code> as in
+<code>#% multiple: yes</code>. However, Python code should use
+<code># %</code> in order to conform to PEP8.
 
 <h2>Conditional parameters</h2>
 
@@ -201,9 +207,9 @@ For C, the relevant functions are those in
 For scripts, relationships are specified using a "rules" section, e.g.
 
 <div class="code"><pre>
-#%rules
-#% required: altitude,elevation
-#%end
+# %rules
+# % required: altitude,elevation
+# %end
 </pre></div>
 
 specifies that at least one of those options must be given. Both
@@ -365,28 +371,28 @@ Parameters:
 
 # g.parser demo script for python programming
 
-#%module
-#% description: g.parser test script (python)
-#% keyword: keyword1
-#% keyword: keyword2
-#%end
-#%flag
-#% key: f
-#% description: A flag
-#%end
-#%option G_OPT_R_MAP
-#% key: raster
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: vector
-#%end
-#%option
-#% key: option1
-#% type: string
-#% description: An option
-#% required: no
-#%end
+# %module
+# % description: g.parser test script (python)
+# % keyword: keyword1
+# % keyword: keyword2
+# %end
+# %flag
+# % key: f
+# % description: A flag
+# %end
+# %option G_OPT_R_MAP
+# % key: raster
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: vector
+# %end
+# %option
+# % key: option1
+# % type: string
+# % description: An option
+# % required: no
+# %end
 
 import os
 import sys
@@ -429,26 +435,26 @@ if __name__ == "__main__":
 
 # g.parser demo script for shell programming
 
-#%module
-#% description: g.parser test script (shell) 
-#%end
-#%flag
-#% key: f
-#% description: A flag
-#%end
-#%option G_OPT_R_MAP
-#% key: raster
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: vector
-#%end
-#%option
-#% key: option1
-#% type: string
-#% description: An option
-#% required: no
-#%end
+# %module
+# % description: g.parser test script (shell)
+# %end
+# %flag
+# % key: f
+# % description: A flag
+# %end
+# %option G_OPT_R_MAP
+# % key: raster
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: vector
+# %end
+# %option
+# % key: option1
+# % type: string
+# % description: An option
+# % required: no
+# %end
 
 if [ -z "$GISBASE" ] ; then
     echo "You must be in GRASS GIS to run this program." 1&gt;&amp;2
@@ -489,28 +495,28 @@ use strict;
 
 # g.parser demo script
 
-#%module
-#%  description: g.parser test script (perl) 
-#%  keyword: keyword1
-#%  keyword: keyword2
-#%end
-#%flag
-#%  key: f
-#%  description: A flag
-#%end
-#%option G_OPT_R_MAP
-#% key: raster
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: vector
-#%end
-#%option
-#% key: option1
-#% type: string
-#% description: An option
-#% required: no
-#%end
+# %module
+# %  description: g.parser test script (perl)
+# %  keyword: keyword1
+# %  keyword: keyword2
+# %end
+# %flag
+# %  key: f
+# %  description: A flag
+# %end
+# %option G_OPT_R_MAP
+# % key: raster
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: vector
+# %end
+# %option
+# % key: option1
+# % type: string
+# % description: An option
+# % required: no
+# %end
 
 if ( !$ENV{'GISBASE'} ) {
     printf(STDERR  "You must be in GRASS GIS to run this program.\n");
@@ -575,74 +581,74 @@ v.what.rast --script
 #
 ############################################################################
 
-#%module
-#% description: Uploads raster values at positions of vector points to the table.
-#% keyword: vector, sampling, raster, position, querying, attribute table, surface information
-#%end
-#%flag
-#% key: i
-#% description: Interpolate values from the nearest four cells
-#%end
-#%flag
-#% key: p
-#% description: Print categories and values instead of updating the database
-#%end
-#%option
-#% key: map
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% label: Name of vector points map for which to edit attributes
-#% description: Or data source for direct OGR access
-#% gisprompt: old,vector,vector
-#%end
-#%option
-#% key: layer
-#% type: string
-#% required: no
-#% multiple: no
-#% label: Layer number or name
-#% description: Vector features can have category values in different layers. This number determines which layer to use. When used with direct OGR access this is the layer name.
-#% answer: 1
-#% gisprompt: old,layer,layer
-#%end
-#%option
-#% key: type
-#% type: string
-#% required: no
-#% multiple: yes
-#% options: point,centroid
-#% description: Input feature type
-#% answer: point
-#%end
-#%option
-#% key: raster
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Name of existing raster map to be queried
-#% gisprompt: old,cell,raster
-#%end
-#%option
-#% key: column
-#% type: string
-#% required: no
-#% multiple: no
-#% key_desc: name
-#% description: Name of attribute column to be updated with the query result
-#% gisprompt: old,dbcolumn,dbcolumn
-#%end
-#%option
-#% key: where
-#% type: string
-#% required: no
-#% multiple: no
-#% key_desc: sql_query
-#% label: WHERE conditions of SQL statement without 'where' keyword
-#% description: Example: income < 1000 and population >= 10000
-#%end
+# %module
+# % description: Uploads raster values at positions of vector points to the table.
+# % keyword: vector, sampling, raster, position, querying, attribute table, surface information
+# %end
+# %flag
+# % key: i
+# % description: Interpolate values from the nearest four cells
+# %end
+# %flag
+# % key: p
+# % description: Print categories and values instead of updating the database
+# %end
+# %option
+# % key: map
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % label: Name of vector points map for which to edit attributes
+# % description: Or data source for direct OGR access
+# % gisprompt: old,vector,vector
+# %end
+# %option
+# % key: layer
+# % type: string
+# % required: no
+# % multiple: no
+# % label: Layer number or name
+# % description: Vector features can have category values in different layers. This number determines which layer to use. When used with direct OGR access this is the layer name.
+# % answer: 1
+# % gisprompt: old,layer,layer
+# %end
+# %option
+# % key: type
+# % type: string
+# % required: no
+# % multiple: yes
+# % options: point,centroid
+# % description: Input feature type
+# % answer: point
+# %end
+# %option
+# % key: raster
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Name of existing raster map to be queried
+# % gisprompt: old,cell,raster
+# %end
+# %option
+# % key: column
+# % type: string
+# % required: no
+# % multiple: no
+# % key_desc: name
+# % description: Name of attribute column to be updated with the query result
+# % gisprompt: old,dbcolumn,dbcolumn
+# %end
+# %option
+# % key: where
+# % type: string
+# % required: no
+# % multiple: no
+# % key_desc: sql_query
+# % label: WHERE conditions of SQL statement without 'where' keyword
+# % description: Example: income < 1000 and population >= 10000
+# %end
 
 import sys
 

--- a/general/g.parser/main.c
+++ b/general/g.parser/main.c
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
     for (ctx.line = 1;; ctx.line++) {
 	char buff[4096];
 	char *cmd, *arg;
+	size_t line_size;
 
 	if (!fgets(buff, sizeof(buff), ctx.fp))
 	    break;
@@ -102,10 +103,19 @@ int main(int argc, char *argv[])
 	}
 	*arg = '\0';
 
-	if (buff[0] != '#' || buff[1] != '%')
+	line_size = strlen(buff);
+	if (line_size > 2 && buff[0] == '#') {
+	    if (buff[1] == '%')
+		cmd = buff + 2;
+	    else if (line_size > 3 && buff[1] == ' ' && buff[2] == '%')
+		cmd = buff + 3;
+	    else
+		continue;
+	}
+	else {
 	    continue;
+	}
 
-	cmd = buff + 2;
 	G_chop(cmd);
 
 	arg = strchr(cmd, ':');

--- a/general/g.parser/test.pl
+++ b/general/g.parser/test.pl
@@ -2,28 +2,28 @@
 use strict;
 # g.parser demo script for perl programming
 
-#%module
-#% description: g.parser test script (perl)
-#% keyword: keyword1
-#% keyword: keyword2
-#%end
-#%flag
-#% key: f
-#% description: A flag
-#%end
-#%option G_OPT_R_MAP
-#% key: raster
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: vector
-#%end
-#%option
-#% key: option1
-#% type: string
-#% description: An option
-#% required: no
-#%end
+# %module
+# % description: g.parser test script (perl)
+# % keyword: keyword1
+# % keyword: keyword2
+# %end
+# %flag
+# % key: f
+# % description: A flag
+# %end
+# %option G_OPT_R_MAP
+# % key: raster
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: vector
+# %end
+# %option
+# % key: option1
+# % type: string
+# % description: An option
+# % required: no
+# %end
 
 if ( !$ENV{'GISBASE'} ) {
     printf(STDERR  "You must be in GRASS GIS to run this program.\n");

--- a/general/g.parser/test.py
+++ b/general/g.parser/test.py
@@ -2,28 +2,28 @@
 
 # g.parser demo script for python programming
 
-#%module
-#% description: g.parser test script (python)
-#% keyword: keyword1
-#% keyword: keyword2
-#%end
-#%flag
-#% key: f
-#% description: A flag
-#%end
-#%option G_OPT_R_MAP
-#% key: raster
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: vector
-#%end
-#%option
-#% key: option1
-#% type: string
-#% description: An option
-#% required: no
-#%end
+# %module
+# % description: g.parser test script (python)
+# % keyword: keyword1
+# % keyword: keyword2
+# %end
+# %flag
+# % key: f
+# % description: A flag
+# %end
+# %option G_OPT_R_MAP
+# % key: raster
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: vector
+# %end
+# %option
+# % key: option1
+# % type: string
+# % description: An option
+# % required: no
+# %end
 
 import sys
 import atexit

--- a/general/g.parser/test.sh
+++ b/general/g.parser/test.sh
@@ -2,28 +2,28 @@
 
 # g.parser demo script for shell programming
 
-#%module
-#% description: g.parser test script (shell)
-#% keyword: keyword1
-#% keyword: keyword2
-#%end
-#%flag
-#% key: f
-#% description: A flag
-#%end
-#%option G_OPT_R_MAP
-#% key: raster
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: vector
-#%end
-#%option
-#% key: option1
-#% type: string
-#% description: An option
-#% required: no
-#%end
+# %module
+# % description: g.parser test script (shell)
+# % keyword: keyword1
+# % keyword: keyword2
+# %end
+# %flag
+# % key: f
+# % description: A flag
+# %end
+# %option G_OPT_R_MAP
+# % key: raster
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: vector
+# %end
+# %option
+# % key: option1
+# % type: string
+# % description: An option
+# % required: no
+# %end
 
 if [ -z "$GISBASE" ] ; then
     echo "You must be in GRASS GIS to run this program." 1>&2

--- a/gui/scripts/d.rast3d.py
+++ b/gui/scripts/d.rast3d.py
@@ -16,19 +16,19 @@
 #
 #############################################################################
 
-#%module
-#% description: Displays a 3D raster map layer.
-#% keyword: display
-#% keyword: raster3d
-#%end
+# %module
+# % description: Displays a 3D raster map layer.
+# % keyword: display
+# % keyword: raster3d
+# %end
 
-#%option
-#% key: map
-#% type: string
-#% gisprompt: old,grid3,3d-raster
-#% description: 3D raster map to be displayed
-#% required : yes
-#%end
+# %option
+# % key: map
+# % type: string
+# % gisprompt: old,grid3,3d-raster
+# % description: 3D raster map to be displayed
+# % required : yes
+# %end
 
 from grass.script import core as grass
 

--- a/gui/scripts/d.wms.py
+++ b/gui/scripts/d.wms.py
@@ -15,145 +15,145 @@
 #
 #############################################################################
 
-#%module
-#% description: Downloads and displays data from WMS/WMTS/NASA OnEarth server.
-#% keyword: raster
-#% keyword: import
-#% keyword: WMS
-#% keyword: WMTS
-#% keyword: OnEarth
-#%end
+# %module
+# % description: Downloads and displays data from WMS/WMTS/NASA OnEarth server.
+# % keyword: raster
+# % keyword: import
+# % keyword: WMS
+# % keyword: WMTS
+# % keyword: OnEarth
+# %end
 
-#%option
-#% key: url
-#% type: string
-#% description: Typically starts with "http://"
-#% required: yes
-#%end
+# %option
+# % key: url
+# % type: string
+# % description: Typically starts with "http://"
+# % required: yes
+# %end
 
-#%option
-#% key: map
-#% type: string
-#% description: Name for output WMS layer in the layer tree
-#% required : yes
-#%end
+# %option
+# % key: map
+# % type: string
+# % description: Name for output WMS layer in the layer tree
+# % required : yes
+# %end
 
-#%option
-#% key: layers
-#% type: string
-#% description: Layer(s) to request from the map server
-#% multiple: yes
-#% required: yes
-#%end
+# %option
+# % key: layers
+# % type: string
+# % description: Layer(s) to request from the map server
+# % multiple: yes
+# % required: yes
+# %end
 
-#%option
-#% key: styles
-#% type: string
-#% description: Layer style(s) to request from the map server
-#% multiple: yes
-#% guisection: Map style
-#%end
+# %option
+# % key: styles
+# % type: string
+# % description: Layer style(s) to request from the map server
+# % multiple: yes
+# % guisection: Map style
+# %end
 
-#%option
-#% key: format
-#% type: string
-#% description: Image format requested from the server
-#% options: geotiff,tiff,jpeg,gif,png,png8
-#% answer: png
-#% guisection: Request
-#%end
+# %option
+# % key: format
+# % type: string
+# % description: Image format requested from the server
+# % options: geotiff,tiff,jpeg,gif,png,png8
+# % answer: png
+# % guisection: Request
+# %end
 
-#%option
-#% key: srs
-#% type: integer
-#% description: EPSG code of requested source projection
-#% answer:4326
-#% guisection: Request
-#%end
+# %option
+# % key: srs
+# % type: integer
+# % description: EPSG code of requested source projection
+# % answer:4326
+# % guisection: Request
+# %end
 
-#%option
-#% key: driver
-#% type:string
-#% description: Driver used to communication with server
-#% descriptions: WMS_GDAL;Download data using GDAL WMS driver;WMS_GRASS;Download data using native GRASS-WMS driver;WMTS_GRASS;Download data using native GRASS-WMTS driver;OnEarth_GRASS;Download data using native GRASS-OnEarth driver;
-#% options:WMS_GDAL, WMS_GRASS, WMTS_GRASS, OnEarth_GRASS
-#% answer:WMS_GRASS
-#% guisection: Connection
-#%end
+# %option
+# % key: driver
+# % type:string
+# % description: Driver used to communication with server
+# % descriptions: WMS_GDAL;Download data using GDAL WMS driver;WMS_GRASS;Download data using native GRASS-WMS driver;WMTS_GRASS;Download data using native GRASS-WMTS driver;OnEarth_GRASS;Download data using native GRASS-OnEarth driver;
+# % options:WMS_GDAL, WMS_GRASS, WMTS_GRASS, OnEarth_GRASS
+# % answer:WMS_GRASS
+# % guisection: Connection
+# %end
 
-#%option
-#% key: wms_version
-#% type:string
-#% description: WMS standard version
-#% options: 1.1.1,1.3.0
-#% answer: 1.1.1
-#% guisection: Request
-#%end
+# %option
+# % key: wms_version
+# % type:string
+# % description: WMS standard version
+# % options: 1.1.1,1.3.0
+# % answer: 1.1.1
+# % guisection: Request
+# %end
 
-#%option
-#% key: maxcols
-#% type:integer
-#% description: Maximum columns to request at a time
-#% answer:512
-#% guisection: Request
-#%end
+# %option
+# % key: maxcols
+# % type:integer
+# % description: Maximum columns to request at a time
+# % answer:512
+# % guisection: Request
+# %end
 
-#%option
-#% key: maxrows
-#% type: integer
-#% description: Maximum rows to request at a time
-#% answer: 512
-#% guisection: Request
-#%end
+# %option
+# % key: maxrows
+# % type: integer
+# % description: Maximum rows to request at a time
+# % answer: 512
+# % guisection: Request
+# %end
 
-#%option
-#% key: urlparams
-#% type:string
-#% description: Additional query parameters to pass to the server
-#% guisection: Request
-#%end
+# %option
+# % key: urlparams
+# % type:string
+# % description: Additional query parameters to pass to the server
+# % guisection: Request
+# %end
 
-#%option
-#% key: username
-#% type:string
-#% description: Username for server connection
-#% guisection: Connection
-#%end
+# %option
+# % key: username
+# % type:string
+# % description: Username for server connection
+# % guisection: Connection
+# %end
 
-#%option
-#% key: password
-#% type:string
-#% description: Password for server connection
-#% guisection: Connection
-#%end
+# %option
+# % key: password
+# % type:string
+# % description: Password for server connection
+# % guisection: Connection
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Interpolation method to use in reprojection
-#% options:nearest,linear,cubic,cubicspline
-#% answer:nearest
-#% required: no
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Interpolation method to use in reprojection
+# % options:nearest,linear,cubic,cubicspline
+# % answer:nearest
+# % required: no
+# %end
 
-#%option
-#% key: bgcolor
-#% type: string
-#% description: Background color
-#% guisection: Map style
-#%end
+# %option
+# % key: bgcolor
+# % type: string
+# % description: Background color
+# % guisection: Map style
+# %end
 
-#%option G_OPT_F_BIN_INPUT
-#% key: capfile
-#% required: no
-#% description: Capabilities file to parse (input). It is relevant for WMTS_GRASS and OnEarth_GRASS drivers
-#%end
+# %option G_OPT_F_BIN_INPUT
+# % key: capfile
+# % required: no
+# % description: Capabilities file to parse (input). It is relevant for WMTS_GRASS and OnEarth_GRASS drivers
+# %end
 
-#%flag
-#% key: o
-#% description: Don't request transparent data
-#% guisection: Map style
-#%end
+# %flag
+# % key: o
+# % description: Don't request transparent data
+# % guisection: Map style
+# %end
 
 import os
 import sys

--- a/gui/wxpython/animation/g.gui.animation.py
+++ b/gui/wxpython/animation/g.gui.animation.py
@@ -19,37 +19,37 @@
 #
 ############################################################################
 
-#%module
-#% description: Tool for animating a series of raster and vector maps or a space time raster or vector dataset.
-#% keyword: general
-#% keyword: GUI
-#% keyword: display
-#% keyword: animation
-#%end
-#%option G_OPT_R_INPUTS
-#% key: raster
-#% description: Raster maps to animate
-#% required: no
-#% guisection: Input
-#%end
-#%option G_OPT_V_INPUTS
-#% key: vector
-#% label: Vector maps to animate
-#% required: no
-#% guisection: Input
-#%end
-#%option G_OPT_STRDS_INPUT
-#% key: strds
-#% description: Space time raster dataset to animate
-#% required: no
-#% guisection: Input
-#%end
-#%option G_OPT_STVDS_INPUT
-#% key: stvds
-#% description: Space time vector dataset to animate
-#% required: no
-#% guisection: Input
-#%end
+# %module
+# % description: Tool for animating a series of raster and vector maps or a space time raster or vector dataset.
+# % keyword: general
+# % keyword: GUI
+# % keyword: display
+# % keyword: animation
+# %end
+# %option G_OPT_R_INPUTS
+# % key: raster
+# % description: Raster maps to animate
+# % required: no
+# % guisection: Input
+# %end
+# %option G_OPT_V_INPUTS
+# % key: vector
+# % label: Vector maps to animate
+# % required: no
+# % guisection: Input
+# %end
+# %option G_OPT_STRDS_INPUT
+# % key: strds
+# % description: Space time raster dataset to animate
+# % required: no
+# % guisection: Input
+# %end
+# %option G_OPT_STVDS_INPUT
+# % key: stvds
+# % description: Space time vector dataset to animate
+# % required: no
+# % guisection: Input
+# %end
 
 import grass.script as gscript
 from grass.exceptions import FatalError

--- a/gui/wxpython/datacatalog/g.gui.datacatalog.py
+++ b/gui/wxpython/datacatalog/g.gui.datacatalog.py
@@ -18,12 +18,12 @@
 #
 ############################################################################
 
-#%module
-#% description: Tool for browsing, modifying and managing GRASS maps.
-#% keyword: general
-#% keyword: GUI
-#% keyword: map management
-#%end
+# %module
+# % description: Tool for browsing, modifying and managing GRASS maps.
+# % keyword: general
+# % keyword: GUI
+# % keyword: map management
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/dbmgr/g.gui.dbmgr.py
+++ b/gui/wxpython/dbmgr/g.gui.dbmgr.py
@@ -18,15 +18,15 @@
 #
 ############################################################################
 
-#%module
-#% description: Launches graphical attribute table manager.
-#% keyword: general
-#% keyword: GUI
-#% keyword: attribute table
-#% keyword: database
-#%end
-#%option G_OPT_V_MAP
-#%end
+# %module
+# % description: Launches graphical attribute table manager.
+# % keyword: general
+# % keyword: GUI
+# % keyword: attribute table
+# % keyword: database
+# %end
+# %option G_OPT_V_MAP
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/gcp/g.gui.gcp.py
+++ b/gui/wxpython/gcp/g.gui.gcp.py
@@ -19,14 +19,14 @@
 #
 ############################################################################
 
-#%module
-#% description: Georectifies a map and allows managing Ground Control Points.
-#% keyword: general
-#% keyword: GUI
-#% keyword: georectification
-#% keyword: geometry
-#% keyword: GCP
-#%end
+# %module
+# % description: Georectifies a map and allows managing Ground Control Points.
+# % keyword: general
+# % keyword: GUI
+# % keyword: georectification
+# % keyword: geometry
+# % keyword: GCP
+# %end
 
 """
 Module to run GCP management tool as stadalone application.

--- a/gui/wxpython/gmodeler/g.gui.gmodeler.py
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.py
@@ -18,21 +18,21 @@
 #
 ############################################################################
 
-#%module
-#% label: Graphical Modeler.
-#% description: Allows interactively creating, editing and managing models.
-#% keyword: general
-#% keyword: GUI
-#% keyword: graphical modeler
-#% keyword: workflow
-#%end
-#%option G_OPT_F_INPUT
-#% key: file
-#% description: Name of model file to be loaded
-#% key_desc: name.gxm
-#% required: no
-#% guisection: Model
-#%end
+# %module
+# % label: Graphical Modeler.
+# % description: Allows interactively creating, editing and managing models.
+# % keyword: general
+# % keyword: GUI
+# % keyword: graphical modeler
+# % keyword: workflow
+# %end
+# %option G_OPT_F_INPUT
+# % key: file
+# % description: Name of model file to be loaded
+# % key_desc: name.gxm
+# % required: no
+# % guisection: Model
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -2557,9 +2557,9 @@ class WritePythonFile:
         # UI
         self.fd.write(
             r"""
-#%module
-#% description: {description}
-#%end
+# %module
+# % description: {description}
+# %end
 """.format(description=' '.join(properties['description'].splitlines())))
 
         modelItems = self.model.GetItems()
@@ -2570,20 +2570,20 @@ class WritePythonFile:
                 else:
                     desc = flag['description']
                 self.fd.write(
-                r"""#%option
-#% key: {flag_name}
-#% description: {description}
-#% required: yes
-#% type: string
-#% options: True, False
-#% guisection: Flags
+                r"""# %option
+# % key: {flag_name}
+# % description: {description}
+# % required: yes
+# % type: string
+# % options: True, False
+# % guisection: Flags
 """.format(flag_name=self._getParamName(flag['name'], item),
            description=desc))
                 if flag['value']:
-                    self.fd.write("#% answer: {}\n".format(flag['value']))
+                    self.fd.write("# % answer: {}\n".format(flag['value']))
                 else:
-                    self.fd.write("#% answer: False\n")
-                self.fd.write("#%end\n")
+                    self.fd.write("# % answer: False\n")
+                self.fd.write("# %end\n")
 
             for param in item.GetParameterizedParams()['params']:
                 if param['label']:
@@ -2591,23 +2591,23 @@ class WritePythonFile:
                 else:
                     desc = param['description']
                 self.fd.write(
-                r"""#%option
-#% key: {param_name}
-#% description: {description}
-#% required: yes
+                r"""# %option
+# % key: {param_name}
+# % description: {description}
+# % required: yes
 """.format(param_name=self._getParamName(param['name'], item),
            description=desc))
                 if param['type'] != 'float':
-                    self.fd.write('#% type: {}\n'.format(param['type']))
+                    self.fd.write('# % type: {}\n'.format(param['type']))
                 else:
-                    self.fd.write('#% type: double\n')
+                    self.fd.write('# % type: double\n')
                 if param['key_desc']:
-                    self.fd.write("#% key_desc: ")
+                    self.fd.write("# % key_desc: ")
                     self.fd.write(', '.join(param['key_desc']))
                     self.fd.write("\n")
                 if param['value']:
-                    self.fd.write("#% answer: {}\n".format(param['value']))
-                self.fd.write("#%end\n")
+                    self.fd.write("# % answer: {}\n".format(param['value']))
+                self.fd.write("# %end\n")
 
         # import modules
         self.fd.write(

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -99,9 +99,9 @@ def module_template():
     # UI
     output.write(
         r"""
-#%%module
-#%% description: %s
-#%%end
+# %%module
+# %% description: %s
+# %%end
 """ % (' '.join(properties['description'].splitlines())))
 
     # import modules
@@ -168,22 +168,22 @@ def module_example():
     """Example of a GRASS module"""
     return r"""#!/usr/bin/env python3
 
-#%module
-#% description: Adds the values of two rasters (A + B)
-#% keyword: raster
-#% keyword: algebra
-#% keyword: sum
-#%end
-#%option G_OPT_R_INPUT
-#% key: araster
-#% description: Name of input raster A in an expression A + B
-#%end
-#%option G_OPT_R_INPUT
-#% key: braster
-#% description: Name of input raster B in an expression A + B
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
+# %module
+# % description: Adds the values of two rasters (A + B)
+# % keyword: raster
+# % keyword: algebra
+# % keyword: sum
+# %end
+# %option G_OPT_R_INPUT
+# % key: araster
+# % description: Name of input raster A in an expression A + B
+# %end
+# %option G_OPT_R_INPUT
+# % key: braster
+# % description: Name of input raster B in an expression A + B
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
 
 
 import sys
@@ -211,16 +211,16 @@ def module_error_handling_example():
     """Example of a GRASS module"""
     return r"""#!/usr/bin/env python3
 
-#%module
-#% description: Selects values from raster above value of mean plus standard deviation
-#% keyword: raster
-#% keyword: select
-#% keyword: standard deviation
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
+# %module
+# % description: Selects values from raster above value of mean plus standard deviation
+# % keyword: raster
+# % keyword: select
+# % keyword: standard deviation
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
 
 
 import sys

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -19,35 +19,35 @@
 #
 ############################################################################
 
-#%module
-#% label: Tool for supervised classification of imagery data.
-#% description: Generates spectral signatures for an image by allowing the user to outline regions of interest.
-#% keyword: general
-#% keyword: GUI
-#% keyword: classification
-#% keyword: supervised classification
-#% keyword: signatures
-#%end
-#%flag
-#% key: m
-#% description: Maximize window
-#%end
-#%option G_OPT_I_GROUP
-#% required: no
-#%end
-#%option G_OPT_I_SUBGROUP
-#% required: no
-#%end
-#%option G_OPT_R_MAP
-#% description: Name of raster map to load
-#% required: no
-#%end
-#%option G_OPT_V_MAP
-#% key: trainingmap
-#% label: Ground truth training map to load
-#% description:
-#% required: no
-#%end
+# %module
+# % label: Tool for supervised classification of imagery data.
+# % description: Generates spectral signatures for an image by allowing the user to outline regions of interest.
+# % keyword: general
+# % keyword: GUI
+# % keyword: classification
+# % keyword: supervised classification
+# % keyword: signatures
+# %end
+# %flag
+# % key: m
+# % description: Maximize window
+# %end
+# %option G_OPT_I_GROUP
+# % required: no
+# %end
+# %option G_OPT_I_SUBGROUP
+# % required: no
+# %end
+# %option G_OPT_R_MAP
+# % description: Name of raster map to load
+# % required: no
+# %end
+# %option G_OPT_V_MAP
+# % key: trainingmap
+# % label: Ground truth training map to load
+# % description:
+# % required: no
+# %end
 
 import os
 import grass.script as gscript

--- a/gui/wxpython/mapdisp/test_mapdisp.py
+++ b/gui/wxpython/mapdisp/test_mapdisp.py
@@ -19,29 +19,29 @@
 #
 ############################################################################
 
-#%module
-#% description: Georectifies a map and allows managing Ground Control Points.
-#% keyword: general
-#% keyword: GUI
-#% keyword: georectification
-#%end
-#%option
-#% key: test
-#% description: Test to run
-#% options: mapwindow,mapdisplay,apitest,distance,profile
-#% descriptions: mapwindow;Opens map window ;mapdisplay;Opens map display; apitest;Open an application to test API of map window; distance;Starts map window with distance measurement activated; profile;Starts map window with profile tool activated
-#% required: yes
-#%end
-#%option G_OPT_R_INPUT
-#% key: raster
-#% multiple: yes
-#% required: no
-#%end
-#%option G_OPT_V_INPUT
-#% key: vector
-#% multiple: yes
-#% required: no
-#%end
+# %module
+# % description: Tests map display and map window widgets
+# % keyword: general
+# % keyword: GUI
+# % keyword: test
+# %end
+# %option
+# % key: test
+# % description: Test to run
+# % options: mapwindow,mapdisplay,apitest,distance,profile
+# % descriptions: mapwindow;Opens map window ;mapdisplay;Opens map display; apitest;Open an application to test API of map window; distance;Starts map window with distance measurement activated; profile;Starts map window with profile tool activated
+# % required: yes
+# %end
+# %option G_OPT_R_INPUT
+# % key: raster
+# % multiple: yes
+# % required: no
+# %end
+# %option G_OPT_V_INPUT
+# % key: vector
+# % multiple: yes
+# % required: no
+# %end
 
 """
 Module to run test map window (BufferedWidnow) and map display (MapFrame).

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.py
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.py
@@ -19,30 +19,30 @@
 #
 ############################################################################
 
-#%module
-#% description: Interactively compares two maps by swiping a visibility bar.
-#% keyword: general
-#% keyword: GUI
-#% keyword: display
-#%end
-#%option G_OPT_R_INPUT
-#% key: first
-#% description: First (top/right) raster map
-#% required: no
-#%end
-#%option G_OPT_R_INPUT
-#% key: second
-#% description: Second (bottom/left) raster map
-#% required: no
-#%end
-#%option
-#% key: mode
-#% description: View mode
-#% options: swipe,mirror
-#% descriptions:swipe;swiping the upper map layer to show the map layer below ;mirror;synchronized maps side by side
-#% answer: swipe
-#% required: no
-#%end
+# %module
+# % description: Interactively compares two maps by swiping a visibility bar.
+# % keyword: general
+# % keyword: GUI
+# % keyword: display
+# %end
+# %option G_OPT_R_INPUT
+# % key: first
+# % description: First (top/right) raster map
+# % required: no
+# %end
+# %option G_OPT_R_INPUT
+# % key: second
+# % description: Second (bottom/left) raster map
+# % required: no
+# %end
+# %option
+# % key: mode
+# % description: View mode
+# % options: swipe,mirror
+# % descriptions:swipe;swiping the upper map layer to show the map layer below ;mirror;synchronized maps side by side
+# % answer: swipe
+# % required: no
+# %end
 
 import os
 import grass.script as gscript

--- a/gui/wxpython/psmap/g.gui.psmap.py
+++ b/gui/wxpython/psmap/g.gui.psmap.py
@@ -18,19 +18,19 @@
 #
 ############################################################################
 
-#%module
-#% description: Tool for creating hardcopy map outputs.
-#% keyword: general
-#% keyword: GUI
-#% keyword: printing
-#%end
-#%option G_OPT_F_INPUT
-#% key: file
-#% label: File containing mapping instructions to load
-#% description: See ps.map manual for details
-#% key_desc: name
-#% required: no
-#%end
+# %module
+# % description: Tool for creating hardcopy map outputs.
+# % keyword: general
+# % keyword: GUI
+# % keyword: printing
+# %end
+# %option G_OPT_F_INPUT
+# % key: file
+# % label: File containing mapping instructions to load
+# % description: See ps.map manual for details
+# % key_desc: name
+# % required: no
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/rdigit/g.gui.rdigit.py
+++ b/gui/wxpython/rdigit/g.gui.rdigit.py
@@ -19,40 +19,40 @@
 #
 ############################################################################
 
-#%module
-#% description: Interactive editing and digitizing of raster maps.
-#% keyword: general
-#% keyword: GUI
-#% keyword: raster
-#% keyword: editing
-#% keyword: digitizer
-#%end
-#%option G_OPT_R_OUTPUT
-#% key: create
-#% label: Name of new raster map to create
-#% required: no
-#% guisection: Create
-#%end
-#%option G_OPT_R_BASE
-#% required: no
-#% guisection: Create
-#%end
-#%option G_OPT_R_TYPE
-#% answer: CELL
-#% required: no
-#% guisection: Create
-#%end
-#%option G_OPT_R_INPUT
-#% key: edit
-#% required: no
-#% label: Name of existing raster map to edit
-#% guisection: Edit
-#%end
-#%rules
-#% exclusive: create, edit
-#% required: create, edit
-#% requires: base, create
-#%end
+# %module
+# % description: Interactive editing and digitizing of raster maps.
+# % keyword: general
+# % keyword: GUI
+# % keyword: raster
+# % keyword: editing
+# % keyword: digitizer
+# %end
+# %option G_OPT_R_OUTPUT
+# % key: create
+# % label: Name of new raster map to create
+# % required: no
+# % guisection: Create
+# %end
+# %option G_OPT_R_BASE
+# % required: no
+# % guisection: Create
+# %end
+# %option G_OPT_R_TYPE
+# % answer: CELL
+# % required: no
+# % guisection: Create
+# %end
+# %option G_OPT_R_INPUT
+# % key: edit
+# % required: no
+# % label: Name of existing raster map to edit
+# % guisection: Edit
+# %end
+# %rules
+# % exclusive: create, edit
+# % required: create, edit
+# % requires: base, create
+# %end
 
 import os
 

--- a/gui/wxpython/rlisetup/g.gui.rlisetup.py
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.py
@@ -18,13 +18,13 @@
 #
 ############################################################################
 
-#%module
-#% description: Configuration tool for r.li modules.
-#% keyword: general
-#% keyword: GUI
-#% keyword: raster
-#% keyword: landscape structure analysis
-#%end
+# %module
+# % description: Configuration tool for r.li modules.
+# % keyword: general
+# % keyword: GUI
+# % keyword: raster
+# % keyword: landscape structure analysis
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/timeline/g.gui.timeline.py
+++ b/gui/wxpython/timeline/g.gui.timeline.py
@@ -19,20 +19,20 @@
 #
 ############################################################################
 
-#%module
-#% description: Allows comparing temporal datasets by displaying their temporal extents in a plot.
-#% keyword: general
-#% keyword: GUI
-#% keyword: temporal
-#% keywords: plot
-#%end
-#%option G_OPT_STDS_INPUTS
-#% required: no
-#%end
-#%flag
-#% key: 3
-#% description: Show also 3D plot of spatio-temporal extents
-#%end
+# %module
+# % description: Allows comparing temporal datasets by displaying their temporal extents in a plot.
+# % keyword: general
+# % keyword: GUI
+# % keyword: temporal
+# % keywords: plot
+# %end
+# %option G_OPT_STDS_INPUTS
+# % required: no
+# %end
+# %flag
+# % key: 3
+# % description: Show also 3D plot of spatio-temporal extents
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/tplot/g.gui.tplot.py
+++ b/gui/wxpython/tplot/g.gui.tplot.py
@@ -20,94 +20,94 @@
 #
 ############################################################################
 
-#%module
-#% description: Plots the values of temporal datasets.
-#% keywords: general
-#% keywords: GUI
-#% keywords: temporal
-#% keywords: plot
-#%end
+# %module
+# % description: Plots the values of temporal datasets.
+# % keywords: general
+# % keywords: GUI
+# % keywords: temporal
+# % keywords: plot
+# %end
 
-#%flag
-#% key: h
-#% description: Set the header of CSV file, to be used with csv option
-#%end
+# %flag
+# % key: h
+# % description: Set the header of CSV file, to be used with csv option
+# %end
 
-#%flag
-#% key: l
-#% description: Show simple linear regression model line
-#%end
+# %flag
+# % key: l
+# % description: Show simple linear regression model line
+# %end
 
-#%option G_OPT_STVDS_INPUTS
-#% key: stvds
-#% required: no
-#%end
+# %option G_OPT_STVDS_INPUTS
+# % key: stvds
+# % required: no
+# %end
 
-#%option G_OPT_STRDS_INPUTS
-#% key: strds
-#% required: no
-#%end
+# %option G_OPT_STRDS_INPUTS
+# % key: strds
+# % required: no
+# %end
 
-#%option G_OPT_M_COORDS
-#% required: no
-#%end
+# %option G_OPT_M_COORDS
+# % required: no
+# %end
 
 # TODO use option G_OPT_V_CATS
-#%option
-#% key: cats
-#% label: Categories of vectores features
-#% description: To use only with stvds
-#% required: no
-#%end
+# %option
+# % key: cats
+# % label: Categories of vectores features
+# % description: To use only with stvds
+# % required: no
+# %end
 
-#%option
-#% key: attr
-#% label: Name of attribute
-#% description: Name of attribute which represent data for plotting
-#% required: no
-#%end
+# %option
+# % key: attr
+# % label: Name of attribute
+# % description: Name of attribute which represent data for plotting
+# % required: no
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#% label: Name for output graphical file
-#% description: Full path for output file containing the plot, ddd extension to specify format (.png, .pdf, .svg)
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# % label: Name for output graphical file
+# % description: Full path for output file containing the plot, ddd extension to specify format (.png, .pdf, .svg)
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% key: csv
-#% required: no
-#% label: Name for output CSV file
-#% description: Full path for the CSV file containing the plotted data
-#%end
+# %option G_OPT_F_OUTPUT
+# % key: csv
+# % required: no
+# % label: Name for output CSV file
+# % description: Full path for the CSV file containing the plotted data
+# %end
 
-#%option
-#% key: title
-#% label: Title for plot
-#% description: The title for the output plot
-#% required: no
-#%end
+# %option
+# % key: title
+# % label: Title for plot
+# % description: The title for the output plot
+# % required: no
+# %end
 
-#%option
-#% key: xlabel
-#% label: Label for x axis
-#% description: The x axis label for the output plot
-#% required: no
-#%end
+# %option
+# % key: xlabel
+# % label: Label for x axis
+# % description: The x axis label for the output plot
+# % required: no
+# %end
 
-#%option
-#% key: ylabel
-#% label: Label for y axis
-#% description: The y axis label for the output plot
-#% required: no
-#%end
+# %option
+# % key: ylabel
+# % label: Label for y axis
+# % description: The y axis label for the output plot
+# % required: no
+# %end
 
-#%option
-#% key: size
-#% type: string
-#% label: The size for output image
-#% description: It works only with output parameter
-#% required: no
-#%end
+# %option
+# % key: size
+# % type: string
+# % label: The size for output image
+# % description: It works only with output parameter
+# % required: no
+# %end
 
 import grass.script as gscript
 

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -18,21 +18,21 @@
 #
 ############################################################################
 
-#%module
-#% description: Interactive editing and digitization of vector maps.
-#% keyword: general
-#% keyword: GUI
-#% keyword: vector
-#% keyword: editing
-#% keyword: digitizer
-#%end
-#%flag
-#% key: c
-#% description: Create new vector map if doesn't exist
-#%end
-#%option G_OPT_V_MAP
-#% label: Name of vector map to edit
-#%end
+# %module
+# % description: Interactive editing and digitization of vector maps.
+# % keyword: general
+# % keyword: GUI
+# % keyword: vector
+# % keyword: editing
+# % keyword: digitizer
+# %end
+# %flag
+# % key: c
+# % description: Create new vector map if doesn't exist
+# %end
+# %option G_OPT_V_MAP
+# % label: Name of vector map to edit
+# %end
 
 import os
 import grass.script as grass

--- a/lib/gis/parser_script.c
+++ b/lib/gis/parser_script.c
@@ -56,35 +56,35 @@ void G__script(void)
     fprintf(fp,
 	    "############################################################################\n\n");
 
-    fprintf(fp, "#%%module\n");
+    fprintf(fp, "# %%module\n");
     if (st->module_info.label)
-	fprintf(fp, "#%% label: %s\n", st->module_info.label);
+	fprintf(fp, "# %% label: %s\n", st->module_info.label);
     if (st->module_info.description)
-	fprintf(fp, "#%% description: %s\n", st->module_info.description);
+	fprintf(fp, "# %% description: %s\n", st->module_info.description);
     if (st->module_info.keywords) {
 	int i;
 
 	for(i = 0; i < st->n_keys; i++) {
-	    fprintf(fp, "#%% keyword: %s\n", st->module_info.keywords[i]);
+	    fprintf(fp, "# %% keyword: %s\n", st->module_info.keywords[i]);
 	}
     }
-    fprintf(fp, "#%%end\n");
+    fprintf(fp, "# %%end\n");
 
     if (st->n_flags) {
 	struct Flag *flag;
 
 	for (flag = &st->first_flag; flag; flag = flag->next_flag) {
-	    fprintf(fp, "#%%flag\n");
-	    fprintf(fp, "#%% key: %c\n", flag->key);
+	    fprintf(fp, "# %%flag\n");
+	    fprintf(fp, "# %% key: %c\n", flag->key);
 	    if (flag->suppress_required)
-		fprintf(fp, "#%% suppress_required: yes\n");
+		fprintf(fp, "# %% suppress_required: yes\n");
 	    if (flag->label)
-		fprintf(fp, "#%% label: %s\n", flag->label);
+		fprintf(fp, "# %% label: %s\n", flag->label);
 	    if (flag->description)
-		fprintf(fp, "#%% description: %s\n", flag->description);
+		fprintf(fp, "# %% description: %s\n", flag->description);
 	    if (flag->guisection)
-		fprintf(fp, "#%% guisection: %s\n", flag->guisection);
-	    fprintf(fp, "#%%end\n");
+		fprintf(fp, "# %% guisection: %s\n", flag->guisection);
+	    fprintf(fp, "# %%end\n");
 	}
     }
 
@@ -107,30 +107,30 @@ void G__script(void)
 		break;
 	    }
 
-	    fprintf(fp, "#%%option\n");
-	    fprintf(fp, "#%% key: %s\n", opt->key);
-	    fprintf(fp, "#%% type: %s\n", type);
-	    fprintf(fp, "#%% required: %s\n", opt->required ? "yes" : "no");
-	    fprintf(fp, "#%% multiple: %s\n", opt->multiple ? "yes" : "no");
+	    fprintf(fp, "# %%option\n");
+	    fprintf(fp, "# %% key: %s\n", opt->key);
+	    fprintf(fp, "# %% type: %s\n", type);
+	    fprintf(fp, "# %% required: %s\n", opt->required ? "yes" : "no");
+	    fprintf(fp, "# %% multiple: %s\n", opt->multiple ? "yes" : "no");
 	    if (opt->options)
-		fprintf(fp, "#%% options: %s\n", opt->options);
+		fprintf(fp, "# %% options: %s\n", opt->options);
 	    if (opt->key_desc)
-		fprintf(fp, "#%% key_desc: %s\n", opt->key_desc);
+		fprintf(fp, "# %% key_desc: %s\n", opt->key_desc);
 	    if (opt->label)
-		fprintf(fp, "#%% label: %s\n", opt->label);
+		fprintf(fp, "# %% label: %s\n", opt->label);
 	    if (opt->description)
-		fprintf(fp, "#%% description: %s\n", opt->description);
+		fprintf(fp, "# %% description: %s\n", opt->description);
 	    if (opt->descriptions)
-		fprintf(fp, "#%% descriptions: %s\n", opt->descriptions);
+		fprintf(fp, "# %% descriptions: %s\n", opt->descriptions);
 	    if (opt->answer)
-		fprintf(fp, "#%% answer: %s\n", opt->answer);
+		fprintf(fp, "# %% answer: %s\n", opt->answer);
 	    if (opt->gisprompt)
-		fprintf(fp, "#%% gisprompt: %s\n", opt->gisprompt);
+		fprintf(fp, "# %% gisprompt: %s\n", opt->gisprompt);
 	    if (opt->guisection)
-		fprintf(fp, "#%% guisection: %s\n", opt->guisection);
+		fprintf(fp, "# %% guisection: %s\n", opt->guisection);
 	    if (opt->guidependency)
-		fprintf(fp, "#%% guidependency: %s\n", opt->guidependency);
-	    fprintf(fp, "#%%end\n");
+		fprintf(fp, "# %% guidependency: %s\n", opt->guidependency);
+	    fprintf(fp, "# %%end\n");
 	}
     }
 

--- a/lib/python/docs/src/script_intro.rst
+++ b/lib/python/docs/src/script_intro.rst
@@ -95,22 +95,22 @@ Providing GRASS module interface to a script
 
     #!/usr/bin/env python3
 
-    #%module
-    #% description: Adds the values of two rasters (A + B)
-    #% keyword: raster
-    #% keyword: algebra
-    #% keyword: sum
-    #%end
-    #%option G_OPT_R_INPUT
-    #% key: araster
-    #% description: Name of input raster A in an expression A + B
-    #%end
-    #%option G_OPT_R_INPUT
-    #% key: braster
-    #% description: Name of input raster B in an expression A + B
-    #%end
-    #%option G_OPT_R_OUTPUT
-    #%end
+    # %module
+    # % description: Adds the values of two rasters (A + B)
+    # % keyword: raster
+    # % keyword: algebra
+    # % keyword: sum
+    # %end
+    # %option G_OPT_R_INPUT
+    # % key: araster
+    # % description: Name of input raster A in an expression A + B
+    # %end
+    # %option G_OPT_R_INPUT
+    # % key: braster
+    # % description: Name of input raster B in an expression A + B
+    # %end
+    # %option G_OPT_R_OUTPUT
+    # %end
 
 
     import sys

--- a/scripts/d.correlate/d.correlate.py
+++ b/scripts/d.correlate/d.correlate.py
@@ -15,16 +15,16 @@
 #
 #############################################################################
 
-#%module
-#% description: Prints a graph of the correlation between raster maps (in pairs).
-#% keyword: display
-#% keyword: statistics
-#% keyword: raster
-#% keyword: diagram
-#% keyword: correlation
-#%end
-#%option G_OPT_R_MAPS
-#%end
+# %module
+# % description: Prints a graph of the correlation between raster maps (in pairs).
+# % keyword: display
+# % keyword: statistics
+# % keyword: raster
+# % keyword: diagram
+# % keyword: correlation
+# %end
+# %option G_OPT_R_MAPS
+# %end
 
 import sys
 import os

--- a/scripts/d.frame/d.frame.py
+++ b/scripts/d.frame/d.frame.py
@@ -19,51 +19,51 @@
 #  GNU General Public License for more details.
 #
 ############################################################################
-#%module
-#% description: Manages display frames on the user's graphics monitor.
-#% keyword: display
-#% keyword: graphics
-#% keyword: monitors
-#% keyword: frame
-#% overwrite: yes
-#%end
-#%flag
-#% key: c
-#% description: Create a new frame if doesn't exist and select
-#%end
-#%flag
-#% key: e
-#% description: Remove all frames, erase the screen and exit
-#% suppress_required: yes
-#%end
-#%flag
-#% key: p
-#% description: Print name of current frame and exit
-#% suppress_required: yes
-#%end
-#%flag
-#% key: a
-#% description: Print names of all frames including 'at' position and exit
-#% suppress_required: yes
-#%end
-#%option
-#% key: frame
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Frame to be selected or created (if -c flag is given)
-#%end
-#%option
-#% key: at
-#% type: double
-#% required: no
-#% multiple: no
-#% key_desc: bottom,top,left,right
-#% label: Screen coordinates in percent where to place the frame (0,0 is lower-left)
-#% options: 0-100
-#% description: Implies only when -c or --overwrite flag is given
-#%end
+# %module
+# % description: Manages display frames on the user's graphics monitor.
+# % keyword: display
+# % keyword: graphics
+# % keyword: monitors
+# % keyword: frame
+# % overwrite: yes
+# %end
+# %flag
+# % key: c
+# % description: Create a new frame if doesn't exist and select
+# %end
+# %flag
+# % key: e
+# % description: Remove all frames, erase the screen and exit
+# % suppress_required: yes
+# %end
+# %flag
+# % key: p
+# % description: Print name of current frame and exit
+# % suppress_required: yes
+# %end
+# %flag
+# % key: a
+# % description: Print names of all frames including 'at' position and exit
+# % suppress_required: yes
+# %end
+# %option
+# % key: frame
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Frame to be selected or created (if -c flag is given)
+# %end
+# %option
+# % key: at
+# % type: double
+# % required: no
+# % multiple: no
+# % key_desc: bottom,top,left,right
+# % label: Screen coordinates in percent where to place the frame (0,0 is lower-left)
+# % options: 0-100
+# % description: Implies only when -c or --overwrite flag is given
+# %end
 
 import os
 import sys

--- a/scripts/d.out.file/d.out.file.py
+++ b/scripts/d.out.file/d.out.file.py
@@ -13,31 +13,31 @@
 #
 #############################################################################
 
-#%module
-#% description: Saves the contents of the active display monitor to a graphics file.
-#% keyword: display
-#% keyword: export
-#% keyword: output
-#%end
-#%option G_OPT_F_OUTPUT
-#% description: Name for output file
-#% required: yes
-#%end
-#%option
-#% key: format
-#% description: Graphics file format
-#% required: yes
-#% options: png,jpg,bmp,gif,tif
-#% answer: png
-#%end
-#%option
-#% key: size
-#% type: integer
-#% key_desc: width,height
-#% description: Width and height of output image
-#% guisection: Images
-#% required : no
-#%end
+# %module
+# % description: Saves the contents of the active display monitor to a graphics file.
+# % keyword: display
+# % keyword: export
+# % keyword: output
+# %end
+# %option G_OPT_F_OUTPUT
+# % description: Name for output file
+# % required: yes
+# %end
+# %option
+# % key: format
+# % description: Graphics file format
+# % required: yes
+# % options: png,jpg,bmp,gif,tif
+# % answer: png
+# %end
+# %option
+# % key: size
+# % type: integer
+# % key_desc: width,height
+# % description: Width and height of output image
+# % guisection: Images
+# % required : no
+# %end
 
 from grass.script import core as gcore
 

--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -19,28 +19,28 @@
 #
 #############################################################################
 
-#%Module
-#% description: Draws polar diagram of angle map such as aspect or flow directions
-#% keyword: display
-#% keyword: diagram
-#%End
-#%option G_OPT_R_MAP
-#% description: Name of raster angle map
-#%End
-#%option
-#% key: undef
-#% type: double
-#% description: Pixel value to be interpreted as undefined (different from NULL)
-#% required : no
-#%End
-#%option G_OPT_F_OUTPUT
-#% description: Name for optional EPS output file
-#% required : no
-#%end
-#%flag
-#% key: x
-#% description: Plot using Xgraph
-#%end
+# %Module
+# % description: Draws polar diagram of angle map such as aspect or flow directions
+# % keyword: display
+# % keyword: diagram
+# %End
+# %option G_OPT_R_MAP
+# % description: Name of raster angle map
+# %End
+# %option
+# % key: undef
+# % type: double
+# % description: Pixel value to be interpreted as undefined (different from NULL)
+# % required : no
+# %End
+# %option G_OPT_F_OUTPUT
+# % description: Name for optional EPS output file
+# % required : no
+# %end
+# %flag
+# % key: x
+# % description: Plot using Xgraph
+# %end
 
 import os
 import string

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -18,61 +18,61 @@
 #
 # /
 
-#%module
-#% description: Edits cell values in a raster map.
-#% keyword: display
-#% keyword: editing
-#% keyword: raster
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
-#%option G_OPT_R_INPUT
-#% key: aspect
-#% required: no
-#% description: Name of input aspect raster map
-#%end
-#%option
-#% key: width
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Width of display canvas
-#% answer: 640
-#%end
-#%option
-#% key: height
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Height of display canvas
-#% answer: 480
-#%end
-#%option
-#% key: size
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Minimum size of each cell
-#% answer: 12
-#%end
-#%option
-#% key: rows
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Maximum number of rows to load
-#% answer: 100
-#%end
-#%option
-#% key: cols
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Maximum number of columns to load
-#% answer: 100
-#%end
+# %module
+# % description: Edits cell values in a raster map.
+# % keyword: display
+# % keyword: editing
+# % keyword: raster
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
+# %option G_OPT_R_INPUT
+# % key: aspect
+# % required: no
+# % description: Name of input aspect raster map
+# %end
+# %option
+# % key: width
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Width of display canvas
+# % answer: 640
+# %end
+# %option
+# % key: height
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Height of display canvas
+# % answer: 480
+# %end
+# %option
+# % key: size
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Minimum size of each cell
+# % answer: 12
+# %end
+# %option
+# % key: rows
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Maximum number of rows to load
+# % answer: 100
+# %end
+# %option
+# % key: cols
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Maximum number of columns to load
+# % answer: 100
+# %end
 
 import sys
 import math

--- a/scripts/d.rast.leg/d.rast.leg.py
+++ b/scripts/d.rast.leg/d.rast.leg.py
@@ -28,38 +28,38 @@
 #
 #############################################################################
 
-#%module
-#% description: Displays a raster map and its legend on a graphics window
-#% keyword: display
-#% keyword: cartography
-#% keyword: legend
-#%end
-#%flag
-#%  key: f
-#%  description: Flip legend
-#%end
-#%flag
-#%  key: n
-#%  description: Omit entries with missing label
-#%end
-#%option G_OPT_R_MAP
-#% description: Name of raster map to display
-#%end
-#%flag
-#%  key: s
-#%  description: Draw smooth gradient
-#%end
-#%option
-#% key: lines
-#% type: integer
-#% description: Number of lines to appear in the legend
-#% required: no
-#%end
-#%option G_OPT_R_INPUT
-#% key: raster
-#% description: Name of input raster map to generate legend from
-#% required: no
-#%end
+# %module
+# % description: Displays a raster map and its legend on a graphics window
+# % keyword: display
+# % keyword: cartography
+# % keyword: legend
+# %end
+# %flag
+# %  key: f
+# %  description: Flip legend
+# %end
+# %flag
+# %  key: n
+# %  description: Omit entries with missing label
+# %end
+# %option G_OPT_R_MAP
+# % description: Name of raster map to display
+# %end
+# %flag
+# %  key: s
+# %  description: Draw smooth gradient
+# %end
+# %option
+# % key: lines
+# % type: integer
+# % description: Number of lines to appear in the legend
+# % required: no
+# %end
+# %option G_OPT_R_INPUT
+# % key: raster
+# % description: Name of input raster map to generate legend from
+# % required: no
+# %end
 
 import sys
 import os

--- a/scripts/d.redraw/d.redraw.py
+++ b/scripts/d.redraw/d.redraw.py
@@ -13,12 +13,12 @@
 #
 #############################################################################
 
-#%module
-#% description: Redraws the content of currently selected monitor.
-#% keyword: display
-#% keyword: graphics
-#% keyword: monitors
-#%end
+# %module
+# % description: Redraws the content of currently selected monitor.
+# % keyword: display
+# % keyword: graphics
+# % keyword: monitors
+# %end
 
 import os
 import sys

--- a/scripts/d.shade/d.shade.py
+++ b/scripts/d.shade/d.shade.py
@@ -14,30 +14,30 @@
 #
 #############################################################################
 
-#%module
-#% description: Drapes a color raster over an shaded relief or aspect map.
-#% keyword: display
-#% keyword: elevation
-#% keyword: relief
-#% keyword: hillshade
-#% keyword: visualization
-#%end
-#%option G_OPT_R_INPUT
-#% key: shade
-#% description: Name of shaded relief or aspect raster map
-#%end
-#%option G_OPT_R_INPUT
-#% key: color
-#% label: Name of raster to drape over relief raster map
-#% description: Typically, this raster is elevation or other colorful raster
-#%end
-#%option
-#% key: brighten
-#% type: integer
-#% description: Percent to brighten
-#% options: -99-99
-#% answer: 0
-#%end
+# %module
+# % description: Drapes a color raster over an shaded relief or aspect map.
+# % keyword: display
+# % keyword: elevation
+# % keyword: relief
+# % keyword: hillshade
+# % keyword: visualization
+# %end
+# %option G_OPT_R_INPUT
+# % key: shade
+# % description: Name of shaded relief or aspect raster map
+# %end
+# %option G_OPT_R_INPUT
+# % key: color
+# % label: Name of raster to drape over relief raster map
+# % description: Typically, this raster is elevation or other colorful raster
+# %end
+# %option
+# % key: brighten
+# % type: integer
+# % description: Percent to brighten
+# % options: -99-99
+# % answer: 0
+# %end
 
 
 from grass.script import core as gcore

--- a/scripts/d.to.rast/d.to.rast.py
+++ b/scripts/d.to.rast/d.to.rast.py
@@ -13,14 +13,14 @@
 #
 #############################################################################
 
-#%module
-#% description: Saves the contents of the active display monitor to a raster map.
-#% keyword: display
-#% keyword: export
-#% keyword: raster
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
+# %module
+# % description: Saves the contents of the active display monitor to a raster map.
+# % keyword: display
+# % keyword: export
+# % keyword: raster
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
 
 
 from grass.script import core as gcore

--- a/scripts/d.what.rast/d.what.rast.py
+++ b/scripts/d.what.rast/d.what.rast.py
@@ -13,14 +13,14 @@
 #
 #############################################################################
 
-#%module
-#% description: Allows the user to interactively query raster map layers at user-selected locations.
-#% keyword: display
-#% keyword: vector
-#%end
-#%option G_OPT_R_INPUTS
-#% key: map
-#%end
+# %module
+# % description: Allows the user to interactively query raster map layers at user-selected locations.
+# % keyword: display
+# % keyword: vector
+# %end
+# %option G_OPT_R_INPUTS
+# % key: map
+# %end
 
 
 from grass.script import core as gcore

--- a/scripts/d.what.vect/d.what.vect.py
+++ b/scripts/d.what.vect/d.what.vect.py
@@ -13,14 +13,14 @@
 #
 #############################################################################
 
-#%module
-#% description: Allows the user to interactively query vector map layers at user-selected locations.
-#% keyword: display
-#% keyword: vector
-#%end
-#%option G_OPT_V_INPUTS
-#% key: map
-#%end
+# %module
+# % description: Allows the user to interactively query vector map layers at user-selected locations.
+# % keyword: display
+# % keyword: vector
+# %end
+# %option G_OPT_V_INPUTS
+# % key: map
+# %end
 
 
 from grass.script import core as gcore

--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -16,24 +16,24 @@
 #
 #############################################################################
 
-#%module
-#% description: Drops a column from selected attribute table.
-#% keyword: database
-#% keyword: attribute table
-#%End
+# %module
+# % description: Drops a column from selected attribute table.
+# % keyword: database
+# % keyword: attribute table
+# %End
 
-#%flag
-#% key: f
-#% description: Force removal (required for actual deletion of files)
-#%end
+# %flag
+# % key: f
+# % description: Force removal (required for actual deletion of files)
+# %end
 
-#%option G_OPT_DB_TABLE
-#% required : yes
-#%end
+# %option G_OPT_DB_TABLE
+# % required : yes
+# %end
 
-#%option G_OPT_DB_COLUMN
-#% required : yes
-#%end
+# %option G_OPT_DB_COLUMN
+# % required : yes
+# %end
 
 import sys
 import string

--- a/scripts/db.droptable/db.droptable.py
+++ b/scripts/db.droptable/db.droptable.py
@@ -14,33 +14,33 @@
 #
 #############################################################################
 
-#%module
-#% description: Drops an attribute table.
-#% keyword: database
-#% keyword: attribute table
-#%end
+# %module
+# % description: Drops an attribute table.
+# % keyword: database
+# % keyword: attribute table
+# %end
 
-#%flag
-#% key: f
-#% description: Force removal (required for actual deletion of files)
-#%end
+# %flag
+# % key: f
+# % description: Force removal (required for actual deletion of files)
+# %end
 
-#%option G_OPT_DB_DRIVER
-#% label: Name of database driver
-#% description: If not given then default driver is used
-#% guisection: Connection
-#%end
+# %option G_OPT_DB_DRIVER
+# % label: Name of database driver
+# % description: If not given then default driver is used
+# % guisection: Connection
+# %end
 
-#%option G_OPT_DB_DATABASE
-#% label: Name of database
-#% description:  If not given then default database is used
-#% guisection: Connection
-#%end
+# %option G_OPT_DB_DATABASE
+# % label: Name of database
+# % description:  If not given then default database is used
+# % guisection: Connection
+# %end
 
-#%option G_OPT_DB_TABLE
-#% description: Name of table to drop
-#% required: yes
-#%end
+# %option G_OPT_DB_TABLE
+# % description: Name of table to drop
+# % required: yes
+# %end
 
 import sys
 import grass.script as grass

--- a/scripts/db.in.ogr/db.in.ogr.py
+++ b/scripts/db.in.ogr/db.in.ogr.py
@@ -14,49 +14,49 @@
 #
 #############################################################################
 
-#%Module
-#% description: Imports attribute tables in various formats.
-#% keyword: database
-#% keyword: import
-#% keyword: attribute table
-#% overwrite: yes
-#%End
+# %Module
+# % description: Imports attribute tables in various formats.
+# % keyword: database
+# % keyword: import
+# % keyword: attribute table
+# % overwrite: yes
+# %End
 
-#%option G_OPT_F_BIN_INPUT
-#% description: Table file to be imported or DB connection string
-#%end
+# %option G_OPT_F_BIN_INPUT
+# % description: Table file to be imported or DB connection string
+# %end
 
-#%option
-#% key: db_table
-#% type: string
-#% key_desc : name
-#% description: Name of table from given DB to be imported
-#% required : no
-#%end
+# %option
+# % key: db_table
+# % type: string
+# % key_desc : name
+# % description: Name of table from given DB to be imported
+# % required : no
+# %end
 
-#%option G_OPT_DB_TABLE
-#% key: output
-#% description: Name for output table
-#% required : no
-#% guisection: Output
-#% gisprompt: new,dbtable,dbtable
-#%end
+# %option G_OPT_DB_TABLE
+# % key: output
+# % description: Name for output table
+# % required : no
+# % guisection: Output
+# % gisprompt: new,dbtable,dbtable
+# %end
 
-#%option
-#% key: key
-#% type: string
-#% description: Name for auto-generated unique key column
-#% required : no
-#% guisection: Output
-#%end
+# %option
+# % key: key
+# % type: string
+# % description: Name for auto-generated unique key column
+# % required : no
+# % guisection: Output
+# %end
 
-#%option
-#% key: encoding
-#% type: string
-#% label: Encoding value for attribute data
-#% descriptions: Overrides encoding interpretation, useful when importing DBF tables
-#% guisection: Output
-#%end
+# %option
+# % key: encoding
+# % type: string
+# % label: Encoding value for attribute data
+# % descriptions: Overrides encoding interpretation, useful when importing DBF tables
+# % guisection: Output
+# %end
 
 import os
 import grass.script as grass

--- a/scripts/db.out.ogr/db.out.ogr.py
+++ b/scripts/db.out.ogr/db.out.ogr.py
@@ -14,46 +14,46 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports attribute tables into various formats.
-#% keyword: database
-#% keyword: export
-#% keyword: output
-#% keyword: attribute table
-#%end
+# %module
+# % description: Exports attribute tables into various formats.
+# % keyword: database
+# % keyword: export
+# % keyword: output
+# % keyword: attribute table
+# %end
 
-#%option G_OPT_V_INPUT
-#% key: input
-#% label: GRASS table name
-#% required: yes
-#%end
+# %option G_OPT_V_INPUT
+# % key: input
+# % label: GRASS table name
+# % required: yes
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% key: output
-#% description: Output table file name or DB connection string
-#% required : yes
-#%end
+# %option G_OPT_F_OUTPUT
+# % key: output
+# % description: Output table file name or DB connection string
+# % required : yes
+# %end
 
-#%option G_OPT_V_FIELD
-#% required: no
-#%end
+# %option G_OPT_V_FIELD
+# % required: no
+# %end
 
-#%option
-#% key: format
-#% type: string
-#% description: Table format
-#% required: yes
-#% options: CSV,DBF,GML,MySQL,PostgreSQL,SQLite
-#% answer: CSV
-#%end
+# %option
+# % key: format
+# % type: string
+# % description: Table format
+# % required: yes
+# % options: CSV,DBF,GML,MySQL,PostgreSQL,SQLite
+# % answer: CSV
+# %end
 
-#%option
-#% key: table
-#% type: string
-#% key_desc: name
-#% description: Name for output table (default: input name)
-#% required: no
-#%end
+# %option
+# % key: table
+# % type: string
+# % key_desc: name
+# % description: Name for output table (default: input name)
+# % required: no
+# %end
 
 import os
 

--- a/scripts/db.test/db.test.py
+++ b/scripts/db.test/db.test.py
@@ -13,18 +13,18 @@
 #
 #############################################################################
 
-#%module
-#% description: Test database driver, database must exist and set by db.connect.
-#% keyword: database
-#% keyword: attribute table
-#%end
-#%option
-#% key: test
-#% type: string
-#% description: Test name
-#% required: yes
-#% options: test1
-#%end
+# %module
+# % description: Test database driver, database must exist and set by db.connect.
+# % keyword: database
+# % keyword: attribute table
+# %end
+# %option
+# % key: test
+# % type: string
+# % description: Test name
+# % required: yes
+# % options: test1
+# %end
 
 import sys
 import os

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -16,44 +16,44 @@
 #
 #############################################################################
 
-#%module
-#% description: Calculates univariate statistics on selected table column.
-#% keyword: database
-#% keyword: statistics
-#% keyword: attribute table
-#%end
-#%option G_OPT_DB_TABLE
-#% key: table
-#% required: yes
-#%end
-#%option G_OPT_DB_COLUMN
-#% description: Name of attribute column on which to calculate statistics (must be numeric)
-#% required: yes
-#%end
-#%option G_OPT_DB_DATABASE
-#%end
-#%option G_OPT_DB_DRIVER
-#% options: dbf,odbc,ogr,sqlite,pg
-#%end
-#%option G_OPT_DB_WHERE
-#%end
-#%option
-#% key: percentile
-#% type: double
-#% description: Percentile to calculate (requires extended statistics flag)
-#% required : no
-#% answer: 90
-#% options: 0-100
-#% multiple: yes
-#%end
-#%flag
-#% key: e
-#% description: Extended statistics (quartiles and 90th percentile)
-#%end
-#%flag
-#% key: g
-#% description: Print stats in shell script style
-#%end
+# %module
+# % description: Calculates univariate statistics on selected table column.
+# % keyword: database
+# % keyword: statistics
+# % keyword: attribute table
+# %end
+# %option G_OPT_DB_TABLE
+# % key: table
+# % required: yes
+# %end
+# %option G_OPT_DB_COLUMN
+# % description: Name of attribute column on which to calculate statistics (must be numeric)
+# % required: yes
+# %end
+# %option G_OPT_DB_DATABASE
+# %end
+# %option G_OPT_DB_DRIVER
+# % options: dbf,odbc,ogr,sqlite,pg
+# %end
+# %option G_OPT_DB_WHERE
+# %end
+# %option
+# % key: percentile
+# % type: double
+# % description: Percentile to calculate (requires extended statistics flag)
+# % required : no
+# % answer: 90
+# % options: 0-100
+# % multiple: yes
+# %end
+# %flag
+# % key: e
+# % description: Extended statistics (quartiles and 90th percentile)
+# %end
+# %flag
+# % key: g
+# % description: Print stats in shell script style
+# %end
 
 import sys
 import atexit

--- a/scripts/g.bands/g.bands.py
+++ b/scripts/g.bands/g.bands.py
@@ -15,33 +15,33 @@
 #
 #############################################################################
 
-#%module
-#% description: Prints available band reference information used for multispectral data.
-#% keyword: general
-#% keyword: imagery
-#% keyword: band reference
-#% keyword: image collections
-#%end
-#%option
-#% key: pattern
-#% type: string
-#% description: Band reference search pattern (examples: L, S2, .*_2, S2_1)
-#% required: no
-#% multiple: no
-#%end
-#%option
-#% key: operation
-#% type: string
-#% required: no
-#% multiple: no
-#% options: print
-#% description: Operation to be performed
-#% answer: print
-#%end
-#%flag
-#% key: e
-#% description: Print extended metadata information
-#%end
+# %module
+# % description: Prints available band reference information used for multispectral data.
+# % keyword: general
+# % keyword: imagery
+# % keyword: band reference
+# % keyword: image collections
+# %end
+# %option
+# % key: pattern
+# % type: string
+# % description: Band reference search pattern (examples: L, S2, .*_2, S2_1)
+# % required: no
+# % multiple: no
+# %end
+# %option
+# % key: operation
+# % type: string
+# % required: no
+# % multiple: no
+# % options: print
+# % description: Operation to be performed
+# % answer: print
+# %end
+# %flag
+# % key: e
+# % description: Print extended metadata information
+# %end
 
 import sys
 

--- a/scripts/g.extension.all/g.extension.all.py
+++ b/scripts/g.extension.all/g.extension.all.py
@@ -16,25 +16,25 @@
 #
 #############################################################################
 
-#%module
-#% label: Rebuilds or removes all locally installed GRASS Addons extensions.
-#% description: By default only extensions built against different GIS Library are rebuilt.
-#% keyword: general
-#% keyword: installation
-#% keyword: extensions
-#%end
-#%option
-#% key: operation
-#% type: string
-#% description: Operation to be performed
-#% required: no
-#% options: rebuild,remove
-#% answer: rebuild
-#%end
-#%flag
-#% key: f
-#% label: Force operation (required for removal)
-#% end
+# %module
+# % label: Rebuilds or removes all locally installed GRASS Addons extensions.
+# % description: By default only extensions built against different GIS Library are rebuilt.
+# % keyword: general
+# % keyword: installation
+# % keyword: extensions
+# %end
+# %option
+# % key: operation
+# % type: string
+# % description: Operation to be performed
+# % required: no
+# % options: rebuild,remove
+# % answer: rebuild
+# %end
+# %flag
+# % key: f
+# % label: Force operation (required for removal)
+# % end
 from __future__ import print_function
 import os
 import sys

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -19,133 +19,133 @@
 #               - fix toolbox support in install_private_extension_xml()
 #############################################################################
 
-#%module
-#% label: Maintains GRASS Addons extensions in local GRASS installation.
-#% description: Downloads and installs extensions from GRASS Addons repository or other source into the local GRASS installation or removes installed extensions.
-#% keyword: general
-#% keyword: installation
-#% keyword: extensions
-#% keyword: addons
-#% keyword: download
-#%end
+# %module
+# % label: Maintains GRASS Addons extensions in local GRASS installation.
+# % description: Downloads and installs extensions from GRASS Addons repository or other source into the local GRASS installation or removes installed extensions.
+# % keyword: general
+# % keyword: installation
+# % keyword: extensions
+# % keyword: addons
+# % keyword: download
+# %end
 
-#%option
-#% key: extension
-#% type: string
-#% key_desc: name
-#% label: Name of extension to install or remove
-#% description: Name of toolbox (set of extensions) when -t flag is given
-#% required: yes
-#%end
-#%option
-#% key: operation
-#% type: string
-#% description: Operation to be performed
-#% required: yes
-#% options: add,remove
-#% answer: add
-#%end
-#%option
-#% key: url
-#% type: string
-#% key_desc: url
-#% label: URL or directory to get the extension from (supported only on Linux and Mac)
-#% description: The official repository is used by default. User can specify a ZIP file, directory or a repository on common hosting services. If not identified, Subversion repository is assumed. See manual for all options.
-#%end
-#%option
-#% key: prefix
-#% type: string
-#% key_desc: path
-#% description: Prefix where to install extension (ignored when flag -s is given)
-#% answer: $GRASS_ADDON_BASE
-#% required: no
-#%end
-#%option
-#% key: proxy
-#% type: string
-#% key_desc: proxy
-#% description: Set the proxy with: "http=<value>,ftp=<value>"
-#% required: no
-#% multiple: yes
-#%end
-#%option
-#% key: branch
-#% type: string
-#% key_desc: branch
-#% description: Specific branch to fetch addon from (only used when fetching from git)
-#% required: no
-#% multiple: no
-#% answer: main
-#%end
+# %option
+# % key: extension
+# % type: string
+# % key_desc: name
+# % label: Name of extension to install or remove
+# % description: Name of toolbox (set of extensions) when -t flag is given
+# % required: yes
+# %end
+# %option
+# % key: operation
+# % type: string
+# % description: Operation to be performed
+# % required: yes
+# % options: add,remove
+# % answer: add
+# %end
+# %option
+# % key: url
+# % type: string
+# % key_desc: url
+# % label: URL or directory to get the extension from (supported only on Linux and Mac)
+# % description: The official repository is used by default. User can specify a ZIP file, directory or a repository on common hosting services. If not identified, Subversion repository is assumed. See manual for all options.
+# %end
+# %option
+# % key: prefix
+# % type: string
+# % key_desc: path
+# % description: Prefix where to install extension (ignored when flag -s is given)
+# % answer: $GRASS_ADDON_BASE
+# % required: no
+# %end
+# %option
+# % key: proxy
+# % type: string
+# % key_desc: proxy
+# % description: Set the proxy with: "http=<value>,ftp=<value>"
+# % required: no
+# % multiple: yes
+# %end
+# %option
+# % key: branch
+# % type: string
+# % key_desc: branch
+# % description: Specific branch to fetch addon from (only used when fetching from git)
+# % required: no
+# % multiple: no
+# % answer: main
+# %end
 
-#%flag
-#% key: l
-#% description: List available extensions in the official GRASS GIS Addons repository
-#% guisection: Print
-#% suppress_required: yes
-#%end
-#%flag
-#% key: c
-#% description: List available extensions in the official GRASS GIS Addons repository including module description
-#% guisection: Print
-#% suppress_required: yes
-#%end
-#%flag
-#% key: g
-#% description: List available extensions in the official GRASS GIS Addons repository (shell script style)
-#% guisection: Print
-#% suppress_required: yes
-#%end
-#%flag
-#% key: a
-#% description: List locally installed extensions
-#% guisection: Print
-#% suppress_required: yes
-#%end
-#%flag
-#% key: s
-#% description: Install system-wide (may need system administrator rights)
-#% guisection: Install
-#%end
-#%flag
-#% key: d
-#% description: Download source code and exit
-#% guisection: Install
-#%end
-#%flag
-#% key: i
-#% description: Do not install new extension, just compile it
-#% guisection: Install
-#%end
-#%flag
-#% key: f
-#% description: Force removal when uninstalling extension (operation=remove)
-#% guisection: Remove
-#%end
-#%flag
-#% key: t
-#% description: Operate on toolboxes instead of single modules (experimental)
-#% suppress_required: yes
-#%end
-#%flag
-#% key: o
-#% description: url refers to a fork of the official extension repository
-#%end
-#%flag
-#% key: j
-#% description: Generates JSON file containing the download URLs of the official Addons
-#% guisection: Install
-#% suppress_required: yes
-#%end
+# %flag
+# % key: l
+# % description: List available extensions in the official GRASS GIS Addons repository
+# % guisection: Print
+# % suppress_required: yes
+# %end
+# %flag
+# % key: c
+# % description: List available extensions in the official GRASS GIS Addons repository including module description
+# % guisection: Print
+# % suppress_required: yes
+# %end
+# %flag
+# % key: g
+# % description: List available extensions in the official GRASS GIS Addons repository (shell script style)
+# % guisection: Print
+# % suppress_required: yes
+# %end
+# %flag
+# % key: a
+# % description: List locally installed extensions
+# % guisection: Print
+# % suppress_required: yes
+# %end
+# %flag
+# % key: s
+# % description: Install system-wide (may need system administrator rights)
+# % guisection: Install
+# %end
+# %flag
+# % key: d
+# % description: Download source code and exit
+# % guisection: Install
+# %end
+# %flag
+# % key: i
+# % description: Do not install new extension, just compile it
+# % guisection: Install
+# %end
+# %flag
+# % key: f
+# % description: Force removal when uninstalling extension (operation=remove)
+# % guisection: Remove
+# %end
+# %flag
+# % key: t
+# % description: Operate on toolboxes instead of single modules (experimental)
+# % suppress_required: yes
+# %end
+# %flag
+# % key: o
+# % description: url refers to a fork of the official extension repository
+# %end
+# %flag
+# % key: j
+# % description: Generates JSON file containing the download URLs of the official Addons
+# % guisection: Install
+# % suppress_required: yes
+# %end
 
 
-#%rules
-#% required: extension, -l, -c, -g, -a, -j
-#% exclusive: extension, -l, -c, -g
-#% exclusive: extension, -l, -c, -a
-#% requires: -o, url
-#% requires: branch, url
-#%end
+# %rules
+# % required: extension, -l, -c, -g, -a, -j
+# % exclusive: extension, -l, -c, -g
+# % exclusive: extension, -l, -c, -a
+# % requires: -o, url
+# % requires: branch, url
+# %end
 
 # TODO: solve addon-extension(-module) confusion
 

--- a/scripts/g.extension/testsuite/data/sample_modules/r.plus.example/r.plus.example.py
+++ b/scripts/g.extension/testsuite/data/sample_modules/r.plus.example/r.plus.example.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 
-#%module
-#% description: Adds the values of two rasters (A + B)
-#% keyword: raster
-#% keyword: algebra
-#% keyword: sum
-#%end
-#%option G_OPT_R_INPUT
-#% key: araster
-#% description: Name of input raster A in an expression A + B
-#%end
-#%option G_OPT_R_INPUT
-#% key: braster
-#% description: Name of input raster B in an expression A + B
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
+# %module
+# % description: Adds the values of two rasters (A + B)
+# % keyword: raster
+# % keyword: algebra
+# % keyword: sum
+# %end
+# %option G_OPT_R_INPUT
+# % key: araster
+# % description: Name of input raster A in an expression A + B
+# %end
+# %option G_OPT_R_INPUT
+# % key: braster
+# % description: Name of input raster B in an expression A + B
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
 
 
 import grass.script as gs

--- a/scripts/g.manual/g.manual.py
+++ b/scripts/g.manual/g.manual.py
@@ -14,37 +14,37 @@
 #
 #############################################################################
 
-#%module
-#% description: Displays the manual pages of GRASS modules.
-#% keyword: general
-#% keyword: manual
-#% keyword: help
-#%end
-#%flag
-#% key: i
-#% description: Display index
-#% suppress_required: yes
-#%end
-#%flag
-#% key: t
-#% description: Display topics
-#% suppress_required: yes
-#%end
-#%flag
-#% key: m
-#% description: Display as MAN text page instead of HTML page in browser
-#%end
-#%flag
-#% key: o
-#% label: Display online manuals instead of locally installed
-#% description: Use online manuals available at https://grass.osgeo.org website. This flag has no effect when displaying MAN text pages.
-#%end
-#%option
-#% key: entry
-#% type: string
-#% description: Manual entry to be displayed
-#% required : yes
-#%end
+# %module
+# % description: Displays the manual pages of GRASS modules.
+# % keyword: general
+# % keyword: manual
+# % keyword: help
+# %end
+# %flag
+# % key: i
+# % description: Display index
+# % suppress_required: yes
+# %end
+# %flag
+# % key: t
+# % description: Display topics
+# % suppress_required: yes
+# %end
+# %flag
+# % key: m
+# % description: Display as MAN text page instead of HTML page in browser
+# %end
+# %flag
+# % key: o
+# % label: Display online manuals instead of locally installed
+# % description: Use online manuals available at https://grass.osgeo.org website. This flag has no effect when displaying MAN text pages.
+# %end
+# %option
+# % key: entry
+# % type: string
+# % description: Manual entry to be displayed
+# % required : yes
+# %end
 
 import sys
 import os

--- a/scripts/g.search.modules/g.search.modules.py
+++ b/scripts/g.search.modules/g.search.modules.py
@@ -12,56 +12,56 @@
 #
 #############################################################################
 
-#%module
-#% description: Search in GRASS modules using keywords
-#% keyword: general
-#% keyword: modules
-#% keyword: search
-#%end
-#%option
-#% key: keyword
-#% multiple: yes
-#% type: string
-#% label: Keyword to be searched
-#% description: List all modules if not given
-#% required : no
-#%end
-#%flag
-#% key: a
-#% description: Display only modules where all keywords are available (AND), default: OR
-#% guisection: Output
-#%end
-#%flag
-#% key: n
-#% description: Invert selection (logical NOT)
-#% guisection: Output
-#%end
-#%flag
-#% key: m
-#% description: Search in manual pages too (can be slow)
-#% guisection: Output
-#%end
-#%flag
-#% key: k
-#% label: Search only for the exact keyword in module keyword list
-#% description: Instead of full text search, search only in actual keywords
-#% guisection: Output
-#%end
-#%flag
-#% key: c
-#% description: Use colorized (more readable) output to terminal
-#% guisection: Output
-#%end
-#%flag
-#% key: g
-#% description: Shell script format
-#% guisection: Output
-#%end
-#%flag
-#% key: j
-#% description: JSON format
-#% guisection: Output
-#%end
+# %module
+# % description: Search in GRASS modules using keywords
+# % keyword: general
+# % keyword: modules
+# % keyword: search
+# %end
+# %option
+# % key: keyword
+# % multiple: yes
+# % type: string
+# % label: Keyword to be searched
+# % description: List all modules if not given
+# % required : no
+# %end
+# %flag
+# % key: a
+# % description: Display only modules where all keywords are available (AND), default: OR
+# % guisection: Output
+# %end
+# %flag
+# % key: n
+# % description: Invert selection (logical NOT)
+# % guisection: Output
+# %end
+# %flag
+# % key: m
+# % description: Search in manual pages too (can be slow)
+# % guisection: Output
+# %end
+# %flag
+# % key: k
+# % label: Search only for the exact keyword in module keyword list
+# % description: Instead of full text search, search only in actual keywords
+# % guisection: Output
+# %end
+# %flag
+# % key: c
+# % description: Use colorized (more readable) output to terminal
+# % guisection: Output
+# %end
+# %flag
+# % key: g
+# % description: Shell script format
+# % guisection: Output
+# %end
+# %flag
+# % key: j
+# % description: JSON format
+# % guisection: Output
+# %end
 
 from __future__ import print_function
 import os

--- a/scripts/i.band/i.band.py
+++ b/scripts/i.band/i.band.py
@@ -16,31 +16,31 @@
 #
 #############################################################################
 
-#%module
-#% description: Manages band reference information assigned to a single raster map or to a list of raster maps.
-#% keyword: general
-#% keyword: imagery
-#% keyword: band reference
-#% keyword: image collections
-#%end
-#%option G_OPT_R_MAPS
-#%end
-#%option
-#% key: band
-#% type: string
-#% key_desc: name
-#% description: Name of band reference identifier (example: S2_1)
-#% required: no
-#% multiple: yes
-#%end
-#%option
-#% key: operation
-#% type: string
-#% required: yes
-#% multiple: no
-#% options: add,remove,print
-#% description: Operation to be performed
-#% answer: add
+# %module
+# % description: Manages band reference information assigned to a single raster map or to a list of raster maps.
+# % keyword: general
+# % keyword: imagery
+# % keyword: band reference
+# % keyword: image collections
+# %end
+# %option G_OPT_R_MAPS
+# %end
+# %option
+# % key: band
+# % type: string
+# % key_desc: name
+# % description: Name of band reference identifier (example: S2_1)
+# % required: no
+# % multiple: yes
+# %end
+# %option
+# % key: operation
+# % type: string
+# % required: yes
+# % multiple: no
+# % options: add,remove,print
+# % description: Operation to be performed
+# % answer: add
 
 import sys
 

--- a/scripts/i.colors.enhance/i.colors.enhance.py
+++ b/scripts/i.colors.enhance/i.colors.enhance.py
@@ -20,52 +20,52 @@
 # TODO: implement better brightness control
 #############################################################################
 
-#%module
-#% description: Performs auto-balancing of colors for RGB images.
-#% keyword: imagery
-#% keyword: RGB
-#% keyword: satellite
-#% keyword: colors
-#%end
-#%option G_OPT_R_INPUT
-#% key: red
-#% description: Name of red channel
-#%end
-#%option G_OPT_R_INPUT
-#% key: green
-#% description: Name of green channel
-#%end
-#%option G_OPT_R_INPUT
-#% key: blue
-#% description: Name of blue channel
-#%end
-#%option
-#% key: strength
-#% type: double
-#% description: Cropping intensity (upper brightness level)
-#% options: 0-100
-#% answer : 98
-#% required: no
-#%end
-#%flag
-#% key: f
-#% description: Extend colors to full range of data on each channel
-#% guisection: Colors
-#%end
-#%flag
-#% key: p
-#% description: Preserve relative colors, adjust brightness only
-#% guisection: Colors
-#%end
-#%flag
-#% key: r
-#% description: Reset to standard color range
-#% guisection: Colors
-#%end
-#%flag
-#% key: s
-#% description: Process bands serially (default: run in parallel)
-#%end
+# %module
+# % description: Performs auto-balancing of colors for RGB images.
+# % keyword: imagery
+# % keyword: RGB
+# % keyword: satellite
+# % keyword: colors
+# %end
+# %option G_OPT_R_INPUT
+# % key: red
+# % description: Name of red channel
+# %end
+# %option G_OPT_R_INPUT
+# % key: green
+# % description: Name of green channel
+# %end
+# %option G_OPT_R_INPUT
+# % key: blue
+# % description: Name of blue channel
+# %end
+# %option
+# % key: strength
+# % type: double
+# % description: Cropping intensity (upper brightness level)
+# % options: 0-100
+# % answer : 98
+# % required: no
+# %end
+# %flag
+# % key: f
+# % description: Extend colors to full range of data on each channel
+# % guisection: Colors
+# %end
+# %flag
+# % key: p
+# % description: Preserve relative colors, adjust brightness only
+# % guisection: Colors
+# %end
+# %flag
+# % key: r
+# % description: Reset to standard color range
+# % guisection: Colors
+# %end
+# %flag
+# % key: s
+# % description: Process bands serially (default: run in parallel)
+# %end
 
 import sys
 

--- a/scripts/i.image.mosaic/i.image.mosaic.py
+++ b/scripts/i.image.mosaic/i.image.mosaic.py
@@ -22,16 +22,16 @@
 #--------------------------------------------------
 
 
-#%module
-#% description: Mosaics several images and extends colormap.
-#% keyword: imagery
-#% keyword: geometry
-#% keyword: mosaicking
-#%end
-#%option G_OPT_R_INPUTS
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
+# %module
+# % description: Mosaics several images and extends colormap.
+# % keyword: imagery
+# % keyword: geometry
+# % keyword: mosaicking
+# %end
+# %option G_OPT_R_INPUTS
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
 from __future__ import print_function
 
 import grass.script as gscript

--- a/scripts/i.in.spotvgt/i.in.spotvgt.py
+++ b/scripts/i.in.spotvgt/i.in.spotvgt.py
@@ -29,23 +29,23 @@
 #   -> correction of 0001/0001_LOG.TXT coordinates by 0.5 pixel
 #############################################################################
 
-#%module
-#% description: Imports SPOT VGT NDVI data into a raster map.
-#% keyword: imagery
-#% keyword: import
-#% keyword: NDVI
-#% keyword: SPOT
-#%end
-#%flag
-#% key: a
-#% description: Also import quality map (SM status map layer) and filter NDVI map
-#%end
-#%option G_OPT_F_INPUT
-#% description: Name of input SPOT VGT NDVI HDF file
-#%end
-#% option G_OPT_R_OUTPUT
-#% required : no
-#%end
+# %module
+# % description: Imports SPOT VGT NDVI data into a raster map.
+# % keyword: imagery
+# % keyword: import
+# % keyword: NDVI
+# % keyword: SPOT
+# %end
+# %flag
+# % key: a
+# % description: Also import quality map (SM status map layer) and filter NDVI map
+# %end
+# %option G_OPT_F_INPUT
+# % description: Name of input SPOT VGT NDVI HDF file
+# %end
+# % option G_OPT_R_OUTPUT
+# % required : no
+# %end
 
 import os
 import atexit

--- a/scripts/i.oif/i.oif.py
+++ b/scripts/i.oif/i.oif.py
@@ -19,26 +19,26 @@
 # Ref.: Jensen: Introductory digital image processing 1996, p.98
 #############################################################################
 
-#% Module
-#% description: Calculates Optimum-Index-Factor table for spectral bands
-#% keyword: imagery
-#% keyword: multispectral
-#% keyword: statistics
-#% End
-#% option G_OPT_R_INPUTS
-#% end
-#% option G_OPT_F_OUTPUT
-#% description: Name for output file (if omitted or "-" output to stdout)
-#% required: no
-#% end
-#% Flag
-#% key: g
-#% description: Print in shell script style
-#% End
-#% Flag
-#% key: s
-#% description: Process bands serially (default: run in parallel)
-#% End
+# % Module
+# % description: Calculates Optimum-Index-Factor table for spectral bands
+# % keyword: imagery
+# % keyword: multispectral
+# % keyword: statistics
+# % End
+# % option G_OPT_R_INPUTS
+# % end
+# % option G_OPT_F_OUTPUT
+# % description: Name for output file (if omitted or "-" output to stdout)
+# % required: no
+# % end
+# % Flag
+# % key: g
+# % description: Print in shell script style
+# % End
+# % Flag
+# % key: s
+# % description: Process bands serially (default: run in parallel)
+# % End
 
 import sys
 import os

--- a/scripts/i.pansharpen/i.pansharpen.py
+++ b/scripts/i.pansharpen/i.pansharpen.py
@@ -35,62 +35,62 @@
 #
 #############################################################################
 
-#%Module
-#% description: Image fusion algorithms to sharpen multispectral with high-res panchromatic channels
-#% keyword: imagery
-#% keyword: fusion
-#% keyword: sharpen
-#% keyword: Brovey
-#% keyword: IHS
-#% keyword: HIS
-#% keyword: PCA
-#% overwrite: yes
-#%End
-#%option G_OPT_R_INPUT
-#% key: red
-#% description: Name of raster map to be used for <red>
-#%end
-#%option G_OPT_R_INPUT
-#% key: green
-#% description: Name of raster map to be used for <green>
-#%end
-#%option G_OPT_R_INPUT
-#% key: blue
-#% description: Name of raster map to be used for <blue>
-#%end
-#% option G_OPT_R_INPUT
-#% key: pan
-#% description: Name of raster map to be used for high resolution panchromatic channel
-#%end
-#%option G_OPT_R_BASENAME_OUTPUT
-#%end
-#%option
-#% key: method
-#% description: Method for pan sharpening
-#% options: brovey,ihs,pca
-#% answer: ihs
-#% required: yes
-#%end
-#%option
-#% key: bitdepth
-#% type: integer
-#% description: Bit depth of image (must be in range of 2-30)
-#% options: 2-32
-#% answer: 8
-#% required: yes
-#%end
-#%flag
-#% key: s
-#% description: Serial processing rather than parallel processing
-#%end
-#%flag
-#% key: l
-#% description: Rebalance blue channel for LANDSAT
-#%end
-#%flag
-#% key: r
-#% description: Rescale (stretch) the range of pixel values in each channel to the entire 0-255 8-bit range for processing (see notes)
-#%end
+# %Module
+# % description: Image fusion algorithms to sharpen multispectral with high-res panchromatic channels
+# % keyword: imagery
+# % keyword: fusion
+# % keyword: sharpen
+# % keyword: Brovey
+# % keyword: IHS
+# % keyword: HIS
+# % keyword: PCA
+# % overwrite: yes
+# %End
+# %option G_OPT_R_INPUT
+# % key: red
+# % description: Name of raster map to be used for <red>
+# %end
+# %option G_OPT_R_INPUT
+# % key: green
+# % description: Name of raster map to be used for <green>
+# %end
+# %option G_OPT_R_INPUT
+# % key: blue
+# % description: Name of raster map to be used for <blue>
+# %end
+# % option G_OPT_R_INPUT
+# % key: pan
+# % description: Name of raster map to be used for high resolution panchromatic channel
+# %end
+# %option G_OPT_R_BASENAME_OUTPUT
+# %end
+# %option
+# % key: method
+# % description: Method for pan sharpening
+# % options: brovey,ihs,pca
+# % answer: ihs
+# % required: yes
+# %end
+# %option
+# % key: bitdepth
+# % type: integer
+# % description: Bit depth of image (must be in range of 2-30)
+# % options: 2-32
+# % answer: 8
+# % required: yes
+# %end
+# %flag
+# % key: s
+# % description: Serial processing rather than parallel processing
+# %end
+# %flag
+# % key: l
+# % description: Rebalance blue channel for LANDSAT
+# %end
+# %flag
+# % key: r
+# % description: Rescale (stretch) the range of pixel values in each channel to the entire 0-255 8-bit range for processing (see notes)
+# %end
 
 import os
 

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -25,58 +25,58 @@
 # 3 March 2006: Added multiple images and group support by Francesco Pirotti - CIRGEO
 #
 
-#%Module
-#% description: Displays spectral response at user specified locations in group or images.
-#% keyword: imagery
-#% keyword: querying
-#% keyword: raster
-#% keyword: multispectral
-#%End
-#%option G_OPT_I_GROUP
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_I_SUBGROUP
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_R_INPUTS
-#% key: raster
-#% required : no
-#% guisection: Input
-#%end
-#%option G_OPT_M_COORDS
-#% multiple: yes
-#% required: yes
-#% guisection: Input
-#%end
-#%option G_OPT_F_OUTPUT
-#% key: output
-#% description: Name for output image (or text file for -t)
-#% guisection: Output
-#% required : no
-#%end
-#%Option
-#% key: format
-#% type: string
-#% description: Graphics format for output file
-#% options: png,eps,svg
-#% answer: png
-#% multiple: no
-#% guisection: Output
-#%End
-#%flag
-#% key: c
-#% description: Show sampling coordinates instead of numbering in the legend
-#%end
-#% flag
-#% key: g
-#% description: Use gnuplot for display
-#%end
-#% flag
-#% key: t
-#% description: output to text file
-#%end
+# %Module
+# % description: Displays spectral response at user specified locations in group or images.
+# % keyword: imagery
+# % keyword: querying
+# % keyword: raster
+# % keyword: multispectral
+# %End
+# %option G_OPT_I_GROUP
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_I_SUBGROUP
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_R_INPUTS
+# % key: raster
+# % required : no
+# % guisection: Input
+# %end
+# %option G_OPT_M_COORDS
+# % multiple: yes
+# % required: yes
+# % guisection: Input
+# %end
+# %option G_OPT_F_OUTPUT
+# % key: output
+# % description: Name for output image (or text file for -t)
+# % guisection: Output
+# % required : no
+# %end
+# %Option
+# % key: format
+# % type: string
+# % description: Graphics format for output file
+# % options: png,eps,svg
+# % answer: png
+# % multiple: no
+# % guisection: Output
+# %End
+# %flag
+# % key: c
+# % description: Show sampling coordinates instead of numbering in the legend
+# %end
+# % flag
+# % key: g
+# % description: Use gnuplot for display
+# %end
+# % flag
+# % key: t
+# % description: output to text file
+# %end
 
 import os
 import atexit

--- a/scripts/i.tasscap/i.tasscap.py
+++ b/scripts/i.tasscap/i.tasscap.py
@@ -54,33 +54,33 @@
 #  Remote Sensing Letters. 5. DOI: 10.1080/2150704X.2014.885148.
 #############################################################################
 
-#%Module
-#% description: Performs Tasseled Cap (Kauth Thomas) transformation.
-#% keyword: imagery
-#% keyword: transformation
-#% keyword: Landsat
-#% keyword: MODIS
-#% keyword: Worldview
-#% keyword: Sentinel
-#% keyword: Tasseled Cap transformation
-#%end
+# %Module
+# % description: Performs Tasseled Cap (Kauth Thomas) transformation.
+# % keyword: imagery
+# % keyword: transformation
+# % keyword: Landsat
+# % keyword: MODIS
+# % keyword: Worldview
+# % keyword: Sentinel
+# % keyword: Tasseled Cap transformation
+# %end
 
-#%option G_OPT_R_INPUTS
-#% description: For Landsat4-7: bands 1, 2, 3, 4, 5, 7; for Landsat8: bands 2, 3, 4, 5, 6, 7; for MODIS: bands 1, 2, 3, 4, 5, 6, 7; for Sentinel-2: bands 1 to 12, 8A; for Worldview-2: bands 1, 2, 3, 4, 5, 6, 7, 8
-#%end
+# %option G_OPT_R_INPUTS
+# % description: For Landsat4-7: bands 1, 2, 3, 4, 5, 7; for Landsat8: bands 2, 3, 4, 5, 6, 7; for MODIS: bands 1, 2, 3, 4, 5, 6, 7; for Sentinel-2: bands 1 to 12, 8A; for Worldview-2: bands 1, 2, 3, 4, 5, 6, 7, 8
+# %end
 
-#%option G_OPT_R_BASENAME_OUTPUT
-#% label: basename for output raster map(s)
-#%end
+# %option G_OPT_R_BASENAME_OUTPUT
+# % label: basename for output raster map(s)
+# %end
 
-#%option
-#% key: sensor
-#% type: string
-#% description: Satellite sensor
-#% required: yes
-#% multiple: no
-#% options: landsat4_tm,landsat5_tm,landsat7_etm,landsat8_oli,modis,sentinel2,worldview2
-#%end
+# %option
+# % key: sensor
+# % type: string
+# % description: Satellite sensor
+# % required: yes
+# % multiple: no
+# % options: landsat4_tm,landsat5_tm,landsat7_etm,landsat8_oli,modis,sentinel2,worldview2
+# %end
 
 import grass.script as grass
 

--- a/scripts/m.proj/m.proj.py
+++ b/scripts/m.proj/m.proj.py
@@ -25,78 +25,78 @@ COPYRIGHT: (c) 2006-2019 Hamish Bowman, and the GRASS Development Team
 #    numeric and string columns would survive the trip, and 3rd column would
 #    not be modified as z.
 
-#%module
-#% description: Converts coordinates from one projection to another (cs2cs frontend).
-#% keyword: miscellaneous
-#% keyword: projection
-#% keyword: transformation
-#%end
-#%option G_OPT_M_COORDS
-#% description: Input coordinates to reproject
-#% guisection: Input coordinates
-#%end
-#%option G_OPT_F_INPUT
-#% label: Name of input coordinate file
-#% description: '-' for standard input
-#% required: no
-#% guisection: Input coordinates
-#%end
-#%option G_OPT_F_OUTPUT
-#% description: Name for output coordinate file (omit to send to stdout)
-#% required : no
-#% guisection: Output
-#%end
-#%option G_OPT_F_SEP
-#% label: Field separator (format: input[,output])
-#% required : no
-#% guisection: Input coordinates
-#%end
-#%option
-#% key: proj_in
-#% type: string
-#% description: Input projection parameters (PROJ.4 style)
-#% required : no
-#% guisection: Projections
-#%end
-#%option
-#% key: proj_out
-#% type: string
-#% description: Output projection parameters (PROJ.4 style)
-#% required : no
-#% guisection: Projections
-#%end
-#%flag
-#% key: i
-#% description: Use LL WGS84 as input and current location as output projection
-#% guisection: Projections
-#%end
-#%flag
-#% key: o
-#% description: Use current location as input and LL WGS84 as output projection
-#% guisection: Projections
-#%end
-#%flag
-#% key: d
-#% description: Output long/lat in decimal degrees, or other projections with many decimal places
-#% guisection: Output
-#%end
-#%flag
-#% key: e
-#% description: Include input coordinates in output file
-#% guisection: Output
-#%end
-#%flag
-#% key: c
-#% description: Include column names in output file
-#% guisection: Output
-#%end
-#%rules
-#% required: coordinates, input
-#% exclusive: coordinates, input
-#% exclusive: proj_in, -i
-#% exclusive: proj_out, -o
-#% exclusive: -i, -o
-#%end
+# %module
+# % description: Converts coordinates from one projection to another (cs2cs frontend).
+# % keyword: miscellaneous
+# % keyword: projection
+# % keyword: transformation
+# %end
+# %option G_OPT_M_COORDS
+# % description: Input coordinates to reproject
+# % guisection: Input coordinates
+# %end
+# %option G_OPT_F_INPUT
+# % label: Name of input coordinate file
+# % description: '-' for standard input
+# % required: no
+# % guisection: Input coordinates
+# %end
+# %option G_OPT_F_OUTPUT
+# % description: Name for output coordinate file (omit to send to stdout)
+# % required : no
+# % guisection: Output
+# %end
+# %option G_OPT_F_SEP
+# % label: Field separator (format: input[,output])
+# % required : no
+# % guisection: Input coordinates
+# %end
+# %option
+# % key: proj_in
+# % type: string
+# % description: Input projection parameters (PROJ.4 style)
+# % required : no
+# % guisection: Projections
+# %end
+# %option
+# % key: proj_out
+# % type: string
+# % description: Output projection parameters (PROJ.4 style)
+# % required : no
+# % guisection: Projections
+# %end
+# %flag
+# % key: i
+# % description: Use LL WGS84 as input and current location as output projection
+# % guisection: Projections
+# %end
+# %flag
+# % key: o
+# % description: Use current location as input and LL WGS84 as output projection
+# % guisection: Projections
+# %end
+# %flag
+# % key: d
+# % description: Output long/lat in decimal degrees, or other projections with many decimal places
+# % guisection: Output
+# %end
+# %flag
+# % key: e
+# % description: Include input coordinates in output file
+# % guisection: Output
+# %end
+# %flag
+# % key: c
+# % description: Include column names in output file
+# % guisection: Output
+# %end
+# %rules
+# % required: coordinates, input
+# % exclusive: coordinates, input
+# % exclusive: proj_in, -i
+# % exclusive: proj_out, -o
+# % exclusive: -i, -o
+# %end
 
 import sys
 import os

--- a/scripts/r.blend/r.blend.py
+++ b/scripts/r.blend/r.blend.py
@@ -14,34 +14,34 @@
 #
 #############################################################################
 
-#%module
-#% description: Blends color components of two raster maps by a given ratio.
-#% keyword: raster
-#% keyword: composite
-#%end
-#%option G_OPT_R_INPUT
-#% key: first
-#% description: Name of first raster map for blending
-#%end
-#%option G_OPT_R_INPUT
-#% key: second
-#% description: Name of second raster map for blending
-#%end
-#%option G_OPT_R_BASENAME_OUTPUT
-#% description: Basename for red, green and blue output raster maps
-#%end
-#%option
-#% key: percent
-#% type: double
-#% answer: 50
-#% options : 0-100
-#% description: Percentage weight of first map for color blending
-#% required : no
-#%end
-#% flag
-#% key: c
-#% description: Combine resulting R,G,B layers into single output map
-#%end
+# %module
+# % description: Blends color components of two raster maps by a given ratio.
+# % keyword: raster
+# % keyword: composite
+# %end
+# %option G_OPT_R_INPUT
+# % key: first
+# % description: Name of first raster map for blending
+# %end
+# %option G_OPT_R_INPUT
+# % key: second
+# % description: Name of second raster map for blending
+# %end
+# %option G_OPT_R_BASENAME_OUTPUT
+# % description: Basename for red, green and blue output raster maps
+# %end
+# %option
+# % key: percent
+# % type: double
+# % answer: 50
+# % options : 0-100
+# % description: Percentage weight of first map for color blending
+# % required : no
+# %end
+# % flag
+# % key: c
+# % description: Combine resulting R,G,B layers into single output map
+# %end
 
 import os
 import string

--- a/scripts/r.buffer.lowmem/r.buffer.lowmem.py
+++ b/scripts/r.buffer.lowmem/r.buffer.lowmem.py
@@ -14,32 +14,32 @@
 #
 #############################################################################
 
-#%module
-#% label: Creates a raster map showing buffer zones surrounding cells that contain non-NULL category values.
-#% description: This is the low-memory alternative to the classic r.buffer module.
-#% keyword: raster
-#% keyword: buffer
-#%end
-#%flag
-#% key: z
-#% description: Ignore zero (0) data cells instead of NULL cells
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
-#%option
-#% key: distances
-#% type: double
-#% required: yes
-#% multiple: yes
-#% description: Distance zone(s)
-#%end
-#%option G_OPT_M_UNITS
-#% options: meters,kilometers,feet,miles,nautmiles
-#% description: Units of distance
-#% answer: meters
-#%end
+# %module
+# % label: Creates a raster map showing buffer zones surrounding cells that contain non-NULL category values.
+# % description: This is the low-memory alternative to the classic r.buffer module.
+# % keyword: raster
+# % keyword: buffer
+# %end
+# %flag
+# % key: z
+# % description: Ignore zero (0) data cells instead of NULL cells
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
+# %option
+# % key: distances
+# % type: double
+# % required: yes
+# % multiple: yes
+# % description: Distance zone(s)
+# %end
+# %option G_OPT_M_UNITS
+# % options: meters,kilometers,feet,miles,nautmiles
+# % description: Units of distance
+# % answer: meters
+# %end
 
 import sys
 import os

--- a/scripts/r.colors.stddev/r.colors.stddev.py
+++ b/scripts/r.colors.stddev/r.colors.stddev.py
@@ -14,21 +14,21 @@
 #
 #############################################################################
 
-#%module
-#% description: Sets color rules based on stddev from a raster map's mean value.
-#% keyword: raster
-#% keyword: color table
-#%end
-#% option G_OPT_R_MAP
-#%end
-#%flag
-#% key: b
-#% description: Color using standard deviation bands
-#%end
-#%flag
-#% key: z
-#% description: Force center at zero
-#%end
+# %module
+# % description: Sets color rules based on stddev from a raster map's mean value.
+# % keyword: raster
+# % keyword: color table
+# %end
+# % option G_OPT_R_MAP
+# %end
+# %flag
+# % key: b
+# % description: Color using standard deviation bands
+# %end
+# %flag
+# % key: z
+# % description: Force center at zero
+# %end
 
 import os
 import atexit

--- a/scripts/r.drain/r.drain.py
+++ b/scripts/r.drain/r.drain.py
@@ -19,94 +19,94 @@
 #
 ############################################################################
 
-#%module
-#% description: Traces a flow through an elevation model or cost surface on a raster map.
-#% keyword: raster
-#% keyword: hydrology
-#% keyword: cost surface
-#%end
-#%option
-#% key: input
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Name of input elevation or cost surface raster map
-#% gisprompt: old,cell,raster
-#%end
-#%option
-#% key: direction
-#% type: string
-#% required: no
-#% multiple: no
-#% key_desc: name
-#% label: Name of input movement direction map associated with the cost surface
-#% description: Direction in degrees CCW from east
-#% gisprompt: old,cell,raster
-#% guisection: Cost surface
-#%end
-#%option
-#% key: output
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Name for output raster map
-#% gisprompt: new,cell,raster
-#%end
-#%option
-#% key: drain
-#% type: string
-#% required: no
-#% multiple: no
-#% key_desc: name
-#% label: Name for output drain vector map
-#% description: Recommended for cost surface made using knight's move
-#% gisprompt: new,vector,vector
-#%end
-#%option
-#% key: start_coordinates
-#% type: double
-#% required: no
-#% multiple: yes
-#% key_desc: east,north
-#% description: Coordinates of starting point(s) (E,N)
-#% gisprompt: old,coords,coords
-#% guisection: Start
-#%end
-#%option
-#% key: start_points
-#% type: string
-#% required: no
-#% multiple: yes
-#% key_desc: name
-#% label: Name of starting vector points map(s)
-#% gisprompt: old,vector,vector
-#% guisection: Start
-#%end
-#%flag
-#% key: c
-#% description: Copy input cell values on output
-#% guisection: Path settings
-#%end
-#%flag
-#% key: a
-#% description: Accumulate input values along the path
-#% guisection: Path settings
-#%end
-#%flag
-#% key: n
-#% description: Count cell numbers along the path
-#% guisection: Path settings
-#%end
-#%flag
-#% key: d
-#% description: The input raster map is a cost surface (direction surface must also be specified)
-#% guisection: Cost surface
-#%end
-#%rules
-#% required: start_coordinates, start_points
-#%end
+# %module
+# % description: Traces a flow through an elevation model or cost surface on a raster map.
+# % keyword: raster
+# % keyword: hydrology
+# % keyword: cost surface
+# %end
+# %option
+# % key: input
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Name of input elevation or cost surface raster map
+# % gisprompt: old,cell,raster
+# %end
+# %option
+# % key: direction
+# % type: string
+# % required: no
+# % multiple: no
+# % key_desc: name
+# % label: Name of input movement direction map associated with the cost surface
+# % description: Direction in degrees CCW from east
+# % gisprompt: old,cell,raster
+# % guisection: Cost surface
+# %end
+# %option
+# % key: output
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Name for output raster map
+# % gisprompt: new,cell,raster
+# %end
+# %option
+# % key: drain
+# % type: string
+# % required: no
+# % multiple: no
+# % key_desc: name
+# % label: Name for output drain vector map
+# % description: Recommended for cost surface made using knight's move
+# % gisprompt: new,vector,vector
+# %end
+# %option
+# % key: start_coordinates
+# % type: double
+# % required: no
+# % multiple: yes
+# % key_desc: east,north
+# % description: Coordinates of starting point(s) (E,N)
+# % gisprompt: old,coords,coords
+# % guisection: Start
+# %end
+# %option
+# % key: start_points
+# % type: string
+# % required: no
+# % multiple: yes
+# % key_desc: name
+# % label: Name of starting vector points map(s)
+# % gisprompt: old,vector,vector
+# % guisection: Start
+# %end
+# %flag
+# % key: c
+# % description: Copy input cell values on output
+# % guisection: Path settings
+# %end
+# %flag
+# % key: a
+# % description: Accumulate input values along the path
+# % guisection: Path settings
+# %end
+# %flag
+# % key: n
+# % description: Count cell numbers along the path
+# % guisection: Path settings
+# %end
+# %flag
+# % key: d
+# % description: The input raster map is a cost surface (direction surface must also be specified)
+# % guisection: Cost surface
+# %end
+# %rules
+# % required: start_coordinates, start_points
+# %end
 
 import os
 import sys

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -23,82 +23,82 @@
 #############################################################################
 
 
-#%module
-#% description: Fills no-data areas in raster maps using spline interpolation.
-#% keyword: raster
-#% keyword: surface
-#% keyword: elevation
-#% keyword: interpolation
-#% keyword: splines
-#% keyword: no-data filling
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
-#%option
-#% key: method
-#% type: string
-#% description: Interpolation method to use
-#% required: yes
-#% options: bilinear,bicubic,rst
-#% answer: rst
-#%end
-#%option
-#% key: tension
-#% type: double
-#% description: Spline tension parameter
-#% required : no
-#% answer : 40.
-#% guisection: RST options
-#%end
-#%option
-#% key: smooth
-#% type: double
-#% description: Spline smoothing parameter
-#% required : no
-#% answer : 0.1
-#% guisection: RST options
-#%end
-#%option
-#% key: edge
-#% type: integer
-#% description: Width of hole edge used for interpolation (in cells)
-#% required : no
-#% answer : 3
-#% options : 2-100
-#% guisection: RST options
-#%end
-#%option
-#% key: npmin
-#% type: integer
-#% description: Minimum number of points for approximation in a segment (>segmax)
-#% required : no
-#% answer : 600
-#% options : 2-10000
-#% guisection: RST options
-#%end
-#%option
-#% key: segmax
-#% type: integer
-#% description: Maximum number of points in a segment
-#% required : no
-#% answer : 300
-#% options : 2-10000
-#% guisection: RST options
-#%end
-#%option
-#% key: lambda
-#% type: double
-#% required: no
-#% multiple: no
-#% label: Tykhonov regularization parameter (affects smoothing)
-#% description: Used in bilinear and bicubic spline interpolation
-#% answer: 0.01
-#% guisection: Spline options
-#%end
-#%option G_OPT_MEMORYMB
-#%end
+# %module
+# % description: Fills no-data areas in raster maps using spline interpolation.
+# % keyword: raster
+# % keyword: surface
+# % keyword: elevation
+# % keyword: interpolation
+# % keyword: splines
+# % keyword: no-data filling
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
+# %option
+# % key: method
+# % type: string
+# % description: Interpolation method to use
+# % required: yes
+# % options: bilinear,bicubic,rst
+# % answer: rst
+# %end
+# %option
+# % key: tension
+# % type: double
+# % description: Spline tension parameter
+# % required : no
+# % answer : 40.
+# % guisection: RST options
+# %end
+# %option
+# % key: smooth
+# % type: double
+# % description: Spline smoothing parameter
+# % required : no
+# % answer : 0.1
+# % guisection: RST options
+# %end
+# %option
+# % key: edge
+# % type: integer
+# % description: Width of hole edge used for interpolation (in cells)
+# % required : no
+# % answer : 3
+# % options : 2-100
+# % guisection: RST options
+# %end
+# %option
+# % key: npmin
+# % type: integer
+# % description: Minimum number of points for approximation in a segment (>segmax)
+# % required : no
+# % answer : 600
+# % options : 2-10000
+# % guisection: RST options
+# %end
+# %option
+# % key: segmax
+# % type: integer
+# % description: Maximum number of points in a segment
+# % required : no
+# % answer : 300
+# % options : 2-10000
+# % guisection: RST options
+# %end
+# %option
+# % key: lambda
+# % type: double
+# % required: no
+# % multiple: no
+# % label: Tykhonov regularization parameter (affects smoothing)
+# % description: Used in bilinear and bicubic spline interpolation
+# % answer: 0.01
+# % guisection: Spline options
+# %end
+# %option G_OPT_MEMORYMB
+# %end
 
 
 import sys

--- a/scripts/r.grow/r.grow.py
+++ b/scripts/r.grow/r.grow.py
@@ -14,51 +14,51 @@
 #
 #############################################################################
 
-#%Module
-#% description: Generates a raster map layer with contiguous areas grown by one cell.
-#% keyword: raster
-#% keyword: distance
-#% keyword: proximity
-#%end
-#%flag
-#% key: m
-#% description: Radius is in map units rather than cells
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
-#%option
-#% key: radius
-#% type: double
-#% required: no
-#% multiple: no
-#% description: Radius of buffer in raster cells
-#% answer: 1.01
-#%end
-#%option
-#% key: metric
-#% type: string
-#% required: no
-#% multiple: no
-#% options: euclidean,maximum,manhattan
-#% description: Metric
-#% answer: euclidean
-#%end
-#%option
-#% key: old
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Value to write for input cells which are non-NULL (-1 => NULL)
-#%end
-#%option
-#% key: new
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Value to write for "grown" cells
-#%end
+# %Module
+# % description: Generates a raster map layer with contiguous areas grown by one cell.
+# % keyword: raster
+# % keyword: distance
+# % keyword: proximity
+# %end
+# %flag
+# % key: m
+# % description: Radius is in map units rather than cells
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
+# %option
+# % key: radius
+# % type: double
+# % required: no
+# % multiple: no
+# % description: Radius of buffer in raster cells
+# % answer: 1.01
+# %end
+# %option
+# % key: metric
+# % type: string
+# % required: no
+# % multiple: no
+# % options: euclidean,maximum,manhattan
+# % description: Metric
+# % answer: euclidean
+# %end
+# %option
+# % key: old
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Value to write for input cells which are non-NULL (-1 => NULL)
+# %end
+# %option
+# % key: new
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Value to write for "grown" cells
+# %end
 
 import os
 import atexit

--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -16,102 +16,102 @@
 #
 #############################################################################
 
-#%module
-#% description: Imports raster data into a GRASS raster map using GDAL library and reprojects on the fly.
-#% keyword: raster
-#% keyword: import
-#% keyword: projection
-#%end
-#%option G_OPT_F_BIN_INPUT
-#% description: Name of GDAL dataset to be imported
-#% guisection: Input
-#%end
-#%option
-#% key: band
-#% type: integer
-#% required: no
-#% multiple: yes
-#% description: Input band(s) to select (default is all bands)
-#% guisection: Input
-#%end
-#%option G_OPT_MEMORYMB
-#%end
-#%option G_OPT_R_OUTPUT
-#% description: Name for output raster map
-#% required: no
-#% guisection: Output
-#%end
-#%option
-#% key: resample
-#% type: string
-#% required: no
-#% multiple: no
-#% options: nearest,bilinear,bicubic,lanczos,bilinear_f,bicubic_f,lanczos_f
-#% description: Resampling method to use for reprojection
-#% descriptions: nearest;nearest neighbor;bilinear;bilinear interpolation;bicubic;bicubic interpolation;lanczos;lanczos filter;bilinear_f;bilinear interpolation with fallback;bicubic_f;bicubic interpolation with fallback;lanczos_f;lanczos filter with fallback
-#% answer: nearest
-#% guisection: Output
-#%end
-#%option
-#% key: extent
-#% type: string
-#% required: no
-#% multiple: no
-#% options: input,region
-#% answer: input
-#% description: Output raster map extent
-#% descriptions: region;extent of current region;input;extent of input map
-#% guisection: Output
-#%end
-#%option
-#% key: resolution
-#% type: string
-#% required: no
-#% multiple: no
-#% answer: estimated
-#% options: estimated,value,region
-#% description: Resolution of output raster map (default: estimated)
-#% descriptions: estimated;estimated resolution;value;user-specified resolution;region;current region resolution
-#% guisection: Output
-#%end
-#%option
-#% key: resolution_value
-#% type: double
-#% required: no
-#% multiple: no
-#% description: Resolution of output raster map (use with option resolution=value)
-#% guisection: Output
-#%end
-#%option
-#% key: title
-#% key_desc: phrase
-#% type: string
-#% required: no
-#% description: Title for resultant raster map
-#% guisection: Metadata
-#%end
-#%flag
-#% key: e
-#% description: Estimate resolution only
-#% guisection: Optional
-#%end
-#%flag
-#% key: n
-#% description: Do not perform region cropping optimization
-#% guisection: Optional
-#%end
-#%flag
-#% key: l
-#% description: Force Lat/Lon maps to fit into geographic coordinates (90N,S; 180E,W)
-#%end
-#%flag
-#% key: o
-#% label: Override projection check (use current location's projection)
-#% description: Assume that the dataset has the same projection as the current location
-#%end
-#%rules
-#% required: output,-e
-#%end
+# %module
+# % description: Imports raster data into a GRASS raster map using GDAL library and reprojects on the fly.
+# % keyword: raster
+# % keyword: import
+# % keyword: projection
+# %end
+# %option G_OPT_F_BIN_INPUT
+# % description: Name of GDAL dataset to be imported
+# % guisection: Input
+# %end
+# %option
+# % key: band
+# % type: integer
+# % required: no
+# % multiple: yes
+# % description: Input band(s) to select (default is all bands)
+# % guisection: Input
+# %end
+# %option G_OPT_MEMORYMB
+# %end
+# %option G_OPT_R_OUTPUT
+# % description: Name for output raster map
+# % required: no
+# % guisection: Output
+# %end
+# %option
+# % key: resample
+# % type: string
+# % required: no
+# % multiple: no
+# % options: nearest,bilinear,bicubic,lanczos,bilinear_f,bicubic_f,lanczos_f
+# % description: Resampling method to use for reprojection
+# % descriptions: nearest;nearest neighbor;bilinear;bilinear interpolation;bicubic;bicubic interpolation;lanczos;lanczos filter;bilinear_f;bilinear interpolation with fallback;bicubic_f;bicubic interpolation with fallback;lanczos_f;lanczos filter with fallback
+# % answer: nearest
+# % guisection: Output
+# %end
+# %option
+# % key: extent
+# % type: string
+# % required: no
+# % multiple: no
+# % options: input,region
+# % answer: input
+# % description: Output raster map extent
+# % descriptions: region;extent of current region;input;extent of input map
+# % guisection: Output
+# %end
+# %option
+# % key: resolution
+# % type: string
+# % required: no
+# % multiple: no
+# % answer: estimated
+# % options: estimated,value,region
+# % description: Resolution of output raster map (default: estimated)
+# % descriptions: estimated;estimated resolution;value;user-specified resolution;region;current region resolution
+# % guisection: Output
+# %end
+# %option
+# % key: resolution_value
+# % type: double
+# % required: no
+# % multiple: no
+# % description: Resolution of output raster map (use with option resolution=value)
+# % guisection: Output
+# %end
+# %option
+# % key: title
+# % key_desc: phrase
+# % type: string
+# % required: no
+# % description: Title for resultant raster map
+# % guisection: Metadata
+# %end
+# %flag
+# % key: e
+# % description: Estimate resolution only
+# % guisection: Optional
+# %end
+# %flag
+# % key: n
+# % description: Do not perform region cropping optimization
+# % guisection: Optional
+# %end
+# %flag
+# % key: l
+# % description: Force Lat/Lon maps to fit into geographic coordinates (90N,S; 180E,W)
+# %end
+# %flag
+# % key: o
+# % label: Override projection check (use current location's projection)
+# % description: Assume that the dataset has the same projection as the current location
+# %end
+# %rules
+# % required: output,-e
+# %end
 
 import sys
 import os

--- a/scripts/r.in.aster/r.in.aster.py
+++ b/scripts/r.in.aster/r.in.aster.py
@@ -21,35 +21,35 @@
 #   gdalwarp
 #   gdal compiled with HDF4 support
 
-#%Module
-#% description: Georeference, rectify, and import Terra-ASTER imagery and relative DEMs using gdalwarp.
-#% keyword: raster
-#% keyword: import
-#% keyword: imagery
-#% keyword: ASTER
-#% keyword: elevation
-#%End
-#%option G_OPT_F_INPUT
-#% description: Name of input ASTER image
-#%end
-#%option
-#% key: proctype
-#% type: string
-#% description: ASTER imagery processing type (Level 1A, Level 1B, or relative DEM)
-#% options: L1A,L1B,DEM
-#% answer: L1B
-#% required: yes
-#%end
-#%option
-#% key: band
-#% type: string
-#% description: List L1A or L1B band to translate (1,2,3n,...), or enter 'all' to translate all bands
-#% answer: all
-#% required: yes
-#%end
-#%option G_OPT_R_OUTPUT
-#% description: Base name for output raster map (band number will be appended to base name)
-#%end
+# %Module
+# % description: Georeference, rectify, and import Terra-ASTER imagery and relative DEMs using gdalwarp.
+# % keyword: raster
+# % keyword: import
+# % keyword: imagery
+# % keyword: ASTER
+# % keyword: elevation
+# %End
+# %option G_OPT_F_INPUT
+# % description: Name of input ASTER image
+# %end
+# %option
+# % key: proctype
+# % type: string
+# % description: ASTER imagery processing type (Level 1A, Level 1B, or relative DEM)
+# % options: L1A,L1B,DEM
+# % answer: L1B
+# % required: yes
+# %end
+# %option
+# % key: band
+# % type: string
+# % description: List L1A or L1B band to translate (1,2,3n,...), or enter 'all' to translate all bands
+# % answer: all
+# % required: yes
+# %end
+# %option G_OPT_R_OUTPUT
+# % description: Base name for output raster map (band number will be appended to base name)
+# %end
 
 import sys
 import os

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -52,23 +52,23 @@
 #
 #########################
 
-#%Module
-#% description: Imports SRTM HGT files into raster map.
-#% keyword: raster
-#% keyword: import
-#% keyword: SRTM
-#%End
-#%option G_OPT_F_INPUT
-#% description: Name of SRTM input tile (file without .hgt.zip extension)
-#%end
-#%option G_OPT_R_OUTPUT
-#% description: Name for output raster map (default: input tile)
-#% required : no
-#%end
-#%flag
-#% key: 1
-#% description: Input is a 1-arcsec tile (default: 3-arcsec)
-#%end
+# %Module
+# % description: Imports SRTM HGT files into raster map.
+# % keyword: raster
+# % keyword: import
+# % keyword: SRTM
+# %End
+# %option G_OPT_F_INPUT
+# % description: Name of SRTM input tile (file without .hgt.zip extension)
+# %end
+# %option G_OPT_R_OUTPUT
+# % description: Name for output raster map (default: input tile)
+# % required : no
+# %end
+# %flag
+# % key: 1
+# % description: Input is a 1-arcsec tile (default: 3-arcsec)
+# %end
 
 tmpl1sec = """BYTEORDER M
 LAYOUT BIL

--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -12,187 +12,187 @@ This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
 """
 
-#%module
-#% description: Downloads and imports data from OGC WMS and OGC WMTS web mapping servers.
-#% keyword: raster
-#% keyword: import
-#% keyword: OGC web services
-#% keyword: OGC WMS
-#% keyword: OGC WMTS
-#%end
+# %module
+# % description: Downloads and imports data from OGC WMS and OGC WMTS web mapping servers.
+# % keyword: raster
+# % keyword: import
+# % keyword: OGC web services
+# % keyword: OGC WMS
+# % keyword: OGC WMTS
+# %end
 
-#%option
-#% key: url
-#% type: string
-#% description: Typically starts with "http://"
-#% required: yes
-#%end
+# %option
+# % key: url
+# % type: string
+# % description: Typically starts with "http://"
+# % required: yes
+# %end
 
-#%option G_OPT_R_OUTPUT
-#% description: Name for output raster map
-#%end
+# %option G_OPT_R_OUTPUT
+# % description: Name for output raster map
+# %end
 
-#%option
-#% key: layers
-#% type: string
-#% description: Layer(s) to request from the map server
-#% multiple: yes
-#% required: yes
-#%end
+# %option
+# % key: layers
+# % type: string
+# % description: Layer(s) to request from the map server
+# % multiple: yes
+# % required: yes
+# %end
 
-#%option
-#% key: styles
-#% type: string
-#% description: Layer style(s) to request from the map server
-#% multiple: yes
-#% guisection: Map style
-#%end
+# %option
+# % key: styles
+# % type: string
+# % description: Layer style(s) to request from the map server
+# % multiple: yes
+# % guisection: Map style
+# %end
 
-#%option
-#% key: format
-#% type: string
-#% description: Image format requested from the server
-#% options: geotiff,tiff,jpeg,gif,png,png8
-#% answer: png
-#% guisection: Request
-#%end
+# %option
+# % key: format
+# % type: string
+# % description: Image format requested from the server
+# % options: geotiff,tiff,jpeg,gif,png,png8
+# % answer: png
+# % guisection: Request
+# %end
 
-#%option
-#% key: srs
-#% type: integer
-#% description: EPSG code of requested source projection
-#% answer:4326
-#% guisection: Request
-#%end
+# %option
+# % key: srs
+# % type: integer
+# % description: EPSG code of requested source projection
+# % answer:4326
+# % guisection: Request
+# %end
 
-#%option
-#% key: driver
-#% type:string
-#% description: Driver used for communication with the server
-#% descriptions: WMS_GDAL;Download data using GDAL WMS driver;WMS_GRASS;Download data using native GRASS-WMS driver;WMTS_GRASS;Download data using native GRASS-WMTS driver;OnEarth_GRASS;Download data using native GRASS-OnEarth driver;
-#% options:WMS_GDAL, WMS_GRASS, WMTS_GRASS, OnEarth_GRASS
-#% answer:WMS_GRASS
-#% guisection: Connection
-#%end
+# %option
+# % key: driver
+# % type:string
+# % description: Driver used for communication with the server
+# % descriptions: WMS_GDAL;Download data using GDAL WMS driver;WMS_GRASS;Download data using native GRASS-WMS driver;WMTS_GRASS;Download data using native GRASS-WMTS driver;OnEarth_GRASS;Download data using native GRASS-OnEarth driver;
+# % options:WMS_GDAL, WMS_GRASS, WMTS_GRASS, OnEarth_GRASS
+# % answer:WMS_GRASS
+# % guisection: Connection
+# %end
 
-#%option
-#% key: wms_version
-#% type:string
-#% description: WMS standard version
-#% options: 1.1.0,1.1.1,1.3.0
-#% answer: 1.1.1
-#% guisection: Request
-#%end
+# %option
+# % key: wms_version
+# % type:string
+# % description: WMS standard version
+# % options: 1.1.0,1.1.1,1.3.0
+# % answer: 1.1.1
+# % guisection: Request
+# %end
 
-#%option
-#% key: maxcols
-#% type:integer
-#% description: Maximum columns to request at a time
-#% answer:512
-#% guisection: Request
-#%end
+# %option
+# % key: maxcols
+# % type:integer
+# % description: Maximum columns to request at a time
+# % answer:512
+# % guisection: Request
+# %end
 
-#%option
-#% key: maxrows
-#% type: integer
-#% description: Maximum rows to request at a time
-#% answer: 512
-#% guisection: Request
-#%end
+# %option
+# % key: maxrows
+# % type: integer
+# % description: Maximum rows to request at a time
+# % answer: 512
+# % guisection: Request
+# %end
 
-#%option
-#% key: urlparams
-#% type:string
-#% description: Additional query parameters to pass to the server
-#% guisection: Request
-#%end
+# %option
+# % key: urlparams
+# % type:string
+# % description: Additional query parameters to pass to the server
+# % guisection: Request
+# %end
 
-#%option
-#% key: username
-#% type:string
-#% description: Username for server connection
-#% guisection: Connection
-#%end
+# %option
+# % key: username
+# % type:string
+# % description: Username for server connection
+# % guisection: Connection
+# %end
 
-#%option
-#% key: password
-#% type:string
-#% description: Password for server connection
-#% guisection: Connection
-#%end
+# %option
+# % key: password
+# % type:string
+# % description: Password for server connection
+# % guisection: Connection
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Interpolation method to use in reprojection
-#% options:nearest,linear,cubic,cubicspline
-#% answer:nearest
-#% required: no
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Interpolation method to use in reprojection
+# % options:nearest,linear,cubic,cubicspline
+# % answer:nearest
+# % required: no
+# %end
 
-#%option
-#% key: region
-#% type: string
-#% description: Request data for this named region instead of the current region bounds
-#% guisection: Request
-#%end
+# %option
+# % key: region
+# % type: string
+# % description: Request data for this named region instead of the current region bounds
+# % guisection: Request
+# %end
 
-#%option
-#% key: bgcolor
-#% type: string
-#% label: Background color
-#% description: Format: 0xRRGGBB
-#% guisection: Map style
-#%end
+# %option
+# % key: bgcolor
+# % type: string
+# % label: Background color
+# % description: Format: 0xRRGGBB
+# % guisection: Map style
+# %end
 
-#%option
-#% key: proxy
-#% label: HTTP proxy only GDAL driver (GDAL_HTTP_PROXY)
-#% type: string
-#% description: HTTP proxy
-#%end
+# %option
+# % key: proxy
+# % label: HTTP proxy only GDAL driver (GDAL_HTTP_PROXY)
+# % type: string
+# % description: HTTP proxy
+# %end
 
-#%option
-#% key: proxy_user_pw
-#% label: User and password for HTTP proxy only for GDAL driver (GDAL_HTTP_PROXYUSERPWD). Must be in the form of [user name]:[password].
-#% type: string
-#% description: User and password for HTTP proxy
-#%end
+# %option
+# % key: proxy_user_pw
+# % label: User and password for HTTP proxy only for GDAL driver (GDAL_HTTP_PROXYUSERPWD). Must be in the form of [user name]:[password].
+# % type: string
+# % description: User and password for HTTP proxy
+# %end
 
-#%option G_OPT_F_BIN_INPUT
-#% key: capfile
-#% required: no
-#% description: Capabilities file to parse (input). It is relevant for WMTS_GRASS and OnEarth_GRASS drivers
-#%end
+# %option G_OPT_F_BIN_INPUT
+# % key: capfile
+# % required: no
+# % description: Capabilities file to parse (input). It is relevant for WMTS_GRASS and OnEarth_GRASS drivers
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% key: capfile_output
-#% required: no
-#% description: File where the server capabilities will be saved ('c' flag)
-#%end
+# %option G_OPT_F_OUTPUT
+# % key: capfile_output
+# % required: no
+# % description: File where the server capabilities will be saved ('c' flag)
+# %end
 
-#%flag
-#% key: c
-#% description: Get the server capabilities, print them out, then exit
-#% guisection: Request
-#% suppress_required: yes
-#%end
+# %flag
+# % key: c
+# % description: Get the server capabilities, print them out, then exit
+# % guisection: Request
+# % suppress_required: yes
+# %end
 
-#%flag
-#% key: o
-#% description: Do not request transparent data
-#% guisection: Map style
-#%end
+# %flag
+# % key: o
+# % description: Do not request transparent data
+# % guisection: Map style
+# %end
 
-#%flag
-#% key: b
-#% description: Keep original bands (default: create composite)
-#% guisection: Map style
-#%end
+# %flag
+# % key: b
+# % description: Keep original bands (default: create composite)
+# % guisection: Map style
+# %end
 
-#%rules
-#% exclusive: capfile_output, capfile
-#%end
+# %rules
+# % exclusive: capfile_output, capfile
+# %end
 
 import os
 import sys

--- a/scripts/r.mapcalc.simple/r.mapcalc.simple.py
+++ b/scripts/r.mapcalc.simple/r.mapcalc.simple.py
@@ -17,78 +17,78 @@ License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 """
 
-#%module
-#% description: Calculates a new raster map from a simple r.mapcalc expression.
-#% keyword: raster
-#% keyword: algebra
-#% keyword: simple
-#%end
-#%option
-#% key: expression
-#% type: string
-#% description: Formula (e.g. A-B or A*C+B)
-#% required : yes
-#%end
-#%option G_OPT_R_INPUT
-#% key: a
-#% description: Name of input A raster map
-#% required : no
-#% guisection: Input maps
-#%end
-#%option G_OPT_R_INPUT
-#% key: b
-#% description: Name of input B raster map
-#% required : no
-#% guisection: Input maps
-#%end
-#%option G_OPT_R_INPUT
-#% key: c
-#% description: Name of input C raster map
-#% required : no
-#% guisection: Input maps
-#%end
-#%option G_OPT_R_INPUT
-#% key: d
-#% description: Name of input D raster map
-#% required : no
-#% guisection: Input maps
-#%end
-#%option G_OPT_R_INPUT
-#% key: e
-#% description: Name of input E raster map
-#% required : no
-#% guisection: Input maps
-#%end
-#%option G_OPT_R_INPUT
-#% key: f
-#% description: Name of input F raster map
-#% required : no
-#% guisection: Input maps
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
-#%option
-#% key: seed
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Seed for rand() function
-#% guisection: Random
-#%end
-#%flag
-#% key: s
-#% description: Generate random seed (result is non-deterministic)
-#% guisection: Random
-#%end
-#%flag
-#% key: q
-#% description: Quote the map names
-#% guisection: Input maps
-#%end
-#%flag
-#% key: c
-#% description: Case sensitive variable names
-#%end
+# %module
+# % description: Calculates a new raster map from a simple r.mapcalc expression.
+# % keyword: raster
+# % keyword: algebra
+# % keyword: simple
+# %end
+# %option
+# % key: expression
+# % type: string
+# % description: Formula (e.g. A-B or A*C+B)
+# % required : yes
+# %end
+# %option G_OPT_R_INPUT
+# % key: a
+# % description: Name of input A raster map
+# % required : no
+# % guisection: Input maps
+# %end
+# %option G_OPT_R_INPUT
+# % key: b
+# % description: Name of input B raster map
+# % required : no
+# % guisection: Input maps
+# %end
+# %option G_OPT_R_INPUT
+# % key: c
+# % description: Name of input C raster map
+# % required : no
+# % guisection: Input maps
+# %end
+# %option G_OPT_R_INPUT
+# % key: d
+# % description: Name of input D raster map
+# % required : no
+# % guisection: Input maps
+# %end
+# %option G_OPT_R_INPUT
+# % key: e
+# % description: Name of input E raster map
+# % required : no
+# % guisection: Input maps
+# %end
+# %option G_OPT_R_INPUT
+# % key: f
+# % description: Name of input F raster map
+# % required : no
+# % guisection: Input maps
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
+# %option
+# % key: seed
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Seed for rand() function
+# % guisection: Random
+# %end
+# %flag
+# % key: s
+# % description: Generate random seed (result is non-deterministic)
+# % guisection: Random
+# %end
+# %flag
+# % key: q
+# % description: Quote the map names
+# % guisection: Input maps
+# %end
+# %flag
+# % key: c
+# % description: Case sensitive variable names
+# %end
 
 import sys
 import re

--- a/scripts/r.mask/r.mask.py
+++ b/scripts/r.mask/r.mask.py
@@ -16,57 +16,57 @@
 #
 #############################################################################
 
-#%module
-#% description: Creates a MASK for limiting raster operation.
-#% keyword: raster
-#% keyword: mask
-#% keyword: null data
-#% keyword: no-data
-#% overwrite: yes
-#%end
-#%option G_OPT_R_INPUT
-#% key: raster
-#% description: Name of raster map to use as mask
-#% required: NO
-#% guisection: Raster
-#%end
-#%option
-#% key: maskcats
-#% type: string
-#% label: Raster values to use for mask
-#% description: Format: 1 2 3 thru 7 *
-#% answer: *
-#% guisection: Raster
-#%end
-#%option G_OPT_V_INPUT
-#% key: vector
-#% label: Name of vector map to use as mask
-#% required: NO
-#% guisection: Vector
-#%end
-#%option G_OPT_V_FIELD
-#% label: Layer number or name (vector)
-#% required: NO
-#% guisection: Vector
-#%end
-#%option G_OPT_V_CATS
-#% label: Category values (vector)
-#% guisection: Vector
-#%end
-#%option G_OPT_DB_WHERE
-#% label: WHERE conditions of SQL statement without 'where' keyword (vector)
-#% guisection: Vector
-#%end
-#%flag
-#% key: i
-#% description: Create inverse mask
-#% guisection: Create
-#%end
-#%flag
-#% key: r
-#% description: Remove existing mask (overrides other options)
-#% guisection: Remove
-#%end
+# %module
+# % description: Creates a MASK for limiting raster operation.
+# % keyword: raster
+# % keyword: mask
+# % keyword: null data
+# % keyword: no-data
+# % overwrite: yes
+# %end
+# %option G_OPT_R_INPUT
+# % key: raster
+# % description: Name of raster map to use as mask
+# % required: NO
+# % guisection: Raster
+# %end
+# %option
+# % key: maskcats
+# % type: string
+# % label: Raster values to use for mask
+# % description: Format: 1 2 3 thru 7 *
+# % answer: *
+# % guisection: Raster
+# %end
+# %option G_OPT_V_INPUT
+# % key: vector
+# % label: Name of vector map to use as mask
+# % required: NO
+# % guisection: Vector
+# %end
+# %option G_OPT_V_FIELD
+# % label: Layer number or name (vector)
+# % required: NO
+# % guisection: Vector
+# %end
+# %option G_OPT_V_CATS
+# % label: Category values (vector)
+# % guisection: Vector
+# %end
+# %option G_OPT_DB_WHERE
+# % label: WHERE conditions of SQL statement without 'where' keyword (vector)
+# % guisection: Vector
+# %end
+# %flag
+# % key: i
+# % description: Create inverse mask
+# % guisection: Create
+# %end
+# %flag
+# % key: r
+# % description: Remove existing mask (overrides other options)
+# % guisection: Remove
+# %end
 
 import os
 import sys

--- a/scripts/r.out.xyz/r.out.xyz.py
+++ b/scripts/r.out.xyz/r.out.xyz.py
@@ -16,27 +16,27 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports a raster map to a text file as x,y,z values based on cell centers.
-#% keyword: raster
-#% keyword: export
-#% keyword: output
-#% keyword: ASCII
-#% keyword: conversion
-#%end
-#%option G_OPT_R_INPUTS
-#% multiple: yes
-#%end
-#%option G_OPT_F_OUTPUT
-#% description: Name for output file (if omitted or "-" output to stdout)
-#% required: no
-#%end
-#%option G_OPT_F_SEP
-#%end
-#%flag
-#% key: i
-#% description: Include no data values
-#%end
+# %module
+# % description: Exports a raster map to a text file as x,y,z values based on cell centers.
+# % keyword: raster
+# % keyword: export
+# % keyword: output
+# % keyword: ASCII
+# % keyword: conversion
+# %end
+# %option G_OPT_R_INPUTS
+# % multiple: yes
+# %end
+# %option G_OPT_F_OUTPUT
+# % description: Name for output file (if omitted or "-" output to stdout)
+# % required: no
+# %end
+# %option G_OPT_F_SEP
+# %end
+# %flag
+# % key: i
+# % description: Include no data values
+# %end
 
 import sys
 from grass.script import core as grass

--- a/scripts/r.pack/r.pack.py
+++ b/scripts/r.pack/r.pack.py
@@ -13,23 +13,23 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports a raster map as GRASS GIS specific archive file
-#% keyword: raster
-#% keyword: export
-#% keyword: copying
-#%end
-#%option G_OPT_R_INPUT
-#% description: Name of raster map to pack up
-#%end
-#%option G_OPT_F_OUTPUT
-#% description: Name for output file (default is <input>.pack)
-#% required : no
-#%end
-#%flag
-#% key: c
-#% description: Switch the compression off
-#%end
+# %module
+# % description: Exports a raster map as GRASS GIS specific archive file
+# % keyword: raster
+# % keyword: export
+# % keyword: copying
+# %end
+# %option G_OPT_R_INPUT
+# % description: Name of raster map to pack up
+# %end
+# %option G_OPT_F_OUTPUT
+# % description: Name for output file (default is <input>.pack)
+# % required : no
+# %end
+# %flag
+# % key: c
+# % description: Switch the compression off
+# %end
 
 import os
 import sys

--- a/scripts/r.plane/r.plane.py
+++ b/scripts/r.plane/r.plane.py
@@ -17,51 +17,51 @@
 #
 #############################################################################
 
-#%module
-#% description: Creates raster plane map given dip (inclination), aspect (azimuth) and one point.
-#% keyword: raster
-#% keyword: elevation
-#%end
-#%option G_OPT_R_OUTPUT
-#%end
-#%option
-#% key: dip
-#% type: double
-#% gisprompt: -90-90
-#% answer: 0.0
-#% description: Dip of plane in degrees
-#% required : yes
-#%end
-#%option
-#% key: azimuth
-#% type: double
-#% gisprompt: 0-360
-#% answer: 0.0
-#% description: Azimuth of the plane in degrees
-#% required : yes
-#%end
-#%option
-#% key: easting
-#% type: double
-#% description: Easting coordinate of a point on the plane
-#% required : yes
-#%end
-#%option
-#% key: northing
-#% type: double
-#% description: Northing coordinate of a point on the plane
-#% required : yes
-#%end
-#%option
-#% key: elevation
-#% type: double
-#% description: Elevation coordinate of a point on the plane
-#% required : yes
-#%end
-#%option G_OPT_R_TYPE
-#% answer: FCELL
-#% required: no
-#%end
+# %module
+# % description: Creates raster plane map given dip (inclination), aspect (azimuth) and one point.
+# % keyword: raster
+# % keyword: elevation
+# %end
+# %option G_OPT_R_OUTPUT
+# %end
+# %option
+# % key: dip
+# % type: double
+# % gisprompt: -90-90
+# % answer: 0.0
+# % description: Dip of plane in degrees
+# % required : yes
+# %end
+# %option
+# % key: azimuth
+# % type: double
+# % gisprompt: 0-360
+# % answer: 0.0
+# % description: Azimuth of the plane in degrees
+# % required : yes
+# %end
+# %option
+# % key: easting
+# % type: double
+# % description: Easting coordinate of a point on the plane
+# % required : yes
+# %end
+# %option
+# % key: northing
+# % type: double
+# % description: Northing coordinate of a point on the plane
+# % required : yes
+# %end
+# %option
+# % key: elevation
+# % type: double
+# % description: Elevation coordinate of a point on the plane
+# % required : yes
+# %end
+# %option G_OPT_R_TYPE
+# % answer: FCELL
+# % required: no
+# %end
 
 import math
 import string

--- a/scripts/r.reclass.area/r.reclass.area.py
+++ b/scripts/r.reclass.area/r.reclass.area.py
@@ -23,54 +23,54 @@
 # 2000: updated to GRASS 5
 # 1998 from NRCS, slightly modified for GRASS 4.2.1
 
-#%module
-#% description: Reclasses a raster map greater or less than user specified area size (in hectares).
-#% keyword: raster
-#% keyword: statistics
-#% keyword: aggregation
-#%end
+# %module
+# % description: Reclasses a raster map greater or less than user specified area size (in hectares).
+# % keyword: raster
+# % keyword: statistics
+# % keyword: aggregation
+# %end
 
-#%option G_OPT_R_INPUT
-#%end
+# %option G_OPT_R_INPUT
+# %end
 
-#%option G_OPT_R_OUTPUT
-#%end
+# %option G_OPT_R_OUTPUT
+# %end
 
-#%option
-#% key: value
-#% type: double
-#% description: Value option that sets the area size limit (in hectares)
-#% required: yes
-#% guisection: Area
-#%end
+# %option
+# % key: value
+# % type: double
+# % description: Value option that sets the area size limit (in hectares)
+# % required: yes
+# % guisection: Area
+# %end
 
-#%option
-#% key: mode
-#% type: string
-#% description: Lesser or greater than specified value
-#% options: lesser,greater
-#% required: yes
-#% guisection: Area
-#%end
+# %option
+# % key: mode
+# % type: string
+# % description: Lesser or greater than specified value
+# % options: lesser,greater
+# % required: yes
+# % guisection: Area
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Method used for reclassification
-#% options: reclass,rmarea
-#% answer: reclass
-#% guisection: Area
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Method used for reclassification
+# % options: reclass,rmarea
+# % answer: reclass
+# % guisection: Area
+# %end
 
-#%flag
-#% key: c
-#% description: Input map is clumped
-#%end
+# %flag
+# % key: c
+# % description: Input map is clumped
+# %end
 
-#%flag
-#% key: d
-#% description: Clumps including diagonal neighbors
-#%end
+# %flag
+# % key: d
+# % description: Clumps including diagonal neighbors
+# %end
 
 import sys
 import os

--- a/scripts/r.rgb/r.rgb.py
+++ b/scripts/r.rgb/r.rgb.py
@@ -13,33 +13,33 @@
 #
 #############################################################################
 
-#%module
-#% description: Splits a raster map into red, green and blue maps.
-#% keyword: raster
-#% keyword: RGB
-#% keyword: separate
-#% keyword: split
-#%end
-#%option G_OPT_R_INPUT
-#%end
-#%option G_OPT_R_OUTPUT
-#% key: red
-#% description: Red channel raster map name
-#% required: no
-#%end
-#%option G_OPT_R_OUTPUT
-#% key: green
-#% description: Green channel raster map name
-#% required: no
-#%end
-#%option G_OPT_R_OUTPUT
-#% key: blue
-#% description: Blue channel raster map name
-#% required: no
-#%end
-#%rules
-#% required: red, green, blue
-#%end
+# %module
+# % description: Splits a raster map into red, green and blue maps.
+# % keyword: raster
+# % keyword: RGB
+# % keyword: separate
+# % keyword: split
+# %end
+# %option G_OPT_R_INPUT
+# %end
+# %option G_OPT_R_OUTPUT
+# % key: red
+# % description: Red channel raster map name
+# % required: no
+# %end
+# %option G_OPT_R_OUTPUT
+# % key: green
+# % description: Green channel raster map name
+# % required: no
+# %end
+# %option G_OPT_R_OUTPUT
+# % key: blue
+# % description: Blue channel raster map name
+# % required: no
+# %end
+# %rules
+# % required: red, green, blue
+# %end
 
 import grass.script as gscript
 

--- a/scripts/r.shade/r.shade.py
+++ b/scripts/r.shade/r.shade.py
@@ -15,48 +15,48 @@
 #
 #############################################################################
 
-#%module
-#% description: Drapes a color raster over an shaded relief or aspect map.
-#% keyword: raster
-#% keyword: elevation
-#% keyword: relief
-#% keyword: hillshade
-#% keyword: visualization
-#%end
-#%option G_OPT_R_INPUT
-#% key: shade
-#% description: Name of shaded relief or aspect raster map
-#%end
-#%option G_OPT_R_INPUT
-#% key: color
-#% label: Name of raster to drape over relief raster map
-#% description: Typically, this raster is elevation or other colorful raster
-#%end
-#%option G_OPT_R_OUTPUT
-#% description: Name of shaded raster map
-#%end
-#%option
-#% key: brighten
-#% type: integer
-#% description: Percent to brighten
-#% options: -99-99
-#% answer: 0
-#%end
-#%option
-#% key: bgcolor
-#% type: string
-#% key_desc: name
-#% label: Color to use instead of NULL values
-#% description: Either a standard color name, R:G:B triplet, or "none"
-#% gisprompt: old,color_none,color
-#%end
-#%flag
-#% key: c
-#% description: Use colors from color tables for NULL values
-#%end
-#%rules
-#% exclusive: bgcolor, -c
-#%end
+# %module
+# % description: Drapes a color raster over an shaded relief or aspect map.
+# % keyword: raster
+# % keyword: elevation
+# % keyword: relief
+# % keyword: hillshade
+# % keyword: visualization
+# %end
+# %option G_OPT_R_INPUT
+# % key: shade
+# % description: Name of shaded relief or aspect raster map
+# %end
+# %option G_OPT_R_INPUT
+# % key: color
+# % label: Name of raster to drape over relief raster map
+# % description: Typically, this raster is elevation or other colorful raster
+# %end
+# %option G_OPT_R_OUTPUT
+# % description: Name of shaded raster map
+# %end
+# %option
+# % key: brighten
+# % type: integer
+# % description: Percent to brighten
+# % options: -99-99
+# % answer: 0
+# %end
+# %option
+# % key: bgcolor
+# % type: string
+# % key_desc: name
+# % label: Color to use instead of NULL values
+# % description: Either a standard color name, R:G:B triplet, or "none"
+# % gisprompt: old,color_none,color
+# %end
+# %flag
+# % key: c
+# % description: Use colors from color tables for NULL values
+# %end
+# %rules
+# % exclusive: bgcolor, -c
+# %end
 
 # TODO: bgcolor is not using standard option because it has default white
 # using `answer:` will cause `default:` which is not the same as no default

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -35,69 +35,69 @@
 #    presenting data in a highly inappropriate projection. Do you really
 #    want their data?
 
-#%module
-#% description: Produces tilings of the source projection for use in the destination region and projection.
-#% keyword: raster
-#% keyword: tiling
-#%end
-#%flag
-#% key: g
-#% description: Produces shell script output
-#%end
-#%flag
-#% key: w
-#% description: Produces web map server query string output
-#%end
-#%option
-#% key: region
-#% type: string
-#% description: Name of region to use instead of current region for bounds and resolution
-#%end
-#%option
-#% key: sourceproj
-#% type: string
-#% description: Source projection
-#% required : yes
-#%end
-#%option
-#% key: sourcescale
-#% type: string
-#% description: Conversion factor from units to meters in source projection
-#% answer : 1
-#%end
-#%option
-#% key: destproj
-#% type: string
-#% description: Destination projection, defaults to this location's projection
-#% required : no
-#%end
-#%option
-#% key: destscale
-#% type: string
-#% description: Conversion factor from units to meters in source projection
-#% required : no
-#%end
-#%option
-#% key: maxcols
-#% type: integer
-#% description: Maximum number of columns for a tile in the source projection
-#% answer: 1024
-#%end
-#%option
-#% key: maxrows
-#% type: integer
-#% description: Maximum number of rows for a tile in the source projection
-#% answer: 1024
-#%end
-#%option
-#% key: overlap
-#% type: integer
-#% description: Number of cells tiles should overlap in each direction
-#% answer: 0
-#%end
-#%option G_OPT_F_SEP
-#% description: Output field separator
-#%end
+# %module
+# % description: Produces tilings of the source projection for use in the destination region and projection.
+# % keyword: raster
+# % keyword: tiling
+# %end
+# %flag
+# % key: g
+# % description: Produces shell script output
+# %end
+# %flag
+# % key: w
+# % description: Produces web map server query string output
+# %end
+# %option
+# % key: region
+# % type: string
+# % description: Name of region to use instead of current region for bounds and resolution
+# %end
+# %option
+# % key: sourceproj
+# % type: string
+# % description: Source projection
+# % required : yes
+# %end
+# %option
+# % key: sourcescale
+# % type: string
+# % description: Conversion factor from units to meters in source projection
+# % answer : 1
+# %end
+# %option
+# % key: destproj
+# % type: string
+# % description: Destination projection, defaults to this location's projection
+# % required : no
+# %end
+# %option
+# % key: destscale
+# % type: string
+# % description: Conversion factor from units to meters in source projection
+# % required : no
+# %end
+# %option
+# % key: maxcols
+# % type: integer
+# % description: Maximum number of columns for a tile in the source projection
+# % answer: 1024
+# %end
+# %option
+# % key: maxrows
+# % type: integer
+# % description: Maximum number of rows for a tile in the source projection
+# % answer: 1024
+# %end
+# %option
+# % key: overlap
+# % type: integer
+# % description: Number of cells tiles should overlap in each direction
+# % answer: 0
+# %end
+# %option G_OPT_F_SEP
+# % description: Output field separator
+# %end
 
 # Data structures used in this program:
 # A bounding box:

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -13,32 +13,32 @@
 #
 #############################################################################
 
-#%module
-#% description: Imports a GRASS GIS specific raster archive file (packed with r.pack) as a raster map
-#% keyword: raster
-#% keyword: import
-#% keyword: copying
-#%end
-#%option G_OPT_F_BIN_INPUT
-#% description: Name of input pack file
-#% key_desc: name.pack
-#%end
-#%option G_OPT_R_OUTPUT
-#% description: Name for output raster map (default: taken from input file internals)
-#% required: no
-#% guisection: Output settings
-#%end
-#%flag
-#% key: o
-#% label: Override projection check (use current location's projection)
-#% description: Assume that the dataset has same projection as the current location
-#% guisection: Output settings
-#%end
-#%flag
-#% key: p
-#% label: Print projection information of input pack file and exit
-#% guisection: Print
-#%end
+# %module
+# % description: Imports a GRASS GIS specific raster archive file (packed with r.pack) as a raster map
+# % keyword: raster
+# % keyword: import
+# % keyword: copying
+# %end
+# %option G_OPT_F_BIN_INPUT
+# % description: Name of input pack file
+# % key_desc: name.pack
+# %end
+# %option G_OPT_R_OUTPUT
+# % description: Name for output raster map (default: taken from input file internals)
+# % required: no
+# % guisection: Output settings
+# %end
+# %flag
+# % key: o
+# % label: Override projection check (use current location's projection)
+# % description: Assume that the dataset has same projection as the current location
+# % guisection: Output settings
+# %end
+# %flag
+# % key: p
+# % label: Print projection information of input pack file and exit
+# % guisection: Print
+# %end
 
 import os
 import re

--- a/scripts/r3.in.xyz/r3.in.xyz.py
+++ b/scripts/r3.in.xyz/r3.in.xyz.py
@@ -20,152 +20,152 @@
 #
 #############################################################################
 
-#%Module
-#% description: Create a 3D raster map from an assemblage of many coordinates using univariate statistics
-#% keyword: raster3d
-#% keyword: import
-#% keyword: voxel
-#% keyword: LIDAR
-#% keyword: statistics
-#% keyword: conversion
-#% keyword: aggregation
-#% keyword: binning
-#%End
-#%Flag
-#% key: s
-#% description: Scan data file for extent then exit
-#%End
-#%Flag
-#% key: g
-#% description: In scan mode, print using shell script style
-#%End
-#%Flag
-#% key: i
-#% description: Ignore broken lines
-#%End
-#%Option G_OPT_F_INPUT
-#% required: yes
-#% description: ASCII file containing input data
-#%End
-#%Option
-#% key: output
-#% type: string
-#% required: yes
-#% multiple: no
-#% key_desc: name
-#% description: Name for output raster map
-#% gisprompt: new,grid3,3d-raster
-#%End
-#%Option
-#% key: method
-#% type: string
-#% required: no
-#% multiple: no
-#% options: n,min,max,range,sum,mean,stddev,variance,coeff_var,median,percentile,skewness,trimmean
-#% description: Statistic to use for raster values
-#% answer: mean
-#% guisection: Statistic
-#%End
-#%Option
-#% key: type
-#% type: string
-#% required: no
-#% multiple: no
-#% options: float,double
-#% description: Storage type for resultant raster map
-#% answer: float
-#%End
-#%Option G_OPT_F_SEP
-#% guisection: Input
-#%End
-#%Option
-#% key: x
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Column number of x coordinates in input file (first column is 1)
-#% answer: 1
-#% guisection: Input
-#%End
-#%Option
-#% key: y
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Column number of y coordinates in input file
-#% answer: 2
-#% guisection: Input
-#%End
-#%Option
-#% key: z
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Column number of z coordinates in input file
-#% answer: 3
-#% guisection: Input
-#%End
-#%Option
-#% key: value_column
-#% type: integer
-#% required: no
-#% multiple: no
-#% label: Column number of data values in input file
-#% description: If not given or set to 0, the data points' z-values are used
-#% answer: 0
-#% guisection: Input
-#%End
-#%Option
-#% key: vrange
-#% type: double
-#% required: no
-#% key_desc: min,max
-#% description: Filter range for value column data (min,max)
-#%End
-#%option
-#% key: vscale
-#% type: double
-#% required: no
-#% multiple: no
-#% description: Scaling factor to apply to value column data
-#% answer: 1.0
-#%end
-#%Option
-#% key: percent
-#% type: integer
-#% required: no
-#% multiple: no
-#% options: 1-100
-#% description: Percent of map to keep in memory
-#% answer: 100
-#%End
-#%Option
-#% key: pth
-#% type: integer
-#% required: no
-#% multiple: no
-#% options: 1-100
-#% description: pth percentile of the values
-#% guisection: Statistic
-#%End
-#%Option
-#% key: trim
-#% type: double
-#% required: no
-#% multiple: no
-#% options: 0-50
-#% description: Discard <trim> percent of the smallest and <trim> percent of the largest observations
-#% guisection: Statistic
-#%End
-#%Option
-#% key: workers
-#% type: integer
-#% required: no
-#% multiple: no
-#% options: 1-256
-#% answer: 1
-#% description: Number of parallel processes to launch
-#%End
+# %Module
+# % description: Create a 3D raster map from an assemblage of many coordinates using univariate statistics
+# % keyword: raster3d
+# % keyword: import
+# % keyword: voxel
+# % keyword: LIDAR
+# % keyword: statistics
+# % keyword: conversion
+# % keyword: aggregation
+# % keyword: binning
+# %End
+# %Flag
+# % key: s
+# % description: Scan data file for extent then exit
+# %End
+# %Flag
+# % key: g
+# % description: In scan mode, print using shell script style
+# %End
+# %Flag
+# % key: i
+# % description: Ignore broken lines
+# %End
+# %Option G_OPT_F_INPUT
+# % required: yes
+# % description: ASCII file containing input data
+# %End
+# %Option
+# % key: output
+# % type: string
+# % required: yes
+# % multiple: no
+# % key_desc: name
+# % description: Name for output raster map
+# % gisprompt: new,grid3,3d-raster
+# %End
+# %Option
+# % key: method
+# % type: string
+# % required: no
+# % multiple: no
+# % options: n,min,max,range,sum,mean,stddev,variance,coeff_var,median,percentile,skewness,trimmean
+# % description: Statistic to use for raster values
+# % answer: mean
+# % guisection: Statistic
+# %End
+# %Option
+# % key: type
+# % type: string
+# % required: no
+# % multiple: no
+# % options: float,double
+# % description: Storage type for resultant raster map
+# % answer: float
+# %End
+# %Option G_OPT_F_SEP
+# % guisection: Input
+# %End
+# %Option
+# % key: x
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Column number of x coordinates in input file (first column is 1)
+# % answer: 1
+# % guisection: Input
+# %End
+# %Option
+# % key: y
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Column number of y coordinates in input file
+# % answer: 2
+# % guisection: Input
+# %End
+# %Option
+# % key: z
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Column number of z coordinates in input file
+# % answer: 3
+# % guisection: Input
+# %End
+# %Option
+# % key: value_column
+# % type: integer
+# % required: no
+# % multiple: no
+# % label: Column number of data values in input file
+# % description: If not given or set to 0, the data points' z-values are used
+# % answer: 0
+# % guisection: Input
+# %End
+# %Option
+# % key: vrange
+# % type: double
+# % required: no
+# % key_desc: min,max
+# % description: Filter range for value column data (min,max)
+# %End
+# %option
+# % key: vscale
+# % type: double
+# % required: no
+# % multiple: no
+# % description: Scaling factor to apply to value column data
+# % answer: 1.0
+# %end
+# %Option
+# % key: percent
+# % type: integer
+# % required: no
+# % multiple: no
+# % options: 1-100
+# % description: Percent of map to keep in memory
+# % answer: 100
+# %End
+# %Option
+# % key: pth
+# % type: integer
+# % required: no
+# % multiple: no
+# % options: 1-100
+# % description: pth percentile of the values
+# % guisection: Statistic
+# %End
+# %Option
+# % key: trim
+# % type: double
+# % required: no
+# % multiple: no
+# % options: 0-50
+# % description: Discard <trim> percent of the smallest and <trim> percent of the largest observations
+# % guisection: Statistic
+# %End
+# %Option
+# % key: workers
+# % type: integer
+# % required: no
+# % multiple: no
+# % options: 1-256
+# % answer: 1
+# % description: Number of parallel processes to launch
+# %End
 
 
 import sys

--- a/scripts/v.build.all/v.build.all.py
+++ b/scripts/v.build.all/v.build.all.py
@@ -12,11 +12,11 @@
 #
 #############################################################################
 
-#%module
-#% description: Rebuilds topology on all vector maps in the current mapset.
-#% keyword: vector
-#% keyword: topology
-#%end
+# %module
+# % description: Rebuilds topology on all vector maps in the current mapset.
+# % keyword: vector
+# % keyword: topology
+# %end
 
 import sys
 from grass.script import core as grass

--- a/scripts/v.centroids/v.centroids.py
+++ b/scripts/v.centroids/v.centroids.py
@@ -11,43 +11,43 @@
 #
 #############################################################################
 
-#%Module
-#% description: Adds missing centroids to closed boundaries.
-#% keyword: vector
-#% keyword: centroid
-#% keyword: area
-#%End
+# %Module
+# % description: Adds missing centroids to closed boundaries.
+# % keyword: vector
+# % keyword: centroid
+# % keyword: area
+# %End
 
-#%option G_OPT_V_INPUT
-#%end
+# %option G_OPT_V_INPUT
+# %end
 
-#%option G_OPT_V_OUTPUT
-#%end
+# %option G_OPT_V_OUTPUT
+# %end
 
-#%option
-#% key: option
-#% type: string
-#% description: Action to be taken
-#% options: add
-#% answer: add
-#% required: no
-#%end
+# %option
+# % key: option
+# % type: string
+# % description: Action to be taken
+# % options: add
+# % answer: add
+# % required: no
+# %end
 
-#%option G_OPT_V_FIELD
-#%end
+# %option G_OPT_V_FIELD
+# %end
 
-#%option G_OPT_V_CAT
-#% description: Category number starting value
-#% answer: 1
-#%end
+# %option G_OPT_V_CAT
+# % description: Category number starting value
+# % answer: 1
+# %end
 
-#%option
-#% key: step
-#% type: integer
-#% description: Category increment
-#% answer: 1
-#% required: no
-#%end
+# %option
+# % key: step
+# % type: integer
+# % description: Category increment
+# % answer: 1
+# % required: no
+# %end
 
 import sys
 import grass.script as gscript

--- a/scripts/v.clip/v.clip.py
+++ b/scripts/v.clip/v.clip.py
@@ -12,45 +12,45 @@
 #
 #############################################################################
 
-#%module
-#% description: Extracts features of input map which overlay features of clip map.
-#% keyword: vector
-#% keyword: clip
-#% keyword: area
-#%end
+# %module
+# % description: Extracts features of input map which overlay features of clip map.
+# % keyword: vector
+# % keyword: clip
+# % keyword: area
+# %end
 
-#%option G_OPT_V_INPUT
-#% label: Name of vector map to be clipped
-#% key: input
-#%end
+# %option G_OPT_V_INPUT
+# % label: Name of vector map to be clipped
+# % key: input
+# %end
 
-#%option G_OPT_V_INPUT
-#% key: clip
-#% label: Name of clip vector map
-#%end
+# %option G_OPT_V_INPUT
+# % key: clip
+# % label: Name of clip vector map
+# %end
 
-#%option G_OPT_V_OUTPUT
-#% key: output
-#%end
+# %option G_OPT_V_OUTPUT
+# % key: output
+# %end
 
-#%flag
-#% key: d
-#% description: Do not dissolve clip map
-#%end
+# %flag
+# % key: d
+# % description: Do not dissolve clip map
+# %end
 
-#%flag
-#% key: r
-#% description: Clip by region
-#% suppress_required: yes
-#% guisection: Region
-#%end
+# %flag
+# % key: r
+# % description: Clip by region
+# % suppress_required: yes
+# % guisection: Region
+# %end
 
 # flags -d and -r are mutualy exclusive
 # with flag -r, suppress_required: yes, but input and output must be defined
-#%rules
-#% exclusive: -d, -r
-#% requires_all: -r, input, output
-#%end
+# %rules
+# % exclusive: -d, -r
+# % requires_all: -r, input, output
+# %end
 
 import os
 import sys

--- a/scripts/v.db.addcolumn/v.db.addcolumn.py
+++ b/scripts/v.db.addcolumn/v.db.addcolumn.py
@@ -16,29 +16,29 @@
 #############################################################################
 
 
-#%module
-#% description: Adds one or more columns to the attribute table connected to a given vector map.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%end
+# %module
+# % description: Adds one or more columns to the attribute table connected to a given vector map.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %end
 
-#%option G_OPT_V_MAP
-#%end
+# %option G_OPT_V_MAP
+# %end
 
-#%option G_OPT_V_FIELD
-#% label: Layer number where to add column(s)
-#%end
+# %option G_OPT_V_FIELD
+# % label: Layer number where to add column(s)
+# %end
 
-#%option
-#% key: columns
-#% type: string
-#% label: Name and type of the new column(s) ('name type [,name type, ...]')
-#% description: Types depend on database backend, but all support VARCHAR(), INT, DOUBLE PRECISION and DATE. Example: 'label varchar(250), value integer'
-#% required: yes
-#% multiple: yes
-#% key_desc: name type
-#%end
+# %option
+# % key: columns
+# % type: string
+# % label: Name and type of the new column(s) ('name type [,name type, ...]')
+# % description: Types depend on database backend, but all support VARCHAR(), INT, DOUBLE PRECISION and DATE. Example: 'label varchar(250), value integer'
+# % required: yes
+# % multiple: yes
+# % key_desc: name type
+# %end
 
 import sys
 import os

--- a/scripts/v.db.addtable/v.db.addtable.py
+++ b/scripts/v.db.addtable/v.db.addtable.py
@@ -16,42 +16,42 @@
 #
 #############################################################################
 
-#%module
-#% description: Creates and connects a new attribute table to a given layer of an existing vector map.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%end
-#%option G_OPT_V_MAP
-#%end
-#%option
-#% key: table
-#% type: string
-#% description: Name of new attribute table (default: vector map name)
-#% required: no
-#% guisection: Definition
-#%end
-#%option
-#% key: layer
-#% type: integer
-#% description: Layer number where to add new attribute table
-#% answer: 1
-#% required: no
-#% guisection: Definition
-#%end
-#%option G_OPT_DB_KEYCOLUMN
-#% guisection: Definition
-#%end
-#%option
-#% key: columns
-#% type: string
-#% label: Name and type of the new column(s) ('name type [,name type, ...]')
-#% description: Types depend on database backend, but all support VARCHAR(), INT, DOUBLE PRECISION and DATE. Example: 'label varchar(250), value integer'
-#% required: no
-#% multiple: yes
-#% key_desc: name type
-#% guisection: Definition
-#%end
+# %module
+# % description: Creates and connects a new attribute table to a given layer of an existing vector map.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %end
+# %option G_OPT_V_MAP
+# %end
+# %option
+# % key: table
+# % type: string
+# % description: Name of new attribute table (default: vector map name)
+# % required: no
+# % guisection: Definition
+# %end
+# %option
+# % key: layer
+# % type: integer
+# % description: Layer number where to add new attribute table
+# % answer: 1
+# % required: no
+# % guisection: Definition
+# %end
+# %option G_OPT_DB_KEYCOLUMN
+# % guisection: Definition
+# %end
+# %option
+# % key: columns
+# % type: string
+# % label: Name and type of the new column(s) ('name type [,name type, ...]')
+# % description: Types depend on database backend, but all support VARCHAR(), INT, DOUBLE PRECISION and DATE. Example: 'label varchar(250), value integer'
+# % required: no
+# % multiple: yes
+# % key_desc: name type
+# % guisection: Definition
+# %end
 
 import sys
 import os

--- a/scripts/v.db.dropcolumn/v.db.dropcolumn.py
+++ b/scripts/v.db.dropcolumn/v.db.dropcolumn.py
@@ -18,24 +18,24 @@
 #############################################################################
 
 
-#%module
-#% description: Drops a column from the attribute table connected to a given vector map.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%end
+# %module
+# % description: Drops a column from the attribute table connected to a given vector map.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %end
 
-#%option G_OPT_V_MAP
-#% key: map
-#%end
+# %option G_OPT_V_MAP
+# % key: map
+# %end
 
-#%option G_OPT_V_FIELD
-#%end
+# %option G_OPT_V_FIELD
+# %end
 
-#%option G_OPT_DB_COLUMNS
-#% description: Name of attribute column(s) to drop
-#% required: yes
-#%end
+# %option G_OPT_DB_COLUMNS
+# % description: Name of attribute column(s) to drop
+# % required: yes
+# %end
 
 import sys
 import os

--- a/scripts/v.db.droprow/v.db.droprow.py
+++ b/scripts/v.db.droprow/v.db.droprow.py
@@ -15,25 +15,25 @@
 #############################################################################
 
 
-#%module
-#% description: Removes a vector feature from a vector map through attribute selection.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%end
+# %module
+# % description: Removes a vector feature from a vector map through attribute selection.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %end
 
-#%option G_OPT_V_INPUT
-#%end
+# %option G_OPT_V_INPUT
+# %end
 
-#%option G_OPT_V_FIELD
-#%end
+# %option G_OPT_V_FIELD
+# %end
 
-#%option G_OPT_DB_WHERE
-#% required :yes
-#%end
+# %option G_OPT_DB_WHERE
+# % required :yes
+# %end
 
-#%option G_OPT_V_OUTPUT
-#%end
+# %option G_OPT_V_OUTPUT
+# %end
 
 import sys
 import grass.script as grass

--- a/scripts/v.db.droptable/v.db.droptable.py
+++ b/scripts/v.db.droptable/v.db.droptable.py
@@ -15,24 +15,24 @@
 #############################################################################
 
 
-#%Module
-#% description: Removes existing attribute table of a vector map.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%End
-#%flag
-#% key: f
-#% description: Force removal (required for actual deletion of table)
-#%end
-#%option G_OPT_V_MAP
-#%end
-#%option G_OPT_DB_TABLE
-#% description: Table name (default: vector map name)
-#%end
-#%option G_OPT_V_FIELD
-#% required : no
-#%end
+# %Module
+# % description: Removes existing attribute table of a vector map.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %End
+# %flag
+# % key: f
+# % description: Force removal (required for actual deletion of table)
+# %end
+# %option G_OPT_V_MAP
+# %end
+# %option G_OPT_DB_TABLE
+# % description: Table name (default: vector map name)
+# %end
+# %option G_OPT_V_FIELD
+# % required : no
+# %end
 
 import sys
 import os

--- a/scripts/v.db.join/v.db.join.py
+++ b/scripts/v.db.join/v.db.join.py
@@ -14,47 +14,47 @@
 #
 #############################################################################
 
-#%module
-#% description: Joins a database table to a vector map table.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%end
+# %module
+# % description: Joins a database table to a vector map table.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %end
 
-#%option G_OPT_V_MAP
-#% description: Vector map to which to join other table
-#% guidependency: layer,column
-#%end
+# %option G_OPT_V_MAP
+# % description: Vector map to which to join other table
+# % guidependency: layer,column
+# %end
 
-#%option G_OPT_V_FIELD
-#% description: Layer where to join
-#% guidependency: column
-#%end
+# %option G_OPT_V_FIELD
+# % description: Layer where to join
+# % guidependency: column
+# %end
 
-#%option G_OPT_DB_COLUMN
-#% description: Identifier column (e.g.: cat) in the vector table to be used for join
-#% required : yes
-#%end
+# %option G_OPT_DB_COLUMN
+# % description: Identifier column (e.g.: cat) in the vector table to be used for join
+# % required : yes
+# %end
 
-#%option G_OPT_DB_TABLE
-#% key: other_table
-#% description: Other table name
-#% required: yes
-#% guidependency: ocolumn,scolumns
-#%end
+# %option G_OPT_DB_TABLE
+# % key: other_table
+# % description: Other table name
+# % required: yes
+# % guidependency: ocolumn,scolumns
+# %end
 
-#%option G_OPT_DB_COLUMN
-#% key: other_column
-#% description: Identifier column (e.g.: id) in the other table used for join
-#% required: yes
-#%end
+# %option G_OPT_DB_COLUMN
+# % key: other_column
+# % description: Identifier column (e.g.: id) in the other table used for join
+# % required: yes
+# %end
 
-#%option G_OPT_DB_COLUMN
-#% key: subset_columns
-#% multiple: yes
-#% required: no
-#% description: Subset of columns from the other table
-#%end
+# %option G_OPT_DB_COLUMN
+# % key: subset_columns
+# % multiple: yes
+# % required: no
+# % description: Subset of columns from the other table
+# %end
 
 import sys
 import string

--- a/scripts/v.db.reconnect.all/v.db.reconnect.all.py
+++ b/scripts/v.db.reconnect.all/v.db.reconnect.all.py
@@ -14,40 +14,40 @@
 #
 #############################################################################
 
-#%module
-#% description: Reconnects attribute tables for all vector maps from the current mapset to a new database.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#%end
-#%flag
-#% key: c
-#% description: Copy attribute tables to the target database if not exist
-#%end
-#%flag
-#% key: d
-#% description: Delete attribute tables from the source database
-#%end
-#%option G_OPT_DB_DATABASE
-#% key: old_database
-#% description: Name of source database
-#%end
-#%option G_OPT_DB_SCHEMA
-#% key: old_schema
-#% label: Name of source database schema
-#%end
-#%option
-#% key: new_driver
-#% description: Name for target driver
-#%end
-#%option G_OPT_DB_DATABASE
-#% key: new_database
-#% description: Name for target database
-#%end
-#%option G_OPT_DB_SCHEMA
-#% key: new_schema
-#% label: Name for target database schema
-#%end
+# %module
+# % description: Reconnects attribute tables for all vector maps from the current mapset to a new database.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# %end
+# %flag
+# % key: c
+# % description: Copy attribute tables to the target database if not exist
+# %end
+# %flag
+# % key: d
+# % description: Delete attribute tables from the source database
+# %end
+# %option G_OPT_DB_DATABASE
+# % key: old_database
+# % description: Name of source database
+# %end
+# %option G_OPT_DB_SCHEMA
+# % key: old_schema
+# % label: Name of source database schema
+# %end
+# %option
+# % key: new_driver
+# % description: Name for target driver
+# %end
+# %option G_OPT_DB_DATABASE
+# % key: new_database
+# % description: Name for target database
+# %end
+# %option G_OPT_DB_SCHEMA
+# % key: new_schema
+# % label: Name for target database schema
+# %end
 
 import sys
 import os

--- a/scripts/v.db.renamecolumn/v.db.renamecolumn.py
+++ b/scripts/v.db.renamecolumn/v.db.renamecolumn.py
@@ -20,25 +20,25 @@
 #############################################################################
 
 
-#%module
-#% description: Renames a column in the attribute table connected to a given vector map.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#% keyword: rename
-#%end
-#%option G_OPT_V_MAP
-#%end
-#%option G_OPT_V_FIELD
-#%end
-#%option
-#% key: column
-#% type: string
-#% description: Old and new name of the column (old,new)
-#% required: yes
-#% multiple: no
-#% key_desc: oldcol,newcol
-#%end
+# %module
+# % description: Renames a column in the attribute table connected to a given vector map.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# % keyword: rename
+# %end
+# %option G_OPT_V_MAP
+# %end
+# %option G_OPT_V_FIELD
+# %end
+# %option
+# % key: column
+# % type: string
+# % description: Old and new name of the column (old,new)
+# % required: yes
+# % multiple: no
+# % key_desc: oldcol,newcol
+# %end
 
 import sys
 import os

--- a/scripts/v.db.univar/v.db.univar.py
+++ b/scripts/v.db.univar/v.db.univar.py
@@ -16,40 +16,40 @@
 #
 #############################################################################
 
-#%module
-#% description: Calculates univariate statistics on selected table column for a GRASS vector map.
-#% keyword: vector
-#% keyword: statistics
-#% keyword: attribute table
-#%end
-#%option G_OPT_V_MAP
-#% required: yes
-#%end
-#%option G_OPT_V_FIELD
-#%end
-#%option G_OPT_DB_COLUMN
-#% description: Name of attribute column on which to calculate statistics (must be numeric)
-#% required: yes
-#%end
-#%option G_OPT_DB_WHERE
-#%end
-#%option
-#% key: percentile
-#% type: double
-#% description: Percentile to calculate (requires extended statistics flag)
-#% required : no
-#% answer: 90
-#% options: 0-100
-#% multiple: yes
-#%end
-#%flag
-#% key: e
-#% description: Extended statistics (quartiles and 90th percentile)
-#%end
-#%flag
-#% key: g
-#% description: Print stats in shell script style
-#%end
+# %module
+# % description: Calculates univariate statistics on selected table column for a GRASS vector map.
+# % keyword: vector
+# % keyword: statistics
+# % keyword: attribute table
+# %end
+# %option G_OPT_V_MAP
+# % required: yes
+# %end
+# %option G_OPT_V_FIELD
+# %end
+# %option G_OPT_DB_COLUMN
+# % description: Name of attribute column on which to calculate statistics (must be numeric)
+# % required: yes
+# %end
+# %option G_OPT_DB_WHERE
+# %end
+# %option
+# % key: percentile
+# % type: double
+# % description: Percentile to calculate (requires extended statistics flag)
+# % required : no
+# % answer: 90
+# % options: 0-100
+# % multiple: yes
+# %end
+# %flag
+# % key: e
+# % description: Extended statistics (quartiles and 90th percentile)
+# %end
+# %flag
+# % key: g
+# % description: Print stats in shell script style
+# %end
 
 import sys
 import os

--- a/scripts/v.db.update/v.db.update.py
+++ b/scripts/v.db.update/v.db.update.py
@@ -15,42 +15,42 @@
 #
 #############################################################################
 
-#%module
-#% description: Updates a column in the attribute table connected to a vector map.
-#% keyword: vector
-#% keyword: attribute table
-#% keyword: database
-#% keyword: attribute update
-#% keyword: type casting
-#%end
-#%option G_OPT_V_MAP
-#%end
-#%option G_OPT_V_FIELD
-#% required: yes
-#%end
-#%option G_OPT_DB_COLUMN
-#% key: column
-#% description: Name of attribute column to update
-#% required: yes
-#%end
-#%option
-#% key: value
-#% type: string
-#% description: Literal value to update the column with
-#% required: no
-#%end
-#%option G_OPT_DB_COLUMN
-#% key: query_column
-#% description: Name of other attribute column to query, can be combination of columns (e.g. co1+col2)
-#%end
-#%option G_OPT_DB_WHERE
-#%end
-#%option G_OPT_F_INPUT
-#% key: sqliteextra
-#% description: Name of SQLite extension file for extra functions (SQLite backend only)
-#% gisprompt: old,bin,file
-#% required: no
-#%end
+# %module
+# % description: Updates a column in the attribute table connected to a vector map.
+# % keyword: vector
+# % keyword: attribute table
+# % keyword: database
+# % keyword: attribute update
+# % keyword: type casting
+# %end
+# %option G_OPT_V_MAP
+# %end
+# %option G_OPT_V_FIELD
+# % required: yes
+# %end
+# %option G_OPT_DB_COLUMN
+# % key: column
+# % description: Name of attribute column to update
+# % required: yes
+# %end
+# %option
+# % key: value
+# % type: string
+# % description: Literal value to update the column with
+# % required: no
+# %end
+# %option G_OPT_DB_COLUMN
+# % key: query_column
+# % description: Name of other attribute column to query, can be combination of columns (e.g. co1+col2)
+# %end
+# %option G_OPT_DB_WHERE
+# %end
+# %option G_OPT_F_INPUT
+# % key: sqliteextra
+# % description: Name of SQLite extension file for extra functions (SQLite backend only)
+# % gisprompt: old,bin,file
+# % required: no
+# %end
 
 import sys
 import os

--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -15,24 +15,24 @@
 #
 #############################################################################
 
-#%module
-#% description: Dissolves boundaries between adjacent areas sharing a common category number or attribute.
-#% keyword: vector
-#% keyword: dissolve
-#% keyword: area
-#% keyword: line
-#%end
-#%option G_OPT_V_INPUT
-#%end
-#%option G_OPT_V_FIELD
-#% label: Layer number or name.
-#% required: no
-#%end
-#%option G_OPT_DB_COLUMN
-#% description: Name of attribute column used to dissolve common boundaries
-#%end
-#%option G_OPT_V_OUTPUT
-#%end
+# %module
+# % description: Dissolves boundaries between adjacent areas sharing a common category number or attribute.
+# % keyword: vector
+# % keyword: dissolve
+# % keyword: area
+# % keyword: line
+# %end
+# %option G_OPT_V_INPUT
+# %end
+# %option G_OPT_V_FIELD
+# % label: Layer number or name.
+# % required: no
+# %end
+# %option G_OPT_DB_COLUMN
+# % description: Name of attribute column used to dissolve common boundaries
+# %end
+# %option G_OPT_V_OUTPUT
+# %end
 import sys
 import os
 import atexit

--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -16,86 +16,86 @@
 #
 #############################################################################
 
-#%module
-#% description: Imports vector data into a GRASS vector map using OGR library and reprojects on the fly.
-#% keyword: vector
-#% keyword: import
-#% keyword: projection
-#%end
-#%option
-#% key: input
-#% type: string
-#% required: yes
-#% description: Name of OGR datasource to be imported
-#% gisprompt: old,datasource,datasource
-#% guisection: Input
-#%end
-#%option
-#% key: layer
-#% type: string
-#% multiple: yes
-#% description: OGR layer name. If not given, all available layers are imported
-#% guisection: Input
-#% gisprompt: old,datasource_layer,datasource_layer
-#%end
-#%option G_OPT_V_OUTPUT
-#% description: Name for output vector map (default: input)
-#% required: no
-#% guisection: Output
-#%end
-#%option
-#% key: extent
-#% type: string
-#% options: input,region
-#% answer: input
-#% description: Output vector map extent
-#% descriptions: input;extent of input map;region;extent of current region
-#% guisection: Output
-#%end
-#%option
-#% key: encoding
-#% type: string
-#% label: Encoding value for attribute data
-#% descriptions: Overrides encoding interpretation, useful when importing ESRI Shapefile
-#% guisection: Output
-#%end
-#%option
-#% key: snap
-#% type: double
-#% label: Snapping threshold for boundaries (map units)
-#% description: A suitable threshold is estimated during import
-#% answer: -1
-#% guisection: Output
-#%end
-#%option
-#% key: epsg
-#% type: integer
-#% options: 1-1000000
-#% guisection: Input SRS
-#% description: EPSG projection code
-#%end
-#%option
-#% key: datum_trans
-#% type: integer
-#% options: -1-100
-#% guisection: Input SRS
-#% label: Index number of datum transform parameters
-#% description: -1 to list available datum transform parameters
-#%end
-#%flag
-#% key: f
-#% description: List supported OGR formats and exit
-#% suppress_required: yes
-#%end
-#%flag
-#% key: l
-#% description: List available OGR layers in data source and exit
-#%end
-#%flag
-#% key: o
-#% label: Override projection check (use current location's projection)
-#% description: Assume that the dataset has the same projection as the current location
-#%end
+# %module
+# % description: Imports vector data into a GRASS vector map using OGR library and reprojects on the fly.
+# % keyword: vector
+# % keyword: import
+# % keyword: projection
+# %end
+# %option
+# % key: input
+# % type: string
+# % required: yes
+# % description: Name of OGR datasource to be imported
+# % gisprompt: old,datasource,datasource
+# % guisection: Input
+# %end
+# %option
+# % key: layer
+# % type: string
+# % multiple: yes
+# % description: OGR layer name. If not given, all available layers are imported
+# % guisection: Input
+# % gisprompt: old,datasource_layer,datasource_layer
+# %end
+# %option G_OPT_V_OUTPUT
+# % description: Name for output vector map (default: input)
+# % required: no
+# % guisection: Output
+# %end
+# %option
+# % key: extent
+# % type: string
+# % options: input,region
+# % answer: input
+# % description: Output vector map extent
+# % descriptions: input;extent of input map;region;extent of current region
+# % guisection: Output
+# %end
+# %option
+# % key: encoding
+# % type: string
+# % label: Encoding value for attribute data
+# % descriptions: Overrides encoding interpretation, useful when importing ESRI Shapefile
+# % guisection: Output
+# %end
+# %option
+# % key: snap
+# % type: double
+# % label: Snapping threshold for boundaries (map units)
+# % description: A suitable threshold is estimated during import
+# % answer: -1
+# % guisection: Output
+# %end
+# %option
+# % key: epsg
+# % type: integer
+# % options: 1-1000000
+# % guisection: Input SRS
+# % description: EPSG projection code
+# %end
+# %option
+# % key: datum_trans
+# % type: integer
+# % options: -1-100
+# % guisection: Input SRS
+# % label: Index number of datum transform parameters
+# % description: -1 to list available datum transform parameters
+# %end
+# %flag
+# % key: f
+# % description: List supported OGR formats and exit
+# % suppress_required: yes
+# %end
+# %flag
+# % key: l
+# % description: List available OGR layers in data source and exit
+# %end
+# %flag
+# % key: o
+# % label: Override projection check (use current location's projection)
+# % description: Assume that the dataset has the same projection as the current location
+# %end
 
 import sys
 import os

--- a/scripts/v.in.e00/v.in.e00.py
+++ b/scripts/v.in.e00/v.in.e00.py
@@ -21,22 +21,22 @@
 # REQUIREMENTS:
 #      -  avcimport: http://avce00.maptools.org
 
-#%module
-#% description: Imports E00 file into a vector map.
-#% keyword: vector
-#% keyword: import
-#% keyword: E00
-#%end
-#%option G_OPT_F_BIN_INPUT
-#% description: Name of input E00 file
-#%end
-#%option G_OPT_V_TYPE
-#% options: point,line,area
-#% answer: point
-#% required: yes
-#%end
-#%option G_OPT_V_OUTPUT
-#%end
+# %module
+# % description: Imports E00 file into a vector map.
+# % keyword: vector
+# % keyword: import
+# % keyword: E00
+# %end
+# %option G_OPT_F_BIN_INPUT
+# % description: Name of input E00 file
+# %end
+# %option G_OPT_V_TYPE
+# % options: point,line,area
+# % answer: point
+# % required: yes
+# %end
+# %option G_OPT_V_OUTPUT
+# %end
 
 import os
 import shutil

--- a/scripts/v.in.geonames/v.in.geonames.py
+++ b/scripts/v.in.geonames/v.in.geonames.py
@@ -22,17 +22,17 @@
 #       fix spurious char stuff in elevation column
 #############################################################################
 
-#%module
-#% description: Imports geonames.org country files into a vector points map.
-#% keyword: vector
-#% keyword: import
-#% keyword: gazetteer
-#%end
-#%option G_OPT_F_INPUT
-#% description: Name of uncompressed geonames file (with .txt extension)
-#%end
-#%option G_OPT_V_OUTPUT
-#%end
+# %module
+# % description: Imports geonames.org country files into a vector points map.
+# % keyword: vector
+# % keyword: import
+# % keyword: gazetteer
+# %end
+# %option G_OPT_F_INPUT
+# % description: Name of uncompressed geonames file (with .txt extension)
+# %end
+# %option G_OPT_V_OUTPUT
+# %end
 
 import os
 import sys

--- a/scripts/v.in.lines/v.in.lines.py
+++ b/scripts/v.in.lines/v.in.lines.py
@@ -15,24 +15,24 @@
 #               for details.
 #
 #############################################################################
-#%module
-#% description: Imports ASCII x,y[,z] coordinates as a series of lines.
-#% keyword: vector
-#% keyword: import
-#% keyword: line
-#% keyword: point
-#%end
-#%flag
-#% key: z
-#% description: Create a 3D line from 3 column data
-#%end
-#%option G_OPT_F_INPUT
-#% description: Name of input file (or "-" to read from stdin)
-#%end
-#%option G_OPT_V_OUTPUT
-#%end
-#%option G_OPT_F_SEP
-#%end
+# %module
+# % description: Imports ASCII x,y[,z] coordinates as a series of lines.
+# % keyword: vector
+# % keyword: import
+# % keyword: line
+# % keyword: point
+# %end
+# %flag
+# % key: z
+# % description: Create a 3D line from 3 column data
+# %end
+# %option G_OPT_F_INPUT
+# % description: Name of input file (or "-" to read from stdin)
+# %end
+# %option G_OPT_V_OUTPUT
+# %end
+# %option G_OPT_F_SEP
+# %end
 
 import sys
 import os

--- a/scripts/v.in.mapgen/v.in.mapgen.py
+++ b/scripts/v.in.mapgen/v.in.mapgen.py
@@ -23,26 +23,26 @@
 #                    http://www.ngdc.noaa.gov/mgg/shorelines/shorelines.html
 #
 
-#%module
-#% description: Imports Mapgen or Matlab-ASCII vector maps into GRASS.
-#% keyword: vector
-#% keyword: import
-#%end
-#%flag
-#% key: f
-#% description: Input map is in Matlab format
-#%end
-#%flag
-#% key: z
-#% description: Create a 3D vector points map from 3 column Matlab data
-#%end
-#%option G_OPT_F_INPUT
-#% description: Name of input file in Mapgen/Matlab format
-#%end
-#%option G_OPT_V_OUTPUT
-#% description: Name for output vector map (omit for display to stdout)
-#% required: no
-#%end
+# %module
+# % description: Imports Mapgen or Matlab-ASCII vector maps into GRASS.
+# % keyword: vector
+# % keyword: import
+# %end
+# %flag
+# % key: f
+# % description: Input map is in Matlab format
+# %end
+# %flag
+# % key: z
+# % description: Create a 3D vector points map from 3 column Matlab data
+# %end
+# %option G_OPT_F_INPUT
+# % description: Name of input file in Mapgen/Matlab format
+# %end
+# %option G_OPT_V_OUTPUT
+# % description: Name for output vector map (omit for display to stdout)
+# % required: no
+# %end
 
 import sys
 import os

--- a/scripts/v.in.wfs/v.in.wfs.py
+++ b/scripts/v.in.wfs/v.in.wfs.py
@@ -22,71 +22,71 @@
 #       http://pypi.python.org/pypi/OWSLib
 #
 
-#%Module
-#% description: Imports GetFeature from a WFS server.
-#% keyword: vector
-#% keyword: import
-#% keyword: OGC web services
-#% keyword: OGC WFS
-#%end
-#%option
-#% key: url
-#% type: string
-#% description: Base URL starting with 'http' and ending in '?'
-#% required: yes
-#%end
-#%option G_OPT_V_OUTPUT
-#%end
-#%option
-#% key: name
-#% type: string
-#% description: Comma separated names of data layers to download
-#% multiple: yes
-#% required: no
-#%end
-#%option
-#% key: srs
-#% type: string
-#% label: Specify alternate spatial reference system (example: EPSG:4326)
-#% description: The given code must be supported by the server, consult the capabilities file
-#% required: no
-#%end
-#%option
-#% key: maximum_features
-#% type: integer
-#% label: Maximum number of features to download
-#% description: (default: unlimited)
-#%end
-#%option
-#% key: start_index
-#% type: integer
-#% label: Skip earlier feature IDs and start downloading at this one
-#% description: (default: start with the first feature)
-#%end
-#%option
-#% key: username
-#% type: string
-#% required: no
-#% multiple: no
-#% label: Username or file with username or environment variable name with username
-#%end
-#%option
-#% key: password
-#% type: string
-#% required: no
-#% multiple: no
-#% label: Password or file with password or environment variable name with password
-#%end
-#%flag
-#% key: l
+# %Module
+# % description: Imports GetFeature from a WFS server.
+# % keyword: vector
+# % keyword: import
+# % keyword: OGC web services
+# % keyword: OGC WFS
+# %end
+# %option
+# % key: url
+# % type: string
+# % description: Base URL starting with 'http' and ending in '?'
+# % required: yes
+# %end
+# %option G_OPT_V_OUTPUT
+# %end
+# %option
+# % key: name
+# % type: string
+# % description: Comma separated names of data layers to download
+# % multiple: yes
+# % required: no
+# %end
+# %option
+# % key: srs
+# % type: string
+# % label: Specify alternate spatial reference system (example: EPSG:4326)
+# % description: The given code must be supported by the server, consult the capabilities file
+# % required: no
+# %end
+# %option
+# % key: maximum_features
+# % type: integer
+# % label: Maximum number of features to download
+# % description: (default: unlimited)
+# %end
+# %option
+# % key: start_index
+# % type: integer
+# % label: Skip earlier feature IDs and start downloading at this one
+# % description: (default: start with the first feature)
+# %end
+# %option
+# % key: username
+# % type: string
+# % required: no
+# % multiple: no
+# % label: Username or file with username or environment variable name with username
+# %end
+# %option
+# % key: password
+# % type: string
+# % required: no
+# % multiple: no
+# % label: Password or file with password or environment variable name with password
+# %end
+# %flag
+# % key: l
 # todo #% description: List available layers and exit
-#% description: Download server capabilities to 'wms_capabilities.xml' in the current directory and exit
-#% suppress_required: yes
-#%end
-#%flag
-#% key: r
-#% description: Restrict fetch to features which touch the current region
-#%end
+# % description: Download server capabilities to 'wms_capabilities.xml' in the current directory and exit
+# % suppress_required: yes
+# %end
+# %flag
+# % key: r
+# % description: Restrict fetch to features which touch the current region
+# %end
 
 
 import os

--- a/scripts/v.pack/v.pack.py
+++ b/scripts/v.pack/v.pack.py
@@ -14,24 +14,24 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports a vector map as GRASS GIS specific archive file
-#% keyword: vector
-#% keyword: export
-#% keyword: copying
-#%end
-#%option G_OPT_V_INPUT
-#% label: Name of vector map to pack up
-#% description:
-#%end
-#%option G_OPT_F_OUTPUT
-#% description: Name for output file (default is <input>.pack)
-#% required : no
-#%end
-#%flag
-#% key: c
-#% description: Switch the compression off
-#%end
+# %module
+# % description: Exports a vector map as GRASS GIS specific archive file
+# % keyword: vector
+# % keyword: export
+# % keyword: copying
+# %end
+# %option G_OPT_V_INPUT
+# % label: Name of vector map to pack up
+# % description:
+# %end
+# %option G_OPT_F_OUTPUT
+# % description: Name for output file (default is <input>.pack)
+# % required : no
+# %end
+# %flag
+# % key: c
+# % description: Switch the compression off
+# %end
 
 import os
 import sys

--- a/scripts/v.rast.stats/v.rast.stats.py
+++ b/scripts/v.rast.stats/v.rast.stats.py
@@ -17,61 +17,61 @@
 #
 #############################################################################
 
-#%module
-#% description: Calculates univariate statistics from a raster map based on a vector map and uploads statistics to new attribute columns.
-#% keyword: vector
-#% keyword: statistics
-#% keyword: raster
-#% keyword: univariate statistics
-#% keyword: zonal statistics
-#% keyword: sampling
-#% keyword: querying
-#%end
-#%flag
-#% key: c
-#% description: Continue if upload column(s) already exist
-#%end
-#%flag
-#% key: d
-#% label: Create densified lines (default: thin lines)
-#% description: All cells touched by the line will be set, not only those on the render path
-#%end
-#%option G_OPT_V_MAP
-#%end
-#%option G_OPT_V_FIELD
-#%end
-#%option G_OPT_V_TYPE
-#%end
-#%option G_OPT_DB_WHERE
-#%end
-#%option G_OPT_R_INPUTS
-#% key: raster
-#% description: Name of input raster map to calculate statistics from
-#%end
-#%option
-#% key: column_prefix
-#% type: string
-#% description: Column prefix for new attribute columns
-#% required : yes
-#% multiple: yes
-#%end
-#%option
-#% key: method
-#% type: string
-#% description: The methods to use
-#% required: no
-#% multiple: yes
-#% options: number,null_cells,minimum,maximum,range,average,stddev,variance,coeff_var,sum,first_quartile,median,third_quartile,percentile
-#% answer: number,null_cells,minimum,maximum,range,average,stddev,variance,coeff_var,sum,first_quartile,median,third_quartile,percentile
-#%end
-#%option
-#% key: percentile
-#% type: integer
-#% description: Percentile to calculate
-#% options: 0-100
-#% answer: 90
-#% required : no
-#%end
+# %module
+# % description: Calculates univariate statistics from a raster map based on a vector map and uploads statistics to new attribute columns.
+# % keyword: vector
+# % keyword: statistics
+# % keyword: raster
+# % keyword: univariate statistics
+# % keyword: zonal statistics
+# % keyword: sampling
+# % keyword: querying
+# %end
+# %flag
+# % key: c
+# % description: Continue if upload column(s) already exist
+# %end
+# %flag
+# % key: d
+# % label: Create densified lines (default: thin lines)
+# % description: All cells touched by the line will be set, not only those on the render path
+# %end
+# %option G_OPT_V_MAP
+# %end
+# %option G_OPT_V_FIELD
+# %end
+# %option G_OPT_V_TYPE
+# %end
+# %option G_OPT_DB_WHERE
+# %end
+# %option G_OPT_R_INPUTS
+# % key: raster
+# % description: Name of input raster map to calculate statistics from
+# %end
+# %option
+# % key: column_prefix
+# % type: string
+# % description: Column prefix for new attribute columns
+# % required : yes
+# % multiple: yes
+# %end
+# %option
+# % key: method
+# % type: string
+# % description: The methods to use
+# % required: no
+# % multiple: yes
+# % options: number,null_cells,minimum,maximum,range,average,stddev,variance,coeff_var,sum,first_quartile,median,third_quartile,percentile
+# % answer: number,null_cells,minimum,maximum,range,average,stddev,variance,coeff_var,sum,first_quartile,median,third_quartile,percentile
+# %end
+# %option
+# % key: percentile
+# % type: integer
+# % description: Percentile to calculate
+# % options: 0-100
+# % answer: 90
+# % required : no
+# %end
 
 import sys
 import os

--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -14,42 +14,42 @@
 #
 #############################################################################
 
-#%module
-#% description: Reports geometry statistics for vector maps.
-#% keyword: vector
-#% keyword: geometry
-#% keyword: statistics
-#%end
-#%option G_OPT_V_MAP
-#%end
-#%option G_OPT_V_FIELD
-#% guisection: Selection
-#%end
-#%option
-#% key: option
-#% type: string
-#% description: Value to calculate
-#% options: area,length,coor
-#% required: yes
-#%end
-#%option G_OPT_M_UNITS
-#% options: miles,feet,meters,kilometers,acres,hectares,percent
-#%end
-#%option
-#% key: sort
-#% type: string
-#% description: Sort the result
-#% options: asc,desc
-#% descriptions: asc;Sort in ascending order;desc;Sort in descending order
-#%end
-#%flag
-#% key: c
-#% description: Do not include column names in output
-#%end
-#%flag
-#% key: d
-#% description: Report for geometries with no database records
-#%end
+# %module
+# % description: Reports geometry statistics for vector maps.
+# % keyword: vector
+# % keyword: geometry
+# % keyword: statistics
+# %end
+# %option G_OPT_V_MAP
+# %end
+# %option G_OPT_V_FIELD
+# % guisection: Selection
+# %end
+# %option
+# % key: option
+# % type: string
+# % description: Value to calculate
+# % options: area,length,coor
+# % required: yes
+# %end
+# %option G_OPT_M_UNITS
+# % options: miles,feet,meters,kilometers,acres,hectares,percent
+# %end
+# %option
+# % key: sort
+# % type: string
+# % description: Sort the result
+# % options: asc,desc
+# % descriptions: asc;Sort in ascending order;desc;Sort in descending order
+# %end
+# %flag
+# % key: c
+# % description: Do not include column names in output
+# %end
+# %flag
+# % key: d
+# % description: Report for geometries with no database records
+# %end
 
 import sys
 import os

--- a/scripts/v.to.lines/v.to.lines.py
+++ b/scripts/v.to.lines/v.to.lines.py
@@ -16,29 +16,29 @@
 #    support centroids (treat as points)?
 #############################################################################
 
-#%module
-#% description: Converts vector polygons or points to lines.
-#% keyword: vector
-#% keyword: geometry
-#% keyword: area
-#% keyword: line
-#% keyword: point
-#%end
+# %module
+# % description: Converts vector polygons or points to lines.
+# % keyword: vector
+# % keyword: geometry
+# % keyword: area
+# % keyword: line
+# % keyword: point
+# %end
 
-#%option G_OPT_V_INPUT
-#%end
+# %option G_OPT_V_INPUT
+# %end
 
-#%option G_OPT_V_OUTPUT
-#%end
+# %option G_OPT_V_OUTPUT
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Method used for point interpolation
-#% options: delaunay
-#% answer: delaunay
-#% guisection: Area
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Method used for point interpolation
+# % options: delaunay
+# % answer: delaunay
+# % guisection: Area
+# %end
 
 import grass.script as grass
 from grass.script.utils import decode

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -14,33 +14,33 @@
 #
 #############################################################################
 
-#%module
-#% description: Imports a GRASS GIS specific vector archive file (packed with v.pack) as a vector map
-#% keyword: vector
-#% keyword: import
-#% keyword: copying
-#%end
-#%option G_OPT_F_BIN_INPUT
-#% description: Name of input pack file
-#% key_desc: name.pack
-#%end
-#%option G_OPT_V_OUTPUT
-#% label: Name for output vector map
-#% description: Default: taken from input file internals
-#% required : no
-#% guisection: Output settings
-#%end
-#%flag
-#% key: o
-#% label: Override projection check (use current location's projection)
-#% description: Assume that the dataset has same projection as the current location
-#% guisection: Output settings
-#%end
-#%flag
-#% key: p
-#% label: Print projection information of input pack file and exit
-#% guisection: Print
-#%end
+# %module
+# % description: Imports a GRASS GIS specific vector archive file (packed with v.pack) as a vector map
+# % keyword: vector
+# % keyword: import
+# % keyword: copying
+# %end
+# %option G_OPT_F_BIN_INPUT
+# % description: Name of input pack file
+# % key_desc: name.pack
+# %end
+# %option G_OPT_V_OUTPUT
+# % label: Name for output vector map
+# % description: Default: taken from input file internals
+# % required : no
+# % guisection: Output settings
+# %end
+# %flag
+# % key: o
+# % label: Override projection check (use current location's projection)
+# % description: Assume that the dataset has same projection as the current location
+# % guisection: Output settings
+# %end
+# %flag
+# % key: p
+# % label: Print projection information of input pack file and exit
+# % guisection: Print
+# %end
 
 import os
 import sys

--- a/scripts/v.what.strds/v.what.strds.py
+++ b/scripts/v.what.strds/v.what.strds.py
@@ -14,40 +14,40 @@
 #
 #############################################################################
 
-#%module
-#% description: Uploads space time raster dataset values at positions of vector points to the table.
-#% keyword: vector
-#% keyword: temporal
-#% keyword: sampling
-#% keyword: position
-#% keyword: querying
-#% keyword: attribute table
-#% keyword: time
-#%end
+# %module
+# % description: Uploads space time raster dataset values at positions of vector points to the table.
+# % keyword: vector
+# % keyword: temporal
+# % keyword: sampling
+# % keyword: position
+# % keyword: querying
+# % keyword: attribute table
+# % keyword: time
+# %end
 
-#%option G_OPT_V_INPUT
-#%end
+# %option G_OPT_V_INPUT
+# %end
 
-#%option G_OPT_STRDS_INPUTS
-#% key: strds
-#%end
+# %option G_OPT_STRDS_INPUTS
+# % key: strds
+# %end
 
-#%option G_OPT_V_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_V_OUTPUT
+# % required: no
+# %end
 
-#%option G_OPT_DB_WHERE
-#%end
+# %option G_OPT_DB_WHERE
+# %end
 
-#%option G_OPT_T_WHERE
-#% key: t_where
-#%end
+# %option G_OPT_T_WHERE
+# % key: t_where
+# %end
 
-#%flag
-#% key: u
-#% label: Update attribute table of input vector map
-#% description: Instead of creating a new vector map update the attribute table with value(s)
-#%end
+# %flag
+# % key: u
+# % label: Update attribute table of input vector map
+# % description: Instead of creating a new vector map update the attribute table with value(s)
+# %end
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/scripts/v.what.vect/v.what.vect.py
+++ b/scripts/v.what.vect/v.what.vect.py
@@ -13,49 +13,49 @@
 #
 #############################################################################
 
-#%module
-#% description: Uploads vector values at positions of vector points to the table.
-#% keyword: vector
-#% keyword: sampling
-#% keyword: database
-#% keyword: position
-#% keyword: querying
-#% keyword: attribute table
-#%end
+# %module
+# % description: Uploads vector values at positions of vector points to the table.
+# % keyword: vector
+# % keyword: sampling
+# % keyword: database
+# % keyword: position
+# % keyword: querying
+# % keyword: attribute table
+# %end
 
-#%option G_OPT_V_MAP
-#% label: Name of vector points map for which to edit attributes
-#% guidependency: layer,column
-#%end
-#%option G_OPT_V_FIELD
-#% guidependency: column
-#%end
-#%option G_OPT_DB_COLUMN
-#% description: Name of attribute column to be updated with the query result
-#% required: yes
-#%end
-#%option G_OPT_V_MAP
-#% key: query_map
-#% label: Name of vector map to be queried
-#% required : yes
-#% guidependency: query_layer,query_column
-#%end
-#%option G_OPT_V_FIELD
-#% key: query_layer
-#% guidependency: query_column
-#%end
-#%option G_OPT_DB_COLUMN
-#% key: query_column
-#% description: Name of attribute column to be queried
-#% required: yes
-#%end
-#%option
-#% key: dmax
-#% type: double
-#% description: Maximum query distance in map units (meters for ll)
-#% answer: 0.0
-#% required: no
-#%end
+# %option G_OPT_V_MAP
+# % label: Name of vector points map for which to edit attributes
+# % guidependency: layer,column
+# %end
+# %option G_OPT_V_FIELD
+# % guidependency: column
+# %end
+# %option G_OPT_DB_COLUMN
+# % description: Name of attribute column to be updated with the query result
+# % required: yes
+# %end
+# %option G_OPT_V_MAP
+# % key: query_map
+# % label: Name of vector map to be queried
+# % required : yes
+# % guidependency: query_layer,query_column
+# %end
+# %option G_OPT_V_FIELD
+# % key: query_layer
+# % guidependency: query_column
+# %end
+# %option G_OPT_DB_COLUMN
+# % key: query_column
+# % description: Name of attribute column to be queried
+# % required: yes
+# %end
+# %option
+# % key: dmax
+# % type: double
+# % description: Maximum query distance in map units (meters for ll)
+# % answer: 0.0
+# % required: no
+# %end
 
 import sys
 from grass.script import core as grass

--- a/scripts/wxpyimgview/wxpyimgview.py
+++ b/scripts/wxpyimgview/wxpyimgview.py
@@ -18,24 +18,24 @@
 #
 # /
 
-#%module
-#% description: Views BMP images from the PNG driver.
-#% keyword: display
-#% keyword: graphics
-#% keyword: raster
-#%end
-#%option G_OPT_F_INPUT
-#% key: image
-#% description: Name of input image file
-#%end
-#%option
-#% key: percent
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Percentage of CPU time to use
-#% answer: 10
-#%end
+# %module
+# % description: Views BMP images from the PNG driver.
+# % keyword: display
+# % keyword: graphics
+# % keyword: raster
+# %end
+# %option G_OPT_F_INPUT
+# % key: image
+# % description: Name of input image file
+# %end
+# %option
+# % key: percent
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Percentage of CPU time to use
+# % answer: 10
+# %end
 
 import sys
 import os

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -18,23 +18,23 @@
 #
 # /
 
-#%module
-#% description: Views BMP images from the PNG driver.
-#% keyword: display
-#% keyword: raster
-#%end
-#%option G_OPT_F_INPUT
-#% key: image
-#% description: Name of input image file
-#%end
-#%option
-#% key: percent
-#% type: integer
-#% required: no
-#% multiple: no
-#% description: Percentage of CPU time to use
-#% answer: 10
-#%end
+# %module
+# % description: Views BMP images from the PNG driver.
+# % keyword: display
+# % keyword: raster
+# %end
+# %option G_OPT_F_INPUT
+# % key: image
+# % description: Name of input image file
+# %end
+# %option
+# % key: percent
+# % type: integer
+# % required: no
+# % multiple: no
+# % description: Percentage of CPU time to use
+# % answer: 10
+# %end
 
 import os
 import signal

--- a/temporal/t.create/t.create.py
+++ b/temporal/t.create/t.create.py
@@ -20,49 +20,49 @@
 #
 #############################################################################
 
-#%module
-#% description: Creates a space time dataset.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: create
-#% keyword: time
-#%end
+# %module
+# % description: Creates a space time dataset.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: create
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_OUTPUT
-#%end
+# %option G_OPT_STDS_OUTPUT
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% description: Type of the output space time dataset
-#%end
+# %option G_OPT_STDS_TYPE
+# % description: Type of the output space time dataset
+# %end
 
-#%option G_OPT_T_TYPE
-#%end
+# %option G_OPT_T_TYPE
+# %end
 
-#%option
-#% key: semantictype
-#% type: string
-#% description: Semantic type of the space time dataset
-#% required: yes
-#% multiple: no
-#% options: min,max,sum,mean
-#% answer: mean
-#%end
+# %option
+# % key: semantictype
+# % type: string
+# % description: Semantic type of the space time dataset
+# % required: yes
+# % multiple: no
+# % options: min,max,sum,mean
+# % answer: mean
+# %end
 
-#%option
-#% key: title
-#% type: string
-#% description: Title of the new space time dataset
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: title
+# % type: string
+# % description: Title of the new space time dataset
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: description
-#% type: string
-#% description: Description of the new space time dataset
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: description
+# % type: string
+# % description: Description of the new space time dataset
+# % required: yes
+# % multiple: no
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.info/t.info.py
+++ b/temporal/t.info/t.info.py
@@ -20,39 +20,39 @@
 #
 #############################################################################
 
-#%module
-#% description: Lists information about space time datasets and maps.
-#% keyword: temporal
-#% keyword: metadata
-#% keyword: extent
-#% keyword: time
-#%end
+# %module
+# % description: Lists information about space time datasets and maps.
+# % keyword: temporal
+# % keyword: metadata
+# % keyword: extent
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% description: Name of an existing space time dataset or map
-#%end
+# %option G_OPT_STDS_INPUT
+# % description: Name of an existing space time dataset or map
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#% options: strds, str3ds, stvds, raster, raster_3d, vector
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# % options: strds, str3ds, stvds, raster, raster_3d, vector
+# %end
 
-#%flag
-#% key: g
-#% description: Print in shell script style
-#%end
+# %flag
+# % key: g
+# % description: Print in shell script style
+# %end
 
-#%flag
-#% key: h
-#% description: Print history information in human readable shell style for space time datasets
-#%end
+# %flag
+# % key: h
+# % description: Print history information in human readable shell style for space time datasets
+# %end
 
-#%flag
-#% key: d
-#% description: Print information about the temporal DBMI interface and exit
-#% suppress_required: yes
-#%end
+# %flag
+# % key: d
+# % description: Print information about the temporal DBMI interface and exit
+# % suppress_required: yes
+# %end
 from __future__ import print_function
 
 import grass.script as grass

--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -20,72 +20,72 @@
 #
 #############################################################################
 
-#%module
-#% description: Lists space time datasets and maps registered in the temporal database.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: list
-#% keyword: time
-#%end
+# %module
+# % description: Lists space time datasets and maps registered in the temporal database.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: list
+# % keyword: time
+# %end
 
-#%option
-#% key: type
-#% type: string
-#% description: Type of the space time dataset or map, default is strds
-#% guisection: Selection
-#% required: no
-#% options: strds, str3ds, stvds, raster, raster_3d, vector
-#% answer: strds
-#%end
+# %option
+# % key: type
+# % type: string
+# % description: Type of the space time dataset or map, default is strds
+# % guisection: Selection
+# % required: no
+# % options: strds, str3ds, stvds, raster, raster_3d, vector
+# % answer: strds
+# %end
 
-#%option G_OPT_T_TYPE
-#% multiple: yes
-#% answer: absolute,relative
-#% guisection: Selection
-#%end
+# %option G_OPT_T_TYPE
+# % multiple: yes
+# % answer: absolute,relative
+# % guisection: Selection
+# %end
 
-#%option
-#% key: order
-#% type: string
-#% description: Columns number_of_maps and granularity only available for space time datasets
-#% label: Sort the space time dataset by category
-#% guisection: Formatting
-#% required: no
-#% multiple: yes
-#% options: id,name,band_reference,creator,mapset,number_of_maps,creation_time,start_time,end_time,interval,north,south,west,east,granularity
-#% answer: id
-#%end
+# %option
+# % key: order
+# % type: string
+# % description: Columns number_of_maps and granularity only available for space time datasets
+# % label: Sort the space time dataset by category
+# % guisection: Formatting
+# % required: no
+# % multiple: yes
+# % options: id,name,band_reference,creator,mapset,number_of_maps,creation_time,start_time,end_time,interval,north,south,west,east,granularity
+# % answer: id
+# %end
 
-#%option
-#% key: columns
-#% type: string
-#% description: Columns number_of_maps and granularity only available for space time datasets
-#% label: Columns to be printed to stdout
-#% guisection: Selection
-#% required: no
-#% multiple: yes
-#% options: id,name,band_reference,creator,mapset,number_of_maps,creation_time,start_time,end_time,north,south,west,east,granularity,all
-#% answer: id
-#%end
+# %option
+# % key: columns
+# % type: string
+# % description: Columns number_of_maps and granularity only available for space time datasets
+# % label: Columns to be printed to stdout
+# % guisection: Selection
+# % required: no
+# % multiple: yes
+# % options: id,name,band_reference,creator,mapset,number_of_maps,creation_time,start_time,end_time,north,south,west,east,granularity,all
+# % answer: id
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%flag
-#% key: c
-#% description: Print the column names as first row
-#% guisection: Formatting
-#%end
+# %flag
+# % key: c
+# % description: Print the column names as first row
+# % guisection: Formatting
+# %end
 
 from __future__ import print_function
 import grass.script as gscript

--- a/temporal/t.merge/t.merge.py
+++ b/temporal/t.merge/t.merge.py
@@ -20,24 +20,24 @@
 #
 #############################################################################
 
-#%module
-#% description: Merges several space time datasets into a single space time dataset.
-#% keyword: temporal
-#% keyword: time management
-#% keyword: merge
-#% keyword: time
-#%end
+# %module
+# % description: Merges several space time datasets into a single space time dataset.
+# % keyword: temporal
+# % keyword: time management
+# % keyword: merge
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUTS
-#%end
+# %option G_OPT_STDS_INPUTS
+# %end
 
-#%option G_OPT_STDS_OUTPUT
-#%end
+# %option G_OPT_STDS_OUTPUT
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: inputs
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: inputs
+# % guisection: Required
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -20,120 +20,120 @@
 #
 #############################################################################
 
-#%module
-#% description: Detects accumulation patterns in temporally accumulated space time raster datasets created by t.rast.accumulate.
-#% keyword: temporal
-#% keyword: accumulation
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Detects accumulation patterns in temporally accumulated space time raster datasets created by t.rast.accumulate.
+# % keyword: temporal
+# % keyword: accumulation
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#% key: minimum
-#% description: Input space time raster dataset that specifies the minimum values to detect the accumulation pattern
-#% required: no
-#%end
+# %option G_OPT_STRDS_INPUT
+# % key: minimum
+# % description: Input space time raster dataset that specifies the minimum values to detect the accumulation pattern
+# % required: no
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#% key: maximum
-#% description: Input space time raster dataset that specifies the maximum values to detect the accumulation pattern
-#% required: no
-#%end
+# %option G_OPT_STRDS_INPUT
+# % key: maximum
+# % description: Input space time raster dataset that specifies the maximum values to detect the accumulation pattern
+# % required: no
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#% key: occurrence
-#% description: The output space time raster dataset that stores the occurrence of the the accumulation pattern using the provided data range
-#% required: yes
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# % key: occurrence
+# % description: The output space time raster dataset that stores the occurrence of the the accumulation pattern using the provided data range
+# % required: yes
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#% key: indicator
-#% description: The output space time raster dataset that stores the indication of the start, intermediate and end of the specified data range
-#% required: no
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# % key: indicator
+# % description: The output space time raster dataset that stores the indication of the start, intermediate and end of the specified data range
+# % required: no
+# %end
 
-#%option
-#% key: start
-#% type: string
-#% description: The temporal starting point to begin the accumulation, eg '2001-01-01'
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: start
+# % type: string
+# % description: The temporal starting point to begin the accumulation, eg '2001-01-01'
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: stop
-#% type: string
-#% description: The temporal date to stop the accumulation, eg '2009-01-01'
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: stop
+# % type: string
+# % description: The temporal date to stop the accumulation, eg '2009-01-01'
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: cycle
-#% type: string
-#% description: The temporal cycle to restart the accumulation, eg '12 months'
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: cycle
+# % type: string
+# % description: The temporal cycle to restart the accumulation, eg '12 months'
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: offset
-#% type: string
-#% description: The temporal offset to the begin of the next cycle, eg '6 months'
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: offset
+# % type: string
+# % description: The temporal offset to the begin of the next cycle, eg '6 months'
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'count' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'count' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: range
-#% type: double
-#% key_desc: min,max
-#% description: The minimum and maximum value of the occurrence of accumulated values, these values will be used if the min/max space time raster datasets are not specified
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: range
+# % type: double
+# % key_desc: min,max
+# % description: The minimum and maximum value of the occurrence of accumulated values, these values will be used if the min/max space time raster datasets are not specified
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: staend
-#% type: integer
-#% key_desc: start,intermediate,end
-#% description: The user defined values that indicate start, intermediate and end status in the indicator output space time raster dataset
-#% answer: 1,2,3
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: staend
+# % type: integer
+# % key_desc: start,intermediate,end
+# % description: The user defined values that indicate start, intermediate and end status in the indicator output space time raster dataset
+# % answer: 1,2,3
+# % required: no
+# % multiple: no
+# %end
 
-#%flag
-#% key: n
-#% description: Register empty maps in the output space time raster dataset, otherwise they will be deleted
-#%end
+# %flag
+# % key: n
+# % description: Register empty maps in the output space time raster dataset, otherwise they will be deleted
+# %end
 
-#%flag
-#% key: r
-#% description: Reverse time direction in cyclic accumulation
-#%end
+# %flag
+# % key: r
+# % description: Reverse time direction in cyclic accumulation
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -20,138 +20,138 @@
 #
 #############################################################################
 
-#%module
-#% description: Computes cyclic accumulations of a space time raster dataset.
-#% keyword: temporal
-#% keyword: accumulation
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Computes cyclic accumulations of a space time raster dataset.
+# % keyword: temporal
+# % keyword: accumulation
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
 
-#%option G_OPT_STRDS_INPUT
-#% key: lower
-#% description: Input space time raster dataset that defines the lower threshold, values lower than this threshold are excluded from accumulation
-#% required: no
-#%end
+# %option G_OPT_STRDS_INPUT
+# % key: lower
+# % description: Input space time raster dataset that defines the lower threshold, values lower than this threshold are excluded from accumulation
+# % required: no
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#% key: upper
-#% description: Input space time raster dataset that defines the upper threshold, values higher than this threshold are excluded from accumulation
-#% required: no
-#%end
+# %option G_OPT_STRDS_INPUT
+# % key: upper
+# % description: Input space time raster dataset that defines the upper threshold, values higher than this threshold are excluded from accumulation
+# % required: no
+# %end
 
-#%option
-#% key: start
-#% type: string
-#% description: The temporal starting point to begin the accumulation, eg '2001-01-01'
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: start
+# % type: string
+# % description: The temporal starting point to begin the accumulation, eg '2001-01-01'
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: stop
-#% type: string
-#% description: The temporal date to stop the accumulation, eg '2009-01-01'
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: stop
+# % type: string
+# % description: The temporal date to stop the accumulation, eg '2009-01-01'
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: cycle
-#% type: string
-#% description: The temporal cycle to restart the accumulation, eg '12 months'
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: cycle
+# % type: string
+# % description: The temporal cycle to restart the accumulation, eg '12 months'
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: offset
-#% type: string
-#% description: The temporal offset to the beginning of the next cycle, eg '6 months'
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: offset
+# % type: string
+# % description: The temporal offset to the beginning of the next cycle, eg '6 months'
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: granularity
-#% type: string
-#% description: The granularity for accumulation '1 day'
-#% answer: 1 day
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: granularity
+# % type: string
+# % description: The granularity for accumulation '1 day'
+# % answer: 1 day
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add to the basename. Set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add to the basename. Set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: limits
-#% type: double
-#% key_desc: lower,upper
-#% description: Use these limits in case lower and/or upper input space time raster datasets are not defined or contain NULL values
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: limits
+# % type: double
+# % key_desc: lower,upper
+# % description: Use these limits in case lower and/or upper input space time raster datasets are not defined or contain NULL values
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: scale
-#% type: double
-#% description: Scale factor for input space time raster dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: scale
+# % type: double
+# % description: Scale factor for input space time raster dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: shift
-#% type: double
-#% description: Shift factor for input space time raster dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: shift
+# % type: double
+# % description: Shift factor for input space time raster dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% label: This method will be applied to compute the accumulative values from the input maps in a single granule
-#% description: Growing Degree Days or Winkler indices; Mean: sum(input maps)/(number of input maps); Biologically Effective Degree Days; Huglin Heliothermal index
-#% options: mean,gdd,bedd,huglin
-#% answer: mean
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: method
+# % type: string
+# % label: This method will be applied to compute the accumulative values from the input maps in a single granule
+# % description: Growing Degree Days or Winkler indices; Mean: sum(input maps)/(number of input maps); Biologically Effective Degree Days; Huglin Heliothermal index
+# % options: mean,gdd,bedd,huglin
+# % answer: mean
+# % required: no
+# % multiple: no
+# %end
 
-#%flag
-#% key: n
-#% description: Register empty maps in the output space time raster dataset, otherwise they will be deleted
-#%end
+# %flag
+# % key: n
+# % description: Register empty maps in the output space time raster dataset, otherwise they will be deleted
+# %end
 
-#%flag
-#% key: r
-#% description: Reverse time direction in cyclic accumulation
-#%end
+# %flag
+# % key: r
+# % description: Reverse time direction in cyclic accumulation
+# %end
 from __future__ import print_function
 
 import grass.script as grass

--- a/temporal/t.rast.aggregate.ds/t.rast.aggregate.ds.py
+++ b/temporal/t.rast.aggregate.ds/t.rast.aggregate.ds.py
@@ -20,88 +20,88 @@
 #
 #############################################################################
 
-#%module
-#% description: Aggregates data of an existing space time raster dataset using the time intervals of a second space time dataset.
-#% keyword: temporal
-#% keyword: aggregation
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Aggregates data of an existing space time raster dataset using the time intervals of a second space time dataset.
+# % keyword: temporal
+# % keyword: aggregation
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% key: sample
-#% description: Time intervals from this space time dataset (raster, vector or raster3d) are used for aggregation computation
-#%end
+# %option G_OPT_STDS_INPUT
+# % key: sample
+# % description: Time intervals from this space time dataset (raster, vector or raster3d) are used for aggregation computation
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% description: Type of the space time dataset from which aggregation will be copied
-#%end
+# %option G_OPT_STDS_TYPE
+# % description: Type of the space time dataset from which aggregation will be copied
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Aggregate operation to be performed on the raster maps
-#% required: yes
-#% multiple: no
-#% options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
-#% answer: average
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Aggregate operation to be performed on the raster maps
+# % required: yes
+# % multiple: no
+# % options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
+# % answer: average
+# %end
 
-#%option
-#% key: offset
-#% type: integer
-#% description: Offset that is used to create the output map ids, output map id is generated as: basename_ (count + offset)
-#% required: no
-#% multiple: no
-#% answer: 0
-#%end
+# %option
+# % key: offset
+# % type: integer
+# % description: Offset that is used to create the output map ids, output map id is generated as: basename_ (count + offset)
+# % required: no
+# % multiple: no
+# % answer: 0
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%option G_OPT_T_SAMPLE
-#% options: equal,overlaps,overlapped,starts,started,finishes,finished,during,contains
-#% answer: contains
-#%end
+# %option G_OPT_T_SAMPLE
+# % options: equal,overlaps,overlapped,starts,started,finishes,finished,during,contains
+# % answer: contains
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
 import grass.script as gcore
 

--- a/temporal/t.rast.aggregate/t.rast.aggregate.py
+++ b/temporal/t.rast.aggregate/t.rast.aggregate.py
@@ -20,96 +20,96 @@
 #
 #############################################################################
 
-#%module
-#% description: Aggregates temporally the maps of a space time raster dataset by a user defined granularity.
-#% keyword: temporal
-#% keyword: aggregation
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Aggregates temporally the maps of a space time raster dataset by a user defined granularity.
+# % keyword: temporal
+# % keyword: aggregation
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: Either a numerical suffix or the start time (s-flag) separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: Either a numerical suffix or the start time (s-flag) separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: granularity
-#% type: string
-#% description: Aggregation granularity, format absolute time "x years, x months, x weeks, x days, x hours, x minutes, x seconds" or an integer value for relative time
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: granularity
+# % type: string
+# % description: Aggregation granularity, format absolute time "x years, x months, x weeks, x days, x hours, x minutes, x seconds" or an integer value for relative time
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Aggregate operation to be performed on the raster maps
-#% required: yes
-#% multiple: no
-#% options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
-#% answer: average
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Aggregate operation to be performed on the raster maps
+# % required: yes
+# % multiple: no
+# % options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
+# % answer: average
+# %end
 
-#%option
-#% key: offset
-#% type: integer
-#% description: Offset that is used to create the output map ids, output map id is generated as: basename_ (count + offset)
-#% required: no
-#% multiple: no
-#% answer: 0
-#%end
+# %option
+# % key: offset
+# % type: integer
+# % description: Offset that is used to create the output map ids, output map id is generated as: basename_ (count + offset)
+# % required: no
+# % multiple: no
+# % answer: 0
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.series processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.series processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%option
-#% key: file_limit
-#% type: integer
-#% description: The maximum number of open files allowed for each r.series process
-#% required: no
-#% multiple: no
-#% answer: 1000
-#%end
+# %option
+# % key: file_limit
+# % type: integer
+# % description: The maximum number of open files allowed for each r.series process
+# % required: no
+# % multiple: no
+# % answer: 1000
+# %end
 
-#%option G_OPT_T_SAMPLE
-#% options: equal,overlaps,overlapped,starts,started,finishes,finished,during,contains
-#% answer: contains
-#%end
+# %option G_OPT_T_SAMPLE
+# % options: equal,overlaps,overlapped,starts,started,finishes,finished,during,contains
+# % answer: contains
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
 import grass.script as gcore
 

--- a/temporal/t.rast.algebra/t.rast.algebra.py
+++ b/temporal/t.rast.algebra/t.rast.algebra.py
@@ -22,66 +22,66 @@
 #
 #############################################################################
 
-#%module
-#% description: Apply temporal and spatial operations on space time raster datasets using temporal raster algebra.
-#% keyword: temporal
-#% keyword: algebra
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Apply temporal and spatial operations on space time raster datasets using temporal raster algebra.
+# % keyword: temporal
+# % keyword: algebra
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: r.mapcalc expression for temporal and spatial analysis of space time raster datasets
-#% required : yes
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: r.mapcalc expression for temporal and spatial analysis of space time raster datasets
+# % required : yes
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: num
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: num
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: s
-#% description: Check the spatial topology of temporally related maps and process only spatially related maps
-#%end
+# %flag
+# % key: s
+# % description: Check the spatial topology of temporally related maps and process only spatially related maps
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
-#%flag
-#% key: g
-#% description: Use granularity sampling instead of the temporal topology approach
-#%end
+# %flag
+# % key: g
+# % description: Use granularity sampling instead of the temporal topology approach
+# %end
 
-#%flag
-#% key: d
-#% description: Perform a dry run, compute all dependencies and module calls but don't run them
-#%end
+# %flag
+# % key: d
+# % description: Perform a dry run, compute all dependencies and module calls but don't run them
+# %end
 
 import grass.script
 import sys

--- a/temporal/t.rast.colors/t.rast.colors.py
+++ b/temporal/t.rast.colors/t.rast.colors.py
@@ -20,87 +20,87 @@
 #
 #############################################################################
 
-#%module
-#% description: Creates/modifies the color table associated with each raster map of the space time raster dataset.
-#% keyword: temporal
-#% keyword: color table
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Creates/modifies the color table associated with each raster map of the space time raster dataset.
+# % keyword: temporal
+# % keyword: color table
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_M_COLR
-#% key: color
-#% type: string
-#% description: Name of color table (see r.color help)
-#% required: no
-#% multiple: no
-#% guisection: Define
-#%end
+# %option G_OPT_M_COLR
+# % key: color
+# % type: string
+# % description: Name of color table (see r.color help)
+# % required: no
+# % multiple: no
+# % guisection: Define
+# %end
 
-#%option G_OPT_R_INPUT
-#% key: raster
-#% description: Raster map from which to copy color table
-#% required: no
-#% guisection: Define
-#%end
+# %option G_OPT_R_INPUT
+# % key: raster
+# % description: Raster map from which to copy color table
+# % required: no
+# % guisection: Define
+# %end
 
-#%option G_OPT_R3_INPUT
-#% key: raster_3d
-#% description: 3D raster map from which to copy color table
-#% required: no
-#% guisection: Define
-#%end
+# %option G_OPT_R3_INPUT
+# % key: raster_3d
+# % description: 3D raster map from which to copy color table
+# % required: no
+# % guisection: Define
+# %end
 
-#%option G_OPT_F_INPUT
-#% key: rules
-#% description: Path to rules file
-#% required: no
-#% guisection: Define
-#%end
+# %option G_OPT_F_INPUT
+# % key: rules
+# % description: Path to rules file
+# % required: no
+# % guisection: Define
+# %end
 
-#%flag
-#% key: r
-#% description: Remove existing color table
-#% guisection: Remove
-#%end
+# %flag
+# % key: r
+# % description: Remove existing color table
+# % guisection: Remove
+# %end
 
-#%flag
-#% key: w
-#% description: Only write new color table if it does not already exist
-#%end
+# %flag
+# % key: w
+# % description: Only write new color table if it does not already exist
+# %end
 
-#%flag
-#% key: l
-#% description: List available rules then exit
-#% guisection: Print
-#%end
+# %flag
+# % key: l
+# % description: List available rules then exit
+# % guisection: Print
+# %end
 
-#%flag
-#% key: n
-#% description: Invert colors
-#% guisection: Define
-#%end
+# %flag
+# % key: n
+# % description: Invert colors
+# % guisection: Define
+# %end
 
-#%flag
-#% key: g
-#% description: Logarithmic scaling
-#% guisection: Define
-#%end
+# %flag
+# % key: g
+# % description: Logarithmic scaling
+# % guisection: Define
+# %end
 
-#%flag
-#% key: a
-#% description: Logarithmic-absolute scaling
-#% guisection: Define
-#%end
+# %flag
+# % key: a
+# % description: Logarithmic-absolute scaling
+# % guisection: Define
+# %end
 
-#%flag
-#% key: e
-#% description: Histogram equalization
-#% guisection: Define
-#%end
+# %flag
+# % key: e
+# % description: Histogram equalization
+# % guisection: Define
+# %end
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/temporal/t.rast.contour/t.rast.contour.py
+++ b/temporal/t.rast.contour/t.rast.contour.py
@@ -20,101 +20,101 @@
 #
 #############################################################################
 
-#%module
-#% description: Produces a space time vector dataset of specified contours from a space time raster dataset.
-#% keyword: temporal
-#% keyword: contour
-#% keyword: raster
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Produces a space time vector dataset of specified contours from a space time raster dataset.
+# % keyword: temporal
+# % keyword: contour
+# % keyword: raster
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STVDS_OUTPUT
-#%end
+# %option G_OPT_STVDS_OUTPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: step
-#% type: double
-#% description: Increment between contour levels
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: step
+# % type: double
+# % description: Increment between contour levels
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: levels
-#% type: double
-#% description: List of contour levels
-#% required: no
-#% multiple: yes
-#%end
+# %option
+# % key: levels
+# % type: double
+# % description: List of contour levels
+# % required: no
+# % multiple: yes
+# %end
 
-#%option
-#% key: minlevel
-#% type:  double
-#% description: Minimum contour level
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: minlevel
+# % type:  double
+# % description: Minimum contour level
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: maxlevel
-#% type: double
-#% description: Maximum contour level
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: maxlevel
+# % type: double
+# % description: Maximum contour level
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: cut
-#% type: integer
-#% description: Minimum number of points for a contour line (0 -> no limit)
-#% required: no
-#% multiple: no
-#% answer: 0
-#%end
+# %option
+# % key: cut
+# % type: integer
+# % description: Minimum number of points for a contour line (0 -> no limit)
+# % required: no
+# % multiple: no
+# % answer: 0
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.contour processes to run in parallel, more than 1 process works only in conjunction with flag -t
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.contour processes to run in parallel, more than 1 process works only in conjunction with flag -t
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register empty vector maps
-#%end
+# %flag
+# % key: n
+# % description: Register empty vector maps
+# %end
 
-#%flag
-#% key: t
-#% description: Do not create attribute tables
-#%end
+# %flag
+# % key: t
+# % description: Do not create attribute tables
+# %end
 
 import sys
 import copy

--- a/temporal/t.rast.export/t.rast.export.py
+++ b/temporal/t.rast.export/t.rast.export.py
@@ -20,87 +20,87 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports space time raster dataset.
-#% keyword: temporal
-#% keyword: export
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Exports space time raster dataset.
+# % keyword: temporal
+# % keyword: export
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% description: Name of a space time raster dataset archive
-#%end
+# %option G_OPT_F_OUTPUT
+# % description: Name of a space time raster dataset archive
+# %end
 
-#%option G_OPT_M_DIR
-#% key: directory
-#% description: Path to the work directory, default is /tmp
-#% required: no
-#% answer: /tmp
-#%end
+# %option G_OPT_M_DIR
+# % key: directory
+# % description: Path to the work directory, default is /tmp
+# % required: no
+# % answer: /tmp
+# %end
 
-#%option
-#% key: compression
-#% type: string
-#% description: Compression method of the tar archive
-#% required: no
-#% multiple: no
-#% options: no,gzip,bzip2
-#% answer: bzip2
-#%end
+# %option
+# % key: compression
+# % type: string
+# % description: Compression method of the tar archive
+# % required: no
+# % multiple: no
+# % options: no,gzip,bzip2
+# % answer: bzip2
+# %end
 
-#%option
-#% key: format
-#% type: string
-#% label: The export format of a single raster map
-#% description: Supported are GTiff, AAIGrid via r.out.gdal and the GRASS package format of r.pack
-#% required: no
-#% multiple: no
-#% options: GTiff,AAIGrid,pack
-#% answer: GTiff
-#%end
+# %option
+# % key: format
+# % type: string
+# % label: The export format of a single raster map
+# % description: Supported are GTiff, AAIGrid via r.out.gdal and the GRASS package format of r.pack
+# % required: no
+# % multiple: no
+# % options: GTiff,AAIGrid,pack
+# % answer: GTiff
+# %end
 
-#%option
-#% key: type
-#% type: string
-#% label: Data type
-#% description: Supported only for GTiff
-#% required: no
-#% multiple: no
-#% options: Byte,Int16,UInt16,Int32,UInt32,Float32,Float64,CInt16,CInt32,CFloat32,CFloat64
-#%end
+# %option
+# % key: type
+# % type: string
+# % label: Data type
+# % description: Supported only for GTiff
+# % required: no
+# % multiple: no
+# % options: Byte,Int16,UInt16,Int32,UInt32,Float32,Float64,CInt16,CInt32,CFloat32,CFloat64
+# %end
 
-#%option
-#% key: createopt
-#% type: string
-#% label: Creation option(s) to pass to the output format driver
-#% description: In the form of "NAME=VALUE", separate multiple entries with a comma
-#% required: no
-#% multiple: yes
-#%end
+# %option
+# % key: createopt
+# % type: string
+# % label: Creation option(s) to pass to the output format driver
+# % description: In the form of "NAME=VALUE", separate multiple entries with a comma
+# % required: no
+# % multiple: yes
+# %end
 
-#%option
-#% key: metaopt
-#% type: string
-#% label: Metadata key(s) and value(s) to include
-#% description: In the form of "META-TAG=VALUE", separate multiple entries with a comma. Not supported by all output format drivers.
-#% required: no
-#% multiple: yes
-#%end
+# %option
+# % key: metaopt
+# % type: string
+# % label: Metadata key(s) and value(s) to include
+# % description: In the form of "META-TAG=VALUE", separate multiple entries with a comma. Not supported by all output format drivers.
+# % required: no
+# % multiple: yes
+# %end
 
-#%option
-#% key: nodata
-#% type: double
-#% label: Assign a specified nodata value to output bands
-#% description: If given, the nodata value is always written to metadata even if there are no NULL cells in the input band (enhances output compatibility).
-#% required: no
-#%end
+# %option
+# % key: nodata
+# % type: double
+# % label: Assign a specified nodata value to output bands
+# % description: If given, the nodata value is always written to metadata even if there are no NULL cells in the input band (enhances output compatibility).
+# % required: no
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.extract/t.rast.extract.py
+++ b/temporal/t.rast.extract/t.rast.extract.py
@@ -20,63 +20,63 @@
 #
 #############################################################################
 
-#%module
-#% description: Extracts a subset of a space time raster datasets.
-#% keyword: temporal
-#% keyword: extract
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Extracts a subset of a space time raster datasets.
+# % keyword: temporal
+# % keyword: extract
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: r.mapcalc expression assigned to all extracted raster maps
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: r.mapcalc expression assigned to all extracted raster maps
+# % required: no
+# % multiple: no
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: no
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: no
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
 
 import grass.script as grass

--- a/temporal/t.rast.gapfill/t.rast.gapfill.py
+++ b/temporal/t.rast.gapfill/t.rast.gapfill.py
@@ -20,53 +20,53 @@
 #
 #############################################################################
 
-#%module
-#% description: Replaces gaps in a space time raster dataset with interpolated raster maps.
-#% keyword: temporal
-#% keyword: interpolation
-#% keyword: raster
-#% keyword: time
-#% keyword: no-data filling
-#%end
+# %module
+# % description: Replaces gaps in a space time raster dataset with interpolated raster maps.
+# % keyword: temporal
+# % keyword: interpolation
+# % keyword: raster
+# % keyword: time
+# % keyword: no-data filling
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of interpolation processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of interpolation processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: t
-#% description: Assign the space time raster dataset start and end time to the output map
-#%end
+# %flag
+# % key: t
+# % description: Assign the space time raster dataset start and end time to the output map
+# %end
 
 import sys
 import copy

--- a/temporal/t.rast.import/t.rast.import.py
+++ b/temporal/t.rast.import/t.rast.import.py
@@ -20,89 +20,89 @@
 #
 #############################################################################
 
-#%module
-#% description: Imports space time raster dataset.
-#% keyword: temporal
-#% keyword: import
-#% keyword: raster
-#% keyword: time
-#% keyword: create location
-#%end
+# %module
+# % description: Imports space time raster dataset.
+# % keyword: temporal
+# % keyword: import
+# % keyword: raster
+# % keyword: time
+# % keyword: create location
+# %end
 
-#%option G_OPT_F_INPUT
-#%end
+# %option G_OPT_F_INPUT
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: no
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: no
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option G_OPT_M_DIR
-#% key: directory
-#% description: Path to the extraction directory
-#% answer: /tmp
-#%end
+# %option G_OPT_M_DIR
+# % key: directory
+# % description: Path to the extraction directory
+# % answer: /tmp
+# %end
 
-#%option
-#% key: title
-#% type: string
-#% description: Title of the new space time dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: title
+# % type: string
+# % description: Title of the new space time dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: description
-#% type: string
-#% description: Description of the new space time dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: description
+# % type: string
+# % description: Description of the new space time dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: location
-#% type: string
-#% description: Create a new location and import the data into it. Do not run this module in parallel or interrupt it when a new location should be created
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: location
+# % type: string
+# % description: Create a new location and import the data into it. Do not run this module in parallel or interrupt it when a new location should be created
+# % required: no
+# % multiple: no
+# %end
 
-#%option G_OPT_MEMORYMB
-#%end
+# %option G_OPT_MEMORYMB
+# %end
 
-#%flag
-#% key: r
-#% description: Set the current region from the last map that was imported
-#%end
+# %flag
+# % key: r
+# % description: Set the current region from the last map that was imported
+# %end
 
-#%flag
-#% key: l
-#% description: Link the raster files using r.external
-#%end
+# %flag
+# % key: l
+# % description: Link the raster files using r.external
+# %end
 
-#%flag
-#% key: e
-#% description: Extend location extents based on new dataset
-#%end
+# %flag
+# % key: e
+# % description: Extend location extents based on new dataset
+# %end
 
-#%flag
-#% key: o
-#% label: Override projection check (use current location's projection)
-#% description: Assume that the dataset has same projection as the current location
-#%end
+# %flag
+# % key: o
+# % label: Override projection check (use current location's projection)
+# % description: Assume that the dataset has same projection as the current location
+# %end
 
-#%flag
-#% key: c
-#% description: Create the location specified by the "location" parameter and exit. Do not import the space time raster datasets.
-#%end
+# %flag
+# % key: c
+# % description: Create the location specified by the "location" parameter and exit. Do not import the space time raster datasets.
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.list/t.rast.list.py
+++ b/temporal/t.rast.list/t.rast.list.py
@@ -20,76 +20,76 @@
 #
 #############################################################################
 
-#%module
-#% description: Lists registered maps of a space time raster dataset.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: raster
-#% keyword: list
-#% keyword: time
-#%end
+# %module
+# % description: Lists registered maps of a space time raster dataset.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: raster
+# % keyword: list
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option
-#% key: order
-#% type: string
-#% description: Sort the space time dataset by category
-#% guisection: Formatting
-#% required: no
-#% multiple: yes
-#% options: id,name,band_reference,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
-#% answer: start_time
-#%end
+# %option
+# % key: order
+# % type: string
+# % description: Sort the space time dataset by category
+# % guisection: Formatting
+# % required: no
+# % multiple: yes
+# % options: id,name,band_reference,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
+# % answer: start_time
+# %end
 
-#%option
-#% key: columns
-#% type: string
-#% description: Columns to be printed to stdout
-#% guisection: Selection
-#% required: no
-#% multiple: yes
-#% options: id,name,band_reference,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
-#% answer: name,mapset,start_time,end_time
-#%end
+# %option
+# % key: columns
+# % type: string
+# % description: Columns to be printed to stdout
+# % guisection: Selection
+# % required: no
+# % multiple: yes
+# % options: id,name,band_reference,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,ewres,cols,rows,number_of_cells,min,max
+# % answer: name,mapset,start_time,end_time
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Method used for data listing
-#% required: no
-#% multiple: no
-#% options: cols,comma,delta,deltagaps,gran
-#% answer: cols
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Method used for data listing
+# % required: no
+# % multiple: no
+# % options: cols,comma,delta,deltagaps,gran
+# % answer: cols
+# %end
 
-#%option
-#% key: granule
-#% type: string
-#% description: The granule to be used for listing. The granule must be specified as string eg.: absolute time "1 months" or relative time "1"
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: granule
+# % type: string
+# % description: The granule to be used for listing. The granule must be specified as string eg.: absolute time "1 months" or relative time "1"
+# % required: no
+# % multiple: no
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%flag
-#% key: u
-#% description: Suppress printing of column names
-#% guisection: Formatting
-#%end
+# %flag
+# % key: u
+# % description: Suppress printing of column names
+# % guisection: Formatting
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.mapcalc/t.rast.mapcalc.py
+++ b/temporal/t.rast.mapcalc/t.rast.mapcalc.py
@@ -20,58 +20,58 @@
 #
 #############################################################################
 
-#%module
-#% description: Performs spatio-temporal mapcalc expressions on temporally sampled maps of space time raster datasets.
-#% keyword: temporal
-#% keyword: algebra
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Performs spatio-temporal mapcalc expressions on temporally sampled maps of space time raster datasets.
+# % keyword: temporal
+# % keyword: algebra
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUTS
-#%end
+# %option G_OPT_STRDS_INPUTS
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: Spatio-temporal mapcalc expression
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: Spatio-temporal mapcalc expression
+# % required: yes
+# % multiple: no
+# %end
 
-#%option G_OPT_T_SAMPLE
-#% key: method
-#% answer: equal
-#%end
+# %option G_OPT_T_SAMPLE
+# % key: method
+# % answer: equal
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
-#%option G_OPT_R_BASENAME_OUTPUT
-#% key: basename
-#% label: Basename for output raster maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#%end
+# %option G_OPT_R_BASENAME_OUTPUT
+# % key: basename
+# % label: Basename for output raster maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
-#%flag
-#% key: s
-#% description: Check the spatial topology of temporally related maps and process only spatially related maps
-#%end
+# %flag
+# % key: s
+# % description: Check the spatial topology of temporally related maps and process only spatially related maps
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.neighbors/t.rast.neighbors.py
+++ b/temporal/t.rast.neighbors/t.rast.neighbors.py
@@ -21,79 +21,79 @@
 #
 #############################################################################
 
-#%module
-#% description: Performs a neighborhood analysis for each map in a space time raster dataset.
-#% keyword: temporal
-#% keyword: aggregation
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Performs a neighborhood analysis for each map in a space time raster dataset.
+# % keyword: temporal
+# % keyword: aggregation
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STRDS_OUTPUT
-#%end
+# %option G_OPT_STRDS_OUTPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: size
-#% type: integer
-#% description: Neighborhood size
-#% required: no
-#% multiple: no
-#% answer: 3
-#%end
+# %option
+# % key: size
+# % type: integer
+# % description: Neighborhood size
+# % required: no
+# % multiple: no
+# % answer: 3
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Aggregate operation to be performed on the raster maps
-#% required: yes
-#% multiple: no
-#% options: average,median,mode,minimum,maximum,range,stddev,sum,count,variance,diversity,interspersion,quart1,quart3,perc90,quantile
-#% answer: average
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Aggregate operation to be performed on the raster maps
+# % required: yes
+# % multiple: no
+# % options: average,median,mode,minimum,maximum,range,stddev,sum,count,variance,diversity,interspersion,quart1,quart3,perc90,quantile
+# % answer: average
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.neighbor processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.neighbor processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
-#%flag
-#% key: r
-#% description: Ignore the current region settings and use the raster map regions
-#%end
+# %flag
+# % key: r
+# % description: Ignore the current region settings and use the raster map regions
+# %end
 
 from __future__ import print_function
 

--- a/temporal/t.rast.out.vtk/t.rast.out.vtk.py
+++ b/temporal/t.rast.out.vtk/t.rast.out.vtk.py
@@ -20,57 +20,57 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports space time raster dataset as VTK time series.
-#% keyword: temporal
-#% keyword: export
-#% keyword: output
-#% keyword: raster
-#% keyword: VTK
-#% keyword: time
-#%end
+# %module
+# % description: Exports space time raster dataset as VTK time series.
+# % keyword: temporal
+# % keyword: export
+# % keyword: output
+# % keyword: raster
+# % keyword: VTK
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option
-#% key: directory
-#% type: string
-#% description: Path to the export directory
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: directory
+# % type: string
+# % description: Path to the export directory
+# % required: yes
+# % multiple: no
+# %end
 
-#%option G_OPT_R_ELEV
-#% required: no
-#%end
+# %option G_OPT_R_ELEV
+# % required: no
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: null
-#% type: double
-#% description: Value to represent no data cell
-#% required: no
-#% multiple: no
-#% answer: -99999.99
-#%end
+# %option
+# % key: null
+# % type: double
+# % description: Value to represent no data cell
+# % required: no
+# % multiple: no
+# % answer: -99999.99
+# %end
 
-#%flag
-#% key: p
-#% description: Create VTK point data instead of VTK cell data (if no elevation map is given)
-#%end
+# %flag
+# % key: p
+# % description: Create VTK point data instead of VTK cell data (if no elevation map is given)
+# %end
 
-#%flag
-#% key: c
-#% description: Correct the coordinates to fit the VTK-OpenGL precision
-#%end
+# %flag
+# % key: c
+# % description: Correct the coordinates to fit the VTK-OpenGL precision
+# %end
 
-#%flag
-#% key: g
-#% description: Export files using the space time dataset granularity for equidistant time between maps, where statement will be ignored
-#%end
+# %flag
+# % key: g
+# % description: Export files using the space time dataset granularity for equidistant time between maps, where statement will be ignored
+# %end
 
 import os
 import grass.script as grass

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -21,62 +21,62 @@
 #
 #############################################################################
 
-#%module
-#% description: Performs different aggregation algorithms from r.series on all or a subset of raster maps in a space time raster dataset.
-#% keyword: temporal
-#% keyword: aggregation
-#% keyword: series
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Performs different aggregation algorithms from r.series on all or a subset of raster maps in a space time raster dataset.
+# % keyword: temporal
+# % keyword: aggregation
+# % keyword: series
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Aggregate operation to be performed on the raster maps
-#% required: yes
-#% multiple: yes
-#% options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
-#% answer: average
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Aggregate operation to be performed on the raster maps
+# % required: yes
+# % multiple: yes
+# % options: average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
+# % answer: average
+# %end
 
-#%option
-#% key: quantile
-#% type: double
-#% description: Quantile to calculate for method=quantile
-#% required: no
-#% multiple: yes
-#% options: 0.0-1.0
-#%end
+# %option
+# % key: quantile
+# % type: double
+# % description: Quantile to calculate for method=quantile
+# % required: no
+# % multiple: yes
+# % options: 0.0-1.0
+# %end
 
-#%option
-#% key: order
-#% type: string
-#% description: Sort the maps by category
-#% required: no
-#% multiple: yes
-#% options: id, name, creator, mapset, creation_time, modification_time, start_time, end_time, north, south, west, east, min, max
-#% answer: start_time
-#%end
+# %option
+# % key: order
+# % type: string
+# % description: Sort the maps by category
+# % required: no
+# % multiple: yes
+# % options: id, name, creator, mapset, creation_time, modification_time, start_time, end_time, north, south, west, east, min, max
+# % answer: start_time
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option G_OPT_R_OUTPUTS
-#%end
+# %option G_OPT_R_OUTPUTS
+# %end
 
-#%flag
-#% key: t
-#% description: Do not assign the space time raster dataset start and end time to the output map
-#%end
+# %flag
+# % key: t
+# % description: Do not assign the space time raster dataset start and end time to the output map
+# %end
 
-#%flag
-#% key: n
-#% description: Propagate NULLs
-#%end
+# %flag
+# % key: n
+# % description: Propagate NULLs
+# %end
 
 
 import grass.script as grass

--- a/temporal/t.rast.to.rast3/t.rast.to.rast3.py
+++ b/temporal/t.rast.to.rast3/t.rast.to.rast3.py
@@ -20,21 +20,21 @@
 #
 #############################################################################
 
-#%module
-#% description: Converts a space time raster dataset into a 3D raster map.
-#% keyword: temporal
-#% keyword: conversion
-#% keyword: raster
-#% keyword: raster3d
-#% keyword: voxel
-#% keyword: time
-#%end
+# %module
+# % description: Converts a space time raster dataset into a 3D raster map.
+# % keyword: temporal
+# % keyword: conversion
+# % keyword: raster
+# % keyword: raster3d
+# % keyword: voxel
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_R3_OUTPUT
-#%end
+# %option G_OPT_R3_OUTPUT
+# %end
 from __future__ import print_function
 
 import os

--- a/temporal/t.rast.to.vect/t.rast.to.vect.py
+++ b/temporal/t.rast.to.vect/t.rast.to.vect.py
@@ -21,100 +21,100 @@
 #
 #############################################################################
 
-#%module
-#% description: Converts a space time raster dataset into a space time vector dataset
-#% keyword: temporal
-#% keyword: conversion
-#% keyword: raster
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Converts a space time raster dataset into a space time vector dataset
+# % keyword: temporal
+# % keyword: conversion
+# % keyword: raster
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_STVDS_OUTPUT
-#%end
+# %option G_OPT_STVDS_OUTPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: type
-#% type: string
-#% description: Output feature type
-#% required: yes
-#% multiple: no
-#% options: point,line,area
-#%end
+# %option
+# % key: type
+# % type: string
+# % description: Output feature type
+# % required: yes
+# % multiple: no
+# % options: point,line,area
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: column
-#% type: string
-#% description: Name of attribute column to store value
-#% required: no
-#% multiple: no
-#% answer: value
-#%end
+# %option
+# % key: column
+# % type: string
+# % description: Name of attribute column to store value
+# % required: no
+# % multiple: no
+# % answer: value
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.to.vect processes to run in parallel, more than 1 process works only in conjunction with flag -t
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.to.vect processes to run in parallel, more than 1 process works only in conjunction with flag -t
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register empty vector maps
-#%end
+# %flag
+# % key: n
+# % description: Register empty vector maps
+# %end
 
-#%flag
-#% key: t
-#% description: Do not create attribute tables
-#%end
+# %flag
+# % key: t
+# % description: Do not create attribute tables
+# %end
 
-#%flag
-#% key: s
-#% description: Smooth corners of area features
-#%end
+# %flag
+# % key: s
+# % description: Smooth corners of area features
+# %end
 
-#%flag
-#% key: z
-#% label: Write raster values as z coordinate
-#% description: Table is not created. Currently supported only for points.
-#%end
+# %flag
+# % key: z
+# % label: Write raster values as z coordinate
+# % description: Table is not created. Currently supported only for points.
+# %end
 
-#%flag
-#% key: b
-#% label: Do not build vector topology
-#% description: Name must be SQL compliant
-#%end
+# %flag
+# % key: b
+# % label: Do not build vector topology
+# % description: Name must be SQL compliant
+# %end
 
-#%flag
-#% key: v
-#% description: Use raster values as categories instead of unique sequence (CELL only)
-#%end
+# %flag
+# % key: v
+# % description: Use raster values as categories instead of unique sequence (CELL only)
+# %end
 
 import sys
 import copy

--- a/temporal/t.rast.univar/t.rast.univar.py
+++ b/temporal/t.rast.univar/t.rast.univar.py
@@ -20,45 +20,45 @@
 #
 #############################################################################
 
-#%module
-#% description: Calculates univariate statistics from the non-null cells for each registered raster map of a space time raster dataset.
-#% keyword: temporal
-#% keyword: statistics
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Calculates univariate statistics from the non-null cells for each registered raster map of a space time raster dataset.
+# % keyword: temporal
+# % keyword: statistics
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#%end
+# %option G_OPT_STRDS_INPUT
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%flag
-#% key: e
-#% description: Calculate extended statistics
-#%end
+# %flag
+# % key: e
+# % description: Calculate extended statistics
+# %end
 
-#%flag
-#% key: r
-#% description: Ignore the current region settings and use the raster map regions for univar statistical calculation
-#%end
+# %flag
+# % key: r
+# % description: Ignore the current region settings and use the raster map regions for univar statistical calculation
+# %end
 
-#%flag
-#% key: u
-#% description: Suppress printing of column names
-#% guisection: Formatting
-#%end
+# %flag
+# % key: u
+# % description: Suppress printing of column names
+# % guisection: Formatting
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast.what/t.rast.what.py
+++ b/temporal/t.rast.what/t.rast.what.py
@@ -22,81 +22,81 @@
 #
 #############################################################################
 
-#%module
-#% description: Sample a space time raster dataset at specific vector point coordinates and write the output to stdout using different layouts
-#% keyword: temporal
-#% keyword: sampling
-#% keyword: raster
-#% keyword: time
-#%end
+# %module
+# % description: Sample a space time raster dataset at specific vector point coordinates and write the output to stdout using different layouts
+# % keyword: temporal
+# % keyword: sampling
+# % keyword: raster
+# % keyword: time
+# %end
 
-#%option G_OPT_V_INPUT
-#% key: points
-#% required: no
-#%end
+# %option G_OPT_V_INPUT
+# % key: points
+# % required: no
+# %end
 
-#%option G_OPT_M_COORDS
-#% required: no
-#% description: Comma separated list of coordinates
-#%end
+# %option G_OPT_M_COORDS
+# % required: no
+# % description: Comma separated list of coordinates
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#% key: strds
-#%end
+# %option G_OPT_STRDS_INPUT
+# % key: strds
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#% description: Name for the output file or "-" in case stdout should be used
-#% answer: -
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# % description: Name for the output file or "-" in case stdout should be used
+# % answer: -
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option G_OPT_M_NULL_VALUE
-#%end
+# %option G_OPT_M_NULL_VALUE
+# %end
 
-#%option G_OPT_F_SEP
-#%end
+# %option G_OPT_F_SEP
+# %end
 
-#%option
-#% key: order
-#% type: string
-#% description: Sort the maps by category
-#% required: no
-#% multiple: yes
-#% options: id, name, creator, mapset, creation_time, modification_time, start_time, end_time, north, south, west, east, min, max
-#% answer: start_time
-#%end
+# %option
+# % key: order
+# % type: string
+# % description: Sort the maps by category
+# % required: no
+# % multiple: yes
+# % options: id, name, creator, mapset, creation_time, modification_time, start_time, end_time, north, south, west, east, min, max
+# % answer: start_time
+# %end
 
-#%option
-#% key: layout
-#% type: string
-#% description: The layout of the output. One point per row (row), one point per column (col), all timsteps in one row (timerow)
-#% required: no
-#% multiple: no
-#% options: row, col, timerow
-#% answer: row
-#%end
+# %option
+# % key: layout
+# % type: string
+# % description: The layout of the output. One point per row (row), one point per column (col), all timsteps in one row (timerow)
+# % required: no
+# % multiple: no
+# % options: row, col, timerow
+# % answer: row
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r.what processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r.what processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Output header row
-#%end
+# %flag
+# % key: n
+# % description: Output header row
+# %end
 
-#%flag
-#% key: i
-#% description: Use stdin as input and ignore coordinates and point option
-#%end
+# %flag
+# % key: i
+# % description: Use stdin as input and ignore coordinates and point option
+# %end
 
 ## Temporary disabled the r.what flags due to test issues
 ##%flag
@@ -114,10 +114,10 @@
 ##% description: Output integer category values, not cell values
 ##%end
 
-#%flag
-#% key: v
-#% description: Show the category for vector points map
-#%end
+# %flag
+# % key: v
+# % description: Show the category for vector points map
+# %end
 
 import sys
 import copy

--- a/temporal/t.rast3d.algebra/t.rast3d.algebra.py
+++ b/temporal/t.rast3d.algebra/t.rast3d.algebra.py
@@ -22,53 +22,53 @@
 #
 #############################################################################
 
-#%module
-#% description: Apply temporal and spatial operations on space time 3D raster datasets using temporal 3D raster algebra.
-#% keyword: temporal
-#% keyword: algebra
-#% keyword: raster3d
-#% keyword: voxel
-#% keyword: time
-#%end
+# %module
+# % description: Apply temporal and spatial operations on space time 3D raster datasets using temporal 3D raster algebra.
+# % keyword: temporal
+# % keyword: algebra
+# % keyword: raster3d
+# % keyword: voxel
+# % keyword: time
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: Algebraic expression for temporal and spatial analysis of space time 3D raster datasets
-#% required : yes
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: Algebraic expression for temporal and spatial analysis of space time 3D raster datasets
+# % required : yes
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r3.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r3.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: s
-#% description: Check the spatial topology of temporally related maps and process only spatially related maps
-#%end
+# %flag
+# % key: s
+# % description: Check the spatial topology of temporally related maps and process only spatially related maps
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
-#%flag
-#% key: g
-#% description: Use granularity sampling instead of the temporal topology approach
-#%end
+# %flag
+# % key: g
+# % description: Use granularity sampling instead of the temporal topology approach
+# %end
 
 
 import grass.script

--- a/temporal/t.rast3d.extract/t.rast3d.extract.py
+++ b/temporal/t.rast3d.extract/t.rast3d.extract.py
@@ -20,62 +20,62 @@
 #
 #############################################################################
 
-#%module
-#% description: Extracts a subset of a space time 3D raster dataset.
-#% keyword: temporal
-#% keyword: extract
-#% keyword: raster3d
-#% keyword: voxel
-#% keyword: time
-#%end
+# %module
+# % description: Extracts a subset of a space time 3D raster dataset.
+# % keyword: temporal
+# % keyword: extract
+# % keyword: raster3d
+# % keyword: voxel
+# % keyword: time
+# %end
 
-#%option G_OPT_STR3DS_INPUT
-#%end
+# %option G_OPT_STR3DS_INPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: The r3.mapcalc expression assigned to all extracted 3D raster maps
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: The r3.mapcalc expression assigned to all extracted 3D raster maps
+# % required: no
+# % multiple: no
+# %end
 
-#%option G_OPT_STR3DS_OUTPUT
-#%end
+# %option G_OPT_STR3DS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% description: Basename of the new generated 3D raster maps
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: basename
+# % type: string
+# % description: Basename of the new generated 3D raster maps
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r3.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r3.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast3d.list/t.rast3d.list.py
+++ b/temporal/t.rast3d.list/t.rast3d.list.py
@@ -20,68 +20,68 @@
 #
 #############################################################################
 
-#%module
-#% description: Lists registered maps of a space time raster3d dataset.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: list
-#% keyword: raster3d
-#% keyword: voxel
-#% keyword: time
-#%end
+# %module
+# % description: Lists registered maps of a space time raster3d dataset.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: list
+# % keyword: raster3d
+# % keyword: voxel
+# % keyword: time
+# %end
 
-#%option G_OPT_STR3DS_INPUT
-#%end
+# %option G_OPT_STR3DS_INPUT
+# %end
 
-#%option
-#% key: order
-#% type: string
-#% description: Order the space time dataset by category
-#% required: no
-#% multiple: yes
-#% options: id,name,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,tbres,ewres,cols,rows,depths,number_of_cells,min,max
-#% answer: start_time
-#%end
+# %option
+# % key: order
+# % type: string
+# % description: Order the space time dataset by category
+# % required: no
+# % multiple: yes
+# % options: id,name,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,tbres,ewres,cols,rows,depths,number_of_cells,min,max
+# % answer: start_time
+# %end
 
-#%option
-#% key: columns
-#% type: string
-#% description: Columns to be printed to stdout
-#% guisection: Selection
-#% required: no
-#% multiple: yes
-#% options: id,name,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,tbres,ewres,cols,rows,depths,number_of_cells,min,max
-#% answer: name,mapset,start_time,end_time
-#%end
+# %option
+# % key: columns
+# % type: string
+# % description: Columns to be printed to stdout
+# % guisection: Selection
+# % required: no
+# % multiple: yes
+# % options: id,name,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,nsres,tbres,ewres,cols,rows,depths,number_of_cells,min,max
+# % answer: name,mapset,start_time,end_time
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Method used for data listing
-#% required: no
-#% multiple: no
-#% options: cols,comma,delta,deltagaps,gran
-#% answer: cols
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Method used for data listing
+# % required: no
+# % multiple: no
+# % options: cols,comma,delta,deltagaps,gran
+# % answer: cols
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%flag
-#% key: s
-#% description: Suppress printing of column names
-#% guisection: Formatting
-#%end
+# %flag
+# % key: s
+# % description: Suppress printing of column names
+# % guisection: Formatting
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
+++ b/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
@@ -20,62 +20,62 @@
 #
 #############################################################################
 
-#%module
-#% description: Performs r3.mapcalc expressions on maps of sampled space time 3D raster datasets.
-#% keyword: temporal
-#% keyword: algebra
-#% keyword: raster3d
-#% keyword: voxel
-#% keyword: time
-#%end
+# %module
+# % description: Performs r3.mapcalc expressions on maps of sampled space time 3D raster datasets.
+# % keyword: temporal
+# % keyword: algebra
+# % keyword: raster3d
+# % keyword: voxel
+# % keyword: time
+# %end
 
-#%option G_OPT_STR3DS_INPUTS
-#%end
+# %option G_OPT_STR3DS_INPUTS
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: r3.mapcalc expression applied to each time step of the sampled data
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: r3.mapcalc expression applied to each time step of the sampled data
+# % required: yes
+# % multiple: no
+# %end
 
-#%option G_OPT_T_SAMPLE
-#% key: method
-#% answer: during,overlap,contain,equal
-#%end
+# %option G_OPT_T_SAMPLE
+# % key: method
+# % answer: during,overlap,contain,equal
+# %end
 
-#%option G_OPT_STR3DS_OUTPUT
-#%end
+# %option G_OPT_STR3DS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: yes
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: yes
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: Number of r3.mapcalc processes to run in parallel
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: Number of r3.mapcalc processes to run in parallel
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register Null maps
-#%end
+# %flag
+# % key: n
+# % description: Register Null maps
+# %end
 
-#%flag
-#% key: s
-#% description: Check the spatial topology of temporally related maps and process only spatially related maps
-#%end
+# %flag
+# % key: s
+# % description: Check the spatial topology of temporally related maps and process only spatially related maps
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rast3d.univar/t.rast3d.univar.py
+++ b/temporal/t.rast3d.univar/t.rast3d.univar.py
@@ -21,41 +21,41 @@
 #
 #############################################################################
 
-#%module
-#% description: Calculates univariate statistics from the non-null cells for each registered 3D raster map of a space time 3D raster dataset.
-#% keyword: temporal
-#% keyword: statistics
-#% keyword: raster3d
-#% keyword: voxel
-#% keyword: time
-#%end
+# %module
+# % description: Calculates univariate statistics from the non-null cells for each registered 3D raster map of a space time 3D raster dataset.
+# % keyword: temporal
+# % keyword: statistics
+# % keyword: raster3d
+# % keyword: voxel
+# % keyword: time
+# %end
 
-#%option G_OPT_STR3DS_INPUT
-#%end
+# %option G_OPT_STR3DS_INPUT
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%flag
-#% key: e
-#% description: Calculate extended statistics
-#%end
+# %flag
+# % key: e
+# % description: Calculate extended statistics
+# %end
 
-#%flag
-#% key: s
-#% description: Suppress printing of column names
-#% guisection: Formatting
-#%end
+# %flag
+# % key: s
+# % description: Suppress printing of column names
+# % guisection: Formatting
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.register/t.register.py
+++ b/temporal/t.register/t.register.py
@@ -20,89 +20,89 @@
 #
 #############################################################################
 
-#%module
-#% description: Assigns timestamps and registers raster, vector and raster3d maps in a space time dataset.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: register
-#% keyword: time
-#% overwrite: yes
-#%end
+# %module
+# % description: Assigns timestamps and registers raster, vector and raster3d maps in a space time dataset.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: register
+# % keyword: time
+# % overwrite: yes
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% required: no
-#% guisection: Input
-#%end
+# %option G_OPT_STDS_INPUT
+# % required: no
+# % guisection: Input
+# %end
 
-#%option G_OPT_MAP_INPUTS
-#% required: no
-#% guisection: Input
-#%end
+# %option G_OPT_MAP_INPUTS
+# % required: no
+# % guisection: Input
+# %end
 
-#%option G_OPT_MAP_TYPE
-#% guidependency: input,maps
-#% guisection: Input
-#%end
+# %option G_OPT_MAP_TYPE
+# % guidependency: input,maps
+# % guisection: Input
+# %end
 
-#%option G_OPT_F_INPUT
-#% key: file
-#% required: no
-#% label: Input file with map names, one per line
-#% description: Additionally the start time and the end time can be specified per line
-#% guisection: Input
-#%end
+# %option G_OPT_F_INPUT
+# % key: file
+# % required: no
+# % label: Input file with map names, one per line
+# % description: Additionally the start time and the end time can be specified per line
+# % guisection: Input
+# %end
 
-#%option
-#% key: start
-#% type: string
-#% label: Valid start date and time of the first map
-#% description: Format for absolute time: "yyyy-mm-dd HH:MM:SS +HHMM", relative time is of type integer.
-#% required: no
-#% multiple: no
-#% guisection: Time & Date
-#%end
+# %option
+# % key: start
+# % type: string
+# % label: Valid start date and time of the first map
+# % description: Format for absolute time: "yyyy-mm-dd HH:MM:SS +HHMM", relative time is of type integer.
+# % required: no
+# % multiple: no
+# % guisection: Time & Date
+# %end
 
-#%option
-#% key: end
-#% type: string
-#% label: Valid end date and time of all map
-#% description: Format for absolute time: "yyyy-mm-dd HH:MM:SS +HHMM", relative time is of type integer.
-#% required: no
-#% multiple: no
-#% guisection: Time & Date
-#%end
+# %option
+# % key: end
+# % type: string
+# % label: Valid end date and time of all map
+# % description: Format for absolute time: "yyyy-mm-dd HH:MM:SS +HHMM", relative time is of type integer.
+# % required: no
+# % multiple: no
+# % guisection: Time & Date
+# %end
 
-#%option
-#% key: unit
-#% type: string
-#% label: Time stamp unit
-#% description: Unit must be set in case of relative timestamps
-#% required: no
-#% multiple: no
-#% options: years,months,days,hours,minutes,seconds
-#% guisection: Time & Date
-#%end
+# %option
+# % key: unit
+# % type: string
+# % label: Time stamp unit
+# % description: Unit must be set in case of relative timestamps
+# % required: no
+# % multiple: no
+# % options: years,months,days,hours,minutes,seconds
+# % guisection: Time & Date
+# %end
 
-#%option
-#% key: increment
-#% type: string
-#% label: Time increment, works only in conjunction with start option
-#% description: Time increment between maps for creation of valid time intervals (format for absolute time: NNN seconds, minutes, hours, days, weeks, months, years; format for relative time is of type integer: 5)
-#% required: no
-#% multiple: no
-#% guisection: Time & Date
-#%end
+# %option
+# % key: increment
+# % type: string
+# % label: Time increment, works only in conjunction with start option
+# % description: Time increment between maps for creation of valid time intervals (format for absolute time: NNN seconds, minutes, hours, days, weeks, months, years; format for relative time is of type integer: 5)
+# % required: no
+# % multiple: no
+# % guisection: Time & Date
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character of the input file
-#% guisection: Input
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character of the input file
+# % guisection: Input
+# %end
 
-#%flag
-#% key: i
-#% description: Create an interval (start and end time) in case an increment and the start time are provided
-#% guisection: Time & Date
-#%end
+# %flag
+# % key: i
+# % description: Create an interval (start and end time) in case an increment and the start time are provided
+# % guisection: Time & Date
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.remove/t.remove.py
+++ b/temporal/t.remove/t.remove.py
@@ -20,46 +20,46 @@
 #
 #############################################################################
 
-#%module
-#% description: Removes space time datasets from temporal database.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: remove
-#% keyword: time
-#%end
+# %module
+# % description: Removes space time datasets from temporal database.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: remove
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUTS
-#% guisection: Input
-#% required: no
-#%end
+# %option G_OPT_STDS_INPUTS
+# % guisection: Input
+# % required: no
+# %end
 
-#%option
-#% key: type
-#% type: string
-#% description: Type of the space time dataset, default is strds
-#% guidependency: inputs
-#% guisection: Input
-#% required: no
-#% options: strds, str3ds, stvds
-#% answer: strds
-#%end
+# %option
+# % key: type
+# % type: string
+# % description: Type of the space time dataset, default is strds
+# % guidependency: inputs
+# % guisection: Input
+# % required: no
+# % options: strds, str3ds, stvds
+# % answer: strds
+# %end
 
-#%option G_OPT_F_INPUT
-#% key: file
-#% description: Input file with dataset names, one per line
-#% guisection: Input
-#% required: no
-#%end
+# %option G_OPT_F_INPUT
+# % key: file
+# % description: Input file with dataset names, one per line
+# % guisection: Input
+# % required: no
+# %end
 
-#%flag
-#% key: r
-#% description: Remove all registered maps from the temporal and also from the spatial database
-#%end
+# %flag
+# % key: r
+# % description: Remove all registered maps from the temporal and also from the spatial database
+# %end
 
-#%flag
-#% key: f
-#% description: Force recursive removing
-#%end
+# %flag
+# % key: f
+# % description: Force recursive removing
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.rename/t.rename.py
+++ b/temporal/t.rename/t.rename.py
@@ -20,24 +20,24 @@
 #
 #############################################################################
 
-#%module
-#% description: Renames a space time dataset
-#% keyword: temporal
-#% keyword: map management
-#% keyword: rename
-#% keyword: time
-#%end
+# %module
+# % description: Renames a space time dataset
+# % keyword: temporal
+# % keyword: map management
+# % keyword: rename
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#%end
+# %option G_OPT_STDS_INPUT
+# %end
 
-#%option G_OPT_STDS_OUTPUT
-#%end
+# %option G_OPT_STDS_OUTPUT
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.sample/t.sample.py
+++ b/temporal/t.sample/t.sample.py
@@ -20,51 +20,51 @@
 #
 #############################################################################
 
-#%module
-#% description: Samples the input space time dataset(s) with a sample space time dataset and print the result to stdout.
-#% keyword: temporal
-#% keyword: sampling
-#% keyword: time
-#%end
+# %module
+# % description: Samples the input space time dataset(s) with a sample space time dataset and print the result to stdout.
+# % keyword: temporal
+# % keyword: sampling
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUTS
-#%end
+# %option G_OPT_STDS_INPUTS
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% key: sample
-#% description: Name of the sample space time dataset
-#%end
+# %option G_OPT_STDS_INPUT
+# % key: sample
+# % description: Name of the sample space time dataset
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% key: intype
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % key: intype
+# % guisection: Required
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% key: samtype
-#% guisection: Required
-#% description: Type of the sample space time dataset
-#%end
+# %option G_OPT_STDS_TYPE
+# % key: samtype
+# % guisection: Required
+# % description: Type of the sample space time dataset
+# %end
 
-#%option G_OPT_T_SAMPLE
-#% key: method
-#% answer: during,overlap,contain,equal
-#%end
+# %option G_OPT_T_SAMPLE
+# % key: method
+# % answer: during,overlap,contain,equal
+# %end
 
-#%option G_OPT_F_SEP
-#% description: Field separator between output columns, default is tabular " | "
-#% label: Do not use "," as this char is reserved to list several map ids in a sample granule
-#%end
+# %option G_OPT_F_SEP
+# % description: Field separator between output columns, default is tabular " | "
+# % label: Do not use "," as this char is reserved to list several map ids in a sample granule
+# %end
 
-#%flag
-#% key: c
-#% description: Print the column names as first row
-#%end
+# %flag
+# % key: c
+# % description: Print the column names as first row
+# %end
 
-#%flag
-#% key: s
-#% description: Check for spatial topological overlap
-#%end
+# %flag
+# % key: s
+# % description: Check for spatial topological overlap
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.select/t.select.py
+++ b/temporal/t.select/t.select.py
@@ -21,35 +21,35 @@
 #
 #############################################################################
 
-#%module
-#% description: Select maps from space time datasets by topological relationships to other space time datasets using temporal algebra.
-#% keyword: temporal
-#% keyword: metadata
-#% keyword: time
-#%end
+# %module
+# % description: Select maps from space time datasets by topological relationships to other space time datasets using temporal algebra.
+# % keyword: temporal
+# % keyword: metadata
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: The temporal mapcalc expression
-#% key_desc: expression
-#% required : yes
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: The temporal mapcalc expression
+# % key_desc: expression
+# % required : yes
+# %end
 
-#%flag
-#% key: s
-#% description: Check the spatial topology of temporally related maps and select only spatially related maps
-#%end
+# %flag
+# % key: s
+# % description: Check the spatial topology of temporally related maps and select only spatially related maps
+# %end
 
-#%flag
-#% key: d
-#% description: Perform a dry run, compute all dependencies and module calls but don't run them
-#%end
+# %flag
+# % key: d
+# % description: Perform a dry run, compute all dependencies and module calls but don't run them
+# %end
 
 
 import grass.script as grass

--- a/temporal/t.shift/t.shift.py
+++ b/temporal/t.shift/t.shift.py
@@ -20,31 +20,31 @@
 #
 #############################################################################
 
-#%module
-#% description: Shifts temporally the maps of a space time dataset.
-#% keyword: temporal
-#% keyword: time management
-#% keyword: shift
-#% keyword: time
-#%end
+# %module
+# % description: Shifts temporally the maps of a space time dataset.
+# % keyword: temporal
+# % keyword: time management
+# % keyword: shift
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% description: Name of an existing space time dataset
-#%end
+# %option G_OPT_STDS_INPUT
+# % description: Name of an existing space time dataset
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# %end
 
-#%option
-#% key: granularity
-#% type: string
-#% label: Shift granularity
-#% description: Format absolute time: "x years, x months, x weeks, x days, x hours, x minutes, x seconds", relative time is of type integer
-#% required: yes
-#% multiple: no
-#%end
+# %option
+# % key: granularity
+# % type: string
+# % label: Shift granularity
+# % description: Format absolute time: "x years, x months, x weeks, x days, x hours, x minutes, x seconds", relative time is of type integer
+# % required: yes
+# % multiple: no
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.snap/t.snap.py
+++ b/temporal/t.snap/t.snap.py
@@ -20,22 +20,22 @@
 #
 #############################################################################
 
-#%module
-#% description: Snaps temporally the maps of a space time dataset.
-#% keyword: temporal
-#% keyword: time management
-#% keyword: snapping
-#% keyword: time
-#%end
+# %module
+# % description: Snaps temporally the maps of a space time dataset.
+# % keyword: temporal
+# % keyword: time management
+# % keyword: snapping
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% description: Name of an existing space time dataset
-#%end
+# %option G_OPT_STDS_INPUT
+# % description: Name of an existing space time dataset
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.support/t.support.py
+++ b/temporal/t.support/t.support.py
@@ -20,65 +20,65 @@
 #
 #############################################################################
 
-#%module
-#% description: Modifies the metadata of a space time dataset.
-#% keyword: temporal
-#% keyword: metadata
-#% keyword: time
-#%end
+# %module
+# % description: Modifies the metadata of a space time dataset.
+# % keyword: temporal
+# % keyword: metadata
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#%end
+# %option G_OPT_STDS_INPUT
+# %end
 
-#%option
-#% key: semantictype
-#% type: string
-#% description: Semantic type of the space time dataset
-#% required: no
-#% multiple: no
-#% options: min,max,sum,mean
-#% answer: mean
-#%end
+# %option
+# % key: semantictype
+# % type: string
+# % description: Semantic type of the space time dataset
+# % required: no
+# % multiple: no
+# % options: min,max,sum,mean
+# % answer: mean
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# %end
 
-#%option
-#% key: title
-#% type: string
-#% description: Title of the space time dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: title
+# % type: string
+# % description: Title of the space time dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: description
-#% type: string
-#% description: Description of the space time dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: description
+# % type: string
+# % description: Description of the space time dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key:  aggr_type
-#% type: string
-#% description: Aggregation type of the space time raster or 3D raster dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key:  aggr_type
+# % type: string
+# % description: Aggregation type of the space time raster or 3D raster dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%flag
-#% key: m
-#% label: Update the metadata information and spatial extent of registered maps from the GRASS spatial database
-#% description: Check for removed maps and delete them from the temporal database and all effected space time datasets
-#%end
+# %flag
+# % key: m
+# % label: Update the metadata information and spatial extent of registered maps from the GRASS spatial database
+# % description: Check for removed maps and delete them from the temporal database and all effected space time datasets
+# %end
 
-#%flag
-#% key: u
-#% description: Update metadata information, temporal and spatial extent from registered maps based on database entries.
-#%end
+# %flag
+# % key: u
+# % description: Update metadata information, temporal and spatial extent from registered maps based on database entries.
+# %end
 
 
 import grass.script as grass

--- a/temporal/t.topology/t.topology.py
+++ b/temporal/t.topology/t.topology.py
@@ -20,33 +20,33 @@
 #
 #############################################################################
 
-#%module
-#% description: Lists temporal topology of a space time dataset.
-#% keyword: temporal
-#% keyword: topology
-#% keyword: time
-#%end
+# %module
+# % description: Lists temporal topology of a space time dataset.
+# % keyword: temporal
+# % keyword: topology
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#%end
+# %option G_OPT_STDS_INPUT
+# %end
 
-#%option G_OPT_STDS_TYPE
-#% guidependency: input
-#% guisection: Required
-#%end
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%flag
-#% key: m
-#% description: Print temporal topological relationships and exit
-#%end
+# %flag
+# % key: m
+# % description: Print temporal topological relationships and exit
+# %end
 
-#%flag
-#% key: s
-#% description: Print spatio-temporal topological relationships and exit
-#%end
+# %flag
+# % key: s
+# % description: Print spatio-temporal topological relationships and exit
+# %end
 from __future__ import print_function
 
 import grass.script as grass

--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -20,33 +20,33 @@
 #
 #############################################################################
 
-#%module
-#% description: Unregisters raster, vector and raster3d maps from the temporal database or a specific space time dataset.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: unregister
-#% keyword: time
-#%end
+# %module
+# % description: Unregisters raster, vector and raster3d maps from the temporal database or a specific space time dataset.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: unregister
+# % keyword: time
+# %end
 
-#%option G_OPT_STDS_INPUT
-#% required: no
-#%end
+# %option G_OPT_STDS_INPUT
+# % required: no
+# %end
 
-#%option G_OPT_F_INPUT
-#% key: file
-#% description: Input file with map names, one per line
-#% required: no
-#%end
+# %option G_OPT_F_INPUT
+# % key: file
+# % description: Input file with map names, one per line
+# % required: no
+# %end
 
-#%option G_OPT_MAP_TYPE
-#% guidependency: input,maps
-#%end
+# %option G_OPT_MAP_TYPE
+# % guidependency: input,maps
+# %end
 
 
-#%option G_OPT_MAP_INPUTS
-#% description: Name(s) of existing raster, vector or raster3d map(s) to unregister
-#% required: no
-#%end
+# %option G_OPT_MAP_INPUTS
+# % description: Name(s) of existing raster, vector or raster3d map(s) to unregister
+# % required: no
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -22,35 +22,35 @@
 #
 #############################################################################
 
-#%module
-#% description: Apply temporal and spatial operations on space time vector datasets using temporal vector algebra.
-#% keyword: temporal
-#% keyword: algebra
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Apply temporal and spatial operations on space time vector datasets using temporal vector algebra.
+# % keyword: temporal
+# % keyword: algebra
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option
-#% key: expression
-#% type: string
-#% description: Spatio-temporal mapcalc expression
-#% key_desc: expression
-#% required : yes
-#%end
+# %option
+# % key: expression
+# % type: string
+# % description: Spatio-temporal mapcalc expression
+# % key_desc: expression
+# % required : yes
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% key_desc: basename
-#% required : yes
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % key_desc: basename
+# % required : yes
+# %end
 
-#%flag
-#% key: s
-#% description: Check the spatial topology of temporally related maps and process only spatially related maps
-#%end
+# %flag
+# % key: s
+# % description: Check the spatial topology of temporally related maps and process only spatially related maps
+# %end
 
 import grass.script
 import sys

--- a/temporal/t.vect.db.select/t.vect.db.select.py
+++ b/temporal/t.vect.db.select/t.vect.db.select.py
@@ -20,35 +20,35 @@
 #
 #############################################################################
 
-#%module
-#% description: Prints attributes of vector maps registered in a space time vector dataset.
-#% keyword: temporal
-#% keyword: attribute table
-#% keyword: vector
-#% keyword: database
-#% keyword: select
-#% keyword: time
-#%end
+# %module
+# % description: Prints attributes of vector maps registered in a space time vector dataset.
+# % keyword: temporal
+# % keyword: attribute table
+# % keyword: vector
+# % keyword: database
+# % keyword: select
+# % keyword: time
+# %end
 
-#%option G_OPT_STVDS_INPUT
-#%end
+# %option G_OPT_STVDS_INPUT
+# %end
 
-#%option G_OPT_DB_COLUMNS
-#%end
+# %option G_OPT_DB_COLUMNS
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# %end
 
-#%option G_OPT_V_FIELD
-#%end
+# %option G_OPT_V_FIELD
+# %end
 
-#%option G_OPT_DB_WHERE
-#%end
+# %option G_OPT_DB_WHERE
+# %end
 
-#%option G_OPT_T_WHERE
-#% key: t_where
-#%end
+# %option G_OPT_T_WHERE
+# % key: t_where
+# %end
 from __future__ import print_function
 
 import grass.script as grass

--- a/temporal/t.vect.export/t.vect.export.py
+++ b/temporal/t.vect.export/t.vect.export.py
@@ -20,51 +20,51 @@
 #
 #############################################################################
 
-#%module
-#% description: Exports a space time vector dataset as GRASS GIS specific archive file.
-#% keyword: temporal
-#% keyword: export
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Exports a space time vector dataset as GRASS GIS specific archive file.
+# % keyword: temporal
+# % keyword: export
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_STVDS_INPUT
-#%end
+# %option G_OPT_STVDS_INPUT
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% description: Name of a space time vector dataset archive
-#%end
+# %option G_OPT_F_OUTPUT
+# % description: Name of a space time vector dataset archive
+# %end
 
-#%option G_OPT_M_DIR
-#% key: directory
-#% description: Path to the work directory, default is /tmp
-#% required: no
-#% answer: /tmp
-#%end
+# %option G_OPT_M_DIR
+# % key: directory
+# % description: Path to the work directory, default is /tmp
+# % required: no
+# % answer: /tmp
+# %end
 
-#%option
-#% key: compression
-#% type: string
-#% description: Compression method of the tar archive
-#% required: no
-#% multiple: no
-#% options: no,gzip,bzip2
-#% answer: bzip2
-#%end
+# %option
+# % key: compression
+# % type: string
+# % description: Compression method of the tar archive
+# % required: no
+# % multiple: no
+# % options: no,gzip,bzip2
+# % answer: bzip2
+# %end
 
-#%option
-#% key: format
-#% type: string
-#% label: The export format of a single vector map
-#% description: Supported are GML and GPKG via v.out.ogr and the GRASS package format of v.pack
-#% required: no
-#% multiple: no
-#% options: GML,GPKG,pack
-#% answer: GML
-#%end
+# %option
+# % key: format
+# % type: string
+# % label: The export format of a single vector map
+# % description: Supported are GML and GPKG via v.out.ogr and the GRASS package format of v.pack
+# % required: no
+# % multiple: no
+# % options: GML,GPKG,pack
+# % answer: GML
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.vect.extract/t.vect.extract.py
+++ b/temporal/t.vect.extract/t.vect.extract.py
@@ -20,65 +20,65 @@
 #
 #############################################################################
 
-#%module
-#% description: Extracts a subset of a space time vector dataset.
-#% keyword: temporal
-#% keyword: extract
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Extracts a subset of a space time vector dataset.
+# % keyword: temporal
+# % keyword: extract
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_STVDS_INPUT
-#%end
+# %option G_OPT_STVDS_INPUT
+# %end
 
-#%option G_OPT_T_WHERE
-#%end
+# %option G_OPT_T_WHERE
+# %end
 
-#%option G_OPT_DB_WHERE
-#% key: expression
-#%end
+# %option G_OPT_DB_WHERE
+# % key: expression
+# %end
 
-#%option G_OPT_STVDS_OUTPUT
-#%end
+# %option G_OPT_STVDS_OUTPUT
+# %end
 
-#%option G_OPT_V_FIELD
-#%end
+# %option G_OPT_V_FIELD
+# %end
 
-#%option G_OPT_V_TYPE
-#%end
+# %option G_OPT_V_TYPE
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: no
-#% multiple: no
-#% gisprompt:
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: no
+# % multiple: no
+# % gisprompt:
+# %end
 
-#%option
-#% key: suffix
-#% type: string
-#% description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
-#% answer: gran
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: suffix
+# % type: string
+# % description: Suffix to add at basename: set 'gran' for granularity, 'time' for the full time format, 'num' for numerical suffix with a specific number of digits (default %05)
+# % answer: gran
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: nprocs
-#% type: integer
-#% description: The number of v.extract processes to run in parallel. Use only if database backend is used which supports concurrent writing
-#% required: no
-#% multiple: no
-#% answer: 1
-#%end
+# %option
+# % key: nprocs
+# % type: integer
+# % description: The number of v.extract processes to run in parallel. Use only if database backend is used which supports concurrent writing
+# % required: no
+# % multiple: no
+# % answer: 1
+# %end
 
-#%flag
-#% key: n
-#% description: Register empty maps
-#%end
+# %flag
+# % key: n
+# % description: Register empty maps
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.vect.import/t.vect.import.py
+++ b/temporal/t.vect.import/t.vect.import.py
@@ -20,74 +20,74 @@
 #
 #############################################################################
 
-#%module
-#% description: Imports a space time vector dataset from a GRASS GIS specific archive file.
-#% keyword: temporal
-#% keyword: import
-#% keyword: vector
-#% keyword: time
-#% keyword: create location
-#%end
+# %module
+# % description: Imports a space time vector dataset from a GRASS GIS specific archive file.
+# % keyword: temporal
+# % keyword: import
+# % keyword: vector
+# % keyword: time
+# % keyword: create location
+# %end
 
-#%option G_OPT_F_INPUT
-#%end
+# %option G_OPT_F_INPUT
+# %end
 
-#%option G_OPT_STVDS_OUTPUT
-#%end
+# %option G_OPT_STVDS_OUTPUT
+# %end
 
-#%option
-#% key: basename
-#% type: string
-#% label: Basename of the new generated output maps
-#% description: A numerical suffix separated by an underscore will be attached to create a unique identifier
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: basename
+# % type: string
+# % label: Basename of the new generated output maps
+# % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
+# % required: no
+# % multiple: no
+# %end
 
-#%option G_OPT_M_DIR
-#% key: directory
-#% description: Path to the extraction directory
-#%end
+# %option G_OPT_M_DIR
+# % key: directory
+# % description: Path to the extraction directory
+# %end
 
-#%option
-#% key: title
-#% type: string
-#% description: Title of the new space time dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: title
+# % type: string
+# % description: Title of the new space time dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: description
-#% type: string
-#% description: Description of the new space time dataset
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: description
+# % type: string
+# % description: Description of the new space time dataset
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: location
-#% type: string
-#% description: Create a new location and import the data into it. Do not run this module in parallel or interrupt it when a new location should be created
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: location
+# % type: string
+# % description: Create a new location and import the data into it. Do not run this module in parallel or interrupt it when a new location should be created
+# % required: no
+# % multiple: no
+# %end
 
-#%flag
-#% key: e
-#% description: Extend location extents based on new dataset
-#%end
+# %flag
+# % key: e
+# % description: Extend location extents based on new dataset
+# %end
 
-#%flag
-#% key: o
-#% label: Override projection check (use current location's projection)
-#% description: Assume that the dataset has same projection as the current location
-#%end
+# %flag
+# % key: o
+# % label: Override projection check (use current location's projection)
+# % description: Assume that the dataset has same projection as the current location
+# %end
 
-#%flag
-#% key: c
-#% description: Create the location specified by the "location" parameter and exit. Do not import the space time vector datasets.
-#%end
+# %flag
+# % key: c
+# % description: Create the location specified by the "location" parameter and exit. Do not import the space time vector datasets.
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.vect.list/t.vect.list.py
+++ b/temporal/t.vect.list/t.vect.list.py
@@ -20,68 +20,68 @@
 #
 #############################################################################
 
-#%module
-#% description: Lists registered maps of a space time vector dataset.
-#% keyword: temporal
-#% keyword: map management
-#% keyword: vector
-#% keyword: list
-#% keyword: time
-#%end
+# %module
+# % description: Lists registered maps of a space time vector dataset.
+# % keyword: temporal
+# % keyword: map management
+# % keyword: vector
+# % keyword: list
+# % keyword: time
+# %end
 
-#%option G_OPT_STVDS_INPUT
-#%end
+# %option G_OPT_STVDS_INPUT
+# %end
 
-#%option
-#% key: order
-#% type: string
-#% description: Sort the space time dataset by category
-#% guisection: Formatting
-#% required: no
-#% multiple: yes
-#% options: id,name,layer,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,points,lines,boundaries,centroids,faces,kernels,primitives,nodes,areas,islands,holes,volumes
-#% answer: start_time
-#%end
+# %option
+# % key: order
+# % type: string
+# % description: Sort the space time dataset by category
+# % guisection: Formatting
+# % required: no
+# % multiple: yes
+# % options: id,name,layer,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,points,lines,boundaries,centroids,faces,kernels,primitives,nodes,areas,islands,holes,volumes
+# % answer: start_time
+# %end
 
-#%option
-#% key: columns
-#% type: string
-#% description: Columns to be printed to stdout
-#% guisection: Selection
-#% required: no
-#% multiple: yes
-#% options: id,name,layer,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,points,lines,boundaries,centroids,faces,kernels,primitives,nodes,areas,islands,holes,volumes
-#% answer: name,layer,mapset,start_time,end_time
-#%end
+# %option
+# % key: columns
+# % type: string
+# % description: Columns to be printed to stdout
+# % guisection: Selection
+# % required: no
+# % multiple: yes
+# % options: id,name,layer,creator,mapset,temporal_type,creation_time,start_time,end_time,north,south,west,east,points,lines,boundaries,centroids,faces,kernels,primitives,nodes,areas,islands,holes,volumes
+# % answer: name,layer,mapset,start_time,end_time
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Method used for data listing
-#% required: no
-#% multiple: no
-#% options: cols,comma,delta,deltagaps,gran
-#% answer: cols
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Method used for data listing
+# % required: no
+# % multiple: no
+# % options: cols,comma,delta,deltagaps,gran
+# % answer: cols
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%flag
-#% key: u
-#% description: Suppress printing of column names
-#% guisection: Formatting
-#%end
+# %flag
+# % key: u
+# % description: Suppress printing of column names
+# % guisection: Formatting
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.vect.observe.strds/t.vect.observe.strds.py
+++ b/temporal/t.vect.observe.strds/t.vect.observe.strds.py
@@ -20,39 +20,39 @@
 #
 #############################################################################
 
-#%module
-#% description: Observes specific locations in a space time raster dataset over a period of time using vector points.
-#% keyword: temporal
-#% keyword: sampling
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Observes specific locations in a space time raster dataset over a period of time using vector points.
+# % keyword: temporal
+# % keyword: sampling
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_V_INPUT
-#%end
+# %option G_OPT_V_INPUT
+# %end
 
-#%option G_OPT_STRDS_INPUTS
-#% key: strds
-#%end
+# %option G_OPT_STRDS_INPUTS
+# % key: strds
+# %end
 
-#%option G_OPT_STVDS_OUTPUT
-#%end
+# %option G_OPT_STVDS_OUTPUT
+# %end
 
-#%option G_OPT_V_OUTPUT
-#% key: vector_output
-#% description: Name of the new created vector map that stores the sampled values in different layers
-#%end
+# %option G_OPT_V_OUTPUT
+# % key: vector_output
+# % description: Name of the new created vector map that stores the sampled values in different layers
+# %end
 
-#%option
-#% key: columns
-#% type: string
-#% description: Names of the vector columns to be created and to store sampled raster values, one name for each STRDS
-#% required: yes
-#% multiple: yes
-#%end
+# %option
+# % key: columns
+# % type: string
+# % description: Names of the vector columns to be created and to store sampled raster values, one name for each STRDS
+# % required: yes
+# % multiple: yes
+# %end
 
-#%option G_OPT_DB_WHERE
-#%end
+# %option G_OPT_DB_WHERE
+# %end
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/temporal/t.vect.univar/t.vect.univar.py
+++ b/temporal/t.vect.univar/t.vect.univar.py
@@ -20,58 +20,58 @@
 #
 #############################################################################
 
-#%module
-#% description: Calculates univariate statistics of attributes for each registered vector map of a space time vector dataset
-#% keyword: temporal
-#% keyword: statistics
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Calculates univariate statistics of attributes for each registered vector map of a space time vector dataset
+# % keyword: temporal
+# % keyword: statistics
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_STVDS_INPUT
-#%end
+# %option G_OPT_STVDS_INPUT
+# %end
 
-#%option G_OPT_F_OUTPUT
-#% required: no
-#%end
+# %option G_OPT_F_OUTPUT
+# % required: no
+# %end
 
-#%option G_OPT_V_FIELD
-#%end
+# %option G_OPT_V_FIELD
+# %end
 
-#%option G_OPT_DB_COLUMN
-#% required: yes
-#%end
+# %option G_OPT_DB_COLUMN
+# % required: yes
+# %end
 
-#%option G_OPT_T_WHERE
-#% guisection: Selection
-#% key: twhere
-#%end
+# %option G_OPT_T_WHERE
+# % guisection: Selection
+# % key: twhere
+# %end
 
-#%option G_OPT_DB_WHERE
-#% guisection: Selection
-#%end
+# %option G_OPT_DB_WHERE
+# % guisection: Selection
+# %end
 
-#%option G_OPT_V_TYPE
-#% options: point,line,boundary,centroid,area
-#% multiple: no
-#% answer: point
-#%end
+# %option G_OPT_V_TYPE
+# % options: point,line,boundary,centroid,area
+# % multiple: no
+# % answer: point
+# %end
 
-#%option G_OPT_F_SEP
-#% label: Field separator character between the output columns
-#% guisection: Formatting
-#%end
+# %option G_OPT_F_SEP
+# % label: Field separator character between the output columns
+# % guisection: Formatting
+# %end
 
-#%flag
-#% key: e
-#% description: Calculate extended statistics
-#%end
+# %flag
+# % key: e
+# % description: Calculate extended statistics
+# %end
 
-#%flag
-#% key: u
-#% description: Suppress printing of column names
-#% guisection: Formatting
-#%end
+# %flag
+# % key: u
+# % description: Suppress printing of column names
+# % guisection: Formatting
+# %end
 
 import grass.script as grass
 

--- a/temporal/t.vect.what.strds/t.vect.what.strds.py
+++ b/temporal/t.vect.what.strds/t.vect.what.strds.py
@@ -20,49 +20,49 @@
 #
 #############################################################################
 
-#%module
-#% description: Stores raster map values at spatial and temporal positions of vector points as vector attributes.
-#% keyword: temporal
-#% keyword: sampling
-#% keyword: vector
-#% keyword: time
-#%end
+# %module
+# % description: Stores raster map values at spatial and temporal positions of vector points as vector attributes.
+# % keyword: temporal
+# % keyword: sampling
+# % keyword: vector
+# % keyword: time
+# %end
 
-#%option G_OPT_STVDS_INPUT
-#%end
+# %option G_OPT_STVDS_INPUT
+# %end
 
-#%option G_OPT_STRDS_INPUT
-#% key: strds
-#%end
+# %option G_OPT_STRDS_INPUT
+# % key: strds
+# %end
 
-#%option
-#% key: column
-#% type: string
-#% label: Name of the vector column to be created and to store sampled raster values
-#% description: The use of a column name forces t.vect.what.rast to sample only values from the first map found in an interval. Otherwise the raster map names are used as column names
-#% required: no
-#% multiple: no
-#%end
+# %option
+# % key: column
+# % type: string
+# % label: Name of the vector column to be created and to store sampled raster values
+# % description: The use of a column name forces t.vect.what.rast to sample only values from the first map found in an interval. Otherwise the raster map names are used as column names
+# % required: no
+# % multiple: no
+# %end
 
-#%option
-#% key: method
-#% type: string
-#% description: Aggregate operation to be performed on the raster maps
-#% required: yes
-#% multiple: no
-#% options: disabled,average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
-#% answer: disabled
-#%end
+# %option
+# % key: method
+# % type: string
+# % description: Aggregate operation to be performed on the raster maps
+# % required: yes
+# % multiple: no
+# % options: disabled,average,count,median,mode,minimum,min_raster,maximum,max_raster,stddev,range,sum,variance,diversity,slope,offset,detcoeff,quart1,quart3,perc90,quantile,skewness,kurtosis
+# % answer: disabled
+# %end
 
-#%option G_OPT_DB_WHERE
-#%end
+# %option G_OPT_DB_WHERE
+# %end
 
-#%option G_OPT_T_WHERE
-#% key: t_where
-#%end
+# %option G_OPT_T_WHERE
+# % key: t_where
+# %end
 
-#%option G_OPT_T_SAMPLE
-#%end
+# %option G_OPT_T_SAMPLE
+# %end
 
 import os
 import grass.script as grass


### PR DESCRIPTION
Accept '# %' in parser script header definition because '#%' is against PEP8
(each line of a block comment starts with a # and a single space).

'#%' is still supported and documented as backwards compatibility.

All documentation and generated code uses the new '# %'.
