### PR TITLE
CI: Handpick C/C++ version combos for GCC tests

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -11,14 +11,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        c:
-        - gnu99
-        - gnu11
-        - gnu17
-        cpp:
-        - c++11
-        - c++14
-        - c++17
+        include:
+        - c: gnu99
+          cpp: c++11
+        - c: gnu11
+          cpp: c++11
+        - c: gnu11
+          cpp: c++14
+        - c: gnu17
+          cpp: c++17
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Not all 9 combinations for C and C++ standards need to be tested.
All versions are still tested for each language.
The combinations are based on corresponding years reducing the number of jobs to 4.
