### PR TITLE
t.register: strip newline from list of maps to avoid error

### DIFF
--- a/lib/python/temporal/register.py
+++ b/lib/python/temporal/register.py
@@ -139,7 +139,7 @@ def register_maps_in_space_time_dataset(
 
         line = True
         while True:
-            line = fd.readline()
+            line = fd.readline().strip()
             if not line:
                 break
 


### PR DESCRIPTION
This should solve the problem when you input file in t.register that has newline:
```
ERROR: Unable to update raster map <@climate_2000_2012>. The map does not exist.
```