### PR TITLE
wxGUI: Add missing title params to frames

### DIFF
--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -28,9 +28,8 @@ from gui_core.wrap import Button
 class DataCatalogFrame(wx.Frame):
     """Frame for testing purposes only."""
 
-    def __init__(self, parent, giface=None):
-        wx.Frame.__init__(self, parent=parent,
-                          title=_('Data Catalog'))
+    def __init__(self, parent, giface=None, title=_('Data Catalog')):
+        wx.Frame.__init__(self, parent=parent, title=title)
         self.SetName("DataCatalog")
         self.SetIcon(
             wx.Icon(

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -69,12 +69,12 @@ def check_version(*version):
 class TimelineFrame(wx.Frame):
     """The main frame of the application"""
 
-    def __init__(self, parent):
+    def __init__(self, parent, title=_("Timeline Tool")):
         wx.Frame.__init__(
             self,
             parent,
             id=wx.ID_ANY,
-            title=_("Timeline Tool"))
+            title=title)
 
         tgis.init(True)
         self.datasets = []

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -95,9 +95,8 @@ def findBetween(s, first, last):
 class TplotFrame(wx.Frame):
     """The main frame of the application"""
 
-    def __init__(self, parent, giface):
-        wx.Frame.__init__(self, parent, id=wx.ID_ANY,
-                          title=_("Temporal Plot Tool"))
+    def __init__(self, parent, giface, title=_("Temporal Plot Tool")):
+        wx.Frame.__init__(self, parent, id=wx.ID_ANY, title=title)
 
         tgis.init(True)
         self._giface = giface


### PR DESCRIPTION
Several frames miss the title parameter which is needed by g.gui.* tools.
This adds the missing parameter (original title is the default value like for other frames).

Fixes 4743d531f77edf3cd976de947fa1627ab65ab827 (#1216).
