### PR TITLE
wxGUI/forms: fix Python 3.8 integer warning

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -717,10 +717,10 @@ class TaskFrame(wx.Frame):
             scale = 0.50
         self.SetSize(
             wx.Size(
-                sizeFrame[0],
-                sizeFrame[1] + scale * max(
+                round(sizeFrame[0]),
+                round(sizeFrame[1] + scale * max(
                     self.notebookpanel.panelMinHeight,
-                    self.notebookpanel.constrained_size[1])))
+                    self.notebookpanel.constrained_size[1]))))
 
         # thread to update dialog
         # create queues


### PR DESCRIPTION
Fixes 
```
gui/wxpython/gui_core/forms.py:719: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```