### PR TITLE
r.terraflow: remove print "Free Memory" to stats file

### DIFF
--- a/raster/r.terraflow/stats.cpp
+++ b/raster/r.terraflow/stats.cpp
@@ -126,44 +126,7 @@ statsRecorder::statsRecorder(char *fname) : ofstream(noclobberFileName(fname)){
   //ofstream that takes an fd; wrote another noclobber() function that
   //closes fd and returns the name;
   rt_start(tm);
-#ifndef __MINGW32__
-  bss = sbrk(0);
-#endif
-  char buf[BUFSIZ];
-  *this << freeMem(buf) << endl;
 }
-
-/* ********************************************************************** */
-
-long 
-statsRecorder::freeMem() {
-#ifdef __MINGW32__
-  return -1;
-#else
-  struct rlimit rlim;
-  if (getrlimit(RLIMIT_DATA, &rlim) == -1) {
-	perror("getrlimit: ");
-	return -1;
-  } 	
-  /* printf("getrlimit returns: %d \n", rlim.rlim_cur); */
-  if (rlim.rlim_cur == RLIM_INFINITY) {
-	/* printf("rlim is infinity\n"); */
-	/* should fix this */
-	return -1; 
-  } 
-  long freeMem = rlim.rlim_cur - ((char*)sbrk(0)-(char*)bss);
-  return freeMem;
-#endif /* __MINGW32__ */
-}
-
-char *
-statsRecorder::freeMem(char *buf) {
-  char buf2[BUFSIZ];
-  sprintf(buf, "Free Memory=%s", formatNumber(buf2, freeMem()));
-  return buf;
-}
-
-
 
 /* ********************************************************************** */
 

--- a/raster/r.terraflow/stats.h
+++ b/raster/r.terraflow/stats.h
@@ -35,14 +35,11 @@ int noclobberFile(char *);
 class statsRecorder : public ofstream {
 private:
   Rtimer tm;
-  void *bss;
 public:
   statsRecorder(char *fname);
   ~statsRecorder() { 
 	this->flush(); 
   }
-  char *freeMem(char *);
-  long freeMem();
   char *timestamp();
   void timestamp(const char *s);
   void comment(const char *s, const int verbose=1);


### PR DESCRIPTION
Generating a statistics file with r.terraflow (e.g. `r.terraflow stats=stats.txt [...]`) the first line in the stats file (is supposed to) state the amount of free memory:

```
head stats.txt 
Free Memory=-1
[0.0] Wed Jan 27 10:31:51 2021
Command Line: 
r.terraflow elevation=elev_srtm_30m@PERMANENT filled=filled_rast stats=stats.txt 
input elevation grid: elev_srtm_30m
output (filled_rast) elevations grid: filled_rast
[0.0] MFD flow direction
[0.0] D8CUT=999999986991104.000000
[0.0] Memory size: 300.00M (314572800) bytes
region size = 219.73K (225000) elts (450 rows x 500 cols)
```
with the value "-1" given if it failed to calculate the size.

Current implementation is based on `getrlimit()`, see: [r.terraflow/stats.cpp](https://github.com/OSGeo/grass/blob/8c8e5bce5a9f15917d490b56b1e12a612ea04df9/raster/r.terraflow/stats.cpp#L138) and the value of `rlimit.rlim_cur`.

On a 64 bit Mac and probably Linux too (https://github.com/OSGeo/grass/issues/712#issuecomment-773299131) `rlimit.rlim_cur == RLIM_INFINITY` and the calculation fails. I may add that this code is already excluded from `__MINGW32__` builds.

Part of the calculation is based on the deprecated `sbrk()`, originally reported with #712.

There is a lot of things to address with present code and **all** it does is printing one line in the stat file.

With this PR I propose to remove this part of the code, as I couldn't come up with a platform independent way to calculate "free memory" (also a vague concept considering virtual memory).

Fixes #712