### PR TITLE
wxGUI/psmap: fix retrieval of projection information

### DIFF
--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -361,24 +361,14 @@ def projInfo():
     """Return region projection and map units information,
     taken from render.py
     """
+    proj_info = grass.parse_key_val(
+        RunCommand('g.proj', flags='g', read=True)
+    )
 
-    projinfo = dict()
-
-    ret = RunCommand('g.proj', read=True, flags='p')
-
-    if not ret:
-        return projinfo
-
-    for line in ret.splitlines():
-        if ':' in line:
-            key, val = line.split(':')
-            projinfo[key.strip()] = val.strip()
-        elif "XY location (unprojected)" in line:
-            projinfo['proj'] = 'xy'
-            projinfo['units'] = ''
-            break
-
-    return projinfo
+    return (
+        proj_info if proj_info.get('name') != 'xy_location_unprojected'
+        else {'proj': 'xy', 'units': ''}
+    )
 
 
 def GetMapBounds(filename, env, portrait=True):

--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -361,8 +361,8 @@ def projInfo():
     """Return region projection and map units information,
     taken from render.py
     """
-    proj_info = grass.parse_key_val(
-        RunCommand('g.proj', flags='g', read=True)
+    proj_info = RunCommand(
+        'g.proj', flags='g', read=True, parse=grass.parse_key_val,
     )
 
     return (


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch Cartographic Composer `g.gui.psmap`
2. Try add Map frame
3. See error message

**Error message:**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py",
line 1532, in MouseActions

self.OnLeftUp(event)
  File "/usr/lib64/grass79/gui/wxpython/psmap/frame.py",
line 1680, in OnLeftUp

settings=self.instruction, env=self.env, rect=rectPaper)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 775, in __init__

notebook=False)
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 850, in __init__

self._layout()
  File "/usr/lib64/grass79/gui/wxpython/psmap/dialogs.py",
line 1163, in _layout

if projInfo()['proj'] == 'll':
  File "/usr/lib64/grass79/gui/wxpython/psmap/utils.py",
line 374, in projInfo

key, val = line.split(':')
ValueError
:
too many values to unpack (expected 2)
```