### PR TITLE
Fix compiler warnings, part 9

### DIFF
--- a/lib/vector/Vlib/build_nat.c
+++ b/lib/vector/Vlib/build_nat.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <inttypes.h>
 #include <grass/glocale.h>
 #include <grass/vector.h>
 
@@ -116,7 +117,7 @@ int Vect_build_nat(struct Map_info *Map, int build)
 	G_progress(1, 1);
 
 	G_verbose_message(n_("One primitive registered", "%d primitives registered", plus->n_lines), plus->n_lines);
-	G_verbose_message(n_("One vertex registered", "%jd vertices registered", npoints), npoints);
+	G_verbose_message(n_("One vertex registered", "%" PRId64 " vertices registered", npoints), npoints);
 
 	plus->built = GV_BUILD_BASE;
     }

--- a/raster/r.info/main.c
+++ b/raster/r.info/main.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -445,7 +446,7 @@ int main(int argc, char **argv)
             fprintf(out, "rows=%d\n", cellhd.rows);
             fprintf(out, "cols=%d\n", cellhd.cols);
             
-            fprintf(out, "cells=%jd\n",
+            fprintf(out, "cells=%" PRId64 "\n",
                     (grass_int64)cellhd.rows * cellhd.cols);
             
 	    fprintf(out, "datatype=%s\n",
@@ -497,7 +498,7 @@ int main(int argc, char **argv)
 
 	    if (!gflag->answer) {
 		/* always report total number of cells */
-		fprintf(out, "cells=%jd\n",
+		fprintf(out, "cells=%" PRId64 "\n",
 			(grass_int64)cellhd.rows * cellhd.cols);
 	    }
 


### PR DESCRIPTION
Use platform independent int64 format specifier, with the `PRId64` macro from <inttypes.h> available with c99.

Lifted out of PR #1256, awaiting community decision on C standard usage within the GRASS GIS project, see [discussion on grass-dev mail list](https://lists.osgeo.org/pipermail/grass-dev/2021-January/094899.html). 

Addresses `-Wformat` compiler warnings.

Ninth part addressing #1247.