### PR TITLE
wxGUI: Make Display related toolbars part of Display tab

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -298,12 +298,12 @@ class GMFrame(wx.Frame):
     def _createDisplayPanel(self):
         """Creates display panel"""
         # create superior display panel
-        display_manager = wx.Panel(self.notebook, id=wx.ID_ANY)
+        display_panel = wx.Panel(self.notebook, id=wx.ID_ANY)
         # create display toolbar
-        dmgrToolbar = DisplayPanelToolbar(guiparent=display_manager,
+        dmgrToolbar = DisplayPanelToolbar(guiparent=display_panel,
                                           parent=self)
         # create display notebook
-        notebookLayers = GNotebook(parent=display_manager,
+        notebookLayers = GNotebook(parent=display_panel,
                                    style=globalvar.FNPageStyle)
         notebookLayers.SetTabAreaColour(globalvar.FNPageColor)
         menu = self._createTabMenu()
@@ -314,12 +314,12 @@ class GMFrame(wx.Frame):
         sizer.Add(dmgrToolbar, proportion=0, flag=wx.EXPAND)
         sizer.Add(notebookLayers, proportion=1, flag=wx.EXPAND)
 
-        display_manager.SetAutoLayout(True)
-        display_manager.SetSizer(sizer)
-        display_manager.Fit()
-        display_manager.Layout()
+        display_panel.SetAutoLayout(True)
+        display_panel.SetSizer(sizer)
+        display_panel.Fit()
+        display_panel.Layout()
 
-        return display_manager, notebookLayers
+        return display_panel, notebookLayers
 
     def _setCopyingOfSelectedText(self):
         copy = UserSettings.Get(
@@ -354,9 +354,9 @@ class GMFrame(wx.Frame):
             name='catalog')
 
         # create displays notebook widget
-        self.display_manager, self.notebookLayers = self._createDisplayPanel()
+        self.display_panel, self.notebookLayers = self._createDisplayPanel()
         self.notebook.AddPage(
-            page=self.display_manager,
+            page=self.display_panel,
             text=_("Display"),
             name='layers')
 

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -61,8 +61,8 @@ from gui_core.dialogs import LocationDialog, MapsetDialog, CreateNewVector, Grou
 from gui_core.menu import SearchModuleWindow
 from gui_core.menu import Menu as GMenu
 from core.debug import Debug
-from lmgr.toolbars import LMWorkspaceToolbar, LMDataToolbar, LMToolsToolbar
-from lmgr.toolbars import LMMiscToolbar, LMVectorToolbar, LMNvizToolbar
+from lmgr.toolbars import LMWorkspaceToolbar, LMToolsToolbar
+from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
 from lmgr.pyshell import PyShellWindow
 from lmgr.giface import LayerManagerGrassInterface
 from datacatalog.catalog import DataCatalog
@@ -147,32 +147,23 @@ class GMFrame(wx.Frame):
         self.statusbar = self.CreateStatusBar(number=1)
         self.notebook = self._createNoteBook()
         self.toolbars = {'workspace': LMWorkspaceToolbar(parent=self),
-                         'data': LMDataToolbar(parent=self),
                          'tools': LMToolsToolbar(parent=self),
                          'misc': LMMiscToolbar(parent=self),
-                         'vector': LMVectorToolbar(parent=self),
                          'nviz': LMNvizToolbar(parent=self)}
         self._toolbarsData = {'workspace': ("toolbarWorkspace",     # name
                                             _("Workspace Toolbar"),  # caption
                                             1, 0),                   # row, position
-                              'data': ("toolbarData",
-                                       _("Data Toolbar"),
-                                       1, 1),
-                              'misc': ("toolbarMisc",
-                                       _("Misc Toolbar"),
-                                       2, 2),
                               'tools': ("toolbarTools",
                                         _("Tools Toolbar"),
-                                        2, 1),
-                              'vector': ("toolbarVector",
-                                         _("Vector Toolbar"),
-                                         2, 0),
+                                        1, 1),
+                              'misc': ("toolbarMisc",
+                                       _("Misc Toolbar"),
+                                       1, 2),
                               'nviz': ("toolbarNviz",
                                        _("3D view Toolbar"),
-                                       2, 3),
+                                       1, 3),
                               }
-        toolbarsList = ('workspace', 'data',
-                        'vector', 'tools', 'misc', 'nviz')
+        toolbarsList = ('workspace', 'tools', 'misc', 'nviz')
         for toolbar in toolbarsList:
             name, caption, row, position = self._toolbarsData[toolbar]
             self._auimgr.AddPane(self.toolbars[toolbar],
@@ -304,6 +295,32 @@ class GMFrame(wx.Frame):
 
         return menu
 
+    def _createDisplayPanel(self):
+        """Creates display panel"""
+        # create superior display panel
+        display_manager = wx.Panel(self.notebook, id=wx.ID_ANY)
+        # create display toolbar
+        dmgrToolbar = DisplayPanelToolbar(guiparent=display_manager,
+                                          parent=self)
+        # create display notebook
+        notebookLayers = GNotebook(parent=display_manager,
+                                   style=globalvar.FNPageStyle)
+        notebookLayers.SetTabAreaColour(globalvar.FNPageColor)
+        menu = self._createTabMenu()
+        notebookLayers.SetRightClickMenu(menu)
+
+        # layout
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(dmgrToolbar, proportion=0, flag=wx.EXPAND)
+        sizer.Add(notebookLayers, proportion=1, flag=wx.EXPAND)
+
+        display_manager.SetAutoLayout(True)
+        display_manager.SetSizer(sizer)
+        display_manager.Fit()
+        display_manager.Layout()
+
+        return display_manager, notebookLayers
+
     def _setCopyingOfSelectedText(self):
         copy = UserSettings.Get(
             group='manager',
@@ -337,13 +354,9 @@ class GMFrame(wx.Frame):
             name='catalog')
 
         # create displays notebook widget
-        self.notebookLayers = GNotebook(parent=self.notebook,
-                                        style=globalvar.FNPageStyle)
-        self.notebookLayers.SetTabAreaColour(globalvar.FNPageColor)
-        menu = self._createTabMenu()
-        self.notebookLayers.SetRightClickMenu(menu)
+        self.display_manager, self.notebookLayers = self._createDisplayPanel()
         self.notebook.AddPage(
-            page=self.notebookLayers,
+            page=self.display_manager,
             text=_("Display"),
             name='layers')
 

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -298,13 +298,11 @@ class GMFrame(wx.Frame):
     def _createDisplayPanel(self):
         """Creates display panel"""
         # create superior display panel
-        display_panel = wx.Panel(self.notebook, id=wx.ID_ANY)
+        displayPanel = wx.Panel(self.notebook, id=wx.ID_ANY)
         # create display toolbar
-        dmgrToolbar = DisplayPanelToolbar(guiparent=display_panel,
-                                          parent=self)
+        dmgrToolbar = DisplayPanelToolbar(guiparent=displayPanel, parent=self)
         # create display notebook
-        notebookLayers = GNotebook(parent=display_panel,
-                                   style=globalvar.FNPageStyle)
+        notebookLayers = GNotebook(parent=displayPanel, style=globalvar.FNPageStyle)
         notebookLayers.SetTabAreaColour(globalvar.FNPageColor)
         menu = self._createTabMenu()
         notebookLayers.SetRightClickMenu(menu)
@@ -314,12 +312,12 @@ class GMFrame(wx.Frame):
         sizer.Add(dmgrToolbar, proportion=0, flag=wx.EXPAND)
         sizer.Add(notebookLayers, proportion=1, flag=wx.EXPAND)
 
-        display_panel.SetAutoLayout(True)
-        display_panel.SetSizer(sizer)
-        display_panel.Fit()
-        display_panel.Layout()
+        displayPanel.SetAutoLayout(True)
+        displayPanel.SetSizer(sizer)
+        displayPanel.Fit()
+        displayPanel.Layout()
 
-        return display_panel, notebookLayers
+        return displayPanel, notebookLayers
 
     def _setCopyingOfSelectedText(self):
         copy = UserSettings.Get(
@@ -354,9 +352,9 @@ class GMFrame(wx.Frame):
             name='catalog')
 
         # create displays notebook widget
-        self.display_panel, self.notebookLayers = self._createDisplayPanel()
+        self.displayPanel, self.notebookLayers = self._createDisplayPanel()
         self.notebook.AddPage(
-            page=self.display_panel,
+            page=self.displayPanel,
             text=_("Display"),
             name='layers')
 

--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -62,6 +62,89 @@ class LMWorkspaceToolbar(BaseToolbar):
                                      ))
 
 
+class DisplayPanelToolbar(BaseToolbar):
+    """Toolbar for display tab
+    """
+
+    def __init__(self, guiparent, parent):
+        BaseToolbar.__init__(self, guiparent)
+        self.parent = parent
+
+        self.InitToolbar(self._toolbarData())
+
+        # realize the toolbar
+        self.Realize()
+
+    def _toolbarData(self):
+        """Toolbar data
+        """
+        icons = {
+            'newdisplay': MetaIcon(
+                img='monitor-create',
+                label=_('Start new map display')),
+            'addMulti': MetaIcon(
+                img='layer-open',
+                label=_('Add multiple raster or vector map layers (Ctrl+Shift+L)')),
+            'addRast': BaseIcons['addRast'].SetLabel(
+                _("Add raster map layer (Ctrl+Shift+R)")),
+            'rastMisc': MetaIcon(
+                img='layer-raster-more',
+                label=_('Add various raster map layers (RGB, HIS, shaded relief...)')),
+            'addVect': BaseIcons['addVect'].SetLabel(
+                _("Add vector map layer (Ctrl+Shift+V)")),
+            'vectMisc': MetaIcon(
+                img='layer-vector-more',
+                label=_('Add various vector map layers (thematic, chart...)')),
+            'addWS': MetaIcon(
+                img='layer-wms-add',
+                label=_('Add web service layer (WMS, WMTS, NASA OnEarth)')),
+            'addGroup': MetaIcon(
+                img='layer-group-add',
+                label=_('Add group')),
+            'addOverlay': MetaIcon(
+                img='layer-more',
+                label=_('Add various overlays')),
+            'delCmd': MetaIcon(
+                img='layer-remove',
+                label=_('Remove selected map layer(s) from layer tree')),
+            'vdigit': MetaIcon(
+                img='edit',
+                label=_('Edit selected vector map')),
+            'attrTable': MetaIcon(
+                img='table',
+                label=_('Show attribute data for selected vector map'))
+        }
+
+        return self._getToolbarData((('newdisplay', icons["newdisplay"],
+                                      self.parent.OnNewDisplay),
+                                     (None, ),
+                                     ('addMulti', icons["addMulti"],
+                                      self.parent.OnAddMaps),
+                                     ('addrast', icons["addRast"],
+                                      self.parent.OnAddRaster),
+                                     ('rastmisc', icons["rastMisc"],
+                                      self.parent.OnAddRasterMisc),
+                                     ('addvect', icons["addVect"],
+                                      self.parent.OnAddVector),
+                                     ('vectmisc', icons["vectMisc"],
+                                      self.parent.OnAddVectorMisc),
+                                     ('addovl', icons["addOverlay"],
+                                      self.parent.OnAddOverlay),
+                                     ('addWS', icons["addWS"],
+                                      self.parent.OnAddWS),
+                                     (None, ),
+                                     ('addgrp', icons["addGroup"],
+                                      self.parent.OnAddGroup),
+                                     ('delcmd', icons["delCmd"],
+                                      self.parent.OnDeleteLayer),
+                                     (None, ),
+                                     ('vdigit', icons["vdigit"],
+                                      self.parent.OnVDigit),
+                                     ('attribute', icons["attrTable"],
+                                      self.parent.OnShowAttributeTable),
+                                     ))
+
+
 class LMToolsToolbar(BaseToolbar):
     """Layer Manager `tools` toolbar
     """
@@ -190,86 +273,3 @@ class LMNvizToolbar(BaseToolbar):
             log = self.lmgr.GetLogWindow()
             log.RunCmd(['g.manual',
                         'entry=wxGUI.nviz'])
-
-
-class DisplayPanelToolbar(BaseToolbar):
-    """Toolbar for display tab
-    """
-
-    def __init__(self, guiparent, parent):
-        BaseToolbar.__init__(self, guiparent)
-        self.parent = parent
-
-        self.InitToolbar(self._toolbarData())
-
-        # realize the toolbar
-        self.Realize()
-
-    def _toolbarData(self):
-        """Toolbar data
-        """
-        icons = {
-            'newdisplay': MetaIcon(
-                img='monitor-create',
-                label=_('Start new map display')),
-            'addMulti': MetaIcon(
-                img='layer-open',
-                label=_('Add multiple raster or vector map layers (Ctrl+Shift+L)')),
-            'addRast': BaseIcons['addRast'].SetLabel(
-                _("Add raster map layer (Ctrl+Shift+R)")),
-            'rastMisc': MetaIcon(
-                img='layer-raster-more',
-                label=_('Add various raster map layers (RGB, HIS, shaded relief...)')),
-            'addVect': BaseIcons['addVect'].SetLabel(
-                _("Add vector map layer (Ctrl+Shift+V)")),
-            'vectMisc': MetaIcon(
-                img='layer-vector-more',
-                label=_('Add various vector map layers (thematic, chart...)')),
-            'addWS': MetaIcon(
-                img='layer-wms-add',
-                label=_('Add web service layer (WMS, WMTS, NASA OnEarth)')),
-            'addGroup': MetaIcon(
-                img='layer-group-add',
-                label=_('Add group')),
-            'addOverlay': MetaIcon(
-                img='layer-more',
-                label=_('Add various overlays')),
-            'delCmd': MetaIcon(
-                img='layer-remove',
-                label=_('Remove selected map layer(s) from layer tree')),
-            'vdigit': MetaIcon(
-                img='edit',
-                label=_('Edit selected vector map')),
-            'attrTable': MetaIcon(
-                img='table',
-                label=_('Show attribute data for selected vector map'))
-        }
-
-        return self._getToolbarData((('newdisplay', icons["newdisplay"],
-                                      self.parent.OnNewDisplay),
-                                     (None, ),
-                                     ('addMulti', icons["addMulti"],
-                                      self.parent.OnAddMaps),
-                                     ('addrast', icons["addRast"],
-                                      self.parent.OnAddRaster),
-                                     ('rastmisc', icons["rastMisc"],
-                                      self.parent.OnAddRasterMisc),
-                                     ('addvect', icons["addVect"],
-                                      self.parent.OnAddVector),
-                                     ('vectmisc', icons["vectMisc"],
-                                      self.parent.OnAddVectorMisc),
-                                     ('addovl', icons["addOverlay"],
-                                      self.parent.OnAddOverlay),
-                                     ('addWS', icons["addWS"],
-                                      self.parent.OnAddWS),
-                                     (None, ),
-                                     ('addgrp', icons["addGroup"],
-                                      self.parent.OnAddGroup),
-                                     ('delcmd', icons["delCmd"],
-                                      self.parent.OnDeleteLayer),
-                                     (None, ),
-                                     ('vdigit', icons["vdigit"],
-                                      self.parent.OnVDigit),
-                                     ('attribute', icons["attrTable"],
-                                      self.parent.OnShowAttributeTable),
-                                     ))

--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -5,11 +5,10 @@
 
 Classes:
  - toolbars::LMWorkspaceToolbar
- - toolbars::LMDataToolbar
  - toolbars::LMToolsToolbar
  - toolbars::LMMiscToolbar
- - toolbars::LMVectorToolbar
  - toolbars::LMNvizToolbar
+ - toolbars::DisplayPanelToolbar
 
 (C) 2007-2013 by the GRASS Development Team
 
@@ -20,6 +19,7 @@ This program is free software under the GNU General Public License
 @author Jachym Cepicky
 @author Martin Landa <landa.martin gmail.com>
 @author Anna Kratochvilova <kratochanna gmail.com>
+@author Linda Kladivova <linda.kladivova gmail com>
 """
 
 from core.gcmd import RunCommand
@@ -43,9 +43,6 @@ class LMWorkspaceToolbar(BaseToolbar):
         """Toolbar data
         """
         icons = {
-            'newdisplay': MetaIcon(
-                img='monitor-create',
-                label=_('Start new map display')),
             'workspaceNew': MetaIcon(
                 img='create',
                 label=_('Create new workspace (Ctrl+N)')),
@@ -56,80 +53,12 @@ class LMWorkspaceToolbar(BaseToolbar):
                 img='save',
                 label=_('Save current workspace to file (Ctrl+S)')),
         }
-        return self._getToolbarData((('newdisplay', icons["newdisplay"],
-                                      self.parent.OnNewDisplay),
-                                     (None, ),
-                                     ('workspaceNew', icons["workspaceNew"],
+        return self._getToolbarData((('workspaceNew', icons["workspaceNew"],
                                       self.parent.OnWorkspaceNew),
                                      ('workspaceOpen', icons["workspaceOpen"],
                                       self.parent.OnWorkspaceOpen),
                                      ('workspaceSave', icons["workspaceSave"],
                                       self.parent.OnWorkspaceSave),
-                                     ))
-
-
-class LMDataToolbar(BaseToolbar):
-    """Layer Manager `data` toolbar
-    """
-
-    def __init__(self, parent):
-        BaseToolbar.__init__(self, parent)
-
-        self.InitToolbar(self._toolbarData())
-
-        # realize the toolbar
-        self.Realize()
-
-    def _toolbarData(self):
-        """Toolbar data
-        """
-        icons = {
-            'addMulti': MetaIcon(
-                img='layer-open',
-                label=_('Add multiple raster or vector map layers (Ctrl+Shift+L)')),
-            'addRast': BaseIcons['addRast'].SetLabel(
-                _("Add raster map layer (Ctrl+Shift+R)")),
-            'rastMisc': MetaIcon(
-                img='layer-raster-more',
-                label=_('Add various raster map layers (RGB, HIS, shaded relief...)')),
-            'addVect': BaseIcons['addVect'].SetLabel(
-                _("Add vector map layer (Ctrl+Shift+V)")),
-            'vectMisc': MetaIcon(
-                img='layer-vector-more',
-                label=_('Add various vector map layers (thematic, chart...)')),
-            'addWS': MetaIcon(
-                img='layer-wms-add',
-                label=_('Add web service layer (WMS, WMTS, NASA OnEarth)')),
-            'addGroup': MetaIcon(
-                img='layer-group-add',
-                label=_('Add group')),
-            'addOverlay': MetaIcon(
-                img='layer-more',
-                label=_('Add various overlays')),
-            'delCmd': MetaIcon(
-                img='layer-remove',
-                label=_('Remove selected map layer(s) from layer tree')),
-        }
-
-        return self._getToolbarData((('addMulti', icons["addMulti"],
-                                      self.parent.OnAddMaps),
-                                     ('addrast', icons["addRast"],
-                                      self.parent.OnAddRaster),
-                                     ('rastmisc', icons["rastMisc"],
-                                      self.parent.OnAddRasterMisc),
-                                     ('addvect', icons["addVect"],
-                                      self.parent.OnAddVector),
-                                     ('vectmisc', icons["vectMisc"],
-                                      self.parent.OnAddVectorMisc),
-                                     ('addovl', icons["addOverlay"],
-                                      self.parent.OnAddOverlay),
-                                     ('addWS', icons["addWS"],
-                                      self.parent.OnAddWS),
-                                     (None, ),
-                                     ('addgrp', icons["addGroup"],
-                                      self.parent.OnAddGroup),
-                                     ('delcmd', icons["delCmd"],
-                                      self.parent.OnDeleteLayer),
                                      ))
 
 
@@ -206,37 +135,6 @@ class LMMiscToolbar(BaseToolbar):
                                      ))
 
 
-class LMVectorToolbar(BaseToolbar):
-    """Layer Manager `vector` toolbar
-    """
-
-    def __init__(self, parent):
-        BaseToolbar.__init__(self, parent)
-
-        self.InitToolbar(self._toolbarData())
-
-        # realize the toolbar
-        self.Realize()
-
-    def _toolbarData(self):
-        """Toolbar data
-        """
-        icons = {
-            'vdigit': MetaIcon(
-                img='edit',
-                label=_('Edit selected vector map')),
-            'attrTable': MetaIcon(
-                img='table',
-                label=_('Show attribute data for selected vector map')),
-        }
-
-        return self._getToolbarData((('vdigit', icons["vdigit"],
-                                      self.parent.OnVDigit),
-                                     ('attribute', icons["attrTable"],
-                                      self.parent.OnShowAttributeTable),
-                                     ))
-
-
 class LMNvizToolbar(BaseToolbar):
     """Nviz toolbar
     """
@@ -292,3 +190,86 @@ class LMNvizToolbar(BaseToolbar):
             log = self.lmgr.GetLogWindow()
             log.RunCmd(['g.manual',
                         'entry=wxGUI.nviz'])
+
+
+class DisplayPanelToolbar(BaseToolbar):
+    """Toolbar for display tab
+    """
+
+    def __init__(self, guiparent, parent):
+        BaseToolbar.__init__(self, guiparent)
+        self.parent = parent
+
+        self.InitToolbar(self._toolbarData())
+
+        # realize the toolbar
+        self.Realize()
+
+    def _toolbarData(self):
+        """Toolbar data
+        """
+        icons = {
+            'newdisplay': MetaIcon(
+                img='monitor-create',
+                label=_('Start new map display')),
+            'addMulti': MetaIcon(
+                img='layer-open',
+                label=_('Add multiple raster or vector map layers (Ctrl+Shift+L)')),
+            'addRast': BaseIcons['addRast'].SetLabel(
+                _("Add raster map layer (Ctrl+Shift+R)")),
+            'rastMisc': MetaIcon(
+                img='layer-raster-more',
+                label=_('Add various raster map layers (RGB, HIS, shaded relief...)')),
+            'addVect': BaseIcons['addVect'].SetLabel(
+                _("Add vector map layer (Ctrl+Shift+V)")),
+            'vectMisc': MetaIcon(
+                img='layer-vector-more',
+                label=_('Add various vector map layers (thematic, chart...)')),
+            'addWS': MetaIcon(
+                img='layer-wms-add',
+                label=_('Add web service layer (WMS, WMTS, NASA OnEarth)')),
+            'addGroup': MetaIcon(
+                img='layer-group-add',
+                label=_('Add group')),
+            'addOverlay': MetaIcon(
+                img='layer-more',
+                label=_('Add various overlays')),
+            'delCmd': MetaIcon(
+                img='layer-remove',
+                label=_('Remove selected map layer(s) from layer tree')),
+            'vdigit': MetaIcon(
+                img='edit',
+                label=_('Edit selected vector map')),
+            'attrTable': MetaIcon(
+                img='table',
+                label=_('Show attribute data for selected vector map'))
+        }
+
+        return self._getToolbarData((('newdisplay', icons["newdisplay"],
+                                      self.parent.OnNewDisplay),
+                                     (None, ),
+                                     ('addMulti', icons["addMulti"],
+                                      self.parent.OnAddMaps),
+                                     ('addrast', icons["addRast"],
+                                      self.parent.OnAddRaster),
+                                     ('rastmisc', icons["rastMisc"],
+                                      self.parent.OnAddRasterMisc),
+                                     ('addvect', icons["addVect"],
+                                      self.parent.OnAddVector),
+                                     ('vectmisc', icons["vectMisc"],
+                                      self.parent.OnAddVectorMisc),
+                                     ('addovl', icons["addOverlay"],
+                                      self.parent.OnAddOverlay),
+                                     ('addWS', icons["addWS"],
+                                      self.parent.OnAddWS),
+                                     (None, ),
+                                     ('addgrp', icons["addGroup"],
+                                      self.parent.OnAddGroup),
+                                     ('delcmd', icons["delCmd"],
+                                      self.parent.OnDeleteLayer),
+                                     (None, ),
+                                     ('vdigit', icons["vdigit"],
+                                      self.parent.OnVDigit),
+                                     ('attribute', icons["attrTable"],
+                                      self.parent.OnShowAttributeTable),
+                                     ))

--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -5,10 +5,11 @@
 
 Classes:
  - toolbars::LMWorkspaceToolbar
+ - toolbars::DisplayPanelToolbar
  - toolbars::LMToolsToolbar
  - toolbars::LMMiscToolbar
  - toolbars::LMNvizToolbar
- - toolbars::DisplayPanelToolbar
+
 
 (C) 2007-2013 by the GRASS Development Team
 


### PR DESCRIPTION

1. The toolbar Data Toolbar and Vector Toolbar only for Display tab were created in that order.
- avoids the new issue created by Data tab re-using the "pencil" icon to allow editing of other mapsets (now user sees two of these icons above each other which is strange)
- avoids the confusion when Data tab is active and a user clicks the Show attribute... button which is associated with selected layer in Displays, not selected vector map in Data tab.

2. We can have NewDisplay button in new Data Toolbar.
- main toolbar will be then a bit shorter than Display toolbar.