### PR TITLE
v.what.rast: no features message wording, switched to be a warning

### DIFF
--- a/vector/v.what.rast/main.c
+++ b/vector/v.what.rast/main.c
@@ -271,8 +271,8 @@ int main(int argc, char *argv[])
     }
 
     if (point_cnt < 1) {
-        G_important_message(_("No features of type (%s) found in vector map <%s>"),
-                            opt.type->answer, opt.vect->answer);
+        G_warning(_("No features of type (%s) found in the current computational region"),
+                  opt.type->answer);
         exit(EXIT_SUCCESS);
     }
     G_debug(1, "Read %d vector points", point_cnt);


### PR DESCRIPTION
From #1257 :

```
g.region n=1 s=0 w=0 e=1 nsres=1 ewres=1
r.random.surface out=rast
g.region n=2 s=1 w=0 e=1 nsres=1 ewres=1
v.random out=vect npoints=1
v.db.addtable vect
g.region n=1 s=0 w=0 e=1 nsres=1 ewres=1
v.what.rast  map=vect raster=rast column=rast
...
Reading features from vector map...
No features of type (point) found in vector map <vect>
```

This PR improves two issues:

* message "No features..." switched to be a warning (to be consistent with `v.what.rast`)
* message clarified (*)

(*)

Input vector map can contain features, as in example above.

```
v.info -t vect
nodes=0
points=1
...
```

Now the module ends up with:

```
v.what.rast  map=vect raster=rast column=rast
Reading features from vector map...
WARNING: No features of type (point) found in the current computational
         region
```