### PR TITLE
datum: add support for D_Rauenberg_1983

### DIFF
--- a/lib/gis/datumtransform.table
+++ b/lib/gis/datumtransform.table
@@ -85,6 +85,7 @@ potsdam "towgs84=590.5,69.5,411.6,-0.796,-0.052,-3.601,8.30" "Germany (West - No
 potsdam "towgs84=584.8,67.0,400.3,0.105,0.013,-2.378,10.29" "Germany (West - Middle - 50d20'N to 52d20'N)" "Accuracy <1m"
 potsdam "towgs84=597.1,71.4,412.1,0.894,0.068,-1.563,7.58" "Germany (West - South - 47d00N to 50d20'N)" "Accuracy <1m"
 potsdam "towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.70" "Germany (Whole Country)" "Accuracy 3m"
+rauenberg83 "towgs84=612.4,77.0,440.2,-0.054,0.057,-2.797,2.55" "Germany (Sachsen)" "Accuracy <1m"
 rd18    "towgs84=565.036,49.914,465.839,-0.4094,0.3597,-1.86854,-4.0772" "Netherlands" "Accuracy about 0.3m"
 bel72   "towgs84=-99.1,53.3,-112.5,0.419,-0.830,1.885,-1.00" "Belgium" "Accuracy about 0.3m"
 por73   "towgs84=-231.0,102.6,29.8,0.615,-0.198,0.881,1.79" "Portugal" " "

--- a/lib/proj/convert.c
+++ b/lib/proj/convert.c
@@ -1062,6 +1062,8 @@ static const char *papszDatumEquiv[] = {
     "Militar_Geographische_Institut",
     "Potsdam_Datum_83",
     "Deutsches_Hauptdreiecksnetz",
+    "Rauenberg_Datum_83",
+    "Deutsches_Hauptdreiecksnetz",
     "South_American_1969",
     "South_American_Datum_1969",
     "ITRF_1992",


### PR DESCRIPTION
The user data provided in https://lists.osgeo.org/pipermail/grass-user/2021-February/082215.html (download at 
https://github.com/amlobat2/Coal-Test-Shapefile) contain a yet unrecognized datum: `Rauenberg_Datum_83` (EPSG:6745, see https://epsg.io/6745-datum).


This PR adds recognition of this datum string:

```
testepsg coal_test.prj
PROJCS["RD/83 / 3-degree Gauss-Kruger zone 5",
    GEOGCS["RD/83",
        DATUM["Rauenberg_Datum_83",
            SPHEROID["Bessel 1841",6377397.155,299.1528128,
                AUTHORITY["EPSG","7004"]],
            AUTHORITY["EPSG","6745"]],
        PRIMEM["Greenwich",0],
        UNIT["Degree",0.0174532925199433]],
    PROJECTION["Transverse_Mercator"],
    PARAMETER["latitude_of_origin",0],
    PARAMETER["central_meridian",15],
    PARAMETER["scale_factor",1],
    PARAMETER["false_easting",5500000],
    PARAMETER["false_northing",0],
    UNIT["metre",1,
        AUTHORITY["EPSG","9001"]],
    AXIS["Easting",EAST],
    AXIS["Northing",NORTH]]
```

My test case:

```
# create location from dataset
grass79 -c coal_test.shp ~/grassdata/RD_83_GK5

GRASS RD_83_GK5/PERMANENT:Coal-Test-Shapefile > g.proj -w
PROJCRS["RD/83 / 3-degree Gauss-Kruger zone 5",
    BASEGEOGCRS["RD/83",
        DATUM["Rauenberg Datum/83",
            ELLIPSOID["Bessel 1841",6377397.155,299.1528128,
                LENGTHUNIT["metre",1]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433]],
        ID["EPSG",4745]],
    CONVERSION["3-degree Gauss-Kruger zone 5",
        METHOD["Transverse Mercator",
            ID["EPSG",9807]],
        PARAMETER["Latitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8801]],
        PARAMETER["Longitude of natural origin",15,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["Scale factor at natural origin",1,
            SCALEUNIT["unity",1],
            ID["EPSG",8805]],
        PARAMETER["False easting",5500000,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["northing (X)",north,
            ORDER[1],
            LENGTHUNIT["metre",1]],
        AXIS["easting (Y)",east,
            ORDER[2],
            LENGTHUNIT["metre",1]],
    USAGE[
        SCOPE["unknown"],
        AREA["Germany - Saxony - east of 13.5°E"],
        BBOX[50.62,13.5,51.58,15.04]],
    ID["EPSG",3399]]
```

Without this PR:

 ```
GRASS RD_83_GK5/PERMANENT:Coal-Test-Shapefile > v.import input=coal_test.shp output=coal_test
WARNING: Datum <Rauenberg_Datum_83> not recognised by GRASS and no
         parameters found
WARNING: Datum <Rauenberg_Datum_83> not recognised by GRASS and no
         parameters found
Check if OGR layer <coal_test> contains polygons...
 100%
...
```

With this PR in place:

```
grass79 -c coal_test.shp ~/grassdata/RD_83_GK5

GRASS RD_83_GK5/PERMANENT:Coal-Test-Shapefile > v.import input=coal_test.shp output=coal_test --o
Importing <coal_test.shp> ...
Check if OGR layer <coal_test> contains polygons...
 100%
Creating attribute table for layer <coal_test>...
...
```

I am not sure if the addition `lib/gis/datumtransform.table` is needed at all or if the addition in `lib/proj/convert.c` is sufficient.