### PR TITLE
v.surf.idw: less confusing error message

### DIFF
--- a/vector/v.surf.idw/main.c
+++ b/vector/v.surf.idw/main.c
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
 	       parm.col->answer, flag.noindex->answer);
     
     if (npoints == 0)
-	G_fatal_error(_("No points found"));
+	G_fatal_error(_("No points found. Check current region with g.region"));
     nsearch = npoints < search_points ? npoints : search_points;
 
     if (!flag.noindex->answer) {


### PR DESCRIPTION
The current error message of v.surf.idw is unhelpful and misleading (see https://lists.osgeo.org/pipermail/grass-user/2021-February/082209.html).

```
GRASS :Coal-Test-Shapefile > v.surf.idw input=coal_test output=coal_test_tested
Input vector map <coal_test@PERMANENT> is 2D - using categories to
interpolate
0 points loaded
ERROR: No points found
```
The reason here is simply that the computation region does not match that of the vector map.

```
GRASS RD_83_GK5/PERMANENT:Coal-Test-Shapefile > v.surf.idw input=coal_test output=coal_test_tested --o
Input vector map <coal_test@PERMANENT> is 2D - using categories to
interpolate
0 points loaded
ERROR: No points found. Check current region with g.region
```

Other candidates in this regard:

```
v.neighbors/main.c
416:        G_warning(_("No points found"));

v.normal/main.c
195:	G_fatal_error(_("No points found"));
```
