### PR TITLE
wxGUI/dbmgr: fix insert record for each category into table

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -3635,7 +3635,8 @@ class LayerBook(wx.Notebook):
                        layer=layer,
                        qlayer=layer,
                        option='cat',
-                       columns=key)
+                       columns=key,
+                       overwrite=True)
 
         if ret == 0:
             # update dialog (only for new layer)


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Create some new vector map without DB table e.g. `v.random output=test npoints=5`
2. Launch Attribute Table Manager `g.gui.dbmgr map=test`
3. Switch to Manage Layers page (tab) -> Add layer page (tab),  create new DB table with name 'test' and add new layer with this table (check 'Insert record for each category into table' checkbox)
4. See error
5. Record for each category have not been added into table

**Error message**

![wxgui_dbmgr_error](https://user-images.githubusercontent.com/50632337/107870624-50875f00-6e9a-11eb-91aa-2f763a43c3cb.png)

**Expected behavior**

The record for each category should be inserted in the table 
