### PR TITLE
wxGUI/dbmgr: fix clik on the 'Modify layer' button if vector map doesn't have any layers

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -3729,7 +3729,11 @@ class LayerBook(wx.Notebook):
     def OnModifyLayer(self, event):
         """Modify layer connection settings"""
 
-        layer = int(self.modifyLayerWidgets['layer'][1].GetStringSelection())
+        layer = self.modifyLayerWidgets['layer'][1].GetStringSelection()
+        if not layer:
+            return
+
+        layer = int(layer)
 
         modify = False
         if self.modifyLayerWidgets['driver'][1].GetStringSelection() != \


### PR DESCRIPTION
Cosmetic fix.

**To Reproduce**
Steps to reproduce the behavior:

1. Create some new vector map without DB table e.g. `v.random output=test npoints=5`
2. Launch Attribute Table Manager `g.gui.dbmgr map=test`
3. Switch to Manage Layers page (tab) -> Modify layer page (tab) and hit 'Modify layer' button
4. See error

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/dbmgr/base.py", line 3733, in OnModifyLayer
    layer = int(self.modifyLayerWidgets['layer'][1].GetStringSelection())
ValueError: invalid literal for int() with base 10:
```