### PR TITLE
libproj: change warning to debug message

### DIFF
--- a/lib/proj/convert.c
+++ b/lib/proj/convert.c
@@ -675,7 +675,7 @@ int GPJ_osr_to_grass(struct Cell_head *cellhd, struct Key_Value **projinfo,
 	    if (datum == NULL) {
 		if (paramspresent < 2)
 		    /* Only give warning if no parameters present */
-		    G_warning(_("Datum <%s> not recognised by GRASS and no parameters found"),
+		    G_debug(1, "Datum <%s> not recognised by GRASS and no parameters found",
 			      pszDatumName);
 	    }
 	    else {
@@ -691,12 +691,12 @@ int GPJ_osr_to_grass(struct Cell_head *cellhd, struct Key_Value **projinfo,
 			GPJ_get_default_datum_params_by_name(datum, &params);
 
 		    if (paramsets < 0)
-			G_warning(_("Datum <%s> apparently recognised by GRASS but no parameters found. "
-				   "You may want to look into this."), datum);
+			G_debug(1, "Datum <%s> apparently recognised by GRASS but no parameters found. "
+				   "You may want to look into this.", datum);
 		    else if (datumtrans > paramsets) {
 
-			G_warning(_("Invalid transformation number %d; valid range is 1 to %d. "
-				   "Leaving datum transform parameters unspecified."),
+			G_debug(1, "Invalid transformation number %d; valid range is 1 to %d. "
+				   "Leaving datum transform parameters unspecified.",
 				  datumtrans, paramsets);
 			datumtrans = 0;
 		    }

--- a/lib/proj/projlib.dox
+++ b/lib/proj/projlib.dox
@@ -36,7 +36,7 @@ versions of GRASS).
 File lib/proj/convert.c contains functions for converting GRASS
 co-ordinate system descriptions to and from the formats used by other
 GIS. Heavy use is made of the OGR library, part of GDAL
-(http://www.gdal.osgeo.org/ogr/).
+(https://gdal.org).
 
 \subsection datum_transformation Datum transformation
 

--- a/lib/proj/projlib.dox
+++ b/lib/proj/projlib.dox
@@ -22,7 +22,11 @@ corrections to account for different datums.
 
 This is transparent for the user as input and output parameters are
 either read from PROJ_INFO and PROJ_UNITS files (<tt>g.proj</tt>,
-<tt>v.proj</tt>, <tt>r.proj</tt>).
+<tt>v.proj</tt>, <tt>r.proj</tt>). In addition, a PROJ_EPSG file is
+stored. GRASS converts a co-ordinate system representation to WKT
+style, the EPSG code is here preferred if available. The TOWGS84 parameter
+is scanned from PROJ_INFO file and appended to co-ordinate system definition
+imported from EPSG code by GDAL library.
 
 In GRASS the wrapper functions in lib/proj/get_proj.c makes the
 preparations to set up the parameter strings and init the info-structures,

--- a/lib/proj/projlib.dox
+++ b/lib/proj/projlib.dox
@@ -1,4 +1,4 @@
-/*! \page projlib GRASS and the PROJ4 projection library
+/*! \page projlib GRASS and the PROJ projection library
 <!-- doxygenized from "GRASS 5 Programmer's Manual" 
      by M. Neteler 11/2005
   -->
@@ -7,16 +7,16 @@ by GRASS Development Team
 
 https://grass.osgeo.org
 
-\section projintro GRASS GIS and the PROJ4 projection library
+\section projintro GRASS GIS and the PROJ projection library
 
-GRASS GIS utilizes the PROJ4 library (<a
-href="http://proj.osgeo.org">http://proj.osgeo.org</a>) originally
+GRASS GIS utilizes the PROJ library (<a
+href="https://proj.org">https://proj.org</a>) originally
 developed by Gerald Evenden/USGS (Cartographic Projection Procedures
 for the UNIX Environment -- A User's Manual, Evenden, 1990, Open-file
-report 90-284). The PROJ4 functions are used through wrapper functions
+report 90-284). The PROJ functions are used through wrapper functions
 in a GRASS environment.
 
-Internally to the PROJ.4 library, projection may involve transformation to
+Internally to the PROJ library, projection may involve transformation to
 and from geodetic co-ordinates (latitude and longitude), and numerical
 corrections to account for different datums.
 
@@ -44,7 +44,10 @@ GRASS generally supports datum transformation (3 parameters, 7 parameters
 and grid).
 <p>
 
-If a warning appears that a certain datum is not recognised by GRASS and
+Note that datum transformation is handled exclusively by PROJ 6 and later.
+In the case that GRASS is compiled with PROJ 5 or older, the datum
+management is still done within GRASS GIS. Only in that case,
+if a warning appears that a certain datum is not recognised by GRASS and
 no parameters found, the datum transformation parameters have to be
 added to $GISBASE/etc/proj/datum.table (and also $GISBASE/etc/proj/datumtransform.table
 if you have 7-parameter transformation parameters). No need to re-compile
@@ -86,19 +89,29 @@ default: cmd
 
  - GPJ_get_datum_params()
  
+ - GPJ_get_datum_transform_by_name()
+
  - GPJ_get_default_datum_params_by_name()
 
  - GPJ_get_ellipsoid_by_name()
  
+ - GPJ__get_ellipsoid_params()
+
  - GPJ_get_ellipsoid_params()
  
  - GPJ_get_equivalent_latlong()
  
  - GPJ_grass_to_osr()
  
+ - GPJ_grass_to_osr2()
+
  - GPJ_grass_to_wkt()
 
+ - GPJ_grass_to_wkt2()
+
  - GPJ_free_datum()
+
+ - GPJ_free_datum_transform()
 
  - GPJ_free_ellps()
  

--- a/scripts/v.import/v.import.html
+++ b/scripts/v.import/v.import.html
@@ -14,7 +14,7 @@ formats including <a href="http://www.gdal.org/drv_shapefile.html">ESRI
 Shapefile</a>, <a href="http://www.gdal.org/drv_mitab.html">Mapinfo
 File</a>, UK .NTF, SDTS, TIGER, IHO S-57 (ENC), DGN, GML, GPX, AVCBin, REC,
 Memory, OGDI, and PostgreSQL, depending on the local OGR installation.
-For details see the <a href="http://www.gdal.org/ogr_formats.html">OGR web
+For details see the <a href="https://gdal.org/drivers/vector/">OGR web
 site</a>. The OGR (Simple Features Library) is part of the
 <a href="http://www.gdal.org">GDAL</a> library, hence GDAL needs to be
 installed to use <em>v.in.ogr</em>.

--- a/vector/v.external.out/v.external.out.html
+++ b/vector/v.external.out/v.external.out.html
@@ -24,7 +24,7 @@ GRASS is not compiled with PostgreSQL support.
 <p>
 Creation <b>options</b> refer to the output format specified
 by <b>format</b> option. See the list of valid creation options
-at <a href="http://www.gdal.org/ogr_formats.html">OGR formats
+at <a href="https://gdal.org/drivers/vector/">OGR formats
 specification page</a>, example
 for <a href="http://www.gdal.org/drv_shapefile.html">ESRI
 Shapefile</a>
@@ -181,7 +181,7 @@ v.external.out loadsettings=gisdb_topo.txt
 
 <ul>
   <li><a href="http://trac.osgeo.org/grass/wiki/Grass7/VectorLib/OGRInterface">GRASS-OGR data provider</a></li>
-  <li><a href="http://www.gdal.org/ogr__api_8h.html">OGR vector library C API</a> documentation</li>
+  <li><a href="https://gdal.org/api/">OGR vector library C API</a> documentation</li>
   <li><a href="http://trac.osgeo.org/grass/wiki/Grass7/VectorLib/PostGISInterface">GRASS-PostGIS data provider</a></li>
   <li><a href="http://www.postgresql.org/docs/9.1/static/libpq.html">libpq - C Library</a></li>
 </ul>

--- a/vector/v.external/v.external.html
+++ b/vector/v.external/v.external.html
@@ -47,7 +47,7 @@ v.external -f
 </pre></div>
 
 For details see
-<a href="http://www.gdal.org/ogr_formats.html">GDAL web site</a>.
+<a href="https://gdal.org/drivers/vector/">GDAL web site</a>.
 
 <h2>EXAMPLES</h2>
 
@@ -124,7 +124,7 @@ Number of areas: 1
 
 <h2>REFERENCES</h2>
 
-<a href="http://www.gdal.org/ogr__api_8h.html">OGR vector library C
+<a href="https://gdal.org/api/">OGR vector library C
 API</a> documentation
 
 <h2>SEE ALSO</h2>

--- a/vector/v.out.ogr/v.out.ogr.html
+++ b/vector/v.out.ogr/v.out.ogr.html
@@ -29,7 +29,7 @@ The list of supported formats is printed with the <em>-l</em> flag.
 
 <p>
 For further available other supported formats go 
-<a href="http://www.gdal.org/ogr_formats.html">here</a>.
+<a href="https://gdal.org/drivers/vector/">here</a>.
 
 <h2>NOTES</h2>
 
@@ -194,7 +194,7 @@ v.out.ogr input=random3d_hull output=random3d_hull.kml format=KML type=face dsco
 
 <ul>
 <li><a href="http://www.gdal.org/">OGR vector library</a></li>
-<li><a href="http://www.gdal.org/ogr__api_8h.html">OGR vector library C API</a>
+<li><a href="https://gdal.org/api/">OGR vector library C API</a>
   documentation</li>
 </ul>
 


### PR DESCRIPTION
- as suggested in the #1331 review, datum transformation is handled exclusively by PROJ 6+ (no backport)
- update of projlib.dox: added note on datum transformation; added missing new functions; fix PROJ4 -> PROJ
- description of PROJ_EPSG file