### PR TITLE
wxGUI: fix 'wxPyDeprecationWarning: Call to deprecated item. Use FindItem instead.'

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1267,7 +1267,7 @@ class GCP(MapFrame, ColumnSorterMixin):
 
         # update key and GCP number
         for newkey in range(key, len(self.mapcoordlist)):
-            index = self.list.FindItemData(-1, newkey + 1)
+            index = self.list.FindItem(-1, newkey + 1)
             self.mapcoordlist[newkey][0] = newkey
             self.list.SetItem(index, 0, str(newkey))
             self.list.SetItemData(index, newkey)
@@ -2484,7 +2484,7 @@ class GCPList(ListCtrl,
 
     def OnColClick(self, event):
         """ListCtrl forgets selected item..."""
-        self.selected = self.FindItemData(-1, self.selectedkey)
+        self.selected = self.FindItem(-1, self.selectedkey)
         self.SetItemState(self.selected,
                           wx.LIST_STATE_SELECTED,
                           wx.LIST_STATE_SELECTED)

--- a/gui/wxpython/gcp/statusbar.py
+++ b/gui/wxpython/gcp/statusbar.py
@@ -61,7 +61,7 @@ class SbGoToGCP(SbItem):
         listCtrl = self.mapFrame.GetListCtrl()
 
         listCtrl.selectedkey = gcpNumber
-        listCtrl.selected = listCtrl.FindItemData(-1, gcpNumber)
+        listCtrl.selected = listCtrl.FindItem(-1, gcpNumber)
         listCtrl.render = False
         listCtrl.SetItemState(listCtrl.selected,
                               wx.LIST_STATE_SELECTED,

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -1233,7 +1233,7 @@ class GCP(MapFrame, ColumnSorterMixin):
 
         # update key and GCP number
         for newkey in range(key, len(self.mapcoordlist)):
-            index = self.list.FindItemData(-1, newkey + 1)
+            index = self.list.FindItem(-1, newkey + 1)
             self.mapcoordlist[newkey][0] = newkey
             self.list.SetItem(index, 0, str(newkey))
             self.list.SetItemData(index, newkey)
@@ -2405,7 +2405,7 @@ class GCPList(ListCtrl,
 
     def OnColClick(self, event):
         """ListCtrl forgets selected item..."""
-        self.selected = self.FindItemData(-1, self.selectedkey)
+        self.selected = self.FindItem(-1, self.selectedkey)
         self.SetItemState(self.selected,
                           wx.LIST_STATE_SELECTED,
                           wx.LIST_STATE_SELECTED)

--- a/gui/wxpython/image2target/ii2t_statusbar.py
+++ b/gui/wxpython/image2target/ii2t_statusbar.py
@@ -61,7 +61,7 @@ class SbGoToGCP(SbItem):
         listCtrl = self.mapFrame.GetListCtrl()
 
         listCtrl.selectedkey = gcpNumber
-        listCtrl.selected = listCtrl.FindItemData(-1, gcpNumber)
+        listCtrl.selected = listCtrl.FindItem(-1, gcpNumber)
         listCtrl.render = False
         listCtrl.SetItemState(listCtrl.selected,
                               wx.LIST_STATE_SELECTED,

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -614,7 +614,7 @@ class GCP(MapFrame, ColumnSorterMixin):
 
         # update key and GCP number
         for newkey in range(key, len(self.mapcoordlist)):
-            index = self.list.FindItemData(-1, newkey + 1)
+            index = self.list.FindItem(-1, newkey + 1)
             self.mapcoordlist[newkey][0] = newkey
             self.list.SetItem(index, 0, str(newkey))
             self.list.SetItemData(index, newkey)
@@ -1711,7 +1711,7 @@ class GCPList(ListCtrl,
 
     def OnColClick(self, event):
         """ListCtrl forgets selected item..."""
-        self.selected = self.FindItemData(-1, self.selectedkey)
+        self.selected = self.FindItem(-1, self.selectedkey)
         self.SetItemState(self.selected,
                           wx.LIST_STATE_SELECTED,
                           wx.LIST_STATE_SELECTED)

--- a/gui/wxpython/photo2image/ip2i_statusbar.py
+++ b/gui/wxpython/photo2image/ip2i_statusbar.py
@@ -61,7 +61,7 @@ class SbGoToGCP(SbItem):
         listCtrl = self.mapFrame.GetListCtrl()
 
         listCtrl.selectedkey = gcpNumber
-        listCtrl.selected = listCtrl.FindItemData(-1, gcpNumber)
+        listCtrl.selected = listCtrl.FindItem(-1, gcpNumber)
         listCtrl.render = False
         listCtrl.SetItemState(listCtrl.selected,
                               wx.LIST_STATE_SELECTED,

--- a/gui/wxpython/vnet/widgets.py
+++ b/gui/wxpython/vnet/widgets.py
@@ -303,7 +303,7 @@ class PointsList(ListCtrl,
 
         # update key and point number
         for newkey in range(key, len(self.itemDataMap)):
-            index = self.FindItemData(-1, newkey + 1)
+            index = self.FindItem(-1, newkey + 1)
             self.itemDataMap[newkey][0] = newkey
             self.SetItem(index, 0, str(newkey + 1))
             self.SetItemData(index, newkey)
@@ -418,7 +418,7 @@ class PointsList(ListCtrl,
 
     def OnColClick(self, event):
         """ListCtrl forgets selected item..."""
-        self.selected = self.FindItemData(-1, self.selectedkey)
+        self.selected = self.FindItem(-1, self.selectedkey)
         self.SetItemState(self.selected,
                           wx.LIST_STATE_SELECTED,
                           wx.LIST_STATE_SELECTED)


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch e.g. Ground Control Points Manager `g.gui.gcp`
2. Increase value for `SpinCtrl` widget (plus button), which is inside `StatusBar` widget
3. See warning message

**Py deprecation warning message**

```
/usr/lib64/grass79/gui/wxpython/gcp/statusbar.py:64: wxPyDeprecationWarning: Call to deprecated item. Use FindItem instead.
```
