### PR TITLE
tests: Output more text and sort files

### DIFF
--- a/lib/python/gunittest/loader.py
+++ b/lib/python/gunittest/loader.py
@@ -59,7 +59,8 @@ def discover_modules(start_dir, skip_dirs, testsuite_dir,
         Implement import_modules.
     """
     modules = []
-    for root, dirs, files in os.walk(start_dir):
+    for root, dirs, unused_files in os.walk(start_dir, topdown=True):
+        dirs.sort()
         for dir_pattern in skip_dirs:
             to_skip = fnmatch.filter(dirs, dir_pattern)
             for skip in to_skip:
@@ -74,8 +75,9 @@ def discover_modules(start_dir, skip_dirs, testsuite_dir,
                 files = fnmatch.filter(all_files, file_pattern)
             if file_regexp:
                 files = [f for f in all_files if re.match(file_regexp, f)]
+            files = sorted(files)
             # get test/module name without .py
-            # extecting all files to end with .py
+            # extpecting all files to end with .py
             # this will not work for invoking bat files but it works fine
             # as long as we handle only Python files (and using Python
             # interpreter for invoking)

--- a/lib/python/gunittest/reporters.py
+++ b/lib/python/gunittest/reporters.py
@@ -958,7 +958,13 @@ class GrassTestFilesTextReporter(GrassTestFilesCountingReporter):
 
     def start_file_test(self, module):
         super(GrassTestFilesTextReporter, self).start_file_test(module)
-        self._stream.flush()  # to get previous lines to the report
+        self._stream.write(
+            "Running {name} ({directory})...\n".format(
+                directory=module.tested_dir, name=module.name
+            )
+        )
+        # get the above line and all previous ones to the report
+        self._stream.flush()
 
     def end_file_test(self, module, cwd, returncode, stdout, stderr,
                       test_summary):
@@ -967,6 +973,13 @@ class GrassTestFilesTextReporter(GrassTestFilesCountingReporter):
             stdout=stdout, stderr=stderr)
 
         if returncode:
+            width = 72
+            self._stream.write(width * "=")
+            self._stream.write("\n")
+            with open(stderr) as text:
+                self._stream.write(text.read())
+            self._stream.write(width * "=")
+            self._stream.write("\n")
             self._stream.write(
                 '{m} from {d} failed'
                 .format(


### PR DESCRIPTION
Text output now contains name of the currently running test and also
error output if the test fails.

Test order should be now stable: directories and files are sorted.
