### PR TITLE
Apply Mega-Linter fixes to GH workflow scripts

### DIFF
--- a/.github/workflows/.editorconfig
+++ b/.github/workflows/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -11,8 +11,7 @@ set -e
 # print commands
 set -x
 
-if [ -z "$1" ]
-then
+if [ -z "$1" ]; then
     echo "Usage: $0 PREFIX"
     exit 1
 fi

--- a/.github/workflows/build_centos.sh
+++ b/.github/workflows/build_centos.sh
@@ -11,8 +11,7 @@ set -e
 # print commands
 set -x
 
-if [ -z "$1" ]
-then
+if [ -z "$1" ]; then
     echo "Usage: $0 PREFIX"
     exit 1
 fi

--- a/.github/workflows/build_osgeo4w.sh
+++ b/.github/workflows/build_osgeo4w.sh
@@ -17,17 +17,17 @@
 set -e
 
 if [ "$1" = "-p" ]; then
-	package=1
-	shift
+    package=1
+    shift
 else
-	package=0
+    package=0
 fi
 
 test -d "$1" && cd "$1"
 
 osgeo4w_path=/c/OSGeo4W64
 arch=x86_64-w64-mingw32
-src=`pwd`
+src=$(pwd)
 
 # compile
 
@@ -35,18 +35,18 @@ export PATH=/mingw64/bin:/c/OSGeo4W64/bin:/usr/bin
 export PROJ_LIB=$osgeo4w_path/share/proj
 
 OSGEO4W_ROOT_MSYS=$osgeo4w_path \
-./configure \
---host=$arch \
---with-includes=$osgeo4w_path/include \
---with-libs="$osgeo4w_path/lib $osgeo4w_path/bin" \
---with-nls \
---with-freetype-includes=$osgeo4w_path/include/freetype2 \
---with-bzlib \
---with-geos=$src/mswindows/osgeo4w/geos-config \
---with-netcdf=$osgeo4w_path/bin/nc-config \
---with-gdal=$src/mswindows/osgeo4w/gdal-config \
---with-liblas=$src/mswindows/osgeo4w/liblas-config \
---with-opengl=windows
+    ./configure \
+    --host=$arch \
+    --with-includes=$osgeo4w_path/include \
+    --with-libs="$osgeo4w_path/lib $osgeo4w_path/bin" \
+    --with-nls \
+    --with-freetype-includes=$osgeo4w_path/include/freetype2 \
+    --with-bzlib \
+    --with-geos=$src/mswindows/osgeo4w/geos-config \
+    --with-netcdf=$osgeo4w_path/bin/nc-config \
+    --with-gdal=$src/mswindows/osgeo4w/gdal-config \
+    --with-liblas=$src/mswindows/osgeo4w/liblas-config \
+    --with-opengl=windows
 
 make
 
@@ -54,19 +54,19 @@ make
 
 bin=bin.$arch
 dist=dist.$arch
-ver=`sed -n '/^INST_DIR[ \t]*=/{s/^.*grass//; p}' include/Make/Platform.make`
+ver=$(sed -n '/^INST_DIR[ \t]*=/{s/^.*grass//; p}' include/Make/Platform.make)
 
 rm -f $dist/grass$ver.tmp $dist/etc/fontcap
 
 # create batch files
 
-src_esc=`echo $src | sed 's#^/\([a-z]\)#\1:#; s#/#\\\\\\\\#g'`
+src_esc=$(echo $src | sed 's#^/\([a-z]\)#\1:#; s#/#\\\\\\\\#g')
 dist_esc="$src_esc\\\\$dist"
 
 (
-sed 's/^\(set GISBASE=\).*/\1'$dist_esc'/' \
-    mswindows/osgeo4w/env.bat.tmpl
-cat<<EOT
+    sed 's/^\(set GISBASE=\).*/\1'$dist_esc'/' \
+        mswindows/osgeo4w/env.bat.tmpl
+    cat <<EOT
 
 set PATH=C:\\msys64\\mingw64\\bin;%OSGEO4W_ROOT%\\apps\\msys\\bin;%PATH%
 
@@ -79,16 +79,16 @@ if not exist %GISBASE%\etc\fontcap (
 	popd
 )
 EOT
-) > $dist/etc/env.bat
+) >$dist/etc/env.bat
 unix2dos $dist/etc/env.bat
 
 (
-sed -e 's/^\(call "\)%~dp0\(.*\)$/\1C:\\OSGeo4W64\\bin\2/' \
-    -e 's/^\(call "\).*\(\\etc\\env\.bat"\)$/\1'$dist_esc'\2/' \
-    -e 's/^\(.* "\)%GISBASE%\\etc\(\\grass.*\)$/\1%GISBASE%\\..\\'$bin'\2/' \
-    -e 's/@POSTFIX@/'$ver'/g' \
-    mswindows/osgeo4w/grass.bat.tmpl
-) > $bin/grass$ver.bat
+    sed -e 's/^\(call "\)%~dp0\(.*\)$/\1C:\\OSGeo4W64\\bin\2/' \
+        -e 's/^\(call "\).*\(\\etc\\env\.bat"\)$/\1'$dist_esc'\2/' \
+        -e 's/^\(.* "\)%GISBASE%\\etc\(\\grass.*\)$/\1%GISBASE%\\..\\'$bin'\2/' \
+        -e 's/@POSTFIX@/'$ver'/g' \
+        mswindows/osgeo4w/grass.bat.tmpl
+) >$bin/grass$ver.bat
 unix2dos $bin/grass$ver.bat
 
 test $package -eq 0 && exit
@@ -101,13 +101,13 @@ grass_path=$opt_path/grass
 mkdir -p $opt_path
 cp -a $dist $grass_path
 cp -a $bin/grass$ver.py $grass_path/etc
-cp -a `ldd $dist/lib/*.dll | awk '/mingw64/{print $3}' |
-	sort -u | grep -v 'lib\(crypto\|ssl\)'` $grass_path/lib
+cp -a $(ldd $dist/lib/*.dll | awk '/mingw64/{print $3}' |
+    sort -u | grep -v 'lib\(crypto\|ssl\)') $grass_path/lib
 
 (
-sed -e 's/^\(set GISBASE=\).*/\1%OSGEO4W_ROOT%\\opt\\grass/' \
-    mswindows/osgeo4w/env.bat.tmpl
-cat<<EOT
+    sed -e 's/^\(set GISBASE=\).*/\1%OSGEO4W_ROOT%\\opt\\grass/' \
+        mswindows/osgeo4w/env.bat.tmpl
+    cat <<EOT
 
 set PATH=%OSGEO4W_ROOT%\\apps\\msys\\bin;%PATH%
 
@@ -120,23 +120,23 @@ if not exist %GISBASE%\etc\fontcap (
 	popd
 )
 EOT
-) > $grass_path/etc/env.bat
+) >$grass_path/etc/env.bat
 unix2dos $grass_path/etc/env.bat
 
 (
-sed -e 's/^\(call "%~dp0\)\(.*\)$/\1\\..\\..\\bin\2/' \
-    -e 's/^\(call "%OSGEO4W_ROOT%\\\).*\(\\etc\\env\.bat"\)$/\1opt\\grass\2/' \
-    -e 's/@POSTFIX@/'$ver'/g' \
-    mswindows/osgeo4w/grass.bat.tmpl
-) > $grass_path/grass$ver.bat
+    sed -e 's/^\(call "%~dp0\)\(.*\)$/\1\\..\\..\\bin\2/' \
+        -e 's/^\(call "%OSGEO4W_ROOT%\\\).*\(\\etc\\env\.bat"\)$/\1opt\\grass\2/' \
+        -e 's/@POSTFIX@/'$ver'/g' \
+        mswindows/osgeo4w/grass.bat.tmpl
+) >$grass_path/grass$ver.bat
 unix2dos $grass_path/grass$ver.bat
 
 exit
 
 # don't package for GitHub workflow; unnecessary
 
-osgeo4w_basename=`basename $osgeo4w_path`
-date=`date +%Y%m%d`
+osgeo4w_basename=$(basename $osgeo4w_path)
+date=$(date +%Y%m%d)
 zip=$src/grass$ver-$arch-osgeo4w64-$date.zip
 
 cd $osgeo4w_path/..

--- a/.github/workflows/test_thorough.sh
+++ b/.github/workflows/test_thorough.sh
@@ -10,5 +10,5 @@ grass79 --tmp-location XY --exec \
 
 grass79 --tmp-location XY --exec \
     python3 -m grass.gunittest.main \
-        --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
-        --min-success 80
+    --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
+    --min-success 80


### PR DESCRIPTION
This applies all fixes from ShellCheck and shfmt (though Mega-Linter).
.editorconfig file is used to configure shfmt to use 4 space indentation
(like we use in Python).
