### PR TITLE
wxGUI/dbmgr: fix calculate column values

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -595,7 +595,8 @@ class VirtualAttributeList(ListCtrl,
                    map=self.mapDBInfo.map,
                    layer=self.layer,
                    option=option,
-                   columns=self.GetColumn(self._col).GetText())
+                   columns=self.GetColumn(self._col).GetText(),
+                   overwrite=True)
 
         self.LoadData(self.layer)
 


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager `g.gui.dbmgr map=railroads`
2. Add some new column e.g. 'line_length' (double precision)
3. Right mouse click on the new added column 'line_length'
4. From the menu choose Calculate (only numeric columns) -> Line length
5. See error message

**Error message**

![wx_dbmgr_calculate_column_values](https://user-images.githubusercontent.com/50632337/108462349-c154bf80-727c-11eb-9c81-b2587558635f.png)

Same as in the PR https://github.com/OSGeo/grass/pull/1333.

**Expected behavior**

Calculated values of the lines length in the column.