### PR TITLE
wxGUI/dbmgr: fix hit 'Refresh' button if vector map doesn't have any layers

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2012,6 +2012,8 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
     def OnApplySqlStatement(self, event):
         """Apply simple/advanced sql statement"""
+        if not self.layerPage:
+            return
         keyColumn = -1  # index of key column
         listWin = self.FindWindowById(self.layerPage[self.selLayer]['data'])
         sql = None


### PR DESCRIPTION
Cosmetic fix.

**To Reproduce**
Steps to reproduce the behavior:

1. Create some new vector map without DB table e.g. `v.random output=test npoints=5`
2. Launch Attribute Table Manager `g.gui.dbmgr map=test`
3. Hit Refresh button
4. See error

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/dbmgr/manager.py",
line 207, in OnReloadData

self.pages['browse'].OnDataReload(event)  # TODO replace by
signal
  File "/usr/lib64/grass79/gui/wxpython/dbmgr/base.py", line
1898, in OnDataReload

self.OnApplySqlStatement(None)
  File "/usr/lib64/grass79/gui/wxpython/dbmgr/base.py", line
2016, in OnApplySqlStatement

listWin =
self.FindWindowById(self.layerPage[self.selLayer]['data'])
KeyError
:
None
```