### PR TITLE
Allow parsing long GISDBASE paths

### DIFF
--- a/lib/gis/env.c
+++ b/lib/gis/env.c
@@ -115,8 +115,9 @@ void G__read_gisrc_env(void)
 }
 
 static void parse_env(FILE *fd, int loc)
-{    
-    char buf[200];
+{
+    /* Account for long lines up to GPATH_MAX. */
+    char buf[GPATH_MAX + 16];
     char *name;
     char *value;
 

--- a/lib/gis/env.c
+++ b/lib/gis/env.c
@@ -116,7 +116,8 @@ void G__read_gisrc_env(void)
 
 static void parse_env(FILE *fd, int loc)
 {
-    /* Account for long lines up to GPATH_MAX. */
+    /* Account for long lines up to GPATH_MAX. 
+       E.g. "GISDBASE: GPATH_MAX\n\0" */
     char buf[GPATH_MAX + 16];
     char *name;
     char *value;


### PR DESCRIPTION
Use a larger buffer when parsing the `.gisrc` file. Use `GPATH_MAX` to fit whatever would fit in the path value, plus the length of the key, plus 2 for newline character and null byte.

Fixes #1373.