### PR TITLE
Add missing #include <stdlib.h> to display/d.where/main.c

### DIFF
--- a/display/d.where/main.c
+++ b/display/d.where/main.c
@@ -19,6 +19,7 @@
  *               for details.
  *
  *****************************************************************************/
+#include <stdlib.h>
 #include <string.h>
 #include <grass/gis.h>
 #include <grass/gprojects.h>


### PR DESCRIPTION
It is required for `exit()`, and more importantly for `EXIT_SUCCESS`. Without this, compilation fails with with Clang 11.0.1 with the flags listed in #1327.