### PR TITLE
Flake8 fixes for utils and man

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,59 @@
+[flake8]
+ignore =
+    E203,  # whitespace before ':' (Black)
+    W503,  # line break before binary operator (Black)
+
+per-file-ignores =
+    utils/mkrest.py: E501, W605
+    utils/gitlog2changelog.py: E722, E712, W605
+    utils/g.html2man/ggroff.py: W605
+    man/build_check_rest.py: F403, F405
+    man/build_full_index_rest.py: F403, F405
+    man/parser_standard_options.py: F403, F405
+    man/build_class.py: F403, F405
+    man/build_class_rest.py: F403, F405
+    man/build_check.py: F403, F405
+    man/build_full_index.py: F403, F405
+    man/build_index.py: F403, F405
+    man/build_index_rest.py: F403, F405
+    man/build_keywords.py: F403, F405, E722
+    man/build_topics.py: F403, F405, E722
+    man/build_html.py: E501
+    man/build_rest.py: E501
+
+max-line-length = 88
+exclude =
+    .git,
+    __pycache__,
+    .env,
+    .venv,
+    env,
+    venv,
+    ENV,
+    env.bak,
+    venv.bak,
+    # Build directories
+    bin.*,
+    dist.*,
+    # Test output directory
+    testreport,
+    # Have their own configs for now
+    lib/init,
+    python/grass,
+    gui/wxpython,
+    scripts,
+    temporal,
+    # No tests checked for now
+    testsuite,
+    # To be resolved later
+    imagery/i.atcorr/create_iwave.py,
+    raster/r.solute.transport,
+    display/d.mon/render_cmd.py,
+    locale/grass_po_stats.py,
+    general/g.parser/test.py,
+    docker/testdata/test_grass_session.py,
+    doc/python,
+    doc/gui/wxpython/example,
+
+builtins =
+    _

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         directory:
+          - .
           - gui/wxpython
           - lib/init
           - python/grass

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # checks for HTML files missing DESCRIPTION section
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009
+# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
 import sys
 import os
-import string
 
 from build_html import *
 

--- a/man/build_check_rest.py
+++ b/man/build_check_rest.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # checks for HTML files missing DESCRIPTION section
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009
+# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
 import sys
 import os
-import string
 
 from build_rest import *
 

--- a/man/build_class.py
+++ b/man/build_class.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # generates HTML man pages docs/html/<category>.html
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009, 2019
+# (C) 2003-2019 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
 import sys
 import os
-import string
 
 from build_html import *
 

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -238,7 +238,6 @@ def main():
     if len(sys.argv) > 2:
         short_family = sys.argv[2]
         module_family = sys.argv[3]
-        classes = [(short_family, module_family)]
         if len(sys.argv) > 4:
             year = sys.argv[4]
 

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # generates REST man pages docs/rest/<category>.txt
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009
+# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
 import sys
 import os
-import string
 
 from build_rest import *
 

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # generates docs/html/full_index.html
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009
+# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
 import sys
 import os
-import string
 
 from build_html import *
 

--- a/man/build_full_index_rest.py
+++ b/man/build_full_index_rest.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 # generates docs/rest/full_index.txt
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009
+# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
-import sys
 import os
-import string
 
 from build_rest import *
 

--- a/man/build_graphical_index.py
+++ b/man/build_graphical_index.py
@@ -16,8 +16,6 @@
 
 import os
 import sys
-import fnmatch
-import re
 
 from build_html import write_html_footer, grass_version, header1_tmpl
 

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -2,14 +2,17 @@
 # -*- coding: utf-8 -*-
 
 # utilities for generating HTML indices
-# (c) 2003-2021 by the GRASS Development Team, Markus Neteler, Glynn Clements, Luca Delucchi
+# (C) 2003-2021 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
+#   Luca Delucchi
 
-import sys
 import os
 import string
 from datetime import datetime
 
-## TODO: better fix this in include/Make/Html.make, see bug RT #5361
+# TODO: better fix this in include/Make/Html.make, see bug RT #5361
 
 # exclude following list of modules from help index:
 
@@ -28,7 +31,7 @@ desc_override = {
     "r.li.daemon": "Support module for r.li landscape index calculations.",
 }
 
-############################################################################
+# File template pieces follow
 
 header1_tmpl = string.Template(
     r"""<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
@@ -198,7 +201,7 @@ overview_tmpl = string.Template(
 )
 # "
 
-footer_tmpl = string.Template(  ## TODO: https://trac.osgeo.org/grass/ticket/3987
+footer_tmpl = string.Template(  # TODO: https://trac.osgeo.org/grass/ticket/3987
     # r"""<a name="wxGUI"></a>
     # <h3>wxGUI: Graphical user interface</h3>
     # <table><tbody>
@@ -403,7 +406,7 @@ def write_file(name, contents):
 def try_mkdir(path):
     try:
         os.mkdir(path)
-    except OSError as e:
+    except OSError:
         pass
 
 
@@ -418,7 +421,7 @@ def replace_file(name):
     else:
         try:
             os.remove(name)
-        except OSError as e:
+        except OSError:
             pass
         os.rename(temp, name)
 

--- a/man/build_index.py
+++ b/man/build_index.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # generates docs/html/index.html
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009
+# (C) 2003-2009 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
 
 import sys
 import os
-import string
 
 from build_html import *
 

--- a/man/build_index_rest.py
+++ b/man/build_index_rest.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 # generates docs/rest/index.txt
-# (c) The GRASS Development Team, Markus Neteler, Glynn Clements 2003, 2004, 2005, 2006, 2009, Luca Delucchi 2012
+# (C) 2003-2012 Markus Neteler and the GRASS Development Team
+# Authors:
+#   Markus Neteler
+#   Glynn Clements
+#   Luca Delucchi
 
-import sys
 import os
-import string
 
 from build_rest import *
 

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -3,17 +3,18 @@
 """
 Created on Thu Aug  9 14:04:12 2012
 
-@author: lucadelu
+@author: Luca Delucchi
+@author: Markus Neteler
+@author: Glynn Clements
 """
 # utilities for generating REST indices
 # utilities for generating HTML indices
-# (c) 2003-2021 by the GRASS Development Team, Markus Neteler, Glynn Clements, Luca Delucchi
+# (C) 2003-2021 by Luca Delucchi and the GRASS Development Team
 
-import sys
 import os
 import string
 
-## TODO: better fix this in include/Make/Rest.make, see bug RT #5361
+# TODO: better fix this in include/Make/Rest.make, see bug RT #5361
 
 # exclude following list of modules from help index:
 
@@ -82,7 +83,7 @@ Display/Graphical User Interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. toctree::
     :maxdepth: 1
-        
+
         wxGUI wxPython-based GUI frontend <wxGUI>
         Display commands manual <display>
         Display drivers <displaydrivers>
@@ -94,7 +95,7 @@ Raster and 3D raster processing
 
 .. toctree::
     :maxdepth: 1
-    
+
         Raster commands manual <raster>
         3D raster (voxel) commands manual <raster3D>
 
@@ -103,26 +104,24 @@ Image processing
 
 .. toctree::
     :maxdepth: 1
-    
+
          Imagery commands manual <imagery>
-         
-         
 
 Vector processing
 ~~~~~~~~~~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
-    
+
         Vector commands manual <vector>
         GRASS ASCII vector format specification <vectorascii>
-        
+
 Database
 ~~~~~~~~~
 
 .. toctree::
     :maxdepth: 1
-    
+
         SQL support in GRASS GIS <sql>
         Database commands manual <database>
 
@@ -131,7 +130,7 @@ General
 
 .. toctree::
     :maxdepth: 1
-    
+
         GRASS startup manual page <grass7>
         General commands manual <general>
 
@@ -140,7 +139,7 @@ Miscellaneous & Variables
 
 .. toctree::
     :maxdepth: 1
-    
+
         Miscellaneous commands manual <miscellaneous>
         GRASS variables and environment variables <variables>
 
@@ -149,7 +148,7 @@ Temporal processing
 
 .. toctree::
     :maxdepth: 1
-    
+
         Temporal commands manual <temporal>
 
 Printing
@@ -157,7 +156,7 @@ Printing
 
 .. toctree::
     :maxdepth: 1
-    
+
         PostScript commands manual <postscript>
 
 """
@@ -184,7 +183,6 @@ ${cmd}.* commands:
 
 .. toctree::
     :maxdepth: 1
-    
 
 """
 )
@@ -239,7 +237,6 @@ modclass_tmpl = string.Template(
 
 .. toctree::
     :maxdepth: 1
-    
 
 """
 )
@@ -289,7 +286,7 @@ def write_file(name, contents):
 def try_mkdir(path):
     try:
         os.mkdir(path)
-    except OSError as e:
+    except OSError:
         pass
 
 
@@ -304,7 +301,7 @@ def replace_file(name):
     else:
         try:
             os.remove(name)
-        except OSError as e:
+        except OSError:
             pass
         os.rename(temp, name)
 
@@ -364,7 +361,7 @@ def get_desc(cmd):
     return ""
 
 
-############################################################################
+# Define global variables
 
 arch_dist_dir = os.environ["ARCH_DISTDIR"]
 rest_dir = os.path.join(arch_dist_dir, "docs", "rest")
@@ -374,5 +371,3 @@ try:
     grass_version = ver.split()[0].strip()
 except IndexError:
     grass_version = ver.split().strip()
-
-############################################################################

--- a/man/sphinx/conf.py
+++ b/man/sphinx/conf.py
@@ -11,9 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -172,11 +169,11 @@ htmlhelp_basename = "grass79Documentationdoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    # 'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/utils/create_python_init_file.py
+++ b/utils/create_python_init_file.py
@@ -22,7 +22,7 @@ import glob
 
 def main(path):
     if not os.path.exists(path) or not os.path.isdir(path):
-        print >>sys.stderr, "'%s' is not a directory" % path
+        print("'{}' is not a directory".format(path), file=sys.stderr)
         return 1
 
     modules = []

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -6,7 +6,7 @@ __all__ = ["Formatter"]
 
 try:
     version = os.environ["VERSION_NUMBER"]
-except:
+except KeyError:
     version = ""
 
 styles = {

--- a/utils/g.html2man/ghtml.py
+++ b/utils/g.html2man/ghtml.py
@@ -14,7 +14,7 @@ try:
     import HTMLParser as base
 
     HTMLParseError = base.HTMLParseError
-except:
+except ImportError:
     # Python 3 import
     import html.parser as base
 

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -3,7 +3,6 @@
 # Minor changes for NUT by Charles Lepple
 # Distributed under the terms of the GNU General Public License v2 or later
 
-import string
 import re
 import os
 from textwrap import TextWrapper

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -27,12 +27,12 @@ import json
 try:
     # Python 2 import
     from HTMLParser import HTMLParser
-except:
+except ImportError:
     # Python 3 import
     from html.parser import HTMLParser
 try:
     import urlparse
-except:
+except ImportError:
     import urllib.parse as urlparse
 
 if sys.version_info[0] == 2:
@@ -110,7 +110,11 @@ header_pgm_desc = """<h2>NAME</h2>
 
 sourcecode = string.Template(
     """<h2>SOURCE CODE</h2>
-<p>Available at: <a href="${URL_SOURCE}">${PGM} source code</a> (<a href="${URL_LOG}">history</a>)</p>
+<p>
+  Available at:
+  <a href="${URL_SOURCE}">${PGM} source code</a>
+  (<a href="${URL_LOG}">history</a>)
+</p>
 """
 )
 

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -13,7 +13,6 @@
 #       for details.
 #
 
-import sys
 import os
 import atexit
 import grass.script as grass


### PR DESCRIPTION
This applies fixes for basic Flake8 issues to Python scripts in utils and man.
Number of issues is ignored in the config file; ideally to be resolved later.

This adds a Flake8 config file to the top level directory and runs Flake8 from there
ignoring directories checked separatelly and files not yet fixed.
However, it checks any other Python file which shows up in the source code outside
of the standard directories (e.g., a script for creating visuals for a module doc).
