### PR TITLE
Remove duplicate declaration of int columns

### DIFF
--- a/raster/r.mapcalc/map.c
+++ b/raster/r.mapcalc/map.c
@@ -23,7 +23,6 @@
 /****************************************************************************/
 
 static void prepare_region_from_maps(expression **, int, int);
-int columns;
 struct Cell_head current_region2;
 
 void setup_region(void)


### PR DESCRIPTION
It is already declared as an extern in `raster/r.mapcalc/globals.h`, which is included in `raster/r.mapcalc/map.c`, so this second declaration should not be necessary. It appears to cause linker errors as described in #1327.

Fixes #1327.