### PR TITLE
CI: Switch Travis to Ubuntu 20.04 (focal)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ cache: ccache
 matrix:
    include:
       - os: linux
-        dist: xenial
+        dist: focal
         compiler: gcc
         sudo: required
         env:
             CC=gcc
 
       - os: linux
-        dist: xenial
+        dist: focal
         compiler: clang
         sudo: required
         env:

--- a/.travis/linux.install.sh
+++ b/.travis/linux.install.sh
@@ -10,7 +10,7 @@ sudo apt-get install --no-install-recommends \
         libgdal-dev \
         libgeos-dev \
         libglu1-mesa-dev \
-        libgsl0-dev \
+        libgsl-dev \
         libjpeg-dev \
         liblapack-dev \
         libncurses5-dev \
@@ -26,7 +26,7 @@ sudo apt-get install --no-install-recommends \
         libreadline-dev \
         libsqlite3-dev \
         libtiff-dev \
-        libwxgtk3.0-dev \
+        libwxgtk3.0-gtk3-dev \
         libxmu-dev \
         libzstd-dev \
         python3 \


### PR DESCRIPTION
This makes it possible to have Python 3.6 only syntax in the source code.
