### PR TITLE
Apply Black to temporal modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ exclude = '''
     | gui
     | imagery
     | lib/gis
-    | temporal
     | raster
     | vector
     | docker/testdata/test_grass_session.py

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 ignore =
+    E203,  # whitespace before ':' (Black)
+    W503,  # line break before binary operator (Black)
     F841, # local variable 'column' is assigned to but never used
     F821, # undefined name '_'
     E265, # block comment should start with '# '

--- a/temporal/.flake8
+++ b/temporal/.flake8
@@ -2,33 +2,17 @@
 ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
-    F841, # local variable 'column' is assigned to but never used
-    F821, # undefined name '_'
-    E265, # block comment should start with '# '
-    E266, # too many leading '#' for block comment
-    E502, # the backslash is redundant between brackets
-    W291, # trailing whitespace
-    W293, # blank line contains whitespace
-    W391, # blank line at end of file
-    W504, # line break after binary operator
-    E117, # over-indented
-    E125, # continuation line with same indent as next logical line
-    E126, # continuation line over-indented for hanging indent
-    E127, # continuation line over-indented for visual indent
-    E128, # continuation line under-indented for visual indent
-    E129, # visually indented line with same indent as next logical line
-    E222, # multiple spaces after operator
-    E225, # missing whitespace around operator
-    E226, # missing whitespace around arithmetic operator
-    E231, # missing whitespace after ','
-    E241, # multiple spaces after ','
-    E251, # unexpected spaces around keyword / parameter equals
-    E271, # multiple spaces after keyword
-    E302, # expected 2 blank lines, found 1
-    E303, # too many blank lines (2)
-    E305, # expected 2 blank lines after class or function definition, found 1
-    E501, # line too long (179 > 150 characters)
-  
+    E501,  # line too long (179 > 150 characters)
+
+per-file-ignores =
+    # local variable 'column' is assigned to but never used
+    t.rast.to.vect/t.rast.to.vect.py: F841
+    # local variable 'stdstype' is assigned to but never used
+    t.vect.algebra/t.vect.algebra.py: F841
+    # ## used (##% key: r etc)
+    # local variable 'map_list' is assigned to but never used
+    t.rast.what/t.rast.what.py: E265, E266, F841
+
 max-line-length = 88
 exclude =
     .git,
@@ -43,3 +27,6 @@ exclude =
     ctypes,
     pydispatch,
     testsuite,
+
+builtins =
+    _

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
@@ -17,8 +17,8 @@ import os
 class TestRasterExtraction(TestCase):
 
     mapsets_to_remove = []
-    outfile = 'rastlist.txt'
-    gisenv = SimpleModule('g.gisenv', get='MAPSET')
+    outfile = "rastlist.txt"
+    gisenv = SimpleModule("g.gisenv", get="MAPSET")
     TestCase.runModule(gisenv, expecting_stdout=True)
     old_mapset = gisenv.outputs.stdout.strip()
 
@@ -29,31 +29,43 @@ class TestRasterExtraction(TestCase):
             mapset_name = "test%i" % i
             cls.runModule("g.mapset", flags="c", mapset=mapset_name)
             cls.mapsets_to_remove.append(mapset_name)
-            cls.runModule("g.region", s=0, n=80,
-                          w=0, e=120, b=0, t=50, res=10, res3=10)
+            cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
             cls.runModule("t.connect", flags="d")
             cls.runModule("t.info", flags="d")
             cls.runModule("r.mapcalc", expression="a1 = 100")
             cls.runModule("r.mapcalc", expression="a2 = 200")
             cls.runModule("r.mapcalc", expression="a3 = 300")
-            cls.runModule("t.create", type="strds", temporaltype="absolute",
-                          output="A", title="A test", description="A test")
-            cls.runModule("t.register", flags="i", type="raster", input="A",
-                          maps="a1,a2,a3",
-                          start="2001-01-01", increment="%i months" % i)
+            cls.runModule(
+                "t.create",
+                type="strds",
+                temporaltype="absolute",
+                output="A",
+                title="A test",
+                description="A test",
+            )
+            cls.runModule(
+                "t.register",
+                flags="i",
+                type="raster",
+                input="A",
+                maps="a1,a2,a3",
+                start="2001-01-01",
+                increment="%i months" % i,
+            )
 
         # Add the new mapsets to the search path
         for mapset in cls.mapsets_to_remove:
             cls.runModule("g.mapset", mapset=mapset)
-            cls.runModule("g.mapsets", operation="add", mapset=','.join(cls.mapsets_to_remove))
-
+            cls.runModule(
+                "g.mapsets", operation="add", mapset=",".join(cls.mapsets_to_remove)
+            )
 
     @classmethod
     def tearDownClass(cls):
-        gisenv = SimpleModule('g.gisenv', get='GISDBASE')
+        gisenv = SimpleModule("g.gisenv", get="GISDBASE")
         cls.runModule(gisenv, expecting_stdout=True)
         gisdbase = gisenv.outputs.stdout.strip()
-        gisenv = SimpleModule('g.gisenv', get='LOCATION_NAME')
+        gisenv = SimpleModule("g.gisenv", get="LOCATION_NAME")
         cls.runModule(gisenv, expecting_stdout=True)
         location = gisenv.outputs.stdout.strip()
         cls.runModule("g.mapset", mapset=cls.old_mapset)
@@ -72,9 +84,12 @@ class TestRasterExtraction(TestCase):
                                 A|test6|2001-01-01 00:00:00|2002-07-01 00:00:00|3"""
 
         t_list = SimpleModule(
-            "t.list", quiet=True,
+            "t.list",
+            quiet=True,
             columns=["name", "mapset,start_time", "end_time", "number_of_maps"],
-            type="strds", where='name = "A"')
+            type="strds",
+            where='name = "A"',
+        )
         self.assertModule(t_list)
 
         out = t_list.outputs["stdout"].value
@@ -83,16 +98,20 @@ class TestRasterExtraction(TestCase):
             self.assertEqual(a.strip(), b.strip())
 
         t_list = SimpleModule(
-            "t.list", quiet=True,
+            "t.list",
+            quiet=True,
             columns=["name", "mapset,start_time", "end_time", "number_of_maps"],
-            type="strds", where='name = "A"', output=self.outfile)
+            type="strds",
+            where='name = "A"',
+            output=self.outfile,
+        )
         self.assertModule(t_list)
         self.assertFileExists(self.outfile)
-        with open(self.outfile, 'r') as f:
+        with open(self.outfile, "r") as f:
             read_data = f.read()
         for a, b in zip(list_string.split("\n"), read_data.split("\n")):
             self.assertEqual(a.strip(), b.strip())
-        #self.assertLooksLike(reference=read_data, actual=list_string)
+        # self.assertLooksLike(reference=read_data, actual=list_string)
         if os.path.isfile(self.outfile):
             os.remove(self.outfile)
 
@@ -103,8 +122,7 @@ class TestRasterExtraction(TestCase):
                                 a2|test1|2001-02-01 00:00:00|2001-03-01 00:00:00
                                 a3|test1|2001-03-01 00:00:00|2001-04-01 00:00:00"""
 
-        trast_list = SimpleModule(
-            "t.rast.list", quiet=True, flags="u", input="A@test1")
+        trast_list = SimpleModule("t.rast.list", quiet=True, flags="u", input="A@test1")
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -116,8 +134,7 @@ class TestRasterExtraction(TestCase):
                                 a2|test2|2001-03-01 00:00:00|2001-05-01 00:00:00
                                 a3|test2|2001-05-01 00:00:00|2001-07-01 00:00:00"""
 
-        trast_list = SimpleModule(
-            "t.rast.list", quiet=True, flags="u", input="A@test2")
+        trast_list = SimpleModule("t.rast.list", quiet=True, flags="u", input="A@test2")
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -129,8 +146,7 @@ class TestRasterExtraction(TestCase):
                                 a2|test3|2001-04-01 00:00:00|2001-07-01 00:00:00
                                 a3|test3|2001-07-01 00:00:00|2001-10-01 00:00:00"""
 
-        trast_list = SimpleModule(
-            "t.rast.list", quiet=True, flags="u", input="A@test3")
+        trast_list = SimpleModule("t.rast.list", quiet=True, flags="u", input="A@test3")
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -142,8 +158,7 @@ class TestRasterExtraction(TestCase):
                                 a2|test4|2001-05-01 00:00:00|2001-09-01 00:00:00
                                 a3|test4|2001-09-01 00:00:00|2002-01-01 00:00:00"""
 
-        trast_list = SimpleModule(
-            "t.rast.list", quiet=True, flags="u", input="A@test4")
+        trast_list = SimpleModule("t.rast.list", quiet=True, flags="u", input="A@test4")
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -155,8 +170,7 @@ class TestRasterExtraction(TestCase):
                                 a2|test5|2001-06-01 00:00:00|2001-11-01 00:00:00
                                 a3|test5|2001-11-01 00:00:00|2002-04-01 00:00:00"""
 
-        trast_list = SimpleModule(
-            "t.rast.list", quiet=True, flags="u", input="A@test5")
+        trast_list = SimpleModule("t.rast.list", quiet=True, flags="u", input="A@test5")
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -164,11 +178,12 @@ class TestRasterExtraction(TestCase):
         for a, b in zip(list_string.split("\n"), out.split("\n")):
             self.assertEqual(a.strip(), b.strip())
 
-        trast_list = SimpleModule("t.rast.list", quiet=True, flags="u",
-                                  input="A@test5", output=self.outfile)
+        trast_list = SimpleModule(
+            "t.rast.list", quiet=True, flags="u", input="A@test5", output=self.outfile
+        )
         self.assertModule(trast_list)
         self.assertFileExists(self.outfile)
-        with open(self.outfile, 'r') as f:
+        with open(self.outfile, "r") as f:
             read_data = f.read()
         for a, b in zip(list_string.split("\n"), read_data.split("\n")):
             self.assertEqual(a.strip(), b.strip())
@@ -186,7 +201,8 @@ class TestRasterExtraction(TestCase):
 
         info = SimpleModule("t.info", flags="g", input="A@test1")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="test3")
         tinfo_string = """id=A@test2
@@ -198,7 +214,8 @@ class TestRasterExtraction(TestCase):
 
         info = SimpleModule("t.info", flags="g", input="A@test2")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="test2")
         tinfo_string = """id=A@test3
@@ -210,7 +227,8 @@ class TestRasterExtraction(TestCase):
 
         info = SimpleModule("t.info", flags="g", input="A@test3")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="test1")
         tinfo_string = """id=A@test4
@@ -222,7 +240,8 @@ class TestRasterExtraction(TestCase):
 
         info = SimpleModule("t.info", flags="g", input="A@test4")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=A@test5
                                     name=A
@@ -233,7 +252,8 @@ class TestRasterExtraction(TestCase):
 
         info = SimpleModule("t.info", flags="g", input="A@test5")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_raster_info(self):
         self.runModule("g.mapset", mapset="test3")
@@ -244,10 +264,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-02-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster", input="a1@test1")
+        info = SimpleModule("t.info", flags="g", type="raster", input="a1@test1")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test2
                                 name=a1
@@ -256,10 +276,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-03-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster", input="a1@test2")
+        info = SimpleModule("t.info", flags="g", type="raster", input="a1@test2")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test3
                                 name=a1
@@ -268,10 +288,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-04-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster", input="a1@test3")
+        info = SimpleModule("t.info", flags="g", type="raster", input="a1@test3")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test4
                                 name=a1
@@ -280,10 +300,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-05-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster", input="a1@test4")
+        info = SimpleModule("t.info", flags="g", type="raster", input="a1@test4")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test5
                                 name=a1
@@ -292,10 +312,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-06-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster", input="a1@test5")
+        info = SimpleModule("t.info", flags="g", type="raster", input="a1@test5")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
@@ -17,8 +17,8 @@ import os
 class testRaster3dExtraction(TestCase):
 
     mapsets_to_remove = []
-    outfile = 'rast3dlist.txt'
-    gisenv = SimpleModule('g.gisenv', get='MAPSET')
+    outfile = "rast3dlist.txt"
+    gisenv = SimpleModule("g.gisenv", get="MAPSET")
     TestCase.runModule(gisenv, expecting_stdout=True)
     old_mapset = gisenv.outputs.stdout.strip()
 
@@ -29,8 +29,7 @@ class testRaster3dExtraction(TestCase):
             mapset_name = "test3d%i" % i
             cls.runModule("g.mapset", flags="c", mapset=mapset_name)
             cls.mapsets_to_remove.append(mapset_name)
-            cls.runModule("g.region", s=0, n=80,
-                          w=0, e=120, b=0, t=50, res=10, res3=10)
+            cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
             # Use always the current mapset as temporal database
             cls.runModule("r3.mapcalc", expression="a1 = 100")
             cls.runModule("r3.mapcalc", expression="a2 = 200")
@@ -38,24 +37,37 @@ class testRaster3dExtraction(TestCase):
             # Create the temporal database
             cls.runModule("t.connect", flags="d")
             cls.runModule("t.info", flags="d")
-            cls.runModule("t.create", type="str3ds", temporaltype="absolute",
-                          output="A", title="A test3d", description="A test3d")
             cls.runModule(
-                "t.register", flags="i", type="raster_3d", input="A",
+                "t.create",
+                type="str3ds",
+                temporaltype="absolute",
+                output="A",
+                title="A test3d",
+                description="A test3d",
+            )
+            cls.runModule(
+                "t.register",
+                flags="i",
+                type="raster_3d",
+                input="A",
                 maps="a1,a2,a3",
-                start="2001-01-01", increment="%i months" % i)
+                start="2001-01-01",
+                increment="%i months" % i,
+            )
 
         # Add the new mapsets to the search path
         for mapset in cls.mapsets_to_remove:
             cls.runModule("g.mapset", mapset=mapset)
-            cls.runModule("g.mapsets", operation="add", mapset=','.join(cls.mapsets_to_remove))
+            cls.runModule(
+                "g.mapsets", operation="add", mapset=",".join(cls.mapsets_to_remove)
+            )
 
     @classmethod
     def tearDownClass(cls):
-        gisenv = SimpleModule('g.gisenv', get='GISDBASE')
+        gisenv = SimpleModule("g.gisenv", get="GISDBASE")
         cls.runModule(gisenv, expecting_stdout=True)
         gisdbase = gisenv.outputs.stdout.strip()
-        gisenv = SimpleModule('g.gisenv', get='LOCATION_NAME')
+        gisenv = SimpleModule("g.gisenv", get="LOCATION_NAME")
         cls.runModule(gisenv, expecting_stdout=True)
         location = gisenv.outputs.stdout.strip()
         cls.runModule("g.mapset", mapset=cls.old_mapset)
@@ -72,9 +84,12 @@ class testRaster3dExtraction(TestCase):
                                 A|test3d4|2001-01-01 00:00:00|2002-01-01 00:00:00|3"""
 
         t_list = SimpleModule(
-            "t.list", quiet=True,
+            "t.list",
+            quiet=True,
             columns=["name", "mapset,start_time", "end_time", "number_of_maps"],
-            type="str3ds", where='name = "A"')
+            type="str3ds",
+            where='name = "A"',
+        )
         self.assertModule(t_list)
 
         out = t_list.outputs["stdout"].value
@@ -83,16 +98,20 @@ class testRaster3dExtraction(TestCase):
             self.assertEqual(a.strip(), b.strip())
 
         t_list = SimpleModule(
-            "t.list", quiet=True,
+            "t.list",
+            quiet=True,
             columns=["name", "mapset,start_time", "end_time", "number_of_maps"],
-            type="str3ds", where='name = "A"', output=self.outfile)
+            type="str3ds",
+            where='name = "A"',
+            output=self.outfile,
+        )
         self.assertModule(t_list)
         self.assertFileExists(self.outfile)
-        with open(self.outfile, 'r') as f:
+        with open(self.outfile, "r") as f:
             read_data = f.read()
         for a, b in zip(list_string.split("\n"), read_data.split("\n")):
             self.assertEqual(a.strip(), b.strip())
-        #self.assertLooksLike(reference=read_data, actual=list_string)
+        # self.assertLooksLike(reference=read_data, actual=list_string)
         if os.path.isfile(self.outfile):
             os.remove(self.outfile)
 
@@ -104,7 +123,8 @@ class testRaster3dExtraction(TestCase):
                                 a3|test3d1|2001-03-01 00:00:00|2001-04-01 00:00:00"""
 
         trast_list = SimpleModule(
-            "t.rast3d.list", quiet=True, flags="s", input="A@test3d1")
+            "t.rast3d.list", quiet=True, flags="s", input="A@test3d1"
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -117,7 +137,8 @@ class testRaster3dExtraction(TestCase):
                                 a3|test3d2|2001-05-01 00:00:00|2001-07-01 00:00:00"""
 
         trast_list = SimpleModule(
-            "t.rast3d.list", quiet=True, flags="s", input="A@test3d2")
+            "t.rast3d.list", quiet=True, flags="s", input="A@test3d2"
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -130,7 +151,8 @@ class testRaster3dExtraction(TestCase):
                                 a3|test3d3|2001-07-01 00:00:00|2001-10-01 00:00:00"""
 
         trast_list = SimpleModule(
-            "t.rast3d.list", quiet=True, flags="s", input="A@test3d3")
+            "t.rast3d.list", quiet=True, flags="s", input="A@test3d3"
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -143,7 +165,8 @@ class testRaster3dExtraction(TestCase):
                                 a3|test3d4|2001-09-01 00:00:00|2002-01-01 00:00:00"""
 
         trast_list = SimpleModule(
-            "t.rast3d.list", quiet=True, flags="s", input="A@test3d4")
+            "t.rast3d.list", quiet=True, flags="s", input="A@test3d4"
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -151,11 +174,16 @@ class testRaster3dExtraction(TestCase):
         for a, b in zip(list_string.split("\n"), out.split("\n")):
             self.assertEqual(a.strip(), b.strip())
 
-        trast_list = SimpleModule("t.rast3d.list", quiet=True, flags="s",
-                                  input="A@test3d4", output=self.outfile)
+        trast_list = SimpleModule(
+            "t.rast3d.list",
+            quiet=True,
+            flags="s",
+            input="A@test3d4",
+            output=self.outfile,
+        )
         self.assertModule(trast_list)
         self.assertFileExists(self.outfile)
-        with open(self.outfile, 'r') as f:
+        with open(self.outfile, "r") as f:
             read_data = f.read()
         for a, b in zip(list_string.split("\n"), read_data.split("\n")):
             self.assertEqual(a.strip(), b.strip())
@@ -171,10 +199,10 @@ class testRaster3dExtraction(TestCase):
                                     end_time='2001-04-01 00:00:00'
                                     granularity='1 month'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="str3ds", input="A@test3d1")
+        info = SimpleModule("t.info", flags="g", type="str3ds", input="A@test3d1")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="test3d3")
         tinfo_string = """id=A@test3d2
@@ -184,10 +212,10 @@ class testRaster3dExtraction(TestCase):
                                     end_time='2001-07-01 00:00:00'
                                     granularity='2 months'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="str3ds", input="A@test3d2")
+        info = SimpleModule("t.info", flags="g", type="str3ds", input="A@test3d2")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="test3d2")
         tinfo_string = """id=A@test3d3
@@ -197,10 +225,10 @@ class testRaster3dExtraction(TestCase):
                                     end_time='2001-10-01 00:00:00'
                                     granularity='3 months'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="str3ds", input="A@test3d3")
+        info = SimpleModule("t.info", flags="g", type="str3ds", input="A@test3d3")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="test3d1")
         tinfo_string = """id=A@test3d4
@@ -210,10 +238,10 @@ class testRaster3dExtraction(TestCase):
                                     end_time='2002-01-01 00:00:00'
                                     granularity='4 months'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="str3ds", input="A@test3d4")
+        info = SimpleModule("t.info", flags="g", type="str3ds", input="A@test3d4")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_raster_info(self):
         self.runModule("g.mapset", mapset="test3d3")
@@ -224,10 +252,10 @@ class testRaster3dExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-02-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster_3d", input="a1@test3d1")
+        info = SimpleModule("t.info", flags="g", type="raster_3d", input="a1@test3d1")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test3d2
                                 name=a1
@@ -236,10 +264,10 @@ class testRaster3dExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-03-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster_3d", input="a1@test3d2")
+        info = SimpleModule("t.info", flags="g", type="raster_3d", input="a1@test3d2")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test3d3
                                 name=a1
@@ -248,10 +276,10 @@ class testRaster3dExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-04-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster_3d", input="a1@test3d3")
+        info = SimpleModule("t.info", flags="g", type="raster_3d", input="a1@test3d3")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@test3d4
                                 name=a1
@@ -260,11 +288,13 @@ class testRaster3dExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-05-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="raster_3d", input="a1@test3d4")
+        info = SimpleModule("t.info", flags="g", type="raster_3d", input="a1@test3d4")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
@@ -17,8 +17,8 @@ import os
 class TestRasterExtraction(TestCase):
 
     mapsets_to_remove = []
-    outfile = 'vectlist.txt'
-    gisenv = SimpleModule('g.gisenv', get='MAPSET')
+    outfile = "vectlist.txt"
+    gisenv = SimpleModule("g.gisenv", get="MAPSET")
     TestCase.runModule(gisenv, expecting_stdout=True)
     old_mapset = gisenv.outputs.stdout.strip()
 
@@ -29,8 +29,7 @@ class TestRasterExtraction(TestCase):
             mapset_name = "testvect%i" % i
             cls.runModule("g.mapset", flags="c", mapset=mapset_name)
             cls.mapsets_to_remove.append(mapset_name)
-            cls.runModule("g.region", s=0, n=80,
-                          w=0, e=120, b=0, t=50, res=10, res3=10)
+            cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
             # Use always the current mapset as temporal database
             cls.runModule("v.random", output="a1", npoints=20)
             cls.runModule("v.random", output="a2", npoints=20)
@@ -38,23 +37,37 @@ class TestRasterExtraction(TestCase):
             # Create the temporal database
             cls.runModule("t.connect", flags="d")
             cls.runModule("t.info", flags="d")
-            cls.runModule("t.create", type="stvds", temporaltype="absolute",
-                          output="A", title="A testvect", description="A testvect")
-            cls.runModule("t.register", flags="i", type="vector", input="A",
-                          maps="a1,a2,a3",
-                          start="2001-01-01", increment="%i months" % i)
+            cls.runModule(
+                "t.create",
+                type="stvds",
+                temporaltype="absolute",
+                output="A",
+                title="A testvect",
+                description="A testvect",
+            )
+            cls.runModule(
+                "t.register",
+                flags="i",
+                type="vector",
+                input="A",
+                maps="a1,a2,a3",
+                start="2001-01-01",
+                increment="%i months" % i,
+            )
 
         # Add the new mapsets to the search path
         for mapset in cls.mapsets_to_remove:
             cls.runModule("g.mapset", mapset=mapset)
-            cls.runModule("g.mapsets", operation="add", mapset=','.join(cls.mapsets_to_remove))
+            cls.runModule(
+                "g.mapsets", operation="add", mapset=",".join(cls.mapsets_to_remove)
+            )
 
     @classmethod
     def tearDownClass(cls):
-        gisenv = SimpleModule('g.gisenv', get='GISDBASE')
+        gisenv = SimpleModule("g.gisenv", get="GISDBASE")
         cls.runModule(gisenv, expecting_stdout=True)
         gisdbase = gisenv.outputs.stdout.strip()
-        gisenv = SimpleModule('g.gisenv', get='LOCATION_NAME')
+        gisenv = SimpleModule("g.gisenv", get="LOCATION_NAME")
         cls.runModule(gisenv, expecting_stdout=True)
         location = gisenv.outputs.stdout.strip()
         cls.runModule("g.mapset", mapset=cls.old_mapset)
@@ -71,9 +84,12 @@ class TestRasterExtraction(TestCase):
                                 A|testvect4|2001-01-01 00:00:00|2002-01-01 00:00:00|3"""
 
         t_list = SimpleModule(
-            "t.list", quiet=True,
+            "t.list",
+            quiet=True,
             columns=["name", "mapset,start_time", "end_time", "number_of_maps"],
-            type="stvds", where='name = "A"')
+            type="stvds",
+            where='name = "A"',
+        )
         self.assertModule(t_list)
 
         out = t_list.outputs["stdout"].value
@@ -82,16 +98,20 @@ class TestRasterExtraction(TestCase):
             self.assertEqual(a.strip(), b.strip())
 
         t_list = SimpleModule(
-            "t.list", quiet=True,
+            "t.list",
+            quiet=True,
             columns=["name", "mapset,start_time", "end_time", "number_of_maps"],
-            type="stvds", where='name = "A"', output=self.outfile)
+            type="stvds",
+            where='name = "A"',
+            output=self.outfile,
+        )
         self.assertModule(t_list)
         self.assertFileExists(self.outfile)
-        with open(self.outfile, 'r') as f:
+        with open(self.outfile, "r") as f:
             read_data = f.read()
         for a, b in zip(list_string.split("\n"), read_data.split("\n")):
             self.assertEqual(a.strip(), b.strip())
-        #self.assertLooksLike(reference=read_data, actual=list_string)
+        # self.assertLooksLike(reference=read_data, actual=list_string)
         if os.path.isfile(self.outfile):
             os.remove(self.outfile)
 
@@ -102,10 +122,13 @@ class TestRasterExtraction(TestCase):
                                 a2|testvect1|2001-02-01 00:00:00|2001-03-01 00:00:00
                                 a3|testvect1|2001-03-01 00:00:00|2001-04-01 00:00:00"""
 
-        trast_list = SimpleModule("t.vect.list", quiet=True, flags="u",
-                                  columns=[
-                                      "name", "mapset", "start_time", "end_time"],
-                                  input="A@testvect1")
+        trast_list = SimpleModule(
+            "t.vect.list",
+            quiet=True,
+            flags="u",
+            columns=["name", "mapset", "start_time", "end_time"],
+            input="A@testvect1",
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -118,9 +141,12 @@ class TestRasterExtraction(TestCase):
                                 a3|testvect2|2001-05-01 00:00:00|2001-07-01 00:00:00"""
 
         trast_list = SimpleModule(
-            "t.vect.list", quiet=True, flags="u",
+            "t.vect.list",
+            quiet=True,
+            flags="u",
             columns=["name", "mapset", "start_time", "end_time"],
-            input="A@testvect2")
+            input="A@testvect2",
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -132,10 +158,13 @@ class TestRasterExtraction(TestCase):
                                 a2|testvect3|2001-04-01 00:00:00|2001-07-01 00:00:00
                                 a3|testvect3|2001-07-01 00:00:00|2001-10-01 00:00:00"""
 
-        trast_list = SimpleModule("t.vect.list", quiet=True, flags="u",
-                                  columns=[
-                                      "name", "mapset", "start_time", "end_time"],
-                                  input="A@testvect3")
+        trast_list = SimpleModule(
+            "t.vect.list",
+            quiet=True,
+            flags="u",
+            columns=["name", "mapset", "start_time", "end_time"],
+            input="A@testvect3",
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -148,9 +177,12 @@ class TestRasterExtraction(TestCase):
                                 a3|testvect4|2001-09-01 00:00:00|2002-01-01 00:00:00"""
 
         trast_list = SimpleModule(
-            "t.vect.list", quiet=True, flags="u",
+            "t.vect.list",
+            quiet=True,
+            flags="u",
             columns=["name", "mapset", "start_time", "end_time"],
-            input="A@testvect4")
+            input="A@testvect4",
+        )
         self.assertModule(trast_list)
 
         out = trast_list.outputs["stdout"].value
@@ -158,12 +190,17 @@ class TestRasterExtraction(TestCase):
         for a, b in zip(list_string.split("\n"), out.split("\n")):
             self.assertEqual(a.strip(), b.strip())
 
-        trast_list = SimpleModule("t.vect.list", quiet=True, flags="u",
-                                  columns=["name", "mapset", "start_time", "end_time"],
-                                  input="A@testvect4", output=self.outfile)
+        trast_list = SimpleModule(
+            "t.vect.list",
+            quiet=True,
+            flags="u",
+            columns=["name", "mapset", "start_time", "end_time"],
+            input="A@testvect4",
+            output=self.outfile,
+        )
         self.assertModule(trast_list)
         self.assertFileExists(self.outfile)
-        with open(self.outfile, 'r') as f:
+        with open(self.outfile, "r") as f:
             read_data = f.read()
         for a, b in zip(list_string.split("\n"), read_data.split("\n")):
             self.assertEqual(a.strip(), b.strip())
@@ -179,10 +216,10 @@ class TestRasterExtraction(TestCase):
                                     end_time='2001-04-01 00:00:00'
                                     granularity='1 month'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="stvds", input="A@testvect1")
+        info = SimpleModule("t.info", flags="g", type="stvds", input="A@testvect1")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="testvect3")
         tinfo_string = """id=A@testvect2
@@ -192,10 +229,10 @@ class TestRasterExtraction(TestCase):
                                     end_time='2001-07-01 00:00:00'
                                     granularity='2 months'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="stvds", input="A@testvect2")
+        info = SimpleModule("t.info", flags="g", type="stvds", input="A@testvect2")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="testvect2")
         tinfo_string = """id=A@testvect3
@@ -205,10 +242,10 @@ class TestRasterExtraction(TestCase):
                                     end_time='2001-10-01 00:00:00'
                                     granularity='3 months'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="stvds", input="A@testvect3")
+        info = SimpleModule("t.info", flags="g", type="stvds", input="A@testvect3")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         self.runModule("g.mapset", mapset="testvect1")
         tinfo_string = """id=A@testvect4
@@ -218,10 +255,10 @@ class TestRasterExtraction(TestCase):
                                     end_time='2002-01-01 00:00:00'
                                     granularity='4 months'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="stvds", input="A@testvect4")
+        info = SimpleModule("t.info", flags="g", type="stvds", input="A@testvect4")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def testv_vector_info(self):
         self.runModule("g.mapset", mapset="testvect3")
@@ -232,10 +269,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-02-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="vector", input="a1@testvect1")
+        info = SimpleModule("t.info", flags="g", type="vector", input="a1@testvect1")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@testvect2
                                 name=a1
@@ -244,10 +281,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-03-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="vector", input="a1@testvect2")
+        info = SimpleModule("t.info", flags="g", type="vector", input="a1@testvect2")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@testvect3
                                 name=a1
@@ -256,10 +293,10 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-04-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="vector", input="a1@testvect3")
+        info = SimpleModule("t.info", flags="g", type="vector", input="a1@testvect3")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         tinfo_string = """id=a1@testvect4
                                 name=a1
@@ -268,11 +305,13 @@ class TestRasterExtraction(TestCase):
                                 start_time='2001-01-01 00:00:00'
                                 end_time='2001-05-01 00:00:00'"""
 
-        info = SimpleModule(
-            "t.info", flags="g", type="vector", input="a1@testvect4")
+        info = SimpleModule("t.info", flags="g", type="vector", input="a1@testvect4")
         self.assertModuleKeyValue(
-            module=info, reference=tinfo_string, precision=2, sep="=")
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.create/t.create.py
+++ b/temporal/t.create/t.create.py
@@ -84,8 +84,10 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.open_new_stds(name, type, temporaltype, title, descr,
-                                     semantic, None, grass.overwrite())
+    tgis.open_new_stds(
+        name, type, temporaltype, title, descr, semantic, None, grass.overwrite()
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.info/t.info.py
+++ b/temporal/t.info/t.info.py
@@ -66,9 +66,9 @@ def main():
 
     name = options["input"]
     type_ = options["type"]
-    shellstyle = flags['g']
-    system = flags['d']
-    history = flags['h']
+    shellstyle = flags["g"]
+    system = flags["d"]
+    history = flags["h"]
 
     # Make sure the temporal database exists
     tgis.init()
@@ -79,24 +79,26 @@ def main():
 
     if system and not shellstyle and not history:
         #      0123456789012345678901234567890
-        print(" +------------------- Temporal DBMI backend information ----------------------+")
+        print(
+            " +------------------- Temporal DBMI backend information ----------------------+"
+        )
         print(" | DBMI Python interface:...... " + str(dbif.get_dbmi().__name__))
-        print(" | Temporal database string:... " + str(
-            tgis.get_tgis_database_string()))
-        print(" | SQL template path:.......... " + str(
-            tgis.get_sql_template_path()))
+        print(" | Temporal database string:... " + str(tgis.get_tgis_database_string()))
+        print(" | SQL template path:.......... " + str(tgis.get_sql_template_path()))
         if rows:
             for row in rows:
-                print(" | %s .......... %s" %(row[0], row[1]))
-        print(" +----------------------------------------------------------------------------+")
+                print(" | %s .......... %s" % (row[0], row[1]))
+        print(
+            " +----------------------------------------------------------------------------+"
+        )
         return
     elif system and not history:
-        print("dbmi_python_interface=\'" + str(dbif.get_dbmi().__name__) + "\'")
-        print("dbmi_string=\'" + str(tgis.get_tgis_database_string()) + "\'")
-        print("sql_template_path=\'" + str(tgis.get_sql_template_path()) + "\'")
+        print("dbmi_python_interface='" + str(dbif.get_dbmi().__name__) + "'")
+        print("dbmi_string='" + str(tgis.get_tgis_database_string()) + "'")
+        print("sql_template_path='" + str(tgis.get_sql_template_path()) + "'")
         if rows:
             for row in rows:
-                print("%s=\'%s\'" %(row[0], row[1]))
+                print("%s='%s'" % (row[0], row[1]))
         return
 
     if not system and not name:
@@ -122,6 +124,7 @@ def main():
         dataset.print_shell_info()
     else:
         dataset.print_info()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.list/t.list.py
+++ b/temporal/t.list/t.list.py
@@ -106,7 +106,7 @@ def main():
     where = options["where"]
     separator = gscript.separator(options["separator"])
     outpath = options["output"]
-    colhead = flags['c']
+    colhead = flags["c"]
 
     # Make sure the temporal database exists
     tgis.init()
@@ -116,11 +116,11 @@ def main():
     dbif.connect()
     first = True
 
-    if  gscript.verbosity() > 0 and not outpath:
+    if gscript.verbosity() > 0 and not outpath:
         sys.stderr.write("----------------------------------------------\n")
 
     if outpath:
-        outfile = open(outpath, 'w')
+        outfile = open(outpath, "w")
 
     for ttype in temporal_type.split(","):
         if ttype == "absolute":
@@ -140,13 +140,21 @@ def main():
                 rows = stds_list[key]
 
                 if rows:
-                    if  gscript.verbosity() > 0 and not outpath:
+                    if gscript.verbosity() > 0 and not outpath:
                         if issubclass(sp.__class__, tgis.AbstractMapDataset):
-                            sys.stderr.write(_("Time stamped %s maps with %s available in mapset <%s>:\n")%
-                                                     (sp.get_type(), time, key))
+                            sys.stderr.write(
+                                _(
+                                    "Time stamped %s maps with %s available in mapset <%s>:\n"
+                                )
+                                % (sp.get_type(), time, key)
+                            )
                         else:
-                            sys.stderr.write(_("Space time %s datasets with %s available in mapset <%s>:\n")%
-                                                     (sp.get_new_map_instance(None).get_type(), time, key))
+                            sys.stderr.write(
+                                _(
+                                    "Space time %s datasets with %s available in mapset <%s>:\n"
+                                )
+                                % (sp.get_new_map_instance(None).get_type(), time, key)
+                            )
 
                     # Print the column names if requested
                     if colhead and first:
@@ -180,6 +188,7 @@ def main():
     if outpath:
         outfile.close()
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = gscript.parser()

--- a/temporal/t.merge/t.merge.py
+++ b/temporal/t.merge/t.merge.py
@@ -45,6 +45,7 @@ import grass.script as grass
 ############################################################################
 grass.set_raise_on_error(True)
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
@@ -57,7 +58,7 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    #Get the current mapset to create the id of the space time dataset
+    # Get the current mapset to create the id of the space time dataset
     mapset = grass.gisenv()["MAPSET"]
 
     inputs_split = inputs.split(",")
@@ -73,7 +74,10 @@ def main():
     if output.find("@") >= 0:
         out_mapset = output.split("@")[1]
         if out_mapset != mapset:
-            grass.fatal(_("Output space time dataset <%s> must be located in this mapset") % (output))
+            grass.fatal(
+                _("Output space time dataset <%s> must be located in this mapset")
+                % (output)
+            )
     else:
         output_id = output + "@" + mapset
 
@@ -90,7 +94,9 @@ def main():
 
         if first.get_temporal_type() != stds.get_temporal_type():
             dbif.close()
-            grass.fatal(_("Space time datasets to merge must have the same temporal type"))
+            grass.fatal(
+                _("Space time datasets to merge must have the same temporal type")
+            )
 
         stds_list.append(stds)
 
@@ -105,16 +111,25 @@ def main():
 
     if output_exists and not grass.overwrite():
         dbif.close()
-        grass.fatal(_("Unable to merge maps into space time %s dataset <%s> "
-                      "please use the overwrite flag.") %
-                      (stds.get_new_map_instance(None).get_type(), output_id))
+        grass.fatal(
+            _(
+                "Unable to merge maps into space time %s dataset <%s> "
+                "please use the overwrite flag."
+            )
+            % (stds.get_new_map_instance(None).get_type(), output_id)
+        )
 
     if not output_exists:
-        output_stds = tgis.open_new_stds(output, type,
-                                   first.get_temporal_type(),
-                                   "Merged space time dataset",
-                                   "Merged space time dataset",
-                                   "mean", dbif=dbif, overwrite=False)
+        output_stds = tgis.open_new_stds(
+            output,
+            type,
+            first.get_temporal_type(),
+            "Merged space time dataset",
+            "Merged space time dataset",
+            "mean",
+            dbif=dbif,
+            overwrite=False,
+        )
     else:
         output_stds.select(dbif=dbif)
 
@@ -147,6 +162,7 @@ def main():
 
     if output_exists:
         output_stds.update_command_string(dbif=dbif)
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -145,6 +145,7 @@ import grass.script as grass
 
 range_relations = ["EQUALS", "DURING", "OVERLAPS", "OVERLAPPING", "CONTAINS"]
 
+
 def main():
     # Get the options
     input = options["input"]
@@ -182,8 +183,10 @@ def main():
 
     if not input_strds.is_in_db():
         dbif.close()
-        grass.fatal(_("Space time %s dataset <%s> not found") % (
-            input_strds.get_output_map_instance(None).get_type(), id))
+        grass.fatal(
+            _("Space time %s dataset <%s> not found")
+            % (input_strds.get_output_map_instance(None).get_type(), id)
+        )
 
     input_strds.select(dbif)
     dummy = input_strds.get_new_map_instance(None)
@@ -193,8 +196,12 @@ def main():
         if not minimum or not maximum:
             if not range_:
                 dbif.close()
-                grass.fatal(_("You need to set the range to compute the occurrence"
-                              " space time raster dataset"))
+                grass.fatal(
+                    _(
+                        "You need to set the range to compute the occurrence"
+                        " space time raster dataset"
+                    )
+                )
 
         if occurrence.find("@") >= 0:
             occurrence_id = occurrence
@@ -205,19 +212,32 @@ def main():
         if occurrence_strds.is_in_db(dbif):
             if not grass.overwrite():
                 dbif.close()
-                grass.fatal(_("Space time raster dataset <%s> is already in the "
-                              "database, use overwrite flag to overwrite") % occurrence_id)
+                grass.fatal(
+                    _(
+                        "Space time raster dataset <%s> is already in the "
+                        "database, use overwrite flag to overwrite"
+                    )
+                    % occurrence_id
+                )
 
     # The indicator space time raster dataset
     if indicator:
         if not occurrence:
             dbif.close()
-            grass.fatal(_("You need to set the occurrence to compute the indicator"
-                          " space time raster dataset"))
+            grass.fatal(
+                _(
+                    "You need to set the occurrence to compute the indicator"
+                    " space time raster dataset"
+                )
+            )
         if not staend:
             dbif.close()
-            grass.fatal(_("You need to set the staend options to compute the indicator"
-                          " space time raster dataset"))
+            grass.fatal(
+                _(
+                    "You need to set the staend options to compute the indicator"
+                    " space time raster dataset"
+                )
+            )
         if indicator.find("@") >= 0:
             indicator = indicator
         else:
@@ -227,8 +247,13 @@ def main():
         if indicator_strds.is_in_db(dbif):
             if not grass.overwrite():
                 dbif.close()
-                grass.fatal(_("Space time raster dataset <%s> is already in the "
-                              "database, use overwrite flag to overwrite") % indicator_id)
+                grass.fatal(
+                    _(
+                        "Space time raster dataset <%s> is already in the "
+                        "database, use overwrite flag to overwrite"
+                    )
+                    % indicator_id
+                )
         staend = staend.split(",")
         indicator_start = int(staend[0])
         indicator_mid = int(staend[1])
@@ -245,11 +270,15 @@ def main():
         minimum_strds = tgis.SpaceTimeRasterDataset(minimum_id)
         if not minimum_strds.is_in_db():
             dbif.close()
-            grass.fatal(_("Space time raster dataset <%s> not found") % (minimum_strds.get_id()))
+            grass.fatal(
+                _("Space time raster dataset <%s> not found") % (minimum_strds.get_id())
+            )
 
         if minimum_strds.get_temporal_type() != input_strds.get_temporal_type():
             dbif.close()
-            grass.fatal(_("Temporal type of input strds and minimum strds must be equal"))
+            grass.fatal(
+                _("Temporal type of input strds and minimum strds must be equal")
+            )
 
         minimum_strds.select(dbif)
 
@@ -264,11 +293,15 @@ def main():
         maximum_strds = tgis.SpaceTimeRasterDataset(maximum_id)
         if not maximum_strds.is_in_db():
             dbif.close()
-            grass.fatal(_("Space time raster dataset <%s> not found") % (maximum_strds.get_id()))
+            grass.fatal(
+                _("Space time raster dataset <%s> not found") % (maximum_strds.get_id())
+            )
 
         if maximum_strds.get_temporal_type() != input_strds.get_temporal_type():
             dbif.close()
-            grass.fatal(_("Temporal type of input strds and maximum strds must be equal"))
+            grass.fatal(
+                _("Temporal type of input strds and maximum strds must be equal")
+            )
 
         maximum_strds.select(dbif)
 
@@ -303,10 +336,8 @@ def main():
         if stop and end > stop:
             end = stop
 
-        where = "start_time >= \'%s\' AND start_time < \'%s\'" %(str(start),
-                                                                str(end))
-        input_maps = input_strds.get_registered_maps_as_objects(where=where,
-                                                                dbif=dbif)
+        where = "start_time >= '%s' AND start_time < '%s'" % (str(start), str(end))
+        input_maps = input_strds.get_registered_maps_as_objects(where=where, dbif=dbif)
 
         grass.debug(len(input_maps))
 
@@ -316,12 +347,24 @@ def main():
         if len(input_maps) == 0:
             continue
 
-        grass.message(_("Processing cycle %s - %s" %(str(start), str(end))))
+        grass.message(_("Processing cycle %s - %s" % (str(start), str(end))))
 
-        count = compute_occurrence(occurrence_maps, input_strds, input_maps,
-                                   start, base, count, time_suffix, mapset,
-                                   where, reverse, range_, minimum_strds,
-                                   maximum_strds, dbif)
+        count = compute_occurrence(
+            occurrence_maps,
+            input_strds,
+            input_maps,
+            start,
+            base,
+            count,
+            time_suffix,
+            mapset,
+            where,
+            reverse,
+            range_,
+            minimum_strds,
+            maximum_strds,
+            dbif,
+        )
 
         # Indicator computation is based on the occurrence so we need to start it after
         # the occurrence cycle
@@ -333,16 +376,29 @@ def main():
                 else:
                     map = input_maps[i]
 
-                if input_strds.get_temporal_type() == 'absolute' and time_suffix == 'gran':
-                    suffix = tgis.create_suffix_from_datetime(map.temporal_extent.get_start_time(),
-                                                              input_strds.get_granularity())
-                    indicator_map_name = "{ba}_indicator_{su}".format(ba=base, su=suffix)
-                elif input_strds.get_temporal_type() == 'absolute' and time_suffix == 'time':
+                if (
+                    input_strds.get_temporal_type() == "absolute"
+                    and time_suffix == "gran"
+                ):
+                    suffix = tgis.create_suffix_from_datetime(
+                        map.temporal_extent.get_start_time(),
+                        input_strds.get_granularity(),
+                    )
+                    indicator_map_name = "{ba}_indicator_{su}".format(
+                        ba=base, su=suffix
+                    )
+                elif (
+                    input_strds.get_temporal_type() == "absolute"
+                    and time_suffix == "time"
+                ):
                     suffix = tgis.create_time_suffix(map)
-                    indicator_map_name = "{ba}_indicator_{su}".format(ba=base, su=suffix)
+                    indicator_map_name = "{ba}_indicator_{su}".format(
+                        ba=base, su=suffix
+                    )
                 else:
-                    indicator_map_name = tgis.create_numeric_suffix(base + "_indicator",
-                                                                    indi_count, time_suffix)
+                    indicator_map_name = tgis.create_numeric_suffix(
+                        base + "_indicator", indi_count, time_suffix
+                    )
                 indicator_map_id = dummy.build_id(indicator_map_name, mapset)
                 indicator_map = input_strds.get_new_map_instance(indicator_map_id)
 
@@ -351,11 +407,17 @@ def main():
                     if grass.overwrite():
                         # Remove the existing temporal database entry
                         indicator_map.delete(dbif)
-                        indicator_map = input_strds.get_new_map_instance(indicator_map_id)
+                        indicator_map = input_strds.get_new_map_instance(
+                            indicator_map_id
+                        )
                     else:
-                        grass.fatal(_("Map <%s> is already registered in the temporal"
-                                     " database, use overwrite flag to overwrite.") %
-                                    (indicator_map.get_map_id()))
+                        grass.fatal(
+                            _(
+                                "Map <%s> is already registered in the temporal"
+                                " database, use overwrite flag to overwrite."
+                            )
+                            % (indicator_map.get_map_id())
+                        )
 
                 curr_map = occurrence_maps[map.get_id()].get_name()
 
@@ -364,50 +426,85 @@ def main():
                     if i == 0:
                         prev_map = curr_map
                         subexpr1 = "null()"
-                        subexpr3 = "%i" %(indicator_start)
+                        subexpr3 = "%i" % (indicator_start)
                     elif i > 0 and i < num_maps - 1:
                         prev_map = occurrence_maps[map.next().get_id()].get_name()
                         next_map = occurrence_maps[map.prev().get_id()].get_name()
                         # In case the previous map is null() set null() or the start indicator
-                        subexpr1 = "if(isnull(%s), null(), %i)" %(curr_map, indicator_start)
+                        subexpr1 = "if(isnull(%s), null(), %i)" % (
+                            curr_map,
+                            indicator_start,
+                        )
                         # In case the previous map was not null() if the current map is null() set null()
                         # if the current map is not null() and the next map is not null() set
                         # intermediate indicator, if the next map is null set the end indicator
-                        subexpr2 = "if(isnull(%s), %i, %i)" %(next_map, indicator_end, indicator_mid)
-                        subexpr3 = "if(isnull(%s), null(), %s)" %(curr_map, subexpr2)
-                        expression = "%s = if(isnull(%s), %s, %s)" %(indicator_map_name,
-                                                                    prev_map, subexpr1,
-                                                                    subexpr3)
+                        subexpr2 = "if(isnull(%s), %i, %i)" % (
+                            next_map,
+                            indicator_end,
+                            indicator_mid,
+                        )
+                        subexpr3 = "if(isnull(%s), null(), %s)" % (curr_map, subexpr2)
+                        expression = "%s = if(isnull(%s), %s, %s)" % (
+                            indicator_map_name,
+                            prev_map,
+                            subexpr1,
+                            subexpr3,
+                        )
                     else:
                         prev_map = occurrence_maps[map.next().get_id()].get_name()
-                        subexpr1 = "if(isnull(%s), null(), %i)" %(curr_map, indicator_start)
-                        subexpr3 = "if(isnull(%s), null(), %i)" %(curr_map, indicator_mid)
+                        subexpr1 = "if(isnull(%s), null(), %i)" % (
+                            curr_map,
+                            indicator_start,
+                        )
+                        subexpr3 = "if(isnull(%s), null(), %i)" % (
+                            curr_map,
+                            indicator_mid,
+                        )
                 else:
                     if i == 0:
                         prev_map = curr_map
                         subexpr1 = "null()"
-                        subexpr3 = "%i" %(indicator_start)
+                        subexpr3 = "%i" % (indicator_start)
                     elif i > 0 and i < num_maps - 1:
                         prev_map = occurrence_maps[map.prev().get_id()].get_name()
                         next_map = occurrence_maps[map.next().get_id()].get_name()
                         # In case the previous map is null() set null() or the start indicator
-                        subexpr1 = "if(isnull(%s), null(), %i)" %(curr_map, indicator_start)
+                        subexpr1 = "if(isnull(%s), null(), %i)" % (
+                            curr_map,
+                            indicator_start,
+                        )
                         # In case the previous map was not null() if the current map is null() set null()
                         # if the current map is not null() and the next map is not null() set
                         # intermediate indicator, if the next map is null set the end indicator
-                        subexpr2 = "if(isnull(%s), %i, %i)" %(next_map, indicator_end, indicator_mid)
-                        subexpr3 = "if(isnull(%s), null(), %s)" %(curr_map, subexpr2)
-                        expression = "%s = if(isnull(%s), %s, %s)" %(indicator_map_name,
-                                                                    prev_map, subexpr1,
-                                                                    subexpr3)
+                        subexpr2 = "if(isnull(%s), %i, %i)" % (
+                            next_map,
+                            indicator_end,
+                            indicator_mid,
+                        )
+                        subexpr3 = "if(isnull(%s), null(), %s)" % (curr_map, subexpr2)
+                        expression = "%s = if(isnull(%s), %s, %s)" % (
+                            indicator_map_name,
+                            prev_map,
+                            subexpr1,
+                            subexpr3,
+                        )
                     else:
                         prev_map = occurrence_maps[map.prev().get_id()].get_name()
-                        subexpr1 = "if(isnull(%s), null(), %i)" %(curr_map, indicator_start)
-                        subexpr3 = "if(isnull(%s), null(), %i)" %(curr_map, indicator_mid)
+                        subexpr1 = "if(isnull(%s), null(), %i)" % (
+                            curr_map,
+                            indicator_start,
+                        )
+                        subexpr3 = "if(isnull(%s), null(), %i)" % (
+                            curr_map,
+                            indicator_mid,
+                        )
 
-                expression = "%s = if(isnull(%s), %s, %s)" %(indicator_map_name,
-                                                            prev_map, subexpr1,
-                                                            subexpr3)
+                expression = "%s = if(isnull(%s), %s, %s)" % (
+                    indicator_map_name,
+                    prev_map,
+                    subexpr1,
+                    subexpr3,
+                )
                 grass.debug(expression)
                 grass.mapcalc(expression, overwrite=True)
 
@@ -416,8 +513,9 @@ def main():
                 if map.is_time_absolute():
                     indicator_map.set_absolute_time(map_start, map_end)
                 else:
-                    indicator_map.set_relative_time(map_start, map_end,
-                                                 map.get_relative_time_unit())
+                    indicator_map.set_relative_time(
+                        map_start, map_end, map.get_relative_time_unit()
+                    )
 
                 indicator_maps[map.get_id()] = indicator_map
                 indi_count += 1
@@ -436,24 +534,36 @@ def main():
 
     empty_maps = []
 
-    create_strds_register_maps(input_strds, occurrence_strds, occurrence_maps,
-                               register_null, empty_maps, dbif)
+    create_strds_register_maps(
+        input_strds, occurrence_strds, occurrence_maps, register_null, empty_maps, dbif
+    )
 
     if indicator:
-        create_strds_register_maps(input_strds, indicator_strds, indicator_maps,
-                                   register_null, empty_maps, dbif)
+        create_strds_register_maps(
+            input_strds,
+            indicator_strds,
+            indicator_maps,
+            register_null,
+            empty_maps,
+            dbif,
+        )
 
     dbif.close()
 
     # Remove empty maps
     if len(empty_maps) > 0:
         for map in empty_maps:
-            grass.run_command("g.remove", flags='f', type="raster", name=map.get_name(), quiet=True)
+            grass.run_command(
+                "g.remove", flags="f", type="raster", name=map.get_name(), quiet=True
+            )
+
 
 ############################################################################
 
-def create_strds_register_maps(in_strds, out_strds, out_maps, register_null,
-                    empty_maps, dbif):
+
+def create_strds_register_maps(
+    in_strds, out_strds, out_maps, register_null, empty_maps, dbif
+):
 
     out_id = out_strds.get_id()
 
@@ -463,22 +573,20 @@ def create_strds_register_maps(in_strds, out_strds, out_maps, register_null,
             out_strds = in_strds.get_new_instance(out_id)
 
     temporal_type, semantic_type, title, description = in_strds.get_initial_values()
-    out_strds.set_initial_values(temporal_type, semantic_type, title,
-                                    description)
+    out_strds.set_initial_values(temporal_type, semantic_type, title, description)
     out_strds.insert(dbif)
 
     # Register the maps in the database
     count = 0
     for map in out_maps.values():
         count += 1
-        if count %10 == 0:
+        if count % 10 == 0:
             grass.percent(count, len(out_maps), 1)
         # Read the raster map data
         map.load()
         # In case of a empty map continue, do not register empty maps
         if not register_null:
-            if map.metadata.get_min() is None and \
-                map.metadata.get_max() is None:
+            if map.metadata.get_min() is None and map.metadata.get_max() is None:
                 empty_maps.append(map)
                 continue
 
@@ -489,22 +597,39 @@ def create_strds_register_maps(in_strds, out_strds, out_maps, register_null,
     out_strds.update_from_registered_maps(dbif)
     grass.percent(1, 1, 1)
 
+
 ############################################################################
 
-def compute_occurrence(occurrence_maps, input_strds, input_maps, start, base,
-                       count, tsuffix, mapset, where, reverse, range_,
-                       minimum_strds, maximum_strds, dbif):
+
+def compute_occurrence(
+    occurrence_maps,
+    input_strds,
+    input_maps,
+    start,
+    base,
+    count,
+    tsuffix,
+    mapset,
+    where,
+    reverse,
+    range_,
+    minimum_strds,
+    maximum_strds,
+    dbif,
+):
 
     if minimum_strds:
-        input_maps_minimum = input_strds.get_registered_maps_as_objects(where=where,
-                                                                      dbif=dbif)
+        input_maps_minimum = input_strds.get_registered_maps_as_objects(
+            where=where, dbif=dbif
+        )
         minimum_maps = minimum_strds.get_registered_maps_as_objects(dbif=dbif)
         minimum_topo = tgis.SpatioTemporalTopologyBuilder()
         minimum_topo.build(input_maps_minimum, minimum_maps)
 
     if maximum_strds:
-        input_maps_maximum = input_strds.get_registered_maps_as_objects(where=where,
-                                                                      dbif=dbif)
+        input_maps_maximum = input_strds.get_registered_maps_as_objects(
+            where=where, dbif=dbif
+        )
         maximum_maps = maximum_strds.get_registered_maps_as_objects(dbif=dbif)
         maximum_topo = tgis.SpatioTemporalTopologyBuilder()
         maximum_topo.build(input_maps_maximum, maximum_maps)
@@ -526,11 +651,12 @@ def compute_occurrence(occurrence_maps, input_strds, input_maps, start, base,
         else:
             days = td
 
-        if input_strds.get_temporal_type() == 'absolute' and tsuffix == 'gran':
-            suffix = tgis.create_suffix_from_datetime(map.temporal_extent.get_start_time(),
-                                                      input_strds.get_granularity())
+        if input_strds.get_temporal_type() == "absolute" and tsuffix == "gran":
+            suffix = tgis.create_suffix_from_datetime(
+                map.temporal_extent.get_start_time(), input_strds.get_granularity()
+            )
             occurrence_map_name = "{ba}_{su}".format(ba=base, su=suffix)
-        elif input_strds.get_temporal_type() == 'absolute' and tsuffix == 'time':
+        elif input_strds.get_temporal_type() == "absolute" and tsuffix == "time":
             suffix = tgis.create_time_suffix(map)
             occurrence_map_name = "{ba}_{su}".format(ba=base, su=suffix)
         else:
@@ -546,9 +672,13 @@ def compute_occurrence(occurrence_maps, input_strds, input_maps, start, base,
                 occurrence_map.delete(dbif)
                 occurrence_map = input_strds.get_new_map_instance(occurrence_map_id)
             else:
-                grass.fatal(_("Map <%s> is already registered in the temporal"
-                             " database, use overwrite flag to overwrite.") %
-                            (occurrence_map.get_map_id()))
+                grass.fatal(
+                    _(
+                        "Map <%s> is already registered in the temporal"
+                        " database, use overwrite flag to overwrite."
+                    )
+                    % (occurrence_map.get_map_id())
+                )
 
         range_vals = range_.split(",")
         min = range_vals[0]
@@ -568,10 +698,14 @@ def compute_occurrence(occurrence_maps, input_strds, input_maps, start, base,
                     max = str(relations[relation][0].get_id())
                     break
 
-        expression = "%s = if(%s > %s && %s < %s, %s, null())" %(occurrence_map_name,
-                                                                map.get_name(),
-                                                                min, map.get_name(),
-                                                                max, days)
+        expression = "%s = if(%s > %s && %s < %s, %s, null())" % (
+            occurrence_map_name,
+            map.get_name(),
+            min,
+            map.get_name(),
+            max,
+            days,
+        )
         grass.debug(expression)
         grass.mapcalc(expression, overwrite=True)
 
@@ -580,8 +714,9 @@ def compute_occurrence(occurrence_maps, input_strds, input_maps, start, base,
         if map.is_time_absolute():
             occurrence_map.set_absolute_time(map_start, map_end)
         else:
-            occurrence_map.set_relative_time(map_start, map_end,
-                                         map.get_relative_time_unit())
+            occurrence_map.set_relative_time(
+                map_start, map_end, map.get_relative_time_unit()
+            )
 
         # Store the new maps
         occurrence_maps[map.get_id()] = occurrence_map
@@ -590,10 +725,12 @@ def compute_occurrence(occurrence_maps, input_strds, input_maps, start, base,
 
     return count
 
+
 ############################################################################
 
 if __name__ == "__main__":
     options, flags = grass.parser()
     # lazy imports
     import grass.temporal as tgis
+
     main()

--- a/temporal/t.rast.accdetect/testsuite/test_simple.py
+++ b/temporal/t.rast.accdetect/testsuite/test_simple.py
@@ -14,34 +14,48 @@ import os
 
 
 class TestRasterExtraction(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        for i in range(1,101):
-            cls.runModule("r.mapcalc", flags='s', overwrite=True,
-                          expression="a_mapcalc{nu} = rand(1,10)".format(nu=i))
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        for i in range(1, 101):
+            cls.runModule(
+                "r.mapcalc",
+                flags="s",
+                overwrite=True,
+                expression="a_mapcalc{nu} = rand(1,10)".format(nu=i),
+            )
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                      output="A", title="A test", description="A test",
-                      overwrite=True)
-        glist = SimpleModule('g.list', type='raster', pattern="a_mapcalc*",
-                             separator=',')
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        glist = SimpleModule(
+            "g.list", type="raster", pattern="a_mapcalc*", separator=","
+        )
         cls.runModule(glist, expecting_stdout=True)
         maps = glist.outputs.stdout.strip()
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                      maps=maps.strip(), increment="1 month",
-                      start="2001-01-01 00:00:00", overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps=maps.strip(),
+            increment="1 month",
+            start="2001-01-01 00:00:00",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -51,74 +65,111 @@ class TestRasterExtraction(TestCase):
         self.runModule("t.remove", flags="rf", type="strds", inputs="C")
 
     def test_simple(self):
-        self.assertModule('t.rast.accdetect', input='A', occurrence='B',
-                          indicator="C", start="2001-01-01", cycle="12 months",
-                          basename='result', range=(1,8))
-        tinfo_string="""semantic_type=mean
+        self.assertModule(
+            "t.rast.accdetect",
+            input="A",
+            occurrence="B",
+            indicator="C",
+            start="2001-01-01",
+            cycle="12 months",
+            basename="result",
+            range=(1, 8),
+        )
+        tinfo_string = """semantic_type=mean
         start_time='2001-01-01 00:00:00'
         end_time='2009-05-01 00:00:00'
         granularity='1 month'
         map_time=interval
         number_of_maps=100"""
         info = SimpleModule("t.info", flags="g", type="strds", input="B")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        tinfo_string="""semantic_type=mean
+        tinfo_string = """semantic_type=mean
         start_time='2001-01-01 00:00:00'
         end_time='2009-05-01 00:00:00'
         granularity='1 month'
         map_time=interval
         number_of_maps=100"""
         info = SimpleModule("t.info", flags="g", type="strds", input="C")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_stop(self):
-        self.assertModule('t.rast.accdetect', input='A', occurrence='B',
-                          indicator="C", start="2001-01-01", stop='2008-12-31',
-                          cycle="12 months", basename='result', range=(1,8))
-        tinfo_string="""semantic_type=mean
+        self.assertModule(
+            "t.rast.accdetect",
+            input="A",
+            occurrence="B",
+            indicator="C",
+            start="2001-01-01",
+            stop="2008-12-31",
+            cycle="12 months",
+            basename="result",
+            range=(1, 8),
+        )
+        tinfo_string = """semantic_type=mean
         start_time='2001-01-01 00:00:00'
         end_time='2009-01-01 00:00:00'
         granularity='1 month'
         map_time=interval
         number_of_maps=96"""
         info = SimpleModule("t.info", flags="g", type="strds", input="B")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        tinfo_string="""semantic_type=mean
+        tinfo_string = """semantic_type=mean
         start_time='2001-01-01 00:00:00'
         end_time='2009-01-01 00:00:00'
         granularity='1 month'
         map_time=interval
         number_of_maps=96"""
         info = SimpleModule("t.info", flags="g", type="strds", input="C")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_time_suffix(self):
-        self.assertModule('t.rast.accdetect', input='A', occurrence='B',
-                          indicator="C", start="2001-01-01", cycle="12 months", suffix='time',
-                          basename='result', range=(1,8))
-        self.assertRasterDoesNotExist('result_2001_01')
-        self.assertRasterExists('result_2001_01_01T00_00_00')
-        self.assertRasterDoesNotExist('result_indicator_2001_01')
-        self.assertRasterExists('result_indicator_2001_01_01T00_00_00')
+        self.assertModule(
+            "t.rast.accdetect",
+            input="A",
+            occurrence="B",
+            indicator="C",
+            start="2001-01-01",
+            cycle="12 months",
+            suffix="time",
+            basename="result",
+            range=(1, 8),
+        )
+        self.assertRasterDoesNotExist("result_2001_01")
+        self.assertRasterExists("result_2001_01_01T00_00_00")
+        self.assertRasterDoesNotExist("result_indicator_2001_01")
+        self.assertRasterExists("result_indicator_2001_01_01T00_00_00")
 
     def test_num_suffix(self):
-        self.assertModule('t.rast.accdetect', input='A', occurrence='B',
-                          indicator="C", start="2001-01-01", cycle="12 months",
-                          suffix='count%03', basename='result', range=(1,8))
-        self.assertRasterDoesNotExist('result_2001_01')
-        self.assertRasterExists('result_001')
-        self.assertRasterDoesNotExist('result_00001')
+        self.assertModule(
+            "t.rast.accdetect",
+            input="A",
+            occurrence="B",
+            indicator="C",
+            start="2001-01-01",
+            cycle="12 months",
+            suffix="count%03",
+            basename="result",
+            range=(1, 8),
+        )
+        self.assertRasterDoesNotExist("result_2001_01")
+        self.assertRasterExists("result_001")
+        self.assertRasterDoesNotExist("result_00001")
 
-        self.assertRasterDoesNotExist('result_indicator_2001_01')
-        self.assertRasterExists('result_indicator_001')
-        self.assertRasterDoesNotExist('result_indicator_00001')
+        self.assertRasterDoesNotExist("result_indicator_2001_01")
+        self.assertRasterExists("result_indicator_001")
+        self.assertRasterDoesNotExist("result_indicator_00001")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -159,6 +159,7 @@ from copy import copy
 
 ############################################################################
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
@@ -215,22 +216,30 @@ def main():
     if output_strds.is_in_db(dbif):
         if not grass.overwrite():
             dbif.close()
-            grass.fatal(_("Space time raster dataset <%s> is already in the "
-                          "database, use overwrite flag to overwrite") % out_id)
+            grass.fatal(
+                _(
+                    "Space time raster dataset <%s> is already in the "
+                    "database, use overwrite flag to overwrite"
+                )
+                % out_id
+            )
 
-    if tgis.check_granularity_string(granularity,
-                                     input_strds.get_temporal_type()) is False:
+    if (
+        tgis.check_granularity_string(granularity, input_strds.get_temporal_type())
+        is False
+    ):
         dbif.close()
         grass.fatal(_("Invalid granularity"))
 
-    if tgis.check_granularity_string(cycle,
-                                     input_strds.get_temporal_type()) is False:
+    if tgis.check_granularity_string(cycle, input_strds.get_temporal_type()) is False:
         dbif.close()
         grass.fatal(_("Invalid cycle"))
 
     if offset:
-        if tgis.check_granularity_string(offset,
-                                         input_strds.get_temporal_type()) is False:
+        if (
+            tgis.check_granularity_string(offset, input_strds.get_temporal_type())
+            is False
+        ):
             dbif.close()
             grass.fatal(_("Invalid offset"))
 
@@ -238,8 +247,12 @@ def main():
     if lower:
         if not range:
             dbif.close()
-            grass.fatal(_("You need to set the range to compute the occurrence"
-                          " space time raster dataset"))
+            grass.fatal(
+                _(
+                    "You need to set the range to compute the occurrence"
+                    " space time raster dataset"
+                )
+            )
 
         if lower.find("@") >= 0:
             lower_id = lower
@@ -249,7 +262,9 @@ def main():
         lower_strds = tgis.SpaceTimeRasterDataset(lower_id)
         if not lower_strds.is_in_db():
             dbif.close()
-            grass.fatal(_("Space time raster dataset <%s> not found") % (lower_strds.get_id()))
+            grass.fatal(
+                _("Space time raster dataset <%s> not found") % (lower_strds.get_id())
+            )
 
         if lower_strds.get_temporal_type() != input_strds.get_temporal_type():
             dbif.close()
@@ -261,7 +276,9 @@ def main():
     if upper:
         if not lower:
             dbif.close()
-            grass.fatal(_("The upper option works only in conjunction with the lower option"))
+            grass.fatal(
+                _("The upper option works only in conjunction with the lower option")
+            )
 
         if upper.find("@") >= 0:
             upper = upper
@@ -271,7 +288,9 @@ def main():
         upper_strds = tgis.SpaceTimeRasterDataset(upper_id)
         if not upper_strds.is_in_db():
             dbif.close()
-            grass.fatal(_("Space time raster dataset <%s> not found") % (upper_strds.get_id()))
+            grass.fatal(
+                _("Space time raster dataset <%s> not found") % (upper_strds.get_id())
+            )
 
         if upper_strds.get_temporal_type() != input_strds.get_temporal_type():
             dbif.close()
@@ -305,19 +324,16 @@ def main():
     count = 1
     output_maps = []
 
-
     while input_strds_end > start and stop > start:
 
         # Make sure that the cyclic computation will stop at the correct time
         if stop and end > stop:
             end = stop
 
-        where = "start_time >= \'%s\' AND start_time < \'%s\'" %(str(start),
-                                                                str(end))
-        input_maps = input_strds.get_registered_maps_as_objects(where=where,
-                                                                dbif=dbif)
+        where = "start_time >= '%s' AND start_time < '%s'" % (str(start), str(end))
+        input_maps = input_strds.get_registered_maps_as_objects(where=where, dbif=dbif)
 
-        grass.message(_("Processing cycle %s - %s" %(str(start), str(end))))
+        grass.message(_("Processing cycle %s - %s" % (str(start), str(end))))
 
         if len(input_maps) == 0:
             continue
@@ -328,17 +344,16 @@ def main():
         gran_list_up = []
         gran_start = start
         while gran_start < end:
-            map = input_strds.get_new_map_instance("%i@%i" %(count, count))
+            map = input_strds.get_new_map_instance("%i@%i" % (count, count))
             if input_strds.is_time_absolute():
-                gran_end = tgis.increment_datetime_by_string(gran_start,
-                                                             granularity)
+                gran_end = tgis.increment_datetime_by_string(gran_start, granularity)
                 map.set_absolute_time(gran_start, gran_end)
-                gran_start = tgis.increment_datetime_by_string(gran_start,
-                                                               granularity)
+                gran_start = tgis.increment_datetime_by_string(gran_start, granularity)
             else:
                 gran_end = gran_start + granularity
-                map.set_relative_time(gran_start, gran_end,
-                                      input_strds.get_relative_time_unit())
+                map.set_relative_time(
+                    gran_start, gran_end, input_strds.get_relative_time_unit()
+                )
                 gran_start = gran_start + granularity
             gran_list.append(copy(map))
             gran_list_low.append(copy(map))
@@ -388,11 +403,14 @@ def main():
                 continue
 
             # New output map
-            if input_strds.get_temporal_type() == 'absolute' and time_suffix == 'gran':
-                suffix = tgis.create_suffix_from_datetime(map.temporal_extent.get_start_time(),
-                                                          input_strds.get_granularity())
+            if input_strds.get_temporal_type() == "absolute" and time_suffix == "gran":
+                suffix = tgis.create_suffix_from_datetime(
+                    map.temporal_extent.get_start_time(), input_strds.get_granularity()
+                )
                 output_map_name = "{ba}_{su}".format(ba=base, su=suffix)
-            elif input_strds.get_temporal_type() == 'absolute' and time_suffix == 'time':
+            elif (
+                input_strds.get_temporal_type() == "absolute" and time_suffix == "time"
+            ):
                 suffix = tgis.create_time_suffix(map)
                 output_map_name = "{ba}_{su}".format(ba=base, su=suffix)
             else:
@@ -408,17 +426,22 @@ def main():
                     output_map.delete(dbif)
                     output_map = input_strds.get_new_map_instance(output_map_id)
                 else:
-                    grass.fatal(_("Map <%s> is already registered in the temporal"
-                                 " database, use overwrite flag to overwrite.") %
-                                (output_map.get_map_id()))
+                    grass.fatal(
+                        _(
+                            "Map <%s> is already registered in the temporal"
+                            " database, use overwrite flag to overwrite."
+                        )
+                        % (output_map.get_map_id())
+                    )
 
             map_start, map_end = map.get_temporal_extent_as_tuple()
 
             if map.is_time_absolute():
                 output_map.set_absolute_time(map_start, map_end)
             else:
-                output_map.set_relative_time(map_start, map_end,
-                                             map.get_relative_time_unit())
+                output_map.set_relative_time(
+                    map_start, map_end, map.get_relative_time_unit()
+                )
 
             limits_vals = limits.split(",")
             limits_lower = float(limits_vals[0])
@@ -445,8 +468,12 @@ def main():
                 input_map_names.append(input_map.get_id())
 
             # Set up the module
-            accmod = Module("r.series.accumulate", input=input_map_names,
-                            output=output_map_name, run_=False)
+            accmod = Module(
+                "r.series.accumulate",
+                input=input_map_names,
+                output=output_map_name,
+                run_=False,
+            )
 
             if old_map_name:
                 accmod.inputs["basemap"].value = old_map_name
@@ -497,8 +524,7 @@ def main():
             output_strds = input_strds.get_new_instance(out_id)
 
     temporal_type, semantic_type, title, description = input_strds.get_initial_values()
-    output_strds.set_initial_values(temporal_type, semantic_type, title,
-                                    description)
+    output_strds.set_initial_values(temporal_type, semantic_type, title, description)
     output_strds.insert(dbif)
 
     empty_maps = []
@@ -506,15 +532,17 @@ def main():
     count = 0
     for output_map in output_maps:
         count += 1
-        if count %10 == 0:
+        if count % 10 == 0:
             grass.percent(count, len(output_maps), 1)
         # Read the raster map data
         output_map.load()
         # In case of a empty map continue, do not register empty maps
 
         if not register_null:
-            if output_map.metadata.get_min() is None and \
-                output_map.metadata.get_max() is None:
+            if (
+                output_map.metadata.get_min() is None
+                and output_map.metadata.get_max() is None
+            ):
                 empty_maps.append(output_map)
                 continue
 
@@ -531,7 +559,10 @@ def main():
     # Remove empty maps
     if len(empty_maps) > 0:
         for map in empty_maps:
-            grass.run_command("g.remove", flags='f', type="raster", name=map.get_name(), quiet=True)
+            grass.run_command(
+                "g.remove", flags="f", type="raster", name=map.get_name(), quiet=True
+            )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.accumulate/testsuite/test_accumulation.py
+++ b/temporal/t.rast.accumulate/testsuite/test_accumulation.py
@@ -13,13 +13,12 @@ import datetime
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestAccumulate(TestCase):
 
+class TestAccumulate(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
-        tgis.init(True) # Raise on error instead of exit(1)
+        """Initiate the temporal GIS and set the region"""
+        tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
@@ -31,46 +30,73 @@ class TestAccumulate(TestCase):
         cls.runModule("r.mapcalc", expression="a_6 = 10", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_7 = 5", overwrite=True)
 
-
         cls.runModule("r.mapcalc", expression="lower = 10", overwrite=True)
         cls.runModule("r.mapcalc", expression="upper = 30", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                   output="A", title="A test",
-                                   description="A test", overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1,a_2,a_3,a_4,a_5,a_6,a_7",
-                                     start="2001-01-01",
-                                     increment="1 day", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1,a_2,a_3,a_4,a_5,a_6,a_7",
+            start="2001-01-01",
+            increment="1 day",
+            overwrite=True,
+        )
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                   output="Lower", title="Lower",
-                                   description="Lower", overwrite=True)
-        cls.runModule("t.register", type="raster", input="Lower",
-                                     maps="lower",
-                                     start="2001-01-01",
-                                     end="2001-01-10",
-                                     overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="Lower",
+            title="Lower",
+            description="Lower",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="Lower",
+            maps="lower",
+            start="2001-01-01",
+            end="2001-01-10",
+            overwrite=True,
+        )
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                   output="Upper", title="Upper",
-                                   description="Upper", overwrite=True)
-        cls.runModule("t.register", type="raster", input="Upper",
-                                     maps="upper",
-                                     start="2001-01-01",
-                                     end="2001-01-10",
-                                     overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="Upper",
+            title="Upper",
+            description="Upper",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="Upper",
+            maps="upper",
+            start="2001-01-01",
+            end="2001-01-10",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="A")
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="Lower")
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="Upper")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="Lower")
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="Upper")
         cls.del_temp_region()
 
     def tearDown(self):
@@ -78,11 +104,18 @@ class TestAccumulate(TestCase):
         self.runModule("t.remove", flags="rf", type="strds", inputs="B")
 
     def test_1(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[0,40], method="gdd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[0, 40],
+            method="gdd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -92,15 +125,22 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 8))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_2(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[10,40], method="gdd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[10, 40],
+            method="gdd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -110,15 +150,22 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 8))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_3(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[10,30], method="bedd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[10, 30],
+            method="bedd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -128,18 +175,24 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 8))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_3_a(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          lower="Lower",
-                          upper="Upper",
-                          limits=[0,40],
-                          method="bedd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            lower="Lower",
+            upper="Upper",
+            limits=[0, 40],
+            method="bedd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -149,15 +202,23 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 8))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_4(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[10,30], method="bedd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b", granularity="2 days",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[10, 30],
+            method="bedd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            granularity="2 days",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -167,18 +228,25 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 9))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_4_a(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          lower="Lower",
-                          upper="Upper",
-                          limits=[0,40],
-                          method="bedd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b", granularity="2 days",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            lower="Lower",
+            upper="Upper",
+            limits=[0, 40],
+            method="bedd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            granularity="2 days",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -188,15 +256,23 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 9))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_5(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[0,40], method="gdd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b", stop="2001-01-05",
-                          overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[0, 40],
+            method="gdd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            stop="2001-01-05",
+            overwrite=True,
+            verbose=True,
+        )
 
         D = tgis.open_old_stds("B", type="strds")
 
@@ -206,35 +282,64 @@ class TestAccumulate(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_count_suffix(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[0,40], method="gdd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b", stop="2001-01-05", suffix="num",
-                          overwrite=True, verbose=True)
-        self.assertRasterExists('b_00001')
-        self.assertRasterDoesNotExist('b_2001_01_07')
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[0, 40],
+            method="gdd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            stop="2001-01-05",
+            suffix="num",
+            overwrite=True,
+            verbose=True,
+        )
+        self.assertRasterExists("b_00001")
+        self.assertRasterDoesNotExist("b_2001_01_07")
 
     def test_count3_suffix(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[0,40], method="gdd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b", stop="2001-01-05", suffix="num%03",
-                          overwrite=True, verbose=True)
-        self.assertRasterExists('b_001')
-        self.assertRasterDoesNotExist('b_2001_01_07')
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[0, 40],
+            method="gdd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            stop="2001-01-05",
+            suffix="num%03",
+            overwrite=True,
+            verbose=True,
+        )
+        self.assertRasterExists("b_001")
+        self.assertRasterDoesNotExist("b_2001_01_07")
 
     def test_time_suffix(self):
-        self.assertModule("t.rast.accumulate", input="A", output="B",
-                          limits=[0,40], method="gdd",
-                          start="2001-01-01", cycle="7 days",
-                          basename="b", stop="2001-01-05", suffix="time",
-                          overwrite=True, verbose=True)
-        self.assertRasterExists('b_2001_01_01T00_00_00')
+        self.assertModule(
+            "t.rast.accumulate",
+            input="A",
+            output="B",
+            limits=[0, 40],
+            method="gdd",
+            start="2001-01-01",
+            cycle="7 days",
+            basename="b",
+            stop="2001-01-05",
+            suffix="time",
+            overwrite=True,
+            verbose=True,
+        )
+        self.assertRasterExists("b_2001_01_01T00_00_00")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.aggregate.ds/t.rast.aggregate.ds.py
+++ b/temporal/t.rast.aggregate.ds/t.rast.aggregate.ds.py
@@ -139,25 +139,34 @@ def main():
 
     if sampler_sp.get_temporal_type() != sp.get_temporal_type():
         dbif.close()
-        gcore.fatal(_("Input and aggregation dataset must have "
-                      "the same temporal type"))
+        gcore.fatal(
+            _("Input and aggregation dataset must have " "the same temporal type")
+        )
 
     # Check if intervals are present
     if sampler_sp.temporal_extent.get_map_time() != "interval":
         dbif.close()
-        gcore.fatal(_("All registered maps of the aggregation dataset "
-                      "must have time intervals"))
+        gcore.fatal(
+            _(
+                "All registered maps of the aggregation dataset "
+                "must have time intervals"
+            )
+        )
 
     # We will create the strds later, but need to check here
     tgis.check_new_stds(output, "strds", dbif, gcore.overwrite())
 
-    map_list = sp.get_registered_maps_as_objects(where=where, order="start_time", dbif=dbif)
+    map_list = sp.get_registered_maps_as_objects(
+        where=where, order="start_time", dbif=dbif
+    )
 
     if not map_list:
         dbif.close()
         gcore.fatal(_("Space time raster dataset <%s> is empty") % input)
 
-    granularity_list = sampler_sp.get_registered_maps_as_objects(where=where, order="start_time", dbif=dbif)
+    granularity_list = sampler_sp.get_registered_maps_as_objects(
+        where=where, order="start_time", dbif=dbif
+    )
 
     if not granularity_list:
         dbif.close()
@@ -165,25 +174,47 @@ def main():
 
     gran = sampler_sp.get_granularity()
 
-    output_list = tgis.aggregate_by_topology(granularity_list=granularity_list, granularity=gran,
-                                                                       map_list=map_list,
-                                                                       topo_list=topo_list, basename=base, time_suffix=time_suffix,
-                                                                       offset=offset, method=method, nprocs=nprocs, spatial=None,
-                                                                       overwrite=gcore.overwrite())
+    output_list = tgis.aggregate_by_topology(
+        granularity_list=granularity_list,
+        granularity=gran,
+        map_list=map_list,
+        topo_list=topo_list,
+        basename=base,
+        time_suffix=time_suffix,
+        offset=offset,
+        method=method,
+        nprocs=nprocs,
+        spatial=None,
+        overwrite=gcore.overwrite(),
+    )
 
     if output_list:
         temporal_type, semantic_type, title, description = sp.get_initial_values()
-        output_strds = tgis.open_new_stds(output, "strds", temporal_type,
-                                                                 title, description, semantic_type,
-                                                                 dbif, gcore.overwrite())
-        tgis.register_map_object_list("rast", output_list, output_strds, register_null,
-                                                       sp.get_relative_time_unit(), dbif)
+        output_strds = tgis.open_new_stds(
+            output,
+            "strds",
+            temporal_type,
+            title,
+            description,
+            semantic_type,
+            dbif,
+            gcore.overwrite(),
+        )
+        tgis.register_map_object_list(
+            "rast",
+            output_list,
+            output_strds,
+            register_null,
+            sp.get_relative_time_unit(),
+            dbif,
+        )
 
         # Update the raster metadata table entries with aggregation type
         output_strds.set_aggregation_type(method)
         output_strds.metadata.update(dbif)
 
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = gcore.parser()

--- a/temporal/t.rast.aggregate/t.rast.aggregate.py
+++ b/temporal/t.rast.aggregate/t.rast.aggregate.py
@@ -116,6 +116,7 @@ import grass.script as gcore
 
 ############################################################################
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
@@ -143,7 +144,9 @@ def main():
 
     sp = tgis.open_old_stds(input, "strds", dbif)
 
-    map_list = sp.get_registered_maps_as_objects(where=where, order="start_time", dbif=dbif)
+    map_list = sp.get_registered_maps_as_objects(
+        where=where, order="start_time", dbif=dbif
+    )
 
     if not map_list:
         dbif.close()
@@ -163,7 +166,7 @@ def main():
 
     # In case no end time is available, then we use the start time of the last map layer
     if end_time is None:
-        end_time = map_list[- 1].temporal_extent.get_start_time()
+        end_time = map_list[-1].temporal_extent.get_start_time()
         has_end_time = False
 
     granularity_list = []
@@ -189,30 +192,53 @@ def main():
 
         granularity_list.append(granule)
 
-    output_list = tgis.aggregate_by_topology(granularity_list=granularity_list, granularity=gran,
-                                                                       map_list=map_list,
-                                                                       topo_list=topo_list, basename=base, time_suffix=time_suffix,
-                                                                       offset=offset, method=method, nprocs=nprocs, spatial=None,
-                                                                       overwrite=gcore.overwrite(), file_limit=file_limit)
+    output_list = tgis.aggregate_by_topology(
+        granularity_list=granularity_list,
+        granularity=gran,
+        map_list=map_list,
+        topo_list=topo_list,
+        basename=base,
+        time_suffix=time_suffix,
+        offset=offset,
+        method=method,
+        nprocs=nprocs,
+        spatial=None,
+        overwrite=gcore.overwrite(),
+        file_limit=file_limit,
+    )
 
     if output_list:
         temporal_type, semantic_type, title, description = sp.get_initial_values()
-        output_strds = tgis.open_new_stds(output, "strds", temporal_type,
-                                                                 title, description, semantic_type,
-                                                                 dbif, gcore.overwrite())
+        output_strds = tgis.open_new_stds(
+            output,
+            "strds",
+            temporal_type,
+            title,
+            description,
+            semantic_type,
+            dbif,
+            gcore.overwrite(),
+        )
         if register_null:
-            register_null=False
+            register_null = False
         else:
-            register_null=True
+            register_null = True
 
-        tgis.register_map_object_list("rast", output_list, output_strds, register_null,
-                                                       sp.get_relative_time_unit(), dbif)
+        tgis.register_map_object_list(
+            "rast",
+            output_list,
+            output_strds,
+            register_null,
+            sp.get_relative_time_unit(),
+            dbif,
+        )
 
         # Update the raster metadata table entries with aggregation type
         output_strds.set_aggregation_type(method)
         output_strds.metadata.update(dbif)
 
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = gcore.parser()

--- a/temporal/t.rast.aggregate/testsuite/test_aggregation_absolute.py
+++ b/temporal/t.rast.aggregate/testsuite/test_aggregation_absolute.py
@@ -13,17 +13,15 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestAggregationAbsolute(TestCase):
 
+class TestAggregationAbsolute(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100.0", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200.0", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300.0", overwrite=True)
@@ -32,20 +30,30 @@ class TestAggregationAbsolute(TestCase):
         cls.runModule("r.mapcalc", expression="a6 = 600.0", overwrite=True)
         cls.runModule("r.mapcalc", expression="a7 = null()", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a1,a2,a3,a4,a5,a6,a7",
-                                     start="2001-01-15 12:05:45",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4,a5,a6,a7",
+            start="2001-01-15 12:05:45",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -55,13 +63,19 @@ class TestAggregationAbsolute(TestCase):
 
     def test_disaggregation(self):
         """Disaggregation with empty maps"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="2 days",
-                          method="average",
-                          sampling=["overlaps","overlapped","during"],
-                          nprocs=2, flags="n")
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="2 days",
+            method="average",
+            sampling=["overlaps", "overlapped", "during"],
+            nprocs=2,
+            flags="n",
+        )
 
-        tinfo_string="""start_time='2001-01-15 00:00:00'
+        tinfo_string = """start_time='2001-01-15 00:00:00'
                         end_time='2001-04-25 00:00:00'
                         granularity='2 days'
                         aggregation_type=average
@@ -73,19 +87,27 @@ class TestAggregationAbsolute(TestCase):
                         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_aggregation_1month(self):
         """Aggregation one month"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="1 months",
-                          method="maximum", sampling=["contains"],
-                          file_limit=0, nprocs=3)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="1 months",
+            method="maximum",
+            sampling=["contains"],
+            file_limit=0,
+            nprocs=3,
+        )
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-04-01 00:00:00'
                         granularity='1 month'
                         map_time=interval
@@ -97,36 +119,58 @@ class TestAggregationAbsolute(TestCase):
                         max_max=500.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         # Check the map names are correct
-        lister = SimpleModule("t.rast.list", input="B", columns="name",
-                              flags="u")
+        lister = SimpleModule("t.rast.list", input="B", columns="name", flags="u")
         self.runModule(lister)
-        #print lister.outputs.stdout
-        maps="b_2001_01" + os.linesep + "b_2001_02" + os.linesep + \
-             "b_2001_03" + os.linesep
+        # print lister.outputs.stdout
+        maps = (
+            "b_2001_01"
+            + os.linesep
+            + "b_2001_02"
+            + os.linesep
+            + "b_2001_03"
+            + os.linesep
+        )
         self.assertEqual(maps, lister.outputs.stdout)
 
     def test_aggregation_1month_time(self):
         """Aggregation one month time suffix"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="1 months",
-                          method="maximum", sampling=["contains"],
-                          file_limit=0, nprocs=3, suffix='time')
-        self.assertRasterExists('b_2001_01_01T00_00_00')
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="1 months",
+            method="maximum",
+            sampling=["contains"],
+            file_limit=0,
+            nprocs=3,
+            suffix="time",
+        )
+        self.assertRasterExists("b_2001_01_01T00_00_00")
 
     def test_aggregation_2months(self):
         """Aggregation two month"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="2 months",
-                          method="minimum", sampling=["contains"],
-                          nprocs=4, offset=10, suffix='num%02')
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="2 months",
+            method="minimum",
+            sampling=["contains"],
+            nprocs=4,
+            offset=10,
+            suffix="num%02",
+        )
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-05-01 00:00:00'
                         granularity='2 months'
                         map_time=interval
@@ -138,28 +182,36 @@ class TestAggregationAbsolute(TestCase):
                         max_max=500.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         # Check the map names are correct
-        lister = SimpleModule("t.rast.list", input="B", columns="name",
-                              flags="u")
+        lister = SimpleModule("t.rast.list", input="B", columns="name", flags="u")
         self.runModule(lister)
-        #print lister.outputs.stdout
-        maps="b_11" + os.linesep + "b_12" + os.linesep
+        # print lister.outputs.stdout
+        maps = "b_11" + os.linesep + "b_12" + os.linesep
         self.assertEqual(maps, lister.outputs.stdout)
 
     def test_aggregation_3months(self):
         """Aggregation three month"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="3 months",
-                          method="sum", sampling=["contains"],
-                          file_limit=0, nprocs=9, offset=100,
-                          suffix='num%03')
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="3 months",
+            method="sum",
+            sampling=["contains"],
+            file_limit=0,
+            nprocs=9,
+            offset=100,
+            suffix="num%03",
+        )
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-04-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -171,19 +223,21 @@ class TestAggregationAbsolute(TestCase):
                         max_max=1500.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
         # Check the map names are correct
-        lister = SimpleModule("t.rast.list", input="B", columns="name",
-                              flags="u")
+        lister = SimpleModule("t.rast.list", input="B", columns="name", flags="u")
         self.runModule(lister)
-        #print lister.outputs.stdout
-        maps="b_101" + os.linesep
+        # print lister.outputs.stdout
+        maps = "b_101" + os.linesep
         self.assertEqual(maps, lister.outputs.stdout)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.aggregate/testsuite/test_aggregation_absolute_parallel.py
+++ b/temporal/t.rast.aggregate/testsuite/test_aggregation_absolute_parallel.py
@@ -16,37 +16,47 @@ from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 from datetime import datetime
 
-class TestAggregationAbsoluteParallel(TestCase):
 
+class TestAggregationAbsoluteParallel(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
         name_list = []
         for i in range(540):
-            cls.runModule("r.mapcalc", expression="a%i = %i" %(i + 1, i + 1), overwrite=True)
-            name_list.append("a%i" %(i + 1))
+            cls.runModule(
+                "r.mapcalc", expression="a%i = %i" % (i + 1, i + 1), overwrite=True
+            )
+            name_list.append("a%i" % (i + 1))
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps=name_list,
-                                     start="2001-01-01",
-                                     increment="4 hours",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps=name_list,
+            start="2001-01-01",
+            increment="4 hours",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -56,12 +66,19 @@ class TestAggregationAbsoluteParallel(TestCase):
 
     def test_aggregation_12hours(self):
         """Aggregation one month"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="12 hours",
-                          method="sum", sampling=["contains"],
-                          nprocs=9, file_limit=2)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="12 hours",
+            method="sum",
+            sampling=["contains"],
+            nprocs=9,
+            file_limit=2,
+        )
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-04-01 00:00:00'
                         granularity='12 hours'
                         map_time=interval
@@ -73,24 +90,31 @@ class TestAggregationAbsoluteParallel(TestCase):
                         max_max=1617.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_aggregation_1day_4procs(self):
         """Aggregation one month"""
         start = datetime.now()
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="1 day",
-                          method="sum", sampling=["contains"],
-                          nprocs=4)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="1 day",
+            method="sum",
+            sampling=["contains"],
+            nprocs=4,
+        )
         end = datetime.now()
 
         delta = end - start
         print("test_aggregation_1day_4procs:", delta.total_seconds())
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-04-01 00:00:00'
                         granularity='1 day'
                         map_time=interval
@@ -98,25 +122,31 @@ class TestAggregationAbsoluteParallel(TestCase):
                         number_of_maps=90"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_aggregation_1day_3procs(self):
         """Aggregation one month"""
         start = datetime.now()
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="1 day",
-                          method="sum", sampling=["contains"],
-                          nprocs=3)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="1 day",
+            method="sum",
+            sampling=["contains"],
+            nprocs=3,
+        )
         end = datetime.now()
 
         delta = end - start
         print("test_aggregation_1day_3procs:", delta.total_seconds())
 
-
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-04-01 00:00:00'
                         granularity='1 day'
                         map_time=interval
@@ -128,25 +158,31 @@ class TestAggregationAbsoluteParallel(TestCase):
                         max_max=3225.0"""
 
         info = SimpleModule("t.info", input="B", flags="g")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_aggregation_1day_2procs(self):
         """Aggregation one month"""
         start = datetime.now()
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity="1 day",
-                          method="sum", sampling=["contains"],
-                          nprocs=2)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity="1 day",
+            method="sum",
+            sampling=["contains"],
+            nprocs=2,
+        )
         end = datetime.now()
 
         delta = end - start
         print("test_aggregation_1day_2procs:", delta.total_seconds())
 
-
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2001-04-01 00:00:00'
                         granularity='1 day'
                         map_time=interval
@@ -158,10 +194,14 @@ class TestAggregationAbsoluteParallel(TestCase):
                         max_max=3225.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
-if __name__ == '__main__':
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
+
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.aggregate/testsuite/test_aggregation_relative.py
+++ b/temporal/t.rast.aggregate/testsuite/test_aggregation_relative.py
@@ -13,17 +13,15 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestAggregationRelative(TestCase):
 
+class TestAggregationRelative(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
@@ -32,19 +30,31 @@ class TestAggregationRelative(TestCase):
         cls.runModule("r.mapcalc", expression="a6 = 600", overwrite=True)
         cls.runModule("r.mapcalc", expression="a7 = null()", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a1,a2,a3,a4,a5,a6,a7",
-                                     start=0, unit="days", increment=3,
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4,a5,a6,a7",
+            start=0,
+            unit="days",
+            increment=3,
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -54,13 +64,20 @@ class TestAggregationRelative(TestCase):
 
     def test_1(self):
         """Simple test"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity=6,
-                          method="average", file_limit=0,
-                          sampling=["overlaps","overlapped","contains"],
-                          nprocs=2, verbose=True)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity=6,
+            method="average",
+            file_limit=0,
+            sampling=["overlaps", "overlapped", "contains"],
+            nprocs=2,
+            verbose=True,
+        )
 
-        tinfo_string="""start_time='0'
+        tinfo_string = """start_time='0'
                         end_time='18'
                         unit=days
                         granularity=6
@@ -73,20 +90,28 @@ class TestAggregationRelative(TestCase):
                         max_max=550.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_2(self):
         """Simple test register null maps"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity=9,
-                          method="maximum",
-                          sampling=["contains"],
-                          nprocs=4, flags="n", verbose=True)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity=9,
+            method="maximum",
+            sampling=["contains"],
+            nprocs=4,
+            flags="n",
+            verbose=True,
+        )
 
-        tinfo_string="""semantic_type=mean
+        tinfo_string = """semantic_type=mean
                         start_time='0'
                         end_time='27'
                         unit=days
@@ -100,20 +125,27 @@ class TestAggregationRelative(TestCase):
                         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_3(self):
         """Simple test"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity=9,
-                          method="maximum",
-                          sampling=["contains"],
-                          nprocs=4, verbose=True)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity=9,
+            method="maximum",
+            sampling=["contains"],
+            nprocs=4,
+            verbose=True,
+        )
 
-        tinfo_string="""semantic_type=mean
+        tinfo_string = """semantic_type=mean
                         start_time='0'
                         end_time='18'
                         unit=days
@@ -127,20 +159,27 @@ class TestAggregationRelative(TestCase):
                         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_4(self):
         """Simple test"""
-        self.assertModule("t.rast.aggregate", input="A", output="B",
-                          basename="b", granularity=21,
-                          method="average",
-                          sampling=["contains"],
-                          nprocs=4, verbose=True)
+        self.assertModule(
+            "t.rast.aggregate",
+            input="A",
+            output="B",
+            basename="b",
+            granularity=21,
+            method="average",
+            sampling=["contains"],
+            nprocs=4,
+            verbose=True,
+        )
 
-        tinfo_string="""semantic_type=mean
+        tinfo_string = """semantic_type=mean
                         start_time='0'
                         end_time='21'
                         unit=days
@@ -154,11 +193,14 @@ class TestAggregationRelative(TestCase):
                         max_max=350.0"""
 
         info = SimpleModule("t.info", flags="g", input="B")
-        #info.run()
-        #print info.outputs.stdout
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        # info.run()
+        # print info.outputs.stdout
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.algebra/t.rast.algebra.py
+++ b/temporal/t.rast.algebra/t.rast.algebra.py
@@ -91,8 +91,8 @@ def main():
     # lazy imports
     import grass.temporal as tgis
 
-    expression = options['expression']
-    basename = options['basename']
+    expression = options["expression"]
+    basename = options["basename"]
     nprocs = options["nprocs"]
     time_suffix = options["suffix"]
     spatial = flags["s"]
@@ -106,27 +106,40 @@ def main():
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
     except ImportError:
-        grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
-                             "You can use t.rast.mapcalc that provides a limited but useful alternative to "
-                             "t.rast.algebra without PLY requirement."))
+        grass.script.fatal(
+            _(
+                "Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
+                "You can use t.rast.mapcalc that provides a limited but useful alternative to "
+                "t.rast.algebra without PLY requirement."
+            )
+        )
 
     tgis.init(True)
-    p = tgis.TemporalRasterAlgebraParser(run = True,
-                                         debug=False,
-                                         spatial=spatial,
-                                         nprocs=nprocs,
-                                         register_null=register_null,
-                                         dry_run=dry_run, time_suffix=time_suffix)
+    p = tgis.TemporalRasterAlgebraParser(
+        run=True,
+        debug=False,
+        spatial=spatial,
+        nprocs=nprocs,
+        register_null=register_null,
+        dry_run=dry_run,
+        time_suffix=time_suffix,
+    )
 
     if granularity:
-        if not p.setup_common_granularity(expression=expression, lexer = tgis.TemporalRasterAlgebraLexer()):
-            grass.script.fatal(_("Unable to process the expression in granularity algebra mode"))
+        if not p.setup_common_granularity(
+            expression=expression, lexer=tgis.TemporalRasterAlgebraLexer()
+        ):
+            grass.script.fatal(
+                _("Unable to process the expression in granularity algebra mode")
+            )
 
     pc = p.parse(expression, basename, grass.script.overwrite())
 
     if dry_run is True:
         import pprint
+
         pprint.pprint(pc)
+
 
 if __name__ == "__main__":
     options, flags = grass.script.parser()

--- a/temporal/t.rast.algebra/testsuite/test_raster_algebra.py
+++ b/temporal/t.rast.algebra/testsuite/test_raster_algebra.py
@@ -15,16 +15,13 @@ from grass.gunittest.main import test
 
 
 class TestTRastAlgebra(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
-        tgis.init(True) # Raise on error instead of exit(1)
+        tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
-        cls.runModule("g.region", n=80.0, s=0.0, e=120.0,
-                                       w=0.0, t=1.0, b=0.0, res=10.0)
+        cls.runModule("g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=1.0, b=0.0, res=10.0)
 
         cls.runModule("r.mapcalc", quiet=True, expression="a1 = 1")
         cls.runModule("r.mapcalc", quiet=True, expression="a2 = 2")
@@ -39,62 +36,128 @@ class TestTRastAlgebra(TestCase):
         cls.runModule("r.mapcalc", quiet=True, expression="singletmap = 99")
         cls.runModule("r.mapcalc", quiet=True, expression="singlemap = 100")
 
-        tgis.open_new_stds(name="A", type="strds", temporaltype="absolute",
-                                         title="A", descr="A", semantic="field")
-        tgis.open_new_stds(name="B", type="strds", temporaltype="absolute",
-                                         title="B", descr="B", semantic="field")
-        tgis.open_new_stds(name="C", type="strds", temporaltype="absolute",
-                                         title="B", descr="C", semantic="field")
-        tgis.open_new_stds(name="D", type="strds", temporaltype="absolute",
-                                         title="D", descr="D", semantic="field")
+        tgis.open_new_stds(
+            name="A",
+            type="strds",
+            temporaltype="absolute",
+            title="A",
+            descr="A",
+            semantic="field",
+        )
+        tgis.open_new_stds(
+            name="B",
+            type="strds",
+            temporaltype="absolute",
+            title="B",
+            descr="B",
+            semantic="field",
+        )
+        tgis.open_new_stds(
+            name="C",
+            type="strds",
+            temporaltype="absolute",
+            title="B",
+            descr="C",
+            semantic="field",
+        )
+        tgis.open_new_stds(
+            name="D",
+            type="strds",
+            temporaltype="absolute",
+            title="D",
+            descr="D",
+            semantic="field",
+        )
 
-        tgis.register_maps_in_space_time_dataset(type="raster", name="A", maps="a1,a2,a3,a4",
-                                                 start="2001-01-01", increment="1 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="B", maps="b1,b2",
-                                                 start="2001-01-01", increment="2 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="C", maps="c1",
-                                                 start="2001-01-02", increment="2 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="D", maps="d1,d2,d3",
-                                                 start="2001-01-03", increment="1 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name=None, maps="singletmap",
-                                                start="2001-01-03", end="2001-01-04")
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="1 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="B",
+            maps="b1,b2",
+            start="2001-01-01",
+            increment="2 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="C",
+            maps="c1",
+            start="2001-01-02",
+            increment="2 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="D",
+            maps="d1,d2,d3",
+            start="2001-01-03",
+            increment="1 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name=None,
+            maps="singletmap",
+            start="2001-01-03",
+            end="2001-01-04",
+        )
 
     def tearDown(self):
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
 
     def test_temporal_conditional_time_dimension_bug(self):
         """Testing the conditional time dimension bug, that uses the time
-            dimension of the conditional statement instead the time dimension
-            of the then/else statement."""
-        self.assertModule("t.rast.algebra", expression="R = if({contains}, B == 5, "
-                                                       "A - 1,  A + 1)", basename="r", flags="d")
-        self.assertModule("t.rast.algebra", expression="R = if({contains}, B == 5, "
-                                                       "A - 1,  A + 1)", basename="r")
+        dimension of the conditional statement instead the time dimension
+        of the then/else statement."""
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = if({contains}, B == 5, " "A - 1,  A + 1)",
+            basename="r",
+            flags="d",
+        )
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = if({contains}, B == 5, " "A - 1,  A + 1)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
-        self.assertEqual(D.metadata.get_min_min(), 0) # 1 - 1
-        self.assertEqual(D.metadata.get_max_max(), 5) # 4 + 1
+        self.assertEqual(D.metadata.get_min_min(), 0)  # 1 - 1
+        self.assertEqual(D.metadata.get_max_max(), 5)  # 4 + 1
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_simple_arith_hash_1(self):
         """Simple arithmetic test including the hash operator"""
 
-        self.assertModule("t.rast.algebra", expression='R = A + (A {#, equal,l} A)', basename="r", flags="d")
-        self.assertModule("t.rast.algebra", expression='R = A + (A {#, equal,l} A)', basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = A + (A {#, equal,l} A)",
+            basename="r",
+            flags="d",
+        )
+        self.assertModule(
+            "t.rast.algebra", expression="R = A + (A {#, equal,l} A)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -105,12 +168,19 @@ class TestTRastAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-
     def test_simple_arith_td_1(self):
         """Simple arithmetic test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A + td(A)', basename="r", flags="d", suffix="time")
-        self.assertModule("t.rast.algebra", expression='R = A + td(A)', basename="r", suffix="time")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = A + td(A)",
+            basename="r",
+            flags="d",
+            suffix="time",
+        )
+        self.assertModule(
+            "t.rast.algebra", expression="R = A + td(A)", basename="r", suffix="time"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -124,8 +194,16 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_td_2(self):
         """Simple arithmetic test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A / td(A)', basename="r", flags="d", suffix="gran")
-        self.assertModule("t.rast.algebra", expression='R = A / td(A)', basename="r", suffix="gran")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = A / td(A)",
+            basename="r",
+            flags="d",
+            suffix="gran",
+        )
+        self.assertModule(
+            "t.rast.algebra", expression="R = A / td(A)", basename="r", suffix="gran"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -139,8 +217,15 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_td_3(self):
         """Simple arithmetic test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A {+,equal} td(A)', basename="r", flags="d")
-        self.assertModule("t.rast.algebra", expression='R = A {+,equal} td(A)', basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = A {+,equal} td(A)",
+            basename="r",
+            flags="d",
+        )
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {+,equal} td(A)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -154,8 +239,15 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_td_4(self):
         """Simple arithmetic test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A {/, equal} td(A)', basename="r", flags="d")
-        self.assertModule("t.rast.algebra", expression='R = A {/, equal} td(A)', basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = A {/, equal} td(A)",
+            basename="r",
+            flags="d",
+        )
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {/, equal} td(A)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -166,12 +258,14 @@ class TestTRastAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-
     def test_simple_arith_if_1(self):
         """Simple arithmetic test with if condition"""
 
-        self.assertModule("t.rast.algebra", expression='R = if({equal}, start_date(A)'
-                                                       ' >= "2001-01-02", A + A)', basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = if({equal}, start_date(A)" ' >= "2001-01-02", A + A)',
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -185,7 +279,11 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_if_2(self):
         """Simple arithmetic test with if condition"""
 
-        self.assertModule("t.rast.algebra", expression='R = if({equal}, A#A == 1, A - A)', basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = if({equal}, A#A == 1, A - A)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -199,15 +297,18 @@ class TestTRastAlgebra(TestCase):
     def test_complex_arith_if_1(self):
         """Complex arithmetic test with if condition"""
 
-        self.assertModule("t.rast.algebra", expression='R = if(start_date(A) < "2001-01-03" && A#A == 1,'
-                                                        ' A{+, starts,l}C, A{+, finishes,l}C)',
-                          basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression='R = if(start_date(A) < "2001-01-03" && A#A == 1,'
+            " A{+, starts,l}C, A{+, finishes,l}C)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 9)  # 2 + 7 a2 + c1
-        self.assertEqual(D.metadata.get_max_max(), 10) # 3 + 7 a3 + c1
+        self.assertEqual(D.metadata.get_max_max(), 10)  # 3 + 7 a3 + c1
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -215,13 +316,15 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_1(self):
         """Simple arithmetic test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {*, equal} A {+, equal} A", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {*, equal} A {+, equal} A", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
         self.assertEqual(D.metadata.get_min_min(), 2)  # 1*1 + 1
-        self.assertEqual(D.metadata.get_max_max(), 20) # 4*4 + 4
+        self.assertEqual(D.metadata.get_max_max(), 20)  # 4*4 + 4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -229,7 +332,11 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_2(self):
         """Simple arithmetic test that creates an empty strds"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {*, during} A {+, during} A", basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = A {*, during} A {+, during} A",
+            basename="r",
+        )
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 0)
@@ -237,13 +344,15 @@ class TestTRastAlgebra(TestCase):
     def test_simple_arith_3(self):
         """Simple arithmetic test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A / A + A*A/A", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A / A + A*A/A", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
-        self.assertEqual(D.metadata.get_min_min(), 2) # 1/1 + 1*1/1
-        self.assertEqual(D.metadata.get_max_max(), 5) # 4/4 + 4*4/4
+        self.assertEqual(D.metadata.get_min_min(), 2)  # 1/1 + 1*1/1
+        self.assertEqual(D.metadata.get_max_max(), 5)  # 4/4 + 4*4/4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -251,7 +360,9 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_1(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {+,equal,i} B", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {+,equal,i} B", basename="r"
+        )
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 0)
@@ -259,13 +370,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_2(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {+,during,i} B", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {+,during,i} B", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
-        self.assertEqual(D.metadata.get_min_min(), 6) # 1 + 5
-        self.assertEqual(D.metadata.get_max_max(), 10) # 4 + 6
+        self.assertEqual(D.metadata.get_min_min(), 6)  # 1 + 5
+        self.assertEqual(D.metadata.get_max_max(), 10)  # 4 + 6
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -273,13 +386,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_3(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {+,starts,i} B", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {+,starts,i} B", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
-        self.assertEqual(D.metadata.get_min_min(), 6) # 1 + 5
-        self.assertEqual(D.metadata.get_max_max(), 9) # 3 + 6
+        self.assertEqual(D.metadata.get_min_min(), 6)  # 1 + 5
+        self.assertEqual(D.metadata.get_max_max(), 9)  # 3 + 6
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -287,13 +402,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_4(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {+,finishes,intersect} B", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {+,finishes,intersect} B", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 7)  # 2 + 5
-        self.assertEqual(D.metadata.get_max_max(), 10) # 4 + 6
+        self.assertEqual(D.metadata.get_max_max(), 10)  # 4 + 6
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -301,13 +418,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_5(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {+,starts|finishes,i} B", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {+,starts|finishes,i} B", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
         self.assertEqual(D.metadata.get_min_min(), 6)  # 1 + 5
-        self.assertEqual(D.metadata.get_max_max(), 10) # 4 + 6
+        self.assertEqual(D.metadata.get_max_max(), 10)  # 4 + 6
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -315,13 +434,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_6(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = B {+,overlaps,u} C", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = B {+,overlaps,u} C", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 1)
-        self.assertEqual(D.metadata.get_min_min(), 12) # 5 + 7
-        self.assertEqual(D.metadata.get_max_max(), 12) # 5 + 7
+        self.assertEqual(D.metadata.get_min_min(), 12)  # 5 + 7
+        self.assertEqual(D.metadata.get_max_max(), 12)  # 5 + 7
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -329,13 +450,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_7(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression="R = B {+,overlapped,u} C", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = B {+,overlapped,u} C", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 1)
-        self.assertEqual(D.metadata.get_min_min(), 13) # 6 + 7
-        self.assertEqual(D.metadata.get_max_max(), 13) # 6 + 7
+        self.assertEqual(D.metadata.get_min_min(), 13)  # 6 + 7
+        self.assertEqual(D.metadata.get_max_max(), 13)  # 6 + 7
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -343,14 +466,17 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_intersection_8(self):
         """Simple temporal intersection test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A {+,during,l} buff_t(C, "1 day") ',
-                  basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression='R = A {+,during,l} buff_t(C, "1 day") ',
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 4)
         self.assertEqual(D.metadata.get_min_min(), 8)  # 1 + 7  a1 + c1
-        self.assertEqual(D.metadata.get_max_max(), 11) # 4 + 7  a4 + c1
+        self.assertEqual(D.metadata.get_max_max(), 11)  # 4 + 7  a4 + c1
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
@@ -358,14 +484,13 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_neighbors_1(self):
         """Simple temporal neighborhood computation test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A[-1] + A[1]',
-                  basename="r")
+        self.assertModule("t.rast.algebra", expression="R = A[-1] + A[1]", basename="r")
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 4)  # 1 + 3
-        self.assertEqual(D.metadata.get_max_max(), 6) # 2 + 4
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 2 + 4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -373,14 +498,15 @@ class TestTRastAlgebra(TestCase):
     def test_temporal_neighbors_2(self):
         """Simple temporal neighborhood computation test"""
 
-        self.assertModule("t.rast.algebra", expression='R = A[0,0,-1] + A[0,0,1]',
-                  basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A[0,0,-1] + A[0,0,1]", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 4)  # 1 + 3
-        self.assertEqual(D.metadata.get_max_max(), 6) # 2 + 4
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 2 + 4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -388,7 +514,9 @@ class TestTRastAlgebra(TestCase):
     def test_tmap_function1(self):
         """Testing the tmap function. """
 
-        self.assertModule("t.rast.algebra", expression='R = tmap(singletmap)', basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = tmap(singletmap)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -399,13 +527,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_tmap_function2(self):
         """Testing the tmap function. """
 
-        self.assertModule("t.rast.algebra", expression='R = tmap(singletmap) + 1', basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = tmap(singletmap) + 1", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -416,13 +546,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_map_function1(self):
         """Testing the map function. """
 
-        self.assertModule("t.rast.algebra", expression='R = map(singlemap) + A', basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = map(singlemap) + A", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -433,13 +565,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_map_function2(self):
         """Testing the map function. """
 
-        self.assertModule("t.rast.algebra", expression='R =  A * map(singlemap)', basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R =  A * map(singlemap)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -450,8 +584,8 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_select(self):
         """Testing the temporal select operator. """
@@ -466,8 +600,8 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_select(self):
         """Testing the temporal select operator. """
@@ -482,8 +616,8 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_select_operators1(self):
         """Testing the temporal select operator. Including temporal relations. """
@@ -498,13 +632,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_select_operators2(self):
         """Testing the temporal select operator. Including temporal relations. """
 
-        self.assertModule("t.rast.algebra", expression="R = A {!:,during} C", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {!:,during} C", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -514,14 +650,16 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_select_operators3(self):
         """Testing the temporal select operator. Including temporal relations and
-            different temporal operators (lr|+&)"""
+        different temporal operators (lr|+&)"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {:,during,d} B", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {:,during,d} B", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -531,14 +669,16 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), False)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), False)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_temporal_select_operators4(self):
         """Testing the temporal select operator. Including temporal relations and
-            different temporal operators (lr|+&)"""
+        different temporal operators (lr|+&)"""
 
-        self.assertModule("t.rast.algebra", expression="R = A {:,equal|during,r} C", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = A {:,equal|during,r} C", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -553,13 +693,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), False)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), False)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_temporal_hash_operator1(self):
         """Testing the temporal hash operator in the raster algebra. """
 
-        self.assertModule("t.rast.algebra", expression="R = if(A # D == 1, A)", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = if(A # D == 1, A)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -569,8 +711,8 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_hash_operator2(self):
         """Testing the temporal hash operator in the raster algebra. """
@@ -585,13 +727,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_hash_operator3(self):
         """Testing the temporal hash operator in the raster algebra. """
 
-        self.assertModule("t.rast.algebra", expression="R = C {#,contains} A", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = C {#,contains} A", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -601,13 +745,17 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_temporal_hash_operator4(self):
         """Testing the temporal hash operator in the raster algebra. """
 
-        self.assertModule("t.rast.algebra", expression="R = if({contains},A # D == 1, C {#,contains} A)", basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = if({contains},A # D == 1, C {#,contains} A)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -617,13 +765,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_raster_arithmetic_relation_1(self):
         """Arithmetic test with temporal intersection"""
 
-        self.assertModule("t.rast.algebra", expression="R = B {+,contains,l} A ", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = B {+,contains,l} A ", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -633,13 +783,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_raster_arithmetic_relation_2(self):
         """Arithmetic test with temporal intersection"""
 
-        self.assertModule("t.rast.algebra", expression="R = B {*,contains,l} A ", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = B {*,contains,l} A ", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -649,13 +801,15 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_raster_arithmetic_relation_3(self):
         """Arithmetic test with temporal intersection"""
 
-        self.assertModule("t.rast.algebra", expression="R = B {+,contains,l} A ", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = B {+,contains,l} A ", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
@@ -665,43 +819,49 @@ class TestTRastAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_raster_arithmetic_relation_4(self):
         """Arithmetic test with temporal intersection"""
 
-        self.assertModule("t.rast.algebra", expression="R = B {+,contains,r} A ", basename="r")
+        self.assertModule(
+            "t.rast.algebra", expression="R = B {+,contains,r} A ", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
-        self.assertEqual(D.metadata.get_number_of_maps(),4)
+        self.assertEqual(D.metadata.get_number_of_maps(), 4)
         self.assertEqual(D.metadata.get_min_min(), 8)
         self.assertEqual(D.metadata.get_max_max(), 13)
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_raster_arithmetic_relation_5(self):
         """Complex arithmetic test with temporal intersection"""
 
-        self.assertModule("t.rast.algebra", expression="R = tmap(singletmap) "
-                                                        "{+,equal| precedes| follows,l} "
-                                                        "A + map(singlemap)", basename="r")
+        self.assertModule(
+            "t.rast.algebra",
+            expression="R = tmap(singletmap) "
+            "{+,equal| precedes| follows,l} "
+            "A + map(singlemap)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="strds")
 
-        self.assertEqual(D.metadata.get_number_of_maps(),1)
+        self.assertEqual(D.metadata.get_number_of_maps(), 1)
         self.assertEqual(D.metadata.get_min_min(), 208)
         self.assertEqual(D.metadata.get_max_max(), 208)
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/temporal/t.rast.algebra/testsuite/test_raster_algebra_fails.py
+++ b/temporal/t.rast.algebra/testsuite/test_raster_algebra_fails.py
@@ -12,32 +12,36 @@ from grass.gunittest.main import test
 
 
 class TestTRastAlgebraFails(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def test_error_handling(self):
         # Syntax error
-        self.assertModuleFail("t.rast.algebra", expression="R == A {+,equal| precedes| follows,l} B",
-                                          basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra",
+            expression="R == A {+,equal| precedes| follows,l} B",
+            basename="r",
+        )
         # No STRDS
-        self.assertModuleFail("t.rast.algebra", expression="R = NoSTRDS + NoSTRDS", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra", expression="R = NoSTRDS + NoSTRDS", basename="r"
+        )
         # No basename
         self.assertModuleFail("t.rast.algebra", expression="R = A + B")
         # Catch temporal algebra expressions that are prohibited in the raster algebra
-        self.assertModuleFail("t.rast.algebra", expression="R = strds(A) + strds(B)", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra", expression="R = strds(A) + strds(B)", basename="r"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/temporal/t.rast.algebra/testsuite/test_raster_algebra_granularity.py
+++ b/temporal/t.rast.algebra/testsuite/test_raster_algebra_granularity.py
@@ -15,16 +15,13 @@ from grass.gunittest.main import test
 
 
 class TestTRastAlgebraGranularity(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
-        tgis.init(True) # Raise on error instead of exit(1)
+        tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
-        cls.runModule("g.region", n=80.0, s=0.0, e=120.0,
-                                       w=0.0, t=1.0, b=0.0, res=10.0)
+        cls.runModule("g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=1.0, b=0.0, res=10.0)
 
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="a1 = 1")
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="a2 = 2")
@@ -38,39 +35,109 @@ class TestTRastAlgebraGranularity(TestCase):
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="d1 = 10")
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="d2 = 11")
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="d3 = 12")
-        cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="singletmap = 99")
+        cls.runModule(
+            "r.mapcalc", overwrite=True, quiet=True, expression="singletmap = 99"
+        )
 
-        tgis.open_new_stds(name="A", type="strds", temporaltype="absolute",
-                                         title="A", descr="A", semantic="field", overwrite=True)
-        tgis.open_new_stds(name="B", type="strds", temporaltype="absolute",
-                                         title="B", descr="B", semantic="field", overwrite=True)
-        tgis.open_new_stds(name="C", type="strds", temporaltype="absolute",
-                                         title="C", descr="C", semantic="field", overwrite=True)
-        tgis.open_new_stds(name="D", type="strds", temporaltype="absolute",
-                                         title="D", descr="D", semantic="field", overwrite=True)
+        tgis.open_new_stds(
+            name="A",
+            type="strds",
+            temporaltype="absolute",
+            title="A",
+            descr="A",
+            semantic="field",
+            overwrite=True,
+        )
+        tgis.open_new_stds(
+            name="B",
+            type="strds",
+            temporaltype="absolute",
+            title="B",
+            descr="B",
+            semantic="field",
+            overwrite=True,
+        )
+        tgis.open_new_stds(
+            name="C",
+            type="strds",
+            temporaltype="absolute",
+            title="C",
+            descr="C",
+            semantic="field",
+            overwrite=True,
+        )
+        tgis.open_new_stds(
+            name="D",
+            type="strds",
+            temporaltype="absolute",
+            title="D",
+            descr="D",
+            semantic="field",
+            overwrite=True,
+        )
 
-        tgis.register_maps_in_space_time_dataset(type="raster", name="A", maps="a1,a2,a3,a4,a5,a6",
-                                                 start="2001-01-01", increment="1 month", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="B", maps="b1,b2",
-                                                 start="2001-01-01", increment="3 months", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="C", maps="c1",
-                                                 start="2001-01-01", increment="1 year", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="D", maps="d1",
-                                                 start="2001-01-01", increment="5 days", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="D", maps="d2",
-                                                 start="2001-03-01", increment="5 days", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name="D", maps="d3",
-                                                 start="2001-05-01", increment="5 days", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="raster", name=None, maps="singletmap",
-                                                start="2001-03-01", end="2001-04-01")
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="A",
+            maps="a1,a2,a3,a4,a5,a6",
+            start="2001-01-01",
+            increment="1 month",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="B",
+            maps="b1,b2",
+            start="2001-01-01",
+            increment="3 months",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="C",
+            maps="c1",
+            start="2001-01-01",
+            increment="1 year",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="D",
+            maps="d1",
+            start="2001-01-01",
+            increment="5 days",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="D",
+            maps="d2",
+            start="2001-03-01",
+            increment="5 days",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name="D",
+            maps="d3",
+            start="2001-05-01",
+            increment="5 days",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster",
+            name=None,
+            maps="singletmap",
+            start="2001-03-01",
+            end="2001-04-01",
+        )
 
     def tearDown(self):
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
@@ -84,13 +151,13 @@ class TestTRastAlgebraGranularity(TestCase):
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 6)
-        self.assertEqual(D.metadata.get_min_min(), 0) # 1 - 1
-        self.assertEqual(D.metadata.get_max_max(), 5) # 6 - 1
+        self.assertEqual(D.metadata.get_min_min(), 0)  # 1 - 1
+        self.assertEqual(D.metadata.get_max_max(), 5)  # 6 - 1
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 month')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 month")
 
     def test_2(self):
         """Simple arithmetik test"""
@@ -101,17 +168,17 @@ class TestTRastAlgebraGranularity(TestCase):
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 15)
-        self.assertEqual(D.metadata.get_min_min(), 2) # 1 - 1
-        self.assertEqual(D.metadata.get_max_max(), 6) # 5 + 1
+        self.assertEqual(D.metadata.get_min_min(), 2)  # 1 - 1
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 5 + 1
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 5, 6))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_simple_arith_hash_1(self):
         """Simple arithmetic test including the hash operator"""
-        expr ='R = A + (A # A)'
+        expr = "R = A + (A # A)"
         self.assertModule("t.rast.algebra", expression=expr, flags="gd", basename="r")
         self.assertModule("t.rast.algebra", expression=expr, flags="g", basename="r")
 
@@ -124,23 +191,22 @@ class TestTRastAlgebraGranularity(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-
     def test_simple_arith_td_1(self):
         """Simple arithmetic test"""
-        expr = 'R = A + td(A:D)'
+        expr = "R = A + td(A:D)"
         self.assertModule("t.rast.algebra", expression=expr, flags="gd", basename="r")
         self.assertModule("t.rast.algebra", expression=expr, flags="g", basename="r")
 
         D = tgis.open_old_stds("R", type="strds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 15)
-        self.assertEqual(D.metadata.get_min_min(), 2) # 1 - 1
-        self.assertEqual(D.metadata.get_max_max(), 6) # 5 + 1
+        self.assertEqual(D.metadata.get_min_min(), 2)  # 1 - 1
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 5 + 1
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 5, 6))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_simple_arith_if_1(self):
         """Simple arithmetic test with if condition"""
@@ -159,7 +225,7 @@ class TestTRastAlgebraGranularity(TestCase):
 
     def test_simple_arith_if_2(self):
         """Simple arithmetic test with if condition"""
-        expr = 'R = if(A#A == 1, A - A)'
+        expr = "R = if(A#A == 1, A - A)"
         self.assertModule("t.rast.algebra", expression=expr, flags="gd", basename="r")
         self.assertModule("t.rast.algebra", expression=expr, flags="g", basename="r")
 
@@ -182,14 +248,14 @@ class TestTRastAlgebraGranularity(TestCase):
 
         self.assertEqual(D.metadata.get_number_of_maps(), 6)
         self.assertEqual(D.metadata.get_min_min(), -6)  # 3 - 9
-        self.assertEqual(D.metadata.get_max_max(), 11) # 2 + 2
+        self.assertEqual(D.metadata.get_max_max(), 11)  # 2 + 2
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
     def test_temporal_neighbors(self):
         """Simple temporal neighborhood computation test"""
-        expr ='R = (A[0,0,-1] : D) + (A[0,0,1] : D)'
+        expr = "R = (A[0,0,-1] : D) + (A[0,0,1] : D)"
         self.assertModule("t.rast.algebra", expression=expr, flags="gd", basename="r")
         self.assertModule("t.rast.algebra", expression=expr, flags="g", basename="r")
 
@@ -197,7 +263,7 @@ class TestTRastAlgebraGranularity(TestCase):
 
         self.assertEqual(D.metadata.get_number_of_maps(), 14)
         self.assertEqual(D.metadata.get_min_min(), 2)  # 1 + 1
-        self.assertEqual(D.metadata.get_max_max(), 10) # 5 + 5
+        self.assertEqual(D.metadata.get_max_max(), 10)  # 5 + 5
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 5, 6))
@@ -212,7 +278,7 @@ class TestTRastAlgebraGranularity(TestCase):
 
         self.assertEqual(D.metadata.get_number_of_maps(), 6)
         self.assertEqual(D.metadata.get_min_min(), 100)  # 1 + 99
-        self.assertEqual(D.metadata.get_max_max(), 105) # 6 + 99
+        self.assertEqual(D.metadata.get_max_max(), 105)  # 6 + 99
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
@@ -225,15 +291,15 @@ class TestTRastAlgebraGranularity(TestCase):
 
         D = tgis.open_old_stds("R", type="strds")
 
-        self.assertEqual(D.metadata.get_number_of_maps(),1)
+        self.assertEqual(D.metadata.get_number_of_maps(), 1)
         self.assertEqual(D.metadata.get_min_min(), 201)
         self.assertEqual(D.metadata.get_max_max(), 201)
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 3, 1))
         self.assertEqual(end, datetime.datetime(2001, 4, 1))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 month')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 month")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/temporal/t.rast.algebra/testsuite/test_raster_algebra_granularity_fails.py
+++ b/temporal/t.rast.algebra/testsuite/test_raster_algebra_granularity_fails.py
@@ -14,51 +14,74 @@ from grass.gunittest.main import test
 
 
 class TestTRastAlgebraGranularityFails(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
-        tgis.init(True) # Raise on error instead of exit(1)
+        tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
-        cls.runModule("g.region", n=80.0, s=0.0, e=120.0,
-                                       w=0.0, t=1.0, b=0.0, res=10.0)
+        cls.runModule("g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=1.0, b=0.0, res=10.0)
 
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="a1 = 7")
         cls.runModule("r.mapcalc", overwrite=True, quiet=True, expression="a2 = 8")
 
+        tgis.open_new_stds(
+            name="A",
+            type="strds",
+            temporaltype="absolute",
+            title="A",
+            descr="A",
+            semantic="field",
+            overwrite=True,
+        )
 
-        tgis.open_new_stds(name="A", type="strds", temporaltype="absolute",
-                                         title="A", descr="A", semantic="field", overwrite=True)
-
-        tgis.register_maps_in_space_time_dataset(type="raster", name="A", maps="a1",
-                                                start="2001-02-01", end="2001-04-01")
-        tgis.register_maps_in_space_time_dataset(type="raster", name="A", maps="a2",
-                                                start="2001-03-01", end="2001-05-01")
+        tgis.register_maps_in_space_time_dataset(
+            type="raster", name="A", maps="a1", start="2001-02-01", end="2001-04-01"
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="raster", name="A", maps="a2", start="2001-03-01", end="2001-05-01"
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A", quiet=True)
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
 
     def test_error_handling(self):
         # Syntax error
-        self.assertModuleFail("t.rast.algebra", flags="g", expression="R = A {+,equal| precedes| follows,l A", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra",
+            flags="g",
+            expression="R = A {+,equal| precedes| follows,l A",
+            basename="r",
+        )
         # Syntax error
-        self.assertModuleFail("t.rast.algebra", flags="g", expression="R = A {+,equal| precedes| follows,l} A", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra",
+            flags="g",
+            expression="R = A {+,equal| precedes| follows,l} A",
+            basename="r",
+        )
         # Syntax error
-        self.assertModuleFail("t.rast.algebra", flags="g", expression="R == A + A", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra", flags="g", expression="R == A + A", basename="r"
+        )
         # No STRDS
-        self.assertModuleFail("t.rast.algebra", flags="g", expression="R = NoSTRDS + NoSTRDS", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra",
+            flags="g",
+            expression="R = NoSTRDS + NoSTRDS",
+            basename="r",
+        )
         # No basename
         self.assertModuleFail("t.rast.algebra", flags="g", expression="R = A + A")
         # Invalid temporal topology
-        self.assertModuleFail("t.rast.algebra", flags="g", expression="R = A + A", basename="r")
+        self.assertModuleFail(
+            "t.rast.algebra", flags="g", expression="R = A + A", basename="r"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/temporal/t.rast.colors/t.rast.colors.py
+++ b/temporal/t.rast.colors/t.rast.colors.py
@@ -127,7 +127,7 @@ def main():
     equi = flags["e"]
 
     if raster == "":
-        raster=None
+        raster = None
 
     if volume == "":
         volume = None
@@ -148,7 +148,7 @@ def main():
     if rows:
         # Create the r.colors input file
         filename = grass.tempfile(True)
-        file = open(filename, 'w')
+        file = open(filename, "w")
 
         for row in rows:
             string = "%s\n" % (row["id"])
@@ -156,28 +156,36 @@ def main():
 
         file.close()
 
-        flags_=""
-        if(remove):
-            flags_+="r"
-        if(write):
-            flags_+="w"
-        if(list):
-            flags_+="l"
-        if(invert):
-            flags_+="n"
-        if(log):
-            flags_+="g"
-        if(abslog):
-            flags_+="a"
-        if(equi):
-            flags_+="e"
+        flags_ = ""
+        if remove:
+            flags_ += "r"
+        if write:
+            flags_ += "w"
+        if list:
+            flags_ += "l"
+        if invert:
+            flags_ += "n"
+        if log:
+            flags_ += "g"
+        if abslog:
+            flags_ += "a"
+        if equi:
+            flags_ += "e"
 
         try:
-            grass.run_command("r.colors", flags=flags_, file=filename,
-                              color=color, raster=raster, volume=volume,
-                              rules=rules, overwrite=grass.overwrite())
+            grass.run_command(
+                "r.colors",
+                flags=flags_,
+                file=filename,
+                color=color,
+                raster=raster,
+                volume=volume,
+                rules=rules,
+                overwrite=grass.overwrite(),
+            )
         except CalledModuleError:
             grass.fatal(_("Error in r.colors call"))
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.contour/testsuite/test_convert.py
+++ b/temporal/t.rast.contour/testsuite/test_convert.py
@@ -13,11 +13,9 @@ from grass.gunittest.gmodules import SimpleModule
 
 
 class TestRasterContour(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
@@ -27,35 +25,52 @@ class TestRasterContour(TestCase):
         cls.runModule("r.mapcalc", expression="a_4 = col()", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_5 = null()", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1,a_2,a_3,a_4,a_5", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1,a_2,a_3,a_4,a_5",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("t.remove", flags="rf", type="stvds",
-                                   inputs="result")
+        self.runModule("t.remove", flags="rf", type="stvds", inputs="result")
 
     def test_register_empty_maps(self):
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          levels=(1,2,3,4,5,6,7,8), flags="n",
-                          basename="test",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            levels=(1, 2, 3, 4, 5, 6, 7, 8),
+            flags="n",
+            basename="test",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-04-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -65,18 +80,26 @@ class TestRasterContour(TestCase):
                         nodes=56"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_simple(self):
         """Do not register empty maps"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          levels=(1,2,3,4,5,6,7,8),
-                          basename="test",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            levels=(1, 2, 3, 4, 5, 6, 7, 8),
+            basename="test",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -86,19 +109,27 @@ class TestRasterContour(TestCase):
                         nodes=56"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_where(self):
         """Use where statement and do not register empty maps"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          levels=(1,2,3,4,5,6,7,8),
-                          basename="test",
-                          where="start_time > '2001-02-01'",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            levels=(1, 2, 3, 4, 5, 6, 7, 8),
+            basename="test",
+            where="start_time > '2001-02-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-04-01 00:00:00'
+        tinfo_string = """start_time='2001-04-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -108,18 +139,27 @@ class TestRasterContour(TestCase):
                         nodes=42"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_parallel(self):
         """Run 4 contour processes do not create attribute tables"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          levels=(1,2,3,4,5,6,7,8),
-                          basename="test", flags="t",
-                          nprocs=4, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            levels=(1, 2, 3, 4, 5, 6, 7, 8),
+            basename="test",
+            flags="t",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -129,18 +169,28 @@ class TestRasterContour(TestCase):
                         nodes=56"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_parallel_cut(self):
         """Do not register empty maps"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          levels=(1,2,3,4,5,6,7,8), cut=2,
-                          basename="test", flags="t",
-                          nprocs=4, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            levels=(1, 2, 3, 4, 5, 6, 7, 8),
+            cut=2,
+            basename="test",
+            flags="t",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -150,19 +200,29 @@ class TestRasterContour(TestCase):
                         nodes=56"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_where_step(self):
         """Use where statement and do not register empty maps"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          step=1, minlevel=1, maxlevel=8,
-                          basename="test",
-                          where="start_time > '2001-02-01'",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            step=1,
+            minlevel=1,
+            maxlevel=8,
+            basename="test",
+            where="start_time > '2001-02-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-04-01 00:00:00'
+        tinfo_string = """start_time='2001-04-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -172,75 +232,121 @@ class TestRasterContour(TestCase):
                         nodes=42"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
-
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_suffix_num(self):
         """Test the -s flag"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          step=1, minlevel=1, maxlevel=8,
-                          basename="time", suffix='num%03',
-                          where="start_time > '2001-02-01'",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            step=1,
+            minlevel=1,
+            maxlevel=8,
+            basename="time",
+            suffix="num%03",
+            where="start_time > '2001-02-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertVectorExists('time_001')
-        self.assertVectorDoesNotExist('time_00005')
-        self.assertVectorDoesNotExist('time_2001_07')
+        self.assertVectorExists("time_001")
+        self.assertVectorDoesNotExist("time_00005")
+        self.assertVectorDoesNotExist("time_2001_07")
 
     def test_suffix_time(self):
         """Test the -s flag"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          step=1, minlevel=1, maxlevel=8,
-                          basename="time", suffix='time',
-                          where="start_time > '2001-02-01'",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            step=1,
+            minlevel=1,
+            maxlevel=8,
+            basename="time",
+            suffix="time",
+            where="start_time > '2001-02-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertVectorExists('time_2001_07_01T00_00_00')
-        self.assertVectorDoesNotExist('time_00005')
-        self.assertVectorDoesNotExist('time_2001_07')
+        self.assertVectorExists("time_2001_07_01T00_00_00")
+        self.assertVectorDoesNotExist("time_00005")
+        self.assertVectorDoesNotExist("time_2001_07")
 
 
 class TestRasterContourFails(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
         cls.runModule("r.mapcalc", expression="a_1 = 100", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                      inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def test_error_handling(self):
         # No basename
-        self.assertModuleFail("t.rast.contour", input="A", output="result",
-                              step=1, minlevel=1, maxlevel=8,
-                              where="start_time > '2001-02-01'",
-                              nprocs=1, overwrite=True, verbose=True)
-
+        self.assertModuleFail(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            step=1,
+            minlevel=1,
+            maxlevel=8,
+            where="start_time > '2001-02-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
     def test_empty_strds(self):
         """Test for empty strds"""
-        self.assertModule("t.rast.contour", input="A", output="result",
-                          basename="test",
-                          step=1, minlevel=1, maxlevel=8,
-                          where="start_time > '2010-01-01'",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.contour",
+            input="A",
+            output="result",
+            basename="test",
+            step=1,
+            minlevel=1,
+            maxlevel=8,
+            where="start_time > '2010-01-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.export/t.rast.export.py
+++ b/temporal/t.rast.export/t.rast.export.py
@@ -118,21 +118,28 @@ def main():
     where = options["where"]
     _format = options["format"]
     _type = options["type"]
-    kws = {key: options[key]
-           for key in ('createopt', 'metaopt', 'nodata') if options[key]}
+    kws = {
+        key: options[key] for key in ("createopt", "metaopt", "nodata") if options[key]
+    }
 
     if _type and _format in ["pack", "AAIGrid"]:
-        grass.warning(_("Type options is not working with pack format, "
-                        "it will be skipped"))
+        grass.warning(
+            _("Type options is not working with pack format, " "it will be skipped")
+        )
         if kws:
-            grass.warning(_("Createopt, metaopt and nodata options are not "
-                            "working with pack and AAIGrid formats, "
-                            "they will be skipped"))
+            grass.warning(
+                _(
+                    "Createopt, metaopt and nodata options are not "
+                    "working with pack and AAIGrid formats, "
+                    "they will be skipped"
+                )
+            )
     # Make sure the temporal database exists
     tgis.init()
     # Export the space time raster dataset
-    tgis.export_stds(_input, output, compression, directory, where, _format,
-                     "strds", _type, **kws)
+    tgis.export_stds(
+        _input, output, compression, directory, where, _format, "strds", _type, **kws
+    )
 
 
 ############################################################################

--- a/temporal/t.rast.export/testsuite/test_rast_export.py
+++ b/temporal/t.rast.export/testsuite/test_rast_export.py
@@ -13,6 +13,7 @@ from grass.gunittest.case import TestCase
 import grass.script as gscript
 import os
 
+
 class TestRasterExport(TestCase):
 
     tmp = gscript.tempdir()
@@ -23,52 +24,76 @@ class TestRasterExport(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10,
-                      res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         maps = []
         for i in range(10):
-            cls.runModule("r.mapcalc", expression="a_{id_} = rand(0.1,1.0)".format(id_=i),
-                          flags="s", overwrite=True)
+            cls.runModule(
+                "r.mapcalc",
+                expression="a_{id_} = rand(0.1,1.0)".format(id_=i),
+                flags="s",
+                overwrite=True,
+            )
             maps.append("a_{id_}".format(id_=i))
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                      output="A", title="A test", description="A test",
-                      overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                      maps=maps, start="2001-01-01",
-                      increment="4 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps=maps,
+            start="2001-01-01",
+            increment="4 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", inputs="A")
 
     def test_simple_geotif(self):
-        self.assertModule("t.rast.export", input="A", output=self.float_,
-                          overwrite=True)
+        self.assertModule(
+            "t.rast.export", input="A", output=self.float_, overwrite=True
+        )
         self.assertFileExists(self.float_)
 
     def test_simple_geotif_int(self):
-        self.assertModule("t.rast.export", input="A", output=self.int_,
-                          overwrite=True, type="Int16")
+        self.assertModule(
+            "t.rast.export", input="A", output=self.int_, overwrite=True, type="Int16"
+        )
         self.assertFileExists(self.int_)
 
     def test_simple_grid(self):
-        self.assertModule("t.rast.export", input="A", output=self.grid,
-                          overwrite=True, format="AAIGrid")
+        self.assertModule(
+            "t.rast.export",
+            input="A",
+            output=self.grid,
+            overwrite=True,
+            format="AAIGrid",
+        )
         self.assertFileExists(self.grid)
 
     def test_simple_pack(self):
-        self.assertModule("t.rast.export", input="A", output=self.pack,
-                          overwrite=True, format="pack")
+        self.assertModule(
+            "t.rast.export", input="A", output=self.pack, overwrite=True, format="pack"
+        )
         self.assertFileExists(self.pack)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.extract/t.rast.extract.py
+++ b/temporal/t.rast.extract/t.rast.extract.py
@@ -102,8 +102,18 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.extract_dataset(input, output, "raster", where, expression,
-                         base, time_suffix, nprocs, register_null)
+    tgis.extract_dataset(
+        input,
+        output,
+        "raster",
+        where,
+        expression,
+        base,
+        time_suffix,
+        nprocs,
+        register_null,
+    )
+
 
 ###############################################################################
 

--- a/temporal/t.rast.extract/testsuite/test_t_rast_extract.py
+++ b/temporal/t.rast.extract/testsuite/test_t_rast_extract.py
@@ -13,12 +13,11 @@ import subprocess
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestRasterExtraction(TestCase):
 
+class TestRasterExtraction(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
@@ -29,22 +28,33 @@ class TestRasterExtraction(TestCase):
         cls.runModule("r.mapcalc", expression="prec_5 = 500", overwrite=True)
         cls.runModule("r.mapcalc", expression="prec_6 = 600", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                      output="precip_abs1", title="A test",
-                      description="A test", overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="precip_abs1",
-                      maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
-                      start="2001-01-01", increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_abs1",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_abs1",
+            maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def setUp(self):
-        """Create input data for transient groundwater flow computation
-        """
+        """Create input data for transient groundwater flow computation"""
         # Use always the current mapset as temporal database
         self.runModule("r.mapcalc", expression="prec_1 = 100", overwrite=True)
         self.runModule("r.mapcalc", expression="prec_2 = 200", overwrite=True)
@@ -53,25 +63,42 @@ class TestRasterExtraction(TestCase):
         self.runModule("r.mapcalc", expression="prec_5 = 500", overwrite=True)
         self.runModule("r.mapcalc", expression="prec_6 = 600", overwrite=True)
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                                     output="precip_abs1", title="A test", description="A test", overwrite=True)
-        self.runModule("t.register", flags="i", type="raster", input="precip_abs1",
-                                     maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
-                                     start="2001-01-01", increment="3 months", overwrite=True)
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_abs1",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_abs1",
+            maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="precip_abs2")
+        self.runModule("t.remove", flags="rf", type="strds", inputs="precip_abs2")
 
     def test_selection(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.rast.extract", input="precip_abs1", output="precip_abs2",
-                                      where="start_time > '2001-06-01'")
+        self.assertModule(
+            "t.rast.extract",
+            input="precip_abs1",
+            output="precip_abs2",
+            where="start_time > '2001-06-01'",
+        )
 
-        #self.assertModule("t.info",  flags="g",  input="precip_abs2")
+        # self.assertModule("t.info",  flags="g",  input="precip_abs2")
 
-        tinfo_string="""start_time='2001-07-01 00:00:00'
+        tinfo_string = """start_time='2001-07-01 00:00:00'
         end_time='2002-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -93,18 +120,26 @@ class TestRasterExtraction(TestCase):
         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", input="precip_abs2")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_selection_and_expression(self):
         """Perform a selection by datetime and a r.mapcalc expression"""
-        self.assertModule("t.rast.extract", input="precip_abs1", output="precip_abs2",
-                                      where="start_time > '2001-06-01'",
-                                      expression=" if(precip_abs1 > 400, precip_abs1, null())",
-                                      basename="new_prec", nprocs=2, overwrite=True)
+        self.assertModule(
+            "t.rast.extract",
+            input="precip_abs1",
+            output="precip_abs2",
+            where="start_time > '2001-06-01'",
+            expression=" if(precip_abs1 > 400, precip_abs1, null())",
+            basename="new_prec",
+            nprocs=2,
+            overwrite=True,
+        )
 
-        #self.assertModule("t.info",  flags="g",  input="precip_abs2")
+        # self.assertModule("t.info",  flags="g",  input="precip_abs2")
 
-        tinfo_string="""start_time='2002-01-01 00:00:00'
+        tinfo_string = """start_time='2002-01-01 00:00:00'
         end_time='2002-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -126,17 +161,26 @@ class TestRasterExtraction(TestCase):
         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", input="precip_abs2")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_expression_with_empty_maps(self):
         """Perform r.mapcalc expression and register empty maps"""
-        self.assertModule("t.rast.extract", flags="n", input="precip_abs1", output="precip_abs2",
-                                      expression=" if(precip_abs1 > 400, precip_abs1, null())",
-                                      basename="new_prec", nprocs=2, overwrite=True)
+        self.assertModule(
+            "t.rast.extract",
+            flags="n",
+            input="precip_abs1",
+            output="precip_abs2",
+            expression=" if(precip_abs1 > 400, precip_abs1, null())",
+            basename="new_prec",
+            nprocs=2,
+            overwrite=True,
+        )
 
-        #self.assertModule("t.info",  flags="g",  input="precip_abs2")
+        # self.assertModule("t.info",  flags="g",  input="precip_abs2")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
         end_time='2002-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -158,55 +202,76 @@ class TestRasterExtraction(TestCase):
         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", input="precip_abs2")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
-
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_time_suffix_with_expression(self):
         """Perform extract with time suffix support and test if maps exists"""
-        self.assertModule("t.rast.extract", flags="n", input="precip_abs1",
-                          output="precip_abs2", basename="new_prec",
-                          nprocs=2, overwrite=True, suffix="time",
-                          expression="if(precip_abs1 > 400, precip_abs1, null())")
-        self.assertRasterExists('new_prec_2001_01_01T00_00_00')
-        self.assertRasterDoesNotExist('new_prec_2001_01')
+        self.assertModule(
+            "t.rast.extract",
+            flags="n",
+            input="precip_abs1",
+            output="precip_abs2",
+            basename="new_prec",
+            nprocs=2,
+            overwrite=True,
+            suffix="time",
+            expression="if(precip_abs1 > 400, precip_abs1, null())",
+        )
+        self.assertRasterExists("new_prec_2001_01_01T00_00_00")
+        self.assertRasterDoesNotExist("new_prec_2001_01")
 
     def test_num_suffix_with_expression(self):
         """Perform extract with time suffix support and test if maps exists"""
-        self.assertModule("t.rast.extract", flags="n", input="precip_abs1",
-                          output="precip_abs2", basename="new_prec",
-                          nprocs=2, overwrite=True, suffix='num%03',
-                          expression="if(precip_abs1 > 400, precip_abs1, null())")
-        self.assertRasterExists('new_prec_001')
-        self.assertRasterDoesNotExist('new_prec_00001')
-
+        self.assertModule(
+            "t.rast.extract",
+            flags="n",
+            input="precip_abs1",
+            output="precip_abs2",
+            basename="new_prec",
+            nprocs=2,
+            overwrite=True,
+            suffix="num%03",
+            expression="if(precip_abs1 > 400, precip_abs1, null())",
+        )
+        self.assertRasterExists("new_prec_001")
+        self.assertRasterDoesNotExist("new_prec_00001")
 
 
 class TestRasterExtractionFails(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def test_error_handling(self):
         """Perform r.mapcalc expression and register empty maps"""
         # No input
-        self.assertModuleFail("t.rast.extract", output="precip_abs2", basename="new_prec")
+        self.assertModuleFail(
+            "t.rast.extract", output="precip_abs2", basename="new_prec"
+        )
         # No output
-        self.assertModuleFail("t.rast.extract", input="precip_abs1", basename="new_prec")
+        self.assertModuleFail(
+            "t.rast.extract", input="precip_abs1", basename="new_prec"
+        )
         # No basename
-        self.assertModuleFail("t.rast.extract", input="precip_abs1", output="precip_abs2",
-                          expression=" if(precip_abs1 > 400, precip_abs1, null())")
+        self.assertModuleFail(
+            "t.rast.extract",
+            input="precip_abs1",
+            output="precip_abs2",
+            expression=" if(precip_abs1 > 400, precip_abs1, null())",
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.gapfill/t.rast.gapfill.py
+++ b/temporal/t.rast.gapfill/t.rast.gapfill.py
@@ -103,9 +103,13 @@ def main():
     num = len(maps)
 
     # Configure the r.to.vect module
-    gapfill_module = pymod.Module("r.series.interp",
-                             overwrite=grass.overwrite(), quiet=True, run_=False,
-                             finish_=False,)
+    gapfill_module = pymod.Module(
+        "r.series.interp",
+        overwrite=grass.overwrite(),
+        quiet=True,
+        run_=False,
+        finish_=False,
+    )
 
     process_queue = pymod.ParallelModuleQueue(int(nprocs))
 
@@ -117,7 +121,7 @@ def main():
     for _map in maps:
         if _map.get_id() is None:
             count += 1
-            if sp.get_temporal_type() == 'absolute' and tsuffix in ['gran', 'time']:
+            if sp.get_temporal_type() == "absolute" and tsuffix in ["gran", "time"]:
                 _id = "{ba}@{ma}".format(ba=base, ma=mapset)
             else:
                 map_name = tgis.create_numeric_suffix(base, num + count, tsuffix)
@@ -137,16 +141,20 @@ def main():
     # Do some checks before computation
     for _map in gap_list:
         if not _map.get_precedes() or not _map.get_follows():
-            grass.fatal(_("Unable to determine successor "
-                          "and predecessor of a gap."))
+            grass.fatal(_("Unable to determine successor " "and predecessor of a gap."))
 
         if len(_map.get_precedes()) > 1:
-            grass.warning(_("More than one successor of the gap found. "
-                            "Using the first found."))
+            grass.warning(
+                _("More than one successor of the gap found. " "Using the first found.")
+            )
 
         if len(_map.get_follows()) > 1:
-            grass.warning(_("More than one predecessor of the gap found. "
-                            "Using the first found."))
+            grass.warning(
+                _(
+                    "More than one predecessor of the gap found. "
+                    "Using the first found."
+                )
+            )
 
     # Interpolate the maps using parallel processing
     result_list = []
@@ -160,29 +168,35 @@ def main():
         end, tmpval = successor.get_temporal_extent_as_tuple()
 
         # Now resample the gap
-        map_matrix = tgis.AbstractSpaceTimeDataset.resample_maplist_by_granularity((_map, ),start, end, gran)
+        map_matrix = tgis.AbstractSpaceTimeDataset.resample_maplist_by_granularity(
+            (_map,), start, end, gran
+        )
 
         map_names = []
         map_positions = []
 
-        increment = 1.0/ (len(map_matrix) + 1.0)
+        increment = 1.0 / (len(map_matrix) + 1.0)
         position = increment
         count = 0
         for intp_list in map_matrix:
             new_map = intp_list[0]
             count += 1
-            if sp.get_temporal_type() == 'absolute' and tsuffix == 'gran':
-                suffix = tgis.create_suffix_from_datetime(new_map.temporal_extent.get_start_time(),
-                                                          sp.get_granularity())
-                new_id = "{ba}_{su}@{ma}".format(ba=new_map.get_name(),
-                                                 su=suffix, ma=mapset)
-            elif sp.get_temporal_type() == 'absolute' and tsuffix == 'time':
+            if sp.get_temporal_type() == "absolute" and tsuffix == "gran":
+                suffix = tgis.create_suffix_from_datetime(
+                    new_map.temporal_extent.get_start_time(), sp.get_granularity()
+                )
+                new_id = "{ba}_{su}@{ma}".format(
+                    ba=new_map.get_name(), su=suffix, ma=mapset
+                )
+            elif sp.get_temporal_type() == "absolute" and tsuffix == "time":
                 suffix = tgis.create_time_suffix(new_map)
-                new_id = "{ba}_{su}@{ma}".format(ba=new_map.get_name(),
-                                                 su=suffix, ma=mapset)
+                new_id = "{ba}_{su}@{ma}".format(
+                    ba=new_map.get_name(), su=suffix, ma=mapset
+                )
             else:
-                map_name = tgis.create_numeric_suffix(new_map.get_name(),
-                                                      count, tsuffix)
+                map_name = tgis.create_numeric_suffix(
+                    new_map.get_name(), count, tsuffix
+                )
                 new_id = "{name}@{ma}".format(name=map_name, ma=mapset)
 
             new_map.set_id(new_id)
@@ -190,8 +204,12 @@ def main():
             overwrite_flags[new_id] = False
             if new_map.map_exists() or new_map.is_in_db(dbif):
                 if not grass.overwrite():
-                    grass.fatal(_("Map with name <%s> already exists. "
-                                  "Please use another base name." % (_id)))
+                    grass.fatal(
+                        _(
+                            "Map with name <%s> already exists. "
+                            "Please use another base name." % (_id)
+                        )
+                    )
                 else:
                     if new_map.is_in_db(dbif):
                         overwrite_flags[new_id] = True
@@ -203,8 +221,12 @@ def main():
             result_list.append(new_map)
 
         mod = copy.deepcopy(gapfill_module)
-        mod(input=(predecessor.get_map_id(), successor.get_map_id()),
-                datapos=(0, 1), output=map_names, samplingpos=map_positions)
+        mod(
+            input=(predecessor.get_map_id(), successor.get_map_id()),
+            datapos=(0, 1),
+            output=map_names,
+            samplingpos=map_positions,
+        )
         sys.stderr.write(mod.get_bash() + "\n")
         process_queue.put(mod)
 
@@ -235,14 +257,22 @@ def main():
     sp.update_command_string(dbif=dbif)
     dbif.close()
 
+
 ###############################################################################
 
 
 def run_interp(inputs, dpos, output, outpos):
     """Helper function to run r.series.interp in parallel"""
-    return grass.run_command("r.series.interp", input=inputs, datapos=dpos,
-                             output=output, samplingpos=outpos,
-                             overwrite=grass.overwrite(), quiet=True)
+    return grass.run_command(
+        "r.series.interp",
+        input=inputs,
+        datapos=dpos,
+        output=output,
+        samplingpos=outpos,
+        overwrite=grass.overwrite(),
+        quiet=True,
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.gapfill/testsuite/test_gapfill.py
+++ b/temporal/t.rast.gapfill/testsuite/test_gapfill.py
@@ -12,12 +12,11 @@ import subprocess
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestRasterToVector(TestCase):
 
+class TestRasterToVector(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
@@ -26,37 +25,68 @@ class TestRasterToVector(TestCase):
         self.runModule("r.mapcalc", expression="a_2 = 400", overwrite=True)
         self.runModule("r.mapcalc", expression="a_3 = 1200", overwrite=True)
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        self.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1", start="2001-01-01",
-                                     increment="1 month", overwrite=True)
-        self.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_2", start="2001-04-01",
-                                     increment="1 months", overwrite=True)
-        self.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_3", start="2001-12-01",
-                                     increment="1 months", overwrite=True)
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1",
+            start="2001-01-01",
+            increment="1 month",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_2",
+            start="2001-04-01",
+            increment="1 months",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_3",
+            start="2001-12-01",
+            increment="1 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="A")
+        self.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
     def test_simple_2procs(self):
-        self.assertModule("t.rast.gapfill", input="A", suffix="num%01",
-                          basename="test", nprocs=2, verbose=True)
+        self.assertModule(
+            "t.rast.gapfill",
+            input="A",
+            suffix="num%01",
+            basename="test",
+            nprocs=2,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="strds", flags="g",  input="A")
+        # self.assertModule("t.info",  type="strds", flags="g",  input="A")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                                 end_time='2002-01-01 00:00:00'
                                 granularity='1 month'
                                 map_time=interval
@@ -67,9 +97,11 @@ class TestRasterToVector(TestCase):
                                 max_max=1200.0"""
 
         info = SimpleModule("t.info", flags="g", type="strds", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        text="""name|start_time|end_time|min|max
+        text = """name|start_time|end_time|min|max
 a_1|2001-01-01 00:00:00|2001-02-01 00:00:00|100.0|100.0
 test_6_1|2001-02-01 00:00:00|2001-03-01 00:00:00|200.0|200.0
 test_6_2|2001-03-01 00:00:00|2001-04-01 00:00:00|300.0|300.0
@@ -84,17 +116,28 @@ test_7_7|2001-11-01 00:00:00|2001-12-01 00:00:00|1100.0|1100.0
 a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
 
 """
-        rast_list = SimpleModule("t.rast.list", columns=("name","start_time","end_time","min,max"), input="A")
+        rast_list = SimpleModule(
+            "t.rast.list",
+            columns=("name", "start_time", "end_time", "min,max"),
+            input="A",
+        )
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
     def test_simple_where(self):
-        self.assertModule("t.rast.gapfill", input="A", where="start_time >= '2001-03-01'",
-                          basename="test", nprocs=1, verbose=True, suffix="num%01")
+        self.assertModule(
+            "t.rast.gapfill",
+            input="A",
+            where="start_time >= '2001-03-01'",
+            basename="test",
+            nprocs=1,
+            verbose=True,
+            suffix="num%01",
+        )
 
-        #self.assertModule("t.info",  type="strds", flags="g",  input="A")
+        # self.assertModule("t.info",  type="strds", flags="g",  input="A")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                                 end_time='2002-01-01 00:00:00'
                                 granularity='1 month'
                                 map_time=interval
@@ -105,9 +148,11 @@ a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
                                 max_max=1200.0"""
 
         info = SimpleModule("t.info", flags="g", type="strds", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        text="""name|start_time|end_time|min|max
+        text = """name|start_time|end_time|min|max
 a_1|2001-01-01 00:00:00|2001-02-01 00:00:00|100.0|100.0
 a_2|2001-04-01 00:00:00|2001-05-01 00:00:00|400.0|400.0
 test_4_1|2001-05-01 00:00:00|2001-06-01 00:00:00|500.0|500.0
@@ -119,17 +164,28 @@ test_4_6|2001-10-01 00:00:00|2001-11-01 00:00:00|1000.0|1000.0
 test_4_7|2001-11-01 00:00:00|2001-12-01 00:00:00|1100.0|1100.0
 a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
 """
-        rast_list = SimpleModule("t.rast.list", columns=("name","start_time","end_time","min,max"), input="A")
+        rast_list = SimpleModule(
+            "t.rast.list",
+            columns=("name", "start_time", "end_time", "min,max"),
+            input="A",
+        )
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
     def test_simple_where_2(self):
-        self.assertModule("t.rast.gapfill", input="A", where="start_time <= '2001-05-01'",
-                          basename="test", nprocs=1, verbose=True, suffix="num%01")
+        self.assertModule(
+            "t.rast.gapfill",
+            input="A",
+            where="start_time <= '2001-05-01'",
+            basename="test",
+            nprocs=1,
+            verbose=True,
+            suffix="num%01",
+        )
 
-        #self.assertModule("t.info",  type="strds", flags="g",  input="A")
+        # self.assertModule("t.info",  type="strds", flags="g",  input="A")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                                 end_time='2002-01-01 00:00:00'
                                 granularity='1 month'
                                 map_time=interval
@@ -140,26 +196,39 @@ a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
                                 max_max=1200.0"""
 
         info = SimpleModule("t.info", flags="g", type="strds", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        text="""name|start_time|end_time|min|max
+        text = """name|start_time|end_time|min|max
 a_1|2001-01-01 00:00:00|2001-02-01 00:00:00|100.0|100.0
 test_4_1|2001-02-01 00:00:00|2001-03-01 00:00:00|200.0|200.0
 test_4_2|2001-03-01 00:00:00|2001-04-01 00:00:00|300.0|300.0
 a_2|2001-04-01 00:00:00|2001-05-01 00:00:00|400.0|400.0
 a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
 """
-        rast_list = SimpleModule("t.rast.list", columns=("name","start_time","end_time","min,max"), input="A")
+        rast_list = SimpleModule(
+            "t.rast.list",
+            columns=("name", "start_time", "end_time", "min,max"),
+            input="A",
+        )
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
     def test_simple_empty(self):
-        self.assertModule("t.rast.gapfill", input="A", where="start_time >= '2001-10-01'",
-                          basename="test", nprocs=1, verbose=True, suffix="num%01")
+        self.assertModule(
+            "t.rast.gapfill",
+            input="A",
+            where="start_time >= '2001-10-01'",
+            basename="test",
+            nprocs=1,
+            verbose=True,
+            suffix="num%01",
+        )
 
-        #self.assertModule("t.info",  type="strds", flags="g",  input="A")
+        # self.assertModule("t.info",  type="strds", flags="g",  input="A")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                                 end_time='2002-01-01 00:00:00'
                                 granularity='1 month'
                                 map_time=interval
@@ -170,24 +239,31 @@ a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
                                 max_max=1200.0"""
 
         info = SimpleModule("t.info", flags="g", type="strds", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        text="""name|start_time|end_time|min|max
+        text = """name|start_time|end_time|min|max
 a_1|2001-01-01 00:00:00|2001-02-01 00:00:00|100.0|100.0
 a_2|2001-04-01 00:00:00|2001-05-01 00:00:00|400.0|400.0
 a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
 """
-        rast_list = SimpleModule("t.rast.list", columns=("name","start_time","end_time","min,max"), input="A")
+        rast_list = SimpleModule(
+            "t.rast.list",
+            columns=("name", "start_time", "end_time", "min,max"),
+            input="A",
+        )
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
     def test_simple_gran(self):
-        self.assertModule("t.rast.gapfill", input="A",
-                          basename="test", nprocs=2, verbose=True)
+        self.assertModule(
+            "t.rast.gapfill", input="A", basename="test", nprocs=2, verbose=True
+        )
 
-        #self.assertModule("t.info",  type="strds", flags="g",  input="A")
+        # self.assertModule("t.info",  type="strds", flags="g",  input="A")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                                 end_time='2002-01-01 00:00:00'
                                 granularity='1 month'
                                 map_time=interval
@@ -198,9 +274,11 @@ a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
                                 max_max=1200.0"""
 
         info = SimpleModule("t.info", flags="g", type="strds", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        text="""name|start_time|end_time|min|max
+        text = """name|start_time|end_time|min|max
 a_1|2001-01-01 00:00:00|2001-02-01 00:00:00|100.0|100.0
 test_2001_02|2001-02-01 00:00:00|2001-03-01 00:00:00|200.0|200.0
 test_2001_03|2001-03-01 00:00:00|2001-04-01 00:00:00|300.0|300.0
@@ -215,17 +293,27 @@ test_2001_11|2001-11-01 00:00:00|2001-12-01 00:00:00|1100.0|1100.0
 a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
 
 """
-        rast_list = SimpleModule("t.rast.list", columns=("name","start_time","end_time","min,max"), input="A")
+        rast_list = SimpleModule(
+            "t.rast.list",
+            columns=("name", "start_time", "end_time", "min,max"),
+            input="A",
+        )
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
     def test_simple_gran(self):
-        self.assertModule("t.rast.gapfill", input="A", suffix="time",
-                          basename="test", nprocs=2, verbose=True)
+        self.assertModule(
+            "t.rast.gapfill",
+            input="A",
+            suffix="time",
+            basename="test",
+            nprocs=2,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="strds", flags="g",  input="A")
+        # self.assertModule("t.info",  type="strds", flags="g",  input="A")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                                 end_time='2002-01-01 00:00:00'
                                 granularity='1 month'
                                 map_time=interval
@@ -236,9 +324,11 @@ a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
                                 max_max=1200.0"""
 
         info = SimpleModule("t.info", flags="g", type="strds", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
-        text="""name|start_time|end_time|min|max
+        text = """name|start_time|end_time|min|max
 a_1|2001-01-01 00:00:00|2001-02-01 00:00:00|100.0|100.0
 test_2001_02_01T00_00_00|2001-02-01 00:00:00|2001-03-01 00:00:00|200.0|200.0
 test_2001_03_01T00_00_00|2001-03-01 00:00:00|2001-04-01 00:00:00|300.0|300.0
@@ -253,10 +343,16 @@ test_2001_11_01T00_00_00|2001-11-01 00:00:00|2001-12-01 00:00:00|1100.0|1100.0
 a_3|2001-12-01 00:00:00|2002-01-01 00:00:00|1200.0|1200.0
 
 """
-        rast_list = SimpleModule("t.rast.list", columns=("name","start_time","end_time","min,max"), input="A")
+        rast_list = SimpleModule(
+            "t.rast.list",
+            columns=("name", "start_time", "end_time", "min,max"),
+            input="A",
+        )
         self.assertModule(rast_list)
         self.assertLooksLike(text, rast_list.outputs.stdout)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.import/t.rast.import.py
+++ b/temporal/t.rast.import/t.rast.import.py
@@ -128,9 +128,23 @@ def main():
 
     tgis.init()
 
-    tgis.import_stds(input, output, directory, title, descr, location,
-                     link, exp, overr, create, "strds", base,
-                     set_current_region, memory)
+    tgis.import_stds(
+        input,
+        output,
+        directory,
+        title,
+        descr,
+        location,
+        link,
+        exp,
+        overr,
+        create,
+        "strds",
+        base,
+        set_current_region,
+        memory,
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.import/testsuite/test_temporal_rast_import.py
+++ b/temporal/t.rast.import/testsuite/test_temporal_rast_import.py
@@ -19,20 +19,21 @@ for details.
 from grass.gunittest.case import TestCase
 import os
 
+
 class TestRasterImport(TestCase):
 
     input_ = os.path.join("data", "precip_2000.tar.bzip2")
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", inputs="A")
 
     def test_import(self):
-        self.assertModule("t.rast.import", input=self.input_, output="A",
-                          basename="a", overwrite=True)
+        self.assertModule(
+            "t.rast.import", input=self.input_, output="A", basename="a", overwrite=True
+        )
         tinfo = """start_time='2000-01-01 00:00:00'
                    end_time='2001-01-01 00:00:00'
                    granularity='1 month'
@@ -44,5 +45,4 @@ class TestRasterImport(TestCase):
                 """
 
         info = SimpleModule("t.info", flags="g", input="A")
-        self.assertModuleKeyValue(module=info, reference=tinfo,
-                                  precision=2, sep="=")
+        self.assertModuleKeyValue(module=info, reference=tinfo, precision=2, sep="=")

--- a/temporal/t.rast.list/t.rast.list.py
+++ b/temporal/t.rast.list/t.rast.list.py
@@ -115,8 +115,19 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.list_maps_of_stds("strds", input, columns, order, where, separator,
-                           method, header, granule, outpath=output)
+    tgis.list_maps_of_stds(
+        "strds",
+        input,
+        columns,
+        order,
+        where,
+        separator,
+        method,
+        header,
+        granule,
+        outpath=output,
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.mapcalc/t.rast.mapcalc.py
+++ b/temporal/t.rast.mapcalc/t.rast.mapcalc.py
@@ -99,8 +99,18 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.dataset_mapcalculator(inputs, output, "raster", expression,
-                               base, method, nprocs, register_null, spatial)
+    tgis.dataset_mapcalculator(
+        inputs,
+        output,
+        "raster",
+        expression,
+        base,
+        method,
+        nprocs,
+        register_null,
+        spatial,
+    )
+
 
 ###############################################################################
 

--- a/temporal/t.rast.neighbors/testsuite/test_neighbors.py
+++ b/temporal/t.rast.neighbors/testsuite/test_neighbors.py
@@ -12,37 +12,50 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
+
 @unittest.skipIf(sys.version_info[0] > 2, "temporary disabled")
 class TestAggregationAbsolute(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        cls.runModule("r.mapcalc", expression="a1 = rand(1,10)", flags=['s'],
-                      overwrite=True)
-        cls.runModule("r.mapcalc", expression="a2 = rand(1,10)", flags=['s'],
-                      overwrite=True)
-        cls.runModule("r.mapcalc", expression="a3 = rand(1,10)", flags=['s'],
-                      overwrite=True)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule(
+            "r.mapcalc", expression="a1 = rand(1,10)", flags=["s"], overwrite=True
+        )
+        cls.runModule(
+            "r.mapcalc", expression="a2 = rand(1,10)", flags=["s"], overwrite=True
+        )
+        cls.runModule(
+            "r.mapcalc", expression="a3 = rand(1,10)", flags=["s"], overwrite=True
+        )
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                      output="A", title="A test", description="A test",
-                      overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                      maps="a1,a2,a3", start="2001-01-01 00:00:00",
-                      increment="1 month", overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3",
+            start="2001-01-01 00:00:00",
+            increment="1 month",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -52,49 +65,87 @@ class TestAggregationAbsolute(TestCase):
 
     def test_where(self):
         """Test simple t.rast.neighbors"""
-        trast_list = SimpleModule("t.rast.neighbors", quiet=True, input="A",
-                                  output="B", basename='b', overwrite=True,
-                                  size="5", where="start_time <= '2001-02-01 00:00:00'")
+        trast_list = SimpleModule(
+            "t.rast.neighbors",
+            quiet=True,
+            input="A",
+            output="B",
+            basename="b",
+            overwrite=True,
+            size="5",
+            where="start_time <= '2001-02-01 00:00:00'",
+        )
         self.assertModule(trast_list)
-        self.assertRasterExists('b_2001_01')
-        self.assertRasterMinMax('b_2001_02', 1, 10)
-        self.assertRasterDoesNotExist('b_2001_03')
+        self.assertRasterExists("b_2001_01")
+        self.assertRasterMinMax("b_2001_02", 1, 10)
+        self.assertRasterDoesNotExist("b_2001_03")
 
     def test_simple(self):
         """Test simple t.rast.neighbors"""
-        trast_list = SimpleModule("t.rast.neighbors", quiet=True, input="A",
-                                  output="B", size="5", basename='b',
-                                  overwrite=True)
+        trast_list = SimpleModule(
+            "t.rast.neighbors",
+            quiet=True,
+            input="A",
+            output="B",
+            size="5",
+            basename="b",
+            overwrite=True,
+        )
         self.assertModule(trast_list)
-        self.assertRasterMinMax('b_2001_01', 1, 10)
-        self.assertRasterMinMax('b_2001_02', 1, 10)
+        self.assertRasterMinMax("b_2001_01", 1, 10)
+        self.assertRasterMinMax("b_2001_02", 1, 10)
 
     def test_time_suffix(self):
         """Test simple t.rast.neighbors"""
-        trast_list = SimpleModule("t.rast.neighbors", quiet=True, input="A",
-                                  output="B", size="5", basename='b',
-                                  suffix="time", overwrite=True)
+        trast_list = SimpleModule(
+            "t.rast.neighbors",
+            quiet=True,
+            input="A",
+            output="B",
+            size="5",
+            basename="b",
+            suffix="time",
+            overwrite=True,
+        )
         self.assertModule(trast_list)
-        self.assertRasterExists('b_2001_01_01T00_00_00')
+        self.assertRasterExists("b_2001_01_01T00_00_00")
 
     def test_num_suffix(self):
         """Test simple t.rast.neighbors"""
-        trast_list = SimpleModule("t.rast.neighbors", quiet=True, input="A",
-                                  output="B", size="5", basename='b',
-                                  suffix="num%03", overwrite=True)
+        trast_list = SimpleModule(
+            "t.rast.neighbors",
+            quiet=True,
+            input="A",
+            output="B",
+            size="5",
+            basename="b",
+            suffix="num%03",
+            overwrite=True,
+        )
         self.assertModule(trast_list)
-        self.assertRasterExists('b_001')
+        self.assertRasterExists("b_001")
 
     def test_num_region(self):
         """Test t.rast.neighbors with parallel region processes"""
-        trast_list = SimpleModule("t.rast.neighbors", quiet=True, input="A",
-                                  output="B", size="5", basename='b', nprocs=2,
-                                  suffix="num%03", flags="r", overwrite=True)
+        trast_list = SimpleModule(
+            "t.rast.neighbors",
+            quiet=True,
+            input="A",
+            output="B",
+            size="5",
+            basename="b",
+            nprocs=2,
+            suffix="num%03",
+            flags="r",
+            overwrite=True,
+        )
         self.assertModule(trast_list)
-        self.assertRasterExists('b_001')
-        self.assertRasterExists('b_002')
-        self.assertRasterExists('b_003')
+        self.assertRasterExists("b_001")
+        self.assertRasterExists("b_002")
+        self.assertRasterExists("b_003")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.out.vtk/t.rast.out.vtk.py
+++ b/temporal/t.rast.out.vtk/t.rast.out.vtk.py
@@ -128,8 +128,7 @@ def main():
             if id is None:
                 id = null_map
 
-            grass.run_command("g.copy", raster="%s,%s" % (id, map_name),
-                              overwrite=True)
+            grass.run_command("g.copy", raster="%s,%s" % (id, map_name), overwrite=True)
             out_name = "%6.6i_%s.vtk" % (count, sp.base.get_name())
 
             mflags = ""
@@ -141,22 +140,33 @@ def main():
             # Export the raster map with r.out.vtk
             try:
                 if elevation:
-                    grass.run_command("r.out.vtk", flags=mflags, null=null,
-                                      input=map_name, elevation=elevation,
-                                      output=out_name,
-                                      overwrite=grass.overwrite())
+                    grass.run_command(
+                        "r.out.vtk",
+                        flags=mflags,
+                        null=null,
+                        input=map_name,
+                        elevation=elevation,
+                        output=out_name,
+                        overwrite=grass.overwrite(),
+                    )
                 else:
-                    grass.run_command("r.out.vtk", flags=mflags, null=null,
-                                      input=map_name, output=out_name,
-                                      overwrite=grass.overwrite())
+                    grass.run_command(
+                        "r.out.vtk",
+                        flags=mflags,
+                        null=null,
+                        input=map_name,
+                        output=out_name,
+                        overwrite=grass.overwrite(),
+                    )
             except CalledModuleError:
                 grass.fatal(_("Unable to export raster map <%s>" % map_name))
 
             count += 1
 
     if use_granularity:
-        grass.run_command("g.remove", flags='f', type='raster', name=null_map)
-    grass.run_command("g.remove", flags='f', type='raster', name=map_name)
+        grass.run_command("g.remove", flags="f", type="raster", name=null_map)
+    grass.run_command("g.remove", flags="f", type="raster", name=map_name)
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -100,14 +100,15 @@ def main():
     nulls = flags["n"]
 
     # Check if number of methods and output maps matches
-    if 'quantile' in method:
-        len_method = len(method.split(',')) - 1
+    if "quantile" in method:
+        len_method = len(method.split(",")) - 1
     else:
-        len_method = len(method.split(','))
+        len_method = len(method.split(","))
 
-    if (len(list(filter(None, quantile.split(',')))) +
-            len_method) != len(output.split(',')):
-        grass.fatal(_('Number requested methods and output maps do not match.'))
+    if (len(list(filter(None, quantile.split(",")))) + len_method) != len(
+        output.split(",")
+    ):
+        grass.fatal(_("Number requested methods and output maps do not match."))
 
     # Make sure the temporal database exists
     tgis.init()
@@ -119,7 +120,7 @@ def main():
     if rows:
         # Create the r.series input file
         filename = grass.tempfile(True)
-        file = open(filename, 'w')
+        file = open(filename, "w")
 
         for row in rows:
             string = "%s\n" % (row["id"])
@@ -129,22 +130,34 @@ def main():
 
         flag = ""
         if len(rows) > 1000:
-            grass.warning(_("Processing over 1000 maps: activating -z flag of r.series which slows down processing"))
+            grass.warning(
+                _(
+                    "Processing over 1000 maps: activating -z flag of r.series which slows down processing"
+                )
+            )
             flag += "z"
         if nulls:
             flag += "n"
 
         try:
-            grass.run_command("r.series", flags=flag, file=filename,
-                              output=output, overwrite=grass.overwrite(),
-                              method=method, quantile=quantile)
+            grass.run_command(
+                "r.series",
+                flags=flag,
+                file=filename,
+                output=output,
+                overwrite=grass.overwrite(),
+                method=method,
+                quantile=quantile,
+            )
         except CalledModuleError:
-            grass.fatal(_("%s failed. Check above error messages.") % 'r.series')
+            grass.fatal(_("%s failed. Check above error messages.") % "r.series")
 
         if not add_time:
 
             # We need to set the temporal extent from the subset of selected maps
-            maps = sp.get_registered_maps_as_objects(where=where, order=order, dbif=None)
+            maps = sp.get_registered_maps_as_objects(
+                where=where, order=order, dbif=None
+            )
             first_map = maps[0]
             last_map = maps[-1]
             start_a, end_a = first_map.get_temporal_extent_as_tuple()
@@ -156,10 +169,13 @@ def main():
             if first_map.is_time_absolute():
                 extent = tgis.AbsoluteTemporalExtent(start_time=start_a, end_time=end_b)
             else:
-                extent = tgis.RelativeTemporalExtent(start_time=start_a, end_time=end_b,
-                                                     unit=first_map.get_relative_time_unit())
+                extent = tgis.RelativeTemporalExtent(
+                    start_time=start_a,
+                    end_time=end_b,
+                    unit=first_map.get_relative_time_unit(),
+                )
 
-            for out_map in output.split(','):
+            for out_map in output.split(","):
 
                 # Create the time range for the output map
                 if out_map.find("@") >= 0:
@@ -178,6 +194,7 @@ def main():
                     map.update_all()
                 else:
                     map.insert()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.series/testsuite/test_series.py
+++ b/temporal/t.rast.series/testsuite/test_series.py
@@ -15,40 +15,49 @@ from grass.gunittest.gmodules import SimpleModule
 
 
 class TestSnapAbsoluteSTRDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                    maps="a1,a2,a3,a4",
-                                    start="2001-01-01",
-                                    increment="1 month",
-                                    flags="i",
-                                    overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="1 month",
+            flags="i",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
-        cls.runModule("t.unregister", type="raster",
-                      maps="series_average,series_maximum,series_minimum,series_minimum_2")
+        cls.runModule(
+            "t.unregister",
+            type="raster",
+            maps="series_average,series_maximum,series_minimum,series_minimum_2",
+        )
         cls.runModule("g.remove", flags="f", type="raster", name="series_average")
         cls.runModule("g.remove", flags="f", type="raster", name="series_maximum")
         cls.runModule("g.remove", flags="f", type="raster", name="series_minimum")
@@ -56,138 +65,190 @@ class TestSnapAbsoluteSTRDS(TestCase):
         cls.runModule("g.remove", flags="f", type="raster", name="series_quantile")
 
     def test_time_stamp(self):
-        self.assertModule("t.rast.series", input="A", method="average",
-                          output="series_time_stamp", where="start_time > '2001-02-01'")
+        self.assertModule(
+            "t.rast.series",
+            input="A",
+            method="average",
+            output="series_time_stamp",
+            where="start_time > '2001-02-01'",
+        )
 
-        tinfo_string="""start_time='2001-02-01 00:00:00'
+        tinfo_string = """start_time='2001-02-01 00:00:00'
                         end_time='2001-05-01 00:00:00'"""
 
-        info = SimpleModule("t.info", flags="g", type="raster", input="series_time_stamp")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        info = SimpleModule(
+            "t.info", flags="g", type="raster", input="series_time_stamp"
+        )
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_average(self):
-        self.assertModule("t.rast.series", input="A", method="average",
-                          output="series_average")
+        self.assertModule(
+            "t.rast.series", input="A", method="average", output="series_average"
+        )
 
-        self.assertRasterMinMax(map="series_average", refmin=250, refmax=250,
-                                msg="Average must be 250")
+        self.assertRasterMinMax(
+            map="series_average", refmin=250, refmax=250, msg="Average must be 250"
+        )
 
     def test_maximum(self):
-        self.assertModule("t.rast.series", input="A", method="maximum",
-                          output="series_maximum")
+        self.assertModule(
+            "t.rast.series", input="A", method="maximum", output="series_maximum"
+        )
 
-        self.assertRasterMinMax(map="series_maximum", refmin=400, refmax=400,
-                                msg="Maximum must be 400")
+        self.assertRasterMinMax(
+            map="series_maximum", refmin=400, refmax=400, msg="Maximum must be 400"
+        )
 
     def test_minimum(self):
-        self.assertModule("t.rast.series", input="A", method="minimum",
-                          output="series_minimum")
+        self.assertModule(
+            "t.rast.series", input="A", method="minimum", output="series_minimum"
+        )
 
-        self.assertRasterMinMax(map="series_minimum", refmin=100, refmax=100,
-                                msg="Minimum must be 100")
+        self.assertRasterMinMax(
+            map="series_minimum", refmin=100, refmax=100, msg="Minimum must be 100"
+        )
 
     def test_multi_stats(self):
-        self.assertModule("t.rast.series", input="A",
-                          method=["average", "maximum", "minimum"],
-                          output=["series_average", "series_maximum",
-                                  "series_minimum"],
-                          overwrite=True)
+        self.assertModule(
+            "t.rast.series",
+            input="A",
+            method=["average", "maximum", "minimum"],
+            output=["series_average", "series_maximum", "series_minimum"],
+            overwrite=True,
+        )
 
-        self.assertRasterMinMax(map="series_average", refmin=250, refmax=250,
-                                msg="Average must be 250")
+        self.assertRasterMinMax(
+            map="series_average", refmin=250, refmax=250, msg="Average must be 250"
+        )
 
-        self.assertRasterMinMax(map="series_maximum", refmin=400, refmax=400,
-                                msg="Maximum must be 400")
+        self.assertRasterMinMax(
+            map="series_maximum", refmin=400, refmax=400, msg="Maximum must be 400"
+        )
 
-        self.assertRasterMinMax(map="series_minimum", refmin=100, refmax=100,
-                                msg="Minimum must be 100")
+        self.assertRasterMinMax(
+            map="series_minimum", refmin=100, refmax=100, msg="Minimum must be 100"
+        )
 
     def test_minimum_where(self):
-        self.assertModule("t.rast.series", input="A", method="minimum",
-                          output="series_minimum_2",
-                          where="start_time >= '2001-03-01'")
+        self.assertModule(
+            "t.rast.series",
+            input="A",
+            method="minimum",
+            output="series_minimum_2",
+            where="start_time >= '2001-03-01'",
+        )
 
-        self.assertRasterMinMax(map="series_minimum_2", refmin=300, refmax=300,
-                                msg="Minimum must be 300")
+        self.assertRasterMinMax(
+            map="series_minimum_2", refmin=300, refmax=300, msg="Minimum must be 300"
+        )
 
     def test_quantile(self):
-        self.assertModule("t.rast.series", input="A", method="quantile", quantile=0.5,
-                          output="series_quantile")
+        self.assertModule(
+            "t.rast.series",
+            input="A",
+            method="quantile",
+            quantile=0.5,
+            output="series_quantile",
+        )
 
-        self.assertRasterMinMax(map="series_quantile", refmin=300, refmax=300,
-                                msg="Minimum must be 300")
+        self.assertRasterMinMax(
+            map="series_quantile", refmin=300, refmax=300, msg="Minimum must be 300"
+        )
 
 
 class TestSnapRelativeSTRDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
-        cls.runModule("t.unregister", type="raster",
-                      maps="series_average,series_maximum,series_minimum,series_minimum_2")
+        cls.runModule(
+            "t.unregister",
+            type="raster",
+            maps="series_average,series_maximum,series_minimum,series_minimum_2",
+        )
         cls.runModule("g.remove", flags="f", type="raster", name="series_average")
         cls.runModule("g.remove", flags="f", type="raster", name="series_maximum")
         cls.runModule("g.remove", flags="f", type="raster", name="series_minimum")
         cls.runModule("g.remove", flags="f", type="raster", name="series_minimum_2")
 
     def test_average(self):
-        self.assertModule("t.rast.series", input="A", method="average",
-                          output="series_average")
+        self.assertModule(
+            "t.rast.series", input="A", method="average", output="series_average"
+        )
 
-        self.assertRasterMinMax(map="series_average", refmin=250, refmax=250,
-                                msg="Average must be 250")
+        self.assertRasterMinMax(
+            map="series_average", refmin=250, refmax=250, msg="Average must be 250"
+        )
 
     def test_maximum(self):
-        self.assertModule("t.rast.series", input="A", method="maximum",
-                          output="series_maximum")
+        self.assertModule(
+            "t.rast.series", input="A", method="maximum", output="series_maximum"
+        )
 
-        self.assertRasterMinMax(map="series_maximum", refmin=400, refmax=400,
-                                msg="Maximum must be 400")
+        self.assertRasterMinMax(
+            map="series_maximum", refmin=400, refmax=400, msg="Maximum must be 400"
+        )
 
     def test_minimum(self):
-        self.assertModule("t.rast.series", input="A", method="minimum",
-                          output="series_minimum")
+        self.assertModule(
+            "t.rast.series", input="A", method="minimum", output="series_minimum"
+        )
 
-        self.assertRasterMinMax(map="series_minimum", refmin=100, refmax=100,
-                                msg="Minimum must be 100")
+        self.assertRasterMinMax(
+            map="series_minimum", refmin=100, refmax=100, msg="Minimum must be 100"
+        )
 
     def test_minimum_where(self):
-        self.assertModule("t.rast.series", input="A", method="minimum",
-                          output="series_minimum_2",
-                          where="start_time >= 28")
+        self.assertModule(
+            "t.rast.series",
+            input="A",
+            method="minimum",
+            output="series_minimum_2",
+            where="start_time >= 28",
+        )
 
-        self.assertRasterMinMax(map="series_minimum_2", refmin=300, refmax=300,
-                                msg="Minimum must be 300")
+        self.assertRasterMinMax(
+            map="series_minimum_2", refmin=300, refmax=300, msg="Minimum must be 300"
+        )
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.to.rast3/t.rast.to.rast3.py
+++ b/temporal/t.rast.to.rast3/t.rast.to.rast3.py
@@ -93,7 +93,7 @@ def main():
         unit = granularity.split(" ")[1]
         granularity = float(granularity.split(" ")[0])
 
-        print("Gran from stds %0.15f" %(granularity))
+        print("Gran from stds %0.15f" % (granularity))
 
         if unit == "years" or unit == "year":
             bottom = float(start.year - 1900)
@@ -116,8 +116,9 @@ def main():
             if unit == "seconds" or unit == "second":
                 seconds = float(granularity)
 
-            granularity = float(days + hours / 24.0 + minutes /
-                1440.0 + seconds / 86400.0)
+            granularity = float(
+                days + hours / 24.0 + minutes / 1440.0 + seconds / 86400.0
+            )
     else:
         unit = sp.get_relative_time_unit()
         bottom = start
@@ -130,9 +131,9 @@ def main():
 
     # Create a NULL map to fill the gaps
     null_map = "temporary_null_map_%i" % os.getpid()
-    if datatype == 'DCELL':
+    if datatype == "DCELL":
         grass.mapcalc("%s = double(null())" % (null_map))
-    elif datatype == 'FCELL':
+    elif datatype == "FCELL":
         grass.mapcalc("%s = float(null())" % (null_map))
     else:
         grass.mapcalc("%s = null()" % (null_map))
@@ -155,23 +156,32 @@ def main():
             count += 1
 
         try:
-            grass.run_command("r.to.rast3", input=map_names,
-                              output=output, overwrite=grass.overwrite())
+            grass.run_command(
+                "r.to.rast3",
+                input=map_names,
+                output=output,
+                overwrite=grass.overwrite(),
+            )
         except CalledModuleError:
             grass.fatal(_("Unable to create 3D raster map <%s>" % output))
 
-    grass.run_command("g.remove", flags='f', type='raster', name=null_map)
+    grass.run_command("g.remove", flags="f", type="raster", name=null_map)
 
     title = _("Space time voxel cube")
     descr = _("This space time voxel cube was created with t.rast.to.rast3")
 
     # Set the unit
     try:
-        grass.run_command("r3.support", map=output, vunit=unit,
-                          title=title, description=descr,
-                          overwrite=grass.overwrite())
+        grass.run_command(
+            "r3.support",
+            map=output,
+            vunit=unit,
+            title=title,
+            description=descr,
+            overwrite=grass.overwrite(),
+        )
     except CalledModuleError:
-        grass.warning(_("%s failed to set units.") % 'r3.support')
+        grass.warning(_("%s failed to set units.") % "r3.support")
 
     # Register the space time voxel cube in the temporal GIS
     if output.find("@") >= 0:
@@ -195,6 +205,7 @@ def main():
         r3ds.set_relative_time(start, end, sp.get_relative_time_unit())
 
     r3ds.insert()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.to.rast3/testsuite/test_strds_to_rast3.py
+++ b/temporal/t.rast.to.rast3/testsuite/test_strds_to_rast3.py
@@ -13,15 +13,14 @@ import subprocess
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestSTRDSToRast3(TestCase):
 
+class TestSTRDSToRast3(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.use_temp_region()
 
     def setUp(self):
-        """Create input data
-        """
+        """Create input data"""
         self.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         self.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
@@ -46,33 +45,67 @@ class TestSTRDSToRast3(TestCase):
         self.runModule("r.mapcalc", expression="prec_5f = float(500.0)")
         self.runModule("r.mapcalc", expression="prec_6f = float(600.0)")
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                       output="precip_i", title="A test integer",
-                       description="A test integer values")
-        self.runModule("t.register", flags="i", type="raster", input="precip_i",
-                       maps="prec_1i,prec_2i,prec_3i,prec_4i,prec_5i,prec_6i",
-                       start="2001-01-01", increment="3 months")
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_i",
+            title="A test integer",
+            description="A test integer values",
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_i",
+            maps="prec_1i,prec_2i,prec_3i,prec_4i,prec_5i,prec_6i",
+            start="2001-01-01",
+            increment="3 months",
+        )
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                       output="precip_f", title="A test float",
-                       description="A test float values")
-        self.runModule("t.register", flags="i", type="raster", input="precip_f",
-                       maps="prec_1f,prec_2f,prec_3f,prec_4f,prec_5f,prec_6f",
-                       start="2001-01-01", increment="3 months")
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_f",
+            title="A test float",
+            description="A test float values",
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_f",
+            maps="prec_1f,prec_2f,prec_3f,prec_4f,prec_5f,prec_6f",
+            start="2001-01-01",
+            increment="3 months",
+        )
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                       output="precip_d", title="A test float",
-                       description="A test float values")
-        self.runModule("t.register", flags="i", type="raster", input="precip_d",
-                       maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
-                       start="2001-01-01", increment="3 months")
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_d",
+            title="A test float",
+            description="A test float values",
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_d",
+            maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
+            start="2001-01-01",
+            increment="3 months",
+        )
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("t.remove", flags="rf", type="strds",
-                       inputs="precip_i,precip_f,precip_d")
-        self.runModule('g.remove', type='raster', pattern='prec_*', flags='f')
-        self.runModule('g.remove', type='raster_3d', pattern='precip_*', flags='f')
+        self.runModule(
+            "t.remove", flags="rf", type="strds", inputs="precip_i,precip_f,precip_d"
+        )
+        self.runModule("g.remove", type="raster", pattern="prec_*", flags="f")
+        self.runModule("g.remove", type="raster_3d", pattern="precip_*", flags="f")
 
     @classmethod
     def tearDownClass(cls):
@@ -86,7 +119,7 @@ class TestSTRDSToRast3(TestCase):
         self.assertModule("t.rast.to.rast3", input="precip_f", output="precip_f")
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -103,9 +136,11 @@ class TestSTRDSToRast3(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_i", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_i", reference=tinfo_string, precision=2
+        )
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -122,9 +157,11 @@ class TestSTRDSToRast3(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_f", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_f", reference=tinfo_string, precision=2
+        )
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -141,7 +178,9 @@ class TestSTRDSToRast3(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
 
     def test_3m_gap(self):
         """Convert STRDS with gaps into 3d raster map, granularity 3 months"""
@@ -152,7 +191,7 @@ class TestSTRDSToRast3(TestCase):
         self.assertModule("t.rast.to.rast3", input="precip_f", output="precip_f")
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -169,9 +208,11 @@ class TestSTRDSToRast3(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_i", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_i", reference=tinfo_string, precision=2
+        )
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -188,9 +229,11 @@ class TestSTRDSToRast3(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_f", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_f", reference=tinfo_string, precision=2
+        )
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -207,14 +250,15 @@ class TestSTRDSToRast3(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
+
 
 class TestSTRDSToRast3MultiGran(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Create input data
-        """
+        """Create input data"""
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
@@ -226,31 +270,43 @@ class TestSTRDSToRast3MultiGran(TestCase):
         cls.runModule("r.mapcalc", expression="prec_5d = 500.0")
         cls.runModule("r.mapcalc", expression="prec_6d = 600.0")
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                       output="precip_d", title="A test float",
-                       description="A test float values")
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_d",
+            title="A test float",
+            description="A test float values",
+        )
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule('g.remove', type='raster_3d', pattern='precip_*', flags='f')
+        self.runModule("g.remove", type="raster_3d", pattern="precip_*", flags="f")
 
     @classmethod
     def tearDownClass(cls):
         """Remove generated data"""
         cls.runModule("t.remove", flags="rf", type="strds", inputs="precip_d")
-        cls.runModule('g.remove', type='raster', pattern='prec_*', flags='f')
+        cls.runModule("g.remove", type="raster", pattern="prec_*", flags="f")
         cls.del_temp_region()
 
     def test_years(self):
         """Convert STRDS into 3d raster map, granularity5 years"""
 
-        self.runModule("t.register", flags="i", type="raster", input="precip_d",
-                       maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
-                       start="2000-01-01", increment="5 years", overwrite=True)
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_d",
+            maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
+            start="2000-01-01",
+            increment="5 years",
+            overwrite=True,
+        )
 
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -267,18 +323,27 @@ class TestSTRDSToRast3MultiGran(TestCase):
                         units="none"
                         vertical_units="years" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
 
     def test_months(self):
         """Convert STRDS into 3d raster map, granularity 6 months"""
 
-        self.runModule("t.register", flags="i", type="raster", input="precip_d",
-                       maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
-                       start="2000-01-01", increment="6 months", overwrite=True)
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_d",
+            maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
+            start="2000-01-01",
+            increment="6 months",
+            overwrite=True,
+        )
 
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -295,19 +360,28 @@ class TestSTRDSToRast3MultiGran(TestCase):
                         units="none"
                         vertical_units="months" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
 
     def test_days(self):
         """Convert STRDS into 3d raster map, granularity 7 days"""
 
-        self.runModule("t.register", flags="i", type="raster", input="precip_d",
-                       maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
-                       start="2000-01-01", increment="7 days", overwrite=True)
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_d",
+            maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
+            start="2000-01-01",
+            increment="7 days",
+            overwrite=True,
+        )
 
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
         self.runModule("r3.info", map="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -324,19 +398,28 @@ class TestSTRDSToRast3MultiGran(TestCase):
                         units="none"
                         vertical_units="days" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
 
     def test_hours(self):
         """Convert STRDS into 3d raster map, granularity 3 hours"""
 
-        self.runModule("t.register", flags="i", type="raster", input="precip_d",
-                       maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
-                       start="2000-01-01", increment="3 hours", overwrite=True)
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_d",
+            maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
+            start="2000-01-01",
+            increment="3 hours",
+            overwrite=True,
+        )
 
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
         self.runModule("r3.info", map="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -353,19 +436,28 @@ class TestSTRDSToRast3MultiGran(TestCase):
                         units="none"
                         vertical_units="hours" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
 
     def test_minutes(self):
         """Convert STRDS into 3d raster map, granularity 17 minutes"""
 
-        self.runModule("t.register", flags="i", type="raster", input="precip_d",
-                       maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
-                       start="2000-01-01", increment="17 minutes", overwrite=True)
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_d",
+            maps="prec_1d,prec_2d,prec_3d,prec_4d,prec_5d,prec_6d",
+            start="2000-01-01",
+            increment="17 minutes",
+            overwrite=True,
+        )
 
         self.assertModule("t.rast.to.rast3", input="precip_d", output="precip_d")
         self.runModule("r3.info", map="precip_d")
 
-        tinfo_string="""north=80
+        tinfo_string = """north=80
                         south=0
                         east=120
                         west=0
@@ -382,8 +474,12 @@ class TestSTRDSToRast3MultiGran(TestCase):
                         units="none"
                         vertical_units="minutes" """
 
-        self.assertRaster3dFitsInfo(raster="precip_d", reference=tinfo_string, precision=2)
+        self.assertRaster3dFitsInfo(
+            raster="precip_d", reference=tinfo_string, precision=2
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.to.vect/testsuite/test_to_vect.py
+++ b/temporal/t.rast.to.vect/testsuite/test_to_vect.py
@@ -12,12 +12,11 @@ import subprocess
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestRasterToVector(TestCase):
 
+class TestRasterToVector(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
@@ -27,35 +26,53 @@ class TestRasterToVector(TestCase):
         cls.runModule("r.mapcalc", expression="a_4 = 400", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_5 = null()", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1,a_2,a_3,a_4,a_5", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1,a_2,a_3,a_4,a_5",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("t.remove", flags="rf", type="stvds",
-                                   inputs="result")
+        self.runModule("t.remove", flags="rf", type="stvds", inputs="result")
 
     def test_simple_points(self):
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="point", flags="n", column="values",
-                          basename="test",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="point",
+            flags="n",
+            column="values",
+            basename="test",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-04-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -64,17 +81,27 @@ class TestRasterToVector(TestCase):
                         primitives=384"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_simple_area(self):
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="area", flags="n", column="values",
-                          basename="test",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="area",
+            flags="n",
+            column="values",
+            basename="test",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-04-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -87,18 +114,28 @@ class TestRasterToVector(TestCase):
                         islands=4"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_simple_area_smooth(self):
         """Test areas with smooth corners"""
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="area", flags="s", column="values",
-                          basename="test",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="area",
+            flags="s",
+            column="values",
+            basename="test",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         map_time=interval
@@ -111,17 +148,27 @@ class TestRasterToVector(TestCase):
                         islands=4"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_parallel(self):
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="point", flags="t", column="values",
-                          basename="test",
-                          nprocs=4, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="point",
+            flags="t",
+            column="values",
+            basename="test",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
 
-        #self.assertModule("t.info",  type="stvds", flags="g",  input="result")
+        # self.assertModule("t.info",  type="stvds", flags="g",  input="result")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
                         end_time='2002-01-01 00:00:00'
                         granularity='3 months'
                         number_of_maps=4
@@ -129,61 +176,100 @@ class TestRasterToVector(TestCase):
                         primitives=384"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="result")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_num_suffix(self):
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="point", flags="t", column="values",
-                          basename="test", suffix="num%03",
-                          nprocs=4, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="point",
+            flags="t",
+            column="values",
+            basename="test",
+            suffix="num%03",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
         self.assertVectorExists("test_001")
 
     def test_time_suffix(self):
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="point", flags="t", column="values",
-                          basename="test", suffix="time",
-                          nprocs=4, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="point",
+            flags="t",
+            column="values",
+            basename="test",
+            suffix="time",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
         self.assertVectorExists("test_2001_01_01T00_00_00")
 
 
 class TestRasterToVectorFails(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
         cls.runModule("r.mapcalc", expression="a_1 = 100", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                      inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def test_error_handling(self):
         # No basename, no type
         self.assertModuleFail("t.rast.to.vect", input="A", output="result")
 
-
     def test_empty_strds(self):
         """Test for empty strds"""
-        self.assertModule("t.rast.to.vect", input="A", output="result",
-                          type="point", flags="n", column="values",
-                          basename="test",
-                          where="start_time > '2010-01-01'",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.to.vect",
+            input="A",
+            output="result",
+            type="point",
+            flags="n",
+            column="values",
+            basename="test",
+            where="start_time > '2010-01-01'",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.univar/t.rast.univar.py
+++ b/temporal/t.rast.univar/t.rast.univar.py
@@ -88,7 +88,9 @@ def main():
         output = None
 
     tgis.print_gridded_dataset_univar_statistics(
-        "strds", input, output, where, extended, no_header, separator, rast_region)
+        "strds", input, output, where, extended, no_header, separator, rast_region
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast.univar/testsuite/test_t_rast_univar.py
+++ b/temporal/t.rast.univar/testsuite/test_t_rast_univar.py
@@ -11,12 +11,11 @@ for details.
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestRasterUnivar(TestCase):
 
+class TestRasterUnivar(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=1, res3=1)
 
@@ -25,36 +24,53 @@ class TestRasterUnivar(TestCase):
         cls.runModule("r.mapcalc", expression="a_3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1,a_2,a_3,a_4", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1,a_2,a_3,a_4",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def test_1(self):
 
-        t_rast_univar = SimpleModule("t.rast.univar", input="A",
-                                                      where="start_time >= '2001-01-01'",
-                                                      overwrite=True, verbose=True)
+        t_rast_univar = SimpleModule(
+            "t.rast.univar",
+            input="A",
+            where="start_time >= '2001-01-01'",
+            overwrite=True,
+            verbose=True,
+        )
         self.runModule("g.region", res=1)
         self.assertModule(t_rast_univar)
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_1@testing|2001-01-01 00:00:00|2001-04-01 00:00:00|100|100|100|100|0|0|0|960000|0|9600|9600
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|1920000|0|9600|9600
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600
 """
-        for ref, res in zip(univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")):
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")
+        ):
             if ref and res:
                 ref_line = ref.split("|", 1)[1]
                 res_line = res.split("|", 1)[1]
@@ -62,18 +78,24 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|384000
 
     def test_2(self):
 
-        t_rast_univar = SimpleModule("t.rast.univar", input="A",
-                                                      where="start_time >= '2001-03-01'",
-                                                      overwrite=True, verbose=True)
+        t_rast_univar = SimpleModule(
+            "t.rast.univar",
+            input="A",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
         self.runModule("g.region", res=1)
         self.assertModule(t_rast_univar)
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|1920000|0|9600|9600
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600
 """
-        for ref, res in zip(univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")):
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")
+        ):
             if ref and res:
                 ref_line = ref.split("|", 1)[1]
                 res_line = res.split("|", 1)[1]
@@ -81,18 +103,24 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|384000
 
     def test_3(self):
 
-        t_rast_univar = SimpleModule("t.rast.univar", input="A",
-                                                      where="start_time >= '2001-03-01'",
-                                                      overwrite=True, verbose=True)
+        t_rast_univar = SimpleModule(
+            "t.rast.univar",
+            input="A",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
         self.runModule("g.region", res=10)
         self.assertModule(t_rast_univar)
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|19200|0|96|96
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|28800|0|96|96
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|38400|0|96|96
 """
-        for ref, res in zip(univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")):
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")
+        ):
             if ref and res:
                 ref_line = ref.split("|", 1)[1]
                 res_line = res.split("|", 1)[1]
@@ -101,12 +129,17 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|38400|
     def test_4(self):
 
         self.runModule("g.region", res=10)
-        self.assertModule("t.rast.univar", input="A", flags="r",
-                                           output="univar_output.txt",
-                                           where="start_time >= '2001-03-01'",
-                                           overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.univar",
+            input="A",
+            flags="r",
+            output="univar_output.txt",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|1920000|0|9600|9600
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600
@@ -124,12 +157,17 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|384000
     def test_5(self):
 
         self.runModule("g.region", res=10)
-        self.assertModule("t.rast.univar", input="A", flags="ru",
-                                           output="univar_output.txt",
-                                           where="start_time >= '2001-03-01'",
-                                           overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.univar",
+            input="A",
+            flags="ru",
+            output="univar_output.txt",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
 
-        univar_text=u"""a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|1920000|0|9600|9600
+        univar_text = """a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|1920000|0|9600|9600
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600
 """
@@ -143,15 +181,21 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|384000
 
     def test_6_error_handling_empty_strds(self):
         # Empty strds
-        self.assertModuleFail("t.rast.univar", input="A",
-                                           output="univar_output.txt",
-                                           where="start_time >= '2015-03-01'",
-                                           overwrite=True, verbose=True)
+        self.assertModuleFail(
+            "t.rast.univar",
+            input="A",
+            output="univar_output.txt",
+            where="start_time >= '2015-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
 
     def test_7_error_handling_no_input(self):
         # No input
         self.assertModuleFail("t.rast.univar", output="out.txt")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast.what/t.rast.what.py
+++ b/temporal/t.rast.what/t.rast.what.py
@@ -126,6 +126,7 @@ import grass.script as gscript
 
 ############################################################################
 
+
 def main(options, flags):
     # lazy imports
     import grass.temporal as tgis
@@ -147,9 +148,9 @@ def main(options, flags):
     use_stdin = flags["i"]
     vcat = flags["v"]
 
-    #output_cat_label = flags["f"]
-    #output_color = flags["r"]
-    #output_cat = flags["i"]
+    # output_cat_label = flags["f"]
+    # output_color = flags["r"]
+    # output_cat = flags["i"]
 
     overwrite = gscript.overwrite()
 
@@ -157,7 +158,11 @@ def main(options, flags):
         gscript.fatal(_("Options coordinates and points are mutually exclusive"))
 
     if not coordinates and not points and not use_stdin:
-        gscript.fatal(_("Please specify the coordinates, the points option or use the 'i' flag to pipe coordinate positions to t.rast.what from stdin, to provide the sampling coordinates"))
+        gscript.fatal(
+            _(
+                "Please specify the coordinates, the points option or use the 'i' flag to pipe coordinate positions to t.rast.what from stdin, to provide the sampling coordinates"
+            )
+        )
 
     if vcat and not points:
         gscript.fatal(_("Flag 'v' required option 'points'"))
@@ -165,7 +170,7 @@ def main(options, flags):
     if use_stdin:
         coordinates_stdin = str(sys.__stdin__.read())
         # Check if coordinates are given with site names or IDs
-        stdin_length = len(coordinates_stdin.split('\n')[0].split())
+        stdin_length = len(coordinates_stdin.split("\n")[0].split())
         if stdin_length <= 2:
             site_input = False
         elif stdin_length >= 3:
@@ -180,49 +185,64 @@ def main(options, flags):
     dbif.connect()
 
     sp = tgis.open_old_stds(strds, "strds", dbif)
-    maps = sp.get_registered_maps_as_objects(where=where, order=order,
-                                             dbif=dbif)
+    maps = sp.get_registered_maps_as_objects(where=where, order=order, dbif=dbif)
     dbif.close()
     if not maps:
         gscript.fatal(_("Space time raster dataset <%s> is empty") % sp.get_id())
 
     # Setup flags are disabled due to test issues
     flags = ""
-    #if output_cat_label is True:
+    # if output_cat_label is True:
     #    flags += "f"
-    #if output_color is True:
+    # if output_color is True:
     #    flags += "r"
-    #if output_cat is True:
+    # if output_cat is True:
     #    flags += "i"
     if vcat is True:
         flags += "v"
 
     # Configure the r.what module
     if points:
-        r_what = pymod.Module("r.what", map="dummy",
-                              output="dummy", run_=False,
-                              separator=separator, points=points,
-                              overwrite=overwrite, flags=flags,
-                              null_value=null_value,
-                              quiet=True)
+        r_what = pymod.Module(
+            "r.what",
+            map="dummy",
+            output="dummy",
+            run_=False,
+            separator=separator,
+            points=points,
+            overwrite=overwrite,
+            flags=flags,
+            null_value=null_value,
+            quiet=True,
+        )
     elif coordinates:
         # Create a list of values
         coord_list = coordinates.split(",")
-        r_what = pymod.Module("r.what", map="dummy",
-                              output="dummy", run_=False,
-                              separator=separator,
-                              coordinates=coord_list,
-                              overwrite=overwrite, flags=flags,
-                              null_value=null_value,
-                              quiet=True)
+        r_what = pymod.Module(
+            "r.what",
+            map="dummy",
+            output="dummy",
+            run_=False,
+            separator=separator,
+            coordinates=coord_list,
+            overwrite=overwrite,
+            flags=flags,
+            null_value=null_value,
+            quiet=True,
+        )
     elif use_stdin:
-        r_what = pymod.Module("r.what", map="dummy",
-                              output="dummy", run_=False,
-                              separator=separator,
-                              stdin_=coordinates_stdin,
-                              overwrite=overwrite, flags=flags,
-                              null_value=null_value,
-                              quiet=True)
+        r_what = pymod.Module(
+            "r.what",
+            map="dummy",
+            output="dummy",
+            run_=False,
+            separator=separator,
+            stdin_=coordinates_stdin,
+            overwrite=overwrite,
+            flags=flags,
+            null_value=null_value,
+            quiet=True,
+        )
     else:
         gscript.error(_("Please specify points or coordinates"))
 
@@ -258,14 +278,25 @@ def main(options, flags):
 
     count = 0
     for loop in range(num_loops):
-        file_name = gscript.tempfile() + "_%i" %(loop)
-        count = process_loop(nprocs, maps, file_name, count, maps_per_process,
-                             remaining_maps_per_loop, output_files,
-                             output_time_list, r_what, process_queue)
+        file_name = gscript.tempfile() + "_%i" % (loop)
+        count = process_loop(
+            nprocs,
+            maps,
+            file_name,
+            count,
+            maps_per_process,
+            remaining_maps_per_loop,
+            output_files,
+            output_time_list,
+            r_what,
+            process_queue,
+        )
 
     process_queue.wait()
 
-    gscript.verbose("Number of raster map layers remaining for sampling %i" %(remaining_maps))
+    gscript.verbose(
+        "Number of raster map layers remaining for sampling %i" % (remaining_maps)
+    )
     if remaining_maps > 0:
         # Use a single process if less then 100 maps
         if remaining_maps <= 100:
@@ -282,33 +313,66 @@ def main(options, flags):
             remaining_maps_per_loop = remaining_maps % nprocs
 
             file_name = "out_remain"
-            process_loop(nprocs, maps, file_name, count, maps_per_process,
-                         remaining_maps_per_loop, output_files,
-                         output_time_list, r_what, process_queue)
+            process_loop(
+                nprocs,
+                maps,
+                file_name,
+                count,
+                maps_per_process,
+                remaining_maps_per_loop,
+                output_files,
+                output_time_list,
+                r_what,
+                process_queue,
+            )
 
     # Wait for unfinished processes
     process_queue.wait()
 
     # Out the output files in the correct order together
     if layout == "row":
-        one_point_per_row_output(separator, output_files, output_time_list,
-                                 output, write_header, site_input, vcat)
+        one_point_per_row_output(
+            separator,
+            output_files,
+            output_time_list,
+            output,
+            write_header,
+            site_input,
+            vcat,
+        )
     elif layout == "col":
-        one_point_per_col_output(separator, output_files, output_time_list,
-                                 output, write_header, site_input, vcat)
+        one_point_per_col_output(
+            separator,
+            output_files,
+            output_time_list,
+            output,
+            write_header,
+            site_input,
+            vcat,
+        )
     else:
-        one_point_per_timerow_output(separator, output_files, output_time_list,
-                                     output, write_header, site_input, vcat)
+        one_point_per_timerow_output(
+            separator,
+            output_files,
+            output_time_list,
+            output,
+            write_header,
+            site_input,
+            vcat,
+        )
+
 
 ############################################################################
 
-def one_point_per_row_output(separator, output_files, output_time_list,
-                             output, write_header, site_input, vcat):
+
+def one_point_per_row_output(
+    separator, output_files, output_time_list, output, write_header, site_input, vcat
+):
     """Write one point per row
-       output is of type: x,y,start,end,value
+    output is of type: x,y,start,end,value
     """
     # open the output file for writing
-    out_file = open(output, 'w') if output != "-" else sys.stdout
+    out_file = open(output, "w") if output != "-" else sys.stdout
 
     if write_header is True:
         out_str = ""
@@ -322,7 +386,7 @@ def one_point_per_row_output(separator, output_files, output_time_list,
 
     for count in range(len(output_files)):
         file_name = output_files[count]
-        gscript.verbose(_("Transforming r.what output file %s" %(file_name)))
+        gscript.verbose(_("Transforming r.what output file %s" % (file_name)))
         map_list = output_time_list[count]
         in_file = open(file_name, "r")
         for line in in_file:
@@ -350,14 +414,29 @@ def one_point_per_row_output(separator, output_files, output_time_list,
                 else:
                     cat_str = ""
                 if site_input:
-                    coor_string = "%(x)10.10f%(sep)s%(y)10.10f%(sep)s%(site_name)s%(sep)s"\
-                        %({"x":float(x),"y":float(y),"site_name":str(site),"sep":separator})
+                    coor_string = (
+                        "%(x)10.10f%(sep)s%(y)10.10f%(sep)s%(site_name)s%(sep)s"
+                        % (
+                            {
+                                "x": float(x),
+                                "y": float(y),
+                                "site_name": str(site),
+                                "sep": separator,
+                            }
+                        )
+                    )
                 else:
-                    coor_string = "%(x)10.10f%(sep)s%(y)10.10f%(sep)s"\
-                        %({"x":float(x),"y":float(y),"sep":separator})
-                time_string = "%(start)s%(sep)s%(end)s%(sep)s%(val)s\n"\
-                               %({"start":str(start), "end":str(end),
-                                  "val":(values[i].strip()),"sep":separator})
+                    coor_string = "%(x)10.10f%(sep)s%(y)10.10f%(sep)s" % (
+                        {"x": float(x), "y": float(y), "sep": separator}
+                    )
+                time_string = "%(start)s%(sep)s%(end)s%(sep)s%(val)s\n" % (
+                    {
+                        "start": str(start),
+                        "end": str(end),
+                        "val": (values[i].strip()),
+                        "sep": separator,
+                    }
+                )
 
                 out_file.write(cat_str + coor_string + time_string)
 
@@ -366,23 +445,26 @@ def one_point_per_row_output(separator, output_files, output_time_list,
     if out_file is not sys.stdout:
         out_file.close()
 
+
 ############################################################################
 
-def one_point_per_col_output(separator, output_files, output_time_list,
-                             output, write_header, site_input, vcat):
-    """Write one point per col
-       output is of type:
-       start,end,point_1 value,point_2 value,...,point_n value
 
-       Each row represents a single raster map, hence a single time stamp
+def one_point_per_col_output(
+    separator, output_files, output_time_list, output, write_header, site_input, vcat
+):
+    """Write one point per col
+    output is of type:
+    start,end,point_1 value,point_2 value,...,point_n value
+
+    Each row represents a single raster map, hence a single time stamp
     """
     # open the output file for writing
-    out_file = open(output, 'w') if output != "-" else sys.stdout
+    out_file = open(output, "w") if output != "-" else sys.stdout
 
     first = True
     for count in range(len(output_files)):
         file_name = output_files[count]
-        gscript.verbose(_("Transforming r.what output file %s" %(file_name)))
+        gscript.verbose(_("Transforming r.what output file %s" % (file_name)))
         map_list = output_time_list[count]
         in_file = open(file_name, "r")
         lines = in_file.readlines()
@@ -395,39 +477,41 @@ def one_point_per_col_output(separator, output_files, output_time_list,
 
         if first is True:
             if write_header is True:
-                out_str = "start%(sep)send" %({"sep":separator})
+                out_str = "start%(sep)send" % ({"sep": separator})
 
                 # Define different separator for coordinates and sites
-                if separator == ',':
-                    coor_sep = ';'
+                if separator == ",":
+                    coor_sep = ";"
                 else:
-                    coor_sep = ','
+                    coor_sep = ","
 
                 for row in matrix:
                     if vcat:
                         cat = row[0]
                         x = row[1]
                         y = row[2]
-                        out_str += "{sep}{cat}{csep}{x:10.10f}{csep}" \
-                                  "{y:10.10f}".format(cat=cat, x=float(x),
-                                                           y=float(y),
-                                                           sep=separator,
-                                                           csep=coor_sep)
+                        out_str += (
+                            "{sep}{cat}{csep}{x:10.10f}{csep}"
+                            "{y:10.10f}".format(
+                                cat=cat,
+                                x=float(x),
+                                y=float(y),
+                                sep=separator,
+                                csep=coor_sep,
+                            )
+                        )
                         if site_input:
                             site = row[3]
-                            out_str += "{sep}{site}".format(sep=coor_sep,
-                                                            site=site)
+                            out_str += "{sep}{site}".format(sep=coor_sep, site=site)
                     else:
                         x = row[0]
                         y = row[1]
-                        out_str += "{sep}{x:10.10f}{csep}" \
-                                   "{y:10.10f}".format(x=float(x), y=float(y),
-                                                       sep=separator,
-                                                       csep=coor_sep)
+                        out_str += "{sep}{x:10.10f}{csep}" "{y:10.10f}".format(
+                            x=float(x), y=float(y), sep=separator, csep=coor_sep
+                        )
                         if site_input:
                             site = row[2]
-                            out_str += "{sep}{site}".format(sep=coor_sep,
-                                                            site=site)
+                            out_str += "{sep}{site}".format(sep=coor_sep, site=site)
 
                 out_file.write(out_str + "\n")
 
@@ -439,34 +523,37 @@ def one_point_per_col_output(separator, output_files, output_time_list,
             ncol = 3
         for col in range(num_cols - ncol):
             start, end = output_time_list[count][col].get_temporal_extent_as_tuple()
-            time_string = "%(start)s%(sep)s%(end)s"\
-                               %({"start":str(start), "end":str(end),
-                                  "sep":separator})
+            time_string = "%(start)s%(sep)s%(end)s" % (
+                {"start": str(start), "end": str(end), "sep": separator}
+            )
             out_file.write(time_string)
             for row in range(len(matrix)):
                 value = matrix[row][col + ncol]
-                out_file.write("%(sep)s%(value)s"
-                                   %({"sep":separator,
-                                      "value":value.strip()}))
+                out_file.write(
+                    "%(sep)s%(value)s" % ({"sep": separator, "value": value.strip()})
+                )
             out_file.write("\n")
 
         in_file.close()
     if out_file is not sys.stdout:
         out_file.close()
 
+
 ############################################################################
 
-def one_point_per_timerow_output(separator, output_files, output_time_list,
-                             output, write_header, site_input, vcat):
-    """Use the original layout of the r.what output and print instead of
-       the raster names, the time stamps as header
 
-       One point per line for all time stamps:
-        x|y|1991-01-01 00:00:00;1991-01-02 00:00:00|1991-01-02 00:00:00;1991-01-03 00:00:00|1991-01-03 00:00:00;1991-01-04 00:00:00|1991-01-04 00:00:00;1991-01-05 00:00:00
-        3730731.49590371|5642483.51236521|6|8|7|7
-        3581249.04638104|5634411.97526282|5|8|7|7
+def one_point_per_timerow_output(
+    separator, output_files, output_time_list, output, write_header, site_input, vcat
+):
+    """Use the original layout of the r.what output and print instead of
+    the raster names, the time stamps as header
+
+    One point per line for all time stamps:
+     x|y|1991-01-01 00:00:00;1991-01-02 00:00:00|1991-01-02 00:00:00;1991-01-03 00:00:00|1991-01-03 00:00:00;1991-01-04 00:00:00|1991-01-04 00:00:00;1991-01-05 00:00:00
+     3730731.49590371|5642483.51236521|6|8|7|7
+     3581249.04638104|5634411.97526282|5|8|7|7
     """
-    out_file = open(output, 'w') if output != "-" else sys.stdout
+    out_file = open(output, "w") if output != "-" else sys.stdout
 
     matrix = []
     header = ""
@@ -474,7 +561,7 @@ def one_point_per_timerow_output(separator, output_files, output_time_list,
     first = True
     for count in range(len(output_files)):
         file_name = output_files[count]
-        gscript.verbose("Transforming r.what output file %s" %(file_name))
+        gscript.verbose("Transforming r.what output file %s" % (file_name))
         map_list = output_time_list[count]
         in_file = open(file_name, "r")
 
@@ -485,14 +572,14 @@ def one_point_per_timerow_output(separator, output_files, output_time_list,
                 else:
                     header = ""
                 if site_input:
-                    header += "x%(sep)sy%(sep)ssite" %({"sep":separator})
+                    header += "x%(sep)sy%(sep)ssite" % ({"sep": separator})
                 else:
-                    header += "x%(sep)sy" %({"sep":separator})
+                    header += "x%(sep)sy" % ({"sep": separator})
             for map in map_list:
                 start, end = map.get_temporal_extent_as_tuple()
-                time_string = "%(sep)s%(start)s;%(end)s"\
-                              %({"start":str(start), "end":str(end),
-                                 "sep":separator})
+                time_string = "%(sep)s%(start)s;%(end)s" % (
+                    {"start": str(start), "end": str(end), "sep": separator}
+                )
                 header += time_string
 
         lines = in_file.readlines()
@@ -520,14 +607,14 @@ def one_point_per_timerow_output(separator, output_files, output_time_list,
     if write_header:
         out_file.write(header + "\n")
 
-    gscript.verbose(_("Writing the output file <%s>" %(output)))
+    gscript.verbose(_("Writing the output file <%s>" % (output)))
     for row in matrix:
         first = True
         for col in row:
             value = col.strip()
 
             if first is False:
-                out_file.write("%s" %(separator))
+                out_file.write("%s" % (separator))
             out_file.write(value)
 
             first = False
@@ -536,11 +623,22 @@ def one_point_per_timerow_output(separator, output_files, output_time_list,
     if out_file is not sys.stdout:
         out_file.close()
 
+
 ############################################################################
 
-def process_loop(nprocs, maps, file_name, count, maps_per_process,
-                 remaining_maps_per_loop, output_files,
-                 output_time_list, r_what, process_queue):
+
+def process_loop(
+    nprocs,
+    maps,
+    file_name,
+    count,
+    maps_per_process,
+    remaining_maps_per_loop,
+    output_files,
+    output_time_list,
+    r_what,
+    process_queue,
+):
     """Call r.what in parallel subprocesses"""
     first = True
     for process in range(nprocs):
@@ -551,7 +649,7 @@ def process_loop(nprocs, maps, file_name, count, maps_per_process,
         first = False
 
         # Temporary output file
-        final_file_name = file_name + "_%i" %(process)
+        final_file_name = file_name + "_%i" % (process)
         output_files.append(final_file_name)
 
         map_names = []
@@ -564,15 +662,25 @@ def process_loop(nprocs, maps, file_name, count, maps_per_process,
 
         output_time_list.append(map_list)
 
-        gscript.verbose(_("Process maps %(samp_start)i to %(samp_end)i (of %(total)i)"
-                                  %({"samp_start":count-len(map_names)+1,
-                                  "samp_end":count, "total":len(maps)})))
+        gscript.verbose(
+            _(
+                "Process maps %(samp_start)i to %(samp_end)i (of %(total)i)"
+                % (
+                    {
+                        "samp_start": count - len(map_names) + 1,
+                        "samp_end": count,
+                        "total": len(maps),
+                    }
+                )
+            )
+        )
         mod = copy.deepcopy(r_what)
         mod(map=map_names, output=final_file_name)
-        #print(mod.get_bash())
+        # print(mod.get_bash())
         process_queue.put(mod)
 
     return count
+
 
 ############################################################################
 

--- a/temporal/t.rast.what/testsuite/test_what.py
+++ b/temporal/t.rast.what/testsuite/test_what.py
@@ -11,126 +11,226 @@ for details.
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestRasterWhat(TestCase):
 
+class TestRasterWhat(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10,
-                      res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
         cls.runModule("r.mapcalc", expression="a_1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a_4 = 400", overwrite=True)
 
-        cls.runModule("v.random", output="points", npoints=3, seed=1,
-                      overwrite=True)
+        cls.runModule("v.random", output="points", npoints=3, seed=1, overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                      output="A", title="A test", description="A test",
-                      overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                      maps="a_1,a_2,a_3,a_4", start="2001-01-01",
-                      increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1,a_2,a_3,a_4",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def test_row_output(self):
-        self.assertModule("t.rast.what", strds="A", output="out_row.txt",
-                          points="points", flags="n", layout="row",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_row.txt",
+            points="points",
+            flags="n",
+            layout="row",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_row.txt", "55209718566d70e1427bd1fecf844d53",
-                           text=True)
-
+        self.assertFileMd5("out_row.txt", "55209718566d70e1427bd1fecf844d53", text=True)
 
     def test_row_output_coords(self):
-        self.assertModule("t.rast.what", strds="A", output="out_row_coords.txt",
-                          coordinates=(30, 30, 45, 45), flags="n", layout="row",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_row_coords.txt",
+            coordinates=(30, 30, 45, 45),
+            flags="n",
+            layout="row",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_row_coords.txt",
-                           "cd917ac4848786f1b944512eed1da5bc", text=True)
-
+        self.assertFileMd5(
+            "out_row_coords.txt", "cd917ac4848786f1b944512eed1da5bc", text=True
+        )
 
     def test_row_output_coords_stdin(self):
-        self.assertModule("t.rast.what", strds="A", output="out_row_coords.txt",
-                          flags="ni", layout="row", stdin_="30 30\n45 45",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_row_coords.txt",
+            flags="ni",
+            layout="row",
+            stdin_="30 30\n45 45",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_row_coords.txt",
-                           "cd917ac4848786f1b944512eed1da5bc", text=True)
+        self.assertFileMd5(
+            "out_row_coords.txt", "cd917ac4848786f1b944512eed1da5bc", text=True
+        )
 
     def test_row_output_cat(self):
-        self.assertModule("t.rast.what", strds="A", output="out_row_cat.txt",
-                          points="points", flags="nv", layout="row",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_row_cat.txt",
+            points="points",
+            flags="nv",
+            layout="row",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_row_cat.txt",
-                           "bddde54bf4f40c41a17305c3442980e5", text=True)
+        self.assertFileMd5(
+            "out_row_cat.txt", "bddde54bf4f40c41a17305c3442980e5", text=True
+        )
 
     def test_col_output(self):
-        self.assertModule("t.rast.what", strds="A", output="out_col.txt",
-                          points="points", flags="n", layout="col",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_col.txt",
+            points="points",
+            flags="n",
+            layout="col",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_col.txt",
-                           "885b6f50405b08fa9fe9ae33ed50e29b", text=True)
+        self.assertFileMd5("out_col.txt", "885b6f50405b08fa9fe9ae33ed50e29b", text=True)
 
     def test_col_output_coords(self):
-        self.assertModule("t.rast.what", strds="A", output="out_col_coords.txt",
-                          coordinates=(30, 30, 45, 45), flags="n", layout="col",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_col_coords.txt",
+            coordinates=(30, 30, 45, 45),
+            flags="n",
+            layout="col",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_col_coords.txt",
-                           "ecdc79a6880a9e1f163cc92fa384b8a3", text=True)
+        self.assertFileMd5(
+            "out_col_coords.txt", "ecdc79a6880a9e1f163cc92fa384b8a3", text=True
+        )
 
     def test_timerow_output(self):
-        self.assertModule("t.rast.what", strds="A", output="out_timerow.txt",
-                          points="points", flags="n", layout="timerow",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_timerow.txt",
+            points="points",
+            flags="n",
+            layout="timerow",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_timerow.txt",
-                           "129fe0b63019e505232efa20ad42c03a", text=True)
+        self.assertFileMd5(
+            "out_timerow.txt", "129fe0b63019e505232efa20ad42c03a", text=True
+        )
 
     def test_col_output_cat(self):
-        self.assertModule("t.rast.what", strds="A", output="out_col_cat.txt",
-                          points="points", flags="nv", layout="col",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_col_cat.txt",
+            points="points",
+            flags="nv",
+            layout="col",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_col_cat.txt",
-                           "ac0a9b14e59920c3f8b5834282a24822", text=True)
+        self.assertFileMd5(
+            "out_col_cat.txt", "ac0a9b14e59920c3f8b5834282a24822", text=True
+        )
 
     def test_timerow_output_cat(self):
-        self.assertModule("t.rast.what", strds="A", output="out_col_trow.txt",
-                          points="points", flags="nv", layout="timerow",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_col_trow.txt",
+            points="points",
+            flags="nv",
+            layout="timerow",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_col_trow.txt",
-                           "1da3350f488df9c919b4009625956b3b", text=True)
+        self.assertFileMd5(
+            "out_col_trow.txt", "1da3350f488df9c919b4009625956b3b", text=True
+        )
 
     def test_timerow_output_coords(self):
-        self.assertModule("t.rast.what", strds="A", output="out_timerow_coords.txt",
-                          coordinates=(30, 30, 45, 45), flags="n", layout="timerow",
-                          nprocs=1, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_timerow_coords.txt",
+            coordinates=(30, 30, 45, 45),
+            flags="n",
+            layout="timerow",
+            nprocs=1,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_timerow_coords.txt",
-                           "ca4ee0e7e4aaca170d6034e0d57d292d", text=True)
+        self.assertFileMd5(
+            "out_timerow_coords.txt", "ca4ee0e7e4aaca170d6034e0d57d292d", text=True
+        )
 
     def test_row_stdout_where_parallel(self):
 
-        t_rast_what = SimpleModule("t.rast.what", strds="A", output="-",
-                                   points="points", flags="n",
-                                   where="start_time > '2001-03-01'",
-                                   nprocs=4, overwrite=True, verbose=True)
+        t_rast_what = SimpleModule(
+            "t.rast.what",
+            strds="A",
+            output="-",
+            points="points",
+            flags="n",
+            where="start_time > '2001-03-01'",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
         self.assertModule(t_rast_what)
 
         text = """x|y|start|end|value
@@ -148,10 +248,17 @@ class TestRasterWhat(TestCase):
 
     def test_row_stdout_where_parallel_cat(self):
 
-        t_rast_what = SimpleModule("t.rast.what", strds="A", output="-",
-                                   points="points", flags="nv",
-                                   where="start_time > '2001-03-01'",
-                                   nprocs=4, overwrite=True, verbose=True)
+        t_rast_what = SimpleModule(
+            "t.rast.what",
+            strds="A",
+            output="-",
+            points="points",
+            flags="nv",
+            where="start_time > '2001-03-01'",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
         self.assertModule(t_rast_what)
 
         text = """cat|x|y|start|end|value
@@ -170,9 +277,16 @@ class TestRasterWhat(TestCase):
     def test_row_stdout_where_parallel2(self):
         """Here without output definition, the default is used then"""
 
-        t_rast_what = SimpleModule("t.rast.what", strds="A", points="points",
-                                   flags="n", where="start_time > '2001-03-01'",
-                                   nprocs=4, overwrite=True, verbose=True)
+        t_rast_what = SimpleModule(
+            "t.rast.what",
+            strds="A",
+            points="points",
+            flags="n",
+            where="start_time > '2001-03-01'",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
         self.assertModule(t_rast_what)
 
         text = """x|y|start|end|value
@@ -189,39 +303,56 @@ class TestRasterWhat(TestCase):
         self.assertLooksLike(text, str(t_rast_what.outputs.stdout))
 
     def test_row_output_where_parallel(self):
-        self.assertModule("t.rast.what", strds="A", output="out_where.txt",
-                          points="points", flags="n",
-                          where="start_time > '2001-03-01'",
-                          nprocs=4, overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast.what",
+            strds="A",
+            output="out_where.txt",
+            points="points",
+            flags="n",
+            where="start_time > '2001-03-01'",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
 
-        self.assertFileMd5("out_where.txt",
-                           "af731bec01fedc262f4ac162fe420707", text=True)
+        self.assertFileMd5(
+            "out_where.txt", "af731bec01fedc262f4ac162fe420707", text=True
+        )
 
     def test_empty_strds(self):
-        self.assertModuleFail("t.rast.what", strds="A", output="out_error.txt",
-                              points="points", flags="n",
-                              where="start_time > '2002-03-01'",
-                              nprocs=4, overwrite=True, verbose=True)
+        self.assertModuleFail(
+            "t.rast.what",
+            strds="A",
+            output="out_error.txt",
+            points="points",
+            flags="n",
+            where="start_time > '2002-03-01'",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
 
 
 class TestRasterWhatFails(TestCase):
-
     def test_error_handling(self):
         # No vector map, no strds, no coordinates
         self.assertModuleFail("t.rast.what", output="out.txt")
         # No vector map, no coordinates
         self.assertModuleFail("t.rast.what", strds="A", output="out.txt")
         # Points and coordinates are mutually exclusive
-        self.assertModuleFail("t.rast.what", points="points", strds="A",
-                              coordinates=(30, 30, 45, 45), output="out.txt")
+        self.assertModuleFail(
+            "t.rast.what",
+            points="points",
+            strds="A",
+            coordinates=(30, 30, 45, 45),
+            output="out.txt",
+        )
 
 
 class TestRasterWhatNull(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
@@ -230,39 +361,57 @@ class TestRasterWhatNull(TestCase):
 
         cls.runModule("v.random", output="points", npoints=1, seed=1, overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                 output="A", title="A test", description="A test",
-                                 overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a_1,a_null", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a_1,a_null",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="strds",
-                                   inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
         cls.del_temp_region()
 
     def test_null_value(self):
-        """Test setting the null value
-        """
+        """Test setting the null value"""
 
-        t_rast_what = SimpleModule("t.rast.what", strds="A", output="-",
-                                   points="points", flags="n",
-                                   where="start_time >= '2001-01-01'",
-                                   null_value="NULL",
-                                   nprocs=4, overwrite=True, verbose=True)
+        t_rast_what = SimpleModule(
+            "t.rast.what",
+            strds="A",
+            output="-",
+            points="points",
+            flags="n",
+            where="start_time >= '2001-01-01'",
+            null_value="NULL",
+            nprocs=4,
+            overwrite=True,
+            verbose=True,
+        )
         self.assertModule(t_rast_what)
 
-        text="""x|y|start|end|value
+        text = """x|y|start|end|value
 115.0043586274|36.3593955783|2001-01-01 00:00:00|2001-04-01 00:00:00|100
 115.0043586274|36.3593955783|2001-04-01 00:00:00|2001-07-01 00:00:00|NULL
 """
         self.assertLooksLike(text, str(t_rast_what.outputs.stdout))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast3d.algebra/t.rast3d.algebra.py
+++ b/temporal/t.rast3d.algebra/t.rast3d.algebra.py
@@ -79,8 +79,8 @@ def main():
     # lazy imports
     import grass.temporal as tgis
 
-    expression = options['expression']
-    basename = options['basename']
+    expression = options["expression"]
+    basename = options["basename"]
     nprocs = options["nprocs"]
     spatial = flags["s"]
     register_null = flags["n"]
@@ -92,18 +92,35 @@ def main():
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
     except ImportError:
-        grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
-                             "You can use t.rast3d.mapcalc that provides a limited but useful alternative to "
-                             "t.rast3d.mapcalc2 without PLY requirement."))
+        grass.script.fatal(
+            _(
+                "Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules. "
+                "You can use t.rast3d.mapcalc that provides a limited but useful alternative to "
+                "t.rast3d.mapcalc2 without PLY requirement."
+            )
+        )
 
     tgis.init(True)
-    p = tgis.TemporalRaster3DAlgebraParser(run = True, debug=False, spatial = spatial, nprocs = nprocs, register_null = register_null)
+    p = tgis.TemporalRaster3DAlgebraParser(
+        run=True,
+        debug=False,
+        spatial=spatial,
+        nprocs=nprocs,
+        register_null=register_null,
+    )
 
     if granularity:
-        if not p.setup_common_granularity(expression=expression, stdstype = 'str3ds', lexer = tgis.TemporalRasterAlgebraLexer()):
-            grass.script.fatal(_("Unable to process the expression in granularity algebra mode"))
+        if not p.setup_common_granularity(
+            expression=expression,
+            stdstype="str3ds",
+            lexer=tgis.TemporalRasterAlgebraLexer(),
+        ):
+            grass.script.fatal(
+                _("Unable to process the expression in granularity algebra mode")
+            )
 
     p.parse(expression, basename, grass.script.overwrite())
+
 
 if __name__ == "__main__":
     options, flags = grass.script.parser()

--- a/temporal/t.rast3d.algebra/testsuite/test_raster3d_algebra.py
+++ b/temporal/t.rast3d.algebra/testsuite/test_raster3d_algebra.py
@@ -17,49 +17,61 @@ import os
 
 
 class TestTRast3dAlgebra(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
-        tgis.init(True) # Raise on error instead of exit(1)
+        tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
-        ret = grass.script.run_command("g.region", n=80.0, s=0.0, e=120.0,
-                                       w=0.0, t=100.0, b=0.0, res=10.0)
+        ret = grass.script.run_command(
+            "g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=100.0, b=0.0, res=10.0
+        )
 
         cls.runModule("r3.mapcalc", overwrite=True, quiet=True, expression="a1 = 1")
         cls.runModule("r3.mapcalc", overwrite=True, quiet=True, expression="a2 = 2")
         cls.runModule("r3.mapcalc", overwrite=True, quiet=True, expression="a3 = 3")
         cls.runModule("r3.mapcalc", overwrite=True, quiet=True, expression="a4 = 4")
 
-        tgis.open_new_stds(name="A", type="str3ds", temporaltype="absolute",
-                                         title="A", descr="A", semantic="field", overwrite=True)
+        tgis.open_new_stds(
+            name="A",
+            type="str3ds",
+            temporaltype="absolute",
+            title="A",
+            descr="A",
+            semantic="field",
+            overwrite=True,
+        )
 
-        tgis.register_maps_in_space_time_dataset(type="raster_3d", name="A", maps="a1,a2,a3,a4",
-                                                 start="2001-01-01", increment="1 day", interval=True)
+        tgis.register_maps_in_space_time_dataset(
+            type="raster_3d",
+            name="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="1 day",
+            interval=True,
+        )
 
     def tearDown(self):
         self.runModule("t.remove", type="str3ds", flags="rf", inputs="D", quiet=True)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.runModule("t.remove", type="str3ds", flags="rf", inputs="A", quiet=True)
         cls.del_temp_region()
 
     def test_temporal_neighbors_1(self):
         """Simple temporal neighborhood computation test"""
 
-        self.assertModule("t.rast3d.algebra", expression='D = A[-1] + A[1]',
-                  basename="d")
+        self.assertModule(
+            "t.rast3d.algebra", expression="D = A[-1] + A[1]", basename="d"
+        )
 
         D = tgis.open_old_stds("D", type="str3ds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 4)  # 1 + 3
-        self.assertEqual(D.metadata.get_max_max(), 6) # 2 + 4
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 2 + 4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -67,14 +79,15 @@ class TestTRast3dAlgebra(TestCase):
     def test_temporal_neighbors_2(self):
         """Simple temporal neighborhood computation test"""
 
-        self.assertModule("t.rast3d.algebra", expression='D = A[0,0,0,-1] + A[0,0,0,1]',
-                  basename="d")
+        self.assertModule(
+            "t.rast3d.algebra", expression="D = A[0,0,0,-1] + A[0,0,0,1]", basename="d"
+        )
 
         D = tgis.open_old_stds("D", type="str3ds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 4)  # 1 + 3
-        self.assertEqual(D.metadata.get_max_max(), 6) # 2 + 4
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 2 + 4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
@@ -82,45 +95,57 @@ class TestTRast3dAlgebra(TestCase):
     def test_temporal_neighbors_granularity(self):
         """Simple temporal neighborhood computation test with granularity algebra"""
 
-        self.assertModule("t.rast3d.algebra", flags="g", expression='D = A[0,0,0,-1] + A[0,0,0,1]',
-                  basename="d")
+        self.assertModule(
+            "t.rast3d.algebra",
+            flags="g",
+            expression="D = A[0,0,0,-1] + A[0,0,0,1]",
+            basename="d",
+        )
 
         D = tgis.open_old_stds("D", type="str3ds")
 
         self.assertEqual(D.metadata.get_number_of_maps(), 2)
         self.assertEqual(D.metadata.get_min_min(), 4)  # 1 + 3
-        self.assertEqual(D.metadata.get_max_max(), 6) # 2 + 4
+        self.assertEqual(D.metadata.get_max_max(), 6)  # 2 + 4
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
 
 class TestTRast3dAlgebraFails(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Set the region
-        """
+        """Set the region"""
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def test_error_handling(self):
         # Syntax error
-        self.assertModuleFail("t.rast3d.algebra", expression="R = A {+,equal| precedes| follows,l B", basename="r")
+        self.assertModuleFail(
+            "t.rast3d.algebra",
+            expression="R = A {+,equal| precedes| follows,l B",
+            basename="r",
+        )
         # Granularity syntax error
-        self.assertModuleFail("t.rast3d.algebra", flags="g", expression="R = A {+,equal| precedes| follows,l} B", basename="r")
+        self.assertModuleFail(
+            "t.rast3d.algebra",
+            flags="g",
+            expression="R = A {+,equal| precedes| follows,l} B",
+            basename="r",
+        )
         # No STRDS
-        self.assertModuleFail("t.rast3d.algebra", expression="R = NoSTR3DS + NoSTR3DS", basename="r")
+        self.assertModuleFail(
+            "t.rast3d.algebra", expression="R = NoSTR3DS + NoSTR3DS", basename="r"
+        )
         # No basename
         self.assertModuleFail("t.rast3d.algebra", expression="R = A + B")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/temporal/t.rast3d.extract/t.rast3d.extract.py
+++ b/temporal/t.rast3d.extract/t.rast3d.extract.py
@@ -100,8 +100,18 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.extract_dataset(input, output, "raster3d", where, expression,
-                         base, time_suffix, nprocs, register_null)
+    tgis.extract_dataset(
+        input,
+        output,
+        "raster3d",
+        where,
+        expression,
+        base,
+        time_suffix,
+        nprocs,
+        register_null,
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast3d.extract/testsuite/test_t_rast3d_extract.py
+++ b/temporal/t.rast3d.extract/testsuite/test_t_rast3d_extract.py
@@ -13,24 +13,21 @@ import subprocess
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestRaster3dExtraction(TestCase):
 
+class TestRaster3dExtraction(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def setUp(self):
-        """Create input data for transient groundwater flow computation
-        """
+        """Create input data for transient groundwater flow computation"""
         # Use always the current mapset as temporal database
         self.runModule("r3.mapcalc", expression="a1 = 100", overwrite=True)
         self.runModule("r3.mapcalc", expression="a2 = 200", overwrite=True)
@@ -39,25 +36,39 @@ class TestRaster3dExtraction(TestCase):
         self.runModule("r3.mapcalc", expression="a5 = 500", overwrite=True)
         self.runModule("r3.mapcalc", expression="a6 = 600", overwrite=True)
 
-        self.runModule("t.create", type="str3ds", temporaltype="absolute",
-                                     output="A", title="A test", description="A test", overwrite=True)
-        self.runModule("t.register", flags="i", type="raster_3d", input="A",
-                                     maps="a1,a2,a3,a4,a5,a6",
-                                     start="2001-01-01", increment="3 months", overwrite=True)
+        self.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster_3d",
+            input="A",
+            maps="a1,a2,a3,a4,a5,a6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("t.remove", flags="rf", type="str3ds",
-                                   inputs="A,B")
+        self.runModule("t.remove", flags="rf", type="str3ds", inputs="A,B")
 
     def test_selection(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.rast3d.extract", input="A", output="B",
-                                      where="start_time > '2001-06-01'")
+        self.assertModule(
+            "t.rast3d.extract", input="A", output="B", where="start_time > '2001-06-01'"
+        )
 
-        #self.assertModule("t.info",  flags="g",  input="B")
+        # self.assertModule("t.info",  flags="g",  input="B")
 
-        tinfo_string="""start_time='2001-07-01 00:00:00'
+        tinfo_string = """start_time='2001-07-01 00:00:00'
         end_time='2002-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -69,18 +80,26 @@ class TestRaster3dExtraction(TestCase):
         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", type="str3ds", input="B")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_selection_and_expression(self):
         """Perform a selection by datetime and a r3.mapcalc expression"""
-        self.assertModule("t.rast3d.extract", input="A", output="B",
-                                      where="start_time > '2001-06-01'",
-                                      expression=" if(A > 400, A, null())",
-                                      basename="b", nprocs=2, overwrite=True)
+        self.assertModule(
+            "t.rast3d.extract",
+            input="A",
+            output="B",
+            where="start_time > '2001-06-01'",
+            expression=" if(A > 400, A, null())",
+            basename="b",
+            nprocs=2,
+            overwrite=True,
+        )
 
-        #self.assertModule("t.info",  flags="g",  input="B")
+        # self.assertModule("t.info",  flags="g",  input="B")
 
-        tinfo_string="""start_time='2002-01-01 00:00:00'
+        tinfo_string = """start_time='2002-01-01 00:00:00'
         end_time='2002-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -92,17 +111,26 @@ class TestRaster3dExtraction(TestCase):
         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", type="str3ds", input="B")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_expression_with_empty_maps(self):
         """Perform r3.mapcalc expression and register empty maps"""
-        self.assertModule("t.rast3d.extract", flags="n", input="A", output="B",
-                                      expression=" if(A > 400, A, null())",
-                                      basename="b", nprocs=2, overwrite=True)
+        self.assertModule(
+            "t.rast3d.extract",
+            flags="n",
+            input="A",
+            output="B",
+            expression=" if(A > 400, A, null())",
+            basename="b",
+            nprocs=2,
+            overwrite=True,
+        )
 
-        #self.assertModule("t.info",  flags="g",  input="B")
+        # self.assertModule("t.info",  flags="g",  input="B")
 
-        tinfo_string="""start_time='2001-01-01 00:00:00'
+        tinfo_string = """start_time='2001-01-01 00:00:00'
         end_time='2002-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -114,38 +142,53 @@ class TestRaster3dExtraction(TestCase):
         max_max=600.0"""
 
         info = SimpleModule("t.info", flags="g", type="str3ds", input="B")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string, precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_time_suffix_with_expression(self):
         """Perform extract with time suffix support and test if maps exists"""
-        self.assertModule("t.rast3d.extract", flags="n", input="A", nprocs=2,
-                          output="B", basename="b", overwrite=True,
-                          suffix="time", expression="if(A > 400, A, null())")
-        self.assertRaster3dExists('b_2001_01_01T00_00_00')
-        self.assertRaster3dDoesNotExist('b_2001_01')
+        self.assertModule(
+            "t.rast3d.extract",
+            flags="n",
+            input="A",
+            nprocs=2,
+            output="B",
+            basename="b",
+            overwrite=True,
+            suffix="time",
+            expression="if(A > 400, A, null())",
+        )
+        self.assertRaster3dExists("b_2001_01_01T00_00_00")
+        self.assertRaster3dDoesNotExist("b_2001_01")
 
     def test_num_suffix_with_expression(self):
         """Perform extract with time suffix support and test if maps exists"""
-        self.assertModule("t.rast3d.extract", flags="n", input="A", nprocs=2,
-                          output="B", basename="b", overwrite=True,
-                          suffix='num%03', expression="if(A > 400, A, null())")
-        self.assertRaster3dExists('b_001')
-        self.assertRaster3dDoesNotExist('b_00001')
+        self.assertModule(
+            "t.rast3d.extract",
+            flags="n",
+            input="A",
+            nprocs=2,
+            output="B",
+            basename="b",
+            overwrite=True,
+            suffix="num%03",
+            expression="if(A > 400, A, null())",
+        )
+        self.assertRaster3dExists("b_001")
+        self.assertRaster3dDoesNotExist("b_00001")
 
 
 class TestRaster3dExtractionFails(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def test_error_handling(self):
@@ -155,9 +198,15 @@ class TestRaster3dExtractionFails(TestCase):
         # No output
         self.assertModuleFail("t.rast3d.extract", input="A", basename="b")
         # No basename
-        self.assertModuleFail("t.rast3d.extract", input="A", output="B",
-                          expression=" if(A > 400, A, null())")
+        self.assertModuleFail(
+            "t.rast3d.extract",
+            input="A",
+            output="B",
+            expression=" if(A > 400, A, null())",
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.rast3d.list/t.rast3d.list.py
+++ b/temporal/t.rast3d.list/t.rast3d.list.py
@@ -106,8 +106,18 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.list_maps_of_stds("str3ds", input, columns, order, where, separator,
-                           method, header, outpath=output)
+    tgis.list_maps_of_stds(
+        "str3ds",
+        input,
+        columns,
+        order,
+        where,
+        separator,
+        method,
+        header,
+        outpath=output,
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
+++ b/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
@@ -103,8 +103,18 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.dataset_mapcalculator(inputs, output, "raster3d", expression,
-                               base, method, nprocs, register_null, spatial)
+    tgis.dataset_mapcalculator(
+        inputs,
+        output,
+        "raster3d",
+        expression,
+        base,
+        method,
+        nprocs,
+        register_null,
+        spatial,
+    )
+
 
 ###############################################################################
 

--- a/temporal/t.rast3d.univar/t.rast3d.univar.py
+++ b/temporal/t.rast3d.univar/t.rast3d.univar.py
@@ -84,7 +84,9 @@ def main():
         output = None
 
     tgis.print_gridded_dataset_univar_statistics(
-        "str3ds", input, output, where, extended, no_header, separator)
+        "str3ds", input, output, where, extended, no_header, separator
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
+++ b/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
@@ -13,11 +13,9 @@ from grass.gunittest.gmodules import SimpleModule
 
 
 class TestRasterUnivar(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=1, res3=1)
 
@@ -26,35 +24,52 @@ class TestRasterUnivar(TestCase):
         cls.runModule("r3.mapcalc", expression="a_3 = 300", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a_4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="str3ds", temporaltype="absolute",
-                                   output="A", title="A test", description="A test",
-                                   overwrite=True)
-        cls.runModule("t.register", flags="i", type="raster_3d", input="A",
-                                     maps="a_1,a_2,a_3,a_4", start="2001-01-01",
-                                     increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster_3d",
+            input="A",
+            maps="a_1,a_2,a_3,a_4",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", type="str3ds",
-                                   inputs="A")
+        """Remove the temporary region"""
+        cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A")
         cls.del_temp_region()
 
     def test_1(self):
 
-        t_rast3d_univar = SimpleModule("t.rast3d.univar", input="A",
-                                                          where="start_time >= '2001-01-01'",
-                                                          overwrite=True, verbose=True)
+        t_rast3d_univar = SimpleModule(
+            "t.rast3d.univar",
+            input="A",
+            where="start_time >= '2001-01-01'",
+            overwrite=True,
+            verbose=True,
+        )
         self.assertModule(t_rast3d_univar)
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_1@testing|2001-01-01 00:00:00|2001-04-01 00:00:00|100|100|100|100|0|0|0|48000000|0|480000|480000
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|96000000|0|480000|480000
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|144000000|0|480000|480000
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000000|0|480000|480000
 """
-        for ref, res in zip(univar_text.split("\n"), t_rast3d_univar.outputs.stdout.split("\n")):
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast3d_univar.outputs.stdout.split("\n")
+        ):
             if ref and res:
                 ref_line = ref.split("|", 1)[1]
                 res_line = res.split("|", 1)[1]
@@ -62,17 +77,23 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000
 
     def test_2(self):
 
-        t_rast3d_univar = SimpleModule("t.rast3d.univar", input="A",
-                                                          where="start_time >= '2001-03-01'",
-                                                          overwrite=True, verbose=True)
+        t_rast3d_univar = SimpleModule(
+            "t.rast3d.univar",
+            input="A",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
         self.assertModule(t_rast3d_univar)
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|96000000|0|480000|480000
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|144000000|0|480000|480000
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000000|0|480000|480000
 """
-        for ref, res in zip(univar_text.split("\n"), t_rast3d_univar.outputs.stdout.split("\n")):
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast3d_univar.outputs.stdout.split("\n")
+        ):
             if ref and res:
                 ref_line = ref.split("|", 1)[1]
                 res_line = res.split("|", 1)[1]
@@ -80,12 +101,16 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000
 
     def test_3(self):
 
-        self.assertModule("t.rast3d.univar", input="A",
-                                             output="univar_output.txt",
-                                             where="start_time >= '2001-03-01'",
-                                             overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast3d.univar",
+            input="A",
+            output="univar_output.txt",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
 
-        univar_text=u"""id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+        univar_text = """id|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
 a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|96000000|0|480000|480000
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|144000000|0|480000|480000
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000000|0|480000|480000
@@ -100,12 +125,17 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000
 
     def test_4(self):
 
-        self.assertModule("t.rast3d.univar", input="A",
-                                             output="univar_output.txt", flags="s",
-                                             where="start_time >= '2001-03-01'",
-                                             overwrite=True, verbose=True)
+        self.assertModule(
+            "t.rast3d.univar",
+            input="A",
+            output="univar_output.txt",
+            flags="s",
+            where="start_time >= '2001-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
 
-        univar_text=u"""a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|96000000|0|480000|480000
+        univar_text = """a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|96000000|0|480000|480000
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|144000000|0|480000|480000
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000000|0|480000|480000
 """
@@ -119,15 +149,21 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000
 
     def test_5_error_handling_empty_strds(self):
         # Empty str3ds
-        self.assertModuleFail("t.rast3d.univar", input="A",
-                                                 output="univar_output.txt",
-                                                 where="start_time >= '2015-03-01'",
-                                                 overwrite=True, verbose=True)
+        self.assertModuleFail(
+            "t.rast3d.univar",
+            input="A",
+            output="univar_output.txt",
+            where="start_time >= '2015-03-01'",
+            overwrite=True,
+            verbose=True,
+        )
 
     def test_6_error_handling_no_input(self):
         # No input
         self.assertModuleFail("t.rast3d.univar", output="out.txt")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.register/t.register.py
+++ b/temporal/t.register/t.register.py
@@ -127,8 +127,18 @@ def main():
     tgis.init()
     # Register maps
     tgis.register_maps_in_space_time_dataset(
-        type=type, name=name, maps=maps, file=file, start=start, end=end,
-        unit=unit, increment=increment, dbif=None, interval=interval, fs=separator)
+        type=type,
+        name=name,
+        maps=maps,
+        file=file,
+        start=start,
+        end=end,
+        unit=unit,
+        increment=increment,
+        dbif=None,
+        interval=interval,
+        fs=separator,
+    )
 
 
 ###############################################################################

--- a/temporal/t.remove/t.remove.py
+++ b/temporal/t.remove/t.remove.py
@@ -68,6 +68,7 @@ import grass.script as grass
 
 ############################################################################
 
+
 def main():
     # Get the options
     datasets = options["inputs"]
@@ -77,7 +78,11 @@ def main():
     force = flags["f"]
 
     if recursive and not force:
-        grass.fatal(_("The recursive flag works only in conjunction with the force flag: use -rf"))
+        grass.fatal(
+            _(
+                "The recursive flag works only in conjunction with the force flag: use -rf"
+            )
+        )
 
     if datasets and file:
         grass.fatal(_("%s= and %s= are mutually exclusive") % ("input", "file"))
@@ -114,7 +119,7 @@ def main():
     statement = ""
 
     # Create the pygrass Module object for g.remove
-    remove = pyg.Module("g.remove", quiet=True, flags='f', run_=False)
+    remove = pyg.Module("g.remove", quiet=True, flags="f", run_=False)
 
     for name in dataset_list:
         name = name.strip()
@@ -137,7 +142,7 @@ def main():
 
                 count += 1
                 # Delete every 100 maps
-                if count %100 == 0:
+                if count % 100 == 0:
                     dbif.execute_transaction(map_statement)
                     if type == "strds":
                         remove(type="raster", name=name_list, run_=True)
@@ -158,7 +163,12 @@ def main():
                 if type == "str3ds":
                     remove(type="raster_3d", name=name_list, run_=True)
         else:
-            grass.message(_("Note: registered maps themselves have not been removed, only the %s" % type))
+            grass.message(
+                _(
+                    "Note: registered maps themselves have not been removed, only the %s"
+                    % type
+                )
+            )
 
         statement += sp.delete(dbif=dbif, execute=False)
 
@@ -166,6 +176,7 @@ def main():
     dbif.execute_transaction(statement)
 
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.rename/t.rename.py
+++ b/temporal/t.rename/t.rename.py
@@ -56,7 +56,7 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    #Get the current mapset to create the id of the space time dataset
+    # Get the current mapset to create the id of the space time dataset
     mapset = grass.gisenv()["MAPSET"]
 
     if input.find("@") >= 0:
@@ -73,31 +73,40 @@ def main():
     if new_id == old_id:
         return
 
-
     dbif = tgis.SQLDatabaseInterfaceConnection()
     dbif.connect()
 
     stds = tgis.dataset_factory(type, old_id)
 
     if new_id.split("@")[1] != mapset:
-        grass.fatal(_("Space time %s dataset <%s> can not be renamed. "
-                      "Mapset of the new identifier differs from the current "
-                      "mapset.") % (stds.get_new_map_instance(None).get_type(),
-                                    old_id))
+        grass.fatal(
+            _(
+                "Space time %s dataset <%s> can not be renamed. "
+                "Mapset of the new identifier differs from the current "
+                "mapset."
+            )
+            % (stds.get_new_map_instance(None).get_type(), old_id)
+        )
 
     if not stds.is_in_db(dbif=dbif):
         dbif.close()
-        grass.fatal(_("Space time %s dataset <%s> not found") % (
-            stds.get_new_map_instance(None).get_type(), old_id))
+        grass.fatal(
+            _("Space time %s dataset <%s> not found")
+            % (stds.get_new_map_instance(None).get_type(), old_id)
+        )
 
     # Check if the new id is in the database
     new_stds = tgis.dataset_factory(type, new_id)
 
     if new_stds.is_in_db(dbif=dbif) and not grass.overwrite():
         dbif.close()
-        grass.fatal(_("Unable to rename Space time %s dataset <%s>. Name <%s> "
-                      "is in use, please use the overwrite flag.") % (
-            stds.get_new_map_instance(None).get_type(), old_id, new_id))
+        grass.fatal(
+            _(
+                "Unable to rename Space time %s dataset <%s>. Name <%s> "
+                "is in use, please use the overwrite flag."
+            )
+            % (stds.get_new_map_instance(None).get_type(), old_id, new_id)
+        )
 
     # Remove an already existing space time dataset
     if new_stds.is_in_db(dbif=dbif):
@@ -106,6 +115,7 @@ def main():
     stds.select(dbif=dbif)
     stds.rename(ident=new_id, dbif=dbif)
     stds.update_command_string(dbif=dbif)
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.sample/t.sample.py
+++ b/temporal/t.sample/t.sample.py
@@ -71,6 +71,7 @@ import grass.script as grass
 
 ############################################################################
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
@@ -88,9 +89,10 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.sample_stds_by_stds_topology(intype, samtype, inputs, sampler,
-                                      header, separator, method, spatial,
-                                      True)
+    tgis.sample_stds_by_stds_topology(
+        intype, samtype, inputs, sampler, header, separator, method, spatial, True
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.select/t.select.py
+++ b/temporal/t.select/t.select.py
@@ -57,11 +57,12 @@ import sys
 
 ############################################################################
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
 
-    expression = options['expression']
+    expression = options["expression"]
     spatial = flags["s"]
     dry_run = flags["d"]
     stdstype = options["type"]
@@ -72,14 +73,21 @@ def main():
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
     except ImportError:
-        grass.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."))
+        grass.fatal(
+            _(
+                "Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."
+            )
+        )
 
     tgis.init(True)
-    p = tgis.TemporalAlgebraParser(run=True, debug=False, spatial=spatial, dry_run=dry_run)
+    p = tgis.TemporalAlgebraParser(
+        run=True, debug=False, spatial=spatial, dry_run=dry_run
+    )
     pc = p.parse(expression, stdstype, overwrite=grass.overwrite())
 
     if dry_run is True:
         import pprint
+
         pprint.pprint(pc)
 
 

--- a/temporal/t.shift/t.shift.py
+++ b/temporal/t.shift/t.shift.py
@@ -71,11 +71,14 @@ def main():
 
     if check is False:
         dbif.close()
-        grass.fatal(_("Unable to temporally shift the space time %s dataset <%s>") %
-                     (stds.get_new_map_instance(None).get_type(), id))
+        grass.fatal(
+            _("Unable to temporally shift the space time %s dataset <%s>")
+            % (stds.get_new_map_instance(None).get_type(), id)
+        )
 
     stds.update_command_string(dbif=dbif)
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.shift/testsuite/test_shift.py
+++ b/temporal/t.shift/testsuite/test_shift.py
@@ -15,35 +15,41 @@ from grass.gunittest.gmodules import SimpleModule
 
 
 class TestShiftAbsoluteSTRDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-01",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -57,9 +63,7 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1 day",
-                          type="strds")
+        self.assertModule("t.shift", input="A", granularity="1 day", type="strds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -67,9 +71,7 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 2)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-1 day",
-                          type="strds")
+        self.assertModule("t.shift", input="A", granularity="-1 day", type="strds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -77,9 +79,7 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-1 year",
-                          type="strds")
+        self.assertModule("t.shift", input="A", granularity="-1 year", type="strds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -87,9 +87,7 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="6 month",
-                          type="strds")
+        self.assertModule("t.shift", input="A", granularity="6 month", type="strds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -97,9 +95,7 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.month, 7)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1 hour",
-                          type="strds")
+        self.assertModule("t.shift", input="A", granularity="1 hour", type="strds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -108,9 +104,9 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.day, 1)
         self.assertEqual(start.hour, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-3630 seconds",
-                          type="strds")
+        self.assertModule(
+            "t.shift", input="A", granularity="-3630 seconds", type="strds"
+        )
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -121,36 +117,44 @@ class TestShiftAbsoluteSTRDS(TestCase):
         self.assertEqual(start.minute, 59)
         self.assertEqual(start.second, 30)
 
-class TestShiftRelativeSTRDS(TestCase):
 
+class TestShiftRelativeSTRDS(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -162,9 +166,7 @@ class TestShiftRelativeSTRDS(TestCase):
         start, end = A.get_temporal_extent_as_tuple()
         self.assertEqual(start, 0)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1",
-                          type="strds")
+        self.assertModule("t.shift", input="A", granularity="1", type="strds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -172,35 +174,41 @@ class TestShiftRelativeSTRDS(TestCase):
 
 
 class TestShiftAbsoluteSTR3DS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r3.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="str3ds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster_3d", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-01",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster_3d",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A")
 
@@ -214,9 +222,7 @@ class TestShiftAbsoluteSTR3DS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1 day",
-                          type="str3ds")
+        self.assertModule("t.shift", input="A", granularity="1 day", type="str3ds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -224,9 +230,7 @@ class TestShiftAbsoluteSTR3DS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 2)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-1 day",
-                          type="str3ds")
+        self.assertModule("t.shift", input="A", granularity="-1 day", type="str3ds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -234,9 +238,7 @@ class TestShiftAbsoluteSTR3DS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-1 year",
-                          type="str3ds")
+        self.assertModule("t.shift", input="A", granularity="-1 year", type="str3ds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -244,9 +246,7 @@ class TestShiftAbsoluteSTR3DS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="6 month",
-                          type="str3ds")
+        self.assertModule("t.shift", input="A", granularity="6 month", type="str3ds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -254,9 +254,7 @@ class TestShiftAbsoluteSTR3DS(TestCase):
         self.assertEqual(start.month, 7)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1 hour",
-                          type="str3ds")
+        self.assertModule("t.shift", input="A", granularity="1 hour", type="str3ds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -265,9 +263,9 @@ class TestShiftAbsoluteSTR3DS(TestCase):
         self.assertEqual(start.day, 1)
         self.assertEqual(start.hour, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-3630 seconds",
-                          type="str3ds")
+        self.assertModule(
+            "t.shift", input="A", granularity="-3630 seconds", type="str3ds"
+        )
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -280,33 +278,41 @@ class TestShiftAbsoluteSTR3DS(TestCase):
 
 
 class TestShiftRelativeSTR3DS(TestCase):
-
     @classmethod
     def setUpClass(cls):
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r3.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="str3ds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster_3d", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster_3d",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A")
 
@@ -318,9 +324,7 @@ class TestShiftRelativeSTR3DS(TestCase):
         start, end = A.get_temporal_extent_as_tuple()
         self.assertEqual(start, 0)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1",
-                          type="str3ds")
+        self.assertModule("t.shift", input="A", granularity="1", type="str3ds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -328,35 +332,42 @@ class TestShiftRelativeSTR3DS(TestCase):
 
 
 class TestShiftAbsoluteSTVDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a4')
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a4")
 
-        cls.runModule("t.create", type="stvds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="stvds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="vector", input="A",
-                                     maps="a1,a2,a3,a4", flags="i",
-                                     start="2001-01-01",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="vector",
+            input="A",
+            maps="a1,a2,a3,a4",
+            flags="i",
+            start="2001-01-01",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="A")
 
@@ -370,9 +381,7 @@ class TestShiftAbsoluteSTVDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1 day",
-                          type="stvds")
+        self.assertModule("t.shift", input="A", granularity="1 day", type="stvds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -380,9 +389,7 @@ class TestShiftAbsoluteSTVDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 2)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-1 day",
-                          type="stvds")
+        self.assertModule("t.shift", input="A", granularity="-1 day", type="stvds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -390,9 +397,7 @@ class TestShiftAbsoluteSTVDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-1 year",
-                          type="stvds")
+        self.assertModule("t.shift", input="A", granularity="-1 year", type="stvds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -400,9 +405,7 @@ class TestShiftAbsoluteSTVDS(TestCase):
         self.assertEqual(start.month, 1)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="6 month",
-                          type="stvds")
+        self.assertModule("t.shift", input="A", granularity="6 month", type="stvds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -410,9 +413,7 @@ class TestShiftAbsoluteSTVDS(TestCase):
         self.assertEqual(start.month, 7)
         self.assertEqual(start.day, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1 hour",
-                          type="stvds")
+        self.assertModule("t.shift", input="A", granularity="1 hour", type="stvds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -421,9 +422,9 @@ class TestShiftAbsoluteSTVDS(TestCase):
         self.assertEqual(start.day, 1)
         self.assertEqual(start.hour, 1)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="-3630 seconds",
-                          type="stvds")
+        self.assertModule(
+            "t.shift", input="A", granularity="-3630 seconds", type="stvds"
+        )
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -436,35 +437,43 @@ class TestShiftAbsoluteSTVDS(TestCase):
 
 
 class TestShiftRelativeSTVDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a4')
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a4")
 
-        cls.runModule("t.create", type="stvds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="stvds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="vector", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0", flags="i",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="vector",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            flags="i",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="A")
 
@@ -476,9 +485,7 @@ class TestShiftRelativeSTVDS(TestCase):
         start, end = A.get_temporal_extent_as_tuple()
         self.assertEqual(start, 0)
 
-        self.assertModule("t.shift", input="A",
-                          granularity="1",
-                          type="stvds")
+        self.assertModule("t.shift", input="A", granularity="1", type="stvds")
 
         A.select()
         start, end = A.get_temporal_extent_as_tuple()
@@ -486,43 +493,51 @@ class TestShiftRelativeSTVDS(TestCase):
 
 
 class TestShiftAbsoluteError(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
-
     def test_1(self):
         pass
-        #self.assterModuleFail()
+        # self.assterModuleFail()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.snap/t.snap.py
+++ b/temporal/t.snap/t.snap.py
@@ -62,6 +62,7 @@ def main():
     stds.update_command_string(dbif=dbif)
     dbif.close()
 
+
 if __name__ == "__main__":
     options, flags = grass.parser()
     main()

--- a/temporal/t.snap/testsuite/test_snap.py
+++ b/temporal/t.snap/testsuite/test_snap.py
@@ -15,35 +15,41 @@ from grass.gunittest.gmodules import SimpleModule
 
 
 class TestSnapAbsoluteSTRDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-01",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -61,35 +67,42 @@ class TestSnapAbsoluteSTRDS(TestCase):
 
 
 class TestSnapRelativeSTRDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
@@ -107,35 +120,41 @@ class TestSnapRelativeSTRDS(TestCase):
 
 
 class TestSnapAbsoluteSTR3DS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r3.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="str3ds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster_3d", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-01",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster_3d",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A")
 
@@ -153,35 +172,42 @@ class TestSnapAbsoluteSTR3DS(TestCase):
 
 
 class TestSnapRelativeSTR3DS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r3.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="str3ds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="raster_3d", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="raster_3d",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A")
 
@@ -198,37 +224,42 @@ class TestSnapRelativeSTR3DS(TestCase):
         self.assertEqual(A.get_map_time(), "interval")
 
 
-
 class TestSnapAbsoluteSTVDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a4')
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a4")
 
-        cls.runModule("t.create", type="stvds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="stvds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="vector", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-01",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="vector",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="A")
 
@@ -246,35 +277,42 @@ class TestSnapAbsoluteSTVDS(TestCase):
 
 
 class TestSnapRelativeSTVDS(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a4')
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a4")
 
-        cls.runModule("t.create", type="stvds", temporaltype="relative",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="stvds",
+            temporaltype="relative",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", type="vector", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="0",
-                                     increment="14", unit="days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            type="vector",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="0",
+            increment="14",
+            unit="days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="A")
 
@@ -291,6 +329,7 @@ class TestSnapRelativeSTVDS(TestCase):
         self.assertEqual(A.get_map_time(), "interval")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.support/t.support.py
+++ b/temporal/t.support/t.support.py
@@ -86,6 +86,7 @@ import grass.script as grass
 
 ############################################################################
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
@@ -110,7 +111,7 @@ def main():
 
     update = False
     if aggr_type and type == "stvds":
-        return()
+        return ()
 
     if aggr_type and type != "stvds":
         stds.metadata.set_aggregation_type(aggregation_type=aggr_type)
@@ -130,7 +131,7 @@ def main():
         stds.update(dbif=dbif)
 
     if map_update:
-        #Update the registered maps from the grass spatial database
+        # Update the registered maps from the grass spatial database
         statement = ""
         # This dict stores the datasets that must be updated
         dataset_dict = {}
@@ -142,7 +143,7 @@ def main():
         for map in maps:
 
             count += 1
-            if count %10 == 0:
+            if count % 10 == 0:
                 grass.percent(count, len(maps), 1)
 
             map.select(dbif=dbif)
@@ -178,6 +179,7 @@ def main():
     stds.update_command_string(dbif=dbif)
 
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.support/testsuite/test_support_str3ds.py
+++ b/temporal/t.support/testsuite/test_support_str3ds.py
@@ -13,52 +13,64 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestSupportAbsoluteSTR3DS(TestCase):
 
+class TestSupportAbsoluteSTR3DS(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r3.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r3.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="str3ds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="str3ds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="raster_3d", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-15 12:05:45",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster_3d",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-15 12:05:45",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A")
 
     def test_1_metadata(self):
         """Set title, description and aggregation"""
 
-        title="A new title"
-        descr="A new description"
-        aggr_type="average"
-        semantic="sum"
+        title = "A new title"
+        descr = "A new description"
+        aggr_type = "average"
+        semantic = "sum"
 
-        self.assertModule("t.support", type="str3ds", input="A",
-                          title=title,
-                          description=descr,
-                          semantictype=semantic,
-                          aggr_type=aggr_type)
+        self.assertModule(
+            "t.support",
+            type="str3ds",
+            input="A",
+            title=title,
+            description=descr,
+            semantictype=semantic,
+            aggr_type=aggr_type,
+        )
 
         A = tgis.open_old_stds("A", type="str3ds")
         A.select()
@@ -101,6 +113,7 @@ class TestSupportAbsoluteSTR3DS(TestCase):
         self.assertEqual(A.metadata.get_number_of_maps(), 3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.support/testsuite/test_support_strds.py
+++ b/temporal/t.support/testsuite/test_support_strds.py
@@ -13,52 +13,63 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestSupportAbsoluteSTRDS(TestCase):
 
+class TestSupportAbsoluteSTRDS(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         cls.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         cls.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         cls.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
         cls.runModule("r.mapcalc", expression="a4 = 400", overwrite=True)
 
-        cls.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-15 12:05:45",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-15 12:05:45",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="strds", inputs="A")
 
     def test_1_metadata(self):
         """Set title, description and aggregation"""
 
-        title="A new title"
-        descr="A new description"
-        aggr_type="average"
-        semantic="sum"
+        title = "A new title"
+        descr = "A new description"
+        aggr_type = "average"
+        semantic = "sum"
 
-        self.assertModule("t.support", input="A",
-                          title=title,
-                          description=descr,
-                          semantictype=semantic,
-                          aggr_type=aggr_type)
+        self.assertModule(
+            "t.support",
+            input="A",
+            title=title,
+            description=descr,
+            semantictype=semantic,
+            aggr_type=aggr_type,
+        )
 
         A = tgis.open_old_stds("A", type="strds")
         A.select()
@@ -101,6 +112,7 @@ class TestSupportAbsoluteSTRDS(TestCase):
         self.assertEqual(A.metadata.get_number_of_maps(), 3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.support/testsuite/test_support_stvds.py
+++ b/temporal/t.support/testsuite/test_support_stvds.py
@@ -13,50 +13,62 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestSupportAbsoluteSTVDS(TestCase):
 
+class TestSupportAbsoluteSTVDS(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
         cls.use_temp_region()
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a4')
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a4")
 
-        cls.runModule("t.create", type="stvds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="stvds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
 
-        cls.runModule("t.register", flags="i", type="vector", input="A",
-                                     maps="a1,a2,a3,a4",
-                                     start="2001-01-15 12:05:45",
-                                     increment="14 days",
-                                     overwrite=True)
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="vector",
+            input="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-15 12:05:45",
+            increment="14 days",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="A")
 
     def test_1_metadata(self):
         """Set title, description and aggregation"""
 
-        title="A new title"
-        descr="A new description"
-        semantic="sum"
+        title = "A new title"
+        descr = "A new description"
+        semantic = "sum"
 
-        self.assertModule("t.support", type="stvds", input="A",
-                          title=title,
-                          description=descr,
-                          semantictype=semantic)
+        self.assertModule(
+            "t.support",
+            type="stvds",
+            input="A",
+            title=title,
+            description=descr,
+            semantictype=semantic,
+        )
 
         A = tgis.open_old_stds("A", type="stvds")
         A.select()
@@ -67,10 +79,10 @@ class TestSupportAbsoluteSTVDS(TestCase):
     def test_2_update(self):
         """Set title, description and aggregation"""
 
-        self.runModule("v.random", quiet=True, npoints=10, seed=1, output='a1')
-        self.runModule("v.random", quiet=True, npoints=10, seed=1, output='a2')
-        self.runModule("v.random", quiet=True, npoints=10, seed=1, output='a3')
-        self.runModule("v.random", quiet=True, npoints=10, seed=1, output='a4')
+        self.runModule("v.random", quiet=True, npoints=10, seed=1, output="a1")
+        self.runModule("v.random", quiet=True, npoints=10, seed=1, output="a2")
+        self.runModule("v.random", quiet=True, npoints=10, seed=1, output="a3")
+        self.runModule("v.random", quiet=True, npoints=10, seed=1, output="a4")
 
         self.assertModule("t.support", type="stvds", input="A", flags="m")
 
@@ -92,6 +104,7 @@ class TestSupportAbsoluteSTVDS(TestCase):
         self.assertEqual(A.metadata.get_number_of_maps(), 3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.topology/t.topology.py
+++ b/temporal/t.topology/t.topology.py
@@ -63,8 +63,8 @@ def main():
     name = options["input"]
     type = options["type"]
     where = options["where"]
-    temporal_relations = flags['m']
-    spatio_temporal_relations = flags['s']
+    temporal_relations = flags["m"]
+    spatio_temporal_relations = flags["s"]
 
     # Make sure the temporal database exists
     tgis.init()
@@ -72,8 +72,7 @@ def main():
     sp = tgis.open_old_stds(name, type)
 
     # Get ordered map list
-    maps = sp.get_registered_maps_as_objects(
-        where=where, order="start_time", dbif=None)
+    maps = sp.get_registered_maps_as_objects(where=where, order="start_time", dbif=None)
 
     spatial = None
 
@@ -90,7 +89,9 @@ def main():
     sp.base.print_info()
 
     #      0123456789012345678901234567890
-    print(" +-------------------- Temporal topology -------------------------------------+")
+    print(
+        " +-------------------- Temporal topology -------------------------------------+"
+    )
     if where:
         print(" | Is subset of dataset: ...... True")
     else:
@@ -124,7 +125,9 @@ def main():
         gran = tgis.compute_relative_time_granularity(maps)
     print(" | Granularity: ............... %s" % str(gran))
 
-    print(" +-------------------- Topological relations ---------------------------------+")
+    print(
+        " +-------------------- Topological relations ---------------------------------+"
+    )
     dict_ = sp.count_temporal_relations(maps)
 
     if dict_:
@@ -156,7 +159,10 @@ def main():
                 print(" | Follows: ................... %s" % (dict_[key]))
             if key == "precedes":
                 print(" | Precedes: .................. %s" % (dict_[key]))
-    print(" +----------------------------------------------------------------------------+")
+    print(
+        " +----------------------------------------------------------------------------+"
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -67,8 +67,7 @@ def main():
     tgis.init()
 
     if maps and file:
-        grass.fatal(_(
-            "%s= and %s= are mutually exclusive") % ("input", "file"))
+        grass.fatal(_("%s= and %s= are mutually exclusive") % ("input", "file"))
 
     if not maps and not file:
         grass.fatal(_("%s= or %s= must be specified") % ("input", "file"))
@@ -89,7 +88,9 @@ def main():
     # Map names as comma separated string
     if maps is not None and maps != "":
         if maps.find(",") == -1:
-            maplist = [maps, ]
+            maplist = [
+                maps,
+            ]
         else:
             maplist = maps.split(",")
 
@@ -122,7 +123,7 @@ def main():
     # Unregister already registered maps
     grass.message(_("Unregister maps"))
     for mapid in maplist:
-        if count %10 == 0:
+        if count % 10 == 0:
             grass.percent(count, num_maps, 1)
 
         map = tgis.dataset_factory(type, mapid)
@@ -132,8 +133,7 @@ def main():
             # Unregister from a single dataset
             if input:
                 # Collect SQL statements
-                statement += sp.unregister_map(
-                    map=map, dbif=dbif, execute=False)
+                statement += sp.unregister_map(map=map, dbif=dbif, execute=False)
 
             # Unregister from temporal database
             else:
@@ -147,8 +147,12 @@ def main():
                 # Collect SQL statements
                 statement += map.delete(dbif=dbif, update=False, execute=False)
         else:
-            grass.warning(_("Unable to find %s map <%s> in temporal database" %
-                            (map.get_type(), map.get_id())))
+            grass.warning(
+                _(
+                    "Unable to find %s map <%s> in temporal database"
+                    % (map.get_type(), map.get_id())
+                )
+            )
 
         count += 1
 
@@ -160,7 +164,7 @@ def main():
 
     # Update space time datasets
     if input:
-        grass.message(_("Unregister maps from space time dataset <%s>" %(input)))
+        grass.message(_("Unregister maps from space time dataset <%s>" % (input)))
     else:
         grass.message(_("Unregister maps from the temporal database"))
 
@@ -177,6 +181,7 @@ def main():
             count += 1
 
     dbif.close()
+
 
 ###############################################################################
 

--- a/temporal/t.unregister/testsuite/test_unregister.py
+++ b/temporal/t.unregister/testsuite/test_unregister.py
@@ -13,27 +13,23 @@ import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestUnregister(TestCase):
 
+class TestUnregister(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         tgis.init()
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
-        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0,
-                      t=50, res=10, res3=10)
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
 
     def setUp(self):
-        """Create input data
-        """
+        """Create input data"""
         self.runModule("r.mapcalc", expression="a1 = 100", overwrite=True)
         self.runModule("r.mapcalc", expression="a2 = 200", overwrite=True)
         self.runModule("r.mapcalc", expression="a3 = 300", overwrite=True)
@@ -41,33 +37,56 @@ class TestUnregister(TestCase):
         self.runModule("r.mapcalc", expression="a5 = 500", overwrite=True)
         self.runModule("r.mapcalc", expression="a6 = 600", overwrite=True)
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="A", title="A test",
-                                    description="A test", overwrite=True)
-        self.runModule("t.register", flags="i", type="raster", input="A",
-                                     maps="a1,a2,a3,a4,a5,a6",
-                                     start="2001-01-01", increment="3 months",
-                                     overwrite=True)
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="A",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="A",
+            maps="a1,a2,a3,a4,a5,a6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
-        self.runModule("t.create", type="strds", temporaltype="absolute",
-                                    output="B", title="B test",
-                                    description="B test", overwrite=True)
-        self.runModule("t.register", flags="i", type="raster", input="B",
-                                     maps="a1,a2,a3,a4,a5,a6",
-                                     start="2001-01-01", increment="3 months",
-                                     overwrite=True)
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="B",
+            title="B test",
+            description="B test",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="B",
+            maps="a1,a2,a3,a4,a5,a6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     def tearDown(self):
         """Remove generated data"""
-        self.runModule("g.remove", flags='f', type="raster",
-                                   name="a1,a2,a3,a4,a5,a6")
+        self.runModule("g.remove", flags="f", type="raster", name="a1,a2,a3,a4,a5,a6")
 
     def test_1(self):
         """Perform several unregistration operations"""
 
         # Prepare some strings for the tests
         new_line = os.linesep
-        a = ["a1","a2","a3","a4","a5","a6"]
+        a = ["a1", "a2", "a3", "a4", "a5", "a6"]
         al = new_line.join(a)
         al += new_line
 
@@ -77,63 +96,75 @@ class TestUnregister(TestCase):
         a456 = new_line.join(a[3:])
         a456 += new_line
 
-
         # Unregister maps a1, a2 and a3 from STRDS A
         self.assertModule("t.unregister", input="A", maps="a1,a2,a3")
 
-        lister = SimpleModule("t.rast.list", input="A", columns="name",
-                              flags="u")
+        lister = SimpleModule("t.rast.list", input="A", columns="name", flags="u")
         self.runModule(lister)
         self.assertEqual(a456, lister.outputs.stdout)
 
-
         # Check if all maps are present in STRDS B
-        lister = SimpleModule("t.rast.list", input="B", columns="name",
-                              flags="u")
+        lister = SimpleModule("t.rast.list", input="B", columns="name", flags="u")
         self.runModule(lister)
         self.assertEqual(al, lister.outputs.stdout)
 
-
         # Check if maps a1, a2 and a3 are still present in the temporal database
-        lister = SimpleModule("t.list", type="raster", columns="name",
-                              where='mapset = "%s" AND (name = "a1" OR name = "a2" OR name = "a3")' %(tgis.get_current_mapset()))
+        lister = SimpleModule(
+            "t.list",
+            type="raster",
+            columns="name",
+            where='mapset = "%s" AND (name = "a1" OR name = "a2" OR name = "a3")'
+            % (tgis.get_current_mapset()),
+        )
         self.runModule(lister)
         self.assertEqual(a123, lister.outputs.stdout)
-
 
         # Unregister maps a1, a2 and a3 from the temporal database
         self.assertModule("t.unregister", maps="a1,a2,a3")
 
-        lister = SimpleModule("t.list", type="raster", columns="name",
-                              where='mapset = "%s" AND (name = "a1" OR name = "a2" OR name = "a3")' %(tgis.get_current_mapset()))
+        lister = SimpleModule(
+            "t.list",
+            type="raster",
+            columns="name",
+            where='mapset = "%s" AND (name = "a1" OR name = "a2" OR name = "a3")'
+            % (tgis.get_current_mapset()),
+        )
         self.runModule(lister)
         self.assertEqual("", lister.outputs.stdout)
 
-
         # Check that masp a1, a2 and a3 are not present in STRDS B
-        lister = SimpleModule("t.rast.list", input="B", columns="name",
-                              flags="u")
+        lister = SimpleModule("t.rast.list", input="B", columns="name", flags="u")
         self.runModule(lister)
         self.assertEqual(a456, lister.outputs.stdout)
-
 
         # Remove STRDS A and B and check if maps a4, a5 and a6 are still in the temporal database
         self.assertModule("t.remove", type="strds", inputs="A,B")
 
-        lister = SimpleModule("t.list", type="raster", columns="name",
-                              where='mapset = "%s" AND (name = "a4" OR name = "a5" OR name = "a6")' %(tgis.get_current_mapset()))
+        lister = SimpleModule(
+            "t.list",
+            type="raster",
+            columns="name",
+            where='mapset = "%s" AND (name = "a4" OR name = "a5" OR name = "a6")'
+            % (tgis.get_current_mapset()),
+        )
         self.runModule(lister)
         self.assertEqual(a456, lister.outputs.stdout)
-
 
         # Unregister maps a4, a5 and a6 from the temporal database
         self.assertModule("t.unregister", maps="a4,a5,a6")
 
-        lister = SimpleModule("t.list", type="raster", columns="name",
-                              where='mapset = "%s" AND (name = "a4" OR name = "a5" OR name = "a6")' %(tgis.get_current_mapset()))
+        lister = SimpleModule(
+            "t.list",
+            type="raster",
+            columns="name",
+            where='mapset = "%s" AND (name = "a4" OR name = "a5" OR name = "a6")'
+            % (tgis.get_current_mapset()),
+        )
         self.runModule(lister)
         self.assertEqual("", lister.outputs.stdout)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -55,12 +55,13 @@
 import grass.script
 import sys
 
+
 def main():
     # lazy imports
     import grass.temporal as tgis
 
-    expression = options['expression']
-    basename = options['basename']
+    expression = options["expression"]
+    basename = options["basename"]
     spatial = flags["s"]
     stdstype = "stvds"
 
@@ -70,11 +71,16 @@ def main():
         import ply.lex as lex  # noqa: F401
         import ply.yacc as yacc  # noqa: F401
     except ImportError:
-        grass.script.fatal(_("Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."))
+        grass.script.fatal(
+            _(
+                "Please install PLY (Lex and Yacc Python implementation) to use the temporal algebra modules."
+            )
+        )
 
     tgis.init(True)
-    p = tgis.TemporalVectorAlgebraParser(run = True, debug=False, spatial = spatial)
+    p = tgis.TemporalVectorAlgebraParser(run=True, debug=False, spatial=spatial)
     p.parse(expression, basename, grass.script.overwrite())
+
 
 if __name__ == "__main__":
     options, flags = grass.script.parser()

--- a/temporal/t.vect.algebra/testsuite/test_vector_algebra.py
+++ b/temporal/t.vect.algebra/testsuite/test_vector_algebra.py
@@ -15,58 +15,109 @@ from grass.gunittest.main import test
 
 
 class TestTemporalVectorAlgebra(TestCase):
-
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
-        tgis.init(True) # Raise on error instead of exit(1)
+        tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
-        cls.runModule("g.region", n=80.0, s=0.0, e=120.0,
-                                       w=0.0, t=1.0, b=0.0, res=10.0)
+        cls.runModule("g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=1.0, b=0.0, res=10.0)
 
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output='a4')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=2, output='b1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=2, output='b2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=3, output='c1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=4, output='d1')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=4, output='d2')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=4, output='d3')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=5, output='singletmap')
-        cls.runModule("v.random", quiet=True, npoints=20, seed=6, output='singlemap')
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=1, output="a4")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=2, output="b1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=2, output="b2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=3, output="c1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=4, output="d1")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=4, output="d2")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=4, output="d3")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=5, output="singletmap")
+        cls.runModule("v.random", quiet=True, npoints=20, seed=6, output="singlemap")
 
-        tgis.open_new_stds(name="A", type="stvds", temporaltype="absolute",
-                                         title="A", descr="A", semantic="field")
-        tgis.open_new_stds(name="B", type="stvds", temporaltype="absolute",
-                                         title="B", descr="B", semantic="field")
-        tgis.open_new_stds(name="C", type="stvds", temporaltype="absolute",
-                                         title="B", descr="C", semantic="field")
-        tgis.open_new_stds(name="D", type="stvds", temporaltype="absolute",
-                                         title="D", descr="D", semantic="field")
+        tgis.open_new_stds(
+            name="A",
+            type="stvds",
+            temporaltype="absolute",
+            title="A",
+            descr="A",
+            semantic="field",
+        )
+        tgis.open_new_stds(
+            name="B",
+            type="stvds",
+            temporaltype="absolute",
+            title="B",
+            descr="B",
+            semantic="field",
+        )
+        tgis.open_new_stds(
+            name="C",
+            type="stvds",
+            temporaltype="absolute",
+            title="B",
+            descr="C",
+            semantic="field",
+        )
+        tgis.open_new_stds(
+            name="D",
+            type="stvds",
+            temporaltype="absolute",
+            title="D",
+            descr="D",
+            semantic="field",
+        )
 
-        tgis.register_maps_in_space_time_dataset(type="vector", name="A", maps="a1,a2,a3,a4",
-                                                 start="2001-01-01", increment="1 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="vector", name="B", maps="b1,b2",
-                                                 start="2001-01-01", increment="2 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="vector", name="C", maps="c1",
-                                                 start="2001-01-02", increment="2 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="vector", name="D", maps="d1,d2,d3",
-                                                 start="2001-01-03", increment="1 day", interval=True)
-        tgis.register_maps_in_space_time_dataset(type="vector", name=None, maps="singletmap",
-                                                start="2001-01-03", end="2001-01-04")
+        tgis.register_maps_in_space_time_dataset(
+            type="vector",
+            name="A",
+            maps="a1,a2,a3,a4",
+            start="2001-01-01",
+            increment="1 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="vector",
+            name="B",
+            maps="b1,b2",
+            start="2001-01-01",
+            increment="2 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="vector",
+            name="C",
+            maps="c1",
+            start="2001-01-02",
+            increment="2 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="vector",
+            name="D",
+            maps="d1,d2,d3",
+            start="2001-01-03",
+            increment="1 day",
+            interval=True,
+        )
+        tgis.register_maps_in_space_time_dataset(
+            type="vector",
+            name=None,
+            maps="singletmap",
+            start="2001-01-03",
+            end="2001-01-04",
+        )
 
     def tearDown(self):
         self.runModule("t.remove", type="stvds", inputs="R", quiet=True)
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
-        cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", type='stvds', quiet=True)
+        """Remove the temporary region"""
+        cls.runModule(
+            "t.remove", flags="rf", inputs="A,B,C,D", type="stvds", quiet=True
+        )
         cls.del_temp_region()
 
     def test_temporal_select(self):
@@ -83,13 +134,15 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_select_operators(self):
         """Testing the temporal select operator. Including temporal relations. """
 
-        self.assertModule("t.vect.algebra", expression="R = A {:,during} C", basename="r")
+        self.assertModule(
+            "t.vect.algebra", expression="R = A {:,during} C", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="stvds")
 
@@ -100,13 +153,15 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_buff_operators_1(self):
         """Testing the bufferoperator."""
 
-        self.assertModule("t.vect.algebra", expression="R = buff_p(A,0.5)", basename="r")
+        self.assertModule(
+            "t.vect.algebra", expression="R = buff_p(A,0.5)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="stvds")
 
@@ -117,13 +172,15 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_buff_operators_2(self):
         """Testing the bufferoperator."""
 
-        self.assertModule("t.vect.algebra", expression="R = buff_a(buff_p(A,1),10)", basename="r")
+        self.assertModule(
+            "t.vect.algebra", expression="R = buff_a(buff_p(A,1),10)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="stvds")
 
@@ -134,13 +191,15 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_overlay_operators_1(self):
         """Testing the spatial overlay operator."""
 
-        self.assertModule("t.vect.algebra", expression="R = buff_p(A,2) & buff_p(D,2)", basename="r")
+        self.assertModule(
+            "t.vect.algebra", expression="R = buff_p(A,2) & buff_p(D,2)", basename="r"
+        )
 
         D = tgis.open_old_stds("R", type="stvds")
 
@@ -151,13 +210,17 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
     def test_temporal_overlay_operators_2(self):
         """Testing the spatial overlay operator."""
 
-        self.assertModule("t.vect.algebra", expression="R = buff_p(A,1.5) {&,during,r} buff_p(B,1.5)", basename="r")
+        self.assertModule(
+            "t.vect.algebra",
+            expression="R = buff_p(A,1.5) {&,during,r} buff_p(B,1.5)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="stvds")
 
@@ -168,13 +231,17 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
-        self.assertEqual( D.check_temporal_topology(), False)
-        self.assertEqual(D.get_granularity(), u'2 days')
+        self.assertEqual(D.check_temporal_topology(), False)
+        self.assertEqual(D.get_granularity(), "2 days")
 
     def test_temporal_overlay_operators_3(self):
         """Testing the spatial overlay operator."""
 
-        self.assertModule("t.vect.algebra", expression="R = buff_p(A,2.5) {&,during,l} buff_p(C,2.5)", basename="r")
+        self.assertModule(
+            "t.vect.algebra",
+            expression="R = buff_p(A,2.5) {&,during,l} buff_p(C,2.5)",
+            basename="r",
+        )
 
         D = tgis.open_old_stds("R", type="stvds")
 
@@ -185,9 +252,9 @@ class TestTemporalVectorAlgebra(TestCase):
         start, end = D.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
-        self.assertEqual( D.check_temporal_topology(), True)
-        self.assertEqual(D.get_granularity(), u'1 day')
+        self.assertEqual(D.check_temporal_topology(), True)
+        self.assertEqual(D.get_granularity(), "1 day")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test()

--- a/temporal/t.vect.db.select/t.vect.db.select.py
+++ b/temporal/t.vect.db.select/t.vect.db.select.py
@@ -80,8 +80,9 @@ def main():
 
     sp = tgis.open_old_stds(input, "stvds")
 
-    rows = sp.get_registered_maps("name,layer,mapset,start_time,end_time",
-                                  tempwhere, "start_time", None)
+    rows = sp.get_registered_maps(
+        "name,layer,mapset,start_time,end_time", tempwhere, "start_time", None
+    )
 
     col_names = ""
     if rows:
@@ -92,13 +93,20 @@ def main():
             if row["layer"]:
                 layer = row["layer"]
 
-            select = grass.read_command("v.db.select", map=vector_name,
-                                        layer=layer, columns=columns,
-                                        separator="%s" % (separator), where=where)
+            select = grass.read_command(
+                "v.db.select",
+                map=vector_name,
+                layer=layer,
+                columns=columns,
+                separator="%s" % (separator),
+                where=where,
+            )
 
             if not select:
-                grass.fatal(_("Unable to run v.db.select for vector map <%s> "
-                              "with layer %s") % (vector_name, layer))
+                grass.fatal(
+                    _("Unable to run v.db.select for vector map <%s> " "with layer %s")
+                    % (vector_name, layer)
+                )
             # The first line are the column names
             list = select.split("\n")
             count = 0
@@ -107,18 +115,32 @@ def main():
                     # print the column names in case they change
                     if count == 0:
                         col_names_new = "start_time%send_time%s%s" % (
-                            separator, separator, entry)
+                            separator,
+                            separator,
+                            entry,
+                        )
                         if col_names != col_names_new:
                             col_names = col_names_new
                             print(col_names)
                     else:
                         if row["end_time"]:
-                            print("%s%s%s%s%s" % (row["start_time"], separator,
-                                                  row["end_time"], separator, entry))
+                            print(
+                                "%s%s%s%s%s"
+                                % (
+                                    row["start_time"],
+                                    separator,
+                                    row["end_time"],
+                                    separator,
+                                    entry,
+                                )
+                            )
                         else:
-                            print("%s%s%s%s" % (row["start_time"],
-                                                separator, separator, entry))
+                            print(
+                                "%s%s%s%s"
+                                % (row["start_time"], separator, separator, entry)
+                            )
                     count += 1
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.vect.export/t.vect.export.py
+++ b/temporal/t.vect.export/t.vect.export.py
@@ -85,8 +85,8 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
     # Export the space time vector dataset
-    tgis.export_stds(
-        _input, output, compression, directory, where, _format, "stvds")
+    tgis.export_stds(_input, output, compression, directory, where, _format, "stvds")
+
 
 ############################################################################
 if __name__ == "__main__":

--- a/temporal/t.vect.extract/t.vect.extract.py
+++ b/temporal/t.vect.extract/t.vect.extract.py
@@ -105,8 +105,20 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.extract_dataset(input, output, "vector", where, expression,
-                         base, time_suffix, nprocs, register_null, layer, type)
+    tgis.extract_dataset(
+        input,
+        output,
+        "vector",
+        where,
+        expression,
+        base,
+        time_suffix,
+        nprocs,
+        register_null,
+        layer,
+        type,
+    )
+
 
 ###############################################################################
 

--- a/temporal/t.vect.extract/testsuite/test_vect_extract.py
+++ b/temporal/t.vect.extract/testsuite/test_vect_extract.py
@@ -11,46 +11,68 @@ for details.
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
-class TestVectorExtraction(TestCase):
 
+class TestVectorExtraction(TestCase):
     @classmethod
     def setUpClass(cls):
-        """Initiate the temporal GIS and set the region
-        """
+        """Initiate the temporal GIS and set the region"""
         cls.use_temp_region()
 
         cls.runModule("g.region", s=0, n=80, w=0, e=120, res=10)
         # Use always the current mapset as temporal database
         for i in range(1, 11):
-            cls.runModule("v.random", output="a{c}".format(c=i), npoints=20,
-                          overwrite=True)
-            cls.runModule("v.db.addtable", map="a{c}".format(c=i),
-                          columns="value integer")
-            cls.runModule("v.db.update", map="a{c}".format(c=i),
-                          column="value", value="'random()'")
+            cls.runModule(
+                "v.random", output="a{c}".format(c=i), npoints=20, overwrite=True
+            )
+            cls.runModule(
+                "v.db.addtable", map="a{c}".format(c=i), columns="value integer"
+            )
+            cls.runModule(
+                "v.db.update",
+                map="a{c}".format(c=i),
+                column="value",
+                value="'random()'",
+            )
         # Create the temporal database
         cls.runModule("t.connect", flags="d")
         cls.runModule("t.info", flags="d")
-        cls.runModule("t.create", type="stvds", temporaltype="absolute",
-                      output="A", title="A testvect", description="A testvect",
-                      overwrite=True)
-        cls.runModule("t.register", flags="i", type="vector", input="A",
-                      maps="a1,a2,a3,a4,a5,a6,a7,a8,a9,a10", start="2001-01-01",
-                      increment="3 months", overwrite=True)
+        cls.runModule(
+            "t.create",
+            type="stvds",
+            temporaltype="absolute",
+            output="A",
+            title="A testvect",
+            description="A testvect",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="vector",
+            input="A",
+            maps="a1,a2,a3,a4,a5,a6,a7,a8,a9,a10",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        """Remove the temporary region
-        """
+        """Remove the temporary region"""
         cls.del_temp_region()
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="A")
 
     def test_selection(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.vect.extract", input="A", output="B",
-                          where="start_time > '2001-06-01'", overwrite=True)
+        self.assertModule(
+            "t.vect.extract",
+            input="A",
+            output="B",
+            where="start_time > '2001-06-01'",
+            overwrite=True,
+        )
 
-        tinfo_string="""start_time='2001-07-01 00:00:00'
+        tinfo_string = """start_time='2001-07-01 00:00:00'
         end_time='2003-07-01 00:00:00'
         granularity='3 months'
         map_time=interval
@@ -59,49 +81,80 @@ class TestVectorExtraction(TestCase):
         points=160"""
 
         info = SimpleModule("t.info", flags="g", type="stvds", input="B")
-        self.assertModuleKeyValue(module=info, reference=tinfo_string,
-                                  precision=2, sep="=")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
 
     def test_selection_no_suffix(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.vect.extract", input="A", output="B",
-                          where="start_time > '2001-06-01'", basename="b",
-                          overwrite=True)
-        self.assertVectorDoesNotExist('b_2001_07')
+        self.assertModule(
+            "t.vect.extract",
+            input="A",
+            output="B",
+            where="start_time > '2001-06-01'",
+            basename="b",
+            overwrite=True,
+        )
+        self.assertVectorDoesNotExist("b_2001_07")
         self.runModule("t.remove", flags="rf", type="stvds", inputs="B")
 
     def test_selection_suffix(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.vect.extract", input="A", output="B",
-                          expression="value > 0", basename="b",
-                          overwrite=True)
-        self.assertVectorDoesNotExist('b_2001_07')
+        self.assertModule(
+            "t.vect.extract",
+            input="A",
+            output="B",
+            expression="value > 0",
+            basename="b",
+            overwrite=True,
+        )
+        self.assertVectorDoesNotExist("b_2001_07")
         self.runModule("t.remove", flags="rf", type="stvds", inputs="B")
 
     def test_selection_time_suffix(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.vect.extract", input="A", output="B",
-                          expression="value > 0", basename="b", suffix="time",
-                          overwrite=True)
-        self.assertVectorExists('b_2001_01_01T00_00_00')
+        self.assertModule(
+            "t.vect.extract",
+            input="A",
+            output="B",
+            expression="value > 0",
+            basename="b",
+            suffix="time",
+            overwrite=True,
+        )
+        self.assertVectorExists("b_2001_01_01T00_00_00")
         self.runModule("t.remove", flags="rf", type="stvds", inputs="B")
 
     def test_selection_num_suffix(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.vect.extract", input="A", output="B",
-                          expression="value > 0", basename="b", suffix="num",
-                          overwrite=True)
-        self.assertVectorExists('b_00001')
+        self.assertModule(
+            "t.vect.extract",
+            input="A",
+            output="B",
+            expression="value > 0",
+            basename="b",
+            suffix="num",
+            overwrite=True,
+        )
+        self.assertVectorExists("b_00001")
         self.runModule("t.remove", flags="rf", type="stvds", inputs="B")
 
     def test_selection_num3_suffix(self):
         """Perform a simple selection by datetime"""
-        self.assertModule("t.vect.extract", input="A", output="B",
-                          expression="value > 0", basename="b",
-                          suffix="num%03", overwrite=True)
-        self.assertVectorExists('b_001')
+        self.assertModule(
+            "t.vect.extract",
+            input="A",
+            output="B",
+            expression="value > 0",
+            basename="b",
+            suffix="num%03",
+            overwrite=True,
+        )
+        self.assertVectorExists("b_001")
         self.runModule("t.remove", flags="rf", type="stvds", inputs="B")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     from grass.gunittest.main import test
+
     test()

--- a/temporal/t.vect.import/t.vect.import.py
+++ b/temporal/t.vect.import/t.vect.import.py
@@ -110,8 +110,21 @@ def main():
 
     tgis.init()
 
-    tgis.import_stds(input, output, directory, title, descr, location,
-                     None, exp, overr, create, "stvds", base)
+    tgis.import_stds(
+        input,
+        output,
+        directory,
+        title,
+        descr,
+        location,
+        None,
+        exp,
+        overr,
+        create,
+        "stvds",
+        base,
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.vect.list/t.vect.list.py
+++ b/temporal/t.vect.list/t.vect.list.py
@@ -90,7 +90,7 @@ import grass.script as grass
 
 
 def main():
-    #lazy imports
+    # lazy imports
     import grass.temporal as tgis
 
     # Get the options
@@ -106,8 +106,10 @@ def main():
     # Make sure the temporal database exists
     tgis.init()
 
-    tgis.list_maps_of_stds("stvds", input, columns, order, where, separator,
-                           method, header, outpath=output)
+    tgis.list_maps_of_stds(
+        "stvds", input, columns, order, where, separator, method, header, outpath=output
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.vect.observe.strds/t.vect.observe.strds.py
+++ b/temporal/t.vect.observe.strds/t.vect.observe.strds.py
@@ -59,8 +59,9 @@ from grass.exceptions import CalledModuleError
 
 ############################################################################
 
+
 class Sample(object):
-    def __init__(self, start = None, end = None, raster_names = None):
+    def __init__(self, start=None, end=None, raster_names=None):
         self.start = start
         self.end = end
         if raster_names is not None:
@@ -69,12 +70,18 @@ class Sample(object):
             self.raster_names = []
 
     def __str__(self):
-        return "Start: %s\nEnd: %s\nNames: %s\n" %(str(self.start), str(self.end), str(self.raster_names))
+        return "Start: %s\nEnd: %s\nNames: %s\n" % (
+            str(self.start),
+            str(self.end),
+            str(self.raster_names),
+        )
+
 
 ############################################################################
 
+
 def main():
-    #lazy imports
+    # lazy imports
     import grass.temporal as tgis
 
     # Get the options
@@ -95,7 +102,11 @@ def main():
     column_names = columns.split(",")
 
     if len(strds_names) != len(column_names):
-        grass.fatal(_("The number of columns must be equal to the number of space time raster datasets"))
+        grass.fatal(
+            _(
+                "The number of columns must be equal to the number of space time raster datasets"
+            )
+        )
 
     # Make sure the temporal database exists
     tgis.init()
@@ -114,18 +125,19 @@ def main():
     # Single space time raster dataset
     if len(strds_names) == 1:
         rows = first_strds.get_registered_maps(
-            columns="name,mapset,start_time,end_time",
-            order="start_time", dbif=dbif)
+            columns="name,mapset,start_time,end_time", order="start_time", dbif=dbif
+        )
 
         if not rows:
             dbif.close()
-            grass.fatal(_("Space time raster dataset <%s> is empty") %
-                        out_sp.get_id())
+            grass.fatal(_("Space time raster dataset <%s> is empty") % out_sp.get_id())
 
         for row in rows:
             start = row["start_time"]
             end = row["end_time"]
-            raster_maps = [row["name"] + "@" + row["mapset"],]
+            raster_maps = [
+                row["name"] + "@" + row["mapset"],
+            ]
 
             s = Sample(start, end, raster_maps)
             samples.append(s)
@@ -134,16 +146,30 @@ def main():
         for name in strds_names[1:]:
             dataset = tgis.open_old_stds(name, "strds", dbif)
             if dataset.get_temporal_type() != first_strds.get_temporal_type():
-                grass.fatal(_("Temporal type of space time raster datasets must be equal\n"
-                              "<%(a)s> of type %(type_a)s do not match <%(b)s> of type %(type_b)s"%
-                              {"a":first_strds.get_id(),
-                               "type_a":first_strds.get_temporal_type(),
-                               "b":dataset.get_id(),
-                               "type_b":dataset.get_temporal_type()}))
+                grass.fatal(
+                    _(
+                        "Temporal type of space time raster datasets must be equal\n"
+                        "<%(a)s> of type %(type_a)s do not match <%(b)s> of type %(type_b)s"
+                        % {
+                            "a": first_strds.get_id(),
+                            "type_a": first_strds.get_temporal_type(),
+                            "b": dataset.get_id(),
+                            "type_b": dataset.get_temporal_type(),
+                        }
+                    )
+                )
 
-        mapmatrizes = tgis.sample_stds_by_stds_topology("strds", "strds", strds_names,
-                                                      strds_names[0], False, None,
-                                                      "equal", False, False)
+        mapmatrizes = tgis.sample_stds_by_stds_topology(
+            "strds",
+            "strds",
+            strds_names,
+            strds_names[0],
+            False,
+            None,
+            "equal",
+            False,
+            False,
+        )
 
         for i in range(len(mapmatrizes[0])):
             isvalid = True
@@ -184,8 +210,7 @@ def main():
     for layer in range(num_samples):
         layer += 1
         # Skip existing layer
-        if vector_db and layer in vector_db and \
-           vector_db[layer]["layer"] == layer:
+        if vector_db and layer in vector_db and vector_db[layer]["layer"] == layer:
             continue
         if first:
             layers += "%i" % (layer)
@@ -197,23 +222,33 @@ def main():
 
     # We create a new vector map using the categories of the original map
     try:
-        grass.run_command("v.category", input=input, layer=layers,
-                          output=vectmap, option="transfer",
-                          overwrite=overwrite)
+        grass.run_command(
+            "v.category",
+            input=input,
+            layer=layers,
+            output=vectmap,
+            option="transfer",
+            overwrite=overwrite,
+        )
     except CalledModuleError:
-        grass.fatal(_("Unable to create new layers for vector map <%s>")
-                    % (vectmap))
+        grass.fatal(_("Unable to create new layers for vector map <%s>") % (vectmap))
 
     title = _("Observaion of space time raster dataset(s) <%s>") % (strds)
-    description= _("Observation of space time raster dataset(s) <%s>"
-                   " with vector map <%s>") % (strds, input)
+    description = _(
+        "Observation of space time raster dataset(s) <%s>" " with vector map <%s>"
+    ) % (strds, input)
 
     # Create the output space time vector dataset
-    out_sp = tgis.open_new_stds(output, "stvds",
-                                              first_strds.get_temporal_type(),
-                                              title, description,
-                                              first_strds.get_semantic_type(),
-                                              dbif, overwrite)
+    out_sp = tgis.open_new_stds(
+        output,
+        "stvds",
+        first_strds.get_temporal_type(),
+        title,
+        description,
+        first_strds.get_semantic_type(),
+        dbif,
+        overwrite,
+    )
 
     dummy = out_sp.get_new_map_instance(None)
 
@@ -224,8 +259,12 @@ def main():
         raster_names = sample.raster_names
 
         if len(raster_names) != len(column_names):
-            grass.fatal(_("The number of raster maps in a granule must "
-                          "be equal to the number of column names"))
+            grass.fatal(
+                _(
+                    "The number of raster maps in a granule must "
+                    "be equal to the number of column names"
+                )
+            )
 
         # Create the columns creation string
         columns_string = ""
@@ -238,47 +277,68 @@ def main():
             if raster_map.metadata.get_datatype() == "CELL":
                 coltype = "INT"
 
-            tmp_string = "%s %s," %(column, coltype)
+            tmp_string = "%s %s," % (column, coltype)
             columns_string += tmp_string
 
         # Remove last comma
-        columns_string = columns_string[0:len(columns_string) - 1]
+        columns_string = columns_string[0 : len(columns_string) - 1]
 
         # Try to add a column
         if vector_db and count in vector_db and vector_db[count]["table"]:
             try:
-                grass.run_command("v.db.addcolumn", map=vectmap,
-                                  layer=count, column=columns_string,
-                                  overwrite=overwrite)
+                grass.run_command(
+                    "v.db.addcolumn",
+                    map=vectmap,
+                    layer=count,
+                    column=columns_string,
+                    overwrite=overwrite,
+                )
             except CalledModuleError:
                 dbif.close()
-                grass.fatal(_("Unable to add column %s to vector map <%s> "
-                              "with layer %i") % (columns_string, vectmap, count))
+                grass.fatal(
+                    _("Unable to add column %s to vector map <%s> " "with layer %i")
+                    % (columns_string, vectmap, count)
+                )
         else:
             # Try to add a new table
             grass.message("Add table to layer %i" % (count))
             try:
-                grass.run_command("v.db.addtable", map=vectmap, layer=count,
-                                  columns=columns_string, overwrite=overwrite)
+                grass.run_command(
+                    "v.db.addtable",
+                    map=vectmap,
+                    layer=count,
+                    columns=columns_string,
+                    overwrite=overwrite,
+                )
             except CalledModuleError:
                 dbif.close()
-                grass.fatal(_("Unable to add table to vector map "
-                              "<%s> with layer %i") % (vectmap, count))
+                grass.fatal(
+                    _("Unable to add table to vector map " "<%s> with layer %i")
+                    % (vectmap, count)
+                )
 
         # Call v.what.rast for each raster map
         for name, column in zip(raster_names, column_names):
             try:
-                grass.run_command("v.what.rast", map=vectmap,
-                                  layer=count, raster=name,
-                                  column=column, where=where)
+                grass.run_command(
+                    "v.what.rast",
+                    map=vectmap,
+                    layer=count,
+                    raster=name,
+                    column=column,
+                    where=where,
+                )
             except CalledModuleError:
                 dbif.close()
-                grass.fatal(_("Unable to run v.what.rast for vector map <%s> "
-                            "with layer %i and raster map <%s>") %
-                            (vectmap, count, str(raster_names)))
+                grass.fatal(
+                    _(
+                        "Unable to run v.what.rast for vector map <%s> "
+                        "with layer %i and raster map <%s>"
+                    )
+                    % (vectmap, count, str(raster_names))
+                )
 
-        vect = out_sp.get_new_map_instance(dummy.build_id(vectmap,
-                                                          mapset, str(count)))
+        vect = out_sp.get_new_map_instance(dummy.build_id(vectmap, mapset, str(count)))
         vect.load()
 
         start = sample.start
@@ -287,8 +347,7 @@ def main():
         if out_sp.is_time_absolute():
             vect.set_absolute_time(start, end)
         else:
-            vect.set_relative_time(
-                start, end, first_strds.get_relative_time_unit())
+            vect.set_relative_time(start, end, first_strds.get_relative_time_unit())
 
         if vect.is_in_db(dbif):
             vect.update_all(dbif)
@@ -300,6 +359,7 @@ def main():
 
     out_sp.update_from_registered_maps(dbif)
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.vect.univar/t.vect.univar.py
+++ b/temporal/t.vect.univar/t.vect.univar.py
@@ -78,8 +78,9 @@ import grass.script as grass
 
 ############################################################################
 
+
 def main():
-    #lazy imports
+    # lazy imports
     import grass.temporal as tgis
 
     # Get the options
@@ -103,7 +104,9 @@ def main():
         output = None
 
     tgis.print_vector_dataset_univar_statistics(
-        input, output, twhere, layer, type, column, where, extended, header, separator)
+        input, output, twhere, layer, type, column, where, extended, header, separator
+    )
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()

--- a/temporal/t.vect.what.strds/t.vect.what.strds.py
+++ b/temporal/t.vect.what.strds/t.vect.what.strds.py
@@ -99,8 +99,9 @@ def main():
 
     if strds_sp.get_temporal_type() != sp.get_temporal_type():
         dbif.close()
-        grass.fatal(_("Input and aggregation dataset must "
-                      "have the same temporal type"))
+        grass.fatal(
+            _("Input and aggregation dataset must " "have the same temporal type")
+        )
 
     # Check if intervals are present in the sample dataset
     if sp.get_temporal_type() == "absolute":
@@ -110,11 +111,16 @@ def main():
 
     if map_time != "interval":
         dbif.close()
-        grass.fatal(_("All registered maps of the space time vector "
-                      "dataset must have time intervals"))
+        grass.fatal(
+            _(
+                "All registered maps of the space time vector "
+                "dataset must have time intervals"
+            )
+        )
 
-    rows = sp.get_registered_maps("name,layer,mapset,start_time,end_time",
-                                  tempwhere, "start_time", dbif)
+    rows = sp.get_registered_maps(
+        "name,layer,mapset,start_time,end_time", tempwhere, "start_time", dbif
+    )
 
     if not rows:
         dbif.close()
@@ -127,8 +133,7 @@ def main():
         vectmap = row["name"] + "@" + row["mapset"]
         layer = row["layer"]
 
-        raster_maps = tgis.collect_map_names(
-            strds_sp, dbif, start, end, sampling)
+        raster_maps = tgis.collect_map_names(strds_sp, dbif, start, end, sampling)
 
         aggreagated_map_name = None
 
@@ -136,17 +141,22 @@ def main():
             # Aggregation
             if method != "disabled" and len(raster_maps) > 1:
                 # Generate the temporary map name
-                aggreagated_map_name = "aggreagated_map_name_" + \
-                    str(os.getpid())
-                new_map = tgis.aggregate_raster_maps(raster_maps,
-                                                     aggreagated_map_name,
-                                                     start, end, 0, method,
-                                                     False, dbif)
+                aggreagated_map_name = "aggreagated_map_name_" + str(os.getpid())
+                new_map = tgis.aggregate_raster_maps(
+                    raster_maps,
+                    aggreagated_map_name,
+                    start,
+                    end,
+                    0,
+                    method,
+                    False,
+                    dbif,
+                )
                 aggreagated_map_name = aggreagated_map_name + "_0"
                 if new_map is None:
                     continue
                 # We overwrite the raster_maps list
-                raster_maps = (new_map.get_id(), )
+                raster_maps = (new_map.get_id(),)
 
             for rastermap in raster_maps:
 
@@ -165,49 +175,77 @@ def main():
 
                 try:
                     if layer:
-                        grass.run_command("v.db.addcolumn",
-                                          map=vectmap, layer=layer,
-                                          column="%s %s" % (col_name, coltype),
-                                          overwrite=grass.overwrite())
+                        grass.run_command(
+                            "v.db.addcolumn",
+                            map=vectmap,
+                            layer=layer,
+                            column="%s %s" % (col_name, coltype),
+                            overwrite=grass.overwrite(),
+                        )
                     else:
-                        grass.run_command("v.db.addcolumn", map=vectmap,
-                                          column="%s %s" % (col_name, coltype),
-                                          overwrite=grass.overwrite())
+                        grass.run_command(
+                            "v.db.addcolumn",
+                            map=vectmap,
+                            column="%s %s" % (col_name, coltype),
+                            overwrite=grass.overwrite(),
+                        )
                 except CalledModuleError:
                     dbif.close()
-                    grass.fatal(_("Unable to add column %s to vector map <%s>")
-                                % (col_name, vectmap))
+                    grass.fatal(
+                        _("Unable to add column %s to vector map <%s>")
+                        % (col_name, vectmap)
+                    )
 
                 # Call v.what.rast
                 try:
                     if layer:
-                        grass.run_command("v.what.rast", map=vectmap,
-                                          layer=layer, raster=rastermap,
-                                          column=col_name, where=where)
+                        grass.run_command(
+                            "v.what.rast",
+                            map=vectmap,
+                            layer=layer,
+                            raster=rastermap,
+                            column=col_name,
+                            where=where,
+                        )
                     else:
-                        grass.run_command("v.what.rast", map=vectmap,
-                                          raster=rastermap, column=col_name,
-                                          where=where)
+                        grass.run_command(
+                            "v.what.rast",
+                            map=vectmap,
+                            raster=rastermap,
+                            column=col_name,
+                            where=where,
+                        )
                 except CalledModuleError:
                     dbif.close()
-                    grass.fatal(_("Unable to run v.what.rast for vector map "
-                                  "<%s> and raster map <%s>") % (vectmap,
-                                                                 rastermap))
+                    grass.fatal(
+                        _(
+                            "Unable to run v.what.rast for vector map "
+                            "<%s> and raster map <%s>"
+                        )
+                        % (vectmap, rastermap)
+                    )
 
                 if aggreagated_map_name:
                     try:
-                        grass.run_command("g.remove", flags='f', type='raster',
-                                          name=aggreagated_map_name)
+                        grass.run_command(
+                            "g.remove",
+                            flags="f",
+                            type="raster",
+                            name=aggreagated_map_name,
+                        )
                     except CalledModuleError:
                         dbif.close()
-                        grass.fatal(_("Unable to remove raster map <%s>")
-                                    % (aggreagated_map_name))
+                        grass.fatal(
+                            _("Unable to remove raster map <%s>")
+                            % (aggreagated_map_name)
+                        )
 
                 # Use the first map in case a column names was provided
                 if column:
                     break
 
     dbif.close()
+
 
 if __name__ == "__main__":
     options, flags = grass.parser()


### PR DESCRIPTION
This applies Black 20.8b1 to all temporal modules and their tests.

Uses: black --target-version=py36
