### PR TITLE
wxGUI/vdigit: fix close settings dialog (if no vector map has been selected)

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -615,7 +615,8 @@ class BufferedMapWindow(MapWindowBase, Window):
                 # decorate with GDDC (transparency)
                 try:
                     gcdc = wx.GCDC(dc)
-                    self.pdcVector.DrawToDCClipped(gcdc, rgn)
+                    if self.pdcVector:
+                        self.pdcVector.DrawToDCClipped(gcdc, rgn)
                 except NotImplementedError as e:
                     print(e, file=sys.stderr)
                     self.pdcVector.DrawToDCClipped(dc, rgn)


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some vector map e.g. 'railroads'
3. Launch Vector digitizer,  2D view -> Vector digitizer, and choose 'railroads' vector map
4. Quit vector digitizer (click on the Quit toolbar tool)
5. Launch Vector digitizer again, but don't choose 'railroads' vector map
6. Launch Vector digitizer settings dialog (gear wheel icon on the vector digitizer toolbar tool)
7. Hit close button on the vector digitizer settings dialog
8. See error

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 605, in OnPaint

self.pdcVector.DrawToDCClipped(gcdc, rgn)
AttributeError
:
'NoneType' object has no attribute 'DrawToDCClipped'
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 605, in OnPaint

self.pdcVector.DrawToDCClipped(gcdc, rgn)
AttributeError
:
'NoneType' object has no attribute 'DrawToDCClipped'
```