### PR TITLE
libgis: Add string concatenation function

### DIFF
--- a/include/defs/gis.h
+++ b/include/defs/gis.h
@@ -748,6 +748,7 @@ char *G_store_upper(const char *);
 char *G_store_lower(const char *);
 char *G_strchg(char *, char, char);
 char *G_str_replace(const char *, const char *, const char *);
+char *G_str_concat(const char **, int, const char *, int);
 void G_strip(char *);
 char *G_chop(char *);
 void G_str_to_upper(char *);


### PR DESCRIPTION
Working on solutions for compiler warnings (#1247), specifically attempting to address a -Wformat-overflow I missed the existence of a string concatenation function.

This PR is a suggestion for a concatenation function added to libgis:

```c
char *G_str_concat(const char **src_strings, int num_strings, const char *sep, int maxsize);
```

It is based on a local version of the memccpy implementation taken from [www.open-std.org : N2349](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2349.htm).

The PR consists of two commits, one with the addition of the G_str_concat() function, the other is a fix for the mentioned warning (and serves as usage example).

This function could possibly find its use elsewhere, e.g. `r.li.cwed` has its own concatenation solution, which may justify the addition.