### PR TITLE
Fix compiler warnings, part 11

### DIFF
--- a/lib/gis/spawn.c
+++ b/lib/gis/spawn.c
@@ -744,32 +744,32 @@ static void parse_argvec(struct spawn *sp, const char **va)
 	    break;
 	}
 	else if (arg == SF_REDIRECT_FILE) {
-	    sp->redirects[sp->num_redirects].dst_fd = NEXT_ARG(va, int);
+	    sp->redirects[sp->num_redirects].dst_fd = (int)NEXT_ARG(va, intptr_t);
 
 	    sp->redirects[sp->num_redirects].src_fd = -1;
-	    sp->redirects[sp->num_redirects].mode = NEXT_ARG(va, int);
+	    sp->redirects[sp->num_redirects].mode = (int)NEXT_ARG(va, intptr_t);
 	    sp->redirects[sp->num_redirects].file = NEXT_ARG(va, const char *);
 
 	    sp->num_redirects++;
 	}
 	else if (arg == SF_REDIRECT_DESCRIPTOR) {
-	    sp->redirects[sp->num_redirects].dst_fd = NEXT_ARG(va, int);
-	    sp->redirects[sp->num_redirects].src_fd = NEXT_ARG(va, int);
+	    sp->redirects[sp->num_redirects].dst_fd = (int)NEXT_ARG(va, intptr_t);
+	    sp->redirects[sp->num_redirects].src_fd = (int)NEXT_ARG(va, intptr_t);
 
 	    sp->redirects[sp->num_redirects].file = NULL;
 	    sp->num_redirects++;
 	}
 	else if (arg == SF_CLOSE_DESCRIPTOR) {
-	    sp->redirects[sp->num_redirects].dst_fd = NEXT_ARG(va, int);
+	    sp->redirects[sp->num_redirects].dst_fd = (int)NEXT_ARG(va, intptr_t);
 
 	    sp->redirects[sp->num_redirects].src_fd = -1;
 	    sp->redirects[sp->num_redirects].file = NULL;
 	    sp->num_redirects++;
 	}
 	else if (arg == SF_SIGNAL) {
-	    sp->signals[sp->num_signals].which = NEXT_ARG(va, int);
-	    sp->signals[sp->num_signals].action = NEXT_ARG(va, int);
-	    sp->signals[sp->num_signals].signum = NEXT_ARG(va, int);
+	    sp->signals[sp->num_signals].which = (int)NEXT_ARG(va, intptr_t);
+	    sp->signals[sp->num_signals].action = (int)NEXT_ARG(va, intptr_t);
+	    sp->signals[sp->num_signals].signum = (int)NEXT_ARG(va, intptr_t);
 
 	    sp->signals[sp->num_signals].valid = 0;
 	    sp->num_signals++;

--- a/lib/gis/spawn.c
+++ b/lib/gis/spawn.c
@@ -732,6 +732,7 @@ static void begin_spawn(struct spawn *sp)
 }
 
 #define NEXT_ARG(var, type) ((type) *(var)++)
+#define NEXT_ARG_INT(var) (int)((intptr_t) *(var)++)
 
 static void parse_argvec(struct spawn *sp, const char **va)
 {
@@ -744,32 +745,32 @@ static void parse_argvec(struct spawn *sp, const char **va)
 	    break;
 	}
 	else if (arg == SF_REDIRECT_FILE) {
-	    sp->redirects[sp->num_redirects].dst_fd = (int)NEXT_ARG(va, intptr_t);
+	    sp->redirects[sp->num_redirects].dst_fd = NEXT_ARG_INT(va);
 
 	    sp->redirects[sp->num_redirects].src_fd = -1;
-	    sp->redirects[sp->num_redirects].mode = (int)NEXT_ARG(va, intptr_t);
+	    sp->redirects[sp->num_redirects].mode = NEXT_ARG_INT(va);
 	    sp->redirects[sp->num_redirects].file = NEXT_ARG(va, const char *);
 
 	    sp->num_redirects++;
 	}
 	else if (arg == SF_REDIRECT_DESCRIPTOR) {
-	    sp->redirects[sp->num_redirects].dst_fd = (int)NEXT_ARG(va, intptr_t);
-	    sp->redirects[sp->num_redirects].src_fd = (int)NEXT_ARG(va, intptr_t);
+	    sp->redirects[sp->num_redirects].dst_fd = NEXT_ARG_INT(va);
+	    sp->redirects[sp->num_redirects].src_fd = NEXT_ARG_INT(va);
 
 	    sp->redirects[sp->num_redirects].file = NULL;
 	    sp->num_redirects++;
 	}
 	else if (arg == SF_CLOSE_DESCRIPTOR) {
-	    sp->redirects[sp->num_redirects].dst_fd = (int)NEXT_ARG(va, intptr_t);
+	    sp->redirects[sp->num_redirects].dst_fd = NEXT_ARG_INT(va);
 
 	    sp->redirects[sp->num_redirects].src_fd = -1;
 	    sp->redirects[sp->num_redirects].file = NULL;
 	    sp->num_redirects++;
 	}
 	else if (arg == SF_SIGNAL) {
-	    sp->signals[sp->num_signals].which = (int)NEXT_ARG(va, intptr_t);
-	    sp->signals[sp->num_signals].action = (int)NEXT_ARG(va, intptr_t);
-	    sp->signals[sp->num_signals].signum = (int)NEXT_ARG(va, intptr_t);
+	    sp->signals[sp->num_signals].which = NEXT_ARG_INT(va);
+	    sp->signals[sp->num_signals].action = NEXT_ARG_INT(va);
+	    sp->signals[sp->num_signals].signum = NEXT_ARG_INT(va);
 
 	    sp->signals[sp->num_signals].valid = 0;
 	    sp->num_signals++;

--- a/raster/r.in.mat/main.c
+++ b/raster/r.in.mat/main.c
@@ -387,7 +387,7 @@ int main(int argc, char *argv[])
     G_adjust_Cell_head(&region, 1, 1);
     Rast_set_window(&region);
 
-    G_verbose_message("");
+    G_verbose_message(" ");
     G_verbose_message(_("Map <%s> bounds set to:"), map_name);
     G_verbose_message(_("northern edge=%f"), region.north);
     G_verbose_message(_("southern edge=%f"), region.south);
@@ -397,7 +397,7 @@ int main(int argc, char *argv[])
     G_verbose_message(_("ewres=%f"), region.ew_res);
     G_verbose_message(_("rows=%d"), region.rows);
     G_verbose_message(_("cols=%d"), region.cols);
-    G_verbose_message("");
+    G_verbose_message(" ");
 
     /* prep memory */
     raster = Rast_allocate_buf(map_type);
@@ -483,7 +483,7 @@ int main(int argc, char *argv[])
     Rast_command_history(&history);
     Rast_write_history(map_name, &history);
 
-    G_done_msg("");
+    G_done_msg(" ");
 
     exit(EXIT_SUCCESS);
 }

--- a/raster/r.info/main.c
+++ b/raster/r.info/main.c
@@ -528,7 +528,7 @@ int main(int argc, char **argv)
 		    }
 		}
 
-		fprintf(out, "n=%jd\n", rstats.count);
+		fprintf(out, "n=%" PRId64 "\n", rstats.count);
 		fprintf(out, "mean=%.15g\n", mean);
 		fprintf(out, "stddev=%.15g\n", sd);
 		fprintf(out, "sum=%.15g\n", rstats.sum);

--- a/raster/r.out.mat/main.c
+++ b/raster/r.out.mat/main.c
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
     }
 
     /***** Write bounds *****/
-    G_verbose_message("");
+    G_verbose_message(" ");
     G_verbose_message(_("Using the Current Region settings:"));
     G_verbose_message(_("northern edge=%f"), region.north);
     G_verbose_message(_("southern edge=%f"), region.south);
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     G_verbose_message(_("ewres=%f"), region.ew_res);
     G_verbose_message(_("rows=%d"), region.rows);
     G_verbose_message(_("cols=%d"), region.cols);
-    G_verbose_message("");
+    G_verbose_message(" ");
 
     for (i = 0; i < 4; i++) {
 	switch (i) {
@@ -374,7 +374,7 @@ int main(int argc, char *argv[])
 
     G_verbose_message(_("%ld bytes written to '%s'"), filesize, outfile);
 
-    G_done_msg("");
+    G_done_msg(" ");
 
     G_free(basename);
     G_free(outfile);

--- a/raster/r.sun/local_proto.h
+++ b/raster/r.sun/local_proto.h
@@ -44,7 +44,7 @@ void setHorizonInterval(double val);
 void setAngularLossDenominator();
 
 
-void cube(int, int);
+/* void cube(int, int); */
 
 double com_sol_const(int no_of_day);
 

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -118,8 +118,8 @@ int OUTGR(void);
 int min(int, int);
 int max(int, int);
 
-void cube(int, int);
-void (*func) (int, int);
+/*void cube(int, int);
+void (*func) (int, int);*/
 
 void joules2(struct SunGeometryConstDay *sunGeom,
 	     struct SunGeometryVarDay *sunVarGeom,
@@ -1685,9 +1685,9 @@ void where_is_point(double *length, struct SunGeometryVarDay *sunVarGeom,
  * }
  */
 
-void cube(jmin, imin)
+/*void cube(jmin, imin)
 {
-}
+}*/
 
 
 /*////////////////////////////////////////////////////////////////////// */
@@ -1837,7 +1837,7 @@ void calculate(double singleSlope, double singleAspect, double singleAlbedo,
 	}
 	sunVarGeom.zmax = zmax;
         shadowoffset_base = (j % (numRows)) * n * arrayNumInt;
-    #pragma omp parallel firstprivate(q1,tan_lam_l,z1,i,shadowoffset,longitTime,coslat,coslatsq,func,latitude,longitude,sin_phi_l,latid_l,sin_u,cos_u,sin_v,cos_v,lum, gridGeom,sunGeom,sunVarGeom,sunSlopeGeom,sunRadVar, elevin,aspin,slopein,civiltime,linkein,albedo,latin,coefbh,coefdh,incidout,longin,horizon,beam_rad,insol_time,diff_rad,refl_rad,glob_rad,mapset,per,decimals,str_step )
+    #pragma omp parallel firstprivate(q1,tan_lam_l,z1,i,shadowoffset,longitTime,coslat,coslatsq,latitude,longitude,sin_phi_l,latid_l,sin_u,cos_u,sin_v,cos_v,lum, gridGeom,sunGeom,sunVarGeom,sunSlopeGeom,sunRadVar, elevin,aspin,slopein,civiltime,linkein,albedo,latin,coefbh,coefdh,incidout,longin,horizon,beam_rad,insol_time,diff_rad,refl_rad,glob_rad,mapset,per,decimals,str_step )
     {
       #pragma omp for schedule(dynamic) 
 	for (i = 0; i < n; i++) {
@@ -1858,7 +1858,7 @@ void calculate(double singleSlope, double singleAspect, double singleAlbedo,
 		coslatsq = coslat * coslat;
 	    }
 
-	    func = NULL;
+	    /* func = NULL; */
 
 	    sunVarGeom.z_orig = z1 = sunVarGeom.zp = z[arrayOffset][i];
 

--- a/raster/r.sun/rsunglobals.h
+++ b/raster/r.sun/rsunglobals.h
@@ -60,4 +60,4 @@ extern struct pj_info iproj;
 extern struct pj_info oproj;
 
 
-extern void (*func) (int, int);
+/* extern void (*func) (int, int); */

--- a/raster/r.sun/rsunlib.c
+++ b/raster/r.sun/rsunlib.c
@@ -300,11 +300,11 @@ int searching(double *length, struct SunGeometryVarDay *sunVarGeom,
 
     if (succes == 1) {
 	where_is_point(length, sunVarGeom, gridGeom);
-	if (func == NULL) {
+	/*if (func == NULL) {
 	    gridGeom->xx0 = gridGeom->xg0;
 	    gridGeom->yy0 = gridGeom->yg0;
 	    return (3);
-	}
+	}*/
 	curvature_diff = EARTHRADIUS * (1. - cos(*length / EARTHRADIUS));
 
 	z2 = sunVarGeom->z_orig + curvature_diff +
@@ -338,7 +338,7 @@ double lumcline2(struct SunGeometryConstDay *sungeom,
     double timeoffset, horizPos;
     double horizonHeight;
 
-    func = cube;
+    /* func = cube; */
     sunVarGeom->isShadow = 0;
 
     if (useShadow()) {


### PR DESCRIPTION
Fixes compiler warnings:

- -Wformat
- -Wpointer-to-int-cast
- -Wimplicit-int
- -Wformat-zero-length


Eleventh part addressing #1247.

Modules / code parts directly affected:

- lib/gis
- r.sun
- r.in.mat
- r.out.mat
- r.info