### PR TITLE
Fix compiler warnings, part 12

### DIFF
--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -89,7 +89,7 @@ static int cmp(const void *a, const void *b)
 static char *icon_files(void)
 {
     char **list, *ret;
-    char buf[GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];
+    char buf[GNAME_MAX + GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];
     int i, count;
     size_t len;
     DIR *dir, *dir_i;
@@ -200,9 +200,9 @@ int main(int argc, char **argv)
     float xscale;
     float yscale;
 
-    char txt[1024], xlabel[512];
+    char txt[1024];
     char tic_name[1024];
-    char *name;
+    char *name, *xlabel;
     char color_name[20];
 
     FILE *fopen();
@@ -898,7 +898,7 @@ int main(int argc, char **argv)
     if ((strcmp(title[0]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
         *xlabel = '\0';
     else
-        sprintf(xlabel, "X: %s %s", title[0]->answer, tic_name);
+        G_asprintf(&xlabel, "X: %s %s", title[0]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 1.5;
     D_text_size(text_width, text_height);
@@ -1010,7 +1010,7 @@ int main(int argc, char **argv)
     if ((strcmp(title[1]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
         *xlabel = '\0';
     else
-        sprintf(xlabel, "Y: %s %s", title[1]->answer, tic_name);
+        G_asprintf(&xlabel, "Y: %s %s", title[1]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 1.5;
     D_text_size(text_width, text_height);

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -647,7 +647,7 @@ int cmp(const void *a, const void *b)
 char *icon_files(void)
 {
     char **list, *ret;
-    char buf[GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];
+    char buf[GNAME_MAX + GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];
     int i, count;
     size_t len;
     DIR *dir, *dir_i;

--- a/display/d.vect/main.c
+++ b/display/d.vect/main.c
@@ -516,7 +516,7 @@ int cmp(const void *a, const void *b)
 char *icon_files(void)
 {
     char **list, *ret;
-    char buf[GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];
+    char buf[GNAME_MAX + GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];
     int i, count;
     size_t len;
     DIR *dir, *dir_i;

--- a/imagery/i.maxlik/main.c
+++ b/imagery/i.maxlik/main.c
@@ -141,13 +141,13 @@ int main(int argc, char *argv[])
     Rast_free_cats(&cats);
 
     if (reject_fd > 0) {
-	char title[100];
+        char *title = NULL;
 	char *label[] = { "no data", "0.1%", "0.5%",
 			  "1%", "2%", "5%", "10%",
 			  "20%", "30%", "50%", "70%",
 			  "80%", "90%", "95%", "98%",
 			  "99%", "100%", "bad" };
-	sprintf(title, "Rejection Probability for %s", class_name);
+        G_asprintf(&title, "Rejection Probability for %s", class_name);
 
 	Rast_init_cats(title, &cats);
 	Rast_set_cats_title(title, &cats);

--- a/imagery/i.rectify/cp.c
+++ b/imagery/i.rectify/cp.c
@@ -4,7 +4,7 @@
 
 int get_control_points(struct Image_Group *group, int order)
 {
-    char msg[200];
+    char msg[GNAME_MAX + GMAPSET_MAX + 64];
 
     if (!I_get_control_points(group->name, &group->control_points))
 	exit(0);

--- a/include/grass/iostream/ami_stream.h
+++ b/include/grass/iostream/ami_stream.h
@@ -669,7 +669,7 @@ void AMI_STREAM<T>::persist(persistence p)  {
 // if you are careful.
 template<class T>
 char *AMI_STREAM<T>::sprint()  {
-  static char desc[BUFSIZ];
+  static char desc[BUFSIZ + 256];
   sprintf(desc, "[AMI_STREAM %s %ld]", path, (long)stream_len());
   return desc;
 }

--- a/lib/db/dbmi_base/error.c
+++ b/lib/db/dbmi_base/error.c
@@ -101,7 +101,7 @@ void db_protocol_error(void)
 void db_syserror(const char *s)
 {
     char lead[1024];
-    char msg[1024];
+    char msg[2048];
 
 
     err_flag = 0;
@@ -192,7 +192,7 @@ void db_print_error(void)
 	sprintf(lead, "%s: ", who);
 
     if (user_print_function) {
-	char buf[1024];
+        char buf[2048];
 
 	sprintf(buf, "%s%s\n", lead, err_msg);
 	user_print_function(buf);

--- a/lib/symbol/read.c
+++ b/lib/symbol/read.c
@@ -236,7 +236,7 @@ SYMBOL *S_read(const char *sname)
 {
     int i, j, k, l;
     FILE *fp;
-    char group[500], name[500], buf[2001];
+    char group[500], name[500], buf[2001], buf2[2048];
     const char *ms;
     char *c;
     double x, y, x2, y2, rad, ang1, ang2;
@@ -357,8 +357,8 @@ SYMBOL *S_read(const char *sname)
 		sscanf(data, "%lf %lf %lf %lf %lf %c", &x, &y, &rad, &ang1,
 		       &ang2, &clock);
 	    if (ret < 5) {
-		sprintf(buf, "Incorrect arc definition: '%s'", buf);
-		return (err(fp, symb, buf));
+		sprintf(buf2, "Incorrect arc definition: '%s'", buf);
+		return (err(fp, symb, buf2));
 	    }
 	    if (ret == 6 && (clock == 'c' || clock == 'C'))
 		i = 1;
@@ -441,8 +441,8 @@ SYMBOL *S_read(const char *sname)
 	    }
 	}
 	else {
-	    sprintf(buf, "Unknown keyword in symbol: '%s'", buf);
-	    return (err(fp, symb, buf));
+	    sprintf(buf2, "Unknown keyword in symbol: '%s'", buf);
+	    return (err(fp, symb, buf2));
 	    break;
 	}
     }

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -352,7 +352,8 @@ struct field_info *Vect_default_field_info(struct Map_info *Map,
 					   int field, const char *field_name, int type)
 {
     struct field_info *fi;
-    char buf[GNAME_MAX], buf2[GNAME_MAX];
+    char buf[GNAME_MAX];
+    char *buf2;
     const char *schema;
     dbConnection connection;
 
@@ -418,8 +419,8 @@ struct field_info *Vect_default_field_info(struct Map_info *Map,
     }
     schema = connection.schemaName;
     if (schema && strlen(schema) > 0) {
-	sprintf(buf2, "%s.%s", schema, buf);
-	fi->table = G_store(buf2);
+        G_asprintf(&buf2, "%s.%s", schema, buf);
+        fi->table = buf2;
     }
     else {
 	fi->table = G_store(buf);

--- a/lib/vector/Vlib/map.c
+++ b/lib/vector/Vlib/map.c
@@ -491,7 +491,13 @@ int Vect__delete(const char *map, int is_tmp)
             (strcmp(ent->d_name, "..") == 0))
             continue;
         
-        sprintf(path_buf, "%s/%s", path, ent->d_name);
+        ret = snprintf(path_buf, GPATH_MAX, "%s/%s", path, ent->d_name);
+        if (ret >= GPATH_MAX) {
+            G_warning(_("Filepath '%s/%s' exceeds max length"), path,
+                      ent->d_name);
+            closedir(dir);
+            return -1;
+        }
         G_debug(3, "delete file '%s'", path_buf);
         ret = unlink(path_buf);
         if (ret == -1) {

--- a/ps/ps.map/r_plt.c
+++ b/ps/ps.map/r_plt.c
@@ -8,7 +8,7 @@
 
 int read_point(double e, double n)
 {
-    char buf[1024], symb[1024];
+    char buf[2048], symb[1024];
     int r, g, b;
     int color_R, color_G, color_B;
     int fcolor_R, fcolor_G, fcolor_B;

--- a/raster/r.li/r.li.daemon/daemon.c
+++ b/raster/r.li/r.li.daemon/daemon.c
@@ -110,13 +110,19 @@ int calculateIndex(char *file, rli_func *f,
 	if (doneDir == -1 && errno != EEXIST)
 	    G_fatal_error(_("Cannot create %s directory"), out);
 
-	/* check if ~/.grass8/r.li/output exists */
-	sprintf(out, "%s%s", rlipath, "output");
+	/* check if ~/.grass7/r.li/output exists */
+        if (snprintf(out, GPATH_MAX, "%s%s", rlipath, "output") >= GPATH_MAX)
+            G_fatal_error(_("Filepath '%s%s' exceeds max length"), rlipath,
+                          "output");
 	doneDir = G_mkdir(out);
 	if (doneDir == -1 && errno != EEXIST)
 	    G_fatal_error(_("Cannot create %s directory"), out);
-	sprintf(out, "%s%s%c%s", rlipath, "output", HOST_DIRSEP, output);
-	res = open(out, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (snprintf(out, GPATH_MAX, "%s%s%c%s", rlipath, "output", HOST_DIRSEP,
+                     output) >= GPATH_MAX)
+            G_fatal_error(_("Filepath '%s%s%c%s' exceeds max length"), rlipath,
+                          "output", HOST_DIRSEP, output);
+        if ((res = open(out, O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1)
+            G_fatal_error(_("Cannot create %s output"), out);
     }
     i = 0;
 

--- a/raster/r.viewshed/main.cpp
+++ b/raster/r.viewshed/main.cpp
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
 	/* ************************************************************ */
 	/* set up external memory mode */
 	/* setup STREAM_DIR if not already set */
-	char buf[1000];
+    char buf[GPATH_MAX + 256];
 
 	if (getenv(STREAM_TMPDIR) != NULL) {
 	    /*if already set */

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -314,7 +314,7 @@ void print_info(const struct Map_info *Map)
     struct TimeStamp ts;
     int time_ok, first_time_ok, second_time_ok;
     struct bound_box box;
-    char tmp1[1024], tmp2[1024];
+    char tmp1[256], tmp2[256];
     
     time_ok = first_time_ok = second_time_ok = FALSE;
     map_type = Vect_maptype(Map);

--- a/vector/v.lidar.correction/main.c
+++ b/vector/v.lidar.correction/main.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
     int nsubregion_col, nsubregion_row;
     int subregion = 0, nsubregions = 0;
     const char *dvr, *db, *mapset;
-    char table_name[GNAME_MAX];
+    char table_name[GNAME_MAX + 64];
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
     double lambda, mean, stepN, stepE, HighThresh,
 	LowThresh;

--- a/vector/v.lidar.edgedetection/main.c
+++ b/vector/v.lidar.edgedetection/main.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     int dim_vect, nparameters, BW, npoints;
     double lambda_B, lambda_F, grad_H, grad_L, alpha, mean;
     const char *dvr, *db, *mapset;
-    char table_interpolation[GNAME_MAX], table_name[GNAME_MAX];
+    char table_interpolation[GNAME_MAX + 64], table_name[GNAME_MAX + 64];
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
 
     int last_row, last_column, flag_auxiliar = FALSE;

--- a/vector/v.lidar.growing/main.c
+++ b/vector/v.lidar.growing/main.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     double Thres_j, Thres_d, ew_resol, ns_resol;
     double minNS, minEW, maxNS, maxEW;
     const char *mapset;
-    char buf[1024], table_name[GNAME_MAX];
+    char buf[1024], table_name[GNAME_MAX + 64];
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
 
     int colorBordo, ripieno, conta, lungPunti, lungHull, xi, c1, c2;

--- a/vector/v.outlier/main.c
+++ b/vector/v.outlier/main.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     int dim_vect, nparameters, BW, npoints;
     double mean, lambda;
     const char *dvr, *db, *mapset;
-    char table_name[GNAME_MAX];
+    char table_name[GNAME_MAX + 64];
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
 
     int last_row, last_column, flag_auxiliar = FALSE;

--- a/vector/v.surf.bspline/main.c
+++ b/vector/v.surf.bspline/main.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     double N_extension, E_extension, edgeE, edgeN;
 
     const char *mapset, *drv, *db, *vector, *map;
-    char table_name[GNAME_MAX], title[64];
+    char table_name[GNAME_MAX + 64], title[64];
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
 
     int dim_vect, nparameters, BW;

--- a/vector/v.to.db/update.c
+++ b/vector/v.to.db/update.c
@@ -10,7 +10,7 @@ static int srch();
 int update(struct Map_info *Map)
 {
     int i, *catexst, *cex, upd, fcat;
-    char buf1[2000], buf2[2000], left[20], right[20];
+    char buf1[2000], buf2[2500], left[20], right[20];
     struct field_info *qFi, *Fi;
     dbString stmt, strval;
     dbDriver *driver;


### PR DESCRIPTION
Fixes compiler warnings:

- -Wformat-overflow=

Twelfth part addressing #1247.

Modules / code parts directly affected:

- lib/db/dbmi_base
- lib/imagery
- lib/symbol
- lib/vector/Vlib
- d.linegraph
- d.vect
- d.vect.thematic
- i.maxlik
- i.rectify
- ps.map
- r.li.daemon
- r.viewshed
- v.info
- v.lidar.correction
- v.lidar.edgedetection
- v.lidar.growing
- v.lidar.growing
- v.outlier
- v.surf.bspline
- v.to.db