### PR TITLE
CI: add proj-bin to have cs2cs for tests

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -11,6 +11,7 @@ libnetcdf-dev
 libopenblas-dev
 libpng-dev
 libproj-dev
+proj-bin
 libreadline-dev
 libzstd-dev
 python3-dateutil


### PR DESCRIPTION
There are several failing tests that can't find cs2cs