### PR TITLE
TGRASS: remove bogus band references error msg

### DIFF
--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -352,7 +352,8 @@ class RasterDataset(AbstractMapDataset):
         set the internal band identifier that should be insert/updated
         in the temporal database.
 
-        :return: True if success, False on error
+        :return: True if success, False if band references could not be
+                 read (due to an error or because not being present)
         """
 
         check, band_ref = self.ciface.read_raster_band_reference(

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -360,12 +360,6 @@ class RasterDataset(AbstractMapDataset):
         )
 
         if check < 1:
-            self.msgr.error(
-                _(
-                    "Unable to read band reference file "
-                    "for raster map <%s>" % (self.get_map_id())
-                )
-            )
             return False
 
         self.metadata.set_band_reference(band_ref)


### PR DESCRIPTION
In `t.register` it must be possible to provide custom band names such as "mask", "ndvi", "prec", "temperature", etc. as per band reference definition.
Hence, the fatal error message `Error when registering strds: Unable to read band reference file` is incorrect.

This PR removes this incorrect error message, originating from #63.

Addresses #505