### PR TITLE
lib/proj: fix results for ll equivalents

### DIFF
--- a/display/d.where/main.c
+++ b/display/d.where/main.c
@@ -113,6 +113,8 @@ int main(int argc, char **argv)
 	if (pj_get_kv(&iproj, in_proj_info, in_unit_info) < 0)
 	    G_fatal_error(_("Can't get projection key values of current location"));
 
+	oproj.pj = NULL;
+
 	if (wgs84->answer) {
 	    struct Key_Value *out_proj_info, *out_unit_info;
 

--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -960,7 +960,7 @@ int GPJ_transform(const struct pj_info *info_in,
 	    in_deg2rad = 0;
 	}
 #endif
-	if (info_out->proj[0]) {
+	if (info_out->pj) {
 	    METERS_out = info_out->meters;
 	    out_is_ll = !strncmp(info_out->proj, "ll", 2);
 #if PROJ_VERSION_MAJOR >= 6
@@ -989,7 +989,7 @@ int GPJ_transform(const struct pj_info *info_in,
 	    out_rad2deg = 0;
 	}
 #endif
-	if (info_out->proj[0]) {
+	if (info_out->pj) {
 	    METERS_in = info_out->meters;
 	    in_is_ll = !strncmp(info_out->proj, "ll", 2);
 #if PROJ_VERSION_MAJOR >= 6
@@ -1179,7 +1179,7 @@ int GPJ_transform_array(const struct pj_info *info_in,
 	    in_deg2rad = 0;
 	}
 #endif
-	if (info_out->proj[0]) {
+	if (info_out->pj) {
 	    METERS_out = info_out->meters;
 	    out_is_ll = !strncmp(info_out->proj, "ll", 2);
 #if PROJ_VERSION_MAJOR >= 6
@@ -1208,7 +1208,7 @@ int GPJ_transform_array(const struct pj_info *info_in,
 	    out_rad2deg = 0;
 	}
 #endif
-	if (info_out->proj[0]) {
+	if (info_out->pj) {
 	    METERS_in = info_out->meters;
 	    in_is_ll = !strncmp(info_out->proj, "ll", 2);
 #if PROJ_VERSION_MAJOR >= 6


### PR DESCRIPTION
On some systems, coordinate transformations to ll equivalents result in inf or very large values. This PR fixes this bug.