### PR TITLE
parser: Accept #-space-% to allow writing PEP8-compliant Python code

### DIFF
--- a/general/g.parser/main.c
+++ b/general/g.parser/main.c
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
     for (ctx.line = 1;; ctx.line++) {
 	char buff[4096];
 	char *cmd, *arg;
+	size_t line_size;
 
 	if (!fgets(buff, sizeof(buff), ctx.fp))
 	    break;
@@ -102,10 +103,19 @@ int main(int argc, char *argv[])
 	}
 	*arg = '\0';
 
-	if (buff[0] != '#' || buff[1] != '%')
+	line_size = strlen(buff);
+	if (line_size > 2 && buff[0] == '#') {
+	    if (buff[1] == '%')
+		cmd = buff + 2;
+	    else if (line_size > 3 && buff[1] == ' ' && buff[2] == '%')
+		cmd = buff + 3;
+	    else
+		continue;
+	}
+	else {
 	    continue;
+	}
 
-	cmd = buff + 2;
 	G_chop(cmd);
 
 	arg = strchr(cmd, ':');


### PR DESCRIPTION
Accept '# %' in parser script header definition because '#%' is against PEP8
(each line of a block comment starts with a # and a single space).
Only minimal changes to achive this support are included.

'#%' is still supported fully supported and remains in documentation.
The full switch to '# %' is left for v8.

Partial backport of 635224115c5ee9c29a9356210c3b03e5511ef6dc (#1287).
