### PR TITLE
d.mon: Do not clear an existing output file on fatal error

### DIFF
--- a/display/d.mon/start.c
+++ b/display/d.mon/start.c
@@ -47,11 +47,9 @@ char *start(const char *name, const char *output, int width, int height, int upd
                 D_setup_unity(0);
                 D_erase("white");
             }
-            else {
-                D_close_driver();
+            else
                 G_fatal_error(_("option <%s>: <%s> exists. To overwrite, use the --overwrite flag"),
                               "output", output_name);
-            }
         }
         D_close_driver(); /* must be called after check because this
                            * function produces default map file */


### PR DESCRIPTION
How to reproduce this issue
```bash
rm -f map.png
d.mon start=png
# draw anything
d.mon stop=png

d.mon start=png
# fatal error because map.png already exists, but at this point map.png is already cleared.
```

This PR causes a fatal error before closing the driver because the driver creates/overwrites a new/existing output file on closing.