### PR TITLE
wxGUI: fix calling coordselect validator

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2463,7 +2463,7 @@ class CoordinatesSelect(Panel):
 
         :return: None if values are not valid
         """
-        if self.coordsField.GetValidator().Validate():
+        if self.coordsField.GetValidator().Validate(self):
             return self.coordsField.GetValue().split(',')
 
         return None


### PR DESCRIPTION
Fixes using coordinate selection in dialogs:

```
Traceback (most recent call last):
  File "/home/anna/dev/grass/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/gselect.py", line 2403, in
<lambda>

self.coordsField.Bind(wx.EVT_TEXT, lambda event:
self._draw(delay=1))
  File "/home/anna/dev/grass/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/gselect.py", line 2451, in _draw

coords = self._getCoords()
  File "/home/anna/dev/grass/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/gui_core/gselect.py", line 2466, in
_getCoords

if self.coordsField.GetValidator().Validate():
TypeError
:
Validate() missing 1 required positional argument: 'parent'
```