### PR TITLE
wxGUI/mapwin: check if 'BufferedMapWindow' instance exist before calling '_runUpdateMap()' method

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -902,7 +902,7 @@ class BufferedMapWindow(MapWindowBase, Window):
                 return
 
     def _onUpdateMap(self, event):
-        if self.timerRunId == event.pid:
+        if self and self.timerRunId == event.pid:
             self._runUpdateMap()
 
     def _runUpdateMap(self):


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some raster elevation map e.g. `d.rast elevation`
3. Switch from 2D view -> 3D view
4. Try to switch to another LOCATION MAPSET via Data catalog
5. See error message

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/core/gthread.py",
line 137, in OnDone

event.ondone(event)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 906, in _onUpdateMap

self._runUpdateMap()
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 911, in _runUpdateMap

self._updateM(self.render, self.renderVector)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py",
line 928, in _updateM

self.Map.ChangeMapSize(self.GetClientSize())
RuntimeError
:
wrapped C/C++ object of type BufferedMapWindow has been
deleted
```