### PR TITLE
r.grow.distance: rename distance parameter to output

### DIFF
--- a/display/d.rast.num/d.rast.num.html
+++ b/display/d.rast.num/d.rast.num.html
@@ -28,7 +28,7 @@ No data cells are indicated with "Null".
 A) Distance from the streams network (North Carolina sample dataset):
 <div class="code"><pre>
 g.region raster=streams_derived -p
-r.grow.distance input=streams_derived distance=dist_from_streams
+r.grow.distance input=streams_derived output=dist_from_streams
 d.rast.num dist_from_streams -a
 </pre></div>
 

--- a/lib/gis/renamed_options
+++ b/lib/gis/renamed_options
@@ -240,6 +240,8 @@ r.flow|barin:barrier
 r.flow|flout:flowline
 r.flow|lgout:flowlength
 r.flow|dsout:flowaccumulation
+# r.grow.distance
+r.grow.distance|distance:output
 # r.his
 r.his|h_map:hue
 r.his|i_map:intensity

--- a/raster/r.grow.distance/main.c
+++ b/raster/r.grow.distance/main.c
@@ -9,7 +9,7 @@
  * PURPOSE:      Generates a raster map layer with contiguous areas 
  *               grown by one cell.
  *
- * COPYRIGHT:    (C) 2006-2013 by the GRASS Development Team
+ * COPYRIGHT:    (C) 2006-2021 by the GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
     opt.in = G_define_standard_option(G_OPT_R_INPUT);
 
     opt.dist = G_define_standard_option(G_OPT_R_OUTPUT);
-    opt.dist->key = "distance";
+    opt.dist->key = "output";
     opt.dist->required = NO;
     opt.dist->description = _("Name for distance output raster map");
     opt.dist->guisection = _("Output");

--- a/raster/r.grow.distance/r.grow.distance.html
+++ b/raster/r.grow.distance/r.grow.distance.html
@@ -71,7 +71,7 @@ distances in meters instead of map units.
 North Carolina sample dataset:
 <div class="code"><pre>
 g.region raster=streams_derived -p
-r.grow.distance input=streams_derived distance=dist_from_streams
+r.grow.distance input=streams_derived output=dist_from_streams
 r.colors map=dist_from_streams color=rainbow
 </pre></div>
 
@@ -90,7 +90,7 @@ r.colors map=dist_from_streams color=rainbow
 
 <div class="code"><pre>
 g.region raster=sea -p
-r.grow.distance -m input=sea distance=dist_from_sea_geodetic metric=geodesic
+r.grow.distance -m input=sea output=dist_from_sea_geodetic metric=geodesic
 r.colors map=dist_from_sea_geodetic color=rainbow
 </pre></div>
 

--- a/raster/r.grow.distance/testsuite/r_grow_distance_test.py
+++ b/raster/r.grow.distance/testsuite/r_grow_distance_test.py
@@ -38,7 +38,7 @@ class TestGrowDistance(TestCase):
     def test_grow(self):
         """Test to see if the outputs are created"""
         # run the grow distance module
-        self.assertModule("r.grow.distance", input=self.lakes, distance=self.distance)
+        self.assertModule("r.grow.distance", input=self.lakes, output=self.distance)
         # check to see if distance output is in mapset
         self.assertRasterExists(self.distance, msg="distance output was not created")
         self.assertRasterMinMax(

--- a/scripts/r.buffer.lowmem/r.buffer.lowmem.py
+++ b/scripts/r.buffer.lowmem/r.buffer.lowmem.py
@@ -100,7 +100,7 @@ def main():
         metric = "squared"
 
     grass.run_command(
-        "r.grow.distance", input=input, metric=metric, distance=temp_dist, flags="m"
+        "r.grow.distance", input=input, metric=metric, output=temp_dist, flags="m"
     )
 
     if zero:


### PR DESCRIPTION
Rename parameter for consistency and to reduce confusion. Updated in

- main.c, manual, testsuite
- lib/gis/renamed_options

The change is backward compatible and the user will be informed accordingly:

```
r.grow.distance input=streams_derived distance=dist_from_streams
WARNING: Please update the usage of <r.grow.distance>: option <distance>
         has been renamed to <output>
...
```

- followup changes also in r.buffer.lowmem + d.rast.num manual