### PR TITLE
wxGUI/lmgr: adjusts the position of the layer context option button (if opacity label is appended into layer name)

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -246,6 +246,14 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
     # for compatibility
     layer_selected = property(fget=_getSelectedLayer)
 
+    def _recalcLyrSettingsBtnPos(self):
+        """Recalculate layer context options button position
+
+        Calculates all the positions of the visible items fix
+        length from item to next non-toplevel window.
+        """
+        self.CalculatePositions()
+
     def GetSelectedLayers(self, checkedOnly=False):
         """Get selected layers as a list.
 
@@ -1234,12 +1242,16 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         dlg.applyOpacity.connect(
             lambda value: self.ChangeLayerOpacity(
                 layer=self.layer_selected, value=value))
+        # Apply button
+        dlg.applyOpacity.connect(
+            lambda: self._recalcLyrSettingsBtnPos())
         dlg.CentreOnParent()
 
         if dlg.ShowModal() == wx.ID_OK:
             self.ChangeLayerOpacity(
                 layer=self.layer_selected,
                 value=dlg.GetOpacity())
+            self._recalcLyrSettingsBtnPos()
         dlg.Destroy()
 
     def ChangeLayerOpacity(self, layer, value):
@@ -2045,9 +2057,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             mapName, found = GetLayerNameFromCmd(dcmd)
             mapLayer = self.GetLayerInfo(layer, key='maplayer')
             self.SetItemText(layer, mapName)
-            # calculates all the positions of the visible items
-            # fix length from item to next non-toplevel window position
-            self.CalculatePositions()
+            self._recalcLyrSettingsBtnPos()
 
             if not mapText or not found:
                 propwin.Hide()

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -246,7 +246,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
     # for compatibility
     layer_selected = property(fget=_getSelectedLayer)
 
-    def _recalcLyrSettingsBtnPos(self):
+    def _recalculateLayerButtonPosition(self):
         """Recalculate layer context options button position
 
         Calculates all the positions of the visible items fix
@@ -1244,14 +1244,14 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                 layer=self.layer_selected, value=value))
         # Apply button
         dlg.applyOpacity.connect(
-            lambda: self._recalcLyrSettingsBtnPos())
+            lambda: self._recalculateLayerButtonPosition())
         dlg.CentreOnParent()
 
         if dlg.ShowModal() == wx.ID_OK:
             self.ChangeLayerOpacity(
                 layer=self.layer_selected,
                 value=dlg.GetOpacity())
-            self._recalcLyrSettingsBtnPos()
+            self._recalculateLayerButtonPosition()
         dlg.Destroy()
 
     def ChangeLayerOpacity(self, layer, value):
@@ -2057,7 +2057,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             mapName, found = GetLayerNameFromCmd(dcmd)
             mapLayer = self.GetLayerInfo(layer, key='maplayer')
             self.SetItemText(layer, mapName)
-            self._recalcLyrSettingsBtnPos()
+            self._recalculateLayerButtonPosition()
 
             if not mapText or not found:
                 propwin.Hide()


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some vector or raster map e.g. `d.rast elevation`
3. Click on layer context option button and choose from invoked menu 'Change opacity level' item
4. Change opacity level to e.g. 80 and hit Ok or Apply button
5. Opacity label is appended into layer name, but context option button overlay this text

![wxgui_lmgr_layer_context_option_btn](https://user-images.githubusercontent.com/50632337/111029271-30e14900-83fc-11eb-8ca6-2c9fac78c7d7.png)

**Expected behavior**

![wxgui_lmgr_layer_context_option_btn_exp](https://user-images.githubusercontent.com/50632337/111029279-3b034780-83fc-11eb-9ae4-ace929016465.png)