### PR TITLE
libproj: added alias for ITRF92

### DIFF
--- a/lib/proj/convert.c
+++ b/lib/proj/convert.c
@@ -1066,6 +1066,8 @@ static const char *papszDatumEquiv[] = {
     "Deutsches_Hauptdreiecksnetz",
     "South_American_1969",
     "South_American_Datum_1969",
+    "International_Terrestrial_Reference_Frame_1992",
+    "ITRF92",
     "ITRF_1992",
     "ITRF92",
     NULL


### PR DESCRIPTION
adds "International_Terrestrial_Reference_Frame_1992" as an alias for ITRF92

Ref: https://lists.osgeo.org/pipermail/grass-user/2021-March/082282.html