### PR TITLE
TGIS DB mismatch: t.upgrade is now available as the core module

### DIFF
--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -703,9 +703,7 @@ def init(raise_fatal_error=False, skip_db_version_check=False):
         "to avoid lossing data.\nSOLUTION: "
     )
     if tgis_db_version > 2:
-        backup_howto += _(
-            "Run t.upgrade command to upgrade your temporal database.\n"
-        )
+        backup_howto += _("Run t.upgrade command to upgrade your temporal database.\n")
     else:
         backup_howto += _(
             "You need to export it by "

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -704,8 +704,7 @@ def init(raise_fatal_error=False, skip_db_version_check=False):
     )
     if tgis_db_version > 2:
         backup_howto += _(
-            "Run t.upgrade command installed from "
-            "GRASS Addons in order to upgrade your temporal database.\n"
+            "Run t.upgrade command to upgrade your temporal database.\n"
         )
     else:
         backup_howto += _(


### PR DESCRIPTION
Message on TGIS DB mismatch:

```
ERROR: Unsupported temporal database: version mismatch.
The format of your actual temporal database is not supported any more.
Please create a backup of your temporal database to avoid lossing data.
SOLUTION: Run t.upgrade command installed from GRASS Addons in order to
upgrade your temporal database.
```

needs to be updated since `t.upgrade` was added to the master branch 98347de41fef20fc677dd55e32eb283c3bc645c1. 

The message is changed by this PR to:

```
ERROR: Unsupported temporal database: version mismatch.
The format of your actual temporal database is not supported any more.
Please create a backup of your temporal database to avoid lossing data.
SOLUTION: Run t.upgrade command to upgrade your temporal database.
```