### PR TITLE
t.info: clarify 'dataset not found' error message

### DIFF
--- a/temporal/t.info/t.info.py
+++ b/temporal/t.info/t.info.py
@@ -112,7 +112,11 @@ def main():
     dataset = tgis.dataset_factory(type_, id_)
 
     if not dataset.is_in_db(dbif):
-        grass.fatal(_("Dataset <%s> not found in temporal database") % (id_))
+        grass.fatal(
+            _("Dataset <{n}> of type <{t}> not found in temporal database").format(
+                n=id_, t=type_
+            )
+        )
 
     dataset.select(dbif)
 


### PR DESCRIPTION
Let's create a vector space-time dataset:

```
t.create v type=stvds title=x desc=y
```

and try print its metadata:

```
t.info v
ERROR: Dataset <v@metadata> not found in temporal database
```

The error message above can be misleading. There is a dataset named 'v' in the temporal database.

This PR adds also information about current `type`.

```
t.info v
ERROR: Dataset <v@metadata> of type <strds> not found in temporal database
```