### PR TITLE
v.colors: Backport #1478

### DIFF
--- a/vector/v.colors/local_proto.h
+++ b/vector/v.colors/local_proto.h
@@ -3,24 +3,24 @@
 #define USE_CAT  2
 #define USE_Z    3
 
-/* make_colors.c */
-void make_colors(struct Colors *, const char *, DCELL, DCELL, int);
-void load_colors(struct Colors *, const char *, DCELL, DCELL, int);
-
-/* scan_attr.c */
-int scan_attr(const struct Map_info *, int, const char *, const char *,
-	      const char *, const struct FPRange *, struct Colors *,
-	      struct Colors *);
-void color_rules_to_cats(dbCatValArray *, int, struct Colors *,
-			 struct Colors *);
-
 /* scan_cats.c */
 void scan_cats(const struct Map_info *, int, const char *, const char *,
 	       const struct FPRange *, struct Colors *);
 
+/* scan_attr.c */
+int scan_attr(const struct Map_info *, int, const char *, const char *,
+	      const char *, const struct FPRange *, struct Colors *,
+	      struct Colors *, int);
+
 /* scan_z.c */
 void scan_z(struct Map_info *, int, const char *, const char *,
-	    const struct FPRange *, struct Colors *);
+	    const struct FPRange *, struct Colors *, int);
+
+/* make_colors.c */
+void make_colors(struct Colors *, const char *, DCELL, DCELL, int);
+void load_colors(struct Colors *, const char *, DCELL, DCELL, int);
+void color_rules_to_cats(dbCatValArray *, int, struct Colors *,
+			 struct Colors *, int, DCELL, DCELL);
 
 /* write_rgb.c */
 void write_rgb_values(const struct Map_info *, int, const char *,

--- a/vector/v.colors/main.c
+++ b/vector/v.colors/main.c
@@ -35,12 +35,13 @@ int main(int argc, char *argv[])
     } flag;
 
     struct {
-	struct Option *map, *field, *colr, *rast, *volume, *rules,
-          *attrcol, *rgbcol, *range, *use;
+	struct Option *map, *field, *colr, *rast, *volume, *rules, *attrcol,
+		      *rgbcol, *range, *use;
     } opt;
 
     int layer;
-    int overwrite, remove, is_from_stdin, stat, have_colors, convert, use;
+    int overwrite, remove, is_from_stdin, stat, have_colors, convert, invert,
+	use;
     const char *mapset, *cmapset;
     const char *style, *rules, *cmap, *attrcolumn, *rgbcolumn;
     char *name;
@@ -188,6 +189,7 @@ int main(int argc, char *argv[])
     attrcolumn = opt.attrcol->answer;
     rgbcolumn = opt.rgbcol->answer;
     convert = flag.c->answer;
+    invert = flag.n->answer;
     use = USE_CAT;
     if (opt.use->answer) {
         switch (opt.use->answer[0]) {
@@ -212,7 +214,8 @@ int main(int argc, char *argv[])
     if (use == USE_ATTR && !attrcolumn)
         G_fatal_error(_("Option <%s> required"), opt.attrcol->key);
     if (use != USE_ATTR && attrcolumn) {
-        G_important_message(_("Option <%s> given, assuming <use=attr>..."), opt.attrcol->key);
+	G_important_message(_("Option <%s> given, assuming <use=attr>..."),
+			    opt.attrcol->key);
         use = USE_ATTR;
     }
 
@@ -253,7 +256,8 @@ int main(int argc, char *argv[])
     if (remove) {
 	stat = Vect_remove_colors(name, mapset);
         if (stat < 0)
-            G_fatal_error(_("Unable to remove color table of vector map <%s>"), name);
+	    G_fatal_error(_("Unable to remove color table of vector map <%s>"),
+			  name);
         if (stat == 0)
             G_warning(_("Color table of vector map <%s> not found"), name);
         return EXIT_SUCCESS;
@@ -262,9 +266,8 @@ int main(int argc, char *argv[])
     G_suppress_warnings(TRUE);
     have_colors = Vect_read_colors(name, mapset, NULL);
 
-    if (have_colors > 0 && !overwrite) {
+    if (have_colors > 0 && !overwrite)
         G_fatal_error(_("Color table exists. Exiting."));
-    }
 
     G_suppress_warnings(FALSE);
 
@@ -302,12 +305,12 @@ int main(int argc, char *argv[])
         else if (use == USE_Z) {
 	    scan_z(&Map, layer, style, rules,
 		      opt.range->answer ? &range : NULL,
-		      &colors);
+		      &colors, invert);
         }
         else {
 	    scan_attr(&Map, layer, attrcolumn, style, rules,
 		      opt.range->answer ? &range : NULL,
-		      &colors, NULL);
+		      &colors, NULL, invert);
 	}
     }
     else {
@@ -332,12 +335,9 @@ int main(int argc, char *argv[])
 	    colors_tmp = colors;
 	    scan_attr(&Map, layer, attrcolumn, style, rules,
 		      opt.range->answer ? &range : NULL,
-		      &colors, &colors_tmp);
+		      &colors, &colors_tmp, invert);
 	}
     }
-
-    if (flag.n->answer)
-        Rast_invert_colors(&colors);
 
     /* TODO ?
     if (flag.e->answer) {
@@ -357,6 +357,9 @@ int main(int argc, char *argv[])
         colors = colors_tmp;
     }
 
+    if (use == USE_CAT && invert)
+	Rast_invert_colors(&colors);
+
     G_important_message(_("Writing color rules..."));
 
     if (style || rules || opt.rast->answer || opt.volume->answer) {
@@ -375,8 +378,8 @@ int main(int argc, char *argv[])
 
     G_message(_("Color table for vector map <%s> set to '%s'"),
 	      G_fully_qualified_name(name, mapset),
-              is_from_stdin || convert ? "rules" : style ? style : rules ? rules :
-              cmap);
+              is_from_stdin || convert ? "rules" :
+	      (style ? style : (rules ? rules : cmap)));
 
     exit(EXIT_SUCCESS);
 }

--- a/vector/v.colors/make_colors.c
+++ b/vector/v.colors/make_colors.c
@@ -2,9 +2,11 @@
 
 #include <grass/gis.h>
 #include <grass/raster.h>
+#include <grass/dbmi.h>
 #include <grass/glocale.h>
 
-void make_colors(struct Colors *colors, const char *style, DCELL min, DCELL max, int is_fp)
+void make_colors(struct Colors *colors, const char *style, DCELL min, DCELL max,
+		 int is_fp)
 {
 
     G_debug(3, "make_colors(): range=%f,%f is_fp=%d", min, max, is_fp);
@@ -38,12 +40,14 @@ void make_colors(struct Colors *colors, const char *style, DCELL min, DCELL max,
     }
 }
 
-void load_colors(struct Colors *colors, const char *rules, DCELL min, DCELL max, int is_fp)
+void load_colors(struct Colors *colors, const char *rules, DCELL min, DCELL max,
+		 int is_fp)
 {
     int ret;
 
     if (rules[0] == '-' && rules[1] == 0)
-	ret = Rast_read_color_rules(colors, min, max, Rast_read_color_rule, stdin);
+	ret = Rast_read_color_rules(colors, min, max, Rast_read_color_rule,
+				    stdin);
     else if (is_fp)
 	ret = Rast_load_fp_colors(colors, rules, (DCELL) min, (DCELL) max);
     else
@@ -51,4 +55,46 @@ void load_colors(struct Colors *colors, const char *rules, DCELL min, DCELL max,
 
     if (ret == 0)
 	G_fatal_error(_("Unable to load rules file <%s>"), rules);
+}
+
+void color_rules_to_cats(dbCatValArray *cvarr, int is_fp,
+			 struct Colors *vcolors, struct Colors *colors,
+			 int invert, DCELL min, DCELL max)
+{
+    int i, cat;
+    dbCatVal *cv;
+    int red, grn, blu;
+
+    /* color table for categories */
+    G_message(_("Converting color rules into categories..."));
+    for (i = 0; i < cvarr->n_values; i++) {
+	G_percent(i, cvarr->n_values, 2);
+	cv = &(cvarr->value[i]);
+	cat = cv->cat;
+	if (is_fp) {
+	    DCELL v = invert ? min + max - cv->val.d : cv->val.d;
+	    if (Rast_get_d_color((const DCELL *) &v, &red, &grn, &blu,
+				 vcolors) == 0) {
+		/* G_warning(_("No color rule defined for value %f"), v); */
+		G_debug(3, "scan_attr(): cat=%d, val=%f -> no color rule",
+			cat, v);
+		continue;
+	    }
+	}
+	else {
+	    CELL v = invert ? (CELL) min + (CELL) max - cv->val.i : cv->val.i;
+	    if (Rast_get_c_color((const CELL *) &v, &red, &grn, &blu,
+				 vcolors) == 0) {
+		/* G_warning(_("No color rule defined for value %d"), v); */
+		G_debug(3, "scan_attr(): cat=%d, val=%d -> no color rule",
+			cat, v);
+		continue;
+	    }
+	}
+	G_debug(3, "scan_attr(): cat=%d, val=%f, r=%d, g=%d, b=%d",
+		cat, is_fp ? cv->val.d : cv->val.i, red, grn, blu);
+	Rast_add_c_color_rule((const CELL*) &cat, red, grn, blu,
+			      (const CELL*) &cat, red, grn, blu, colors);
+    }
+    G_percent(2, 2, 2);
 }

--- a/vector/v.colors/scan_cats.c
+++ b/vector/v.colors/scan_cats.c
@@ -52,9 +52,8 @@ void scan_cats(const struct Map_info *Map, int field,
 
     if (style)
 	make_colors(colors, style, (DCELL) cmin, (DCELL) cmax, FALSE);
-    else if (rules) {
+    else if (rules)
 	load_colors(colors, rules, (DCELL) cmin, (DCELL) cmax, FALSE);
-    }
 
     Vect_destroy_cats_struct(Cats);
 }

--- a/vector/v.colors/scan_z.c
+++ b/vector/v.colors/scan_z.c
@@ -6,7 +6,7 @@
 
 void scan_z(struct Map_info *Map, int field,
             const char *style, const char *rules,
-            const struct FPRange *range, struct Colors *colors)
+            const struct FPRange *range, struct Colors *colors, int invert)
 {
     int ltype, line, cat, i, found;
     int items_alloc;
@@ -26,7 +26,9 @@ void scan_z(struct Map_info *Map, int field,
     cvarr.ctype = DB_C_TYPE_DOUBLE;
 
     Vect_set_constraint_field(Map, field);
-    Vect_set_constraint_type(Map, GV_POINTS); /* points, centroids or kernels only) */
+
+    /* points, centroids or kernels only) */
+    Vect_set_constraint_type(Map, GV_POINTS);
 
     G_message(_("Reading features..."));
     line = i = found = 0;
@@ -78,15 +80,13 @@ void scan_z(struct Map_info *Map, int field,
 
     if (style)
 	make_colors(&vcolors, style, (DCELL) zmin, (DCELL) zmax, TRUE);
-    else if (rules) {
+    else if (rules)
 	load_colors(&vcolors, rules, (DCELL) zmin, (DCELL) zmax, TRUE);
-    }
 
     /* color table for categories */
-    color_rules_to_cats(&cvarr, TRUE, &vcolors, colors);
+    color_rules_to_cats(&cvarr, TRUE, &vcolors, colors, invert, zmin, zmax);
 
     Vect_destroy_line_struct(Points);
     Vect_destroy_cats_struct(Cats);
     db_CatValArray_free(&cvarr);
-
 }

--- a/vector/v.colors/write_rgb.c
+++ b/vector/v.colors/write_rgb.c
@@ -4,8 +4,8 @@
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
-void write_rgb_values(const struct Map_info *Map, int layer, const char *column_name,
-		      struct Colors *colors)
+void write_rgb_values(const struct Map_info *Map, int layer,
+		      const char *column_name, struct Colors *colors)
 {
     int ctype, nrec, i;
     int red, grn, blu;


### PR DESCRIPTION
* v.colors: Fix color inversion

* 80 columns

* Consistent spacing after casting

* Use val.i for CELL

* Use Rast_invert_colors() instead of invert_cat_colors() for cat-based colors