### PR TITLE
CI: Make test report available as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,9 @@ jobs:
       run: .github/workflows/test_simple.sh
     - name: Run tests
       run: .github/workflows/test_thorough.sh
+    - name: Make HTML test report available
+      uses: actions/upload-artifact@v2
+      with:
+        name: testreport-${{ matrix.os }}
+        path: testreport
+        retention-days: 3


### PR DESCRIPTION
Make the HTML test report available as an GitHub Actions artifact.
One ZIP file for each run for download, available for 3 days.

Backport of #1290.
