### PR TITLE
pythonlib: Fix stylistic Flake8 warnings

### DIFF
--- a/python/grass/.flake8
+++ b/python/grass/.flake8
@@ -2,15 +2,11 @@
 ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
-    E266, # too many leading '#' for block comment
     E722, # do not use bare 'except'
     E741, # ambiguous variable name 'l'
     F403, # 'from ctypes import *' used; unable to detect undefined names
     F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
     F841, # local variable 't0' is assigned to but never used
-    W293, # blank line contains whitespace
-    W503, # line break before binary operator
-    W504, # line break after binary operator
     W605, # invalid escape sequence '\_'
 
 per-file-ignores =

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -120,7 +120,7 @@ def main():
     # grass7bin = 'C:\Program Files (x86)\GRASS GIS 7.9.git\grass79dev.bat'
     grass7bin = args.grassbin  # TODO: can be used if pressent
 
-    ########### SOFTWARE
+    # Software
     # query GRASS 7 itself for its GISBASE
     # we assume that GRASS GIS' start script is available and in the PATH
     # the shell=True is here because of MS Windows? (code taken from wiki)
@@ -143,7 +143,7 @@ def main():
     grass_python_dir = os.path.join(gisbase, "etc", "python")
     sys.path.append(grass_python_dir)
 
-    ########### DATA
+    # Data
     # define GRASS DATABASE
 
     # Set GISDBASE environment variable

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -140,7 +140,7 @@ def checkImages(images):
     return images2
 
 
-## Base functions and classes
+# Base functions and classes
 
 
 class BitArray:
@@ -411,7 +411,7 @@ def _readFrom(fp, n):
     return bb
 
 
-## Base Tag
+# Base Tag
 
 
 class Tag:
@@ -480,7 +480,7 @@ class Tag:
         return bits
 
 
-## Control tags
+# Control tags
 
 
 class ControlTag(Tag):
@@ -550,7 +550,9 @@ class DoActionTag(Tag):
         self.bytes = bb
 
 
-## Definition tags
+# Definition tags
+
+
 class DefinitionTag(Tag):
     counter = 0  # to give automatically id's
 
@@ -760,7 +762,9 @@ class ShapeTag(DefinitionTag):
         # return bitsToBytes(bits)
 
 
-## Last few functions
+# Last few functions
+
+
 def buildFile(fp, taglist, nframes=1, framesize=(500, 500), fps=10, version=8):
     """ Give the given file (as bytes) a header. """
 

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -719,12 +719,9 @@ class Module(object):
         """{cmd_name}({cmd_params})"""
         head = DOC["head"].format(
             cmd_name=self.name,
-            cmd_params=(
-                "\n"
-                +  # go to a new line
-                # give space under the function name
-                (" " * (len(self.name) + 1))
-            ).join(
+            # go to a new line
+            # give space under the function name
+            cmd_params=("\n" + (" " * (len(self.name) + 1))).join(
                 [
                     ", ".join(
                         # transform each parameter in string

--- a/python/grass/pygrass/raster/raster_type.py
+++ b/python/grass/pygrass/raster/raster_type.py
@@ -7,7 +7,7 @@ import grass.lib.raster as libraster
 import ctypes
 import numpy as np
 
-## Private dictionary to convert RASTER_TYPE into type string.
+# Private dictionary to convert RASTER_TYPE into type string.
 RTYPE_STR = {
     libraster.CELL_TYPE: "CELL",
     libraster.FCELL_TYPE: "FCELL",

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1655,7 +1655,7 @@ def verbosity():
         return 2
 
 
-## various utilities, not specific to GRASS
+# Various utilities, not specific to GRASS
 
 
 def find_program(pgm, *args):

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -479,8 +479,6 @@ from .datetime_math import create_numeric_suffix
 if sys.version_info[0] >= 3:
     unicode = str
 
-##############################################################################
-
 
 class TemporalAlgebraLexer(object):
     """Lexical analyzer for the GRASS GIS temporal algebra"""
@@ -706,9 +704,6 @@ class TemporalAlgebraLexer(object):
             print(tok)
 
 
-###############################################################################
-
-
 class GlobalTemporalVar(object):
     """This class handles global temporal variable conditional expressions,
     like start_doy() == 3.
@@ -760,18 +755,12 @@ class GlobalTemporalVar(object):
         return str(self.tfunc) + str(self.compop) + str(self.value)
 
 
-###############################################################################
-
-
 class FatalError(Exception):
     def __init__(self, msg):
         self.value = msg
 
     def __str__(self):
         return self.value
-
-
-###############################################################################
 
 
 class TemporalAlgebraParser(object):
@@ -1186,13 +1175,10 @@ class TemporalAlgebraParser(object):
             # Append map to result map list.
             # if returncode == 1:
             #    resultlist.append(map_new)
-        # Get sorted map objects as values from result dictionoary.
+        # Get sorted map objects as values from result dictionary.
         resultlist = resultdict.values()
         resultlist = sorted(resultlist, key=AbstractDatasetComparisonKeyStartTime)
-
         return resultlist
-
-    ######################### Temporal functions ##############################
 
     def remove_maps(self):
         """Removes empty or intermediate maps of different type."""
@@ -2331,8 +2317,6 @@ class TemporalAlgebraParser(object):
         else:
             return resultlist
 
-    ###########################################################################
-
     def p_statement_assign(self, t):
         # The expression should always return a list of maps
         # This function starts all the work and is the last one that is called from the parser
@@ -3351,8 +3335,6 @@ class TemporalAlgebraParser(object):
         else:
             raise SyntaxError("Unexpected syntax error")
 
-
-###############################################################################
 
 if __name__ == "__main__":
     import doctest

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -25,9 +25,6 @@ import grass.pygrass.modules as pymod
 from .space_time_datasets import Raster3DDataset
 
 
-###############################################################################
-
-
 class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
     """The temporal raster algebra class"""
 
@@ -84,8 +81,6 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
         self.parser.parse(expression)
 
         return self.process_chain_dict
-
-    ######################### Temporal functions ##############################
 
     def p_statement_assign(self, t):
         # The expression should always return a list of maps.
@@ -161,8 +156,6 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
 
             t[0] = resultlist
 
-
-###############################################################################
 
 if __name__ == "__main__":
     import doctest

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -65,8 +65,6 @@ from .temporal_raster_base_algebra import (
 import grass.pygrass.modules as pymod
 from .space_time_datasets import RasterDataset
 
-###############################################################################
-
 
 class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
     """The temporal raster algebra class"""
@@ -129,8 +127,6 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
         self.parser.parse(expression)
 
         return self.process_chain_dict
-
-    ######################### Temporal functions ##############################
 
     def p_statement_assign(self, t):
         # The expression should always return a list of maps.
@@ -202,8 +198,6 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
 
             t[0] = resultlist
 
-
-###############################################################################
 
 if __name__ == "__main__":
     import doctest

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -63,9 +63,6 @@ from .datetime_math import create_time_suffix
 from .datetime_math import create_numeric_suffix
 
 
-##############################################################################
-
-
 class TemporalRasterAlgebraLexer(TemporalAlgebraLexer):
     """Lexical analyzer for the GRASS GIS temporal algebra"""
 
@@ -147,9 +144,6 @@ class TemporalRasterAlgebraLexer(TemporalAlgebraLexer):
         return t
 
 
-##############################################################################
-
-
 class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
     """The temporal algebra class"""
 
@@ -203,7 +197,6 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         except ValueError:
             return "null()"
 
-    ######################### Temporal functions ##############################
     def build_spatio_temporal_topology_list(
         self,
         maplistA,
@@ -631,7 +624,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             # Append map to result map list.
             # if returncode == 1:
             #    resultlist.append(map_new)
-        # Get sorted map objects as values from result dictionoary.
+        # Get sorted map objects as values from result dictionary.
         resultlist = resultdict.values()
         resultlist = sorted(resultlist, key=AbstractDatasetComparisonKeyStartTime)
 
@@ -741,8 +734,6 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                 cmd_type="condition",
             )
             return resultlist
-
-    ###########################################################################
 
     def p_statement_assign(self, t):
         # This function executes the processing of raster/raster3d algebra
@@ -2056,8 +2047,6 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-
-###############################################################################
 
 if __name__ == "__main__":
     import doctest

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -63,9 +63,6 @@ from .spatio_temporal_relationships import SpatioTemporalTopologyBuilder
 from .space_time_datasets import VectorDataset
 
 
-##############################################################################
-
-
 class TemporalVectorAlgebraLexer(TemporalAlgebraLexer):
     """Lexical analyzer for the GRASS GIS temporal vector algebra"""
 
@@ -115,9 +112,6 @@ class TemporalVectorAlgebraLexer(TemporalAlgebraLexer):
         else:
             t.type = "NAME"
         return t
-
-
-##############################################################################
 
 
 class TemporalVectorAlgebraParser(TemporalAlgebraParser):
@@ -183,8 +177,6 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         self.basename = basename
         self.expression = expression
         self.parser.parse(expression)
-
-    ######################### Temporal functions ##############################
 
     def build_spatio_temporal_topology_list(
         self,
@@ -416,13 +408,10 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
             # Append map to result map list.
             # if returncode == 1:
             #    resultlist.append(map_new)
-        # Get sorted map objects as values from result dictionoary.
+        # Get sorted map objects as values from result dictionary.
         resultlist = resultdict.values()
         resultlist = sorted(resultlist, key=AbstractDatasetComparisonKeyStartTime)
-
         return resultlist
-
-    ###########################################################################
 
     def p_statement_assign(self, t):
         # The expression should always return a list of maps.


### PR DESCRIPTION
* Removes lines with many hash marks. ## is considered bad style and the lines
  were mostly used just to separate classes which are separated by whispace
  (which is enforced unlike the comment), can be found using search, etc.
* The Temporal functions headings removed as too generic label and most of the
  time starting close to the `__init__` function anyway.
* Removes empty line before a single return statement in related functions.
* Fixes typo dictionoary -> dictionary.
* Removes extra # from comments starting with ##.
* Reduces intermingling of code and comments in pygrass...module to simplify
  formatting.
