### PR TITLE
scripts: Fix stylistic Flake8 warnings

### DIFF
--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -2,6 +2,7 @@
 ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
+    E402, # module level import not at top of file
     E722, # do not use bare 'except'
     E741, # ambiguous variable name 'l'
     F841, # local variable 'center' is assigned to but never used

--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -1,37 +1,11 @@
 [flake8]
 ignore =
-    E265, # block comment should start with '# '
-    E266, # too many leading '#' for block comment
-    E402, # module level import not at top of file
+    E203,  # whitespace before ':' (Black)
+    W503,  # line break before binary operator (Black)
     E722, # do not use bare 'except'
     E741, # ambiguous variable name 'l'
     F841, # local variable 'center' is assigned to but never used
-    E121, # continuation line under-indented for hanging indent
-    E125, # continuation line with same indent as next logical line
-    E127, # continuation line over-indented for visual indent
-    E128, # continuation line under-indented for visual indent
-    E202, # whitespace before ')'
-    E211, # whitespace before '['
-    E221, # multiple spaces before operator
-    E225, # missing whitespace around operator
-    E226, # missing whitespace around arithmetic operator
-    E231, # missing whitespace after ','
-    E251, # unexpected spaces around keyword / parameter equals
-    E261, # at least two spaces before inline comment
-    E271, # multiple spaces after keyword
-    E272, # multiple spaces before keyword
-    E302, # expected 2 blank lines, found 1
-    E303, # too many blank lines (2)
-    E305, # expected 2 blank lines after class or function definition, found 1
     E501, # line too long (161 > 150 characters)
-    W293, # blank line contains whitespace
-    W503, # line break before binary operator
-    W504, # line break after binary operator
-
-# Ignores for Black compatibility
-# This is not to be removed unlike the ones in ignore.
-extend-ignore =
-    E203,  # whitespace before ':' (in a slice the colon acts like a binary operator)
 
 max-line-length = 88
 exclude =
@@ -47,5 +21,6 @@ exclude =
     ctypes,
     pydispatch,
     testsuite,
+
 builtins =
     _

--- a/scripts/i.tasscap/i.tasscap.py
+++ b/scripts/i.tasscap/i.tasscap.py
@@ -90,7 +90,7 @@ import grass.script as grass
 # Sentinel-2: B1 ... B12, B8A
 # Worldview-2: B1 ... B8 (PAN not used)
 #
-## entries: 1. Brightness, 2. Greeness, 3. Wetness and shadows, 4. Haze
+# entries: 1. Brightness, 2. Greeness, 3. Wetness and shadows, 4. Haze
 parms = [
     [
         (0.3037, 0.2793, 0.4743, 0.5585, 0.5082, 0.1863),  # Landsat TM4

--- a/scripts/r.plane/r.plane.py
+++ b/scripts/r.plane/r.plane.py
@@ -86,7 +86,7 @@ def main():
 
     # reg = gscript.region()
 
-    ### test input values ###
+    # Test input values
     if abs(dip) >= 90:
         gscript.fatal(_("dip must be between -90 and 90."))
 

--- a/scripts/v.rast.stats/v.rast.stats.py
+++ b/scripts/v.rast.stats/v.rast.stats.py
@@ -112,10 +112,11 @@ def main():
     percentile = options["percentile"]
     basecols = options["method"].split(",")
 
-    ### setup enviro vars ###
+    # Get current mapset
     env = grass.gisenv()
     mapset = env["MAPSET"]
 
+    # Get mapset of the vector
     vs = vector.split("@")
     if len(vs) > 1:
         vect_mapset = vs[1]


### PR DESCRIPTION
* Remove extra # from comments starting with ##.
* Enable stylistic warnings (mostly fixed and controled by Black now).
* Sync .flake8 file to python/grass as much as possible.
