### PR TITLE
v.patch: fix #1488

### DIFF
--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -217,6 +217,9 @@ int main(int argc, char *argv[])
 		}
 		db_close_database_shutdown_driver(driver_in);
 	    }
+	    else {
+		G_fatal_error(_("Missing attribute table for vector map <%s>"), in_name);
+	    }
 
 	    /* Get the output table structure */
 	    if (i == 0 ) {


### PR DESCRIPTION
Fix segmentation fault if attribute tables should be copied, but one of the input vectors does not have an attribute table.
Fixes #1488 