### PR TITLE
CI: Enable Perl in Super-Linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,7 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSON: true
           VALIDATE_MD: false
-          VALIDATE_PERL: false
+          VALIDATE_PERL: true
           VALIDATE_POWERSHELL: true
           VALIDATE_XML: true
           VALIDATE_YAML: true


### PR DESCRIPTION
This enables Perl in Super-Linter check since local perlcritic does not give any errors after #766 and #1431.
