### PR TITLE
g.extension: ignore cruft __pycache__ files

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1462,7 +1462,8 @@ def extract_zip(name, directory, tmpdir):
         extract_dir = os.path.join(tmpdir, "extract_dir")
         os.mkdir(extract_dir)
         for subfile in file_list:
-            # this should be safe in Python 2.7.4
+            if "__pycache__" in subfile:
+                continue
             zip_file.extract(subfile, extract_dir)
         files = os.listdir(extract_dir)
         move_extracted_files(extract_dir=extract_dir, target_dir=directory, files=files)


### PR DESCRIPTION
winGRASS related fix in `g.extension` to skip if precompiled zip-files contains an (undesired) `__pycache__` subdirectory.

Example: [i.fusion.hpf.zip](https://wingrass.fsv.cvut.cz/grass78/x86_64/addons/latest/i.fusion.hpf.zip) contains for whatever reason:

```
etc/i.fusion.hpf/__pycache__/constants.cpython-37.pyc
etc/i.fusion.hpf/__pycache__/high_pass_filter.cpython-37.pyc
```
With this PR the unwanted subdir shall be skipped.

(hopefully) fixes #1477