### PR TITLE
wxGUI: toolbar and infobar overlaps on Windows

### DIFF
--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -73,6 +73,7 @@ class DataCatalog(wx.Panel):
         """Do layout"""
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.toolbar, proportion=0, flag=wx.EXPAND)
+        sizer.AddSpacer(3)
         sizer.Add(self.infoBar, proportion=0, flag=wx.EXPAND)
         sizer.Add(self.tree.GetControl(), proportion=1, flag=wx.EXPAND)
 


### PR DESCRIPTION
After the first-time user startup, the info structure infobar is a bit overlapped by toolbar bitmaps.

Before on Windows:
![strange_layout](https://user-images.githubusercontent.com/49241681/113388364-61c6f500-938e-11eb-982a-f4d2cfc544ad.PNG)

After on Windows:
![dobry_](https://user-images.githubusercontent.com/49241681/113388314-4956da80-938e-11eb-893d-153ca2b240aa.PNG)
After on Ubuntu:
![ubuntu_dobry](https://user-images.githubusercontent.com/49241681/113388307-465bea00-938e-11eb-9383-0cfa0750ad12.PNG)

