### PR TITLE
wxGUI: more suitable color for infobar on Windows

### DIFF
--- a/gui/wxpython/gui_core/infobar.py
+++ b/gui/wxpython/gui_core/infobar.py
@@ -16,6 +16,7 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com>
 """
 
+import sys
 import wx
 import wx.aui
 try:
@@ -55,13 +56,25 @@ class InfoBar(IB.InfoBar):
 
         self.button_ids = []
 
+        # set background color according to OS
+        if sys.platform == "win32":
+            self._background_color = wx.SystemSettings.GetColour(
+                wx.SYS_COLOUR_INFOBK
+            )
+            self._foreground_color = wx.SystemSettings.GetColour(
+                wx.SYS_COLOUR_INFOTEXT
+            )
+        else:
+            self._background_color = wx.SystemSettings.GetColour(
+                wx.SYS_COLOUR_HIGHLIGHT
+            )
+            self._foreground_color = wx.SystemSettings.GetColour(
+                wx.SYS_COLOUR_HIGHLIGHTTEXT
+            )
         # some system themes have alpha, remove it
-        self._background_color = wx.SystemSettings.GetColour(
-            wx.SYS_COLOUR_HIGHLIGHT
-        ).Get(False)
-        self._foreground_color = wx.SystemSettings.GetColour(
-            wx.SYS_COLOUR_HIGHLIGHTTEXT
-        ).Get(False)
+        self._background_color = self._background_color.Get(False)
+        self._foreground_color = self._foreground_color.Get(False)
+
         self.SetBackgroundColour(self._background_color)
         self.SetForegroundColour(self._foreground_color)
         self._text.SetBackgroundColour(self._background_color)

--- a/gui/wxpython/gui_core/infobar.py
+++ b/gui/wxpython/gui_core/infobar.py
@@ -56,24 +56,17 @@ class InfoBar(IB.InfoBar):
 
         self.button_ids = []
 
-        # set background color according to OS
+        # color according to OS
         if sys.platform == "win32":
-            self._background_color = wx.SystemSettings.GetColour(
-                wx.SYS_COLOUR_INFOBK
-            )
-            self._foreground_color = wx.SystemSettings.GetColour(
-                wx.SYS_COLOUR_INFOTEXT
-            )
+            bgcolor = wx.SYS_COLOUR_INFOBK
+            fgcolor = wx.SYS_COLOUR_INFOTEXT
         else:
-            self._background_color = wx.SystemSettings.GetColour(
-                wx.SYS_COLOUR_HIGHLIGHT
-            )
-            self._foreground_color = wx.SystemSettings.GetColour(
-                wx.SYS_COLOUR_HIGHLIGHTTEXT
-            )
-        # some system themes have alpha, remove it
-        self._background_color = self._background_color.Get(False)
-        self._foreground_color = self._foreground_color.Get(False)
+            bgcolor = wx.SYS_COLOUR_HIGHLIGHT
+            fgcolor = wx.SYS_COLOUR_HIGHLIGHTTEXT
+
+        # set background and foreground color and remove alpha
+        self._background_color = wx.SystemSettings.GetColour(bgcolor).Get(False)
+        self._foreground_color = wx.SystemSettings.GetColour(fgcolor).Get(False)
 
         self.SetBackgroundColour(self._background_color)
         self.SetForegroundColour(self._foreground_color)


### PR DESCRIPTION
Before:
![strange_color](https://user-images.githubusercontent.com/49241681/113752032-d2626e80-970c-11eb-97ba-b6f26eac09e3.PNG)
After:
![win](https://user-images.githubusercontent.com/49241681/113751377-2de02c80-970c-11eb-944b-2df9c276fa06.PNG)


