### PR TITLE
pythonlib: Enable unused var warning

### DIFF
--- a/python/grass/.flake8
+++ b/python/grass/.flake8
@@ -6,7 +6,6 @@ ignore =
     E741, # ambiguous variable name 'l'
     F403, # 'from ctypes import *' used; unable to detect undefined names
     F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
-    F841, # local variable 't0' is assigned to but never used
     W605, # invalid escape sequence '\_'
 
 per-file-ignores =
@@ -25,7 +24,7 @@ per-file-ignores =
     pygrass/utils.py: E402, E501
     script/db.py: E501
     script/vector.py: E501  # Long doctest lines which need review anyway
-    temporal/*.py: E501
+    temporal/*.py: E501, F841
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     pygrass/tests/benchmark.py: E501, E402, F401, F821

--- a/python/grass/imaging/images2gif.py
+++ b/python/grass/imaging/images2gif.py
@@ -65,7 +65,6 @@ Useful links:
 # todo: This module should be part of imageio (or at least based on)
 
 import os
-import time
 
 try:
     import PIL
@@ -319,7 +318,6 @@ class GifWriter:
         # Prepare
         ims2 = [ims[0]]
         xy = [(0, 0)]
-        t0 = time.time()
 
         # Iterate over images
         prev = ims[0]

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -218,39 +218,16 @@ class BitArray:
         return bb
 
 
-if PY3:
-
-    def intToUint32(i):
-        return int(i).to_bytes(4, "little")
-
-    def intToUint16(i):
-        return int(i).to_bytes(2, "little")
-
-    def intToUint8(i):
-        return int(i).to_bytes(1, "little")
+def intToUint32(i):
+    return int(i).to_bytes(4, "little")
 
 
-else:
+def intToUint16(i):
+    return int(i).to_bytes(2, "little")
 
-    def intToUint32(i):
-        number = int(i)
-        n1, n2, n3, n4 = 1, 256, 256 * 256, 256 * 256 * 256
-        b4, number = number // n4, number % n4
-        b3, number = number // n3, number % n3
-        b2, number = number // n2, number % n2
-        b1 = number
-        return chr(b1) + chr(b2) + chr(b3) + chr(b4)
 
-    def intToUint16(i):
-        i = int(i)
-        # divide in two parts (bytes)
-        i1 = i % 256
-        i2 = int(i // 256)
-        # make string (little endian)
-        return chr(i1) + chr(i2)
-
-    def intToUint8(i):
-        return chr(int(i))
+def intToUint8(i):
+    return int(i).to_bytes(1, "little")
 
 
 def intToBits(i, n=None):
@@ -875,7 +852,7 @@ def _readPixels(bb, i, tagType, L1):
         raise RuntimeError("Need Numpy to read an SWF file.")
 
     # Get info
-    charId = bb[i : i + 2]
+    # charId = bb[i : i + 2]  # unused
     i += 2
     format = ord(bb[i : i + 1])
     i += 1
@@ -884,7 +861,7 @@ def _readPixels(bb, i, tagType, L1):
     height = bitsToInt(bb[i : i + 2], 16)
     i += 2
 
-    # If we can, get pixeldata and make nunmpy array
+    # If we can, get pixeldata and make numpy array
     if format != 5:
         print("Can only read 24bit or 32bit RGB(A) lossless images.")
     else:

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -465,7 +465,9 @@ def start_command(
     :return: Popen object
     """
     if "encoding" in kwargs.keys():
-        encoding = kwargs.pop("encoding")
+        # This variable was never used for anything.
+        # See https://github.com/OSGeo/grass/issues/1521
+        encoding = kwargs.pop("encoding")  # noqa: F841
 
     options = {}
     popts = {}


### PR DESCRIPTION
Ignore whole temporal subpackage.
Remove unused in imaging including some Python 2 support (and fix a typo).
