### PR TITLE
scripts: Enable import not at top warning

### DIFF
--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -2,7 +2,6 @@
 ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
-    E402, # module level import not at top of file
     E722, # do not use bare 'except'
     E741, # ambiguous variable name 'l'
     E501, # line too long (161 > 150 characters)
@@ -10,6 +9,7 @@ ignore =
 per-file-ignores =
     # Many of these ignores can and should be removed and the problem fixed.
     # F841 local variable is assigned to but never used
+    # E402 module level import not at top of file
     d.polar/d.polar.py: F841
     r.in.wms/wms_gdal_drv.py: F841
     r.in.wms/wms_cap_parsers.py: F841
@@ -19,6 +19,7 @@ per-file-ignores =
     g.extension/g.extension.py: F841
     v.unpack/v.unpack.py: F841
     v.import/v.import.py: F841
+    r.in.wms/wms_drv.py: E402
 
 max-line-length = 88
 exclude =

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -70,6 +70,14 @@
 # % description: Input is a 1-arcsec tile (default: 3-arcsec)
 # %end
 
+
+import os
+import shutil
+import atexit
+import grass.script as grass
+import zipfile as zfile
+
+
 tmpl1sec = """BYTEORDER M
 LAYOUT BIL
 NROWS 3601
@@ -131,12 +139,6 @@ proj = "".join(
         "]",
     ]
 )
-
-import os
-import shutil
-import atexit
-import grass.script as grass
-import zipfile as zfile
 
 
 def cleanup():

--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -225,7 +225,6 @@ def GetRegionParams(opt_region):
 
 
 def main():
-
     sys.path.insert(1, os.path.join(os.path.dirname(sys.path[0]), "etc", "r.in.wms"))
 
     if "GRASS" in options["driver"]:

--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -197,8 +197,6 @@ This program is free software under the GNU General Public License
 import os
 import sys
 
-sys.path.insert(1, os.path.join(os.path.dirname(sys.path[0]), "etc", "r.in.wms"))
-
 import grass.script as grass
 from grass.script.utils import decode
 
@@ -227,6 +225,8 @@ def GetRegionParams(opt_region):
 
 
 def main():
+
+    sys.path.insert(1, os.path.join(os.path.dirname(sys.path[0]), "etc", "r.in.wms"))
 
     if "GRASS" in options["driver"]:
         grass.debug("Using GRASS driver")

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -40,16 +40,15 @@ import signal
 import struct
 import sys
 import time
+import numpy
+
+import wx
 
 import grass.script as grass
 from grass.script.setup import set_gui_path
 
 set_gui_path()
-from gui_core.wrap import BitmapFromImage
-
-import numpy
-
-import wx
+from gui_core.wrap import BitmapFromImage  # noqa: E402
 
 
 class Frame(wx.Frame):


### PR DESCRIPTION
Move imports and path modifications around as needed.
Ignore some complex cases for now.
