### PR TITLE
Flake8 fixes for docs and others

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,9 @@ ignore =
     W503,  # line break before binary operator (Black)
 
 per-file-ignores =
+    # Quick reference for some of the most common errors
+    # F401 imported but unused
+    # E501 line too long
     utils/mkrest.py: E501, W605
     utils/gitlog2changelog.py: E722, E712, W605
     utils/g.html2man/ggroff.py: W605
@@ -20,6 +23,13 @@ per-file-ignores =
     man/build_topics.py: F403, F405, E722
     man/build_html.py: E501
     man/build_rest.py: E501
+    imagery/i.atcorr/create_iwave.py: E501, F632, F821, W293
+    doc/python/raster_example_ctypes.py: F403, F405
+    doc/python/vector_example_ctypes.py: F403, F405
+    doc/python/m.distance.py: F403, F405, E501
+    doc/gui/wxpython/example/dialogs.py: F401
+    doc/gui/wxpython/example/g.gui.example.py: E501
+    locale/grass_po_stats.py: E122, E128, E231, E401, E501, E722, E741
 
 max-line-length = 88
 exclude =
@@ -35,6 +45,7 @@ exclude =
     # Build directories
     bin.*,
     dist.*,
+    OBJ.*,
     # Test output directory
     testreport,
     # Have their own configs for now
@@ -45,15 +56,6 @@ exclude =
     temporal,
     # No tests checked for now
     testsuite,
-    # To be resolved later
-    imagery/i.atcorr/create_iwave.py,
-    raster/r.solute.transport,
-    display/d.mon/render_cmd.py,
-    locale/grass_po_stats.py,
-    general/g.parser/test.py,
-    docker/testdata/test_grass_session.py,
-    doc/python,
-    doc/gui/wxpython/example,
 
 builtins =
     _

--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -7,6 +7,7 @@ from grass.script import core as grass
 from grass.script import task as gtask
 from grass.exceptions import CalledModuleError
 
+
 # read environment variables from file
 def read_env_file(env_file):
     width = height = legfile = None
@@ -14,10 +15,10 @@ def read_env_file(env_file):
     if fd is None:
         grass.fatal("Unable to open file '{0}'".format(env_file))
     lines = fd.readlines()
-    for l in lines:
-        if l.startswith("#"):
+    for line in lines:
+        if line.startswith("#"):
             continue
-        k, v = l.rstrip("\n").split("#", 1)[0].strip().split("=", 1)
+        k, v = line.rstrip("\n").split("#", 1)[0].strip().split("=", 1)
         os.environ[k] = v
         if width is None and k == "GRASS_RENDER_WIDTH":
             width = int(v)
@@ -120,12 +121,13 @@ def read_stdin(cmd):
 
     if (
         cmd[0] == "d.text"
-        and not "text" in cmd[1]
-        and (not "input" in cmd[1] or cmd[1]["input"] == "-")
+        and "text" not in cmd[1]
+        and ("input" not in cmd[1] or cmd[1]["input"] == "-")
     ):
         if sys.stdin.isatty():
             sys.stderr.write(
-                "\nPlease enter text instructions.  Enter EOF (ctrl-d) on last line to quit\n"
+                "\nPlease enter text instructions."
+                " Enter EOF (ctrl-d) on last line to quit.\n"
             )
         opt = "input"
 

--- a/doc/gui/wxpython/example/dialogs.py
+++ b/doc/gui/wxpython/example/dialogs.py
@@ -30,7 +30,8 @@ from gui_core import gselect
 class ExampleMapDialog(SimpleDialog):
     """!Dialog for adding raster map.
 
-    Dialog can be easily changed to enable to choose vector, imagery groups or other elements.
+    Dialog can be easily changed to enable to choose vector,
+    imagery groups, or other elements.
     """
 
     def __init__(self, parent, title=_("Choose raster map")):

--- a/doc/gui/wxpython/example/toolbars.py
+++ b/doc/gui/wxpython/example/toolbars.py
@@ -19,7 +19,6 @@ for details.
 import wx
 
 from gui_core.toolbars import BaseToolbar, BaseIcons
-from icons.icon import MetaIcon
 
 
 class ExampleMapToolbar(BaseToolbar):

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -44,7 +44,6 @@
 # % suppress_required: yes
 # %end
 
-import os
 import sys
 
 import grass.script as gs

--- a/doc/python/raster_example_ctypes.py
+++ b/doc/python/raster_example_ctypes.py
@@ -22,7 +22,7 @@ from grass.lib.gis import *
 from grass.lib.raster import *
 
 # check if GRASS is running or not
-if not os.environ.has_key("GISBASE"):
+if "GISBASE" not in os.environ:
     sys.exit("You must be in GRASS GIS to run this program")
 
 # parse command line arguments, prompt user for a raster map name if one wasn't given

--- a/doc/python/vector_example_ctypes.py
+++ b/doc/python/vector_example_ctypes.py
@@ -11,7 +11,7 @@ import sys
 from grass.lib.gis import *
 from grass.lib.vector import *
 
-if not os.environ.has_key("GISBASE"):
+if "GISBASE" not in os.environ:
     sys.exit("You must be in GRASS GIS to run this program.")
 
 if len(sys.argv) == 2:

--- a/general/g.parser/test.py
+++ b/general/g.parser/test.py
@@ -42,7 +42,8 @@ def main():
     raster = options["raster"]
     vector = options["vector"]
 
-    #### add your code here ####
+    # Add your main code here
+
     exitcode = 0
 
     if flag_f:
@@ -57,7 +58,7 @@ def main():
     gs.message(_("Value of raster option: '%s'" % raster))
     gs.message(_("Value of vector option: '%s'" % vector))
 
-    #### end of your code ####
+    # End of your main code here
 
     sys.exit(exitcode)
 

--- a/raster/r.solute.transport/example.py
+++ b/raster/r.solute.transport/example.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # This is an example script how groundwater flow and solute transport are
 # computed within GRASS GIS
-import sys
-import os
 import grass.script as gs
 
 # Overwrite existing maps
@@ -17,7 +15,7 @@ gs.run_command("r.mapcalc", expression="phead=if(col() ==200  , 45 + row()/40, p
 gs.run_command("r.mapcalc", expression="status=if(col() == 1 || col() == 200 , 2, 1)")
 gs.run_command(
     "r.mapcalc",
-    expression="well=if((row() == 50 && col() == 175) || (row() == 10 && col() == 135) , -0.001, 0)",
+    expression="well=if((row() == 50 && col() == 175) || (row() == 10 && col() == 135) , -0.001, 0)",  # noqa: E501
 )
 gs.run_command("r.mapcalc", expression="hydcond=0.00005")
 gs.run_command("r.mapcalc", expression="recharge=0")

--- a/raster/r.solute.transport/seguin_verify.py
+++ b/raster/r.solute.transport/seguin_verify.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 # Shellscript to verify r.solute.transport calculation, this calculation is based on
 # the example 1.1 and 1.2 at page 175 of the following book:
-# 	title = "Str{\"o}mungs und Transportmodellierung",
-# 	author = "Lege, T. and Kolditz, O. and Zielke W.",
-# 	publisher = "Springer (Berlin; Heidelberg; New York; Barcelona; Hongkong; London; Mailand; Paris; Singapur; Tokio)",
-# 	edition = "2. Auflage",
-# 	year = "1996",
-# 	series = "Handbuch zur Erkundung des Untergrundes von Deponien und Altlasten"
-#
+# title = "Str{\"o}mungs und Transportmodellierung",
+# author = "Lege, T. and Kolditz, O. and Zielke W.",
+# publisher = "Springer",
+# edition = "2. Auflage",
+# year = "1996",
+# series = "Handbuch zur Erkundung des Untergrundes von Deponien und Altlasten"
 
 import grass.script as grass
 
@@ -24,7 +23,8 @@ grass.message(_("Create all the input maps needed for groundwater flow computati
 # Initial condition of the piezometric head, we have a huge gradient from 275m to 50m
 # over a distance of 2000m
 grass.run_command("r.mapcalc", expression="phead_1=if(col() == 1 , 275, 50)")
-# Set the active cells and the dirichlet boundary condition, the first and the last cells a dirichlet
+# Set the active cells and the dirichlet boundary condition,
+# the first and the last cells a dirichlet
 grass.run_command(
     "r.mapcalc", expression="status_1=if(col() == 1 || col() == 40 , 2, 1)"
 )
@@ -45,7 +45,8 @@ grass.run_command("r.mapcalc", expression="syield_1=0.0001")
 grass.run_command("r.mapcalc", expression="null_1=0.0")
 
 grass.message(
-    "First compute a steady state groundwater flow with a mean velocity of 5.88 m/d or 6.8*10^5m/s"
+    "First compute a steady state groundwater flow with a mean velocity"
+    " of 5.88 m/d or 6.8*10^5m/s"
 )
 
 # Compute the steady state groundwater flow
@@ -92,7 +93,8 @@ grass.run_command("r.mapcalc", expression="R_1=1.0")
 AL = 100
 AT = 10
 
-# Compute the solute transport using the above defined dispersivity coefficients for a timestep of 1000d
+# Compute the solute transport using the above defined dispersivity coefficients
+# for a timestep of 1000d
 grass.run_command(
     "r.solute.transport",
     "c",
@@ -140,10 +142,12 @@ grass.run_command(
 
 # The second computation uses different porosity for higher groundwater velocity
 
-# Used to compute a lower velocity, so the mean velocity is about 1 m/d or 1.15*10^-5 m/s
+# Used to compute a lower velocity, so the mean velocity is
+# about 1 m/d or 1.15*10^-5 m/s
 grass.run_command("r.mapcalc", expression="poros_2=1")
 
-# Compute the solute transport using the above defined dispersivity coefficients for a timestep of 1000d
+# Compute the solute transport using the above defined dispersivity coefficients for
+# a timestep of 1000d
 grass.run_command(
     "r.solute.transport",
     "c",

--- a/raster/r.solute.transport/seguin_verify_well.py
+++ b/raster/r.solute.transport/seguin_verify_well.py
@@ -3,7 +3,7 @@
 # the example 2.1 and 2.2 at page 181 of the following book:
 # 	title = "Str{\"o}mungs und Transportmodellierung",
 # 	author = "Lege, T. and Kolditz, O. and Zielke W.",
-# 	publisher = "Springer (Berlin; Heidelberg; New York; Barcelona; Hongkong; London; Mailand; Paris; Singapur; Tokio)",
+# 	publisher = "Springer",
 # 	edition = "2. Auflage",
 # 	year = "1996",
 # 	series = "Handbuch zur Erkundung des Untergrundes von Deponien und Altlasten"
@@ -92,7 +92,8 @@ grass.run_command("r.mapcalc", expression="R_1=1.0")
 AL = 50
 AT = 5
 
-# Compute the solute transport using the above defined dispersivity coefficients for a timestep of 250d
+# Compute the solute transport using the above defined dispersivity coefficients
+# for a timestep of 250d
 grass.run_command(
     "r.solute.transport",
     "c",
@@ -140,7 +141,8 @@ grass.run_command(
 AL = 10
 AT = 1
 
-# Compute the solute transport using the above defined dispersivity coefficients for a timestep of 250d
+# Compute the solute transport using the above defined dispersivity coefficients
+# for a timestep of 250d
 grass.run_command(
     "r.solute.transport",
     "c",


### PR DESCRIPTION
Fix small Flake8 issues for most of docs and other files. Ignore rest on per-file basis.
Reduce line length. No need for all Springer locations in a comment.
