### PR TITLE
Git: Un-ignore locale directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.lock
 *.pyc
 OBJ.*
-locale/*
+locale/scriptstrings/*
 bin.*/*
 dist.*/*
 config.log


### PR DESCRIPTION
The whole locale dir was ignored since 4c874e8110df823ed575fec7172a0817a6e5a7db.
Most of the dir is source code, so ignoring just the scriptstrings subdir.
