### PR TITLE
scripts: Enable ambiguous variable name warning

### DIFF
--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -3,16 +3,16 @@ ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
     E722, # do not use bare 'except'
-    E741, # ambiguous variable name 'l'
     E501, # line too long (161 > 150 characters)
 
 per-file-ignores =
     # Many of these ignores can and should be removed and the problem fixed.
     # F841 local variable is assigned to but never used
     # E402 module level import not at top of file
+    # E741 ambiguous variable name 'l' (needs longer name)
     d.polar/d.polar.py: F841
     r.in.wms/wms_gdal_drv.py: F841
-    r.in.wms/wms_cap_parsers.py: F841
+    r.in.wms/wms_cap_parsers.py: F841, E741
     i.band/i.band.py: F841
     v.report/v.report.py: F841
     db.out.ogr/db.out.ogr.py: F841
@@ -20,6 +20,8 @@ per-file-ignores =
     v.unpack/v.unpack.py: F841
     v.import/v.import.py: F841
     r.in.wms/wms_drv.py: E402
+    db.univar/db.univar.py: E741
+    d.rast.leg/d.rast.leg.py: E741
 
 max-line-length = 88
 exclude =

--- a/scripts/d.correlate/d.correlate.py
+++ b/scripts/d.correlate/d.correlate.py
@@ -75,8 +75,8 @@ def main():
 
                 ifile = open(tmpfile, "r")
                 first = True
-                for l in ifile:
-                    f = l.rstrip("\r\n").split(" ")
+                for line in ifile:
+                    f = line.rstrip("\r\n").split(" ")
                     x = float(f[0])
                     y = float(f[1])
                     if first:
@@ -100,8 +100,8 @@ def main():
                 ofile = p.stdin
 
                 ifile = open(tmpfile, "r")
-                for l in ifile:
-                    f = l.rstrip("\r\n").split(" ")
+                for line in ifile:
+                    f = line.rstrip("\r\n").split(" ")
                     x = float(f[0])
                     y = float(f[1])
                     ofile.write(

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -409,15 +409,15 @@ def wxGUI():
 
             tools = wx.BoxSizer(wx.HORIZONTAL)
 
-            l = wx.StaticText(parent=self, label="New Value:")
-            tools.Add(l, flag=wx.ALIGN_CENTER_VERTICAL)
+            label = wx.StaticText(parent=self, label="New Value:")
+            tools.Add(label, flag=wx.ALIGN_CENTER_VERTICAL)
             tools.AddSpacer(5)
 
             self.newval = wx.TextCtrl(parent=self, style=wx.TE_PROCESS_ENTER)
             tools.Add(self.newval, flag=wx.ALIGN_CENTER_VERTICAL)
 
-            l = wx.StaticText(parent=self, label="Color:")
-            tools.Add(l, flag=wx.ALIGN_CENTER_VERTICAL)
+            label = wx.StaticText(parent=self, label="Color:")
+            tools.Add(label, flag=wx.ALIGN_CENTER_VERTICAL)
             tools.AddSpacer(5)
 
             self.color = ColorPanel(parent=self, size=(30, 5))

--- a/scripts/db.in.ogr/db.in.ogr.py
+++ b/scripts/db.in.ogr/db.in.ogr.py
@@ -105,8 +105,8 @@ def main():
         grass.read_command("db.connect", flags="c")
         s = grass.read_command("db.tables", flags="p", quiet=True)
 
-    for l in decode(s).splitlines():
-        if l == output:
+    for line in decode(s).splitlines():
+        if line == output:
             if grass.overwrite():
                 grass.warning(
                     _("Table <%s> already exists and will be " "overwritten") % output

--- a/scripts/i.in.spotvgt/i.in.spotvgt.py
+++ b/scripts/i.in.spotvgt/i.in.spotvgt.py
@@ -75,8 +75,8 @@ vrt = """<VRTDataset rasterXSize="$XSIZE" rasterYSize="$YSIZE">
 def create_VRT_file(projfile, vrtfile, infile):
     fh = open(projfile)
     kv = {}
-    for l in fh:
-        f = l.rstrip("\r\n").split()
+    for line in fh:
+        f = line.rstrip("\r\n").split()
         if f < 2:
             continue
         kv[f[0]] = f[1]

--- a/scripts/i.pansharpen/i.pansharpen.py
+++ b/scripts/i.pansharpen/i.pansharpen.py
@@ -599,10 +599,10 @@ def pca(pan, ms1, ms2, ms3, out, pid, sproc):
     b1evect = []
     b2evect = []
     b3evect = []
-    for l in pca_out.replace("(", ",").replace(")", ",").splitlines():
-        b1evect.append(float(l.split(",")[1]))
-        b2evect.append(float(l.split(",")[2]))
-        b3evect.append(float(l.split(",")[3]))
+    for line in pca_out.replace("(", ",").replace(")", ",").splitlines():
+        b1evect.append(float(line.split(",")[1]))
+        b2evect.append(float(line.split(",")[2]))
+        b3evect.append(float(line.split(",")[3]))
 
     # inverse PCA with hi res pan channel substituted for principal component 1
     pca2 = "tmp%s.pca.2" % pid

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -251,8 +251,8 @@ def main():
     if len(s) == 0:
         gcore.fatal(_("No data returned from query"))
 
-    for l in s.splitlines():
-        f = l.split("|")
+    for line in s.splitlines():
+        f = line.split("|")
         for i, v in enumerate(f):
             if v in ["", "*"]:
                 f[i] = 0

--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -59,10 +59,10 @@ import grass.script as grass
 from grass.script.utils import separator, decode
 
 
-def uniq(l):
+def uniq(items):
     result = []
     last = None
-    for i in l:
+    for i in items:
         if i != last:
             result.append(i)
             last = i


### PR DESCRIPTION
Enable Flake8 warning about ambiguous variables name l in scripts.
Fix clear cases such as l is line.
Use per file ignores to ignore the rest.
