### PR TITLE
wxGUI: Enable multiple hash warning

### DIFF
--- a/gui/wxpython/.flake8
+++ b/gui/wxpython/.flake8
@@ -2,7 +2,6 @@
 ignore =
     W605, # invalid escape sequence '\.'
     E265, # block comment should start with '# '
-    E266, # too many leading '#' for block comment
     E402, # module level import not at top of file
     E722, # do not use bare 'except'
     E731, # do not assign a lambda expression, use a def
@@ -47,14 +46,14 @@ per-file-ignores =
     dbmgr/*: F841
     gcp/*: F841
     gmodeler/*: F841
-    gui_core/*: F841
+    gui_core/*: F841, E266
     image2target/*: F841
     iscatt/*: F841
-    lmgr/*: F841
+    lmgr/*: F841, E266
     modules/*: F841
-    nviz/*: F841
+    nviz/*: F841, E266
     photo2image/*: F841
-    psmap/*: F841
+    psmap/*: F841, E266
     vdigit/*: F841
     vnet/*: F841
     wxgui.py: F841

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -179,7 +179,7 @@ class DisplayAttributesDialog(wx.Dialog):
 
         if self.notebook.GetPageCount() == 0:
             Debug.msg(2, "DisplayAttributesDialog(): Nothing found!")
-            ### self.mapDBInfo = None
+            # self.mapDBInfo = None
 
     def OnSQLStatement(self, event):
         """Update SQL statement"""

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -494,7 +494,7 @@ class Model(object):
                                 _("undefined variable '%s'") %
                                 var)
             # TODO: check variables in file only optionally
-            ### errList += self._substituteFile(action, checkOnly = True)
+            # errList += self._substituteFile(action, checkOnly = True)
 
         return errList
 

--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -711,7 +711,7 @@ class VDigitSettingsDialog(wx.Dialog):
             # checkbox
             check = CheckBox(parent=panel, id=wx.ID_ANY,
                              label=self.geomAttrb[attrb]['label'])
-            ### self.deleteRecord.SetValue(UserSettings.Get(group='vdigit', key="delRecord", subkey='enabled'))
+            # self.deleteRecord.SetValue(UserSettings.Get(group='vdigit', key="delRecord", subkey='enabled'))
             check.Bind(wx.EVT_CHECKBOX, self.OnGeomAttrb)
             # column (only numeric)
             column = ColumnSelect(parent=panel, size=(200, -1))

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -827,7 +827,7 @@ class DisplayDriver:
         if layer > 0:
             self.selected['cats'] = ids
             self.selected['ids'] = list()
-            ### cidx is not up-to-date
+            # cidx is not up-to-date
             # Vect_cidx_find_all(self.poMapInfo, layer, GV_POINTS | GV_LINES, lid, ilist)
             nlines = Vect_get_num_lines(self.poMapInfo)
             for line in range(1, nlines + 1):


### PR DESCRIPTION
Enable Flake8 warning about too many leading hashes for a comment.
Fix some cases.
Use per file ignores to ignore the rest.
