### PR TITLE
wxGUI: Enable lambda, escape, except, l warnings

### DIFF
--- a/gui/wxpython/.flake8
+++ b/gui/wxpython/.flake8
@@ -1,11 +1,7 @@
 [flake8]
 ignore =
-    W605, # invalid escape sequence '\.'
     E265, # block comment should start with '# '
     E402, # module level import not at top of file
-    E722, # do not use bare 'except'
-    E731, # do not assign a lambda expression, use a def
-    E741, # ambiguous variable name 'l'
     F403, # 'from gmodeler.model import *' used; unable to detect undefined names
     F405, # '_' may be undefined, or defined from star imports: gmodeler.model
     E117, # over-indented
@@ -42,32 +38,46 @@ ignore =
 per-file-ignores =
     # Many of these ignores can and should be removed and the problem fixed.
     # F841 local variable is assigned to but never used
-    core/*: F841
-    dbmgr/*: F841
-    gcp/*: F841
-    gmodeler/*: F841
-    gui_core/*: F841, E266
-    image2target/*: F841
-    iscatt/*: F841
-    lmgr/*: F841, E266
-    modules/*: F841
-    nviz/*: F841, E266
-    photo2image/*: F841
-    psmap/*: F841, E266
-    vdigit/*: F841
+    core/*: F841, E722, W605
+    datacatalog/tree.py: E731
+    dbmgr/*: F841, E722
+    gcp/*: F841, E722
+    gmodeler/*: F841, E722, W605
+    gui_core/*: F841, E266, E722, W605
+    image2target/*: F841, E722
+    iscatt/*: F841, E722, E741
+    lmgr/*: F841, E266, E722, E741, W605
+    modules/*: F841, E722, W605
+    nviz/*: F841, E266, E722, W605
+    photo2image/*: F841, E722
+    psmap/*: F841, E266, E722
+    vdigit/*: F841, E722, E741
     vnet/*: F841
     wxgui.py: F841
     animation/mapwindow.py: F841
     animation/provider.py: F841
-    tplot/frame.py: F841
+    tplot/frame.py: F841, E722
     rdigit/g.gui.rdigit.py: F841
+    iclass/dialogs.py: E741
     iclass/statistics.py: F841
-    wxplot/profile.py: F841
-    wxplot/base.py: F841
+    wxplot/histogram.py: E722
+    wxplot/profile.py: F841, E722
+    wxplot/base.py: F841, E722
     location_wizard/dialogs.py: F841
+    location_wizard/wizard.py: E722
+    mapdisp/main.py: E722
     mapdisp/statusbar.py: F841
-    web_services/widgets.py: F841
+    mapwin/base.py: E722
+    mapwin/buffered.py: E722
+    mapwin/graphics.py: E722
+    startup/locdownload.py: E722
+    tools/build_modules_xml.py: E722
+    web_services/widgets.py: F841, E741, W605
+    rlisetup/frame.py: E741
     rlisetup/sampling_frame.py: F841
+    rlisetup/wizard.py: E722, E741
+    # This file will be deleted.
+    gis_set.py: E722
 
 max-line-length = 88
 exclude =

--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -878,7 +878,7 @@ def test():
     prov.mapsLoaded.connect(
         lambda: sys.stdout.write("Maps loading finished\n"))
     cmdMatrix = layerListToCmdsMatrix(layerList)
-    prov.SetCmds(cmdMatrix, [l.opacity for l in layerList])
+    prov.SetCmds(cmdMatrix, [layer.opacity for layer in layerList])
     app = wx.App()
 
     prov.Load(bgcolor=(13, 156, 230), nprocs=4)

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -748,34 +748,38 @@ class HelpWindow(HtmlWindow):
         try:
             contents = []
             skip = False
-            for l in open(htmlFile, "rb").readlines():
-                if "DESCRIPTION" in l:
+            for line in open(htmlFile, "rb").readlines():
+                if "DESCRIPTION" in line:
                     skip = False
                 if not skip:
                     # do skip the options description if requested
-                    if "SYNOPSIS" in l:
+                    if "SYNOPSIS" in line:
                         skip = skipDescription
                     else:
                         # FIXME: find only first item
-                        findALink = aLink.search(l)
+                        findALink = aLink.search(line)
                         if findALink is not None:
                             contents.append(
                                 aLink.sub(
                                     findALink.group(1) +
                                     self.fspath +
                                     findALink.group(2),
-                                    l))
-                        findImgLink = imgLink.search(l)
+                                    line
+                                )
+                            )
+                        findImgLink = imgLink.search(line)
                         if findImgLink is not None:
                             contents.append(
                                 imgLink.sub(
                                     findImgLink.group(1) +
                                     self.fspath +
                                     findImgLink.group(2),
-                                    l))
+                                    line
+                                )
+                            )
 
                         if findALink is None and findImgLink is None:
-                            contents.append(l)
+                            contents.append(line)
             self.SetPage("".join(contents))
             self.loaded = True
         except:  # The Manual file was not found

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -1313,8 +1313,9 @@ class MapManager:
         :param str name: layer (raster) name
         :param str resultsLayer: True if layer is temp. raster showing the results of computation
         """
-        if (resultsLayer and name in [l.GetName()
-                                      for l in self.map.GetListOfLayers(name=name)]):
+        if resultsLayer and name in [
+            layer.GetName() for layer in self.map.GetListOfLayers(name=name)
+        ]:
             self.frame.Render(self.mapWindow)
             return
 

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -1971,23 +1971,22 @@ class BufferedMapWindow(MapWindowBase, Window):
         rast3d = None
         vect = []
         updated = False
-        for l in layers:
+        for layer in layers:
             # only one raster is used: g.region does not support multiple
-            if l.type == 'raster':
-                rast.append(l.GetName())
-            elif l.type == 'raster_3d':
-                rast3d = l.GetName()
-            elif l.type == 'vector':
-                if self.digit and \
-                        self.toolbar.GetLayer() == l:
+            if layer.type == "raster":
+                rast.append(layer.GetName())
+            elif layer.type == "raster_3d":
+                rast3d = layer.GetName()
+            elif layer.type == "vector":
+                if self.digit and self.toolbar.GetLayer() == layer:
                     w, s, b, e, n, t = self.digit.GetDisplay().GetMapBoundingBox()
                     self.Map.GetRegion(n=n, s=s, w=w, e=e,
                                        update=True)
                     updated = True
                 else:
-                    vect.append(l.name)
-            elif l.type == 'rgb':
-                for rname in l.GetName().splitlines():
+                    vect.append(layer.name)
+            elif layer.type == "rgb":
+                for rname in layer.GetName().splitlines():
                     rast.append(rname)
 
         if not updated:

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -264,7 +264,7 @@ class TimelineFrame(wx.Frame):
         if self.temporalType == 'absolute':
             convert = mdates.date2num
         else:
-            convert = lambda x: x
+            convert = lambda x: x  # noqa: E731
 
         colors = cycle(COLORS)
         plots = []
@@ -310,7 +310,7 @@ class TimelineFrame(wx.Frame):
         if self.temporalType == 'absolute':
             convert = mdates.date2num
         else:
-            convert = lambda x: x
+            convert = lambda x: x  # noqa: E731
 
         colors = cycle(COLORS)
 

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -1946,7 +1946,7 @@ class TurnAnglesList(
         if column in [1, 2, 3]:
             try:
                 text = float(text)
-            except:
+            except ValueError:
                 return
         if column in [1, 2]:
             text = DegreesToRadians(text)

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -701,9 +701,9 @@ class VNETAnalysisParameters:
         # check arc/node layer
         layers = utils.GetVectorNumberOfLayers(params["input"])
 
-        for l in ['arc_layer', 'node_layer', 'turn_layer', 'turn_cat_layer']:
-            if not layers or params[l] not in layers:
-                invParams.append(l)
+        for layer in ["arc_layer", "node_layer", "turn_layer", "turn_cat_layer"]:
+            if not layers or params[layer] not in layers:
+                invParams.append(layer)
 
         dbInfo = VectorDBInfo(params["input"])
 

--- a/gui/wxpython/web_services/cap_interface.py
+++ b/gui/wxpython/web_services/cap_interface.py
@@ -38,9 +38,9 @@ class CapabilitiesBase:
     def GetLayerByName(self, name):
         """Find layer by name
         """
-        for l in self.layers_by_id:
-            if name == l.GetLayerData('name'):
-                return l
+        for layer in self.layers_by_id:
+            if name == layer.GetLayerData("name"):
+                return layer
         return None
 
     def GetRootLayer(self):
@@ -101,8 +101,8 @@ class WMSCapabilities(CapabilitiesBase, WMSCapabilitiesTree):
 
         layer_nodes = parent_layer.GetLayerNode().findall((self.xml_ns.Ns("Layer")))
 
-        for l in layer_nodes:
-            layer = WMSLayer(l, id, self)
+        for node in layer_nodes:
+            layer = WMSLayer(node, id, self)
             parent_layer.AddChildLayer(layer)
             self.layers_by_id[id] = layer
             id += 1
@@ -374,8 +374,8 @@ class OnEarthLayer(LayerBase):
 
     def __init__(self, layer_node, parent_layer, id, cap):
         """Common interface for web_services.widgets to NASA Earth
-            capabilities <TiledGroup>\<TiledGroups> element
-            (equivalent to  WMS, WMTS <Layer> element)
+        capabilities <TiledGroup>/<TiledGroups> element
+        (equivalent to  WMS, WMTS <Layer> element)
         """
         self.id = id
         self.cap = cap


### PR DESCRIPTION
* Enable warnings for invalid escape sequence, bare except, lambda vs def, and ambiguous variable names.
* Fix cases where l is line, layer, or (layer) node.
* Ignore two trivial lambdas inline.
* Resolve one except with ValueError and one backslash which should be forward (an alternative).
* Use Black for modified lines.
