### PR TITLE
wxGUI: Enable import-related warnings

### DIFF
--- a/gui/wxpython/.flake8
+++ b/gui/wxpython/.flake8
@@ -1,9 +1,6 @@
 [flake8]
 ignore =
     E265, # block comment should start with '# '
-    E402, # module level import not at top of file
-    F403, # 'from gmodeler.model import *' used; unable to detect undefined names
-    F405, # '_' may be undefined, or defined from star imports: gmodeler.model
     E117, # over-indented
     E122, # continuation line missing indentation or outdented
     E123, # closing bracket does not match indentation of opening bracket's line
@@ -38,20 +35,32 @@ ignore =
 per-file-ignores =
     # Many of these ignores can and should be removed and the problem fixed.
     # F841 local variable is assigned to but never used
-    core/*: F841, E722, W605
-    datacatalog/tree.py: E731
+    # F403 star import used; unable to detect undefined names
+    # F405 variable may be undefined, or defined from star imports
+    # E402 module level import not at top of file
+    core/gcmd.py: E402
+    core/gthread.py: F841
+    core/gconsole.py: E722, W605
+    core/toolboxes.py: E722
+    core/utils.py: E722, F841, W605
+    core/workspace.py: E722
+    core/render.py: E722, F841
+    core/ws.py: F841
+    core/settings.py: E722
+    datacatalog/tree.py: E731, E402
     dbmgr/*: F841, E722
+    docs/wxgui_sphinx/conf.py: E402
     gcp/*: F841, E722
-    gmodeler/*: F841, E722, W605
+    gmodeler/*: F841, E722, W605, F405, F403, E402
     gui_core/*: F841, E266, E722, W605
     image2target/*: F841, E722
-    iscatt/*: F841, E722, E741
+    iscatt/*: F841, E722, E741, F405, F403
     lmgr/*: F841, E266, E722, E741, W605
     modules/*: F841, E722, W605
-    nviz/*: F841, E266, E722, W605
+    nviz/*: F841, E266, E722, W605, F403, F405
     photo2image/*: F841, E722
-    psmap/*: F841, E266, E722
-    vdigit/*: F841, E722, E741
+    psmap/*: F841, E266, E722, F405, F403
+    vdigit/*: F841, E722, E741, F405, F403
     vnet/*: F841
     wxgui.py: F841
     animation/mapwindow.py: F841
@@ -59,7 +68,9 @@ per-file-ignores =
     tplot/frame.py: F841, E722
     rdigit/g.gui.rdigit.py: F841
     iclass/dialogs.py: E741
-    iclass/statistics.py: F841
+    iclass/digit.py: F405, F403
+    iclass/frame.py: F405, F403
+    iclass/statistics.py: F841, F405, F403
     wxplot/histogram.py: E722
     wxplot/profile.py: F841, E722
     wxplot/base.py: F841, E722
@@ -70,9 +81,9 @@ per-file-ignores =
     mapwin/base.py: E722
     mapwin/buffered.py: E722
     mapwin/graphics.py: E722
-    startup/locdownload.py: E722
+    startup/locdownload.py: E722, E402
     tools/build_modules_xml.py: E722
-    web_services/widgets.py: F841, E741, W605
+    web_services/widgets.py: F841, E741, W605, E402
     rlisetup/frame.py: E741
     rlisetup/sampling_frame.py: F841
     rlisetup/wizard.py: E722, E741

--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -20,6 +20,12 @@ import locale
 if not os.getenv("GISBASE"):
     sys.exit("GRASS is not running. Exiting...")
 
+# i18n is taken care of in the grass library code.
+# So we need to import it before any of the GUI code.
+from grass.script.core import get_commands
+
+from core.debug import Debug
+
 # path to python scripts
 ETCDIR = os.path.join(os.getenv("GISBASE"), "etc")
 GUIDIR = os.path.join(os.getenv("GISBASE"), "gui")
@@ -27,12 +33,6 @@ WXGUIDIR = os.path.join(GUIDIR, "wxpython")
 ICONDIR = os.path.join(GUIDIR, "icons")
 IMGDIR = os.path.join(GUIDIR, "images")
 SYMBDIR = os.path.join(IMGDIR, "symbols")
-
-# i18n is taken care of in the grass library code.
-# So we need to import it before any of the GUI code.
-from grass.script.core import get_commands
-
-from core.debug import Debug
 
 WXPY3_MIN_VERSION = [4, 0, 0, 0]
 
@@ -114,7 +114,8 @@ def CheckForWx():
 
 if not os.getenv("GRASS_WXBUNDLED"):
     CheckForWx()
-import wx
+# Importing wx only after checks.
+import wx  # noqa: E402
 
 if CheckWxPhoenix():
     try:

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -35,24 +35,25 @@ import time
 import shutil
 import fileinput
 
-from grass.script.setup import set_gui_path
-set_gui_path()
-
-from core import globalvar
-import wx
-
-from core import utils
-from core.giface import StandaloneGrassInterface
-from core.gcmd import RunCommand
-from core.render import Map, MapLayer, RenderMapMgr
-from mapdisp.frame import MapFrame
-from core.debug import Debug
-from core.settings import UserSettings
-
 from grass.script.utils import try_remove
 from grass.script import core as grass
 from grass.script.task import cmdtuple_to_list, cmdlist_to_tuple
 from grass.pydispatch.signal import Signal
+
+from grass.script.setup import set_gui_path
+set_gui_path()
+
+# GUI imports require path to GUI code to be set.
+from core import globalvar  # noqa: E402
+import wx  # noqa: E402
+
+from core import utils  # noqa: E402
+from core.giface import StandaloneGrassInterface  # noqa: E402
+from core.gcmd import RunCommand  # noqa: E402
+from core.render import Map, MapLayer, RenderMapMgr  # noqa: E402
+from mapdisp.frame import MapFrame  # noqa: E402
+from core.debug import Debug  # noqa: E402
+from core.settings import UserSettings  # noqa: E402
 
 # for standalone app
 monFile = {'cmd': None,

--- a/gui/wxpython/mapdisp/test_mapdisp.py
+++ b/gui/wxpython/mapdisp/test_mapdisp.py
@@ -58,14 +58,15 @@ import grass.script as grass
 from grass.script.setup import set_gui_path
 set_gui_path()
 
-from core.settings import UserSettings
-from core.giface import StandaloneGrassInterface
-from mapwin.base import MapWindowProperties
-from mapwin.buffered import BufferedMapWindow
-from core.render import Map
-from rlisetup.sampling_frame import RLiSetupMapPanel
-from mapdisp.main import LayerList
-from gui_core.wrap import StaticText
+# GUI imports require path to GUI code to be set.
+from core.settings import UserSettings  # noqa: E402
+from core.giface import StandaloneGrassInterface  # noqa: E402
+from mapwin.base import MapWindowProperties  # noqa: E402
+from mapwin.buffered import BufferedMapWindow  # noqa: E402
+from core.render import Map  # noqa: E402
+from rlisetup.sampling_frame import RLiSetupMapPanel  # noqa: E402
+from mapdisp.main import LayerList  # noqa: E402
+from gui_core.wrap import StaticText  # noqa: E402
 
 
 class MapdispGrassInterface(StandaloneGrassInterface):

--- a/gui/wxpython/modules/mapsets_picker.py
+++ b/gui/wxpython/modules/mapsets_picker.py
@@ -5,8 +5,9 @@ import wx
 from grass.script.setup import set_gui_path
 set_gui_path()
 
-from core.gcmd import RunCommand
-from gui_core.preferences import MapsetAccess
+# Imports require path to GUI code to be set.
+from core.gcmd import RunCommand  # noqa: E402
+from gui_core.preferences import MapsetAccess  # noqa: E402
 
 
 def main():

--- a/gui/wxpython/web_services/cap_interface.py
+++ b/gui/wxpython/web_services/cap_interface.py
@@ -28,9 +28,12 @@ WMSLibPath = os.path.join(os.getenv("GISBASE"), "etc", "r.in.wms")
 if WMSLibPath not in sys.path:
     sys.path.append(WMSLibPath)
 
-from wms_cap_parsers import WMSCapabilitiesTree, \
-    WMTSCapabilitiesTree, \
-    OnEarthCapabilitiesTree
+# Import only after the path has been set up.
+from wms_cap_parsers import (  # noqa: E402
+    WMSCapabilitiesTree,
+    WMTSCapabilitiesTree,
+    OnEarthCapabilitiesTree,
+)
 
 
 class CapabilitiesBase:


### PR DESCRIPTION
Enable Flake8 warnings for star import, not at top file import, and may be undefined var with star import.
Fix or make in-file exceptions for some. Use per-file-ignore for the rest.
Replace directory ignore for core by separate ignore lists for each file.
