### PR TITLE
wxGUI/g.extension: fix failure to uninstall addon

### DIFF
--- a/gui/wxpython/modules/extensions.py
+++ b/gui/wxpython/modules/extensions.py
@@ -546,7 +546,7 @@ class CheckListExtension(GListCtrl):
         """
         extList = list()
         for i in range(self.GetItemCount()):
-            if self.IsChecked(i):
+            if self.IsItemChecked(i):
                 name = self.GetItemText(i)
                 if name:
                     extList.append(name)


### PR DESCRIPTION
Attempt to uninstall add-ons in GUI (via `Settings > Addons extensions > Manage installed extension`) fails with following error message: 


<img width="878" alt="screenshot" src="https://user-images.githubusercontent.com/14186207/114594869-0e0db300-9c8e-11eb-8d3a-e7c569072f7e.png">


```
Traceback (most recent call last):
  File "/Applications/GRASS-7.9.app/Contents/Resources/gui/w
xpython/modules/extensions.py", line 477, in OnUninstall

eList = self._getSelectedExtensions()
  File "/Applications/GRASS-7.9.app/Contents/Resources/gui/w
xpython/modules/extensions.py", line 466, in
_getSelectedExtensions

eList = self.extList.GetExtensions()
  File "/Applications/GRASS-7.9.app/Contents/Resources/gui/w
xpython/modules/extensions.py", line 549, in GetExtensions

if self.IsChecked(i):
AttributeError
:
'CheckListExtension' object has no attribute 'IsChecked'
```


this PR addresses this (calling `ListCtrl::IsItemChecked()` declared in `wxpython/gui_core/wrap.py`).