### PR TITLE
lib/init: set HISTSIZE to empty string for unlimited size

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1930,7 +1930,7 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
     """Start Bash or Z shell (but not sh (Bourne Shell))"""
     if sh == "bash":
         # set bash history to record an unlimited command history
-        sh_history_limit = "-1"  # unlimited
+        sh_history_limit = ""  # unlimited
         os.environ["HISTSIZE"] = sh_history_limit
         os.environ["HISTFILESIZE"] = sh_history_limit
         sh_history = ".bash_history"


### PR DESCRIPTION
Value "-1" only works for bash 4.3 and later, whereas built-in bash on Mac is frozen at 3.2.57.