### PR TITLE
pythonlib: Enable escape sequence warning

### DIFF
--- a/python/grass/.flake8
+++ b/python/grass/.flake8
@@ -6,7 +6,6 @@ ignore =
     E741, # ambiguous variable name 'l'
     F403, # 'from ctypes import *' used; unable to detect undefined names
     F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
-    W605, # invalid escape sequence '\_'
 
 per-file-ignores =
     # C wrappers call libgis.G_gisinit before importing other modules.
@@ -14,17 +13,25 @@ per-file-ignores =
     pygrass/vector/__init__.py: E402,
     pygrass/raster/__init__.py: E402,
     # Files and directories which need fixes or specific exceptions
+    # E501 line too long
+    # W605 invalid escape sequence
     gunittest/*.py: E501  # These are mainly just todo comments
+    gunittest/gmodules.py: E501, W605
+    pygrass/vector/geometry.py: W605
     pygrass/vector/table.py: E501
     pygrass/vector/__init__.py: E501, E402
     pygrass/modules/interface/*.py: E501, F401
+    pygrass/modules/interface/module.py: E501, W605
+    pygrass/modules/interface/parameter.py: E501, W605
     pygrass/modules/grid/*.py: E501, F401
     pygrass/raster/*.py: E501
     pygrass/rpc/__init__.py: E501, F401
     pygrass/utils.py: E402, E501
     script/db.py: E501
+    script/task.py: W605
     script/vector.py: E501  # Long doctest lines which need review anyway
     temporal/*.py: E501, F841
+    temporal/abstract_space_time_dataset.py: W605, E501, F841
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     pygrass/tests/benchmark.py: E501, E402, F401, F821

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -497,7 +497,7 @@ def create_test_vector_map(map_name="test_vector"):
 
 
 def create_test_stream_network_map(map_name="streams"):
-    """
+    R"""
        This functions creates a vector map layer with lines that represent
        a stream network with two different graphs. The first graph
        contains a loop, the second can be used as directed graph.

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -155,7 +155,7 @@ def db_select(sql=None, filename=None, table=None, env=None, **args):
     :param str sql: SQL statement to perform (or None)
     :param str filename: name of file with SQL statements (or None)
     :param str table: name of table to query (or None)
-    :param str args:  see \gmod{db.select} arguments
+    :param str args: see *db.select* arguments
     :param env: environment
     """
     fname = tempfile(create=False, env=env)

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -1,4 +1,4 @@
-"""Setup, initialization, and clean-up functions
+R"""Setup, initialization, and clean-up functions
 
 Functions can be used in Python scripts to setup a GRASS environment
 and session without using grassXY.


### PR DESCRIPTION
* Enable globally invalid escape sequence from Flake8 in grass pkg.
* Fix two unrelated usages of backslashes by raw string with R (often used
  as a standard for non-regexp raw strings).
* Remove outdated module formatting/reference from Doxygen.
* Ignore the rest for now using per file ignores.
