### PR TITLE
wxGUI: Enable all Flake8 warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -30,6 +30,8 @@ per-file-ignores =
     doc/gui/wxpython/example/dialogs.py: F401
     doc/gui/wxpython/example/g.gui.example.py: E501
     locale/grass_po_stats.py: E122, E128, E231, E401, E501, E722, E741
+    gui/scripts/d.rast3d.py: E501
+    gui/scripts/d.wms.py: E501
 
 max-line-length = 88
 exclude =
@@ -52,8 +54,8 @@ exclude =
     lib/init,
     python/grass,
     gui/wxpython,
-    scripts,
-    temporal,
+    scripts/*/*.py,
+    temporal/*/*.py,
     # No tests checked for now
     testsuite,
 

--- a/gui/scripts/d.rast3d.py
+++ b/gui/scripts/d.rast3d.py
@@ -30,8 +30,7 @@
 # % required : yes
 # %end
 
-from grass.script import core as grass
+import grass.script as gs
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
-    main()
+    gs.parser()

--- a/gui/wxpython/.flake8
+++ b/gui/wxpython/.flake8
@@ -2,8 +2,6 @@
 ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
-    E501,  # line too long (fix needed)
-    E265,  # block comment should start with '# ' (fix needed)
 
 per-file-ignores =
     # Many of these ignores can and should be removed and the problem fixed.
@@ -11,59 +9,92 @@ per-file-ignores =
     # F403 star import used; unable to detect undefined names
     # F405 variable may be undefined, or defined from star imports
     # E402 module level import not at top of file
-    core/gcmd.py: E402
+    # E501 line too long
+    core/debug.py: E501
+    core/gcmd.py: E402, E501
+    core/giface.py: E501
     core/gthread.py: F841
     core/gconsole.py: E722, W605
-    core/toolboxes.py: E722
+    core/toolboxes.py: E722, E501
     core/utils.py: E722, F841, W605
-    core/workspace.py: E722
-    core/render.py: E722, F841
-    core/ws.py: F841
+    core/workspace.py: E722, E501
+    core/render.py: E722, F841, E501
+    core/ws.py: F841, E501
     core/settings.py: E722
-    datacatalog/tree.py: E731, E402
-    dbmgr/*: F841, E722
-    docs/wxgui_sphinx/conf.py: E402
-    gcp/*: F841, E722
+    datacatalog/tree.py: E731, E402, E501
+    dbmgr/base.py: E501, E722, F841
+    dbmgr/dialogs.py: E501, F841, E722
+    dbmgr/sqlbuilder.py: E501, E722, F841
+    dbmgr/manager.py: E501, E722
+    dbmgr/vinfo.py: F841
+    docs/wxgui_sphinx/conf.py: E402, E501
+    gcp/g.gui.gcp.py: F841
+    gcp/manager.py: E501, F841, E722
+    gcp/mapdisplay.py: F841
     gmodeler/*: F841, E722, W605, F405, F403, E402
     gui_core/*: F841, E266, E722, W605
-    image2target/*: F841, E722
-    iscatt/*: F841, E722, E741, F405, F403
-    lmgr/*: F841, E266, E722, E741, W605
+    gui_core/dialogs.py: E501, E722, F841, W605
+    gui_core/forms.py: E501, E722, F841
+    gui_core/ghelp.py: E501, E722
+    gui_core/gselect.py: E501, F841, E266, E722
+    gui_core/preferences.py: E501, E266, F841
+    gui_core/treeview.py: E501, F841
+    gui_core/widgets.py: E501, F841, E722, E266
+    image2target/*: F841, E722, E265, E501
+    iscatt/*: F841, E722, E741, F405, F403, E501
+    lmgr/giface.py: E501, E741
+    lmgr/frame.py: F841, E722, W605, E501
     # layertree still includes some formatting issues (it is ignored by Black)
-    lmgr/layertree.py: E722, E266, W504, E225
-    modules/*: F841, E722, W605
-    nviz/*: F841, E266, E722, W605, F403, F405
-    photo2image/*: F841, E722
-    psmap/*: F841, E266, E722, F405, F403
-    vdigit/*: F841, E722, E741, F405, F403
-    vnet/*: F841
+    lmgr/layertree.py: E722, E266, W504, E225, E501
+    lmgr/workspace.py: F841
+    modules/*: F841, E722, W605, E501
+    nviz/*: F841, E266, E722, W605, F403, F405, E501
+    photo2image/*: F841, E722, E265, E501
+    psmap/*: F841, E266, E722, F405, F403, E501
+    vdigit/*: F841, E722, E741, F405, F403, E501
+    vnet/*: F841, E501
     wxgui.py: F841
+    animation/g.gui.animation.py: E501
     animation/mapwindow.py: F841
-    animation/provider.py: F841
+    animation/provider.py: F841, E501
+    animation/temporal_manager.py: E501
     tplot/frame.py: F841, E722
+    tplot/g.gui.tplot.py: E501
     rdigit/g.gui.rdigit.py: F841
-    iclass/dialogs.py: E741
+    rdigit/toolbars.py: E501
+    iclass/dialogs.py: E741, E501
     iclass/digit.py: F405, F403
-    iclass/frame.py: F405, F403
+    iclass/frame.py: F405, F403, E501
+    iclass/g.gui.iclass.py: E501
     iclass/statistics.py: F841, F405, F403
+    wxplot/dialogs.py: E501
     wxplot/histogram.py: E722
     wxplot/profile.py: F841, E722
     wxplot/base.py: F841, E722
-    location_wizard/dialogs.py: F841
+    wxplot/scatter.py: E501
+    location_wizard/dialogs.py: F841, E501
     location_wizard/wizard.py: E722
-    mapdisp/main.py: E722
-    mapdisp/statusbar.py: F841
-    mapwin/base.py: E722
-    mapwin/buffered.py: E722
+    mapdisp/frame.py: E501
+    mapdisp/main.py: E722, E501
+    mapdisp/test_mapdisp.py: E501
+    mapdisp/toolbars.py: E501
+    mapdisp/statusbar.py: F841, E501
+    mapswipe/g.gui.mapswipe.py: E501
+    mapwin/base.py: E722, E501
+    mapwin/buffered.py: E722, E501
+    mapwin/decorations.py: E501
     mapwin/graphics.py: E722
-    startup/locdownload.py: E722, E402
-    tools/build_modules_xml.py: E722
-    web_services/widgets.py: F841, E741, W605, E402
+    startup/locdownload.py: E722, E402, E501
+    timeline/g.gui.timeline.py: E501
+    tools/build_modules_xml.py: E722, E501
+    web_services/cap_interface.py: E501
+    web_services/dialogs.py: E501
+    web_services/widgets.py: F841, E741, W605, E402, E501
     rlisetup/frame.py: E741
     rlisetup/sampling_frame.py: F841
     rlisetup/wizard.py: E722, E741
-    # This file will be deleted.
-    gis_set.py: E722
+    # Generated file
+    menustrings.py: E501
 
 max-line-length = 88
 exclude =

--- a/gui/wxpython/datacatalog/infomanager.py
+++ b/gui/wxpython/datacatalog/infomanager.py
@@ -41,7 +41,8 @@ class DataCatalogInfoManager:
             "which contain Mapsets (subprojects). All data in one Location is "
             "in the same coordinate reference system (CRS).\n\n"
             "You are currently in Mapset PERMANENT in default Location {loc} "
-            "which uses WGS 84 (EPSG:4326). Consider creating a new Location with a CRS "
+            "which uses WGS 84 (EPSG:4326). "
+            "Consider creating a new Location with a CRS "
             "specific to your area. You can do it now or anytime later from "
             "the toolbar above."
         ).format(loc=gisenv()["LOCATION_NAME"])

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -221,7 +221,7 @@ latex_elements = {
     # The font size ('10pt', '11pt' or '12pt').
     "pointsize": "10pt",
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # "preamble": "",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -333,7 +333,7 @@ class RLIWizard(object):
             x = float(self.SF_X) / float(self.rasterinfo["cols"])
             y = float(self.SF_Y) / float(self.rasterinfo["rows"])
             fil.write("SAMPLEAREA %r|%r|%r|%r\n" % (self.per_x, self.per_y, rl, cl))
-        ##KMWINC = samplingtype=moving, regionbox=keyboard, shape=circle
+        # KMWINC = samplingtype=moving, regionbox=keyboard, shape=circle
         elif samtype == SamplingType.KMVWINC:
             self._circle(self.moving.width, self.moving.height)
             cl = float(self.CIR_CL) / float(self.rasterinfo["cols"])
@@ -361,8 +361,8 @@ class RLIWizard(object):
             fil.write("SAMPLEAREA -1|-1|%r|%r" % (rl, cl))
             fil.write("|%s" % self.msAreaList[0].raster)
             fil.write("\nMOVINGWINDOW\n")
-        ##KUNITSC = samplingtype=units, regionbox=keyboard, shape=cirlce
-        ##KUNITSR = samplingtype=units, regionbox=keyboard, shape=rectangle
+        # KUNITSC = samplingtype=units, regionbox=keyboard, shape=cirlce
+        # KUNITSR = samplingtype=units, regionbox=keyboard, shape=rectangle
         elif samtype == SamplingType.KUNITSC or samtype == SamplingType.KUNITSR:
             if samtype == SamplingType.KUNITSC:
                 self._circle(self.units.width, self.units.height)
@@ -389,8 +389,8 @@ class RLIWizard(object):
         # elif self.samplingareapage.samplingtype == SamplingType.UNITS and
         # self.samplingareapage.regionbox=='mouse':
 
-        ##MUNITSC = samplingtype=units, regionbox=mouse, shape=cirlce
-        ##MUNITSR = samplingtype=units, regionbox=mouse, shape=rectangle
+        # MUNITSC = samplingtype=units, regionbox=mouse, shape=cirlce
+        # MUNITSR = samplingtype=units, regionbox=mouse, shape=rectangle
         elif self.samplingareapage.samplingtype in [
             SamplingType.MUNITSR,
             SamplingType.MUNITSC,
@@ -1274,7 +1274,7 @@ class DrawRegionsPage(TitledPage):
             )
 
     # def OnExitPage(self, event=None):
-    #!Function during exiting
+    # Function during exiting
     # print event.GetDirection()
     # if event.GetDirection():
     #    self.SetNext(self.parent.samplingareapage)
@@ -1789,7 +1789,7 @@ class DrawSampleUnitsPage(TitledPage):
             )
 
     def OnExitPage(self, event=None):
-        #!Function during exiting
+        """Function during exiting"""
         pass
 
         # if event.GetDirection():

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -40,7 +40,8 @@ except ImportError as e:
     raise ImportError(
         _(
             'The Timeline Tool needs the "matplotlib" '
-            "(python-matplotlib and on some systems also python-matplotlib-wx) package(s) to be installed. {0}"
+            "(python-matplotlib and on some systems also python-matplotlib-wx) "
+            "package(s) to be installed. {}"
         ).format(e)
     )
 

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -798,7 +798,7 @@ class VNETDialog(wx.Dialog):
     def _updateParamsTab(self, params, flags):
         # TODO flag
 
-        #'turn_layer', 'turn_cat_layer',
+        # 'turn_layer', 'turn_cat_layer',
         for k in [
             "input",
             "arc_layer",

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -251,7 +251,10 @@ class ProfileFrame(BasePlotFrame):
             self.ylabel = self.ylabel.rstrip(",")
 
     def CreateDatalist(self, raster, coords):
-        """Build a list of distance, value pairs for points along transect using r.profile"""
+        """Build a list of distance, value pairs for points along transect
+
+        Uses r.profile to obtain the data.
+        """
         datalist = []
 
         # keep total number of transect points to 500 or less to avoid


### PR DESCRIPTION
* Enable remaning Flake8 warnings globally.
* More precise (narrow) pattern for scripts and temporal dirs.
* Previously ignored gui/scripts directory is now checked.
* Simplify d.rast3d.
* Fix some hash-hash comments and long lines.
* Ignore remaining warnings using per file ignores.
* Break down some directory ignore into true per file ignores for easier fixing
  and greater current checks.
