### PR TITLE
pythonlib: Enable ambiguous variable name warning

### DIFF
--- a/python/grass/.flake8
+++ b/python/grass/.flake8
@@ -3,7 +3,6 @@ ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
     E722, # do not use bare 'except'
-    E741, # ambiguous variable name 'l'
     F403, # 'from ctypes import *' used; unable to detect undefined names
     F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
 
@@ -15,6 +14,7 @@ per-file-ignores =
     # Files and directories which need fixes or specific exceptions
     # E501 line too long
     # W605 invalid escape sequence
+    # E741 ambiguous variable name 'l'
     gunittest/*.py: E501  # These are mainly just todo comments
     gunittest/gmodules.py: E501, W605
     pygrass/vector/geometry.py: W605
@@ -25,6 +25,7 @@ per-file-ignores =
     pygrass/modules/interface/parameter.py: E501, W605
     pygrass/modules/grid/*.py: E501, F401
     pygrass/raster/*.py: E501
+    pygrass/raster/rowio.py: E741
     pygrass/rpc/__init__.py: E501, F401
     pygrass/utils.py: E402, E501
     script/db.py: E501
@@ -32,6 +33,10 @@ per-file-ignores =
     script/vector.py: E501  # Long doctest lines which need review anyway
     temporal/*.py: E501, F841
     temporal/abstract_space_time_dataset.py: W605, E501, F841
+    temporal/temporal_algebra.py: E741, E501, F841
+    temporal/temporal_raster_algebra.py: E741
+    temporal/temporal_raster3d_algebra.py: E741
+    temporal/temporal_vector_algebra.py: E741, E501, F841
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     pygrass/tests/benchmark.py: E501, E402, F401, F821

--- a/python/grass/gunittest/checkers.py
+++ b/python/grass/gunittest/checkers.py
@@ -52,10 +52,10 @@ def unify_projection(dic):
     # possible name for a projection system
     lookup = [["Universal Transverse Mercator", "Universe Transverse Mercator"]]
     dic = dict(dic)
-    for l in lookup:
+    for item in lookup:
         for n in range(len(dic["name"])):
-            if dic["name"][n] in l:
-                dic["name"][n] = l[0]
+            if dic["name"][n] in item:
+                dic["name"][n] = item[0]
     return dic
 
 
@@ -87,21 +87,21 @@ def unify_units(dic):
         ["Kilometers", "Kilometres"],
     ]
     dic = dict(dic)
-    for l in lookup:
+    for item in lookup:
         if not isinstance(dic["unit"], str):
             for n in range(len(dic["unit"])):
-                if dic["unit"][n] in l:
-                    dic["unit"][n] = l[0]
+                if dic["unit"][n] in item:
+                    dic["unit"][n] = item[0]
         else:
-            if dic["unit"] in l:
-                dic["unit"] = l[0]
+            if dic["unit"] in item:
+                dic["unit"] = item[0]
         if not isinstance(dic["units"], str):
             for n in range(len(dic["units"])):
-                if dic["units"][n] in l:
-                    dic["units"][n] = l[0]
+                if dic["units"][n] in item:
+                    dic["units"][n] = item[0]
         else:
-            if dic["units"] in l:
-                dic["units"] = l[0]
+            if dic["units"] in item:
+                dic["units"] = item[0]
     return dic
 
 

--- a/python/grass/pygrass/gis/__init__.py
+++ b/python/grass/pygrass/gis/__init__.py
@@ -443,7 +443,7 @@ class VisibleMapset(object):
         with open(self.spath, "ab+") as f:
             lines = f.readlines()
             if lines:
-                return [decode(l.strip()) for l in lines]
+                return [decode(line.strip()) for line in lines]
         lns = [
             "PERMANENT",
         ]

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -538,29 +538,29 @@ def create_test_stream_network_map(map_name="streams"):
     with VectorTopo(map_name, mode="w", tab_name=map_name, tab_cols=cols) as streams:
 
         # First flow graph
-        l = Line([(0, 2), (0.22, 1.75), (0.55, 1.5), (1, 1)])
-        streams.write(l, cat=1, attrs=(1,))
-        l = Line([(2, 2), (1, 1)])
-        streams.write(l, cat=2, attrs=(2,))
-        l = Line([(1, 1), (0.85, 0.5), (1, 0)])
-        streams.write(l, cat=3, attrs=(3,))
-        l = Line([(2, 1), (1, 0)])
-        streams.write(l, cat=4, attrs=(4,))
-        l = Line([(0, 1), (1, 0)])
-        streams.write(l, cat=5, attrs=(5,))
-        l = Line([(1, 0), (1, -1)])
-        streams.write(l, cat=6, attrs=(6,))
+        line = Line([(0, 2), (0.22, 1.75), (0.55, 1.5), (1, 1)])
+        streams.write(line, cat=1, attrs=(1,))
+        line = Line([(2, 2), (1, 1)])
+        streams.write(line, cat=2, attrs=(2,))
+        line = Line([(1, 1), (0.85, 0.5), (1, 0)])
+        streams.write(line, cat=3, attrs=(3,))
+        line = Line([(2, 1), (1, 0)])
+        streams.write(line, cat=4, attrs=(4,))
+        line = Line([(0, 1), (1, 0)])
+        streams.write(line, cat=5, attrs=(5,))
+        line = Line([(1, 0), (1, -1)])
+        streams.write(line, cat=6, attrs=(6,))
         # Reverse line 3
-        l = Line([(1, 0), (1.15, 0.5), (1, 1)])
-        streams.write(l, cat=7, attrs=(7,))
+        line = Line([(1, 0), (1.15, 0.5), (1, 1)])
+        streams.write(line, cat=7, attrs=(7,))
 
         # second flow graph
-        l = Line([(0, -1), (1, -2)])
-        streams.write(l, cat=8, attrs=(8,))
-        l = Line([(2, -1), (1, -2)])
-        streams.write(l, cat=9, attrs=(9,))
-        l = Line([(1, -2), (1, -3)])
-        streams.write(l, cat=10, attrs=(10,))
+        line = Line([(0, -1), (1, -2)])
+        streams.write(line, cat=8, attrs=(8,))
+        line = Line([(2, -1), (1, -2)])
+        streams.write(line, cat=9, attrs=(9,))
+        line = Line([(1, -2), (1, -3)])
+        streams.write(line, cat=10, attrs=(10,))
 
         streams.organization = "Thuenen Institut"
         streams.person = "Soeren Gebbert"

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -730,9 +730,9 @@ class VectorTopo(Vector):
             self.table.filters.select(",".join(self.table.columns.names()))
             # Execute the query and fetch the result
             cur = self.table.execute()
-            l = cur.fetchall()
+            entries = cur.fetchall()
             # Generate the dictionary
-            for entry in l:
+            for entry in entries:
                 table_dict[entry[cat_index]] = list(entry)
 
             return table_dict
@@ -842,7 +842,7 @@ class VectorTopo(Vector):
 
         if bboxlist is not None and len(bboxlist) > 0:
 
-            l = []
+            wkb_list = []
             line_p = libvect.line_pnts()
             line_c = libvect.line_cats()
             size = ctypes.c_size_t()
@@ -875,10 +875,10 @@ class VectorTopo(Vector):
                 else:
                     pcat = cat.value
 
-                l.append((f_id, pcat, ctypes.string_at(barray, size.value)))
+                wkb_list.append((f_id, pcat, ctypes.string_at(barray, size.value)))
                 libgis.G_free(barray)
 
-            return l
+            return wkb_list
         return None
 
     @must_be_open
@@ -942,7 +942,7 @@ class VectorTopo(Vector):
 
         if bboxlist is not None and len(bboxlist) > 0:
 
-            l = []
+            wkb_list = []
             line_c = libvect.line_cats()
             size = ctypes.c_size_t()
             cat = ctypes.c_int()
@@ -966,10 +966,10 @@ class VectorTopo(Vector):
                     if ok > 0:
                         pcat = cat.value
 
-                l.append((a_id, pcat, ctypes.string_at(barray, size.value)))
+                wkb_list.append((a_id, pcat, ctypes.string_at(barray, size.value)))
                 libgis.G_free(barray)
 
-            return l
+            return wkb_list
         return None
 
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1047,13 +1047,13 @@ def _compare_units(dic):
         ["kilometer", "kilometre"],
         ["kilometers", "kilometres"],
     ]
-    for l in lookup:
+    for item in lookup:
         for n in range(len(dic["unit"])):
-            if dic["unit"][n].lower() in l:
-                dic["unit"][n] = l[0]
+            if dic["unit"][n].lower() in item:
+                dic["unit"][n] = item[0]
         for n in range(len(dic["units"])):
-            if dic["units"][n].lower() in l:
-                dic["units"][n] = l[0]
+            if dic["units"][n].lower() in item:
+                dic["units"][n] = item[0]
     return dic
 
 

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -51,8 +51,8 @@ def db_describe(table, env=None, **args):
 
     cols = []
     result = {}
-    for l in s.splitlines():
-        f = l.split(":")
+    for line in s.splitlines():
+        f = line.split(":")
         key = f[0]
         f[1] = f[1].lstrip(" ")
         if key.startswith("Column "):

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -334,21 +334,21 @@ def split(s):
 # source:
 #    http://stackoverflow.com/questions/4836710/
 #    does-python-have-a-built-in-function-for-string-natural-sort/4836734#4836734
-def natural_sort(l):
+def natural_sort(items):
     """Returns sorted list using natural sort
     (deprecated, use naturally_sorted)
     """
-    return naturally_sorted(l)
+    return naturally_sorted(items)
 
 
-def naturally_sorted(l, key=None):
+def naturally_sorted(items, key=None):
     """Returns sorted list using natural sort"""
-    copy_l = l[:]
-    naturally_sort(copy_l, key)
-    return copy_l
+    copy_items = items[:]
+    naturally_sort(copy_items, key)
+    return copy_items
 
 
-def naturally_sort(l, key=None):
+def naturally_sort(items, key=None):
     """Sorts lists using natural sort"""
 
     def convert(text):
@@ -361,7 +361,7 @@ def naturally_sort(l, key=None):
             sort_key = actual_key
         return [convert(c) for c in re.split("([0-9]+)", sort_key)]
 
-    l.sort(key=alphanum_key)
+    items.sort(key=alphanum_key)
 
 
 def get_lib_path(modname, libname=None):

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -44,8 +44,8 @@ def vector_db(map, env=None, **kwargs):
     )
     result = {}
 
-    for l in s.splitlines():
-        f = l.split(";")
+    for line in s.splitlines():
+        f = line.split(";")
         if len(f) != 5:
             continue
 
@@ -379,7 +379,7 @@ def vector_what(
 
     if layer:
         if isinstance(layer, (tuple, list)):
-            layer_list = [str(l) for l in layer]
+            layer_list = [str(item) for item in layer]
         else:
             layer_list = [str(layer)]
         if len(layer_list) != len(map_list):

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1142,13 +1142,13 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             else:
                 end = end + gran
 
-        l = AbstractSpaceTimeDataset.resample_maplist_by_granularity(
+        maplist = AbstractSpaceTimeDataset.resample_maplist_by_granularity(
             maps, start, end, gran
         )
         if connection_state_changed:
             dbif.close()
 
-        return l
+        return maplist
 
     @staticmethod
     def resample_maplist_by_granularity(maps, start, end, gran):


### PR DESCRIPTION
Enable Flake8 warning about ambiguous variables name l in grass pkg.
Fix most of the cases (e.g., l is line).
Use per-file ignores for the rest (e.g., lexer in temporal).
