### PR TITLE
v.surf.idw: fix using potentially uninitialized ret value causing bogus warning

### DIFF
--- a/vector/v.surf.idw/read_sites.c
+++ b/vector/v.surf.idw/read_sites.c
@@ -86,7 +86,7 @@ void read_sites(const char *name, const char *field_name, const char *col,
             continue;
 
         if (!with_z) {
-            int cat, ival, ret;
+            int cat;
 
             /* TODO: what to do with multiple cats */
             Vect_cat_get(Cats, field, &cat);
@@ -94,6 +94,8 @@ void read_sites(const char *name, const char *field_name, const char *col,
                 continue;
 
             if (col) {
+                int ival, ret;
+
                 if (ctype == DB_C_TYPE_INT) {
                     ret = db_CatValArray_get_value_int(&cvarr, cat, &ival);
                     dval = ival;
@@ -101,14 +103,13 @@ void read_sites(const char *name, const char *field_name, const char *col,
                 else {          /* DB_C_TYPE_DOUBLE */
                     ret = db_CatValArray_get_value_double(&cvarr, cat, &dval);
                 }
+                if (ret != DB_OK) {
+                    G_warning(_("No record for point (cat = %d)"), cat);
+                    continue;
+                }
             }
             else {
                 dval = cat;
-            }
-
-            if (ret != DB_OK) {
-                G_warning(_("No record for point (cat = %d)"), cat);
-                continue;
             }
         }
         else


### PR DESCRIPTION
Sometimes causes this warning when no column is specified:
```
WARNING: No record for point (cat = 1)
...
```