### PR TITLE
pythonlib: Reduce usage of bare except in script

### DIFF
--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -108,7 +108,7 @@ def try_remove(path):
     """
     try:
         os.remove(path)
-    except:
+    except Exception:
         pass
 
 
@@ -120,7 +120,7 @@ def try_rmdir(path):
     """
     try:
         os.rmdir(path)
-    except:
+    except Exception:
         shutil.rmtree(path, ignore_errors=True)
 
 


### PR DESCRIPTION
* Finer error reporting in the parser() function.
* Only ValueError errors in the key-value parsing function.
* Only specific errors in the del_temp_region() function.
* Generic Exception used instead of bare except (satisifies Flake8, although not Pylint).
