### PR TITLE
wxGUI: fix another wx flag assertion error in DefaultFontDialog

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -2535,9 +2535,7 @@ class DefaultFontDialog(wx.Dialog):
         btnsizer.AddButton(btn)
         btnsizer.Realize()
 
-        border.Add(
-            btnsizer, proportion=0, flag=wx.EXPAND | wx.ALIGN_RIGHT | wx.ALL, border=5
-        )
+        border.Add(btnsizer, proportion=0, flag=wx.EXPAND | wx.ALL, border=5)
 
         panel.SetAutoLayout(True)
         panel.SetSizer(border)


### PR DESCRIPTION
Addresses another wx flag assertion error, this time in `DefaultFontDialog`.

Error happened using Python 3.8.8/wxPython 4.1.1 with following steps:
d.legend > Font settings > Select font

```
Traceback (most recent call last):
  File "/Applications/GRASS-7.8.app/Contents/Resources/gui/w
xpython/gui_core/forms.py", line 2732, in OnSelectFont

dlg = DefaultFontDialog(parent=self,
  File "/Applications/GRASS-7.8.app/Contents/Resources/gui/w
xpython/gui_core/dialogs.py", line 2531, in __init__

border.Add(btnsizer, proportion=0,
wx._core
.
wxAssertionError
:
C++ assertion "!(flags & (wxALIGN_RIGHT |
wxALIGN_CENTRE_HORIZONTAL))" failed at
/Users/runner/miniforge3/conda-bld/wxpython_1616628568892/wo
rk/ext/wxWidgets/src/common/sizer.cpp(2159) in DoInsert():
Horizontal alignment flags are ignored with wxEXPAND
```
