### PR TITLE
pythonlib: Remove star imports

### DIFF
--- a/python/grass/.flake8
+++ b/python/grass/.flake8
@@ -3,8 +3,6 @@ ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
     E722, # do not use bare 'except'
-    F403, # 'from ctypes import *' used; unable to detect undefined names
-    F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
 
 per-file-ignores =
     # C wrappers call libgis.G_gisinit before importing other modules.
@@ -26,7 +24,7 @@ per-file-ignores =
     pygrass/modules/grid/*.py: E501, F401
     pygrass/raster/*.py: E501
     pygrass/raster/rowio.py: E741
-    pygrass/rpc/__init__.py: E501, F401
+    pygrass/rpc/__init__.py: E501, F401, F403
     pygrass/utils.py: E402, E501
     script/db.py: E501
     script/task.py: W605
@@ -45,10 +43,12 @@ per-file-ignores =
     docs/conf.py: E402, E501,
     # Files not managed by Black
     imaging/images2gif.py: E226, E501
-    # Unused imports
-    */__init__.py: F401,
-    */*/__init__.py: F401,
-    */*/*/__init__.py: F401
+    # Unused imports in init files
+    # F401 imported but unused
+    # F403 star import used; unable to detect undefined names
+    */__init__.py: F401, F403
+    */*/__init__.py: F401, F403
+    */*/*/__init__.py: F401, F403
 
 
 max-line-length = 88

--- a/python/grass/pygrass/rpc/__init__.py
+++ b/python/grass/pygrass/rpc/__init__.py
@@ -14,11 +14,12 @@ import time
 import threading
 import sys
 from multiprocessing import Process, Lock, Pipe
-from ctypes import *
+from ctypes import CFUNCTYPE, c_void_p
 
 from grass.exceptions import FatalError
-from grass.pygrass.vector import *
-from grass.pygrass.raster import *
+from grass.pygrass.vector import VectorTopo
+from grass.pygrass.vector.basic import Bbox
+from grass.pygrass.raster import RasterRow, raster2numpy_img
 import grass.lib.gis as libgis
 from .base import RPCServerBase
 from grass.pygrass.gis.region import Region
@@ -156,7 +157,7 @@ def _get_vector_features_as_wkb_list(lock, conn, data):
 
         if layer.exist() is True:
             if extent is not None:
-                bbox = basic.Bbox(
+                bbox = Bbox(
                     north=extent["north"],
                     south=extent["south"],
                     east=extent["east"],

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -19,7 +19,16 @@ for details.
 .. sectionauthor:: Martin Landa <landa.martin gmail.com>
 """
 from __future__ import absolute_import
-from .core import *
+
+import os
+from .core import (
+    run_command,
+    parse_command,
+    read_command,
+    tempfile,
+    fatal,
+    list_strings,
+)
 from .utils import try_remove
 from grass.exceptions import CalledModuleError
 

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -24,7 +24,17 @@ import sys
 import string
 import time
 
-from .core import *
+from .core import (
+    gisenv,
+    find_file,
+    tempfile,
+    run_command,
+    read_command,
+    write_command,
+    feed_command,
+    warning,
+    fatal,
+)
 from grass.exceptions import CalledModuleError
 from .utils import encode, float_or_dms, parse_key_val, try_remove
 

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -20,9 +20,11 @@ for details.
 """
 from __future__ import absolute_import
 
+import os
+import time
 import string
 
-from .core import *
+from .core import read_command, write_command, fatal
 from .utils import float_or_dms, parse_key_val
 from grass.exceptions import CalledModuleError
 

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -17,12 +17,13 @@ for details.
 
 .. sectionauthor:: Martin Landa <landa.martin gmail.com>
 """
+import os
 import re
 import sys
 
+from grass.exceptions import ScriptError
 from .utils import decode, split
-from .core import *
-
+from .core import Popen, PIPE, get_real_command
 
 try:
     import xml.etree.ElementTree as etree

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -18,10 +18,18 @@ for details.
 """
 from __future__ import absolute_import
 import os
+import sys
 
 from .utils import parse_key_val
-from .core import *
-from grass.exceptions import CalledModuleError
+from .core import (
+    run_command,
+    read_command,
+    error,
+    fatal,
+    debug,
+)
+
+from grass.exceptions import CalledModuleError, ScriptError
 
 unicode = str
 

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -14,7 +14,7 @@ from grass.exceptions import FatalError
 import sys
 from multiprocessing import Process, Lock, Pipe
 import logging
-from ctypes import *
+from ctypes import byref, cast, c_char_p, c_int, c_void_p, CFUNCTYPE, POINTER
 from datetime import datetime
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -33,7 +33,7 @@ import os
 import sys
 import grass.script as gscript
 
-from .c_libraries_interface import *
+from .c_libraries_interface import CLibrariesInterface
 from grass.pygrass import messages
 from grass.script.utils import decode
 

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -18,7 +18,7 @@ for details.
 :authors: Soeren Gebbert
 """
 from __future__ import print_function
-from .datetime_math import *
+from .datetime_math import compute_datetime_delta
 from functools import reduce
 from collections import OrderedDict
 import ast

--- a/python/grass/temporal/unit_tests.py
+++ b/python/grass/temporal/unit_tests.py
@@ -13,14 +13,24 @@ from __future__ import print_function
 import copy
 from datetime import datetime
 import grass.script.core as core
-from .temporal_granularity import *
-from .datetime_math import *
-from .space_time_datasets import *
+from .abstract_dataset import (
+    AbstractDatasetComparisonKeyStartTime,
+    AbstractDatasetComparisonKeyEndTime,
+)
+from .core import init
+from .datetime_math import increment_datetime_by_string, compute_datetime_delta
+from .space_time_datasets import RasterDataset
+from .spatial_extent import SpatialExtent
+from .spatio_temporal_relationships import SpatioTemporalTopologyBuilder
+from .temporal_granularity import (
+    adjust_datetime_to_granularity,
+    compute_absolute_time_granularity,
+)
 
 import grass.lib.vector as vector
 import grass.lib.rtree as rtree
 import grass.lib.gis as gis
-from ctypes import *
+from ctypes import byref
 
 # Uncomment this to detect the error
 core.set_raise_on_error(True)


### PR DESCRIPTION
Replaces star import (from x import *) by regular imports (from x import y).

Enables the relevant Flake8 warnings.

Adds the warning to per-file ignores for init files where we expect and allow
using star imports (unfortunatelly some init files contain actual code suffers
from these warning being disabled, but that's a different issue).
