### PR TITLE
pythonlib: Enable bare except warning

### DIFF
--- a/python/grass/.flake8
+++ b/python/grass/.flake8
@@ -2,7 +2,6 @@
 ignore =
     E203,  # whitespace before ':' (Black)
     W503,  # line break before binary operator (Black)
-    E722, # do not use bare 'except'
     F403, # 'from ctypes import *' used; unable to detect undefined names
     F405, # 'RasterRow' may be undefined, or defined from star imports: ctypes, grass.pygrass.raster, grass.pygrass.vector
 
@@ -31,12 +30,31 @@ per-file-ignores =
     script/db.py: E501
     script/task.py: W605
     script/vector.py: E501  # Long doctest lines which need review anyway
-    temporal/*.py: E501, F841
-    temporal/abstract_space_time_dataset.py: W605, E501, F841
-    temporal/temporal_algebra.py: E741, E501, F841
+    temporal/abstract_map_dataset.py: E501
+    temporal/abstract_space_time_dataset.py: W605, E501, F841, E722
+    temporal/aggregation.py: E501
+    temporal/base.py: E501
+    temporal/c_libraries_interface.py: E501, F841, E722
+    temporal/core.py: E501, E722
+    temporal/datetime_math.py: E501, F841, E722
+    temporal/list_stds.py: E501
+    temporal/metadata.py: E501
+    temporal/open_stds.py: F841
+    temporal/register.py: E501
+    temporal/space_time_datasets.py: E501
+    temporal/spatial_extent.py: E501
+    temporal/spatial_topology_dataset_connector.py: E501, E722
+    temporal/spatio_temporal_relationships.py: E501
+    temporal/temporal_algebra.py: E741, E501, F841, E722
+    temporal/temporal_extent.py: E501
+    temporal/temporal_granularity.py: E501, F841, E722
+    temporal/temporal_operator.py: E501
     temporal/temporal_raster_algebra.py: E741
+    temporal/temporal_raster_base_algebra.py: E501, F841, E722
     temporal/temporal_raster3d_algebra.py: E741
+    temporal/temporal_topology_dataset_connector.py: E501, E722
     temporal/temporal_vector_algebra.py: E741, E501, F841
+    temporal/univar_statistics.py: E501
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     pygrass/tests/benchmark.py: E501, E402, F401, F821

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -582,9 +582,6 @@ def import_stds(
         )
 
         os.chdir(old_cwd)
-    except:
-        raise
-
     # Make sure the location is switched back correctly
     finally:
         if location:

--- a/python/grass/temporal/temporal_operator.py
+++ b/python/grass/temporal/temporal_operator.py
@@ -144,7 +144,7 @@ from __future__ import print_function
 try:
     import ply.lex as lex
     import ply.yacc as yacc
-except:
+except ImportError:
     pass
 
 

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 
 try:
     import ply.yacc as yacc
-except:
+except ImportError:
     pass
 
 from .temporal_raster_base_algebra import (

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -55,7 +55,7 @@ from __future__ import print_function
 
 try:
     import ply.yacc as yacc
-except:
+except ImportError:
     pass
 
 from .temporal_raster_base_algebra import (

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -45,7 +45,7 @@ from __future__ import print_function
 
 try:
     import ply.yacc as yacc
-except:
+except ImportError:
     pass
 
 import grass.pygrass.modules as pygrass


### PR DESCRIPTION
* Enable Flake8 warning for bare except globally.
* Fix files with only ImportError missing or bare except-raise with finally
  (where finally is sufficient).
* Replace temporal directory ignores by true per-file ignores.
