### PR TITLE
wxGUI/LocWiz: remove unneeded +ellps proj4string tag

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2770,7 +2770,6 @@ class LocationWizard(wx.Object):
         proj4params = self.paramspage.p4projparams
 
         datumparams = self.datumpage.datumparams
-        ellipse = self.ellipsepage.ellipse
         ellipseparams = self.ellipsepage.ellipseparams
 
         #
@@ -2779,8 +2778,6 @@ class LocationWizard(wx.Object):
         proj4string = "%s %s" % (proj, proj4params)
 
         # set ellipsoid parameters
-        if ellipse != "":
-            proj4string = "%s +ellps=%s" % (proj4string, ellipse)
         for item in ellipseparams:
             if item[:4] == "f=1/":
                 item = " +rf=" + item[4:]


### PR DESCRIPTION
GRASS has private ellipse names which are not recognised by PROJ and should not be given as argument to the latter. More importantly, the ellipse params defined in `ellipse.table` are passed and this should be fully sufficient.

Fixes #758

