### PR TITLE
r.in.wms: enable CreateOptions for GDAL driver 

### DIFF
--- a/scripts/r.in.wms/r.in.wms.html
+++ b/scripts/r.in.wms/r.in.wms.html
@@ -50,7 +50,7 @@ r.in.wms -c url="http://wms.cuzk.cz/wms.asp"
 <h4>Open Street Map</h4>
 
 <div class="code"><pre>
-# OSM
+# OSM, using WMS_GRASS driver
 g.region n=90 s=-90 w=-180 e=180 res=0:10:00 -p
 r.in.wms url="http://watzmann-geog.urz.uni-heidelberg.de/cached/osm" layers=osm_auto:all output=osm format=png
 r.info osm
@@ -76,6 +76,7 @@ and on the <a href="http://wiki.openstreetmap.org/wiki/OSM-WMS-EUROPE">OSM-WMS-E
 <h4>Countries and coastlines</h4>
 
 <div class="code"><pre>
+# using WMS_GRASS driver
 r.in.wms url="http://www2.demis.nl/WMS/wms.asp" layers=Countries,Borders,Coastline output=countries srs=4326 format=png 
 r.info countries
 </pre></div>
@@ -85,6 +86,7 @@ r.info countries
 <div class="code"><pre>
 # North Carolina sample data
 g.region raster=elevation -p
+# using WMS_GRASS driver
 r.in.wms url="https://tiles.maps.eox.at/wms?" layers=s2cloudless output=sentinel2 format=png
 r.info sentinel2
 </pre></div>
@@ -97,6 +99,7 @@ r.info sentinel2
 <h4>OGC WMTS Example</h4>
 
 <div class="code"><pre>
+# using WMTS_GRASS driver
 r.in.wms url="http://gpp3-wxs.ign.fr/yourAPIkey/geoportail/wmts" layers=ORTHOIMAGERY.ORTHOPHOTOS \
          output=orthophoto srs=3857 format=jpeg driver=WMTS_GRASS style=normal password="*" username="*"
 r.info orthophoto
@@ -107,10 +110,12 @@ Note: username, password and API key can be obtained from <a href="http://api.ig
 <h4>Data covering the Czech Republic</h4>
 
 <div class="code"><pre>
+# using WMS_GRASS driver
 r.in.wms url="http://wms.cuzk.cz/wms.asp" layers=prehledka_kraju-linie srs=4326 output=kn format=png
 </pre></div>
 
 <div class="code"><pre>
+# using WMTS_GRASS driver
 r.in.wms url="http://geoportal.cuzk.cz/WMTS_ORTOFOTO/WMTService.aspx" layers=orto output=orthophoto \
          srs=3857 format=jpeg driver=WMTS_GRASS style=default
 r.info orthophoto
@@ -133,16 +138,24 @@ r.in.wms -c url="http://cidportal.jrc.ec.europa.eu/copernicus/services/ows/wms/p
 # spatial subset of Europe
 # enlarging maxcols and maxrows in order to minimize impact of copyright notice in map
 g.region n=56 s=47 w=5 e=16 res=0:00:10 -pa
+# using WMS_GRASS driver
 r.in.wms url="http://cidportal.jrc.ec.europa.eu/copernicus/services/ows/wms/public/core003?" \
          layer="OI.Mosaic.NaturalColor.Feathering" output="jrc_copernicus_core003_mosaik" \
          maxcols=3400 maxrows=3400
 r.info jrc_copernicus_core003_mosaik
+
+# Alternatively, using WMS_GDAL driver with BIGTIFF enabled
+r.in.wms url="http://cidportal.jrc.ec.europa.eu/copernicus/services/ows/wms/public/core003?" \
+         layer="OI.Mosaic.NaturalColor.Feathering" output="jrc_copernicus_core003_mosaik2" \
+         maxcols=3400 maxrows=3400 driver=WMS_GDAL gdal_createopt="BIGTIFF=YES"
+r.info jrc_copernicus_core003_mosaik2
+
 </pre></div>
 
 
 <h2>REQUIREMENTS</h2>
 
-<em>r.in.wms</em> requires the <a href="https://www.gdal.org/gdalwarp.html">gdalwarp</a>
+<em>r.in.wms</em> requires the <a href="https://gdal.org/gdalwarp.html">gdalwarp</a>
 utility from the GDAL/OGR library.
 
 <h2>REFERENCES</h2>

--- a/scripts/r.in.wms/r.in.wms.html
+++ b/scripts/r.in.wms/r.in.wms.html
@@ -144,10 +144,10 @@ r.in.wms url="http://cidportal.jrc.ec.europa.eu/copernicus/services/ows/wms/publ
          maxcols=3400 maxrows=3400
 r.info jrc_copernicus_core003_mosaik
 
-# Alternatively, using WMS_GDAL driver with BIGTIFF enabled
+# Alternatively, using WMS_GDAL driver with BIGTIFF and compression enabled
 r.in.wms url="http://cidportal.jrc.ec.europa.eu/copernicus/services/ows/wms/public/core003?" \
          layer="OI.Mosaic.NaturalColor.Feathering" output="jrc_copernicus_core003_mosaik2" \
-         maxcols=3400 maxrows=3400 driver=WMS_GDAL gdal_createopt="BIGTIFF=YES"
+         maxcols=3400 maxrows=3400 driver=WMS_GDAL gdal_createopt="BIGTIFF=YES,COMPRESS=DEFLATE"
 r.info jrc_copernicus_core003_mosaik2
 
 </pre></div>

--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -130,15 +130,15 @@ This program is free software under the GNU General Public License
 # % required: no
 # %end
 
-#%option
-#% key: gdal_createopt
-#% type: string
-#% required: no
-#% multiple: yes
-#% label: GDAL creation option(s) to pass to the output format driver
-#% description: In the form of "NAME=VALUE", separate multiple entries with a comma
-#% guisection: Request
-#%end
+# %option
+# % key: gdal_createopt
+# % type: string
+# % required: no
+# % multiple: yes
+# % label: GDAL creation option(s) to pass to the output format driver
+# % description: In the form of "NAME=VALUE", separate multiple entries with a comma
+# % guisection: Request
+# %end
 
 # %option
 # % key: region

--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -6,7 +6,7 @@ AUTHOR(S): Stepan Turek <stepan.turek AT seznam.cz>
 
 PURPOSE:   Downloads and imports data from WMS/WMTS/NASA OnEarth server.
 
-COPYRIGHT: (C) 2012 Stepan Turek, and by the GRASS Development Team
+COPYRIGHT: (C) 2012-2021 Stepan Turek, and by the GRASS Development Team
 
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -130,6 +130,16 @@ This program is free software under the GNU General Public License
 # % required: no
 # %end
 
+#%option
+#% key: gdal_createopt
+#% type: string
+#% required: no
+#% multiple: yes
+#% label: GDAL creation option(s) to pass to the output format driver
+#% description: In the form of "NAME=VALUE", separate multiple entries with a comma
+#% guisection: Request
+#%end
+
 # %option
 # % key: region
 # % type: string
@@ -236,7 +246,11 @@ def main():
         grass.debug("Using GDAL WMS driver")
         from wms_gdal_drv import WMSGdalDrv
 
-        wms = WMSGdalDrv()
+        if options["gdal_createopt"]:
+            create_options = options["gdal_createopt"].split(",")
+        else:
+            create_options = None
+        wms = WMSGdalDrv(create_options)
 
     if flags["c"]:
         wms.GetCapabilities(options)

--- a/scripts/r.in.wms/wms_gdal_drv.py
+++ b/scripts/r.in.wms/wms_gdal_drv.py
@@ -188,7 +188,9 @@ class WMSGdalDrv(WMSBase):
             temp_map_dataset = driver.CreateCopy(temp_map, wms_dataset, 0)
         else:
             self._debug("_download", "Using GDAL createopt <%s>" % str(self.createopt))
-            temp_map_dataset = driver.CreateCopy(temp_map, wms_dataset, 0, self.createopt)
+            temp_map_dataset = driver.CreateCopy(
+                temp_map, wms_dataset, 0, self.createopt
+            )
 
         if temp_map_dataset is None:
             grass.fatal(_("Incorrect WMS query"))

--- a/scripts/r.in.wms/wms_gdal_drv.py
+++ b/scripts/r.in.wms/wms_gdal_drv.py
@@ -5,7 +5,7 @@ List of classes:
  - wms_drv::NullDevice
  - wms_drv::WMSGdalDrv
 
-(C) 2012 by the GRASS Development Team
+(C) 2012-2021 by the GRASS Development Team
 
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -35,10 +35,11 @@ class NullDevice:
 
 
 class WMSGdalDrv(WMSBase):
-    def __init__(self):
+    def __init__(self, createopt):
         super(WMSGdalDrv, self).__init__()
         self.proxy = None
         self.proxy_user_pw = None
+        self.createopt = createopt
 
     def setProxy(self, proxy, proxy_user_pw=None):
         """Set the HTTP proxy and its user and password
@@ -183,7 +184,11 @@ class WMSGdalDrv(WMSBase):
 
         self._debug("_download", "calling GDAL CreateCopy...")
 
-        temp_map_dataset = driver.CreateCopy(temp_map, wms_dataset, 0)
+        if self.createopt is None:
+            temp_map_dataset = driver.CreateCopy(temp_map, wms_dataset, 0)
+        else:
+            self._debug("_download", "Using GDAL createopt <%s>" % str(self.createopt))
+            temp_map_dataset = driver.CreateCopy(temp_map, wms_dataset, 0, self.createopt)
 
         if temp_map_dataset is None:
             grass.fatal(_("Incorrect WMS query"))


### PR DESCRIPTION
This PR enables `gdal_createopt` to let the user pass on e.g. `BIGTIFF=YES,COMPRESS=DEFLATE` to the GDAL driver.

Co-authored-by: @anikaweinmann 