### PR TITLE
r.out.gdal / v.out.ogr: fix xy export

### DIFF
--- a/lib/gis/get_projinfo.c
+++ b/lib/gis/get_projinfo.c
@@ -195,7 +195,14 @@ char *G_get_projwkt(void)
     if (fclose(fp) != 0)
 	G_fatal_error(_("Error closing output file <%s>: %s"), path, strerror(errno));
 
-    return G_chop(wktstring);
+    if (wktstring && *wktstring)
+	G_chop(wktstring);
+    if (wktstring && *wktstring == '\0') {
+	G_free(wktstring);
+	wktstring = NULL;
+    }
+
+    return wktstring;
 }
 
 /*!
@@ -310,5 +317,12 @@ char *G_get_projsrid(void)
     if (fclose(fp) != 0)
 	G_fatal_error(_("Error closing output file <%s>: %s"), path, strerror(errno));
 
-    return G_chop(sridstring);
+    if (sridstring && *sridstring)
+	G_chop(sridstring);
+    if (sridstring && *sridstring == '\0') {
+	G_free(sridstring);
+	sridstring = NULL;
+    }
+
+    return sridstring;
 }

--- a/raster/r.out.gdal/main.c
+++ b/raster/r.out.gdal/main.c
@@ -327,7 +327,7 @@ int main(int argc, char *argv[])
 
 #if GDAL_VERSION_MAJOR >= 3 && PROJ_VERSION_MAJOR >= 6
 	/* convert bound CRS */
-	{
+	if (srswkt && *srswkt) {
 	    PJ *obj = NULL;
 
 	    indef = srswkt;
@@ -664,7 +664,7 @@ int main(int argc, char *argv[])
     /* Set Projection  */
     CPLErr ret = CE_None;
 
-    if (srswkt)
+    if (srswkt && *srswkt)
 	ret = GDALSetProjection(hCurrDS, srswkt);
     if (!srswkt || ret == CE_Failure)
 	G_warning(_("Unable to set projection"));

--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
 	if (!inwkt) {
 	    inwkt = G_get_projwkt();
 	}
-	if (inwkt) {
+	if (inwkt && *inwkt) {
 	    Ogr_projection = OSRNewSpatialReference(inwkt);
 	}
 #endif


### PR DESCRIPTION
With certain combinations of GDAL/PROJ, export of raster/vector data from a XY location can fail because of an assertion error in PROJ.