### PR TITLE
g.extension: match module files on Windows

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -154,6 +154,7 @@ from __future__ import print_function
 import fileinput
 import http
 import os
+import codecs
 import sys
 import re
 import atexit
@@ -188,6 +189,29 @@ HEADERS = {
     "User-Agent": "Mozilla/5.0",
 }
 HTTP_STATUS_CODES = list(http.HTTPStatus)
+
+
+def replace_shebang_win(python_file):
+    """
+    Replaces "python" with "python3" in python files
+    using UTF8 encoding on MS Windows
+    """
+
+    cur_dir = os.path.dirname(python_file)
+    tmp_name = os.path.join(cur_dir, gscript.tempname(12))
+
+    with codecs.open(file, "r", encoding="utf8") as in_file, codecs.open(
+        tmp_name, "w", encoding="utf8"
+    ) as out_file:
+
+        for line in in_file:
+            new_line = line.replace(
+                "#!/usr/bin/env python\n", "#!/usr/bin/env python3\n"
+            )
+            out_file.write(new_line)
+
+    os.remove(python_file)  # remove original
+    os.rename(tmp_name, python_file)  # rename temp to original name
 
 
 def urlretrieve(url, filename, *args, **kwargs):
@@ -1291,7 +1315,8 @@ def install_extension_win(name):
     module_list = list()
     for r, d, f in os.walk(srcdir):
         for file in f:
-            if re.search(r"^[d,db,g,i,m,r,r3,v]\..*[\.py,\.exe]$", file):
+            # Filter GRASS module name patterns
+            if re.search(r"^[d,db,g,i,m,p,ps,r,r3,s,v,wx]\..*[\.py,\.exe]$", file):
                 modulename = os.path.splitext(file)[0]
                 module_list.append(modulename)
     # remove duplicates in case there are .exe wrappers for python scripts
@@ -1305,12 +1330,7 @@ def install_extension_win(name):
                 pyfiles.append(os.path.join(r, file))
 
     for filename in pyfiles:
-        with fileinput.FileInput(filename, inplace=True) as file:
-            for line in file:
-                print(
-                    line.replace("#!/usr/bin/env python\n", "#!/usr/bin/env python3\n"),
-                    end="",
-                )
+        replace_shebang_win(filename)
 
     # collect old files
     old_file_list = list()

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1316,7 +1316,7 @@ def install_extension_win(name):
     for r, d, f in os.walk(srcdir):
         for file in f:
             # Filter GRASS module name patterns
-            if re.search(r"^[d,db,g,i,m,p,ps,r,r3,s,v,wx]\..*[\.py,\.exe]$", file):
+            if re.search(r"^[d,db,g,i,m,p,ps,r,r3,s,t,v,wx]\..*[\.py,\.exe]$", file):
                 modulename = os.path.splitext(file)[0]
                 module_list.append(modulename)
     # remove duplicates in case there are .exe wrappers for python scripts

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1291,11 +1291,8 @@ def install_extension_win(name):
     module_list = list()
     for r, d, f in os.walk(srcdir):
         for file in f:
-            if file.endswith(".py"):
-                modulename = file.rsplit(".py")[0]
-                module_list.append(modulename)
-            if file.endswith(".exe"):
-                modulename = file.rsplit(".exe")[0]
+            if re.search(r"^[d,db,g,i,m,r,r3,v]\..*[\.py,\.exe]", file):
+                modulename = os.path.splitext(file)[0]
                 module_list.append(modulename)
     # remove duplicates in case there are .exe wrappers for python scripts
     module_list = set(module_list)

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1291,7 +1291,7 @@ def install_extension_win(name):
     module_list = list()
     for r, d, f in os.walk(srcdir):
         for file in f:
-            if re.search(r"^[d,db,g,i,m,r,r3,v]\..*[\.py,\.exe]", file):
+            if re.search(r"^[d,db,g,i,m,r,r3,v]\..*[\.py,\.exe]$", file):
                 modulename = os.path.splitext(file)[0]
                 module_list.append(modulename)
     # remove duplicates in case there are .exe wrappers for python scripts

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -200,7 +200,7 @@ def replace_shebang_win(python_file):
     cur_dir = os.path.dirname(python_file)
     tmp_name = os.path.join(cur_dir, gscript.tempname(12))
 
-    with codecs.open(file, "r", encoding="utf8") as in_file, codecs.open(
+    with codecs.open(python_file, "r", encoding="utf8") as in_file, codecs.open(
         tmp_name, "w", encoding="utf8"
     ) as out_file:
 


### PR DESCRIPTION
Just a swift attempt to fix some issues with installation of extensions on windows.
Cuts number of failing addons to half (~) compared to:
https://gist.github.com/ninsbl/8051f51d372b565ca6f5a29b480d2463

There you also find a test-recipie...

The remaining need to be fixed on AddOn side, I guess...