### PR TITLE
v.hull: use standard C boolean type

### DIFF
--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -23,6 +23,8 @@
 /* System include files */
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
+
 
 /* Grass and local include files */
 #include <grass/config.h>
@@ -51,13 +53,14 @@ static const char *GRASS_copyright __attribute__ ((unused))
 #define G_gisinit(pgm) G__gisinit(GIS_H_VERSION, (pgm))
 #define G_no_gisinit() G__no_gisinit(GIS_H_VERSION)
 
-/* Define TRUE and FALSE for boolean comparisons */
+/* For boolean values and comparisons use the C99 type 'bool' with values 'true' */
+/* and 'false' For historical reasons 'TRUE' and 'FALSE' are still valid.        */
 #ifndef TRUE
-#define TRUE 1
+#define TRUE true
 #endif
 
 #ifndef FALSE
-#define FALSE 0
+#define FALSE false
 #endif
 
 #if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) || (__APPLE__ && __LP64__)

--- a/lib/lidar/lidar.h
+++ b/lib/lidar/lidar.h
@@ -62,9 +62,6 @@
     /* INTERPOLATOR */
 #define P_BILINEAR 		1
 #define P_BICUBIC 		0
-    /* Boolean definitions */
-#define TRUE 			1
-#define FALSE 			0
 
 /*----------------------------------------------------------------------------------------------------------*/
     /*STRUCTS DECLARATION */

--- a/raster/r.param.scale/param.h
+++ b/raster/r.param.scale/param.h
@@ -18,8 +18,6 @@
 				/* 'blank' edge around raster.          */
 #define MAX_WSIZE 499		/* Maximum dimensions of window.        */
 				/* Some useful labels.                  */
-#define TRUE 1
-#define FALSE 0
 
 #define RAD2DEG M_R2D
 #define DEG2RAD M_D2R

--- a/raster/r.surf.idw/main.h
+++ b/raster/r.surf.idw/main.h
@@ -1,8 +1,6 @@
 #include <grass/raster.h>
 
 #define         SHORT           short
-#define         TRUE    1
-#define         FALSE   0
 
 #define MELEMENT        struct Melement
 MELEMENT {

--- a/raster3d/r3.showdspf/Ball.c
+++ b/raster3d/r3.showdspf/Ball.c
@@ -7,8 +7,6 @@
 #include "Ball.h"
 #include "BallMath.h"
 #include <stdio.h>
-#define TRUE 1
-#define FALSE 0
 
 HMatrix mId = { {1, 0, 0, 0}
 , {0, 1, 0, 0}

--- a/raster3d/r3.showdspf/togif.c
+++ b/raster3d/r3.showdspf/togif.c
@@ -324,9 +324,6 @@ static int ditherrow(unsigned short *r, unsigned short *g, unsigned short *b,
  *
  *****************************************************************************/
 
-#define TRUE 1
-#define FALSE 0
-
 
 /************************** BumpPixel() ********************************/
 /*

--- a/vector/v.hull/chull.c
+++ b/vector/v.hull/chull.c
@@ -22,16 +22,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <stdbool.h>
 
 #include <grass/gis.h>
 #include <grass/vector.h>
 #include <grass/glocale.h>
 
 #include "globals.h"
-
-/*Define Boolean type */
-typedef enum
-{ BFALSE, BTRUE } bool;
 
 /* Define vertex indices. */
 #define X   0
@@ -76,10 +73,10 @@ struct tFaceStructure
 };
 
 /* Define flags */
-#define ONHULL   	BTRUE
-#define REMOVED  	BTRUE
-#define VISIBLE  	BTRUE
-#define PROCESSED	BTRUE
+#define ONHULL   	true
+#define REMOVED  	true
+#define VISIBLE  	true
+#define PROCESSED	true
 
 /* Global variable definitions */
 tVertex vertices = NULL;
@@ -436,7 +433,7 @@ bool AddOne(tVertex p)
     tFace f;
     tEdge e, temp;
     long int vol;
-    bool vis = BFALSE;
+    bool vis = false;
 
 
     /* Mark faces visible from p. */
@@ -446,7 +443,7 @@ bool AddOne(tVertex p)
 
 	if (vol < 0) {
 	    f->visible = VISIBLE;
-	    vis = BTRUE;
+	    vis = true;
 	}
 	f = f->next;
     } while (f != faces);
@@ -454,7 +451,7 @@ bool AddOne(tVertex p)
     /* If no faces are visible from p, then p is inside the hull. */
     if (!vis) {
 	p->onhull = !ONHULL;
-	return BFALSE;
+	return false;
     }
 
     /* Mark edges in interior of visible region for deletion.
@@ -470,7 +467,7 @@ bool AddOne(tVertex p)
 	    e->newface = MakeConeFace(e, p);
 	e = temp;
     } while (e != edges);
-    return BTRUE;
+    return true;
 }
 
 /*---------------------------------------------------------------------

--- a/vector/v.hull/chull.c
+++ b/vector/v.hull/chull.c
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <stdbool.h>
 
 #include <grass/gis.h>
 #include <grass/vector.h>


### PR DESCRIPTION
GDAL 3.3.0 introduces the use of standard C bool type. Redefining bool locally, as in `vector/v.hull/chull.c` causes failure. Since GRASS now adhere to C11 standard this PR addresses this issue by replacing the local bool with the standard C bool.

Fixes #1563