### PR TITLE
Dockerfile_alpine: fix broken pip six installation

### DIFF
--- a/docker/alpine/Dockerfile_alpine
+++ b/docker/alpine/Dockerfile_alpine
@@ -193,7 +193,9 @@ COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
 # pip 20.0.0 fix
 RUN apk add curl && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py pip==20.0.2 && rm get-pip.py
-RUN pip3 install --upgrade pip six grass-session
+
+# install external Python API
+RUN pip3 install --upgrade grass-session
 
 RUN ln -s /usr/local/grass /usr/local/grass7
 RUN ln -s /usr/local/grass `grass --config path`


### PR DESCRIPTION
Fixes docker hub error:

```
Step 32/49 : RUN pip3 install --upgrade pip six grass-session
---> Running in 1c63e0d56789
Collecting pip
Downloading pip-21.1.1-py3-none-any.whl (1.5 MB)
Collecting six
Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting grass-session
Downloading grass_session-0.5-py2.py3-none-any.whl (31 kB)
Installing collected packages: pip, six, grass-session
Attempting uninstall: pip
Found existing installation: pip 20.0.2
Uninstalling pip-20.0.2:
Successfully uninstalled pip-20.0.2
Attempting uninstall: six
Found existing installation: six 1.15.0
ERROR: Cannot uninstall 'six'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```