### PR TITLE
wxGUI/dbmgr: fix get statistics for character column type if it contains NULL value

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -4047,7 +4047,8 @@ class FieldStatistics(wx.Frame):
             )
         varSum = 0
         for var in decode(dataVar).splitlines():
-            varSum += float(var)
+            if var:
+                varSum += float(var)
         stddev = math.sqrt(varSum / count)
 
         self.SetTitle(_("Field statistics <%s>") % column)


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Attribute Table Manager `g.gui.dbmgr map=geology` (Basic NC location)
2. Erase (set NULL) column 'GEO_NAME' value for row with column cat = 1
3. Right mouse click on the 'GEO_NAME' column and choose from the menu Statistics item
4. An empty Statistics window opened, and you see error message in the wxGUI Console tab

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/dbmgr/base.py", line
654, in OnFieldStatistics

column=self.GetColumn(self._col).GetText(),
  File "/usr/lib64/grass79/gui/wxpython/dbmgr/base.py", line
4054, in Update

varSum += float(var)
ValueError
:
could not convert string to float:
```