### PR TITLE
wxGUI/gui_core: fix trigger 'wx.EVT_CHOICE' event if you set widget selection programatically 

### DIFF
--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -214,9 +214,9 @@ class ModelSearchDialog(wx.Dialog):
             parent=self.panel, model=menuModel.GetModel(), showTip=True
         )
         self.search.moduleSelected.connect(
-            lambda name: self.cmd_prompt.SetTextAndFocus(name + " ")
+            lambda name: (self.cmd_prompt.SetText(name + " "),
+                          self.label.SetValue(name))
         )
-        wx.CallAfter(self.cmd_prompt.SetFocus)
 
         self.label = TextCtrl(parent=self.panel, id=wx.ID_ANY)
         self.comment = TextCtrl(parent=self.panel, id=wx.ID_ANY, style=wx.TE_MULTILINE)

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -214,8 +214,10 @@ class ModelSearchDialog(wx.Dialog):
             parent=self.panel, model=menuModel.GetModel(), showTip=True
         )
         self.search.moduleSelected.connect(
-            lambda name: (self.cmd_prompt.SetText(name + " "),
-                          self.label.SetValue(name))
+            lambda name: (
+                self.cmd_prompt.SetText(name + " "),
+                self.label.SetValue(name),
+            )
         )
 
         self.label = TextCtrl(parent=self.panel, id=wx.ID_ANY)

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1281,6 +1281,7 @@ class SearchModuleWidget(wx.Panel):
             self._searchChoice.SetItems(commands)
             if commands:
                 self._searchChoice.SetSelection(0)
+                self.OnSelectModule()
 
         label = _("%d modules match") % len(commands)
         if self._showTip:
@@ -1310,7 +1311,7 @@ class SearchModuleWidget(wx.Panel):
 
         return commands
 
-    def OnSelectModule(self, event):
+    def OnSelectModule(self, event=None):
         """Module selected from choice, update command prompt"""
         cmd = self._searchChoice.GetStringSelection()
         self.moduleSelected.emit(name=cmd)


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch Graphical Modeler
2. From the Graphical Modeler toolbar launch 'Add command (GRASS module) to model' tool dialog
3. Try to type 'db.' (without quotation marks)
4. Choose first option from the Choice widget options 'db.columns'
5. TextCtrl widgets 'Command' and 'Label' value is not updated automatically after you select module from Choice widget

Another example:
3. Try type exactly 'db.tables' (without quotation marks)

![gmodeler_add_gg_module_dialog_choice_widget](https://user-images.githubusercontent.com/50632337/118397563-e75be700-b654-11eb-93ac-77bdbef2cbe1.png)

**Expected behavior:**

![gmodeler_add_gg_module_dialog_choice_widget_exp](https://user-images.githubusercontent.com/50632337/118397564-eaef6e00-b654-11eb-9d80-755dfd8e2b85.png)

