### PR TITLE
g.proj: fix reading input WKT

### DIFF
--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -106,7 +106,7 @@ static void set_authnamecode(OGRSpatialReferenceH);
 int input_wkt(char *wktfile)
 {
     FILE *infd;
-    char buff[8000], *tmpwkt;
+    char buff[8192], *tmpwkt;
     OGRSpatialReferenceH hSRS;
     char *papszOptions[3];
     int ret;
@@ -119,8 +119,8 @@ int input_wkt(char *wktfile)
     if (infd) {
 	size_t wktlen;
 
-	wktlen = fread(buff, 1, sizeof(buff) - 1, infd);
-	if (wktlen == sizeof(buff) - 1)
+	wktlen = fread(buff, 1, sizeof(buff), infd);
+	if (wktlen == sizeof(buff))
 	    G_fatal_error(_("Input WKT definition is too long"));
 	if (ferror(infd))
 	    G_fatal_error(_("Error reading WKT definition"));

--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -116,15 +116,18 @@ int input_wkt(char *wktfile)
     else
 	infd = fopen(wktfile, "r");
 
-    /* init buff, otherwise valgrind complains about uninitialized values */
-    G_zero(buff, sizeof(buff));
-
     if (infd) {
-	fread(buff, 1, sizeof(buff) - 1, infd);
+	size_t wktlen;
+
+	wktlen = fread(buff, 1, sizeof(buff) - 1, infd);
+	if (wktlen == sizeof(buff) - 1)
+	    G_fatal_error(_("Input WKT definition is too long"));
 	if (ferror(infd))
 	    G_fatal_error(_("Error reading WKT definition"));
 	else
 	    fclose(infd);
+	/* terminate WKT string */
+	buff[wktlen] = '\0';
 	/* Get rid of newlines */
 	G_squeeze(buff);
     }

--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -116,8 +116,11 @@ int input_wkt(char *wktfile)
     else
 	infd = fopen(wktfile, "r");
 
+    /* init buff, otherwise valgrind complains about uninitailized values */
+    G_zero(buff, sizeof(buff));
+
     if (infd) {
-	fread(buff, sizeof(buff), 1, infd);
+	fread(buff, 1, sizeof(buff) - 1, infd);
 	if (ferror(infd))
 	    G_fatal_error(_("Error reading WKT definition"));
 	else

--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -116,7 +116,7 @@ int input_wkt(char *wktfile)
     else
 	infd = fopen(wktfile, "r");
 
-    /* init buff, otherwise valgrind complains about uninitailized values */
+    /* init buff, otherwise valgrind complains about uninitialized values */
     G_zero(buff, sizeof(buff));
 
     if (infd) {


### PR DESCRIPTION
Apparently, buffer must be initialized when using fread().