### PR TITLE
wxGUI/datacatalog: fix setting output vector/raster format

### DIFF
--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -19,6 +19,7 @@ import glob
 import shlex
 import re
 import inspect
+import operator
 import six
 
 from grass.script import core as grass
@@ -649,7 +650,7 @@ def _getOGRFormats():
 
 def _parseFormats(output, writableOnly=False):
     """Parse r.in.gdal/v.in.ogr -f output"""
-    formats = {"file": list(), "database": list(), "protocol": list()}
+    formats = {"file": {}, "database": {}, "protocol": {}}
 
     if not output:
         return formats
@@ -660,7 +661,6 @@ def _parseFormats(output, writableOnly=False):
 
     for line in output.splitlines():
         key, name = map(lambda x: x.strip(), line.strip().split(":", 1))
-
         if writableOnly and not patt.search(key):
             continue
 
@@ -678,7 +678,7 @@ def _parseFormats(output, writableOnly=False):
             "MSSQLSpatial",
             "FileGDB",
         ):
-            formats["database"].append(name)
+            formats["database"][key.split(" ")[0]] = name
         elif name in (
             "GeoJSON",
             "OGC Web Coverage Service",
@@ -687,12 +687,12 @@ def _parseFormats(output, writableOnly=False):
             "GeoRSS",
             "HTTP Fetching Wrapper",
         ):
-            formats["protocol"].append(name)
+            formats["protocol"][key.split(" ")[0]] = name
         else:
-            formats["file"].append(name)
+            formats["file"][key.split(" ")[0]] = name
 
-    for items in six.itervalues(formats):
-        items.sort()
+    for k, v in formats.items():
+        formats[k] = dict(sorted(v.items(), key=operator.itemgetter(1)))
 
     return formats
 

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1864,7 +1864,6 @@ class GdalSelect(wx.Panel):
             flag=wx.ALIGN_CENTER_VERTICAL | wx.EXPAND,
             pos=(3, 0),
             span=(1, 2),
-
         )
         sizer.Add(
             self.dbWidgets["textLabel2"], flag=wx.ALIGN_CENTER_VERTICAL, pos=(4, 0)

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -790,7 +790,11 @@ class GdalOutputDialog(wx.Dialog):
                     {"directory": dsn, "extension": extension},
                 )
             RunCommand(
-                cmd, parent=self, format=frmt, options=options, **params,
+                cmd,
+                parent=self,
+                format=frmt,
+                options=options,
+                **params,
             )
         self.Close()
 

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -776,14 +776,21 @@ class GdalOutputDialog(wx.Dialog):
             RunCommand("v.external.out", parent=self, flags="r")
         else:
             dsn = self.dsnInput.GetDsn()
-            frmt = self.dsnInput.GetFormat()
+            frmt = self.dsnInput.GetFormat(getFormatAbbreviation=True)
+            extension = self.dsnInput.GetFormatExt()
             options = self.dsnInput.GetOptions()
             if not dsn:
                 GMessage(_("No data source selected."), parent=self)
                 return
-
+            if self.ogr:
+                cmd, params = "v.external.out", {"output": dsn}
+            else:
+                cmd, params = (
+                    "r.external.out",
+                    {"directory": dsn, "extension": extension},
+                )
             RunCommand(
-                "v.external.out", parent=self, output=dsn, format=frmt, options=options
+                cmd, parent=self, format=frmt, options=options, **params,
             )
         self.Close()
 


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2.  On the Data tab (page) choose from toolbar 'Select another import option' tool and invoke menu and choose 'Link external data' -> 'Set raster output format [r.external.out]'
3. Choose Directory as Output type
4. Choose e.g. GeoTIFF format 
5. Set Directory path e.g.  /tmp
6.  Hit Ok button
7. You get error message

**Error message**

![wxgui_datacatalog_set_output_raster_format_error_message](https://user-images.githubusercontent.com/50632337/119274497-7eeea600-bc10-11eb-8aaa-d167e16897f0.png)

**Additional info**
1. 'Set raster output format [r.external.out]' dialog internally use `v.external.out` command instead of `r.external.out` and params args are incorrect
2. Mapping output formats between dialog wx.Choice widget items (which use long format name) and command `r.external.out` or `v.external.out` (which use format abbreaviation) is incorrect . Simple e.g. 'Set raster output format [r.external.out]'  dialog wx.Choice format type widget use for GeoTIFF format string 'GeoTIFF', but internall command `r.external.out` as format param argument  accept for GeoTIFF format string arg 'GTiff' (check all format options `r.external.out`), the same is true for 'Set vector output format [v.external.out]' dialog.