### PR TITLE
PyGRASS: MultiModule: return MultiModule object

### DIFF
--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -996,7 +996,7 @@ class MultiModule(object):
             for module in self.module_list:
                 module.finish_ = True
                 module.run()
-            return None
+            return self
         else:
             if self.set_temp_region is True:
                 self.p = Process(

--- a/temporal/t.rast.neighbors/testsuite/test_neighbors.py
+++ b/temporal/t.rast.neighbors/testsuite/test_neighbors.py
@@ -12,7 +12,7 @@ from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
 
-@unittest.skipIf(sys.version_info[0] > 2, "temporary disabled")
+#@unittest.skipIf(sys.version_info[0] > 2, "temporary disabled")
 class TestAggregationAbsolute(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/temporal/t.rast.neighbors/testsuite/test_neighbors.py
+++ b/temporal/t.rast.neighbors/testsuite/test_neighbors.py
@@ -12,7 +12,7 @@ from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
 
-#@unittest.skipIf(sys.version_info[0] > 2, "temporary disabled")
+# @unittest.skipIf(sys.version_info[0] > 2, "temporary disabled")
 class TestAggregationAbsolute(TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This PR should make MultiModule work again in the PrallelModuleQueue.

See:
https://lists.osgeo.org/pipermail/grass-dev/2021-May/095177.html
and
https://github.com/OSGeo/grass/blob/master/temporal/t.rast.neighbors/testsuite/test_neighbors.py