### PR TITLE
wxGUI: Single-Window GUI: arrangement of basic widgets

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -2158,16 +2158,6 @@ class GMFrame(wx.Frame):
         """Key pressed"""
         kc = event.GetKeyCode()
 
-        #        if event.ControlDown():
-        #            if kc == wx.WXK_TAB:
-        #                # switch layer list / command output
-        #                if self.notebook.GetSelection() == self.notebook.GetPageIndexByName(
-        #                    "layers"
-        #                ):
-        #                    self.notebook.SetSelectionByName("output")
-        #                else:
-        #                    self.notebook.SetSelectionByName("layers")
-
         try:
             kc = chr(kc)
         except ValueError:

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -92,7 +92,7 @@ class GMFrame(wx.Frame):
         id=wx.ID_ANY,
         title=None,
         workspace=None,
-        size=wx.Display(0).GetGeometry().GetSize(),
+        size=globalvar.GM_WINDOW_SIZE,
         style=wx.DEFAULT_FRAME_STYLE,
         **kwargs,
     ):
@@ -150,7 +150,7 @@ class GMFrame(wx.Frame):
         self.dialogs["atm"] = list()
 
         # set pane sizes according to the full screen size of the primary monitor
-        size = wx.Display(0).GetGeometry().GetSize()
+        size = wx.Display().GetGeometry().GetSize()
         self.PANE_BEST_SIZE = tuple(t / 5 for t in size)
         self.PANE_MIN_SIZE = tuple(t / 10 for t in size)
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -25,8 +25,13 @@ import platform
 import re
 
 from core import globalvar
+#try:
+#    from agw import aui
+#except ImportError:
+#    import wx.lib.agw.aui as aui
+
 import wx
-import wx.aui
+import wx.aui as aui
 
 try:
     import wx.lib.agw.flatnotebook as FN
@@ -45,7 +50,7 @@ from core.utils import SetAddOnPath, GetLayerNameFromCmd, command2ltype, get_she
 from gui_core.preferences import MapsetAccess, PreferencesDialog
 from lmgr.layertree import LayerTree, LMIcons
 from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
-from gui_core.widgets import GNotebook, FormNotebook
+from gui_core.widgets import GNotebook
 from core.gconsole import GConsole, EVT_IGNORED_CMD_RUN
 from core.giface import Notification
 from gui_core.goutput import GConsoleWindow, GC_PROMPT
@@ -87,7 +92,7 @@ class GMFrame(wx.Frame):
         id=wx.ID_ANY,
         title=None,
         workspace=None,
-        size=globalvar.GM_WINDOW_SIZE,
+        size=wx.DisplaySize(),
         style=wx.DEFAULT_FRAME_STYLE,
         **kwargs,
     ):
@@ -136,7 +141,7 @@ class GMFrame(wx.Frame):
         self._menuTreeBuilder = LayerManagerMenuData(message_handler=add_menu_error)
         # the search tree and command console
         self._moduleTreeBuilder = LayerManagerModuleTree(message_handler=add_menu_error)
-        self._auimgr = wx.aui.AuiManager(self)
+        self._auimgr = aui.AuiManager(self)
 
         # list of open dialogs
         self.dialogs = dict()
@@ -144,83 +149,15 @@ class GMFrame(wx.Frame):
         self.dialogs["nvizPreferences"] = None
         self.dialogs["atm"] = list()
 
-        # create widgets
-        self._createMenuBar()
-        self.statusbar = self.CreateStatusBar(number=1)
-        self.notebook = self._createNotebook()
-        self._createDataCatalog(self.notebook)
-        self._createDisplay(self.notebook)
-        self._createSearchModule(self.notebook)
-        self._createConsole(self.notebook)
-        self._createPythonShell(self.notebook)
-        self._addPagesToNotebook()
-        self.toolbars = {
-            "workspace": LMWorkspaceToolbar(parent=self),
-            "tools": LMToolsToolbar(parent=self),
-            "misc": LMMiscToolbar(parent=self),
-            "nviz": LMNvizToolbar(parent=self),
-        }
-        self._toolbarsData = {
-            "workspace": (
-                "toolbarWorkspace",  # name
-                _("Workspace Toolbar"),  # caption
-                1,
-                0,
-            ),  # row, position
-            "tools": ("toolbarTools", _("Tools Toolbar"), 1, 1),
-            "misc": ("toolbarMisc", _("Misc Toolbar"), 1, 2),
-            "nviz": ("toolbarNviz", _("3D view Toolbar"), 1, 3),
-        }
-        toolbarsList = ("workspace", "tools", "misc", "nviz")
-        for toolbar in toolbarsList:
-            name, caption, row, position = self._toolbarsData[toolbar]
-            self._auimgr.AddPane(
-                self.toolbars[toolbar],
-                wx.aui.AuiPaneInfo()
-                .Name(name)
-                .Caption(caption)
-                .ToolbarPane()
-                .Top()
-                .Row(row)
-                .Position(position)
-                .LeftDockable(False)
-                .RightDockable(False)
-                .BottomDockable(False)
-                .TopDockable(True)
-                .CloseButton(False)
-                .Layer(2)
-                .BestSize((self.toolbars[toolbar].GetBestSize())),
-            )
-
-        self._auimgr.GetPane("toolbarNviz").Hide()
-        # bindings
-        self.Bind(wx.EVT_CLOSE, self.OnCloseWindowOrExit)
-        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
+        # create widgets and build panes
+        self.CreateMenuBar()
+        self.CreateStatusBar(number=1)
+        self.BuildPanes()
+        self.BuildEvents()
 
         self._giface.mapCreated.connect(self.OnMapCreated)
         self._giface.updateMap.connect(self._updateCurrentMap)
         self._giface.currentMapsetChanged.connect(self.OnMapsetChanged)
-
-        # minimal frame size
-        self.SetMinSize(globalvar.GM_WINDOW_MIN_SIZE)
-
-        # AUI stuff
-        self._auimgr.AddPane(
-            self.notebook,
-            wx.aui.AuiPaneInfo()
-            .Left()
-            .CentrePane()
-            .BestSize((-1, -1))
-            .Dockable(False)
-            .CloseButton(False)
-            .DestroyOnClose(True)
-            .Row(1)
-            .Layer(0),
-        )
-
-        self._auimgr.Update()
-
-        wx.CallAfter(self.notebook.SetSelectionByName, "catalog")
 
         # use default window layout ?
         if UserSettings.Get(group="general", key="defWindowPos", subkey="enabled"):
@@ -238,6 +175,7 @@ class GMFrame(wx.Frame):
 
         self.Layout()
         self.Show()
+        self.Maximize(True)
 
         # load workspace file if requested
         if workspace:
@@ -247,7 +185,7 @@ class GMFrame(wx.Frame):
             # start default initial display
             self.NewDisplay(show=False)
 
-        # show map display widnow
+        # show map display window
         # -> OnSize() -> UpdateMap()
         for mapdisp in self.GetMapDisplay(onlyCurrent=False):
             mapdisp.Show()
@@ -291,7 +229,7 @@ class GMFrame(wx.Frame):
                 )
             )
 
-    def _createMenuBar(self):
+    def CreateMenuBar(self):
         """Creates menu bar"""
         self.menubar = GMenu(
             parent=self, model=self._menuTreeBuilder.GetModel(separators=True)
@@ -346,13 +284,6 @@ class GMFrame(wx.Frame):
         if self._auimgr.GetPane(name).IsOk():
             return self._auimgr.GetPane(name).IsShown()
         return False
-
-    def _createNotebook(self):
-        """Initialize notebook widget"""
-        if sys.platform == "win32":
-            return GNotebook(parent=self, style=globalvar.FNPageDStyle)
-        else:
-            return FormNotebook(parent=self, style=wx.NB_BOTTOM)
 
     def _createDataCatalog(self, parent):
         """Initialize Data Catalog widget"""
@@ -424,35 +355,87 @@ class GMFrame(wx.Frame):
         else:
             self.pyshell = None
 
-    def _addPagesToNotebook(self):
-        """Add pages to notebook widget"""
-        # add 'data catalog' widget to main notebook page
-        self.notebook.AddPage(page=self.datacatalog, text=_("Data"), name="catalog")
+    def BuildPanes(self):
+        """Build panes - toolbars as well as panels"""
 
-        # add 'display' widget to main notebook page
-        self.notebook.AddPage(page=self.displayPanel, text=_("Display"), name="layers")
+        # minimal frame size
+        self.SetMinSize((1200, 600))
 
-        # add 'modules' widget to main notebook page
-        if self.search:
-            self.notebook.AddPage(page=self.search, text=_("Modules"), name="search")
+        # initialize all main widgets
+        self._createDataCatalog(parent=self)
+        self._createDisplay(parent=self)
+        self._createSearchModule(parent=self)
+        self._createConsole(parent=self)
+        self._createPythonShell(parent=self)
+        self.toolbars = {
+            "workspace": LMWorkspaceToolbar(parent=self),
+            "tools": LMToolsToolbar(parent=self),
+            "misc": LMMiscToolbar(parent=self),
+            "nviz": LMNvizToolbar(parent=self),
+        }
+        self._toolbarsData = {
+            "workspace": (
+                "toolbarWorkspace",  # name
+                _("Workspace Toolbar"),  # caption
+                1,
+                0,
+            ),  # row, position
+            "tools": ("toolbarTools", _("Tools Toolbar"), 1, 1),
+            "misc": ("toolbarMisc", _("Misc Toolbar"), 1, 2),
+            "nviz": ("toolbarNviz", _("3D view Toolbar"), 1, 3),
+        }
 
-        # add 'console' widget to main notebook page and add connect switch page signal
-        self.notebook.AddPage(page=self.goutput, text=_("Console"), name="output")
-        self.goutput.contentChanged.connect(
-            lambda notification: self._switchPage(notification)
-        )
+        # add a bunch of panes
+        toolbarsList = ("workspace", "tools", "misc", "nviz")
+        for toolbar in toolbarsList:
+            name, caption, row, position = self._toolbarsData[toolbar]
+            self._auimgr.AddPane(
+                self.toolbars[toolbar],
+                aui.AuiPaneInfo()
+                .Name(name)
+                .Caption(caption)
+                .ToolbarPane()
+                .Top()
+                .Row(row)
+                .Position(position)
+                .LeftDockable(False)
+                .RightDockable(False)
+                .BottomDockable(False)
+                .TopDockable(True)
+                .CloseButton(False)
+                .Layer(2)
+                .BestSize((self.toolbars[toolbar].GetBestSize())),
+            )
 
-        # add 'python shell' widget to main notebook page
-        if self.pyshell:
-            self.notebook.AddPage(page=self.pyshell, text=_("Python"), name="pyshell")
+        self._auimgr.AddPane(self.datacatalog, aui.AuiPaneInfo().Name("datacatalog").
+                          CenterPane().PaneBorder(False))
 
-        # bindings
-        if sys.platform == "win32":
-            self.notebook.Bind(FN.EVT_FLATNOTEBOOK_PAGE_CHANGED, self.OnPageChanged)
-        else:
-            self.notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.OnPageChanged)
+        self._auimgr.AddPane(self.displayPanel, aui.AuiPaneInfo().
+                          Name("display").Caption("Display").
+                          Right().Layer(1).Position(1).BestSize(wx.Size(1400,150)).MinSize(wx.Size(800,150)).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
 
+        self._auimgr.AddPane(self.search, aui.AuiPaneInfo().
+                          Name("modules").Caption("Modules").
+                          Right().Layer(2).Position(1).BestSize(wx.Size(400,150)).MinSize(wx.Size(150,150)).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+
+        self._auimgr.AddPane(self.goutput, aui.AuiPaneInfo().
+                          Name("console").Caption("Console").
+                          Right().Layer(2).Position(2).BestSize(wx.Size(400,150)).MinSize(wx.Size(150,150)).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+
+        self._auimgr.AddPane(self.pyshell, aui.AuiPaneInfo().
+                          Name("python").Caption("Python").
+                          Right().Layer(2).Position(3).BestSize(wx.Size(400,150)).MinSize(wx.Size(150,150)).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+
+        self._auimgr.GetPane("toolbarNviz").Hide()
+        self._auimgr.GetPane("datacatalog").Show()
         wx.CallAfter(self.datacatalog.LoadItems)
+
+        self._auimgr.Update()
+
+    def BuildEvents(self):
+        # bindings
+        self.Bind(wx.EVT_CLOSE, self.OnCloseWindowOrExit)
+        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
 
     def _show_demo_map(self):
         """If in demolocation, add demo map to map display
@@ -679,15 +662,6 @@ class GMFrame(wx.Frame):
 
         event.Skip()
 
-    def OnPageChanged(self, event):
-        """Page in notebook changed"""
-        page = event.GetSelection()
-        if page == self.notebook.GetPageIndexByName("output"):
-            wx.CallAfter(self.goutput.ResetFocus)
-        self.SetStatusText("", 0)
-
-        event.Skip()
-
     def OnCBPageClosing(self, event):
         """Page of notebook is being closed
         from Layer Manager (x button next to arrows)
@@ -714,21 +688,6 @@ class GMFrame(wx.Frame):
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
         self.notebookLayers.DeletePage(page_index)
         self.notebookLayers.Bind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.OnCBPageClosing)
-
-    def _switchPageHandler(self, event, notification):
-        self._switchPage(notification=notification)
-        event.Skip()
-
-    def _switchPage(self, notification):
-        """Manages @c 'output' notebook page according to event notification."""
-        if notification == Notification.HIGHLIGHT:
-            self.notebook.HighlightPageByName("output")
-        if notification == Notification.MAKE_VISIBLE:
-            self.notebook.SetSelectionByName("output")
-        if notification == Notification.RAISE_WINDOW:
-            self.notebook.SetSelectionByName("output")
-            self.SetFocus()
-            self.Raise()
 
     def RunSpecialCmd(self, command):
         """Run command from command line, check for GUI wrappers"""
@@ -1888,7 +1847,6 @@ class GMFrame(wx.Frame):
         if not self.currentPage:
             self.NewDisplay(show=True)
 
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("raster")
 
     def OnAddRasterMisc(self, event):
@@ -1920,7 +1878,6 @@ class GMFrame(wx.Frame):
         if not self.currentPage:
             self.NewDisplay(show=True)
 
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("vector")
 
     def OnAddVectorMisc(self, event):
@@ -1941,12 +1898,10 @@ class GMFrame(wx.Frame):
 
     def OnAddVectorTheme(self, event):
         """Add thematic vector map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("thememap")
 
     def OnAddVectorChart(self, event):
         """Add chart vector map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("themechart")
 
     def OnAddOverlay(self, event):
@@ -1971,27 +1926,22 @@ class GMFrame(wx.Frame):
 
     def OnAddRaster3D(self, event):
         """Add 3D raster map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("raster_3d")
 
     def OnAddRasterRGB(self, event):
         """Add RGB raster map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("rgb")
 
     def OnAddRasterHIS(self, event):
         """Add HIS raster map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("his")
 
     def OnAddRasterShaded(self, event):
         """Add shaded relief raster map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("shaded")
 
     def OnAddRasterArrow(self, event):
         """Add flow arrows raster map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         # here it seems that it should be retrieved from the mapwindow
         mapdisplay = self.GetMapDisplay()
         resolution = mapdisplay.mapWindowProperties.resolution
@@ -2005,7 +1955,6 @@ class GMFrame(wx.Frame):
 
     def OnAddRasterNum(self, event):
         """Add cell number raster map to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         mapdisplay = self.GetMapDisplay()
         resolution = mapdisplay.mapWindowProperties.resolution
         if not resolution:
@@ -2030,7 +1979,6 @@ class GMFrame(wx.Frame):
         if not self.currentPage:
             self.NewDisplay(show=True)
 
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("command")
 
         # show map display
@@ -2042,7 +1990,6 @@ class GMFrame(wx.Frame):
         if not self.currentPage:
             self.NewDisplay(show=True)
 
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("group")
 
         # show map display
@@ -2050,17 +1997,14 @@ class GMFrame(wx.Frame):
 
     def OnAddGrid(self, event):
         """Add grid map layer to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("grid")
 
     def OnAddGeodesic(self, event):
         """Add geodesic line map layer to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("geodesic")
 
     def OnAddRhumb(self, event):
         """Add rhumb map layer to the current layer tree"""
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("rhumb")
 
     def OnAddLabels(self, event):
@@ -2069,7 +2013,6 @@ class GMFrame(wx.Frame):
         if not self.currentPage:
             self.NewDisplay(show=True)
 
-        self.notebook.SetSelectionByName("layers")
         self.GetLayerTree().AddLayer("labels")
 
         # show map display
@@ -2145,15 +2088,15 @@ class GMFrame(wx.Frame):
         """Key pressed"""
         kc = event.GetKeyCode()
 
-        if event.ControlDown():
-            if kc == wx.WXK_TAB:
-                # switch layer list / command output
-                if self.notebook.GetSelection() == self.notebook.GetPageIndexByName(
-                    "layers"
-                ):
-                    self.notebook.SetSelectionByName("output")
-                else:
-                    self.notebook.SetSelectionByName("layers")
+#        if event.ControlDown():
+#            if kc == wx.WXK_TAB:
+#                # switch layer list / command output
+#                if self.notebook.GetSelection() == self.notebook.GetPageIndexByName(
+#                    "layers"
+#                ):
+#                    self.notebook.SetSelectionByName("output")
+#                else:
+#                    self.notebook.SetSelectionByName("layers")
 
         try:
             kc = chr(kc)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -25,6 +25,7 @@ import platform
 import re
 
 from core import globalvar
+
 try:
     from agw import aui
 except ImportError:
@@ -148,9 +149,9 @@ class GMFrame(wx.Frame):
         self.dialogs["nvizPreferences"] = None
         self.dialogs["atm"] = list()
 
-        #set pane sizes according to the full screen size
-        self.PANE_BEST_SIZE = tuple(t/5 for t in wx.DisplaySize())
-        self.PANE_MIN_SIZE = tuple(t/10 for t in wx.DisplaySize())
+        # set pane sizes according to the full screen size
+        self.PANE_BEST_SIZE = tuple(t / 5 for t in wx.DisplaySize())
+        self.PANE_MIN_SIZE = tuple(t / 10 for t in wx.DisplaySize())
 
         # create widgets and build panes
         self.CreateMenuBar()
@@ -363,7 +364,6 @@ class GMFrame(wx.Frame):
         # blank panel for testing
         self.mapdisplay = wx.Panel(parent=parent)
 
-
     def BuildPanes(self):
         """Build panes - toolbars as well as panels"""
 
@@ -417,28 +417,85 @@ class GMFrame(wx.Frame):
                 .BestSize((self.toolbars[toolbar].GetBestSize())),
             )
 
-        self._auimgr.AddPane(self.mapdisplay, aui.AuiPaneInfo().Name("map display").
-                          CenterPane().PaneBorder(True))
+        self._auimgr.AddPane(
+            self.mapdisplay,
+            aui.AuiPaneInfo().Name("map display").CenterPane().PaneBorder(True),
+        )
 
-        self._auimgr.AddPane(self.datacatalog, aui.AuiPaneInfo().
-                          Name("datacatalog").Caption("Data Catalog").
-                          Left().Layer(1).Position(1).BestSize(self.PANE_BEST_SIZE).MinSize(self.PANE_MIN_SIZE).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+        self._auimgr.AddPane(
+            self.datacatalog,
+            aui.AuiPaneInfo()
+            .Name("datacatalog")
+            .Caption("Data Catalog")
+            .Left()
+            .Layer(1)
+            .Position(1)
+            .BestSize(self.PANE_BEST_SIZE)
+            .MinSize(self.PANE_MIN_SIZE)
+            .CloseButton(False)
+            .MinimizeButton(True)
+            .MaximizeButton(True),
+        )
 
-        self._auimgr.AddPane(self.displayPanel, aui.AuiPaneInfo().
-                          Name("display").Caption("Display").
-                          Left().Layer(1).Position(2).BestSize(self.PANE_BEST_SIZE).MinSize(self.PANE_MIN_SIZE).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+        self._auimgr.AddPane(
+            self.displayPanel,
+            aui.AuiPaneInfo()
+            .Name("display")
+            .Caption("Display")
+            .Left()
+            .Layer(1)
+            .Position(2)
+            .BestSize(self.PANE_BEST_SIZE)
+            .MinSize(self.PANE_MIN_SIZE)
+            .CloseButton(False)
+            .MinimizeButton(True)
+            .MaximizeButton(True),
+        )
 
-        self._auimgr.AddPane(self.search, aui.AuiPaneInfo().
-                          Name("modules").Caption("Modules").
-                          Right().Layer(2).Position(1).BestSize(self.PANE_BEST_SIZE).MinSize(self.PANE_MIN_SIZE).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+        self._auimgr.AddPane(
+            self.search,
+            aui.AuiPaneInfo()
+            .Name("modules")
+            .Caption("Modules")
+            .Right()
+            .Layer(2)
+            .Position(1)
+            .BestSize(self.PANE_BEST_SIZE)
+            .MinSize(self.PANE_MIN_SIZE)
+            .CloseButton(False)
+            .MinimizeButton(True)
+            .MaximizeButton(True),
+        )
 
-        self._auimgr.AddPane(self.goutput, aui.AuiPaneInfo().
-                          Name("console").Caption("Console").
-                          Right().Layer(2).Position(2).BestSize(self.PANE_BEST_SIZE).MinSize(self.PANE_MIN_SIZE).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+        self._auimgr.AddPane(
+            self.goutput,
+            aui.AuiPaneInfo()
+            .Name("console")
+            .Caption("Console")
+            .Right()
+            .Layer(2)
+            .Position(2)
+            .BestSize(self.PANE_BEST_SIZE)
+            .MinSize(self.PANE_MIN_SIZE)
+            .CloseButton(False)
+            .MinimizeButton(True)
+            .MaximizeButton(True),
+        )
 
-        self._auimgr.AddPane(self.pyshell, aui.AuiPaneInfo().
-                          Name("python").Caption("Python").
-                          Right().Layer(2).Position(3).BestSize(self.PANE_BEST_SIZE).MinSize(self.PANE_MIN_SIZE).CloseButton(False).MinimizeButton(True).MaximizeButton(True))
+        self._auimgr.AddPane(
+            self.pyshell,
+            aui.AuiPaneInfo()
+            .Name("python")
+            .Caption("Python")
+            .Right()
+            .Layer(2)
+            .Position(3)
+            .BestSize(self.PANE_BEST_SIZE)
+            .MinSize(self.PANE_MIN_SIZE)
+            .CloseButton(False)
+            .MinimizeButton(True)
+            .MaximizeButton(True),
+        )
 
         self._auimgr.GetPane("toolbarNviz").Hide()
         wx.CallAfter(self.datacatalog.LoadItems)
@@ -2101,15 +2158,15 @@ class GMFrame(wx.Frame):
         """Key pressed"""
         kc = event.GetKeyCode()
 
-#        if event.ControlDown():
-#            if kc == wx.WXK_TAB:
-#                # switch layer list / command output
-#                if self.notebook.GetSelection() == self.notebook.GetPageIndexByName(
-#                    "layers"
-#                ):
-#                    self.notebook.SetSelectionByName("output")
-#                else:
-#                    self.notebook.SetSelectionByName("layers")
+        #        if event.ControlDown():
+        #            if kc == wx.WXK_TAB:
+        #                # switch layer list / command output
+        #                if self.notebook.GetSelection() == self.notebook.GetPageIndexByName(
+        #                    "layers"
+        #                ):
+        #                    self.notebook.SetSelectionByName("output")
+        #                else:
+        #                    self.notebook.SetSelectionByName("layers")
 
         try:
             kc = chr(kc)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -367,9 +367,6 @@ class GMFrame(wx.Frame):
     def BuildPanes(self):
         """Build panes - toolbars as well as panels"""
 
-        # minimal frame size
-        self.SetMinSize((1200, 600))
-
         # initialize all main widgets
         self._createDataCatalog(parent=self)
         self._createDisplay(parent=self)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -92,7 +92,7 @@ class GMFrame(wx.Frame):
         id=wx.ID_ANY,
         title=None,
         workspace=None,
-        size=globalvar.GM_WINDOW_SIZE,
+        size=wx.Display(0).GetGeometry().GetSize(),
         style=wx.DEFAULT_FRAME_STYLE,
         **kwargs,
     ):
@@ -149,9 +149,10 @@ class GMFrame(wx.Frame):
         self.dialogs["nvizPreferences"] = None
         self.dialogs["atm"] = list()
 
-        # set pane sizes according to the full screen size
-        self.PANE_BEST_SIZE = tuple(t / 5 for t in wx.DisplaySize())
-        self.PANE_MIN_SIZE = tuple(t / 10 for t in wx.DisplaySize())
+        # set pane sizes according to the full screen size of the primary monitor
+        size = wx.Display(0).GetGeometry().GetSize()
+        self.PANE_BEST_SIZE = tuple(t / 5 for t in size)
+        self.PANE_MIN_SIZE = tuple(t / 10 for t in size)
 
         # create widgets and build panes
         self.CreateMenuBar()


### PR DESCRIPTION
This PR deals with the base settings for the full screen layout with main dockable panes. 
Map Displays as well as 3D view are not solved in this PR - we just need to prepare the base structure here.

There are two main things that we need to figure out:

- Any content "not dockable" pane is necessary in terms of implementation. So first we need to decide whether to employ Data Catalog as the content pane.  The advantage is that all other panes would be dockable then. :-) And also after changes made last year the Data Catalog is kind of the center point of GRASS so it could make sense to have it as the content  pane. The con is that visually it might look a bit strange. There the layout I suggest so far in this PR (using wx.AUI):

![tmploc-PERMANENT - GRASS GIS_010](https://user-images.githubusercontent.com/49241681/120901314-a88bd200-c5ff-11eb-957e-770806292f40.png)

- Second important thing is to decide which library to use. We have two options: the traditional **wx.AUI** C++ library and the newer **wx.lib.agw.aui** python library. I tried to compared them a bit. There is a bit strange thing about wx.AUI -> MinimizeButton method does not work to me although according to https://wxpython.org/Phoenix/docs/html/wx.aui.AuiPaneInfo.html#wx.aui.AuiPaneInfo.MinimizeButton documentation, it should work. :-( The second thing I have come up with so far is the missing guide docking styles such as nice aui.AUI_MGR_WHIDBEY_DOCKING_GUIDES style.
Both of these functions work for wx.lib.agw.aui.

But there may be (and probably are) more things that are not implemented for wx.AUI. But I think we do not have to make the decision about the library right now.



