### PR TITLE
g.region: do not update WIND file when not needed

### DIFF
--- a/general/g.region/g.region.html
+++ b/general/g.region/g.region.html
@@ -122,6 +122,14 @@ This format can be given back to <em>g.region</em> on its command line.
 This may also be used to save region settings as shell environment variables
 with the UNIX eval command, "<tt>eval `g.region -g`</tt>".
 
+<p>With <b>-u</b> flag current region is not updated even if one or more
+options for changing region is used (<b>res=</b>, <b>raster=</b>, etc).
+This can be used for example to print modified region values for further use
+without actually modifing the current region.
+Similarly, <b>-o</b> flag forces to update current region file even when e.g., only
+printing was specified. Flag <b>-o</b> was added in GRASS GIS version 8 to simulate
+<em>g.region</em> behavior in prior versions when current region file was
+always updated unless <b>-u</b> was specified.
 
 <h3>Additional parameter information:</h3>
 

--- a/general/g.region/main.c
+++ b/general/g.region/main.c
@@ -16,7 +16,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
-#include <stdbool.h>
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/raster3d.h>
@@ -374,6 +373,9 @@ int main(int argc, char *argv[])
                       parm.res, parm.res3, parm.nsres, parm.ewres, parm.tbres,
                       parm.zoom, parm.align, parm.save, parm.grow, NULL);
     G_option_exclusive(flag.noupdate, flag.force, NULL);
+    G_option_requires(flag.noupdate, flag.savedefault, flag.print, flag.lprint,
+                      flag.eprint, flag.center, flag.gmt_style, flag.wms_style,
+                      flag.dist_res, flag.nangle, flag.z, flag.bbox, flag.gprint, parm.save, NULL);
 
     if (G_parser(argc, argv))
 	exit(EXIT_FAILURE);


### PR DESCRIPTION
Changes default behavior to behave more intuitively, now WIND file is written only with certain
options (e.g. raster=, n=, ...) and it is left untouched if only printing is needed.
Added force flag -o to force writing WIND file if desired.
This change help avoid issues with parallel processing.
Flag -u still makes sense for some cases (also keeps backward compatibility).

Documentation is missing, will add it soon.

For more discussion on this, see:
https://trac.osgeo.org/grass/ticket/2230