### PR TITLE
Add a standard option for nprocs= (G_OPT_M_NPROCS)

### DIFF
--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -99,12 +99,12 @@ static const char *GRASS_copyright __attribute__ ((unused))
 #define U_DEGREES	8
 #define U_USFEET	9
 /* Temporal units from the datetime library */
-#define U_YEARS         DATETIME_YEAR   
-#define U_MONTHS        DATETIME_MONTH  
-#define U_DAYS          DATETIME_DAY    
-#define U_HOURS         DATETIME_HOUR   
-#define U_MINUTES       DATETIME_MINUTE 
-#define U_SECONDS       DATETIME_SECOND 
+#define U_YEARS         DATETIME_YEAR
+#define U_MONTHS        DATETIME_MONTH
+#define U_DAYS          DATETIME_DAY
+#define U_HOURS         DATETIME_HOUR
+#define U_MINUTES       DATETIME_MINUTE
+#define U_SECONDS       DATETIME_SECOND
 
 /*! \brief Projection code - XY coordinate system (unreferenced data) */
 #define PROJECTION_XY     0
@@ -302,10 +302,11 @@ typedef enum
     G_OPT_M_DBASE,              /*!< dbase */
     G_OPT_M_COORDS,             /*!< coordinates */
     G_OPT_M_COLR,               /*!< color rules */
-    G_OPT_M_DIR,                /*!< directory input */    
+    G_OPT_M_DIR,                /*!< directory input */
     G_OPT_M_REGION,             /*!< saved region */
     G_OPT_M_NULL_VALUE,         /*!< null value string */
-    
+    G_OPT_M_NPROCS,             /*!< number of threads for parallel computing */
+
     G_OPT_STDS_INPUT,           /*!< old input space time dataset of type strds, str3ds or stvds */
     G_OPT_STDS_INPUTS,          /*!< old input space time datasets */
     G_OPT_STDS_OUTPUT,          /*!< new output space time dataset */
@@ -321,7 +322,7 @@ typedef enum
     G_OPT_STVDS_OUTPUT,         /*!< new output space time vector dataset */
     G_OPT_MAP_INPUT,            /*!< old input map of type raster, vector or raster3d  */
     G_OPT_MAP_INPUTS,           /*!< old input maps of type raster, vector or raster3d  */
-    G_OPT_STDS_TYPE,            /*!< the type of a space time dataset: strds, str3ds, stvds */ 
+    G_OPT_STDS_TYPE,            /*!< the type of a space time dataset: strds, str3ds, stvds */
     G_OPT_MAP_TYPE,             /*!< The type of an input map: raster, vect, rast3d */
     G_OPT_T_TYPE,               /*!< The temporal type of a space time dataset */
     G_OPT_T_WHERE,              /*!< A temporal GIS framework SQL WHERE statement */
@@ -447,15 +448,15 @@ struct Cell_head
     /*! \brief Resolution - east to west cell size for 2D data */
     double ew_res;
     /*! \brief Resolution - east to west cell size for 3D data */
-    double ew_res3;   
+    double ew_res3;
     /*! \brief Resolution - north to south cell size for 2D data */
-    double ns_res;     
+    double ns_res;
     /*! \brief Resolution - north to south cell size for 3D data */
-    double ns_res3;   
+    double ns_res3;
     /*! \brief Resolution - top to bottom cell size for 3D data */
-    double tb_res;    
+    double tb_res;
     /*! \brief Extent coordinates (north) */
-    double north;     
+    double north;
     /*! \brief Extent coordinates (south) */
     double south;
     /*! \brief Extent coordinates (east) */

--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -760,8 +760,8 @@ struct Option *G_define_standard_option(int opt)
         Opt->key = "nprocs";
         Opt->type = TYPE_INTEGER;
         Opt->required = NO;
-	Opt->multiple = NO;
-	Opt->answer = "1";
+        Opt->multiple = NO;
+        Opt->answer = "1";
         Opt->description = _("Number of threads for parallel computing");
         break;
 

--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -109,6 +109,7 @@
    - G_OPT_M_COLR
    - G_OPT_M_REGION
    - G_OPT_M_NULL_VALUE
+   - G_OPT_M_NPROCS
 
   - temporal GIS framework
    - G_OPT_STDS_INPUT
@@ -753,6 +754,15 @@ struct Option *G_define_standard_option(int opt)
         Opt->required = NO;
         Opt->gisprompt = "old,windows,region";
         Opt->description = _("Name of saved region");
+        break;
+
+    case G_OPT_M_NPROCS:
+        Opt->key = "nprocs";
+        Opt->type = TYPE_INTEGER;
+        Opt->required = NO;
+	Opt->multiple = NO;
+	Opt->answer = "1";
+        Opt->description = _("Number of threads for parallel computing");
         break;
 
     /* Spatio-temporal modules of the temporal GIS framework */


### PR DESCRIPTION
This PR implements the standard G_OPT_M_NPROCS option for the number of threads for parallel computing. See https://github.com/OSGeo/grass/pull/1634#discussion_r650575434.