### PR TITLE
Fix source code URL when addon path starts with root path

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -428,7 +428,7 @@ if not year:
 # check the names of scripts to assign the right folder
 topdir = os.path.abspath(os.getenv("MODULE_TOPDIR"))
 curdir = os.path.abspath(os.path.curdir)
-if curdir.startswith(topdir):
+if curdir.startswith(topdir + os.path.sep):
     source_url = trunk_url
     pgmdir = curdir.replace(topdir, "").lstrip(os.path.sep)
 else:


### PR DESCRIPTION
Fix https://github.com/OSGeo/grass-addons/issues/546

* Core path: `/home/user/usr/grass/grass`
* Addon path: `/home/user/usr/grass/grass-addons`

Addon path starts with core path, but that doesn't mean I'm inside the core.