### PR TITLE
wxGUI: refactoring: build display status bar based on wx.StatusBar widget

### DIFF
--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -259,10 +259,10 @@ class LayerManagerGrassInterface(object):
         self.lmgr.goutput.GetPrompt().UpdateCmdHistory(cmd)
 
     def ShowStatusbar(self, show=True):
-        self.lmgr.GetMapDisplay().statusbarManager.Show(show)
+        self.lmgr.GetMapDisplay().ShowStatusbar(show)
 
     def IsStatusbarShown(self):
-        return self.lmgr.GetMapDisplay().statusbarManager.IsShown()
+        return self.lmgr.GetMapDisplay().IsStatusbarShown()
 
     def ShowAllToolbars(self, show=True):
         if not show:  # hide

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -223,7 +223,8 @@ class MapFrame(SingleMapFrame):
             .CloseButton(False)
             .DestroyOnClose(True)
             .ToolbarPane()
-            .Dockable(False),
+            .Dockable(False)
+            .Gripper(False),
         )
         self._mgr.Update()
 
@@ -282,7 +283,6 @@ class MapFrame(SingleMapFrame):
         statusbarpanel = wx.Panel(self, size=wx.DefaultSize, style=wx.SUNKEN_BORDER)
         statusbar = wx.StatusBar(statusbarpanel, id=wx.ID_ANY)
         statusbar.SetFieldsCount(4)
-        statusbar.SetMinHeight(30)
         statusbar.SetStatusWidths([-5, -2, -1, -1])
 
         container = wx.BoxSizer(wx.VERTICAL)

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -312,17 +312,12 @@ class MapFrame(SingleMapFrame):
 
     def ShowStatusbar(self, show):
         """Show/hide statusbar and associated pane"""
-        self.statusbarManager.Show(show)
-        if show:
-            self._mgr.GetPane("statusbar").Show()
-        else:
-            self._mgr.GetPane("statusbar").Hide()
-
+        self._mgr.GetPane("statusbar").Show(show)
         self._mgr.Update()
 
     def IsStatusbarShown(self):
         """Check if statusbar is shown"""
-        return self.statusbarManager.IsShown()
+        return self._mgr.GetPane("statusbar").IsShown()
 
     def SetStatusText(self, *args):
         """Overide wx.StatusBar method"""

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -224,6 +224,7 @@ class MapFrame(SingleMapFrame):
             .DestroyOnClose(True)
             .ToolbarPane()
             .Dockable(False)
+            .PaneBorder(False)
             .Gripper(False),
         )
         self._mgr.Update()
@@ -315,6 +316,10 @@ class MapFrame(SingleMapFrame):
             )
         )
         return statusbarpanel, statusbar
+
+    def SetStatusText(self, *args):
+        """Overide wx.StatusBar method"""
+        self.statusbar.SetStatusText(*args)
 
     def GetMapWindow(self):
         return self.MapWindow
@@ -475,7 +480,7 @@ class MapFrame(SingleMapFrame):
         self._giface.WriteCmdLog(
             _("Starting 3D view mode..."), notification=Notification.HIGHLIGHT
         )
-        self.statusbar.SetStatusText(_("Please wait, loading data..."), 0)
+        self.SetStatusText(_("Please wait, loading data..."), 0)
 
         # create GL window
         if not self.MapWindow3D:
@@ -543,7 +548,7 @@ class MapFrame(SingleMapFrame):
         # is called during update and it must give reasonable values
         wx.CallAfter(self.MapWindow3D.UpdateOverlays)
 
-        self.statusbar.SetStatusText("", 0)
+        self.SetStatusText("", 0)
         self._mgr.Update()
 
     def Disable3dMode(self):
@@ -568,7 +573,7 @@ class MapFrame(SingleMapFrame):
         self.statusbarManager.SetMode(
             UserSettings.Get(group="display", key="statusbarMode", subkey="selection")
         )
-        self.statusbar.SetStatusText(_("Please wait, unloading data..."), 0)
+        self.SetStatusText(_("Please wait, unloading data..."), 0)
         # unloading messages from library cause highlight anyway
         self._giface.WriteCmdLog(
             _("Switching back to 2D view mode..."),
@@ -1699,7 +1704,7 @@ class MapFrame(SingleMapFrame):
             self.toolbars["rdigit"].UpdateCellValues
         )
         self.rdigit.showNotification.connect(
-            lambda text: self.statusbar.SetStatusText(text, 0)
+            lambda text: self.SetStatusText(text, 0)
         )
         self.rdigit.quitDigitizer.connect(self.QuitRDigit)
         self.rdigit.Bind(

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -311,6 +311,20 @@ class MapFrame(SingleMapFrame):
         )
         return statusbar
 
+    def ShowStatusbar(self, show):
+        """Show/hide statusbar and associated pane"""
+        self.statusbarManager.Show(show)
+        if show:
+            self._mgr.GetPane("statusbar").Show()
+        else:
+            self._mgr.GetPane("statusbar").Hide()
+
+        self._mgr.Update()
+
+    def IsStatusbarShown(self):
+        """Check if statusbar is shown"""
+        return self.statusbarManager.IsShown()
+
     def SetStatusText(self, *args):
         """Overide wx.StatusBar method"""
         self.statusbar.SetStatusText(*args)

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -284,7 +284,6 @@ class MapFrame(SingleMapFrame):
         statusbar.SetMinHeight(24)
         statusbar.SetFieldsCount(4)
         statusbar.SetStatusWidths([-5, -2, -1, -1])
-
         self.statusbarManager = sb.SbManager(mapframe=self, statusbar=statusbar)
 
         # fill statusbar manager

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -150,7 +150,7 @@ class MapFrame(SingleMapFrame):
         #
         self.statusbarManager = None
         if statusbar:
-            statusbarpanel, self.statusbar = self.CreateStatusbar()
+            self.statusbar = self.CreateStatusbar()
 
         # init decoration objects
         self.decorations = {}
@@ -214,7 +214,7 @@ class MapFrame(SingleMapFrame):
         )
 
         self._mgr.AddPane(
-            statusbarpanel,
+            self.statusbar,
             wx.aui.AuiPaneInfo()
             .Bottom()
             .MinSize(30, 30)
@@ -280,16 +280,10 @@ class MapFrame(SingleMapFrame):
             sb.SbMapScale,
         )
 
-        # create statusbar and its manager
-        statusbarpanel = wx.Panel(self, size=wx.DefaultSize, style=wx.SUNKEN_BORDER)
-        statusbar = wx.StatusBar(statusbarpanel, id=wx.ID_ANY)
+        statusbar = wx.StatusBar(self, id=wx.ID_ANY)
+        statusbar.SetMinHeight(24)
         statusbar.SetFieldsCount(4)
         statusbar.SetStatusWidths([-5, -2, -1, -1])
-
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(statusbar, proportion=1, flag=wx.EXPAND)
-        statusbarpanel.SetSizer(sizer)
-        statusbarpanel.Layout()
 
         self.statusbarManager = sb.SbManager(mapframe=self, statusbar=statusbar)
 
@@ -315,7 +309,7 @@ class MapFrame(SingleMapFrame):
                 % dict(command=" ".join(cmd), error=error)
             )
         )
-        return statusbarpanel, statusbar
+        return statusbar
 
     def SetStatusText(self, *args):
         """Overide wx.StatusBar method"""

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -285,10 +285,9 @@ class MapFrame(SingleMapFrame):
         statusbar.SetFieldsCount(4)
         statusbar.SetStatusWidths([-5, -2, -1, -1])
 
-        container = wx.BoxSizer(wx.VERTICAL)
-        container.Add(statusbar, proportion=1, flag=wx.EXPAND)
-        statusbarpanel.SetSizer(container)
-        statusbarpanel.Fit()
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(statusbar, proportion=1, flag=wx.EXPAND)
+        statusbarpanel.SetSizer(sizer)
         statusbarpanel.Layout()
 
         self.statusbarManager = sb.SbManager(mapframe=self, statusbar=statusbar)

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1697,9 +1697,7 @@ class MapFrame(SingleMapFrame):
         self.rdigit.uploadMapCategories.connect(
             self.toolbars["rdigit"].UpdateCellValues
         )
-        self.rdigit.showNotification.connect(
-            lambda text: self.SetStatusText(text, 0)
-        )
+        self.rdigit.showNotification.connect(lambda text: self.SetStatusText(text, 0))
         self.rdigit.quitDigitizer.connect(self.QuitRDigit)
         self.rdigit.Bind(
             EVT_UPDATE_PROGRESS,

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -223,7 +223,7 @@ class MapFrame(SingleMapFrame):
             .CloseButton(False)
             .DestroyOnClose(True)
             .ToolbarPane()
-            .Dockable(False)
+            .Dockable(False),
         )
         self._mgr.Update()
 
@@ -1699,7 +1699,9 @@ class MapFrame(SingleMapFrame):
         self.rdigit.uploadMapCategories.connect(
             self.toolbars["rdigit"].UpdateCellValues
         )
-        self.rdigit.showNotification.connect(lambda text: self.statusbar.SetStatusText(text, 0))
+        self.rdigit.showNotification.connect(
+            lambda text: self.statusbar.SetStatusText(text, 0)
+        )
         self.rdigit.quitDigitizer.connect(self.QuitRDigit)
         self.rdigit.Bind(
             EVT_UPDATE_PROGRESS,

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -330,14 +330,6 @@ class SbManager:
         if text:
             self.statusbar.SetStatusText(text)
 
-    def Show(self, show=True):
-        """Show/hide statusbar"""
-        self.statusbar.Show(show)
-
-    def IsShown(self):
-        """Check if statusbar is shown"""
-        return self.statusbar.IsShown()
-
 
 class SbItem:
     """Base class for statusbar items.


### PR DESCRIPTION
This PR redesigning the form of display map status bar implementation.
It was originally created directly using CreateStatusBar function, which is, however, directly connected to the wx.Frame widget. 
For further implementation of the SingleLayout, we need to replace MapFrame widget by MapPanel widget. 
MapPanel widget does not support CreateStatusBar function.

Reimplemented status bar in a Map Display for a better context:
![Map Display 1_024](https://user-images.githubusercontent.com/49241681/122086346-3cf8f000-cdc9-11eb-8235-f49cb8a26d4b.png)

Original status bar:
![Map Display 1_023](https://user-images.githubusercontent.com/49241681/122083676-b04d3280-cdc6-11eb-8a60-f3dc65558c1c.png)
