### PR TITLE
pygrass: call centroid function when buffering areas

### DIFF
--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1758,7 +1758,7 @@ class Area(Geo):
         )
         return (
             Line(c_points=p_bound.contents),
-            self.centroid,
+            self.centroid(),
             [Line(c_points=pp_isle[i].contents) for i in range(n_isles.contents.value)],
         )
 


### PR DESCRIPTION
The buffer function in pygrass returns a tuple where for all geometries - except areas - the second element is a point representing the centroid. However, for buffers around areas, the second element is a function that needs to be called to get the centroid. This PR aims at unifying this by calling the centroid function within the buffer function also for areas...

I am not sure if that is a proper solution, though, so I would be glad about a review / comment on the little change...
Also, should it be backported?

See: https://github.com/OSGeo/grass-addons/issues/541
for a related bug...