### PR TITLE
libpython: Make parallel region test somewhat more robust

### DIFF
--- a/python/grass/script/testsuite/test_parallel_temp_region.sh
+++ b/python/grass/script/testsuite/test_parallel_temp_region.sh
@@ -56,6 +56,9 @@ fi
 MAP_PARALLEL_PATTERN="${MAP_PARALLEL}_*_size_*_nesting_*"
 MAP_NEST_PATTERN="${MAP_NEST}_*_size_*_nesting_*"
 
+# After each wait, sleep for additional n seconds.
+SLEEP_AFTER_WAIT=5
+
 # Remove maps at exit.
 cleanup () {
     EXIT_CODE=$?
@@ -99,6 +102,7 @@ do
 done
 
 wait
+sleep $SLEEP_AFTER_WAIT
 
 EXPECTED=$NUM_PARALLELS
 NUM=$(g.list type=raster pattern="${MAP_PARALLEL_PATTERN}" mapset=. | wc -l)
@@ -122,6 +126,7 @@ do
 done
 
 wait
+sleep $SLEEP_AFTER_WAIT
 
 EXPECTED=$(( $NUM_PARALLELS * $NUM_NEST ))
 NUM=$(g.list type=raster pattern="${MAP_NEST_PATTERN}" mapset=. | wc -l)


### PR DESCRIPTION
Test introduced in #638 uses raster maps to determine if the subprocess was
successfully executed. However, in GitHub Actions this fails randomly
with a random number of rasters missing.

This PR makes the test wait for couple seconds before counting the rasters
in case the file system needs to catch up. If there is an actual error,
waiting won't fix it, so the test will still do its job.

If running and rerunning the tests here is successful, it suggests
that it is a good fix at least in the sense of accomodating
the given environment.

Alternative fix for the test would be to replace Bash by Python
which would allow leaving out the raster creation check (which is
replacing return code check here) and provide more control.

On one hand, we want to make the test run, on the other,
we want to have the actual code robust, but maybe writing 50
rasters in parallel in a small VM in GitHub Actions is not
a use case we need to cover in code and thus modifying the test is enough.
