### PR TITLE
r.report: add default units, change to full unit names

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1128,7 +1128,11 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         if rasters:
             self._giface.RunCmd(
-                ["r.report", "map=%s" % ",".join(rasters), "units=hectares,cells,percent"]
+                [
+                    "r.report",
+                    "map=%s" % ",".join(rasters),
+                    "units=hectares,cells,percent",
+                ]
             )
 
     def OnStartEditing(self, event):

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1128,7 +1128,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         if rasters:
             self._giface.RunCmd(
-                ["r.report", "map=%s" % ",".join(rasters), "units=h,c,p"]
+                ["r.report", "map=%s" % ",".join(rasters), "units=hectares,cells,percent"]
             )
 
     def OnStartEditing(self, event):

--- a/raster/r.report/parse.c
+++ b/raster/r.report/parse.c
@@ -45,7 +45,7 @@ int parse_command_line(int argc, char *argv[])
     parms.units->description = _("Units to report");
     desc = NULL;
     G_asprintf(&desc,
-	       "mi;%s;me;%s;k;%s;a;%s;h;%s;c;%s;p;%s",
+	       "miles;%s;meters;%s;kilometers;%s;acres;%s;hectares;%s;cells;%s;percent;%s",
 	       _("area in square miles"),
 	       _("area in square meters"),
 	       _("area in square kilometers"),
@@ -54,7 +54,8 @@ int parse_command_line(int argc, char *argv[])
 	       _("number of cells"),
 	       _("percent cover"));
     parms.units->descriptions = desc;
-    parms.units->options = "mi,me,k,a,h,c,p";
+    parms.units->options = "miles,meters,kilometers,acres,hectares,cells,percent";
+    parms.units->answer = "cells,percent";
     parms.units->guisection = _("Statistics");
 
     parms.outfile = G_define_standard_option(G_OPT_F_OUTPUT);
@@ -239,9 +240,7 @@ int parse_units(char *s)
 	x = ACRES;
     else if (match(s, "hectares", 1))
 	x = HECTARES;
-    else if (match(s, "cell_counts", 1))
-	x = CELL_COUNTS;
-    else if (match(s, "counts", 1))
+    else if (match(s, "cells", 1))
 	x = CELL_COUNTS;
     else if (match(s, "percent_cover", 1))
 	x = PERCENT_COVER;


### PR DESCRIPTION
Addresses #1061 by using cell count and percent cover as defaults:

```
> r.report lakes

+-----------------------------------------------------------------------------+
|                         RASTER MAP CATEGORY REPORT                          |
|LOCATION: nc_spm_08_grass7                           Sat Jun 19 00:56:00 2021|
|-----------------------------------------------------------------------------|
|          north: 228500    east: 645000                                      |
|REGION    south: 215000    west: 630000                                      |
|          res:       10    res:      10                                      |
|-----------------------------------------------------------------------------|
|MASK: none                                                                   |
|-----------------------------------------------------------------------------|
|MAP: South-West Wake county: Wake county lakes (lakes in PERMANENT)          |
|-----------------------------------------------------------------------------|
|                    Category Information                      |   cell|   %  |
|    #|description                                             |  count| cover|
|-----------------------------------------------------------------------------|
|34300|Dam/Weir . . . . . . . . . . . . . . . . . . . . . . . .|    442|  0.02|
|39000|Lake/Pond. . . . . . . . . . . . . . . . . . . . . . . .|  35099|  1.73|
|43600|Reservoir. . . . . . . . . . . . . . . . . . . . . . . .|    470|  0.02|
|    *|no data. . . . . . . . . . . . . . . . . . . . . . . . .|1988989| 98.22|
|-----------------------------------------------------------------------------|

```
Note this is different than v.report, which uses meters by default, but I felt cell count and percent is generally more useful info in this case.

Also standardizes unit names:
```
        units   Units to report
                options: miles,meters,kilometers,acres,hectares,cells,percent
                default: cells,percent
```
 but short unit names still work (`r.report lakes units=c`)