### PR TITLE
sqlite driver: support no locking for sqlite over nfs

### DIFF
--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -34,7 +34,7 @@ int db__driver_open_database(dbHandle * handle)
 {
     char name2[GPATH_MAX], *path;
     const char *name;
-    char name3[GPATH_MAX], *env_nolock;
+    char name3[GPATH_MAX + 14], *env_nolock;
     int i;
 
     G_debug(3, "\ndb_driver_open_database()");

--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -109,6 +109,7 @@ int db__driver_open_database(dbHandle * handle)
 	    if (sprintf(name3, "file:%s?nolock=1", name2) < 0) {
 		return DB_FAILED;
 	    }
+	    G_important_message(_("Disabling SQLite locking"));
 	}
 	else {
 	    G_warning(_("The sqlite config option '%s' is not supported"),
@@ -181,6 +182,7 @@ int db__driver_create_database(dbHandle *handle)
 	    if (sprintf(name2, "file:%s?nolock=1", name) < 0) {
 		return DB_FAILED;
 	    }
+	    G_important_message(_("Disabling SQLite locking"));
 	}
 	else {
 	    G_warning(_("The sqlite config option '%s' is not supported"),


### PR DESCRIPTION
From https://sqlite.org/faq.html: "file locking is broken on many NFS implementations"
This causes db operations to be extremely slow or not working at all if the GRASS SQLite db is located on a NFS drive.

This PR attempts to solve this issue for affected NFS implementations.

The NFS implementations I have access to are all working fine wrt SQLite, therefore additional testing is needed.

This is not a bug in GRASS, but a bug in certain combinations of SQLite + NFS. 