### PR TITLE
WMS: replace broken URLs with alternative WMS (backport)

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -9,7 +9,7 @@ List of classes:
  - dialogs::WSPropertiesDialog
  - dialogs::SaveWMSLayerDialog
 
-(C) 2009-2013 by the GRASS Development Team
+(C) 2009-2021 by the GRASS Development Team
 
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -66,10 +66,17 @@ class WSDialogBase(wx.Dialog):
 
         # TODO: should be in file
         self.default_servers = {
-            'OSM-WMS-EUROPE':
-            ['http://watzmann-geog.urz.uni-heidelberg.de/cached/osm', '', ''],
-            'irs.gis-lab.info (OSM)': ['http://irs.gis-lab.info', '', ''],
-            'NASA GIBS WMTS': ['http://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi', '', '']}
+            'OSM-WMS': [
+                'https://ows.terrestris.de/osm/service?',
+                '',
+                '',
+            ],
+            'tiles.maps.eox.at (Sentinel-2)': [
+                'https://tiles.maps.eox.at/wms',
+                '',
+                '',
+            ],
+        }
 
         # holds reference to web service panel which is showed
         self.active_ws_panel = None


### PR DESCRIPTION
WMS URL updates:

- both NASA GIBS and irs.gis-lab.info are no longer reachable
- replaced with global WMS by terrestris and Sentinel-2 by EOX

Note that the list shown in the GUI may be extended by the local list in `$HOME/.grass7/wxWS` if present (i.e., old WMS records to be removed there)

Backport of #1635
