### PR TITLE
libgis: Recover when directory already exists

### DIFF
--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -85,6 +85,7 @@ int make_mapset_element(const char *p_path, const char *p_element)
     while (1) {
 	if (*element == '/' || *element == 0) {
 	    *p = 0;
+            char *msg = NULL;
             if (access(path, 0) != 0) {
                 /* Assuming that directory does not exist. */
                 if (G_mkdir(path) != 0)

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -85,14 +85,24 @@ int make_mapset_element(const char *p_path, const char *p_element)
     while (1) {
 	if (*element == '/' || *element == 0) {
 	    *p = 0;
-	    if (access(path, 0) != 0) { /* directory not yet created */
-		if (G_mkdir(path) != 0)
-		    G_fatal_error(_("Unable to make mapset element %s (%s): %s"),
-				  p_element, path, strerror(errno));
-	    }
-	    if (access(path, 0) != 0)  /* directory not accessible */
-		G_fatal_error(_("Unable to access mapset element %s (%s): %s"),
-			      p_element, path, strerror(errno));
+            if (access(path, 0) != 0) {
+                /* Assuming that directory does not exist. */
+                if (G_mkdir(path) != 0)
+                    msg = G_store(strerror(errno));
+            }
+            if (access(path, 0) != 0) {
+                /* Directory is not accessible even after attempt to create it. */
+                if (msg) {
+                    /* Error already happened when mkdir. */
+                    G_fatal_error(_("Unable to make mapset element %s (%s): %s"),
+                                  p_element, path, strerror(errno));
+                }
+                else {
+                    /* Access error is not related to mkdir. */
+                    G_fatal_error(_("Unable to access mapset element %s (%s): %s"),
+                                  p_element, path, strerror(errno));
+                }
+            }
 	    if (*element == 0)
 		return 1;
 	}


### PR DESCRIPTION
When another process creates the directory between the access test
and mkdir call, mkdir ends with an error even though the desired
state now exists.

This chanages the error handling so that on mkdir error,
the access test is still performed and only when it fails
the mkdir errno is used for fatal error. The access errno
is used when mkdir succeeds but access fails.

This follows the behavior before 3c374600e3cc7d91c542cab4411fdf40f31ce931
where only the second access failure causes an error, but not a failed
mkdir call in betwee the access calls.

This error handling is also possibly more aligned with the documentation
of the higher level function from API G_make_mapset_element() which
should 'do nothing if it is found'. However, the documentation is
not written with parallel processes in mind, so it only states that
the function 'can be called even if the element already exists'
and does not specify what if the element comes to existence during
the function execution. However, I would say that since existence
is a valid pre-condition and it does not matter how the post-condition,
i.e., existing directory, was achieved. Hence finding out that some
other process created it is fine.

If my understanding is correct, this approach should work well for
directories in mapset such as cell, fcell, or vector, for example
we have calls such as `G_make_mapset_element("fcell");`.

However, it seems to me that in several places this is used for to create
nested directories such as grid3/some_raster3d_name. This is is place
where you want the function to fail when the some_raster3d_name directory
exists, because that's definitevely a race condition unlike creating grid3
which may be just two processes peacefully co-existing.
To accomode this scenario the new error handling is not good
and the original one works. What would be needed is a better API which
does not use vague element in the function name, but instead distinguishes
between element group directories (such as cell) and specific elements
(sub-directory for a specific vector map).
If this is the correct approach, this PR is currently experimental.
