### PR TITLE
Jupyter: Interactive display

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -2,3 +2,4 @@ numpy
 matplotlib
 Pillow
 ply
+folium

--- a/doc/notebooks/jupyter_integration.ipynb
+++ b/doc/notebooks/jupyter_integration.ipynb
@@ -21,8 +21,7 @@
    "source": [
     "import os\n",
     "import subprocess\n",
-    "import sys\n",
-    "from IPython.display import Image"
+    "import sys"
    ]
   },
   {
@@ -75,17 +74,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's display the DTM of our sample area to ensure all's working\n",
-    "\n",
     "# Set computational region to the study area.\n",
-    "gs.parse_command(\"g.region\", raster=\"elevation\", flags=\"pg\")\n",
+    "gs.run_command(\"g.region\", raster=\"elevation\", flags=\"p\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstration of GrassRenderer2 for interactive map display with folium\n",
     "\n",
-    "# Draw elevation (DTM) to get an overview of the area.\n",
-    "gs.run_command(\"r.colors\", map=\"elevation\", color=\"elevation\")\n",
-    "gs.run_command(\"d.erase\")\n",
-    "gs.run_command(\"d.rast\", map=\"elevation\")\n",
-    "gs.run_command(\"d.legend\", raster=\"elevation\", at=(65, 90, 85, 90), fontsize=15, flags=\"b\", title=\"DTM\")\n",
-    "Image(filename=\"map.png\")"
+    "spm_map.gj.GrassRenderer2(width = 600)\n",
+    "\n",
+    "spm_map.d_rast(\"elevation_shade\")\n",
+    "\n",
+    "spm_map.show_interactively(opacity=0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's see what is in the example database\n",
+    "print(gs.read_command(\"g.list\", type=\"all\"))"
    ]
   }
  ],

--- a/doc/notebooks/jupyter_integration.ipynb
+++ b/doc/notebooks/jupyter_integration.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "# Demonstration of GrassRenderer2 for interactive map display with folium\n",
     "\n",
-    "spm_map.gj.GrassRenderer2(width = 600)\n",
+    "spm_map = gj.GrassRenderer2(width = 600)\n",
     "\n",
     "spm_map.d_rast(\"elevation_shade\")\n",
     "\n",

--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -9,7 +9,7 @@ List of classes:
  - dialogs::WSPropertiesDialog
  - dialogs::SaveWMSLayerDialog
 
-(C) 2009-2013 by the GRASS Development Team
+(C) 2009-2021 by the GRASS Development Team
 
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -66,14 +66,13 @@ class WSDialogBase(wx.Dialog):
 
         # TODO: should be in file
         self.default_servers = {
-            "OSM-WMS-EUROPE": [
-                "http://watzmann-geog.urz.uni-heidelberg.de/cached/osm",
+            "OSM-WMS": [
+                "https://ows.terrestris.de/osm/service?",
                 "",
                 "",
             ],
-            "irs.gis-lab.info (OSM)": ["http://irs.gis-lab.info", "", ""],
-            "NASA GIBS WMTS": [
-                "http://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi",
+            "tiles.maps.eox.at (Sentinel-2)": [
+                "https://tiles.maps.eox.at/wms",
                 "",
                 "",
             ],

--- a/python/grass/jupyter/Makefile
+++ b/python/grass/jupyter/Makefile
@@ -5,7 +5,7 @@ include $(MODULE_TOPDIR)/include/Make/Python.make
 
 DSTDIR = $(ETC)/python/grass/jupyter
 
-MODULES = setup
+MODULES = setup interact_display
 
 PYFILES := $(patsubst %,$(DSTDIR)/%.py,$(MODULES) __init__)
 PYCFILES := $(patsubst %,$(DSTDIR)/%.pyc,$(MODULES) __init__)

--- a/python/grass/jupyter/__init__.py
+++ b/python/grass/jupyter/__init__.py
@@ -1,1 +1,3 @@
 from .setup import *
+from interact_display import *
+

--- a/python/grass/jupyter/interact_display.py
+++ b/python/grass/jupyter/interact_display.py
@@ -1,0 +1,115 @@
+#
+# AUTHOR(S): Caitlin Haedrich <caitlin DOT haedrich AT gmail>
+#
+# PURPOSE:   This module contains functions for interactive display
+#            in Jupyter Notebooks.
+#
+# COPYRIGHT: (C) 2021 Caitlin Haedrich, and by the GRASS Development Team
+#
+#            This program is free software under the GNU Gernal Public
+#            License (>=v2). Read teh file COPYING that comes with GRASS
+#            for details.
+
+import folium
+import grass.script as gs
+
+class GrassRenderer2:
+    """This class will be merged with display.py eventually?"""
+
+    def __init__(self, width=400, height=400):
+        """This initiates an instance of GrassRenderer"""
+        self.height = height
+        self.width = width
+        # We still need d.erase because folium uses png overlay
+        # for rasters
+        gs.run_command("d.erase")
+        
+    def d_rast(self, raster):
+        """This is a wrapper for d.rast that adds a raster to map.png"""
+        gs.run_command("d.rast", map=raster)
+
+    def _convert_coordinates(self, coordinates, proj_in):
+        """This function reprojects coordinates to WGS84, the required
+           projection for folium.
+           
+           Coordinates should be a string with x and y values separated
+           by a comma.
+           
+           proj_in is a proj4 string, for example, the output of g.region
+           with the `g` flag."""
+        
+        coords_folium = gs.read_command(
+                "m.proj",
+                coordinates = coordinates,
+                proj_in = proj_in,
+                separator = "comma",
+                flags = "do"
+            )
+        
+        # Reformat from string to array
+        coords_folium = coords_folium.strip() # Remove '\n' at end of string
+        coords_folium = coords_folium.split(',') #Split on comma
+        coords_folium = [float(value) for value in coords_folium] #Convert to floats
+        
+        return coords_folium[1], coords_folium[0] # Return Lat and Lon
+    
+    def _get_folium_bounding_box(self):
+        """This function returns the bounding box of the current region
+        in WGS84, the required projection for folium"""
+        
+        # Get proj of current GRASS region
+        proj = gs.read_command("g.proj", flags="jf")
+        
+        # Get extent
+        extent = gs.parse_command("g.region", flags="g")
+        extent_ne = "{}, {}".format(extent['e'], extent['n'])
+        extent_sw = "{}, {}".format(extent['w'], extent['s'])
+        
+        # Convert extent to EPSG:3857, required projection for Folium
+        bb_n, bb_e = self._convert_coordinates(extent_ne, proj)
+        bb_s, bb_w = self._convert_coordinates(extent_sw, proj)
+        
+        bounding_box = [[bb_n, bb_w], [bb_s, bb_e]]
+        
+        return bounding_box
+    
+    def show_interactively(self, opacity=0.8):
+        """This function creates a folium map with a GRASS raster
+        overlayed on a basemap"""
+        # Get extent and center of GRASS region
+        center = gs.parse_command("g.region", flags="cg")
+        center = "{}, {}".format(center['center_easting'], center['center_northing'])
+
+        # Get proj of current GRASS region
+        proj = gs.read_command("g.proj", flags="jf")
+
+        # Convert center and extent to EPSG:3857 for Folium
+        center_folium = self._convert_coordinates(center, proj)
+        
+        bounding_box = self._get_folium_bounding_box()
+        
+        # Create Folium Map
+        fig = folium.Figure(width = self.width, height = self.height)
+        m = folium.Map(
+                width = self.width,   # not sure this work work
+                height = self.height, 
+                location = center_folium,
+                tiles = "cartodbpositron"
+            )
+
+        # Overlay map.png on folium
+        img = folium.raster_layers.ImageOverlay(
+                image = 'map.png',
+                bounds = bounding_box,
+                opacity = opacity,
+                interactive = True,
+                cross_origin = False,
+            )
+
+        # Add img layer to m
+        img.add_to(m)
+        
+        # Add map to figure
+        fig.add_child(m)
+        
+        return fig

--- a/python/grass/jupyter/interact_display.py
+++ b/python/grass/jupyter/interact_display.py
@@ -13,6 +13,7 @@
 import folium
 import grass.script as gs
 
+
 class GrassRenderer2:
     """This class will be merged with display.py eventually?"""
 
@@ -23,93 +24,93 @@ class GrassRenderer2:
         # We still need d.erase because folium uses png overlay
         # for rasters
         gs.run_command("d.erase")
-        
+
     def d_rast(self, raster):
         """This is a wrapper for d.rast that adds a raster to map.png"""
         gs.run_command("d.rast", map=raster)
 
     def _convert_coordinates(self, coordinates, proj_in):
         """This function reprojects coordinates to WGS84, the required
-           projection for folium.
-           
-           Coordinates should be a string with x and y values separated
-           by a comma.
-           
-           proj_in is a proj4 string, for example, the output of g.region
-           with the `g` flag."""
-        
+        projection for folium.
+
+        Coordinates should be a string with x and y values separated
+        by a comma.
+
+        proj_in is a proj4 string, for example, the output of g.region
+        with the `g` flag."""
+
         coords_folium = gs.read_command(
-                "m.proj",
-                coordinates = coordinates,
-                proj_in = proj_in,
-                separator = "comma",
-                flags = "do"
-            )
-        
+            "m.proj",
+            coordinates=coordinates,
+            proj_in=proj_in,
+            separator="comma",
+            flags="do",
+        )
+
         # Reformat from string to array
-        coords_folium = coords_folium.strip() # Remove '\n' at end of string
-        coords_folium = coords_folium.split(',') #Split on comma
-        coords_folium = [float(value) for value in coords_folium] #Convert to floats
-        
-        return coords_folium[1], coords_folium[0] # Return Lat and Lon
-    
+        coords_folium = coords_folium.strip()  # Remove '\n' at end of string
+        coords_folium = coords_folium.split(",")  # Split on comma
+        coords_folium = [float(value) for value in coords_folium]  # Convert to floats
+
+        return coords_folium[1], coords_folium[0]  # Return Lat and Lon
+
     def _get_folium_bounding_box(self):
         """This function returns the bounding box of the current region
         in WGS84, the required projection for folium"""
-        
+
         # Get proj of current GRASS region
         proj = gs.read_command("g.proj", flags="jf")
-        
+
         # Get extent
         extent = gs.parse_command("g.region", flags="g")
-        extent_ne = "{}, {}".format(extent['e'], extent['n'])
-        extent_sw = "{}, {}".format(extent['w'], extent['s'])
-        
+        extent_ne = "{}, {}".format(extent["e"], extent["n"])
+        extent_sw = "{}, {}".format(extent["w"], extent["s"])
+
         # Convert extent to EPSG:3857, required projection for Folium
         bb_n, bb_e = self._convert_coordinates(extent_ne, proj)
         bb_s, bb_w = self._convert_coordinates(extent_sw, proj)
-        
+
         bounding_box = [[bb_n, bb_w], [bb_s, bb_e]]
-        
+
         return bounding_box
-    
+
     def show_interactively(self, opacity=0.8):
         """This function creates a folium map with a GRASS raster
         overlayed on a basemap"""
         # Get extent and center of GRASS region
         center = gs.parse_command("g.region", flags="cg")
-        center = "{}, {}".format(center['center_easting'], center['center_northing'])
+        center = "{}, {}".format(center["center_easting"], center["center_northing"])
 
         # Get proj of current GRASS region
         proj = gs.read_command("g.proj", flags="jf")
 
         # Convert center and extent to EPSG:3857 for Folium
         center_folium = self._convert_coordinates(center, proj)
-        
+
         bounding_box = self._get_folium_bounding_box()
-        
+
         # Create Folium Map
-        fig = folium.Figure(width = self.width, height = self.height)
+        fig = folium.Figure(width=self.width, height=self.height)
         m = folium.Map(
-                width = self.width,   # not sure this work work
-                height = self.height, 
-                location = center_folium,
-                tiles = "cartodbpositron"
-            )
+            width=self.width,  # not sure this work work
+            height=self.height,
+            location=center_folium,
+            tiles="cartodbpositron",
+        )
 
         # Overlay map.png on folium
         img = folium.raster_layers.ImageOverlay(
-                image = 'map.png',
-                bounds = bounding_box,
-                opacity = opacity,
-                interactive = True,
-                cross_origin = False,
-            )
+            image="map.png",
+            bounds=bounding_box,
+            opacity=opacity,
+            interactive=True,
+            cross_origin=False,
+        )
 
         # Add img layer to m
         img.add_to(m)
-        
+
         # Add map to figure
         fig.add_child(m)
-        
+
         return fig


### PR DESCRIPTION
This PR contains interactive functions for displaying GRASS maps in Jupyter Notebooks using folium. It is part of an ongoing Google Summer of Code project, Improved Integration of GRASS and Jupyter Notebooks. You can find more information [here](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS). 

The functions can also be tried in this Jupyter Notebook:

https://mybinder.org/v2/gh/chaedri/grass/interactive-display?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fjupyter_integration.ipynb