### PR TITLE
gunittest: init super() to initialise 'errors' attribute

### DIFF
--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -209,6 +209,7 @@ class GrassTestLoader(unittest.TestLoader):
     universal_tests_value = "universal"
 
     def __init__(self, grass_location):
+        super().__init__()
         self.grass_location = grass_location
 
     # TODO: what is the purpose of top_level_dir, can it be useful?


### PR DESCRIPTION
Fixes failing unit tests which fail to present error message because of uninitialised attribute `errors` of `GrassTestLoader`'s parent class `unittest.TestLoader`:

```
Traceback (most recent call last):
  File "/Volumes/dev/grass/python/grass/pygrass/testsuite/test_pygrass_doctests.py", line 49, in <module>
    grass.gunittest.main.test()
  File "/Volumes/dev/grass/dist.x86_64-apple-darwin19.6.0/etc/python/grass/gunittest/main.py", line 104, in test
    program = GrassTestProgram(
  File "/Volumes/dev/grass/dist.x86_64-apple-darwin19.6.0/etc/python/grass/gunittest/main.py", line 70, in __init__
    super(GrassTestProgram, self).__init__(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/main.py", line 156, in createTests
    self.test = self.testLoader.loadTestsFromModule(self.module)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/loader.py", line 134, in loadTestsFromModule
    self.errors.append(error_message)
AttributeError: 'GrassTestLoader' object has no attribute 'errors'
```

Tested on master with:
```
python3 -c "import sys, wx; print(sys.version); print(wx.version())" 
3.9.1 (v3.9.1:1e5d33e9b9, Dec  7 2020, 12:10:52) 
[Clang 6.0 (clang-600.0.57)]
4.1.1 osx-cocoa (phoenix) wxWidgets 3.1.5
```