### PR TITLE
Added additional GRASS info to example_notebook

### DIFF
--- a/doc/notebooks/example_notebook.ipynb
+++ b/doc/notebooks/example_notebook.ipynb
@@ -1,23 +1,8 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": 3
-  },
-  "orig_nbformat": 2
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Try GRASS GIS in Jupyter Notebook with Python\n",
     "\n",
@@ -35,9 +20,7 @@
     "## Start\n",
     "\n",
     "There are several ways to use GRASS GIS. When using Python in a notebook, we usually find GRASS GIS Python packages first, import them, initialize GRASS GIS session, and set several variables useful for using GRASS GIS in a notebook."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -77,14 +60,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Raster buffer\n",
     "\n",
     "Set computational region and create multiple buffers in given distances\n",
     "around lakes represented as raster:"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -101,15 +84,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Vector buffer\n",
     "\n",
     "Create a negative buffer around state boundary represented as a vector.\n",
     "Vector modules typically don't follow computational region,\n",
     "but we set it to inform display modules about our area of interest."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -126,6 +109,70 @@
     "gs.run_command('d.legend.vect', at=(10, 35))\n",
     "Image(filename=\"map.png\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional GRASS Information and Tutorials\n",
+    "\n",
+    "To find more information on what one can do with GRASS GIS APIs, check out:\n",
+    "    \n",
+    " - [GRASS GIS Manual](https://grass.osgeo.org/grass-stable/manuals)\n",
+    "    \n",
+    " - [GRASS Python API Manual](https://grass.osgeo.org/grass-stable/manuals/libpython)\n",
+    "\n",
+    "For more Jupyter Notebook GRASS GIS tutorials, visit:\n",
+    " - [Try GRASS GIS online](https://grass.osgeo.org/learn/tryonline/)\n",
+    "\n",
+    "## What else is in the sample North Carolina dataset?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(gs.read_command(\"g.list\", type=\"all\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What other GRASS modules can I try in this notebooks?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(gs.read_command(\"g.search.modules\", flags=\"g\"))"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR contains a few changes proposed in #1668 that I think would be better placed here. I'm working on the example notebook and other Jupyter Notebooks as part of the Google Summer of Code project, [Improved Integration of GRASS GIS and Jupyter Notebooks[(https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS).

You can see and test this updated notebook here:
https://mybinder.org/v2/gh/chaedri/grass/example_notebook_update?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fexample_notebook.ipynb