### PR TITLE
Fix a typo and remove -z flag mention in v.out.ogr warning messages

### DIFF
--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -685,7 +685,7 @@ int main(int argc, char *argv[])
 	else {
 	    G_warning(_("Vector map <%s> is 3D. "
 			"Use format specific layer creation options (parameter 'lco') "
-			"to export <in 3D rather than 2D (default)."),
+			"to export in 3D rather than 2D (default)."),
 		      options.input->answer);
 	}
     }

--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -666,7 +666,7 @@ int main(int argc, char *argv[])
 	    if (!shpt || shpt[strlen(shpt) - 1] != 'Z') {
 		G_warning(_("Vector map <%s> is 3D. "
 			    "Use format specific layer creation options SHPT (parameter 'lco') "
-			    "or '-z' flag to export in 3D rather than 2D (default)"),
+			    "to export in 3D rather than 2D (default)"),
 			  options.input->answer);
 	    }
 	}


### PR DESCRIPTION
- Fix a typo in v.out.ogr warning message:
from `Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default).`
to `Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default).`

- Remove -z flag mention in v.out.ogr warning: the -z flag was introduced in [GRASS 6.4](https://old.grass.osgeo.org/grass64/manuals/v.out.ogr.html) with commit ffaa430 and removed in [GRASS 7.0](https://web.archive.org/web/20150225052346/http://grass.osgeo.org/grass70/manuals/v.out.ogr.html) with commit 606b979
from `Use format specific layer creation options SHPT (parameter 'lco') or '-z' flag to export in 3D rather than 2D (default).`
to `Use format specific layer creation options SHPT (parameter 'lco') to export in 3D rather than 2D (default).`