### PR TITLE
Fix Cairo for Windows

### DIFF
--- a/lib/cairodriver/text.c
+++ b/lib/cairodriver/text.c
@@ -17,8 +17,13 @@
 
 #if CAIRO_HAS_FT_FONT
 #include <cairo-ft.h>
+#if CAIRO_VERSION < CAIRO_VERSION_ENCODE(1,10,0) || defined(CAIRO_HAS_FC_FONT)
+#define USE_FONTCONFIG 1
 #include <fontconfig/fontconfig.h>
+#else
+#define USE_FONTCONFIG 0
 #endif
+#endif /* CAIRO_HAS_FT_FONT */
 
 #ifdef HAVE_ICONV_H
 #include <iconv.h>
@@ -170,7 +175,7 @@ static void set_font_toy(const char *name)
     G_free(font);
 }
 
-#if CAIRO_HAS_FT_FONT
+#if USE_FONTCONFIG
 
 static void fc_init(void)
 {
@@ -281,7 +286,7 @@ static int is_toy_font(const char *name)
 */
 void Cairo_set_font(const char *name)
 {
-#if CAIRO_HAS_FT_FONT
+#if USE_FONTCONFIG
     if (is_toy_font(name))
 	set_font_toy(name);
     else
@@ -322,7 +327,7 @@ static void font_list_toy(char ***list, int *count, int verbose)
 void Cairo_font_list(char ***list, int *count)
 {
     font_list_toy(list, count, 0);
-#if CAIRO_HAS_FT_FONT
+#if USE_FONTCONFIG
     font_list_fc(list, count, 0);
 #endif
 }
@@ -336,7 +341,7 @@ void Cairo_font_list(char ***list, int *count)
 void Cairo_font_info(char ***list, int *count)
 {
     font_list_toy(list, count, 1);
-#if CAIRO_HAS_FT_FONT
+#if USE_FONTCONFIG
     font_list_fc(list, count, 1);
 #endif
 }


### PR DESCRIPTION
Windows compilation with OSGeo4W fails on building lib/cairodriver:

```
gcc -shared -o /d/a/grass/grass/dist.x86_64-w64-mingw32/lib/libgrass_cairodriver.8.0.dll -L/d/a/grass/grass/dist.x86_64-w64-mingw32/lib -L/d/a/grass/grass/dist.x86_64-w64-mingw32/lib -Wl,--export-dynamic,--enable-runtime-pseudo-reloc  -L/c/OSGeo4W/lib -L/c/OSGeo4W/bin   OBJ.x86_64-w64-mingw32/box.o OBJ.x86_64-w64-mingw32/color.o OBJ.x86_64-w64-mingw32/draw.o OBJ.x86_64-w64-mingw32/draw_bitmap.o OBJ.x86_64-w64-mingw32/driver.o OBJ.x86_64-w64-mingw32/erase.o OBJ.x86_64-w64-mingw32/graph.o OBJ.x86_64-w64-mingw32/line_width.o OBJ.x86_64-w64-mingw32/raster.o OBJ.x86_64-w64-mingw32/read.o OBJ.x86_64-w64-mingw32/read_bmp.o OBJ.x86_64-w64-mingw32/read_ppm.o OBJ.x86_64-w64-mingw32/read_xid.o OBJ.x86_64-w64-mingw32/set_window.o OBJ.x86_64-w64-mingw32/text.o OBJ.x86_64-w64-mingw32/write.o OBJ.x86_64-w64-mingw32/write_bmp.o OBJ.x86_64-w64-mingw32/write_ppm.o OBJ.x86_64-w64-mingw32/write_xid.o  -lgrass_driver.8.0 -lgrass_gis.8.0 -lintl -LC:/msys64/mingw64/bin/../lib -lcairo -lpng16 -lz -lfontconfig -lfreetype     -liconv 
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: warning: --export-dynamic is not supported for PE+ targets, did you mean --export-all-symbols?
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: OBJ.x86_64-w64-mingw32/text.o: in function `set_font_fc':
D:\a\grass\grass\lib\cairodriver/text.c:202: undefined reference to `cairo_ft_font_face_create_for_pattern'
collect2.exe: error: ld returned 1 exit status
make[3]: *** [../../include/Make/Shlib.make:10: /d/a/grass/grass/dist.x86_64-w64-mingw32/lib/libgrass_cairodriver.8.0.dll] Error 1
make[3]: Leaving directory '/d/a/grass/grass/lib/cairodriver'
```

This is an attempt to address this.

Based on patch at https://github.com/jef-n/OSGeo4W/blob/master/src/grass/osgeo4w/patch.
