### PR TITLE
gunittest: update module interface doctest

### DIFF
--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -348,30 +348,30 @@ class Module(object):
     >>> neighbors.inputs.size = 5
     >>> neighbors.inputs.quantile = 0.5
     >>> neighbors.get_bash()
-    'r.neighbors input=mapA method=average size=5 quantile=0.5 output=mapB'
+    'r.neighbors input=mapA size=5 method=average weighting_function=none quantile=0.5 output=mapB'
 
     >>> new_neighbors1 = copy.deepcopy(neighbors)
     >>> new_neighbors1.inputs.input = "mapD"
     >>> new_neighbors1.inputs.size = 3
     >>> new_neighbors1.inputs.quantile = 0.5
     >>> new_neighbors1.get_bash()
-    'r.neighbors input=mapD method=average size=3 quantile=0.5 output=mapB'
+    'r.neighbors input=mapD size=3 method=average weighting_function=none quantile=0.5 output=mapB'
 
     >>> new_neighbors2 = copy.deepcopy(neighbors)
     >>> new_neighbors2(input="mapD", size=3, run_=False)
     Module('r.neighbors')
     >>> new_neighbors2.get_bash()
-    'r.neighbors input=mapD method=average size=3 quantile=0.5 output=mapB'
+    'r.neighbors input=mapD size=3 method=average weighting_function=none quantile=0.5 output=mapB'
 
     >>> neighbors = Module("r.neighbors")
     >>> neighbors.get_bash()
-    'r.neighbors method=average size=3'
+    'r.neighbors size=3 method=average weighting_function=none'
 
     >>> new_neighbors3 = copy.deepcopy(neighbors)
     >>> new_neighbors3(input="mapA", size=3, output="mapB", run_=False)
     Module('r.neighbors')
     >>> new_neighbors3.get_bash()
-    'r.neighbors input=mapA method=average size=3 output=mapB'
+    'r.neighbors input=mapA size=3 method=average weighting_function=none output=mapB'
 
     >>> mapcalc = Module("r.mapcalc", expression="test_a = 1",
     ...                  overwrite=True, run_=False)


### PR DESCRIPTION
Adapts documentation to the addition of 'weighting_function' parameter to 'r.neighbors' introduced with https://github.com/OSGeo/grass/commit/20f370c9ee983fd8bb30e9dd55c9acf528f562ad (#597).

Unit tests fails with errors like:
```
FAIL: Module (grass.pygrass.modules.interface.module)
Doctest: grass.pygrass.modules.interface.module.Module
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/doctest.py", line 2204, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for grass.pygrass.modules.interface.module.Module
  File "/Volumes/dev/grass/dist.x86_64-apple-darwin19.6.0/etc/python/grass/pygrass/modules/interface/module.py", line 323, in Module

----------------------------------------------------------------------
File "/Volumes/dev/grass/dist.x86_64-apple-darwin19.6.0/etc/python/grass/pygrass/modules/interface/module.py", line 350, in grass.pygrass.modules.interface.module.Module
Failed example:
    neighbors.get_bash()
Expected:
    'r.neighbors input=mapA method=average size=5 quantile=0.5 output=mapB'
Got:
    'r.neighbors input=mapA size=5 method=average weighting_function=none quantile=0.5 output=mapB'
```