### PR TITLE
CI: Make test report available even on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
         run: .github/workflows/test_thorough.sh
 
       - name: Make HTML test report available
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: testreport-${{ matrix.os }}


### PR DESCRIPTION
This specifies that the upload artifact step should run even if the previous step fails
which is what happens when one of the test fails.
