### PR TITLE
CI: Add matplotlib to apt deps

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -17,6 +17,7 @@ proj-bin
 libreadline-dev
 libzstd-dev
 python3-dateutil
+python3-matplotlib
 python3-numpy
 python3-ply
 python3-six


### PR DESCRIPTION
Already in yum. Should be available to tests. (Now needed by grass.benchmark.)
