### PR TITLE
wxGUI/mapdisplay: register context menu items, addresses #1691

### DIFF
--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -258,23 +258,6 @@ class LayerManagerGrassInterface(object):
     def UpdateCmdHistory(self, cmd):
         self.lmgr.goutput.GetPrompt().UpdateCmdHistory(cmd)
 
-    def ShowStatusbar(self, show=True):
-        self.lmgr.GetMapDisplay().ShowStatusbar(show)
-
-    def IsStatusbarShown(self):
-        return self.lmgr.GetMapDisplay().IsStatusbarShown()
-
-    def ShowAllToolbars(self, show=True):
-        if not show:  # hide
-            action = self.lmgr.GetMapDisplay().RemoveToolbar
-        else:
-            action = self.lmgr.GetMapDisplay().AddToolbar
-        for toolbar in self.lmgr.GetMapDisplay().GetToolbarNames():
-            action(toolbar)
-
-    def AreAllToolbarsShown(self):
-        return self.lmgr.GetMapDisplay().GetMapToolbar().IsShown()
-
 
 class LayerManagerGrassInterfaceForMapDisplay(object):
     """Provides reference only to the given layer list (according to tree),

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -172,6 +172,9 @@ class MapFrame(SingleMapFrame):
         self.MapWindow2D.InitZoomHistory()
         self.MapWindow2D.zoomChanged.connect(self.StatusbarUpdate)
 
+        # register context menu actions
+        self._registerContextMenuActions()
+
         self._giface.updateMap.connect(self.MapWindow2D.UpdateMap)
         # default is 2D display mode
         self.MapWindow = self.MapWindow2D
@@ -245,6 +248,37 @@ class MapFrame(SingleMapFrame):
         self.measureController = None
 
         self._resize()
+
+    def _registerContextMenuActions(self):
+        """Register show/hide toolbars and statusbar context menu actions"""
+
+        def show_hide_toolbar_label():
+            return (
+                _("Hide toolbars") if self.AreAllToolbarsShown() else _("Show toolbars")
+            )
+
+        def on_show_hide_toolbar(event):
+            self.ShowAllToolbars(not self.AreAllToolbarsShown())
+
+        self.MapWindow2D.RegisterContextAction(
+            name="showAllToolbars",
+            label=show_hide_toolbar_label,
+            action=on_show_hide_toolbar,
+        )
+
+        def show_hide_statusbar_label():
+            return (
+                _("Hide statusbar") if self.IsStatusbarShown() else _("Show statusbar")
+            )
+
+        def on_show_hide_statusbar(event):
+            self.ShowStatusbar(not self.IsStatusbarShown())
+
+        self.MapWindow2D.RegisterContextAction(
+            name="showStatusbar",
+            label=show_hide_statusbar_label,
+            action=on_show_hide_statusbar,
+        )
 
     def CreateStatusbar(self):
         if self.statusbarManager:
@@ -670,6 +704,17 @@ class MapFrame(SingleMapFrame):
         self.toolbars["map"].Enable2D(True)
 
         self._mgr.Update()
+
+    def ShowAllToolbars(self, show=True):
+        if not show:  # hide
+            action = self.RemoveToolbar
+        else:
+            action = self.AddToolbar
+        for toolbar in self.GetToolbarNames():
+            action(toolbar)
+
+    def AreAllToolbarsShown(self):
+        return self.GetMapToolbar().IsShown()
 
     def IsPaneShown(self, name):
         """Check if pane (toolbar, mapWindow ...) of given name is currently shown"""

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -456,36 +456,6 @@ class DMonGrassInterface(StandaloneGrassInterface):
     def GetProgress(self):
         return self._mapframe.GetProgressBar()
 
-    def ShowStatusbar(self, show=True):
-        if not self._mapframe.statusbarManager:
-            self._mapframe.CreateStatusbar()
-
-        self._mapframe.ShowStatusbar(show)
-
-    def IsStatusbarShown(self):
-        if not self._mapframe.statusbarManager:
-            return False
-
-        return self._mapframe.IsStatusbarShown()
-
-    def ShowAllToolbars(self, show=True):
-        if not show:  # hide
-            action = self._mapframe.RemoveToolbar
-        else:
-            action = self._mapframe.AddToolbar
-        toolbars = list(self._mapframe.GetToolbarNames())
-        if not toolbars:
-            toolbars.append("map")
-        for toolbar in toolbars:
-            action(toolbar)
-
-    def AreAllToolbarsShown(self):
-        toolbar = self._mapframe.GetMapToolbar()
-        if toolbar is None:
-            return False
-
-        return toolbar.IsShown()
-
 
 class DMonFrame(MapFrame):
     def OnZoomToMap(self, event):

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -223,6 +223,9 @@ class BufferedMapWindow(MapWindowBase, Window):
         # list for registration of graphics to draw
         self.graphicsSetList = []
 
+        # dict for registration of context menu actions
+        self._extraContextActions = {}
+
     def OnUpdateMap(self):
         # before lambda func was used, however it was problem
         # to disconnect it from signal
@@ -253,6 +256,15 @@ class BufferedMapWindow(MapWindowBase, Window):
         self.Bind(wx.EVT_MOTION, self.OnMotion)
         self.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
 
+    def RegisterContextAction(self, name, label, action):
+        """Register context menu item.
+
+        :param name: action name
+        :param label: callback function returning label
+        :param action: handler
+        """
+        self._extraContextActions[name] = {"label": label, "action": action}
+
     def OnContextMenu(self, event):
         """Show Map Display context menu"""
         if self.digit:
@@ -266,25 +278,14 @@ class BufferedMapWindow(MapWindowBase, Window):
             self.popupCopyCoordinates = NewId()
             self.Bind(wx.EVT_MENU, self.OnCopyCoordinates, id=self.popupCopyCoordinates)
         menu.Append(self.popupCopyCoordinates, _("Copy coordinates to clipboard"))
-        menu.AppendSeparator()
-        if not hasattr(self, "popupShowAllToolbars"):
-            self.popupShowAllToolbars = NewId()
-            self.Bind(wx.EVT_MENU, self.OnShowAllToolbars, id=self.popupShowAllToolbars)
-        menu.Append(
-            self.popupShowAllToolbars,
-            _("Hide toolbars")
-            if self._giface.AreAllToolbarsShown()
-            else _("Show toolbars"),
-        )
-        if not hasattr(self, "popupShowStatusbar"):
-            self.popupShowStatusbar = NewId()
-            self.Bind(wx.EVT_MENU, self.OnShowStatusbar, id=self.popupShowStatusbar)
-        menu.Append(
-            self.popupShowStatusbar,
-            _("Hide statusbar")
-            if self._giface.IsStatusbarShown()
-            else _("Show statusbar"),
-        )
+        if self._extraContextActions:
+            menu.AppendSeparator()
+        for key, action_dict in self._extraContextActions.items():
+            if not hasattr(self, key):
+                aid = NewId()
+                setattr(self, key, aid)
+                self.Bind(wx.EVT_MENU, action_dict["action"], id=aid)
+            menu.Append(getattr(self, key), action_dict["label"]())
 
         pos = self.ScreenToClient(event.GetPosition())
         idlist = self.pdc.FindObjects(pos[0], pos[1], self.hitradius)
@@ -1724,14 +1725,6 @@ class BufferedMapWindow(MapWindowBase, Window):
             do.SetText(str(e) + delim + str(n))
             wx.TheClipboard.SetData(do)
             wx.TheClipboard.Close()
-
-    def OnShowStatusbar(self, event):
-        """Show/hide statusbar"""
-        self._giface.ShowStatusbar(not self._giface.IsStatusbarShown())
-
-    def OnShowAllToolbars(self, event):
-        """Show/hide all toolbars"""
-        self._giface.ShowAllToolbars(not self._giface.AreAllToolbarsShown())
 
     def ClearLines(self, pdc=None):
         """Clears temporary drawn lines from PseudoDC"""


### PR DESCRIPTION
Show/hide toolbars and statusbar context menu items now need to be added explicitly. This PR registers them in MapFrame class only, so they won't show up in any of the other frames with BufferedMapWindow. The related functions are removed from giface.