### PR TITLE
gunittest: Fix stdout used instead of stderr

### DIFF
--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -225,7 +225,7 @@ class GrassTestFilesInvoker(object):
             """
             for encoding in encodings:
                 try:
-                    return decode(stdout, encoding=encoding)
+                    return decode(data, encoding=encoding)
                 except UnicodeError:
                     pass
             if isinstance(data, bytes):


### PR DESCRIPTION
Changes in 51fc3d6276a4f7468e3add3e535f99ff5f21ee91 introduced a bug where stdout
was used always, so stderr was never visible in test results.
This uses the correct local variable, not the stdout from outer scope.
