### PR TITLE
wxGUI/splashscreen: use standard one, try to show it before main app, increase timeout

### DIFF
--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -86,11 +86,6 @@ class GMApp(wx.App):
             from lmgr.frame import GMFrame
 
             mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
-
-            # testing purposes
-            # from main_window.frame import GMFrame
-            # mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
-
             mainframe.Show()
             self.SetTopWindow(mainframe)
 

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -71,54 +71,30 @@ class GMApp(wx.App):
         introImagePath = os.path.join(globalvar.IMGDIR, "splash_screen.png")
         introImage = wx.Image(introImagePath, wx.BITMAP_TYPE_PNG)
         introBmp = introImage.ConvertToBitmap()
-        if SC and sys.platform != "darwin":
-            # AdvancedSplash is buggy on the Mac as of 2.8.12.1
-            # and raises annoying (though seemingly harmless) errors everytime
-            # the GUI is started
-            splash = SC.AdvancedSplash(
-                bitmap=introBmp, timeout=2000, parent=None, id=wx.ID_ANY
-            )
-            splash.SetText(_("Starting GRASS GUI..."))
-            splash.SetTextColour(wx.Colour(45, 52, 27))
-            splash.SetTextFont(
-                wx.Font(
-                    pointSize=15, family=wx.DEFAULT, style=wx.NORMAL, weight=wx.BOLD
-                )
-            )
-            splash.SetTextPosition((150, 430))
-        else:
-            if globalvar.wxPythonPhoenix:
-                import wx.adv as wxadv
-
-                wxadv.SplashScreen(
-                    bitmap=introBmp,
-                    splashStyle=wxadv.SPLASH_CENTRE_ON_SCREEN | wxadv.SPLASH_TIMEOUT,
-                    milliseconds=2000,
-                    parent=None,
-                    id=wx.ID_ANY,
-                )
-            else:
-                wx.SplashScreen(
-                    bitmap=introBmp,
-                    splashStyle=wx.SPLASH_CENTRE_ON_SCREEN | wx.SPLASH_TIMEOUT,
-                    milliseconds=2000,
-                    parent=None,
-                    id=wx.ID_ANY,
-                )
+        wx.adv.SplashScreen(
+            bitmap=introBmp,
+            splashStyle=wx.adv.SPLASH_CENTRE_ON_SCREEN | wx.adv.SPLASH_TIMEOUT,
+            milliseconds=3000,
+            parent=None,
+            id=wx.ID_ANY,
+        )
 
         wx.GetApp().Yield()
 
-        # create and show main frame
-        from lmgr.frame import GMFrame
+        def show_main_gui():
+            # create and show main frame
+            from lmgr.frame import GMFrame
 
-        mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
+            mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
 
-        # testing purposes
-        # from main_window.frame import GMFrame
-        # mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
+            # testing purposes
+            # from main_window.frame import GMFrame
+            # mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
 
-        mainframe.Show()
-        self.SetTopWindow(mainframe)
+            mainframe.Show()
+            self.SetTopWindow(mainframe)
+
+        wx.CallAfter(show_main_gui)
 
         return True
 


### PR DESCRIPTION
Currently, the splash screen shows up only after the main application shows up, at least on Ubuntu. This attempts to start showing it before the application.

Ideally, it would be good to test on Windows/Mac, if there is any difference in behavior, but we can also just merge it and test then.