### PR TITLE
Temporary Directory support for Non-Interactive Jupyter displays

### DIFF
--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -309,7 +309,7 @@ class SbManager:
             self.statusbarItems["region"].SetValue(True)
             # redraw map if auto-rendering is enabled
             if self.mapFrame.IsAutoRendered():
-                self.mapFrame.GetMapWindow().UpdateMap(render=False)
+                self.mapFrame.GetWindow().UpdateMap(render=False)
 
     def SetMode(self, modeIndex):
         """Sets current mode
@@ -495,7 +495,7 @@ class SbShowRegion(SbItem):
 
         # redraw map if auto-rendering is enabled
         if self.mapFrame.IsAutoRendered():
-            self.mapFrame.GetMapWindow().UpdateMap(render=False)
+            self.mapFrame.GetWindow().UpdateMap(render=False)
 
     def SetValue(self, value):
         self._disconnectShowRegion()
@@ -603,7 +603,7 @@ class SbResolution(SbItem):
         self._connectResolutionChange()
         # redraw map if auto-rendering is enabled
         if self.mapFrame.IsAutoRendered():
-            self.mapFrame.GetMapWindow().UpdateMap()
+            self.mapFrame.GetWindow().UpdateMap()
 
 
 class SbMapScale(SbItem):

--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -31,17 +31,23 @@ class GrassRenderer:
         else:
             self._env = os.environ.copy()
 
+	# Make temporary folder for all our files
+        self._tmp_dir = Path("./tmp/")
+        try:
+            os.mkdir(self._tmp_dir)
+        except FileExistsError:
+            pass
+        self._filepath = os.join(self._tmp_dir, filename)
+        
         self._env["GRASS_RENDER_WIDTH"] = str(width)
         self._env["GRASS_RENDER_HEIGHT"] = str(height)
         self._env["GRASS_TEXT_SIZE"] = str(text_size)
         self._env["GRASS_RENDER_IMMEDIATE"] = "cairo"
-        self._env["GRASS_RENDER_FILE"] = str(filename)
+        self._env["GRASS_RENDER_FILE"] = str(self._filepath)
         self._env["GRASS_RENDER_FILE_READ"] = "TRUE"
-
-        self._legend_file = Path(filename).with_suffix(".grass_vector_legend")
+        
+        self._legend_file = self._filepath.with_suffix(".grass_vector_legend")
         self._env["GRASS_LEGEND_FILE"] = str(self._legend_file)
-
-        self._filename = filename
 
         self.run("d.erase")
 
@@ -55,4 +61,4 @@ class GrassRenderer:
 
     def show(self):
         """Displays a PNG image of the map (non-interactive)"""
-        return Image(self._filename)
+        return Image(self._filepath)

--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -31,21 +31,21 @@ class GrassRenderer:
         else:
             self._env = os.environ.copy()
 
-	# Make temporary folder for all our files
+        # Make temporary folder for all our files
         self._tmp_dir = Path("./tmp/")
         try:
             os.mkdir(self._tmp_dir)
         except FileExistsError:
             pass
         self._filepath = os.join(self._tmp_dir, filename)
-        
+
         self._env["GRASS_RENDER_WIDTH"] = str(width)
         self._env["GRASS_RENDER_HEIGHT"] = str(height)
         self._env["GRASS_TEXT_SIZE"] = str(text_size)
         self._env["GRASS_RENDER_IMMEDIATE"] = "cairo"
         self._env["GRASS_RENDER_FILE"] = str(self._filepath)
         self._env["GRASS_RENDER_FILE_READ"] = "TRUE"
-        
+
         self._legend_file = self._filepath.with_suffix(".grass_vector_legend")
         self._env["GRASS_LEGEND_FILE"] = str(self._legend_file)
 

--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -37,7 +37,7 @@ class GrassRenderer:
             os.mkdir(self._tmp_dir)
         except FileExistsError:
             pass
-        self._filepath = os.join(self._tmp_dir, filename)
+        self._filepath = os.path.join(self._tmp_dir, filename)
 
         self._env["GRASS_RENDER_WIDTH"] = str(width)
         self._env["GRASS_RENDER_HEIGHT"] = str(height)

--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -46,7 +46,7 @@ class GrassRenderer:
         self._env["GRASS_RENDER_FILE"] = str(self._filepath)
         self._env["GRASS_RENDER_FILE_READ"] = "TRUE"
 
-        self._legend_file = self._filepath.with_suffix(".grass_vector_legend")
+        self._legend_file = Path(self._filepath).with_suffix(".grass_vector_legend")
         self._env["GRASS_LEGEND_FILE"] = str(self._legend_file)
 
         self.run("d.erase")


### PR DESCRIPTION
This PR contains modifications to display.py that move temporary files from the current working directory to a temporary directory that can be deleted later. The temporary directory is the same one used by the interactive mapping functions in PR #1710. You can test it out in Binder here:

https://mybinder.org/v2/gh/chaedri/grass/add-temp-directory?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fjupyter_integration.ipynb