### PR TITLE
lib/raster: add strerror(errno) to write failures

### DIFF
--- a/lib/raster/put_row.c
+++ b/lib/raster/put_row.c
@@ -388,14 +388,14 @@ static void put_data(int fd, char *null_buf, const CELL * cell,
 	    nwrite++;
 
 	    if (write(fcb->data_fd, compressed_buf, nwrite) != nwrite)
-		G_fatal_error(_("Error writing compressed data for row %d of <%s>"),
-			      row, fcb->name);
+		G_fatal_error(_("Error writing compressed data for row %d of <%s>: %s"),
+			      row, fcb->name, strerror(errno));
 	}
 	else {
 	    nwrite = nbytes * n + 1;
 	    if (write(fcb->data_fd, work_buf, nwrite) != nwrite)
-		G_fatal_error(_("Error writing compressed data for row %d of <%s>"),
-			      row, fcb->name);
+		G_fatal_error(_("Error writing compressed data for row %d of <%s>: %s"),
+			      row, fcb->name, strerror(errno));
 	}
 
 	G_free(compressed_buf);
@@ -404,8 +404,8 @@ static void put_data(int fd, char *null_buf, const CELL * cell,
 	nwrite = fcb->nbytes * n;
 
 	if (write(fcb->data_fd, work_buf, nwrite) != nwrite)
-	    G_fatal_error(_("Error writing uncompressed data for row %d of <%s>"),
-			  row, fcb->name);
+	    G_fatal_error(_("Error writing uncompressed data for row %d of <%s>: %s"),
+			  row, fcb->name, strerror(errno));
     }
 
     G_free(work_buf);
@@ -518,13 +518,13 @@ static void write_null_bits_compressed(const unsigned char *flags,
 
     if (nwrite > 0 && nwrite < size) {
 	if (write(fcb->null_fd, compressed_buf, nwrite) != nwrite)
-	    G_fatal_error(_("Error writing compressed null data for row %d of <%s>"),
-			  row, fcb->name);
+	    G_fatal_error(_("Error writing compressed null data for row %d of <%s>: %s"),
+			  row, fcb->name, strerror(errno));
     }
     else {
 	if (write(fcb->null_fd, flags, size) != size)
-	    G_fatal_error(_("Error writing compressed null data for row %d of <%s>"),
-			  row, fcb->name);
+	    G_fatal_error(_("Error writing compressed null data for row %d of <%s>: %s"),
+			  row, fcb->name, strerror(errno));
     }
 
     G_free(compressed_buf);
@@ -557,10 +557,12 @@ void Rast__write_null_bits(int fd, const unsigned char *flags)
     offset = (off_t) size * row;
 
     if (lseek(fcb->null_fd, offset, SEEK_SET) < 0)
-	G_fatal_error(_("Error writing null row %d of <%s>"), row, fcb->name);
+	G_fatal_error(_("Error writing null row %d of <%s>"),
+	              row, fcb->name);
 
     if (write(fcb->null_fd, flags, size) != size)
-	G_fatal_error(_("Error writing null row %d of <%s>"), row, fcb->name);
+	G_fatal_error(_("Error writing null row %d of <%s>: %s"),
+	              row, fcb->name, strerror(errno));
 }
 
 static void convert_and_write_if(int fd, const void *vbuf)


### PR DESCRIPTION
try to better explain errors when writing out raster maps