### PR TITLE
wxGUI: remove deprecated methods from MapDisplay

### DIFF
--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -16,6 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import os
+import sys
 
 import grass.script as grass
 
@@ -139,6 +140,10 @@ class GrassInterface:
 
     def WriteError(self, text):
         """Writes error message for the user."""
+        raise NotImplementedError()
+
+    def GetLog(self, err=False):
+        """Returns file-like object for writing."""
         raise NotImplementedError()
 
     def GetLayerTree(self):
@@ -312,6 +317,11 @@ class StandaloneGrassInterface(GrassInterface):
         os.environ["GRASS_MESSAGE_FORMAT"] = "standard"
         function(text)
         os.environ["GRASS_MESSAGE_FORMAT"] = orig
+
+    def GetLog(self, err=False):
+        if err:
+            return sys.stdout
+        return sys.stderr
 
     def GetLayerList(self):
         return []

--- a/gui/wxpython/gcp/mapdisplay.py
+++ b/gui/wxpython/gcp/mapdisplay.py
@@ -563,11 +563,6 @@ class MapFrame(SingleMapFrame):
         self.PopupMenu(zoommenu)
         zoommenu.Destroy()
 
-    def IsStandalone(self):
-        """Check if Map display is standalone"""
-        # we do not know and we do not care, so always False
-        return True
-
     def GetLayerManager(self):
         """Get reference to Layer Manager
 

--- a/gui/wxpython/gcp/mapdisplay.py
+++ b/gui/wxpython/gcp/mapdisplay.py
@@ -297,7 +297,7 @@ class MapFrame(SingleMapFrame):
         """
         # default toolbar
         if name == "map":
-            self.toolbars["map"] = MapToolbar(self, self._toolSwitcher)
+            self.toolbars["map"] = MapToolbar(self, self._toolSwitcher, self._giface)
 
             self._mgr.AddPane(
                 self.toolbars["map"],
@@ -562,13 +562,6 @@ class MapFrame(SingleMapFrame):
         # will be called before PopupMenu returns.
         self.PopupMenu(zoommenu)
         zoommenu.Destroy()
-
-    def GetLayerManager(self):
-        """Get reference to Layer Manager
-
-        :return: always None
-        """
-        return None
 
     def GetSrcWindow(self):
         return self.SrcMapWindow

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -349,10 +349,6 @@ class MapFrameBase(wx.Frame):
         for toolbar in six.itervalues(self.toolbars):
             toolbar.EnableLongHelp(enable)
 
-    def IsStandalone(self):
-        """Check if map frame is standalone"""
-        raise NotImplementedError("IsStandalone")
-
     def OnRender(self, event):
         """Re-render map composition (each map layer)"""
         raise NotImplementedError("OnRender")

--- a/gui/wxpython/iclass/digit.py
+++ b/gui/wxpython/iclass/digit.py
@@ -118,8 +118,8 @@ class IClassVDigitWindow(VDigitWindow):
 class IClassVDigit(IVDigit):
     """Class similar to IVDigit but specialized for wxIClass."""
 
-    def __init__(self, mapwindow):
-        IVDigit.__init__(self, mapwindow, driver=IClassDisplayDriver)
+    def __init__(self, giface, mapwindow):
+        IVDigit.__init__(self, giface, mapwindow, driver=IClassDisplayDriver)
         self._settings["closeBoundary"] = True  # snap to the first node
 
     def _getNewFeaturesLayer(self):

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -107,9 +107,9 @@ class IClassMapFrame(DoubleMapFrame):
             **kwargs,
         )
         if giface:
-            self._giface = giface
+            self.giface = giface
         else:
-            self._giface = StandaloneMapDisplayGrassInterface(self)
+            self.giface = StandaloneMapDisplayGrassInterface(self)
         self.tree = None
         self.mapWindowProperties = MapWindowProperties()
         self.mapWindowProperties.setValuesFromUserSettings()
@@ -118,13 +118,13 @@ class IClassMapFrame(DoubleMapFrame):
 
         self.firstMapWindow = IClassVDigitWindow(
             parent=self,
-            giface=self._giface,
+            giface=self.giface,
             properties=self.mapWindowProperties,
             map=self.firstMap,
         )
         self.secondMapWindow = BufferedMapWindow(
             parent=self,
-            giface=self._giface,
+            giface=self.giface,
             properties=self.mapWindowProperties,
             Map=self.secondMap,
         )
@@ -223,7 +223,7 @@ class IClassMapFrame(DoubleMapFrame):
 
         # PyPlot init
         self.plotPanel = PlotPanel(
-            self, giface=self._giface, stats_data=self.stats_data
+            self, giface=self.giface, stats_data=self.stats_data
         )
 
         self._addPanes()
@@ -262,7 +262,7 @@ class IClassMapFrame(DoubleMapFrame):
 
     def OnHelp(self, event):
         """Show help page"""
-        self._giface.Help(entry="wxGUI.iclass")
+        self.giface.Help(entry="wxGUI.iclass")
 
     def _getTempVectorName(self):
         """Return new name for temporary vector map (training areas)"""
@@ -393,7 +393,7 @@ class IClassMapFrame(DoubleMapFrame):
                 toolSwitcher=self._toolSwitcher,
                 MapWindow=self.GetFirstWindow(),
                 digitClass=IClassVDigit,
-                giface=self._giface,
+                giface=self.giface,
                 tools=[
                     "addArea",
                     "moveVertex",

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -39,6 +39,7 @@ except ImportError as e:
 import grass.script as grass
 
 from mapdisp import statusbar as sb
+from mapdisp.main import StandaloneMapDisplayGrassInterface
 from mapwin.buffered import BufferedMapWindow
 from vdigit.toolbars import VDigitToolbar
 from gui_core.mapdisp import DoubleMapFrame
@@ -105,7 +106,10 @@ class IClassMapFrame(DoubleMapFrame):
             secondMap=Map(),
             **kwargs,
         )
-        self._giface = giface
+        if giface:
+            self._giface = giface
+        else:
+            self._giface = StandaloneMapDisplayGrassInterface(self)
         self.tree = None
         self.mapWindowProperties = MapWindowProperties()
         self.mapWindowProperties.setValuesFromUserSettings()

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -222,9 +222,7 @@ class IClassMapFrame(DoubleMapFrame):
         self.dialogs["category"] = None
 
         # PyPlot init
-        self.plotPanel = PlotPanel(
-            self, giface=self.giface, stats_data=self.stats_data
-        )
+        self.plotPanel = PlotPanel(self, giface=self.giface, stats_data=self.stats_data)
 
         self._addPanes()
         self._mgr.Update()

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -485,10 +485,6 @@ class IClassMapFrame(DoubleMapFrame):
             .Position(position),
         )
 
-    def IsStandalone(self):
-        """Check if Map display is standalone"""
-        return True
-
     def OnUpdateActive(self, event):
         """
         .. todo::

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -114,10 +114,10 @@ def main():
     if group_name:
         frame.SetGroup(group_name, subgroup_name)
     if map_name:
-        giface.WriteLog(_("Loading raster map <%s>...") % map_name)
+        frame.giface.WriteLog(_("Loading raster map <%s>...") % map_name)
         frame.trainingMapManager.AddLayer(map_name)
     if trainingmap_name:
-        giface.WriteLog(_("Loading training map <%s>...") % trainingmap_name)
+        frame.giface.WriteLog(_("Loading training map <%s>...") % trainingmap_name)
         frame.ImportAreas(trainingmap_name)
 
     frame.Show()

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -64,7 +64,6 @@ def main():
     set_gui_path()
 
     from core.settings import UserSettings
-    from core.giface import StandaloneGrassInterface
     from iclass.frame import IClassMapFrame
 
     group_name = subgroup_name = map_name = trainingmap_name = None
@@ -105,10 +104,9 @@ def main():
     app = wx.App()
 
     # show main frame
-    giface = StandaloneGrassInterface()
     frame = IClassMapFrame(
         parent=None,
-        giface=giface,
+        giface=None,
         title=_("Supervised Classification Tool - GRASS GIS"),
     )
     if not flags["m"]:

--- a/gui/wxpython/image2target/ii2t_mapdisplay.py
+++ b/gui/wxpython/image2target/ii2t_mapdisplay.py
@@ -563,11 +563,6 @@ class MapFrame(SingleMapFrame):
         self.PopupMenu(zoommenu)
         zoommenu.Destroy()
 
-    def IsStandalone(self):
-        """Check if Map display is standalone"""
-        # we do not know and we do not care, so always False
-        return True
-
     def GetLayerManager(self):
         """Get reference to Layer Manager
 

--- a/gui/wxpython/image2target/ii2t_mapdisplay.py
+++ b/gui/wxpython/image2target/ii2t_mapdisplay.py
@@ -297,7 +297,7 @@ class MapFrame(SingleMapFrame):
         """
         # default toolbar
         if name == "map":
-            self.toolbars["map"] = MapToolbar(self, self._toolSwitcher)
+            self.toolbars["map"] = MapToolbar(self, self._toolSwitcher, self._giface)
 
             self._mgr.AddPane(
                 self.toolbars["map"],
@@ -562,13 +562,6 @@ class MapFrame(SingleMapFrame):
         # will be called before PopupMenu returns.
         self.PopupMenu(zoommenu)
         zoommenu.Destroy()
-
-    def GetLayerManager(self):
-        """Get reference to Layer Manager
-
-        :return: always None
-        """
-        return None
 
     def GetSrcWindow(self):
         return self.SrcMapWindow

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1472,7 +1472,7 @@ class GMFrame(wx.Frame):
             )
             return
 
-        win = IClassMapFrame(parent=self, giface=self._giface)
+        win = IClassMapFrame(parent=self)
         win.CentreOnScreen()
 
         win.Show()

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -234,6 +234,9 @@ class LayerManagerGrassInterface(object):
     def WriteError(self, text):
         self.lmgr._gconsole.WriteError(text=text)
 
+    def GetLog(self, err=False):
+        return self.lmgr._gconsole.GetLog(err=err)
+
     def GetLayerTree(self):
         return self.lmgr.GetLayerTree()
 

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1636,25 +1636,6 @@ class MapFrame(SingleMapFrame):
         self.mapWindowProperties.alignExtent = alignExtent
         self.mapWindowProperties.resolution = constrainRes
 
-    def IsStandalone(self):
-        """Check if Map display is standalone
-
-        .. deprecated:: 7.0
-        """
-        # TODO: once it is removed from 2 places in vdigit it can be deleted
-        # here and also in base class and other classes in the tree (hopefully)
-        # and one place here still uses IsStandalone
-        Debug.msg(
-            1,
-            "MapFrame.IsStandalone(): Method IsStandalone is"
-            "deprecated, use some general approach instead such as"
-            " Signals or giface",
-        )
-        if self._layerManager:
-            return False
-
-        return True
-
     def GetLayerManager(self):
         """Get reference to Layer Manager
 

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1548,11 +1548,7 @@ class MapFrame(SingleMapFrame):
         NULLs) or vector map.
         """
         Debug.msg(3, "MapFrame.OnZoomToMap()")
-        layers = None
-        if self.IsStandalone():
-            layers = self.MapWindow.GetMap().GetListOfLayers(active=False)
-
-        self.MapWindow.ZoomToMap(layers=layers)
+        self.MapWindow.ZoomToMap(layers=None)
 
     def OnZoomToRaster(self, event):
         """Set display extents to match selected raster map (ignore NULLs)"""

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -420,6 +420,11 @@ class MapFrame(SingleMapFrame):
                 giface=self._giface,
             )
             self.toolbars["vdigit"].quitDigitizer.connect(self.QuitVDigit)
+
+            def openATM(selection):
+                self._layerManager.OnShowAttributeTable(None, selection=selection)
+
+            self.toolbars["vdigit"].openATM.connect(lambda selection: openATM(selection))
             self.Map.layerAdded.connect(self._updateVDigitLayers)
         self.MapWindowVDigit.SetToolbar(self.toolbars["vdigit"])
 
@@ -587,7 +592,9 @@ class MapFrame(SingleMapFrame):
             self.toolbars["map"].combo.Delete(1)
 
     def RemoveNviz(self):
-        """Restore 2D view"""
+        """Restore 2D view. Can be called even if 3D is not active."""
+        if not self.IsPaneShown("3d"):
+            return
         try:
             self.toolbars["map"].RemoveTool(self.toolbars["map"].rotate)
             self.toolbars["map"].RemoveTool(self.toolbars["map"].flyThrough)
@@ -648,7 +655,8 @@ class MapFrame(SingleMapFrame):
         # default toolbar
         if name == "map":
             if "map" not in self.toolbars:
-                self.toolbars["map"] = MapToolbar(self, toolSwitcher=self._toolSwitcher)
+                self.toolbars["map"] = MapToolbar(self, toolSwitcher=self._toolSwitcher,
+                                                  giface=self._giface)
 
             self._mgr.AddPane(
                 self.toolbars["map"],
@@ -1024,8 +1032,7 @@ class MapFrame(SingleMapFrame):
             maplayer = self.toolbars["vdigit"].GetLayer()
             if maplayer:
                 self.toolbars["vdigit"].OnExit()
-        if self.IsPaneShown("3d"):
-            self.RemoveNviz()
+        self.RemoveNviz()
         if hasattr(self, "rdigit") and self.rdigit:
             self.rdigit.CleanUp()
         if self.dialogs["vnet"]:
@@ -1635,22 +1642,6 @@ class MapFrame(SingleMapFrame):
         self.mapWindowProperties.showRegion = showCompExtent
         self.mapWindowProperties.alignExtent = alignExtent
         self.mapWindowProperties.resolution = constrainRes
-
-    def GetLayerManager(self):
-        """Get reference to Layer Manager
-
-        :return: window reference
-        :return: None (if standalone)
-
-        .. deprecated:: 7.0
-        """
-        Debug.msg(
-            1,
-            "MapFrame.GetLayerManager(): Method GetLayerManager is"
-            "deprecated, use some general approach instead such as"
-            " Signals or giface",
-        )
-        return self._layerManager
 
     def GetMapToolbar(self):
         """Returns toolbar with zooming tools"""

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -424,7 +424,9 @@ class MapFrame(SingleMapFrame):
             def openATM(selection):
                 self._layerManager.OnShowAttributeTable(None, selection=selection)
 
-            self.toolbars["vdigit"].openATM.connect(lambda selection: openATM(selection))
+            self.toolbars["vdigit"].openATM.connect(
+                lambda selection: openATM(selection)
+            )
             self.Map.layerAdded.connect(self._updateVDigitLayers)
         self.MapWindowVDigit.SetToolbar(self.toolbars["vdigit"])
 
@@ -655,8 +657,9 @@ class MapFrame(SingleMapFrame):
         # default toolbar
         if name == "map":
             if "map" not in self.toolbars:
-                self.toolbars["map"] = MapToolbar(self, toolSwitcher=self._toolSwitcher,
-                                                  giface=self._giface)
+                self.toolbars["map"] = MapToolbar(
+                    self, toolSwitcher=self._toolSwitcher, giface=self._giface
+                )
 
             self._mgr.AddPane(
                 self.toolbars["map"],

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1785,25 +1785,19 @@ class MapFrame(SingleMapFrame):
     def QuitRDigit(self):
         """Calls digitizer cleanup, removes digitizer object and disconnects
         signals from Map."""
-        if not self.IsStandalone():
-            self.rdigit.CleanUp()
-            # disconnect updating layers
-            self.GetMap().layerAdded.disconnect(self._updateRDigitLayers)
-            self.GetMap().layerRemoved.disconnect(self._updateRDigitLayers)
-            self.GetMap().layerChanged.disconnect(self._updateRDigitLayers)
-            self._toolSwitcher.toggleToolChanged.disconnect(
-                self.toolbars["rdigit"].CheckSelectedTool,
-            )
+        self.rdigit.CleanUp()
+        # disconnect updating layers
+        self.GetMap().layerAdded.disconnect(self._updateRDigitLayers)
+        self.GetMap().layerRemoved.disconnect(self._updateRDigitLayers)
+        self.GetMap().layerChanged.disconnect(self._updateRDigitLayers)
+        self._toolSwitcher.toggleToolChanged.disconnect(
+            self.toolbars["rdigit"].CheckSelectedTool,
+        )
 
-            self.RemoveToolbar("rdigit", destroy=True)
-            self.rdigit = None
-        else:
-            self.Close()
+        self.RemoveToolbar("rdigit", destroy=True)
+        self.rdigit = None
 
     def QuitVDigit(self):
         """Quit VDigit"""
-        if not self.IsStandalone():
-            # disable the toolbar
-            self.RemoveToolbar("vdigit", destroy=True)
-        else:
-            self.Close()
+        # disable the toolbar
+        self.RemoveToolbar("vdigit", destroy=True)

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -437,7 +437,7 @@ class LayerList(object):
         return None
 
 
-class DMonGrassInterface(StandaloneGrassInterface):
+class StandaloneMapDisplayGrassInterface(StandaloneGrassInterface):
     """@implements GrassInterface"""
 
     def __init__(self, mapframe):
@@ -455,6 +455,13 @@ class DMonGrassInterface(StandaloneGrassInterface):
 
     def GetProgress(self):
         return self._mapframe.GetProgressBar()
+
+
+class DMonGrassInterface(StandaloneMapDisplayGrassInterface):
+    """@implements GrassInterface"""
+
+    def __init__(self, mapframe):
+        StandaloneMapDisplayGrassInterface.__init__(self, mapframe)
 
 
 class DMonFrame(MapFrame):

--- a/gui/wxpython/mapdisp/toolbars.py
+++ b/gui/wxpython/mapdisp/toolbars.py
@@ -79,7 +79,7 @@ NvizIcons = {
 class MapToolbar(BaseToolbar):
     """Map Display toolbar"""
 
-    def __init__(self, parent, toolSwitcher):
+    def __init__(self, parent, toolSwitcher, giface):
         """Map Display constructor
 
         :param parent: reference to MapFrame
@@ -88,6 +88,7 @@ class MapToolbar(BaseToolbar):
 
         self.InitToolbar(self._toolbarData())
         self._default = self.pointer
+        self._giface = giface
 
         # optional tools
         toolNum = 0
@@ -96,9 +97,6 @@ class MapToolbar(BaseToolbar):
         ]
         self.toolId = {"2d": toolNum}
         toolNum += 1
-        if self.parent.GetLayerManager():
-            log = self.parent.GetLayerManager().GetLogWindow()
-
         if haveNviz:
             choices.append(_("3D view"))
             self.toolId["3d"] = toolNum
@@ -106,9 +104,8 @@ class MapToolbar(BaseToolbar):
         else:
             from nviz.main import errorMsg
 
-            if self.parent.GetLayerManager():
-                log.WriteCmdLog(_("3D view mode not available"))
-                log.WriteWarning(_("Reason: %s") % str(errorMsg))
+            self._giface.WriteCmdLog(_("3D view mode not available"))
+            self._giface.WriteWarning(_("Reason: %s") % str(errorMsg))
 
             self.toolId["3d"] = -1
 
@@ -119,18 +116,17 @@ class MapToolbar(BaseToolbar):
         else:
             from vdigit.main import errorMsg
 
-            if self.parent.GetLayerManager():
-                log.WriteCmdLog(_("Vector digitizer not available"))
-                log.WriteWarning(_("Reason: %s") % errorMsg)
-                log.WriteLog(
-                    _(
-                        "Note that the wxGUI's vector digitizer is disabled in this installation. "
-                        "Please keep an eye out for updated versions of GRASS. "
-                        'In the meantime you can use "v.edit" for non-interactive editing '
-                        "from the Develop vector map menu."
-                    ),
-                    wrap=60,
-                )
+            self._giface.WriteCmdLog(_("Vector digitizer not available"))
+            self._giface.WriteWarning(_("Reason: %s") % errorMsg)
+            self._giface.WriteLog(
+                _(
+                    "Note that the wxGUI's vector digitizer is disabled in this installation. "
+                    "Please keep an eye out for updated versions of GRASS. "
+                    'In the meantime you can use "v.edit" for non-interactive editing '
+                    "from the Develop vector map menu."
+                ),
+                wrap=60,
+            )
 
             self.toolId["vdigit"] = -1
         choices.append(_("Raster digitizer"))
@@ -276,10 +272,7 @@ class MapToolbar(BaseToolbar):
     def ExitToolbars(self):
         if self.parent.GetToolbar("vdigit"):
             self.parent.toolbars["vdigit"].OnExit()
-        if self.parent.GetLayerManager() and self.parent.GetLayerManager().IsPaneShown(
-            "toolbarNviz"
-        ):
-            self.parent.RemoveNviz()
+        self.parent.RemoveNviz()
         if self.parent.GetToolbar("rdigit"):
             self.parent.QuitRDigit()
 

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -820,10 +820,6 @@ class SwipeMapFrame(DoubleMapFrame):
         """Returns toolbar with zooming tools"""
         return self.toolbars["swipeMap"]
 
-    def IsStandalone(self):
-        """Since we do not need layer manager, we are standalone"""
-        return True
-
     def OnHelp(self, event):
         self._giface.Help(entry="wxGUI.mapswipe")
 

--- a/gui/wxpython/photo2image/ip2i_mapdisplay.py
+++ b/gui/wxpython/photo2image/ip2i_mapdisplay.py
@@ -296,7 +296,7 @@ class MapFrame(SingleMapFrame):
         """
         # default toolbar
         if name == "map":
-            self.toolbars["map"] = MapToolbar(self, self._toolSwitcher)
+            self.toolbars["map"] = MapToolbar(self, self._toolSwitcher, self._giface)
 
             self._mgr.AddPane(
                 self.toolbars["map"],
@@ -561,13 +561,6 @@ class MapFrame(SingleMapFrame):
         # will be called before PopupMenu returns.
         self.PopupMenu(zoommenu)
         zoommenu.Destroy()
-
-    def GetLayerManager(self):
-        """Get reference to Layer Manager
-
-        :return: always None
-        """
-        return None
 
     def GetSrcWindow(self):
         return self.SrcMapWindow

--- a/gui/wxpython/photo2image/ip2i_mapdisplay.py
+++ b/gui/wxpython/photo2image/ip2i_mapdisplay.py
@@ -562,11 +562,6 @@ class MapFrame(SingleMapFrame):
         self.PopupMenu(zoommenu)
         zoommenu.Destroy()
 
-    def IsStandalone(self):
-        """Check if Map display is standalone"""
-        # we do not know and we do not care, so always False
-        return True
-
     def GetLayerManager(self):
         """Get reference to Layer Manager
 

--- a/gui/wxpython/rdigit/g.gui.rdigit.py
+++ b/gui/wxpython/rdigit/g.gui.rdigit.py
@@ -122,6 +122,9 @@ def main():
             else:
                 rdigit._mapSelectionCombo.SetSelection(n=1)
                 rdigit.OnMapSelection()
+            # use Close instead of QuitRDigit for standalone tool
+            self.rdigit.quitDigitizer.disconnect(self.QuitRDigit)
+            self.rdigit.quitDigitizer.connect(lambda: self.Close())
 
         def _addLayer(self, name, ltype="raster"):
             """Add layer into map

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -88,7 +88,9 @@ def main():
 
             # start editing
             self.toolbars["vdigit"].StartEditing(mapLayer)
-
+            # use Close instead of QuitVDigit for standalone tool
+            self.toolbars["vdigit"].quitDigitizer.disconnect(self.QuitVDigit)
+            self.toolbars["vdigit"].quitDigitizer.connect(lambda: self.Close())
     if not haveVDigit:
         grass.fatal(_("Vector digitizer not available. %s") % errorMsg)
 

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -91,6 +91,7 @@ def main():
             # use Close instead of QuitVDigit for standalone tool
             self.toolbars["vdigit"].quitDigitizer.disconnect(self.QuitVDigit)
             self.toolbars["vdigit"].quitDigitizer.connect(lambda: self.Close())
+
     if not haveVDigit:
         grass.fatal(_("Vector digitizer not available. %s") % errorMsg)
 

--- a/gui/wxpython/vdigit/main.py
+++ b/gui/wxpython/vdigit/main.py
@@ -30,9 +30,10 @@ except (ImportError, NameError) as err:
 
 
 class VDigit(IVDigit):
-    def __init__(self, mapwindow):
+    def __init__(self, giface, mapwindow):
         """Base class of vector digitizer
 
+        :param giface: reference to a grass interface instance
         :param mapwindow: reference to a map window instance
         """
-        IVDigit.__init__(self, mapwindow)
+        IVDigit.__init__(self, giface, mapwindow)

--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -897,8 +897,7 @@ class VDigitSettingsDialog(wx.Dialog):
         .. todo::
             Needs refactoring
         """
-        if self.parent.GetLayerManager():
-            self._giface.workspaceChanged.emit()
+        self._giface.workspaceChanged.emit()
         # symbology
         for key, (enabled, color) in six.iteritems(self.symbology):
             if enabled:

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -47,6 +47,7 @@ class VDigitToolbar(BaseToolbar):
         self.editingStopped = Signal("VDigitToolbar.editingStopped")
         self.editingBgMap = Signal("VDigitToolbar.editingBgMap")
         self.quitDigitizer = Signal("VDigitToolbar.quitDigitizer")
+        self.openATM = Signal("VDigitToolbar.openATM")
         layerTree = self._giface.GetLayerTree()
         if layerTree:
             self.editingStarted.connect(layerTree.StartEditing)
@@ -915,13 +916,10 @@ class VDigitToolbar(BaseToolbar):
 
                 # create table ?
                 if dlg.IsChecked("table"):
-                    # TODO: replace this by signal
-                    # also note that starting of tools such as atm, iclass,
+                    # TODO: starting of tools such as atm, iclass,
                     # plots etc. should be handled in some better way
                     # than starting randomly from mapdisp and lmgr
-                    lmgr = self.parent.GetLayerManager()
-                    if lmgr:
-                        lmgr.OnShowAttributeTable(None, selection="table")
+                    self.openATM.emit(selection="table")
                 dlg.Destroy()
             else:
                 self.combo.SetValue(_("Select vector map"))

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -1002,8 +1002,9 @@ class VDigitToolbar(BaseToolbar):
             )
 
         self.MapWindow.pdcVector = PseudoDC()
-        self.digit = self.MapWindow.digit = self.digitClass(giface=self._giface,
-                                                            mapwindow=self.MapWindow)
+        self.digit = self.MapWindow.digit = self.digitClass(
+            giface=self._giface, mapwindow=self.MapWindow
+        )
 
         self.mapLayer = mapLayer
         # open vector map (assume that 'hidden' map layer is temporary vector

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -593,7 +593,7 @@ class VDigitToolbar(BaseToolbar):
         if self.digit is None:
             try:
                 self.digit = self.MapWindow.digit = self.digitClass(
-                    mapwindow=self.MapWindow
+                    giface=self._giface, mapwindow=self.MapWindow
                 )
             except SystemExit:
                 self.digit = self.MapWindow.digit = None
@@ -1004,7 +1004,8 @@ class VDigitToolbar(BaseToolbar):
             )
 
         self.MapWindow.pdcVector = PseudoDC()
-        self.digit = self.MapWindow.digit = self.digitClass(mapwindow=self.MapWindow)
+        self.digit = self.MapWindow.digit = self.digitClass(giface=self._giface,
+                                                            mapwindow=self.MapWindow)
 
         self.mapLayer = mapLayer
         # open vector map (assume that 'hidden' map layer is temporary vector

--- a/gui/wxpython/vdigit/wxdigit.py
+++ b/gui/wxpython/vdigit/wxdigit.py
@@ -147,27 +147,23 @@ class VDigitError:
 
 
 class IVDigit:
-    def __init__(self, mapwindow, driver=DisplayDriver):
+    def __init__(self, giface, mapwindow, driver=DisplayDriver):
         """Base class for vector digitizer (ctypes interface)
 
         :param mapwindow: reference to a map window
         """
         self.poMapInfo = None  # pointer to Map_info
         self.mapWindow = mapwindow
+        self._giface = giface
 
         # background map
         self.bgMapInfo = Map_info()
         self.poBgMapInfo = self.popoBgMapInfo = None
-
-        # TODO: replace this by using giface
-        if not mapwindow.parent.IsStandalone():
-            goutput = mapwindow.parent.GetLayerManager().GetLogWindow()
-            log = goutput.GetLog(err=True)
-            progress = mapwindow.parent._giface.GetProgress()
-        else:
-            log = sys.stderr
+        try:
+            progress = self._giface.GetProgress()
+        except NotImplementedError:
             progress = None
-
+        log = self._giface.GetLog(err=True)
         self.toolbar = mapwindow.parent.toolbars["vdigit"]
 
         self._error = VDigitError(parent=self.mapWindow)


### PR DESCRIPTION
Replaces deprecated methods IsStandalone and GetLayerManager from map display with giface and signals.

@lindakladivova, this may be little difficult to review, but even testing would be helpful.