### PR TITLE
v.rast.stats: note about vector overlap limitation

### DIFF
--- a/scripts/v.rast.stats/v.rast.stats.html
+++ b/scripts/v.rast.stats/v.rast.stats.html
@@ -31,8 +31,10 @@ in the use of the column prefix when using DBF as any additional characters
 will be chopped off.
 <p>If a MASK is present, it will be restored after the script finished.
 The script changes temporarily to the resolution of the given raster map.
-<p>If some vectors overlap, only one category will be kept during the
-rasterization process. Statistics for these vectors will thus be partial.
+<p>If an area has several categories in the selected layer (equivalent
+to overlapping polygons in Simple Features), only one category will be
+kept during the rasterization process. Statistics for the skipped
+categories will thus be partial.
 <p><!-- r.univar limitation -->
 Large amounts of system memory can be used when extended statistics
 (<em>first_quartile,median,third_quartile,percentile </em>) are being requested

--- a/scripts/v.rast.stats/v.rast.stats.html
+++ b/scripts/v.rast.stats/v.rast.stats.html
@@ -31,6 +31,8 @@ in the use of the column prefix when using DBF as any additional characters
 will be chopped off.
 <p>If a MASK is present, it will be restored after the script finished.
 The script changes temporarily to the resolution of the given raster map.
+<p>If some vectors overlap, only one category will be kept during the
+rasterization process. Statistics for these vectors will thus be partial.
 <p><!-- r.univar limitation -->
 Large amounts of system memory can be used when extended statistics
 (<em>first_quartile,median,third_quartile,percentile </em>) are being requested

--- a/scripts/v.rast.stats/v.rast.stats.html
+++ b/scripts/v.rast.stats/v.rast.stats.html
@@ -35,6 +35,12 @@ The script changes temporarily to the resolution of the given raster map.
 to overlapping polygons in Simple Features), only one category will be
 kept during the rasterization process. Statistics for the skipped
 categories will thus be partial.
+<p>
+For example, if there are three areas: area 1 with cat 1, area 2 with
+cat 2, area 3 with cats 1, 2. Only one category value of area 3 will be
+used for rasterization, the other category value will be skipped. Thus
+statistics for the used category value will be complete, while
+statistics for the skipped category value will be incomplete.
 <p><!-- r.univar limitation -->
 Large amounts of system memory can be used when extended statistics
 (<em>first_quartile,median,third_quartile,percentile </em>) are being requested


### PR DESCRIPTION
Short note warning the user that if the vector map contains overlapping vectors, only one category will be picked during the rasterization process.

I'm suggesting that note because it took me a while recently before understanding why I was not always getting the stats I was expecting...