### PR TITLE
wxGUI: Single-Window GUI: Integrate new map display wx.Panels into a AuiNotebook center pane #1735

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -301,7 +301,6 @@ class GMFrame(wx.Frame):
         notebook_style = (
             aui.AUI_NB_DEFAULT_STYLE | aui.AUI_NB_TAB_EXTERNAL_MOVE | wx.NO_BORDER
         )
-        notebook_theme = 0
         self.mapnotebook = aui.AuiNotebook(
             self,
             -1,
@@ -309,18 +308,7 @@ class GMFrame(wx.Frame):
             wx.Size(430, 200),
             agwStyle=notebook_style,
         )
-
-        arts = [
-            aui.AuiDefaultTabArt,
-            aui.AuiSimpleTabArt,
-            aui.VC71TabArt,
-            aui.FF2TabArt,
-            aui.VC8TabArt,
-            aui.ChromeTabArt,
-        ]
-
-        art = arts[notebook_theme]()
-        self.mapnotebook.SetArtProvider(art)
+        self.mapnotebook.SetArtProvider(aui.AuiDefaultTabArt())
 
     def _createDataCatalog(self, parent):
         """Initialize Data Catalog widget"""
@@ -408,7 +396,9 @@ class GMFrame(wx.Frame):
 
         # make a new page in the bookcontrol for the layer tree (on page 0 of
         # the notebook)
-        self.pg_panel = wx.Panel(self.notebookLayers, id=wx.ID_ANY, style=wx.EXPAND)
+        self.pg_panel = wx.Panel(
+            self.notebookLayers, id=wx.ID_ANY, style=wx.BORDER_NONE
+        )
         self.notebookLayers.AddPage(page=self.pg_panel, text=name, select=True)
         self.currentPage = self.notebookLayers.GetCurrentPage()
         self.currentPageNum = self.notebookLayers.GetSelection()
@@ -432,6 +422,7 @@ class GMFrame(wx.Frame):
                 lmgr=self,
                 Map=layertree.Map,
                 title=name,
+                size=globalvar.MAP_WINDOW_SIZE
             )
             # add map display panel to notebook and make it current
             self.mapnotebook.AddPage(mapdisplay, name)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -422,7 +422,7 @@ class GMFrame(wx.Frame):
                 lmgr=self,
                 Map=layertree.Map,
                 title=name,
-                size=globalvar.MAP_WINDOW_SIZE
+                size=globalvar.MAP_WINDOW_SIZE,
             )
             # add map display panel to notebook and make it current
             self.mapnotebook.AddPage(mapdisplay, name)
@@ -489,7 +489,7 @@ class GMFrame(wx.Frame):
         )
 
         mapdisplay.starting3dMode.connect(
-            lambda firstTime, mapDisplayPage=self.currentPage: self._onMapDisplayStarting3dMode(
+            lambda firstTime, mapDisplayPage=self.currentPage: self._onStarting3dMode(
                 mapDisplayPage
             )
         )
@@ -1876,7 +1876,7 @@ class GMFrame(wx.Frame):
             self.notebookLayers.SetSelection(pgnum)
             self.currentPage = self.notebookLayers.GetCurrentPage()
 
-    def _onMapDisplayStarting3dMode(self, mapDisplayPage):
+    def _onStarting3dMode(self, mapDisplayPage):
         """Disables 3D mode for all map displays except for @p mapDisplay"""
         # TODO: it should be disabled also for newly created map windows
         # moreover mapdisp.Disable3dMode() does not work properly

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -298,13 +298,26 @@ class GMFrame(wx.Frame):
         """Create Map Display notebook"""
         # create the notebook off-window to avoid flicker
         client_size = self.GetClientSize()
-        notebook_style = aui.AUI_NB_DEFAULT_STYLE | aui.AUI_NB_TAB_EXTERNAL_MOVE | wx.NO_BORDER
+        notebook_style = (
+            aui.AUI_NB_DEFAULT_STYLE | aui.AUI_NB_TAB_EXTERNAL_MOVE | wx.NO_BORDER
+        )
         notebook_theme = 0
-        self.mapnotebook = aui.AuiNotebook(self, -1, wx.Point(client_size.x, client_size.y),
-                              wx.Size(430, 200), agwStyle=notebook_style)
+        self.mapnotebook = aui.AuiNotebook(
+            self,
+            -1,
+            wx.Point(client_size.x, client_size.y),
+            wx.Size(430, 200),
+            agwStyle=notebook_style,
+        )
 
-        arts = [aui.AuiDefaultTabArt, aui.AuiSimpleTabArt, aui.VC71TabArt, aui.FF2TabArt,
-                aui.VC8TabArt, aui.ChromeTabArt]
+        arts = [
+            aui.AuiDefaultTabArt,
+            aui.AuiSimpleTabArt,
+            aui.VC71TabArt,
+            aui.FF2TabArt,
+            aui.VC8TabArt,
+            aui.ChromeTabArt,
+        ]
 
         art = arts[notebook_theme]()
         self.mapnotebook.SetArtProvider(art)
@@ -1064,8 +1077,8 @@ class GMFrame(wx.Frame):
 
     def GetMapDisplayIndex(self):
         """Get the index of the currently active map display tab.
-           Can be different than index of related layertree."""
-        return  self.mapnotebook.GetPageIndex(self.GetMapDisplay())
+        Can be different than index of related layertree."""
+        return self.mapnotebook.GetPageIndex(self.GetMapDisplay())
 
     def GetLogWindow(self):
         """Gets console for command output and messages"""


### PR DESCRIPTION
This PR follows up the changes that are about to be merged - https://github.com/OSGeo/grass/pull/1729, https://github.com/OSGeo/grass/pull/1689, https://github.com/OSGeo/grass/pull/1675.

So far, it is based on my local merged branch which already knows these changes. But I think even without the mentor's testing it makes sense to start working on this as later we can rebase it.

This PR aims at the basic integration of the new Map Display into the center AuiNotebook pane. Apart from this integration, it repairs existing event handlers and methods. It does not add any new ones.

As we have basically several small things for coding, I have eventually decided to solve them in this one PR. Some of them require changing of one, two rows, so it probably does not make sense to have more than one PR.

Tasks are as follow:

- [x]  Remove methods related to the depreciated Map Display wx.Frame.

- [x]  Fix behaviour when adding or switching to a new location (now it does not close previously opened map displays)

- [x]  Make a newly added AuiNotebook tab active when adding a new Display tab.

- [x]  Edit an existing closing event for the Display tab. This event should close the related AuiNotebook tab.

- [x]  Edit an existing event for the switching between Display tabs. This event should make the related AuiNotebook tab active.

- [x] Fix an existing RenameDisplay event handler.

- [x] Fix adding and removing of the 3D View pane. Decide where should this tab go when launching 3D for the first time.
