### PR TITLE
feat(misc): set NPROCS environment variable

### DIFF
--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -762,6 +762,12 @@ struct Option *G_define_standard_option(int opt)
         Opt->required = NO;
         Opt->multiple = NO;
         Opt->answer = "1";
+        /* start dynamic answer */
+        /* check NPROCS in GISRC, set with g.gisenv */
+        memstr = G_store(G_getenv_nofatal("NPROCS"));
+        if (memstr && *memstr)
+            Opt->answer = memstr;
+        /* end dynamic answer */
         Opt->description = _("Number of threads for parallel computing");
         break;
 

--- a/lib/init/variables.html
+++ b/lib/init/variables.html
@@ -539,6 +539,13 @@ g.gisenv set=DEBUG=0
 # set to 6 GB (default: 300 MB)
 g.gisenv set="MEMORYMB=6000"
 </pre></div>
+  
+  <dt>NPROCS</dt>
+  <dd>sets the number of threads for parallel computing
+<div class="code"><pre>
+# set to use 12 threads (default: 1)
+g.gisenv set="NPROCS=12"
+</pre></div></dd>
 
   <dt>OVERWRITE</dt>
   <dd>[all modules]<br>


### PR DESCRIPTION
This PR allows users to set nprocs parameter globally using g.gisenv. This is similar to the previous PR for raster module memory (MEMORYMB: #922).
