### PR TITLE
WMS: restore NASA GIBS

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -71,6 +71,11 @@ class WSDialogBase(wx.Dialog):
                 "",
                 "",
             ],
+            "NASA GIBS WMTS": [
+                "http://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi",
+                "",
+                "",
+            ],
             "tiles.maps.eox.at (Sentinel-2)": [
                 "https://tiles.maps.eox.at/wms",
                 "",


### PR DESCRIPTION
I can connect without issue to http://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi using GRASS 7.8.5 OSGeo4W on Windows 7.
![image](https://user-images.githubusercontent.com/16253859/124015481-06d08880-d9e5-11eb-84ec-9ca87b3b52cf.png)

Partially reverts https://github.com/OSGeo/grass/pull/1635