### PR TITLE
Improve G_open|find _misc function documentation

### DIFF
--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -31,10 +31,25 @@ static void append_char(char*, char);
   Paths to files are in form:
   /home/user/GISDBASE/LOCATION/mapset/element/name
 
-  path input buffer memory must be preallocated by caller:
-  char path[GPATH_MAX];
+  path input buffer memory must be preallocated by caller.
 
-  \param[out] path buffer to hold resultant full path to file
+  C:
+  @code
+  char path[GPATH_MAX];
+  @endcode
+  Python:
+  @code
+  import ctypes
+  from grass.pygrass.utils import decode
+  from grass.lib.gis import G_file_name, GPATH_MAX
+
+  path = ctypes.create_string_buffer(GPATH_MAX)
+  path_str = decode(G_file_name(path, "elem", "name", "mapset"))
+  print(path_str)
+  /home/user/gisdb/loc/mapset/elem/name
+  @endcode
+
+  \param[out] path preallocated buffer to hold resultant full path to file
   \param element database element (eg, "cell", "cellhd", "vector", etc)
   \param name name of file to build path to (fully qualified names allowed)
   \param mapset mapset name
@@ -53,12 +68,27 @@ char *G_file_name(char *path,
   Paths to misc files are in form:
   /home/user/GISDBASE/LOCATION/mapset/dir/name/element
 
-  path input buffer memory must be preallocated by caller:
-  char path[GPATH_MAX];
+  path input buffer memory must be preallocated by caller.
 
-  \param[out] path buffer to hold resultant full path to file
-  \param dir misc directory
-  \param element database element (eg, "cell", "cellhd", "vector", etc)
+  C:
+  @code
+  char path[GPATH_MAX];
+  @endcode
+  Python:
+  @code
+  import ctypes
+  from grass.pygrass.utils import decode
+  from grass.lib.gis import G_file_name_misc, GPATH_MAX
+
+  path = ctypes.create_string_buffer(GPATH_MAX)
+  path_str = decode(G_file_name_misc(path, "dir", "elem", "name", "mapset"))
+  print(path_str)
+  /home/user/gisdb/loc/mapset/dir/name/elem
+  @endcode
+
+  \param[out] path preallocated buffer to hold resultant full path to file
+  \param dir misc directory (e.g., "cell_misc", "group")
+  \param element database element (e.g., "history", "REF")
   \param name name of file to build path to (fully qualified names allowed)
   \param mapset mapset name
 

--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -34,13 +34,13 @@ static void append_char(char*, char);
   path input buffer memory must be allocated by caller.
 
   C:
-  @code
+  @code{.c}
   char path[GPATH_MAX];
   G_file_name(path, "fcell", "my_raster", "my_mapset");
   // path now is "/full/path/to/my_mapset/fcell/my_raster"
   @endcode
   Python:
-  @code
+  @code{.py}
   import ctypes
   from grass.pygrass.utils import decode
   from grass.lib.gis import G_file_name, GPATH_MAX

--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -92,8 +92,8 @@ char *G_file_name(char *path,
 
   \param[out] path allocated buffer to hold resultant full path to file
   \param dir misc directory (e.g., "cell_misc", "group")
-  \param element database element (e.g., "history", "REF")
-  \param name name of file to build path to (fully qualified names allowed)
+  \param element database element (in this case – file to build path to e.g., "history", "REF")
+  \param name name of object (raster, group; fully qualified names allowed e.g., "my_raster@PERMANENT")
   \param mapset mapset name
 
   \return pointer to <i>path</i> buffer

--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -27,7 +27,13 @@ static void append_char(char*, char);
   If <i>name</i> is of the form "nnn@ppp" then path is set as if name
   had been "nnn" and mapset had been "ppp" (mapset parameter itself is
   ignored in this case).
-  
+
+  Paths to files are in form:
+  /home/user/GISDBASE/LOCATION/mapset/element/name
+
+  path input buffer memory must be preallocated by caller:
+  char path[GPATH_MAX];
+
   \param[out] path buffer to hold resultant full path to file
   \param element database element (eg, "cell", "cellhd", "vector", etc)
   \param name name of file to build path to (fully qualified names allowed)
@@ -43,6 +49,12 @@ char *G_file_name(char *path,
 
 /*!
   \brief Builds full path names to GIS misc data files
+
+  Paths to misc files are in form:
+  /home/user/GISDBASE/LOCATION/mapset/dir/name/element
+
+  path input buffer memory must be preallocated by caller:
+  char path[GPATH_MAX];
 
   \param[out] path buffer to hold resultant full path to file
   \param dir misc directory

--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -28,14 +28,16 @@ static void append_char(char*, char);
   had been "nnn" and mapset had been "ppp" (mapset parameter itself is
   ignored in this case).
 
-  Paths to files are in form:
-  /home/user/GISDBASE/LOCATION/mapset/element/name
+  Paths to files are currently in form:
+  /path/to/location/mapset/element/name
 
-  path input buffer memory must be preallocated by caller.
+  path input buffer memory must be allocated by caller.
 
   C:
   @code
   char path[GPATH_MAX];
+  G_file_name(path, "fcell", "my_raster", "my_mapset");
+  // path now is "/full/path/to/my_mapset/fcell/my_raster"
   @endcode
   Python:
   @code
@@ -46,10 +48,10 @@ static void append_char(char*, char);
   path = ctypes.create_string_buffer(GPATH_MAX)
   path_str = decode(G_file_name(path, "elem", "name", "mapset"))
   print(path_str)
-  /home/user/gisdb/loc/mapset/elem/name
+  >>> /full/path/to/mapset/elem/name
   @endcode
 
-  \param[out] path preallocated buffer to hold resultant full path to file
+  \param[out] path allocated buffer to hold resultant full path to file
   \param element database element (eg, "cell", "cellhd", "vector", etc)
   \param name name of file to build path to (fully qualified names allowed)
   \param mapset mapset name
@@ -65,17 +67,19 @@ char *G_file_name(char *path,
 /*!
   \brief Builds full path names to GIS misc data files
 
-  Paths to misc files are in form:
-  /home/user/GISDBASE/LOCATION/mapset/dir/name/element
+  Paths to misc files are currently in form:
+  /path/to/location/mapset/dir/name/element
 
-  path input buffer memory must be preallocated by caller.
+  path input buffer memory must be allocated by caller.
 
   C:
-  @code
+  @code{.c}
   char path[GPATH_MAX];
+  G_file_name_misc(path, "cell_misc", "history", "my_raster", "my_mapset");
+  // path now contains "/full/path/to/my_mapset/cell_misc/my_raster/history"
   @endcode
   Python:
-  @code
+  @code{.py}
   import ctypes
   from grass.pygrass.utils import decode
   from grass.lib.gis import G_file_name_misc, GPATH_MAX
@@ -83,10 +87,10 @@ char *G_file_name(char *path,
   path = ctypes.create_string_buffer(GPATH_MAX)
   path_str = decode(G_file_name_misc(path, "dir", "elem", "name", "mapset"))
   print(path_str)
-  /home/user/gisdb/loc/mapset/dir/name/elem
+  >>> /full/path/to/mapset/dir/name/elem
   @endcode
 
-  \param[out] path preallocated buffer to hold resultant full path to file
+  \param[out] path allocated buffer to hold resultant full path to file
   \param dir misc directory (e.g., "cell_misc", "group")
   \param element database element (e.g., "history", "REF")
   \param name name of file to build path to (fully qualified names allowed)

--- a/lib/gis/find_file.c
+++ b/lib/gis/find_file.c
@@ -206,10 +206,12 @@ const char *G_find_file(const char *element, char *name, const char *mapset)
 }
 
 /*!
- * \brief Searches for a file from the mapset search list or in a
+ * \brief Searches for a misc file from the mapset search list or in a
  * specified mapset.
  *
- * Returns the mapset name where the file was found.
+ * Returns the mapset name where the misc file was found.
+ * Misc files follow structure:
+ * mapset/dir/name/element
  *
  * \param dir     file directory
  * \param element database element (eg, "cell", "cellhd", "colr", etc)
@@ -250,11 +252,12 @@ const char *G_find_file2(const char *element, const char *name, const char *maps
 }
 
 /*!
- * \brief Searches for a file from the mapset search list or in a
+ * \brief Searches for a misc file from the mapset search list or in a
  * specified mapset. (look but don't touch)
  *
- * Returns the mapset name where the file was found.
- *
+ * Returns the mapset name where the misc file was found.
+ * Misc files follow structure:
+ * mapset/dir/name/element
  *
  * \param dir        file directory
  * \param element    database element (eg, "cell", "cellhd", "colr", etc)

--- a/lib/gis/find_file.c
+++ b/lib/gis/find_file.c
@@ -210,7 +210,7 @@ const char *G_find_file(const char *element, char *name, const char *mapset)
  * specified mapset.
  *
  * Returns the mapset name where the misc file was found.
- * Misc files follow structure:
+ * Paths to misc files currently follow structure:
  * mapset/dir/name/element
  *
  * \param dir     file directory
@@ -256,7 +256,7 @@ const char *G_find_file2(const char *element, const char *name, const char *maps
  * specified mapset. (look but don't touch)
  *
  * Returns the mapset name where the misc file was found.
- * Misc files follow structure:
+ * Paths to misc files currently follow structure:
  * mapset/dir/name/element
  *
  * \param dir        file directory

--- a/lib/gis/open_misc.c
+++ b/lib/gis/open_misc.c
@@ -99,7 +99,7 @@ static int G__open_misc(const char *dir,
 /*!
  * \brief open a new database misc file
  *
- * The database file <b>element</b> under the <b>dir/name</b> in the
+ * The database file <b>element</b> under <b>dir/name</b> in the
  * current mapset is created and opened for writing (but not reading).
  * The UNIX open( ) routine is used to open the file. If the file does not exist,
  * -1 is returned. Otherwise the file is positioned at the end of the file and
@@ -119,7 +119,7 @@ int G_open_new_misc(const char *dir, const char *element, const char *name)
 /*!
  * \brief open a database misc file for reading
  *
- * The database file <b>element</b> under the
+ * The database file <b>element</b> under
  * <b>dir/name</b> in the specified <b>mapset</b> is opened for reading (but
  * not for writing).
  * The UNIX open( ) routine is used to open the file. If the file does not exist,
@@ -141,7 +141,7 @@ int G_open_old_misc(const char *dir, const char *element, const char *name,
 /*!
  * \brief open a database misc file for update
  *
- * The database file <b>element</b> under the <b>dir/name</b> in the
+ * The database file <b>element</b> under <b>dir/name</b> in the
  * current mapset is opened for reading and writing.
  * The UNIX open( ) routine is used to open the file. If the file does not exist,
  * -1 is returned. Otherwise the file is positioned at the end of the file and
@@ -167,7 +167,7 @@ int G_open_update_misc(const char *dir, const char *element, const char *name)
 /*!
  * \brief open a new database misc file
  *
- * The database file <b>element</b> under the <b>dir/name</b> in the
+ * The database file <b>element</b> under <b>dir/name</b> in the
  * current mapset is created and opened for writing (but not reading).
  * The UNIX fopen( ) routine, with "w" write mode, is used to open the file.  If
  * the file does not exist, the NULL pointer is returned. Otherwise the file is
@@ -194,7 +194,7 @@ FILE *G_fopen_new_misc(const char *dir, const char *element, const char *name)
 /*!
  * \brief open a database misc file for reading
  *
- * The database file <b>element</b> under the
+ * The database file <b>element</b> under
  * <b>dir/name</b> in the specified <b>mapset</b> is opened for reading (but
  * not for writing).
  * The UNIX fopen( ) routine, with "r" read mode, is used to open the file.  If

--- a/lib/gis/open_misc.c
+++ b/lib/gis/open_misc.c
@@ -97,9 +97,9 @@ static int G__open_misc(const char *dir,
 
 
 /*!
- * \brief open a new database file
+ * \brief open a new database misc file
  *
- * The database file <b>name</b> under the <b>element</b> in the
+ * The database file <b>element</b> under the <b>dir/name</b> in the
  * current mapset is created and opened for writing (but not reading).
  * The UNIX open( ) routine is used to open the file. If the file does not exist,
  * -1 is returned. Otherwise the file is positioned at the end of the file and
@@ -117,10 +117,10 @@ int G_open_new_misc(const char *dir, const char *element, const char *name)
 
 
 /*!
- * \brief open a database file for reading
+ * \brief open a database misc file for reading
  *
- * The database file <b>name</b> under the
- * <b>element</b> in the specified <b>mapset</b> is opened for reading (but
+ * The database file <b>element</b> under the
+ * <b>dir/name</b> in the specified <b>mapset</b> is opened for reading (but
  * not for writing).
  * The UNIX open( ) routine is used to open the file. If the file does not exist,
  * -1 is returned. Otherwise the file descriptor from the open( ) is returned.
@@ -139,9 +139,9 @@ int G_open_old_misc(const char *dir, const char *element, const char *name,
 
 
 /*!
- * \brief open a database file for update
+ * \brief open a database misc file for update
  *
- * The database file <b>name</b> under the <b>element</b> in the
+ * The database file <b>element</b> under the <b>dir/name</b> in the
  * current mapset is opened for reading and writing.
  * The UNIX open( ) routine is used to open the file. If the file does not exist,
  * -1 is returned. Otherwise the file is positioned at the end of the file and
@@ -165,9 +165,9 @@ int G_open_update_misc(const char *dir, const char *element, const char *name)
 
 
 /*!
- * \brief open a new database file
+ * \brief open a new database misc file
  *
- * The database file <b>name</b> under the <b>element</b> in the
+ * The database file <b>element</b> under the <b>dir/name</b> in the
  * current mapset is created and opened for writing (but not reading).
  * The UNIX fopen( ) routine, with "w" write mode, is used to open the file.  If
  * the file does not exist, the NULL pointer is returned. Otherwise the file is
@@ -192,10 +192,10 @@ FILE *G_fopen_new_misc(const char *dir, const char *element, const char *name)
 
 
 /*!
- * \brief open a database file for reading
+ * \brief open a database misc file for reading
  *
- * The database file <b>name</b> under the
- * <b>element</b> in the specified <b>mapset</b> is opened for reading (but
+ * The database file <b>element</b> under the
+ * <b>dir/name</b> in the specified <b>mapset</b> is opened for reading (but
  * not for writing).
  * The UNIX fopen( ) routine, with "r" read mode, is used to open the file.  If
  * the file does not exist, the NULL pointer is returned. Otherwise the file


### PR DESCRIPTION
lib/gis functions dealing with elements are hard to understand due to opposite layout in the mapset for "normal" and "misc" elements:
* in the "usual" case element = directory with named files or folders (e.g. vector/my_roads/; cell/my_raster)
* in the "misc" case element = file inside a named subfolder (e.g. cell_misc/my_raster/history; group/my_group/REF)

This PR just replaces factually wrong documentation of G_open_misc and adds notes to G_find_file and G_file_name.