### PR TITLE
libpython: Add plot nprocs to benchmark CLI

### DIFF
--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -37,7 +37,7 @@ def get_pyplot(to_file):
     return plt
 
 
-def nprocs_plot(results, filename=None):
+def nprocs_plot(results, filename=None, title=None):
     """Plot results from a multiple nprocs (thread) benchmarks.
 
     *results* is a list of individual results from separate benchmarks.
@@ -67,9 +67,16 @@ def nprocs_plot(results, filename=None):
             maxes = [max(i) for i in result.all_times]
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
     plt.legend()
-    axes.set(xticks=sorted(x_ticks))
-    plt.xlabel("Number of cores (threads, processes)")
+    # If there is not many x values, show ticks for each, but use default
+    # ticks when there is a lot of x values.
+    if len(x_ticks) < 10:
+        axes.set(xticks=sorted(x_ticks))
+    plt.xlabel("Number of processing elements (cores, threads, processes)")
     plt.ylabel("Time [s]")
+    if title:
+        plt.title(title)
+    else:
+        plt.title("Execution time by processing elements")
     if filename:
         plt.savefig(filename)
     else:

--- a/python/grass/benchmark/results.py
+++ b/python/grass/benchmark/results.py
@@ -71,7 +71,7 @@ def load_results_from_file(filename):
         return load_results(file.read())
 
 
-def join_results(results, prefixes=None):
+def join_results(results, prefixes=None, select=None, prefixes_as_labels=False):
     """Join multiple lists of results together
 
     The *results* argument either needs to be a list of result objects
@@ -88,16 +88,28 @@ def join_results(results, prefixes=None):
             # This is the actual list in the full results structure.
             result_list = result_list.results
         for result in result_list:
+            if select and not select(result):
+                continue
             result = copy.deepcopy(result)
             if prefix:
-                result.label = f"{prefix}: {result.label}"
+                if prefixes_as_labels:
+                    result.label = prefix
+                else:
+                    result.label = f"{prefix}: {result.label}"
             joined.append(result)
     return joined
 
 
-def join_results_from_files(source_filenames, prefixes):
+def join_results_from_files(
+    source_filenames, prefixes=None, select=None, prefixes_as_labels=False
+):
     """Join multiple files into one results object."""
     to_merge = []
     for result_file in source_filenames:
         to_merge.append(load_results_from_file(result_file))
-    return join_results(to_merge, prefixes=prefixes)
+    return join_results(
+        to_merge,
+        prefixes=prefixes,
+        select=select,
+        prefixes_as_labels=prefixes_as_labels,
+    )


### PR DESCRIPTION
* Adds new subcommand plot nprocs.
* Uses more general plot title.
* Allows user to select results by label.
* Prefixes can replace labels instead of prefixing them.
