### PR TITLE
wxGUI: fix deleting dict key while iterating overlays

### DIFF
--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -90,7 +90,7 @@ class WorkspaceManager:
 
         # delete all decorations
         for display in self.lmgr.GetAllMapDisplays():
-            for overlayId in display.decorations.keys():
+            for overlayId in list(display.decorations):
                 display.RemoveOverlay(overlayId)
 
         self.workspaceFile = None


### PR DESCRIPTION
Causes `RuntimeError: dictionary changed size during iteration`.