### PR TITLE
r.in.pdal: info.cpp also needs PDALCPPFLAGS

### DIFF
--- a/raster/r.in.pdal/Makefile
+++ b/raster/r.in.pdal/Makefile
@@ -12,6 +12,8 @@ include $(MODULE_TOPDIR)/include/Make/Module.make
 
 $(OBJDIR)/main.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
 
+$(OBJDIR)/info.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
+
 $(OBJDIR)/grasslidarfilter.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
 
 LINK = $(CXX)


### PR DESCRIPTION
Without this PR, I'm getting:
```bash
c++  -g -O2 -Wall  -I/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/include -I/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/include   -I/usr/include -I/usr/include -DPACKAGE=\""grassmods"\"    -I/usr/include -I/usr/include -I/usr/include/libxml2 -I/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/include -I/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/include -DRELDIR=\"raster/r.in.pdal\" -o OBJ.x86_64-pc-linux-gnu/info.o -c info.cpp
In file included from /usr/include/c++/5.5.0/cstdint:35:0,
                 from /usr/include/pdal/util/Utils.hpp:41,
                 from /usr/include/pdal/pdal_types.hpp:46,
                 from /usr/include/pdal/pdal_internal.hpp:42,
                 from /usr/include/pdal/pdal_config.hpp:39,
                 from info.h:15,
                 from info.cpp:12:
/usr/include/c++/5.5.0/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^
```
This PR adds `PDALCPPFLAGS` (including the suggested `-std=c++11`) to `EXTRA_CFLAGS` for compiling `info.cpp`.