### PR TITLE
wxGUI: Fix Location Wizard titles being cut off.

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -97,6 +97,8 @@ class TitledPage(WizardPageSimple):
 
     def __init__(self, parent, title):
         self.page = WizardPageSimple.__init__(self, parent)
+        font = wx.Font(13, wx.SWISS, wx.NORMAL, wx.BOLD)
+        font_height = font.GetPixelSize()[1]
 
         # page title
         self.title = StaticText(
@@ -104,9 +106,9 @@ class TitledPage(WizardPageSimple):
             id=wx.ID_ANY,
             label=title,
             style=wx.ALIGN_CENTRE_HORIZONTAL,
-            size=(-1, 30),
+            size=(-1, font_height),
         )
-        self.title.SetFont(wx.Font(13, wx.SWISS, wx.NORMAL, wx.BOLD))
+        self.title.SetFont(font)
         # main sizers
         self.pagesizer = wx.BoxSizer(wx.VERTICAL)
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -100,8 +100,11 @@ class TitledPage(WizardPageSimple):
 
         # page title
         self.title = StaticText(
-            parent=self, id=wx.ID_ANY, label=title, style=wx.ALIGN_CENTRE_HORIZONTAL,
-            size=(-1, 30)
+            parent=self,
+            id=wx.ID_ANY,
+            label=title,
+            style=wx.ALIGN_CENTRE_HORIZONTAL,
+            size=(-1, 30),
         )
         self.title.SetFont(wx.Font(13, wx.SWISS, wx.NORMAL, wx.BOLD))
         # main sizers

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -97,6 +97,7 @@ class TitledPage(WizardPageSimple):
 
     def __init__(self, parent, title):
         self.page = WizardPageSimple.__init__(self, parent)
+
         font = wx.Font(13, wx.SWISS, wx.NORMAL, wx.BOLD)
         font_height = font.GetPixelSize()[1]
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -100,7 +100,8 @@ class TitledPage(WizardPageSimple):
 
         # page title
         self.title = StaticText(
-            parent=self, id=wx.ID_ANY, label=title, style=wx.ALIGN_CENTRE_HORIZONTAL
+            parent=self, id=wx.ID_ANY, label=title, style=wx.ALIGN_CENTRE_HORIZONTAL,
+            size=(-1, 30)
         )
         self.title.SetFont(wx.Font(13, wx.SWISS, wx.NORMAL, wx.BOLD))
         # main sizers


### PR DESCRIPTION
This addresses #1773