### PR TITLE
wxGUI/Single-Window: arrange a startup GUI

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -648,7 +648,7 @@ class GMFrame(wx.Frame):
 
         # Set Modules as active tab
         modules = self._auimgr.GetPane("modules")
-        notebook = self._auimgr._notebooks[modules.notebook_id]
+        notebook = self._auimgr.GetNotebooks()[0]
         notebook.SetSelectionToPage(modules)
 
         wx.CallAfter(self.datacatalog.LoadItems)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -651,6 +651,10 @@ class GMFrame(wx.Frame):
         notebook = self._auimgr.GetNotebooks()[0]
         notebook.SetSelectionToPage(modules)
 
+        # Set the size for automatic notebook
+        pane = self._auimgr.GetPane(notebook)
+        pane.MinSize(self.goutput.GetMinSize())
+
         wx.CallAfter(self.datacatalog.LoadItems)
 
         self._auimgr.Update()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -653,7 +653,7 @@ class GMFrame(wx.Frame):
 
         # Set the size for automatic notebook
         pane = self._auimgr.GetPane(notebook)
-        pane.MinSize(self.goutput.GetMinSize())
+        pane.MinSize(self.search.GetMinSize())
 
         wx.CallAfter(self.datacatalog.LoadItems)
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -627,7 +627,7 @@ class GMFrame(wx.Frame):
             .CloseButton(False)
             .MinimizeButton(True)
             .MaximizeButton(True),
-            target=self._auimgr.GetPane("modules")
+            target=self._auimgr.GetPane("modules"),
         )
 
         self._auimgr.AddPane(
@@ -641,7 +641,7 @@ class GMFrame(wx.Frame):
             .CloseButton(False)
             .MinimizeButton(True)
             .MaximizeButton(True),
-            target=self._auimgr.GetPane("modules")
+            target=self._auimgr.GetPane("modules"),
         )
 
         self._auimgr.GetPane("toolbarNviz").Hide()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -156,7 +156,7 @@ class GMFrame(wx.Frame):
         # set pane sizes according to the full screen size of the primary monitor
         size = wx.Display().GetGeometry().GetSize()
         self.PANE_BEST_SIZE = tuple(t / 3 for t in size)
-        self.PANE_MIN_SIZE = tuple(t / 7 for t in size)
+        self.PANE_MIN_SIZE = tuple(t / 5 for t in size)
 
         # create widgets and build panes
         self.CreateMenuBar()
@@ -607,7 +607,7 @@ class GMFrame(wx.Frame):
             .Name("modules")
             .Caption("Modules")
             .Right()
-            .Layer(2)
+            .Layer(1)
             .Position(1)
             .BestSize(self.PANE_BEST_SIZE)
             .MinSize(self.PANE_MIN_SIZE)
@@ -622,13 +622,12 @@ class GMFrame(wx.Frame):
             .Name("console")
             .Caption("Console")
             .Right()
-            .Layer(2)
-            .Position(2)
             .BestSize(self.PANE_BEST_SIZE)
             .MinSize(self.PANE_MIN_SIZE)
             .CloseButton(False)
             .MinimizeButton(True)
             .MaximizeButton(True),
+            target=self._auimgr.GetPane("modules")
         )
 
         self._auimgr.AddPane(
@@ -637,16 +636,21 @@ class GMFrame(wx.Frame):
             .Name("python")
             .Caption("Python")
             .Right()
-            .Layer(2)
-            .Position(3)
             .BestSize(self.PANE_BEST_SIZE)
             .MinSize(self.PANE_MIN_SIZE)
             .CloseButton(False)
             .MinimizeButton(True)
             .MaximizeButton(True),
+            target=self._auimgr.GetPane("modules")
         )
 
         self._auimgr.GetPane("toolbarNviz").Hide()
+
+        # Set Modules as active tab
+        modules = self._auimgr.GetPane("modules")
+        notebook = self._auimgr._notebooks[modules.notebook_id]
+        notebook.SetSelectionToPage(modules)
+
         wx.CallAfter(self.datacatalog.LoadItems)
 
         self._auimgr.Update()


### PR DESCRIPTION
This PR implements the startup GUI arrangement according to the third proposal from https://github.com/OSGeo/grass/issues/1747 which looks as follows:
![126859885-4cc53bf0-293c-42e5-9716-ff51eb7e0e83](https://user-images.githubusercontent.com/49241681/128175406-0ad69859-4bdb-4bd7-b908-7a5acc83dfd4.png)
