### PR TITLE
wxGUI: NewDisplay button moved to LMToolsToolbar

### DIFF
--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -76,9 +76,6 @@ class DisplayPanelToolbar(BaseToolbar):
     def _toolbarData(self):
         """Toolbar data"""
         icons = {
-            "newdisplay": MetaIcon(
-                img="monitor-create", label=_("Start new map display")
-            ),
             "addMulti": MetaIcon(
                 img="layer-open",
                 label=_("Add multiple raster or vector map layers (Ctrl+Shift+L)"),
@@ -115,8 +112,6 @@ class DisplayPanelToolbar(BaseToolbar):
 
         return self._getToolbarData(
             (
-                ("newdisplay", icons["newdisplay"], self.parent.OnNewDisplay),
-                (None,),
                 ("addMulti", icons["addMulti"], self.parent.OnAddMaps),
                 ("addrast", icons["addRast"], self.parent.OnAddRaster),
                 ("rastmisc", icons["rastMisc"], self.parent.OnAddRasterMisc),
@@ -148,6 +143,9 @@ class LMToolsToolbar(BaseToolbar):
     def _toolbarData(self):
         """Toolbar data"""
         icons = {
+            "newdisplay": MetaIcon(
+                img="monitor-create", label=_("Start new map display")
+            ),
             "mapcalc": MetaIcon(
                 img="raster-calculator", label=_("Raster Map Calculator")
             ),
@@ -164,6 +162,8 @@ class LMToolsToolbar(BaseToolbar):
 
         return self._getToolbarData(
             (
+                ("newdisplay", icons["newdisplay"], self.parent.OnNewDisplay),
+                (None,),
                 ("mapCalc", icons["mapcalc"], self.parent.OnMapCalculator),
                 ("georect", icons["georectify"], self.parent.OnGCPManager),
                 ("modeler", icons["modeler"], self.parent.OnGModeler),


### PR DESCRIPTION
On the video call on August 5th, we decided to put the NewDisplay button to LMToolsToolbar. It is a more straightforward way how to approach this function, especially for a new Single-Window GUI. But it is also a more advantageous solution for a current Multi-Window layout.

Before:
![pred](https://user-images.githubusercontent.com/49241681/128902304-ad6aa953-df87-4814-9c3d-67e71893ebf5.PNG)
The NewDisplay button is a part of the toolbar for the Display panel.

After:
![po](https://user-images.githubusercontent.com/49241681/128902543-d1500836-53ad-4485-9c3a-5ea745fa9ba6.PNG)
The NewDisplay button is a part of the upper Tools toolbar, so it is available always regardless of which notebook tab is active.

