### PR TITLE
gunittest: CalledModuleError constructor accepts module, code, returncode, and errors

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1343,7 +1343,7 @@ class TestCase(unittest.TestCase):
                 errors += call_module("g.list", type="vector")
             # TODO: message format, parameters
             raise CalledModuleError(
-                module.returncode, module.name, module.get_python(), errors=errors
+                module.name, module.get_python(), module.returncode, errors=errors
             )
         # TODO: use this also in assert and apply when appropriate
         if expecting_stdout and not module.outputs.stdout.strip():

--- a/python/grass/gunittest/gmodules.py
+++ b/python/grass/gunittest/gmodules.py
@@ -137,5 +137,5 @@ def call_module(
     output, errors = process.communicate(input=encode(decode(stdin)) if stdin else None)
     returncode = process.poll()
     if returncode:
-        raise CalledModuleError(returncode, module, kwargs, errors)
+        raise CalledModuleError(module, kwargs, returncode, errors)
     return decode(output) if output else None


### PR DESCRIPTION
https://github.com/OSGeo/grass/blob/599cdff029ea0d5279c33dd83b4d868c4bd86fb4/python/grass/exceptions/__init__.py#L64

Without this PR, running `r.slope.aspect/testsuite/test_r_slope_aspect.py` fails with
```
======================================================================
ERROR: test_limits (__main__.TestSlopeAspect)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_r_slope_aspect.py", line 30, in setUp
    call_module("g.region", raster="elevation")
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/gunittest/gmodules.py", line 142, in call_module
    raise CalledModuleError(returncode, module, kwargs, errors)
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/exceptions/__init__.py", line 74, in __init__
    if not module or module in code:
TypeError: 'in <string>' requires string as left operand, not int
```
because `returncode` is passed as a module name.