### PR TITLE
wxGUI/Single-Window: New close page event for AuiNotebook

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -482,6 +482,7 @@ class GMFrame(wx.Frame):
             """Window closed.
             Also close associated layer tree page
             """
+
             def CanCloseDisplay(askIfSaveWorkspace):
                 """Check if user wants to close display"""
                 pgnum = self.notebookLayers.GetPageIndex(page)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -309,7 +309,6 @@ class GMFrame(wx.Frame):
             agwStyle=notebook_style,
         )
         self.mapnotebook.SetArtProvider(aui.AuiDefaultTabArt())
-
         # bindings
         self.mapnotebook.Bind(
             aui.EVT_AUINOTEBOOK_PAGE_CHANGED,
@@ -483,9 +482,8 @@ class GMFrame(wx.Frame):
             """Window closed.
             Also close associated layer tree page
             """
-
             def CanCloseDisplay(askIfSaveWorkspace):
-                """Callback to check if user wants to close display"""
+                """Check if user wants to close display"""
                 pgnum = self.notebookLayers.GetPageIndex(page)
                 name = self.notebookLayers.GetPageText(pgnum)
                 caption = _("Close Map Display {}").format(name)
@@ -515,7 +513,6 @@ class GMFrame(wx.Frame):
         mapdisplay.closingDisplay.connect(
             lambda page=self.currentPage: self._onMapDisplayClose(page)
         )
-
         mapdisplay.starting3dMode.connect(
             lambda firstTime, mapDisplayPage=self.currentPage: self._onStarting3dMode(
                 mapDisplayPage

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -111,8 +111,10 @@ class MapFrame(SingleMapFrame):
         # Layer Manager layer tree object
         # used for VDigit toolbar and window and GLWindow
         self.tree = tree
-        # checks for saving workspace
+        # checks for saving workspace, used only for Multi-Window GUI
         self.canCloseDisplayCallback = None
+        # map display close, used only for Single-Window GUI
+        self.onCloseWindow = None
 
         # Emitted when switching map notebook tabs (Single-Window)
         self.onFocus = Signal("MapPanel.onFocus")
@@ -975,7 +977,8 @@ class MapFrame(SingleMapFrame):
 
     def OnCloseWindow(self, event, askIfSaveWorkspace=True):
         """Window closed.
-        Also close associated layer tree page
+        Also close associated layer tree page.
+        Used only for Multi-Window GUI.
         """
         Debug.msg(2, "MapFrame.OnCloseWindow()")
         if self.canCloseDisplayCallback:


### PR DESCRIPTION
This PR addresses several smaller tasks:

- [x] Implements a new aui.EVT_AUINOTEBOOK_PAGE_CLOSE event
- [x] Fixes OnDisplayClose and OnDisplayCloseAll event handlers which are important for the closing of a map notebook page from File menu
- [x] Update list of shorcuts so that the map notebook page can be also closed by CTRL+W shortcut

It moves all OnCloseWindow logic to NewDisplay method.
Multi-Window GUI is not influenced by any changes.

By merging this PR the Issue https://github.com/OSGeo/grass/issues/1750 will be closed.