### PR TITLE
libraster: fix Rast_legal_bandref()

### DIFF
--- a/lib/raster/raster_metadata.c
+++ b/lib/raster/raster_metadata.c
@@ -135,8 +135,7 @@ void Rast_write_bandref(const char *name, const char *str)
  */
 int Rast_legal_bandref(const char *bandref)
 {
-    char **tokens;
-    int ntok;
+    const char *s;
 
     if (strlen(bandref) >= GNAME_MAX) {
         G_warning(_("Band reference is too long"));
@@ -146,20 +145,16 @@ int Rast_legal_bandref(const char *bandref)
     if (G_legal_filename(bandref) != 1)
         return -1;
 
-    tokens = G_tokenize(bandref, "_");
-    ntok = G_number_of_tokens(tokens);
-    if (ntok < 2) {
-        G_warning(_("Band reference must be in form <shortcut>_<bandname>"));
-        G_free_tokens(tokens);
-        return -1;
+    s = bandref;
+    while (*s) {
+	if (!((*s >= 'A' && *s <= 'Z') || (*s >= 'a' && *s <= 'z') ||
+	      (*s >= '0' && *s <= '9') || *s == '_'  || *s == '-')) {
+	    G_warning(_("Character '%c' not allowed in band reference."), *s);
+	    return -1;
+	}
+	s++;
     }
 
-    if (strlen(tokens[1]) < 1) {
-        G_free_tokens(tokens);
-        return -1;
-    }
-
-    G_free_tokens(tokens);
     return 1;
 }
 

--- a/lib/raster/testsuite/test_raster_metadata.py
+++ b/lib/raster/testsuite/test_raster_metadata.py
@@ -32,27 +32,11 @@ class RastLegalBandIdTestCase(TestCase):
     def test_illegal_name(self):
         ret = Rast_legal_bandref(".a")
         self.assertEqual(ret, -1)
-        ret = Rast_legal_bandref("1")
-        self.assertEqual(ret, -1)
-        ret = Rast_legal_bandref("1a")
-        self.assertEqual(ret, -1)
         ret = Rast_legal_bandref("a/b")
         self.assertEqual(ret, -1)
         ret = Rast_legal_bandref("a@b")
         self.assertEqual(ret, -1)
         ret = Rast_legal_bandref("a#b")
-        self.assertEqual(ret, -1)
-        ret = Rast_legal_bandref("GRASS")
-        self.assertEqual(ret, -1)
-        ret = Rast_legal_bandref("USER")
-        self.assertEqual(ret, -1)
-
-    def test_no_second_token(self):
-        ret = Rast_legal_bandref("GRASS_")
-        self.assertEqual(ret, -1)
-        ret = Rast_legal_bandref("USER_")
-        self.assertEqual(ret, -1)
-        ret = Rast_legal_bandref("S2_")
         self.assertEqual(ret, -1)
 
     def test_too_long(self):
@@ -66,6 +50,14 @@ class RastLegalBandIdTestCase(TestCase):
         self.assertEqual(ret, -1)
 
     def test_good_name(self):
+        ret = Rast_legal_bandref("1")
+        self.assertEqual(ret, 1)
+        ret = Rast_legal_bandref("1a")
+        self.assertEqual(ret, 1)
+        ret = Rast_legal_bandref("clouds")
+        self.assertEqual(ret, 1)
+        ret = Rast_legal_bandref("rededge1")
+        self.assertEqual(ret, 1)
         ret = Rast_legal_bandref("S2_1")
         self.assertEqual(ret, 1)
         ret = Rast_legal_bandref("GRASS_aspect_deg")


### PR DESCRIPTION
`Rast_legal_bandref()` was too restrictive requiring band names of the form `<shortcut>_<bandname>`. Such band names are not STAC or openeo compatible, see [https://github.com/stac-extensions/eo#band-object](https://github.com/stac-extensions/eo#band-object) and [https://github.com/stac-extensions/eo#common-band-names](https://github.com/stac-extensions/eo#common-band-names). Most importantly, custom band names must be allowed.
This PR relaxes the test for a legal band name, allowing letters, numbers, "_", and "-", but "_" is no longer required.