### PR TITLE
r.random.cells: treat distance as minimum distance

### DIFF
--- a/raster/r.random.cells/indep.c
+++ b/raster/r.random.cells/indep.c
@@ -34,7 +34,7 @@ void Indep(void)
 	    Out[DRow][DCol] = ++Found;
 	    for (R = DRow; R < Rs; R++) {
 		RowDist = NS * (R - DRow);
-		if (RowDist > MaxDistSq) {
+		if (RowDist >= MaxDistSq) {
 		    R = Rs;
 		}
 		else {
@@ -45,7 +45,7 @@ void Indep(void)
 			G_debug(3, "(ColDist):%.12lf", ColDist);
 			G_debug(3, "(MaxDistSq):%.12lf", MaxDistSq);
 			
-			if (MaxDistSq >= RowDistSq + ColDist * ColDist) {
+			if (MaxDistSq > RowDistSq + ColDist * ColDist) {
 			    if (0 != FlagGet(Cells, R, C)) {
 				G_debug(2, "unset()");
 				FLAG_UNSET(Cells, R, C);
@@ -62,14 +62,14 @@ void Indep(void)
 	    G_debug(2, "it1()");
 	    for (R = DRow - 1; R >= 0; R--) {
 		RowDist = NS * (DRow - R);
-		if (RowDist > MaxDistSq) {
+		if (RowDist >= MaxDistSq) {
 		    R = 0;
 		}
 		else {
 		    RowDistSq = RowDist * RowDist;
 		    for (C = DCol; C < Cs; C++) {
 			ColDist = EW * (C - DCol);
-			if (MaxDistSq >= RowDistSq + ColDist * ColDist) {
+			if (MaxDistSq > RowDistSq + ColDist * ColDist) {
 			    if (0 != FlagGet(Cells, R, C)) {
 				G_debug(2, "unset()");
 				FLAG_UNSET(Cells, R, C);
@@ -86,14 +86,14 @@ void Indep(void)
 	    G_debug(2, "it2()");
 	    for (R = DRow; R < Rs; R++) {
 		RowDist = NS * (R - DRow);
-		if (RowDist > MaxDistSq) {
+		if (RowDist >= MaxDistSq) {
 		    R = Rs;
 		}
 		else {
 		    RowDistSq = RowDist * RowDist;
 		    for (C = DCol - 1; C >= 0; C--) {
 			ColDist = EW * (DCol - C);
-			if (MaxDistSq >= RowDistSq + ColDist * ColDist) {
+			if (MaxDistSq > RowDistSq + ColDist * ColDist) {
 			    if (0 != FlagGet(Cells, R, C)) {
 				G_debug(2, "unset()");
 				FLAG_UNSET(Cells, R, C);
@@ -110,14 +110,14 @@ void Indep(void)
 	    G_debug(2, "it3()");
 	    for (R = DRow - 1; R >= 0; R--) {
 		RowDist = NS * (DRow - R);
-		if (RowDist > MaxDistSq) {
+		if (RowDist >= MaxDistSq) {
 		    R = 0;
 		}
 		else {
 		    RowDistSq = RowDist * RowDist;
 		    for (C = DCol - 1; C >= 0; C--) {
 			ColDist = EW * (DCol - C);
-			if (MaxDistSq >= RowDistSq + ColDist * ColDist) {
+			if (MaxDistSq > RowDistSq + ColDist * ColDist) {
 			    if (0 != FlagGet(Cells, R, C)) {
 				G_debug(2, "unset()");
 				FLAG_UNSET(Cells, R, C);

--- a/raster/r.random.cells/init.c
+++ b/raster/r.random.cells/init.c
@@ -73,7 +73,7 @@ void Init()
     G_debug(1, "(CellCount):%d", CellCount);
 
     sscanf(Distance->answer, "%lf", &MaxDist);
-    if (!(MaxDist > 0.0))
+    if (MaxDist <= 0.0)
 	G_fatal_error(_("Distance must be > 0.0"));
     
     G_debug(3, "(MaxDist):%.12lf", MaxDist);

--- a/raster/r.random.cells/init.c
+++ b/raster/r.random.cells/init.c
@@ -73,8 +73,8 @@ void Init()
     G_debug(1, "(CellCount):%d", CellCount);
 
     sscanf(Distance->answer, "%lf", &MaxDist);
-    if (MaxDist < 0.0)
-	G_fatal_error(_("Distance must be >= 0.0"));
+    if (!(MaxDist > 0.0))
+	G_fatal_error(_("Distance must be > 0.0"));
     
     G_debug(3, "(MaxDist):%.12lf", MaxDist);
     MaxDistSq = MaxDist * MaxDist;

--- a/raster/r.random.cells/testsuite/test_random_cells.py
+++ b/raster/r.random.cells/testsuite/test_random_cells.py
@@ -61,7 +61,7 @@ class TestCounts(TestCase):
         )
 
     def test_fill_some(self):
-        self.assertModule("r.random.cells", output=self.some_rast, distance=2, seed=100)
+        self.assertModule("r.random.cells", output=self.some_rast, distance=2.00001, seed=100)
         self.to_remove.append(self.some_rast)
         self.assertRasterFitsUnivar(
             self.some_rast, reference=dict(cells=self.n_cells, min=1)

--- a/raster/r.random.cells/testsuite/test_random_cells.py
+++ b/raster/r.random.cells/testsuite/test_random_cells.py
@@ -61,7 +61,9 @@ class TestCounts(TestCase):
         )
 
     def test_fill_some(self):
-        self.assertModule("r.random.cells", output=self.some_rast, distance=2.00001, seed=100)
+        self.assertModule(
+            "r.random.cells", output=self.some_rast, distance=2.00001, seed=100
+        )
         self.to_remove.append(self.some_rast)
         self.assertRasterFitsUnivar(
             self.some_rast, reference=dict(cells=self.n_cells, min=1)


### PR DESCRIPTION
Currently, the documentation says that "`r.random.cells` generates a random sets of raster cells that are at least distance apart", but in fact `r.random.cells` generates a random sets of raster cells that are more than distance apart.
This PR syncs the behaviour to the documentation: random cells are at least distance apart. Fixes #1779.