### PR TITLE
Output both Bash and Python for failed tests

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1410,10 +1410,11 @@ class TestCase(unittest.TestCase):
             stdmsg = (
                 "Running <{m.name}> module ended"
                 " with non-zero return code ({m.returncode})\n"
-                "Called: {code}\n"
+                "Called (Python): {code}\n"
+                "Called (Bash): {bash}\n"
                 "See the following errors:\n"
                 "{errors}".format(
-                    m=module, code=module.get_python(), errors=module.outputs.stderr
+                    m=module, code=module.get_python(), bash=module.get_bash(), errors=module.outputs.stderr
                 )
             )
             self.fail(self._formatMessage(msg, stdmsg))

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1414,7 +1414,10 @@ class TestCase(unittest.TestCase):
                 "Called (Bash): {bash}\n"
                 "See the following errors:\n"
                 "{errors}".format(
-                    m=module, code=module.get_python(), bash=module.get_bash(), errors=module.outputs.stderr
+                    m=module,
+                    code=module.get_python(),
+                    bash=module.get_bash(),
+                    errors=module.outputs.stderr,
                 )
             )
             self.fail(self._formatMessage(msg, stdmsg))


### PR DESCRIPTION
When test fails to run a module, both Python and Bash code for the run is printed.
Previously, it was only Python. Having Bash syntax at hand may be more convenient when using
command line or GDB to debug the test.
