### PR TITLE
Rename the master branch to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, releasebranch_7_8]
+    branches: [main, releasebranch_7_8]
   pull_request:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - "**/*.html"
       - "**/*.md"

--- a/AUTHORS
+++ b/AUTHORS
@@ -23,13 +23,13 @@ A list of recently active contributors is available at
 https://github.com/OSGeo/grass/graphs/contributors
 
 A list of contributors with write access is available in
-https://github.com/OSGeo/grass/blob/master/contributors.csv
+https://github.com/OSGeo/grass/blob/main/contributors.csv
 
 A list of contributors without write access is available in
-https://github.com/OSGeo/grass/blob/master/contributors_extra.csv
+https://github.com/OSGeo/grass/blob/main/contributors_extra.csv
 
 A list of translators is available in
-https://github.com/OSGeo/grass/blob/master/translators.csv
+https://github.com/OSGeo/grass/blob/main/translators.csv
 
 (note: email addresses below have been spam-proofed to protect the innocent;
 add "@" and "." as needed.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ on GitHub.
 ## Changing code and documentation
 
 This guide covers contributing to the main version of GRASS GIS source
-code which is the master branch.
+code which is in the branch called _main_.
 It assumes that you have some very basic knowledge of Git and GitHub,
 but if you don't just go through some tutorial online or ask on the
 GRASS GIS developer mailing list.
@@ -86,22 +86,23 @@ It is important that "origin" points to your fork.
 
 ### Update before creating a feature branch
 
-* Make sure your are using master branch:
+* Make sure your are using the _main_ branch to create the new branch:
 
 ```
-git checkout master
+git checkout main
 ```
 
-* Download updates from all branches from all remotes:
+* Download updates from all branches from the _upstream_ remote:
 
 ```
 git fetch upstream
 ```
 
-* Update your local master branch to match master in the main repository:
+* Update your local _main_ branch to match the _main_ branch
+  in the _upstream_ repository:
 
 ```
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 ### Update if you have local branches
@@ -116,7 +117,7 @@ git stash
 * Now you can rebase:
 
 ```
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 * Apply your local changes on top:
@@ -133,7 +134,7 @@ git stash pop
 
 ### Creating a new feature branch
 
-Now you have updated your local master branch, you can create a feature branch
+Now you have updated your local _main_ branch, you can create a feature branch
 based on it.
 
 * Create a new feature branch and switch to it:
@@ -186,11 +187,11 @@ GRASS GIS maintainers will now review your pull request.
 If needed, the maintainers will work with you to improve your changes.
 
 Once the changes in the pull request are ready to be accepted,
-the maintainers will decide if it is more appropriate to:
+the maintainers will usually squash all your commits into one commit and merge it
+to the _main_ branch.
 
-* merge your feature branch,
-* squash all commit into one commit, or
-* rebase (i.e., replay) all commits on top of the master branch.
+Once the pull request is merged, it is a good time to update your
+local _main_ branch in order to get the change you just contributed.
 
 ### Further notes
 

--- a/INSTALL
+++ b/INSTALL
@@ -190,7 +190,7 @@ In detail:
 
     cd /where/your/grass-source-code/lives/
     git fetch --all
-    git merge upstream/master
+    git merge upstream/main
     ./configure ...
     make
     make install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/OSGeo/grass.svg?branch=master)](https://travis-ci.com/OSGeo/grass)
+[![Build Status](https://travis-ci.com/OSGeo/grass.svg?branch=main)](https://travis-ci.com/OSGeo/grass)
 [![GCC C/C++ standards check](https://github.com/OSGeo/grass/workflows/GCC%20C/C++%20standards%20check/badge.svg)](https://github.com/OSGeo/grass/actions?query=workflow%3A%22GCC+C%2FC%2B%2B+standards+check%22)
 [![Python code quality check](https://github.com/OSGeo/grass/workflows/Python%20code%20quality%20check/badge.svg)](https://github.com/OSGeo/grass/actions?query=workflow%3A%22Python+code+quality+check%22)
 [![General linting](https://github.com/OSGeo/grass/workflows/General%20linting/badge.svg)](https://github.com/OSGeo/grass/actions?query=workflow%3A%22General+linting%22)
@@ -17,7 +17,7 @@ visualization.
 
 Launch this repository in Binder and experiment with GRASS's Python API in Jupyter Notebooks by clicking the button below:
 
-[![Binder](https://camo.githubusercontent.com/581c077bdbc6ca6899c86d0acc6145ae85e9d80e6f805a1071793dbe48917982/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/OSGeo/grass/master?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fexample_notebook.ipynb)
+[![Binder](https://camo.githubusercontent.com/581c077bdbc6ca6899c86d0acc6145ae85e9d80e6f805a1071793dbe48917982/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/OSGeo/grass/main?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fexample_notebook.ipynb)
 
 
 ## How to get write access here

--- a/display/d.mon/main.c
+++ b/display/d.mon/main.c
@@ -18,8 +18,8 @@
  d.mon delegates rendering to Python script [1] through GRASS_RENDER_COMMAND [2].
  See also document [3].
 
- [1] https://github.com/OSGeo/grass/tree/master/display/d.mon/render_cmd.py
- [2] https://github.com/OSGeo/grass/tree/master/lib/display/r_raster.c#L107
+ [1] display/d.mon/render_cmd.py
+ [2] lib/display/r_raster.c
  [3] https://grass.osgeo.org/grass80/manuals/displaydrivers.html
 
 */

--- a/doc/infrastructure.md
+++ b/doc/infrastructure.md
@@ -25,7 +25,7 @@ The GitHub repositories are:
 
 Git usage:
 
-* https://github.com/OSGeo/grass/blob/master/CONTRIBUTING.md
+* [CONTRIBUTING.md file](../CONTRIBUTING.md)
 * https://trac.osgeo.org/grass/wiki/HowToGit
 
 Issues:

--- a/grasslib.dox
+++ b/grasslib.dox
@@ -37,8 +37,9 @@ href="https://grass.osgeo.org">https://grass.osgeo.org</a>
 
 <i>Note: Missing entries below still need to be documented in Doxygen format.</i>
 
-<!-- original:
-  https://github.com/OSGeo/grass/blob/master/doc/grass8_arch.odg
+<!--
+  original:
+  doc/grass8_arch.odg
 -->
 \image html "grass8_arch.png" "GRASS GIS 8 Architecture"
 
@@ -184,8 +185,9 @@ as follows:
   storage in database (DBMS).</dd>
 </dl>
 
-<!-- original: 
-  https://raw.githubusercontent.com/OSGeo/grass/master/doc/help_loc_structure.odg
+<!--
+  original:
+  doc/help_loc_structure.odg
 -->
 \image html "loc_struct.png" "Diagram of GRASS file structure"
 

--- a/gui/wxpython/gmodeler/g.gui.gmodeler.html
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.html
@@ -430,8 +430,8 @@ r.colors = map = %map color = ndvi
 </em>
 
 <p>
-See also selected user models available from this 
-<a href="https://github.com/OSGeo/grass-addons/blob/master/grass7/models/">git repository</a>.
+See also selected user models available from
+<a href="https://grass.osgeo.org/grass78/manuals/addons/">GRASS Addons repository</a>.
 
 <p>
 See also

--- a/include/Make/Docs.make
+++ b/include/Make/Docs.make
@@ -91,7 +91,7 @@ html2pdfdoccomplete:
 	$(call html_pdf vector,v.*.html)
 
 changelog:
-	@ echo "creating ChangeLog file (following 'master' only)..."
+	@ echo "creating ChangeLog file (following the 'main' branch only)..."
 	@ # utils/gitlog2changelog.py creates a GNU style ChangeLog file:
 	python utils/gitlog2changelog.py
 

--- a/mswindows/osgeo4w/setup_x86.hint.tmpl
+++ b/mswindows/osgeo4w/setup_x86.hint.tmpl
@@ -1,5 +1,5 @@
 sdesc: "GRASS GIS - daily builds of development version"
-ldesc: "Geographic Resources Analysis Support System (GRASS GIS) - daily builds of git master"
+ldesc: "Geographic Resources Analysis Support System (GRASS GIS) - daily builds of the main branch from Git"
 category: Desktop
 requires: liblas avce00 gpsbabel gs python3-gdal python3-matplotlib msvcrt msvcrt2013 msvcrt2015 iconv libtiff gdal proj freetype-mingw pdcurses zlib fftw libpng python3-wx python3-numpy python3-pillow python3-pip python3-ply python3-pyopengl cairo python3-psycopg2 python3-six rbatch zstd zstd-bin python3-pywin32
 maintainer: MartinLanda

--- a/mswindows/osgeo4w/setup_x86_64.hint.tmpl
+++ b/mswindows/osgeo4w/setup_x86_64.hint.tmpl
@@ -1,5 +1,5 @@
 sdesc: "GRASS GIS - daily builds of development version"
-ldesc: "Geographic Resources Analysis Support System (GRASS GIS) - daily builds of git master"
+ldesc: "Geographic Resources Analysis Support System (GRASS GIS) - daily builds of the main branch from Git"
 category: Desktop
 requires: liblas avce00 gpsbabel gs python3-gdal python3-matplotlib msvcrt msvcrt2013 msvcrt2015 iconv libtiff gdal proj pdcurses zlib fftw libpng python3-wx python3-numpy python3-pillow python3-pip python3-ply python3-pyopengl cairo python3-psycopg2 python3-six rbatch zstd zstd-bin python3-pywin32
 maintainer: MartinLanda

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -16,13 +16,7 @@ cd grass
 __Build the singularity with__:
 
 ```bash
-sudo singularity build grass_master.simg singularity/debian/singularity_debian
-```
-
-The image can be used as:
-
-```bash
-singularity exec containers/grass_7.8.simg grass --version
+sudo singularity build grass_development.simg singularity/debian/singularity_debian
 ```
 
 __To build a stable version__:
@@ -37,4 +31,10 @@ and build and enter with:
 
 ```bash
 sudo singularity build grass_7_8.simg singularity/debian/singularity_debian
+```
+
+The image can be used as:
+
+```bash
+singularity exec containers/grass_7.8.simg grass --version
 ```

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -78,7 +78,7 @@ pgm = sys.argv[1]
 src_file = "%s.html" % pgm
 tmp_file = "%s.tmp.html" % pgm
 
-trunk_url = "https://github.com/OSGeo/grass/tree/master/"
+trunk_url = "https://github.com/OSGeo/grass/tree/main/"
 addons_url = "https://github.com/OSGeo/grass-addons/tree/master/"
 
 header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">


### PR DESCRIPTION
* Changes master to main in CI and URLs.
* In descriptions and instructions it further changes wording to say branch for more clarity.
* Removes full web URLs when a file path is more appropriate or sufficient.
* In manual page, it refers to Addons overview page instead of the repo.
* Singularity instructions now don't mix the different versions.
