### PR TITLE
wxGUI: fix settings when item added to settings but it doesn't exist yet locally

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -26,6 +26,7 @@ import sys
 import copy
 import wx
 import json
+import collections.abc
 
 from core import globalvar
 from core.gcmd import GException, GError
@@ -900,9 +901,19 @@ class Settings:
 
         :param settings: dict where to store settings (None for self.userSettings)
         """
+
+        def update_nested_dict_by_dict(dictionary, update):
+            """Recursively update nested dictionary by another nested dictionary"""
+            for key, value in update.items():
+                if isinstance(value, collections.abc.Mapping):
+                    update_nested_dict_by_dict(dictionary.get(key, {}), value)
+                else:
+                    dictionary[key] = value
+
         try:
             with open(self.filePath, "r") as f:
-                settings.update(json.load(f, object_hook=settings_JSON_decode_hook))
+                update = json.load(f, object_hook=settings_JSON_decode_hook)
+                update_nested_dict_by_dict(settings, update)
         except json.JSONDecodeError as e:
             sys.stderr.write(
                 _("Unable to read settings file <{path}>:\n{err}").format(


### PR DESCRIPTION
Upon initialization user settings dict needs to be correctly updated by nested dict from local settings file.