### PR TITLE
r.compress: Reversing logic to fix Failure Reporting

### DIFF
--- a/raster/r.compress/main.c
+++ b/raster/r.compress/main.c
@@ -94,10 +94,10 @@ int main(int argc, char *argv[])
         exit(EXIT_SUCCESS);
     }
 
-    stat = EXIT_FAILURE;
+    stat = EXIT_SUCCESS;
     for (n = 0; (name = map->answers[n]); n++)
-	if ( ! process(name, uncompress->answer) )
-	    stat = EXIT_SUCCESS;
+	if (process(name, uncompress->answer))
+	    stat = EXIT_FAILURE;
     exit(stat);
 }
 

--- a/raster/r.compress/main.c
+++ b/raster/r.compress/main.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 
     stat = EXIT_FAILURE;
     for (n = 0; (name = map->answers[n]); n++)
-	if (process(name, uncompress->answer))
+	if ( ! process(name, uncompress->answer) )
 	    stat = EXIT_SUCCESS;
     exit(stat);
 }


### PR DESCRIPTION
Currently when recompressing data from one compression to another, everything works but we still get `Exit 1` status.
This PR reverses the logic of the EXIT_FAILURE and EXIT_SUCCESS status, which fixes #1802.