### PR TITLE
wxGUI/vdigit: fix double click on the line/boundary after activate 'Edit selected line/boundary' editing tool

### DIFF
--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -689,7 +689,8 @@ class VDigitWindow(BufferedMapWindow):
                     else:
                         # unselect
                         self.digit.GetDisplay().SetSelected([])
-                        del self.moveInfo
+                        if hasattr(self, "moveInfo"):
+                            del self.moveInfo
 
                     self.UpdateMap(render=False)
 


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Vector Digitizer: `g.gui.vdigit -c test`
2. Draw some line
3. Activate 'Edit selected line/boundary' editing tool
4. Double click on the line
5. You get error message

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 1397, in MouseActions
    self.OnLeftUp(event)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 1575, in OnLeftUp
    self._onLeftUp(event)
  File "/usr/lib64/grass79/gui/wxpython/vdigit/mapwindow.py", line 949, in _onLeftUp
    self.OnLeftUpVarious(event)
  File "/usr/lib64/grass79/gui/wxpython/vdigit/mapwindow.py", line 697, in OnLeftUpVarious
    del self.moveInfo
AttributeError: moveInfo
```

**Expected behavior**

No error message after double-clicking on the line/boundary, border after activating the 'Edit selected line/boundary' editing tool.