### PR TITLE
 wxGUI/vdigit: fix double click on the line/boundary after activate 'Move selected vertex' editing tool and then switch to 'Edit selected line/boundary' editing tool

### DIFF
--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -1235,9 +1235,10 @@ class VDigitWindow(BufferedMapWindow):
                     self.DrawLines(pdc=self.pdcTmp)
 
                 if action == "editLine":
-                    self.MouseDraw(
-                        pdc=self.pdcTmp, begin=self.Cell2Pixel(self.polycoords[-1])
-                    )
+                    if self.polycoords:
+                        self.MouseDraw(
+                            pdc=self.pdcTmp, begin=self.Cell2Pixel(self.polycoords[-1])
+                        )
 
             self.Refresh()  # TODO: use RefreshRect()
             self.mouse["begin"] = self.mouse["end"]


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Vector Digitizer: `g.gui.vdigit -c test`
2. Draw some line
3. Activate 'Move selected vertex' editing tool
4. Double left click on the line
5. Activate (switch to) 'Edit selected line/boundary' editing tool
6. You get error message

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 1430, in MouseActions
    self.OnMouseMoving(event)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 1703, in OnMouseMoving
    self._onMouseMoving(event)
  File "/usr/lib64/grass79/gui/wxpython/vdigit/mapwindow.py", line 1246, in _onMouseMoving
    pdc=self.pdcTmp, begin=self.Cell2Pixel(self.polycoords[-1])
IndexError: list index out of range
```

**Expected behavior**

No error message after double-clicking on the line/boundary, after activate the 'Move selected vertex' editing tool and then activate (switch to) 'Edit selected line/boundary' editing tool.