### PR TITLE
wxGUI/vdigit: fix 'Copy categories/features' editing tool if you select only one feature

### DIFF
--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -1091,7 +1091,7 @@ class VDigitWindow(BufferedMapWindow):
                     fid,
                 ]
             )
-        elif action in ("copyCats", "copyAttrs"):
+        elif action in ("copyCats", "copyAttrs") and hasattr(self, "copyCatsIds"):
             if action == "copyCats":
                 if (
                     self.digit.CopyCats(


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Vector Digitizer: `g.gui.vdigit -c test`
2. Draw one line
3. Activate 'Copy categories' editing tool
4. Left click on the line (select line)
5. Right click outside of the selected line
6. You get error message

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 1421, in MouseActions
    self.OnRightUp(event)
  File "/usr/lib64/grass79/gui/wxpython/mapwin/buffered.py", line 1662, in OnRightUp
    self._onRightUp(event)
  File "/usr/lib64/grass79/gui/wxpython/vdigit/mapwindow.py", line 1103, in _onRightUp
    self.copyCatsList, self.copyCatsIds, copyAttrb=False
AttributeError: 'VDigitWindow' object has no attribute 'copyCatsIds'
```

**Expected behavior**

No error message.