### PR TITLE
libsymbol: fix bad argument order

### DIFF
--- a/lib/symbol/read.c
+++ b/lib/symbol/read.c
@@ -221,7 +221,7 @@ SYMBOL *err(FILE * fp, SYMBOL * s, char *msg)
 {
     fclose(fp);
     G_free(s);			/* TODO: free all */
-    G_warning(msg, "%s");
+    G_warning("%s", msg);
     return NULL;
 }
 


### PR DESCRIPTION
Originally part of #1406.