### PR TITLE
wxGUI/settings: fix updating nested dict when reading settings file

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -906,9 +906,12 @@ class Settings:
             """Recursively update nested dictionary by another nested dictionary"""
             for key, value in update.items():
                 if isinstance(value, collections.abc.Mapping):
-                    update_nested_dict_by_dict(dictionary.get(key, {}), value)
+                    dictionary[key] = update_nested_dict_by_dict(
+                        dictionary.get(key, {}), value
+                    )
                 else:
                     dictionary[key] = value
+            return dictionary
 
         try:
             with open(self.filePath, "r") as f:


### PR DESCRIPTION
Problem shows up for settings of external GUI plugins, that are not in the default dict.
