### PR TITLE
wxGUI/gui_core: fix preferences dialog rendered height on wxPython 4.1.1

### DIFF
--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -140,7 +140,6 @@ class PreferencesBaseDialog(wx.Dialog):
         mainSizer.Add(btnStdSizer, proportion=0, flag=wx.EXPAND | wx.ALL, border=5)
 
         self.SetSizer(mainSizer)
-        mainSizer.Fit(self)
 
     def OnDefault(self, event):
         """Button 'Set to default' pressed"""


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. From main window menu choose Settings -> Preferences or click on the main window toolbar 'GUI settings' tool
3. The Preferences dialog opens, but with the wrong rendered height 

**Screenshots**

![preferences_dialog_default](https://user-images.githubusercontent.com/50632337/130838134-6adbe24b-ceca-47f3-a054-37f2bde9da02.png)

**System description:**

```
GRASS nc_basic_spm_grass7/PERMANENT:~ > python -c "import sys, wx; print(sys.version); print(wx.version())"
3.9.6 (default, Aug  8 2021, 07:26:00) 
[GCC 10.3.0]
4.1.1 gtk3 (phoenix) wxWidgets 3.1.5
```

With wxPython `4.0.7.post2 gtk3 (phoenix) wxWidgets 3.0.4`, Preferences dialog height is rendered correctly.


**Additional context**

Dialogs that are inherited from the `PreferencesBaseDialog` class and use panel with scrollbar are affected: g.gui.animation, g.gui.mapswipe wxGUI component Preferences dialog, and GUI settings Preferences dialog.
