### PR TITLE
jupyter: Add virtual framebuffer X server dependency

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -4,6 +4,8 @@ bison
 flex
 g++
 gettext
+git
+imagemagick
 libblas-dev
 libbz2-dev
 libcairo2-dev
@@ -27,10 +29,9 @@ libxmu-dev
 libzstd-dev
 make
 netcdf-bin
+p7zip
 proj-bin
 sqlite3
 unixodbc-dev
+xvfb
 zlib1g-dev
-p7zip
-imagemagick
-git

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,6 @@
-numpy
+folium
 matplotlib
+numpy
 Pillow
 ply
-folium
+PyVirtualDisplay


### PR DESCRIPTION
* Add xvfb (virtual framebuffer X server) as a dependency to Binder apt file be able to run m.nviz.image from notebooks on Binder.
* Sort entries in the apt file.

Running m.nviz.image in Binder still requires a standard headless machine setup, i.e., xvfb-run or Xvfb :5 -screen followed by export DISPLAY (although simple Xvfb in background does not work in Jupyter). In any case, the setup of the environment is now possible.
