### PR TITLE
jupyter: Fix main notebook URL, note grass.jupyter is a preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ visualization.
 
 Launch this repository in Binder and experiment with GRASS's Python API in Jupyter Notebooks by clicking the button below:
 
-[![Binder](https://camo.githubusercontent.com/581c077bdbc6ca6899c86d0acc6145ae85e9d80e6f805a1071793dbe48917982/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/OSGeo/grass/main?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fexample_notebook.ipynb)
+[![Binder](https://camo.githubusercontent.com/581c077bdbc6ca6899c86d0acc6145ae85e9d80e6f805a1071793dbe48917982/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/OSGeo/grass/main?urlpath=lab%2Ftree%2Fdoc%2Fnotebooks%2Fbasic_example.ipynb)
 
 
 ## How to get write access here

--- a/doc/notebooks/basic_example.ipynb
+++ b/doc/notebooks/basic_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Try GRASS GIS in Jupyter Notebook with Python\n",
     "\n",
-    "[<img src=\"../../man/grass_logo.png\" alt=\"GRASS GIS\" style=\"width:200px;\"/>](https://grass.osgeo.org/)\n",
+    "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"width:200px;\"/>](https://grass.osgeo.org/)\n",
     "\n",
     "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the *Python* scripting language.\n",
     "The interactive notebook is available online thanks to the [*Binder*](https://mybinder.org/) service.\n",

--- a/doc/notebooks/basic_example.ipynb
+++ b/doc/notebooks/basic_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Try GRASS GIS in Jupyter Notebook with Python\n",
     "\n",
-    "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"width:200px;\"/>](https://grass.osgeo.org/)\n",
+    "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"height: 20ex;\"/>](https://grass.osgeo.org/)\n",
     "\n",
     "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the *Python* scripting language.\n",
     "The interactive notebook is available online thanks to the [*Binder*](https://mybinder.org/) service.\n",

--- a/doc/notebooks/basic_example_grass_jupyter.ipynb
+++ b/doc/notebooks/basic_example_grass_jupyter.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Try GRASS GIS in Jupyter Notebook with Python and grass.jupyter\n",
     "\n",
-    "[<img src=\"../../man/grass_logo.png\" alt=\"GRASS GIS\" style=\"width:200px;\"/>](https://grass.osgeo.org/)\n",
+    "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"width:200px;\"/>](https://grass.osgeo.org/)\n",
     "\n",
     "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the `grass.jupyter` package and the *Python* scripting language. The `grass.jupyter` package shortens the launch of *GRASS GIS* in *Jupyter Notebook* and provides several useful classes for creating, displaying and saving *GRASS GIS* maps. This notebook can be directly compared with [basic_example.ipynb](basic_example.ipynb) to see how the package improves the integration of *GRASS GIS* and *Jupyter Notebooks*.\n",
     "\n",

--- a/doc/notebooks/basic_example_grass_jupyter.ipynb
+++ b/doc/notebooks/basic_example_grass_jupyter.ipynb
@@ -11,7 +11,7 @@
     "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the `grass.jupyter` package and the *Python* scripting language. The `grass.jupyter` package shortens the launch of *GRASS GIS* in *Jupyter Notebook* and provides several useful classes for creating, displaying and saving *GRASS GIS* maps. This notebook can be directly compared with [basic_example.ipynb](basic_example.ipynb) to see how the package improves the integration of *GRASS GIS* and *Jupyter Notebooks*.\n",
     "\n",
     "\n",
-    "The `grass.jupyter` package was written as part of Google Summer of Code in 2021. For more information, visit the [wiki page](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS).\n",
+    "The `grass.jupyter` package was written as part of Google Summer of Code in 2021 and is experimentally included in version 8.0. For more information, visit the [wiki page](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS).\n",
     "\n",
     "\n",
     "Examples here are using a sample GRASS GIS dataset for North Carolina, USA. The dataset is included in this environment.\n",

--- a/doc/notebooks/basic_example_grass_jupyter.ipynb
+++ b/doc/notebooks/basic_example_grass_jupyter.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Try GRASS GIS in Jupyter Notebook with Python and grass.jupyter\n",
     "\n",
-    "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"width:200px;\"/>](https://grass.osgeo.org/)\n",
+    "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"height: 20ex;\"/>](https://grass.osgeo.org/)\n",
     "\n",
     "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the `grass.jupyter` package and the *Python* scripting language. The `grass.jupyter` package shortens the launch of *GRASS GIS* in *Jupyter Notebook* and provides several useful classes for creating, displaying and saving *GRASS GIS* maps. This notebook can be directly compared with [basic_example.ipynb](basic_example.ipynb) to see how the package improves the integration of *GRASS GIS* and *Jupyter Notebooks*.\n",
     "\n",

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# Improved Integration of GRASS and Jupyter\n",
     "\n",
-    "As part of Google Summer of Code 2021, we've been working to shorten and simplify the launch of GRASS in Jupyter and imporve the map displays. You can find out more about the project and follow the progress on the [GRASS wiki page](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS).\n",
+    "As part of Google Summer of Code 2021, we've been working to shorten and simplify the launch of GRASS in Jupyter and imporve the map displays. It is experimentally included in version 8.0 as a preview and will be officially available in version 8.2. You can find out more about the project and follow the progress on the [GRASS wiki page](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS).\n",
     "\n",
-    "In addition to simplifying the launch of *GRASS GIS* with `init()`, `grass.jupyter` has two main dislay classes, `GrassRenderer` and `InteractiveMap`. Using the *GRASS* rendering engine in the background,`GrassRenderer` creates maps as PNG images. `InteractiveMap` displays *GRASS GIS* rasters and vectors with [*folium*](http://python-visualization.github.io/folium/), a [*leaflet*](https://leafletjs.com/) library for *Python*.\n",
+    "In addition to simplifying the launch of *GRASS GIS* with `init()`, `grass.jupyter` has two main dislay classes, `GrassRenderer` and `InteractiveMap`. Using the *GRASS* rendering engine in the background, `GrassRenderer` creates maps as PNG images. `InteractiveMap` displays *GRASS GIS* rasters and vectors with [*folium*](http://python-visualization.github.io/folium/), a [*leaflet*](https://leafletjs.com/) library for *Python*.\n",
     "\n",
     "This interactive notebook is available online thanks to the [https://mybinder.org](Binder) service. To run the select part (called a *cell*), hit `Shift + Enter`."
    ]

--- a/doc/notebooks/hydrology.ipynb
+++ b/doc/notebooks/hydrology.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Hydrology with GRASS GIS\n",
     "\n",
-    "This is a short introduction to common hydrologic workflows in *GRASS GIS* in *Jupyter Notebook*. In addition to common *Python* packages, it demonstrates the usage of `grass.script`, the *Python* API for GRASS GIS, and `grass.jupyter`, a *Jupyter Notebook* specific package that helps with the launch of *GRASS GIS* and with displaying maps. \n",
+    "This is a short introduction to common hydrologic workflows in *GRASS GIS* in *Jupyter Notebook*. In addition to common *Python* packages, it demonstrates the usage of `grass.script`, the *Python* API for GRASS GIS, and `grass.jupyter`, an experimental *Jupyter Notebook* specific package that helps with the launch of *GRASS GIS* and with displaying maps.\n",
     "\n",
     "This interactive notebook is available online thanks to the [https://mybinder.org](Binder) service. To run the select part (called a *cell*), hit `Shift + Enter`.\n"
    ]

--- a/doc/notebooks/solar_potential.ipynb
+++ b/doc/notebooks/solar_potential.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Solar Energy Potential Analysis\n",
     "\n",
-    "This is an introduction to solar radiation modeling in *GRASS GIS* in *Jupyter Notebook*. In addition to common *Python* packages, it demonstrates the usage of `grass.script`, the *Python* API for GRASS GIS, and `grass.jupyter`, a *Jupyter Notebook* specific package that helps with the launch of *GRASS GIS* and with displaying maps. \n",
+    "This is an introduction to solar radiation modeling in *GRASS GIS* in *Jupyter Notebook*. In addition to common *Python* packages, it demonstrates the usage of `grass.script`, the *Python* API for GRASS GIS, and `grass.jupyter`, an experimental *Jupyter Notebook* specific package that helps with the launch of *GRASS GIS* and with displaying maps.\n",
     "\n",
     "This interactive notebook is available online thanks to the [https://mybinder.org](Binder) service. To run the select part (called a *cell*), hit `Shift + Enter`."
    ]

--- a/doc/notebooks/viewshed_analysis.ipynb
+++ b/doc/notebooks/viewshed_analysis.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook is a basic introduction to viewshed analysis in *GRASS GIS* in *Jupyter Notebook*. In addition to common *Python* packages, it demonstrates the usage of `grass.script`, the *Python* API for GRASS GIS, and `grass.jupyter`, a *Jupyter Notebook* specific package that helps with the launch of *GRASS GIS* and with displaying maps. \n",
+    "This notebook is a basic introduction to viewshed analysis in *GRASS GIS* in *Jupyter Notebook*. In addition to common *Python* packages, it demonstrates the usage of `grass.script`, the *Python* API for GRASS GIS, and `grass.jupyter`, an experimental *Jupyter Notebook* specific package that helps with the launch of *GRASS GIS* and with displaying maps.\n",
     "\n",
     "This interactive notebook is available online thanks to the [https://mybinder.org](Binder) service. To run the select part (called a *cell*), hit `Shift + Enter`."
    ]


### PR DESCRIPTION
* Fix main (landing) notebook URL in README (renamed).
* Note in the two main grass.jupyter notebooks that the package is experimental.
