### PR TITLE
libpython: Resolve path to mapset in setup.init

### DIFF
--- a/doc/notebooks/basic_example.ipynb
+++ b/doc/notebooks/basic_example.ipynb
@@ -44,7 +44,7 @@
     "import grass.script.setup as gsetup\n",
     "\n",
     "# Create a GRASS GIS session.\n",
-    "gsetup.init(\"~/grassdata/nc_basic_spm_grass7/user1\")\n",
+    "gsetup.init(\"~/data/grassdata/nc_basic_spm_grass7/user1\")\n",
     "\n",
     "# We want functions to raise exceptions and see standard output of the modules in the notebook.\n",
     "gs.set_raise_on_error(True)\n",

--- a/doc/notebooks/basic_example.ipynb
+++ b/doc/notebooks/basic_example.ipynb
@@ -44,7 +44,7 @@
     "import grass.script.setup as gsetup\n",
     "\n",
     "# Create a GRASS GIS session.\n",
-    "rcfile = gsetup.init(gisbase, \"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
+    "gsetup.init(\"~/grassdata/nc_basic_spm_grass7/user1\")\n",
     "\n",
     "# We want functions to raise exceptions and see standard output of the modules in the notebook.\n",
     "gs.set_raise_on_error(True)\n",
@@ -151,6 +151,25 @@
    "outputs": [],
    "source": [
     "print(gs.read_command(\"g.search.modules\", flags=\"g\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## When the work finished\n",
+    "\n",
+    "When we are finished working the mapset, we should end the GRASS session using `finish()` which will remove the temporary files created in the background. After the call, GRASS modules can no longer be executed, so the call is commented out in this notebook to allow running all cells and, at the same time, going back and experimenting with the code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment and run when done.\n",
+    "# gsetup.finish()"
    ]
   }
  ],

--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -15,6 +15,9 @@ import shutil
 from pathlib import Path
 
 
+import grass.grassdb.config
+
+
 def delete_mapset(database, location, mapset):
     """Deletes a specified mapset"""
     if mapset == "PERMANENT":
@@ -47,13 +50,6 @@ def rename_mapset(database, location, old_name, new_name):
 def rename_location(database, old_name, new_name):
     """Rename location from *old_name* to *new_name*"""
     os.rename(os.path.join(database, old_name), os.path.join(database, new_name))
-
-
-def split_mapset_path(mapset_path):
-    """Split mapset path to three parts - grassdb, location, mapset"""
-    path, mapset = os.path.split(Path(mapset_path))
-    grassdb, location = os.path.split(path)
-    return grassdb, location, mapset
 
 
 class MapsetPath:
@@ -108,6 +104,13 @@ class MapsetPath:
         return self._mapset
 
 
+def split_mapset_path(mapset_path):
+    """Split mapset path to three parts - grassdb, location, mapset"""
+    path, mapset = os.path.split(Path(mapset_path))
+    grassdb, location = os.path.split(path)
+    return grassdb, location, mapset
+
+
 def resolve_mapset_path(path, location=None, mapset=None):
     """Resolve full path to mapset from given combination of parameters.
 
@@ -137,7 +140,7 @@ def resolve_mapset_path(path, location=None, mapset=None):
 
     # This also resolves symlinks which may or may not be desired.
     path = Path(path).expanduser().resolve()
-    default_mapset = "PERMANENT"
+    default_mapset = grass.grassdb.config.permanent_mapset
     if location and mapset:
         directory = str(path)
         path = path / location / mapset

--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -106,9 +106,16 @@ class MapsetPath:
 
 def split_mapset_path(mapset_path):
     """Split mapset path to three parts - grassdb, location, mapset"""
-    path, mapset = os.path.split(Path(mapset_path))
-    grassdb, location = os.path.split(path)
-    return grassdb, location, mapset
+    mapset_path = Path(mapset_path)
+    if len(mapset_path.parts) < 3:
+        ValueError(
+            _("Mapset path '{}' needs at least three components").format(mapset_path)
+        )
+    mapset = mapset_path.name
+    location_path = mapset_path.parent
+    location = location_path.name
+    grassdb = location_path.parent
+    return os.fspath(grassdb), location, mapset
 
 
 def resolve_mapset_path(path, location=None, mapset=None):
@@ -169,7 +176,5 @@ def resolve_mapset_path(path, location=None, mapset=None):
                     "or location and mapset need to be set"
                 )
             )
-        mapset = parts[-1]
-        location = parts[-2]
-        directory = Path(*parts[:-2])
+        directory, location, mapset = split_mapset_path(path)
     return MapsetPath(path=path, directory=directory, location=location, mapset=mapset)

--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -57,6 +57,28 @@ def split_mapset_path(mapset_path):
     return grassdb, location, mapset
 
 
+class MapsetPath:
+    def __init__(self, path, directory, location, mapset):
+        # Path as an attribute. Inheriting from Path would be something to consider
+        # here, however the Path inheritance is somewhat complex, but may be possible
+        # in the future.
+        self.path=Path(path)
+        self.directory=str(directory)
+        self.location=location
+        self.mapset=mapset
+
+    def __repr__(self):
+       return (f'{self.__class__.__name__}('
+               f'{self.path!r}, '
+               f'{self.directory!r}, {self.location!r}, {self.mapset!r})')
+
+    def __str__(self):
+        return str(self.path)
+
+    def __fspath__(self):
+        return os.fspath(self.path)
+
+
 def resolve_mapset_path(path, location=None, mapset=None):
     """Resolve full path to mapset from given combination of parameters.
 
@@ -85,12 +107,12 @@ def resolve_mapset_path(path, location=None, mapset=None):
     path = Path(path).expanduser().resolve()
     default_mapset = "PERMANENT"
     if location and mapset:
+        directory = str(path)
         path = path / location / mapset
-        db = str(path)
     elif location:
         mapset = default_mapset
+        directory = str(path)
         path = path / location / mapset
-        db = str(path)
     elif mapset:
         # mapset, but not location
         raise ValueError(
@@ -114,8 +136,5 @@ def resolve_mapset_path(path, location=None, mapset=None):
             )
         mapset = parts[-1]
         location = parts[-2]
-        db = Path(*parts[:-2])
-    MapsetPath = collections.namedtuple(
-        "MapsetPath", ["path", "db", "location", "mapset"]
-    )
-    return MapsetPath(path=path, db=db, location=location, mapset=mapset)
+        directory = Path(*parts[:-2])
+    return MapsetPath(path=path, directory=directory, location=location, mapset=mapset)

--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -55,8 +55,8 @@ def rename_location(database, old_name, new_name):
 class MapsetPath:
     """This is a representation of a path to mapset.
 
-    Individual components are accessible through read-only properties.
-    It has with os.PathLike interface.
+    Individual components are accessible through read-only properties
+    and objects have an os.PathLike interface.
 
     Paths are currently stored as is (not resolved, not expanded),
     but that may change in the future.
@@ -123,7 +123,7 @@ def resolve_mapset_path(path, location=None, mapset=None):
     is not, mapset defaults to PERMANENT.
 
     The function does not enforce the existence of the directory or that it
-    it a mapset. It only manipulates the paths except for internal checks
+    is a mapset. It only manipulates the paths except for internal checks
     to determine default values in some cases.
 
     Home represented by ``~`` (tilde) and relative paths are resolved

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -73,8 +73,8 @@ class TestResolveMapsetPath(TestCase):
         path = "does/not/exist/"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
-        path = str(Path(path) / location_name / mapset_name)
-        mapset_path = resolve_mapset_path(path=path)
+        full_path = str(Path(path) / location_name / mapset_name)
+        mapset_path = resolve_mapset_path(path=full_path)
         self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
@@ -91,9 +91,9 @@ class TestMapsetPath(TestCase):
         path = "does/not/exist/"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
-        path = Path(path) / location_name / mapset_name
+        full_path = Path(path) / location_name / mapset_name
         mapset_path = MapsetPath(
-            path=path, directory=path, location=location_name, mapset=mapset_name
+            path=full_path, directory=path, location=location_name, mapset=mapset_name
         )
         # Paths are currently stored as is (not resolved).
         self.assertEqual(mapset_path.directory, path)
@@ -103,12 +103,12 @@ class TestMapsetPath(TestCase):
 
     def test_mapset_from_str(self):
         """Check with path from str and database directory as Path"""
-        path = "does/not/exist/"
+        path = "does/not/exist"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
-        path = Path(path) / location_name / mapset_name
+        full_path = Path(path) / location_name / mapset_name
         mapset_path = MapsetPath(
-            path=str(path),
+            path=str(full_path),
             directory=Path(path),
             location=location_name,
             mapset=mapset_name,

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -20,69 +20,6 @@ from grass.gunittest.gmodules import call_module
 from grass.gunittest.main import test
 
 
-class TestResolveMapsetPath(TestCase):
-    """Check expected results for current mapset and for a non-existent one"""
-
-    def test_default_mapset_exists(self):
-        """Check that default mapset is found for real path/location.
-
-        The location (or mapset) may not exist, but exist in the test.
-        """
-        db_path = call_module("g.gisenv", get="GISDBASE").strip()
-        loc_name = call_module("g.gisenv", get="LOCATION_NAME").strip()
-        mapset_path = resolve_mapset_path(path=db_path, location=loc_name)
-        self.assertEqual(mapset_path.mapset, "PERMANENT")
-
-    def test_default_mapset_does_not_exist(self):
-        """Check that default mapset is found for non-existent path/location.
-
-        The location (or mapset) do not exist.
-        """
-        mapset_path = resolve_mapset_path(
-            path="does/not/exist", location="does_not_exit"
-        )
-        self.assertEqual(mapset_path.mapset, "PERMANENT")
-
-    def test_default_mapset_with_path(self):
-        """Check that default mapset is found for path.
-
-        This requires the location (with default mapset) to exists.
-        """
-        db_path = call_module("g.gisenv", get="GISDBASE").strip()
-        loc_name = call_module("g.gisenv", get="LOCATION_NAME").strip()
-        mapset_path = resolve_mapset_path(path=Path(db_path) / loc_name)
-        self.assertEqual(mapset_path.mapset, "PERMANENT")
-
-    def test_mapset_from_parts(self):
-        """Check that a non-existing path is correctly constructed."""
-        path = "does/not/exist"
-        location_name = "test_location_A"
-        mapset_name = "test_mapset_1"
-        mapset_path = resolve_mapset_path(
-            path=path, location=location_name, mapset=mapset_name
-        )
-        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
-        self.assertEqual(mapset_path.location, location_name)
-        self.assertEqual(mapset_path.mapset, mapset_name)
-        self.assertEqual(
-            mapset_path.path, Path(path).resolve() / location_name / mapset_name
-        )
-
-    def test_mapset_from_path(self):
-        """Check that a non-existing path is correctly parsed."""
-        path = "does/not/exist/"
-        location_name = "test_location_A"
-        mapset_name = "test_mapset_1"
-        full_path = str(Path(path) / location_name / mapset_name)
-        mapset_path = resolve_mapset_path(path=full_path)
-        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
-        self.assertEqual(mapset_path.location, location_name)
-        self.assertEqual(mapset_path.mapset, mapset_name)
-        self.assertEqual(
-            mapset_path.path, Path(path).resolve() / location_name / mapset_name
-        )
-
-
 class TestMapsetPath(TestCase):
     """Check that object can be constructed"""
 
@@ -155,6 +92,69 @@ class TestSplitMapsetPath(TestCase):
         self.assertEqual(new_db, ref_db)
         self.assertEqual(new_location, ref_location)
         self.assertEqual(new_mapset, ref_mapset)
+
+
+class TestResolveMapsetPath(TestCase):
+    """Check expected results for current mapset and for a non-existent one"""
+
+    def test_default_mapset_exists(self):
+        """Check that default mapset is found for real path/location.
+
+        The location (or mapset) may not exist, but exist in the test.
+        """
+        db_path = call_module("g.gisenv", get="GISDBASE").strip()
+        loc_name = call_module("g.gisenv", get="LOCATION_NAME").strip()
+        mapset_path = resolve_mapset_path(path=db_path, location=loc_name)
+        self.assertEqual(mapset_path.mapset, "PERMANENT")
+
+    def test_default_mapset_does_not_exist(self):
+        """Check that default mapset is found for non-existent path/location.
+
+        The location (or mapset) do not exist.
+        """
+        mapset_path = resolve_mapset_path(
+            path="does/not/exist", location="does_not_exit"
+        )
+        self.assertEqual(mapset_path.mapset, "PERMANENT")
+
+    def test_default_mapset_with_path(self):
+        """Check that default mapset is found for path.
+
+        This requires the location (with default mapset) to exists.
+        """
+        db_path = call_module("g.gisenv", get="GISDBASE").strip()
+        loc_name = call_module("g.gisenv", get="LOCATION_NAME").strip()
+        mapset_path = resolve_mapset_path(path=Path(db_path) / loc_name)
+        self.assertEqual(mapset_path.mapset, "PERMANENT")
+
+    def test_mapset_from_parts(self):
+        """Check that a non-existing path is correctly constructed."""
+        path = "does/not/exist"
+        location_name = "test_location_A"
+        mapset_name = "test_mapset_1"
+        mapset_path = resolve_mapset_path(
+            path=path, location=location_name, mapset=mapset_name
+        )
+        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
+        self.assertEqual(mapset_path.location, location_name)
+        self.assertEqual(mapset_path.mapset, mapset_name)
+        self.assertEqual(
+            mapset_path.path, Path(path).resolve() / location_name / mapset_name
+        )
+
+    def test_mapset_from_path(self):
+        """Check that a non-existing path is correctly parsed."""
+        path = "does/not/exist/"
+        location_name = "test_location_A"
+        mapset_name = "test_mapset_1"
+        full_path = str(Path(path) / location_name / mapset_name)
+        mapset_path = resolve_mapset_path(path=full_path)
+        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
+        self.assertEqual(mapset_path.location, location_name)
+        self.assertEqual(mapset_path.mapset, mapset_name)
+        self.assertEqual(
+            mapset_path.path, Path(path).resolve() / location_name / mapset_name
+        )
 
 
 if __name__ == "__main__":

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -1,0 +1,161 @@
+# MODULE:    Test of grass.grassdb.manage
+#
+# AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+#
+# PURPOSE:   Test of managing the GRASS database/location/mapset structure
+#
+# COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
+#
+#            This program is free software under the GNU General Public
+#            License (>=v2). Read the file COPYING that comes with GRASS
+#            for details.
+
+"""Tests of grass.grassdb.manage"""
+
+from pathlib import Path
+
+from grass.grassdb.manage import MapsetPath, resolve_mapset_path, split_mapset_path
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import call_module
+from grass.gunittest.main import test
+
+
+class TestResolveMapsetPath(TestCase):
+    """Check expected results for current mapset and for a non-existent one"""
+
+    def test_default_mapset_exists(self):
+        """Check that default mapset is found for real path/location.
+
+        The location (or mapset) may not exist, but exist in the test.
+        """
+        db_path = call_module("g.gisenv", get="GISDBASE").strip()
+        loc_name = call_module("g.gisenv", get="LOCATION_NAME").strip()
+        mapset_path = resolve_mapset_path(path=db_path, location=loc_name)
+        self.assertEqual(mapset_path.mapset, "PERMANENT")
+
+    def test_default_mapset_does_not_exist(self):
+        """Check that default mapset is found for non-existent path/location.
+
+        The location (or mapset) do not exist.
+        """
+        mapset_path = resolve_mapset_path(
+            path="does/not/exist", location="does_not_exit"
+        )
+        self.assertEqual(mapset_path.mapset, "PERMANENT")
+
+    def test_default_mapset_with_path(self):
+        """Check that default mapset is found for path.
+
+        This requires the location (with default mapset) to exists.
+        """
+        db_path = call_module("g.gisenv", get="GISDBASE").strip()
+        loc_name = call_module("g.gisenv", get="LOCATION_NAME").strip()
+        mapset_path = resolve_mapset_path(path=Path(db_path) / loc_name)
+        self.assertEqual(mapset_path.mapset, "PERMANENT")
+
+    def test_mapset_from_parts(self):
+        """Check that a non-existing path is correctly constructed."""
+        path = "does/not/exist"
+        location_name = "test_location_A"
+        mapset_name = "test_mapset_1"
+        mapset_path = resolve_mapset_path(
+            path=path, location=location_name, mapset=mapset_name
+        )
+        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
+        self.assertEqual(mapset_path.location, location_name)
+        self.assertEqual(mapset_path.mapset, mapset_name)
+        self.assertEqual(
+            mapset_path.path, Path(path).resolve() / location_name / mapset_name
+        )
+
+    def test_mapset_from_path(self):
+        """Check that a non-existing path is correctly parsed."""
+        path = "does/not/exist/"
+        location_name = "test_location_A"
+        mapset_name = "test_mapset_1"
+        path = str(Path(path) / location_name / mapset_name)
+        mapset_path = resolve_mapset_path(path=path)
+        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
+        self.assertEqual(mapset_path.location, location_name)
+        self.assertEqual(mapset_path.mapset, mapset_name)
+        self.assertEqual(
+            mapset_path.path, Path(path).resolve() / location_name / mapset_name
+        )
+
+
+class TestMapsetPath(TestCase):
+    """Check that object can be constructed"""
+
+    def test_mapset_from_path_object(self):
+        """Check that path is correctly stored"""
+        path = "does/not/exist/"
+        location_name = "test_location_A"
+        mapset_name = "test_mapset_1"
+        path = Path(path) / location_name / mapset_name
+        mapset_path = MapsetPath(
+            path=path, directory=path, location=location_name, mapset=mapset_name
+        )
+        # Paths are currently stored as is (not resolved).
+        self.assertEqual(mapset_path.directory, path)
+        self.assertEqual(mapset_path.location, location_name)
+        self.assertEqual(mapset_path.mapset, mapset_name)
+        self.assertEqual(mapset_path.path, Path(path) / location_name / mapset_name)
+
+    def test_mapset_from_str(self):
+        """Check with path from str and database directory as Path"""
+        path = "does/not/exist/"
+        location_name = "test_location_A"
+        mapset_name = "test_mapset_1"
+        path = Path(path) / location_name / mapset_name
+        mapset_path = MapsetPath(
+            path=str(path),
+            directory=Path(path),
+            location=location_name,
+            mapset=mapset_name,
+        )
+        # Paths are currently stored as is (not resolved).
+        self.assertEqual(mapset_path.directory, path)
+        self.assertEqual(mapset_path.location, location_name)
+        self.assertEqual(mapset_path.mapset, mapset_name)
+        self.assertEqual(mapset_path.path, Path(path) / location_name / mapset_name)
+
+
+class TestSplitMapsetPath(TestCase):
+    """Check that split works with different parameters"""
+
+    def test_split_path(self):
+        """Check that pathlib.Path is correctly split"""
+        ref_db = "does/not/exist"
+        ref_location = "test_location_A"
+        ref_mapset = "test_mapset_1"
+        path = Path(ref_db) / ref_location / ref_mapset
+        new_db, new_location, new_mapset = split_mapset_path(path)
+        self.assertEqual(new_db, ref_db)
+        self.assertEqual(new_location, ref_location)
+        self.assertEqual(new_mapset, ref_mapset)
+
+    def test_split_str(self):
+        """Check that path as str is correctly split"""
+        ref_db = "does/not/exist"
+        ref_location = "test_location_A"
+        ref_mapset = "test_mapset_1"
+        path = Path(ref_db) / ref_location / ref_mapset
+        new_db, new_location, new_mapset = split_mapset_path(str(path))
+        self.assertEqual(new_db, ref_db)
+        self.assertEqual(new_location, ref_location)
+        self.assertEqual(new_mapset, ref_mapset)
+
+    def test_split_str_trailing_slash(self):
+        """Check that path as str with a trailing slash is correctly split"""
+        ref_db = "does/not/exist"
+        ref_location = "test_location_A"
+        ref_mapset = "test_mapset_1"
+        path = Path(ref_db) / ref_location / ref_mapset
+        new_db, new_location, new_mapset = split_mapset_path(str(path) + "/")
+        self.assertEqual(new_db, ref_db)
+        self.assertEqual(new_location, ref_location)
+        self.assertEqual(new_mapset, ref_mapset)
+
+
+if __name__ == "__main__":
+    test()

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -44,6 +44,6 @@ def init(path, location=None, mapset=None):
     :param str mapset: name of mapset within location
     """
     # Create a GRASS GIS session.
-    gsetup.init(dbase=path, location=location, mapset=mapset)
+    gsetup.init(path, location=location, mapset=mapset)
     # Set GRASS env. variables
     _set_notebook_defaults()

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -34,14 +34,6 @@ def _set_notebook_defaults():
     os.environ["GRASS_OVERWRITE"] = "1"
 
 
-class _JupyterSession:
-    def __init__(self):
-        self._finalizer = weakref.finalize(self, gsetup.finish)
-
-    def finish(self):
-        self._finalizer()
-
-
 def init(path, location=None, mapset=None):
     """
     This function initiates a GRASS session and sets GRASS
@@ -55,4 +47,3 @@ def init(path, location=None, mapset=None):
     gsetup.init(dbase=path, location=location, mapset=mapset)
     # Set GRASS env. variables
     _set_notebook_defaults()
-    return _JupyterSession()

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -12,6 +12,7 @@
 #           for details.
 
 import os
+import weakref
 
 import grass.script as gs
 import grass.script.setup as gsetup
@@ -33,7 +34,15 @@ def _set_notebook_defaults():
     os.environ["GRASS_OVERWRITE"] = "1"
 
 
-def init(path, location, mapset):
+class _JupyterSession:
+    def __init__(self):
+        self._finalizer = weakref.finalize(self, gsetup.finish)
+
+    def finish(self):
+        self._finalizer()
+
+
+def init(path, location=None, mapset=None):
     """
     This function initiates a GRASS session and sets GRASS
     environment variables.
@@ -43,6 +52,7 @@ def init(path, location, mapset):
     :param str mapset: name of mapset within location
     """
     # Create a GRASS GIS session.
-    gsetup.init(os.environ["GISBASE"], path, location, mapset)
+    gsetup.init(dbase=path, location=location, mapset=mapset)
     # Set GRASS env. variables
     _set_notebook_defaults()
+    return _JupyterSession()

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -12,7 +12,6 @@
 #           for details.
 
 import os
-import weakref
 
 import grass.script as gs
 import grass.script.setup as gsetup

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -33,7 +33,7 @@ def _set_notebook_defaults():
     os.environ["GRASS_OVERWRITE"] = "1"
 
 
-def init(path, location=None, mapset=None):
+def init(path, location=None, mapset=None, grass_path=None):
     """
     This function initiates a GRASS session and sets GRASS
     environment variables.
@@ -43,6 +43,6 @@ def init(path, location=None, mapset=None):
     :param str mapset: name of mapset within location
     """
     # Create a GRASS GIS session.
-    gsetup.init(path, location=location, mapset=mapset)
+    gsetup.init(path, location=location, mapset=mapset, grass_path=grass_path)
     # Set GRASS env. variables
     _set_notebook_defaults()

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -252,7 +252,7 @@ def setup_runtime_env(gisbase):
     os.environ["PYTHONPATH"] = path
 
 
-def init(path=None, location=None, mapset=None, grass_path=None):
+def init(path, location=None, mapset=None, grass_path=None):
     """Initialize system variables to run GRASS modules
 
     This function is for running GRASS GIS without starting it with the
@@ -277,7 +277,7 @@ def init(path=None, location=None, mapset=None, grass_path=None):
 
         # ... setup GISBASE and sys.path before import
         import grass.script as gs
-        gisrc = gs.setup.init(
+        gs.setup.init(
             "~/grassdata/nc_spm_08/user1",
             grass_path="/usr/lib/grass",
         )
@@ -285,12 +285,12 @@ def init(path=None, location=None, mapset=None, grass_path=None):
         # end the session
         gs.setup.finish()
 
-    :param gisbase: path to GRASS installation
-    :param dbase: path to GRASS database (default: '')
-    :param location: location name (default: 'demolocation')
+    :param path: path to GRASS database
+    :param location: location name
     :param mapset: mapset within given location (default: 'PERMANENT')
+    :param grass_path: path to GRASS installation or executable
 
-    :returns: path to ``gisrc`` file (to be deleted later)
+    :returns: path to ``gisrc`` file (may change in future versions)
     """
     grass_path = get_install_path(grass_path)
     if not grass_path:

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -264,6 +264,8 @@ def init(path, location=None, mapset=None, grass_path=None):
     path not being updated for the current process which is a common
     operating system limitation).
 
+    When the path or specified mapset does not exist, ValueError is raised.
+
     The :func:`get_install_path` function is used to determine where
     the rest of GRASS files is installed. The *grass_path* parameter is
     passed to it if provided. If the path cannot be determined,
@@ -302,6 +304,14 @@ def init(path, location=None, mapset=None, grass_path=None):
     from grass.grassdb.checks import get_mapset_invalid_reason, is_mapset_valid
     from grass.grassdb.manage import resolve_mapset_path
 
+    # A simple existence test. The directory, whatever it is, should exist.
+    if not Path(path).exists():
+        raise ValueError(_("Path '{path}' does not exist").format(path=path))
+    # A specific message when it exists, but it is a file.
+    if Path(path).is_file():
+        raise ValueError(
+            _("Path '{path}' is a file, but a directory is needed").format(path=path)
+        )
     mapset_path = resolve_mapset_path(path=path, location=location, mapset=mapset)
     if not is_mapset_valid(mapset_path):
         raise ValueError(


### PR DESCRIPTION
This replaces the db/loc/mapset defaults in grass.script.setup.init which were for demolocation
by more useful behavior: Basic case is passing all three values as before, but when gisdbase
and location are provided and mapset is not PERMANENT is used. This is actually also the same as
before, but now it fails if location is not provided. Additionally, location and mapset parameters
can be left out if the gisdbase (aka path) parameter points to the mapset or location.
In that case, additional check is done to resolve to see if it is a valid mapset
if not, PERMANENT is used instead. If there is no PERMANENT, the path is left as is.
The grass.jupyter.init uses grass.script.setup.init, so these changes apply there, too.

The gisbase is now automatically detected if possible, but also customizable with new convenient options (see doc).

No more gisbase and gisdbase. Renamed to grass_path and path, respectively. Parameters are also reordered. This will break existing code, but for 7 to 8 switch that's okay.

A possibly breaking change of behavior is that the init function checks for validity of the mapset
and raises an exception if the mapset is invalid (does not exist or fails validity test from grass.grassdb).

Most of the original code from grass.script.setup.init is now in a separate function which sets up the
runtime environment (env vars for libs etc.), but does not do anything with the data (or session file/gisrc).

grass.grassdb now has a new MapsetPath class to simplify path operations around mapset and especially switching between db/loc/mapset and full path to mapset. New function resolve_mapset_path takes care of the path or db/loc/mapset to actual mapset conversion.