### PR TITLE
wxGUI/Single-Window: Ensure display tab to be visible when added

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -390,6 +390,7 @@ class GMFrame(wx.Frame):
         self.notebookLayers.AddPage(page=self.pg_panel, text=name, select=True)
         self.currentPage = self.notebookLayers.GetCurrentPage()
         self.currentPageNum = self.notebookLayers.GetSelection()
+        self.notebookLayers.EnsureVisible(self.currentPageNum)
 
         def CreateNewMapDisplay(layertree):
             """Callback function which creates a new Map Display window


### PR DESCRIPTION
When more display tabs are added, the last one, which goes beyond the pane border, is not focused. This PR is relevant only for Single-Window GUI, the Multi-Window works well.