### PR TITLE
jupyter: Render 3D images with m.nviz.image

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -12,14 +12,15 @@ libopenblas-dev
 libpdal-dev
 libpng-dev
 libproj-dev
-pdal
-proj-bin
 libreadline-dev
 libzstd-dev
+pdal
+proj-bin
 python3-dateutil
 python3-matplotlib
 python3-numpy
 python3-ply
+python3-pyvirtualdisplay
 python3-six
 python3-termcolor
 sqlite3

--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -19,6 +19,7 @@ proj-bin
 python3-dateutil
 python3-matplotlib
 python3-numpy
+python3-pil
 python3-ply
 python3-pyvirtualdisplay
 python3-six

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -234,35 +234,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now render a 3D visualization of an elevation raster colored using the :"
-   ]
+    "Now, render a 3D visualization of an elevation raster as a surface colored using, again, the elevation raster:"
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "img.render(elevation_map=\"elevation\", color_map=\"landuse\", perspective=20)"
-   ]
+    "img.render(elevation_map=\"elevation\", color_map=\"elevation\", perspective=20)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "To add a raster legend on the image as an overlay using the 2D rendering capabilities accessible with `overlay.d_legend`:"
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "img.overlay.d_legend(raster=\"elevation\", at=(60, 97, 87, 92))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Finally, we show "
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "img.show()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now, let's color the elevation surface using a landuse raster (note that the call to `render` removes the result of the previous `render` as well as the current overlays):"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "img.render(elevation_map=\"elevation\", color_map=\"landuse\", perspective=20)\n",
+    "img.show()"
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -202,6 +202,67 @@
    "source": [
     "fig.save(filename=\"test_map.html\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GRASS 3D Renderer\n",
+    "\n",
+    "The `Grass3dRenderer` class creates 3D visualizations as PNG images. The *m.nviz.image* module is used in the background and the function `render()` accepts parameters of this module.\n",
+    "The `Grass3dRenderer` objects have `overlay` attribute which can be used in the same way as `GrassRenderer` and 2D images on top of the 3D visualization.\n",
+    "To display the image, call `show()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's create the object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = gj.Grass3dRenderer()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now render a 3D visualization of an elevation raster colored using the :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img.render(elevation_map=\"elevation\", color_map=\"landuse\", perspective=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img.overlay.d_legend(raster=\"elevation\", at=(60, 97, 87, 92))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img.show()"
+   ]
   }
  ],
  "metadata": {

--- a/python/grass/jupyter/Makefile
+++ b/python/grass/jupyter/Makefile
@@ -9,6 +9,7 @@ MODULES = \
 	setup \
 	display \
 	interact_display \
+	render3d \
 	utils
 
 PYFILES := $(patsubst %,$(DSTDIR)/%.py,$(MODULES) __init__)

--- a/python/grass/jupyter/__init__.py
+++ b/python/grass/jupyter/__init__.py
@@ -21,7 +21,8 @@ Notebooks. The original version was written as part of Google Summer of Code in 
 For more information, visit https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS
 """
 
-from .setup import *
-from .interact_display import *
 from .display import *
+from .interact_display import *
+from .render3d import *
+from .setup import *
 from .utils import *

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -132,6 +132,16 @@ class Grass3dRenderer:
             renderer=renderer2d,
         )
 
+    @property
+    def filename(self):
+        """Filename or full path to the file with the resulting image.
+
+        The value can be set during initialization. When the filename was not provided
+        during initialization, a path to temporary file is returned. In that case, the
+        file is guaranteed to exist as long as the object exists.
+        """
+        return self._filename
+
     def render(self, **kwargs):
         """Run rendering using *m.nviz.image*.
 

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -167,13 +167,18 @@ class Grass3dRenderer:
             kwargs["resolution_fine"] = self._resolution_fine
 
         if self._screen_backend == "pyvirtualdisplay":
+            import inspect
+
             # This is imported only when needed and when the package is available,
             # but generally, it may not be available.
             # pylint: disable=import-outside-toplevel,import-error
             from pyvirtualdisplay import Display
 
+            additional_kwargs = {}
+            if "manage_global_env" in inspect.signature().parameters:
+                additional_kwargs["manage_global_env"] = False
             with Display(
-                size=(self._width, self._height), manage_global_env=False
+                size=(self._width, self._height), **additional_kwargs
             ) as display:
                 gs.run_command(module, env=display.env(), **kwargs)
         else:

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -175,7 +175,7 @@ class Grass3dRenderer:
             from pyvirtualdisplay import Display
 
             additional_kwargs = {}
-            if "manage_global_env" in inspect.signature().parameters:
+            if "manage_global_env" in inspect.signature(Display).parameters:
                 additional_kwargs["manage_global_env"] = False
             with Display(
                 size=(self._width, self._height), **additional_kwargs

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -167,7 +167,7 @@ class Grass3dRenderer:
             kwargs["resolution_fine"] = self._resolution_fine
 
         if self._screen_backend == "pyvirtualdisplay":
-            import inspect
+            import inspect  # pylint: disable=import-outside-toplevel
 
             # This is imported only when needed and when the package is available,
             # but generally, it may not be available.
@@ -175,12 +175,18 @@ class Grass3dRenderer:
             from pyvirtualdisplay import Display
 
             additional_kwargs = {}
+            has_env_copy = False
             if "manage_global_env" in inspect.signature(Display).parameters:
                 additional_kwargs["manage_global_env"] = False
+                has_env_copy = True
             with Display(
                 size=(self._width, self._height), **additional_kwargs
             ) as display:
-                gs.run_command(module, env=display.env(), **kwargs)
+                if has_env_copy:
+                    env = display.env()
+                else:
+                    env = os.environ
+                gs.run_command(module, env=env, **kwargs)
         else:
             gs.run_command(module, **kwargs)
 

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -97,7 +97,8 @@ class Grass3dRenderer:
         try:
             # This tests availability of the module and needs to work even
             # when the package is not installed.
-            import pyvirtualdisplay  # pylint: disable=import-outside-toplevel
+            # pylint: disable=import-outside-toplevel,unused-import
+            import pyvirtualdisplay  # noqa: F401
 
             pyvirtualdisplay_available = True
         except ImportError:

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -30,10 +30,10 @@ class Grass3dRenderer:
 
     Basic usage::
 
-    >>> m = Grass3dRenderer()
+    >>> img = Grass3dRenderer()
     >>> img.render(elevation_map="elevation", color_map="elevation", perspective=20)
     >>> img.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
-    >>> m.show()
+    >>> img.show()
 
     For the OpenGL rendering with *m.nviz.image* to work, a display (screen) is needed.
     This is not guaranteed on headless systems such as continuous integration (CI) or
@@ -103,7 +103,9 @@ class Grass3dRenderer:
         except ImportError:
             pyvirtualdisplay_available = False
         if screen_backend == "auto" and pyvirtualdisplay_available:
-            self._screen_backend = pyvirtualdisplay
+            self._screen_backend = "pyvirtualdisplay"
+        elif screen_backend == "auto":
+            self._screen_backend = "simple"
         elif screen_backend == "pyvirtualdisplay" and not pyvirtualdisplay_available:
             raise ValueError(
                 _(
@@ -111,8 +113,8 @@ class Grass3dRenderer:
                     "because pyvirtualdisplay cannot be imported"
                 ).format(screen_backend)
             )
-        elif screen_backend in ["simple", "auto"]:
-            self._screen_backend = "simple"
+        elif screen_backend in ["simple", "pyvirtualdisplay"]:
+            self._screen_backend = screen_backend
         else:
             raise ValueError(
                 _(

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -1,0 +1,155 @@
+# MODULE:    grass.jupyter.display
+#
+# AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+#
+# PURPOSE:   This module contains functions for non-interactive display
+#            in Jupyter Notebooks
+#
+# COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
+#
+#           This program is free software under the GNU General Public
+#           License (>=v2). Read the file COPYING that comes with GRASS
+#           for details.
+
+import os
+import tempfile
+
+import grass.script as gs
+from grass.jupyter import GrassRenderer
+
+
+class Grass3dRenderer:
+    """Creates and displays 3D visualization using GRASS GIS 3D rendering engine NVIZ.
+
+    The 3D image is created using the *render* function. Additional images can be
+    placed on the image using the *overlay* attribute which is the 2D renderer, i.e.,
+    has interface of the *GrassRenderer* class.
+
+    Basic usage::
+    >>> m = Grass3dRenderer()
+    >>> img.render(elevation_map="elevation", color_map="elevation", perspective=20)
+    >>> img.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
+    >>> m.show()
+    """
+
+    def __init__(
+        self,
+        width=600,
+        height=400,
+        filename=None,
+        mode="fine",
+        resolution_fine=1,
+        screen_backend="auto",
+        font="sans",
+        text_size=12,
+        renderer2d="cairo",
+    ):
+        """Creates an instance of the GrassRenderer class.
+
+        :param int height: height of map in pixels
+        :param int width: width of map in pixels
+        :param str filename: filename or path to save a PNG of map
+        :param str env: environment
+        :param str font: font to use in rendering; either the name of a font from
+                        $GISBASE/etc/fontcap (or alternative fontcap file specified
+                        by GRASS_FONT_CAP), or alternatively the full path to a FreeType
+                        font file
+        :param int text_size: default text size, overwritten by most display modules
+        :param renderer: GRASS renderer driver (options: cairo, png, ps, html)
+        """
+        self._width = width
+        self._height = height
+        self._mode = mode
+        self._resolution_fine = resolution_fine
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        if filename:
+            self._filename = filename
+        else:
+            self._filename = os.path.join(self._tmpdir.name, "map.png")
+
+        try:
+            # This tests availability of the module and needs to work even
+            # when the package is not installed.
+            import pyvirtualdisplay  # pylint: disable=import-outside-toplevel
+
+            pyvirtualdisplay_available = True
+        except ImportError:
+            pyvirtualdisplay_available = False
+        if screen_backend == "auto" and pyvirtualdisplay_available:
+            self._screen_backend = pyvirtualdisplay
+        elif screen_backend == "pyvirtualdisplay" and not pyvirtualdisplay_available:
+            raise ValueError(
+                _(
+                    "Screen backend '{}' cannot be used "
+                    "because pyvirtualdisplay cannot be imported"
+                ).format(screen_backend)
+            )
+        elif screen_backend == "simple":
+            self._screen_backend = screen_backend
+        else:
+            raise ValueError(
+                _(
+                    "Screen backend '{}' does not exist. "
+                    "See documentation for the list of supported backends."
+                ).format(screen_backend)
+            )
+
+        self.overlay = GrassRenderer(
+            height=height,
+            width=width,
+            filename=self._filename,
+            font=font,
+            text_size=text_size,
+            renderer=renderer2d,
+        )
+
+    def render(self, **kwargs):
+        """Run rendering using *m.nviz.image*.
+
+        Keyword arguments are passed as parameters to the *m.nviz.image* module.
+        Parameters set in constructor such as *mode* are used here unless another value
+        is provided. Parameters related to size, file, and format are handled
+        internally and will be ignored when passed here.
+
+        For the OpenGL rendering to work, a display is needed. This is not guaranteed
+        on headless systems such as continuous integration (CI) or Binder service(s).
+        When pyvirtualdisplay Python package is present, the function assumes that it
+        """
+        module = "m.nviz.image"
+        name = os.path.join(self._tmpdir.name, "nviz")
+        ext = "tif"
+        full_name = f"{name}.{ext}"
+        kwargs["output"] = name
+        kwargs["format"] = ext
+        kwargs["size"] = (self._width, self._height)
+        if "mode" not in kwargs:
+            kwargs["mode"] = self._mode
+        if "resolution_fine" not in kwargs:
+            kwargs["resolution_fine"] = self._resolution_fine
+
+        if self._screen_backend == "pyvirtualdisplay":
+            # This is imported only when needed and when the package is available,
+            # but generally, it may not be available.
+            # pylint: disable=import-outside-toplevel,import-error
+            from pyvirtualdisplay import Display
+
+            with Display(
+                size=(self._width, self._height), manage_global_env=False
+            ) as display:
+                gs.run_command(module, env=display.env(), **kwargs)
+        else:
+            gs.run_command(module, **kwargs)
+
+        # Lazy import to avoid an import-time dependency on PIL.
+        from PIL import Image  # pylint: disable=import-outside-toplevel
+
+        img = Image.open(full_name)
+        img.save(self._filename)
+
+    def show(self):
+        """Displays a PNG image of map"""
+        # Lazy import to avoid an import-time dependency on IPython.
+        from IPython.display import Image  # pylint: disable=import-outside-toplevel
+
+        return Image(self._filename)

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -111,8 +111,8 @@ class Grass3dRenderer:
                     "because pyvirtualdisplay cannot be imported"
                 ).format(screen_backend)
             )
-        elif screen_backend == "simple":
-            self._screen_backend = screen_backend
+        elif screen_backend in ["simple", "auto"]:
+            self._screen_backend = "simple"
         else:
             raise ValueError(
                 _(

--- a/python/grass/jupyter/testsuite/test_render3d.py
+++ b/python/grass/jupyter/testsuite/test_render3d.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+############################################################################
+#
+# NAME:      Test 3D renderer
+#
+# AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+#
+# PURPOSE:   Test script for grass.jupyter's Grass3dRenderer
+#
+# COPYRIGHT: (C) 2021 by Vaclav Petras and the GRASS Development Team
+#
+#            This program is free software under the GNU General Public
+#            License (>=v2). Read the file COPYING that comes with GRASS
+#            for details.
+#
+#############################################################################
+
+"""Test of 3D renderer"""
+
+import os
+import unittest
+import sys
+from pathlib import Path
+import grass.jupyter as gj
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+def can_import_ipython():
+    """Return True if IPython can be imported, False otherwise"""
+    try:
+        import IPython
+
+        return True
+    except ImportError:
+        return False
+
+
+def can_import_pyvirtualdisplay():
+    """Return True if pyvirtualdisplay can be imported, False otherwise"""
+    try:
+        import pyvirtualdisplay
+
+        return True
+    except ImportError:
+        return False
+
+
+class TestDisplay(TestCase):
+    # Setup variables
+    files = []
+
+    @classmethod
+    def setUpClass(cls):
+        """Ensures expected computational region"""
+        # to not override mapset's region (which might be used by other tests)
+        cls.use_temp_region()
+        # cls.runModule or self.runModule is used for general module calls
+        # we'll use the elevation raster as a test display
+        cls.runModule("g.region", raster="elevation")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove temporary region"""
+        cls.del_temp_region()
+
+    def tearDown(self):
+        """
+        Remove the PNG file created after testing with "filename =" option.
+        This is executed after each test run.
+        """
+        for f in self.files:
+            f = Path(f)
+            if sys.version_info < (3, 8):
+                try:
+                    os.remove(f)
+                except FileNotFoundError:
+                    pass
+            else:
+                f.unlink(missing_ok=True)
+
+    def test_defaults(self):
+        """Check that default settings work"""
+        renderer = gj.Grass3dRenderer()
+        renderer.render(elevation_map="elevation", color_map="elevation")
+        self.assertFileExists(renderer.filename)
+
+    def test_filename(self):
+        """Check that custom filename works"""
+        custom_filename = "test_filename.png"
+        renderer = gj.Grass3dRenderer(filename=custom_filename)
+        # Add files to self for cleanup later
+        self.files.append(custom_filename)
+        renderer.render(elevation_map="elevation", color_map="elevation")
+        self.assertFileExists(custom_filename)
+
+    def test_hw(self):
+        """Check that custom width and height works"""
+        renderer = gj.Grass3dRenderer(width=200, height=400)
+        renderer.render(elevation_map="elevation", color_map="elevation")
+        self.assertFileExists(renderer.filename)
+
+    def test_overlay(self):
+        """Check that overlay works"""
+        renderer = gj.Grass3dRenderer()
+        renderer.render(elevation_map="elevation", color_map="elevation")
+        renderer.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
+        self.assertFileExists(renderer.filename)
+
+    @unittest.skipIf(
+        not can_import_pyvirtualdisplay(), "Cannot import PyVirtualDisplay"
+    )
+    def test_pyvirtualdisplay_backend(self):
+        """Check that pyvirtualdisplay backend works"""
+        renderer = gj.Grass3dRenderer(screen_backend="pyvirtualdisplay")
+        renderer.render(elevation_map="elevation", color_map="elevation")
+        self.assertFileExists(renderer.filename)
+
+    def test_shortcut_error(self):
+        """Check that wrong screen backend fails"""
+        with self.assertRaisesRegex(ValueError, "does_not_exist"):
+            gj.Grass3dRenderer(screen_backend="does_not_exist")
+
+    @unittest.skipIf(not can_import_ipython(), "Cannot import IPython")
+    def test_image_creation(self):
+        """Check that show() works"""
+        renderer = gj.Grass3dRenderer()
+        renderer.render(elevation_map="elevation", color_map="elevation")
+        self.assertTrue(renderer.show(), "Failed to create IPython Image object")
+
+
+if __name__ == "__main__":
+    test()

--- a/python/grass/jupyter/testsuite/test_render3d.py
+++ b/python/grass/jupyter/testsuite/test_render3d.py
@@ -51,6 +51,7 @@ def can_import_pyvirtualdisplay():
 
 class TestDisplay(TestCase):
     """Test Grass3dRenderer"""
+
     files = []
 
     @classmethod

--- a/python/grass/jupyter/testsuite/test_render3d.py
+++ b/python/grass/jupyter/testsuite/test_render3d.py
@@ -30,7 +30,8 @@ from grass.gunittest.main import test
 def can_import_ipython():
     """Return True if IPython can be imported, False otherwise"""
     try:
-        import IPython
+        # pylint: disable=import-outside-toplevel,unused-import
+        import IPython  # noqa: F401
 
         return True
     except ImportError:
@@ -40,7 +41,8 @@ def can_import_ipython():
 def can_import_pyvirtualdisplay():
     """Return True if pyvirtualdisplay can be imported, False otherwise"""
     try:
-        import pyvirtualdisplay
+        # pylint: disable=import-outside-toplevel,unused-import
+        import pyvirtualdisplay  # noqa: F401
 
         return True
     except ImportError:
@@ -48,7 +50,7 @@ def can_import_pyvirtualdisplay():
 
 
 class TestDisplay(TestCase):
-    # Setup variables
+    """Test Grass3dRenderer"""
     files = []
 
     @classmethod
@@ -66,19 +68,16 @@ class TestDisplay(TestCase):
         cls.del_temp_region()
 
     def tearDown(self):
-        """
-        Remove the PNG file created after testing with "filename =" option.
-        This is executed after each test run.
-        """
-        for f in self.files:
-            f = Path(f)
+        """After each run, remove the created files if exist"""
+        for file in self.files:
+            file = Path(file)
             if sys.version_info < (3, 8):
                 try:
-                    os.remove(f)
+                    os.remove(file)
                 except FileNotFoundError:
                     pass
             else:
-                f.unlink(missing_ok=True)
+                file.unlink(missing_ok=True)
 
     def test_defaults(self):
         """Check that default settings work"""


### PR DESCRIPTION
* 3D is rendered using m.nviz.image.
* The interface to m.nviz.image is direct/basic, i.e., the parameters are just passed as is.
* There is several special m.nviz.image parameters which are handled separately such as size and mode.
* The main function to pass the parameters is called render.
* The 2D renderer is used to create 'overlays' such as raster legend.
* In Binder and other headless environments, PyVirtualDisplay is used to call m.nviz.image.
* PyVirtualDisplay is not an optional dependency (in turn it depends on Xvfb).
* Given the API of PyVirtualDisplay, the 3D renderer cannot support custom environments (i.e., it always uses os.environ) although it makes effort not to modify it if possible.
