### PR TITLE
ci: Print version info for Ubuntu and CentOS runs

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -58,4 +58,6 @@ jobs:
           .github/workflows/test_simple.sh
       - name: Print installed versions
         if: always()
-        run: .github/workflows/print_versions.sh
+        run: |
+          source $CONDA_ACTIVATE
+          .github/workflows/print_versions.sh

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -56,3 +56,6 @@ jobs:
         run: |
           source $CONDA_ACTIVATE
           .github/workflows/test_simple.sh
+      - name: Print installed versions
+        if: always()
+        run: .github/workflows/print_versions.sh

--- a/.github/workflows/print_versions.sh
+++ b/.github/workflows/print_versions.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Print versions, esp. versions of dependencies.
+
+# fail on non-zero return code from a subprocess
+set -e
+
+grass --version
+grass --tmp-location XY --exec g.version
+python --version

--- a/.github/workflows/print_versions.sh
+++ b/.github/workflows/print_versions.sh
@@ -6,5 +6,8 @@
 set -e
 
 grass --version
-grass --tmp-location XY --exec g.version
+grass --tmp-location XY --exec g.version -e
+# Detailed Python version info (in one line thanks to echo)
+grass --tmp-location XY --exec bash -c "echo Python: \$(\$GRASS_PYTHON -c 'import sys; print(sys.version)')"
+python3 --version
 python --version

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -59,3 +59,7 @@ jobs:
           name: testreport-${{ matrix.os }}
           path: testreport
           retention-days: 3
+
+      - name: Print installed versions
+        if: always()
+        run: .github/workflows/print_versions.sh


### PR DESCRIPTION
To clearly show what version was installed and what dependencies are used, this prints version info at the end of Ubuntu and CentOS workflows (regardless of build status so possibly failing when GRASS GIS does not build correctly).
