### PR TITLE
grass.jupyter: Return session from init

### DIFF
--- a/doc/notebooks/basic_example_grass_jupyter.ipynb
+++ b/doc/notebooks/basic_example_grass_jupyter.ipynb
@@ -46,7 +46,7 @@
     "import grass.jupyter as gj\n",
     "\n",
     "# Start GRASS Session\n",
-    "gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")"
+    "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")"
    ]
   },
   {

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -357,45 +357,37 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Mapset and Session Management\n",
+    "## Switching Mapsets and Session Management\n",
     "\n",
-    "The `init` function returns a reference to a session object which can be used to manipulate the current session. The session is global (the global state of the environment is changed), but the session object is a handle for accessing this global session. Most importantly, keeping the reference means keeping the session active and that's all that is needed to properly use the session object.\n",
+    "The `init` function returns a reference to a session object which can be used to manipulate the current session. The session is global, i.e., the global state of the environment is changed. The session object is a handle for accessing this global session. When the kernel for the notebooks shuts down or is restarted, the session ends automatically. The session can be explicitly ended using `session.finish()`, but that's usually not needed in notebooks.\n",
     "\n",
     "Additionally, the session object can be used to change the current mapset. Here, we will switch to mapset called *PERMANENT*:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "session.switch_mapset(\"PERMANENT\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now we could add more data to the PERMANENT mapset or modify the existing data there. We don't need to do anything there, so we switch back to the mapset we were in before:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "session.switch_mapset(\"user1\")"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "When the kernel for the notebooks shuts down or is restarted, the session ends automatically. Specifically, the session is ended when the session object is garbage-collected. So, not keeping the reference returned by `init` will cause the session to end whenever Python decides to garbage-collect the session object. The session can be explicitly ended using `session.finish()`, but that's usually not needed in notebooks."
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -293,69 +293,69 @@
    "metadata": {},
    "source": [
     "Now, render a 3D visualization of an elevation raster as a surface colored using, again, the elevation raster:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "img.render(elevation_map=\"elevation\", color_map=\"elevation\", perspective=20)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To add a raster legend on the image as an overlay using the 2D rendering capabilities accessible with `overlay.d_legend`:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "img.overlay.d_legend(raster=\"elevation\", at=(60, 97, 87, 92))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Finally, we show "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "img.show()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Now, let's color the elevation surface using a landuse raster (note that the call to `render` removes the result of the previous `render` as well as the current overlays):"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "img.render(elevation_map=\"elevation\", color_map=\"landuse\", perspective=20)\n",
     "img.show()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Switching Mapsets and Session Management\n",
     "\n",

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -353,6 +353,49 @@
    ],
    "outputs": [],
    "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Mapset and Session Management\n",
+    "\n",
+    "The `init` function returns a reference to a session object which can be used to manipulate the current session. The session is global (the global state of the environment is changed), but the session object is a handle for accessing this global session. Most importantly, keeping the reference means keeping the session active and that's all that is needed to properly use the session object.\n",
+    "\n",
+    "Additionally, the session object can be used to change the current mapset. Here, we will switch to mapset called *PERMANENT*:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "session.switch_mapset(\"PERMANENT\")"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now we could add more data to the PERMANENT mapset or modify the existing data there. We don't need to do anything there, so we switch back to the mapset we were in before:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "session.switch_mapset(\"user1\")"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "When the kernel for the notebooks shuts down or is restarted, the session ends automatically. Specifically, the session is ended when the session object is garbage-collected. So, not keeping the reference returned by `init` will cause the session to end whenever Python decides to garbage-collect the session object. The session can be explicitly ended using `session.finish()`, but that's usually not needed in notebooks."
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -40,7 +40,7 @@
     "import grass.jupyter as gj\n",
     "\n",
     "# Start GRASS Session\n",
-    "gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
+    "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to the elevation raster.\n",
     "gs.run_command(\"g.region\", raster=\"elevation\")"

--- a/doc/notebooks/hydrology.ipynb
+++ b/doc/notebooks/hydrology.ipynb
@@ -43,7 +43,7 @@
     "import grass.jupyter as gj\n",
     "\n",
     "# Start GRASS Session\n",
-    "gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
+    "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to elevation raster\n",
     "gs.run_command(\"g.region\", raster=\"elevation\", flags=\"pg\")"

--- a/doc/notebooks/solar_potential.ipynb
+++ b/doc/notebooks/solar_potential.ipynb
@@ -42,7 +42,7 @@
     "import grass.jupyter as gj\n",
     "\n",
     "# Start GRASS Session\n",
-    "gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
+    "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to elevation raster\n",
     "gs.run_command(\"g.region\", raster=\"elevation@PERMANENT\", flags=\"pg\")"

--- a/doc/notebooks/viewshed_analysis.ipynb
+++ b/doc/notebooks/viewshed_analysis.ipynb
@@ -44,7 +44,7 @@
     "import grass.jupyter as gj\n",
     "\n",
     "# Start GRASS Session\n",
-    "gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
+    "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to elevation raster\n",
     "gs.run_command(\"g.region\", raster=\"elevation@PERMANENT\", flags=\"pg\")"

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -113,6 +113,14 @@ def init(path, location=None, mapset=None, grass_path=None):
     value to a variable. If you see ``GISRC - variable not set`` after calling
     a GRASS module, you know you have forgot to assign the result to a variable.
 
+    Since the clean up happens when the object is garbadge-collected, it may or may
+    not happen immediately. When you forget to assign the result to a variable, your
+    code may still work even if you don't assign it. However, you need to assign it
+    to ensure that your code always works.
+
+    The returned object can be used to switch to another mapset:
+
+    >>> session.switch_mapset("mapset_name")
 
     :param str path: path to grass databases
     :param str location: name of GRASS location

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -73,15 +73,17 @@ class _JupyterGlobalSession:
 
         if mapset_exists(arg):
             path, location, mapset = split_mapset_path(arg)
-            # TODO: Requires direct session file modification.
+            # This requires direct session file modification using g.gisenv because
             # g.mapset locks the mapset which is not how init and finish behave.
-            gs.run_command("g.mapset", dbase=path, location=location, mapset=mapset)
+            gs.run_command("g.gisenv", set=f"GISDBASE={path}")
+            gs.run_command("g.gisenv", set=f"LOCATION_NAME={location}")
+            gs.run_command("g.gisenv", set=f"MAPSET={mapset}")
             return
         gisenv = gs.gisenv()
         if mapset_exists(
             path=gisenv["GISDBASE"], location=gisenv["LOCATION_NAME"], mapset=arg
         ):
-            gs.run_command("g.mapset", mapset=arg)
+            gs.run_command("g.gisenv", set=f"MAPSET={arg}")
             return
         raise ValueError(_("Mapset '{}' does not exist").format(arg))
 

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -12,6 +12,7 @@
 #           for details.
 
 import os
+import weakref
 
 import grass.script as gs
 import grass.script.setup as gsetup
@@ -33,10 +34,85 @@ def _set_notebook_defaults():
     os.environ["GRASS_OVERWRITE"] = "1"
 
 
+class _JupyterGlobalSession:
+    """Represents a global GRASS session for Jupyter Notebooks.
+
+    Do not create objects of this class directly. Use the standalone *init* function
+    and an object will be returned to you, e.g.:
+
+    >>> import grass.jupyter as gj
+    >>> session = gj.init(...)
+
+    An object ends the session when it is destroyed or when the *finish* method is
+    called explicitely.
+
+    Notably, only the mapset is closed, but the libraries and GRASS modules
+    remain on path.
+    """
+
+    def __init__(self):
+        self._finalizer = weakref.finalize(self, gsetup.finish)
+
+    def switch_mapset(self, arg):
+        """Switch to a mapset provided as a name or path.
+
+        The *arg* positional-only parameter can be either name of a mapset in the
+        current location or a full path to a mapset.
+
+        Raises ValueError if the mapset does not exist or CalledModuleError if
+        call to the underlying the g.mapset module fails (e.g., when mapset is
+        invalid).
+        """
+        # The method could be a function, but this is more general (would work even for
+        # a non-global session) and users need to keep the reference anyway.
+        # pylint: disable=no-self-use
+        # Functions needed only here.
+        # pylint: disable=import-outside-toplevel
+        from grass.grassdb.checks import mapset_exists
+        from grass.grassdb.manage import split_mapset_path
+
+        if mapset_exists(arg):
+            path, location, mapset = split_mapset_path(arg)
+            # TODO: Requires direct session file modification.
+            # g.mapset locks the mapset which is not how init and finish behave.
+            gs.run_command("g.mapset", dbase=path, location=location, mapset=mapset)
+            return
+        gisenv = gs.gisenv()
+        if mapset_exists(
+            path=gisenv["GISDBASE"], location=gisenv["LOCATION_NAME"], mapset=arg
+        ):
+            gs.run_command("g.mapset", mapset=arg)
+            return
+        raise ValueError(_("Mapset '{}' does not exist").format(arg))
+
+    def finish(self):
+        """Close the session, i.e., close the opened mapset.
+
+        Subsequent calls to GRASS GIS modules will fail because there will be
+        no current (opened) mapset anymore.
+
+        The finish procedure is done automatically when process finishes or the object
+        is destroyed.
+        """
+        self._finalizer()
+
+
 def init(path, location=None, mapset=None, grass_path=None):
     """
     This function initiates a GRASS session and sets GRASS
     environment variables.
+
+    Calling this function returns an object which represents the session.
+
+    >>> import grass.jupyter as gj
+    >>> session = gj.init(...)
+
+    When the object is destroyed, the session is ended. Therefore, it is necessary
+    to keep a reference to the object as long as the session should remain active.
+    In a notebook, this is normally achieved by simply assigning the function return
+    value to a variable. If you see ``GISRC - variable not set`` after calling
+    a GRASS module, you know you have forgot to assign the result to a variable.
+
 
     :param str path: path to grass databases
     :param str location: name of GRASS location
@@ -46,3 +122,4 @@ def init(path, location=None, mapset=None, grass_path=None):
     gsetup.init(path, location=location, mapset=mapset, grass_path=grass_path)
     # Set GRASS env. variables
     _set_notebook_defaults()
+    return _JupyterGlobalSession()


### PR DESCRIPTION
* Calling grass.script.setup.init needs to paired with a call to finish.
* Explicit call to finish would have to be commented out in most notebooks with notes about nothing working once this is called, but an explanation of the need to call it at some point (confusing).
* atexit does not or may not work in Jupyter (IPython kernel). It does not for me locally and the Internet is full of various notes about not working in certain cases or versions.
* Returned session object uses weakref.finalize technique (used, e.g., in the Python standard library temporary directory object) to call the finish procedure.
* The session object takes care of switching the mapset although there is nothing in the object needed to do that since the state is global anyway.
* User needs to hold result of init, e.g., s = init(...), otherwise the session will end immediately.
