### PR TITLE
init: Default to Bash, fallback to sh

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1664,12 +1664,20 @@ def get_shell():
         os.environ["SHELL"] = "/usr/bin/bash.exe"
         os.environ["OSTYPE"] = "cygwin"
     else:
-        # in docker the 'SHELL' variable may not be
-        # visible in a Python session unless 'ENV SHELL /bin/bash' is set in Dockerfile
-        try:
-            sh = os.path.basename(os.getenv("SHELL"))
-        except:
-            sh = "sh"
+        # In a Docker container the 'SHELL' variable may not be set
+        # unless 'ENV SHELL /bin/bash' is set in Dockerfile. However, often Bash
+        # is available, so we try Bash first and fall back to sh if needed.
+        sh = os.getenv("SHELL")
+        if sh:
+            sh = os.path.basename(sh)
+        else:
+            # If SHELL is not set, see if there is Bash and use it.
+            if shutil.which("bash"):
+                sh = "bash"
+            else:
+                # Fallback to sh if there is no Bash on path.
+                sh = "sh"
+            # Ensure the variable is set.
             os.environ["SHELL"] = sh
 
         if WINDOWS and sh:


### PR DESCRIPTION
* When SHELL env var was not set, sh would be used which likely unexpected if bash is on path.
* Now bash presence is tested and it is used if available.
* If there is no bash on path, sh is used as a fallback.
* As a bonus, this works also with an empty SHELL variable and avoids use of bare except.
