### PR TITLE
open_stds: check for unknown band references

### DIFF
--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -197,9 +197,13 @@ def dataset_mapcalculator(
         for dataset in input_list:
             list = dataset.get_registered_maps_as_objects(dbif=dbif)
 
-            if list is None:
+            if list is None or len(list) < 1:
                 dbif.close()
-                msgr.message(_("No maps registered in input dataset"))
+                msgr.message(
+                    _("No maps registered in input dataset <{}>").format(
+                        dataset.get_name()
+                    )
+                )
                 return 0
 
             map_name_list = []

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -52,7 +52,15 @@ def open_old_stds(name, type, dbif=None):
     band_ref = None
     if name.find(".") > -1:
         try:
+            from grass.bandref import BandReferenceReader
+
             name, band_ref = name.split(".")
+            if band_ref not in BandReferenceReader().get_bands():
+                msgr.fatal(
+                    "Unknown <{}> band reference. Run g.bands module to list supported bands.".format(
+                        band_ref
+                    )
+                )
         except ValueError:
             msgr.fatal("Invalid name of the space time dataset. Only one dot allowed.")
     id = name + "@" + mapset

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -58,7 +58,7 @@ def open_old_stds(name, type, dbif=None):
             if band_ref not in BandReferenceReader().get_bands():
                 msgr.fatal(
                     "Unknown <{}> band reference. "
-                    "Run g.bands module to list supported bands.".format(band_ref)
+                    "Check available band names in the current strds .".format(band_ref)
                 )
         except ValueError:
             msgr.fatal("Invalid name of the space time dataset. Only one dot allowed.")

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -52,14 +52,7 @@ def open_old_stds(name, type, dbif=None):
     band_ref = None
     if name.find(".") > -1:
         try:
-            from grass.bandref import BandReferenceReader
-
             name, band_ref = name.split(".")
-            if band_ref not in BandReferenceReader().get_bands():
-                msgr.fatal(
-                    "Unknown <{}> band reference. "
-                    "Check available band names in the current strds .".format(band_ref)
-                )
         except ValueError:
             msgr.fatal("Invalid name of the space time dataset. Only one dot allowed.")
     id = name + "@" + mapset

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -57,9 +57,8 @@ def open_old_stds(name, type, dbif=None):
             name, band_ref = name.split(".")
             if band_ref not in BandReferenceReader().get_bands():
                 msgr.fatal(
-                    "Unknown <{}> band reference. Run g.bands module to list supported bands.".format(
-                        band_ref
-                    )
+                    "Unknown <{}> band reference. "
+                    "Run g.bands module to list supported bands.".format(band_ref)
                 )
         except ValueError:
             msgr.fatal("Invalid name of the space time dataset. Only one dot allowed.")


### PR DESCRIPTION
`t.rast.mapcalc` on unknown band reference (in this case `S2_B4`):

```bash
t.rast.mapcalc inputs=s2_tile_5606.S2_8A,s2_tile_5606.S2_B4 output=ndvi basename=ndvi expression="float(s2_tile_5606.S2_8A - s2_tile_5606.S2_4) / (s2_tile_5606.S2_8A + s2_tile_5606.S2_4)" --o 
```

fails with unclear error message:

```py
Starting temporal sampling...
Traceback (most recent call last):
Starting mapcalc   File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/t.rast.mapcalc", line 119, in <module>
computation...
    main()
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/t.rast.mapcalc", line 102, in main
    tgis.dataset_mapcalculator(
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/temporal/mapcalc.py", line 248, in dataset_mapcalculator
    if map_matrix[j][i] is None:
IndexError: list index out of range
```

This PR introduces a proper error message:

```bash
ERROR: Unknown <S2_B4> band reference. Run g.bands module to list supported
bands.
 ```