### PR TITLE
grass.jupyter: add property filename to GrassRenderer

### DIFF
--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -96,6 +96,16 @@ class GrassRenderer:
         self._legend_file = os.path.join(self._tmpdir.name, "legend.txt")
         self._env["GRASS_LEGEND_FILE"] = str(self._legend_file)
 
+    @property
+    def filename(self):
+        """Filename or full path to the file with the resulting image.
+
+        The value can be set during initialization. When the filename was not provided
+        during initialization, a path to temporary file is returned. In that case, the
+        file is guaranteed to exist as long as the object exists.
+        """
+        return self._filename
+
     def run(self, module, **kwargs):
         """Run modules from the GRASS display family (modules starting with "d.").
 

--- a/python/grass/jupyter/testsuite/grassrenderer_test.py
+++ b/python/grass/jupyter/testsuite/grassrenderer_test.py
@@ -92,6 +92,14 @@ class TestDisplay(TestCase):
         # Make sure image was created
         self.assertFileExists(custom_filename)
 
+    def test_filename_property(self):
+        """Test of GrassRenderer filename property."""
+        # Create map with unique filename
+        grass_renderer = gj.GrassRenderer()
+        grass_renderer.run("d.rast", map="elevation")
+        # Make sure image was created
+        self.assertFileExists(grass_renderer.filename)
+
     def test_hw(self):
         """Test that GrassRenderer creates maps with custom height and widths."""
         # Create map with height and width parameters


### PR DESCRIPTION
Useful for directly accessing filename of rendered image, e.g. for creating animations
