### PR TITLE
r.external: add flag to read min/max from metadata

### DIFF
--- a/raster/r.external/link.c
+++ b/raster/r.external/link.c
@@ -47,8 +47,21 @@ void query_band(GDALRasterBandH hBand, const char *output,
 	break;
     }
 
-    if (info->have_minmax)
+    if (info->have_minmax == 1) {
 	GDALComputeRasterMinMax(hBand, 0, info->minmax);
+    }
+    else if (info->have_minmax == 2) {
+	double min, max, mean, stddev;
+
+	G_warning(_("Statistics in metadata are sometimes approximations: min and max can be wrong!"));
+
+	if (GDALGetRasterStatistics(hBand, false, true, &min, &max,
+	                            &mean, &stddev) != CE_None) {
+	    G_fatal_error(_("Unable to get raster band statistics"));
+	}
+	info->minmax[0] = min;
+	info->minmax[1] = max;
+    }
 
     Rast_init_colors(&info->colors);
 


### PR DESCRIPTION
This PR adds a new flag `-m` to read min/max from metadata. This is DANGEROUS because statistics in metadata are sometimes approximations: min and max can be wrong. Amongst other issues, display will not work, with cell values outside the wrong range being invisible. However, reading statistics from metadata happens instantly, while scanning the actual data to determine min/max can take some time for larger raster maps. Thus, if a user is confident that the statistics in the metadata of a GDAL raster band are accurate, this new flag can be used to speed up data registration.