### PR TITLE
TGIS: add list of band names to t.info

### DIFF
--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -1406,12 +1406,10 @@ class STRDSMetadata(STDSRasterMetadataBase):
 
         sql = "SELECT distinct band_reference FROM %s WHERE %s.id " % (
             "raster_metadata",
-            "raster_metadata"
+            "raster_metadata",
         )
 
-        sql += "IN (SELECT id FROM %s)" % (
-            str(self.get_raster_register())
-        )
+        sql += "IN (SELECT id FROM %s)" % (str(self.get_raster_register()))
 
         dbif = SQLDatabaseInterfaceConnection()
         dbif.connect()
@@ -1456,7 +1454,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
             print("band_names=" + str(self.get_band_names()))
         else:
             print(" | Number of registered bands:. " + str(self.get_number_of_bands()))
-            print(" | Bands:...................... " + str(self.get_band_names()))
+            print(" | Band names:................. " + str(self.get_band_names()))
 
 
 ###############################################################################

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -201,9 +201,7 @@ def register_maps_in_space_time_dataset(
             if band_reference_in_file:
                 idx = 3 if end_time_in_file else 2
                 # case-sensitive, the user decides on the band name
-                row["band_reference"] = (
-                    line_list[idx].strip()
-                )
+                row["band_reference"] = line_list[idx].strip()
 
             row["id"] = AbstractMapDataset.build_id(mapname, mapset)
 

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -200,9 +200,10 @@ def register_maps_in_space_time_dataset(
 
             if band_reference_in_file:
                 idx = 3 if end_time_in_file else 2
+                # case-sensitive, the user decides on the band name
                 row["band_reference"] = (
-                    line_list[idx].strip().upper()
-                )  # case-insensitive
+                    line_list[idx].strip()
+                )
 
             row["id"] = AbstractMapDataset.build_id(mapname, mapset)
 


### PR DESCRIPTION
Currently, `t.info` lists only the number of bands, but not the band names.This PR adds a list of band names, if present, to the output of `t.info`. Such a list of band names provided by `t.info` is needed by actinia and the openeo GRASS backend.

How to test (adapted from a test in `t.register`):
```
# The region setting should work for UTM and LL test locations
g.region s=0 n=80 w=0 e=120 b=0 t=50 res=10 res3=10 -p3

# Generate data
r.mapcalc  expr="prec_1 = rand(0, 550)" -s
r.mapcalc  expr="prec_2 = rand(0, 450)" -s
r.mapcalc  expr="prec_3 = rand(0, 320)" -s
r.mapcalc  expr="prec_4 = rand(0, 510)" -s
r.mapcalc  expr="prec_5 = rand(0, 300)" -s
r.mapcalc  expr="prec_6 = rand(0, 650)" -s

# create a strds
t.create  type=strds temporaltype=absolute output=prec_bands title="A test" descr="A test"

# create a text file with dummy band names (different names, each name at least twice)
cat > file_list_with_bands << EOF
prec_1|2001-01-01 00:00:00|2001-02-01 00:00:00|prec1
prec_2|2001-02-01 00:00:00|2001-03-01 00:00:00|prec1
prec_3|2001-03-01 00:00:00|2001-04-01 00:00:00|prec2
prec_4|2001-04-01 00:00:00|2001-05-01 00:00:00|prec2
prec_5|2001-05-01 00:00:00|2001-06-01 00:00:00|prec3
prec_6|2001-06-01 00:00:00|2001-07-01 00:00:00|prec3
EOF

# register the raster maps
t.register --o -i input=prec_bands file=file_list_with_bands

# t.info
t.info type=strds input=prec_bands
```

Output contains
```
 | Number of registered bands:. 3
 | Band names:................. prec1,prec2,prec3
```
in shell style
```
number_of_bands=3
band_names=prec1,prec2,prec3
```
