### PR TITLE
docker: fix configuration error and warnings after autoconf-2.69 update

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -89,17 +89,16 @@ FROM common as build
 ENV GRASS_CONFIG="\
       --enable-largefile \
       --with-cxx \
-      --with-proj --with-proj-share=/usr/share/proj \
+      --with-proj-share=/usr/share/proj \
       --with-gdal \
       --with-pdal \
-      --with-python \
       --with-geos \
       --with-sqlite \
       --with-bzlib \
       --with-zstd \
       --with-cairo --with-cairo-ldflags=-lfontconfig \
       --with-fftw \
-      --with-postgres --with-postgres-includes='/usr/include/postgresql' \
+      --with-postgres --with-postgres-includes=/usr/include/postgresql \
       --without-freetype \
       --without-openmp \
       --without-opengl \
@@ -107,7 +106,6 @@ ENV GRASS_CONFIG="\
       --without-mysql \
       --without-odbc \
       --without-openmp \
-      --without-ffmpeg \
       "
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -174,14 +174,14 @@ RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
   --with-cxx \
   --enable-largefile \
-  --with-proj --with-proj-share=/usr/share/proj \
+  --with-proj-share=/usr/share/proj \
   --with-gdal=/usr/bin/gdal-config \
   --with-geos \
   --with-sqlite \
   --with-cairo --with-cairo-ldflags=-lfontconfig \
   --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
   --with-fftw \
-  --with-postgres=yes --with-postgres-includes="/usr/include/postgresql" \
+  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
   --with-netcdf \
   --with-zstd \
   --with-bzlib \
@@ -189,7 +189,6 @@ RUN /src/grass_build/configure \
   --without-mysql \
   --without-odbc \
   --without-openmp \
-  --without-ffmpeg \
   --without-opengl \
     && make -j $NUMTHREADS \
     && make install && ldconfig

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -166,14 +166,14 @@ RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
   --with-cxx \
   --enable-largefile \
-  --with-proj --with-proj-share=/usr/share/proj \
+  --with-proj-share=/usr/share/proj \
   --with-gdal=/usr/bin/gdal-config \
   --with-geos \
   --with-sqlite \
   --with-cairo --with-cairo-ldflags=-lfontconfig \
   --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
   --with-fftw \
-  --with-postgres=yes --with-postgres-includes="/usr/include/postgresql" \
+  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
   --with-netcdf \
   --with-zstd \
   --with-bzlib \
@@ -181,7 +181,6 @@ RUN /src/grass_build/configure \
   --without-mysql \
   --without-odbc \
   --without-openmp \
-  --without-ffmpeg \
   --without-opengl \
     && make -j $NUMTHREADS \
     && make install && ldconfig


### PR DESCRIPTION
This addresses configuration failure on Alpine Docker and warnings on all (Alpine, Debian, Ubuntu).

- Remove single quotes around include directory in configuration causing compilation error
- Remove non-existing configuration options

(To check available configuration options: `./configure --help`.


ALPINE

```
#22 [build 4/6] RUN echo "  => Configure and compile grass" &&     /src/grass_build/configure       --enable-largefile       --with-cxx       --with-proj --with-proj-share=/usr/share/proj       --with-gdal       --with-pdal       --with-python       --with-geos       --with-sqlite       --with-bzlib       --with-zstd       --with-cairo --with-cairo-ldflags=-lfontconfig       --with-fftw       --with-postgres --with-postgres-includes='/usr/include/postgresql'       --without-freetype       --without-openmp       --without-opengl       --without-nls       --without-mysql       --without-odbc       --without-openmp       --without-ffmpeg        &&     make -j 2 &&     make install &&     ldconfig /etc/ld.so.conf.d
#22 0.066   => Configure and compile grass
#22 0.145 configure: WARNING: unrecognized options: --with-proj, --with-python, --without-ffmpeg


...

#22 6.350 checking for location of PostgreSQL includes... '/usr/include/postgresql'
#22 6.351 configure: error: *** PostgreSQL includes directory '/usr/include/postgresql' does not exist.
------
Dockerfile:167
--------------------
 166 |     # Configure compile and install GRASS GIS
 167 | >>> RUN echo "  => Configure and compile grass" && \
 168 | >>>     /src/grass_build/configure $GRASS_CONFIG && \
 169 | >>>     make -j $NUMTHREADS && \
 170 | >>>     make install && \
 171 | >>>     ldconfig /etc/ld.so.conf.d
 172 |     
--------------------
error: failed to solve: process "/bin/sh -c echo \"  => Configure and compile grass\" &&     /src/grass_build/configure $GRASS_CONFIG &&     make -j $NUMTHREADS &&     make install &&     ldconfig /etc/ld.so.conf.d" did not complete successfully: exit code: 1
##[error]buildx failed with: error: failed to solve: process "/bin/sh -c echo \"  => Configure and compile grass\" &&     /src/grass_build/configure $GRASS_CONFIG &&     make -j $NUMTHREADS &&     make install &&     ldconfig /etc/ld.so.conf.d" did not complete successfully: exit code: 1
```


UBUNTU + DEBIAN
```
#23 [18/33] RUN /src/grass_build/configure   --with-cxx   --enable-largefile   --with-proj --with-proj-share=/usr/share/proj   --with-gdal=/usr/bin/gdal-config   --with-geos   --with-sqlite   --with-cairo --with-cairo-ldflags=-lfontconfig   --with-freetype --with-freetype-includes="/usr/include/freetype2/"   --with-fftw   --with-postgres=yes --with-postgres-includes="/usr/include/postgresql"   --with-netcdf   --with-zstd   --with-bzlib   --with-pdal   --without-mysql   --without-odbc   --without-openmp   --without-ffmpeg   --without-opengl     && make -j 4     && make install && ldconfig
#23 0.238 configure: WARNING: unrecognized options: --with-proj, --without-ffmpeg

```