### PR TITLE
configure: fix some autoconf-2.69 update issues (branch 7.8)

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -316,7 +316,7 @@ int main(void) {
 
 AC_DEFUN([LOC_CHECK_FP_INF_NAN],[
 AC_MSG_CHECKING([for full floating-point support]$1)
-AC_RUN_IFELSE([AC_LANG_SOURCE([[LOC_FP_TEST]])],[   AC_MSG_RESULT(yes)
+AC_RUN_IFELSE([AC_LANG_SOURCE([LOC_FP_TEST])],[   AC_MSG_RESULT(yes)
     $2],[   AC_MSG_RESULT(no)
     $3],[   AC_MSG_RESULT([unknown (cross-compiling)])
     $4

--- a/configure
+++ b/configure
@@ -582,7 +582,7 @@ PACKAGE_STRING=
 PACKAGE_BUGREPORT=
 PACKAGE_URL=
 
-ac_unique_file="configure.in"
+ac_unique_file="configure.ac"
 # Factoring default headers for most tests.
 ac_includes_default="\
 #include <stdio.h>

--- a/configure
+++ b/configure
@@ -3607,7 +3607,17 @@ CFLAGS=${ac_save_cflags}
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-LOC_FP_TEST
+
+#include <float.h>
+int main(void) {
+ double one = 1.0;
+ double zero = 0.0;
+ if (one/zero > DBL_MAX)        /* infinity */
+   if (zero/zero != zero/zero)  /* NaN */
+     return 0;
+ return 1;
+}
+
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
@@ -3629,7 +3639,17 @@ $as_echo "unknown (cross-compiling)" >&6; }
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-LOC_FP_TEST
+
+#include <float.h>
+int main(void) {
+ double one = 1.0;
+ double zero = 0.0;
+ if (one/zero > DBL_MAX)        /* infinity */
+   if (zero/zero != zero/zero)  /* NaN */
+     return 0;
+ return 1;
+}
+
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/configure
+++ b/configure
@@ -3746,38 +3746,6 @@ fi
 
 
 
-# Use absolute path for aux directory so that install-sh works
-
-ac_aux_dir=
-for ac_dir in "$SRCDIR" "$srcdir"/"$SRCDIR"; do
-  if test -f "$ac_dir/install-sh"; then
-    ac_aux_dir=$ac_dir
-    ac_install_sh="$ac_aux_dir/install-sh -c"
-    break
-  elif test -f "$ac_dir/install.sh"; then
-    ac_aux_dir=$ac_dir
-    ac_install_sh="$ac_aux_dir/install.sh -c"
-    break
-  elif test -f "$ac_dir/shtool"; then
-    ac_aux_dir=$ac_dir
-    ac_install_sh="$ac_aux_dir/shtool install -c"
-    break
-  fi
-done
-if test -z "$ac_aux_dir"; then
-  as_fn_error $? "cannot find install-sh, install.sh, or shtool in \"$SRCDIR\" \"$srcdir\"/\"$SRCDIR\"" "$LINENO" 5
-fi
-
-# These three variables are undocumented and unsupported,
-# and are intended to be withdrawn in a future Autoconf release.
-# They can cause serious problems if a builder's source tree is in a directory
-# whose full name contains unusual characters.
-ac_config_guess="$SHELL $ac_aux_dir/config.guess"  # Please don't use this var.
-ac_config_sub="$SHELL $ac_aux_dir/config.sub"  # Please don't use this var.
-ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
-
-
-
 # Set GISBASE and GRASS_BIN
 
 GISBASE="${WINDSTDIR}/dist.${ARCH}"

--- a/configure.ac
+++ b/configure.ac
@@ -102,10 +102,6 @@ fi
 
 AC_SUBST(ARCH)
 
-# Use absolute path for aux directory so that install-sh works
-
-AC_CONFIG_AUX_DIR("$SRCDIR")
-
 # Set GISBASE and GRASS_BIN
 
 GISBASE="${WINDSTDIR}/dist.${ARCH}"

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ $2
 ])
 
 AC_INIT
-AC_CONFIG_SRCDIR([configure.in])
+AC_CONFIG_SRCDIR([configure.ac])
 AC_PREREQ([2.69])
 AC_CONFIG_HEADER(include/config.h)
 AC_CANONICAL_HOST

--- a/lib/gis/compress.h
+++ b/lib/gis/compress.h
@@ -12,7 +12,7 @@
 
 /* adding a new compressor:
  * add the corresponding functions G_*compress() and G_*_expand()
- * if needed, add checks to configure.in and include/config.in
+ * if needed, add checks to configure.ac and include/config.h.in
  * modify compress.h (this file)
  * nothing to change in compress.c
  */


### PR DESCRIPTION
This renames `configure.in` to `configure.ac`, the previous name has long been deprecated and became obsolete with 2.70. 

Also addressed:
- No need to set AC_CONFIG_AUX_DIR, default will do
- Remove double quote on macro 'LOC_FP_TEST'

Addresses remaining issues after merging #1867 as reported with #560.