### PR TITLE
lib/raster/gdal.c: add recent GDAL dlls

### DIFF
--- a/lib/raster/gdal.c
+++ b/lib/raster/gdal.c
@@ -116,6 +116,9 @@ static void load_library(void)
 	"libgdal1.7.0.so",
 # endif
 # ifdef _WIN32
+	"gdal303.dll",
+	"gdal302.dll",
+	"gdal301.dll",
 	"gdal300.dll",
 	"gdal204.dll",        
 	"gdal203.dll",        


### PR DESCRIPTION
This is a quick fix / work around for #1872
It kicks the can down the road (until after release of 7.8.6), if no one else comes up with a proper solution before that.
It is a rather simple change and should probably go into 7.8.6...