### PR TITLE
Fix link to startup script manual page

### DIFF
--- a/man/build_html.py
+++ b/man/build_html.py
@@ -122,7 +122,7 @@ overview_tmpl = string.Template(
       </td>
       <td width="33%" valign="top" class="box"><h3>&nbsp;General</h3>
        <ul>
-        <li class="box"><a href="grass${grass_version_major}.html">GRASS GIS startup manual</a></li>
+        <li class="box"><a href="grass.html">GRASS GIS startup manual</a></li>
         <li class="box"><a href="general.html">General commands manual</a></li>
        </ul>
         <h3>&nbsp;Addons</h3>


### PR DESCRIPTION
The startup script no longer contains the major version and hence it now lives here https://grass.osgeo.org/grass80/manuals/grass.html instead of https://grass.osgeo.org/grass80/manuals/grass8.html.

This should fix what was pointed out in grass-user by Rich Sheppard: https://lists.osgeo.org/pipermail/grass-user/2021-September/082548.html