### PR TITLE
wxGUI/vdigit: show error message dialog if no vector map is open for editing, after activate 'Z bulk-labeling of 3D lines' tool

### DIFF
--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -360,7 +360,13 @@ class VDigitToolbar(BaseToolbar):
         :return: True if no vector map is open for editing else None
         """
         if not self.digit:
-            GError(_("No vector map is open for editing."), self.parent)
+            GError(
+                _(
+                    "No vector map is open for editing. Please select first"
+                    "the vector map from the combo box."
+                ),
+                self.parent,
+            )
             return True
 
     def OnTool(self, event):

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -354,6 +354,15 @@ class VDigitToolbar(BaseToolbar):
 
         return self._getToolbarData(data)
 
+    def _noVMapOpenForEditingErrDlg(self):
+        """Show error message dialog if no vector map is open for editing
+
+        :return: True if no vector map is open for editing else None
+        """
+        if not self.digit:
+            GError(_("No vector map is open for editing."), self.parent)
+            return True
+
     def OnTool(self, event):
         """Tool selected -> untoggles previusly selected tool in
         toolbar"""
@@ -687,8 +696,7 @@ class VDigitToolbar(BaseToolbar):
 
     def OnCopy(self, event):
         """Copy selected features from (background) vector map"""
-        if not self.digit:
-            GError(_("No vector map open for editing."), self.parent)
+        if self._noVMapOpenForEditingErrDlg():
             return
 
         # select background map
@@ -847,6 +855,8 @@ class VDigitToolbar(BaseToolbar):
 
     def OnZBulk(self, event):
         """Z bulk-labeling selected lines/boundaries"""
+        if self._noVMapOpenForEditingErrDlg():
+            return
         if not self.digit.IsVector3D():
             GError(
                 parent=self.parent,

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -363,7 +363,7 @@ class VDigitToolbar(BaseToolbar):
             GError(
                 _(
                     "No vector map is open for editing. Please select first"
-                    "the vector map from the combo box."
+                    "a vector map from the combo box."
                 ),
                 self.parent,
             )


### PR DESCRIPTION
**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Add some vector map e.g. railroads
3. On the Map Display window activate Vector digitizer
4. Don't choose any vector map from ComboBox widget
5. On the Vector digitizer toolbar from the Additional tool menu, choose Z bulk-labeling of 3D lines tool
6. You get error message

**Error message**

```
Traceback (most recent call last):
  File "/usr/lib64/grass79/gui/wxpython/vdigit/toolbars.py",
line 857, in OnZBulk

if not self.digit.IsVector3D():
AttributeError
:
'NoneType' object has no attribute 'IsVector3D'
```

**Expected behavior**

Show error message dialog with the relevant text message.

**Additional context**

Cosmetic fix.