### PR TITLE
wxGUI/lmgr: add the ability to restart the wxGUI

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -2383,6 +2383,10 @@ class QuitDialog(wx.Dialog):
         if self._shell_running:
             self.btnClose = Button(parent=self.panel, id=wx.ID_NO, label=_("Close GUI"))
             self.btnClose.Bind(wx.EVT_BUTTON, self.OnClose)
+            self.btnRestart = Button(
+                parent=self.panel, id=wx.ID_NO, label=_("Restart GUI")
+            )
+            self.btnRestart.Bind(wx.EVT_BUTTON, self.OnRestart)
         self.btnQuit = Button(
             parent=self.panel, id=wx.ID_YES, label=_("Quit GRASS GIS")
         )
@@ -2398,6 +2402,7 @@ class QuitDialog(wx.Dialog):
         btnSizer = wx.BoxSizer(wx.HORIZONTAL)
         btnSizer.Add(self.btnCancel, flag=wx.RIGHT, border=5)
         if self._shell_running:
+            btnSizer.Add(self.btnRestart, flag=wx.RIGHT, border=5)
             btnSizer.Add(self.btnClose, flag=wx.RIGHT, border=5)
         btnSizer.Add(self.btnQuit, flag=wx.RIGHT, border=5)
 
@@ -2411,6 +2416,9 @@ class QuitDialog(wx.Dialog):
         self.panel.SetSizer(sizer)
         sizer.Fit(self)
         self.Layout()
+
+    def OnRestart(self, event):
+        self.EndModal(wx.ID_RESET)
 
     def OnClose(self, event):
         self.EndModal(wx.ID_NO)

--- a/gui/wxpython/xml/toolboxes.xml
+++ b/gui/wxpython/xml/toolboxes.xml
@@ -42,6 +42,7 @@
       <wxgui-item name="LaunchScript"/>
       <wxgui-item name="PyEdit"/>
       <separator/>
+      <wxgui-item name="RestartGUI"/>
       <wxgui-item name="CloseGUI"/>
       <wxgui-item name="Quit"/>
     </items>

--- a/gui/wxpython/xml/wxgui_items.xml
+++ b/gui/wxpython/xml/wxgui_items.xml
@@ -67,6 +67,11 @@
     <handler>OnSimpleEditor</handler>
     <description>Launches Simple Python Editor.</description>
   </wxgui-item>
+  <wxgui-item name="RestartGUI">
+    <label>Restart GUI</label>
+    <handler>OnRestartWindow</handler>
+    <description>Restart graphical user interface.</description>
+  </wxgui-item>
   <wxgui-item name="CloseGUI">
     <label>Close GUI</label>
     <handler>OnCloseWindow</handler>


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
After changing the wxGUI settings, some changes require a restart of the wxGUI, ie closing the wxGUI and launching it again via type `g.gui` command into emulator terminal.

**Describe the solution you'd like**
Interactive way to restart wxGUI via menu item or button on the quit dialog.

**Screenshots**

Restart wxGUI via menu item:

<img width="648" alt="wxGUI_restart_gui_via_menu_item" src="https://user-images.githubusercontent.com/50632337/133925501-d39c67dd-f596-4111-bb95-b9981fbe44b9.png">

Restart wxGUI via button on the quit dialog:

<img width="648" alt="wxGUI_restart_gui_via_quit_dialog_button" src="https://user-images.githubusercontent.com/50632337/133925995-a50f1fb0-e25b-4f53-a312-7be138aaf485.png">

