### PR TITLE
gui: restrict north/south to 90/-90 and west/east to -180/180

### DIFF
--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -249,8 +249,8 @@ class RenderWMSMgr(wx.EvtHandler):
 
             center = (region["east"] - region["west"]) / 2
 
-            region["east"] = center + delta + region["west"]
-            region["west"] = center - delta + region["west"]
+            region["east"] = min(center + delta + region["west"], 180.0)
+            region["west"] = max(center - delta + region["west"], -180.0)
             region["e-w resol"] = region["n-s resol"]
 
         else:
@@ -258,8 +258,8 @@ class RenderWMSMgr(wx.EvtHandler):
 
             center = (region["north"] - region["south"]) / 2
 
-            region["north"] = center + delta + region["south"]
-            region["south"] = center - delta + region["south"]
+            region["north"] = min(center + delta + region["south"], 90.0)
+            region["south"] = max(center - delta + region["south"], -90.0)
             region["n-s resol"] = region["e-w resol"]
 
     def Abort(self):

--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -253,7 +253,7 @@ class RenderWMSMgr(wx.EvtHandler):
             region["west"] = center - delta + region["west"]
             region["e-w resol"] = region["n-s resol"]
 
-            if region["proj"] == 3: # LL locations
+            if region["proj"] == 3:  # LL locations
                 region["east"] = min(region["east"], 180.0)
                 region["west"] = max(region["west"], -180.0)
 
@@ -266,7 +266,7 @@ class RenderWMSMgr(wx.EvtHandler):
             region["south"] = center - delta + region["south"]
             region["n-s resol"] = region["e-w resol"]
 
-            if region["proj"] == 3: # LL locations
+            if region["proj"] == 3:  # LL locations
                 region["north"] = min(region["north"], 90.0)
                 region["south"] = max(region["south"], -90.0)
 

--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -249,18 +249,26 @@ class RenderWMSMgr(wx.EvtHandler):
 
             center = (region["east"] - region["west"]) / 2
 
-            region["east"] = min(center + delta + region["west"], 180.0)
-            region["west"] = max(center - delta + region["west"], -180.0)
+            region["east"] = center + delta + region["west"]
+            region["west"] = center - delta + region["west"]
             region["e-w resol"] = region["n-s resol"]
+
+            if region["proj"] == 3: # LL locations
+                region["east"] = min(region["east"], 180.0)
+                region["west"] = max(region["west"], -180.0)
 
         else:
             delta = region["e-w resol"] * size["rows"] / 2
 
             center = (region["north"] - region["south"]) / 2
 
-            region["north"] = min(center + delta + region["south"], 90.0)
-            region["south"] = max(center - delta + region["south"], -90.0)
+            region["north"] = center + delta + region["south"]
+            region["south"] = center - delta + region["south"]
             region["n-s resol"] = region["e-w resol"]
+
+            if region["proj"] == 3: # LL locations
+                region["north"] = min(region["north"], 90.0)
+                region["south"] = max(region["south"], -90.0)
 
     def Abort(self):
         """Abort rendering process"""


### PR DESCRIPTION
# How to reproduce the issue that this PR fixes
```bash
grass -c epsg:4326 test
# set the world region
g.region n=90 s=-90 w=-180 e=180
g.gui
# add OpenStreetMap WMS through GUI
```
![image](https://user-images.githubusercontent.com/7456117/133942467-25d40134-d15d-4d7e-9f20-c08fbfb0b662.png)

Get the following error:
```
GRASS_INFO_ERROR(14353,1): Illegal latitude for North: 112.855
GRASS_INFO_END(14353,1)
Traceback (most recent call last):
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/gui/scripts/d.wms", line 218, in <module>
    sys.exit(main())
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/gui/scripts/d.wms", line 210, in main
    temp_map = wms.GetMap(options, flags)
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/etc/r.in.wms/wms_base.py", line 229, in GetMap
    self._initializeParameters(options, flags)
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/etc/r.in.wms/wms_base.py", line 129, in _initializeParameters
    self.proj_location = grass.read_command("g.proj", flags="jf").rstrip("\n")
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 610, in read_command
    return handle_errors(returncode, stdout, args, kwargs)
  File "/home/user/usr/grass/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 428, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `g.proj -jf` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.

GRASS_INFO_ERROR(14354,1): Module run `d.wms --q wms_version=1.1.1 driver=WMS_GRASS url=https://ows.terrestris.de/osm/service? layers=OSM-WMS styles= format=png srs=4326 maxcols=500 maxrows=500 urlparams= method=cubicspline map=OpenStreetMap WMS - by terrestris` ended with an error.

GRASS_INFO_ERROR(14354,1): The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
GRASS_INFO_END(14354,1)
ERROR 4: /home/user/tmp/test/PERMANENT/.tmp/yoga/13841.4: No such file or directory
ERROR 4: /home/user/tmp/test/PERMANENT/.tmp/yoga/13841.4: No such file or directory
```

# Why it happens
The following line adjusts north=90 and south=-90 to north=112.85540704139999 and south=-112.8554070414 using the aspect ratio of the display:
https://github.com/OSGeo/grass/blob/75dd60a694198f7bca17b7e3d6387b6eefa9bb7a/gui/wxpython/core/ws.py#L98

# Solution
This PR restricts the limits of north/south/west/east to 90/-90/-180/180 in `_fitAspect()`.

# BUT?
The world OSM basemap extends beyond the world region?
![image](https://user-images.githubusercontent.com/7456117/133942669-c4de7323-78e6-45b0-9155-0f2ede6de194.png)