### PR TITLE
wxGUI/vdigit: use 'FloatSpin' widget, which allows you to set the decimal snapping threshold value

### DIFF
--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -23,7 +23,7 @@ import wx.lib.colourselect as csel
 from gui_core.gselect import ColumnSelect
 from core.units import Units
 from core.settings import UserSettings
-from gui_core.wrap import Button, CheckBox, SpinCtrl, StaticBox, StaticText
+from gui_core.wrap import Button, CheckBox, FloatSpin, SpinCtrl, StaticBox, StaticText
 
 
 class VDigitSettingsDialog(wx.Dialog):
@@ -179,13 +179,14 @@ class VDigitSettingsDialog(wx.Dialog):
 
         # snapping
         text = StaticText(parent=panel, id=wx.ID_ANY, label=_("Snapping threshold"))
-        self.snappingValue = SpinCtrl(
+        self.snappingValue = FloatSpin(
             parent=panel,
             id=wx.ID_ANY,
             size=(75, -1),
-            initial=UserSettings.Get(group="vdigit", key="snapping", subkey="value"),
-            min=-1,
-            max=1e6,
+            value=UserSettings.Get(group="vdigit", key="snapping", subkey="value"),
+            min_val=-1,
+            max_val=1e6,
+            digits=7,
         )
         self.snappingValue.Bind(wx.EVT_SPINCTRL, self.OnChangeSnappingValue)
         self.snappingValue.Bind(wx.EVT_TEXT, self.OnChangeSnappingValue)
@@ -933,7 +934,7 @@ class VDigitSettingsDialog(wx.Dialog):
             group="vdigit",
             key="snapping",
             subkey="value",
-            value=int(self.snappingValue.GetValue()),
+            value=self.snappingValue.GetValue(),
         )
         UserSettings.Set(
             group="vdigit",

--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -430,8 +430,14 @@ class VDigitSettingsDialog(wx.Dialog):
         self.queryLengthSL.SetSelection(
             UserSettings.Get(group="vdigit", key="queryLength", subkey="than-selection")
         )
-        self.queryLengthValue = SpinCtrl(
-            parent=panel, id=wx.ID_ANY, size=(100, -1), initial=1, min=0, max=1e6
+        self.queryLengthValue = FloatSpin(
+            parent=panel,
+            id=wx.ID_ANY,
+            size=(100, -1),
+            value=1,
+            min_val=0,
+            max_val=1e6,
+            digits=7,
         )
         self.queryLengthValue.SetValue(
             UserSettings.Get(group="vdigit", key="queryLength", subkey="thresh")
@@ -1033,7 +1039,7 @@ class VDigitSettingsDialog(wx.Dialog):
             group="vdigit",
             key="queryLength",
             subkey="thresh",
-            value=int(self.queryLengthValue.GetValue()),
+            value=self.queryLengthValue.GetValue(),
         )
         UserSettings.Set(
             group="vdigit",


### PR DESCRIPTION
**Describe the bug**
If LOCATION has WGS84 (EPSG:4326) coordinate system with degree map unit, it isn't possible set Vector Digitizer decimal snapping threshold value < 1 degree (map unit), 1 degree is approximatelly 111 km. Affected is Query tool Select lines widget too.

**To Reproduce**
Steps to reproduce the behavior:

1. Lauch wxGUI, create new  or switch to LOCATION with WGS84  (EPSG:4326) coordinate system
2. Switch to Vector Digitizer (edit some existed or create new vector map) and open Preference dialog
3. Try to set decimal snapping treshold value < 1 degree (map unit)  e.g.  0.0001 degree which is aproximatelly 11.11 m
4. Actually isn't possible set decimal snapping threshold value

**Expected behavior**
Allow setting decimal snapping threshold value.
