### PR TITLE
configure: Fix ODBC configuration on Windows (branch 7.8)

### DIFF
--- a/configure
+++ b/configure
@@ -12265,27 +12265,32 @@ if test -n "$with_odbc_includes" ; then
 fi
 
 
+ac_fn_c_check_header_mongrel "$LINENO" "windows.h" "ac_cv_header_windows_h" "$ac_includes_default"
+if test "x$ac_cv_header_windows_h" = xyes; then :
 
-ac_save_cppflags="$CPPFLAGS"
-CPPFLAGS="$ODBCINC $CPPFLAGS"
-for ac_header in sql.h
-do :
-  ac_fn_c_check_header_mongrel "$LINENO" "sql.h" "ac_cv_header_sql_h" "$ac_includes_default"
-if test "x$ac_cv_header_sql_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SQL_H 1
-_ACEOF
-
-else
-
-    as_fn_error $? "*** Unable to locate ODBC includes." "$LINENO" 5
+$as_echo "#define HAVE_WINDOWS_H 1" >>confdefs.h
 
 fi
 
-done
+
+
+ac_save_cppflags="$CPPFLAGS"
+CPPFLAGS="$ODBCINC $CPPFLAGS"
+ac_fn_c_check_header_compile "$LINENO" "sql.h" "ac_cv_header_sql_h" "#if defined(HAVE_WINDOWS_H)
+# include <windows.h>
+#endif
+
+"
+if test "x$ac_cv_header_sql_h" = xyes; then :
+
+$as_echo "#define HAVE_SQL_H 1" >>confdefs.h
+
+else
+  as_fn_error $? "*** Unable to locate <sql.h>." "$LINENO" 5
+fi
+
 
 CPPFLAGS=$ac_save_cppflags
-
 
 # With ODBC library directory
 

--- a/configure.ac
+++ b/configure.ac
@@ -1438,7 +1438,18 @@ if test -n "$USE_ODBC"; then
 
 LOC_CHECK_INC_PATH(odbc,ODBC,ODBCINC)
 
-LOC_CHECK_INCLUDES(sql.h,ODBC,$ODBCINC)
+AC_CHECK_HEADER([windows.h],
+    AC_DEFINE(HAVE_WINDOWS_H, 1, [Define to 1 if you have the <windows.h> header file.]))
+
+ac_save_cppflags="$CPPFLAGS"
+CPPFLAGS="$ODBCINC $CPPFLAGS"
+AC_CHECK_HEADER([sql.h],
+AC_DEFINE(HAVE_SQL_H, 1, [Define to 1 if you have the <sql.h> header file.]),
+AC_MSG_ERROR([*** Unable to locate <sql.h>.]),[#if defined(HAVE_WINDOWS_H)
+# include <windows.h>
+#endif
+])
+CPPFLAGS=$ac_save_cppflags
 
 # With ODBC library directory
 

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -275,6 +275,9 @@
 /* Define to 1 if you have the <values.h> header file. */
 #undef HAVE_VALUES_H
 
+/* Define to 1 if you have the <windows.h> header file. */
+#undef HAVE_WINDOWS_H
+
 /* Define to 1 if you have the <zlib.h> header file. */
 #undef HAVE_ZLIB_H
 


### PR DESCRIPTION
The update to autoconf 2.69 cause configure failure for including ODBC on Windows.

[Windows configure log](https://wingrass.fsv.cvut.cz/grass78/x86_64/logs/log-r341370e46-648/package.log):
```
...
checking whether to use ODBC... "yes"
checking for location of ODBC includes... 
checking sql.h usability... no
checking sql.h presence... yes
configure: WARNING: sql.h: present but cannot be compiled
configure: WARNING: sql.h:     check for missing prerequisite headers?
configure: WARNING: sql.h: see the Autoconf documentation
configure: WARNING: sql.h:     section "Present But Cannot Be Compiled"
configure: WARNING: sql.h: proceeding with the compiler's result
checking for sql.h... no
configure: error: *** Unable to locate ODBC includes.
```

This is caused by changes on how `AC_CHECK_HEADER` works, see [autoconf manual](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/autoconf.html#Present-But-Cannot-Be-Compiled).

Specifically in this case, on Windows the header `<windows.h>` must be included for the check to succeed.

This fix has been tested on non-Windows machine, with and without ODBC; as well as on Windows CI on my fork.