### PR TITLE
v.out.ogr: Remove a garbage character from warning

### DIFF
--- a/locale/po/grassmods_ar.po
+++ b/locale/po/grassmods_ar.po
@@ -40032,7 +40032,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Vector map <%s> is 3D. Use format specific layer creation options (parameter "
-"'lco') to export <in 3D rather than 2D (default)."
+"'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_bn.po
+++ b/locale/po/grassmods_bn.po
@@ -35433,7 +35433,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_cs.po
+++ b/locale/po/grassmods_cs.po
@@ -36656,7 +36656,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_de.po
+++ b/locale/po/grassmods_de.po
@@ -36606,7 +36606,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_el.po
+++ b/locale/po/grassmods_el.po
@@ -35776,7 +35776,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_es.po
+++ b/locale/po/grassmods_es.po
@@ -36888,7 +36888,7 @@ msgstr "El mapa vectorial <%s> es 3D. Use opciones de creación de capa específ
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr "El mapa vectorial <%s> es 3D. Use opciones de creación de capa específicas (parámetro 'Ico') para exportar en 3D en vez de 2D (predeterminado)."
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_fi.po
+++ b/locale/po/grassmods_fi.po
@@ -35453,7 +35453,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_fr.po
+++ b/locale/po/grassmods_fr.po
@@ -36574,7 +36574,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_hu.po
+++ b/locale/po/grassmods_hu.po
@@ -35561,7 +35561,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_id_ID.po
+++ b/locale/po/grassmods_id_ID.po
@@ -35364,7 +35364,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_it.po
+++ b/locale/po/grassmods_it.po
@@ -36474,7 +36474,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_ja.po
+++ b/locale/po/grassmods_ja.po
@@ -36361,7 +36361,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_ko.po
+++ b/locale/po/grassmods_ko.po
@@ -36089,7 +36089,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_lv.po
+++ b/locale/po/grassmods_lv.po
@@ -37764,7 +37764,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Vector map <%s> is 3D. Use format specific layer creation options (parameter "
-"'lco') to export <in 3D rather than 2D (default)."
+"'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_ml.po
+++ b/locale/po/grassmods_ml.po
@@ -35433,7 +35433,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_pl.po
+++ b/locale/po/grassmods_pl.po
@@ -36494,7 +36494,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_pt.po
+++ b/locale/po/grassmods_pt.po
@@ -36103,7 +36103,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_pt_BR.po
+++ b/locale/po/grassmods_pt_BR.po
@@ -36268,8 +36268,8 @@ msgstr "O mapa vetorial <%s> é 3D. Use opções de criação de camada específ
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
-msgstr "O mapa vetorial <%s> é 3D. Use opções de criação de camada específicas de formato (parâmetro 'lco') para exportar <em 3D em vez de 2D (padrão)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
+msgstr "O mapa vetorial <%s> é 3D. Use opções de criação de camada específicas de formato (parâmetro 'lco') para exportar em 3D em vez de 2D (padrão)."
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56
 #, c-format

--- a/locale/po/grassmods_ro.po
+++ b/locale/po/grassmods_ro.po
@@ -36158,7 +36158,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_ru.po
+++ b/locale/po/grassmods_ru.po
@@ -35899,7 +35899,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_si.po
+++ b/locale/po/grassmods_si.po
@@ -35433,7 +35433,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_sl.po
+++ b/locale/po/grassmods_sl.po
@@ -40166,7 +40166,7 @@ msgstr ""
 #, c-format
 msgid ""
 "Vector map <%s> is 3D. Use format specific layer creation options (parameter "
-"'lco') to export <in 3D rather than 2D (default)."
+"'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_ta.po
+++ b/locale/po/grassmods_ta.po
@@ -35460,7 +35460,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_th.po
+++ b/locale/po/grassmods_th.po
@@ -35687,7 +35687,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_tr.po
+++ b/locale/po/grassmods_tr.po
@@ -36270,7 +36270,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_uk.po
+++ b/locale/po/grassmods_uk.po
@@ -35571,7 +35571,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_vi.po
+++ b/locale/po/grassmods_vi.po
@@ -35688,7 +35688,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_zh.po
+++ b/locale/po/grassmods_zh.po
@@ -36038,7 +36038,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/locale/po/grassmods_zh_CN.po
+++ b/locale/po/grassmods_zh_CN.po
@@ -35365,7 +35365,7 @@ msgstr ""
 
 #: ../vector/v.out.ogr/main.c:686
 #, c-format
-msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export <in 3D rather than 2D (default)."
+msgid "Vector map <%s> is 3D. Use format specific layer creation options (parameter 'lco') to export in 3D rather than 2D (default)."
 msgstr ""
 
 #: ../vector/v.out.ogr/main.c:713 ../db/drivers/ogr/execute.c:56

--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -685,7 +685,7 @@ int main(int argc, char *argv[])
 	else {
 	    G_warning(_("Vector map <%s> is 3D. "
 			"Use format specific layer creation options (parameter 'lco') "
-			"to export <in 3D rather than 2D (default)."),
+			"to export in 3D rather than 2D (default)."),
 		      options.input->answer);
 	}
     }


### PR DESCRIPTION
`<in 3D ...` => `in 3D ...`