### PR TITLE
wxGUI/gui_core: fix 'Set image size' dialog rendered size on wxPython 4.1.1

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -2007,7 +2007,7 @@ class ImageSizeDialog(wx.Dialog):
         sizer.Add(btnsizer, proportion=0, flag=wx.EXPAND | wx.ALL, border=5)
 
         self.panel.SetSizer(sizer)
-        sizer.Fit(self.panel)
+        sizer.Fit(self)
         self.Layout()
 
     def GetValues(self):


### PR DESCRIPTION
**Describe the bug**
Wrong rendered  'Set image size' dialog size on wxPython 4.1.1.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some vector map e.g. `d.vect geology`
3. Launch 'Set image size' dialog from map display window ('Save display to file' toolbar icon tool)

**Expected behavior**
Rendered dialog with correct size.

**Screenshots**

Correct rendered dialog size on wxPython 4.0.7:

![exp_img_dialog_wx407](https://user-images.githubusercontent.com/50632337/134769984-562ed16e-27b3-4e44-9ba4-580813260f0d.png)

Wrong rendered dialog size on wxPython 4.1.1:

![exp_img_dialog_wx411](https://user-images.githubusercontent.com/50632337/134770002-02c42030-533e-416a-ad9c-94171c99f8c5.png)

**System description (please complete the following information):**

```
wx.version()
4.1.1 gtk3 (phoenix) wxWidgets 3.1.5
```
