### PR TITLE
wxGUI/lmgr: prevent the scrollbar from scrolling up when a layer item is checked or unchecked (set focus on the layer item)

### DIFF
--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -137,7 +137,6 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         self.forceCheck = False  # force check layer if CheckItem is called
         # forms default to centering on screen, this will put on lmgr
         self.centreFromsOnParent = True
-        self.thisItem = None  # identified layer item by mouse motion event
 
         try:
             ctstyle |= CT.TR_ALIGN_WINDOWS
@@ -1797,7 +1796,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         Detects if mouse points at checkbox.
         """
-        self.thisItem, flags = self.HitTest(event.GetPosition())
+        thisItem, flags = self.HitTest(event.GetPosition())
         # workaround: in order not to check checkox when clicking outside
         # we need flag TREE_HITTEST_ONITEMCHECKICON but not TREE_HITTEST_ONITEMLABEL
         # this applies only for TR_FULL_ROW_HIGHLIGHT style
@@ -1815,8 +1814,6 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         If the user is clicking on checkbox, selection change is vetoed.
         """
         if self.hitCheckbox:
-            # Prevent the scrollbar from scrolling up when a layer item is checked or unchecked
-            self.thisItem.GetWindow().SetFocus()
             event.Veto()
 
     def OnChangeSel(self, event):

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -137,6 +137,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         self.forceCheck = False  # force check layer if CheckItem is called
         # forms default to centering on screen, this will put on lmgr
         self.centreFromsOnParent = True
+        self.thisItem = None  # identified layer item by mouse motion event
 
         try:
             ctstyle |= CT.TR_ALIGN_WINDOWS
@@ -1796,7 +1797,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
 
         Detects if mouse points at checkbox.
         """
-        thisItem, flags = self.HitTest(event.GetPosition())
+        self.thisItem, flags = self.HitTest(event.GetPosition())
         # workaround: in order not to check checkox when clicking outside
         # we need flag TREE_HITTEST_ONITEMCHECKICON but not TREE_HITTEST_ONITEMLABEL
         # this applies only for TR_FULL_ROW_HIGHLIGHT style
@@ -1814,6 +1815,8 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         If the user is clicking on checkbox, selection change is vetoed.
         """
         if self.hitCheckbox:
+            # Prevent the scrollbar from scrolling up when a layer item is checked or unchecked
+            self.thisItem.GetWindow().SetFocus()
             event.Veto()
 
     def OnChangeSel(self, event):

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1814,6 +1814,9 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         If the user is clicking on checkbox, selection change is vetoed.
         """
         if self.hitCheckbox:
+            # Prevent the scrollbar from scrolling up when a layer item
+            # is checked or unchecked
+            self.EnsureVisible(event.GetItem())
             event.Veto()
 
     def OnChangeSel(self, event):


### PR DESCRIPTION
Closes #1279.