### PR TITLE
libraster: change Rast_legal_bandref() return value to bool

### DIFF
--- a/include/grass/defs/raster.h
+++ b/include/grass/defs/raster.h
@@ -549,7 +549,7 @@ char *Rast_get_bandref_or_name(const char *, const char *);
 void Rast_write_units(const char *, const char *);
 void Rast_write_vdatum(const char *, const char *);
 void Rast_write_bandref(const char *, const char *);
-int Rast_legal_bandref(const char *);
+bool Rast_legal_bandref(const char *);
 
 /* rast_to_img_string.c */
 int Rast_map_to_img_str(char *, int, unsigned char*);

--- a/lib/raster/raster_metadata.c
+++ b/lib/raster/raster_metadata.c
@@ -138,7 +138,7 @@ void Rast_write_bandref(const char *name, const char *str)
  * They are in format <shortcut>_<bandname>.
  * Band identifiers are capped in legth to GNAME_MAX.
  *
- * This function will return -1 if provided band id is not considered
+ * This function will return false if provided band id is not considered
  * to be valid.
  * This function does not check if band id maps to any entry in band
  * metadata files as not all band id's have files with extra metadata.
@@ -147,32 +147,32 @@ void Rast_write_bandref(const char *name, const char *str)
  *
  * \param bandref band reference to check
  *
- * \return 1 success
- * \return -1 failure
+ * \return true success
+ * \return false failure
  */
-int Rast_legal_bandref(const char *bandref)
+bool Rast_legal_bandref(const char *bandref)
 {
     const char *s;
 
     if (strlen(bandref) >= GNAME_MAX) {
         G_warning(_("Band reference is too long"));
-        return -1;
+        return false;
     }
 
     if (G_legal_filename(bandref) != 1)
-        return -1;
+        return false;
 
     s = bandref;
     while (*s) {
 	if (!((*s >= 'A' && *s <= 'Z') || (*s >= 'a' && *s <= 'z') ||
 	      (*s >= '0' && *s <= '9') || *s == '_'  || *s == '-')) {
 	    G_warning(_("Character '%c' not allowed in band reference."), *s);
-	    return -1;
+	    return false;
 	}
 	s++;
     }
 
-    return 1;
+    return true;
 }
 
 /*!

--- a/lib/raster/testsuite/test_raster_metadata.py
+++ b/lib/raster/testsuite/test_raster_metadata.py
@@ -30,43 +30,43 @@ from grass.lib.raster import (
 class RastLegalBandIdTestCase(TestCase):
     def test_empty_name(self):
         ret = Rast_legal_bandref("")
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
         ret = Rast_legal_bandref(" ")
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
 
     def test_illegal_name(self):
         ret = Rast_legal_bandref(".a")
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
         ret = Rast_legal_bandref("a/b")
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
         ret = Rast_legal_bandref("a@b")
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
         ret = Rast_legal_bandref("a#b")
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
 
     def test_too_long(self):
         ret = Rast_legal_bandref(
             "a_" + "".join(random.choices(string.ascii_letters, k=253))
         )
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
         ret = Rast_legal_bandref(
             "a_" + "".join(random.choices(string.ascii_letters, k=254))
         )
-        self.assertEqual(ret, -1)
+        self.assertEqual(ret, False)
 
     def test_good_name(self):
         ret = Rast_legal_bandref("1")
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
         ret = Rast_legal_bandref("1a")
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
         ret = Rast_legal_bandref("clouds")
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
         ret = Rast_legal_bandref("rededge1")
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
         ret = Rast_legal_bandref("S2_1")
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
         ret = Rast_legal_bandref("GRASS_aspect_deg")
-        self.assertEqual(ret, 1)
+        self.assertEqual(ret, True)
 
 
 class RastBandReferenceTestCase(TestCase):

--- a/python/grass/pygrass/raster/abstract.py
+++ b/python/grass/pygrass/raster/abstract.py
@@ -180,7 +180,7 @@ class Info(object):
         :param str bandref: band reference to assign or None to remove (unset)
         """
         if bandref:
-            if libraster.Rast_legal_bandref(bandref) < 0:
+            if libraster.Rast_legal_bandref(bandref) is False:
                 raise ValueError(_("Invalid band reference"))
             libraster.Rast_write_bandref(self.name, bandref)
         else:

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -585,7 +585,7 @@ def _write_band_reference(lock, conn, data):
         bandref = data[5]
 
         if maptype == RPCDefs.TYPE_RASTER:
-            if libraster.Rast_legal_bandref(bandref) < 0:
+            if libraster.Rast_legal_bandref(bandref) is False:
                 raise ValueError(_("Invalid band reference"))
             libraster.Rast_write_bandref(name, bandref)
         else:

--- a/raster/r.support/main.c
+++ b/raster/r.support/main.c
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
     }
 
     if (bandref_opt->answer) {
-        if (Rast_legal_bandref(bandref_opt->answer) < 0)
+        if (Rast_legal_bandref(bandref_opt->answer) == false)
             G_fatal_error(_("Provided band reference is not valid. "
                             "See documentation for valid examples"));
 


### PR DESCRIPTION
The suggestion https://github.com/OSGeo/grass/pull/1272#discussion_r647796961 to implement `Rast_legal_bandref()` with `bool` as return value couldn't be fulfilled due to limitations of embedded version of ctypesgen. Upgrading to upstream ctypesgen version with #1651 enables this change.

~~Putting this PR up as a draft, as this contains the changes of #1651, which will have to be dropped if/when #1651 is merged.~~

