### PR TITLE
g.rename: avoid buffer overflow

### DIFF
--- a/lib/manage/do_copy.c
+++ b/lib/manage/do_copy.c
@@ -76,9 +76,11 @@ int M_do_copy(int n, const char *old, const char *mapset, const char *new)
 
     /* special case: remove (yes, remove) the secondary color table, if it exists */
     if (G_strcasecmp(list[n].element[0], "cell") == 0) {
-	char colr2[GNAME_MAX];
+	char colr2[6 + GMAPSET_MAX];
 
-	sprintf(colr2, "colr2/%s", G_mapset());
+	if (snprintf(colr2, 6 + GMAPSET_MAX, "colr2/%s", G_mapset()) >=
+	    6 + GMAPSET_MAX)
+	    G_warning(_("String for secondary color table has been truncated"));
 	G_remove(colr2, new);
     }
     M__hold_signals(0);

--- a/lib/manage/do_remove.c
+++ b/lib/manage/do_remove.c
@@ -11,6 +11,7 @@
   \author Original author CERL
 */
 
+#include <stdio.h>
 #include <string.h>
 
 #include <grass/gis.h>
@@ -32,16 +33,12 @@
 int M_do_remove(int n, const char *old)
 {
     int i, ret;
-
-    /* int len; */
     const char *mapset;
     int result = 0;
     int removed = 0;
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
 
     G_message(_("Removing %s <%s>"), list[n].maindesc, old);
-
-    /* len = get_description_len(n); */
 
     M__hold_signals(1);
 
@@ -97,9 +94,11 @@ int M_do_remove(int n, const char *old)
     }
 
     if (G_strcasecmp(list[n].element[0], "cell") == 0) {
-	char colr2[GPATH_MAX];
+	char colr2[6 + GMAPSET_MAX];
 
-	G_snprintf(colr2, GPATH_MAX, "colr2/%s", G_mapset());
+	if (snprintf(colr2, 6 + GMAPSET_MAX, "colr2/%s", G_mapset()) >=
+	    6 + GMAPSET_MAX)
+	    G_warning(_("String for secondary color table has been truncated"));
 	switch (G_remove(colr2, old)) {
 	case -1:
 	    G_warning(_("Unable to remove %s"), colr2);

--- a/lib/manage/do_rename.c
+++ b/lib/manage/do_rename.c
@@ -11,6 +11,7 @@
   \author Original author CERL
 */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -34,7 +35,6 @@
 int M_do_rename(int n, const char *old, const char *new)
 {
     int i, ret;
-    int len;
     const char *mapset;
     int result = 0;
     int renamed = 0;
@@ -44,8 +44,6 @@ int M_do_rename(int n, const char *old, const char *new)
     
     if (G_strcasecmp(old, new) == 0)
 	return 1;
-
-    len = M__get_description_len(n);
 
     M__hold_signals(1);
 
@@ -94,9 +92,11 @@ int M_do_rename(int n, const char *old, const char *new)
 	}
 
 	if (G_strcasecmp(list[n].element[0], "cell") == 0) {
-	    char colr2[GNAME_MAX];
+	    char colr2[6 + GMAPSET_MAX];
 
-	    sprintf(colr2, "colr2/%s", G_mapset());
+	    if (snprintf(colr2, 6 + GMAPSET_MAX, "colr2/%s", G_mapset()) >=
+		6 + GMAPSET_MAX)
+		G_warning(_("String for secondary color table has been truncated"));
 	    G_remove(colr2, new);
 	    switch (G_rename(colr2, old, new)) {
 	    case -1:

--- a/lib/manage/do_rename.c
+++ b/lib/manage/do_rename.c
@@ -94,7 +94,7 @@ int M_do_rename(int n, const char *old, const char *new)
 	}
 
 	if (G_strcasecmp(list[n].element[0], "cell") == 0) {
-	    char colr2[50];
+	    char colr2[GNAME_MAX];
 
 	    sprintf(colr2, "colr2/%s", G_mapset());
 	    G_remove(colr2, new);

--- a/lib/manage/empty.c
+++ b/lib/manage/empty.c
@@ -29,7 +29,7 @@ int M__empty(char *elem)
 {
     DIR *dirp;
     struct dirent *dp;
-    char dir[1024];
+    char dir[GPATH_MAX];
     int any;
 
     G_file_name(dir, elem, "", G_mapset());


### PR DESCRIPTION
A string buffer was too small, set to size 50 instead of `GNAME_MAX`, causing buffer overflow and segmentation fault. This PR fixes it, using the same method like `g.copy`.