### PR TITLE
wxGUI/mapdisp: fix launch light-weight wx monitor without toolbars and statusbar

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -113,6 +113,7 @@ class MapFrame(SingleMapFrame):
         self.tree = tree
         # checks for saving workspace
         self.canCloseDisplayCallback = None
+        self.statusbar = None
 
         # Emitted when switching map notebook tabs (Single-Window)
         self.onFocus = Signal("MapPanel.onFocus")
@@ -207,7 +208,8 @@ class MapFrame(SingleMapFrame):
         self.MapWindow2D.zoomChanged.connect(self.StatusbarUpdate)
 
         # register context menu actions
-        self._registerContextMenuActions()
+        if self.statusbar:
+            self._registerContextMenuActions()
 
         self._giface.updateMap.connect(self.MapWindow2D.UpdateMap)
         # default is 2D display mode
@@ -243,7 +245,8 @@ class MapFrame(SingleMapFrame):
         )
 
         # statusbar
-        self.AddStatusbarPane()
+        if self.statusbar:
+            self.AddStatusbarPane()
 
         self._mgr.Update()
 


### PR DESCRIPTION
**Describe the bug**
The `d.mon -x start=wx0` (light-weight wx monitor without toolbars and statusbar) doesn't launch.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch GRASS GIS `grass80 --text`
2. Try launch light-weight wx monitor without toolbars and statusbar `d.mon -x start=wx0` 
3. You get error message

```
GRASS nc_spm_08_grass7/landsat:~ > Traceback (most recent call last):
  File "/usr/lib64/grass80/gui/wxpython/mapdisp/main.py", line 636, in <module>
    mapFrame = gmMap.CreateMapFrame(monName, monDecor)
  File "/usr/lib64/grass80/gui/wxpython/mapdisp/main.py", line 514, in CreateMapFrame
    self.mapFrm = DMonFrame(
  File "/usr/lib64/grass80/gui/wxpython/mapdisp/frame.py", line 246, in __init__
    self.AddStatusbarPane()
  File "/usr/lib64/grass80/gui/wxpython/gui_core/mapdisp.py", line 368, in AddStatusbarPane
    self.statusbar,
AttributeError: 'DMonFrame' object has no attribute 'statusbar'
Error in atexit._run_exitfuncs:
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /tmp/pip-req-build-oxkmg2wi/ext/wxWidgets/src/common/wincmn.cpp(477) in ~wxWindowBase(): any pushed event handlers must have been removed
```

**Expected behavior**
Launch light-weight wx monitor without errors.
