### PR TITLE
macOS/install: do not install system level docs

### DIFF
--- a/include/Make/Install.make
+++ b/include/Make/Install.make
@@ -115,11 +115,6 @@ real-install: | $(DESTDIR) $(DESTDIR)$(INST_DIR) $(DESTDIR)$(UNIX_BIN)
 
 	-$(CHMOD) -R a+rX $(DESTDIR)$(INST_DIR) 2>/dev/null
 
-ifneq ($(findstring darwin,$(ARCH)),)
-	@# enable OSX Help Viewer
-	@/bin/ln -sfh "$(INST_DIR)/docs/html" /Library/Documentation/Help/GRASS-$(GRASS_VERSION_MAJOR).$(GRASS_VERSION_MINOR)
-endif
-
 $(DESTDIR):
 	$(MAKE_DIR_CMD) -p $@
 


### PR DESCRIPTION
It is no longer (never became) custom to install documentation in `/Library/Documentation/Help/` in general for Mac.
This behaviour is being patched out of all packages to my knowledge (official Mac GRASS release, MacPorts, Homebrew, QGIS).
This removes this installation (of a symlink) and make further patching unnecessary.