### PR TITLE
libpython: start_command added comment on why encoding is popped

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -92,6 +92,7 @@ _popen_args = [
     "universal_newlines",
     "startupinfo",
     "creationflags",
+    "encoding"
 ]
 
 
@@ -464,12 +465,6 @@ def start_command(
 
     :return: Popen object
     """
-    # If encoding is in kwargs, remove it,
-    # as we dont want it to be used on the
-    # call to make_command
-    if "encoding" in kwargs:
-        kwargs.pop("encoding")
-
     options = {}
     popts = {}
     for opt, val in kwargs.items():

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -464,10 +464,11 @@ def start_command(
 
     :return: Popen object
     """
-    if "encoding" in kwargs.keys():
-        # This variable was never used for anything.
-        # See https://github.com/OSGeo/grass/issues/1521
-        encoding = kwargs.pop("encoding")  # noqa: F841
+    # If encoding is in kwargs, remove it,
+    # as we dont want it to be used on the
+    # call to make_command
+    if "encoding" in kwargs:
+        kwargs.pop("encoding")
 
     options = {}
     popts = {}

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -92,7 +92,7 @@ _popen_args = [
     "universal_newlines",
     "startupinfo",
     "creationflags",
-    "encoding"
+    "encoding",
 ]
 
 


### PR DESCRIPTION
#1521 

Added comment on why encoding kwarg is popped in start_command, it's that the rest of the kwargs will be used to construct the call to Popen.

I simply didnt assign it to any variable. It could also have been done with the `del` keyword.

A different approach could have been to, instead of popping `"encoding"`, do the following:
```diff
@@ -464,18 +464,12 @@ def start_command(
 
     :return: Popen object
     """
-    # If encoding is in kwargs, remove it,
-    # as we dont want it to be used on the
-    # call to make_command
-    if "encoding" in kwargs:
-        kwargs.pop("encoding")
-
     options = {}
     popts = {}
     for opt, val in kwargs.items():
         if opt in _popen_args:
             popts[opt] = val
-        else:
+        elif opt != "encoding":
             options[opt] = val
 
     args = make_command(prog, flags, overwrite, quiet, verbose, **options)

```

Done as part of Hacktoberfest