### PR TITLE
wxGUI/gui_core: enable/disable toolbar long help if toolbar exists

### DIFF
--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -400,7 +400,8 @@ class MapFrameBase(wx.Frame):
     def StatusbarEnableLongHelp(self, enable=True):
         """Enable/disable toolbars long help"""
         for toolbar in six.itervalues(self.toolbars):
-            toolbar.EnableLongHelp(enable)
+            if toolbar:
+                toolbar.EnableLongHelp(enable)
 
     def ShowAllToolbars(self, show=True):
         if not show:  # hide


### PR DESCRIPTION
**Describe the bug**
After you quit Vector digizer (instance is destroyed), method for enable/disable toolbar long help is called.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Switch from 2D view -> Vector digitizer
3. Quit Vector digitizer
4. You get error message

```
Traceback (most recent call last):
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\gui_core\mapdisp.py", line 169, in OnSize

self.StatusbarUpdate()
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\gui_core\mapdisp.py", line 325, in
StatusbarUpdate

self.statusbarManager.Update()
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\mapdisp\statusbar.py", line 249, in Update

item.Update()
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\mapdisp\statusbar.py", line 943, in Update

self._update(longHelp=True)
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\mapdisp\statusbar.py", line 397, in _update

self.mapFrame.StatusbarEnableLongHelp(longHelp)
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\gui_core\mapdisp.py", line 405, in
StatusbarEnableLongHelp

toolbar.EnableLongHelp(enable)
  File "C:\Program Files\GRASS GIS
8.0\gui\wxpython\gui_core\toolbars.py", line 168, in
EnableLongHelp

self.SetToolLongHelp(vars(self)[tool[0]], tool[4])
RuntimeError
:
wrapped C/C++ object of type VDigitToolbar has been deleted
```

**Expected behavior**
No error message.

**System description (please complete the following information):**

- MS Windows (wxMSW) 
