### PR TITLE
r.colors fix -g and -a (#1480)

### DIFF
--- a/lib/raster/color_xform.c
+++ b/lib/raster/color_xform.c
@@ -5,7 +5,7 @@
  *
  * (C) 2001-2009 by the GRASS Development Team
  *
- * This program is free software under the GNU General Public License 
+ * This program is free software under the GNU General Public License
  * (>=v2). Read the file COPYING that comes with GRASS for details.
  *
  * \author Original author CERL
@@ -193,10 +193,17 @@ void Rast_log_colors(struct Colors *dst, struct Colors *src, int samples)
     Rast_init_colors(dst);
 
     Rast_get_d_color_range(&min, &max, src);
-
-    lmin = log(min);
-    lmax = log(max);
-
+		/* Make sure that the log makes sense, floor values < 1.0 to 1. */
+		if (min < 1.0) {
+ 	lmin = 0.0;
+		} else {
+ 	lmin = log(min);
+		}
+		if (max < 1.0) {
+ 	lmax = 1.0;
+		} else {
+	lmax = log(max);
+		}
     Rast_get_default_color(&red, &grn, &blu, src);
     Rast_set_default_color(red, grn, blu, dst);
 


### PR DESCRIPTION
This pr fixes the `-g` flag so that it clamps any values < 1.0 to 0.

For `-a` it does the same, and also uses `log(fabs(min))` when calculating the interval instead of assuming 0.

```
r.colors map=censusblk_median_age col=plasma
```
![r colors](https://user-images.githubusercontent.com/166694/135744836-0bb7a414-7bd0-43ca-8d2b-929b9198b240.png)

```
r.colors map=censusblk_median_age col=plasma -g
```
![r colors-g_fixed](https://user-images.githubusercontent.com/166694/135744852-ef1eea01-5d87-4747-a205-2f8fc51db0cf.png)

```
r.colors map=censusblk_median_age col=plasma -a
```
![r colors-a_fixed](https://user-images.githubusercontent.com/166694/135744862-0e0b233e-698b-40c4-b65e-d954d5715797.png)


