### PR TITLE
register.py: allow registering from io objects

### DIFF
--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -59,7 +59,7 @@ def register_maps_in_space_time_dataset(
                  to None
     :param maps: A comma separated list of map names
     :param file: Input file, one map per line map with start and optional
-                end time
+                end time, or the same as io object (with readline capability)
     :param start: The start date and time of the first map
                  (format absolute: "yyyy-mm-dd HH:MM:SS" or "yyyy-mm-dd",
                  format relative is integer 5)

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -154,7 +154,10 @@ def register_maps_in_space_time_dataset(
 
     # Read the map list from file
     if file:
-        fd = open(file, "r")
+        if hasattr(file, "readline"):
+            fd = file
+        else:
+            fd = open(file, "r")
 
         line = True
         while True:


### PR DESCRIPTION
Currently, `register_maps_in_space_time_dataset` takes a file as input. This PR allowes to use the function in Python also with `io` objects (like `StinrgIO`)

It is a small change that would be nice to have in 8.0, but feel free to bump up the milestone...