### PR TITLE
TGIS: new module t.copy

### DIFF
--- a/temporal/Makefile
+++ b/temporal/Makefile
@@ -2,6 +2,7 @@ MODULE_TOPDIR = ..
 
 SUBDIRS = \
 	t.connect \
+	t.copy \
 	t.create \
 	t.support \
 	t.topology \

--- a/temporal/t.copy/Makefile
+++ b/temporal/t.copy/Makefile
@@ -1,0 +1,7 @@
+MODULE_TOPDIR = ../../
+
+PGM = t.copy
+
+include $(MODULE_TOPDIR)/include/Make/Script.make
+
+default: script $(TEST_DST)

--- a/temporal/t.copy/t.copy.html
+++ b/temporal/t.copy/t.copy.html
@@ -8,7 +8,7 @@ different mapset as long as this mapset is in the search path.
 <p>
 If the <em>-c</em> flag is given, the maps of the old space time dataset
 will also be copied to the current mapset, otherwise the original maps
-will be simply registered in the temporal database. When new copyies will
+will be simply registered in the temporal database. The new copies will
 have the same name like the old maps.
 
 <h2>NOTES</h2>

--- a/temporal/t.copy/t.copy.html
+++ b/temporal/t.copy/t.copy.html
@@ -9,7 +9,7 @@ different mapset as long as this mapset is in the search path.
 If the <em>-c</em> flag is given, the maps of the old space time dataset
 will also be copied to the current mapset, otherwise the original maps
 will be simply registered in the temporal database. The new copies will
-have the same name like the old maps.
+have the same name as the old maps.
 
 <h2>NOTES</h2>
 A fully qualified name for the input space-time dataset is only required

--- a/temporal/t.copy/t.copy.html
+++ b/temporal/t.copy/t.copy.html
@@ -23,7 +23,7 @@ mapset <em>modis_lst</em> included, copy the space-time raster dataset
 
 <div class="code"><pre>
 g.mapsets mapset=modis_lst operation=add
-t.copy input=LST_Day_monthly type=strds output=LST_Day_monthly
+t.copy input=LST_Day_monthly@modis_lst type=strds output=LST_Day_monthly
 </pre></div>
 
 <h2>SEE ALSO</h2>

--- a/temporal/t.copy/t.copy.html
+++ b/temporal/t.copy/t.copy.html
@@ -1,0 +1,46 @@
+<h2>DESCRIPTION</h2>
+
+The purpose of <b>t.copy</b> is to create a copy of a space
+time raster dataset. The new space time dataset will be located in the
+current mapset, whereas the old space time dataset can be located in a
+different mapset as long as this mapset is in the search path.
+
+<p>
+If the <em>-c</em> flag is given, the maps of the old space time dataset
+will also be copied to the current mapset, otherwise the original maps
+will be simply registered in the temporal database. When new copyies will
+have the same name like the old maps.
+
+<h2>NOTES</h2>
+A fully qualified name for the input space-time dataset is only required
+if space-time datasets with the same name exist in different mapsets.
+
+<h2>EXAMPLE</h2>
+
+In the North Carolina sample dataset with the separately available
+mapset <em>modis_lst</em> included, copy the space-time raster dataset
+<em>LST_Day_monthly@modis_lst</em> to the current mapset <em>user1</em>:
+
+<div class="code"><pre>
+g.mapsets mapset=modis_lst operation=add
+t.copy input=LST_Day_monthly type=strds output=LST_Day_monthly
+</pre></div>
+
+<h2>SEE ALSO</h2>
+
+<em>
+<a href="t.rast.extract.html">t.rast.extract</a>,
+<a href="t.rast3d.extract.html">t.rast3d.extract</a>,
+<a href="t.vect.extract.html">t.vect.extract</a>,
+<a href="t.info.html">t.info</a>
+</em>
+
+<h2>AUTHOR</h2>
+
+Markus Metz, mundialis
+
+<!--
+<p>
+<i>Last changed: $Date$</i>
+-->
+

--- a/temporal/t.copy/t.copy.html
+++ b/temporal/t.copy/t.copy.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 The purpose of <b>t.copy</b> is to create a copy of a space
-time raster dataset. The new space time dataset will be located in the
+time dataset. The new space time dataset will be located in the
 current mapset, whereas the old space time dataset can be located in a
 different mapset as long as this mapset is in the search path.
 

--- a/temporal/t.copy/t.copy.py
+++ b/temporal/t.copy/t.copy.py
@@ -167,7 +167,7 @@ def main():
                 else:
                     msgr.error(
                         _(
-                            "Map <%s> is already in temporal database"
+                            "Map <%s> is already in the temporal database"
                             ", use overwrite flag to overwrite"
                         )
                         % (new_map.get_map_id())

--- a/temporal/t.copy/t.copy.py
+++ b/temporal/t.copy/t.copy.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+############################################################################
+#
+# MODULE:	t.copy
+# AUTHOR(S):	Markus Metz
+#
+# PURPOSE:	Create a copy of a space time dataset
+# COPYRIGHT:	(C) 2021 by the GRASS Development Team
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#############################################################################
+
+# %module
+# % description: Creates a copy of a space time raster dataset.
+# % keyword: temporal
+# % keyword: copy
+# % keyword: time
+# %end
+
+# %option G_OPT_STDS_INPUT
+# %end
+
+# %option G_OPT_STDS_TYPE
+# % guidependency: input
+# % guisection: Required
+# % options: strds, str3ds, stvds
+# %end
+
+# %option G_OPT_STDS_OUTPUT
+# %end
+
+# %flag
+# % key: c
+# % label: Also copy maps of the space-time dataset
+# % description: By default the old maps are only registered in the new dataset.
+# %end
+
+
+import grass.script as gscript
+
+
+############################################################################
+
+
+def main():
+    # lazy imports
+    import grass.temporal as tgis
+
+    # Get the options
+    input = options["input"]
+    output = options["output"]
+    stdstype = options["type"]
+    copy_maps = flags["c"]
+
+    maptype = "raster"
+    element = "cell"
+    if stdstype == "str3ds":
+        maptype = "raster_3d"
+        element = "g3dcell"
+    elif stdstype == "stvds":
+        maptype = "vector"
+        element = "vector"
+
+    # Make sure the temporal database exists
+    tgis.init()
+
+    # Get the current mapset to create the id of the space time dataset
+    mapset = gscript.gisenv()["MAPSET"]
+
+    inname = input
+    inmapset = None
+    if "@" in input:
+        inname, inmapset = input.split("@")
+
+    outname = output
+    outmapset = mapset
+    if "@" in output:
+        outname, outmapset = output.split("@")
+        if outmapset != mapset:
+            gscript.fatal(
+                _("The output dataset <%s> must be in the current mapset<%s>.")
+                % (input, mapset)
+            )
+
+    # simplified version of extract_dataset() in temporal/extract.py
+    msgr = tgis.get_tgis_message_interface()
+
+    dbif = tgis.SQLDatabaseInterfaceConnection()
+    dbif.connect()
+
+    old_sp = tgis.open_old_stds(input, stdstype, dbif)
+    # Check the new stds
+    new_sp = tgis.check_new_stds(output, stdstype, dbif, gscript.overwrite())
+    if stdstype == "stvds":
+        rows = old_sp.get_registered_maps(
+            "id,name,mapset,layer", None, "start_time", dbif
+        )
+    else:
+        rows = old_sp.get_registered_maps("id,name,mapset", None, "start_time", dbif)
+
+    if rows is None or len(rows) == 0:
+        gscript.message(
+            _("Empty space-time %s dataset <%s>, nothing to copy") % (maptype, input)
+        )
+        dbif.close()
+        return
+
+    new_maps = {}
+    num_rows = len(rows)
+
+    msgr.percent(0, num_rows, 1)
+
+    if copy_maps:
+        count = 0
+
+        for row in rows:
+            count += 1
+
+            if row["mapset"] != mapset:
+                found = gscript.find_file(
+                    name=row["name"], element=element, mapset=mapset
+                )
+                if found["name"] is not None and len(found["name"]) > 0:
+                    gscript.fatal(
+                        _("A %s map <%s> exists already in the current mapset <%s>.")
+                        % (maptype, row["name"], mapset)
+                    )
+
+                kwargs = {maptype: "%s,%s" % (row["id"], row["name"])}
+                gscript.run_command("g.copy", **kwargs)
+            else:
+                # the map is already in the current mapset
+                gscript.message(
+                    _("The %s map <%s> is already in the current mapset, not copying")
+                    % (maptype, row["name"])
+                )
+
+            if count % 10 == 0:
+                msgr.percent(count, num_rows, 1)
+
+            # We need to build the id
+            if maptype != "vector":
+                map_id = tgis.AbstractMapDataset.build_id(row["name"], mapset)
+            else:
+                map_id = tgis.AbstractMapDataset.build_id(
+                    row["name"], mapset, row["layer"]
+                )
+
+            new_map = old_sp.get_new_map_instance(map_id)
+
+            # Check if new map is in the temporal database
+            if new_map.is_in_db(dbif, mapset):
+                if gscript.overwrite():
+                    # Remove the existing temporal database entry
+                    new_map.delete(dbif)
+                    new_map = old_sp.get_new_map_instance(map_id)
+                else:
+                    msgr.error(
+                        _(
+                            "Map <%s> is already in temporal database"
+                            ", use overwrite flag to overwrite"
+                        )
+                        % (new_map.get_map_id())
+                    )
+                    continue
+
+            # Store the new maps
+            new_maps[row["id"]] = new_map
+
+    msgr.percent(0, num_rows, 1)
+
+    temporal_type, semantic_type, title, description = old_sp.get_initial_values()
+    new_sp = tgis.open_new_stds(
+        output,
+        stdstype,
+        old_sp.get_temporal_type(),
+        title,
+        description,
+        semantic_type,
+        dbif,
+        gscript.overwrite(),
+    )
+
+    # Register the maps in the database
+    count = 0
+    for row in rows:
+        count += 1
+
+        if count % 10 == 0:
+            msgr.percent(count, num_rows, 1)
+
+        old_map = old_sp.get_new_map_instance(row["id"])
+        old_map.select(dbif)
+
+        if copy_maps:
+            # Register the new maps
+            if row["id"] in new_maps:
+                new_map = new_maps[row["id"]]
+
+                # Read the raster map data
+                new_map.load()
+
+                # Set the time stamp
+                new_map.set_temporal_extent(old_map.get_temporal_extent())
+
+                if maptype == "raster":
+                    # Set the band reference
+                    band_reference = old_map.metadata.get_band_reference()
+                    if band_reference is not None:
+                        new_map.set_band_reference(band_reference)
+
+                # Insert map in temporal database
+                new_map.insert(dbif)
+
+                new_sp.register_map(new_map, dbif)
+        else:
+            new_sp.register_map(old_map, dbif)
+
+    # Update the spatio-temporal extent and the metadata table entries
+    new_sp.update_from_registered_maps(dbif)
+
+    msgr.percent(num_rows, num_rows, 1)
+
+    dbif.close()
+
+
+###############################################################################
+
+if __name__ == "__main__":
+    options, flags = gscript.parser()
+    main()

--- a/temporal/t.copy/testsuite/test_t_copy.py
+++ b/temporal/t.copy/testsuite/test_t_copy.py
@@ -1,4 +1,4 @@
-"""Test t.rast.extract
+"""Test t.copy
 
 (C) 2014 by the GRASS Development Team
 This program is free software under the GNU General Public

--- a/temporal/t.copy/testsuite/test_t_copy.py
+++ b/temporal/t.copy/testsuite/test_t_copy.py
@@ -1,0 +1,163 @@
+"""Test t.rast.extract
+
+(C) 2014 by the GRASS Development Team
+This program is free software under the GNU General Public
+License (>=v2). Read the file COPYING that comes with GRASS
+for details.
+
+@author Soeren Gebbert
+"""
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+
+
+class TestSTDSCopy(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Initiate the temporal GIS and set the region"""
+        cls.use_temp_region()
+        cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("r.mapcalc", expression="prec_1 = 100", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_2 = 200", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_3 = 300", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_4 = 400", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_5 = 500", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_6 = 600", overwrite=True)
+
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_abs1",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_abs1",
+            maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the temporary region"""
+        cls.del_temp_region()
+
+    def setUp(self):
+        """Create input data for t.copy"""
+        # Use always the current mapset as temporal database
+        self.runModule("r.mapcalc", expression="prec_1 = 100", overwrite=True)
+        self.runModule("r.mapcalc", expression="prec_2 = 200", overwrite=True)
+        self.runModule("r.mapcalc", expression="prec_3 = 300", overwrite=True)
+        self.runModule("r.mapcalc", expression="prec_4 = 400", overwrite=True)
+        self.runModule("r.mapcalc", expression="prec_5 = 500", overwrite=True)
+        self.runModule("r.mapcalc", expression="prec_6 = 600", overwrite=True)
+
+        self.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_abs1",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        self.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_abs1",
+            maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
+
+    def tearDown(self):
+        """Remove generated data"""
+        self.runModule("t.remove", flags="df", type="strds", inputs="precip_abs1")
+
+    def test_copy(self):
+        """Copy a strds"""
+        self.assertModule(
+            "t.copy",
+            input="precip_abs1",
+            output="precip_abs2",
+            type="strds",
+        )
+
+        # self.assertModule("t.info",  flags="g",  input="precip_abs2")
+
+        tinfo_string = """start_time='2001-01-01 00:00:00'
+        end_time='2002-07-01 00:00:00'
+        granularity='3 months'
+        map_time=interval
+        north=80.0
+        south=0.0
+        east=120.0
+        west=0.0
+        top=0.0
+        bottom=0.0
+        aggregation_type=None
+        number_of_maps=6
+        nsres_min=10.0
+        nsres_max=10.0
+        ewres_min=10.0
+        ewres_max=10.0
+        min_min=100.0
+        min_max=600.0
+        max_min=100.0
+        max_max=600.0"""
+
+        info = SimpleModule("t.info", flags="g", input="precip_abs2")
+        self.assertModuleKeyValue(
+            module=info, reference=tinfo_string, precision=2, sep="="
+        )
+
+
+class TestSTDSCopyFails(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Initiate the temporal GIS and set the region"""
+        cls.use_temp_region()
+        cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
+        cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the temporary region"""
+        cls.del_temp_region()
+
+    def test_error_handling(self):
+        """Test arguments for t.copy"""
+        # No input
+        self.assertModuleFail("t.copy", output="precip_abs2")
+        # No output
+        self.assertModuleFail("t.copy", input="precip_abs1")
+        # Wrong type
+        self.assertModuleFail(
+            "t.copy",
+            input="precip_abs1",
+            output="precip_abs2",
+            type="stvds",
+        )
+        # Input does not exist
+        self.assertModuleFail(
+            "t.copy",
+            input="precip_abs1@this_mapset_does_not_exist",
+            output="precip_abs2",
+        )
+
+
+if __name__ == "__main__":
+    from grass.gunittest.main import test
+
+    test()

--- a/temporal/t.copy/testsuite/test_t_copy.py
+++ b/temporal/t.copy/testsuite/test_t_copy.py
@@ -5,7 +5,7 @@ This program is free software under the GNU General Public
 License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
-@author Soeren Gebbert
+@author Markus Metz
 """
 
 from grass.gunittest.case import TestCase

--- a/temporal/t.copy/testsuite/test_t_copy.py
+++ b/temporal/t.copy/testsuite/test_t_copy.py
@@ -19,37 +19,12 @@ class TestSTDSCopy(TestCase):
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
-        cls.runModule("r.mapcalc", expression="prec_1 = 100", overwrite=True)
-        cls.runModule("r.mapcalc", expression="prec_2 = 200", overwrite=True)
-        cls.runModule("r.mapcalc", expression="prec_3 = 300", overwrite=True)
-        cls.runModule("r.mapcalc", expression="prec_4 = 400", overwrite=True)
-        cls.runModule("r.mapcalc", expression="prec_5 = 500", overwrite=True)
-        cls.runModule("r.mapcalc", expression="prec_6 = 600", overwrite=True)
-
-        cls.runModule(
-            "t.create",
-            type="strds",
-            temporaltype="absolute",
-            output="precip_abs1",
-            title="A test",
-            description="A test",
-            overwrite=True,
-        )
-        cls.runModule(
-            "t.register",
-            flags="i",
-            type="raster",
-            input="precip_abs1",
-            maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
-            start="2001-01-01",
-            increment="3 months",
-            overwrite=True,
-        )
 
     @classmethod
     def tearDownClass(cls):
         """Remove the temporary region"""
         cls.del_temp_region()
+        cls.runModule("g.remove", flags="f", type="raster", pattern="prec_*")
 
     def setUp(self):
         """Create input data for t.copy"""
@@ -121,6 +96,7 @@ class TestSTDSCopy(TestCase):
         self.assertModuleKeyValue(
             module=info, reference=tinfo_string, precision=2, sep="="
         )
+        self.runModule("t.remove", flags="df", type="strds", inputs="precip_abs2")
 
 
 class TestSTDSCopyFails(TestCase):
@@ -130,11 +106,39 @@ class TestSTDSCopyFails(TestCase):
         cls.use_temp_region()
         cls.runModule("g.gisenv", set="TGIS_USE_CURRENT_MAPSET=1")
         cls.runModule("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        cls.runModule("r.mapcalc", expression="prec_1 = 100", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_2 = 200", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_3 = 300", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_4 = 400", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_5 = 500", overwrite=True)
+        cls.runModule("r.mapcalc", expression="prec_6 = 600", overwrite=True)
+
+        cls.runModule(
+            "t.create",
+            type="strds",
+            temporaltype="absolute",
+            output="precip_abs1",
+            title="A test",
+            description="A test",
+            overwrite=True,
+        )
+        cls.runModule(
+            "t.register",
+            flags="i",
+            type="raster",
+            input="precip_abs1",
+            maps="prec_1,prec_2,prec_3,prec_4,prec_5,prec_6",
+            start="2001-01-01",
+            increment="3 months",
+            overwrite=True,
+        )
 
     @classmethod
     def tearDownClass(cls):
         """Remove the temporary region"""
         cls.del_temp_region()
+        cls.runModule("t.remove", flags="df", type="strds", inputs="precip_abs1")
+        cls.runModule("g.remove", flags="f", type="raster", pattern="prec_*")
 
     def test_error_handling(self):
         """Test arguments for t.copy"""


### PR DESCRIPTION
This new module `t.copy` creates a copy of a space-time dataset. It can also copy datasets from a different mapset to the current mapset. Optionally, maps registered in the dataset are also copied. By default, only a new space-time dataset is created.
This PR requires PR #1924 to work properly across mapsets.