### PR TITLE
Rast_log_colors: Another attempt to address r.colors -g/-a (#1480)

### DIFF
--- a/lib/raster/color_xform.c
+++ b/lib/raster/color_xform.c
@@ -270,6 +270,7 @@ void Rast_abs_log_colors(struct Colors *dst, struct Colors *src, int samples)
     if (min * max <= 0.0) {
 	/* 0 <= abs(cell) <= amax */
 	amin = 0;
+	/* use the same shifting for Rast_log_colors */
 	delta = 1 - amin;
 	lamin = log(amin + delta);
 	lamax = log(amax + delta);


### PR DESCRIPTION
Unlike #1481 or #1923, two other PRs trying to address #1480, this PR *shifts* cell values by a delta if the min is less than or equal to 0 such that the logs of shifted min and max can be calculated. Then, just before writing color rules, unshifted cell values are approximated by subtracting the delta.