### PR TITLE
mswindows: crosscompile under WSL

### DIFF
--- a/mswindows/crosscompile.sh
+++ b/mswindows/crosscompile.sh
@@ -165,6 +165,7 @@ RANLIB=$mxe_bin-ranlib \
 WINDRES=$mxe_bin-windres \
 PKG_CONFIG=$mxe_bin-pkg-config \
 ./configure \
+--build=$build_arch \
 --host=$arch \
 --with-nls \
 --with-readline \


### PR DESCRIPTION
In WSL, it's not possible to check for cross compiling by running a compiled executable because EXEs run fine. This PR uses soon-to-be-removed (?) code in configure to flag ``cross_compiling`` if ``--build`` is different from ``--host``.
```bash
# FIXME: To remove some day.
if test "x$host_alias" != x; then
  if test "x$build_alias" = x; then
    cross_compiling=maybe
  elif test "x$build_alias" != "x$host_alias"; then
    cross_compiling=yes
  fi
fi
```