### PR TITLE
crosscompile: Fix python.exe search

### DIFF
--- a/mswindows/crosscompile.sh
+++ b/mswindows/crosscompile.sh
@@ -295,6 +295,7 @@ cp -a bin.$arch/grass.py $dist/etc/grass$version.py
 
 cat<<'EOT' | sed "s/\$version/$version/g" > $dist/grass.bat
 @echo off
+setlocal EnableDelayedExpansion
 
 rem Change this variable to override auto-detection of python.exe in PATH
 set GRASS_PYTHON=C:\Python39\python.exe
@@ -322,7 +323,7 @@ if not exist %GISBASE%\etc\fontcap (
 
 if not exist "%GRASS_PYTHON%" (
 	set GRASS_PYTHON=
-	for /f usebackq %%i in (`where python.exe`) do set GRASS_PYTHON=%%i
+	for /f usebackq %%i in (`where python.exe`) do if "!GRASS_PYTHON!"=="" set GRASS_PYTHON=%%i
 )
 if "%GRASS_PYTHON%"=="" (
 	echo.


### PR DESCRIPTION
We don't want to pick up the Windows python.exe app for installation.