### PR TITLE
crosscompile enhancements

### DIFF
--- a/mswindows/crosscompile.sh
+++ b/mswindows/crosscompile.sh
@@ -31,6 +31,7 @@
 #
 # cd ~/usr/src
 # git clone https://github.com/OSGeo/grass.git
+# git clone https://github.com/OSGeo/grass-addons.git
 # cd grass
 # mswindows/crosscompile.sh --mxe-path=$HOME/usr/src/mxe --update --package \
 #      > crosscompile.log 2>&1


### PR DESCRIPTION
1. Do not check path existence for GRASS_SH when defined by the user to avoid having to specify a full path to the shell.
2. Compile addons if source is available