### PR TITLE
wxGUI/psmap: remove setpdfwrite on Windows

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -415,6 +415,9 @@ class PsMapFrame(wx.Frame):
                     "-P-",
                     "-dSAFER",
                     "-dCompatibilityLevel=1.4",
+                    "-c",
+                    "30000000",
+                    "setvmthreshold",
                     "-f",
                     event.userData["filename"],
                 ]

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -415,8 +415,6 @@ class PsMapFrame(wx.Frame):
                     "-P-",
                     "-dSAFER",
                     "-dCompatibilityLevel=1.4",
-                    "-c",
-                    ".setpdfwrite",
                     "-f",
                     event.userData["filename"],
                 ]


### PR DESCRIPTION
.setpdfwrite is no longer supported with ghostscript 9.5 shipped with OSGeo4W
See: https://trac.osgeo.org/osgeo4w/ticket/697