### PR TITLE
remove .setpdfwrite option on MS Windows

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -404,6 +404,7 @@ class PsMapFrame(wx.Frame):
                            '-sOutputFile=%s' % event.userData['pdfname'],
                            '-P-', '-dSAFER',
                            '-dCompatibilityLevel=1.4',
+                           '-c', '30000000', 'setvmthreshold',
                            '-f', event.userData['filename']]
             else:
                 command = [

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -404,8 +404,7 @@ class PsMapFrame(wx.Frame):
                            '-sOutputFile=%s' % event.userData['pdfname'],
                            '-P-', '-dSAFER',
                            '-dCompatibilityLevel=1.4',
-                           '-c', '.setpdfwrite', '-f',
-                           event.userData['filename']]
+                           '-f', event.userData['filename']]
             else:
                 command = [
                     'ps2pdf',


### PR DESCRIPTION
.setpdfwrite is no longer supported with ghostscript 9.5 shipped with OSGeo4W
See: https://trac.osgeo.org/osgeo4w/ticket/697