### PR TITLE
CI: Run Docker for all release branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,11 @@ name: Docker
 
 on:
   push:
-    branches: [main, releasebranch_7_8]
+    branches:
+      - 'main'
+      - 'releasebranch_*'
+      - '!releasebranch_7_*'
+      - 'releasebranch_7_8'
     tags: ['*.*.*']
     paths-ignore: ['doc/**']
   release:


### PR DESCRIPTION
Adding all release branches (now v8, later v9 etc.), excluding v7 except for 7.8 (lower are not in this repo).
