### PR TITLE
wxGUI/xml/toolboxes.xml: add missing 'r.fill.stats' module item inside 'InterpolateSurfaces' toolbox

### DIFF
--- a/gui/wxpython/xml/toolboxes.xml
+++ b/gui/wxpython/xml/toolboxes.xml
@@ -1076,6 +1076,10 @@
       <module-item name="r.fillnulls">
         <label>Fill NULL cells</label>
       </module-item>
+      <separator/>
+      <module-item name="r.fill.stats">
+        <label>Fill NULL cells with IDW</label>
+      </module-item>
     </items>
   </toolbox>
   <toolbox name="RasterReportsAndStatistics">

--- a/gui/wxpython/xml/toolboxes.xml
+++ b/gui/wxpython/xml/toolboxes.xml
@@ -1078,7 +1078,7 @@
       </module-item>
       <separator/>
       <module-item name="r.fill.stats">
-        <label>Fill NULL cells with IDW</label>
+        <label>Fill NULL cells using IDW</label>
       </module-item>
     </items>
   </toolbox>


### PR DESCRIPTION
Fixes #1976.