### PR TITLE
display/d.linegraph: fix generate graph image if 'x_title', 'y_title' param arg isn't defined

### DIFF
--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -193,10 +193,9 @@ int main(int argc, char **argv)
     float xscale;
     float yscale;
 
-    char xlabel;
     char txt[1024];
     char tic_name[1024];
-    char *name, *pxlabel = &xlabel;
+    char *name, *xlabel;
     char color_name[20];
 
     FILE *fopen();
@@ -890,16 +889,16 @@ int main(int argc, char **argv)
 
     /* draw the x-axis label */
     if ((strcmp(title[0]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
-        *pxlabel = '\0';
+        *xlabel = '\0';
     else
-        G_asprintf(&pxlabel, "X: %s %s", title[0]->answer, tic_name);
+        G_asprintf(&xlabel, "X: %s %s", title[0]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 1.5;
     D_text_size(text_width, text_height);
-    D_get_text_box(pxlabel, &tt, &tb, &tl, &tr);
+    D_get_text_box(xlabel, &tt, &tb, &tl, &tr);
     D_pos_abs((l + (r - l) / 2 - (tr - tl) / 2), (b - LABEL_1 * (b - t)));
     D_use_color(title_color);
-    D_text(pxlabel);
+    D_text(xlabel);
 
     /* DRAW Y-AXIS TIC-MARKS AND NUMBERS
        first, figure tic_every and tic_units for the x-axis of the bar-chart.
@@ -1002,30 +1001,30 @@ int main(int argc, char **argv)
 
     /* draw the y-axis label */
     if ((strcmp(title[1]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
-        *pxlabel = '\0';
+        *xlabel = '\0';
     else
-        G_asprintf(&pxlabel, "Y: %s %s", title[1]->answer, tic_name);
+        G_asprintf(&xlabel, "Y: %s %s", title[1]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 1.5;
     D_text_size(text_width, text_height);
-    D_get_text_box(pxlabel, &tt, &tb, &tl, &tr);
+    D_get_text_box(xlabel, &tt, &tb, &tl, &tr);
     D_pos_abs(l + (r - l) / 2 - (tr - tl) / 2, b - LABEL_2 * (b - t));
     D_use_color(title_color);
-    D_text(pxlabel);
+    D_text(xlabel);
 
     /* top label */
-    sprintf(pxlabel, "%s", title[2]->answer);
+    sprintf(xlabel, "%s", title[2]->answer);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 2.0;
     D_text_size(text_width, text_height);
-    D_get_text_box(pxlabel, &tt, &tb, &tl, &tr);
+    D_get_text_box(xlabel, &tt, &tb, &tl, &tr);
     /*
        D_move_abs((int)(((r-l)/2)-(tr-tl)/2),
        (int) (t+ (b-t)*.07) );
      */
     D_pos_abs(l + (r - l) / 2 - (tr - tl) / 2, t + (b - t) * .07);
     D_use_color(title_color);
-    D_text(pxlabel);
+    D_text(xlabel);
 
     /* draw x and y axis lines */
     D_use_color(title_color);

--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -193,9 +193,10 @@ int main(int argc, char **argv)
     float xscale;
     float yscale;
 
+    char xlabel;
     char txt[1024];
     char tic_name[1024];
-    char *name, *xlabel;
+    char *name, *pxlabel = &xlabel;
     char color_name[20];
 
     FILE *fopen();
@@ -889,16 +890,16 @@ int main(int argc, char **argv)
 
     /* draw the x-axis label */
     if ((strcmp(title[0]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
-        *xlabel = '\0';
+        *pxlabel = '\0';
     else
-        G_asprintf(&xlabel, "X: %s %s", title[0]->answer, tic_name);
+        G_asprintf(&pxlabel, "X: %s %s", title[0]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 1.5;
     D_text_size(text_width, text_height);
-    D_get_text_box(xlabel, &tt, &tb, &tl, &tr);
+    D_get_text_box(pxlabel, &tt, &tb, &tl, &tr);
     D_pos_abs((l + (r - l) / 2 - (tr - tl) / 2), (b - LABEL_1 * (b - t)));
     D_use_color(title_color);
-    D_text(xlabel);
+    D_text(pxlabel);
 
     /* DRAW Y-AXIS TIC-MARKS AND NUMBERS
        first, figure tic_every and tic_units for the x-axis of the bar-chart.
@@ -1001,30 +1002,30 @@ int main(int argc, char **argv)
 
     /* draw the y-axis label */
     if ((strcmp(title[1]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
-        *xlabel = '\0';
+        *pxlabel = '\0';
     else
-        G_asprintf(&xlabel, "Y: %s %s", title[1]->answer, tic_name);
+        G_asprintf(&pxlabel, "Y: %s %s", title[1]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 1.5;
     D_text_size(text_width, text_height);
-    D_get_text_box(xlabel, &tt, &tb, &tl, &tr);
+    D_get_text_box(pxlabel, &tt, &tb, &tl, &tr);
     D_pos_abs(l + (r - l) / 2 - (tr - tl) / 2, b - LABEL_2 * (b - t));
     D_use_color(title_color);
-    D_text(xlabel);
+    D_text(pxlabel);
 
     /* top label */
-    sprintf(xlabel, "%s", title[2]->answer);
+    sprintf(pxlabel, "%s", title[2]->answer);
     text_height = (b - t) * TEXT_HEIGHT;
     text_width = (r - l) * TEXT_WIDTH * 2.0;
     D_text_size(text_width, text_height);
-    D_get_text_box(xlabel, &tt, &tb, &tl, &tr);
+    D_get_text_box(pxlabel, &tt, &tb, &tl, &tr);
     /*
        D_move_abs((int)(((r-l)/2)-(tr-tl)/2),
        (int) (t+ (b-t)*.07) );
      */
     D_pos_abs(l + (r - l) / 2 - (tr - tl) / 2, t + (b - t) * .07);
     D_use_color(title_color);
-    D_text(xlabel);
+    D_text(pxlabel);
 
     /* draw x and y axis lines */
     D_use_color(title_color);

--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -889,7 +889,7 @@ int main(int argc, char **argv)
 
     /* draw the x-axis label */
     if ((strcmp(title[0]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
-        *xlabel = '\0';
+        xlabel =  G_store("");
     else
         G_asprintf(&xlabel, "X: %s %s", title[0]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;
@@ -1001,7 +1001,7 @@ int main(int argc, char **argv)
 
     /* draw the y-axis label */
     if ((strcmp(title[1]->answer, "") == 0) && (strcmp(tic_name, "") == 0))
-        *xlabel = '\0';
+        xlabel = G_store("");
     else
         G_asprintf(&xlabel, "Y: %s %s", title[1]->answer, tic_name);
     text_height = (b - t) * TEXT_HEIGHT;


### PR DESCRIPTION
**Describe the bug**
`d.linegraph` module doesn't generate graph image if `x_title`, `y_title` param arg isn't defined

**To Reproduce**
Steps to reproduce the behavior (according `d.linegraph` manual page):

1. Launch GRASS GIS `grass80 --text`
2. Create some example text data files.
```
cat > /tmp/x.txt <<EOF
1
3
4
6
9
EOF
cat > /tmp/y1.txt <<EOF
50
58
65
34
27
EOF
cat > /tmp/y2.txt <<EOF
10
20
35
50
45
EOF
``` 
3. `d.mon start=cairo output=/tmp/plot.png`
4. `d.linegraph x_file=/tmp/x.txt y_file=/tmp/y1.txt,/tmp/y2.txt`
5. `d.mon stop=cairo`
6. Result 'plot.png' image file doesn't exists `file /tmp/plot.png`

**Expected behavior**
Result 'plot.png' image file exists with rendered graph.

**Screenshots**

![plot](https://user-images.githubusercontent.com/50632337/141674118-364adc0b-1020-4a62-8f4c-8336560cce9b.png)

**System description (please complete the following information):**

- GRASS GIS version 8.0 dev is affected with this bug only

