### PR TITLE
wxGUI/digitizer: don't attempt to draw zero-length lines

### DIFF
--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -362,7 +362,14 @@ class DisplayDriver:
                 for i in range(robj.npoints):
                     p = robj.point[i]
                     points.append(wx.Point(p.x, p.y))
-
+                if len(points) <= 1:
+                    self.log.write(
+                        _(
+                            "WARNING: Zero-length line or boundary drawing skipped. "
+                            "Use v.clean to remove it."
+                        )
+                    )
+                    return
                 if robj.type == TYPE_AREA:
                     pdc.DrawPolygon(points)
                 else:


### PR DESCRIPTION
Fixes bug #488. This PR prevents zero-length lines from rendering and reports warning with suggestion to use v.clean.
I would prefer this over #911, because it's simpler.