### PR TITLE
r.object.geometry: fix msg typo and test script

### DIFF
--- a/raster/r.object.geometry/main.c
+++ b/raster/r.object.geometry/main.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
     in_fd = Rast_open_old(opt_in->answer, "");
 
     if (Rast_get_map_type(in_fd) != CELL_TYPE)
-        G_fatal_error(_("Input raster mus be of type CELL"));
+        G_fatal_error(_("Input raster must be of type CELL"));
 
     if (opt_out->answer != NULL && strcmp(opt_out->answer, "-") != 0) {
         if (!(out_fp = fopen(opt_out->answer, "w")))

--- a/raster/r.object.geometry/testsuite/r_object_geometry_test.py
+++ b/raster/r.object.geometry/testsuite/r_object_geometry_test.py
@@ -34,7 +34,11 @@ class TestObjectGeometryPixel(TestCase):
     def setUpClass(cls):
         """Imports test raster(s), ensures expected computational region and setup"""
         cls.runModule(
-            "r.in.ascii", input="-", type="CELL", stdin_=testraster1, output=cls.test_objects1
+            "r.in.ascii",
+            input="-",
+            type="CELL",
+            stdin_=testraster1,
+            output=cls.test_objects1,
         )
         cls.use_temp_region()
         cls.runModule("g.region", raster=cls.test_objects1)

--- a/raster/r.object.geometry/testsuite/r_object_geometry_test.py
+++ b/raster/r.object.geometry/testsuite/r_object_geometry_test.py
@@ -34,7 +34,7 @@ class TestObjectGeometryPixel(TestCase):
     def setUpClass(cls):
         """Imports test raster(s), ensures expected computational region and setup"""
         cls.runModule(
-            "r.in.ascii", input="-", stdin_=testraster1, output=cls.test_objects1
+            "r.in.ascii", input="-", type="CELL", stdin_=testraster1, output=cls.test_objects1
         )
         cls.use_temp_region()
         cls.runModule("g.region", raster=cls.test_objects1)


### PR DESCRIPTION
Fixes typo and CI test

```
Running ./raster/r.object.geometry/testsuite/r_object_geometry_test.py...
========================================================================
F.
======================================================================
FAIL: test_object_geometry_meter (__main__.TestObjectGeometryMeter)
Test to see if the outputs are created and are correct in meter units
----------------------------------------------------------------------
Traceback (most recent call last):
  File "etc/python/grass/gunittest/case.py", line 1403, in assertModule
    module.run()
  File "etc/python/grass/pygrass/modules/interface/module.py", line 823, in run
    self.wait()
grass.exceptions.CalledModuleError: Module run `r.object.geometry input=test_objects1 separator=pipe output=output_file_meter.csv -m` ended with an error.
The subprocess ended with a non-zero return code: 1. See the following errors:
b'ERROR: Input raster mus be of type CELL\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "raster/r.object.geometry/testsuite/r_object_geometry_test.py", line 105, in test_object_geometry_meter
    self.assertModule(
  File "etc/python/grass/gunittest/case.py", line 1419, in assertModule
    self.fail(self._formatMessage(msg, stdmsg))
AssertionError: Running <r.object.geometry> module ended with non-zero return code (1)
Called: r.object_geometry(input='test_objects1', output='output_file_meter.csv', separator='pipe', flags='m')
See the following errors:
ERROR: Input raster mus be of type CELL
```