### PR TITLE
libgmath: fix incorrect memset of double array

### DIFF
--- a/lib/gmath/la.c
+++ b/lib/gmath/la.c
@@ -90,7 +90,7 @@ int G_matrix_zero(mat_struct * A)
     if (!A->vals)
 	return 0;
 
-    memset(A->vals, 0, A->ldim * A->cols * sizeof(doublereal));
+    memset(A->vals, 0, (A->ldim * A->cols) * sizeof(doublereal));
 
     return 1;
 }

--- a/lib/gmath/la.c
+++ b/lib/gmath/la.c
@@ -90,7 +90,7 @@ int G_matrix_zero(mat_struct * A)
     if (!A->vals)
 	return 0;
 
-    memset(A->vals, 0, sizeof(A->vals));
+    memset(A->vals, 0, A->ldim * A->cols * sizeof(doublereal));
 
     return 1;
 }


### PR DESCRIPTION
Fixes the following compiler (clang 12) warning:

```
la.c:93:34: warning: 'memset' call operates on objects of type 'doublereal' (aka 'double') while the size is based on a different type 'doublereal *' (aka 'double *') [-Wsizeof-pointer-memaccess]
    memset(A->vals, 0, sizeof(A->vals));
           ~~~~~~~            ~~~^~~~
la.c:93:34: note: did you mean to dereference the argument to 'sizeof' (and multiply it by the number of elements)?
    memset(A->vals, 0, sizeof(A->vals));
                              ~~~^~~~
```