### PR TITLE
CI: Remove Ubuntu 16.04 from GH Actions for 7.8 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-16.04
         - ubuntu-18.04
         - ubuntu-20.04
       fail-fast: false


### PR DESCRIPTION
Ubuntu 16.04 environment was removed from GitHub in September. The job for the 7.8 branch now always fails with time out.