### PR TITLE
TGIS: number_of_bands -> number_of_semantic_labels

### DIFF
--- a/lib/temporal/SQL/strds_metadata_table.sql
+++ b/lib/temporal/SQL/strds_metadata_table.sql
@@ -18,7 +18,7 @@ CREATE TABLE  strds_metadata (
   ewres_min DOUBLE PRECISION,   -- The lowest east-west resolution of the registered raster maps
   ewres_max DOUBLE PRECISION,   -- The highest east-west resolution of the registered raster maps
   aggregation_type VARCHAR,     -- The aggregation type of the dataset (mean, min, max, ...) set by aggregation modules
-  number_of_bands INTEGER,       -- The number of registered bands
+  number_of_semantic_labels INTEGER,       -- The number of registered semantic labels
   title VARCHAR,                -- Title of the space-time raster dataset
   description VARCHAR,          -- Detailed description of the space-time raster dataset
   command VARCHAR,              -- The command that was used to create the space time raster dataset

--- a/lib/temporal/SQL/update_strds_metadata_template.sql
+++ b/lib/temporal/SQL/update_strds_metadata_template.sql
@@ -42,7 +42,7 @@ UPDATE strds_metadata SET ewres_max =
     		(SELECT id FROM SPACETIME_REGISTER_TABLE)
        ) WHERE id = 'SPACETIME_ID';
 -- Update the number of registered bands
-UPDATE strds_metadata SET number_of_bands =
+UPDATE strds_metadata SET number_of_semantic_labels =
        (SELECT count(distinct semantic_label) FROM raster_metadata WHERE
        raster_metadata.id IN
     		(SELECT id FROM SPACETIME_REGISTER_TABLE)

--- a/lib/temporal/SQL/update_strds_metadata_template_v3.sql
+++ b/lib/temporal/SQL/update_strds_metadata_template_v3.sql
@@ -7,9 +7,9 @@
 -- SPACETIME_REGISTER_TABLE is a placeholder for specific stds map register table name (SQL compliant)
 -- SPACETIME_ID is a placeholder for specific stds id: name@mapset
 
--- Update the number of semantic labels
+-- Update the number of registered semantic labels
 UPDATE strds_metadata SET number_of_semantic_labels =
        (SELECT count(distinct semantic_label) FROM raster_metadata WHERE
        raster_metadata.id IN
-    		(SELECT id FROM SPACETIME_REGISTER_TABLE)
+               (SELECT id FROM SPACETIME_REGISTER_TABLE)
        ) WHERE id = 'SPACETIME_ID';

--- a/lib/temporal/SQL/upgrade_db_2_to_3.sql
+++ b/lib/temporal/SQL/upgrade_db_2_to_3.sql
@@ -10,7 +10,7 @@ ALTER TABLE raster_metadata
 
 -- strds_metadata_table.sql
 ALTER TABLE strds_metadata
- ADD COLUMN number_of_bands INTEGER;
+ ADD COLUMN number_of_semantic_labels INTEGER;
 
 -- tgis_metadata
 UPDATE tgis_metadata

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -1342,7 +1342,8 @@ class STRDSMetadata(STDSRasterMetadataBase):
          | Maximum value min:.......... None
          | Maximum value max:.......... None
          | Aggregation type:........... None
-         | Number of registered bands:. None
+         | Number of semantic labels:.. None
+         | Semantic labels:............ None
          | Number of registered maps:.. None
          |
          | Title:
@@ -1361,7 +1362,8 @@ class STRDSMetadata(STDSRasterMetadataBase):
         max_min=None
         max_max=None
         aggregation_type=None
-        number_of_bands=None
+        number_of_semantic_labels=None
+        semantic_labels=None
         number_of_maps=None
 
     """
@@ -1372,7 +1374,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
             self, "strds_metadata", ident, title, description
         )
 
-        self.D["number_of_bands"] = None
+        self.D["number_of_semantic_labels"] = None
 
         self.set_raster_register(raster_register)
 
@@ -1388,18 +1390,18 @@ class STRDSMetadata(STDSRasterMetadataBase):
         else:
             return None
 
-    def get_number_of_bands(self):
-        """Get the number of registered bands
+    def get_number_of_semantic_labels(self):
+        """Get the number of registered semantic labels
         :return: None if not found
         """
-        if "number_of_bands" in self.D:
-            return self.D["number_of_bands"]
+        if "number_of_semantic_labels" in self.D:
+            return self.D["number_of_semantic_labels"]
         else:
             return None
 
-    def get_band_names(self):
-        """Get the distinct names of registered bands
-           The distinct band names are not stored in the metadata table
+    def get_semantic_labels(self):
+        """Get the distinct semantic lables of registered maps
+           The distinct semantic labels are not stored in the metadata table
            and fetched on-the-fly
         :return: None if not found
         """
@@ -1436,8 +1438,8 @@ class STRDSMetadata(STDSRasterMetadataBase):
             return None
 
     raster_register = property(fget=get_raster_register, fset=set_raster_register)
-    number_of_bands = property(fget=get_number_of_bands)
-    band_names = property(fget=get_band_names)
+    number_of_semantic_labels = property(fget=get_number_of_semantic_labels)
+    semantic_labels = property(fget=get_semantic_labels)
 
     def _print_info_body(self, shell=False):
         """Print information about this class (body part).
@@ -1450,11 +1452,11 @@ class STRDSMetadata(STDSRasterMetadataBase):
             print(" | Raster register table:...... " + str(self.get_raster_register()))
         super()._print_info_body(shell)
         if shell:
-            print("number_of_bands=" + str(self.get_number_of_bands()))
-            print("band_names=" + str(self.get_band_names()))
+            print("number_of_semantic_labels=" + str(self.get_number_of_semantic_labels()))
+            print("semantic_labels=" + str(self.get_semantic_labels()))
         else:
-            print(" | Number of registered bands:. " + str(self.get_number_of_bands()))
-            print(" | Band names:................. " + str(self.get_band_names()))
+            print(" | Number of semantic labels:.. " + str(self.get_number_of_semantic_labels()))
+            print(" | Semantic labels:............ " + str(self.get_semantic_labels()))
 
 
 ###############################################################################

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -1457,10 +1457,15 @@ class STRDSMetadata(STDSRasterMetadataBase):
             print(" | Raster register table:...... " + str(self.get_raster_register()))
         super()._print_info_body(shell)
         if shell:
-            print("number_of_semantic_labels=" + str(self.get_number_of_semantic_labels()))
+            print(
+                "number_of_semantic_labels=" + str(self.get_number_of_semantic_labels())
+            )
             print("semantic_labels=" + str(self.get_semantic_labels()))
         else:
-            print(" | Number of semantic labels:.. " + str(self.get_number_of_semantic_labels()))
+            print(
+                " | Number of semantic labels:.. "
+                + str(self.get_number_of_semantic_labels())
+            )
             print(" | Semantic labels:............ " + str(self.get_semantic_labels()))
 
 


### PR DESCRIPTION
This PR changes TGIS DB attribute from `number_of_bands` to `number_of_semantic_labels` as discussed in https://github.com/OSGeo/grass/pull/1454#issuecomment-984810602.

After registering two Sentinel bands:

```
T35VLG_20211016T094029_B03_10m|2021-10-16 09:43:56.893568|S2_3
T35VLG_20211016T094029_B02_10m|2021-10-16 09:43:56.893568|S2_2
```

`t.info` reports:

```
 | Number of semantic labels:.. 2
 | Semantic labels:............ S2_2,S2_3
```

```
number_of_semantic_labels=2
semantic_labels=S2_2,S2_3
```

Bumping this PR as blocker for GRASS 8.0 because TGIS DB attribute name is changed.


