### PR TITLE
Jupyter: Bug fix for 3D renderer with KeyError: "GRASS_REGION" 

### DIFF
--- a/python/grass/jupyter/region.py
+++ b/python/grass/jupyter/region.py
@@ -124,7 +124,8 @@ class RegionManagerFor2D:
     def set_region_from_env(self, env):
         """Copies GRASS_REGION from provided environment
         to local environment to set the computational region"""
-        self._env["GRASS_REGION"] = env["GRASS_REGION"]
+        if "GRASS_REGION" in env:
+            self._env["GRASS_REGION"] = env["GRASS_REGION"]
 
     def set_region_from_command(self, module, **kwargs):
         """Sets computational region for rendering.
@@ -185,7 +186,6 @@ class RegionManagerFor3D:
         """
         self._use_region = use_region
         self._saved_region = saved_region
-        self._region_set = False
 
     def set_region_from_command(self, env, **kwargs):
         """Sets computational region for rendering.
@@ -199,17 +199,13 @@ class RegionManagerFor3D:
         """
         if self._saved_region:
             env["GRASS_REGION"] = gs.region_env(region=self._saved_region, env=env)
-            self._region_set = True
             return
         if self._use_region:
             # use current
-            return
-        if self._region_set:
             return
         if "elevation_map" in kwargs:
             elev = kwargs["elevation_map"].split(",")[0]
             try:
                 env["GRASS_REGION"] = gs.region_env(raster=elev, env=env)
-                self._region_set = True
             except CalledModuleError:
                 return

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -93,7 +93,6 @@ class Grass3dRenderer:
         self._height = height
         self._mode = mode
         self._resolution_fine = resolution_fine
-        self._env = os.environ.copy()
 
         # Temporary dir and files
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -203,14 +202,15 @@ class Grass3dRenderer:
                 if has_env_copy:
                     env = display.env()
                 else:
-                    env = self._env
+                    env = os.environ.copy()
                 self._region_manager.set_region_from_command(env=env, **kwargs)
                 self.overlay.region_manager.set_region_from_env(env)
                 gs.run_command(module, env=env, **kwargs)
         else:
-            self._region_manager.set_region_from_command(env=self._env, **kwargs)
-            self.overlay.region_manager.set_region_from_env(self._env)
-            gs.run_command(module, env=self._env, **kwargs)
+            env = os.environ.copy()
+            self._region_manager.set_region_from_command(env=env, **kwargs)
+            self.overlay.region_manager.set_region_from_env(env)
+            gs.run_command(module, env=env, **kwargs)
 
         # Lazy import to avoid an import-time dependency on PIL.
         from PIL import Image  # pylint: disable=import-outside-toplevel

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -93,6 +93,7 @@ class Grass3dRenderer:
         self._height = height
         self._mode = mode
         self._resolution_fine = resolution_fine
+        self._env = os.environ.copy()
 
         # Temporary dir and files
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -202,15 +203,14 @@ class Grass3dRenderer:
                 if has_env_copy:
                     env = display.env()
                 else:
-                    env = os.environ.copy()
+                    env = self._env
                 self._region_manager.set_region_from_command(env=env, **kwargs)
                 self.overlay.region_manager.set_region_from_env(env)
                 gs.run_command(module, env=env, **kwargs)
         else:
-            env = os.environ.copy()
-            self._region_manager.set_region_from_command(env=env, **kwargs)
-            self.overlay.region_manager.set_region_from_env(env)
-            gs.run_command(module, env=env, **kwargs)
+            self._region_manager.set_region_from_command(env=self._env, **kwargs)
+            self.overlay.region_manager.set_region_from_env(self._env)
+            gs.run_command(module, env=self._env, **kwargs)
 
         # Lazy import to avoid an import-time dependency on PIL.
         from PIL import Image  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
* Fixes bug. 

Bug description: When `render()` is called more than once in an instance of the `Grass3dRenderer` class, it raises `KeyError: 'GRASS_REGION'`.

Fix: I'm still not sure why exactly this occurs but I think it's because each time `render()` is called it copies the `os.environ` again. I created a new attribute `self._env` in the `__init__()` function and replaced all `os.environ.copy()`. Then, the code ran for me. Feedback and comments welcome.