### PR TITLE
wxGUI/location_wizard: make TextCtrl widgets horizontally growable

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -180,6 +180,7 @@ class DatabasePage(TitledPage):
         self.sizer = wx.GridBagSizer(vgap=0, hgap=0)
         self.sizer.SetCols(5)
         self.sizer.SetRows(8)
+        self.sizer.AddGrowableCol(1)
 
         # definition of variables
         self.grassdatabase = grassdatabase
@@ -191,7 +192,7 @@ class DatabasePage(TitledPage):
 
         # text controls
         self.tgisdbase = self.MakeLabel(grassdatabase)
-        self.tlocation = self.MakeTextCtrl("newLocation", size=(400, -1))
+        self.tlocation = self.MakeTextCtrl("newLocation")
         self.tlocation.SetFocus()
 
         checks = [
@@ -199,7 +200,7 @@ class DatabasePage(TitledPage):
             (self._checkLocationNotExists, self._locationAlreadyExists),
         ]
         self.tlocation.SetValidator(GenericMultiValidator(checks))
-        self.tlocTitle = self.MakeTextCtrl(size=(400, -1))
+        self.tlocTitle = self.MakeTextCtrl()
 
         # text for required options
         required_txt = self.MakeLabel("*")
@@ -226,7 +227,7 @@ class DatabasePage(TitledPage):
         )
         self.sizer.Add(
             self.tlocation,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.EXPAND,
             border=5,
             pos=(2, 1),
         )
@@ -248,7 +249,7 @@ class DatabasePage(TitledPage):
         )
         self.sizer.Add(
             self.tlocTitle,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL | wx.EXPAND,
             border=5,
             pos=(4, 1),
         )


### PR DESCRIPTION
**Describe the bug**
Location wizard TextCtrl widgets on the database page (first page) aren't horizontally growable, if you increase window size.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. On the Layer Manager window Data page, launch Location Wizard (Define new GRASS Location)
3. Increase window width size
4. TextCtrl widgets on the database page (first page) aren't horizontally growable if window width increase

**Expected behavior**
TextCtrl widgets on the database page (first page) should be horizontally growable if window width increase.

**Screenshots**

Actual behavior:

![wxgui_location_wizard](https://user-images.githubusercontent.com/50632337/146879318-72609eb2-a1e9-482a-8e41-0a1f91c67ed2.png)

Expected behavior:

![wxgui_location_wizard_expected](https://user-images.githubusercontent.com/50632337/146879409-ad51a776-9a87-403b-89e6-b30bb1237b5a.png)

**System description (please complete the following information):**

- GRASS GIS version 8.0 dev