### PR TITLE
Remove pip install for alpine docker

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -185,8 +185,6 @@ ENV LC_ALL="en_US.UTF-8"
 # Copy GRASS GIS from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
-# pip 20.0.0 fix
-RUN apk add curl && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py pip==20.0.2 && rm get-pip.py
 
 # install external Python API
 RUN pip3 install --upgrade pip six grass-session --ignore-installed six


### PR DESCRIPTION
Fixes #2027

This PR simply removes the installation of `pip` from the alpine Dockerimage. By the time this installation was necessary, there was an issue with pip 20.0.0 which came with package sources, so installing another version was required.
This is no longer needed as the package sources of the alpine version we use delivers pip 21.3.1 already.

I tested it locally, it builds successfully and contains above mentioned pip version.