### PR TITLE
wxGUI: fix unexpected type float error with Python 3.10

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -1793,8 +1793,8 @@ class BufferedMapWindow(MapWindowBase, Window):
         w = self.Map.region["center_easting"] - (self.Map.width / 2) * res
         n = self.Map.region["center_northing"] + (self.Map.height / 2) * res
 
-        x = (east - w) / res
-        y = (n - north) / res
+        x = round((east - w) / res)
+        y = round((n - north) / res)
 
         return (x, y)
 


### PR DESCRIPTION
This fixes a problem with Python 3.10
```
  File "/usr/local/usrapps/geospatial/grass-8.0-2021-12-10/grass80/gui/wxpython/mapwin/buffered.py", line 1017, in _updateMFinished
    self.DrawCompRegionExtent()
  File "/usr/local/usrapps/geospatial/grass-8.0-2021-12-10/grass80/gui/wxpython/mapwin/buffered.py", line 1071, in DrawCompRegionExtent
    self.DrawLines(pdc=self.pdcTransparent, polycoords=regionCoords)
  File "/usr/local/usrapps/geospatial/grass-8.0-2021-12-10/grass80/gui/wxpython/mapwin/buffered.py", line 1216, in DrawLines
    self.Draw(pdc, drawid=self.plineid, pdctype="polyline", coords=coords)
  File "/usr/local/usrapps/geospatial/grass-8.0-2021-12-10/grass80/gui/wxpython/mapwin/buffered.py", line 432, in Draw
    wx.Point(coords[i - 1][0], coords[i - 1][1]),
TypeError: Point(): arguments did not match any overloaded call:
  overload 1: too many arguments
  overload 2: argument 1 has unexpected type 'float'
  overload 3: argument 1 has unexpected type 'float'
  overload 4: argument 1 has unexpected type 'float'
```