### PR TITLE
i18N: fix long dash confusing xgettext

### DIFF
--- a/imagery/i.cca/main.c
+++ b/imagery/i.cca/main.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 
     err = I_sort_signatures_by_semantic_label(&sigs, &refs);
     if (err)
-        G_fatal_error(_("Signature – group member semantic label mismatch.\n"
+        G_fatal_error(_("Signature - group member semantic label mismatch.\n"
             "Extra signatures for bands: %s\n"
             "Imagery group bands without signatures: %s"),
             err[0] ? err[0] : _("none"),

--- a/imagery/i.cluster/open_files.c
+++ b/imagery/i.cluster/open_files.c
@@ -68,7 +68,7 @@ int open_files(void)
 
         err = I_sort_signatures_by_semantic_label(&in_sig, &ref);
         if (err)
-            G_fatal_error(_("Signature – group member semantic label mismatch.\n"
+            G_fatal_error(_("Signature - group member semantic label mismatch.\n"
                 "Extra signatures for bands: %s\n"
                 "Imagery group bands without signatures: %s"),
                 err[0] ? err[0] : _("none"),

--- a/imagery/i.maxlik/open.c
+++ b/imagery/i.maxlik/open.c
@@ -48,7 +48,7 @@ int open_files(void)
 
     err = I_sort_signatures_by_semantic_label(&S, &Ref);
     if (err)
-        G_fatal_error(_("Signature – group member semantic label mismatch.\n"
+        G_fatal_error(_("Signature - group member semantic label mismatch.\n"
             "Extra signatures for bands: %s\n"
             "Imagery group bands without signatures: %s"),
             err[0] ? err[0] : _("none"),

--- a/imagery/i.smap/openfiles.c
+++ b/imagery/i.smap/openfiles.c
@@ -39,7 +39,7 @@ int openfiles(struct parms *parms, struct files *files, struct SigSet *S)
 
     err = I_SortSigSetBySemanticLabel(S, &Ref);
     if (err)
-        G_fatal_error(_("Signature – group member semantic label mismatch.\n"
+        G_fatal_error(_("Signature - group member semantic label mismatch.\n"
             "Extra signatures for bands: %s\n"
             "Imagery group bands without signatures: %s"),
             err[0] ? err[0] : _("none"),

--- a/raster/r.in.pdal/r.in.pdal.html
+++ b/raster/r.in.pdal/r.in.pdal.html
@@ -342,7 +342,7 @@ to importing the dataset.
 Point Z axis values can be altered by scaling parameter set by <em>zscale</em>.
 Each point X axis value is multiplied by provided value before any
 filtering or further transformation takes place. In the same way act
-<em>iscale</em> and <em>dscale</em> parametres – values are multiplied
+<em>iscale</em> and <em>dscale</em> parameters - values are multiplied
 before range filters <em>irange</em> or <em>drnage</em> are applied (if present).
 <p>
 Output value scaling can be performed independently of filtering by providing


### PR DESCRIPTION
Fixes

```
Generating grassmods...
xgettext --keyword=_ --keyword=n_:1,2 -cGTC -o ./templates/grassmods.pot `find ../ -name '*.c' | grep -v '../lib' | xargs grep -l "_(\"\|n_(\""`
xgettext: Non-ASCII string at ../imagery/i.smap/openfiles.c:43.
          Please specify the source encoding through --from-code.
make: *** [Makefile:52: pot] Error 1
```

This (probably) requires the update of the messages on Transifex.