### PR TITLE
utils/mkhtml.py: fix setting source code and history URL if official addon is installed from the local directory

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -79,8 +79,13 @@ pgm = sys.argv[1]
 src_file = "%s.html" % pgm
 tmp_file = "%s.tmp.html" % pgm
 
-trunk_url = "https://github.com/OSGeo/grass/tree/main/"
-addons_url = "https://github.com/OSGeo/grass-addons/tree/grass8/"
+grass_version = os.getenv("VERSION_NUMBER", "unknown")
+trunk_url = ""
+addons_url = ""
+if grass_version != "unknown":
+    major, minor, patch = grass_version.split(".")
+    trunk_url = "https://github.com/OSGeo/grass/tree/main/"
+    addons_url = f"https://github.com/OSGeo/grass-addons/tree/grass{major}/"
 
 header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
@@ -415,7 +420,6 @@ else:
     index_name = index_names.get(mod_class, "")
     index_name_cap = index_titles.get(mod_class, "")
 
-grass_version = os.getenv("VERSION_NUMBER", "unknown")
 year = os.getenv("VERSION_DATE")
 if not year:
     year = str(datetime.now().year)

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -80,7 +80,7 @@ src_file = "%s.html" % pgm
 tmp_file = "%s.tmp.html" % pgm
 
 trunk_url = "https://github.com/OSGeo/grass/tree/main/"
-addons_url = "https://github.com/OSGeo/grass-addons/tree/master/"
+addons_url = "https://github.com/OSGeo/grass-addons/tree/grass8/"
 
 header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
@@ -434,10 +434,17 @@ url_source = ""
 if os.getenv("SOURCE_URL", ""):
     addon_path = get_addon_path()
     if addon_path:
-        url_source = urlparse.urljoin(
-            os.environ["SOURCE_URL"].split("src")[0],
-            addon_path,
-        )
+        # Addon is installed from the local dir
+        if os.path.exists(os.getenv("SOURCE_URL")):
+            url_source = urlparse.urljoin(
+                addons_url,
+                addon_path,
+            )
+        else:
+            url_source = urlparse.urljoin(
+                os.environ["SOURCE_URL"].split("src")[0],
+                addon_path,
+            )
 else:
     url_source = urlparse.urljoin(source_url, pgmdir)
 if sys.platform == "win32":


### PR DESCRIPTION
**Describe the bug**
When official addon is installed from the local directory, addon manual page source code and history URL is incorrect.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch GRASS GIS `grass80 --text`
3. Download some addon only `g.extension -d wx.metadata`
4. Install downloaded addon from the local directory `g.extension  wx.metadata url=/tmp/grass8-tomas-29693/tmpwzb3fd_m/wx.metadata` 
5. Check installed addon manual page source code and history URL e.g. g.gui.cswbrowser.html `cat .grass8/addons/docs/html/g.gui.cswbrowser.html`

```
<p>
  Available at:
  <a href="file:///usr/lib64/grass80/docs/html//tmp/grass8-tomas-29693/tmpwzb3fd_m/src/gui/wxpython/wx.metadata/g.gui.cswbrowser">g.gui.cswbrowser source code</a>
  (<a href="file:///usr/lib64/grass80/docs/html//tmp/grass8-tomas-29693/tmpwzb3fd_m/src/gui/wxpython/wx.metadata/g.gui.cswbrowser">history</a>)
</p>
```

**Expected behavior**
Correct addon manual page source code and history URL.

e.g. g.gui.cswbrowser.html

```
<p>
  Available at:
  <a href="https://github.com/OSGeo/grass-addons/tree/grass8/src/gui/wxpython/wx.metadata/g.gui.cswbrowser">g.gui.cswbrowser source code</a>
  (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/gui/wxpython/wx.metadata/g.gui.cswbrowser">history</a>)
</p>
```

**System description:**

- GRASS GIS version: main, releasebranch_7_8