### PR TITLE
tools/mkhtml.py: fix module/official addons source code and history URL branch

### DIFF
--- a/tools/mkhtml.py
+++ b/tools/mkhtml.py
@@ -81,8 +81,8 @@ trunk_url = ""
 addons_url = ""
 if grass_version != "unknown":
     major, minor, patch = grass_version.split(".")
-    trunk_url = "https://github.com/OSGeo/grass/tree/main/"
-    addons_url = f"https://github.com/OSGeo/grass-addons/tree/grass{major}/"
+    trunk_url = "https://github.com/OSGeo/grass/tree/releasebranch_7_8/"
+    addons_url = "https://github.com/OSGeo/grass-addons/tree/grass7/"
 
 header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>

--- a/tools/mkhtml.py
+++ b/tools/mkhtml.py
@@ -81,8 +81,8 @@ trunk_url = ""
 addons_url = ""
 if grass_version != "unknown":
     major, minor, patch = grass_version.split(".")
-    trunk_url = "https://github.com/OSGeo/grass/tree/releasebranch_7_8/"
-    addons_url = "https://github.com/OSGeo/grass-addons/tree/grass7/"
+    trunk_url = f"https://github.com/OSGeo/grass/tree/releasebranch_{major}_{minor}/"
+    addons_url = f"https://github.com/OSGeo/grass-addons/tree/grass{major}/"
 
 header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>


### PR DESCRIPTION
**Describe the bug**
Module (compilation), official addon which is installed from the local directory have incorrect manual page source code and history URL, which URL path don't match GRASS GIS release branch name.

**To Reproduce**
Steps to reproduce the behavior:

Module:
1. Install GRASS GIS 7.8 release version
2. Check some module manual page source code and history URL e.g. v.surf.rst `cat /usr/lib64/grass78/docs/html/v.surf.rst.html`

```
<p>
<i>Last changed: $Date$</i>
--><h2>SOURCE CODE</h2>
<p>Available at: <a href="https://github.com/OSGeo/grass/tree/master/vector/v.surf.rst">v.surf.rst source code</a> (<a href="https://github.com/OSGeo/grass/commits/master/vector/v.surf.rst">history</a>)</p>
<hr class="header">
<p>
```

Addon:
1. Install GRASS 7.8 release version with this [PR](https://github.com/OSGeo/grass/pull/2037) applied
2. Download some addon only e.g. `g.extension -d wx.metadata`
3. Install downloaded addon from the local directory `g.extension  wx.metadata url=/tmp/grass7-tomas-25558/tmpi9syivf2/wx.metadata` 
4.  Check installed addon manual page source code and history URL e.g. g.gui.cswbrowser.html `cat .grass7/addons/docs/html/g.gui.cswbrowser.html`

**Expected behavior**
Module, official addon which is installed from the local directory should be have correct manual page source code and history URL which match GRASS GIS release.

**System description:**

- GRASS GIS version: releasebranch_7_8