### PR TITLE
wxGUI/preferences.py: fix loading default user settings

### DIFF
--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -155,7 +155,11 @@ class PreferencesBaseDialog(wx.Dialog):
                 )
             win = self.FindWindowById(self.winId[gks])
 
-            if win.GetName() in ("GetValue", "IsChecked"):
+            if win.GetName() == "IsChecked":
+                value = win.SetValue(value)
+            elif win.GetName() == "GetValue":
+                if isinstance(win, (wx.ComboBox, wx.TextCtrl)):
+                    value = str(value)
                 value = win.SetValue(value)
             elif win.GetName() == "GetSelection":
                 value = win.SetSelection(value)


### PR DESCRIPTION
Fixes #2032. [wx.ComboBox](https://www.wxpython.org/Phoenix/docs/html/wx.ComboBox.html#wx.ComboBox.SetValue), [wx.TextCtrl](https://www.wxpython.org/Phoenix/docs/html/wx.TextEntry.html#wx.TextEntry.SetValue) widgets require string value for setting value via SetValue() method, instead of integer.