### PR TITLE
Fix spelling errors.

### DIFF
--- a/general/g.region/g.region.html
+++ b/general/g.region/g.region.html
@@ -125,7 +125,7 @@ with the UNIX eval command, "<tt>eval `g.region -g`</tt>".
 <p>With <b>-u</b> flag current region is not updated even if one or more
 options for changing region is used (<b>res=</b>, <b>raster=</b>, etc).
 This can be used for example to print modified region values for further use
-without actually modifing the current region.
+without actually modifying the current region.
 Similarly, <b>-o</b> flag forces to update current region file even when e.g., only
 printing was specified. Flag <b>-o</b> was added in GRASS GIS version 8 to simulate
 <em>g.region</em> behavior in prior versions when current region file was

--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -483,8 +483,8 @@ class WSDialogBase(wx.Dialog):
 
     def OnChooseWs(self, event):
         """Show panel corresponding to selected web service."""
-        choosen_r = event.GetInt()
-        self._showWsPanel(self.web_service_sel[choosen_r])
+        chosen_r = event.GetInt()
+        self._showWsPanel(self.web_service_sel[chosen_r])
 
     def _showWsPanel(self, ws):
         """Helper function"""

--- a/imagery/i.smap/i.smap.html
+++ b/imagery/i.smap/i.smap.html
@@ -182,7 +182,7 @@ Semantic labels are set by means of <em>r.support</em>
 as shown below:
 
 <div class="code"><pre>
-# Define sematic labels for all LANDSAT bands
+# Define semantic labels for all LANDSAT bands
 r.support map=lsat7_2002_10 semantic_label=TM7_1
 r.support map=lsat7_2002_20 semantic_label=TM7_2
 r.support map=lsat7_2002_30 semantic_label=TM7_3

--- a/lib/gis/lz4.h
+++ b/lib/gis/lz4.h
@@ -85,7 +85,7 @@ extern "C" {
 #if defined(LZ4_DLL_EXPORT) && (LZ4_DLL_EXPORT==1)
 #  define LZ4LIB_API __declspec(dllexport) LZ4LIB_VISIBILITY
 #elif defined(LZ4_DLL_IMPORT) && (LZ4_DLL_IMPORT==1)
-#  define LZ4LIB_API __declspec(dllimport) LZ4LIB_VISIBILITY /* It isn't required but allows to generate better code, saving a function pointer load from the IAT and an indirect jump.*/
+#  define LZ4LIB_API __declspec(dllimport) LZ4LIB_VISIBILITY /* It isn't required but allows generating better code, saving a function pointer load from the IAT and an indirect jump.*/
 #else
 #  define LZ4LIB_API LZ4LIB_VISIBILITY
 #endif

--- a/locale/po/grassmods_ar.po
+++ b/locale/po/grassmods_ar.po
@@ -22781,7 +22781,7 @@ msgstr "الخريطة المدخلة حاوية الخطوط"
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
 msgid ""
 "Vector points map where each point is used as training sample. Handling of "
-"missing values in training data can be choosen later."
+"missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -24661,7 +24661,7 @@ msgid "Interpolation command string"
 msgstr "طريقة الاستيفاء المستخدمة"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -64505,7 +64505,7 @@ msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
 msgid ""
-"The proxy will be ignored by the choosen GRASS driver. It is only used with "
+"The proxy will be ignored by the chosen GRASS driver. It is only used with "
 "the GDAL driver."
 msgstr ""
 

--- a/locale/po/grassmods_bn.po
+++ b/locale/po/grassmods_bn.po
@@ -20151,7 +20151,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21774,7 +21774,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57155,7 +57155,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_cs.po
+++ b/locale/po/grassmods_cs.po
@@ -20892,7 +20892,7 @@ msgid "Vector map with training samples"
 msgstr "Vstupní mapa obsahující linie"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22633,7 +22633,7 @@ msgid "Interpolation command string"
 msgstr "Interpolace selhala"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58545,7 +58545,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_de.po
+++ b/locale/po/grassmods_de.po
@@ -20948,7 +20948,7 @@ msgid "Vector map with training samples"
 msgstr "Eingabe-Vektorkarte mit Linien."
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22679,7 +22679,7 @@ msgid "Interpolation command string"
 msgstr "Zu benutzende Interpolationsmethode."
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58424,7 +58424,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_el.po
+++ b/locale/po/grassmods_el.po
@@ -20413,7 +20413,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22072,7 +22072,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57503,7 +57503,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_es.po
+++ b/locale/po/grassmods_es.po
@@ -21134,7 +21134,7 @@ msgid "Vector map with training samples"
 msgstr "Nombre de mapa vectorial de entrada que contiene puntos de entrenamiento"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22889,7 +22889,7 @@ msgid "Interpolation command string"
 msgstr "Falló interpolación"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58715,7 +58715,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_fi.po
+++ b/locale/po/grassmods_fi.po
@@ -20167,7 +20167,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21791,7 +21791,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57177,7 +57177,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_fr.po
+++ b/locale/po/grassmods_fr.po
@@ -20970,7 +20970,7 @@ msgid "Vector map with training samples"
 msgstr "Outil de profilage de la carte vecteur"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22721,7 +22721,7 @@ msgid "Interpolation command string"
 msgstr "Méthode d'interpolation à utiliser"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58368,7 +58368,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_hu.po
+++ b/locale/po/grassmods_hu.po
@@ -20240,7 +20240,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21876,7 +21876,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57284,7 +57284,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_id_ID.po
+++ b/locale/po/grassmods_id_ID.po
@@ -20150,7 +20150,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21773,7 +21773,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57045,7 +57045,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_it.po
+++ b/locale/po/grassmods_it.po
@@ -20877,7 +20877,7 @@ msgid "Vector map with training samples"
 msgstr "Mappa vettoriale di input contenente le linee"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22597,7 +22597,7 @@ msgid "Interpolation command string"
 msgstr "Metodo di interpolazione da usare"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58268,7 +58268,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_ja.po
+++ b/locale/po/grassmods_ja.po
@@ -20845,7 +20845,7 @@ msgid "Vector map with training samples"
 msgstr "指定したベクトルマップはラインを含む"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22559,7 +22559,7 @@ msgid "Interpolation command string"
 msgstr "補間方法 "
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58117,7 +58117,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_ko.po
+++ b/locale/po/grassmods_ko.po
@@ -20695,7 +20695,7 @@ msgid "Vector map with training samples"
 msgstr "출력할 격자지도"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22383,7 +22383,7 @@ msgid "Interpolation command string"
 msgstr "사용할 보간 방법"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57795,7 +57795,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_lv.po
+++ b/locale/po/grassmods_lv.po
@@ -21591,7 +21591,7 @@ msgstr "Ieejošā karte satur līnijas"
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
 msgid ""
 "Vector points map where each point is used as training sample. Handling of "
-"missing values in training data can be choosen later."
+"missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -23372,7 +23372,7 @@ msgid "Interpolation command string"
 msgstr "Rakstu jaunu failu... \n"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -60571,7 +60571,7 @@ msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
 msgid ""
-"The proxy will be ignored by the choosen GRASS driver. It is only used with "
+"The proxy will be ignored by the chosen GRASS driver. It is only used with "
 "the GDAL driver."
 msgstr ""
 

--- a/locale/po/grassmods_ml.po
+++ b/locale/po/grassmods_ml.po
@@ -20151,7 +20151,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21774,7 +21774,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57155,7 +57155,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_pl.po
+++ b/locale/po/grassmods_pl.po
@@ -20808,7 +20808,7 @@ msgid "Vector map with training samples"
 msgstr "Tytuł mapy wektorowej"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22517,7 +22517,7 @@ msgid "Interpolation command string"
 msgstr "Metoda interpolacji która ma być użyta"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58314,7 +58314,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_pt.po
+++ b/locale/po/grassmods_pt.po
@@ -20620,7 +20620,7 @@ msgid "Vector map with training samples"
 msgstr "Título do mapa vetoria"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22328,7 +22328,7 @@ msgid "Interpolation command string"
 msgstr "Método de intepolação a usar"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57844,7 +57844,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_pt_BR.po
+++ b/locale/po/grassmods_pt_BR.po
@@ -20676,7 +20676,7 @@ msgid "Vector map with training samples"
 msgstr "Título do mapa vetorial"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22390,7 +22390,7 @@ msgid "Interpolation command string"
 msgstr "Interpolando %d pontos"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58053,7 +58053,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr "O driver %s suporta apenas '%s' parâmetro em '%s'. Outros parâmetros são ignorados."
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_ro.po
+++ b/locale/po/grassmods_ro.po
@@ -20627,7 +20627,7 @@ msgid "Vector map with training samples"
 msgstr "Numele hărții raster care conține netezirea"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22298,7 +22298,7 @@ msgid "Interpolation command string"
 msgstr "Interpolare eșuată"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57928,7 +57928,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_ru.po
+++ b/locale/po/grassmods_ru.po
@@ -20378,7 +20378,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22058,7 +22058,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57707,7 +57707,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_si.po
+++ b/locale/po/grassmods_si.po
@@ -20151,7 +20151,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21774,7 +21774,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57155,7 +57155,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_sl.po
+++ b/locale/po/grassmods_sl.po
@@ -22843,7 +22843,7 @@ msgstr "Vhodni sloj vsebuje linije."
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
 msgid ""
 "Vector points map where each point is used as training sample. Handling of "
-"missing values in training data can be choosen later."
+"missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -24723,7 +24723,7 @@ msgid "Interpolation command string"
 msgstr "Interpolacijska metoda, ki jo želite uporabiti"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -64842,7 +64842,7 @@ msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
 msgid ""
-"The proxy will be ignored by the choosen GRASS driver. It is only used with "
+"The proxy will be ignored by the chosen GRASS driver. It is only used with "
 "the GDAL driver."
 msgstr ""
 

--- a/locale/po/grassmods_ta.po
+++ b/locale/po/grassmods_ta.po
@@ -20171,7 +20171,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21797,7 +21797,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57184,7 +57184,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_th.po
+++ b/locale/po/grassmods_th.po
@@ -20373,7 +20373,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22050,7 +22050,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57371,7 +57371,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_tr.po
+++ b/locale/po/grassmods_tr.po
@@ -20725,7 +20725,7 @@ msgid "Vector map with training samples"
 msgstr "Çizgileri içeren girdi vektör haritası"
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22442,7 +22442,7 @@ msgid "Interpolation command string"
 msgstr "Kullanılacak enterpolasyon metodu"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -58013,7 +58013,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_uk.po
+++ b/locale/po/grassmods_uk.po
@@ -20153,7 +20153,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21776,7 +21776,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57375,7 +57375,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_vi.po
+++ b/locale/po/grassmods_vi.po
@@ -20373,7 +20373,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22051,7 +22051,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57372,7 +57372,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_zh.po
+++ b/locale/po/grassmods_zh.po
@@ -20649,7 +20649,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -22337,7 +22337,7 @@ msgid "Interpolation command string"
 msgstr "使用的插值方法"
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57729,7 +57729,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/locale/po/grassmods_zh_CN.po
+++ b/locale/po/grassmods_zh_CN.po
@@ -20151,7 +20151,7 @@ msgid "Vector map with training samples"
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:13
-msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be choosen later."
+msgid "Vector points map where each point is used as training sample. Handling of missing values in training data can be chosen later."
 msgstr ""
 
 #: ../locale/scriptstrings/r.learn.ml_to_translate.c:15
@@ -21774,7 +21774,7 @@ msgid "Interpolation command string"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:36
-msgid "Additional settings for choosen interpolation (see manual)"
+msgid "Additional settings for chosen interpolation (see manual)"
 msgstr ""
 
 #: ../locale/scriptstrings/r.mwprecip_to_translate.c:38
@@ -57046,7 +57046,7 @@ msgid "%s driver supports only '%s' parameter in '%s'. Other parameters are igno
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:250
-msgid "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+msgid "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
 msgstr ""
 
 #: ../scripts/r.in.wms/r.in.wms.py:255

--- a/raster/r.in.pdal/r.in.pdal.html
+++ b/raster/r.in.pdal/r.in.pdal.html
@@ -250,9 +250,9 @@ the analysis itself but it can also speed up the processing.
 <p>
 LiDAR points can contain a lot of attributes besides their coordinates.
 By default <em>r.in.pdal</em> will use point Z coordinate as the output
-raster value source. The <em>dimension</em> option allows to use different
+raster value source. The <em>dimension</em> option allows using different
 point attributes as an output instead of Z value. In case if other than Z
-value is choosen, output map type will be set to CELL. Explanation
+value is chosen, output map type will be set to CELL. Explanation
 of various attributes can be found in LAS Specification chapter "Point
 Data Records". Be ware - not all attributes might be present and also
 their value ranges and meaning might vary between LAS file producers.

--- a/scripts/i.band.library/i.band.library.html
+++ b/scripts/i.band.library/i.band.library.html
@@ -178,7 +178,7 @@ identifier.
 <p>
 System-defined registry files are located in GRASS GIS installation
 directory (<tt>$GISBASE/etc/i.band.library</tt>). Note that
-currently <i>i.band.library</i> allows to manage only system-defined registry
+currently <i>i.band.library</i> allows managing only system-defined registry
 files. Support for user-defined registry files is planned to be
 implemented, see <a href="#known-issues">KNOWN ISSUES</a> section for
 details.

--- a/scripts/r.in.wms/r.in.wms.py
+++ b/scripts/r.in.wms/r.in.wms.py
@@ -265,7 +265,7 @@ def main():
             if "GRASS" in options["driver"]:
                 grass.warning(
                     _(
-                        "The proxy will be ignored by the choosen GRASS driver. It is only used with the GDAL driver."
+                        "The proxy will be ignored by the chosen GRASS driver. It is only used with the GDAL driver."
                     )
                 )
 


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * modifing  -> modifying
 * allows to -> allows &lt;verb&gt;ing
 * sematic   -> semantic
 * choosen   -> chosen