### PR TITLE
wxGUI: no is_shell_running available

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -48,7 +48,6 @@ from gui_core.widgets import SingleSymbolPanel, GListCtrl, SimpleValidator, \
     MapValidator
 from core.settings import UserSettings
 from core.debug import Debug
-from core.utils import is_shell_running
 from gui_core.wrap import (
     Button,
     CheckListBox,


### PR DESCRIPTION
Remove spurious import (backport leftover in ecd13587d7ccde56b9f443ee884870076983c471) to enable wxGUI startup.

(`is_shell_running()` got introduced in #1219, likely not needed in G78)