### PR TITLE
g.extension: catch missing modules.xml error

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -237,7 +237,7 @@ def urlopen(url, *args, **kwargs):
     except URLError:
         gscript.fatal(
             _(
-                "Download file from <{url}>, "
+                "Download file <{url}>, "
                 "failed. File not on server or check internet connection.".format(
                     url=url,
                 ),

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -232,17 +232,6 @@ def urlopen(url, *args, **kwargs):
     ability to define headers.
     """
     request = urlrequest.Request(url, headers=HEADERS)
-    try:
-        urlrequest.urlopen(request, *args, **kwargs)
-    except URLError:
-        gscript.fatal(
-            _(
-                "Download file <{url}>, "
-                "failed. File not on server or check internet connection.".format(
-                    url=url,
-                ),
-            ),
-        )
     return urlrequest.urlopen(request, *args, **kwargs)
 
 
@@ -391,7 +380,18 @@ def etree_fromfile(filename):
 
 def etree_fromurl(url):
     """Create XML element tree from a given URL"""
-    file_ = urlopen(url)
+    try:
+        file_ = urlopen(url)
+    except URLError:
+        gscript.fatal(
+            _(
+                "Download file from <{url}>,"
+                " failed. File is not on the server or"
+                " check your internet connection.".format(
+                    url=url,
+                ),
+            ),
+        )
     return etree.fromstring(file_.read())
 
 

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -232,6 +232,17 @@ def urlopen(url, *args, **kwargs):
     ability to define headers.
     """
     request = urlrequest.Request(url, headers=HEADERS)
+    try:
+        urlrequest.urlopen(request, *args, **kwargs)
+    except URLError:
+        gscript.fatal(
+            _(
+                "Download file from <{url}>, "
+                "failed. File not on server or check internet connection.".format(
+                    url=url,
+                ),
+            ),
+        )
     return urlrequest.urlopen(request, *args, **kwargs)
 
 


### PR DESCRIPTION
Print error message when
https://grass.osgeo.org/addons/grass8/modules.xml
is missing on server (generated here: https://github.com/OSGeo/grass-addons/tree/grass8/utils/cronjobs_osgeo_lxd).

So far this error appears:

```
GRASS nc_spm_08_grass7/user1:grass_main > g.extension -l
/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension:167: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.dir_util import copy_tree
List of available extensions (modules):
https://grass.osgeo.org/addons/grass8/modules.xml
Fetching list of extensions from GRASS-Addons SVN repository (be
patient)...
https://grass.osgeo.org/addons/grass8/
Traceback (most recent call last):
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 682, in list_available_modules
    tree = etree_fromurl(file_url)
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 384, in etree_fromurl
    file_ = urlopen(url)
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 236, in urlopen
    return urlrequest.urlopen(request, *args, **kwargs)
  File "/usr/lib64/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.10/urllib/request.py", line 525, in open
    response = meth(req, response)
  File "/usr/lib64/python3.10/urllib/request.py", line 634, in http_response
    response = self.parent.error(
  File "/usr/lib64/python3.10/urllib/request.py", line 563, in error
    return self._call_chain(*args)
  File "/usr/lib64/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.10/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 2571, in <module>
    sys.exit(main())
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 2518, in main
    list_available_extensions(xmlurl)
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 557, in list_available_extensions
    list_available_modules(url)
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 694, in list_available_modules
    list_available_extensions_svn(url)
  File "/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension", line 762, in list_available_extensions_svn
    sline = pattern.search(line)
TypeError: cannot use a string pattern on a bytes-like object
```

With this PR:

```
GRASS nc_spm_08_grass7/user1:grass_main > g.extension -l
/home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/scripts/g.extension:167: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.dir_util import copy_tree
List of available extensions (modules):
ERROR: Download file from
       <https://grass.osgeo.org/addons/grass8/modules.xml>, failed. File
       not on server or check internet connection.
```