### PR TITLE
wxGUI: use basic top module notebook style on all platforms as default

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -190,9 +190,7 @@ class Settings:
                 "menustyle": {"selection": 1},
                 "gSelectPopupHeight": {"value": 200},
                 "iconTheme": {"type": "grass"},
-                "commandNotebook": {
-                    "selection": 0 if sys.platform in ("win32", "darwin") else 1
-                },
+                "commandNotebook": {"selection": 0},
             },
             #
             # language


### PR DESCRIPTION
Basic left style no longer looks good on linux with newer wxwidgets
