### PR TITLE
wxGUI/gui_core: fix open map display overlay settings dialog

### DIFF
--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -81,7 +81,7 @@ class MapPanelBase(wx.Panel):
 
         self.parent = parent
 
-        wx.Panel.__init__(self, parent, id, **kwargs)
+        wx.Panel.__init__(self, parent, id, name=name, **kwargs)
 
         # toolbars
         self.toolbars = {}


### PR DESCRIPTION
**Describe the bug**
The map overlay dialog doesn't open when you add an overlay to the map and double click on it again.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Add some overlay e.g. north arrow
3. Left double mouse click on north arrow overlay or via right mouse click to invoke  overlay menu -> North arrow properties
4. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass80/gui/wxpython/mapwin/buffered.py",
line 1405, in MouseActions

self.OnButtonDClick(event)
  File "/usr/lib64/grass80/gui/wxpython/mapwin/buffered.py",
line 1643, in OnButtonDClick

self.overlayActivated.emit(overlayId=self.dragid)
  File
"/usr/lib64/grass80/etc/python/grass/pydispatch/signal.py",
line 233, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass80/etc/python/grass/pydispatch/dispa
tcher.py", line 344, in send

response = robustapply.robustApply(
  File "/usr/lib64/grass80/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File "/usr/lib64/grass80/gui/wxpython/mapdisp/frame.py",
line 1344, in _activateOverlay

if dlg.IsShown():
RuntimeError
:
wrapped C/C++ object of type TaskFrame has been deleted
```

**Expected behavior**
The map overlay dialog should be open when you add an overlay to the map and double click on it again.

**System description:**

- GRASS GIS version main git branch

**Additional context**

Bug was introduced with this [commit](https://github.com/OSGeo/grass/commit/2f94d78a6622dd3f78d66bb6b01dc6795dcba2b8#diff-1a65edc3e5ca648c4bcd5e84bdddf3349912cbe99c2832a315c0efe1158df01bR84).