### PR TITLE
wxGUI/gui_core: fix change opacity level dialog min/max size, widgets expand horizontally

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1818,6 +1818,7 @@ class SetOpacityDialog(wx.Dialog):
         sizer = wx.BoxSizer(wx.VERTICAL)
 
         box = wx.GridBagSizer(vgap=5, hgap=5)
+        box.AddGrowableCol(0)
         self.value = Slider(
             panel,
             id=wx.ID_ANY,
@@ -1825,10 +1826,9 @@ class SetOpacityDialog(wx.Dialog):
             style=wx.SL_HORIZONTAL | wx.SL_AUTOTICKS | wx.SL_TOP | wx.SL_LABELS,
             minValue=0,
             maxValue=100,
-            size=(350, -1),
         )
 
-        box.Add(self.value, flag=wx.ALIGN_CENTRE, pos=(0, 0), span=(1, 2))
+        box.Add(self.value, flag=wx.EXPAND, pos=(0, 0), span=(1, 2))
         box.Add(
             StaticText(parent=panel, id=wx.ID_ANY, label=_("transparent")), pos=(1, 0)
         )
@@ -1863,7 +1863,10 @@ class SetOpacityDialog(wx.Dialog):
         panel.SetSizer(sizer)
         sizer.Fit(panel)
 
-        self.SetSize(self.GetBestSize())
+        w, h = self.GetBestSize()
+        self.SetSize(wx.Size(w, h))
+        self.SetMaxSize(wx.Size(-1, h))
+        self.SetMinSize(wx.Size(w, h))
 
         self.Layout()
 


### PR DESCRIPTION
**Describe the bug**
Opacity level dialog doesn't have min/max size set and widgets aren't horizontally growable.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Add some vector/raster map `d.rast elevation`
3. Invoke vector/raster map menu on the Layers page (tab), and choose Change opacity level item 
4. Try change window width/height

**Screenshots**

Default behavior:

![wxgui_change_opacity_level_dialog_default](https://user-images.githubusercontent.com/50632337/148111842-de560220-562a-4b28-84ec-3d425d25e008.png)


Expected behavior:

![wxgui_change_opacity_level_dialog_expected](https://user-images.githubusercontent.com/50632337/148111857-9421f8ca-4e0b-4e98-b602-abaea8d61aae.png)

**System description:**

- GRASS GIS version main, releasebranch_8_0, releasebranch_7_8 git branch
