### PR TITLE
winGRASS: change form BU Execute to "GenericRead + GenericExecute"

### DIFF
--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -758,7 +758,8 @@ Section "GRASS" SecGRASS
 	Push 'config_projshare = "$INSTDIR\share\proj"' ; string to replace whole line with
 	Call ReplaceLineStr
 
-        AccessControl::SetOnFile "$INSTDIR\etc\grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@.py" "(BU)" "Execute"                 
+	;replace BU with numeric group name for local users
+        AccessControl::SetOnFile "$INSTDIR\etc\grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@.py" "(S-1-5-32-545)" "GenericRead + GenericExecute"                 
 SectionEnd
 
 ;--------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes Line 761 of of the nsis installer template in the mswindows directory, GRASS-installer.nsi.tmpl from using "BU" "Execute" to using the language - independent ""(s-1-5-32-545)" "GenericRead + GenericExecute"
Should fix issue identified in #1965 . Fix based off information at https://peter.bloomfield.online/nsis-access-control-problem-with-built-in-users-group/ , where the BU permissions option does not work on installations of a different language than the language the NSIS installer was created on Windows version 8 and above computers.