### PR TITLE
wxGUI: get rid of gradient in map display notebook tabs

### DIFF
--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -23,6 +23,7 @@ import wx.lib.filebrowsebutton as filebrowse
 import wx.lib.scrolledpanel as scrolled
 from wx.lib import expando
 from wx.lib import buttons
+from wx.lib.agw.aui import tabart
 
 try:
     import wx.lib.agw.customtreectrl as CT
@@ -944,3 +945,38 @@ class ComboBox(wx.ComboBox):
             wx.ComboBox.SetToolTip(self, tipString=tip)
         else:
             wx.ComboBox.SetToolTipString(self, tip)
+
+
+class SimpleTabArt(tabart.AuiDefaultTabArt):
+    """A class simplifying the appearance of AUI notebook tabs."""
+
+    def __init__(self):
+        """Default class constructor."""
+        tabart.AuiDefaultTabArt.__init__(self)
+
+    def SetDefaultColours(self, base_colour=None):
+        """
+        Overrides AuiDefaultTabArt.SetDefaultColours
+        to get rid of gradient and to look more like
+        flatnotebook tabs.
+        """
+
+        if base_colour is None:
+            base_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE)
+
+        self.SetBaseColour(base_colour)
+        tab_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+
+        self._border_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW)
+        self._border_pen = wx.Pen(self._border_colour)
+        self._background_top_colour = base_colour
+        self._background_bottom_colour = base_colour
+        self._tab_top_colour = tab_color
+        self._tab_bottom_colour = tab_color
+        self._tab_gradient_highlight_colour = tab_color
+        self._tab_inactive_top_colour = base_colour
+        self._tab_inactive_bottom_colour = base_colour
+        self._tab_text_colour = lambda page: page.text_colour
+        self._tab_disabled_text_colour = wx.SystemSettings.GetColour(
+            wx.SYS_COLOUR_GRAYTEXT
+        )

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -76,7 +76,7 @@ from lmgr.giface import (
 from mapdisp.frame import MapPanel
 from datacatalog.catalog import DataCatalog
 from gui_core.forms import GUI
-from gui_core.wrap import Menu, TextEntryDialog
+from gui_core.wrap import Menu, TextEntryDialog, SimpleTabArt
 from startup.guiutils import (
     can_switch_mapset_interactive,
     switch_mapset_interactively,
@@ -284,7 +284,7 @@ class GMFrame(wx.Frame):
             wx.Size(430, 200),
             agwStyle=notebook_style,
         )
-        self.mapnotebook.SetArtProvider(aui.AuiDefaultTabArt())
+        self.mapnotebook.SetArtProvider(SimpleTabArt())
         # bindings
         self.mapnotebook.Bind(
             aui.EVT_AUINOTEBOOK_PAGE_CHANGED,
@@ -506,7 +506,7 @@ class GMFrame(wx.Frame):
 
     def BuildPanes(self):
         """Build panes - toolbars as well as panels"""
-
+        self._auimgr.SetAutoNotebookTabArt(SimpleTabArt())
         # initialize all main widgets
         self._createMapNotebook()
         self._createDataCatalog(parent=self)


### PR DESCRIPTION
Applies to single window layout only.
Based on https://github.com/wxWidgets/Phoenix/blob/master/wx/lib/agw/aui/tabart.py