### PR TITLE
wxGUI/main_window: fix close map notebook page

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -857,7 +857,7 @@ class GMFrame(wx.Frame):
         generating notebook page closing event
 
         :param dict pgnum_dict: "display" key represent map display
-        notebook layer tree page index
+        notebook layers tree page index
         """
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
         self.notebookLayers.DeletePage(pgnum_dict["display"])

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -517,8 +517,9 @@ class GMFrame(wx.Frame):
         def CanCloseDisplay(askIfSaveWorkspace):
             """Callback to check if user wants to close display.
 
-            :param dict pgnum_dict: dict "layers" key represent map display
-                                    notebook layers tree page index
+            :return dict/None pgnum_dict/None: dict "layers" key represent
+                                               map display notebook layers
+                                               tree page index
             """
             pgnum_dict = {}
             pgnum_dict["layers"] = self.notebookLayers.GetPageIndex(page)
@@ -857,8 +858,8 @@ class GMFrame(wx.Frame):
         event.Skip()
 
     def _closePageNoEvent(self, pgnum_dict):
-        """Close page and destroy map display without
-        generating notebook page closing event
+        """Close page and destroy map display without generating notebook
+        page closing event.
 
         :param dict pgnum_dict: dict "layers" key represent map display
                                 notebook layers tree page index

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -516,13 +516,14 @@ class GMFrame(wx.Frame):
 
         def CanCloseDisplay(askIfSaveWorkspace):
             """Callback to check if user wants to close display"""
-            pgnum = self.notebookLayers.GetPageIndex(page)
-            name = self.notebookLayers.GetPageText(pgnum)
+            pgnum_dict = {}
+            pgnum_dict["display"] = self.notebookLayers.GetPageIndex(page)
+            name = self.notebookLayers.GetPageText(pgnum_dict["display"])
             caption = _("Close Map Display {}").format(name)
             if not askIfSaveWorkspace or (
                 askIfSaveWorkspace and self.workspace_manager.CanClosePage(caption)
             ):
-                return pgnum
+                return pgnum_dict
             return None
 
         mapdisplay.canCloseDisplayCallback = CanCloseDisplay
@@ -851,12 +852,19 @@ class GMFrame(wx.Frame):
 
         event.Skip()
 
-    def _closePageNoEvent(self, page_index):
+    def _closePageNoEvent(self, pgnum_dict):
         """Close page and destroy map display without
-        generating notebook page closing event"""
+        generating notebook page closing event
+
+        :param dict pgnum_dict: "display" key represent map display
+        notebook layer tree page index
+        """
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
-        self.notebookLayers.DeletePage(page_index)
-        self.notebookLayers.Bind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.OnCBPageClosing)
+        self.notebookLayers.DeletePage(pgnum_dict["display"])
+        self.notebookLayers.Bind(
+            FN.EVT_FLATNOTEBOOK_PAGE_CLOSING,
+            self.OnCBPageClosing,
+        )
 
     def _switchPageHandler(self, event, notification):
         self._switchPage(notification=notification)

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -515,10 +515,14 @@ class GMFrame(wx.Frame):
         page = self.currentPage
 
         def CanCloseDisplay(askIfSaveWorkspace):
-            """Callback to check if user wants to close display"""
+            """Callback to check if user wants to close display.
+
+            :param dict pgnum_dict: dict "layers" key represent map display
+                                    notebook layer tree page index
+            """
             pgnum_dict = {}
-            pgnum_dict["display"] = self.notebookLayers.GetPageIndex(page)
-            name = self.notebookLayers.GetPageText(pgnum_dict["display"])
+            pgnum_dict["layers"] = self.notebookLayers.GetPageIndex(page)
+            name = self.notebookLayers.GetPageText(pgnum_dict["layers"])
             caption = _("Close Map Display {}").format(name)
             if not askIfSaveWorkspace or (
                 askIfSaveWorkspace and self.workspace_manager.CanClosePage(caption)
@@ -856,11 +860,11 @@ class GMFrame(wx.Frame):
         """Close page and destroy map display without
         generating notebook page closing event
 
-        :param dict pgnum_dict: "display" key represent map display
-        notebook layers tree page index
+        :param dict pgnum_dict: dict "layers" key represent map display
+                                notebook layers tree page index
         """
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
-        self.notebookLayers.DeletePage(pgnum_dict["display"])
+        self.notebookLayers.DeletePage(pgnum_dict["layers"])
         self.notebookLayers.Bind(
             FN.EVT_FLATNOTEBOOK_PAGE_CLOSING,
             self.OnCBPageClosing,

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -518,7 +518,7 @@ class GMFrame(wx.Frame):
             """Callback to check if user wants to close display.
 
             :param dict pgnum_dict: dict "layers" key represent map display
-                                    notebook layer tree page index
+                                    notebook layers tree page index
             """
             pgnum_dict = {}
             pgnum_dict["layers"] = self.notebookLayers.GetPageIndex(page)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -466,12 +466,12 @@ class GMFrame(wx.Frame):
             """Callback to check if user wants to close display. Map
             Display index can be different from index in Display tab.
 
-            :return dict/None pgnum_dict: dict "layers" key represent map
-                                          display notebook layers tree
-                                          page index and "mapnotebook"
-                                          key represent map display
-                                          notebook page index (single
-                                          window mode)
+            :return dict/None pgnum_dict/None: dict "layers" key represent
+                                               map display notebook layers
+                                               tree page index and
+                                               "mapnotebook" key represent
+                                               map display notebook page
+                                               index (single window mode)
             """
             pgnum_dict = {}
             pgnum_dict["layers"] = self.notebookLayers.GetPageIndex(page)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -463,14 +463,17 @@ class GMFrame(wx.Frame):
         page = self.currentPage
 
         def CanCloseDisplay(askIfSaveWorkspace):
-            """Callback to check if user wants to close display"""
-            pgnum = self.notebookLayers.GetPageIndex(page)
-            name = self.notebookLayers.GetPageText(pgnum)
+            """Callback to check if user wants to close display.
+            Map Display index can be different from index in Display tab."""
+            pgnum_dict = {}
+            pgnum_dict["display"] = self.notebookLayers.GetPageIndex(page)
+            pgnum_dict["mapnotebook"] = self.mapnotebook.GetPageIndex(mapdisplay)
+            name = self.notebookLayers.GetPageText(pgnum_dict["display"])
             caption = _("Close Map Display {}").format(name)
             if not askIfSaveWorkspace or (
                 askIfSaveWorkspace and self.workspace_manager.CanClosePage(caption)
             ):
-                return pgnum
+                return pgnum_dict
             return None
 
         mapdisplay.canCloseDisplayCallback = CanCloseDisplay
@@ -919,13 +922,13 @@ class GMFrame(wx.Frame):
 
         event.Skip()
 
-    def _closePageNoEvent(self, page_index):
+    def _closePageNoEvent(self, pgnum_dict):
         """Close page and destroy map display without
         generating notebook page closing event"""
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
-        self.notebookLayers.DeletePage(page_index)
+        self.notebookLayers.DeletePage(pgnum_dict["display"])
         self.notebookLayers.Bind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.OnCBPageClosing)
-        self.mapnotebook.DeletePage(page_index)
+        self.mapnotebook.DeletePage(pgnum_dict["mapnotebook"])
 
     def RunSpecialCmd(self, command):
         """Run command from command line, check for GUI wrappers"""

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -467,7 +467,7 @@ class GMFrame(wx.Frame):
             Display index can be different from index in Display tab.
 
             :return dict/None pgnum_dict: dict "layers" key represent map
-                                          display notebook layer tree
+                                          display notebook layers tree
                                           page index and "mapnotebook"
                                           key represent map display
                                           notebook page index (single
@@ -935,7 +935,7 @@ class GMFrame(wx.Frame):
         page closing event.
 
         :param dict pgnum_dict: dict "layers" key represent map display
-                                notebook layer tree page index and
+                                notebook layers tree page index and
                                 "mapnotebook" key represent map display
                                 notebook page index (single window mode)
         """

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -463,12 +463,20 @@ class GMFrame(wx.Frame):
         page = self.currentPage
 
         def CanCloseDisplay(askIfSaveWorkspace):
-            """Callback to check if user wants to close display.
-            Map Display index can be different from index in Display tab."""
+            """Callback to check if user wants to close display. Map
+            Display index can be different from index in Display tab.
+
+            :return dict/None pgnum_dict: dict "layers" key represent map
+                                          display notebook layer tree
+                                          page index and "mapnotebook"
+                                          key represent map display
+                                          notebook page index (single
+                                          window mode)
+            """
             pgnum_dict = {}
-            pgnum_dict["display"] = self.notebookLayers.GetPageIndex(page)
+            pgnum_dict["layers"] = self.notebookLayers.GetPageIndex(page)
             pgnum_dict["mapnotebook"] = self.mapnotebook.GetPageIndex(mapdisplay)
-            name = self.notebookLayers.GetPageText(pgnum_dict["display"])
+            name = self.notebookLayers.GetPageText(pgnum_dict["layers"])
             caption = _("Close Map Display {}").format(name)
             if not askIfSaveWorkspace or (
                 askIfSaveWorkspace and self.workspace_manager.CanClosePage(caption)
@@ -923,16 +931,20 @@ class GMFrame(wx.Frame):
         event.Skip()
 
     def _closePageNoEvent(self, pgnum_dict):
-        """Close page and destroy map display without
-        generating notebook page closing event
+        """Close page and destroy map display without generating notebook
+        page closing event.
 
-        :param dict pgnum_dict: "display" key represent map display
-        notebook layer tree page index and "mapnotebook" key represent
-        map display notebook page index (single window mode)
+        :param dict pgnum_dict: dict "layers" key represent map display
+                                notebook layer tree page index and
+                                "mapnotebook" key represent map display
+                                notebook page index (single window mode)
         """
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
-        self.notebookLayers.DeletePage(pgnum_dict["display"])
-        self.notebookLayers.Bind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.OnCBPageClosing)
+        self.notebookLayers.DeletePage(pgnum_dict["layers"])
+        self.notebookLayers.Bind(
+            FN.EVT_FLATNOTEBOOK_PAGE_CLOSING,
+            self.OnCBPageClosing,
+        )
         self.mapnotebook.DeletePage(pgnum_dict["mapnotebook"])
 
     def RunSpecialCmd(self, command):

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -290,6 +290,10 @@ class GMFrame(wx.Frame):
             aui.EVT_AUINOTEBOOK_PAGE_CHANGED,
             lambda evt: self.mapnotebook.GetCurrentPage().onFocus.emit(),
         )
+        self.mapnotebook.Bind(
+            aui.EVT_AUINOTEBOOK_PAGE_CLOSE,
+            self.OnMapNotebookClose,
+        )
 
     def _createDataCatalog(self, parent):
         """Initialize Data Catalog widget"""
@@ -2304,3 +2308,9 @@ class GMFrame(wx.Frame):
             style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION | wx.CENTRE,
         )
         return dlg
+
+    def OnMapNotebookClose(self, event):
+        """Page of map notebook is being closed"""
+        display = self.GetMapDisplay(onlyCurrent=True)
+        display.OnCloseWindow(event=None, askIfSaveWorkspace=True)
+        event.Veto()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -924,7 +924,12 @@ class GMFrame(wx.Frame):
 
     def _closePageNoEvent(self, pgnum_dict):
         """Close page and destroy map display without
-        generating notebook page closing event"""
+        generating notebook page closing event
+
+        :param dict pgnum_dict: "display" key represent map display
+        notebook layer tree page index and "mapnotebook" key represent
+        map display notebook page index (single window mode)
+        """
         self.notebookLayers.Unbind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING)
         self.notebookLayers.DeletePage(pgnum_dict["display"])
         self.notebookLayers.Bind(FN.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.OnCBPageClosing)

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -981,11 +981,13 @@ class MapPanel(SingleMapPanel):
         """
         Debug.msg(2, "MapPanel.OnCloseWindow()")
         if self.canCloseDisplayCallback:
-            pgnum = self.canCloseDisplayCallback(askIfSaveWorkspace=askIfSaveWorkspace)
-            if pgnum is not None:
+            pgnum_dict = self.canCloseDisplayCallback(
+                askIfSaveWorkspace=askIfSaveWorkspace
+            )
+            if pgnum_dict["display"] is not None:
                 self.CleanUp()
-                if pgnum > -1:
-                    self.closingDisplay.emit(page_index=pgnum)
+                if pgnum_dict["display"] > -1:
+                    self.closingDisplay.emit(pgnum_dict=pgnum_dict)
                     # Destroy is called when notebook page is deleted
         else:
             self.CleanUp()

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -986,7 +986,7 @@ class MapPanel(SingleMapPanel):
             )
             if pgnum_dict is not None:
                 self.CleanUp()
-                if pgnum_dict["display"] > -1:
+                if pgnum_dict["layers"] > -1:
                     self.closingDisplay.emit(pgnum_dict=pgnum_dict)
                     # Destroy is called when notebook page is deleted
         else:

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -984,7 +984,7 @@ class MapPanel(SingleMapPanel):
             pgnum_dict = self.canCloseDisplayCallback(
                 askIfSaveWorkspace=askIfSaveWorkspace
             )
-            if pgnum_dict["display"] is not None:
+            if pgnum_dict is not None:
                 self.CleanUp()
                 if pgnum_dict["display"] > -1:
                     self.closingDisplay.emit(pgnum_dict=pgnum_dict)


### PR DESCRIPTION
**Describe the bug**
Closing the map notebook page ends with an error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI with single window mode
2. Try close map notebook page
4. See error

```
Traceback (most recent call last):
  File "/home/tomas/.local/lib/python3.9/site-
packages/wx/core.py", line 3285, in <lambda>

lambda event: event.callable(*event.args, **event.kw) )
  File "/home/tomas/.local/lib/python3.9/site-
packages/wx/lib/agw/aui/auibook.py", line 3685, in
DeletePage

wnd.Destroy()
wx._core
.
wxAssertionError
:
C++ assertion "GetEventHandler() == this" failed at
/tmp/pip-req-build-
oxkmg2wi/ext/wxWidgets/src/common/wincmn.cpp(477) in
~wxWindowBase(): any pushed event handlers must have been
removed
```
**Expected behavior**
Closing the map notebook page should work without an error message. 

**System description:**
- GRASS GIS version main git branch

**Additional context**
Only in single window mode.
