### PR TITLE
Update alpine version in Dockerfile

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,5 +1,4 @@
-FROM mundialis/docker-pdal:2.1.0 as pdal
-FROM alpine:3.12 as common
+FROM alpine:3.15 as common
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile
@@ -26,8 +25,10 @@ ENV PACKAGES="\
       geos \
       gnutls \
       jsoncpp \
+      laszip \
       libbz2 \
       libexecinfo \
+      libgeotiff \
       libjpeg-turbo \
       libpng \
       libunwind \
@@ -39,8 +40,10 @@ ENV PACKAGES="\
       py3-numpy \
       py3-pillow \
       py3-six \
+      pdal \
+      pdal-dev \
       postgresql \
-      proj-datumgrid \
+    #   proj-datumgrid \
       proj-util \
       sqlite \
       sqlite-libs \
@@ -70,13 +73,6 @@ RUN echo "Install Python";\
 RUN echo "Install main packages";\
     apk update; \
     apk add --no-cache $PACKAGES
-
-COPY --from=pdal /usr/bin/pdal* /usr/bin/
-COPY --from=pdal /usr/lib/libpdal* /usr/lib/
-COPY --from=pdal /usr/lib/pkgconfig/pdal.pc /usr/lib/pkgconfig/pdal.pc
-COPY --from=pdal /usr/include/pdal /usr/include/pdal
-COPY --from=pdal /usr/local/lib/liblaszip* /usr/local/lib/
-COPY --from=pdal /usr/local/include/laszip /usr/local/include/laszip
 
 
 FROM common as build
@@ -210,6 +206,7 @@ RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -s
 
 # Test addon installation
+RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.bioclim
 RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.learn.ml
 
 


### PR DESCRIPTION
This PR suggests to update the alpine version from 3.12 to 3.15 in the alpine Dockerfile. It was released in November.
As pdal is available via alpine package manager now, the `mundialis/docker-pdal` is not needed anymore.

Two questions / problems appear:

1. the package `proj-datumgrid` does not exist anymore. When comparing the content and version of the differen alpine versions here: https://pkgs.alpinelinux.org/contents?branch=v3.12&name=proj-datumgrid&arch=x86_64&repo=community, it shows:
=> 3.12. contains proj 7.0.1-r0
=> 3.15. contains proj 8.2.0-r0 - is proj-datumgrid not needed here any more?

2. The test stage fails where `r.learn.ml` is installed:
```
Step 34/40 : RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.learn.ml
 ---> Running in 639e3fcf8360
Starting GRASS GIS...
Creating new GRASS GIS location <tmploc>...
Cleaning up temporary files...
Executing <g.extension extension=r.learn.ml> ...
Fetching <r.learn.ml> from GRASS GIS Addons repository (be patient)...
Compiling...
Traceback (most recent call last):
  File "/tmp/grass8-root-1/tmpac7nraye/r.learn.ml/scripts/r.learn.ml", line 414, in <module>
    from grass.pygrass.gis.region import Region
  File "/usr/local/grass80/etc/python/grass/pygrass/gis/__init__.py", line 19, in <module>
    import grass.lib.gis as libgis
  File "/usr/local/grass80/etc/python/grass/lib/gis.py", line 581, in <module>
    struct_timespec._fields_ = [
ValueError: number of bits invalid for bit field
make: *** [/usr/local/grass80/include/Make/Html.make:14: r.learn.ml.tmp.html] Error 1
ERROR: Compilation failed, sorry. Please check above error messages.
Execution of <g.extension extension=r.learn.ml> finished.
Cleaning up temporary files...
The command '/bin/sh -c grass --tmp-location EPSG:4326 --exec g.extension extension=r.learn.ml' returned a non-zero code: 1
```

This happens for building with `main` branch as well as `releasebranch_8_0`. As the test stage is ommited when building with github actions (as this stage is not needed for the final image), it can be tested only locally, e.g. with
```
docker build --file docker/alpine/Dockerfile --tag grass-py3-pdal:latest-alpine .
```

I did not check yet wether this error already appeared with alpine 3.12 yet. I will do so and then update this description.

