### PR TITLE
wxGUI/main_window: increase datacatalog pane min width to display the datacatalog toolbar SearchCtrl widget

### DIFF
--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -63,8 +63,16 @@ class DataCatalog(wx.Panel):
 
         Debug.msg(1, "DataCatalog.__init__()")
 
+        self._single_win_mode = UserSettings.Get(
+            group="general", key="singleWindow", subkey="enabled"
+        )
+
         # toolbar
-        self.toolbar = DataCatalogToolbar(parent=self)
+        if self._single_win_mode:
+            self.toolbar = DataCatalogToolbar(parent=self, showFilter=False)
+            self.toolbar1 = DataCatalogToolbar(parent=self, showTools=False)
+        else:
+            self.toolbar = DataCatalogToolbar(parent=self)
 
         # tree with layers
         self.tree = DataCatalogTree(self, giface=giface)
@@ -106,6 +114,8 @@ class DataCatalog(wx.Panel):
         """Do layout"""
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.toolbar, proportion=0, flag=wx.EXPAND)
+        if self._single_win_mode:
+            sizer.Add(self.toolbar1, proportion=0, flag=wx.EXPAND)
         sizer.Add(self.infoBar, proportion=0, flag=wx.EXPAND)
         sizer.Add(self.tree.GetControl(), proportion=1, flag=wx.EXPAND)
 

--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -56,44 +56,50 @@ icons = {
 class DataCatalogToolbar(BaseToolbar):
     """Main data catalog toolbar"""
 
-    def __init__(self, parent):
-        """Main toolbar constructor"""
+    def __init__(self, parent, showTools=True, showFilter=True):
+        """Main toolbar constructor
+
+        :param bool showTools: show/hide toolbar tools
+        :param bool showFilter: show/hide toolbar SearchCtrl widget (filter)
+        """
 
         BaseToolbar.__init__(self, parent)
 
-        self.InitToolbar(self._toolbarData())
-        self.filter_element = None
-        self.filter = SearchCtrl(parent=self)
-        self.filter.SetDescriptiveText(_("Search"))
-        self.filter.ShowCancelButton(True)
-        self.filter.SetSize((150, self.filter.GetBestSize()[1]))
-        self.filter.Bind(
-            wx.EVT_TEXT,
-            lambda event: self.parent.Filter(
-                self.filter.GetValue(), self.filter_element
-            ),
-        )
-        self.filter.Bind(
-            wx.EVT_SEARCHCTRL_CANCEL_BTN, lambda evt: self.parent.Filter("")
-        )
-        self.AddControl(self.filter)
-        filterMenu = wx.Menu()
-        item = filterMenu.AppendRadioItem(-1, "All")
-        self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
-        item = filterMenu.AppendRadioItem(-1, "Raster maps")
-        self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
-        item = filterMenu.AppendRadioItem(-1, "Vector maps")
-        self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
-        item = filterMenu.AppendRadioItem(-1, "3D raster maps")
-        self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
-        self.filter.SetMenu(filterMenu)
-        help = _(
-            "Type to search database by map type or name. "
-            "Use Python regular expressions to refine your search."
-        )
-        self.SetToolShortHelp(self.filter.GetId(), help)
-        # realize the toolbar
-        self.Realize()
+        if showTools:
+            self.InitToolbar(self._toolbarData())
+            # realize the toolbar
+            self.Realize()
+        if showFilter:
+            self.filter_element = None
+            self.filter = SearchCtrl(parent=self)
+            self.filter.SetDescriptiveText(_("Search"))
+            self.filter.ShowCancelButton(True)
+            self.filter.SetSize((150, self.filter.GetBestSize()[1]))
+            self.filter.Bind(
+                wx.EVT_TEXT,
+                lambda event: self.parent.Filter(
+                    self.filter.GetValue(), self.filter_element
+                ),
+            )
+            self.filter.Bind(
+                wx.EVT_SEARCHCTRL_CANCEL_BTN, lambda evt: self.parent.Filter("")
+            )
+            self.AddControl(self.filter)
+            filterMenu = wx.Menu()
+            item = filterMenu.AppendRadioItem(-1, "All")
+            self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
+            item = filterMenu.AppendRadioItem(-1, "Raster maps")
+            self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
+            item = filterMenu.AppendRadioItem(-1, "Vector maps")
+            self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
+            item = filterMenu.AppendRadioItem(-1, "3D raster maps")
+            self.Bind(wx.EVT_MENU, self.OnFilterMenu, item)
+            self.filter.SetMenu(filterMenu)
+            help = _(
+                "Type to search database by map type or name. "
+                "Use Python regular expressions to refine your search."
+            )
+            self.SetToolShortHelp(self.filter.GetId(), help)
 
     def _toolbarData(self):
         """Returns toolbar data (name, icon, handler)"""

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -155,9 +155,8 @@ class GMFrame(wx.Frame):
 
         # set pane sizes according to the full screen size of the primary monitor
         size = wx.Display().GetGeometry().GetSize()
-        self.PANE_MIN_SIZE = self.PANE_BEST_SIZE = (
-            tuple(round(t // 3.6) for t in size),
-        )
+        self.PANE_BEST_SIZE = tuple(t // 3 for t in size)
+        self.PANE_MIN_SIZE = tuple(t // 5 for t in size)
 
         # create widgets and build panes
         self.CreateMenuBar()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -155,8 +155,9 @@ class GMFrame(wx.Frame):
 
         # set pane sizes according to the full screen size of the primary monitor
         size = wx.Display().GetGeometry().GetSize()
-        self.PANE_BEST_SIZE = tuple(t // 3 for t in size)
-        self.PANE_MIN_SIZE = tuple(t // 5 for t in size)
+        self.PANE_MIN_SIZE = self.PANE_BEST_SIZE = (
+            tuple(round(t // 3.6) for t in size),
+        )
 
         # create widgets and build panes
         self.CreateMenuBar()


### PR DESCRIPTION
**Describe the bug**
Datacatalog toolbar SearchCtrl widget (filter) isn't visible by default in single window mode.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI with single window mode
2. Check if Datacatalog toolbar SearchCtrl widget (filter) is visible

**Expected behavior**
Datacatalog toolbar SearchCtrl widget (filter) should be visible by default in single window mode.

**Screenshots**

Default:

![wxgui_single_window_mode_def_datatcatalog_pane_min_width](https://user-images.githubusercontent.com/50632337/148730481-7cf07938-4f2d-483d-9164-219534ab358a.png)

Expected:

![wxgui_single_window_mode_exp_datatcatalog_pane_min_width](https://user-images.githubusercontent.com/50632337/148730503-ebf1ebf6-7d5a-489b-b322-8ed8212e1fef.png)


**System description (please complete the following information):**

- GRASS GIS version main git branch

**Additional context**
wxGUI single window mode. Another solution would be to add a new toolbar with the SearchCtrl widget if we wanted to keep the current  Datacatalog pane widget minimum width as it is now.
