### PR TITLE
tools/mkhtml.py: replace f-string with format() function to maintain compatibility with Python 3.5/2.7 version

### DIFF
--- a/tools/mkhtml.py
+++ b/tools/mkhtml.py
@@ -81,8 +81,13 @@ trunk_url = ""
 addons_url = ""
 if grass_version != "unknown":
     major, minor, patch = grass_version.split(".")
-    trunk_url = f"https://github.com/OSGeo/grass/tree/releasebranch_{major}_{minor}/"
-    addons_url = f"https://github.com/OSGeo/grass-addons/tree/grass{major}/"
+    base_url = "https://github.com/OSGeo"
+    trunk_url = "{base_url}/grass/tree/releasebranch_{major}_{minor}/".format(
+        base_url=base_url, major=major, minor=minor
+    )
+    addons_url = "{base_url}/grass-addons/tree/grass{major}/".format(
+        base_url=base_url, major=major
+    )
 
 header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>


### PR DESCRIPTION
Fixes #2070.