### PR TITLE
.github/workflows/osgeo4w.yml: bump GRASS GIS executable version to 8.1

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -36,10 +36,10 @@ jobs:
         run: C:\msys64\usr\bin\bash.exe -l (''+(Get-Location)+'\.github\workflows\build_osgeo4w.sh') (Get-Location)
 
       - name: Test executing of the grass command
-        run: .github/workflows/test_simple.bat 'C:\OSGeo4W\opt\grass\grass80.bat'
+        run: .github/workflows/test_simple.bat 'C:\OSGeo4W\opt\grass\grass81.bat'
 
       - name: Test executing of the grass command in bash
         run: C:\msys64\usr\bin\bash.exe .github/workflows/test_simple.sh
 
       - name: Run tests
-        run: .github/workflows/test_thorough.bat 'C:\OSGeo4W\opt\grass\grass80.bat' 'C:\OSGeo4W\bin\python3'
+        run: .github/workflows/test_thorough.bat 'C:\OSGeo4W\opt\grass\grass81.bat' 'C:\OSGeo4W\bin\python3'


### PR DESCRIPTION
Fixes OSGeo4W / windows-2019 build and tests CI error mentioned here https://github.com/OSGeo/grass/pull/2082#issuecomment-1011250868. Related with this commit https://github.com/OSGeo/grass/commit/029cd8ea8e9c98b575f57f148b1552c8821a0494.