### PR TITLE
Sync TGIS DB version mismatch version with g78

### DIFF
--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -712,13 +712,14 @@ def init(raise_fatal_error=False, skip_db_version_check=False):
         if dbif.fetchone()[0]:
             db_exists = True
 
-    backup_howto = _(
-        "Please create a backup of your temporal database to avoid losing data.\n"
-    )
     if tgis_db_version > 2:
-        backup_howto += _("Run t.upgrade command to upgrade your temporal database.\n")
+        backup_howto = _(
+            "Run t.upgrade command to upgrade your temporal database.\n"
+            "Consider creating a backup of your temporal database to avoid "
+            "loosing data in case something goes wrong.\n"
+        )
     else:
-        backup_howto += _(
+        backup_howto = _(
             "You need to export it by "
             "restoring the GRASS GIS version used for creating this DB."
             "Notes: Use t.rast.export and t.vect.export "


### PR DESCRIPTION
This PR will change message below:

```
WARNING: Temporal database version mismatch detected.
         Please create a backup of your temporal database to avoid losing
         data.
         Run t.upgrade command to upgrade your temporal database.
         Supported temporal database version is: 3
         Your existing temporal database version: 2
         Current temporal database info:
         DBMI interface:..... sqlite3
         Temporal database:..
         /home/martin/grassdata/tgis_test/tgis2/tgis/sqlite.db
```

to

```
WARNING: Temporal database version mismatch detected.
         Run t.upgrade command to upgrade your temporal database.
         Consider creating a backup of your temporal database to avoid
         loosing data in case something goes wrong.
         Supported temporal database version is: 3
         Your existing temporal database version: 2
         Current temporal database info:
         DBMI interface:..... sqlite3
         Temporal database:..
         /home/martin/grassdata/tgis_test/tgis2/tgis/sqlite.db
```

The message is synchronized with GRASS 78 (see #2002)