### PR TITLE
scripts/g.extension: fix link generation in multi-addon man page for addons

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2224,6 +2224,8 @@ def update_manual_page(module):
     # fix logo URL
     pattern = r'''<a href="([^"]+)"><img src="grass_logo.png"'''
     for match in re.finditer(pattern, shtml):
+        if match.group(1)[:4] == "http":
+            continue
         pos.append(match.start(1))
 
     # find URIs

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1273,23 +1273,13 @@ def install_extension_xml(edict):
     return None
 
 
-def filter_multi_addon_addons(mlist):
-    """Filter out list of multi-addon addons which contains
-    and installs only *.html manual page, without source/binary
-    excutable module and doesn't need to check metadata.
+def get_multi_addon_addons_which_install_only_html_man_page():
+    """Get multi-addon addons which install only manual html page
 
-    e.g. the i.sentinel multi-addon consists of several full i.sentinel.*
-    addons along with a i.sentinel.html overview file.
-
-
-    :param list mlist: list of multi-addons (groups of addons
-                       with respective addon overview HTML pages)
-
-    :return list mlist: list of individual multi-addons without respective
-                        addon overview HTML pages
+    :return list addons: list of multi-addon addons which install
+                         only manual html page
     """
-    # Make a list of unique addons
-    mlist = list(set(mlist))
+    addons = []
     all_addon_dirs = []
     addon_dirs_with_source_module = []  # *.py, *.c file
     addon_pattern = re.compile(r".*{}".format(options["extension"]))
@@ -1315,12 +1305,31 @@ def filter_multi_addon_addons(mlist):
             # Add all addon dirs
             all_addon_dirs.append(addon["path"])
 
+    for addon in set(all_addon_dirs) ^ set(addon_dirs_with_source_module):
+        addons.append(os.path.basename(addon))
+    return addons
+
+
+def filter_multi_addon_addons(mlist):
+    """Filter out list of multi-addon addons which contains
+    and installs only *.html manual page, without source/binary
+    excutable module and doesn't need to check metadata.
+
+    e.g. the i.sentinel multi-addon consists of several full i.sentinel.*
+    addons along with a i.sentinel.html overview file.
+
+
+    :param list mlist: list of multi-addons (groups of addons
+                       with respective addon overview HTML pages)
+
+    :return list mlist: list of individual multi-addons without respective
+                        addon overview HTML pages
+    """
     # Filters out add-ons that only contain the *.html man page,
     # e.g. multi-addon i.sentinel (root directory) contains only
     # the *.html manual page for installation, it does not need
     # to check if metadata is available if there is no executable module.
-    for subaddon in set(all_addon_dirs) ^ set(addon_dirs_with_source_module):
-        addon = os.path.basename(subaddon)
+    for addon in get_multi_addon_addons_which_install_only_html_man_page():
         if addon in mlist:
             mlist.pop(mlist.index(addon))
     return mlist
@@ -1794,7 +1803,8 @@ def install_extension_std_platforms(name, source, url, branch):
                             try:
                                 modulename = line.split("=")[1].strip()
                                 if modulename:
-                                    module_list.append(modulename)
+                                    if modulename not in module_list:
+                                        module_list.append(modulename)
                                 else:
                                     grass.fatal(pgm_not_found_message)
                             except IndexError:
@@ -2217,6 +2227,12 @@ def update_manual_page(module):
     # find URIs
     pattern = r"""<a href="([^"]+)">([^>]+)</a>"""
     addons = get_installed_extensions(force=True)
+    # Multi-addon
+    if len(addons) > 1:
+        for a in get_multi_addon_addons_which_install_only_html_man_page():
+            # Add multi-addon addons which install only manual html page
+            addons.append(a)
+
     for match in re.finditer(pattern, shtml):
         if match.group(1)[:4] == "http":
             continue

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1351,7 +1351,9 @@ def install_module_xml(mlist):
 
     # Filter multi-addon addons
     if len(mlist) > 1:
-        mlist = filter_multi_addon_addons(mlist)
+        mlist = filter_multi_addon_addons(
+            mlist.copy()
+        )  # mlist.copy() keep the original list of add-ons
 
     # update tree
     for name in mlist:


### PR DESCRIPTION
**Describe the bug**
When multi-addon contains addons, which install only html manual page and manual page contains link to these addon, link source URL is wrong pointed to GISBASE directory e.g. i.sentinel.mask has "Overview of i.sentinel toolset" link to the i.sentinel addon manual page i.sentinel.html with wrong path `"file:///usr/lib64/grass81/docs/html/i.sentinel.html"`.

**To Reproduce**
Steps to reproduce the behavior:

1. Install some multi-addon e.g. `g.extension i.sentinel`
2. Check i.sentinel.mask addon generated manual html page `cat $HOME/.grass8/addons/docs/html/i.sentinel.mask.html`
3. Check "SEE ALSO" section, **"Overview of i.sentinel toolset"** link source URL

```html
<h2><a name="see-also">SEE ALSO</a></h2>

<em>
<a href="file:///usr/lib64/grass81/docs/html/i.sentinel.html">Overview of i.sentinel toolset</a>
</em>
<p>
<em>
```

4. Link source URL `"file:///usr/lib64/grass81/docs/html/i.sentinel.html"` is wrong, check with

 ```
GRASS nc_basic_spm_grass7/PERMANENT:html > file $GISBASE/docs/html/i.sentinel.html
/usr/lib64/grass81/docs/html/i.sentinel.html: cannot open `/usr/lib64/grass81/docs/html/i.sentinel.html' (No such file or directory)
```
5. Or try open i.sentinel.mask module gui `i.sentinel.mask --ui`, switch to the Manual page and click on the "Overview of i.sentinel toolset" link (redirection not work)

**Expected behavior**
The correct link URL for add-ons on the multi-add-ons man page e.g. i.sentinel.mask has "Overview of i.sentinel toolset" link to the i.sentinel addon manual page i.sentinel.html with correct URL path `"i.sentinel.html"`.

```html

<h2><a name="see-also">SEE ALSO</a></h2>

<em>
<a href="i.sentinel.html">Overview of i.sentinel toolset</a>
</em>
<p>
<em>
```

**System description:**

- GRASS GIS version main, releasebranch_8_0, releasebranch_7_8