### PR TITLE
wxGUI: Fix the error when statusbar does know statusbarItem property "region"

### DIFF
--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -303,7 +303,7 @@ class SbManager:
     def OnToggleStatus(self, event):
         """Toggle status text"""
         self.Update()
-        if event.GetSelection() == 3:  # use something better than magic numbers
+        if event.GetSelection() == 3 and self.HasProperty("region"):
             # show computation region extent by default
             self.statusbarItems["region"].SetValue(True)
             # redraw map if auto-rendering is enabled


### PR DESCRIPTION
Map Display statusbar does know statusbarItem property "region" because now this property is the part of Map Display settings.
This PR fixes the error shown in the console after clicking on "Display geometry" option in Map Display statusbar combobox.