### PR TITLE
g.gui.timeline: fix annotation box

### DIFF
--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -372,6 +372,7 @@ class TimelineFrame(wx.Frame):
                         facecolors=color,
                         edgecolor="black",
                         alpha=ALPHA,
+                        picker=True,
                     )
                 )
             else:
@@ -382,6 +383,7 @@ class TimelineFrame(wx.Frame):
                         marker="o",
                         linestyle="None",
                         color=color,
+                        picker=True,
                     )[0]
                 )
 


### PR DESCRIPTION
Clicking on a plot doesn't bring up the annotation box, probably some defaults changed in more recent versions of matplotlib.