### PR TITLE
wxGUI/gui_core: fix right mouse click on the root tree node to invoke menu

### DIFF
--- a/gui/wxpython/gui_core/query.py
+++ b/gui/wxpython/gui_core/query.py
@@ -133,8 +133,9 @@ class QueryDialog(wx.Dialog):
         else:
             label1 = nodes[0].label
             texts.append((_("Copy '%s'" % self._cutLabel(label1)), label1))
-            if nodes[0].data and nodes[0].data[self._colNames[1]]:
-                label2 = nodes[0].data[self._colNames[1]]
+            col1 = self._colNames[1]
+            if nodes[0].data and col1 in nodes[0].data and nodes[0].data[col1]:
+                label2 = nodes[0].data[col1]
                 texts.insert(0, (_("Copy '%s'" % self._cutLabel(label2)), label2))
                 texts.append((_("Copy line"), label1 + ": " + label2))
 


### PR DESCRIPTION
**Describe the bug**
When you query map and you right mouse click on the query map dialog root tree node to invoke menu you get error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some raster/vector map e.g. `d.rast elevation`
3. Activate Query map tool, and query displayed map
4. On the query map dialog try right mouse click on the root tree node to invoke menu
5. See error message

```
Traceback (most recent call last):
  File
"/usr/lib64/grass81/gui/wxpython/gui_core/treeview.py", line
248, in <lambda>

lambda evt: self._emitSignal(evt.GetItem(),
self.contextMenu),
  File
"/usr/lib64/grass81/gui/wxpython/gui_core/treeview.py", line
200, in _emitSignal

signal.emit(node=node, **kwargs)
  File
"/usr/lib64/grass81/etc/python/grass/pydispatch/signal.py",
line 233, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass81/etc/python/grass/pydispatch/dispa
tcher.py", line 344, in send

response = robustapply.robustApply(
  File "/usr/lib64/grass81/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File "/usr/lib64/grass81/gui/wxpython/gui_core/query.py",
line 136, in ShowContextMenu

if nodes[0].data and nodes[0].data[self._colNames[1]]:
KeyError
:
'Value'
```

**Expected behavior**
Invoked menu when you query map and you right mouse click on the query map dialog root tree node.

**Screenshots**

![wxgui_map_query_dialog](https://user-images.githubusercontent.com/50632337/150626142-e73884a3-f591-4a86-9ce6-faeda5606755.png)


**System description**

- GRASS GIS version main, releasebranch_8_0, releasebranch_7_8 git branch
