### PR TITLE
wxGUI Single-Window: Focus the Console pane when console content has been changed

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -349,6 +349,9 @@ class GMFrame(wx.Frame):
         self.goutput.showNotification.connect(
             lambda message: self.SetStatusText(message)
         )
+        self.goutput.contentChanged.connect(
+            lambda notification: self._switchPage(notification)
+        )
 
         self._gconsole.mapCreated.connect(self.OnMapCreated)
         self._gconsole.Bind(
@@ -946,6 +949,23 @@ class GMFrame(wx.Frame):
             self.OnCBPageClosing,
         )
         self.mapnotebook.DeletePage(pgnum_dict["mapnotebook"])
+
+    def _switchPage(self, notification):
+        """Manages @c 'output' notebook page according to event notification."""
+        if (
+            notification == Notification.HIGHLIGHT
+            or notification == Notification.MAKE_VISIBLE
+            or notification == Notification.RAISE_WINDOW
+        ):
+            self.FocusPage("Console")
+
+    def FocusPage(self, page_text):
+        """Focus the page if part of any of aui notebooks"""
+        notebooks = self._auimgr.GetNotebooks()
+        for notebook in notebooks:
+            for i in range(notebook.GetPageCount()):
+                if notebook.GetPageText(i) == page_text:
+                    notebook.SetSelection(i)
 
     def RunSpecialCmd(self, command):
         """Run command from command line, check for GUI wrappers"""

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -350,7 +350,7 @@ class GMFrame(wx.Frame):
             lambda message: self.SetStatusText(message)
         )
         self.goutput.contentChanged.connect(
-            lambda notification: self._switchPage(notification)
+            lambda notification: self._focusPage(notification)
         )
 
         self._gconsole.mapCreated.connect(self.OnMapCreated)
@@ -950,8 +950,8 @@ class GMFrame(wx.Frame):
         )
         self.mapnotebook.DeletePage(pgnum_dict["mapnotebook"])
 
-    def _switchPage(self, notification):
-        """Manages @c 'output' notebook page according to event notification."""
+    def _focusPage(self, notification):
+        """Focus the 'Console' notebook page according to event notification."""
         if (
             notification == Notification.HIGHLIGHT
             or notification == Notification.MAKE_VISIBLE


### PR DESCRIPTION
Fixes the behavior for Single-Window GUI. It makes Console pane focused If its content has been changed.
Only applicable if the Console pane is part of any auinotebook. If a user uses Console pane as an independent pane, nothing happens.