### PR TITLE
Add Zenodo DOI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Ubuntu](https://github.com/OSGeo/grass/workflows/Ubuntu/badge.svg)](https://github.com/OSGeo/grass/actions?query=workflow%3AUbuntu)
 [![OSGeo4W](https://github.com/OSGeo/grass/workflows/OSGeo4W/badge.svg)](https://github.com/OSGeo/grass/actions?query=workflow%3AOSGeo4W)
 [![CentOS](https://github.com/OSGeo/grass/workflows/CentOS/badge.svg)](https://github.com/OSGeo/grass/actions?query=workflow%3ACentOS)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5176030.svg)](https://doi.org/10.5281/zenodo.5176030)
 
 # GRASS GIS Repository
 


### PR DESCRIPTION
This adds a badge which shows the DOI from Zenodo. The DOI used is the "cite all versions" DOI which redirects to the latest version on Zenodo.

An alternative would be a badge (also provided by Zenodo) which shows the latest version, but this seems to be more misleading as it would show, for example, whatever is the latest release in the readme file for the main branch. The "cite all versions" DOI at least shows the version-neutral DOI, although it leads to the latest version on Zenodo (which is the latest release in terms of time).