### PR TITLE
Mention session in the missing GISRC message

### DIFF
--- a/lib/gis/env.c
+++ b/lib/gis/env.c
@@ -3,7 +3,7 @@
 
   \brief GIS library - environment routines
   
-  (C) 2001-2014 by the GRASS Development Team
+  (C) 2001-2022 by the GRASS Development Team
   
   This program is free software under the GNU General Public License
   (>=v2).  Read the file COPYING that comes with GRASS for details.
@@ -310,7 +310,8 @@ static FILE *open_env(const char *mode, int loc)
 	    st->gisrc = getenv("GISRC");
 
 	if (!st->gisrc) {
-	    G_fatal_error(_("GISRC - variable not set"));
+            G_fatal_error(_("No active GRASS session: "
+                            "GISRC environment variable not set"));
 	    return NULL;
 	}
 	strcpy(buf, st->gisrc);


### PR DESCRIPTION
This links the missing GISRC environment variable to a GRASS session in the error message. In case the error message appears without much context, it says GRASS session rather than just session. It says active session to emphasize that a finished/ended/closed session is not good enough which is likely the context when users may encounter the message (besides the case with GRASS runtime set up, but without an open/connected mapset).

The message now says environment variable instead of just variable and leaves out the dash/hyphen for better flow of the sentence. The format of the message is issue-colon-reason.

This is highly relevant to Jupyter notebooks, but it applies to the standard _grass.script.setup.init_ function as well.

## Test case

### Code

```python
sys.path.append(
    subprocess.check_output(["grass", "--config", "python_path"], text=True).strip()
)

import grass.script as gs
import grass.script.setup

gs.setup.init("~/grassdata/nc_basic_spm_grass7/user1")
gs.setup.finish()
gs.run_command("g.region", flags="p")
```

### Previous output

```
ERROR: GISRC - variable not set
Traceback (most recent call last):
  File "test.py", line 20, in <module>
    gs.run_command("g.region", flags="p")
  File ".../etc/python/grass/script/core.py", line 541, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
  File ".../etc/python/grass/script/core.py", line 429, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `g.region -p` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
```

### New output

```
ERROR: No active GRASS session: GISRC environment variable not set
Traceback (most recent call last):
  File "test.py", line 20, in <module>
    gs.run_command("g.region", flags="p")
  File ".../etc/python/grass/script/core.py", line 541, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
  File ".../etc/python/grass/script/core.py", line 429, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `g.region -p` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
```