### PR TITLE
wxGUI/xml: add Raster digitizer tool among GUI tools toolbox items

### DIFF
--- a/gui/wxpython/xml/toolboxes.xml
+++ b/gui/wxpython/xml/toolboxes.xml
@@ -2023,6 +2023,7 @@
       <wxgui-item name="TplotTool"/>
       <wxgui-item name="TimelineTool"/>
       <wxgui-item name="VDigit"/>
+      <wxgui-item name="RDigit"/>
     </items>
   </toolbox>
 </toolboxes>

--- a/gui/wxpython/xml/wxgui_items.xml
+++ b/gui/wxpython/xml/wxgui_items.xml
@@ -402,4 +402,10 @@
     <description>Interactive editing and digitization of vector maps.</description>
     <keywords>general,gui,vector,editing,digitizer</keywords>
   </wxgui-item>
+  <wxgui-item name="RDigit">
+    <label>Raster digitizer</label>
+    <command>g.gui.rdigit</command>
+    <description>Interactive editing and digitization of raster maps.</description>
+    <keywords>general,gui,raster,editing,digitizer</keywords>
+  </wxgui-item>
 </wxgui-items>


### PR DESCRIPTION
**Describe the bug**
Missing Raster digitizer tool among GUI tools toolbox items. Raster digitizer also exists as a standalone module `g.gui.rdigit`.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. On GRASS GIS main window switch to Tools page (tab)
3. Expand GUI tools toolbox
4. See Raster digitizer item

**Expected behavior**
Raster digitizer tool should be among GUI tools toolbox items.


**System description:**

- GRASS GIS version main, releasebranch_8_0 git branch
