### PR TITLE
Mention session in the variable not set message

### DIFF
--- a/lib/gis/env.c
+++ b/lib/gis/env.c
@@ -342,7 +342,7 @@ const char *G_getenv(const char *name)
     if (value)
 	return value;
 
-    G_fatal_error(_("Variable '%s' not set"), name);
+    G_fatal_error(_("Incomplete GRASS session: Variable '%s' not set"), name);
     return NULL;
 }
 
@@ -368,7 +368,7 @@ const char *G_getenv2(const char *name, int loc)
     if (value)
 	return value;
 
-    G_fatal_error(_("Variable '%s' not set"), name);
+    G_fatal_error(_("Incomplete GRASS session: Variable '%s' not set"), name);
     return NULL;
 }
 


### PR DESCRIPTION
This changes the message in _G_getenv_ and _G_getenv2_ to say "Incomplete GRASS session" in the first place and then say that the variable is not set, e.g., `Incomplete GRASS session: Variable 'LOCATION_NAME' not set`.

I used the wording "incomplete GRASS session". Alternative to _incomplete_ is, e.g., _corrupted_, but _incomplete_ is more general. Perhaps it can say "Incomplete or corrupted GRASS session", e.g., `Incomplete or corrupted GRASS session: Variable 'LOCATION_NAME' not set`. Let me know.

## Details

Unfortunately, there is not much information readily available in the code to enhance the message so that the user has more information. The variable may not be set as the message says, but chances are, the session has ended and the process is dangling and reading a deleted session (GISRC) file. To obtain the information, we would have to actually run more code because the underlying _read_env_ function does not consider a missing file to be an error (I think that's correct for the mapset var file, i.e., `loc == G_VAR_MAPSET`).

In general there are might be many reasons why variable is missing. However, my understanding is that optional variables should be read with the no-fatal versions of these functions (_G_getenv_nofatal_ and _G_getenv_nofatal2_), so the functions producing a fatal error (_G_getenv_ and _G_getenv2_) are likely used for some session-critical variables. Therefore, it seems appropriate to me to assume that that there is an issue with the session and say that in the error message.

The same message is there twice because there are two similar functions. Maybe the duplication can be removed by calling _G_getenv2_ from _G_getenv_, but that's out of scope for this PR.

## Test case 1

### Code

```sh
grass --text
```

```sh
d.mon wx0
exit
```


### Previous output

```
GRASS_INFO_ERROR(425398,1): Variable 'LOCATION_NAME' not set
GRASS_INFO_END(425398,1)
```

### New output

```
GRASS_INFO_ERROR(425398,1): Incomplete GRASS session: Variable 'LOCATION_NAME' not set
GRASS_INFO_END(425398,1)
```

## Test case 2

### Code

```sh
grass8 --tmp-location XY --exec d.mon wx0
```

Similarly with g.gui (without -f), but with many more messages.

### Previous output

```
ERROR: Variable 'LOCATION_NAME' not set
Traceback (most recent call last):
  File ".../gui/wxpython/mapdisp/main.py", line 623, in <module>
    fd = open(pidFile, 'w')
FileNotFoundError: [Errno 2] No such file or directory: '.../MONITORS/wx0/pid'
```

### New output

```
ERROR: Incomplete GRASS session: Variable 'LOCATION_NAME' not set
Traceback (most recent call last):
  File ".../gui/wxpython/mapdisp/main.py", line 662, in <module>
    fd = open(pidFile, "w")
FileNotFoundError: [Errno 2] No such file or directory: '.../MONITORS/wx0/pid'
```