### PR TITLE
dbmi client: check if driver name is null or empty

### DIFF
--- a/lib/db/dbmi_client/start.c
+++ b/lib/db/dbmi_client/start.c
@@ -94,7 +94,7 @@ dbDriver *db_start_driver(const char *name)
 	return (dbDriver *) NULL;
 
     /* if name is empty use connection.driverName, added by RB 4/2000 */
-    if (name[0] == '\0') {
+    if (name == NULL || name[0] == '\0') {
 	db_get_connection(&connection);
 	if (NULL == (name = connection.driverName))
 	    return (dbDriver *) NULL;


### PR DESCRIPTION
This PR fixes an issue discovered with `v.distance`, where the start of the driver caused a `segmentation fault` when output should be produced, rendering `v.distance` unusable for creating connection lines.


Co-authored-by: Vaclav Petras wenzeslaus@gmail.com