### PR TITLE
dbmi_client_start_driver: check if driver name is null or empty (#2131)

### DIFF
--- a/lib/db/dbmi_client/start.c
+++ b/lib/db/dbmi_client/start.c
@@ -94,7 +94,7 @@ dbDriver *db_start_driver(const char *name)
 	return (dbDriver *) NULL;
 
     /* if name is empty use connection.driverName, added by RB 4/2000 */
-    if (name[0] == '\0') {
+    if (name == NULL || name[0] == '\0') {
 	db_get_connection(&connection);
 	if (NULL == (name = connection.driverName))
 	    return (dbDriver *) NULL;


### PR DESCRIPTION
Backport of #2131 (8644a82)