### PR TITLE
libdisplay: remove redundant GRASS_NOTIFY

### DIFF
--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -158,17 +158,10 @@ int D_open_driver(void)
 
 /*!
   \brief Close display driver
-
-  If GRASS_NOTIFY is defined, run notifier.
 */
 void D_close_driver(void)
 {
-    const char *cmd = getenv("GRASS_NOTIFY");
-
     COM_Graph_close();
-
-    if (cmd)
-	system(cmd);
 }
 
 /*!


### PR DESCRIPTION
This addresses one of the '-Wunused-result' compiler warnings reported in #2128.

The warning is caused by a call of `system(cmd)` upon display driver closure, where `cmd` is set by the environment variable `GRASS_NOTIFY` (if set). The warning in itself is not critical.

This PR is a suggestion to address this warning by removing this GRASS_NOTIFY "hack" or whatever it is.
This is the only place in GRASS sources where `GRASS_NOTIFY` is used at all.

The big question is, is this GRASS_NOTIFY mechanism used by anyone, or any platform?
My research into the motivation of its introduction to GRASS 7.0 [1], or of any of its use, turned up empty. I assume there was a good reason for this in the transition to G7, but now? The GRASS_NOTIFY environment variable is also [not documented](https://grass.osgeo.org/grass80/manuals/variables.html).

[1] initially committed to trunk: https://trac.osgeo.org/grass/changeset/32602/grass/trunk/lib/raster/raster.c
