### PR TITLE
utils/mkhtml: fix print warning/fatal message during compilation

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -48,12 +48,14 @@ try:
     import grass.script as gs
 except ImportError:
     # During compilation GRASS GIS
+    _ = str
+
     class gs:
-        def warning(self, message):
+        def warning(message):
             pass
 
-        def fatal(self, message):
-            print(message, file=sys.stderr)
+        def fatal(message):
+            pass
 
 
 HEADERS = {

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -48,7 +48,13 @@ try:
     import grass.script as gs
 except ImportError:
     # During compilation GRASS GIS
-    gs = None
+    class gs:
+        def warning(self, message):
+            pass
+
+        def fatal(self, message):
+            print(message, file=sys.stderr)
+
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0",


### PR DESCRIPTION
Fixes #2137, #2138. Suggested by https://github.com/OSGeo/grass/issues/2137#issuecomment-1024585007.

Note:

Git repository build: core modules manuals have git commit info

Non Git repository build: some core modules manuals have git commit info and some haven't, due GitHub API server error `urllib.error.HTTPError: HTTP Error 403: rate limit exceeded`