### PR TITLE
Fix typo in v.import documentation

### DIFF
--- a/scripts/v.import/v.import.html
+++ b/scripts/v.import/v.import.html
@@ -17,7 +17,7 @@ Memory, OGDI, and PostgreSQL, depending on the local OGR installation.
 For details see the <a href="https://gdal.org/drivers/vector/">OGR web
 site</a>. The OGR (Simple Features Library) is part of the
 <a href="http://www.gdal.org">GDAL</a> library, hence GDAL needs to be
-installed to use <em>v.in.ogr</em>.
+installed to use <em>v.import</em>.
 
 <p>
 The list of actually supported formats can be printed by <b>-f</b> flag.


### PR DESCRIPTION
Substitute 'GDAL needs to be installed to use **v.in.ogr**' with 'GDAL needs to be installed to use **v.import**' in the [v.import](https://grass.osgeo.org/grass78/manuals/v.import.html) documentation.