### PR TITLE
CI: Add check for CRLF line endings

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Check for CRLF endings
         uses: erclu/check-crlf@v1
+        with:
+          # Ignore all test data, Windows-specific directories and scripts.
+          exclude: mswindows .*\.bat .*/testsuite/data/.*

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -10,7 +10,7 @@ on:
   - pull_request
 
 jobs:
-  additional-black:
+  additional-checks:
     name: Additional checks
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -1,0 +1,22 @@
+name: Additional Checks
+
+# Checks which are not in standardized tools such as custom checks by scripts
+# in the source code or 3rd party checks without large projects behind them.
+# Number of disconnected, but simple checks can be combined into one workflow
+# (and job) to reduce the number of jobs.
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  additional-black:
+    name: Additional checks
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository contents
+        uses: actions/checkout@v2
+
+      - name: Check for CRLF endings
+        uses: erclu/check-crlf@v1

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -1,7 +1,7 @@
 name: Additional Checks
 
 # Checks which are not in standardized tools such as custom checks by scripts
-# in the source code or 3rd party checks without large projects behind them.
+# in the source code or small 3rd party checks without large projects behind them.
 # Number of disconnected, but simple checks can be combined into one workflow
 # (and job) to reduce the number of jobs.
 


### PR DESCRIPTION
This adds an new workflow with one new job which is check of CRLF line endings.
The idea is that this workflow (and job) can by extended to have more steps which are
other simple, custom checks like that (like those in utils or other 3rd party checks which are not proper linters).

The check excludes those where we expect CRLF (Windows specific files) or allow anything, i.e., not check at all (data for tests).

The CRFL check used is a simple action erclu/check-crlf which is used, e.g., in MapServer.
Alternatives seem to be AODocs/check-eol which uses .gitattributes and microsoftgraph/eol-blocker which interacts more with the PR.
