### PR TITLE
wxGUI: remove unnecessary printing of invalid map size

### DIFF
--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -1018,9 +1018,6 @@ class Map(object):
             self.width = int(size[0])
             self.height = int(size[1])
             if self.width < 1 or self.height < 1:
-                sys.stderr.write(
-                    _("Invalid map size %d,%d\n") % (self.width, self.height)
-                )
                 raise ValueError
         except ValueError:
             self.width = 640


### PR DESCRIPTION
When GUI in single window layout starts it prints "Invalid map size" error to console. It's not helpful and there is no actual problem to deal with.