### PR TITLE
Fix -Wunused-variable compiler warnings

### DIFF
--- a/display/d.grid/plot.c
+++ b/display/d.grid/plot.c
@@ -567,7 +567,6 @@ void init_proj(struct pj_info *info_in, struct pj_info *info_out,
     info_out->pj = NULL;
     if (wgs84) {
 	struct Key_Value *out_proj_info, *out_unit_info;
-        char buff[256], dum[256];
 
         out_proj_info = G_create_key_value();
         out_unit_info = G_create_key_value();
@@ -576,6 +575,8 @@ void init_proj(struct pj_info *info_in, struct pj_info *info_out,
          * the WGS84 values would be meaningless), and if they are set the 
          * input datum to WGS84 */
 #if PROJ_VERSION_MAJOR < 6
+        char buff[256], dum[256];
+
 	/* PROJ6+ has its own datum transformation parameters */
         if (G_get_datumparams_from_projinfo(in_proj_info, buff, dum) < 0)
             G_fatal_error(_("WGS84 grid output not possible as this location does not contain\n"

--- a/display/d.histogram/main.c
+++ b/display/d.histogram/main.c
@@ -73,7 +73,6 @@ int main(int argc, char **argv)
     struct Option *opt5;
     struct Flag *flag1;
     struct Flag *flag2;
-    struct Flag *flag3;
 
 
     /* Initialize the GIS calls */
@@ -131,9 +130,9 @@ int main(int argc, char **argv)
     flag1->key = 'n';
     flag1->description = _("Display information for null cells");
 
-    flag3 = G_define_flag();
-    flag3->key = 'c';
-    flag3->description =
+    flag2 = G_define_flag();
+    flag2->key = 'c';
+    flag2->description =
 	_("Report for ranges defined in cats file (fp maps only)");
 
     if (G_parser(argc, argv))
@@ -160,7 +159,7 @@ int main(int argc, char **argv)
     if (sscanf(opt5->answer, "%d", &nsteps) != 1)
 	G_fatal_error(_("Invalid number of steps: %s"), opt5->answer);
 
-    cat_ranges = flag3->answer;
+    cat_ranges = flag2->answer;
 
     if (cat_ranges && nsteps != 255)
 	G_warning(_("When -C flag is set, the nsteps argument is ignored"));

--- a/display/d.where/main.c
+++ b/display/d.where/main.c
@@ -101,7 +101,6 @@ int main(int argc, char **argv)
 
     if (have_spheroid == 1) {
 	struct Key_Value *in_proj_info, *in_unit_info;
-	char buff[100], dum[100];
 
 	/* read current projection info */
 	if ((in_proj_info = G_get_projinfo()) == NULL)
@@ -128,6 +127,8 @@ int main(int argc, char **argv)
 	     * the WGS84 values would be meaningless), and if they are set the 
 	     * output datum to WGS84 */
 #if PROJ_VERSION_MAJOR < 6
+            char buff[100], dum[100];
+
 	    /* PROJ6+ has its own datum transformation parameters */
 	    if (G_get_datumparams_from_projinfo(in_proj_info, buff, dum) < 0)
 		G_fatal_error(_("WGS84 output not possible as this location does not contain\n"

--- a/general/g.parser/translate.c
+++ b/general/g.parser/translate.c
@@ -9,8 +9,6 @@
    If global variable to output strings for translation is set it spits them out */
 char *translate(const char *arg)
 {
-    static const char *domain;
-
     if (arg == NULL)
 	return (char *) arg;
 
@@ -23,6 +21,8 @@ char *translate(const char *arg)
     }
 
 #if defined(HAVE_LIBINTL_H) && defined(USE_NLS)
+    static const char *domain;
+
     if (!domain) {
 	domain = getenv("GRASS_TRANSLATION_DOMAIN");
 	if (domain)

--- a/general/g.region/printwindow.c
+++ b/general/g.region/printwindow.c
@@ -548,7 +548,6 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag)
 	    struct pj_info iproj;	/* input map proj parameters  */
 	    struct pj_info oproj;	/* output map proj parameters  */
 	    struct pj_info tproj;	/* transformation parameters  */
-	    char buff[100], dum[100];
 	    int r, c;
 
 	    /* read current projection info */
@@ -573,6 +572,8 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag)
 	    G_set_key_value("proj", "ll", out_proj_info);
 
 #if PROJ_VERSION_MAJOR < 6
+            char buff[100], dum[100];
+
 	    /* PROJ6+ has its own datum transformation parameters */
 	    if (G_get_datumparams_from_projinfo(in_proj_info, buff, dum) < 0)
 		G_fatal_error(_("WGS84 output not possible as this location does not contain "

--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -57,7 +57,6 @@ int main(int argc, char *argv[])
     struct Option *input1, *input2;
     struct Flag *flag0, *flag1, *flag2;
     struct Flag *flag3, *flag4, *flag5;
-    struct History history;     /*metadata */
 
     /************************************/
     char *name;                 /*input raster name */
@@ -81,7 +80,7 @@ int main(int argc, char *argv[])
     /* For some strange reason infd[0] cannot be used later */
     /* So nfiles is initialized with nfiles = 1 */
     int nfiles = 0;
-    int i = 0, j = 0;
+    int i = 0;
     int radiance = 0;
     void *inrast[MAXFILES];
     DCELL *outrast[MAXFILES];

--- a/imagery/i.eb.hsebal01/main.c
+++ b/imagery/i.eb.hsebal01/main.c
@@ -56,8 +56,6 @@ int main(int argc, char *argv[])
     DCELL *outrast;
     int nrows = 0, ncols = 0;
     int row = 0, col = 0;
-    int row_wet = 0, col_wet = 0;
-    int row_dry = 0, col_dry = 0;
     double m_row_wet = 0.0, m_col_wet = 0.0;
     double m_row_dry = 0.0, m_col_dry = 0.0;
     int infd_Rn, infd_g0;

--- a/imagery/i.eb.netrad/main.c
+++ b/imagery/i.eb.netrad/main.c
@@ -26,25 +26,20 @@ double r_net(double bbalb, double ndvi, double tempk, double dtair,
 	      double sunzangle);
 int main(int argc, char *argv[]) 
 {
-    struct Cell_head cellhd;	/*region+header info */
-    char *mapset;		/*mapset name */
     int nrows, ncols;
     int row, col;
     struct GModule *module;
     struct Option *input1, *input2, *input3, *input4, *input5;
     struct Option *input6, *input7, *input8, *input9, *output1;
-    struct Flag *flag1;
     struct History history;	/*metadata */
     struct Colors colors;	/*Color rules */
-    char *name;			/*input raster name */
     char *result;		/*output raster name */
     int infd_albedo, infd_ndvi, infd_tempk, infd_time, infd_dtair;
     int infd_emissivity, infd_tsw, infd_doy, infd_sunzangle;
     int outfd;
     char *albedo, *ndvi, *tempk, *time, *dtair, *emissivity;
     char *tsw, *doy, *sunzangle;
-    int i = 0, j = 0;
-    void *inrast_albedo, *inrast_ndvi, *inrast_tempk, *inrast_rnet;
+    void *inrast_albedo, *inrast_ndvi, *inrast_tempk;
     void *inrast_time, *inrast_dtair, *inrast_emissivity, *inrast_tsw;
     void *inrast_doy, *inrast_sunzangle;
     DCELL * outrast;

--- a/imagery/i.eb.netrad/r_net.c
+++ b/imagery/i.eb.netrad/r_net.c
@@ -16,8 +16,8 @@ double r_net(double bbalb, double ndvi, double tempk, double dtair,
     /* sunzangle = sun zenith angle at sat. overpass */ 
     /* tair = air temperature (approximative, or met.station) */ 
     double Kin = 0.0, Lin = 0.0, Lout = 0.0, Lcorr = 0.0, result = 0.0;
-    double temp = 0.0, ds = 0.0, e_atm = 0.0, delta = 0.0;
-    double tsw_for_e_atm = 0.7;	/*Special tsw, consider it a coefficient */
+    double ds = 0.0, e_atm = 0.0, delta = 0.0;
+    /* double tsw_for_e_atm = 0.7; */	/* Special tsw, consider it a coefficient */
     
     /* Atmospheric emissivity (Bastiaanssen, 1995) */ 
     e_atm = 1.08 * pow(-log(tsw), 0.265);

--- a/imagery/i.emissivity/main.c
+++ b/imagery/i.emissivity/main.c
@@ -34,7 +34,6 @@ int main(int argc, char *argv[])
     char *result1;    /*output raster name */
     int infd, outfd;    /*File Descriptors */ 
     char *ndvi;
-    char *emissivity;
     void *inr;
     DCELL * outr;
 

--- a/imagery/i.evapo.time/main.c
+++ b/imagery/i.evapo.time/main.c
@@ -26,7 +26,6 @@
 int main(int argc, char *argv[])
 {
     struct Cell_head cellhd;	/*region+header info */
-    char *mapset;		/*mapset name */
     int nrows, ncols;
     int row, col;
     struct GModule *module;
@@ -65,9 +64,9 @@ int main(int argc, char *argv[])
     DCELL *outrast;
     CELL val1, val2;
     
-    RASTER_MAP_TYPE in_data_type[MAXFILES];	/* ETa */
-    RASTER_MAP_TYPE in_data_type1[MAXFILES];	/* DOY of ETa */
-    RASTER_MAP_TYPE in_data_type2[MAXFILES];	/* ETo */
+    /* RASTER_MAP_TYPE in_data_type[MAXFILES];  */	/* ETa */
+    /* RASTER_MAP_TYPE in_data_type1[MAXFILES]; */	/* DOY of ETa */
+    /* RASTER_MAP_TYPE in_data_type2[MAXFILES]; */	/* ETo */
     RASTER_MAP_TYPE out_data_type = DCELL_TYPE;
 
     /************************************/

--- a/imagery/i.ortho.photo/i.ortho.elev/main.c
+++ b/imagery/i.ortho.photo/i.ortho.elev/main.c
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     struct GModule *module;
     struct Option *group_opt, *loc_opt, *mapset_opt, *elev_opt;
     struct Option *math_opt, *unit_opt, *nd_opt;
-    struct Flag *list_flag, *print_flag;
+    struct Flag *print_flag;
 
     char location[GMAPSET_MAX];
     char mapset[GMAPSET_MAX];
@@ -56,7 +56,6 @@ int main(int argc, char *argv[])
 
     char buf[GPATH_MAX];
     int stat;
-    int overwrite;
 
     G_gisinit(argv[0]);
 

--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -27,8 +27,7 @@
 
 int main(int argc, char **argv)
 {
-    char title[80];
-    char buf[80], *p;
+    char *p;
     struct Ortho_Image_Group group;
     struct GModule *module;
     struct Option *group_opt, *ortho_opt;
@@ -36,7 +35,6 @@ int main(int argc, char **argv)
     char *moduletorun;
     const char *grname;
     char tosystem[99];
-    const char *to_system;
     int err=0;
 
     /* initialize grass */

--- a/lib/gis/locale.c
+++ b/lib/gis/locale.c
@@ -24,7 +24,6 @@
 void G_init_locale(void)
 {
     static int initialized;
-    const char *gisbase;
 
     if (G_is_initialized(&initialized))
 	return;

--- a/lib/gis/locale.c
+++ b/lib/gis/locale.c
@@ -34,8 +34,7 @@ void G_init_locale(void)
 #ifdef LC_MESSAGES
     setlocale(LC_MESSAGES, "");
 #endif
-
-    gisbase = getenv("GISBASE");
+    const char *gisbase = getenv("GISBASE");
     if (gisbase && *gisbase) {
 	char localedir[GPATH_MAX];
 

--- a/lib/gis/make_loc.c
+++ b/lib/gis/make_loc.c
@@ -191,7 +191,6 @@ int G_make_location_crs(const char *location_name,
 			const char *proj_wkt)
 {
     int ret;
-    char path[GPATH_MAX];
 
     ret = G_make_location(location_name, wind, proj_info, proj_units);
 

--- a/lib/gis/parser_json.c
+++ b/lib/gis/parser_json.c
@@ -188,7 +188,6 @@ char *G__json(void)
     FILE *fp = stdout;
 
     /*FILE *fp = NULL; */
-    char *type;
     char *file_name = NULL;
     int c;
     int random_int = rand();

--- a/lib/imagery/manage_signatures.c
+++ b/lib/imagery/manage_signatures.c
@@ -73,7 +73,6 @@ int I_signatures_remove(I_SIGFILE_TYPE type, const char *name)
 {
     char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
     char dir[GNAME_MAX];
-    int ret = 0;
 
     G_debug(1, "I_signatures_remove(%d, %s);", type, name);
 

--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -572,7 +572,6 @@ int GPJ_init_transform(const struct pj_info *info_in,
 
 	    G_important_message(_("Found %d possible transformations"), op_count);
 	    for (i = 0; i < op_count; i++) {
-		const char *str;
 		const char *area_of_use, *projstr;
 		double e, w, s, n;
 		PJ_PROJ_INFO pj_info;
@@ -609,7 +608,7 @@ int GPJ_init_transform(const struct pj_info *info_in,
 					pj_info.accuracy);
 		}
 #if PROJ_VERSION_NUM >= 6020000
-		str = proj_get_remarks(op);
+		const char *str = proj_get_remarks(op);
 		if (str && *str) {
 		    G_important_message(" ");
 		    G_important_message(_("Remarks: %s"), str);

--- a/lib/raster/init.c
+++ b/lib/raster/init.c
@@ -77,7 +77,7 @@ void Rast__error_handler(void *p)
 
 static int init(void)
 {
-    char *zlib, *nulls, *cname;
+    char *nulls, *cname;
 
     Rast__init_window();
 

--- a/lib/vector/Vlib/intersect2.c
+++ b/lib/vector/Vlib/intersect2.c
@@ -107,7 +107,7 @@ static int n_cross;
 static CROSS *cross = NULL;
 static int *use_cross = NULL;
 
-static double rethresh = 0.000001;	/* TODO */
+/* static double rethresh = 0.000001; */	/* TODO */
 
 static double d_ulp(double a, double b)
 {
@@ -1198,7 +1198,7 @@ Vect_line_intersection2(struct line_pnts *APoints,
     return 1;
 }
 
-static int cross_found;		/* set by find_cross() */
+/* static int cross_found; */		/* set by find_cross() */
 
 /* find segment intersection, used by Vect_line_check_intersection2 */
 static int find_cross(int i, int j, int b)

--- a/lib/vector/Vlib/overlay.c
+++ b/lib/vector/Vlib/overlay.c
@@ -102,7 +102,7 @@ Vect_overlay_and(struct Map_info *AMap, int atype, struct ilist *AList,
 		 struct ilist *BList, struct ilist *BAList,
 		 struct Map_info *OMap)
 {
-    int i, j, k, node, line, altype, bltype, oltype, area, centr;
+    int i, j, k, line, altype, bltype, oltype, area, centr;
     struct line_pnts *Points;
     struct line_cats *ACats, *BCats, *OCats;
     struct ilist *AOList, *BOList;

--- a/lib/vector/diglib/update.c
+++ b/lib/vector/diglib/update.c
@@ -36,13 +36,12 @@ void dig_line_reset_updated(struct Plus_head *Plus)
  */
 void dig_line_add_updated(struct Plus_head *Plus, int line, off_t offset)
 {
-    int i;
-    
     G_debug(3, "dig_line_add_updated(): line = %d", line);
 
     /* undo/redo in the digitizer needs all steps, 
      * disable check */
 #if 0
+    int i;
     /* Check if already in list */
     for (i = 0; i < Plus->uplist.n_uplines; i++) {
 	if (Plus->uplist.uplines[i] == line) {

--- a/raster/r.fill.stats/main.c
+++ b/raster/r.fill.stats/main.c
@@ -148,7 +148,6 @@ void print_weights_matrix(long int rows, long int cols)
 {
     int i, j;
     int weight_matrix_line_length = 80;
-    int weight_matrix_weight_length = 7;
     char weight_matrix_line_buf[weight_matrix_line_length + 1];
     char weight_matrix_weight_buf[weight_matrix_line_length + 1];
 

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
 
     {                           /* calculate parameters */
         int num_outputs = 0;
-        double search_radius, skip_radius, start_radius, step_radius;
+        double search_radius, skip_radius;
         double ns_resolution;
 
         if (!strcmp(par_comparison->answer, "anglev1"))

--- a/raster/r.kappa/prt2csv_mat.c
+++ b/raster/r.kappa/prt2csv_mat.c
@@ -20,7 +20,7 @@ void prn2csv_error_mat(int out_cols, int hdr)
     int first_col = 0, last_col = 0;
     int thisone;
     long t_row, t_col;
-    long t_rowcount, grand_count;
+    long t_rowcount;
     const char *mapone;
     FILE *fd;
 

--- a/raster/r.random.surface/init.c
+++ b/raster/r.random.surface/init.c
@@ -17,7 +17,6 @@ void Init(void)
     struct Cell_head Region;
     int row, col, i, j, NumWeight, NumDist, NumExp;
     char *Name, *Number, String[80];
-    char msg[128], msg2[64];
     double MinRes;
 
     G_debug(2, "Init");

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -96,7 +96,6 @@
 /****************************************/
 int main(int argc, char *argv[])
 {
-    int ii;
     int threads;
     int ret_val;
     double x_orig, y_orig;

--- a/raster/r.support/check.c
+++ b/raster/r.support/check.c
@@ -16,7 +16,6 @@ int check_stats(const char *name)
     struct Categories cats;
     struct Range range;
     struct FPRange fprange;
-    int i;
     int cats_ok;
     int max;
 

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -971,7 +971,7 @@ save_io_vis_and_elev_to_GRASS(IOVisibilityGrid * visgrid, char *elevfname,
     }
 
     dimensionType i, j;
-    double elev = 0, viewshed_value;
+    double elev = 0;
 
     for (i = 0; i < Rast_window_rows(); i++) {
 

--- a/raster/r.watershed/seg/slope_len.c
+++ b/raster/r.watershed/seg/slope_len.c
@@ -3,7 +3,6 @@
 int slope_length(int r, int c, int dr, int dc)
 {
     CELL top_alt, bot_alt, ridge;
-    char asp_value;
     double res, top_ls, bot_ls;
     WAT_ALT wa;
 

--- a/raster3d/r3.null/main.c
+++ b/raster3d/r3.null/main.c
@@ -90,7 +90,7 @@ modifyNull(char *name, d_Mask * maskRules, int changeNull, double newNullVal)
     RASTER3D_Region region;
     int tileX, tileY, tileZ, x, y, z;
     double value;
-    int doCompress, doLzw, doRle, precision;
+    int doCompress, precision;
     int cacheSize;
 
     cacheSize = Rast3d_cache_size_encode(RASTER3D_USE_CACHE_XY, 1);

--- a/raster3d/r3.to.rast/main.c
+++ b/raster3d/r3.to.rast/main.c
@@ -144,7 +144,6 @@ void g3d_to_raster(void *map, RASTER3D_Region region, int *fd,
                    int output_type, int use_coeffs, double coeff_a,
                    double coeff_b)
 {
-    CELL c1 = 0;
     FCELL f1 = 0;
     DCELL d1 = 0;
     int x, y, z;

--- a/vector/v.extract/main.c
+++ b/vector/v.extract/main.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
     
     struct Cat_index *ci;
     
-    int ucat_count, *ucat_array, prnd, seed, nrandom, nfeatures;
+    int ucat_count, *ucat_array, prnd, nrandom, nfeatures;
     char *dissolve_key;
 
     Fi = NULL;

--- a/vector/v.info/parse.c
+++ b/vector/v.info/parse.c
@@ -10,7 +10,6 @@ void parse_args(int argc, char** argv,
 		int* history, int* columns, int *shell)
 {
     int i;
-    const char *answer;
     
     struct Option *input_opt, *field_opt;
     struct Flag *hist_flag, *col_flag, *shell_flag, *region_flag, *topo_flag;

--- a/vector/v.out.ogr/export_areas.c
+++ b/vector/v.out.ogr/export_areas.c
@@ -146,7 +146,7 @@ int export_areas_multi(struct Map_info *In, int field, int donocat,
                        int *n_noatt, int *n_nocat, int outer_ring_ccw)
 {
     int i, n_exported, area;
-    int cat, ncats_field, line, type, findex, ipart;
+    int cat, ncats_field, line, findex, ipart;
 
     struct line_pnts *Points;
     struct line_cats *Cats;

--- a/vector/v.overlay/area_area.c
+++ b/vector/v.overlay/area_area.c
@@ -30,7 +30,7 @@ int area_area(struct Map_info *In, int *field, struct Map_info *Tmp,
 	      ATTRIBUTES * attr, struct ilist *BList, double snap)
 {
     int ret, input, line, nlines, area, nareas;
-    int in_area, in_centr, out_cat;
+    int in_centr, out_cat;
     struct line_pnts *Points;
     struct line_cats *Cats;
     CENTR *Centr;

--- a/vector/v.to.rast/support.c
+++ b/vector/v.to.rast/support.c
@@ -494,12 +494,7 @@ int update_labels(const char *rast_name, const char *vector_map, int field,
 	break;
     case USE_CAT:
 	{
-	    int row, rows, fd;
-	    void *rowbuf;
-	    struct Cell_stats stats;
-	    CELL n;
 	    RASTER_MAP_TYPE map_type;
-	    long count;
 
 	    map_type = Rast_map_type(rast_name, G_mapset());
 
@@ -601,7 +596,13 @@ int update_labels(const char *rast_name, const char *vector_map, int field,
 		 * -> skip */
 
 #if 0
-		fd = Rast_open_old(rast_name, G_mapset());
+                int row, rows, fd;
+                void *rowbuf;
+                struct Cell_stats stats;
+                CELL n;
+                long count;
+                
+                fd = Rast_open_old(rast_name, G_mapset());
 		rowbuf = Rast_allocate_buf(map_type);
 		Rast_init_cell_stats(&stats);
 		rows = Rast_window_rows();

--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -73,7 +73,6 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
     int first_time = 1;
     CELL *cellmask;
     const char *mapsetm;
-    char buf[500];
     int cat, intval;
     struct field_info *Fi;
     dbDriver *Driver;


### PR DESCRIPTION
As reported in #2156.


**Affects:**

Modules

- d.grid
- d.histogram
- d.where
- g.parser
- g.region
- i.aster.toar
- i.eb.hsebal01
- i.eb.netrad
- i.emissivity
- i.evapo.time
- i.ortho.elev
- i.ortho.photo
- r.fill.stats
- r.geomorphon
- r.kappa
- r.random.surface
- r.sim/r.sim.water
- r.support
- r.viewshed
- r.watershed
- r3.null
- r3.to.rast
- v.extract
- v.info
- v.out.ogr
- v.overlay
- v.to.rast
- v.vol.rst

GRASS Library parts

- lib/gis
- lib/imagery
- lib/proj
- lib/raster
- lib/vector
- lib/vector/Vlib
