### PR TITLE
Fix -Wunused-const-variable compiler warnings

### DIFF
--- a/raster/r.terraflow/sweep.cpp
+++ b/raster/r.terraflow/sweep.cpp
@@ -34,11 +34,6 @@
 #include "sortutils.h"
 
 
-/* frequency; used to print progress dots */
-static const int DOT_CYCLE = 50;
-static const int PQSIZE_CYCLE = 100;
-
-
 /* globals in common.H
 
 extern statsRecorder *stats;       stats file 


### PR DESCRIPTION
As reported in #2156.

**Affects:**

- r.terraflow