### PR TITLE
Fix -Wunused-function compiler warnings

### DIFF
--- a/display/d.vect.thematic/local_proto.h
+++ b/display/d.vect.thematic/local_proto.h
@@ -12,8 +12,6 @@ int dareatheme(struct Map_info *, struct cat_list *, dbCatValArray *,
                const struct color_rgb *, int, struct Cell_head *, int);
 
 int dcmp(const void *, const void *);
-static int cmp(const void *, const void *);
-static char *icon_files(void);
 
 /* display.c */
 int draw_line(int ltype, int line,

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -27,8 +27,12 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 #include <grass/arraystats.h>
-#include "plot.h"
 #include "local_proto.h"
+#include "plot.h"
+
+/* prototypes */
+static int cmp(const void *, const void *);
+static char *icon_files(void);
 
 int main(int argc, char **argv)
 {
@@ -643,13 +647,13 @@ int main(int argc, char **argv)
     exit(stat);
 }
 
-int cmp(const void *a, const void *b)
+static int cmp(const void *a, const void *b)
 {
     return (strcmp(*(char **)a, *(char **)b));
 }
 
 /* adopted from r.colors */
-char *icon_files(void)
+static char *icon_files(void)
 {
     char **list, *ret;
     char buf[GNAME_MAX + GNAME_MAX], path[GPATH_MAX], path_i[GPATH_MAX];

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -320,8 +320,8 @@ int main(int argc, char **argv)
         G_debug(4, "cat = %d  %s = %d", cvarr.value[i].cat,
                 column_opt->answer,
                 (cvarr.ctype ==
-                 DB_C_TYPE_INT ? cvarr.value[i].val.i : (int)cvarr.
-                 value[i].val.d));
+                 DB_C_TYPE_INT ? cvarr.value[i].val.i : (int)cvarr.value[i].
+                 val.d));
     }
 
     /*Get the sorted data */

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -553,7 +553,7 @@ static int find_best_neighbour(struct globals *globals, int row, int col,
     return best_n_id;
 }
 
-#if 0 /* unused */
+#if 0                           /* unused */
 static int check_reg_size(struct globals *globals, int minsize, int row,
                           int col)
 {
@@ -630,7 +630,7 @@ static int check_reg_size(struct globals *globals, int minsize, int row,
 
     return reg_size;
 }
-#endif /* if 0 unused */
+#endif /* unused */
 
 static int update_rid(struct globals *globals, int row, int col, int new_id)
 {

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -553,6 +553,7 @@ static int find_best_neighbour(struct globals *globals, int row, int col,
     return best_n_id;
 }
 
+#if 0 /* unused */
 static int check_reg_size(struct globals *globals, int minsize, int row,
                           int col)
 {
@@ -629,6 +630,7 @@ static int check_reg_size(struct globals *globals, int minsize, int row,
 
     return reg_size;
 }
+#endif /* if 0 unused */
 
 static int update_rid(struct globals *globals, int row, int col, int new_id)
 {

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -158,6 +158,7 @@ static int compare_sim_ngbrs(double simi, double simk, int candi, int candk,
     return (Ri->col > Rk->col);
 }
 
+#if 0 /* unused */
 static int dump_Ri(struct ngbr_stats *Ri, struct reg_stats *Ri_rs,
                    double *Ri_sim, double *Rk_sim, int *Ri_nn, int *Rk_nn,
                    struct globals *globals)
@@ -181,7 +182,7 @@ static int dump_Ri(struct ngbr_stats *Ri, struct reg_stats *Ri_rs,
 
     return 1;
 }
-
+#endif /* if 0 unused */
 
 int region_growing(struct globals *globals)
 {

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -158,7 +158,7 @@ static int compare_sim_ngbrs(double simi, double simk, int candi, int candk,
     return (Ri->col > Rk->col);
 }
 
-#if 0 /* unused */
+#if 0                           /* unused */
 static int dump_Ri(struct ngbr_stats *Ri, struct reg_stats *Ri_rs,
                    double *Ri_sim, double *Rk_sim, int *Ri_nn, int *Rk_nn,
                    struct globals *globals)
@@ -182,7 +182,7 @@ static int dump_Ri(struct ngbr_stats *Ri, struct reg_stats *Ri_rs,
 
     return 1;
 }
-#endif /* if 0 unused */
+#endif /* unused */
 
 int region_growing(struct globals *globals)
 {
@@ -809,8 +809,7 @@ static int find_best_neighbor(struct ngbr_stats *Ri,
 
                                 tempsim =
                                     (globals->calculate_similarity) (Ri,
-                                                                     &globals->
-                                                                     ns,
+                                                                     &globals->ns,
                                                                      globals);
                                 candtmp =
                                     (FLAG_GET

--- a/include/grass/iostream/pqheap.h
+++ b/include/grass/iostream/pqheap.h
@@ -83,7 +83,7 @@ static inline unsigned int heap_parent(unsigned int index) {
 
 
 // return minimum of two integers
-static unsigned int mymin(unsigned int a, unsigned int b) {
+static inline unsigned int mymin(unsigned int a, unsigned int b) {
   return (a<=b)? a:b;
 }
 

--- a/lib/cairodriver/graph.c
+++ b/lib/cairodriver/graph.c
@@ -339,8 +339,7 @@ static void init_cairo(void)
                                                                     CAIRO_FORMAT_ARGB32,
                                                                     ca.width,
                                                                     ca.height,
-                                                                    ca.
-                                                                    stride);
+                                                                    ca.stride);
         break;
 #if CAIRO_HAS_PDF_SURFACE
     case FTYPE_PDF:
@@ -368,8 +367,7 @@ static void init_cairo(void)
 #endif
 #if CAIRO_HAS_XLIB_XRENDER_SURFACE
     case FTYPE_X11:
-        surface =
-            (cairo_surface_t *)
+        surface = (cairo_surface_t *)
             cairo_xlib_surface_create_with_xrender_format(ca.dpy, ca.win,
                                                           ca.screen,
                                                           ca.format, ca.width,

--- a/lib/cairodriver/graph.c
+++ b/lib/cairodriver/graph.c
@@ -49,9 +49,9 @@ static void init_cairo(void);
 static int ends_with(const char *string, const char *suffix);
 static void map_file(void);
 
+#if CAIRO_HAS_XLIB_XRENDER_SURFACE
 static void init_xlib(void)
 {
-#if CAIRO_HAS_XLIB_XRENDER_SURFACE
     char *p;
     unsigned long xid;
     XVisualInfo templ;
@@ -101,16 +101,14 @@ static void init_xlib(void)
     if (!ca.win)
         ca.win = XCreatePixmap(ca.dpy, RootWindow(ca.dpy, scrn),
                                ca.width, ca.height, ca.depth);
-#endif
 }
 
 static void fini_xlib(void)
 {
-#if CAIRO_HAS_XLIB_XRENDER_SURFACE
     XSetCloseDownMode(ca.dpy, RetainTemporary);
     XCloseDisplay(ca.dpy);
-#endif
 }
+#endif
 
 static void init_file(void)
 {

--- a/lib/gis/parser_wps.c
+++ b/lib/gis/parser_wps.c
@@ -40,8 +40,6 @@ static void wps_print_mimetype_raster_jpeg(void);
 static void wps_print_mimetype_raster_hfa(void);
 static void wps_print_mimetype_raster_netCDF(void);
 static void wps_print_mimetype_raster_netCDF_other(void);
-/* static void wps_print_mimetype_raster_grass_binary(void);
-static void wps_print_mimetype_raster_grass_ascii(void); */
 static void wps_print_mimetype_vector_gml311(void);
 static void wps_print_mimetype_vector_gml311_appl(void);
 static void wps_print_mimetype_vector_gml212(void);
@@ -50,8 +48,14 @@ static void wps_print_mimetype_vector_kml22(void);
 static void wps_print_mimetype_vector_dgn(void);
 static void wps_print_mimetype_vector_shape(void);
 static void wps_print_mimetype_vector_zipped_shape(void);
-/* static void wps_print_mimetype_vector_grass_ascii(void);
-static void wps_print_mimetype_vector_grass_binary(void); */
+
+#if 0                           /* unused */
+static void wps_print_mimetype_raster_grass_binary(void);
+static void wps_print_mimetype_raster_grass_ascii(void);
+static void wps_print_mimetype_vector_grass_ascii(void);
+static void wps_print_mimetype_vector_grass_binary(void);
+#endif
+
 static void wps_print_mimetype_space_time_datasets(void);
 static void wps_print_mimetype_space_time_raster_datasets(void);
 static void wps_print_mimetype_space_time_vector_datasets(void);
@@ -927,8 +931,8 @@ static void wps_print_mimetype_raster_png(void)
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
 
+#if 0                           /* unused */
 /* *** Native GRASS raster format urn:grass:raster:location/mapset/raster *** */
-/*
 static void wps_print_mimetype_raster_grass_binary(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -936,9 +940,8 @@ static void wps_print_mimetype_raster_grass_binary(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-raster-binary</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-*/
+
 /* *** GRASS raster maps exported via r.out.ascii ************************** */
-/*
 static void wps_print_mimetype_raster_grass_ascii(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -946,7 +949,7 @@ static void wps_print_mimetype_raster_grass_ascii(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-raster-ascii</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-*/
+#endif
 /* ************************************************************************** */
 
 static void wps_print_mimetype_vector_gml311_appl(void)
@@ -985,7 +988,7 @@ static void wps_print_mimetype_vector_gml311(void)
 }
 
 /* ************************************************************************** */
-
+#if 0                           /* unused */
 static void wps_print_mimetype_vector_gml212(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -997,7 +1000,7 @@ static void wps_print_mimetype_vector_gml212(void)
 }
 
 /* *** GRASS vector format exported via v.out.ascii ************************** */
-/*
+
 static void wps_print_mimetype_vector_grass_ascii(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -1005,9 +1008,9 @@ static void wps_print_mimetype_vector_grass_ascii(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-vector-ascii</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-*/
+
 /* *** Native GRASS vector format urn:grass:vector:location/mapset/vector *** */
-/*
+
 static void wps_print_mimetype_vector_grass_binary(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -1015,7 +1018,7 @@ static void wps_print_mimetype_vector_grass_binary(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-vector-binary</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-*/
+#endif
 /* *** Space time dataset format using tar, tar.gz and tar.bz2 methods for packaging */
 
 static void wps_print_mimetype_space_time_datasets(void)

--- a/lib/gis/parser_wps.c
+++ b/lib/gis/parser_wps.c
@@ -40,8 +40,8 @@ static void wps_print_mimetype_raster_jpeg(void);
 static void wps_print_mimetype_raster_hfa(void);
 static void wps_print_mimetype_raster_netCDF(void);
 static void wps_print_mimetype_raster_netCDF_other(void);
-static void wps_print_mimetype_raster_grass_binary(void);
-static void wps_print_mimetype_raster_grass_ascii(void);
+/* static void wps_print_mimetype_raster_grass_binary(void);
+static void wps_print_mimetype_raster_grass_ascii(void); */
 static void wps_print_mimetype_vector_gml311(void);
 static void wps_print_mimetype_vector_gml311_appl(void);
 static void wps_print_mimetype_vector_gml212(void);
@@ -50,8 +50,8 @@ static void wps_print_mimetype_vector_kml22(void);
 static void wps_print_mimetype_vector_dgn(void);
 static void wps_print_mimetype_vector_shape(void);
 static void wps_print_mimetype_vector_zipped_shape(void);
-static void wps_print_mimetype_vector_grass_ascii(void);
-static void wps_print_mimetype_vector_grass_binary(void);
+/* static void wps_print_mimetype_vector_grass_ascii(void);
+static void wps_print_mimetype_vector_grass_binary(void); */
 static void wps_print_mimetype_space_time_datasets(void);
 static void wps_print_mimetype_space_time_raster_datasets(void);
 static void wps_print_mimetype_space_time_vector_datasets(void);
@@ -928,7 +928,7 @@ static void wps_print_mimetype_raster_png(void)
 }
 
 /* *** Native GRASS raster format urn:grass:raster:location/mapset/raster *** */
-
+/*
 static void wps_print_mimetype_raster_grass_binary(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -936,9 +936,9 @@ static void wps_print_mimetype_raster_grass_binary(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-raster-binary</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-
+*/
 /* *** GRASS raster maps exported via r.out.ascii ************************** */
-
+/*
 static void wps_print_mimetype_raster_grass_ascii(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -946,7 +946,7 @@ static void wps_print_mimetype_raster_grass_ascii(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-raster-ascii</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-
+*/
 /* ************************************************************************** */
 
 static void wps_print_mimetype_vector_gml311_appl(void)
@@ -997,7 +997,7 @@ static void wps_print_mimetype_vector_gml212(void)
 }
 
 /* *** GRASS vector format exported via v.out.ascii ************************** */
-
+/*
 static void wps_print_mimetype_vector_grass_ascii(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -1005,9 +1005,9 @@ static void wps_print_mimetype_vector_grass_ascii(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-vector-ascii</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-
+*/
 /* *** Native GRASS vector format urn:grass:vector:location/mapset/vector *** */
-
+/*
 static void wps_print_mimetype_vector_grass_binary(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -1015,7 +1015,7 @@ static void wps_print_mimetype_vector_grass_binary(void)
             "\t\t\t\t\t\t\t<MimeType>application/grass-vector-binary</MimeType>\n");
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
-
+*/
 /* *** Space time dataset format using tar, tar.gz and tar.bz2 methods for packaging */
 
 static void wps_print_mimetype_space_time_datasets(void)

--- a/lib/gis/parser_wps.c
+++ b/lib/gis/parser_wps.c
@@ -988,7 +988,7 @@ static void wps_print_mimetype_vector_gml311(void)
 }
 
 /* ************************************************************************** */
-#if 0                           /* unused */
+
 static void wps_print_mimetype_vector_gml212(void)
 {
     fprintf(stdout, "\t\t\t\t\t\t<Format>\n");
@@ -999,6 +999,7 @@ static void wps_print_mimetype_vector_gml212(void)
     fprintf(stdout, "\t\t\t\t\t\t</Format>\n");
 }
 
+#if 0                           /* unused */
 /* *** GRASS vector format exported via v.out.ascii ************************** */
 
 static void wps_print_mimetype_vector_grass_ascii(void)

--- a/lib/raster3d/cache1.c
+++ b/lib/raster3d/cache1.c
@@ -229,6 +229,7 @@ static void cache_queue_enqueue(RASTER3D_cache * c, int left, int index)
 
 /*---------------------------------------------------------------------------*/
 
+/* unused
 static int cache_queue_get_top(RASTER3D_cache * c)
 {
     int top;
@@ -239,6 +240,7 @@ static int cache_queue_get_top(RASTER3D_cache * c)
 
     return top;
 }
+*/
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/raster3d/cache1.c
+++ b/lib/raster3d/cache1.c
@@ -87,7 +87,7 @@ void Rast3d_cache_dispose(RASTER3D_cache * c)
 
 void *Rast3d_cache_new(int nofElts, int sizeOfElts, int nofNames,
                        int (*eltRemoveFun)(), void *eltRemoveFunData,
-                       int(*eltLoadFun)(), void *eltLoadFunData)
+                       int (*eltLoadFun)(), void *eltLoadFunData)
 {
     RASTER3D_cache *tmp;
     int i;
@@ -229,7 +229,7 @@ static void cache_queue_enqueue(RASTER3D_cache * c, int left, int index)
 
 /*---------------------------------------------------------------------------*/
 
-/* unused
+#if 0                           /* unused */
 static int cache_queue_get_top(RASTER3D_cache * c)
 {
     int top;
@@ -240,7 +240,7 @@ static int cache_queue_get_top(RASTER3D_cache * c)
 
     return top;
 }
-*/
+#endif
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/vector/Vlib/write_pg.c
+++ b/lib/vector/Vlib/write_pg.c
@@ -64,10 +64,11 @@ static char *build_insert_stmt(const struct Format_info_pg *, const char *,
 static int insert_topo_element(struct Map_info *, int, int, const char *);
 static int type_to_topogeom(const struct Format_info_pg *);
 static int update_next_edge(struct Map_info *, int, int);
-#if 0 /* unused */
+
+#if 0                           /* unused */
 static int delete_face(const struct Map_info *, int);
 static int update_topo_edge(struct Map_info *, int);
-#endif /* if 0 */
+#endif
 static int update_topo_face(struct Map_info *, int);
 static int add_line_to_topo_pg(struct Map_info *, off_t, int,
                                const struct line_pnts *);
@@ -2588,7 +2589,7 @@ int Vect__insert_face_pg(struct Map_info *Map, int area)
     return area;
 }
 
-#if 0 /* unused */
+#if 0                           /* unused */
 /*!
    \brief Delete existing face (currently unused)
 
@@ -2748,7 +2749,7 @@ int update_topo_edge(struct Map_info *Map, int line)
 
     return 0;
 }
-#endif /* if 0 */
+#endif
 
 /*!
    \brief Update lines (left and right faces)

--- a/lib/vector/Vlib/write_pg.c
+++ b/lib/vector/Vlib/write_pg.c
@@ -64,8 +64,10 @@ static char *build_insert_stmt(const struct Format_info_pg *, const char *,
 static int insert_topo_element(struct Map_info *, int, int, const char *);
 static int type_to_topogeom(const struct Format_info_pg *);
 static int update_next_edge(struct Map_info *, int, int);
+#if 0 /* unused */
 static int delete_face(const struct Map_info *, int);
 static int update_topo_edge(struct Map_info *, int);
+#endif /* if 0 */
 static int update_topo_face(struct Map_info *, int);
 static int add_line_to_topo_pg(struct Map_info *, off_t, int,
                                const struct line_pnts *);
@@ -2586,6 +2588,7 @@ int Vect__insert_face_pg(struct Map_info *Map, int area)
     return area;
 }
 
+#if 0 /* unused */
 /*!
    \brief Delete existing face (currently unused)
 
@@ -2745,6 +2748,7 @@ int update_topo_edge(struct Map_info *Map, int line)
 
     return 0;
 }
+#endif /* if 0 */
 
 /*!
    \brief Update lines (left and right faces)

--- a/lib/vector/rtree/split.c
+++ b/lib/vector/rtree/split.c
@@ -171,6 +171,7 @@ void RTreeInitPVars(struct RTree_PartitionVars *p, int maxrects, int minfill,
     }
 }
 
+#ifdef DEBUG
 /*----------------------------------------------------------------------
 | Print out data for a partition from PartitionVars struct.
 | Unused, for debugging only
@@ -210,6 +211,7 @@ static void RTreePrintPVars(struct RTree_PartitionVars *p, struct RTree *t,
     fprintf(stdout, "cover[1]:\n");
     RTreePrintRect(&p->cover[1], 0, t);
 }
+#endif /* DEBUG */
 
 /*----------------------------------------------------------------------
 | Method #0 for choosing a partition: this is Toni Guttman's quadratic

--- a/lib/vector/rtree/split.c
+++ b/lib/vector/rtree/split.c
@@ -172,6 +172,7 @@ void RTreeInitPVars(struct RTree_PartitionVars *p, int maxrects, int minfill,
 }
 
 #ifdef DEBUG
+
 /*----------------------------------------------------------------------
 | Print out data for a partition from PartitionVars struct.
 | Unused, for debugging only

--- a/raster/r.mapcalc/mapcalc.l
+++ b/raster/r.mapcalc/mapcalc.l
@@ -93,6 +93,8 @@ static int get_input_stream(char *buf, int max_size)
 
 %}
 
+%option nounput
+
 W		[ \t\r]+
 N		[^ ^#@,"'\000-\037()\[\]+\-*/%><!=&|?:;~]+
 I		[0-9]+


### PR DESCRIPTION
As reported in #2156.

Initially this is a draft, I commented in code to highlight the unused functions. We need to decide which ones to keep (in one way or other) and which ones that can be removed.

**Affects:**

- include/grass/iostream

Modules

- d.vect.thematic
- i.segment
- r.mapcalc

GRASS Library parts

- lib/cairodriver
- lib/gis
- lib/raster3d
- lib/vector/rtree
- lib/vector/Vlib

