### PR TITLE
Fix -Wuninitialized compiler warnings

### DIFF
--- a/imagery/i.gensig/means.c
+++ b/imagery/i.gensig/means.c
@@ -33,7 +33,7 @@ int compute_means(struct files *files, struct Signature *S)
                            files->band_cell[b], row);
             for (col = 0; col < ncols; col++) {
                 if (Rast_is_d_null_value(&cell[col])) {
-                    n_nulls++;
+                    n_nulls++; // 'n_nulls' is uninitialized when used here
                     continue;
                 }
                 n = class[col];

--- a/imagery/i.gensig/means.c
+++ b/imagery/i.gensig/means.c
@@ -9,7 +9,7 @@
 
 int compute_means(struct files *files, struct Signature *S)
 {
-    int n, n_nulls;
+    int n;
     int b;
     int nrows, ncols, row, col;
     CELL *class;
@@ -33,7 +33,7 @@ int compute_means(struct files *files, struct Signature *S)
                            files->band_cell[b], row);
             for (col = 0; col < ncols; col++) {
                 if (Rast_is_d_null_value(&cell[col])) {
-                    n_nulls++; // 'n_nulls' is uninitialized when used here
+                    // n_nulls++; // 'n_nulls' is uninitialized when used here, this line will be removed
                     continue;
                 }
                 n = class[col];

--- a/imagery/i.gensig/means.c
+++ b/imagery/i.gensig/means.c
@@ -32,10 +32,8 @@ int compute_means(struct files *files, struct Signature *S)
             Rast_get_d_row(files->band_fd[b], cell =
                            files->band_cell[b], row);
             for (col = 0; col < ncols; col++) {
-                if (Rast_is_d_null_value(&cell[col])) {
-                    // n_nulls++; // 'n_nulls' is uninitialized when used here, this line will be removed
+                if (Rast_is_d_null_value(&cell[col]))
                     continue;
-                }
                 n = class[col];
                 if (n < 0)
                     continue;

--- a/lib/cdhc/enormp.c
+++ b/lib/cdhc/enormp.c
@@ -49,7 +49,7 @@ double Cdhc_enormp(double x)
     }
     else {
         x2 = x * x;
-        // x4 *= 1.;               /* huh, what? See original FORTRAN */ // 'x4' is uninitialized when used here
+        // x4 *= 1.;               /* huh, what? See original FORTRAN */
         x4 = 0.5;
         yy1 = (((xt[0] * x4 + xt[1]) * x4 + xt[2]) * x4 + xt[3]) * x4 + xt[4];
         yy2 = (((xu[0] * x4 + xu[1]) * x4 + xu[2]) * x4 + xu[3]) * x4 + 1.;

--- a/lib/cdhc/enormp.c
+++ b/lib/cdhc/enormp.c
@@ -49,7 +49,7 @@ double Cdhc_enormp(double x)
     }
     else {
         x2 = x * x;
-        // x4 *= 1.;               /* huh, what? See original FORTRAN */
+        x4 *= 1.;               /* huh, what? See original FORTRAN */
         x4 = 0.5;
         yy1 = (((xt[0] * x4 + xt[1]) * x4 + xt[2]) * x4 + xt[3]) * x4 + xt[4];
         yy2 = (((xu[0] * x4 + xu[1]) * x4 + xu[2]) * x4 + xu[3]) * x4 + 1.;

--- a/lib/cdhc/enormp.c
+++ b/lib/cdhc/enormp.c
@@ -49,7 +49,7 @@ double Cdhc_enormp(double x)
     }
     else {
         x2 = x * x;
-        x4 *= 1.;               /* huh, what? See original FORTRAN */ // 'x4' is uninitialized when used here
+        // x4 *= 1.;               /* huh, what? See original FORTRAN */ // 'x4' is uninitialized when used here
         x4 = 0.5;
         yy1 = (((xt[0] * x4 + xt[1]) * x4 + xt[2]) * x4 + xt[3]) * x4 + xt[4];
         yy2 = (((xu[0] * x4 + xu[1]) * x4 + xu[2]) * x4 + xu[3]) * x4 + 1.;

--- a/lib/cdhc/enormp.c
+++ b/lib/cdhc/enormp.c
@@ -49,7 +49,7 @@ double Cdhc_enormp(double x)
     }
     else {
         x2 = x * x;
-        x4 *= 1.;               /* huh, what? See original FORTRAN */
+        x4 *= 1.;               /* huh, what? See original FORTRAN */ // 'x4' is uninitialized when used here
         x4 = 0.5;
         yy1 = (((xt[0] * x4 + xt[1]) * x4 + xt[2]) * x4 + xt[3]) * x4 + xt[4];
         yy2 = (((xu[0] * x4 + xu[1]) * x4 + xu[2]) * x4 + xu[3]) * x4 + 1.;

--- a/lib/raster3d/test/test_put_get_value_large_file.c
+++ b/lib/raster3d/test/test_put_get_value_large_file.c
@@ -444,7 +444,8 @@ int test_large_file_sparse_random(int depths, int rows, int cols,
             for (x = 0; x < region.cols; x++) {
                 /* Check the counter as cell value */
                 Rast3d_get_value(map, x, y, z, &value, DCELL_TYPE);
-                if (fabs(value - random_value_vector[i]) > EPSILON) {
+				random_value = random_value_vector[i];
+                if (fabs(value - random_value) > EPSILON) {
                     G_message
                         ("At: z %i y %i x %i -- value %.14lf != %.14lf\n", z,
                          y, x, value, random_value); // 'random_value' is uninitialized when used here

--- a/lib/raster3d/test/test_put_get_value_large_file.c
+++ b/lib/raster3d/test/test_put_get_value_large_file.c
@@ -444,11 +444,11 @@ int test_large_file_sparse_random(int depths, int rows, int cols,
             for (x = 0; x < region.cols; x++) {
                 /* Check the counter as cell value */
                 Rast3d_get_value(map, x, y, z, &value, DCELL_TYPE);
-				random_value = random_value_vector[i];
+                random_value = random_value_vector[i];
                 if (fabs(value - random_value) > EPSILON) {
                     G_message
                         ("At: z %i y %i x %i -- value %.14lf != %.14lf\n", z,
-                         y, x, value, random_value); // 'random_value' is uninitialized when used here
+                         y, x, value, random_value);
                     sum++;
                 }
                 i++;

--- a/lib/raster3d/test/test_put_get_value_large_file.c
+++ b/lib/raster3d/test/test_put_get_value_large_file.c
@@ -447,7 +447,7 @@ int test_large_file_sparse_random(int depths, int rows, int cols,
                 if (fabs(value - random_value_vector[i]) > EPSILON) {
                     G_message
                         ("At: z %i y %i x %i -- value %.14lf != %.14lf\n", z,
-                         y, x, value, random_value);
+                         y, x, value, random_value); // 'random_value' is uninitialized when used here
                     sum++;
                 }
                 i++;

--- a/lib/rst/interp_float/ressegm2d.c
+++ b/lib/rst/interp_float/ressegm2d.c
@@ -203,7 +203,7 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
         b[0] = 0.;
         G_lubksb(matrix, m1 + 1, indx, b);
 
-        params->check_points(params, data, b, ertot, zmin, *dnorm, triple);
+        params->check_points(params, data, b, ertot, zmin, *dnorm, triple); // 'triple' is uninitialized when used here
 
         if (params->grid_calc(params, data, bitmask,
                               zmin, zmax, zminac, zmaxac, gmin, gmax,

--- a/lib/rst/interp_float/ressegm2d.c
+++ b/lib/rst/interp_float/ressegm2d.c
@@ -81,7 +81,7 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
     double xmax, xmin, ymax, ymin;
     int totsegm;                /* total number of segments */
     int total_points = 0;
-    struct triple triple;       /* contains garbage */
+    struct triple triple = {0.0,0.0,0.0,0.0} ;       /* contains garbage */
 
 
     xmin = params->x_orig;

--- a/lib/rst/interp_float/ressegm2d.c
+++ b/lib/rst/interp_float/ressegm2d.c
@@ -81,7 +81,7 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
     double xmax, xmin, ymax, ymin;
     int totsegm;                /* total number of segments */
     int total_points = 0;
-    struct triple triple = {0.0,0.0,0.0,0.0} ;       /* contains garbage */
+    struct triple triple = { 0.0, 0.0, 0.0, 0.0 };      /* contains garbage */
 
 
     xmin = params->x_orig;
@@ -203,7 +203,7 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
         b[0] = 0.;
         G_lubksb(matrix, m1 + 1, indx, b);
 
-        params->check_points(params, data, b, ertot, zmin, *dnorm, triple); // 'triple' is uninitialized when used here
+        params->check_points(params, data, b, ertot, zmin, *dnorm, triple);
 
         if (params->grid_calc(params, data, bitmask,
                               zmin, zmax, zminac, zmaxac, gmin, gmax,

--- a/lib/rst/interp_float/segmen2d_parallel.c
+++ b/lib/rst/interp_float/segmen2d_parallel.c
@@ -175,7 +175,7 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
                                     (1 + params->kmin * pr / params->KMAX2));
                 /* fprintf(stderr,"MINPTS=%d, KMIN=%d, KMAX=%d, pr=%lf, smseg=%lf, DX=%lf \n", MINPTS,params->kmin,params->KMAX2,pr,smseg,xmx-xmn); */
 
-                data_local[tid] =
+                data_local[tid] = // 'tid' is uninitialized when used here
                     (struct quaddata *)quad_data_new(xmn - distx, ymn - disty,
                                                      xmx + distx, ymx + disty,
                                                      0, 0, 0, params->KMAX2);

--- a/lib/rst/interp_float/segmen2d_parallel.c
+++ b/lib/rst/interp_float/segmen2d_parallel.c
@@ -49,7 +49,7 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
                                    double dnorm, int threads)
 {
     int some_thread_failed = 0;
-    int tid;
+    int tid = 0;
     int i = 0;
     int j = 0;
     int i_cnt;

--- a/lib/rst/interp_float/segmen2d_parallel.c
+++ b/lib/rst/interp_float/segmen2d_parallel.c
@@ -175,7 +175,7 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
                                     (1 + params->kmin * pr / params->KMAX2));
                 /* fprintf(stderr,"MINPTS=%d, KMIN=%d, KMAX=%d, pr=%lf, smseg=%lf, DX=%lf \n", MINPTS,params->kmin,params->KMAX2,pr,smseg,xmx-xmn); */
 
-                data_local[tid] = // 'tid' is uninitialized when used here
+                data_local[tid] =
                     (struct quaddata *)quad_data_new(xmn - distx, ymn - disty,
                                                      xmx + distx, ymx + disty,
                                                      0, 0, 0, params->KMAX2);

--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -542,7 +542,7 @@ int Vect_write_ascii(FILE * ascii,
         if (columns) {
             for (i = 0; columns[i]; i++) {
                 if (db_select_value
-                    (driver, Fi->table, Fi->key, 0, columns[i], &value) < 0)  // 'cat' is uninitialized here
+                    (driver, Fi->table, Fi->key, 0, columns[i], &value) < 0)
                     G_fatal_error(_("Unable to select record from table <%s> (key %s, column %s)"),
                                   Fi->table, Fi->key, columns[i]);
                 if (columns[i])

--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -542,7 +542,7 @@ int Vect_write_ascii(FILE * ascii,
         if (columns) {
             for (i = 0; columns[i]; i++) {
                 if (db_select_value
-                    (driver, Fi->table, Fi->key, cat, columns[i], &value) < 0)
+                    (driver, Fi->table, Fi->key, cat, columns[i], &value) < 0)  // 'cat' is uninitialized here
                     G_fatal_error(_("Unable to select record from table <%s> (key %s, column %s)"),
                                   Fi->table, Fi->key, columns[i]);
                 if (columns[i])

--- a/lib/vector/Vlib/ascii.c
+++ b/lib/vector/Vlib/ascii.c
@@ -542,7 +542,7 @@ int Vect_write_ascii(FILE * ascii,
         if (columns) {
             for (i = 0; columns[i]; i++) {
                 if (db_select_value
-                    (driver, Fi->table, Fi->key, cat, columns[i], &value) < 0)  // 'cat' is uninitialized here
+                    (driver, Fi->table, Fi->key, 0, columns[i], &value) < 0)  // 'cat' is uninitialized here
                     G_fatal_error(_("Unable to select record from table <%s> (key %s, column %s)"),
                                   Fi->table, Fi->key, columns[i]);
                 if (columns[i])

--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -79,7 +79,7 @@ Vect_net_ttb_build_graph(struct Map_info *Map,
     struct bound_box box;
     struct boxlist *List;
 
-    dglInt32_t dgl_cost = cost;
+    dglInt32_t dgl_cost = cost; // 'cost' is uninitialized when used here
 
     /*TODO attributes of turntable should be stored in one place */
     const char *tcols[] = { "cat", "ln_from", "ln_to", "cost", "isec", NULL

--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -79,7 +79,7 @@ Vect_net_ttb_build_graph(struct Map_info *Map,
     struct bound_box box;
     struct boxlist *List;
 
-    dglInt32_t dgl_cost = cost; // 'cost' is uninitialized when used here
+    dglInt32_t dgl_cost; // 'cost' is uninitialized when used here
 
     /*TODO attributes of turntable should be stored in one place */
     const char *tcols[] = { "cat", "ln_from", "ln_to", "cost", "isec", NULL

--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -79,7 +79,7 @@ Vect_net_ttb_build_graph(struct Map_info *Map,
     struct bound_box box;
     struct boxlist *List;
 
-    dglInt32_t dgl_cost; // 'cost' is uninitialized when used here
+    dglInt32_t dgl_cost;
 
     /*TODO attributes of turntable should be stored in one place */
     const char *tcols[] = { "cat", "ln_from", "ln_to", "cost", "isec", NULL

--- a/lib/vector/neta/path.c
+++ b/lib/vector/neta/path.c
@@ -273,7 +273,7 @@ int NetA_find_path(dglGraph_s * graph, int from, int to, int *edges,
     prev[from] = NULL;
     while (begin != end) {
         dglInt32_t vertex = queue[begin++];
-        dglInt32_t *edge, *node;
+        dglInt32_t *edge = NULL, *node;
 
         if (vertex == to)
             break;

--- a/lib/vector/neta/path.c
+++ b/lib/vector/neta/path.c
@@ -281,7 +281,7 @@ int NetA_find_path(dglGraph_s * graph, int from, int to, int *edges,
         /* do not go through closed nodes */
         if (have_node_costs && prev[vertex]) {
             memcpy(&ncost,
-                   dglNodeGet_Attr(graph, dglEdgeGet_Tail(graph, edge)), // 'edge' is uninitialized when used here
+                   dglNodeGet_Attr(graph, dglEdgeGet_Tail(graph, edge)),
                    sizeof(ncost));
             if (ncost < 0)
                 continue;

--- a/lib/vector/neta/path.c
+++ b/lib/vector/neta/path.c
@@ -281,7 +281,7 @@ int NetA_find_path(dglGraph_s * graph, int from, int to, int *edges,
         /* do not go through closed nodes */
         if (have_node_costs && prev[vertex]) {
             memcpy(&ncost,
-                   dglNodeGet_Attr(graph, dglEdgeGet_Tail(graph, edge)),
+                   dglNodeGet_Attr(graph, dglEdgeGet_Tail(graph, edge)), // 'edge' is uninitialized when used here
                    sizeof(ncost));
             if (ncost < 0)
                 continue;

--- a/raster/r.statistics/o_sum.c
+++ b/raster/r.statistics/o_sum.c
@@ -44,7 +44,7 @@ int o_sum(const char *basemap, const char *covermap, const char *outputmap,
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
 
-    return stat;
+    return stat; // 'stat' is uninitialized when used here
 }
 
 static void sum_out(FILE * fp, long cat, double sum1)

--- a/raster/r.statistics/o_sum.c
+++ b/raster/r.statistics/o_sum.c
@@ -43,7 +43,7 @@ int o_sum(const char *basemap, const char *covermap, const char *outputmap,
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
 
-    return 0; // 'stat' is uninitialized when used here
+    return 0;
 }
 
 static void sum_out(FILE * fp, long cat, double sum1)

--- a/raster/r.statistics/o_sum.c
+++ b/raster/r.statistics/o_sum.c
@@ -13,7 +13,6 @@ int o_sum(const char *basemap, const char *covermap, const char *outputmap,
 {
     long catb, basecat, covercat;
     double x, area, sum1;
-    int stat;
     struct Popen stats_child, reclass_child;
     FILE *stats, *reclass;
 
@@ -44,7 +43,7 @@ int o_sum(const char *basemap, const char *covermap, const char *outputmap,
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
 
-    return stat; // 'stat' is uninitialized when used here
+    return 0; // 'stat' is uninitialized when used here
 }
 
 static void sum_out(FILE * fp, long cat, double sum1)

--- a/raster/r.stream.extract/streams.c
+++ b/raster/r.stream.extract/streams.c
@@ -331,7 +331,7 @@ int do_accum(double d8cut)
                     }
                     else if (ct_dir == np_side) {
                         /* check for consistency with A * path */
-                        workedon++;
+                        workedon++;  // 'workedon' is uninitialized when used here
                     }
                 }
             }

--- a/raster/r.stream.extract/streams.c
+++ b/raster/r.stream.extract/streams.c
@@ -151,7 +151,7 @@ int do_accum(double d8cut)
     int asp_c[9] = { 0, 1, 0, -1, -1, -1, 0, 1, 1 };
     int nextdr[8] = { 1, -1, 0, 0, -1, 1, 1, -1 };
     int nextdc[8] = { 0, 0, -1, 1, 1, -1, 1, -1 };
-    GW_LARGE_INT workedon, killer;
+    GW_LARGE_INT killer;
     char *flag_nbr;
     POINT astarpoint;
     WAT_ALT wa;
@@ -331,7 +331,7 @@ int do_accum(double d8cut)
                     }
                     else if (ct_dir == np_side) {
                         /* check for consistency with A * path */
-                        workedon++;  // 'workedon' is uninitialized when used here
+                        // workedon++;  // 'workedon' is uninitialized when used here, not used, this line will be removed
                     }
                 }
             }

--- a/raster/r.stream.extract/streams.c
+++ b/raster/r.stream.extract/streams.c
@@ -70,7 +70,7 @@ static int continue_stream(CELL stream_id, int r_max, int c_max,
         /* debug */
         if (n_stream_nodes != *stream_no)
             G_warning(_("Stream_no %d and n_stream_nodes %" PRI_OFF_T
-                       " out of sync"), *stream_no, n_stream_nodes);
+                        " out of sync"), *stream_no, n_stream_nodes);
 
         stream_node[*stream_no].n_alloc += 2;
         new_size = stream_node[*stream_no].n_alloc * sizeof(int);
@@ -331,7 +331,6 @@ int do_accum(double d8cut)
                     }
                     else if (ct_dir == np_side) {
                         /* check for consistency with A * path */
-                        // workedon++;  // 'workedon' is uninitialized when used here, not used, this line will be removed
                     }
                 }
             }
@@ -660,7 +659,7 @@ int extract_streams(double threshold, double mont_exp, int internal_acc)
             /* debug */
             if (n_stream_nodes != stream_no)
                 G_warning(_("Stream_no %d and n_stream_nodes %" PRI_OFF_T
-                           " out of sync"), stream_no, n_stream_nodes);
+                            " out of sync"), stream_no, n_stream_nodes);
         }
 
         /*********************/

--- a/vector/v.lrs/v.lrs.label/main.c
+++ b/vector/v.lrs/v.lrs.label/main.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
     /* For each line select all existeng reference segments, sort them along the line
      *  and fcreate stationing. */
 
-    G_debug(2, "find_line(): lfield = %d", lfield); // 'lcat' is uninitialized when used here
+    G_debug(2, "find_line(): lfield = %d", lfield);
 
     arseg = 1000;
     rseg = (RSEGMENT *) G_malloc(arseg * sizeof(RSEGMENT));

--- a/vector/v.lrs/v.lrs.label/main.c
+++ b/vector/v.lrs/v.lrs.label/main.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
     /* For each line select all existeng reference segments, sort them along the line
      *  and fcreate stationing. */
 
-    G_debug(2, "find_line(): lfield = %d lcat = %d", lfield, lcat);
+    G_debug(2, "find_line(): lfield = %d lcat = %d", lfield, lcat); // 'lcat' is uninitialized when used here
 
     arseg = 1000;
     rseg = (RSEGMENT *) G_malloc(arseg * sizeof(RSEGMENT));

--- a/vector/v.lrs/v.lrs.label/main.c
+++ b/vector/v.lrs/v.lrs.label/main.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
     /* For each line select all existeng reference segments, sort them along the line
      *  and fcreate stationing. */
 
-    G_debug(2, "find_line(): lfield = %d lcat = %d", lfield, lcat); // 'lcat' is uninitialized when used here
+    G_debug(2, "find_line(): lfield = %d", lfield); // 'lcat' is uninitialized when used here
 
     arseg = 1000;
     rseg = (RSEGMENT *) G_malloc(arseg * sizeof(RSEGMENT));

--- a/vector/v.net.salesman/main.c
+++ b/vector/v.net.salesman/main.c
@@ -500,8 +500,8 @@ int main(int argc, char **argv)
 
             /* tmpcost must always be > 0 */
 
-            G_debug(2, "? %d - %d cost = %f x %f", cities[cycle[j]], cities[cycle[j+1]], // 'node1' and 'node2' is uninitialized when used here
-				tmpcost, cost);
+            G_debug(2, "? %d - %d cost = %f x %f", cities[cycle[j]],
+                    cities[cycle[j + 1]], tmpcost, cost);
             /* always true for j = 0 */
             if (tmpcost < cost) {
                 city1 = j;

--- a/vector/v.net.salesman/main.c
+++ b/vector/v.net.salesman/main.c
@@ -500,8 +500,8 @@ int main(int argc, char **argv)
 
             /* tmpcost must always be > 0 */
 
-            G_debug(2, "? %d - %d cost = %f x %f", node1, node2, tmpcost,  // 'node1' and 'node2' is uninitialized when used here
-                    cost);
+            G_debug(2, "? %d - %d cost = %f x %f", cities[cycle[j]], cities[cycle[j+1]], // 'node1' and 'node2' is uninitialized when used here
+				tmpcost, cost);
             /* always true for j = 0 */
             if (tmpcost < cost) {
                 city1 = j;

--- a/vector/v.net.salesman/main.c
+++ b/vector/v.net.salesman/main.c
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
 
             /* tmpcost must always be > 0 */
 
-            G_debug(2, "? %d - %d cost = %f x %f", node1, node2, tmpcost,
+            G_debug(2, "? %d - %d cost = %f x %f", node1, node2, tmpcost,  // 'node1' and 'node2' is uninitialized when used here
                     cost);
             /* always true for j = 0 */
             if (tmpcost < cost) {

--- a/vector/v.split/main.c
+++ b/vector/v.split/main.c
@@ -238,6 +238,7 @@ int main(int argc, char *argv[])
                         Vect_reset_line(Points3);
 
                     double x = 0.0, y = 0.0, z = 0.0;
+
                     for (i = 0; i < n; i++) {
                         int ret;
 
@@ -257,9 +258,9 @@ int main(int argc, char *argv[])
 
                         /* To be sure that the coordinates are identical */
                         if (i > 0) {
-                            Points2->x[0] = x;  // 'x' is uninitialized when used here
-                            Points2->y[0] = y; // 'y' is uninitialized when used here
-                            Points2->z[0] = z; // 'z' is uninitialized when used here
+                            Points2->x[0] = x;
+                            Points2->y[0] = y;
+                            Points2->z[0] = z;
                         }
                         if (i == n - 1) {
                             Points2->x[Points2->n_points - 1] =

--- a/vector/v.split/main.c
+++ b/vector/v.split/main.c
@@ -257,9 +257,9 @@ int main(int argc, char *argv[])
 
                         /* To be sure that the coordinates are identical */
                         if (i > 0) {
-                            Points2->x[0] = x;
-                            Points2->y[0] = y;
-                            Points2->z[0] = z;
+                            Points2->x[0] = x;  // 'x' is uninitialized when used here
+                            Points2->y[0] = y; // 'y' is uninitialized when used here
+                            Points2->z[0] = z; // 'z' is uninitialized when used here
                         }
                         if (i == n - 1) {
                             Points2->x[Points2->n_points - 1] =

--- a/vector/v.split/main.c
+++ b/vector/v.split/main.c
@@ -237,9 +237,9 @@ int main(int argc, char *argv[])
                     if (nosplit)
                         Vect_reset_line(Points3);
 
+                    double x = 0.0, y = 0.0, z = 0.0;
                     for (i = 0; i < n; i++) {
                         int ret;
-                        double x, y, z;
 
                         if (i == n - 1) {
                             to = l;     /* to be sure that it goes to end */


### PR DESCRIPTION
As reported in #2156.

Initially this is a draft, I commented in code to highlight the uninitialised variables.
We need to decide how to address them.

**Affects:**

Modules

- i.gensig
- r.statistics
- r.stream.extract
- v.lrs.label
- v.net.salesman
- v.split

GRASS Library parts

- ~lib/cdhc~
- lib/raster
- lib/raster3d
- lib/rst/interp_float
- lib/vector/neta
- lib/vector/Vlib

