### PR TITLE
Fix -Wsometimes-uninitialized compiler warnings

### DIFF
--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -162,8 +162,8 @@ int describe_table(OGRLayerH hLayer, dbTable ** table, cursor * c)
     }
 
     for (i = 0; i < ncols; i++, col++) {
-        int sqlType;
-        int size, precision, scale;
+        int sqlType = DB_SQL_TYPE_UNKNOWN;
+        int size = 0, precision = 0, scale;
 
         hFieldDefn = OGR_FD_GetFieldDefn(hFeatureDefn, i);
         ogrType = OGR_Fld_GetType(hFieldDefn);

--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -208,7 +208,7 @@ int describe_table(OGRLayerH hLayer, dbTable ** table, cursor * c)
             precision = 0;
             break;
 
-        default: // 'size', 'precision' and 'sqlType' are used uninitialized whenever switch default is taken
+        default:
             G_warning(_("Unknown type"));
             break;
         }

--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -208,7 +208,7 @@ int describe_table(OGRLayerH hLayer, dbTable ** table, cursor * c)
             precision = 0;
             break;
 
-        default:
+        default: // 'size', 'precision' and 'sqlType' are used uninitialized whenever switch default is taken
             G_warning(_("Unknown type"));
             break;
         }

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
         G_fatal_error(_("'layer' must be > 0"));
     if ((fi = Vect_get_field(&Map, Clist->field)) == NULL)
         G_fatal_error(_("Database connection not defined"));
-    if (fi != NULL) { // 'driver' is used uninitialized whenever 'if' condition is false
+    if (fi != NULL) {
         driver = db_start_driver(fi->driver);
         if (driver == NULL)
             G_fatal_error(_("Unable to start driver <%s>"), fi->driver);

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
     int *cats, ncat, nrec, ctype;
     struct Map_info Map;
     struct field_info *fi;
-    dbDriver *driver;
+    dbDriver *driver = NULL;
     dbHandle handle;
     dbCatValArray cvarr;
     struct Cell_head window;

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
         G_fatal_error(_("'layer' must be > 0"));
     if ((fi = Vect_get_field(&Map, Clist->field)) == NULL)
         G_fatal_error(_("Database connection not defined"));
-    if (fi != NULL) {
+    if (fi != NULL) { // 'driver' is used uninitialized whenever 'if' condition is false
         driver = db_start_driver(fi->driver);
         if (driver == NULL)
             G_fatal_error(_("Unable to start driver <%s>"), fi->driver);

--- a/display/d.vect/opt.c
+++ b/display/d.vect/opt.c
@@ -109,7 +109,7 @@ void options_to_lattr(LATTR *lattr, const char *layer,
 
 int option_to_color(struct color_rgb *color, const char *color_val)
 {
-    int has_color, ret;
+    int has_color = 0, ret;
     int r, g, b;
     
     ret = G_str_to_color(color_val, &r, &g, &b);

--- a/imagery/i.eb.soilheatflux/g0.c
+++ b/imagery/i.eb.soilheatflux/g0.c
@@ -14,7 +14,7 @@ double g_0(double bbalb, double ndvi, double tempk, double rnet,
         r0_coef = 1.0;
     else if (time > 11.0 && time <= 13.0)
         r0_coef = 0.9;
-    else if (time > 13.0 && time <= 15.0)
+    else if (time > 13.0 && time <= 15.0) //  'r0_coef' is used uninitialized whenever 'if' condition is false
         r0_coef = 1.0;
     a = (0.0032 * (bbalb / r0_coef) +
          0.0062 * (bbalb / r0_coef) * (bbalb / r0_coef));

--- a/imagery/i.eb.soilheatflux/g0.c
+++ b/imagery/i.eb.soilheatflux/g0.c
@@ -14,7 +14,7 @@ double g_0(double bbalb, double ndvi, double tempk, double rnet,
         r0_coef = 1.0;
     else if (time > 11.0 && time <= 13.0)
         r0_coef = 0.9;
-    else if (time > 13.0 && time <= 15.0) //  'r0_coef' is used uninitialized whenever 'if' condition is false
+    else if (time > 13.0 && time <= 15.0)
         r0_coef = 1.0;
     a = (0.0032 * (bbalb / r0_coef) +
          0.0062 * (bbalb / r0_coef) * (bbalb / r0_coef));

--- a/imagery/i.eb.soilheatflux/g0.c
+++ b/imagery/i.eb.soilheatflux/g0.c
@@ -6,7 +6,7 @@ double g_0(double bbalb, double ndvi, double tempk, double rnet,
            double time, int roerink)
 {
     double a, b, result;
-    double r0_coef;
+    double r0_coef = 1.1;
 
     if (time <= 9.0 || time > 15.0)
         r0_coef = 1.1;

--- a/lib/imagery/iscatt_structs.c
+++ b/lib/imagery/iscatt_structs.c
@@ -154,7 +154,7 @@ void I_sc_free_cats(struct scCats *cats)
  */
 int I_sc_add_cat(struct scCats *cats)
 {
-    int i_scatt, i_cat_id, cat_id;
+    int i_scatt, i_cat_id, cat_id = 0;
     int n_a_cats = cats->n_a_cats;
 
     if (cats->n_a_cats >= cats->n_cats)

--- a/lib/imagery/iscatt_structs.c
+++ b/lib/imagery/iscatt_structs.c
@@ -160,7 +160,7 @@ int I_sc_add_cat(struct scCats *cats)
     if (cats->n_a_cats >= cats->n_cats)
         return -1;
 
-    for (i_cat_id = 0; i_cat_id < cats->n_cats; i_cat_id++)
+    for (i_cat_id = 0; i_cat_id < cats->n_cats; i_cat_id++) // 'cat_id' is used uninitialized whenever 'for' loop exits because its condition is false
         if (cats->cats_idxs[i_cat_id] < 0) {
             cat_id = i_cat_id;
             break;

--- a/lib/imagery/iscatt_structs.c
+++ b/lib/imagery/iscatt_structs.c
@@ -160,7 +160,7 @@ int I_sc_add_cat(struct scCats *cats)
     if (cats->n_a_cats >= cats->n_cats)
         return -1;
 
-    for (i_cat_id = 0; i_cat_id < cats->n_cats; i_cat_id++) // 'cat_id' is used uninitialized whenever 'for' loop exits because its condition is false
+    for (i_cat_id = 0; i_cat_id < cats->n_cats; i_cat_id++)
         if (cats->cats_idxs[i_cat_id] < 0) {
             cat_id = i_cat_id;
             break;

--- a/lib/ogsf/gs3.c
+++ b/lib/ogsf/gs3.c
@@ -1162,7 +1162,7 @@ int Gs_update_attrange(geosurf * gs, int desc)
             p = (char *)tb->cb;
             SET_MINMAX(p, nm, size, min, max);
         }
-        else if (tb->fb) { // 'min' and 'max' are used uninitialized whenever 'if' condition is false
+        else if (tb->fb) {
             float *p;
 
             size = (size_t)gs->rows * gs->cols;

--- a/lib/ogsf/gs3.c
+++ b/lib/ogsf/gs3.c
@@ -1162,7 +1162,7 @@ int Gs_update_attrange(geosurf * gs, int desc)
             p = (char *)tb->cb;
             SET_MINMAX(p, nm, size, min, max);
         }
-        else if (tb->fb) {
+        else if (tb->fb) { // 'min' and 'max' are used uninitialized whenever 'if' condition is false
             float *p;
 
             size = (size_t)gs->rows * gs->cols;

--- a/lib/raster3d/getblock.c
+++ b/lib/raster3d/getblock.c
@@ -18,7 +18,7 @@ Rast3d_get_block_nocache(RASTER3D_Map * map, int x0, int y0, int z0, int nx,
     int tx, ty, tz, dx, dy, dz, x, y, z, rows, cols, depths;
     int tileIndex;
 
-    if (!map->useCache)
+    if (!map->useCache) // 'tile' is used uninitialized whenever 'if' condition is false
         tile = Rast3d_alloc_tiles_type(map, 1, type);
     if (tile == NULL)
         Rast3d_fatal_error

--- a/lib/raster3d/getblock.c
+++ b/lib/raster3d/getblock.c
@@ -18,7 +18,7 @@ Rast3d_get_block_nocache(RASTER3D_Map * map, int x0, int y0, int z0, int nx,
     int tx, ty, tz, dx, dy, dz, x, y, z, rows, cols, depths;
     int tileIndex;
 
-    if (!map->useCache) // 'tile' is used uninitialized whenever 'if' condition is false
+    if (!map->useCache)
         tile = Rast3d_alloc_tiles_type(map, 1, type);
     if (tile == NULL)
         Rast3d_fatal_error

--- a/lib/raster3d/getblock.c
+++ b/lib/raster3d/getblock.c
@@ -12,7 +12,7 @@ void
 Rast3d_get_block_nocache(RASTER3D_Map * map, int x0, int y0, int z0, int nx,
                          int ny, int nz, void *block, int type)
 {
-    void *tile;
+    void *tile = NULL;
     int tileX0, tileY0, tileZ0, tileOffsX0, tileOffsY0, tileOffsZ0;
     int tileX1, tileY1, tileZ1, tileOffsX1, tileOffsY1, tileOffsZ1;
     int tx, ty, tz, dx, dy, dz, x, y, z, rows, cols, depths;

--- a/lib/vector/Vlib/build_pg.c
+++ b/lib/vector/Vlib/build_pg.c
@@ -199,7 +199,7 @@ int build_topo(struct Map_info *Map, int build)
         Vect_build_partial(Map, GV_BUILD_NONE);
     }
 
-    if (plus->built < GV_BUILD_BASE) {
+    if (plus->built < GV_BUILD_BASE) { // 'n_nodes' is used uninitialized whenever 'if' condition is false
         /* force loading nodes from DB to get up-to-date node
          * offsets, see write_nodes() for details */
         Vect__free_offset(&(pg_info->offset));

--- a/lib/vector/Vlib/build_pg.c
+++ b/lib/vector/Vlib/build_pg.c
@@ -199,7 +199,7 @@ int build_topo(struct Map_info *Map, int build)
         Vect_build_partial(Map, GV_BUILD_NONE);
     }
 
-    if (plus->built < GV_BUILD_BASE) { // 'n_nodes' is used uninitialized whenever 'if' condition is false
+    if (plus->built < GV_BUILD_BASE) {
         /* force loading nodes from DB to get up-to-date node
          * offsets, see write_nodes() for details */
         Vect__free_offset(&(pg_info->offset));

--- a/lib/vector/Vlib/build_pg.c
+++ b/lib/vector/Vlib/build_pg.c
@@ -142,7 +142,7 @@ int Vect_build_pg(struct Map_info *Map, int build)
  */
 int build_topo(struct Map_info *Map, int build)
 {
-    int line, type, s, n_nodes;
+    int line, type, s, n_nodes = 0;
     int area, nareas, isle, nisles;
     int face[2];
     char stmt[DB_SQL_MAX];

--- a/raster/r.buffer/main.c
+++ b/raster/r.buffer/main.c
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
         to_meters = KILOMETERS_TO_METERS;
     else if (strcmp(units, "miles") == 0)
         to_meters = MILES_TO_METERS;
-    else if (strcmp(units, "nautmiles") == 0) // 'to_meters' is used uninitialized whenever 'if'
+    else if (strcmp(units, "nautmiles") == 0)
         to_meters = NAUT_MILES_TO_METERS;
 
     /* parse distances */

--- a/raster/r.buffer/main.c
+++ b/raster/r.buffer/main.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     struct Distance *pd;
     const char *input, *output, *mapset;
     char **zone_list;
-    double to_meters;
+    double to_meters = 1.0;
     const char *units;
     int offset;
     int count;

--- a/raster/r.buffer/main.c
+++ b/raster/r.buffer/main.c
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
         to_meters = KILOMETERS_TO_METERS;
     else if (strcmp(units, "miles") == 0)
         to_meters = MILES_TO_METERS;
-    else if (strcmp(units, "nautmiles") == 0)
+    else if (strcmp(units, "nautmiles") == 0) // 'to_meters' is used uninitialized whenever 'if'
         to_meters = NAUT_MILES_TO_METERS;
 
     /* parse distances */

--- a/raster/r.fill.stats/main.c
+++ b/raster/r.fill.stats/main.c
@@ -1091,7 +1091,7 @@ int main(int argc, char *argv[])
     else if (OUT_TYPE == FCELL_TYPE) {
         data_type_string_out = "single";
     }
-    else if (OUT_TYPE == DCELL_TYPE) { // 'data_type_string_out' is used uninitialized whenever 'if' condition is false
+    else if (OUT_TYPE == DCELL_TYPE) {
         data_type_string_out = "double";
     }
 

--- a/raster/r.fill.stats/main.c
+++ b/raster/r.fill.stats/main.c
@@ -1091,7 +1091,7 @@ int main(int argc, char *argv[])
     else if (OUT_TYPE == FCELL_TYPE) {
         data_type_string_out = "single";
     }
-    else if (OUT_TYPE == DCELL_TYPE) {
+    else if (OUT_TYPE == DCELL_TYPE) { // 'data_type_string_out' is used uninitialized whenever 'if' condition is false
         data_type_string_out = "double";
     }
 

--- a/raster/r.fill.stats/main.c
+++ b/raster/r.fill.stats/main.c
@@ -1073,8 +1073,8 @@ int main(int argc, char *argv[])
             }
         }
     }
-    char *data_type_string_in;
-    char *data_type_string_out;
+    char *data_type_string_in = NULL;
+    char *data_type_string_out = NULL;
 
     if (IN_TYPE == CELL_TYPE) {
         data_type_string_in = "integer";

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -364,7 +364,7 @@ int main(int argc, char *argv[])
         if ((winhd.ew_res != smhd.ew_res) || (winhd.ns_res != smhd.ns_res))
             G_fatal_error(_("Map <%s> is the wrong resolution"), smooth);
 
-        if (Rast_read_fp_range(smooth, "", &range) >= 0) // 'cellmin' is used uninitialized whenever 'if' condition is false
+        if (Rast_read_fp_range(smooth, "", &range) >= 0)
             Rast_get_fp_range_min_max(&range, &cellmin, &cellmax);
 
         fcellmin = (float)cellmin;

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -364,7 +364,7 @@ int main(int argc, char *argv[])
         if ((winhd.ew_res != smhd.ew_res) || (winhd.ns_res != smhd.ns_res))
             G_fatal_error(_("Map <%s> is the wrong resolution"), smooth);
 
-        if (Rast_read_fp_range(smooth, "", &range) >= 0)
+        if (Rast_read_fp_range(smooth, "", &range) >= 0) // 'cellmin' is used uninitialized whenever 'if' condition is false
             Rast_get_fp_range_min_max(&range, &cellmin, &cellmax);
 
         fcellmin = (float)cellmin;

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
 {
     int m1;
     struct FPRange range;
-    DCELL cellmin, cellmax;
+    DCELL cellmin = 0.0, cellmax;
     FCELL *cellrow, fcellmin;
 
     struct GModule *module;

--- a/raster3d/r3.in.bin/main.c
+++ b/raster3d/r3.in.bin/main.c
@@ -397,7 +397,7 @@ int main(int argc, char *argv[])
         order = 1;
     else if (G_strcasecmp(parm.order->answer, "native") == 0)
         order = G_is_little_endian()? 1 : 0;
-    else if (G_strcasecmp(parm.order->answer, "swap") == 0) // 'order' is used uninitialized whenever 'if' condition is false
+    else if (G_strcasecmp(parm.order->answer, "swap") == 0)
         order = G_is_little_endian()? 0 : 1;
 
     byte_swap = order == (G_is_little_endian()? 0 : 1);

--- a/raster3d/r3.in.bin/main.c
+++ b/raster3d/r3.in.bin/main.c
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
     int is_integer;
     int is_signed;
     int bytes;
-    int order;
+    int order = 0;
     int byte_swap;
     RASTER_MAP_TYPE map_type;
     off_t file_size;

--- a/raster3d/r3.in.bin/main.c
+++ b/raster3d/r3.in.bin/main.c
@@ -397,7 +397,7 @@ int main(int argc, char *argv[])
         order = 1;
     else if (G_strcasecmp(parm.order->answer, "native") == 0)
         order = G_is_little_endian()? 1 : 0;
-    else if (G_strcasecmp(parm.order->answer, "swap") == 0)
+    else if (G_strcasecmp(parm.order->answer, "swap") == 0) // 'order' is used uninitialized whenever 'if' condition is false
         order = G_is_little_endian()? 0 : 1;
 
     byte_swap = order == (G_is_little_endian()? 0 : 1);

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -2063,7 +2063,7 @@ int v5dReadCompressedGrid(v5dstruct * v, int time, int var,
     else if (v->CompressMode == 2) {
         k = read_block(v->FileDesc, compdata, n, 2) == n;
     }
-    else if (v->CompressMode == 4) {
+    else if (v->CompressMode == 4) { // 'k' is used uninitialized whenever 'if' condition is false
         k = read_block(v->FileDesc, compdata, n, 4) == n;
     }
     if (!k) {
@@ -2115,7 +2115,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) {
+    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
@@ -2514,7 +2514,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) {
+    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -2029,7 +2029,7 @@ v5dstruct *v5dOpenFile(const char *filename, v5dstruct * v)
 int v5dReadCompressedGrid(v5dstruct * v, int time, int var,
                           float *ga, float *gb, void *compdata)
 {
-    int pos, n, k;
+    int pos, n, k = 0;
 
     if (time < 0 || time >= v->NumTimes) {
         printf("Error in v5dReadCompressedGrid: bad timestep argument (%d)\n",
@@ -2097,7 +2097,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
 {
     float ga[MAXLEVELS], gb[MAXLEVELS];
     void *compdata;
-    int bytes;
+    int bytes = 0;
 
     if (time < 0 || time >= v->NumTimes) {
         printf("Error in v5dReadGrid: bad timestep argument (%d)\n", time);
@@ -2490,7 +2490,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
 {
     float ga[MAXLEVELS], gb[MAXLEVELS];
     void *compdata;
-    int n, bytes;
+    int n, bytes = 0;
     float min, max;
 
     if (v->Mode != 'w') {

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -2063,7 +2063,7 @@ int v5dReadCompressedGrid(v5dstruct * v, int time, int var,
     else if (v->CompressMode == 2) {
         k = read_block(v->FileDesc, compdata, n, 2) == n;
     }
-    else if (v->CompressMode == 4) { // 'k' is used uninitialized whenever 'if' condition is false
+    else if (v->CompressMode == 4) {
         k = read_block(v->FileDesc, compdata, n, 4) == n;
     }
     if (!k) {
@@ -2115,7 +2115,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
+    else if (v->CompressMode == 4) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
@@ -2514,7 +2514,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
+    else if (v->CompressMode == 4) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);

--- a/raster3d/r3.out.bin/main.c
+++ b/raster3d/r3.out.bin/main.c
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
         order = 1;
     else if (G_strcasecmp(parm.order->answer, "native") == 0)
         order = G_is_little_endian()? 1 : 0;
-    else if (G_strcasecmp(parm.order->answer, "swap") == 0) // 'order' is used uninitialized whenever 'if' condition is false
+    else if (G_strcasecmp(parm.order->answer, "swap") == 0)
         order = G_is_little_endian()? 0 : 1;
 
     swap_flag = order == (G_is_little_endian()? 0 : 1);

--- a/raster3d/r3.out.bin/main.c
+++ b/raster3d/r3.out.bin/main.c
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
         order = 1;
     else if (G_strcasecmp(parm.order->answer, "native") == 0)
         order = G_is_little_endian()? 1 : 0;
-    else if (G_strcasecmp(parm.order->answer, "swap") == 0)
+    else if (G_strcasecmp(parm.order->answer, "swap") == 0) // 'order' is used uninitialized whenever 'if' condition is false
         order = G_is_little_endian()? 0 : 1;
 
     swap_flag = order == (G_is_little_endian()? 0 : 1);

--- a/raster3d/r3.out.bin/main.c
+++ b/raster3d/r3.out.bin/main.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
     char *outfile;
     double null_val;
     int do_stdout;
-    int order;
+    int order = 0;
     int swap_flag;
     int bytes;
     int as_integer = 0;

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -2027,7 +2027,7 @@ v5dstruct *v5dOpenFile(const char *filename, v5dstruct * v)
 int v5dReadCompressedGrid(v5dstruct * v, int time, int var,
                           float *ga, float *gb, void *compdata)
 {
-    int n, k;
+    int n, k = 0;
     off_t pos;
 
     if (time < 0 || time >= v->NumTimes) {
@@ -2096,7 +2096,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
 {
     float ga[MAXLEVELS], gb[MAXLEVELS];
     void *compdata;
-    int bytes;
+    int bytes = 0;
 
     if (time < 0 || time >= v->NumTimes) {
         printf("Error in v5dReadGrid: bad timestep argument (%d)\n", time);
@@ -2491,7 +2491,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
 {
     float ga[MAXLEVELS], gb[MAXLEVELS];
     void *compdata;
-    int n, bytes;
+    int n, bytes = 0;
     float min, max;
 
     if (v->Mode != 'w') {

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -2062,7 +2062,7 @@ int v5dReadCompressedGrid(v5dstruct * v, int time, int var,
     else if (v->CompressMode == 2) {
         k = read_block(v->FileDesc, compdata, n, 2) == n;
     }
-    else if (v->CompressMode == 4) {
+    else if (v->CompressMode == 4) { // 'k' is used uninitialized whenever 'if' condition is false
         k = read_block(v->FileDesc, compdata, n, 4) == n;
     }
     if (!k) {
@@ -2114,7 +2114,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) {
+    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
@@ -2515,7 +2515,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) {
+    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -2062,7 +2062,7 @@ int v5dReadCompressedGrid(v5dstruct * v, int time, int var,
     else if (v->CompressMode == 2) {
         k = read_block(v->FileDesc, compdata, n, 2) == n;
     }
-    else if (v->CompressMode == 4) { // 'k' is used uninitialized whenever 'if' condition is false
+    else if (v->CompressMode == 4) {
         k = read_block(v->FileDesc, compdata, n, 4) == n;
     }
     if (!k) {
@@ -2114,7 +2114,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
+    else if (v->CompressMode == 4) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
@@ -2515,7 +2515,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
     else if (v->CompressMode == 2) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
-    else if (v->CompressMode == 4) { // 'bytes' is used uninitialized whenever 'if' condition is false
+    else if (v->CompressMode == 4) {
         bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);

--- a/vector/v.normal/main.c
+++ b/vector/v.normal/main.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
     nsites = 0;
     for (line = 1; line <= nlines; line++) {
         int type, cat, ret, cval;
-        double dval;
+        double dval = 0.0;
 
         G_debug(3, "line = %d", line);
 

--- a/vector/v.normal/main.c
+++ b/vector/v.normal/main.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
             }
             dval = cval;
         }
-        else if (ctype == DB_C_TYPE_DOUBLE) {
+        else if (ctype == DB_C_TYPE_DOUBLE) { // 'dval' is used uninitialized whenever 'if' condition is false
             ret = db_CatValArray_get_value_double(&cvarr, cat, &dval);
             if (ret != DB_OK) {
                 G_warning(_("No record for cat %d"), cat);

--- a/vector/v.normal/main.c
+++ b/vector/v.normal/main.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
             }
             dval = cval;
         }
-        else if (ctype == DB_C_TYPE_DOUBLE) { // 'dval' is used uninitialized whenever 'if' condition is false
+        else if (ctype == DB_C_TYPE_DOUBLE) {
             ret = db_CatValArray_get_value_double(&cvarr, cat, &dval);
             if (ret != DB_OK) {
                 G_warning(_("No record for cat %d"), cat);

--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -360,7 +360,7 @@ int main(int argc, char *argv[])
             G_fatal_error(_("Unable to initialize coordinate transformation"));
 
     }
-    else if (stat < 0) { // 'in_proj_keys' and 'in_unit_keys' are used uninitialized whenever 'if' condition is false
+    else if (stat < 0) {
         /* allow 0 (i.e. denied permission) */
         /* need to be able to read from others */
         if (stat == 0)

--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
 #ifdef HAVE_PROJ_H
     struct Option *pipeline;    /* name of custom PROJ pipeline */
 #endif
-    struct Key_Value *in_proj_keys, *in_unit_keys;
+    struct Key_Value *in_proj_keys = NULL, *in_unit_keys = NULL;
     struct Key_Value *out_proj_keys, *out_unit_keys;
     struct line_pnts *Points, *Points2;
     struct line_cats *Cats;

--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -360,7 +360,7 @@ int main(int argc, char *argv[])
             G_fatal_error(_("Unable to initialize coordinate transformation"));
 
     }
-    else if (stat < 0) {
+    else if (stat < 0) { // 'in_proj_keys' and 'in_unit_keys' are used uninitialized whenever 'if' condition is false
         /* allow 0 (i.e. denied permission) */
         /* need to be able to read from others */
         if (stat == 0)

--- a/vector/v.sample/main.c
+++ b/vector/v.sample/main.c
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
     nlines = Vect_get_num_lines(&In);
 
     for (line = 1; line <= nlines; line++) {
-        int type, cat = 0, ret, cval;
+        int type, cat = -1, ret, cval;
         double dval;
 
         G_debug(3, "line = %d", line);
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
         type = Vect_read_line(&In, Points, Cats, line);
         if (!(type & GV_POINT))
             continue;
-        if (field != -1 && !Vect_cat_get(Cats, field, &cat)) // 'cat' is used uninitialized whenever '&&' condition is false
+        if (field != -1 && !Vect_cat_get(Cats, field, &cat))
             continue;
 
         G_debug(4, "cat = %d", cat);

--- a/vector/v.sample/main.c
+++ b/vector/v.sample/main.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
         type = Vect_read_line(&In, Points, Cats, line);
         if (!(type & GV_POINT))
             continue;
-        if (field != -1 && !Vect_cat_get(Cats, field, &cat))
+        if (field != -1 && !Vect_cat_get(Cats, field, &cat)) // 'cat' is used uninitialized whenever '&&' condition is false
             continue;
 
         G_debug(4, "cat = %d", cat);

--- a/vector/v.sample/main.c
+++ b/vector/v.sample/main.c
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
     nlines = Vect_get_num_lines(&In);
 
     for (line = 1; line <= nlines; line++) {
-        int type, cat, ret, cval;
+        int type, cat = 0, ret, cval;
         double dval;
 
         G_debug(3, "line = %d", line);

--- a/vector/v.to.rast3/main.c
+++ b/vector/v.to.rast3/main.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
             ret = db_CatValArray_get_value_int(&cvarr, cat, &ivalue);
             value = ivalue;
         }
-        else if (ctype == DB_C_TYPE_DOUBLE) { // 'ret' is used uninitialized whenever 'if' condition is false
+        else if (ctype == DB_C_TYPE_DOUBLE) {
             ret = db_CatValArray_get_value_double(&cvarr, cat, &value);
         }
 

--- a/vector/v.to.rast3/main.c
+++ b/vector/v.to.rast3/main.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 
     nlines = Vect_get_num_lines(&Map);
     for (line = 1; line <= nlines; line++) {
-        int type, cat, depth, row, col, ret;
+        int type, cat, depth, row, col, ret = DB_FAILED;
         double value;
 
         G_percent(line, nlines, 2);

--- a/vector/v.to.rast3/main.c
+++ b/vector/v.to.rast3/main.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
             ret = db_CatValArray_get_value_int(&cvarr, cat, &ivalue);
             value = ivalue;
         }
-        else if (ctype == DB_C_TYPE_DOUBLE) {
+        else if (ctype == DB_C_TYPE_DOUBLE) { // 'ret' is used uninitialized whenever 'if' condition is false
             ret = db_CatValArray_get_value_double(&cvarr, cat, &value);
         }
 


### PR DESCRIPTION
As reported in #2156.

Initially this is a draft, I commented in code to highlight the *sometimes* uninitialised variables.
We need to decide how to address them.

**Affects:**

Modules

- db/drivers/ogr
- d.vect
- d.vect.thematic
- i.eb.soilheatflux
- r.buffer
- r.fill.stats
- r.resamp.rst
- r3.in.bin
- r3.in.v5d
- r3.out.bin
- r3.out.v5d
- v.normal
- v.proj
- v.sample
- v.to.rast3

GRASS Library parts

- lib/imagery
- lib/ogsf
- lib/raster3d
- lib/vector/Vlib
