### PR TITLE
Fix some code scanning CodeQL overflow warnings

### DIFF
--- a/lib/ogsf/gs3.c
+++ b/lib/ogsf/gs3.c
@@ -1156,7 +1156,7 @@ int Gs_update_attrange(geosurf * gs, int desc)
 		return (-1);
 	    }
 
-	    size = gs->rows * gs->cols;
+	    size = (long)gs->rows * gs->cols;
 	    p = (char *)tb->cb;
 	    SET_MINMAX(p, nm, size, min, max);
 	}

--- a/lib/ogsf/gs3.c
+++ b/lib/ogsf/gs3.c
@@ -1086,7 +1086,7 @@ int Gs_load_3dview(const char *vname, geoview * gv, geodisplay * gd,
  */
 int Gs_update_attrange(geosurf * gs, int desc)
 {
-    long size;
+    size_t size;
     float min, max;
     typbuff *tb;
     struct BM *nm;
@@ -1115,7 +1115,7 @@ int Gs_update_attrange(geosurf * gs, int desc)
 	if (tb->ib) {
 	    int *p;
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = tb->ib;
 	    INIT_MINMAX(p, nm, size, min, max, found);
 
@@ -1124,14 +1124,14 @@ int Gs_update_attrange(geosurf * gs, int desc)
 		return (-1);
 	    }
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = tb->ib;
 	    SET_MINMAX(p, nm, size, min, max);
 	}
 	else if (tb->sb) {
 	    short *p;
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = tb->sb;
 	    INIT_MINMAX(p, nm, size, min, max, found);
 
@@ -1140,14 +1140,14 @@ int Gs_update_attrange(geosurf * gs, int desc)
 		return (-1);
 	    }
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = tb->sb;
 	    SET_MINMAX(p, nm, size, min, max);
 	}
 	else if (tb->cb) {
 	    char *p;
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = (char *)tb->cb;
 	    INIT_MINMAX(p, nm, size, min, max, found);
 
@@ -1156,14 +1156,14 @@ int Gs_update_attrange(geosurf * gs, int desc)
 		return (-1);
 	    }
 
-	    size = (long)gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = (char *)tb->cb;
 	    SET_MINMAX(p, nm, size, min, max);
 	}
 	else if (tb->fb) {
 	    float *p;
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = tb->fb;
 	    INIT_MINMAX(p, nm, size, min, max, found);
 
@@ -1172,7 +1172,7 @@ int Gs_update_attrange(geosurf * gs, int desc)
 		return (-1);
 	    }
 
-	    size = gs->rows * gs->cols;
+	    size = (size_t)gs->rows * gs->cols;
 	    p = tb->fb;
 	    SET_MINMAX(p, nm, size, min, max);
 	}

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -2112,7 +2112,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned short);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);
@@ -2511,7 +2511,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned short);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -2109,13 +2109,13 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
 
     /* allocate compdata buffer */
     if (v->CompressMode == 1) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
     if (!compdata) {
@@ -2508,13 +2508,13 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
 
     /* allocate compdata buffer */
     if (v->CompressMode == 1) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
     if (!compdata) {

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -2112,7 +2112,7 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned short);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);
@@ -2513,7 +2513,7 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned short);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -1513,7 +1513,7 @@ static int read_comp_header(int f, v5dstruct * v)
 	for (i = 0; i < v->NumVars; i++) {
 	    v->GridSize[i] = gridsize;
 	}
-	v->SumGridSizes = gridsize * v->NumVars;
+	v->SumGridSizes = (off_t)gridsize * v->NumVars;
 
 	/* read McIDAS numbers??? */
 
@@ -2109,13 +2109,13 @@ int v5dReadGrid(v5dstruct * v, int time, int var, float data[])
 
     /* allocate compdata buffer */
     if (v->CompressMode == 1) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
     if (!compdata) {
@@ -2510,13 +2510,13 @@ int v5dWriteGrid(v5dstruct * v, int time, int var, const float data[])
 
     /* allocate compdata buffer */
     if (v->CompressMode == 1) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(unsigned char);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned char);
     }
     else if (v->CompressMode == 2) {
 	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(unsigned short);
     }
     else if (v->CompressMode == 4) {
-	bytes = v->Nr * v->Nc * v->Nl[var] * sizeof(float);
+	bytes = v->Nr * v->Nc * v->Nl[var] * (int)sizeof(float);
     }
     compdata = (void *)G_malloc(bytes);
     if (!compdata) {


### PR DESCRIPTION
Touching files with PR #2165 triggered CodeQL overflow warnings.

This PR addresses these issues:

- Multiplication result may overflow 'int' before it is converted to 'long'.
- Multiplication result may overflow 'int' before it is converted to 'unsigned long'.