### PR TITLE
r.watershed: Keep 0 accumulation with -a as 0 as opposed to null

### DIFF
--- a/raster/r.watershed/ram/close_maps.c
+++ b/raster/r.watershed/ram/close_maps.c
@@ -34,34 +34,25 @@ int close_maps(void)
 	    G_message("Writing out only positive flow accumulation values.");
 	    G_message
 		("Cells with a likely underestimate for flow accumulation can no longer be identified.");
-	    for (r = 0; r < nrows; r++) {
-		Rast_set_d_null_value(dbuf, ncols);	/* reset row to all NULL */
-		for (c = 0; c < ncols; c++) {
-		    dvalue = wat[SEG_INDEX(wat_seg, r, c)];
-		    if (Rast_is_d_null_value(&dvalue) == 0 && dvalue) {
-			dvalue = ABS(dvalue);
-			dbuf[c] = dvalue;
-			sum += dvalue;
-			sum_sqr += dvalue * dvalue;
-		    }
-		}
-		Rast_put_row(fd, dbuf, DCELL_TYPE);
-	    }
 	}
-	else {
-	    for (r = 0; r < nrows; r++) {
-		Rast_set_d_null_value(dbuf, ncols);	/* reset row to all NULL */
-		for (c = 0; c < ncols; c++) {
-		    dvalue = wat[SEG_INDEX(wat_seg, r, c)];
-		    if (!Rast_is_d_null_value(&dvalue)) {
+	for (r = 0; r < nrows; r++) {
+	    Rast_set_d_null_value(dbuf, ncols);	/* reset row to all NULL */
+	    for (c = 0; c < ncols; c++) {
+		dvalue = wat[SEG_INDEX(wat_seg, r, c)];
+		if (!Rast_is_d_null_value(&dvalue)) {
+		    if (abs_acc) {
+			dvalue = ABS(dvalue);
+			dbuf[c] = dvalue;
+		    }
+		    else {
 			dbuf[c] = dvalue;
 			dvalue = ABS(dvalue);
-			sum += dvalue;
-			sum_sqr += dvalue * dvalue;
 		    }
+		    sum += dvalue;
+		    sum_sqr += dvalue * dvalue;
 		}
-		Rast_put_row(fd, dbuf, DCELL_TYPE);
 	    }
+	    Rast_put_row(fd, dbuf, DCELL_TYPE);
 	}
 	Rast_close(fd);
 

--- a/raster/r.watershed/ram/close_maps.c
+++ b/raster/r.watershed/ram/close_maps.c
@@ -42,13 +42,12 @@ int close_maps(void)
 		if (!Rast_is_d_null_value(&dvalue)) {
 		    if (abs_acc) {
 			dvalue = ABS(dvalue);
-			dbuf[c] = dvalue;
+			sum += dvalue;
 		    }
-		    else {
-			dbuf[c] = dvalue;
-			dvalue = ABS(dvalue);
-		    }
-		    sum += dvalue;
+		    else
+			sum += ABS(dvalue);
+
+		    dbuf[c] = dvalue;
 		    sum_sqr += dvalue * dvalue;
 		}
 	    }

--- a/raster/r.watershed/seg/close_maps.c
+++ b/raster/r.watershed/seg/close_maps.c
@@ -40,7 +40,7 @@ int close_maps(void)
 	    for (c = 0; c < ncols; c++) {
 		/* dseg_get(&wat, &dvalue, r, c); */
 		dvalue = wabuf[c].wat;
-		if (Rast_is_d_null_value(&dvalue) == 0 && dvalue) {
+		if (!Rast_is_d_null_value(&dvalue)) {
 		    if (abs_acc) {
 			dvalue = fabs(dvalue);
 			sum += dvalue;


### PR DESCRIPTION
This PR addresses #2003 by saving 0 accumulated cells as 0, not as null, for the -a flag. It does not change the default behavior without -a.

Its side effect is that cells outside non-null input are also saved as 0 (was null before this PR), which is in fact more consistent with the default output without the -a flag. I think with/without -a, null input cells should produce null output cells (TODO).