### PR TITLE
CI: Cancel in-progress runs on update for PR

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,14 @@ on:
     # Check every Saturday at 18:36
     - cron: "36 18 * * 6"
 
+# Cancel previous workflow runs for pull requests.
+# The concurrency group is workflow name and the branch name for pull requests,
+# but it is the commit hash for any other events, so the group is unique and no
+# runs are canceled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: ${{ matrix.language }}

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -4,6 +4,14 @@ on:
   - push
   - pull_request
 
+# Cancel previous workflow runs for pull requests.
+# The concurrency group is workflow name and the branch name for pull requests,
+# but it is the commit hash for any other events, so the group is unique and no
+# runs jobs are canceled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.os }} build and tests

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -7,7 +7,7 @@ on:
 # Cancel previous workflow runs for pull requests.
 # The concurrency group is workflow name and the branch name for pull requests,
 # but it is the commit hash for any other events, so the group is unique and no
-# runs jobs are canceled.
+# runs are canceled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,6 +5,14 @@ on:
   - push
   - pull_request
 
+# Cancel previous workflow runs for pull requests.
+# The concurrency group is workflow name and the branch name for pull requests,
+# but it is the commit hash for any other events, so the group is unique and no
+# runs are canceled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: ${{ matrix.os }} tests


### PR DESCRIPTION
Using GitHub Actions concurrency, runs from the previous commits are canceled within the same group which is defined by workflow and head_ref/branch name. It explicitly checks for event being pull request and if it is not, it uses commit hash which makes it unique, so commits to the main and release branches will not be canceled.

See also #1794.
