### PR TITLE
CI: enable skip hint [ci skip] in GitHub actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run-black:
     name: Check
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.os }} build
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
 
     runs-on: ubuntu-18.04
     container: ${{ matrix.os }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   analyze:
     name: ${{ matrix.language }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
     runs-on: ubuntu-20.04
 
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,8 @@ jobs:
   # stable-alpine, stable-debian, stable-ubuntu
   docker-branch-os-matrix:
     name: build and push ${{ matrix.os }} for branch
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
     if: startsWith(github.ref, 'refs/heads/') && github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
 
@@ -104,6 +106,8 @@ jobs:
   # again for main branch to create latest tag.
   docker-main-latest:
     name: build and push latest for main branch
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
     if: github.ref == 'refs/heads/main' && github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
 
@@ -144,6 +148,8 @@ jobs:
   # run for releases, take care of release tags
   docker-release-os-matrix:
     name: build and push release for ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
     if: startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   flake8:
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.c }} & ${{ matrix.cpp }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
 
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     name: ${{ matrix.os }} build and tests
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   super-linter:
     name: GitHub Super Linter
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-test:
     name: ${{ matrix.os }} tests
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
 
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Using `github.event.head_commit.message` the GitHub actions may be skipped with `[ci skip]` or `[skip ci]` in the commit message.

Inspired by GDAL, https://github.com/OSGeo/gdal/commit/635faad3988df177896b16cfa6da6a346ec7253e (author: @rouault).

Fixes #2174