### PR TITLE
CI: Ignore in GHA CI yml files HTML, Markdown, or Text changes

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -8,6 +8,10 @@ name: Additional Checks
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   additional-checks:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,6 +3,10 @@ name: Python Black Formatting
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   run-black:

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -3,6 +3,10 @@ name: CentOS
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   build:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -3,6 +3,10 @@ name: Python Flake8 Code Quality
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   flake8:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -3,6 +3,10 @@ name: GCC C/C++ standards check
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   build:

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -3,6 +3,10 @@ name: OSGeo4W
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   build:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -3,6 +3,10 @@ name: General linting
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   super-linter:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,6 +4,10 @@ name: Ubuntu
 on:
   - push
   - pull_request
+      paths-ignore:
+        - "**/*.html"
+        - "**/*.md"
+        - "**/*.txt"
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Do not run CI runners on PR when only HTML, Markdown, or txt is changed (inspired by #1778).

Closes #2175 (replacement)

Fixes issue #2174