### PR TITLE
wxGUI: update statusbar when projection settings checkbox has been toggled

### DIFF
--- a/gui/wxpython/gcp/mapdisplay.py
+++ b/gui/wxpython/gcp/mapdisplay.py
@@ -30,7 +30,6 @@ from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.mapdisp import SingleMapPanel
 from gui_core.wrap import Menu
 from mapwin.buffered import BufferedMapWindow
-from mapwin.base import MapWindowProperties
 
 import mapdisp.statusbar as sb
 import gcp.statusbar as sbgcp
@@ -78,9 +77,7 @@ class MapPanel(SingleMapPanel):
         )
 
         self._giface = giface
-        # properties are shared in other objects, so defining here
-        self.mapWindowProperties = MapWindowProperties()
-        self.mapWindowProperties.setValuesFromUserSettings()
+
         self.mapWindowProperties.alignExtent = True
 
         #

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -91,7 +91,7 @@ class MapPanelBase(wx.Panel):
         # properties are shared in other objects, so defining here
         self.mapWindowProperties = MapWindowProperties()
         self.mapWindowProperties.setValuesFromUserSettings()
-        # update statusbar when using defined projection
+        # update statusbar when user-defined projection changed
         self.mapWindowProperties.useDefinedProjectionChanged.connect(
             self.StatusbarUpdate
         )

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -28,6 +28,7 @@ from core.debug import Debug
 from gui_core.toolbars import ToolSwitcher
 from gui_core.wrap import NewId
 from mapdisp import statusbar as sb
+from mapwin.base import MapWindowProperties
 
 from grass.script import core as grass
 
@@ -86,6 +87,12 @@ class MapPanelBase(wx.Panel):
         # toolbars
         self.toolbars = {}
         self.iconsize = (16, 16)
+
+        # properties are shared in other objects, so defining here
+        self.mapWindowProperties = MapWindowProperties()
+        self.mapWindowProperties.setValuesFromUserSettings()
+        # update statusbar when using defined projection
+        self.mapWindowProperties.useDefinedProjectionChanged.connect(self.StatusbarUpdate)
 
         #
         # Fancy gui

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -92,7 +92,9 @@ class MapPanelBase(wx.Panel):
         self.mapWindowProperties = MapWindowProperties()
         self.mapWindowProperties.setValuesFromUserSettings()
         # update statusbar when using defined projection
-        self.mapWindowProperties.useDefinedProjectionChanged.connect(self.StatusbarUpdate)
+        self.mapWindowProperties.useDefinedProjectionChanged.connect(
+            self.StatusbarUpdate
+        )
 
         #
         # Fancy gui

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -49,7 +49,6 @@ from core.render import Map
 from core.gcmd import RunCommand, GMessage, GError
 from gui_core.dialogs import SetOpacityDialog
 from gui_core.wrap import Menu
-from mapwin.base import MapWindowProperties
 from dbmgr.vinfo import VectorDBInfo
 
 from iclass.digit import IClassVDigitWindow, IClassVDigit
@@ -113,8 +112,7 @@ class IClassMapPanel(DoubleMapPanel):
         else:
             self.giface = StandaloneMapDisplayGrassInterface(self)
         self.tree = None
-        self.mapWindowProperties = MapWindowProperties()
-        self.mapWindowProperties.setValuesFromUserSettings()
+
         # show computation region by defaut
         self.mapWindowProperties.showRegion = True
 

--- a/gui/wxpython/image2target/ii2t_mapdisplay.py
+++ b/gui/wxpython/image2target/ii2t_mapdisplay.py
@@ -30,7 +30,6 @@ from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.mapdisp import SingleMapPanel
 from gui_core.wrap import Menu
 from mapwin.buffered import BufferedMapWindow
-from mapwin.base import MapWindowProperties
 
 import mapdisp.statusbar as sb
 import gcp.statusbar as sbgcp
@@ -78,9 +77,7 @@ class MapPanel(SingleMapPanel):
         )
 
         self._giface = giface
-        # properties are shared in other objects, so defining here
-        self.mapWindowProperties = MapWindowProperties()
-        self.mapWindowProperties.setValuesFromUserSettings()
+
         self.mapWindowProperties.alignExtent = True
 
         #

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -37,7 +37,6 @@ from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from core.debug import Debug
 from core.settings import UserSettings
 from gui_core.mapdisp import SingleMapPanel, FrameMixin
-from mapwin.base import MapWindowProperties
 from gui_core.query import QueryDialog, PrepareQueryResults
 from mapwin.buffered import BufferedMapWindow
 from mapwin.decorations import (
@@ -129,10 +128,6 @@ class MapPanel(SingleMapPanel):
 
         # Emitted when closing display by closing its window.
         self.closingVNETDialog = Signal("MapPanel.closingVNETDialog")
-
-        # properties are shared in other objects, so defining here
-        self.mapWindowProperties = MapWindowProperties()
-        self.mapWindowProperties.setValuesFromUserSettings()
 
         #
         # Add toolbars

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -24,7 +24,6 @@ import grass.script as grass
 from gui_core.mapdisp import DoubleMapPanel, FrameMixin
 from gui_core.dialogs import GetImageHandlers
 from gui_core.wrap import Slider
-from mapwin.base import MapWindowProperties
 from core.render import Map
 from mapdisp import statusbar as sb
 from core.debug import Debug
@@ -68,8 +67,6 @@ class SwipeMapPanel(DoubleMapPanel):
         self.sliderH = Slider(self, id=wx.ID_ANY, style=wx.SL_HORIZONTAL)
         self.sliderV = Slider(self, id=wx.ID_ANY, style=wx.SL_VERTICAL)
 
-        self.mapWindowProperties = MapWindowProperties()
-        self.mapWindowProperties.setValuesFromUserSettings()
         self.mapWindowProperties.autoRenderChanged.connect(self.OnAutoRenderChanged)
         self.firstMapWindow = SwipeBufferedWindow(
             parent=self.splitter,

--- a/gui/wxpython/mapwin/base.py
+++ b/gui/wxpython/mapwin/base.py
@@ -104,7 +104,9 @@ class MapWindowProperties(object):
 
     @useDefinedProjection.setter
     def useDefinedProjection(self, value):
-        self._useDefinedProjection = value
+        if value != self._useDefinedProjection:
+            self._useDefinedProjection = value
+            self.useDefinedProjectionChanged.emit(value=value)
 
     @property
     def epsg(self):

--- a/gui/wxpython/photo2image/ip2i_mapdisplay.py
+++ b/gui/wxpython/photo2image/ip2i_mapdisplay.py
@@ -25,7 +25,6 @@ from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.mapdisp import SingleMapPanel
 from gui_core.wrap import Menu
 from mapwin.buffered import BufferedMapWindow
-from mapwin.base import MapWindowProperties
 
 import mapdisp.statusbar as sb
 import gcp.statusbar as sbgcp
@@ -72,9 +71,7 @@ class MapPanel(SingleMapPanel):
         )
 
         self._giface = giface
-        # properties are shared in other objects, so defining here
-        self.mapWindowProperties = MapWindowProperties()
-        self.mapWindowProperties.setValuesFromUserSettings()
+
         self.mapWindowProperties.alignExtent = True
 
         #


### PR DESCRIPTION
This PR moves self.mapWindowProperties to map window base class and connects signal which updates map display statusbar whenever the projection settings in Map Display Settings dialog is toggled.