### PR TITLE
grass.gunittest: Fix fail with no config

### DIFF
--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -137,9 +137,12 @@ def get_config(start_directory):
     config_file = Path(start_directory) / CONFIG_FILENAME
     if config_file.is_file():
         config_parser.read(config_file)
+    else:
+        # Create an empty section if file is not available.
+        config_parser.read_dict({"gunittest": {}})
     if "gunittest" in config_parser:
         return config_parser["gunittest"]
-    return {}
+    return config_parser
 
 
 def main():


### PR DESCRIPTION
Adds an empty section to the parser when no config file is available and returning the section proxy instead of returning and empty dict which has a different API than the section proxy.

Fixes an issue introduced in #2172 which shows in grass-addons CI.
