### PR TITLE
CI: Add Flake8 check for selected tests

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -24,3 +24,7 @@ jobs:
       - name: Run Flake8
         run: |
           flake8 --count --statistics --show-source --jobs=$(nproc) .
+
+      - name: Run Flake8 on additional files
+        run: |
+          flake8 --count --statistics --show-source --jobs=$(nproc) python/grass/{script,jupyter}/testsuite/

--- a/python/grass/jupyter/testsuite/grassrenderer_test.py
+++ b/python/grass/jupyter/testsuite/grassrenderer_test.py
@@ -28,7 +28,7 @@ from grass.gunittest.main import test
 def can_import_ipython():
     """Test folium import to see if test can be run."""
     try:
-        import IPython
+        import IPython  # noqa
 
         return True
     except ImportError:

--- a/python/grass/jupyter/testsuite/interactivemap_test.py
+++ b/python/grass/jupyter/testsuite/interactivemap_test.py
@@ -29,7 +29,7 @@ from grass.gunittest.main import test
 def can_import_folium():
     """Test folium import to see if test can be run."""
     try:
-        import folium
+        import folium  # noqa
 
         return True
     except ImportError:

--- a/python/grass/script/testsuite/test_start_command_functions.py
+++ b/python/grass/script/testsuite/test_start_command_functions.py
@@ -2,7 +2,6 @@
 Tests of start_command function family (location independent)
 """
 
-import sys
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -98,10 +97,7 @@ class TestPythonModuleWithStdinStdout(TestCase):
         )
         res = read_command("r.category", map=self.raster, separator=":").strip()
         self.assertEquals(res, "1:kůň\n2:kráva\n3:ovečka\n4:býk")
-        if sys.version_info.major >= 3:
-            self.assertIsInstance(res, str)
-        else:
-            self.assertIsInstance(res, unicode)
+        self.assertIsInstance(res, str)
 
     def test_write_labels_bytes(self):
         """This tests if Python module works"""

--- a/python/grass/script/testsuite/test_start_command_functions_nc.py
+++ b/python/grass/script/testsuite/test_start_command_functions_nc.py
@@ -1,11 +1,11 @@
 """Tests of start_command function family in nc location"""
 
-LOCATION = "nc"
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
 from grass.script.core import start_command, PIPE
+
+LOCATION = "nc"
 
 
 class TestPythonKeywordsInParameters(TestCase):


### PR DESCRIPTION
grass.jupyter and grass.script tests are almost Flake8 compliant. This fixes the reported issues and removes Python 2 specific check.

A new step in the flake8 job checks explicitly for the files in the two testsuite directories. (There is no way in Flake8 itself to include previosly excluded files which is needed because testsuite directories are ignored in the main .flake8 file and here we need to check them.)
