### PR TITLE
wxGUI: do not import from pygrass on gui startup

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -59,7 +59,6 @@ import wx.lib.filebrowsebutton as filebrowse
 import grass.script as grass
 from grass.script import task as gtask
 from grass.exceptions import CalledModuleError
-from grass.pygrass.utils import decode
 
 from gui_core.widgets import ManageSettingsWidget, CoordinatesValidator
 
@@ -2840,7 +2839,7 @@ class SignatureSelect(wx.ComboBox):
         sig_list = list_ptr()
         count = I_signatures_list_by_type(sig_type, mapset, ctypes.byref(sig_list))
         for n in range(count):
-            items.append(decode(sig_list[n]))
+            items.append(grass.decode(sig_list[n]))
         I_free_signatures_list(count, ctypes.byref(sig_list))
 
 


### PR DESCRIPTION
Replaces pygrass.utils.decode as not needed here, grass.utils.decode was called anyway.
This should prevent that gui crashes when loading C libraries fails, see #2192.
