### PR TITLE
 grass.jupyter: Use weakref.finalize to manage TemporaryDirectory

### DIFF
--- a/python/grass/benchmark/results.py
+++ b/python/grass/benchmark/results.py
@@ -48,7 +48,7 @@ def save_results_to_file(results, filename):
     See :func:`save_results` for details.
     """
     text = save_results(results)
-    with open(filename, "w") as file:
+    with open(filename, "w", encoding="utf-8") as file:
         file.write(text)
 
 
@@ -67,7 +67,7 @@ def load_results_from_file(filename):
 
     See :func:`load_results` for details.
     """
-    with open(filename, "r") as file:
+    with open(filename, "r", encoding="utf-8") as file:
         return load_results(file.read())
 
 

--- a/python/grass/benchmark/results.py
+++ b/python/grass/benchmark/results.py
@@ -48,7 +48,7 @@ def save_results_to_file(results, filename):
     See :func:`save_results` for details.
     """
     text = save_results(results)
-    with open(filename, "w", encoding="utf-8") as file:
+    with open(filename, "w") as file:
         file.write(text)
 
 
@@ -67,7 +67,7 @@ def load_results_from_file(filename):
 
     See :func:`load_results` for details.
     """
-    with open(filename, "r", encoding="utf-8") as file:
+    with open(filename, "r") as file:
         return load_results(file.read())
 
 

--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -14,6 +14,7 @@
 import os
 import shutil
 import tempfile
+import weakref
 import grass.script as gs
 
 from .region import RegionManagerFor2D

--- a/python/grass/jupyter/display.py
+++ b/python/grass/jupyter/display.py
@@ -91,7 +91,15 @@ class GrassRenderer:
         # temporary directory that we can delete later. We need
         # this temporary directory for the legend anyways so we'll
         # make it now
-        self._tmpdir = tempfile.TemporaryDirectory()
+        # Resource managed by weakref.finalize.
+        self._tmpdir = (
+            tempfile.TemporaryDirectory()
+        )  # pylint: disable=consider-using-with
+
+        def cleanup(tmpdir):
+            tmpdir.cleanup()
+
+        weakref.finalize(self, cleanup, self._tmpdir)
 
         if filename:
             self._filename = filename

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -95,11 +95,20 @@ class Grass3dRenderer:
         self._resolution_fine = resolution_fine
 
         # Temporary dir and files
-        self._tmpdir = tempfile.TemporaryDirectory()
+
         if filename:
             self._filename = filename
         else:
+            # Resource managed by weakref.finalize.
+            self._tmpdir = (
+                tempfile.TemporaryDirectory()
+            )  # pylint: disable=consider-using-with
             self._filename = os.path.join(self._tmpdir.name, "map.png")
+
+            def cleanup(tmpdir):
+                tmpdir.cleanup()
+
+            weakref.finalize(self, cleanup, self._tmpdir)
 
         # Screen backend
         try:

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -96,20 +96,20 @@ class Grass3dRenderer:
         self._resolution_fine = resolution_fine
 
         # Temporary dir and files
+        # Resource managed by weakref.finalize.
+        self._tmpdir = (
+            tempfile.TemporaryDirectory()
+        )  # pylint: disable=consider-using-with
+
+        def cleanup(tmpdir):
+            tmpdir.cleanup()
+
+        weakref.finalize(self, cleanup, self._tmpdir)
 
         if filename:
             self._filename = filename
         else:
-            # Resource managed by weakref.finalize.
-            self._tmpdir = (
-                tempfile.TemporaryDirectory()
-            )  # pylint: disable=consider-using-with
             self._filename = os.path.join(self._tmpdir.name, "map.png")
-
-            def cleanup(tmpdir):
-                tmpdir.cleanup()
-
-            weakref.finalize(self, cleanup, self._tmpdir)
 
         # Screen backend
         try:

--- a/python/grass/jupyter/render3d.py
+++ b/python/grass/jupyter/render3d.py
@@ -15,6 +15,7 @@
 
 import os
 import tempfile
+import weakref
 
 import grass.script as gs
 from grass.jupyter import GrassRenderer


### PR DESCRIPTION
Although tempfile.TemporaryDirectory uses weakref.finalize to delete the directory and its documentation does mention deletion during garbage-collection and during interpreter shutdown, the intention in its source code is that a with statement or explicit cleanup call is made because otherwise it generates a warning about implicit deletion. Pylint correctly generates warning suggesting with statement (consider-using-with).

In the future, we may consider implementing context-manager and cleanup method to the render classes, but even with that we need to stretch the existence of the temporary directory beyond one method, so the with statement is not applicable. For now, the classes are using only weakref.finalize which is sufficient for a notebook where the object life time is linked with the notebook's kernel life time which is relatively short. The Pylint warning is disabled and an explanatory comment is above.