### PR TITLE
Update to Black 22.1.0

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,13 +1,28 @@
 name: Python Black Formatting
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+    tags:
+      - "*.*.*"
+  pull_request:
 
 jobs:
   run-black:
-    name: Check
-    runs-on: ubuntu-20.04
+    name: Black ${{ matrix.black-version }}
+
+    # Using matrix just to get variables which are not environmental variables
+    # and also to sync with other workflows which use matrix.
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.10"
+            black-version: "22.1.0"
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -15,12 +30,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
 
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install black==21.5b1
+          pip install black==${{ matrix.black-version }}
 
       - name: Run Black
         run: |

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -44,7 +44,6 @@ if sys.version_info.major >= 3:
         else:
             return str(value)
 
-
 else:
 
     def GetUnicodeValue(value):

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -2127,7 +2127,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         # SD
         if GCPcount > 0:
             self.rmsmean = sum_fwd_err / GCPcount
-            self.rmssd = (sumsq_fwd_err - self.rmsmean ** 2) ** 0.5
+            self.rmssd = (sumsq_fwd_err - self.rmsmean**2) ** 0.5
             self.rmsthresh = self.rmsmean + sdfactor * self.rmssd
         else:
             self.rmsthresh = 0

--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -476,7 +476,6 @@ if CheckWxVersion([4, 1, 0]):
             self.EnableCheckBoxes(True)
             self.AssignImageList(wx.ImageList(16, 16), wx.IMAGE_LIST_SMALL)
 
-
 else:
     import wx.lib.mixins.listctrl as listmix
 

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -2052,7 +2052,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         # SD
         if GCPcount > 0:
             self.rmsmean = sum_fwd_err / GCPcount
-            self.rmssd = (sumsq_fwd_err - self.rmsmean ** 2) ** 0.5
+            self.rmssd = (sumsq_fwd_err - self.rmsmean**2) ** 0.5
             self.rmsthresh = self.rmsmean + sdfactor * self.rmssd
         else:
             self.rmsthresh = 0

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -515,15 +515,11 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                     wx.EVT_MENU, self.OnPopupProperties, id=self.popupID["properties"]
                 )
 
-                if (
-                    ltype
-                    in (
-                        "raster",
-                        "vector",
-                        "raster_3d",
-                    )
-                    and self.mapdisplay.IsPaneShown("3d")
-                ):
+                if ltype in (
+                    "raster",
+                    "vector",
+                    "raster_3d",
+                ) and self.mapdisplay.IsPaneShown("3d"):
                     self.popupMenu.Append(self.popupID["nviz"], _("3D view properties"))
                     self.Bind(
                         wx.EVT_MENU, self.OnNvizProperties, id=self.popupID["nviz"]

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1344,7 +1344,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         # SD
         if GCPcount > 0:
             self.rmsmean = sum_fwd_err / GCPcount
-            self.rmssd = (sumsq_fwd_err - self.rmsmean ** 2) ** 0.5
+            self.rmssd = (sumsq_fwd_err - self.rmsmean**2) ** 0.5
             self.rmsthresh = self.rmsmean + sdfactor * self.rmssd
         else:
             self.rmsthresh = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 (
@@ -19,11 +19,6 @@ exclude = '''
         | dist\..*
     )/
     | python/libgrass_interface_generator/
-    # Bug in Black related to r-string prefix capitalization reformats
-    # a line in this file unnecessarily. File is however fully Black-formatted
-    # at the time of writing.
-    # https://github.com/psf/black/issues/1244
-    | python/grass/pygrass/utils.py
 )
 '''
 

--- a/python/grass/gunittest/checkers.py
+++ b/python/grass/gunittest/checkers.py
@@ -577,7 +577,7 @@ def check_text_ellipsis_doctest(reference, actual):
 
 
 # optimal size depends on file system and maybe on hasher.block_size
-_BUFFER_SIZE = 2 ** 16
+_BUFFER_SIZE = 2**16
 
 
 # TODO: accept also open file object

--- a/python/grass/imaging/images2gif.py
+++ b/python/grass/imaging/images2gif.py
@@ -207,7 +207,7 @@ class GifWriter:
         """
 
         if loops == 0 or loops == float("inf"):
-            loops = 2 ** 16 - 1
+            loops = 2**16 - 1
             # bb = ""
             # application extension should not be used
             # (the extension interprets zero loops

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -371,7 +371,7 @@ def floatsToBits(arr):
         i1 = int(i)
         i2 = i - i1
         bits += intToBits(i1, 15)
-        bits += intToBits(i2 * 2 ** 16, 16)
+        bits += intToBits(i2 * 2**16, 16)
     return bits
 
 

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -124,7 +124,7 @@ def mapcalc(
     """
 
     if seed == "auto":
-        seed = hash((os.getpid(), time.time())) % (2 ** 32)
+        seed = hash((os.getpid(), time.time())) % (2**32)
 
     t = string.Template(exp)
     e = t.substitute(**kwargs)
@@ -177,7 +177,7 @@ def mapcalc_start(
     """
 
     if seed == "auto":
-        seed = hash((os.getpid(), time.time())) % (2 ** 32)
+        seed = hash((os.getpid(), time.time())) % (2**32)
 
     t = string.Template(exp)
     e = t.substitute(**kwargs)

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -84,7 +84,7 @@ def mapcalc3d(
     """
 
     if seed == "auto":
-        seed = hash((os.getpid(), time.time())) % (2 ** 32)
+        seed = hash((os.getpid(), time.time())) % (2**32)
 
     t = string.Template(exp)
     e = t.substitute(**kwargs)

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -48,7 +48,7 @@ def float_or_dms(s):
     """
     if s[-1] in ["E", "W", "N", "S"]:
         s = s[:-1]
-    return sum(float(x) / 60 ** n for (n, x) in enumerate(s.split(":")))
+    return sum(float(x) / 60**n for (n, x) in enumerate(s.split(":")))
 
 
 def separator(sep):


### PR DESCRIPTION
Black is no longer a beta and has a (more strict) stability policy in place.
Changes are expected to happen over years and with updating Python versions (removing the old ones to be exact).

The changes in formatting are specialized no-spaces style for simple operands of power operator and better formatting of a compex if statement.

Python 3.10 is now among target versions. File which had to be ignored by Black due to a, now fixed, bug in Black is not ignored anymore.

In CI, matrix is used to define variables for versions (as in Pylint workflow and workflows with actual matrix). Workflow's on now specifies branches and tags for push.
