### PR TITLE
wxGUI Single-Window: Make Tools pane wider after startup

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -157,7 +157,7 @@ class GMFrame(wx.Frame):
 
         # set pane sizes according to the full screen size of the primary monitor
         self.PANE_BEST_SIZE = tuple(t // 5 for t in self.size)
-        self.PANE_MIN_SIZE = tuple(t // 6 for t in self.size)
+        self.PANE_MIN_SIZE = tuple(t // 8 for t in self.size)
 
         # create widgets and build panes
         self.CreateMenuBar()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -679,7 +679,8 @@ class GMFrame(wx.Frame):
 
         # Set the size for automatic notebook
         pane = self._auimgr.GetPane(notebook)
-        pane.BestSize(self.PANE_MIN_SIZE)
+        pane.BestSize(self.PANE_BEST_SIZE)
+        pane.MinSize(self.PANE_MIN_SIZE)
 
         wx.CallAfter(self.datacatalog.LoadItems)
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -679,7 +679,7 @@ class GMFrame(wx.Frame):
 
         # Set the size for automatic notebook
         pane = self._auimgr.GetPane(notebook)
-        pane.MinSize(self.PANE_MIN_SIZE)
+        pane.BestSize(self.PANE_MIN_SIZE)
 
         wx.CallAfter(self.datacatalog.LoadItems)
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -156,8 +156,8 @@ class GMFrame(wx.Frame):
         self.dialogs["atm"] = list()
 
         # set pane sizes according to the full screen size of the primary monitor
-        self.PANE_BEST_SIZE = tuple(t // 3 for t in self.size)
-        self.PANE_MIN_SIZE = tuple(t // 5 for t in self.size)
+        self.PANE_BEST_SIZE = tuple(t // 5 for t in self.size)
+        self.PANE_MIN_SIZE = tuple(t // 6 for t in self.size)
 
         # create widgets and build panes
         self.CreateMenuBar()
@@ -183,8 +183,8 @@ class GMFrame(wx.Frame):
             self.Centre()
 
         self.Layout()
+        self.Fit()
         self.Show()
-        self.Maximize(True)
 
         # load workspace file if requested
         if workspace:
@@ -679,7 +679,7 @@ class GMFrame(wx.Frame):
 
         # Set the size for automatic notebook
         pane = self._auimgr.GetPane(notebook)
-        pane.MinSize(self.search.GetMinSize())
+        pane.MinSize(self.PANE_MIN_SIZE)
 
         wx.CallAfter(self.datacatalog.LoadItems)
 


### PR DESCRIPTION
Before:
![Screenshot from 2022-02-17 01-21-45](https://user-images.githubusercontent.com/49241681/154425456-ffe5d0ac-c8c3-4004-83ae-b0d525a4cdcd.png)

After:
![Screenshot from 2022-02-17 01-18-37](https://user-images.githubusercontent.com/49241681/154425085-762848b5-2c4a-412c-a7d7-94054fda7bb5.png)
The width is the same for both side panels.

