### PR TITLE
t.rast.mapcalc: transfer semantic label

### DIFF
--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -288,6 +288,11 @@ def dataset_mapcalculator(
                 start, end, unit = sample_map_list[i].get_relative_time()
                 new_map.set_relative_time(start, end, unit)
 
+            # Set the semantic label
+            semantic_label = sample_map_list[i].metadata.get_semantic_label()
+            if semantic_label is not None:
+                new_map.set_semantic_label(semantic_label)
+
             # Parse the temporal expressions
             expr = _operator_parser(expr, sample_map_list[0], sample_map_list[i])
             # Add the output map name

--- a/temporal/t.rast.mapcalc/t.rast.mapcalc.html
+++ b/temporal/t.rast.mapcalc/t.rast.mapcalc.html
@@ -122,6 +122,8 @@ r.mapcalc expression="c_5 = if(7 == 5 || 7 == 6, (a7 + b7), (a7 * b7))"
 r.mapcalc expression="c_6 = if(8 == 5 || 8 == 6, (a8 + b8), (a8 * b8))"
 </pre></div>
 <p>
+Semantic labels present in the sample dataset A will be transferred to
+the output dataset.
 
 <h2>EXAMPLES</h2>
 


### PR DESCRIPTION
More often than not, transferring the semantic label in `t.rast.mapcalc` from the first input (also used as sampling reference for the time stamp) makes sense. If the semantic label gets lost, an unusable STRDS might be created.

An example is application of a multiplication factor to a STRDS with Landsat or Sentinel bands where semantic labels must be preserved.