### PR TITLE
r.buildvrt: check if all input maps are NULL-only

### DIFF
--- a/raster/r.buildvrt/main.c
+++ b/raster/r.buildvrt/main.c
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
 	if (strcmp(nsresstr, tnsresstr) != 0)
 	    G_warning(_("Input ns resolutions are different"));
 	if (strcmp(ewresstr, tewresstr) != 0)
-	    G_warning(_("Input ns resolutions are different"));
+	    G_warning(_("Input ew resolutions are different"));
 
 	if (cellhd.north < p->cellhd.north)
 	    cellhd.north = p->cellhd.north;

--- a/raster/r.buildvrt/main.c
+++ b/raster/r.buildvrt/main.c
@@ -219,6 +219,8 @@ int main(int argc, char *argv[])
     	}
 	num_inputs = j;
     }
+    if (num_inputs == 0)
+	G_fatal_error(_("All input maps only contain NULL, cannot continue"));
 
     qsort(inputs, num_inputs, sizeof(struct input), cmp_wnd);
 


### PR DESCRIPTION
Do not continue if all input raster maps only contain no-data.
Feel free to suggest a better error message.

**To Reproduce**

```
r.mapcalc expression="a=null()"
r.mapcalc expression="b=null()"
r.buildvrt input=a,b output=c
```

Old behaviour:
```
GRASS nc_spm_08_grass7/user1:grass_main > r.buildvrt input=a,b output=c --verbose
Input map <a@user1> is all NULL, skipping
Input map <b@user1> is all NULL, skipping
WARNING: Illegal filename <���>. Character <�> not allowed.
ERROR: Raster map <���> not found in mapset <���>
```

New error message:
```
GRASS nc_spm_08_grass7/user1:grass_main > r.buildvrt input=a,b output=c --verbose
Input map <a@user1> is all NULL, skipping
Input map <b@user1> is all NULL, skipping
ERROR: All input maps only contain NULL, cannot continue
```

Fixes #2217