### PR TITLE
r.watershed: Null accumulation outside elevation, 0 flow from null flow

### DIFF
--- a/raster/r.watershed/ram/init_vars.c
+++ b/raster/r.watershed/ram/init_vars.c
@@ -190,7 +190,6 @@ int init_vars(int argc, char *argv[])
 
     /* read elevation input and mark NULL/masked cells */
     /* initialize accumulation and drainage direction */
-    MASK_flag = 0;
     do_points = nrows * ncols;
     for (r = 0; r < nrows; r++) {
 	Rast_get_row(fd, elebuf, r, ele_map_type);
@@ -243,8 +242,7 @@ int init_vars(int argc, char *argv[])
     }
     Rast_close(fd);
     G_free(elebuf);
-    if (do_points < nrows * ncols)
-	MASK_flag = 1;
+    MASK_flag = (do_points < nrows * ncols);
 
     /* read flow accumulation from input map flow: amount of overland flow per cell */
     if (run_flag) {
@@ -257,8 +255,6 @@ int init_vars(int argc, char *argv[])
 		    block_value = FLAG_GET(worked, r, c);
 		    if (!block_value)
 			wat[SEG_INDEX(wat_seg, r, c)] = dbuf[c];
-		    else
-			wat[SEG_INDEX(wat_seg, r, c)] = 0.0;
 		}
 		else
 		    wat[SEG_INDEX(wat_seg, r, c)] = dbuf[c];

--- a/raster/r.watershed/ram/init_vars.c
+++ b/raster/r.watershed/ram/init_vars.c
@@ -251,7 +251,9 @@ int init_vars(int argc, char *argv[])
 	for (r = 0; r < nrows; r++) {
 	    Rast_get_d_row(fd, dbuf, r);
 	    for (c = 0; c < ncols; c++) {
-		if (MASK_flag) {
+		if (Rast_is_d_null_value(&dbuf[c]))
+		    wat[SEG_INDEX(wat_seg, r, c)] = 0.0;
+		else if (MASK_flag) {
 		    block_value = FLAG_GET(worked, r, c);
 		    if (!block_value)
 			wat[SEG_INDEX(wat_seg, r, c)] = dbuf[c];

--- a/raster/r.watershed/seg/init_vars.c
+++ b/raster/r.watershed/seg/init_vars.c
@@ -24,7 +24,6 @@ int init_vars(int argc, char *argv[])
     WAT_ALT wa, *wabuf;
     ASP_FLAG af, af_nbr, *afbuf;
     A_TANB sca_tanb;
-    char MASK_flag;
     void *elebuf, *ptr, *watbuf, *watptr;
     int ele_map_type, wat_map_type;
     size_t ele_size, wat_size;
@@ -400,8 +399,6 @@ int init_vars(int argc, char *argv[])
 	Rast_close(wat_fd);
 	G_free(watbuf);
     }
-
-    MASK_flag = (do_points < nrows * ncols);
 
     /* read retention map to adjust flow distribution (AG) */
     if (rtn_flag) {

--- a/raster/r.watershed/seg/init_vars.c
+++ b/raster/r.watershed/seg/init_vars.c
@@ -310,7 +310,6 @@ int init_vars(int argc, char *argv[])
 
     /* read elevation input and mark NULL/masked cells */
     G_message("SECTION 1a: Mark masked and NULL cells");
-    MASK_flag = 0;
     do_points = (GW_LARGE_INT) nrows *ncols;
 
     for (r = 0; r < nrows; r++) {


### PR DESCRIPTION
This PR sets accumulation to null where there is no data in elevation. This behavior is consistent with the disk swap -m flag. It also partly addresses https://github.com/OSGeo/grass/issues/1901 by assigning 0 flow amount to null flow cells.