### PR TITLE
.github/workflows: automatically create new GitHub release draft

### DIFF
--- a/.github/workflows/create_new_release_draft.yml
+++ b/.github/workflows/create_new_release_draft.yml
@@ -1,0 +1,59 @@
+name: Create new release draft
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checks-out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Generate core modules with last commit JSON file and patch file
+        run: |
+          python utils/generate_last_commit_file.py .
+          git add core_modules_with_last_commit.json
+          git diff --cached > core_modules_with_last_commit.patch
+
+      - name: Create new release draft
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: GRASS GIS ${{ github.ref }}
+          body: |
+            Overview of changes
+            - First change
+            - Second change
+          draft: true
+          prerelease: false
+
+      - name: Upload core_modules_with_last_commit.json file
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: core_modules_with_last_commit.json
+          asset_name: core_modules_with_last_commit.json
+          asset_content_type: application/json
+
+      - name: Upload core_modules_with_last_commit.patch file
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: core_modules_with_last_commit.patch
+          asset_name: core_modules_with_last_commit.patch
+          asset_content_type: text/plain


### PR DESCRIPTION
In the context of creating and using a core_modules_with_last_commit.json file #2140, after creating and submitting a new release tag to remote repository e.g. `git tag -a 8.2.0 -m "Release 8.2.0"` and `git push origin 8.2.0` a new draft is automatically created with GitHub action workflow "Create new release draft" with attached two files core_modules_with_last_commit.json and core_modules_with_last_commit.patch.