### PR TITLE
r.geomorphon: combine profile parser rules to allow usage as pygrass …

### DIFF
--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -17,7 +17,6 @@ exclude =
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
     python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
     raster/r.contour/testsuite/testrc.py
-    raster/r.geomorphon/testsuite/test_r_geom.py
     raster/r.in.gdal/testsuite/test_r_in_gdal.py
     raster/r.in.lidar/testsuite/test_base_resolution.sh
     raster/r.in.lidar/testsuite/test_base_resolution.sh

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -178,22 +178,22 @@ int main(int argc, char **argv)
 
         par_profiledata = G_define_standard_option(G_OPT_F_OUTPUT);
         par_profiledata->key = "profiledata";
-        par_profiledata->answer = "-";
         par_profiledata->required = NO;
         par_profiledata->description =
             _("Profile output file name (\"-\" for stdout)");
         par_profiledata->guisection = _("Profile");
         G_option_requires(par_profiledata, par_coords, NULL);
+        G_option_requires(par_coords, par_profiledata, NULL);
 
         par_profileformat = G_define_option();
         par_profileformat->key = "profileformat";
         par_profileformat->type = TYPE_STRING;
         par_profileformat->options = "json,yaml,xml";
-        par_profileformat->answer = "json";
         par_profileformat->required = NO;
         par_profileformat->description = _("Profile output format");
         par_profileformat->guisection = _("Profile");
         G_option_requires(par_profileformat, par_coords, NULL);
+        G_option_requires(par_coords, par_profileformat, NULL);
 
         if (G_parser(argc, argv))
             exit(EXIT_FAILURE);

--- a/raster/r.geomorphon/r.geomorphon.html
+++ b/raster/r.geomorphon/r.geomorphon.html
@@ -101,10 +101,9 @@ write to the standard output. The data is in a machine-readable format
 and it includes assorted values describing the computation context and
 parameters, as well as its intermediate and final results.</DD>
 <DT><b>profileformat</b></DT>
-<DD>Format of the profile data: "json" (the default),
-"yaml" or "xml".</DD>
+<DD>Format of the profile data: "json", "yaml" or "xml".</DD>
 </DL>
-<P><em>NOTE: parameters below are very experimental. The usefulness of these parameters are currently under investigation.</em></P>
+<P><em>NOTE: parameters below are experimental. The usefulness of these parameters are currently under investigation.</em></P>
 <DL>
 <DT><b>intensity</b></DT>
 <DD>returns avarage difference between central cell of geomorphon and eight cells in visibility neighbourhood. This parameter shows local (as is visible) exposition/abasement of the form in the terrain.</DD>


### PR DESCRIPTION
Backport of #2154
Fixes #2029

* remove defaults and add back parser rules

* adjust manual

* reactivate r.geomorphon test

Co-authored by: Denis Ovsienko <denis@ovsienko.info>