### PR TITLE
init: fix help string config options

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -390,7 +390,7 @@ def help_message(default_gui):
             gui_detail=_("and set as default"),
             config=_("print GRASS configuration parameters"),
             config_detail=_(
-                "options: arch,build,compiler,date,path,revision,svn_revision,version"
+                "options: arch,build,compiler,date,path,python_path,revision,version"
             ),
             params=_("Parameters"),
             gisdbase=_("initial GRASS database directory"),

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -390,7 +390,7 @@ def help_message(default_gui):
             gui_detail=_("and set as default"),
             config=_("print GRASS configuration parameters"),
             config_detail=_(
-                "options: arch,build,compiler,date,path,python_path,revision,version"
+                "options: arch,build,compiler,date,path,python_path,revision,svn_revision,version"
             ),
             params=_("Parameters"),
             gisdbase=_("initial GRASS database directory"),


### PR DESCRIPTION
Add python_path and remove svn_revision as obsolete.
