### PR TITLE
DB driver PG: convert character varying without length to text

### DIFF
--- a/db/drivers/postgres/create_table.c
+++ b/db/drivers/postgres/create_table.c
@@ -128,7 +128,7 @@ int db__driver_create_table(dbTable * table)
     res = PQexec(pg_conn, db_get_string(&sql));
 
     if (!res || PQresultStatus(res) != PGRES_COMMAND_OK) {
-	db_d_append_error("%s\n%s\%s",
+	db_d_append_error("%s\n%s\n%s",
 			  _("Unable to grant select on table:"),
 			  db_get_string(&sql),
 			  PQerrorMessage(pg_conn));

--- a/db/drivers/postgres/describe.c
+++ b/db/drivers/postgres/describe.c
@@ -203,6 +203,13 @@ int get_column_info(PGresult * res, int col, int *pgtype, int *gpgtype,
     case PG_TYPE_VARCHAR:
 	*sqltype = DB_SQL_TYPE_CHARACTER;
 	*size = PQfmod(res, col) - 4;	/* Looks strange but works, something better? */
+	/* special case for character varying without length modifier:
+	 * treat as text, do not truncate */
+	if (*size < 0) {
+	    *gpgtype = PG_TYPE_TEXT;
+	    *sqltype = DB_SQL_TYPE_TEXT;
+	    *size = 1000;
+	}
 	break;
 
     case PG_TYPE_TEXT:

--- a/db/drivers/postgres/describe.c
+++ b/db/drivers/postgres/describe.c
@@ -131,9 +131,10 @@ int describe_table(PGresult * res, dbTable ** table, cursor * c)
 		       "some data may be damaged"), fname);
 
 	if (gpgtype == PG_TYPE_VARCHAR && fsize < 0) {
-	    G_warning(_("Column '%s' : type character varying is stored as varchar(250) "
-		       "some data may be lost"), fname);
-	    fsize = 250;
+	    /* character varying without length modifier: treat as text */
+	    gpgtype = PG_TYPE_TEXT;
+	    sqltype = DB_SQL_TYPE_TEXT;
+	    fsize = 1000;
 	}
 
 	if (gpgtype == PG_TYPE_BOOL)
@@ -203,13 +204,6 @@ int get_column_info(PGresult * res, int col, int *pgtype, int *gpgtype,
     case PG_TYPE_VARCHAR:
 	*sqltype = DB_SQL_TYPE_CHARACTER;
 	*size = PQfmod(res, col) - 4;	/* Looks strange but works, something better? */
-	/* special case for character varying without length modifier:
-	 * treat as text, do not truncate */
-	if (*size < 0) {
-	    *gpgtype = PG_TYPE_TEXT;
-	    *sqltype = DB_SQL_TYPE_TEXT;
-	    *size = 1000;
-	}
 	break;
 
     case PG_TYPE_TEXT:


### PR DESCRIPTION
* convert `character varying` without length specifier to `text`, do not truncate to 250 characters
* fix escape sequence in error message