### PR TITLE
GridModule: use parallel r.patch when overlap=0 to speed up patching tiles

### DIFF
--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -481,7 +481,6 @@ class GridModule(object):
         self.out_prefix = out_prefix
         self.log = log
         self.move = move
-        self.patch_backend = patch_backend
         # by default RasterRow is used as previously
         # if overlap > 0, r.patch won't work properly
         if not patch_backend:

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -22,7 +22,7 @@ from grass.pygrass.modules import Module
 from grass.pygrass.utils import get_mapset_raster, findmaps
 
 from grass.pygrass.modules.grid.split import split_region_tiles
-from grass.pygrass.modules.grid.patch import rpatch_map
+from grass.pygrass.modules.grid.patch import rpatch_map, rpatch_map_no_overlap
 
 
 def select(parms, ptype):
@@ -665,16 +665,28 @@ class GridModule(object):
         for otmap in self.module.outputs:
             otm = self.module.outputs[otmap]
             if otm.typedesc == "raster" and otm.value:
-                rpatch_map(
-                    otm.value,
-                    self.mset.name,
-                    self.msetstr,
-                    bboxes,
-                    self.module.flags.overwrite,
-                    self.start_row,
-                    self.start_col,
-                    self.out_prefix,
-                )
+                if self.overlap:
+                    rpatch_map(
+                        otm.value,
+                        self.mset.name,
+                        self.msetstr,
+                        bboxes,
+                        self.module.flags.overwrite,
+                        self.start_row,
+                        self.start_col,
+                        self.out_prefix,
+                    )
+                else:
+                    rpatch_map_no_overlap(
+                        otm.value,
+                        self.msetstr,
+                        bboxes,
+                        self.module.flags.overwrite,
+                        self.start_row,
+                        self.start_col,
+                        self.out_prefix,
+                        self.processes,
+                    )
                 noutputs += 1
         if noutputs < 1:
             msg = "No raster output option defined for <{}>".format(self.module.name)

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -424,13 +424,16 @@ class GridModule(object):
     :type split: bool
     :param mapset_prefix: if specified created mapsets start with this prefix
     :type mapset_prefix: str
-    :param patch_backend: if "r.patch" and overlap == 0, use r.patch, otherwise
-                          use original RasterRow method
+    :param patch_backend: "r.patch", "RasterRow", or None for for default
     :type patch_backend: None or str
     :param run_: if False only instantiate the object
     :type run_: bool
     :param args: give all the parameters to the command
     :param kargs: give all the parameters to the command
+
+    When patch_backend is None, the RasterRow method is used for patching the result.
+    When patch_backend is "r.patch", r.patch is used with nprocs=processes.
+    r.patch can only be used when overlap is 0.
 
     >>> grd = GridModule('r.slope.aspect',
     ...                  width=500, height=500, overlap=2,
@@ -686,25 +689,25 @@ class GridModule(object):
             if otm.typedesc == "raster" and otm.value:
                 if self.patch_backend == "RasterRow":
                     rpatch_map(
-                        otm.value,
-                        self.mset.name,
-                        self.msetstr,
-                        bboxes,
-                        self.module.flags.overwrite,
-                        self.start_row,
-                        self.start_col,
-                        self.out_prefix,
+                        raster=otm.value,
+                        mapset=self.mset.name,
+                        mset_str=self.msetstr,
+                        bbox_list=bboxes,
+                        overwrite=self.module.flags.overwrite,
+                        start_row=self.start_row,
+                        start_col=self.start_col,
+                        prefix=self.out_prefix,
                     )
                 else:
                     rpatch_map_r_patch_backend(
-                        otm.value,
-                        self.msetstr,
-                        bboxes,
-                        self.module.flags.overwrite,
-                        self.start_row,
-                        self.start_col,
-                        self.out_prefix,
-                        self.processes,
+                        raster=otm.value,
+                        mset_str=self.msetstr,
+                        bbox_list=bboxes,
+                        overwrite=self.module.flags.overwrite,
+                        start_row=self.start_row,
+                        start_col=self.start_col,
+                        prefix=self.out_prefix,
+                        processes=self.processes,
                     )
                 noutputs += 1
         if noutputs < 1:

--- a/python/grass/pygrass/modules/grid/patch.py
+++ b/python/grass/pygrass/modules/grid/patch.py
@@ -114,7 +114,7 @@ def rpatch_map(
     rast.close()
 
 
-def rpatch_map_no_overlap(
+def rpatch_map_r_patch_backend(
     raster,
     mset_str,
     bbox_list,

--- a/python/grass/pygrass/modules/grid/patch.py
+++ b/python/grass/pygrass/modules/grid/patch.py
@@ -15,6 +15,7 @@ from __future__ import (
 from grass.pygrass.gis.region import Region
 from grass.pygrass.raster import RasterRow
 from grass.pygrass.utils import coor2pixel
+from grass.pygrass.modules import Module
 
 
 def get_start_end_index(bbox_list):
@@ -111,3 +112,47 @@ def rpatch_map(
             del rst
 
     rast.close()
+
+
+def rpatch_map_no_overlap(
+    raster,
+    mset_str,
+    bbox_list,
+    overwrite=False,
+    start_row=0,
+    start_col=0,
+    prefix="",
+    processes=1,
+):
+    """Patch raster using a r.patch. Only use with overlap=0.
+    Will be faster than rpatch_map, since r.patch is parallelized.
+
+    :param raster: the name of output raster
+    :type raster: str
+    :param mset_str:
+    :type mset_str: str
+    :param bbox_list: a list of BBox object to convert
+    :type bbox_list: list of BBox object
+    :param overwrite: overwrite existing raster
+    :type overwrite: bool
+    :param start_row: the starting row of original raster
+    :type start_row: int
+    :param start_col: the starting column of original raster
+    :type start_col: int
+    :param prefix: the prefix of output raster
+    :type prefix: str
+    :param processes: number of parallel process for r.patch
+    :type processes: int
+    """
+    rasts = []
+    for row, rbbox in enumerate(bbox_list):
+        for col in range(len(rbbox)):
+            mapset = mset_str % (start_row + row, start_col + col)
+            rasts.append(f"{raster}@{mapset}")
+    Module(
+        "r.patch",
+        input=rasts,
+        output=prefix + raster,
+        overwrite=overwrite,
+        nprocs=processes,
+    )


### PR DESCRIPTION
When overlap is 0, GridModule will merge computed tiles using r.patch, which is now parallel and therefore it will be faster for large data. If overlap is >= 1, r.patch can't be used, original implementation is used.