### PR TITLE
r.object.geometry test: explicitly specify CELL type in r.in.ascii

### DIFF
--- a/raster/r.object.geometry/testsuite/r_object_geometry_test.py
+++ b/raster/r.object.geometry/testsuite/r_object_geometry_test.py
@@ -84,7 +84,11 @@ class TestObjectGeometryMeter(TestCase):
     def setUpClass(cls):
         """Imports test raster(s), ensures expected computational region and setup"""
         cls.runModule(
-            "r.in.ascii", input="-", stdin_=testraster1, output=cls.test_objects1
+            "r.in.ascii",
+            input="-",
+            type="CELL",
+            stdin_=testraster1,
+            output=cls.test_objects1,
         )
         cls.use_temp_region()
         cls.runModule("g.region", raster=cls.test_objects1)


### PR DESCRIPTION
If type is not specified in r.in.ascii call, it will try to autodetect it from the values. It seems that in some cases this might fail, see #2264.