### PR TITLE
MacOS/BSD Use gnu indent

### DIFF
--- a/utils/grass_indent.sh
+++ b/utils/grass_indent.sh
@@ -16,12 +16,12 @@
 # TODO: replace short flags by long ones to improve readability
 
 case "$(uname)" in 
-  Darwin | *BSD*)
-    INDENT=$(which gindent)
-    ;;
-  *)
-    INDENT=$(which indent)
-    ;;
+ Darwin | *BSD*)
+  INDENT=$(which gindent)
+  ;;
+ *)
+  INDENT=$(which indent)
+  ;;
 esac
 
 if [ -z "$INDENT" ]; then

--- a/utils/grass_indent.sh
+++ b/utils/grass_indent.sh
@@ -15,12 +15,17 @@
 
 # TODO: replace short flags by long ones to improve readability
 
+GP=
+
+if [ `uname` == FreeBSD ] ; then
+ GP=g
+fi
 
 if [ $# -lt 1 ] ; then
  echo "No files specified (give file name(s) as parameter)"
  exit 1
 else
- indent -npro -bad -bap -bbb -br -bli0 -bls -cli0 -ncs -fc1 -hnl -i4 \
+ ${GP}indent -npro -bad -bap -bbb -br -bli0 -bls -cli0 -ncs -fc1 -hnl -i4 \
       -nbbo -nbc -nbfda -nbfde -ncdb -ncdw -nce -nfca -npcs -nprs \
       -npsl -nsc -nsob -saf -sai -saw -sbi0 -ss --no-tabs "$@"
 

--- a/utils/grass_indent.sh
+++ b/utils/grass_indent.sh
@@ -15,17 +15,25 @@
 
 # TODO: replace short flags by long ones to improve readability
 
-GP=
+case "$(uname)" in 
+  Darwin | *BSD*)
+    INDENT=$(which gindent)
+    ;;
+  *)
+    INDENT=$(which indent)
+    ;;
+esac
 
-if [ `uname` == FreeBSD ] ; then
- GP=g
+if [ -z "$INDENT" ]; then
+ echo "Failed to find the 'indent' (or 'gindent' on BSD platforms) command."
+ exit 1
 fi
 
 if [ $# -lt 1 ] ; then
  echo "No files specified (give file name(s) as parameter)"
  exit 1
 else
- ${GP}indent -npro -bad -bap -bbb -br -bli0 -bls -cli0 -ncs -fc1 -hnl -i4 \
+ ${INDENT} -npro -bad -bap -bbb -br -bli0 -bls -cli0 -ncs -fc1 -hnl -i4 \
       -nbbo -nbc -nbfda -nbfde -ncdb -ncdw -nce -nfca -npcs -nprs \
       -npsl -nsc -nsob -saf -sai -saw -sbi0 -ss --no-tabs "$@"
 


### PR DESCRIPTION
The `indent` program used by Grass is not the original BSD one.

On FreeBSD (and other BSD and maybe MacOs) we have to use `gindent` which is the gnu indent.