### PR TITLE
ci/centos:  use C++11 standard compile mode

### DIFF
--- a/.github/workflows/build_centos.sh
+++ b/.github/workflows/build_centos.sh
@@ -24,6 +24,7 @@ export INSTALL_PREFIX=$1
 # Old versions of GCC on CentOS default to C89 although are C11 capable
 # This causes compilation to fail on >C89 code
 export CFLAGS="-O2 -std=gnu11"
+export CXXFLAGS="-std=gnu++11"
 
 ./configure \
     --prefix="$INSTALL_PREFIX/" \


### PR DESCRIPTION
Older versions of gcc support, but does not default to C++11.
Presently the gcc version in the ci centos build is [4.8.5](https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Standards.html#Standards), which causes build failure with C++11 standard code.

Extract of build log for #2272 formatting with ClangFormat:
```
/__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/empq_impl.h: In member function 'AMI_err em_pqueue<T, Key>::merge_streams(AMI_STREAM<ExtendedEltMergeType<T, Key> >**, short unsigned int, AMI_STREAM<ExtendedEltMergeType<T, Key> >*, long int)':
/__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/empq_impl.h:1385:44: error: '>>' should be '> >' within a nested template argument list
     std::vector<ExtendedEltMergeType<T, Key>> in_objects(arity);
                                            ^
/__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/empq_impl.h:1422:28: error: '>>' should be '> >' within a nested template argument list
     pqheap_t1<merge_key<Key>> mergeheap(
                            ^
In file included from /__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/empq_adaptive_impl.h:46:0,
                 from /__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/ami.h:57,
                 from common.h:26,
                 from common.cpp:34:
/__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/empq_adaptive.h: In constructor 'EMPQueueAdaptive<T, Key>::EMPQueueAdaptive(long int)':
/__w/grass/grass/dist.x86_64-pc-linux-gnu/include/grass/iostream/empq_adaptive.h:65:49: warning: delegating constructors only available with -std=c++11 or -std=gnu++11 [enabled by default]
     EMPQueueAdaptive(long N) : EMPQueueAdaptive(){};
```