### PR TITLE
CI: Update to Black 22.3 with fixed Click

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: "3.10"
-            black-version: "22.1.0"
+            black-version: "22.3.0"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
A new version of Click broke Black. The new version of Black fixes the issue.

See also https://github.com/psf/black/issues/2964
