### PR TITLE
alpine/Dockerfile: openMP enabled, PDAL support fixed

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.15 as common
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile
-LABEL authors="Pietro Zambelli,Markus Neteler"
-LABEL maintainer="peter.zamb@gmail.com,neteler@osgeo.org"
+LABEL authors="Carmen Tawalika,Pietro Zambelli,Markus Neteler"
+LABEL maintainer="neteler@osgeo.org"
 
 # PACKAGES VERSIONS
 ARG PYTHON_VERSION=3
@@ -94,13 +94,12 @@ ENV GRASS_CONFIG="\
       --with-cairo --with-cairo-ldflags=-lfontconfig \
       --with-fftw \
       --with-postgres --with-postgres-includes=/usr/include/postgresql \
+      --with-openmp \
       --without-freetype \
-      --without-openmp \
       --without-opengl \
       --without-nls \
       --without-mysql \
       --without-odbc \
-      --without-openmp \
       "
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols
@@ -132,6 +131,8 @@ ENV GRASS_BUILD_PACKAGES="\
       make \
       openjpeg-dev \
       openblas-dev \
+      pdal \
+      pdal-dev \
       postgresql-dev \
       proj-dev \
       python3-dev \
@@ -185,7 +186,7 @@ COPY --from=build /usr/local/grass* /usr/local/grass/
 RUN pip3 install --upgrade pip six grass-session --ignore-installed six
 
 RUN ln -sf /usr/local/grass `grass --config path`
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-location XY --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
@@ -198,14 +199,16 @@ RUN apk add make gcc
 COPY docker/testdata/simple.laz /tmp/simple.laz
 COPY docker/testdata/test_grass_session.py /scripts/test_grass_session.py
 ENV GRASSBIN=grass
-RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal
 
+# Test grass-session
 # Not yet ready for GRASS GIS 8:
-#RUN /usr/bin/python3 /scripts/test_grass_session.py
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -s
+RUN /usr/bin/python3 /scripts/test_grass_session.py
+# Test PDAL
+RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 # Test addon installation
-RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.learn.ml2
+RUN apk add py3-scikit-learn
+RUN grass --tmp-location XY --exec g.extension extension=r.learn.ml2
 
 
 FROM grass as final
@@ -219,7 +222,7 @@ ENV PROJ_NETWORK="ON"
 
 
 # show installed version
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-location XY --exec g.version -rge && \
     pdal --version && \
     python3 --version
 

--- a/docker/testdata/test_grass_session.py
+++ b/docker/testdata/test_grass_session.py
@@ -15,7 +15,7 @@ with Session(
         input="/tmp/simple.laz",
         output="count_1",
         method="n",
-        flags="s",
+        flags="g",
         resolution=1,
         overwrite=True,
     )


### PR DESCRIPTION
This PR updates the following items

- use `r.in.pdal` from core (drop outdated addon)
    - update `-s` flag to `-g` in Dockerfile and test
- OpenMP support: yes
- grass-session test enabled
- use `grass --tmp-location XY` for `--exec` calls (suggested by @wenzeslaus in https://github.com/OSGeo/grass/pull/2073#pullrequestreview-924640702)
- install `py3-scikit-learn` for `r.learn.ml2` addon
- add @mmacata to list of authors