### PR TITLE
raster3d/r3.showdspf: fix resource leak

### DIFF
--- a/raster3d/r3.showdspf/new_init_graphics.c
+++ b/raster3d/r3.showdspf/new_init_graphics.c
@@ -231,6 +231,7 @@ int loadrect(char *name)
     if (NULL ==
 	(buffer = (unsigned long *)G_malloc(xsiz * ysiz * sizeof(long)))) {
 	fprintf(stderr, "Out of memory\n");
+	fclose(fp);
 	return -1;
     }
 


### PR DESCRIPTION
Here, `fp` must be closed.