### PR TITLE
display/d.graph: remove useless condition

### DIFF
--- a/display/d.graph/do_graph.c
+++ b/display/d.graph/do_graph.c
@@ -244,9 +244,7 @@ int check_alloc(int num)
     if (num < coors_allocated)
 	return 0;
 
-    to_alloc = coors_allocated;
-    if (num >= to_alloc)
-	to_alloc = num + CHUNK;
+    to_alloc = num + CHUNK;
 
     xarray = G_realloc(xarray, to_alloc * sizeof(double));
     yarray = G_realloc(yarray, to_alloc * sizeof(double));


### PR DESCRIPTION
`alloc` returns 0 if `num < coors_allocated` since to_alloc is assigned with `coors_allocated`, the condition is always true. So, we can directly assign `to_alloc` with `num + CHUNK`