### PR TITLE
Replace hardcoded POSIX path dir separator "/" with cross platform HOST_DIRSEP macro

### DIFF
--- a/display/d.mon/list.c
+++ b/display/d.mon/list.c
@@ -12,14 +12,16 @@
 char *get_path(const char *name, int fpath)
 {
     char tmpdir[GPATH_MAX];
+    char *buff = NULL;
     
     G_temp_element(tmpdir);
-    strcat(tmpdir, "/");
-    strcat(tmpdir, "MONITORS");
     if (name) {
-        strcat(tmpdir, "/");
-        strcat(tmpdir, name);
+        G_asprintf(&buff, "%cMONITORS%c%s", HOST_DIRSEP, HOST_DIRSEP, name);
+    } else {
+        G_asprintf(&buff, "%cMONITORS", HOST_DIRSEP);
     }
+    strcat(tmpdir, buff);
+    G_free(buff);
 
     if (fpath) {
         char ret[GPATH_MAX];
@@ -130,13 +132,13 @@ void list_files(const char *name, FILE *fd_out)
     char tmpdir[GPATH_MAX], mon_path[GPATH_MAX];
     struct dirent *dp;
     DIR *dirp;
-    
+    char *buff = NULL;
+
     G_temp_element(tmpdir);
-    strcat(tmpdir, "/");
-    strcat(tmpdir, "MONITORS");
-    strcat(tmpdir, "/");
-    strcat(tmpdir, name);
-    
+    G_asprintf(&buff, "%cMONITORS%c%s", HOST_DIRSEP, HOST_DIRSEP, name);
+    strcat(tmpdir, buff);
+    G_free(buff);
+
     G_file_name(mon_path, tmpdir, NULL, G_mapset());
     fprintf(fd_out, "path=%s\n", mon_path);
     

--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -106,12 +106,12 @@ int D_open_driver(void)
             sprintf(progname, "%s", c);
         else { /* monitors managed by d.mon -> call default renderer */
             char element[GPATH_MAX];
-            
+            char *buff = NULL;
+
             G_temp_element(element);
-            strcat(element, "/");
-            strcat(element, "MONITORS");
-            strcat(element, "/");
-            strcat(element, m);
+            G_asprintf(&buff, "%cMONITORS%c%s", HOST_DIRSEP, HOST_DIRSEP, m);
+            strcat(element, buff);
+            G_free(buff);
             G_file_name(progname, element, "render.py", G_mapset());
         }
 

--- a/lib/gis/tempfile.c
+++ b/lib/gis/tempfile.c
@@ -113,14 +113,17 @@ void G_temp_element(char *element)
 void G__temp_element(char *element, int tmp)
 {
     const char *machine;
+    char *buff = NULL;
 
-    strcpy(element, ".tmp");
     machine = G__machine_name();
     if (machine != NULL && *machine != 0) {
-	strcat(element, "/");
-	strcat(element, machine);
+        G_asprintf(&buff, ".tmp%c%s", HOST_DIRSEP, machine);
+        strcpy(element, buff);
+        G_free(buff);
+    } else {
+        strcpy(element, ".tmp");
     }
-    
+
     if (!tmp)
         G_make_mapset_object_group(element);
     else


### PR DESCRIPTION
Replace hardcoded POSIX path dir separator "/" with cross platform HOST_DIRSEP macro.

Fixes https://github.com/OSGeo/grass-addons/issues/289.