### PR TITLE
jupyter: Rename grass.jupyter classes

### DIFF
--- a/doc/notebooks/basic_example_grass_jupyter.ipynb
+++ b/doc/notebooks/basic_example_grass_jupyter.ipynb
@@ -68,15 +68,15 @@
     "gs.parse_command(\"g.region\", raster=\"lakes\", flags=\"pg\")\n",
     "gs.run_command(\"r.buffer\", input=\"lakes\", output=\"lakes_buff\", distances=[60, 120, 240, 500])\n",
     "\n",
-    "# Start a GrassRenderer\n",
-    "img = gj.GrassRenderer()\n",
+    "# Start a Map\n",
+    "r_buffer_map = gj.Map()\n",
     "\n",
     "# Add a raster and vector to the map\n",
-    "img.d_rast(map=\"lakes_buff\")\n",
-    "img.d_legend(raster=\"lakes_buff\", range=(2, 5), at=(80, 100, 2, 10))\n",
+    "r_buffer_map.d_rast(map=\"lakes_buff\")\n",
+    "r_buffer_map.d_legend(raster=\"lakes_buff\", range=(2, 5), at=(80, 100, 2, 10))\n",
     "\n",
     "# Display map\n",
-    "img.show()"
+    "r_buffer_map.show()"
    ]
   },
   {
@@ -99,16 +99,16 @@
     "gs.run_command(\"v.buffer\", input=\"boundary_state\", output=\"buffer\", distance=-10000)\n",
     "gs.parse_command(\"g.region\", vector=\"boundary_state\", flags=\"pg\")\n",
     "\n",
-    "# Start another GrassRenderer\n",
-    "img2 = gj.GrassRenderer()\n",
+    "# Start another Map\n",
+    "v_buffer_map = gj.Map()\n",
     "\n",
     "# Add vector layers and legend\n",
-    "img2.d_vect(map=\"boundary_state\", fill_color=\"#5A91ED\", legend_label=\"State boundary\")\n",
-    "img2.d_vect(map=\"buffer\", fill_color=\"#F8766D\", legend_label=\"Inner portion\")\n",
-    "img2.d_legend_vect(at=(10, 35))\n",
+    "v_buffer_map.d_vect(map=\"boundary_state\", fill_color=\"#5A91ED\", legend_label=\"State boundary\")\n",
+    "v_buffer_map.d_vect(map=\"buffer\", fill_color=\"#F8766D\", legend_label=\"Inner portion\")\n",
+    "v_buffer_map.d_legend_vect(at=(10, 35))\n",
     "\n",
     "# Display map\n",
-    "img2.show()"
+    "v_buffer_map.show()"
    ]
   },
   {

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "# Display map\n",
-    "example.show()"
+    "example_map.show()"
    ]
   },
   {

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "As part of Google Summer of Code 2021, we've been working to shorten and simplify the launch of GRASS in Jupyter and imporve the map displays. It is experimentally included in version 8.0 as a preview and will be officially available in version 8.2. You can find out more about the project and follow the progress on the [GRASS wiki page](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS).\n",
     "\n",
-    "In addition to simplifying the launch of *GRASS GIS* with `init()`, `grass.jupyter` has two main dislay classes, `GrassRenderer` and `InteractiveMap`. Using the *GRASS* rendering engine in the background, `GrassRenderer` creates maps as PNG images. `InteractiveMap` displays *GRASS GIS* rasters and vectors with [*folium*](http://python-visualization.github.io/folium/), a [*leaflet*](https://leafletjs.com/) library for *Python*.\n",
+    "In addition to simplifying the launch of *GRASS GIS* with `init()`, `grass.jupyter` has two main dislay classes, `Map` and `InteractiveMap`. Using the *GRASS* rendering engine in the background, `Map` creates maps as PNG images. `InteractiveMap` displays *GRASS GIS* rasters and vectors with [*folium*](http://python-visualization.github.io/folium/), a [*leaflet*](https://leafletjs.com/) library for *Python*.\n",
     "\n",
     "This interactive notebook is available online thanks to the [https://mybinder.org](Binder) service. To run the select part (called a *cell*), hit `Shift + Enter`."
    ]
@@ -52,15 +52,15 @@
    "source": [
     "## GRASS Renderer\n",
     "\n",
-    "The `GrassRenderer` class creates and displays GRASS maps as PNG images. There are two ways to add elements to the display. First, the name of the *GRASS* display module can be called as an attribute by replacing the \".\" with \"\\_\" in the module name. For example:\n",
+    "The `Map` class creates and displays GRASS maps as PNG images. There are two ways to add elements to the display. First, the name of the *GRASS* display module can be called as an attribute by replacing the \".\" with \"\\_\" in the module name. For example:\n",
     "````\n",
-    "m = GrassRenderer()\n",
+    "m = Map()\n",
     "m.d_rast(map=\"elevation\")\n",
     "````\n",
     "\n",
     "Alternatively, *GRASS* display modules can be called with the `run()` method:\n",
     "````\n",
-    "m = GrassRenderer()\n",
+    "m = Map()\n",
     "m.run(\"d.rast\", map=\"elevation\")\n",
     "````\n",
     "\n",
@@ -73,8 +73,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create GrassRenderer instance\n",
-    "img = gj.GrassRenderer()"
+    "# Create Map instance\n",
+    "example_map = gj.Map()"
    ]
   },
   {
@@ -84,9 +84,9 @@
    "outputs": [],
    "source": [
     "# Add a raster, vector and legend to the map\n",
-    "img.d_rast(map=\"elevation\")\n",
-    "img.d_vect(map=\"streams\")\n",
-    "img.d_legend(raster=\"elevation\", at=(55, 95, 80, 84), flags=\"b\")"
+    "example_map.d_rast(map=\"elevation\")\n",
+    "example_map.d_vect(map=\"streams\")\n",
+    "example_map.d_legend(raster=\"elevation\", at=(55, 95, 80, 84), flags=\"b\")"
    ]
   },
   {
@@ -96,14 +96,14 @@
    "outputs": [],
    "source": [
     "# Display map\n",
-    "img.show()"
+    "example.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also have multiple instances of `GrassRenderer`. Here, we create another map then go back and modify the first map."
+    "We can also have multiple instances of `Map`. Here, we create another map then go back and modify the first map."
    ]
   },
   {
@@ -114,7 +114,7 @@
    "source": [
     "# Make a second instance.\n",
     "# Just for variety, we'll make this one a different size\n",
-    "img2 = gj.GrassRenderer(height=200, width=220)"
+    "small_map = gj.Map(height=200, width=220)"
    ]
   },
   {
@@ -125,11 +125,11 @@
    "source": [
     "# Add a some layers\n",
     "# We can also add layers with the run() methods\n",
-    "img2.run(\"d.rast\", map=\"elevation_shade\")\n",
-    "img2.run(\"d.vect\", map=\"roadsmajor\")\n",
+    "small_map.run(\"d.rast\", map=\"elevation_shade\")\n",
+    "small_map.run(\"d.vect\", map=\"roadsmajor\")\n",
     "\n",
     "# Display second map\n",
-    "img2.show()"
+    "small_map.show()"
    ]
   },
   {
@@ -140,8 +140,8 @@
    "source": [
     "# Then, we return to the first instance and continue to modify and display it\n",
     "# Notice that layers a drawn in the order they are added\n",
-    "img.run(\"d.vect\", map = \"zipcodes\", color=\"red\", fill_color=\"none\")\n",
-    "img.show()"
+    "example_map.run(\"d.vect\", map = \"zipcodes\", color=\"red\", fill_color=\"none\")\n",
+    "example_map.show()"
    ]
   },
   {
@@ -157,10 +157,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img3 = gj.GrassRenderer()\n",
-    "img3.d_vect(map=\"boundary_state\")\n",
-    "img3.d_rast(map=\"geology\")\n",
-    "img3.show()"
+    "nc_map = gj.Map()\n",
+    "nc_map.d_vect(map=\"boundary_state\")\n",
+    "nc_map.d_rast(map=\"geology\")\n",
+    "nc_map.show()"
    ]
   },
   {
@@ -176,10 +176,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img4 = gj.GrassRenderer(use_region=True)\n",
-    "img4.d_vect(map=\"boundary_state\")\n",
-    "img4.d_rast(map=\"geology\")\n",
-    "img4.show()"
+    "geol_map = gj.Map(use_region=True)\n",
+    "geol_map.d_vect(map=\"boundary_state\")\n",
+    "geol_map.d_rast(map=\"geology\")\n",
+    "geol_map.show()"
    ]
   },
   {
@@ -196,10 +196,10 @@
    "outputs": [],
    "source": [
     "gs.run_command(\"g.region\", save=\"myregion\", n=224000, s=222000, w=633500, e=637300)\n",
-    "img5 = gj.GrassRenderer(saved_region=\"myregion\")\n",
-    "img5.d_rast(map=\"elevation\")\n",
-    "img5.d_rast(map=\"lakes\")\n",
-    "img5.show()"
+    "myregion_map = gj.Map(saved_region=\"myregion\")\n",
+    "myregion_map.d_rast(map=\"elevation\")\n",
+    "myregion_map.d_rast(map=\"lakes\")\n",
+    "myregion_map.show()"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "outputs": [],
    "source": [
     "# Create Interactive Map\n",
-    "fig = gj.InteractiveMap(width = 600)"
+    "raleigh_map = gj.InteractiveMap(width = 600)"
    ]
   },
   {
@@ -228,9 +228,9 @@
    "outputs": [],
    "source": [
     "# Add raster, vector and layer control to map\n",
-    "fig.add_raster(\"elevation\")\n",
-    "fig.add_vector(\"roadsmajor\")\n",
-    "fig.add_layer_control(position = \"bottomright\")"
+    "raleigh_map.add_raster(\"elevation\")\n",
+    "raleigh_map.add_vector(\"roadsmajor\")\n",
+    "raleigh_map.add_layer_control(position = \"bottomright\")"
    ]
   },
   {
@@ -239,8 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Display map\n",
-    "fig.show()"
+    "raleigh_map.show()"
    ]
   },
   {
@@ -258,7 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig.save(filename=\"test_map.html\")"
+    "raleigh_map.save(filename=\"raleigh_map.html\")"
    ]
   },
   {
@@ -308,8 +307,8 @@
    "source": [
     "## GRASS 3D Renderer\n",
     "\n",
-    "The `Grass3dRenderer` class creates 3D visualizations as PNG images. The *m.nviz.image* module is used in the background and the function `render()` accepts parameters of this module.\n",
-    "The `Grass3dRenderer` objects have `overlay` attribute which can be used in the same way as `GrassRenderer` and 2D images on top of the 3D visualization.\n",
+    "The `Map3D` class creates 3D visualizations as PNG images. The *m.nviz.image* module is used in the background and the function `render()` accepts parameters of this module.\n",
+    "The `Map3D` objects have `overlay` attribute which can be used in the same way as `Map` and 2D images on top of the 3D visualization.\n",
     "To display the image, call `show()`."
    ]
   },
@@ -326,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img = gj.Grass3dRenderer()"
+    "elev_map = gj.Map3D()"
    ]
   },
   {
@@ -342,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.render(elevation_map=\"elevation\", color_map=\"elevation\", perspective=20)"
+    "elev_map.render(elevation_map=\"elevation\", color_map=\"elevation\", perspective=20)"
    ]
   },
   {
@@ -358,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.overlay.d_legend(raster=\"elevation\", at=(60, 97, 87, 92))"
+    "elev_map.overlay.d_legend(raster=\"elevation\", at=(60, 97, 87, 92))"
    ]
   },
   {
@@ -374,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.show()"
+    "elev_map.show()"
    ]
   },
   {
@@ -390,8 +389,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.render(elevation_map=\"elevation\", color_map=\"landuse\", perspective=20)\n",
-    "img.show()"
+    "elev_map.render(elevation_map=\"elevation\", color_map=\"landuse\", perspective=20)\n",
+    "elev_map.show()"
    ]
   },
   {

--- a/doc/notebooks/hydrology.ipynb
+++ b/doc/notebooks/hydrology.ipynb
@@ -64,16 +64,15 @@
    },
    "outputs": [],
    "source": [
-    "# Start a GrassRenderer map\n",
-    "# GrassRenderer makes non-interactive maps using a PNG image\n",
-    "img = gj.GrassRenderer()\n",
+    "# Start a Map\n",
+    "elev_map = gj.Map()\n",
     "\n",
     "# Add a raster, vector and legend to the map\n",
-    "img.d_rast(map=\"elevation\")\n",
-    "img.d_legend(raster=\"elevation\", at=(65, 90, 85, 88), fontsize=12, flags=\"b\", title=\"DTM\")\n",
+    "elev_map.d_rast(map=\"elevation\")\n",
+    "elev_map.d_legend(raster=\"elevation\", at=(65, 90, 85, 88), fontsize=12, flags=\"b\", title=\"DTM\")\n",
     "\n",
     "# Display map\n",
-    "img.show()"
+    "elev_map.show()"
    ]
   },
   {
@@ -157,7 +156,7 @@
    },
    "outputs": [],
    "source": [
-    "fig = gj.InteractiveMap(height=400, width=600)\n",
+    "hydro_map = gj.InteractiveMap(height=400, width=600)\n",
     "\n",
     "# We can modify with color table for rasters with `r.colors`.\n",
     "# Note that if the raster is located in a different mapset (for example,\n",
@@ -167,15 +166,15 @@
     "\n",
     "# Add elements to map\n",
     "# We set opacity to 1.0 (default is 0.8) so layers won't interfere with eachother.\n",
-    "fig.add_raster(\"elevation\")\n",
-    "fig.add_raster(\"drainage\", opacity=1.0)\n",
-    "fig.add_raster(\"flowacc\", opacity=1.0)\n",
-    "fig.add_raster(\"watersheds\", opacity=1.0)\n",
-    "fig.add_vector(\"streams\")\n",
+    "hydro_map.add_raster(\"elevation\")\n",
+    "hydro_map.add_raster(\"drainage\", opacity=1.0)\n",
+    "hydro_map.add_raster(\"flowacc\", opacity=1.0)\n",
+    "hydro_map.add_raster(\"watersheds\", opacity=1.0)\n",
+    "hydro_map.add_vector(\"streams\")\n",
     "\n",
-    "fig.add_layer_control()\n",
+    "hydro_map.add_layer_control()\n",
     "\n",
-    "fig.show()"
+    "hydro_map.show()"
    ]
   },
   {
@@ -219,10 +218,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Display a map of watershed areas. We'll use GrassRenderer here\n",
+    "# Display a map of watershed areas.\n",
     "gs.run_command(\"r.colors\", map=\"watershed_area\", color=\"plasma\")\n",
     "               \n",
-    "watershed_map = gj.GrassRenderer()\n",
+    "watershed_map = gj.Map()\n",
     "watershed_map.d_rast(map=\"watershed_area\")\n",
     "watershed_map.d_legend(raster=\"watershed_area\",\n",
     "                       bgcolor=\"none\",\n",
@@ -264,7 +263,7 @@
    "outputs": [],
    "source": [
     "# Display slope map\n",
-    "slope_map = gj.GrassRenderer()\n",
+    "slope_map = gj.Map()\n",
     "slope_map.d_rast(map=\"slope\")\n",
     "slope_map.d_legend(raster=\"slope\", at=(65, 90, 85, 90), fontsize=15, flags=\"b\", title=\"Slope\", units=\"°\")\n",
     "slope_map.show()"
@@ -344,9 +343,9 @@
    "outputs": [],
    "source": [
     "# Display\n",
-    "watershed_map2 = gj.GrassRenderer()\n",
-    "watershed_map2.d_rast(map=\"elevation\")\n",
-    "watershed_map2.d_vect(map=\"watersheds_vector\",\n",
+    "watershed_vect_map = gj.Map()\n",
+    "watershed_vect_map.d_rast(map=\"elevation\")\n",
+    "watershed_vect_map.d_vect(map=\"watersheds_vector\",\n",
     "                      fill_color=\"none\",\n",
     "                      width=1.5,\n",
     "                      color=\"black\",\n",
@@ -354,7 +353,7 @@
     "                      label_bgcolor=\"black\",\n",
     "                      label_color=\"white\",\n",
     "                      label_size=10)\n",
-    "watershed_map2.show()"
+    "watershed_vect_map.show()"
    ]
   }
  ],

--- a/doc/notebooks/solar_potential.ipynb
+++ b/doc/notebooks/solar_potential.ipynb
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "# Display incident angles\n",
-    "solar_map = gj.GrassRenderer()\n",
+    "solar_map = gj.Map()\n",
     "solar_map.d_rast(map=\"incident\")\n",
     "solar_map.d_legend(raster=\"incident\", fontsize=12, at=\"25,75,1,5\")\n",
     "solar_map.show()"
@@ -158,7 +158,7 @@
    "outputs": [],
    "source": [
     "# Display 4:15pm Shadows\n",
-    "shadow_map = gj.GrassRenderer()\n",
+    "shadow_map = gj.Map()\n",
     "shadow_map.d_shade(shade=\"shadow\", color=\"elevation\")\n",
     "shadow_map.show()"
    ]

--- a/doc/notebooks/temporal.ipynb
+++ b/doc/notebooks/temporal.ipynb
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set the color table for all rasters in timeseries"
+    "Set the color table for all rasters in the space time raster dataset"
    ]
   },
   {
@@ -208,7 +208,7 @@
    "source": [
     "## Temporal Visualizations\n",
     "\n",
-    "The `TimeSeries` class contains visualization functions for GRASS space time dataset (strds or stvds). The `time_slider` function allows users to interactively view the evolution of the dataset through time using IPython and Jupyter Widgets."
+    "The `TimeSeriesMap` class contains visualization functions for GRASS space time dataset (strds or stvds). The `time_slider` function allows users to interactively view the evolution of the dataset through time using IPython and Jupyter Widgets."
    ]
   },
   {
@@ -217,18 +217,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img = gj.TimeSeries(\"precip_sum_2010\", fill_gaps=False, use_region=True)\n",
-    "img.d_legend(color=\"black\", at=(10,40,2,6)) #Add legend\n",
-    "img.overlay.d_vect(map=\"boundary_county\", fill_color=\"none\")\n",
-    "img.overlay.d_barscale()\n",
-    "img.time_slider()"
+    "precip_map = gj.TimeSeriesMap(\"precip_sum_2010\", fill_gaps=False, use_region=True)\n",
+    "precip_map.d_legend(color=\"black\", at=(10,40,2,6)) #Add legend\n",
+    "precip_map.overlay.d_vect(map=\"boundary_county\", fill_color=\"none\")\n",
+    "precip_map.overlay.d_barscale()\n",
+    "precip_map.time_slider()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also display the TimeSeries as an animation with `animate`."
+    "We can also display the space time dataset as an animation with `animate`."
    ]
   },
   {
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.animate(duration=500, label=True, text_size=16, text_color=\"gray\")"
+    "precip_map.animate(duration=500, label=True, text_size=16, text_color=\"gray\")"
    ]
   },
   {
@@ -270,9 +270,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img2 = gj.TimeSeries(\"precip_sum_2010\")\n",
-    "img2.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
-    "img2.time_slider()  # Create TimeSlider"
+    "gaps_map = gj.TimeSeriesMap(\"precip_sum_2010\")\n",
+    "gaps_map.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
+    "gaps_map.time_slider()  # Create TimeSlider"
    ]
   },
   {
@@ -288,9 +288,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img3 = gj.TimeSeries(\"precip_sum_2010\", fill_gaps=True)\n",
-    "img3.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
-    "img3.time_slider()  # Create TimeSlider"
+    "filled_map = gj.TimeSeriesMap(\"precip_sum_2010\", fill_gaps=True)\n",
+    "filled_map.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
+    "filled_map.time_slider()  # Create TimeSlider"
    ]
   }
  ],

--- a/python/grass/jupyter/Makefile
+++ b/python/grass/jupyter/Makefile
@@ -7,14 +7,13 @@ DSTDIR = $(ETC)/python/grass/jupyter
 
 MODULES = \
 	setup \
-	display \
-	interact_display \
+	map \
+	interactivemap \
 	region \
-	render3d \
+	map3d \
 	reprojection_renderer \
 	utils \
-	timeseries \
-	utils
+	timeseriesmap
 
 PYFILES := $(patsubst %,$(DSTDIR)/%.py,$(MODULES) __init__)
 PYCFILES := $(patsubst %,$(DSTDIR)/%.pyc,$(MODULES) __init__)

--- a/python/grass/jupyter/__init__.py
+++ b/python/grass/jupyter/__init__.py
@@ -41,10 +41,10 @@ The objects in submodules and names of submodules may change in the future.
 .. versionadded:: 8.2
 """
 
-from .display import *
-from .interact_display import *
-from .render3d import *
-from .setup import *
-from .utils import *
-from .timeseries import *
+from .interactivemap import *
+from .map import *
+from .map3d import *
 from .reprojection_renderer import *
+from .setup import *
+from .timeseriesmap import *
+from .utils import *

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -1,7 +1,7 @@
 #
 # AUTHOR(S): Caitlin Haedrich <caitlin DOT haedrich AT gmail>
 #
-# PURPOSE:   This module contains functions for interactive display
+# PURPOSE:   This module contains functions for interactive visualizations
 #            in Jupyter Notebooks.
 #
 # COPYRIGHT: (C) 2021 Caitlin Haedrich, and by the GRASS Development Team

--- a/python/grass/jupyter/map.py
+++ b/python/grass/jupyter/map.py
@@ -1,4 +1,4 @@
-# MODULE:    grass.jupyter.display
+# MODULE:    grass.jupyter.map
 #
 # AUTHOR(S): Caitlin Haedrich <caitlin DOT haedrich AT gmail>
 #
@@ -23,15 +23,15 @@ import grass.script as gs
 from .region import RegionManagerFor2D
 
 
-class GrassRenderer:
-    """GrassRenderer creates and displays GRASS maps in
+class Map:
+    """Map creates and displays GRASS maps in
     Jupyter Notebooks.
 
     Elements are added to the display by calling GRASS display modules.
 
     Basic usage::
 
-    >>> m = GrassRenderer()
+    >>> m = Map()
     >>> m.run("d.rast", map="elevation")
     >>> m.run("d.legend", raster="elevation")
     >>> m.show()
@@ -41,7 +41,7 @@ class GrassRenderer:
 
     Shortcut usage::
 
-    >>> m = GrassRenderer()
+    >>> m = Map()
     >>> m.d_rast(map="elevation")
     >>> m.d_legend(raster="elevation")
     >>> m.show()
@@ -62,7 +62,7 @@ class GrassRenderer:
         read_file=False,
     ):
 
-        """Creates an instance of the GrassRenderer class.
+        """Creates an instance of the Map class.
 
         :param int height: height of map in pixels
         :param int width: width of map in pixels

--- a/python/grass/jupyter/map3d.py
+++ b/python/grass/jupyter/map3d.py
@@ -19,21 +19,21 @@ import weakref
 
 import grass.script as gs
 
-from .display import GrassRenderer
+from .map import Map
 from .region import RegionManagerFor3D
 
 
-class Grass3dRenderer:
+class Map3D:
     """Creates and displays 3D visualization using GRASS GIS 3D rendering engine NVIZ.
 
     The 3D image is created using the *render* function which uses the *m.nviz.image*
     module in the background. Additional images can be
     placed on the image using the *overlay* attribute which is the 2D renderer, i.e.,
-    has interface of the *GrassRenderer* class.
+    has interface of the *Map* class.
 
     Basic usage::
 
-    >>> img = Grass3dRenderer()
+    >>> img = Map()
     >>> img.render(elevation_map="elevation", color_map="elevation", perspective=20)
     >>> img.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
     >>> img.show()
@@ -142,7 +142,7 @@ class Grass3dRenderer:
                 ).format(screen_backend)
             )
 
-        self.overlay = GrassRenderer(
+        self.overlay = Map(
             height=height,
             width=width,
             filename=self._filename,

--- a/python/grass/jupyter/reprojection_renderer.py
+++ b/python/grass/jupyter/reprojection_renderer.py
@@ -19,7 +19,7 @@ import tempfile
 import weakref
 from pathlib import Path
 import grass.script as gs
-from .display import GrassRenderer
+from .map import Map
 from .utils import (
     estimate_resolution,
     get_location_proj_string,
@@ -117,10 +117,10 @@ class ReprojectionRenderer:
             resolution=resolution,
             env=self._psmerc_env,
         )
-        # Write raster to png file with GrassRenderer
+        # Write raster to png file with Map
         region_info = gs.region(env=self._src_env)
         filename = os.path.join(self._tmp_dir.name, f"{tgt_name}.png")
-        img = GrassRenderer(
+        img = Map(
             width=region_info["cols"],
             height=region_info["rows"],
             env=self._psmerc_env,

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -1,4 +1,4 @@
-"""Test TimeSeries functions"""
+"""Test TimeSeriesMap functions"""
 
 
 from pathlib import Path
@@ -50,16 +50,16 @@ def test_method_call_collector():
 
 
 def test_default_init(space_time_raster_dataset):
-    """Check that TimeSeries init runs with default parameters"""
-    img = gj.TimeSeries(space_time_raster_dataset.name)
+    """Check that TimeSeriesMap init runs with default parameters"""
+    img = gj.TimeSeriesMap(space_time_raster_dataset.name)
     assert img.timeseries == space_time_raster_dataset.name
 
 
 @pytest.mark.parametrize("fill_gaps", [False, True])
 def test_render_layers(space_time_raster_dataset, fill_gaps):
     """Check that layers are rendered"""
-    # create instance of TimeSeries
-    img = gj.TimeSeries(space_time_raster_dataset.name, fill_gaps=fill_gaps)
+    # create instance of TimeSeriesMap
+    img = gj.TimeSeriesMap(space_time_raster_dataset.name, fill_gaps=fill_gaps)
     # test baselayer, overlay and d_legend here too for efficiency (rendering is
     # time-intensive)
     img.baselayer.d_rast(map=space_time_raster_dataset.raster_names[0])
@@ -78,5 +78,5 @@ def test_render_layers(space_time_raster_dataset, fill_gaps):
 @pytest.mark.skipif(ipywidgets is None, reason="ipywidgets package not available")
 def test_animate_time_slider(space_time_raster_dataset):
     """Test returns from animate and time_slider are correct object types"""
-    img = gj.TimeSeries(space_time_raster_dataset.name)
+    img = gj.TimeSeriesMap(space_time_raster_dataset.name)
     assert isinstance(img.animate(), IPython.display.Image)

--- a/python/grass/jupyter/testsuite/map3d_test.py
+++ b/python/grass/jupyter/testsuite/map3d_test.py
@@ -6,7 +6,7 @@
 #
 # AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
 #
-# PURPOSE:   Test script for grass.jupyter's Grass3dRenderer
+# PURPOSE:   Test script for grass.jupyter's Map3D
 #
 # COPYRIGHT: (C) 2021 by Vaclav Petras and the GRASS Development Team
 #
@@ -50,8 +50,8 @@ def can_import_pyvirtualdisplay():
         return False
 
 
-class TestDisplay(TestCase):
-    """Test Grass3dRenderer"""
+class TestMap3D(TestCase):
+    """Test Map3D"""
 
     files = []
 
@@ -83,14 +83,14 @@ class TestDisplay(TestCase):
 
     def test_defaults(self):
         """Check that default settings work"""
-        renderer = gj.Grass3dRenderer()
+        renderer = gj.Map3D()
         renderer.render(elevation_map="elevation", color_map="elevation")
         self.assertFileExists(renderer.filename)
 
     def test_filename(self):
         """Check that custom filename works"""
         custom_filename = "test_filename.png"
-        renderer = gj.Grass3dRenderer(filename=custom_filename)
+        renderer = gj.Map3D(filename=custom_filename)
         # Add files to self for cleanup later
         self.files.append(custom_filename)
         renderer.render(elevation_map="elevation", color_map="elevation")
@@ -98,13 +98,13 @@ class TestDisplay(TestCase):
 
     def test_hw(self):
         """Check that custom width and height works"""
-        renderer = gj.Grass3dRenderer(width=200, height=400)
+        renderer = gj.Map3D(width=200, height=400)
         renderer.render(elevation_map="elevation", color_map="elevation")
         self.assertFileExists(renderer.filename)
 
     def test_overlay(self):
         """Check that overlay works"""
-        renderer = gj.Grass3dRenderer()
+        renderer = gj.Map3D()
         renderer.render(elevation_map="elevation", color_map="elevation")
         renderer.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
         self.assertFileExists(renderer.filename)
@@ -114,19 +114,19 @@ class TestDisplay(TestCase):
     )
     def test_pyvirtualdisplay_backend(self):
         """Check that pyvirtualdisplay backend works"""
-        renderer = gj.Grass3dRenderer(screen_backend="pyvirtualdisplay")
+        renderer = gj.Map3D(screen_backend="pyvirtualdisplay")
         renderer.render(elevation_map="elevation", color_map="elevation")
         self.assertFileExists(renderer.filename)
 
     def test_shortcut_error(self):
         """Check that wrong screen backend fails"""
         with self.assertRaisesRegex(ValueError, "does_not_exist"):
-            gj.Grass3dRenderer(screen_backend="does_not_exist")
+            gj.Map3D(screen_backend="does_not_exist")
 
     @unittest.skipIf(not can_import_ipython(), "Cannot import IPython")
     def test_image_creation(self):
         """Check that show() works"""
-        renderer = gj.Grass3dRenderer()
+        renderer = gj.Map3D()
         renderer.render(elevation_map="elevation", color_map="elevation")
         self.assertTrue(renderer.show(), "Failed to create IPython Image object")
 

--- a/python/grass/jupyter/testsuite/map_test.py
+++ b/python/grass/jupyter/testsuite/map_test.py
@@ -2,11 +2,11 @@
 
 ############################################################################
 #
-# NAME:      grassrenderer_test.py
+# NAME:      map_test.py
 #
 # AUTHOR:    Caitlin Haedrich (caitlin dot haedrich gmail com)
 #
-# PURPOSE:   This is a test script for grass.jupyter's GrassRenderer
+# PURPOSE:   This is a test script for grass.jupyter's Map
 #
 # COPYRIGHT: (C) 2021 by Caitlin Haedrich and the GRASS Development Team
 #
@@ -36,7 +36,7 @@ def can_import_ipython():
         return False
 
 
-class TestDisplay(TestCase):
+class TestMap(TestCase):
     # Setup variables
     files = []
 
@@ -70,9 +70,9 @@ class TestDisplay(TestCase):
                 f.unlink(missing_ok=True)
 
     def test_defaults(self):
-        """Test that GrassRenderer can create a map with default settings."""
+        """Test that Map can create a map with default settings."""
         # Create a map with default inputs
-        grass_renderer = gj.GrassRenderer()
+        grass_renderer = gj.Map()
         # Adding vectors and rasters to the map
         grass_renderer.run("d.rast", map="elevation")
         grass_renderer.run("d.vect", map="roadsmajor")
@@ -80,10 +80,10 @@ class TestDisplay(TestCase):
         self.assertFileExists(grass_renderer._filename)
 
     def test_filename(self):
-        """Test that GrassRenderer creates maps with unique filenames."""
+        """Test that Map creates maps with unique filenames."""
         # Create map with unique filename
         custom_filename = "test_filename.png"
-        grass_renderer = gj.GrassRenderer(filename=custom_filename)
+        grass_renderer = gj.Map(filename=custom_filename)
         # Add files to self for cleanup later
         self.files.append(custom_filename)
         self.files.append(f"{custom_filename}.grass_vector_legend")
@@ -94,38 +94,38 @@ class TestDisplay(TestCase):
         self.assertFileExists(custom_filename)
 
     def test_filename_property(self):
-        """Test of GrassRenderer filename property."""
+        """Test of Map filename property."""
         # Create map with unique filename
-        grass_renderer = gj.GrassRenderer()
+        grass_renderer = gj.Map()
         grass_renderer.run("d.rast", map="elevation")
         # Make sure image was created
         self.assertFileExists(grass_renderer.filename)
 
     def test_hw(self):
-        """Test that GrassRenderer creates maps with custom height and widths."""
+        """Test that Map creates maps with custom height and widths."""
         # Create map with height and width parameters
-        grass_renderer = gj.GrassRenderer(width=400, height=400)
+        grass_renderer = gj.Map(width=400, height=400)
         # Add just a vector (for variety here)
         grass_renderer.run("d.vect", map="roadsmajor")
 
     def test_env(self):
-        """Test that we can hand an environment to GrassRenderer."""
+        """Test that we can hand an environment to Map."""
         # Create map with environment parameter
-        grass_renderer = gj.GrassRenderer(env=os.environ.copy())
+        grass_renderer = gj.Map(env=os.environ.copy())
         # Add just a raster (again for variety)
         grass_renderer.run("d.rast", map="elevation")
 
     def test_text(self):
-        """Test that we can set a unique text_size in GrassRenderer."""
+        """Test that we can set a unique text_size in Map."""
         # Create map with unique text_size parameter
-        grass_renderer = gj.GrassRenderer(text_size=10)
+        grass_renderer = gj.Map(text_size=10)
         grass_renderer.run("d.vect", map="roadsmajor")
         grass_renderer.run("d.rast", map="elevation")
 
     def test_shortcut(self):
         """Test that we can use display shortcuts with __getattr__."""
         # Create map
-        grass_renderer = gj.GrassRenderer()
+        grass_renderer = gj.Map()
         # Use shortcut
         grass_renderer.d_rast(map="elevation")
         grass_renderer.d_vect(map="roadsmajor")
@@ -134,7 +134,7 @@ class TestDisplay(TestCase):
         """Test that passing an incorrect attribute raises
         appropriate error"""
         # Create map
-        grass_renderer = gj.GrassRenderer()
+        grass_renderer = gj.Map()
         # Pass bad shortcuts
         with self.assertRaisesRegex(AttributeError, "Module must begin with 'd_'"):
             grass_renderer.r_watersheds()
@@ -145,7 +145,7 @@ class TestDisplay(TestCase):
     def test_image_creation(self):
         """Test that show() returns an image object."""
         # Create map
-        grass_renderer = gj.GrassRenderer()
+        grass_renderer = gj.Map()
         grass_renderer.d_rast(map="elevation")
         self.assertTrue(grass_renderer.show(), "Failed to open PNG image")
 

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -1,4 +1,4 @@
-# MODULE:    grass.jupyter.timeseries
+# MODULE:    grass.jupyter.timeseriesmap
 #
 # AUTHOR(S): Caitlin Haedrich <caitlin DOT haedrich AT gmail>
 #
@@ -18,7 +18,7 @@ import weakref
 import shutil
 import grass.script as gs
 
-from .display import GrassRenderer
+from .map import Map
 from .region import RegionManagerForTimeSeries
 
 
@@ -102,9 +102,9 @@ def collect_layers(timeseries, element_type, fill_gaps):
 
 
 class MethodCallCollector:
-    """Records lists of GRASS modules calls to hand to GrassRenderer.run().
+    """Records lists of GRASS modules calls to hand to Map.run().
 
-    Used for base layers and overlays in TimeSeries visualizations."""
+    Used for base layers and overlays in TimeSeriesMap visualizations."""
 
     def __init__(self):
         """Create list of GRASS display module calls"""
@@ -129,13 +129,13 @@ class MethodCallCollector:
         return wrapper
 
 
-class TimeSeries:
+class TimeSeriesMap:
     """Creates visualizations of time-space raster and vector datasets in Jupyter
     Notebooks.
 
     Basic usage::
 
-    >>> img = TimeSeries("series_name")
+    >>> img = TimeSeriesMap("series_name")
     >>> img.d_legend()  # Add legend
     >>> img.time_slider()  # Create TimeSlider
     >>> img.animate()
@@ -145,7 +145,7 @@ class TimeSeries:
     """
 
     # pylint: disable=too-many-instance-attributes
-    # Need more attributes to build timeseries visuals
+    # Need more attributes to build timeseriesmap visuals
 
     def __init__(
         self,
@@ -156,7 +156,7 @@ class TimeSeries:
         use_region=False,
         saved_region=None,
     ):
-        """Creates an instance of the TimeSeries visualizations class.
+        """Creates an instance of the TimeSeriesMap visualizations class.
 
         :param str timeseries: name of space-time dataset
         :param str element_type: element type, strds (space-time raster dataset)
@@ -225,13 +225,13 @@ class TimeSeries:
 
     @property
     def overlay(self):
-        """Add overlay to TimeSeries visualization"""
+        """Add overlay to TimeSeriesMap visualization"""
         self._layers_rendered = False
         return self._overlays
 
     @property
     def baselayer(self):
-        """Add base layer to TimeSeries visualization"""
+        """Add base layer to TimeSeriesMap visualization"""
         self._layers_rendered = False
         return self._baselayers
 
@@ -241,7 +241,7 @@ class TimeSeries:
         Passed to d.rast and d.erase. Either a standard color name, R:G:B triplet, or
         Hex. Default is white.
 
-        >>> img = TimeSeries("series_name")
+        >>> img = TimeSeriesMap("series_name")
         >>> img.set_background_color("#088B36")  # GRASS GIS green
         >>> img.animate()
 
@@ -259,12 +259,12 @@ class TimeSeries:
         self._layers_rendered = False
 
     def _render_baselayers(self, img):
-        """Add collected baselayers to GrassRenderer instance"""
+        """Add collected baselayers to Map instance"""
         for grass_module, kwargs in self._baselayers.calls:
             img.run(grass_module, **kwargs)
 
     def _render_legend(self, img):
-        """Add legend to GrassRenderer instance"""
+        """Add legend to Map instance"""
         info = gs.parse_command(
             "t.info", input=self.timeseries, flags="g", env=self._env
         )
@@ -277,7 +277,7 @@ class TimeSeries:
         )
 
     def _render_overlays(self, img):
-        """Add collected overlays to GrassRenderer instance"""
+        """Add collected overlays to Map instance"""
         for grass_module, kwargs in self._overlays.calls:
             img.run(grass_module, **kwargs)
 
@@ -286,7 +286,7 @@ class TimeSeries:
 
         Adds overlays and legend to base map.
         """
-        img = GrassRenderer(
+        img = Map(
             filename=filename, use_region=True, env=self._env, read_file=True
         )
         # Add overlays
@@ -297,7 +297,7 @@ class TimeSeries:
 
     def _render_layer(self, layer, filename):
         """Render layer to file with overlays and legend"""
-        img = GrassRenderer(
+        img = Map(
             filename=filename, use_region=True, env=self._env, read_file=True
         )
         if self._element_type == "strds":
@@ -322,7 +322,7 @@ class TimeSeries:
         # Random name needed to avoid potential conflict with layer names
         random_name_base = gs.append_random("base", 8) + ".png"
         base_file = os.path.join(self._tmpdir.name, random_name_base)
-        img = GrassRenderer(
+        img = Map(
             filename=base_file, use_region=True, env=self._env, read_file=True
         )
         # Fill image background

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -286,9 +286,7 @@ class TimeSeriesMap:
 
         Adds overlays and legend to base map.
         """
-        img = Map(
-            filename=filename, use_region=True, env=self._env, read_file=True
-        )
+        img = Map(filename=filename, use_region=True, env=self._env, read_file=True)
         # Add overlays
         self._render_overlays(img)
         # Add legend if needed
@@ -297,9 +295,7 @@ class TimeSeriesMap:
 
     def _render_layer(self, layer, filename):
         """Render layer to file with overlays and legend"""
-        img = Map(
-            filename=filename, use_region=True, env=self._env, read_file=True
-        )
+        img = Map(filename=filename, use_region=True, env=self._env, read_file=True)
         if self._element_type == "strds":
             img.d_rast(map=layer)
         elif self._element_type == "stvds":
@@ -322,9 +318,7 @@ class TimeSeriesMap:
         # Random name needed to avoid potential conflict with layer names
         random_name_base = gs.append_random("base", 8) + ".png"
         base_file = os.path.join(self._tmpdir.name, random_name_base)
-        img = Map(
-            filename=base_file, use_region=True, env=self._env, read_file=True
-        )
+        img = Map(filename=base_file, use_region=True, env=self._env, read_file=True)
         # Fill image background
         img.d_erase(bgcolor=self._bgcolor)
         # Add baselayers


### PR DESCRIPTION
Renaming  grass.jupyter classes as discussed in #2283 

- `GrassRenderer` -> `Map`
- `Grass3dRenderer` -> `Map3D`
- `TimeSeries` -> `TimeSeriesMap`

Updated notebooks and changed grass.jupyter filenames to match classes contained.

[Binder](https://mybinder.org/v2/gh/chaedri/grass/renaming?labpath=doc%2Fnotebooks%2Fgrass_jupyter.ipynb)