### PR TITLE
Restructure TimeSeriesMap

### DIFF
--- a/doc/notebooks/temporal.ipynb
+++ b/doc/notebooks/temporal.ipynb
@@ -240,7 +240,7 @@
    "source": [
     "from IPython.display import Image\n",
     "\n",
-    "Image(precip_map.save(duration=500, label=True, text_size=16, text_color=\"gray\"))"
+    "Image(precip_map.save(\"image.gif\", duration=500, label=True, text_size=16, text_color=\"gray\"))"
    ]
   },
   {

--- a/doc/notebooks/temporal.ipynb
+++ b/doc/notebooks/temporal.ipynb
@@ -208,7 +208,7 @@
    "source": [
     "## Temporal Visualizations\n",
     "\n",
-    "The `TimeSeriesMap` class contains visualization functions for GRASS space time dataset (strds or stvds). The `time_slider` function allows users to interactively view the evolution of the dataset through time using IPython and Jupyter Widgets."
+    "The `TimeSeriesMap` class contains visualization functions for GRASS space time dataset (strds or stvds) with either a time slider using `show` or by exporting as a GIF with `save`."
    ]
   },
   {
@@ -217,18 +217,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "precip_map = gj.TimeSeriesMap(\"precip_sum_2010\", fill_gaps=False, use_region=True)\n",
+    "precip_map = gj.TimeSeriesMap(use_region=True)\n",
+    "precip_map.add_raster_series(\"precip_sum_2010\")\n",
     "precip_map.d_legend(color=\"black\", at=(10,40,2,6)) #Add legend\n",
-    "precip_map.overlay.d_vect(map=\"boundary_county\", fill_color=\"none\")\n",
-    "precip_map.overlay.d_barscale()\n",
-    "precip_map.time_slider()"
+    "precip_map.d_vect(map=\"boundary_county\", fill_color=\"none\")\n",
+    "precip_map.d_barscale()\n",
+    "precip_map.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also display the space time dataset as an animation with `animate`."
+    "We can also display the space time dataset as a GIF with IPython and `save`."
    ]
   },
   {
@@ -237,7 +238,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "precip_map.animate(duration=500, label=True, text_size=16, text_color=\"gray\")"
+    "from IPython.display import Image\n",
+    "\n",
+    "Image(precip_map.save(duration=500, label=True, text_size=16, text_color=\"gray\"))"
    ]
   },
   {
@@ -270,9 +273,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gaps_map = gj.TimeSeriesMap(\"precip_sum_2010\")\n",
+    "gaps_map = gj.TimeSeriesMap()\n",
+    "gaps_map.add_raster_series(\"precip_sum_2010\", fill_gaps=False)\n",
     "gaps_map.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
-    "gaps_map.time_slider()  # Create TimeSlider"
+    "gaps_map.show()  # Create TimeSlider"
    ]
   },
   {
@@ -288,9 +292,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filled_map = gj.TimeSeriesMap(\"precip_sum_2010\", fill_gaps=True)\n",
+    "filled_map = gj.TimeSeriesMap()\n",
+    "precip_map.add_raster_series(\"precip_sum_2010\", fill_gaps=True)\n",
     "filled_map.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
-    "filled_map.time_slider()  # Create TimeSlider"
+    "filled_map.show()  # Create TimeSlider"
    ]
   }
  ],

--- a/doc/notebooks/temporal.ipynb
+++ b/doc/notebooks/temporal.ipynb
@@ -293,7 +293,7 @@
    "outputs": [],
    "source": [
     "filled_map = gj.TimeSeriesMap()\n",
-    "precip_map.add_raster_series(\"precip_sum_2010\", fill_gaps=True)\n",
+    "filled_map.add_raster_series(\"precip_sum_2010\", fill_gaps=True)\n",
     "filled_map.d_legend(color=\"gray\", at=(10, 0, 30, 0))  # Add legend\n",
     "filled_map.show()  # Create TimeSlider"
    ]

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -73,5 +73,5 @@ def test_save(space_time_raster_dataset):
     """Test returns from animate and time_slider are correct object types"""
     img = gj.TimeSeriesMap()
     img.add_raster_series(space_time_raster_dataset.name)
-    gif_file = img.save()
+    gif_file = img.save("image.gif")
     assert Path(gif_file).is_file()

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -50,11 +50,12 @@ def test_default_init(space_time_raster_dataset):
 def test_render_layers(space_time_raster_dataset, fill_gaps):
     """Check that layers are rendered"""
     # create instance of TimeSeriesMap
-    img = gj.TimeSeriesMap(space_time_raster_dataset.name, fill_gaps=fill_gaps)
-    # test baselayer, overlay and d_legend here too for efficiency (rendering is
+    img = gj.TimeSeriesMap()
+    # test adding base layer and d_legend here too for efficiency (rendering is
     # time-intensive)
-    img.baselayer.d_rast(map=space_time_raster_dataset.raster_names[0])
-    img.overlay.d_barscale()
+    img.d_rast(map=space_time_raster_dataset.raster_names[0])
+    img.add_raster_series(space_time_raster_dataset.name, fill_gaps=fill_gaps)
+    img.d_barscale()
     img.d_legend()
     # Render layers
     img.render()

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -42,7 +42,8 @@ def test_collect_layers(space_time_raster_dataset):
 
 def test_default_init(space_time_raster_dataset):
     """Check that TimeSeriesMap init runs with default parameters"""
-    img = gj.TimeSeriesMap(space_time_raster_dataset.name)
+    img = gj.TimeSeriesMap()
+    img.add_raster_series(space_time_raster_dataset.name)
     assert img.timeseries == space_time_raster_dataset.name
 
 
@@ -68,7 +69,9 @@ def test_render_layers(space_time_raster_dataset, fill_gaps):
 
 @pytest.mark.skipif(IPython is None, reason="IPython package not available")
 @pytest.mark.skipif(ipywidgets is None, reason="ipywidgets package not available")
-def test_animate_time_slider(space_time_raster_dataset):
+def test_save(space_time_raster_dataset):
     """Test returns from animate and time_slider are correct object types"""
-    img = gj.TimeSeriesMap(space_time_raster_dataset.name)
-    assert isinstance(img.animate(), IPython.display.Image)
+    img = gj.TimeSeriesMap()
+    img.add_raster_series(space_time_raster_dataset.name)
+    gif_file = img.save()
+    assert Path(gif_file).is_file()

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -40,15 +40,6 @@ def test_collect_layers(space_time_raster_dataset):
     assert len(names) == len(dates)
 
 
-def test_method_call_collector():
-    """Check that MethodCallCollector constructs and collects GRASS calls"""
-    mcc = gj.MethodCallCollector()
-    mcc.d_rast(map="elevation")
-    module, kwargs = mcc.calls[0]
-    assert module == "d.rast"
-    assert kwargs["map"] == "elevation"
-
-
 def test_default_init(space_time_raster_dataset):
     """Check that TimeSeriesMap init runs with default parameters"""
     img = gj.TimeSeriesMap(space_time_raster_dataset.name)

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -186,6 +186,8 @@ class TimeSeriesMap:
         :param str timeseries: name of space-time dataset
         :param bool fill_gaps: fill empty time steps with data from previous step
         """
+        if self._timeseries_added and self.timeseries != timeseries:
+            raise AttributeError("Cannot add more than one space time dataset")
         self._element_type = "strds"
         check_timeseries_exists(timeseries, self._element_type)
         self.timeseries = timeseries
@@ -206,6 +208,8 @@ class TimeSeriesMap:
         :param str timeseries: name of space-time dataset
         :param bool fill_gaps: fill empty time steps with data from previous step
         """
+        if self._timeseries_added and self.timeseries != timeseries:
+            raise AttributeError("Cannot add more than one space time dataset")
         self._element_type = "stvds"
         check_timeseries_exists(timeseries, self._element_type)
         self.timeseries = timeseries
@@ -311,6 +315,13 @@ class TimeSeriesMap:
         (i.e. time_slider or animate). Can be time-consuming to run with large
         space-time datasets.
         """
+
+        if not self._timeseries_added:
+            raise RuntimeError(
+                "Cannot render space time dataset since none has been added."
+                "Use TimeSeriesMap.add_raster_series() or "
+                "TimeSeriesMap.add_vector_series() to add dataset"
+            )
 
         # Make base image (background and baselayers)
         # Random name needed to avoid potential conflict with layer names

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -154,7 +154,6 @@ class TimeSeriesMap:
         self.timeseries = None
         self._element_type = None
         self._fill_gaps = None
-        self._bgcolor = "white"
         self._legend = None
         self._base_layer_calls = []
         self._overlay_calls = []
@@ -243,20 +242,6 @@ class TimeSeriesMap:
 
         return wrapper
 
-    def d_background(self, color):
-        """Set background color of images.
-
-        Passed to d.rast and d.erase. Either a standard color name, R:G:B triplet, or
-        Hex. Default is white.
-
-        >>> img = TimeSeriesMap("series_name")
-        >>> img.d_background("#088B36")  # GRASS GIS green
-        >>> img.show()
-
-        """
-        self._bgcolor = color
-        self._layers_rendered = False
-
     def d_legend(self, **kwargs):
         """Display legend.
 
@@ -332,8 +317,6 @@ class TimeSeriesMap:
         random_name_base = gs.append_random("base", 8) + ".png"
         base_file = os.path.join(self._tmpdir.name, random_name_base)
         img = Map(filename=base_file, use_region=True, env=self._env, read_file=True)
-        # Fill image background
-        img.d_erase(bgcolor=self._bgcolor)
         # Add baselayers
         self._render_baselayers(img)
 

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -101,14 +101,126 @@ def collect_layers(timeseries, element_type, fill_gaps):
     return names, dates
 
 
-class MethodCallCollector:
-    """Records lists of GRASS modules calls to hand to Map.run().
+def check_timeseries_exists(timeseries):
+    """Check that timeseries is time space dataset"""
+    test = gs.read_command("t.list", where=f"name='{timeseries}'")
+    if not test:
+        raise NameError(
+            _("Could not find space time raster or vector dataset named {}").format(
+                timeseries
+            )
+        )
 
-    Used for base layers and overlays in TimeSeriesMap visualizations."""
 
-    def __init__(self):
-        """Create list of GRASS display module calls"""
-        self.calls = []
+class TimeSeriesMap:
+    """Creates visualizations of time-space raster and vector datasets in Jupyter
+    Notebooks.
+
+    Basic usage::
+
+    >>> img = TimeSeriesMap("series_name")
+    >>> img.d_legend()  # Add legend
+    >>> img.show()  # Create TimeSlider
+    >>> img.save()
+
+    This class of grass.jupyter is experimental and under development. The API can
+    change at anytime.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    # Need more attributes to build timeseriesmap visuals
+
+    def __init__(
+        self,
+        env=None,
+        use_region=False,
+        saved_region=None,
+    ):
+        """Creates an instance of the TimeSeriesMap visualizations class.
+
+        :param str env: environment
+        :param use_region: if True, use either current or provided saved region,
+                          else derive region from rendered layers
+        :param saved_region: if name of saved_region is provided,
+                            this region is then used for rendering
+        """
+
+        # Copy Environment
+        if env:
+            self._env = env.copy()
+        else:
+            self._env = os.environ.copy()
+
+        self.timeseries = None
+        self._element_type = None
+        self._fill_gaps = None
+        self._bgcolor = "white"
+        self._legend = None
+        self._base_layer_calls = []
+        self._overlay_calls = []
+        self._timeseries_added = False
+        self._layers_rendered = False
+        self._layers = None
+        self._dates = None
+        self._date_layer_dict = {}
+        self._date_filename_dict = {}
+
+        # Create a temporary directory for our PNG images
+        # Resource managed by weakref.finalize.
+        self._tmpdir = (
+            # pylint: disable=consider-using-with
+            tempfile.TemporaryDirectory()
+        )
+
+        def cleanup(tmpdir):
+            tmpdir.cleanup()
+
+        weakref.finalize(self, cleanup, self._tmpdir)
+
+        # Handle Regions
+        self._region_manager = RegionManagerForTimeSeries(
+            use_region, saved_region, self._env
+        )
+
+    def add_raster_series(self, timeseries, fill_gaps=False):
+        """
+        :param str timeseries: name of space-time dataset
+        :param bool fill_gaps: fill empty time steps with data from previous step
+        """
+        check_timeseries_exists(timeseries)
+        self.timeseries = timeseries
+        self._element_type = "strds"
+        self._fill_gaps = fill_gaps
+        self._timeseries_added = True
+        # create list of layers to render and date/times
+        self._layers, self._dates = collect_layers(
+            self.timeseries, self._element_type, self._fill_gaps
+        )
+        self._date_layer_dict = {
+            self._dates[i]: self._layers[i] for i in range(len(self._dates))
+        }
+        # Update Region
+        self._region_manager.set_region_from_timeseries(self.timeseries)
+
+    def add_vector_series(self, timeseries, fill_gaps=False):
+        """
+        :param str timeseries: name of space-time dataset
+        :param bool fill_gaps: fill empty time steps with data from previous step
+        """
+        check_timeseries_exists(timeseries)
+        self.timeseries = timeseries
+        self._element_type = "stvds"
+        self._fill_gaps = fill_gaps
+        self._timeseries_added = True
+        # create list of layers to render and date/times
+        self._layers, self._dates = collect_layers(
+            self.timeseries, self._element_type, self._fill_gaps
+        )
+        self._date_layer_dict = {
+            self._dates[i]: self._layers[i] for i in range(len(self._dates))
+        }
+        # Update Region
+        self._region_manager.set_region_from_timeseries(self.timeseries)
 
     def __getattr__(self, name):
         """Parse attribute to GRASS display module. Attribute should be in
@@ -124,126 +236,22 @@ class MethodCallCollector:
             raise AttributeError(_("Cannot find GRASS module {}").format(grass_module))
 
         def wrapper(**kwargs):
-            self.calls.append((grass_module, kwargs))
+            if not self._timeseries_added:
+                self._base_layer_calls.append((grass_module, kwargs))
+            if self._timeseries_added:
+                self._overlay_calls.append((grass_module, kwargs))
 
         return wrapper
 
-
-class TimeSeriesMap:
-    """Creates visualizations of time-space raster and vector datasets in Jupyter
-    Notebooks.
-
-    Basic usage::
-
-    >>> img = TimeSeriesMap("series_name")
-    >>> img.d_legend()  # Add legend
-    >>> img.time_slider()  # Create TimeSlider
-    >>> img.animate()
-
-    This class of grass.jupyter is experimental and under development. The API can
-    change at anytime.
-    """
-
-    # pylint: disable=too-many-instance-attributes
-    # Need more attributes to build timeseriesmap visuals
-
-    def __init__(
-        self,
-        timeseries,
-        element_type="strds",
-        fill_gaps=False,
-        env=None,
-        use_region=False,
-        saved_region=None,
-    ):
-        """Creates an instance of the TimeSeriesMap visualizations class.
-
-        :param str timeseries: name of space-time dataset
-        :param str element_type: element type, strds (space-time raster dataset)
-                          or stvds (space-time vector dataset)
-        :param bool fill_gaps: fill empty time steps with data from previous step
-        :param str env: environment
-        :param use_region: if True, use either current or provided saved region,
-                          else derive region from rendered layers
-        :param saved_region: if name of saved_region is provided,
-                            this region is then used for rendering
-        """
-
-        # Copy Environment
-        if env:
-            self._env = env.copy()
-        else:
-            self._env = os.environ.copy()
-
-        self.timeseries = timeseries
-        self._element_type = element_type
-        self._fill_gaps = fill_gaps
-        self._bgcolor = "white"
-        self._legend = None
-        self._baselayers = MethodCallCollector()
-        self._overlays = MethodCallCollector()
-        self._layers_rendered = False
-
-        self._layers = None
-        self._dates = None
-
-        self._date_layer_dict = {}
-        self._date_filename_dict = {}
-
-        # create list of layers to render and date/times
-        self._layers, self._dates = collect_layers(
-            self.timeseries, self._element_type, self._fill_gaps
-        )
-        self._date_layer_dict = {
-            self._dates[i]: self._layers[i] for i in range(len(self._dates))
-        }
-
-        # Check that map is time space dataset
-        test = gs.read_command("t.list", where=f"name='{timeseries}'")
-        if not test:
-            raise NameError(
-                _(
-                    "Could not find space time raster or vector " "dataset named {}"
-                ).format(timeseries)
-            )
-
-        # Create a temporary directory for our PNG images
-        # Resource managed by weakref.finalize.
-        self._tmpdir = (
-            # pylint: disable=consider-using-with
-            tempfile.TemporaryDirectory()
-        )
-
-        def cleanup(tmpdir):
-            tmpdir.cleanup()
-
-        weakref.finalize(self, cleanup, self._tmpdir)
-
-        # Handle Regions
-        region_manager = RegionManagerForTimeSeries(use_region, saved_region, self._env)
-        region_manager.set_region_from_timeseries(self.timeseries)
-
-    @property
-    def overlay(self):
-        """Add overlay to TimeSeriesMap visualization"""
-        self._layers_rendered = False
-        return self._overlays
-
-    @property
-    def baselayer(self):
-        """Add base layer to TimeSeriesMap visualization"""
-        self._layers_rendered = False
-        return self._baselayers
-
-    def set_background_color(self, color):
+    def d_background(self, color):
         """Set background color of images.
 
         Passed to d.rast and d.erase. Either a standard color name, R:G:B triplet, or
         Hex. Default is white.
 
         >>> img = TimeSeriesMap("series_name")
-        >>> img.set_background_color("#088B36")  # GRASS GIS green
-        >>> img.animate()
+        >>> img.d_background("#088B36")  # GRASS GIS green
+        >>> img.show()
 
         """
         self._bgcolor = color
@@ -254,13 +262,18 @@ class TimeSeriesMap:
 
         Wraps d.legend and uses same keyword arguments.
         """
-        self._legend = kwargs
-        # If d_legend has been called, we need to re-render layers
-        self._layers_rendered = False
+        if "raster" in kwargs and not self._timeseries_added:
+            self._base_layer_calls.append(("d.legend", kwargs))
+        if "raster" in kwargs and self._timeseries_added:
+            self._overlay_calls.append(("d.legend", kwargs))
+        else:
+            self._legend = kwargs
+            # If d_legend has been called, we need to re-render layers
+            self._layers_rendered = False
 
     def _render_baselayers(self, img):
         """Add collected baselayers to Map instance"""
-        for grass_module, kwargs in self._baselayers.calls:
+        for grass_module, kwargs in self._base_layer_calls:
             img.run(grass_module, **kwargs)
 
     def _render_legend(self, img):
@@ -278,7 +291,7 @@ class TimeSeriesMap:
 
     def _render_overlays(self, img):
         """Add collected overlays to Map instance"""
-        for grass_module, kwargs in self._overlays.calls:
+        for grass_module, kwargs in self._overlay_calls:
             img.run(grass_module, **kwargs)
 
     def _render_blank_layer(self, filename):
@@ -350,7 +363,7 @@ class TimeSeriesMap:
                 self._render_layer(layer, filename)
         self._layers_rendered = True
 
-    def time_slider(self, slider_width=None):
+    def show(self, slider_width=None):
         """Create interactive timeline slider.
 
         param str slider_width: width of datetime selection slider
@@ -394,14 +407,14 @@ class TimeSeriesMap:
         # Return interact widget with image and slider
         widgets.interact(view_image, date=slider)
 
-    def animate(
+    def save(
         self,
+        filename=None,
         duration=500,
         label=True,
         font="DejaVuSans.ttf",
         text_size=12,
         text_color="gray",
-        filename=None,
     ):
         """
         Creates a GIF animation of rendered layers.
@@ -410,25 +423,26 @@ class TimeSeriesMap:
         formats, visit:
         https://pillow.readthedocs.io/en/stable/reference/ImageColor.html#color-names
 
+        param str filename: name of output GIF file
         param int duration: time to display each frame; milliseconds
         param bool label: include date/time stamp on each frame
         param str font: font file
         param int text_size: size of date/time text
         param str text_color: color to use for the text.
-        param str filename: name of output GIF file
         """
         # Create a GIF from the PNG images
         import PIL.Image  # pylint: disable=import-outside-toplevel
         import PIL.ImageDraw  # pylint: disable=import-outside-toplevel
         import PIL.ImageFont  # pylint: disable=import-outside-toplevel
-        import IPython.display  # pylint: disable=import-outside-toplevel
 
         # Render images if they have not been already
         if not self._layers_rendered:
             self.render()
 
         # filepath to output GIF
-        if not filename:
+        if filename:
+            assert filename.endswith(".gif"), "filename must end in '.gif'"
+        else:
             filename = os.path.join(self._tmpdir.name, "image.gif")
 
         images = []
@@ -456,4 +470,4 @@ class TimeSeriesMap:
         )
 
         # Display the GIF
-        return IPython.display.Image(filename)
+        return filename


### PR DESCRIPTION
* Restructure TimeSeriesMap so methods are consistent with other grass.jupyter classes by removing `overlay` and `baselayer` in favor of adding layers to map in order they are called with `__getattr__`  magic.
* Update notebook example

For example:
```
precip_map = gj.TimeSeriesMap(use_region=True)
precip_map.add_raster_series("precip_sum_2010")
precip_map.d_legend(color="black", at=(10,40,2,6)) #Add legend
precip_map.d_vect(map="boundary_county", fill_color="none")
precip_map.d_barscale()
precip_map.show()
precip_map.save("image.gif")
```

[Binder](https://mybinder.org/v2/gh/chaedri/grass/timeseries-restructure?labpath=doc%2Fnotebooks%2Fgrass_jupyter.ipynb)
