### PR TITLE
jupyter notebooks: use gs.parse_command() for g.region

### DIFF
--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -43,7 +43,7 @@
     "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to the elevation raster.\n",
-    "gs.parse_command(\"g.region\", raster=\"elevation\")"
+    "gs.parse_command(\"g.region\", raster=\"elevation\", flags=\"pg\"))"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gs.parse_command(\"g.region\", save=\"myregion\", n=224000, s=222000, w=633500, e=637300)\n",
+    "gs.run_command(\"g.region\", save=\"myregion\", n=224000, s=222000, w=633500, e=637300)\n",
     "myregion_map = gj.Map(saved_region=\"myregion\")\n",
     "myregion_map.d_rast(map=\"elevation\")\n",
     "myregion_map.d_rast(map=\"lakes\")\n",

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -43,7 +43,7 @@
     "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to the elevation raster.\n",
-    "gs.run_command(\"g.region\", raster=\"elevation\")"
+    "gs.parse_command(\"g.region\", raster=\"elevation\")"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gs.run_command(\"g.region\", save=\"myregion\", n=224000, s=222000, w=633500, e=637300)\n",
+    "gs.parse_command(\"g.region\", save=\"myregion\", n=224000, s=222000, w=633500, e=637300)\n",
     "myregion_map = gj.Map(saved_region=\"myregion\")\n",
     "myregion_map.d_rast(map=\"elevation\")\n",
     "myregion_map.d_rast(map=\"lakes\")\n",

--- a/doc/notebooks/grass_jupyter.ipynb
+++ b/doc/notebooks/grass_jupyter.ipynb
@@ -43,7 +43,7 @@
     "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to the elevation raster.\n",
-    "gs.parse_command(\"g.region\", raster=\"elevation\", flags=\"pg\"))"
+    "gs.parse_command(\"g.region\", raster=\"elevation\", flags=\"pg\")"
    ]
   },
   {

--- a/doc/notebooks/hydrology.ipynb
+++ b/doc/notebooks/hydrology.ipynb
@@ -46,7 +46,7 @@
     "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to elevation raster\n",
-    "gs.run_command(\"g.region\", raster=\"elevation\", flags=\"pg\")"
+    "gs.parse_command(\"g.region\", raster=\"elevation\", flags=\"pg\")"
    ]
   },
   {

--- a/doc/notebooks/solar_potential.ipynb
+++ b/doc/notebooks/solar_potential.ipynb
@@ -45,7 +45,7 @@
     "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to elevation raster\n",
-    "gs.run_command(\"g.region\", raster=\"elevation@PERMANENT\", flags=\"pg\")"
+    "gs.parse_command(\"g.region\", raster=\"elevation@PERMANENT\", flags=\"pg\")"
    ]
   },
   {

--- a/doc/notebooks/temporal.ipynb
+++ b/doc/notebooks/temporal.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gs.run_command(\"g.region\", raster=\"elev_state_500m\")"
+    "gs.parse_command(\"g.region\", raster=\"elev_state_500m\")"
    ]
   },
   {

--- a/doc/notebooks/temporal.ipynb
+++ b/doc/notebooks/temporal.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gs.parse_command(\"g.region\", raster=\"elev_state_500m\")"
+    "gs.run_command(\"g.region\", raster=\"elev_state_500m\")"
    ]
   },
   {

--- a/doc/notebooks/viewshed_analysis.ipynb
+++ b/doc/notebooks/viewshed_analysis.ipynb
@@ -47,7 +47,7 @@
     "session = gj.init(\"../../data/grassdata\", \"nc_basic_spm_grass7\", \"user1\")\n",
     "\n",
     "# Set computational region to elevation raster\n",
-    "gs.run_command(\"g.region\", raster=\"elevation@PERMANENT\", flags=\"pg\")"
+    "gs.parse_command(\"g.region\", raster=\"elevation@PERMANENT\", flags=\"pg\")"
    ]
   },
   {


### PR DESCRIPTION
This PR replaces `gs.run_command()` with `gs.parse_command()` in order to print `´g.region` output into jupyter notebook instead of shell terminal.