### PR TITLE
Update __init__.py to only necessary modules

### DIFF
--- a/python/grass/jupyter/__init__.py
+++ b/python/grass/jupyter/__init__.py
@@ -44,7 +44,5 @@ The objects in submodules and names of submodules may change in the future.
 from .interactivemap import *
 from .map import *
 from .map3d import *
-from .reprojection_renderer import *
 from .setup import *
 from .timeseriesmap import *
-from .utils import *


### PR DESCRIPTION
* Remove reprojection_renderer and utils from __init__.py

These modules are not for direct by users of grass.jupyter. They are imported by other modules as needed. This will also shorted the API documentation page to only include modules intended for usage.