### PR TITLE
manual: add entries about Jupyter notebook support

### DIFF
--- a/man/build_html.py
+++ b/man/build_html.py
@@ -191,6 +191,7 @@ overview_tmpl = string.Template(
        <ul>
         <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/index.html">GRASS GIS Python library documentation</a></li>
         <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/pygrass_index.html">PyGRASS documentation</a></li>
+        <li class="box"><a href="https://grass.osgeo.org/grass${grass_version_major}${grass_version_minor}/manuals/libpython/grass.jupyter.html">GRASS GIS in Jupyter Notebooks</a></li>
        </ul>
       </td>
     </tr>

--- a/python/grass/docs/src/index.rst
+++ b/python/grass/docs/src/index.rst
@@ -19,6 +19,8 @@ at various levels:
   modules
 * **GRASS GIS Temporal Framework** implements the temporal GIS functionality
   of GRASS GIS and provides an API to implement spatio-temporal processing modules
+* **grass.jupyter package** offers classes and setup functions for
+  running GRASS GIS in Jupyter Notebooks
 * **Testing GRASS GIS source code and modules** using gunittest package
 * **exceptions package** contains exceptions used by other packages
 * **imaging package** is a library to create animated images and films


### PR DESCRIPTION
This PR adds two entries.

Add link to main manual index, "Python" section:

![image](https://user-images.githubusercontent.com/1295172/163980389-ba2058e3-31e2-4a97-882a-57a221fac136.png)



Add `grass.jupyter` to TOC list in libpython page:

![image](https://user-images.githubusercontent.com/1295172/163980285-f591441e-3eec-4d56-b674-3c66318890b5.png)
