### PR TITLE
Sphinx: Generate class doc from class and init

### DIFF
--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -421,3 +421,6 @@ epub_exclude_files = ["search.html"]
 
 # If false, no index is generated.
 # epub_use_index = True
+
+# Where class documentation comes from (class or __init__ docstring).
+autoclass_content = "both"


### PR DESCRIPTION
By default, only class doc is used to document class and init is ignored. This uses both to create the doc in Sphinx. Parameters can then be documented with the function as for any other function.
