### PR TITLE
grass.benchmark: compute parallel efficiency

### DIFF
--- a/python/grass/benchmark/runners.py
+++ b/python/grass/benchmark/runners.py
@@ -90,8 +90,8 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
     Optional *nprocs* is passed to the module if present.
 
     Returns an object with attributes *times* (list of average execution times),
-    *all_times* (list of lists of measured execution times), *nprocs*
-    (list of *nprocs* values used), and *label* (the provided parameter as is).
+    *all_times* (list of lists of measured execution times), *efficiency* (parallel efficiency),
+    *nprocs* (list of *nprocs* values used), and *label* (the provided parameter as is).
     """
     term_size = shutil.get_terminal_size()
     if hasattr(module, "get_bash"):
@@ -104,6 +104,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
     serial_avg = None
     avg_times = []
     all_times = []
+    efficiency = []
     nprocs_list = list(range(1, max_nprocs + 1))
     nprocs_list_shuffled = sorted(nprocs_list * repeat)
     if shuffle:
@@ -127,6 +128,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
         if avg < min_avg:
             min_avg = avg
             min_time = nprocs
+        efficiency.append(serial_avg / (nprocs * avg))
 
     print("\u2500" * term_size.columns)
     if serial_avg is not None:
@@ -136,6 +138,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
     return SimpleNamespace(
         all_times=all_times,
         times=avg_times,
+        efficiency=efficiency,
         nprocs=nprocs_list,
         label=label,
     )


### PR DESCRIPTION
This PR adds only the computing of parallel efficiency, not plotting it, so it only partially addresses #2118.