### PR TITLE
wxGUI: fix saving and setting display position in workspace for multiple window layout

### DIFF
--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -857,3 +857,9 @@ class FrameMixin:
 
     def Destroy(self):
         self.GetParent().Destroy()
+
+    def GetPosition(self):
+        return self.GetParent().GetPosition()
+
+    def SetPosition(self, pt):
+        self.GetParent().SetPosition(pt)


### PR DESCRIPTION
Previously, GetPosition returned 0,0 because it was called on a Panel, not Frame.