### PR TITLE
CI: Remove Ubuntu 18.04 check

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
       fail-fast: false
 


### PR DESCRIPTION
We don't support Ubuntu 18.04 for 8.0 anymore.