### PR TITLE
version: Reduce usage of the current version number

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -40,11 +40,11 @@ Installation order:
 
 GRASS source code is currently distributed in 2 forms:
 
-1) Officially released source code (e.g. grass-8.2.0.tar.gz or later)
+1) Officially released source code (e.g. grass-3.7.0.tar.gz)
 
   The full source code version contains all the GRASS source code
   required for compilation. It is distributed as one file (*.tar.gz
-  package) and the version is composed of 3 numbers, e.g. 8.2.0, 8.2.1
+  package) and the version is composed of 3 numbers, e.g. 3.7.0, 3.7.1
   etc. See
   https://github.com/OSGeo/grass/releases
 
@@ -54,7 +54,7 @@ GRASS source code is currently distributed in 2 forms:
   repository (https://github.com/OSGeo/grass/) or as a auto-generated snapshot
   (*.tar.gz package) of the GitHub repository. The snapshot name
   contains the date when the snapshot was created (checked out from
-  the GitHub repository), e.g. grass-8.3.git_src_snapshot_2022_04_27.tar.gz
+  the GitHub repository), e.g. grass-3.7.git_src_snapshot_2022_04_27.tar.gz
   from https://grass.osgeo.org/grass-devel/source/snapshot/
   Further instructions at https://trac.osgeo.org/grass/wiki/DownloadSource
 

--- a/mswindows/crosscompile.sh
+++ b/mswindows/crosscompile.sh
@@ -61,7 +61,7 @@ Usage: crosscompile.sh [OPTIONS]
                              (default: /usr/include/freetype2)
     --update                 update the current branch
     --package                package the cross-compiled build as
-                             grass83-x86_64-w64-mingw32-YYYYMMDD.zip
+                             grassVV-x86_64-w64-mingw32-YYYYMMDD.zip
 EOT
 		exit
 		;;

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -117,21 +117,20 @@ def main():
     # TODO: create directory according to date and revision and create reports there
 
     # some predefined variables, name of the GRASS launch script + location/mapset
-    # grass8bin = 'C:\Program Files (x86)\GRASS GIS 8.2.git\grass.bat'
-    grass8bin = args.grassbin  # TODO: can be used if pressent
+    grass_executable = args.grassbin
 
     # Software
-    # query GRASS GIS 8 itself for its GISBASE
-    # we assume that GRASS GIS' start script is available and in the PATH
+    # query GRASS GIS itself for its GISBASE
+    # we assume that the start script is available and in the PATH
     # the shell=True is here because of MS Windows? (code taken from wiki)
-    startcmd = grass8bin + " --config path"
+    startcmd = grass_executable + " --config path"
     p = subprocess.Popen(
         startcmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     out, err = p.communicate()
     if p.returncode != 0:
         print(
-            "ERROR: Cannot find GRASS GIS 8 start script (%s):\n%s" % (startcmd, err),
+            "ERROR: Cannot find GRASS GIS start script (%s):\n%s" % (startcmd, err),
             file=sys.stderr,
         )
         return 1

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -24,19 +24,19 @@ Usage::
     # query GRASS itself for its GISBASE
     # (with fixes for specific platforms)
     # needs to be edited by the user
-    grass8bin = "grass"
+    grass_executable = "grass"
     if sys.platform.startswith("win"):
         # MS Windows
-        grass8bin = r"C:\OSGeo4W\bin\grass.bat"
+        grass_executable = r"C:\OSGeo4W\bin\grass.bat"
         # uncomment when using standalone WinGRASS installer
-        # grass8bin = r'C:\Program Files (x86)\GRASS GIS 8.2.0\grass.bat'
-        # this can be avoided if GRASS executable is added to PATH
+        # grass_executable = r'C:\Program Files (x86)\GRASS GIS <version>\grass.bat'
+        # this can be skipped if GRASS executable is added to PATH
     elif sys.platform == "darwin":
         # Mac OS X
-        grass8bin = "/Applications/GRASS-8.2.app/Contents/Resources/bin/grass"
+        grass_executable = "/Applications/GRASS-<version>.app/Contents/Resources/bin/grass"
 
     # query GRASS GIS itself for its Python package path
-    grass_cmd = [grass8bin, "--config", "python_path"]
+    grass_cmd = [grass_executable, "--config", "python_path"]
     process = subprocess.run(grass_cmd, check=True, text=True, stdout=subprocess.PIPE)
 
     # define GRASS-Python environment
@@ -65,7 +65,7 @@ Usage::
     gsetup.finish()
 
 
-(C) 2010-2021 by the GRASS Development Team
+(C) 2010-2022 by the GRASS Development Team
 This program is free software under the GNU General Public
 License (>=v2). Read the file COPYING that comes with GRASS
 for details.

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -24,19 +24,20 @@ Usage::
     # query GRASS itself for its GISBASE
     # (with fixes for specific platforms)
     # needs to be edited by the user
-    grass_executable = "grass"
+    executable = "grass"
     if sys.platform.startswith("win"):
         # MS Windows
-        grass_executable = r"C:\OSGeo4W\bin\grass.bat"
+        executable = r"C:\OSGeo4W\bin\grass.bat"
         # uncomment when using standalone WinGRASS installer
-        # grass_executable = r'C:\Program Files (x86)\GRASS GIS <version>\grass.bat'
+        # executable = r'C:\Program Files (x86)\GRASS GIS <version>\grass.bat'
         # this can be skipped if GRASS executable is added to PATH
     elif sys.platform == "darwin":
         # Mac OS X
-        grass_executable = "/Applications/GRASS-<version>.app/Contents/Resources/bin/grass"
+        version = "@GRASS_VERSION_MAJOR@.@GRASS_VERSION_MINOR@"
+        executable = f"/Applications/GRASS-{version}.app/Contents/Resources/bin/grass"
 
     # query GRASS GIS itself for its Python package path
-    grass_cmd = [grass_executable, "--config", "python_path"]
+    grass_cmd = [executable, "--config", "python_path"]
     process = subprocess.run(grass_cmd, check=True, text=True, stdout=subprocess.PIPE)
 
     # define GRASS-Python environment


### PR DESCRIPTION
When the current version is used, it needs to be updated usually every minor release. This reduces how much the current version is used where it is not essential.

* When in variable name, use more general variable name.
* When in comment or doc, use '<version>' or VV when no specific example is needed.
* When a specific version is need for an example, use 3.y.z which is obviously an example.
* When not essential in the context, remove it completely.
