### PR TITLE
r3.out.netcdf: Use current major version in history attribute

### DIFF
--- a/raster3d/r3.out.netcdf/main.c
+++ b/raster3d/r3.out.netcdf/main.c
@@ -55,8 +55,9 @@
 #define UNITS           "units"
 #define DEGREES_EAST    "degrees_east"
 #define DEGREES_NORTH   "degrees_north"
-#define HISTORY_TEXT    "GRASS GIS " STR(GRASS_VERSION_MAJOR) " netCDF export of r3.out.netcdf"
-#define CF_SUPPORT      "CF-1.5"
+#define HISTORY_TEXT \
+    "GRASS GIS " STR(GRASS_VERSION_MAJOR) " netCDF export of r3.out.netcdf"
+#define CF_SUPPORT "CF-1.5"
 
 #define ERR(e)                      \
     {                               \

--- a/raster3d/r3.out.netcdf/main.c
+++ b/raster3d/r3.out.netcdf/main.c
@@ -140,7 +140,6 @@ static void write_netcdf_header(int ncid, RASTER3D_Region *region, int *varid,
     if ((retval = nc_put_att_text(ncid, NC_GLOBAL, "Conventions",
                                   strlen(CF_SUPPORT), CF_SUPPORT)))
         ERR(retval);
-
     if ((retval = nc_put_att_text(ncid, NC_GLOBAL, "history",
                                   strlen(HISTORY_TEXT), HISTORY_TEXT)))
         ERR(retval);

--- a/raster3d/r3.out.netcdf/main.c
+++ b/raster3d/r3.out.netcdf/main.c
@@ -51,7 +51,7 @@
 #define UNITS           "units"
 #define DEGREES_EAST    "degrees_east"
 #define DEGREES_NORTH   "degrees_north"
-#define HISTORY_TEXT    "GRASS GIS 8 netCDF export of r3.out.netcdf"
+#define HISTORY_TEXT    "GRASS GIS netCDF export of r3.out.netcdf"
 #define CF_SUPPORT      "CF-1.5"
 
 #define ERR(e)                      \

--- a/raster3d/r3.out.netcdf/main.c
+++ b/raster3d/r3.out.netcdf/main.c
@@ -31,6 +31,10 @@
 #include <grass/glocale.h>
 #include <grass/gprojects.h>
 
+// Constant to string conversion
+#define STR_HELPER(x)   #x
+#define STR(x)          STR_HELPER(x)
+
 #define NDIMS           3
 #define LONG_NAME       "long_name"
 #define STANDARD_NAME   "standard_name"
@@ -51,7 +55,7 @@
 #define UNITS           "units"
 #define DEGREES_EAST    "degrees_east"
 #define DEGREES_NORTH   "degrees_north"
-#define HISTORY_TEXT    "GRASS GIS %d netCDF export of r3.out.netcdf"
+#define HISTORY_TEXT    "GRASS GIS " STR(GRASS_VERSION_MAJOR) " netCDF export of r3.out.netcdf"
 #define CF_SUPPORT      "CF-1.5"
 
 #define ERR(e)                      \
@@ -136,13 +140,8 @@ static void write_netcdf_header(int ncid, RASTER3D_Region *region, int *varid,
                                   strlen(CF_SUPPORT), CF_SUPPORT)))
         ERR(retval);
 
-    // Works up to version 9999.
-    // 2 in original, 2 more, \0 is in the original string which sizeof counts.
-    size_t history_size = sizeof(HISTORY_TEXT) / sizeof(char) + 2;
-    char history_string[history_size];
-    snprintf(history_string, history_size, HISTORY_TEXT, GRASS_VERSION_MAJOR);
     if ((retval = nc_put_att_text(ncid, NC_GLOBAL, "history",
-                                  strlen(history_string), history_string)))
+                                  strlen(HISTORY_TEXT), HISTORY_TEXT)))
         ERR(retval);
 
     G_get_window(&window);

--- a/raster3d/r3.out.netcdf/main.c
+++ b/raster3d/r3.out.netcdf/main.c
@@ -51,7 +51,7 @@
 #define UNITS           "units"
 #define DEGREES_EAST    "degrees_east"
 #define DEGREES_NORTH   "degrees_north"
-#define HISTORY_TEXT    "GRASS GIS netCDF export of r3.out.netcdf"
+#define HISTORY_TEXT    "GRASS GIS %d netCDF export of r3.out.netcdf"
 #define CF_SUPPORT      "CF-1.5"
 
 #define ERR(e)                      \
@@ -135,8 +135,14 @@ static void write_netcdf_header(int ncid, RASTER3D_Region *region, int *varid,
     if ((retval = nc_put_att_text(ncid, NC_GLOBAL, "Conventions",
                                   strlen(CF_SUPPORT), CF_SUPPORT)))
         ERR(retval);
+
+    // Works up to version 9999.
+    // 2 in original, 2 more, \0 is in the original string which sizeof counts.
+    size_t history_size = sizeof(HISTORY_TEXT) / sizeof(char) + 2;
+    char history_string[history_size];
+    snprintf(history_string, history_size, HISTORY_TEXT, GRASS_VERSION_MAJOR);
     if ((retval = nc_put_att_text(ncid, NC_GLOBAL, "history",
-                                  strlen(HISTORY_TEXT), HISTORY_TEXT)))
+                                  strlen(history_string), history_string)))
         ERR(retval);
 
     G_get_window(&window);

--- a/raster3d/r3.out.netcdf/r3.out.netcdf.html
+++ b/raster3d/r3.out.netcdf/r3.out.netcdf.html
@@ -124,7 +124,7 @@ variables:
 
 // global attributes:
                 :Conventions = "CF-1.5" ;
-                :history = "GRASS GIS 7 netCDF export of r3.out.netcdf" ;
+                :history = "GRASS GIS netCDF export of r3.out.netcdf" ;
 data:
 
  longitude = -175, -165, -155, -145, -135, -125, -115, -105, -95, -85, -75,
@@ -179,7 +179,7 @@ variables:
 
 // global attributes:
                 :Conventions = "CF-1.5" ;
-                :history = "GRASS GIS 7 netCDF export of r3.out.netcdf" ;
+                :history = "GRASS GIS netCDF export of r3.out.netcdf" ;
 data:
 
  longitude = -175, -165, -155, -145, -135, -125, -115, -105, -95, -85, -75,
@@ -236,7 +236,7 @@ variables:
 
 // global attributes:
                 :Conventions = "CF-1.5" ;
-                :history = "GRASS GIS 7 netCDF export of r3.out.netcdf" ;
+                :history = "GRASS GIS netCDF export of r3.out.netcdf" ;
 data:
 
  longitude = -175, -165, -155, -145, -135, -125, -115, -105, -95, -85, -75,


### PR DESCRIPTION
r3.out.netcdf creates a netCDF file with attribute history which contains software. This removes the hard-coded software version information and uses the current major version instead for the history text. It uses fairly general macros to encapsulate stringification to avoid complex code needed to use snprintf.

The documentation contains the output, so the version should be there, but I removed it from the examples to avoid the need for updates (making the documentation little less precise).