### PR TITLE
CI: Run workflows on main and release branches, PRs, not tags

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -6,8 +6,13 @@ name: Additional Checks
 # (and job) to reduce the number of jobs.
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   additional-checks:

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -8,11 +8,12 @@ name: Additional Checks
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   additional-checks:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,11 +3,12 @@ name: Python Black Formatting
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   run-black:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,9 +5,9 @@ on:
     branches:
     - main
     - releasebranch_*
-    tags:
-      - "*.*.*"
   pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   run-black:

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -3,11 +3,12 @@ name: CentOS
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -1,8 +1,13 @@
 name: CentOS
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
     paths-ignore:
       - "**/*.html"
       - "**/*.md"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main, releasebranch_7_8]
+    branches: [main]
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -3,11 +3,12 @@ name: Python Flake8 Code Quality
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   flake8:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,8 +1,13 @@
 name: Python Flake8 Code Quality
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   flake8:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -3,11 +3,12 @@ name: GCC C/C++ standards check
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,8 +1,13 @@
 name: GCC C/C++ standards check
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -1,8 +1,13 @@
 name: OSGeo4W
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -3,11 +3,12 @@ name: OSGeo4W
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,9 +5,9 @@ on:
     branches:
     - main
     - releasebranch_*
-    tags:
-      - "*.*.*"
   pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   pylint:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,11 +3,12 @@ name: Python Pylint Code Quality
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   pylint:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,8 +1,13 @@
 name: pytest
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,11 +3,12 @@ name: pytest
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   pytest:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -3,11 +3,12 @@ name: General linting
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   super-linter:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,8 +1,13 @@
 name: General linting
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   super-linter:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,11 +4,12 @@ name: Ubuntu
 on:
   push:
     branches:
-    - main
-    - releasebranch_*
+      - main
+      - releasebranch_*
   pull_request:
-    - main
-    - releasebranch_*
+    branches:
+      - main
+      - releasebranch_*
 
 jobs:
   build-and-test:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,8 +2,13 @@ name: Ubuntu
 # Build and run tests on Ubuntu
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - main
+    - releasebranch_*
+  pull_request:
+    - main
+    - releasebranch_*
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This limits when workflows are running using the 'on' specification. Workflows now run on pushed to the main branch and the release branches and on pull requests against these branches. They no longer run on tags and feature/fix branches.

Additionally, CodeQL runs only on main and PRs to main. (Was missing for 8.0 branch already anyway.)