### PR TITLE
CI: Compile r.example and v.example

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -86,6 +86,11 @@ jobs:
           export LD_LIBRARY_PATH=$HOME/install/grass83/lib:$LD_LIBRARY_PATH
           pytest --pylint -m pylint --pylint-rcfile=.pylintrc --pylint-jobs=$(nproc) --pylint-ignore-patterns="python/.*,gui/wxpython/.*,doc/.*,man/.*,utils/.*,locale/.*,raster/.*,imagery/.*,scripts/r.in.wms/wms_drv.py,scripts/g.extension/g.extension.py,temporal/t.rast.accdetect/t.rast.accdetect.py,temporal/t.rast.accumulate/t.rast.accumulate.py,scripts/d.rast.edit/d.rast.edit.py"
 
+      - name: Test compiling example modules
+        run: |
+          ( cd doc/raster/r.example/ && make )
+          ( cd doc/vector/v.example/ && make )
+
       - name: Run Sphinx to check API documentation build
         run: |
           pip install sphinx


### PR DESCRIPTION
Compiling the two example C modules was part of the release procedure. This makes it part of the CI.

For now the check is (strangely) in the Pylint workflow because it is documentation and that workflow already does a test build of Sphinx (all three need to build from source first). Other places would be a separate doc generating and checking workflow or adding these to GCC checks to ensure higher quality standard.
