### PR TITLE
RFC: Version Numbering

### DIFF
--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -7,6 +7,7 @@ Status: Draft
 ## Summary
 
 Use version number in a format _major.minor.micro_ where
+
 - _major_ is for large additions or backwards incompatible changes,
 - _minor_ is for additions, and
 - _micro_ is for fixes.
@@ -14,10 +15,11 @@ Use version number in a format _major.minor.micro_ where
 These numbers are assigned to releases. Development versions, pre-release,
 and builds are marked by additional labels as suffixes.
 
-Once a version number is assigned to a release, the associated source code cannot change,
-or in other words, version number is assigned to a particular state of the source code.
-This is sometimes called a hard freeze (or code freeze). Unlike soft freeze
-(or feature freeze) and branching, code freeze does not allow any changes of the code.
+Once a version number is assigned to a release, the associated source code
+cannot change, or in other words, version number is assigned to a particular
+state of the source code. This is sometimes called a hard freeze (or code
+freeze). Unlike soft freeze (or feature freeze) and branching, code freeze
+does not allow any changes of the code.
 
 All major and minor version numbers are used for releases,
 i.e., there is no distinction between even and odd numbers.
@@ -41,9 +43,9 @@ version 5 and 6 series.
 This odd-even practice followed the numbering scheme of the Linux kernel
 which abandoned the practice since then.
 
-At the time of version 5, the odd-even practice replaced a system where multiple numbered beta
-versions were released. Version 5.0beta10 was the last beta release before the first
-pre-release of 5.0.0.
+At the time of version 5, the odd-even practice replaced a system where multiple
+numbered beta versions were released. Version 5.0beta10 was the last beta
+release before the first pre-release of 5.0.0.
 
 The beta version practice was shortly picked up again for 7.0.0 which had four
 beta releases before the first release candidate of 7.0.0.
@@ -88,13 +90,15 @@ any backwards incompatible change in the API which includes
 both interface and behavior changes (API also defines what happens,
 not just names and signatures).
 
-Additionally, major feature additions which would require only a minor release in terms of API stability,
-are strongly suggested to trigger a major release as well.
-This in turn helps to address the issue of outdated tutorials and small, but breaking, changes.
+Additionally, major feature additions which would require only a minor release
+in terms of API stability, are strongly suggested to trigger a major release
+as well. This in turn helps to address the issue of outdated tutorials and
+small, but breaking, changes.
 
 Some major features, such as changes in the GUI, are fully backwards compatible
-(GUI API is not a public API in versions 7 and 8), but major features may heavily influence tutorials and
-other teaching materials. In that case, increasing a major version should be considered given that,
+(GUI API is not a public API in versions 7 and 8), but major features may
+heavily influence tutorials and other teaching materials. In that case,
+increasing a major version should be considered given that,
 in a sense, behavior linked to a particular interface is changed.
 
 There is always a list of many small changes which are not backwards compatible,
@@ -114,8 +118,8 @@ which are not bug fixes.
 If only backwards compatible bug fixes, i.e., fixes of incorrect behavior, are applied,
 a micro version can be released.
 
-The micro version is also known as _patch_ (which is what Semantic Versioning is using)
-and _point_ (which is what was used in some GRASS GIS documents).
+The micro version is also known as _patch_ (which is what Semantic Versioning
+is using) and _point_ (which is what was used in some GRASS GIS documents).
 The word _micro_, rather than patch, is used
 to avoid collision with patch referring to an individual changeset or fix
 (a release contains one or more of these changes).
@@ -194,26 +198,35 @@ In documentation, the version is often really needed, but don't say
 This way the version number in the sentence will always be valid because
 the version when the change was introduced stays the same and does not change.
 
-When a version is part of an output or displayed to the user, the version number should
-be determined dynamically, not hardcoded, even if it is just the major version
-number.
+When a version is part of an output or displayed to the user, the version
+number should be determined dynamically, not hardcoded, even if it is just
+the major version number.
 
 Don't include the version number where it is not needed, for example, text for links
 in a release announcement doesn't need a version because version is already given
 by the context.
 
-In short comments, references using GN where N is major version number are not common in general.
-When the version is important to mention, use vN which is a common practice.
+In short comments, references using GN where N is major version number are not
+common in general. When the version is important to mention, use vN which is
+a common practice.
 
 ## Relation to Other Documents
 
-* [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure): This RFC describes changes to the numbering. RFC 4 describes the release procedure.
-* [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule) (at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
-* [Semantic Versioning](https://semver.org/) (version 2.0.0 at the time of writing): Semantic Versioning treatment of _major_, _minor_, and _micro_ numbers should be respected. The labeling of other versions does not comply with Semantic Versioning, but it is a desired state for the future.
+- [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure):
+  This RFC describes changes to the numbering. RFC 4 describes the release procedure.
+- [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule)
+  (at Trac wiki under Release): The Release Schedule document describes
+  schedule, branching, release maintenance, and numbering. The numbering is
+  changed, specifically the use of odd version numbers for development.
+- [Semantic Versioning](https://semver.org/) (version 2.0.0 at the time of
+  writing): Semantic Versioning treatment of _major_, _minor_, and _micro_
+  numbers should be respected. The labeling of other versions does not comply
+  with Semantic Versioning, but it is a desired state for the future.
 
 ## Other Projects
 
-GDAL and PROJ follow the Semantic versioning. QGIS does as well, but in combination with odd numbers marking the development versions.
+GDAL and PROJ follow the Semantic versioning. QGIS does as well, but in
+combination with odd numbers marking the development versions.
 
 Ubuntu and Black lock their version numbering with the release schedule.
 Black, after transitioning from beta, releases a major release yearly in January
@@ -221,5 +234,8 @@ using the last two digits of year as major version and month as minor release.
 
 ## Historical Documents
 
-* Glynn Clements (2007). GRASS-dev GRASS 6.3.0 release preparation. Aug. 12 18:12:32 EDT 2007. <https://lists.osgeo.org/pipermail/grass-dev/2007-August/032705.html>
-* Neteler, Markus (2001). Towards a stable open source GIS: Status and future directions in GRASS development. Second Italian GRASS Users Meeting, University of Trento, Feb. 1-2 2001. <https://www.academia.edu/download/5140572/10.1.1.16.8991.pdf>
+- Glynn Clements (2007). GRASS-dev GRASS 6.3.0 release preparation.
+  Aug. 12 18:12:32 EDT 2007. <https://lists.osgeo.org/pipermail/grass-dev/2007-August/032705.html>
+- Neteler, Markus (2001). Towards a stable open source GIS: Status and future
+  directions in GRASS development. Second Italian GRASS Users Meeting,
+  University of Trento, Feb. 1-2 2001. <https://www.academia.edu/download/5140572/10.1.1.16.8991.pdf>

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -167,7 +167,7 @@ control system, but builds are managed separately.
 ## Relation to Other Documents
 
 * [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure): No changes to release procedure, only the numbering is changed.
-* [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule#Externalreleaseschedules) (at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
+* [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule) (at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
 * [Semantic Versioning](https://semver.org/) (version 2.0.0 at the time of writing): Semantic Versioning treatment of _major_, _minor_, and _micro_ numbers should be respected. The labeling of other versions does not comply with Semantic Versioning, but it is a desired state for the future.
 
 ## Other Projects

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -52,10 +52,10 @@ beta releases before the first release candidate of 7.0.0.
 
 Explaining the version numbering should be as easy as possible.
 Ideally, it would not need any explanation at all.
-When all version numbers refer to releases, previews (alphas, betas, daily builds),
+When all version numbers refer to releases, previews (alphas, betas, daily builds)
 always need additional indication of the version being a preview.
-However, using odd version to mark the development versions requires
-still additional explanation, for example, download for 8.1 on the website
+However, using odd version to mark the development versions still requires
+additional explanation, for example, download for 8.1 on the website
 said _preview_ anyway because the odd number does not indicate a
 development version by itself, i.e., it's not self-explanatory.
 Hence, odd numbers for development versions do not bring any advantage.
@@ -66,9 +66,8 @@ a minor version is created, the branch needs to change all the mentions
 of the minor version number to the next even number and, at the same time,
 the _main_ branch needs to change to the next odd number.
 Without the even and odd distinction, the branch keeps the version from
-the main branch while the main branch advanced to the next upcoming version
-resulting only in one operation which is the same whether the current version
-is even or odd.
+the main branch while the main branch advances to the next upcoming version
+resulting only in one operation.
 
 The Semantic Versioning uses labels after the version number to indicate development
 versions, so using that system or a similar one should be sufficient to mark the
@@ -87,10 +86,10 @@ Additionally, major feature additions which would require only a minor release i
 are strongly suggested to trigger a major release as well.
 This in turn helps to address the issue of outdated tutorials and small, but breaking, changes.
 
-Some major features such as changes in the GUI are fully backwards compatible
-(GUI API is not a public API in versions 7 and 8), but are heavily influencing tutorials and
-other teaching materials. In that sense, the behavior linked to a particular interface is changed,
-so a major version is required.
+Some major features, such as changes in the GUI, are fully backwards compatible
+(GUI API is not a public API in versions 7 and 8), but major features may heavily influence tutorials and
+other teaching materials. In that case, increasing a major version should be considered given that,
+in a sense, behavior linked to a particular interface is changed.
 
 There is always a list of many small changes which are not backwards compatible,
 for example, a cleanup of deprecated functions. None of these changes alone
@@ -109,8 +108,8 @@ which are not bug fixes.
 If only backwards compatible bug fixes, i.e., fixes of incorrect behavior, are applied,
 a micro version can be released.
 
-The micro version is also known as _patch_ which is what Semantic Versioning is using
-and _point_ which is what was used in some GRASS GIS documents.
+The micro version is also known as _patch_ (which is what Semantic Versioning is using)
+and _point_ (which is what was used in some GRASS GIS documents).
 The word _micro_, rather than patch, is used
 to avoid collision with patch referring to an individual changeset or fix
 (a release contains one or more of these changes).
@@ -120,7 +119,7 @@ using minor and micro does not have that ambiguity.
 Although minor and micro have potential for confusion due to the
 similarity of their names, minor is an established term in this context
 and micro is sometimes used in this context and in other contexts,
-it has the right connotations.
+so it has the right connotations.
 
 ### Development Versions
 
@@ -147,22 +146,24 @@ may use additional dashes to specify the actual source version, e.g.,
 3.5.1-dev-05e5df2e7.
 
 Any version parsing or build system, must support both systems, the one without
-a dash and the one with dash.
+a dash and the one with a dash.
 
 ### Build Information
 
 When build information is captured in the version number, Semantic Versioning
-prescribed plus sign as a separator, e.g., 3.5.1+1 or 3.5.1-RC1+1.
+prescribes a plus sign as a separator, e.g., 3.5.1+1 or 3.5.1-RC1+1.
 However, filenames with a plus sign may not work well, so a dash as a separator
 is allowed too while keeping in mind that automated semantic version tools
 won't parse the version correctly. A suggested workaround is to use the dash
-only in a file name and elsewhere use plus.
+only in a file name and use plus sign everywhere else.
 
-Any version parsing or build system, must support the form with dash
-and the form with plus.
+Any version parsing or build system, must support the form with a dash
+and the form with a plus sign.
 
 While the assignment of a version is typically done by tagging in a version
-control system, but builds are managed separately.
+control system, so the assumption is that there is always a related tag,
+the builds are managed separately, so the assumption is there is not tag in
+the version control system.
 
 ## Relation to Other Documents
 

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -1,0 +1,146 @@
+# RFC: Version Numbering
+
+Author: Vaclav Petras
+
+Status: Draft
+
+## Summary
+
+Use version number in a format _major.minor.micro_ where
+- _major_ is for large additions or backwards incompatible changes,
+- _minor_ is for additions, and
+- _micro_ is for fixes.
+These numbers are assigned to releases. Development versions, pre-release,
+and builds are marked by additional labels as suffixes.
+All major and minor version numbers are used for releases,
+i.e., there is no distinction between even and odd numbers.
+
+## Background
+
+The increasing versions was always following the same ideas as in
+the Semantic Versioning, i.e., _major_, _minor_, and _patch_
+with major for breaking changes, minor for backwards compatible
+features, and patch for fixes.
+
+For the versions 7.0 till 8.2, there was a distinction between even and odd minor versions.
+Even minor versions were released, while odd minor version marked development version.
+This odd versions never had a patch number assigned and were never released.
+
+## Motivation
+
+Explaining the version numbering should be as easy as possible.
+Ideally, it would not need any explanation at all.
+When all version numbers refer to releases, previews (alphas, betas, daily builds),
+always need additional indication of the version being a preview.
+However, using odd version to mark the development versions requires
+still additional explanation, for example, download for 8.1 on the website
+said _preview_ anyway because the odd number does not indicate the
+development version.
+Hence, odd numbers for development versions do not bring any advantage.
+
+The branching and release procedure with even minor numbers for releases
+and odd numbers for development versions require that when new branch for
+a minor version is created, the branch needs to change all the mentions
+of the minor version number to the next even number and, at the same time,
+the _main_ branch needs to change to the next odd number.
+Without the even and odd distinction, the branch keeps the version from
+the main branch while the main branch advanced to the next upcoming version
+resulting only in one operation which is the same whether the current version
+is even or odd.
+
+The Semantic Versioning uses labels after the version number to indicate development
+versions, so using that system or a similar one should be sufficient to mark the
+development versions.
+
+## Version Numbering Specification
+
+### Major
+
+In accordance with Semantic Versioning, major release must happen with
+any backwards incompatible change in the API which includes
+both interface and behavior changes (API also defines what happens,
+not just names and signatures).
+
+Additionally, major feature additions which would require only minor release in terms of API stability,
+are strongly suggested to trigger major release as well.
+This in turn helps to address the issue of outdated tutorials and small, but breaking, changes.
+
+Some major features such as changes in the GUI are fully backwards compatible
+(GUI API is not a public API in versions 7 and 8), but are heavily influencing tutorials and
+other teaching materials. In that sense, behavior linked to a particular interface is changed,
+so a major version is required.
+
+There is always a list of many small changes which are not backwards compatible,
+for example, a cleanup of depreciated functions. None of these changes alone does
+not seem worth a major release, but because it would require one, it is never done.
+With more common major releases, small changes can happen more often.
+
+### Minor
+
+Minor version must be incremented if new functionality is added
+or if existing functionality is marked as deprecated.
+Minor version increment is strongly recommend for all new functionality or improvements
+which are not bug fixes.
+
+### Micro
+
+If only backwards compatible bug fixes, i.e., fixes of incorrect behavior, are applied,
+a micro version can be released.
+
+The micro version is also known as _patch_ which is what Semantic Versioning is using
+and _point_ which is what was used in some GRASS GIS documents. The work _micro_ is used
+to avoid collision with patch in the meaning of individual changeset or fix
+(release contain one or more of these changes). Point release (or _dot_ release)
+can generally apply to anything after the first dot, so minor or micro release.
+
+### Development Versions
+
+Development versions have the version number of the next release which will be released
+from a given code base which is defined by a branch.
+
+Development versions of source code on each branch have a dev suffix,
+e.g., 3.5.1-dev.
+Transition to the Semantic Versioning style is strongly recommend
+which means including dash (hyphen) before dev, e.g., 3.5.1-dev.
+Notably, these are not unique and multiple versions are marked the same.
+
+Release candidates (RCs) are pre-releases marked by appending RC and
+a release candidate number to the version, e.g., 3.5.1RC2.
+
+Transition to the Semantic Versioning style for pre-releases is strongly recommend.
+Version number is followed by a dash (hyphen) followed by a dot-separated identifier
+which consists of identification of pre-release type, i.e., rc or RC, optional dot,
+and a release candidate number, e.g., 3.5.1-rc.2, 3.5.1-RC.2, 3.5.1-rc2, or 3.5.1-RC2.
+
+Daily builds and other builds of development versions other than release candidates
+are may use additional dashes to specify the actual source version, e.g.,
+3.5.1-dev-05e5df2e7.
+
+Any version parsing or build system, must support both systems, the one without
+a dash and the one with dash.
+
+### Build Information
+
+When build information is captured in the version number, Semantic Versioning
+prescribed plus sign as a separator, e.g., 3.5.1+1 or 3.5.1-RC1+1.
+However, filenames with a plus sign my not work well, so a dash as a separator
+is allowed too while keeping in mind that automated semantic version tools
+won't parse the version correctly. A suggested workaround is to use the dash
+only in a file name and elsewhere use plus.
+
+Any version parsing or build system, must support the form with dash
+and the form with plus.
+
+## Relation to Other Documents
+
+* [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure): No changes to release procedure, only the numbering is changed.
+* [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule#Externalreleaseschedules) (from  at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
+* [Semantic Versioning](https://semver.org/) (version 2.0.0 at the time of writing): Semantic Versioning treatment of _major_, _minor_, and _micro_ numbers should be respected. The labeling of other versions does not comply with Semantic Versioning, but it is a desired state for the future.
+
+## Other Projects
+
+GDAL and PROJ follow the Semantic versioning. QGIS does as well, but in combination of odd numbers marking the development versions.
+
+Ubuntu and Black lock their version numbering with release schedule.
+Black, after transitioning from beta, releases a major release yearly in January
+using last two digits of year as major version and month as minor release.

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -22,9 +22,20 @@ the Semantic Versioning, i.e., _major_, _minor_, and _patch_
 with major for breaking changes, minor for backwards compatible
 features, and patch for fixes.
 
-For the versions 7.0 till 8.2, there was a distinction between even and odd minor versions.
+For the versions 7.0 till 8.2, there was a distinction between even
+and odd minor versions.
 Even minor versions were released, while odd minor versions marked development versions.
 These odd versions never had a patch number assigned and were never released.
+
+The practice of odd minor version denoting development versions and even minor versions
+denoting releases was introduced with 5.0.0 and was followed in various ways in the
+version 5 and 6 series.
+This odd-even practice followed the numbering scheme of the Linux kernel
+which abandoned the practice since then.
+
+The odd-even practice replaced a system where multiple numbered beta
+versions were released. Version 5.0beta10 was a last beta release before the first
+pre-release of 5.0.0.
 
 ## Motivation
 

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -15,8 +15,9 @@ These numbers are assigned to releases. Development versions, pre-release,
 and builds are marked by additional labels as suffixes.
 
 Once a version number is assigned to a release, the associated source code cannot change,
-or in other words, version number is assigned to a particular state of the source code. This is called a code freeze and unlike feature freeze,
-code freeze does not allow any changes of the code.
+or in other words, version number is assigned to a particular state of the source code.
+This is sometimes called a hard freeze (or code freeze). Unlike soft freeze
+(or feature freeze) and branching, code freeze does not allow any changes of the code.
 
 All major and minor version numbers are used for releases,
 i.e., there is no distinction between even and odd numbers.
@@ -159,6 +160,9 @@ only in a file name and elsewhere use plus.
 
 Any version parsing or build system, must support the form with dash
 and the form with plus.
+
+While the assignment of a version is typically done by tagging in a version
+control system, but builds are managed separately.
 
 ## Relation to Other Documents
 

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -173,3 +173,8 @@ GDAL and PROJ follow the Semantic versioning. QGIS does as well, but in combinat
 Ubuntu and Black lock their version numbering with release schedule.
 Black, after transitioning from beta, releases a major release yearly in January
 using last two digits of year as major version and month as minor release.
+
+## Historical Documents
+
+* Glynn Clements (2007). GRASS-dev GRASS 6.3.0 release preparation. Aug. 12 18:12:32 EDT 2007. <https://lists.osgeo.org/pipermail/grass-dev/2007-August/032705.html>
+* Neteler, Markus (2001). Towards a stable open source GIS: Status and future directions in GRASS development. Second Italian GRASS Users Meeting, University of Trento, Feb. 1-2 2001. <https://www.academia.edu/download/5140572/10.1.1.16.8991.pdf>

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -24,7 +24,7 @@ i.e., there is no distinction between even and odd numbers.
 
 ## Background
 
-The increasing versions was always following the same ideas as in
+The increasing versions were always following the same ideas as in
 the [Semantic Versioning](https://semver.org/),
 i.e., _major_, _minor_, and _patch_,
 with major for breaking changes, minor for backwards compatible
@@ -35,14 +35,14 @@ and odd minor versions.
 Even minor versions were released, while odd minor versions marked development versions.
 These odd versions never had a patch number assigned and were never released.
 
-The practice of odd minor version denoting development versions and even minor versions
+The practice of odd minor versions denoting development versions and even minor versions
 denoting releases was introduced with 5.0.0 and was followed in various ways in the
 version 5 and 6 series.
 This odd-even practice followed the numbering scheme of the Linux kernel
 which abandoned the practice since then.
 
 At the time of version 5, the odd-even practice replaced a system where multiple numbered beta
-versions were released. Version 5.0beta10 was a last beta release before the first
+versions were released. Version 5.0beta10 was the last beta release before the first
 pre-release of 5.0.0.
 
 The beta version practice was shortly picked up again for 7.0.0 which had four
@@ -54,7 +54,7 @@ Explaining the version numbering should be as easy as possible.
 Ideally, it would not need any explanation at all.
 When all version numbers refer to releases, previews (alphas, betas, daily builds)
 always need additional indication of the version being a preview.
-However, using odd version to mark the development versions still requires
+However, using odd versions to mark the development versions still requires
 additional explanation, for example, download for 8.1 on the website
 said _preview_ anyway because the odd number does not indicate a
 development version by itself, i.e., it's not self-explanatory.
@@ -74,6 +74,12 @@ versions, so using that system or a similar one should be sufficient to mark the
 development versions.
 
 ## Version Numbering Specification
+
+### Format
+
+Major, minor, and micro versions are separated by periods (dots),
+i.e., _major.minor.micro_. The format for development versions and
+build information is described in their respective sections.
 
 ### Major
 
@@ -100,7 +106,7 @@ With more common major releases, small changes can happen more often.
 
 Minor version must be incremented if new functionality is added
 or if existing functionality is marked as deprecated.
-Minor version increment is strongly recommend for all new functionality or improvements
+Minor version increment is strongly recommended for all new functionality or improvements
 which are not bug fixes.
 
 ### Micro
@@ -118,8 +124,8 @@ the first dot, i.e., minor or micro release, while
 using minor and micro does not have that ambiguity.
 Although minor and micro have potential for confusion due to the
 similarity of their names, minor is an established term in this context
-and micro is sometimes used in this context and in other contexts,
-so it has the right connotations.
+and micro is sometimes used in this context and in other contexts
+(e.g., micro donations), so it has the right connotations.
 
 ### Development Versions
 
@@ -128,7 +134,7 @@ from a given code base which is defined by a branch.
 
 Development versions of source code on each branch have a dev suffix,
 e.g., 3.5.1-dev.
-Transition to the Semantic Versioning style is strongly recommend
+Transition to the Semantic Versioning style is strongly recommended
 which means including dash (hyphen) before dev, e.g., 3.5.1-dev.
 Notably, these dev-suffixed version numbers are not unique, i.e.,
 multiple source code versions are marked the same.
@@ -136,16 +142,16 @@ multiple source code versions are marked the same.
 Release candidates (RCs) are pre-releases marked by appending RC and
 a release candidate number to the version, e.g., 3.5.1RC2.
 
-Transition to the Semantic Versioning style for pre-releases is strongly recommend.
+Transition to the Semantic Versioning style for pre-releases is strongly recommended.
 Version number is followed by a dash (hyphen) followed by a dot-separated identifier
 which consists of identification of pre-release type, i.e., rc or RC, optional dot,
 and a release candidate number, e.g., 3.5.1-rc.2, 3.5.1-RC.2, 3.5.1-rc2, or 3.5.1-RC2.
 
 Daily builds and other builds of development versions other than release candidates
 may use additional dashes to specify the actual source version, e.g.,
-3.5.1-dev-05e5df2e7.
+3.5.1-dev-05e5df2e7, or day, e.g., 3.5.1-dev-2023-05-29.
 
-Any version parsing or build system, must support both systems, the one without
+Any version parsing or build system must support both systems, the one without
 a dash and the one with a dash.
 
 ### Build Information
@@ -157,27 +163,61 @@ is allowed too while keeping in mind that automated semantic version tools
 won't parse the version correctly. A suggested workaround is to use the dash
 only in a file name and use plus sign everywhere else.
 
-Any version parsing or build system, must support the form with a dash
+Any version parsing or build system must support the form with a dash
 and the form with a plus sign.
 
 While the assignment of a version is typically done by tagging in a version
 control system, so the assumption is that there is always a related tag,
-the builds are managed separately, so the assumption is there is not tag in
+the builds are managed separately, so the assumption is there is no tag in
 the version control system.
+
+## Usage
+
+Version numbers should be presented in their specified format.
+When appropriate, a shorter version can be used, for example 4
+to refer to the whole series or 4.3 to refer to the latest releases
+(regardless of the current micro version).
+
+Leaving out the periods (dots) from the version numbers and combining
+major, minor, and micro into a single number is discouraged because of
+the lack of clarity for humans and because of the
+ambiguity for parsing (35 can be version 3.5 or 35).
+
+Version should be considered a separate item from the name.
+The name of the project and software is GRASS GIS, not GRASS GIS 8.
+So, don't use "GRASS GIS 8 includes foo and bar" when you simply mean
+"the current version includes foo and bar" or "GRASS GIS includes foo and bar".
+
+In documentation, the version is often really needed, but don't say
+"the default database driver in GRASS GIS 7 is SQLite", instead say
+"the default database driver in GRASS GIS is SQLite (since version 7)."
+This way the version number in the sentence will always be valid because
+the version when the change was introduced stays the same and does not change.
+
+When a version is part of an output or displayed to the user, the version number should
+be determined dynamically, not hardcoded, even if it is just the major version
+number.
+
+Don't include the version number where it is not needed, for example, text for links
+in a release announcement doesn't need a version because version is already given
+by the context.
+
+In short comments, references using GN where N is major version number are not common in general.
+When the version is important to mention, use vN which is a common practice.
 
 ## Relation to Other Documents
 
-* [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure): No changes to release procedure, only the numbering is changed.
+* [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure): This RFC describes changes to the numbering. RFC 4 describes the release procedure.
 * [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule) (at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
 * [Semantic Versioning](https://semver.org/) (version 2.0.0 at the time of writing): Semantic Versioning treatment of _major_, _minor_, and _micro_ numbers should be respected. The labeling of other versions does not comply with Semantic Versioning, but it is a desired state for the future.
 
 ## Other Projects
 
-GDAL and PROJ follow the Semantic versioning. QGIS does as well, but in combination of odd numbers marking the development versions.
+GDAL and PROJ follow the Semantic versioning. QGIS does as well, but in combination with odd numbers marking the development versions.
 
-Ubuntu and Black lock their version numbering with release schedule.
+Ubuntu and Black lock their version numbering with the release schedule.
 Black, after transitioning from beta, releases a major release yearly in January
-using last two digits of year as major version and month as minor release.
+using the last two digits of year as major version and month as minor release.
 
 ## Historical Documents
 

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -18,7 +18,8 @@ i.e., there is no distinction between even and odd numbers.
 ## Background
 
 The increasing versions was always following the same ideas as in
-the Semantic Versioning, i.e., _major_, _minor_, and _patch_
+the [Semantic Versioning](https://semver.org/),
+i.e., _major_, _minor_, and _patch_,
 with major for breaking changes, minor for backwards compatible
 features, and patch for fixes.
 
@@ -33,7 +34,7 @@ version 5 and 6 series.
 This odd-even practice followed the numbering scheme of the Linux kernel
 which abandoned the practice since then.
 
-The odd-even practice replaced a system where multiple numbered beta
+At the time of version 5, the odd-even practice replaced a system where multiple numbered beta
 versions were released. Version 5.0beta10 was a last beta release before the first
 pre-release of 5.0.0.
 
@@ -82,7 +83,7 @@ other teaching materials. In that sense, the behavior linked to a particular int
 so a major version is required.
 
 There is always a list of many small changes which are not backwards compatible,
-for example, a cleanup of depreciated functions. None of these changes alone 
+for example, a cleanup of deprecated functions. None of these changes alone
 seems worth a major release, but because it would require one, it is never done.
 With more common major releases, small changes can happen more often.
 
@@ -99,15 +100,18 @@ If only backwards compatible bug fixes, i.e., fixes of incorrect behavior, are a
 a micro version can be released.
 
 The micro version is also known as _patch_ which is what Semantic Versioning is using
-and _point_ which is what was used in some GRASS GIS documents. The word _micro_ is used
-to avoid collision with patch in the meaning of individual changeset or fix
-(release contain one or more of these changes). Point release (or _dot_ release)
-can generally apply to anything after the first dot, i.e., minor or micro release.
-Using minor and micro does not have that ambiguity.
-Minor and micro have potential for confusion between these two due to the
-similarity of the names, but minor is an established term in this context
-and minor is sometimes used in this context and other contexts it has
-the right connotations.
+and _point_ which is what was used in some GRASS GIS documents.
+The word _micro_, rather than patch, is used
+to avoid collision with patch referring to an individual changeset or fix
+(a release contains one or more of these changes).
+A point release (or a _dot_ release) can generally apply to anything after
+the first dot, i.e., minor or micro release, while
+using minor and micro does not have that ambiguity.
+Although minor and micro have potential for confusion due to the
+similarity of their names, minor is an established term in this context
+and micro is sometimes used in this context and in other contexts,
+it has the right connotations.
+
 ### Development Versions
 
 Development versions have the version number of the next release which will be released
@@ -138,7 +142,7 @@ a dash and the one with dash.
 
 When build information is captured in the version number, Semantic Versioning
 prescribed plus sign as a separator, e.g., 3.5.1+1 or 3.5.1-RC1+1.
-However, filenames with a plus sign my not work well, so a dash as a separator
+However, filenames with a plus sign may not work well, so a dash as a separator
 is allowed too while keeping in mind that automated semantic version tools
 won't parse the version correctly. A suggested workaround is to use the dash
 only in a file name and elsewhere use plus.

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -10,8 +10,13 @@ Use version number in a format _major.minor.micro_ where
 - _major_ is for large additions or backwards incompatible changes,
 - _minor_ is for additions, and
 - _micro_ is for fixes.
+
 These numbers are assigned to releases. Development versions, pre-release,
 and builds are marked by additional labels as suffixes.
+
+Once a version number is assigned to a release, the associated source code cannot change,
+or in other words, version number is assigned to a particular state of the source code.
+
 All major and minor version numbers are used for releases,
 i.e., there is no distinction between even and odd numbers.
 
@@ -37,6 +42,9 @@ which abandoned the practice since then.
 At the time of version 5, the odd-even practice replaced a system where multiple numbered beta
 versions were released. Version 5.0beta10 was a last beta release before the first
 pre-release of 5.0.0.
+
+The beta version practice was shortly picked up again for 7.0.0 which had four
+beta releases before the first release candidate of 7.0.0.
 
 ## Motivation
 
@@ -121,7 +129,8 @@ Development versions of source code on each branch have a dev suffix,
 e.g., 3.5.1-dev.
 Transition to the Semantic Versioning style is strongly recommend
 which means including dash (hyphen) before dev, e.g., 3.5.1-dev.
-Notably, these are not unique and multiple versions are marked the same.
+Notably, these dev-suffixed version numbers are not unique, i.e.,
+multiple source code versions are marked the same.
 
 Release candidates (RCs) are pre-releases marked by appending RC and
 a release candidate number to the version, e.g., 3.5.1RC2.

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -23,8 +23,8 @@ with major for breaking changes, minor for backwards compatible
 features, and patch for fixes.
 
 For the versions 7.0 till 8.2, there was a distinction between even and odd minor versions.
-Even minor versions were released, while odd minor version marked development version.
-This odd versions never had a patch number assigned and were never released.
+Even minor versions were released, while odd minor versions marked development versions.
+These odd versions never had a patch number assigned and were never released.
 
 ## Motivation
 
@@ -34,12 +34,12 @@ When all version numbers refer to releases, previews (alphas, betas, daily build
 always need additional indication of the version being a preview.
 However, using odd version to mark the development versions requires
 still additional explanation, for example, download for 8.1 on the website
-said _preview_ anyway because the odd number does not indicate the
-development version.
+said _preview_ anyway because the odd number does not indicate a
+development version by itself, i.e., it's not self-explanatory.
 Hence, odd numbers for development versions do not bring any advantage.
 
 The branching and release procedure with even minor numbers for releases
-and odd numbers for development versions require that when new branch for
+and odd numbers for development versions require that when a new branch for
 a minor version is created, the branch needs to change all the mentions
 of the minor version number to the next even number and, at the same time,
 the _main_ branch needs to change to the next odd number.
@@ -56,23 +56,23 @@ development versions.
 
 ### Major
 
-In accordance with Semantic Versioning, major release must happen with
+In accordance with Semantic Versioning, a major release must happen with
 any backwards incompatible change in the API which includes
 both interface and behavior changes (API also defines what happens,
 not just names and signatures).
 
-Additionally, major feature additions which would require only minor release in terms of API stability,
-are strongly suggested to trigger major release as well.
+Additionally, major feature additions which would require only a minor release in terms of API stability,
+are strongly suggested to trigger a major release as well.
 This in turn helps to address the issue of outdated tutorials and small, but breaking, changes.
 
 Some major features such as changes in the GUI are fully backwards compatible
 (GUI API is not a public API in versions 7 and 8), but are heavily influencing tutorials and
-other teaching materials. In that sense, behavior linked to a particular interface is changed,
+other teaching materials. In that sense, the behavior linked to a particular interface is changed,
 so a major version is required.
 
 There is always a list of many small changes which are not backwards compatible,
-for example, a cleanup of depreciated functions. None of these changes alone does
-not seem worth a major release, but because it would require one, it is never done.
+for example, a cleanup of depreciated functions. None of these changes alone 
+seems worth a major release, but because it would require one, it is never done.
 With more common major releases, small changes can happen more often.
 
 ### Minor
@@ -88,11 +88,15 @@ If only backwards compatible bug fixes, i.e., fixes of incorrect behavior, are a
 a micro version can be released.
 
 The micro version is also known as _patch_ which is what Semantic Versioning is using
-and _point_ which is what was used in some GRASS GIS documents. The work _micro_ is used
+and _point_ which is what was used in some GRASS GIS documents. The word _micro_ is used
 to avoid collision with patch in the meaning of individual changeset or fix
 (release contain one or more of these changes). Point release (or _dot_ release)
-can generally apply to anything after the first dot, so minor or micro release.
-
+can generally apply to anything after the first dot, i.e., minor or micro release.
+Using minor and micro does not have that ambiguity.
+Minor and micro have potential for confusion between these two due to the
+similarity of the names, but minor is an established term in this context
+and minor is sometimes used in this context and other contexts it has
+the right connotations.
 ### Development Versions
 
 Development versions have the version number of the next release which will be released
@@ -113,7 +117,7 @@ which consists of identification of pre-release type, i.e., rc or RC, optional d
 and a release candidate number, e.g., 3.5.1-rc.2, 3.5.1-RC.2, 3.5.1-rc2, or 3.5.1-RC2.
 
 Daily builds and other builds of development versions other than release candidates
-are may use additional dashes to specify the actual source version, e.g.,
+may use additional dashes to specify the actual source version, e.g.,
 3.5.1-dev-05e5df2e7.
 
 Any version parsing or build system, must support both systems, the one without
@@ -134,7 +138,7 @@ and the form with plus.
 ## Relation to Other Documents
 
 * [RFC 4: Release Procedure](https://trac.osgeo.org/grass/wiki/RFC/4_ReleaseProcedure): No changes to release procedure, only the numbering is changed.
-* [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule#Externalreleaseschedules) (from  at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
+* [Release Schedule](https://trac.osgeo.org/grass/wiki/Release/Schedule#Externalreleaseschedules) (at Trac wiki under Release): The Release Schedule document describes schedule, branching, release maintenance, and numbering. The numbering is changed, specifically the use of odd version numbers for development.
 * [Semantic Versioning](https://semver.org/) (version 2.0.0 at the time of writing): Semantic Versioning treatment of _major_, _minor_, and _micro_ numbers should be respected. The labeling of other versions does not comply with Semantic Versioning, but it is a desired state for the future.
 
 ## Other Projects

--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -15,7 +15,8 @@ These numbers are assigned to releases. Development versions, pre-release,
 and builds are marked by additional labels as suffixes.
 
 Once a version number is assigned to a release, the associated source code cannot change,
-or in other words, version number is assigned to a particular state of the source code.
+or in other words, version number is assigned to a particular state of the source code. This is called a code freeze and unlike feature freeze,
+code freeze does not allow any changes of the code.
 
 All major and minor version numbers are used for releases,
 i.e., there is no distinction between even and odd numbers.

--- a/utils/update_version.md
+++ b/utils/update_version.md
@@ -54,7 +54,7 @@ echo $VERSION
 
 ### Updating Minor Version
 
-Let's say were are at the main branch, version 3.2.0dev, and just created
+Let's say we are at the main branch, version 3.2.0dev, and just created
 a new branch for 3.2 release, so we want to update the minor version
 on the main branch to the next minor version:
 

--- a/utils/update_version.md
+++ b/utils/update_version.md
@@ -1,6 +1,6 @@
 # Updating Version File
 
-Version file (`include/VERSION`) can be updated using the _update_version.md_ script.
+Version file (`include/VERSION`) can be updated using the _update_version.py_ script.
 
 The script captures the logic of updating the version file incorporating
 the common actions and workflow checks.
@@ -54,20 +54,22 @@ echo $VERSION
 
 ### Updating Minor Version
 
-Let's say we are at development-only version 3.1.dev and just created
+Let's say were are at the main branch, version 3.2.0dev, and just created
 a new branch for 3.2 release, so we want to update the minor version
-to the next minor version:
+on the main branch to the next minor version:
 
 ```sh
 ./utils/update_version.py minor
 ```
 
 Separately, or as part of other changes, now is the time to commit,
-so the script suggests a commit message:
+so the script suggests a commit message in the output, e.g.:
 
 ```yaml
-message: Use the provided title as a commit message
-title: 'version: Start 3.2.0dev'
+read:
+  user_message: Use the provided message for the commit
+use:
+  commit_message: 'version: Start 3.2.0dev'
 ```
 
 ### Error Handling
@@ -85,15 +87,4 @@ only after the release:
 
 ```text
 Already dev with micro '0dev'. Release first before update.
-```
-
-### Updating Development-only Version
-
-Development-only versions have odd minor version numbers and are never actually
-released. Given the branching model, all these versions are on the _main_ branch,
-so there the minor version is increased by two. This can be done by running
-the _minor_ command twice or by using the `minor --dev`:
-
-```sh
-./utils/update_version.py minor --dev
 ```

--- a/utils/update_version.py
+++ b/utils/update_version.py
@@ -143,22 +143,9 @@ def update_minor(args):
     version_file = read_version_file()
     micro = version_file.micro
     minor = int(version_file.minor)
-    if args.dev:
-        if not minor % 2:
-            sys.exit(
-                "Updating to a development-only version "
-                f"from an even minor version '{minor}' is not possible"
-            )
-        minor += 2
-    else:
-        minor += 1
+    minor += 1
     if micro.endswith("dev"):
-        if minor % 2:
-            # Odd is development-only, never released and without micro version.
-            micro = "dev"
-        else:
-            # Even will be released, so adding micro version.
-            micro = "0dev"
+        micro = "0dev"
     else:
         sys.exit("Updating version from a non-dev VERSION file is not possible")
     write_version_file(
@@ -282,9 +269,6 @@ def main():
 
     subparser = subparsers.add_parser(
         "minor", help="increase minor (x.Y.z) version (uses dev in micro)"
-    )
-    subparser.add_argument(
-        "--dev", action="store_true", help="increase development-only version"
     )
     subparser.set_defaults(func=update_minor)
 


### PR DESCRIPTION
This PR is a RFC for a new version numbering system. The main point is not making any distinction between even and odd version numbers. After 8.2.z, 8.3.0 would follow.

Notably, this RFC does not follow the current RFC procedure (if any), but creates a PR as suggested in the past as a possible improvement of the procedure.

Closes #2335.