### PR TITLE
Vlib: Return all intersection points from Vect_line_get_intersections

### DIFF
--- a/lib/vector/Vlib/intersect.c
+++ b/lib/vector/Vlib/intersect.c
@@ -56,7 +56,7 @@
    of limited number of decimal places and for different order of
    coordinates, the results would be different)
 
-   (C) 2001-2009 by the GRASS Development Team
+   (C) 2001-2009, 2022 by the GRASS Development Team
 
    This program is free software under the GNU General Public License
    (>=v2).  Read the file COPYING that comes with GRASS for details.

--- a/lib/vector/Vlib/intersect.c
+++ b/lib/vector/Vlib/intersect.c
@@ -637,6 +637,9 @@ static int cross_seg(int id, const struct RTree_Rect *rect, void *arg)
  * intersection with B line. Points (Points->n_points == 1) are not
  * supported.
  *
+ * Superseded by the faster Vect_line_intersection2()
+ * Kept as reference implementation
+ *
  * \param APoints first input line 
  * \param BPoints second input line 
  * \param[out] ALines array of new lines created from original A line
@@ -1438,6 +1441,9 @@ line_check_intersection(struct line_pnts *APoints,
  *
  * Points (Points->n_points == 1) are also supported.
  *
+ * Superseded by the faster Vect_line_check_intersection2()
+ * Kept as reference implementation
+ *
  * \param APoints first input line 
  * \param BPoints second input line 
  * \param with_z 3D, not supported (only if one or both are points)!
@@ -1457,6 +1463,9 @@ Vect_line_check_intersection(struct line_pnts *APoints,
  * \brief Get 2 lines intersection points.
  * 
  * A wrapper around Vect_line_check_intersection() function.
+ *
+ * Superseded by the faster Vect_line_get_intersections2()
+ * Kept as reference implementation
  *
  * \param APoints first input line 
  * \param BPoints second input line 

--- a/lib/vector/Vlib/intersect2.c
+++ b/lib/vector/Vlib/intersect2.c
@@ -56,7 +56,7 @@
    of limited number of decimal places and for different order of
    coordinates, the results would be different)
 
-   (C) 2001-2014 by the GRASS Development Team
+   (C) 2001-2014, 2022 by the GRASS Development Team
 
    This program is free software under the GNU General Public License
    (>=v2).  Read the file COPYING that comes with GRASS for details.

--- a/lib/vector/Vlib/intersect2.c
+++ b/lib/vector/Vlib/intersect2.c
@@ -667,7 +667,9 @@ static int boq_load(struct boq *q, struct line_pnts *Pnts,
  * intersection with B line. Points (Points->n_points == 1) are not
  * supported. If B line is NULL, A line is intersected with itself.
  * 
- * simplified Bentley–Ottmann Algorithm
+ * simplified Bentley–Ottmann Algorithm:
+ * similar to Vect_line_intersection(), but faster
+ * additionally, self-intersections of a line are handled more efficiently
  *
  * \param APoints first input line 
  * \param BPoints second input line or NULL
@@ -1543,6 +1545,9 @@ line_check_intersection2(struct line_pnts *APoints,
  *
  * Points (Points->n_points == 1) are also supported.
  *
+ * simplified Bentley–Ottmann Algorithm:
+ * similar to Vect_line_check_intersection(), but faster
+ *
  * \param APoints first input line 
  * \param BPoints second input line 
  * \param with_z 3D, not supported (only if one or both are points)!
@@ -1561,7 +1566,10 @@ Vect_line_check_intersection2(struct line_pnts *APoints,
 /*!
  * \brief Get 2 lines intersection points.
  * 
- * A wrapper around Vect_line_check_intersection() function.
+ * A wrapper around Vect_line_check_intersection2() function.
+ *
+ * simplified Bentley–Ottmann Algorithm:
+ * similar to Vect_line_get_intersections(), but faster
  *
  * \param APoints first input line 
  * \param BPoints second input line 

--- a/lib/vector/Vlib/testsuite/test_vlib_intersect.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_intersect.py
@@ -101,7 +101,7 @@ class TestLineIntersect(TestCase):
         )
         self.assertEqual(ret, 1)
         self.assertEqual(c_lp_cps.contents.n_points, 1)
-        
+
     def testColinearIntersections(self):
         """Line overlap or continuation"""
         c_lp_cps = libvect.Vect_new_line_struct()
@@ -152,57 +152,39 @@ class TestLineIntersect(TestCase):
 
     def testNoFarCheckIntersection(self):
         """Both lines are far away"""
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_snake, self.c_lp_fmiss, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_snake, self.c_lp_fmiss, 0)
         self.assertEqual(ret, 0)
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_snake, self.c_lp_fmiss, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_snake, self.c_lp_fmiss, 0)
         self.assertEqual(ret, 0)
 
     def testNoNearCheckIntersection(self):
         """Second line is inside first bbox but do not cross"""
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_snake, self.c_lp_nmiss, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_snake, self.c_lp_nmiss, 0)
         self.assertEqual(ret, 0)
 
     def testSingleCheckIntersection(self):
         """Both lines have a single intersection point"""
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_snake, self.c_lp_scross, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_snake, self.c_lp_scross, 0)
         self.assertEqual(ret, 1)
 
     def testColinearCheckIntersections(self):
         """Line overlap or continuation"""
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_cont1, self.c_lp_mcross, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_cont1, self.c_lp_mcross, 0)
         self.assertEqual(ret, 0)
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_cont2, self.c_lp_mcross, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_cont2, self.c_lp_mcross, 0)
         self.assertEqual(ret, 0)
         ret = libvect.Vect_line_check_intersection(
             self.c_lp_scross, self.c_lp_mcross, 0
         )
         self.assertEqual(ret, 1)
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_cont2, self.c_lp_cont3, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_cont2, self.c_lp_cont3, 0)
         self.assertEqual(ret, 1)
 
     def testMultiCheckIntersections(self):
         """Both lines intersect at multiple points"""
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_snake, self.c_lp_mcross, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_snake, self.c_lp_mcross, 0)
         self.assertEqual(ret, 1)
-        ret = libvect.Vect_line_check_intersection(
-            self.c_lp_snake, self.c_lp_ssnake, 0
-        )
+        ret = libvect.Vect_line_check_intersection(self.c_lp_snake, self.c_lp_ssnake, 0)
         self.assertEqual(ret, 1)
 
 
@@ -289,7 +271,7 @@ class TestLineIntersect2(TestCase):
         )
         self.assertEqual(ret, 1)
         self.assertEqual(c_lp_cps.contents.n_points, 1)
-        
+
     def testColinearIntersections2(self):
         """Line overlap or continuation"""
         c_lp_cps = libvect.Vect_new_line_struct()
@@ -340,20 +322,14 @@ class TestLineIntersect2(TestCase):
 
     def testNoFarCheckIntersection2(self):
         """Both lines are far away"""
-        ret = libvect.Vect_line_check_intersection2(
-            self.c_lp_snake, self.c_lp_fmiss, 0
-        )
+        ret = libvect.Vect_line_check_intersection2(self.c_lp_snake, self.c_lp_fmiss, 0)
         self.assertEqual(ret, 0)
-        ret = libvect.Vect_line_check_intersection2(
-            self.c_lp_snake, self.c_lp_fmiss, 0
-        )
+        ret = libvect.Vect_line_check_intersection2(self.c_lp_snake, self.c_lp_fmiss, 0)
         self.assertEqual(ret, 0)
 
     def testNoNearCheckIntersection2(self):
         """Second line is inside first bbox but do not cross"""
-        ret = libvect.Vect_line_check_intersection2(
-            self.c_lp_snake, self.c_lp_nmiss, 0
-        )
+        ret = libvect.Vect_line_check_intersection2(self.c_lp_snake, self.c_lp_nmiss, 0)
         self.assertEqual(ret, 0)
 
     def testSingleCheckIntersection2(self):
@@ -377,9 +353,7 @@ class TestLineIntersect2(TestCase):
             self.c_lp_scross, self.c_lp_mcross, 0
         )
         self.assertEqual(ret, 1)
-        ret = libvect.Vect_line_check_intersection2(
-            self.c_lp_cont2, self.c_lp_cont3, 0
-        )
+        ret = libvect.Vect_line_check_intersection2(self.c_lp_cont2, self.c_lp_cont3, 0)
         self.assertEqual(ret, 2)
 
     def testMultiCheckIntersections2(self):

--- a/lib/vector/Vlib/testsuite/test_vlib_intersect.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_intersect.py
@@ -1,0 +1,376 @@
+"""
+TEST:      intersect.c & intersect2.c
+
+AUTHOR(S): Maris Nartiss
+
+PURPOSE:   Test functions related to line intersection
+
+COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
+
+           This program is free software under the GNU General Public
+           License (>=v2). Read the file COPYING that comes with GRASS
+           for details.
+"""
+
+import grass.lib.vector as libvect
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+class TestLineIntersect(TestCase):
+    """Test functions related to line intersection"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create lines for intersecting"""
+        cls.c_lp_snake = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_snake, 1, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 1, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 2, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 2, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 3, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 3, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 4, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 4, 1, 0)
+        cls.c_lp_ssnake = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_ssnake, 1.5, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 1.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 2.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 2.5, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 3.5, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 3.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 4.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 4.5, 2, 0)
+        cls.c_lp_scross = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_scross, 0, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_scross, 1.5, 2, 0)
+        cls.c_lp_mcross = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_mcross, 0, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_mcross, 5, 2, 0)
+        cls.c_lp_fmiss = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_fmiss, 10, 10, 0)
+        libvect.Vect_append_point(cls.c_lp_fmiss, 20, 20, 0)
+        cls.c_lp_nmiss = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_nmiss, 2.5, 1.5, 0)
+        libvect.Vect_append_point(cls.c_lp_nmiss, 2.5, 2.5, 0)
+        cls.c_lp_cont1 = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_cont1, 6, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_cont1, 8, 1, 0)
+        cls.c_lp_cont2 = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_cont2, 6, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_cont2, 8, 2, 0)
+        cls.c_lp_cont3 = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_cont3, 8, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_cont3, 9, 2, 0)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Free memory just in case"""
+        libvect.Vect_destroy_line_struct(cls.c_lp_snake)
+        libvect.Vect_destroy_line_struct(cls.c_lp_ssnake)
+        libvect.Vect_destroy_line_struct(cls.c_lp_scross)
+        libvect.Vect_destroy_line_struct(cls.c_lp_mcross)
+        libvect.Vect_destroy_line_struct(cls.c_lp_fmiss)
+        libvect.Vect_destroy_line_struct(cls.c_lp_nmiss)
+        libvect.Vect_destroy_line_struct(cls.c_lp_cont1)
+        libvect.Vect_destroy_line_struct(cls.c_lp_cont2)
+        libvect.Vect_destroy_line_struct(cls.c_lp_cont3)
+
+    def testNoFarGetIntersections(self):
+        """Both lines are far away"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_snake, self.c_lp_fmiss, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testNoNearGetIntersections(self):
+        """Second line is inside first bbox but do not cross"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_snake, self.c_lp_nmiss, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testSingleGetIntersections(self):
+        """Both lines have a single intersection point"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_snake, self.c_lp_scross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 1)
+        
+    def testColinearIntersections(self):
+        """Line overlap or continuation"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_cont1, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_cont2, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_scross, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_cont2, self.c_lp_cont3, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 1)
+
+    def testMultiGetIntersections(self):
+        """Both lines intersect at multiple points"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_snake, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 4)
+        libvect.Vect_reset_line(c_lp_cps)
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_snake, self.c_lp_ssnake, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 3)
+
+    def testNoFarCheckIntersection(self):
+        """Both lines are far away"""
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_snake, self.c_lp_fmiss, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_snake, self.c_lp_fmiss, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testNoNearCheckIntersection(self):
+        """Second line is inside first bbox but do not cross"""
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_snake, self.c_lp_nmiss, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testSingleCheckIntersection(self):
+        """Both lines have a single intersection point"""
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_snake, self.c_lp_scross, 0
+        )
+        self.assertEqual(ret, 1)
+
+    def testColinearCheckIntersections(self):
+        """Line overlap or continuation"""
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_cont1, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_cont2, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_scross, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 1)
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_cont2, self.c_lp_cont3, 0
+        )
+        self.assertEqual(ret, 1)
+
+    def testMultiCheckIntersections(self):
+        """Both lines intersect at multiple points"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_snake, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 1)
+        ret = libvect.Vect_line_check_intersection(
+            self.c_lp_snake, self.c_lp_ssnake, 0
+        )
+        self.assertEqual(ret, 1)
+
+
+class TestLineIntersect2(TestCase):
+    """Test functions related to line intersection"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create lines for intersecting"""
+        cls.c_lp_snake = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_snake, 1, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 1, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 2, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 2, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 3, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 3, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 4, 3, 0)
+        libvect.Vect_append_point(cls.c_lp_snake, 4, 1, 0)
+        cls.c_lp_ssnake = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_ssnake, 1.5, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 1.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 2.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 2.5, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 3.5, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 3.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 4.5, 4, 0)
+        libvect.Vect_append_point(cls.c_lp_ssnake, 4.5, 2, 0)
+        cls.c_lp_scross = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_scross, 0, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_scross, 1.5, 2, 0)
+        cls.c_lp_mcross = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_mcross, 0, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_mcross, 5, 2, 0)
+        cls.c_lp_fmiss = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_fmiss, 10, 10, 0)
+        libvect.Vect_append_point(cls.c_lp_fmiss, 20, 20, 0)
+        cls.c_lp_nmiss = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_nmiss, 2.5, 1.5, 0)
+        libvect.Vect_append_point(cls.c_lp_nmiss, 2.5, 2.5, 0)
+        cls.c_lp_cont1 = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_cont1, 6, 1, 0)
+        libvect.Vect_append_point(cls.c_lp_cont1, 8, 1, 0)
+        cls.c_lp_cont2 = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_cont2, 6, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_cont2, 8, 2, 0)
+        cls.c_lp_cont3 = libvect.Vect_new_line_struct()
+        libvect.Vect_append_point(cls.c_lp_cont3, 8, 2, 0)
+        libvect.Vect_append_point(cls.c_lp_cont3, 9, 2, 0)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Free memory just in case"""
+        libvect.Vect_destroy_line_struct(cls.c_lp_snake)
+        libvect.Vect_destroy_line_struct(cls.c_lp_ssnake)
+        libvect.Vect_destroy_line_struct(cls.c_lp_scross)
+        libvect.Vect_destroy_line_struct(cls.c_lp_mcross)
+        libvect.Vect_destroy_line_struct(cls.c_lp_fmiss)
+        libvect.Vect_destroy_line_struct(cls.c_lp_nmiss)
+        libvect.Vect_destroy_line_struct(cls.c_lp_cont1)
+        libvect.Vect_destroy_line_struct(cls.c_lp_cont2)
+        libvect.Vect_destroy_line_struct(cls.c_lp_cont3)
+
+    def testNoFarGetIntersections2(self):
+        """Both lines are far away"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_snake, self.c_lp_fmiss, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testNoNearGetIntersections2(self):
+        """Second line is inside first bbox but do not cross"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_snake, self.c_lp_nmiss, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testSingleGetIntersections2(self):
+        """Both lines have a single intersection point"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_snake, self.c_lp_scross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 1)
+        
+    def testColinearIntersections2(self):
+        """Line overlap or continuation"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_cont1, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_cont2, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_scross, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_cont2, self.c_lp_cont3, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 2)
+        self.assertEqual(c_lp_cps.contents.n_points, 1)
+
+    def testMultiGetIntersections2(self):
+        """Both lines intersect at multiple points"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_snake, self.c_lp_mcross, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 4)
+        libvect.Vect_reset_line(c_lp_cps)
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_snake, self.c_lp_ssnake, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 3)
+
+    def testNoFarCheckIntersection2(self):
+        """Both lines are far away"""
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_snake, self.c_lp_fmiss, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_snake, self.c_lp_fmiss, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testNoNearCheckIntersection2(self):
+        """Second line is inside first bbox but do not cross"""
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_snake, self.c_lp_nmiss, 0
+        )
+        self.assertEqual(ret, 0)
+
+    def testSingleCheckIntersection2(self):
+        """Both lines have a single intersection point"""
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_snake, self.c_lp_scross, 0
+        )
+        self.assertEqual(ret, 1)
+
+    def testColinearCheckIntersections2(self):
+        """Line overlap or continuation"""
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_cont1, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_cont2, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 0)
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_scross, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 1)
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_cont2, self.c_lp_cont3, 0
+        )
+        self.assertEqual(ret, 2)
+
+    def testMultiCheckIntersections2(self):
+        """Both lines intersect at multiple points"""
+        c_lp_cps = libvect.Vect_new_line_struct()
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_snake, self.c_lp_mcross, 0
+        )
+        self.assertEqual(ret, 1)
+        ret = libvect.Vect_line_check_intersection2(
+            self.c_lp_snake, self.c_lp_ssnake, 0
+        )
+        self.assertEqual(ret, 1)
+
+
+if __name__ == "__main__":
+    test()

--- a/lib/vector/Vlib/testsuite/test_vlib_intersect.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_intersect.py
@@ -137,6 +137,18 @@ class TestLineIntersect(TestCase):
         )
         self.assertEqual(ret, 1)
         self.assertEqual(c_lp_cps.contents.n_points, 3)
+        # Order of intersecting lines should not matter
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_mcross, self.c_lp_snake, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 4)
+        libvect.Vect_reset_line(c_lp_cps)
+        ret = libvect.Vect_line_get_intersections(
+            self.c_lp_ssnake, self.c_lp_snake, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 3)
 
     def testNoFarCheckIntersection(self):
         """Both lines are far away"""
@@ -184,7 +196,6 @@ class TestLineIntersect(TestCase):
 
     def testMultiCheckIntersections(self):
         """Both lines intersect at multiple points"""
-        c_lp_cps = libvect.Vect_new_line_struct()
         ret = libvect.Vect_line_check_intersection(
             self.c_lp_snake, self.c_lp_mcross, 0
         )
@@ -314,6 +325,18 @@ class TestLineIntersect2(TestCase):
         )
         self.assertEqual(ret, 1)
         self.assertEqual(c_lp_cps.contents.n_points, 3)
+        # Order of intersecting lines should not matter
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_mcross, self.c_lp_snake, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 4)
+        libvect.Vect_reset_line(c_lp_cps)
+        ret = libvect.Vect_line_get_intersections2(
+            self.c_lp_ssnake, self.c_lp_snake, c_lp_cps, 0
+        )
+        self.assertEqual(ret, 1)
+        self.assertEqual(c_lp_cps.contents.n_points, 3)
 
     def testNoFarCheckIntersection2(self):
         """Both lines are far away"""
@@ -361,7 +384,6 @@ class TestLineIntersect2(TestCase):
 
     def testMultiCheckIntersections2(self):
         """Both lines intersect at multiple points"""
-        c_lp_cps = libvect.Vect_new_line_struct()
         ret = libvect.Vect_line_check_intersection2(
             self.c_lp_snake, self.c_lp_mcross, 0
         )

--- a/lib/vector/Vlib/testsuite/test_vlib_intersect.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_intersect.py
@@ -5,7 +5,7 @@ AUTHOR(S): Maris Nartiss
 
 PURPOSE:   Test functions related to line intersection
 
-COPYRIGHT: (C) 2021 Vaclav Petras, and by the GRASS Development Team
+COPYRIGHT: (C) 2022 Maris Nartiss, and by the GRASS Development Team
 
            This program is free software under the GNU General Public
            License (>=v2). Read the file COPYING that comes with GRASS

--- a/vector/v.profile/testsuite/test_v_profile.py
+++ b/vector/v.profile/testsuite/test_v_profile.py
@@ -240,7 +240,7 @@ class TestProfiling(TestCase):
         vpro = SimpleModule(
             "v.profile",
             input=self.multiline,
-            coordinates=(2, 0, 2, 5),
+            coordinates=(0, 2, 5, 2),
             buffer=10,
         )
         vpro.run()

--- a/vector/v.profile/testsuite/test_v_profile.py
+++ b/vector/v.profile/testsuite/test_v_profile.py
@@ -4,7 +4,7 @@ Purpose:    Tests v.profile input parsing and simle output generation.
             Uses NC Basic data set.
 
 Author:     Maris Nartiss
-Copyright:  (C) 2017 by Maris Nartiss and the GRASS Development Team
+Copyright:  (C) 2017, 2022 by Maris Nartiss and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
             License (>=v2). Read the file COPYING that comes with GRASS
             for details.

--- a/vector/v.profile/testsuite/test_v_profile.py
+++ b/vector/v.profile/testsuite/test_v_profile.py
@@ -48,10 +48,30 @@ Number,Distance,cat,dbl_1,dbl_2,int_1
 3,2960.822,1,626382.68026139,228917.44816672,1
 """
 
+multi_line_in = """\
+L 8
+  1 1
+  1 3
+  2 3
+  2 1
+  3 1
+  3 3
+  4 3
+  4 1
+"""
+multi_line_out = """\
+Number|Distance
+1|1.00
+2|2.00
+3|3.00
+4|4.00
+"""
+
 
 class TestProfiling(TestCase):
     to_remove = []
     points = "test_v_profile_points"
+    multiline = "test_v_profile_multiline"
     in_points = "poi_names_wake"
     in_map = "roadsmajor"
     where = "cat='354'"
@@ -63,16 +83,25 @@ class TestProfiling(TestCase):
         """Create vector map with points for sampling"""
         cls.runModule("v.in.ascii", input="-", output=cls.points, stdin=buf_points)
         cls.to_remove.append(cls.points)
+        cls.runModule(
+            "v.in.ascii",
+            flags="n",
+            input="-",
+            format="standard",
+            output=cls.multiline,
+            stdin=multi_line_in,
+        )
+        cls.to_remove.append(cls.multiline)
 
     @classmethod
     def tearDownClass(cls):
         """Remove vector maps"""
-        if cls.to_remove:
+        for to_remove in cls.to_remove:
             cls.runModule(
                 "g.remove",
                 flags="f",
                 type="vector",
-                name=",".join(cls.to_remove),
+                name=",".join(to_remove),
                 verbose=True,
             )
 
@@ -204,6 +233,18 @@ class TestProfiling(TestCase):
             profile_where="cat=193",
         )
         vpro.run()
+
+    def testMultiCrossing(self):
+        """If profile crosses single line multiple times, all crossings
+        should be reported"""
+        vpro = SimpleModule(
+            "v.profile",
+            input=self.multiline,
+            coordinates=(2, 0, 2, 5),
+            buffer=10,
+        )
+        vpro.run()
+        self.assertLooksLike(reference=multi_line_out, actual=vpro.outputs.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Initial implementation (by me in 2008 https://trac.osgeo.org/grass/changeset/34306) of Vect_line_get_intersections and Vect_line_get_intersections2 returns just one of intersection points between two lines. This is wrong as per bug #2344 users do expect to get back all intersection points. This PR fixes both functions and adds tests to Vlib, v.profile.

Might be a candidate for a backport.