### PR TITLE
lib/imagery: fix missing SONAME

### DIFF
--- a/lib/imagery/Makefile
+++ b/lib/imagery/Makefile
@@ -5,6 +5,7 @@ LIB = IMAGERY
 EXTRA_INC = $(VECT_INC)
 EXTRA_CFLAGS = $(VECT_CFLAGS)
 
+include $(MODULE_TOPDIR)/include/Make/Vars.make
 include $(MODULE_TOPDIR)/include/Make/Lib.make
 include $(MODULE_TOPDIR)/include/Make/Doxygen.make
 


### PR DESCRIPTION
The change implemented in #2269 actually didn't fix the SONAME problem (see issue #2268), at least on Fedora:

```
# status after PR 2269:
readelf -d /usr/lib64/grass80/lib/libgrass_imagery.so

Dynamic section at offset 0x16860 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libgrass_gis.8.0.so]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgrass_raster.8.0.so]
 0x0000000000000001 (NEEDED)             Shared library: [libgrass_vector.8.0.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [/usr/lib64/grass80/lib]
 0x000000000000000c (INIT)               0x5000
 0x000000000000000d (FINI)               0x11e8c
 0x0000000000000019 (INIT_ARRAY)         0x17848
...
```

==> The SONAME is still missing which means that #2269 did not solve it (tested on Fedora).

With this PR (see e.g. also `lib/display/Makefile`) the SONAME appears:

```
readelf -d /home/mneteler/software/grass80/dist.x86_64-pc-linux-gnu/lib/libgrass_imagery.so

Dynamic section at offset 0x14db8 contains 30 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libgrass_gis.8.0.so]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgrass_raster.8.0.so]
 0x0000000000000001 (NEEDED)             Shared library: [libgrass_vector.8.0.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000e (SONAME)             Library soname: [libgrass_imagery.8.0.so]
 0x000000000000001d (RUNPATH)            Library runpath: [/usr/local/grass80/lib]
 0x000000000000000c (INIT)               0x5000
 0x000000000000000d (FINI)               0x10864
 0x0000000000000019 (INIT_ARRAY)         0x15da0
...
```

which is a requirement to compile, install and run the GDAL-GRASS driver (https://github.com/OSGeo/gdal-grass).

Can @t0b3 please check if this works on Gentoo as well?