### PR TITLE
grass.script.core: Remove which and unicode for Python 2

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -11,6 +11,7 @@ for details.
 from __future__ import print_function
 
 import os
+import shutil
 import subprocess
 import sys
 import hashlib
@@ -19,7 +20,7 @@ import unittest
 
 from grass.pygrass.modules import Module
 from grass.exceptions import CalledModuleError
-from grass.script import shutil_which, text_to_string, encode, decode
+from grass.script import text_to_string, encode, decode
 
 from .gmodules import call_module, SimpleModule
 from .checkers import (
@@ -1396,7 +1397,7 @@ class TestCase(unittest.TestCase):
         """
         module = _module_from_parameters(module, **kwargs)
         _check_module_run_parameters(module)
-        if not shutil_which(module.name):
+        if not shutil.which(module.name):
             stdmsg = "Cannot find the module '{0}'".format(module.name)
             self.fail(self._formatMessage(msg, stdmsg))
         try:

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -33,10 +33,6 @@ from tempfile import NamedTemporaryFile
 from .utils import KeyValue, parse_key_val, basename, encode, decode, try_remove
 from grass.exceptions import ScriptError, CalledModuleError
 
-# PY2/PY3 compat
-if sys.version_info.major >= 3:
-    unicode = str
-
 
 # subprocess wrapper that uses shell on Windows
 class Popen(subprocess.Popen):
@@ -54,7 +50,7 @@ class Popen(subprocess.Popen):
             and not kwargs.get("shell", False)
             and kwargs.get("executable") is None
         ):
-            cmd = shutil_which(args[0])
+            cmd = shutil.which(args[0])
             if cmd is None:
                 raise OSError(_("Cannot find the executable {0}").format(args[0]))
             args = [cmd] + args[1:]
@@ -97,16 +93,16 @@ _popen_args = [
 
 
 def _make_val(val):
-    """Convert value to unicode"""
-    if isinstance(val, (bytes, str, unicode)):
+    """Convert value to a unicode string"""
+    if isinstance(val, (bytes, str)):
         return decode(val)
     if isinstance(val, (int, float)):
-        return unicode(val)
+        return str(val)
     try:
         return ",".join(map(_make_val, iter(val)))
     except TypeError:
         pass
-    return unicode(val)
+    return str(val)
 
 
 def _make_unicode(val, enc):
@@ -166,87 +162,6 @@ def get_commands():
     return set(cmd), scripts
 
 
-# TODO: Please replace this function with shutil.which() before 8.0 comes out
-# replacement for which function from shutil (not available in all versions)
-# from http://hg.python.org/cpython/file/6860263c05b3/Lib/shutil.py#l1068
-# added because of Python scripts running Python scripts on MS Windows
-# see also ticket #2008 which is unrelated but same function was proposed
-def shutil_which(cmd, mode=os.F_OK | os.X_OK, path=None):
-    """Given a command, mode, and a PATH string, return the path which
-    conforms to the given mode on the PATH, or None if there is no such
-    file.
-
-    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
-    of os.environ.get("PATH"), or can be overridden with a custom search
-    path.
-
-    :param cmd: the command
-    :param mode:
-    :param path:
-
-    """
-    # Check that a given file can be accessed with the correct mode.
-    # Additionally check that `file` is not a directory, as on Windows
-    # directories pass the os.access check.
-    def _access_check(fn, mode):
-        return os.path.exists(fn) and os.access(fn, mode) and not os.path.isdir(fn)
-
-    # If we're given a path with a directory part, look it up directly rather
-    # than referring to PATH directories. This includes checking relative to the
-    # current directory, e.g. ./script
-    if os.path.dirname(cmd):
-        if _access_check(cmd, mode):
-            return cmd
-        return None
-
-    if path is None:
-        path = os.environ.get("PATH", os.defpath)
-    if not path:
-        return None
-    path = path.split(os.pathsep)
-
-    if sys.platform == "win32":
-        # The current directory takes precedence on Windows.
-        if os.curdir not in path:
-            path.insert(0, os.curdir)
-
-        # PATHEXT is necessary to check on Windows (force lowercase)
-        pathext = list(
-            map(lambda x: x.lower(), os.environ.get("PATHEXT", "").split(os.pathsep))
-        )
-        if ".py" not in pathext:
-            # we assume that PATHEXT contains always '.py'
-            pathext.insert(0, ".py")
-        # See if the given file matches any of the expected path extensions.
-        # This will allow us to short circuit when given "python3.exe".
-        # If it does match, only test that one, otherwise we have to try
-        # others.
-        if any(cmd.lower().endswith(ext) for ext in pathext):
-            files = [cmd]
-        else:
-            files = [cmd + ext for ext in pathext]
-    else:
-        # On other platforms you don't have things like PATHEXT to tell you
-        # what file suffixes are executable, so just pass on cmd as-is.
-        files = [cmd]
-
-    seen = set()
-    for dir in path:
-        normdir = os.path.normcase(dir)
-        if normdir not in seen:
-            seen.add(normdir)
-            for thefile in files:
-                name = os.path.join(dir, thefile)
-                if _access_check(name, mode):
-                    return name
-    return None
-
-
-if sys.version_info.major >= 3:
-    # Use shutil.which in Python 3, not the custom implementation.
-    shutil_which = shutil.which  # noqa: F811
-
-
 # Added because of scripts calling scripts on MS Windows.
 # Module name (here cmd) differs from the file name (does not have extension).
 # Additionally, we don't run scripts using system executable mechanism,
@@ -288,7 +203,7 @@ def get_real_command(cmd):
         if ".py" not in pathext:
             # we assume that PATHEXT contains always '.py'
             os.environ["PATHEXT"] = ".py;" + os.environ["PATHEXT"]
-        full_path = shutil_which(cmd + ".py")
+        full_path = shutil.which(cmd + ".py")
         if full_path:
             return full_path
 

--- a/raster/r.in.pdal/testsuite/test_r_in_pdal_binning.py
+++ b/raster/r.in.pdal/testsuite/test_r_in_pdal_binning.py
@@ -12,10 +12,10 @@ Licence:   This program is free software under the GNU General Public
 import os
 import pathlib
 import unittest
+import shutil
 from tempfile import TemporaryDirectory
 
 from grass.script import core as grass
-from grass.script import shutil_which
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -28,7 +28,7 @@ class BinningTest(TestCase):
     """
 
     @classmethod
-    @unittest.skipIf(shutil_which("pdal") is None, "Cannot find pdal utility")
+    @unittest.skipIf(shutil.which("pdal") is None, "Cannot find pdal utility")
     def setUpClass(cls):
         """Ensures expected computational region and generated data"""
         cls.use_temp_region()
@@ -62,7 +62,7 @@ class BinningTest(TestCase):
         cls.tmp_dir.cleanup()
         cls.del_temp_region()
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def tearDown(self):
         """Remove the outputs created by the import
 
@@ -71,7 +71,7 @@ class BinningTest(TestCase):
         self.runModule("g.remove", flags="f", type="raster", name=self.bin_raster)
         self.runModule("g.remove", flags="f", type="raster", name=self.ref_raster)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_n(self):
         """Test binning with n method"""
         self.bin_raster = "bin_n"
@@ -94,7 +94,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_min(self):
         self.bin_raster = "bin_min"
         self.ref_raster = "ref_min"
@@ -116,7 +116,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_max(self):
         self.bin_raster = "bin_max"
         self.ref_raster = "ref_max"
@@ -138,7 +138,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_range(self):
         self.bin_raster = "bin_range"
         self.ref_raster = "ref_range"
@@ -160,7 +160,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_sum(self):
         self.bin_raster = "bin_sum"
         self.ref_raster = "ref_sum"
@@ -182,7 +182,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_mean(self):
         self.bin_raster = "bin_mean"
         self.ref_raster = "ref_mean"
@@ -204,7 +204,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0.0001)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_stddev(self):
         self.bin_raster = "bin_stddev"
         self.ref_raster = "ref_stddev"
@@ -226,7 +226,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0.0001)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_variance(self):
         self.bin_raster = "bin_variance"
         self.ref_raster = "ref_variance"
@@ -248,7 +248,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0.0001)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_coeff_var(self):
         self.bin_raster = "bin_coeff_var"
         self.ref_raster = "ref_coeff_var"
@@ -270,7 +270,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0.0001)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_median(self):
         self.bin_raster = "bin_median"
         self.ref_raster = "ref_median"
@@ -292,7 +292,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0.0001)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_mode(self):
         self.bin_raster = "bin_mode"
         self.ref_raster = "ref_mode"
@@ -314,7 +314,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_sidnmax(self):
         self.bin_raster = "bin_sidnmax"
         self.ref_raster = "ref_sidnmax"
@@ -336,7 +336,7 @@ class BinningTest(TestCase):
         )
         self.assertRastersEqual(self.bin_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_method_sidnmin(self):
         self.bin_raster = "bin_sidnmin"
         self.ref_raster = "ref_sidnmin"

--- a/raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
+++ b/raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
@@ -11,6 +11,7 @@ Licence:   This program is free software under the GNU General Public
 
 import os
 import pathlib
+import shutil
 import unittest
 from tempfile import TemporaryDirectory
 

--- a/raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
+++ b/raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
@@ -15,7 +15,6 @@ import unittest
 from tempfile import TemporaryDirectory
 
 from grass.script import core as grass
-from grass.script import shutil_which
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -28,7 +27,7 @@ class SelectionTest(TestCase):
     """
 
     @classmethod
-    @unittest.skipIf(shutil_which("pdal") is None, "Cannot find pdal utility")
+    @unittest.skipIf(shutil.which("pdal") is None, "Cannot find pdal utility")
     def setUpClass(cls):
         """Ensures expected computational region and generated data"""
         cls.use_temp_region()
@@ -74,7 +73,7 @@ class SelectionTest(TestCase):
         except AttributeError:
             pass
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_dimension(self):
         """Test LAS dimension selection"""
         self.imp_raster = "imp_intensity"
@@ -99,7 +98,7 @@ class SelectionTest(TestCase):
         )
         self.assertRastersEqual(self.imp_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_user_dimension(self):
         """Test PDAL user dimension selection"""
         self.imp_raster = "imp_cellid"
@@ -124,7 +123,7 @@ class SelectionTest(TestCase):
         )
         self.assertRastersEqual(self.imp_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_filter(self):
         """Test input filtering"""
         self.imp_raster = "imp_filtered"
@@ -152,7 +151,7 @@ class SelectionTest(TestCase):
         )
         self.assertRastersEqual(self.imp_raster, self.ref_raster, 0)
 
-    @unittest.skipIf(shutil_which("r.in.pdal") is None, "Cannot find r.in.pdal")
+    @unittest.skipIf(shutil.which("r.in.pdal") is None, "Cannot find r.in.pdal")
     def test_base_raster(self):
         """Test Z adjustement by base raster"""
         self.imp_raster = "imp_base_adj"

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
@@ -13,7 +13,6 @@ import os
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 import unittest
-from grass.script import shutil_which
 
 
 class BasicTest(TestCase):
@@ -72,7 +71,7 @@ class BasicTest(TestCase):
         """
         self.runModule("g.remove", flags="f", type="vector", name=self.imported_points)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_same_data(self):
         """Test to see if the standard outputs are created"""
         self.assertModule(

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
@@ -13,7 +13,6 @@ import os
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 import unittest
-from grass.script import shutil_which
 
 POINTS = """\
 17.46938776,18.67346939,143,1,1,2
@@ -93,7 +92,7 @@ class FilterTest(TestCase):
         """
         self.runModule("g.remove", flags="f", type="vector", name=self.imported_points)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_no_filter(self):
         """Test to see if the standard outputs are created
 
@@ -105,7 +104,7 @@ class FilterTest(TestCase):
             vector=self.imported_points, reference=dict(points=19)
         )
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def return_filter(self, name, npoints):
         """Mid return filter test"""
         self.assertModule(
@@ -119,22 +118,22 @@ class FilterTest(TestCase):
             vector=self.imported_points, reference=dict(points=npoints)
         )
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_first_return_filter(self):
         """First return filter test"""
         self.return_filter("first", 9)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_mid_return_filter(self):
         """Mid return filter test"""
         self.return_filter("mid", 5)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_last_return_filter(self):
         """Last return filter test"""
         self.return_filter("last", 5)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def class_filter(self, class_n, npoints):
         """Actual code for testing class filter"""
         self.assertModule(
@@ -148,27 +147,27 @@ class FilterTest(TestCase):
             vector=self.imported_points, reference=dict(points=npoints)
         )
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_class_2_filter(self):
         """Test to filter classes"""
         self.class_filter(2, 2)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_class_3_filter(self):
         """Test to filter classes"""
         self.class_filter(3, 5)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_class_4_filter(self):
         """Test to filter classes"""
         self.class_filter(4, 4)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_class_5_filter(self):
         """Test to filter classes"""
         self.class_filter(5, 8)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def return_and_class_filter(self, return_name, class_n, npoints):
         """Return and class filter combined test code"""
         self.assertModule(
@@ -183,17 +182,17 @@ class FilterTest(TestCase):
             vector=self.imported_points, reference=dict(points=npoints)
         )
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_first_return_and_class_filter(self):
         """Combined test for return and class"""
         self.return_and_class_filter("first", 2, 2)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_last_return_and_class_filter(self):
         """Combined test for return and class"""
         self.return_and_class_filter("last", 5, 3)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def zrange_filter(self, zrange, npoints):
         """Actual code for zrange option test"""
         self.assertModule(
@@ -204,12 +203,12 @@ class FilterTest(TestCase):
             vector=self.imported_points, reference=dict(points=npoints)
         )
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_zrange_filter(self):
         """Test zrange option"""
         self.zrange_filter((130.1, 139.9), 3)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_non_int_zrange_filter(self):
         """Test zrange option with float number
 
@@ -217,7 +216,7 @@ class FilterTest(TestCase):
         """
         self.zrange_filter((140.5, 900), 8)
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_zrange_and_class_filter(self):
         """zrange and class_filter option combined test"""
         self.assertModule(
@@ -232,7 +231,7 @@ class FilterTest(TestCase):
             vector=self.imported_points, reference=dict(points=4)
         )
 
-    @unittest.skipIf(shutil_which("v.in.pdal") is None, "Cannot find v.in.pdal")
+    @unittest.skipIf(shutil.which("v.in.pdal") is None, "Cannot find v.in.pdal")
     def test_zrange_and_return_filter(self):
         """zrange and class_filter option combined test"""
         self.assertModule(


### PR DESCRIPTION
- Remove shutil.which replacement for Python 2.
- Remove unicode alias for Python 3.
