### PR TITLE
grass.jupyter: Add save PNG method to Map

### DIFF
--- a/python/grass/jupyter/map.py
+++ b/python/grass/jupyter/map.py
@@ -192,3 +192,7 @@ class Map:
         from IPython.display import Image  # pylint: disable=import-outside-toplevel
 
         return Image(self._filename)
+
+    def save(self, filename):
+        """Saves a PNG image of map to the specified *filename*"""
+        shutil.copy(self._filename, filename)

--- a/python/grass/jupyter/testsuite/map_test.py
+++ b/python/grass/jupyter/testsuite/map_test.py
@@ -101,7 +101,7 @@ class TestMap(TestCase):
         # Make sure image was created
         self.assertFileExists(grass_renderer.filename)
 
-    def test_filename_property(self):
+    def test_safe_file(self):
         """Test saving of file"""
         grass_renderer = gj.Map()
         # Add a vector and a raster to the map

--- a/python/grass/jupyter/testsuite/map_test.py
+++ b/python/grass/jupyter/testsuite/map_test.py
@@ -82,7 +82,7 @@ class TestMap(TestCase):
     def test_filename(self):
         """Test that Map creates maps with unique filenames."""
         # Create map with unique filename
-        custom_filename = "test_filename.png"
+        custom_filename = "test_filename_provided.png"
         grass_renderer = gj.Map(filename=custom_filename)
         # Add files to self for cleanup later
         self.files.append(custom_filename)
@@ -101,12 +101,12 @@ class TestMap(TestCase):
         # Make sure image was created
         self.assertFileExists(grass_renderer.filename)
 
-    def test_safe_file(self):
+    def test_save_file(self):
         """Test saving of file"""
         grass_renderer = gj.Map()
         # Add a vector and a raster to the map
         grass_renderer.run("d.rast", map="elevation")
-        custom_filename = "test_filename.png"
+        custom_filename = "test_filename_save.png"
         grass_renderer.save(custom_filename)
         # Add files to self for cleanup later
         self.files.append(custom_filename)

--- a/python/grass/jupyter/testsuite/map_test.py
+++ b/python/grass/jupyter/testsuite/map_test.py
@@ -101,6 +101,18 @@ class TestMap(TestCase):
         # Make sure image was created
         self.assertFileExists(grass_renderer.filename)
 
+    def test_filename_property(self):
+        """Test saving of file"""
+        grass_renderer = gj.Map()
+        # Add a vector and a raster to the map
+        grass_renderer.run("d.rast", map="elevation")
+        custom_filename = "test_filename.png"
+        grass_renderer.save(custom_filename)
+        # Add files to self for cleanup later
+        self.files.append(custom_filename)
+        # Make sure image was created
+        self.assertFileExists(custom_filename)
+
     def test_hw(self):
         """Test that Map creates maps with custom height and widths."""
         # Create map with height and width parameters


### PR DESCRIPTION
Map from grass.jupyter can now save PNG images. This is easier than using the filename property and it is consistent with TimeSeriesMap.
