### PR TITLE
grass.jupyter: fix resolution handling for InteractiveMap

### DIFF
--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -165,13 +165,13 @@ class InteractiveMap:
         folium documentation:
         https://python-visualization.github.io/folium/modules.html
 
-        Raster and vector data are always reprojected to pseudomercator.
-        With use_region=True or saved_region=myregion region extent
+        Raster and vector data are always reprojected to Pseudo-Mercator.
+        With use_region=True or saved_region=myregion, the region extent
         is reprojected and the number of rows and columns of that region
         is kept the same. This region is then used for reprojection.
-        By default use_region is False, resulting in
-        reprojecting entire raster in its native resolution,
-        the reprojected resolution is estimated with r.proj.
+        By default, use_region is False, which results in the
+        reprojection of the entire raster in its native resolution.
+        The reprojected resolution is estimated with r.proj.
         Vector data are always reprojected without any clipping,
         i.e., region options don't do anything.
 

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -165,6 +165,16 @@ class InteractiveMap:
         folium documentation:
         https://python-visualization.github.io/folium/modules.html
 
+        Raster and vector data are always reprojected to pseudomercator.
+        With use_region=True or saved_region=myregion region extent
+        is reprojected and the number of rows and columns of that region
+        is kept the same. This region is then used for reprojection.
+        By default use_region is False, resulting in
+        reprojecting entire raster in its native resolution,
+        the reprojected resolution is estimated with r.proj.
+        Vector data are always reprojected without any clipping,
+        i.e., region options don't do anything.
+
         :param int height: height in pixels of figure (default 400)
         :param int width: width in pixels of figure (default 400)
         :param str tiles: map tileset to use

--- a/python/grass/jupyter/region.py
+++ b/python/grass/jupyter/region.py
@@ -17,6 +17,7 @@ from grass.exceptions import CalledModuleError
 
 from .utils import (
     get_map_name_from_d_command,
+    estimate_resolution,
     set_target_region,
     get_rendering_size,
 )
@@ -39,22 +40,35 @@ class RegionManagerForInteractiveMap:
         self._saved_region = saved_region
         self._src_env = src_env
         self._tgt_env = tgt_env
+        self._resolution = None
         # [SW, NE]: inverted to easily expand based on data, see _set_bbox
         self._bbox = [[90, 180], [-90, -180]]
         if self._use_region:
-            # tgt region already set
+            # tgt region already set, set resolution
+            self._resolution = self._get_psmerc_region_resolution()
             self._set_bbox(self._src_env)
         if self._saved_region:
             self._src_env["GRASS_REGION"] = gs.region_env(
                 region=self._saved_region, env=self._src_env
             )
             set_target_region(src_env=self._src_env, tgt_env=self._tgt_env)
+            self._resolution = self._get_psmerc_region_resolution()
             self._set_bbox(self._src_env)
 
     @property
     def bbox(self):
         """Bbox property for accessing maximum bounding box of all rendered layers."""
         return self._bbox
+
+    @property
+    def resolution(self):
+        """Resolution to be used for reprojection."""
+        return self._resolution
+
+    def _get_psmerc_region_resolution(self):
+        """Get region resolution (average ns and ew) of psmerc mapset"""
+        reg = gs.region(env=self._tgt_env)
+        return (reg["nsres"] + reg["ewres"]) / 2
 
     def set_region_from_raster(self, raster):
         """Sets computational region for rendering.
@@ -71,8 +85,20 @@ class RegionManagerForInteractiveMap:
         if self._use_region or self._saved_region:
             # target region and bbox already set
             return
+        # set target location region extent
         self._src_env["GRASS_REGION"] = gs.region_env(raster=raster, env=self._src_env)
         set_target_region(src_env=self._src_env, tgt_env=self._tgt_env)
+        # set resolution based on r.proj estimate
+        env_info = gs.gisenv(env=self._src_env)
+        name, mapset = raster.split("@")
+        resolution = estimate_resolution(
+            raster=name,
+            mapset=mapset,
+            location=env_info["LOCATION_NAME"],
+            dbase=env_info["GISDBASE"],
+            env=self._tgt_env,
+        )
+        self._resolution = resolution
         self._set_bbox(self._src_env)
 
     def set_bbox_vector(self, vector):

--- a/python/grass/jupyter/region.py
+++ b/python/grass/jupyter/region.py
@@ -91,14 +91,13 @@ class RegionManagerForInteractiveMap:
         # set resolution based on r.proj estimate
         env_info = gs.gisenv(env=self._src_env)
         name, mapset = raster.split("@")
-        resolution = estimate_resolution(
+        self._resolution = estimate_resolution(
             raster=name,
             mapset=mapset,
             location=env_info["LOCATION_NAME"],
             dbase=env_info["GISDBASE"],
             env=self._tgt_env,
         )
-        self._resolution = resolution
         self._set_bbox(self._src_env)
 
     def set_bbox_vector(self, vector):

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -131,7 +131,10 @@ def setup_location(name, path, epsg, src_env):
 
 
 def set_target_region(src_env, tgt_env):
-    """Set target region based on source region"""
+    """Set target region based on source region.
+
+    Number of rows and columns is preserved.
+    """
     region = get_region(env=src_env)
     from_proj = get_location_proj_string(src_env)
     to_proj = get_location_proj_string(env=tgt_env)

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -143,6 +143,8 @@ def set_target_region(src_env, tgt_env):
         s=new_region["south"],
         e=new_region["east"],
         w=new_region["west"],
+        rows=new_region["rows"],
+        cols=new_region["cols"],
         env=tgt_env,
     )
 


### PR DESCRIPTION
Should address #2369. Now when use_region=True or saved_region, it should reproject the map with the correct resolution. Note that in these cases the resolution is not estimated by r.proj but is estimated by reprojecting the extent and using the same ncols/nrows as in the source region, which might not be the most precise way.