### PR TITLE
init: Use VACUUM for large, modified SQLite files only

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -42,6 +42,7 @@ import sys
 import os
 import errno
 import atexit
+import datetime
 import gettext
 import shutil
 import signal
@@ -2111,11 +2112,11 @@ def clean_temp():
     nul.close()
 
 
-def clean_all():
+def clean_all(*, start_time):
     from grass.script import setup as gsetup
 
     # clean default sqlite db
-    gsetup.clean_default_db()
+    gsetup.clean_default_db(modified_after=start_time)
     # remove leftover temp files
     clean_temp()
     # save 'last used' GISRC after removing variables which shouldn't
@@ -2648,6 +2649,8 @@ def main():
         fatal(e.args[0])
         sys.exit(_("Exiting..."))
 
+    start_time = datetime.datetime.now(datetime.timezone.utc)
+
     # unlock the mapset which is current at the time of turning off
     # in case mapset was changed
     atexit.register(lambda: unlock_gisrc_mapset(gisrc, gisrcrc))
@@ -2667,12 +2670,12 @@ def main():
     # only non-error, interactive version continues from here
     if params.batch_job:
         returncode = run_batch_job(params.batch_job)
-        clean_all()
+        clean_all(start_time=start_time)
         sys.exit(returncode)
     elif params.exit_grass:
         # clean always at exit, cleans whatever is current mapset based on
         # the GISRC env variable
-        clean_all()
+        clean_all(start_time=start_time)
         sys.exit(0)
     else:
         if use_shell:
@@ -2727,7 +2730,7 @@ def main():
         close_gui()
 
         # here we are at the end of grass session
-        clean_all()
+        clean_all(start_time=start_time)
         mapset_settings = load_gisrc(gisrc, gisrcrc=gisrcrc)
         if not params.tmp_location or (
             params.tmp_location and mapset_settings.gisdbase != os.environ["TMPDIR"]

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -431,7 +431,7 @@ def clean_default_db(*, modified_after=None):
     import grass.script as gs
 
     conn = gs.db_connection()
-    if conn and conn["driver"] != "sqlite":
+    if not conn or conn["driver"] != "sqlite":
         return
     # check if db exists
     gis_env = gs.gisenv()

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -433,7 +433,8 @@ def clean_default_db():
         database = database.replace("$LOCATION_NAME", gisenv["LOCATION_NAME"])
         database = database.replace("$MAPSET", gisenv["MAPSET"])
         database = Path(database)
-        small_db_size = 1e8  # 100 MB (not MiB) in bytes
+        # Small size based on MEMORYMB (MiB) or its default.
+        small_db_size = int(gisenv.get("MEMORYMB", 300)) * (1 << 20)
         if database.is_file() and database.stat().st_size > small_db_size:
             process = gs.start_command("db.execute", sql="VACUUM")
             gs.verbose(_("Cleaning up default SQLite database..."))

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -453,10 +453,12 @@ def clean_default_db(*, modified_after=None):
         )
         if modified_after >= modified_time:
             return
+    # Start the vacuum process, then show the message in parallel while
+    # the vacuum is running. Finally, wait for the vacuum process to finish.
+    # Error handling is the same as errors="ignore".
     process = gs.start_command("db.execute", sql="VACUUM")
     gs.verbose(_("Cleaning up default SQLite database..."))
     process.wait()
-    # Error handling is the same as errors="ignore".
 
 
 def call(cmd, **kwargs):


### PR DESCRIPTION
For SQLite database, VACUUM is used when the session is ending. There is a cost in running the task even when the database is small and no vacuuming is needed. This change adds a check for the size of the database and ignores databases under 100MB.

The message is now only verbose and printed when the task is running.

Unlike the original implementation, the vacuum task is now synchronous so that there is no running GRASS process after the session has ended.

The original implementation comes from Trac ticket 3697 (https://trac.osgeo.org/grass/ticket/3697)
and is best visible in a bulk backport commit 73736 (f790d68470cf8c3eba0de8feb2d6937c4f9c7493).
