### PR TITLE
lib/cairo: Add cairo status to error message

### DIFF
--- a/lib/cairodriver/graph.c
+++ b/lib/cairodriver/graph.c
@@ -373,7 +373,10 @@ static void init_cairo(void)
     }
 
     if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
-	G_fatal_error(_("Failed to initialize Cairo surface"));
+        G_fatal_error(_("Failed to initialize Cairo surface"
+                        " (width: %d, height: %d): %s"),
+                      ca.width, ca.height,
+                      cairo_status_to_string(cairo_surface_status(surface)));
 
     cairo = cairo_create(surface);
 }


### PR DESCRIPTION
The original message about failing to initialize a Cairo surface does not include any reason. This adds size and status from Cairo.

## Comparison

### Original

```
ERROR: Failed to initialize Cairo surface
```

### New

```
ERROR: Failed to initialize Cairo surface (width: 100000, height: 100000):
       invalid value (typically too big) for the size of the input
       (surface, pattern, etc.)
```

The result depends on what message is generated by Cairo.

## In action

```
> d.mon stop=cairo; d.mon start=cairo width=10000 height=10000 --o; d.rast map=dsm; d.mon stop=cairo
WARNING: File <map.png> already exists and will be overwritten
Output file: /home/vpetras/Projects/grass/code/grass/map.png
 100%
> d.mon start=cairo width=100000 height=10000 --o; d.rast map=dsm; d.mon stop=cairo
Current region rows: 1991, cols: 2027
ERROR: G_malloc: unable to allocate 18446744073414584320 bytes of memory at
       lib/cairodriver/graph.c:210
> d.mon start=cairo width=100000 height=100000 --o; d.rast map=dsm; d.mon stop=cairo
ERROR: Failed to initialize Cairo surface (width: 100000, height: 100000):
       invalid value (typically too big) for the size of the input
       (surface, pattern, etc.)
```