### PR TITLE
wxGUI: Report non-zero return code from modules

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -715,6 +715,10 @@ class GConsole(wx.EvtHandler):
                 )
             )
             msg = _("Command aborted")
+        elif event.returncode != 0:
+            msg = _("Command ended with non-zero return code {returncode}").format(
+                returncode=event.returncode
+            )
         else:
             msg = _("Command finished")
 


### PR DESCRIPTION
When a module is executed, currently, two states are reported, aborted by the user and finished. This adds a third state, finished, but with non-zero return code. This does not add much because the interpretation is unclear and the error message should be clear from the output above, but it adds some info when debugging strange issues because it prints the return code.

Here are examples for r.mapcalc and g.findfile. r.mapcalc is a typical GRASS module in terms of return codes while g.findfile is using non-zero return code as part of its standard operation.

![Screenshot from 2022-05-18 10-53-02](https://user-images.githubusercontent.com/5449060/169071637-d4be7ee5-f4a3-456a-97a5-47c08ca0943d.png)
![Screenshot from 2022-05-18 10-36-31](https://user-images.githubusercontent.com/5449060/169071727-c5ebb913-2279-41fc-8fcf-51428fcc9b90.png)

