### PR TITLE
temporal: dont fail when registering maps with missing range file

### DIFF
--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -743,10 +743,8 @@ def _read_raster_info(name, mapset):
         range = libraster.FPRange()
         libraster.Rast_init_fp_range(byref(range))
         ret = libraster.Rast_read_fp_range(name, mapset, byref(range))
-        if ret < 0:
-            logging.error(_("Unable to read range file"))
-            return None
-        if ret == 2:
+        if ret < 0 or ret == 2:
+            logging.warning(_("Unable to read range file"))
             kvp["min"] = None
             kvp["max"] = None
         else:
@@ -759,10 +757,8 @@ def _read_raster_info(name, mapset):
         range = libraster.Range()
         libraster.Rast_init_range(byref(range))
         ret = libraster.Rast_read_range(name, mapset, byref(range))
-        if ret < 0:
-            logging.error(_("Unable to read range file"))
-            return None
-        if ret == 2:
+        if ret < 0 or ret == 2:
+            logging.warning(_("Unable to read range file"))
             kvp["min"] = None
             kvp["max"] = None
         else:

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -743,8 +743,12 @@ def _read_raster_info(name, mapset):
         range = libraster.FPRange()
         libraster.Rast_init_fp_range(byref(range))
         ret = libraster.Rast_read_fp_range(name, mapset, byref(range))
-        if ret < 0 or ret == 2:
+        if ret < 0:
             logging.warning(_("Unable to read range file"))
+            kvp["min"] = None
+            kvp["max"] = None
+        elif ret == 2:
+            logging.warning(_("Raster range file is empty"))
             kvp["min"] = None
             kvp["max"] = None
         else:
@@ -757,8 +761,12 @@ def _read_raster_info(name, mapset):
         range = libraster.Range()
         libraster.Rast_init_range(byref(range))
         ret = libraster.Rast_read_range(name, mapset, byref(range))
-        if ret < 0 or ret == 2:
+        if ret < 0:
             logging.warning(_("Unable to read range file"))
+            kvp["min"] = None
+            kvp["max"] = None
+        elif ret == 2:
+            logging.warning(_("Raster range file is empty"))
             kvp["min"] = None
             kvp["max"] = None
         else:


### PR DESCRIPTION
If maps are linked to the GRASS GIS database with `r.external -r` those maps do not have a range file.
When trying to register them in a STRDS, the process fails because no map info is returned at all, meaning no north, south, ... info either. In consequence, NON-NULL constraints of the TGIS DB are violated.

This PR fixes the inconsistency, so I tagged it as a bug and added a backport label. If others feel different about it, please feel free to change the labels.

In case of a missing range file, now None/NULL is returned as range of map values together with a valid spatial extent.