### PR TITLE
v.surf.idw: fix applying mask

### DIFF
--- a/vector/v.surf.idw/main.c
+++ b/vector/v.surf.idw/main.c
@@ -280,7 +280,7 @@ int main(int argc, char *argv[])
         for (col = 0; col < window.cols; col++) {
             east += window.ew_res;
             /* don't interpolate outside of the mask */
-            if (mask && mask[col] == 0) {
+            if (mask && (mask[col] == 0 || Rast_is_c_null_value(&mask[col]))) {
                 Rast_set_d_null_value(&dcell[col], 1);
                 continue;
             }


### PR DESCRIPTION
v.surf.idw doesn't apply mask properly, it works only when the mask has value 0, not null. So when you create mask with r.mask, v.surf.idw ignores that and interpolates for those values as well.

See also https://trac.osgeo.org/grass/ticket/3677 (not sure why I couldn't reproduce it there.)