### PR TITLE
wxGUI/rlisetup: allow EVT_KILL_FOCUS event handler event processing to continue

### DIFF
--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -649,6 +649,7 @@ class FirstPage(TitledPage):
             )
             self.newconftxt.SetValue("")
             self.conf_name = ""
+        event.Skip()
 
     def OnNameChanged(self, event):
         """Name of configuration file has changed"""


### PR DESCRIPTION
Fixes #2380. On wxMSW (OS MS Windows), [SetFocus()](https://github.com/OSGeo/grass/blob/main/gui/wxpython/rlisetup/wizard.py#L514) method trigger [EVT_KILL_FOCUS](https://github.com/OSGeo/grass/blob/main/gui/wxpython/rlisetup/wizard.py#L618) event which [handler ](https://github.com/OSGeo/grass/blob/main/gui/wxpython/rlisetup/wizard.py#L640) require allow event processing to continue.