### PR TITLE
modules: Add JSON output for db.univar and v.db.univar

### DIFF
--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -46,6 +46,14 @@
 # % options: 0-100
 # % multiple: yes
 # %end
+# %option
+# % key: format
+# % type: string
+# % multiple: no
+# % options: plain,json,shell
+# % label: Output format
+# % descriptions: plain;Plain text output;json;JSON (JavaScript Object Notation);shell;Shell script style for Bash eval
+# %end
 # %flag
 # % key: e
 # % description: Extended statistics (quartiles and 90th percentile)
@@ -57,6 +65,7 @@
 
 import sys
 import atexit
+import json
 import math
 
 import grass.script as gscript
@@ -99,8 +108,19 @@ def main():
     driver = options["driver"]
     where = options["where"]
     perc = options["percentile"]
+    output_format = options["format"]
 
     perc = [float(p) for p in perc.split(",")]
+
+    if not output_format:
+        if shellstyle:
+            output_format = "shell"
+        else:
+            output_format = "plain"
+    elif shellstyle:
+        # This can be a message or warning in future versions.
+        # In version 9, -g may be removed.
+        gscript.verbose(_("The format option is used and -g flag ignored"))
 
     desc_table = gscript.db_describe(table, database=database, driver=driver)
     if not desc_table:
@@ -114,7 +134,7 @@ def main():
     if not found:
         gscript.fatal(_("Column <%s> not found in table <%s>") % (column, table))
 
-    if not shellstyle:
+    if output_format == "plain":
         gscript.verbose(
             _("Calculation for column <%s> of table <%s>...") % (column, table)
         )
@@ -145,11 +165,12 @@ def main():
     # check if result is empty
     tmpf = open(tmp)
     if tmpf.read(1) == "":
-        gscript.fatal(_("Table <%s> contains no data.") % table)
+        if output_format in ["plain", "shell"]:
+            gscript.fatal(_("Table <%s> contains no data.") % table)
         tmpf.close()
 
     # calculate statistics
-    if not shellstyle:
+    if output_format == "plain":
         gscript.verbose(_("Calculating statistics..."))
 
     N = 0
@@ -174,9 +195,27 @@ def main():
     tmpf.close()
 
     if N <= 0:
-        gscript.fatal(_("No non-null values found"))
+        if output_format in ["plain", "shell"]:
+            gscript.fatal(_("No non-null values found"))
+        else:
+            # We produce valid JSON with a value for n even when the query returned
+            # no rows or when all values are nulls.
+            result = {}
+            result["n"] = N
+            nan_value = None
+            result["min"] = nan_value
+            result["max"]=nan_value
+            result["range"] = nan_value
+            result["mean"] = nan_value
+            result["mean_abs"] = nan_value
+            result["variance"] = nan_value
+            result["stddev"] = nan_value
+            result["coeff_var"] = nan_value
+            result["sum"] = nan_value
+            json.dump({"statistics": result}, sys.stdout)
+            return
 
-    if not shellstyle:
+    if output_format == "plain":
         sys.stdout.write("Number of values: %d\n" % N)
         sys.stdout.write("Minimum: %.15g\n" % minv)
         sys.stdout.write("Maximum: %.15g\n" % maxv)
@@ -197,7 +236,26 @@ def main():
             sys.stdout.write("Standard deviation: 0\n")
             sys.stdout.write("Coefficient of variation: 0\n")
         sys.stdout.write("Sum: %.15g\n" % sum)
-    else:
+    elif output_format == "json":
+        result = {}
+        result["n"] = N
+        result["min"] = minv
+        result["max"]=maxv
+        result["range"] = (maxv - minv)
+        result["mean"] = (sum / N)
+        result["mean_abs"] = (sum3 / N)
+        if not ((sum2 - sum * sum / N) / N) < 0:
+            result["variance"] = ((sum2 - sum * sum / N) / N)
+            result["stddev"] = (math.sqrt((sum2 - sum * sum / N) / N))
+            result["coeff_var"] = (math.sqrt((sum2 - sum * sum / N) / N)) / (math.sqrt(sum * sum) / N)
+        else:
+            result["variance"]=0
+            result["stddev"]=0
+            result["coeff_var"]=0
+        result["sum"] = sum
+        if not extend:
+            json.dump({"statistics": result}, sys.stdout)
+    elif output_format == "shell":
         sys.stdout.write("n=%d\n" % N)
         sys.stdout.write("min=%.15g\n" % minv)
         sys.stdout.write("max=%.15g\n" % maxv)
@@ -216,6 +274,8 @@ def main():
             sys.stdout.write("stddev=0\n")
             sys.stdout.write("coeff_var=0\n")
         sys.stdout.write("sum=%.15g\n" % sum)
+    else:
+        raise ValueError(f"Unknown output format {output_format}")
 
     if not extend:
         return
@@ -290,6 +350,16 @@ def main():
                     )
             else:
                 sys.stdout.write("%.15g Percentile: %.15g\n" % (perc[i], pval[i]))
+    elif output_format == "json":
+        result["first_quartile"] = q25
+        result["median"] = q50
+        result["third_quartile"] = q75
+        if options["percentile"]:
+            percentiles = []
+            for str_percentile, value in zip(perc, pval):
+                percentiles.append({"percentile": str_percentile, "value": value})
+        result["percentiles"] = percentiles
+        json.dump({"statistics": result}, sys.stdout)
     else:
         sys.stdout.write("first_quartile=%.15g\n" % q25)
         sys.stdout.write("median=%.15g\n" % q50)

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -97,6 +97,11 @@ def sortfile(infile, outfile):
 
 
 def main():
+    # A more substantial rewrite of the code is needed, possibly to C or
+    # using Python packages such as statistics or NumPy,
+    # so ignoring the duplication of final computation of some statistics
+    # as well as pushing the limit of how long the function can be.
+    # pylint: disable=too-many-branches
     global tmp
     tmp = gscript.tempfile()
 
@@ -204,7 +209,7 @@ def main():
             result["n"] = N
             nan_value = None
             result["min"] = nan_value
-            result["max"]=nan_value
+            result["max"] = nan_value
             result["range"] = nan_value
             result["mean"] = nan_value
             result["mean_abs"] = nan_value
@@ -240,18 +245,20 @@ def main():
         result = {}
         result["n"] = N
         result["min"] = minv
-        result["max"]=maxv
-        result["range"] = (maxv - minv)
-        result["mean"] = (sum / N)
-        result["mean_abs"] = (sum3 / N)
+        result["max"] = maxv
+        result["range"] = maxv - minv
+        result["mean"] = sum / N
+        result["mean_abs"] = sum3 / N
         if not ((sum2 - sum * sum / N) / N) < 0:
-            result["variance"] = ((sum2 - sum * sum / N) / N)
-            result["stddev"] = (math.sqrt((sum2 - sum * sum / N) / N))
-            result["coeff_var"] = (math.sqrt((sum2 - sum * sum / N) / N)) / (math.sqrt(sum * sum) / N)
+            result["variance"] = (sum2 - sum * sum / N) / N
+            result["stddev"] = math.sqrt((sum2 - sum * sum / N) / N)
+            result["coeff_var"] = (math.sqrt((sum2 - sum * sum / N) / N)) / (
+                math.sqrt(sum * sum) / N
+            )
         else:
-            result["variance"]=0
-            result["stddev"]=0
-            result["coeff_var"]=0
+            result["variance"] = 0
+            result["stddev"] = 0
+            result["coeff_var"] = 0
         result["sum"] = sum
         if not extend:
             json.dump({"statistics": result}, sys.stdout)
@@ -326,7 +333,7 @@ def main():
 
     q50 = (q50a + q50b) / 2
 
-    if not shellstyle:
+    if output_format == "plain":
         sys.stdout.write("1st Quartile: %.15g\n" % q25)
         sys.stdout.write("Median (%s N): %.15g\n" % (eostr, q50))
         sys.stdout.write("3rd Quartile: %.15g\n" % q75)
@@ -356,8 +363,8 @@ def main():
         result["third_quartile"] = q75
         if options["percentile"]:
             percentiles = []
-            for str_percentile, value in zip(perc, pval):
-                percentiles.append({"percentile": str_percentile, "value": value})
+            for i, one_percentile in enumerate(perc):
+                percentiles.append({"percentile": one_percentile, "value": pval[i]})
         result["percentiles"] = percentiles
         json.dump({"statistics": result}, sys.stdout)
     else:

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -362,10 +362,11 @@ def main():
         result["median"] = q50
         result["third_quartile"] = q75
         if options["percentile"]:
-            percentiles = []
-            for i, one_percentile in enumerate(perc):
-                percentiles.append({"percentile": one_percentile, "value": pval[i]})
-        result["percentiles"] = percentiles
+            percentile_values = []
+            for i in range(len(perc)):
+                percentile_values.append(pval[i])
+        result["percentiles"] = perc
+        result["percentile_values"] = percentile_values
         json.dump({"statistics": result}, sys.stdout)
     else:
         sys.stdout.write("first_quartile=%.15g\n" % q25)

--- a/scripts/db.univar/testsuite/test_db_univar.py
+++ b/scripts/db.univar/testsuite/test_db_univar.py
@@ -17,7 +17,7 @@ class TestDbUnivar(TestCase):
     map_name = "samples"
 
     @classmethod
-    def setUpClass(cls):  # pylint: disable=invalid-name
+    def setUpClass(cls):
         """Generate vector points in extend larger than raster with values"""
         cls.use_temp_region()
         cls.runModule("g.region", raster="elevation")
@@ -26,17 +26,17 @@ class TestDbUnivar(TestCase):
         cls.runModule(
             "v.db.addtable",
             map=cls.map_name,
-            columns="{} double precision".format(cls.column_name),
+            columns=f"{cls.column_name} double precision",
         )
         cls.runModule(
             "v.what.rast", map=cls.map_name, raster="elevation", column=cls.column_name
         )
 
     @classmethod
-    def tearDownClass(cls):  # pylint: disable=invalid-name
+    def tearDownClass(cls):
         """Remove temporary region and vector"""
-        cls.del_temp_region()
         cls.runModule("g.remove", flags="f", type="vector", name=cls.map_name)
+        cls.del_temp_region()
 
     def test_calculate(self):
         """Check that db.univar runs"""

--- a/scripts/v.db.univar/tests/conftest.py
+++ b/scripts/v.db.univar/tests/conftest.py
@@ -1,0 +1,69 @@
+"""Fixtures for v.db.univar tests"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import grass.script as gs
+import grass.script.setup as grass_setup
+
+
+def updates_as_transaction(table, cat_column, column, cats, values):
+    """Create SQL statement for categories and values for a given column"""
+    sql = ["BEGIN TRANSACTION"]
+    for cat, value in zip(cats, values):
+        sql.append(f"UPDATE {table} SET {column} = {value} WHERE {cat_column} = {cat};")
+    sql.append("END TRANSACTION")
+    return "\n".join(sql)
+
+
+def value_update_by_category(map_name, layer, column_name, cats, values):
+    """Update column value for multiple rows based on category"""
+    db_info = gs.vector_db(map_name)[layer]
+    table = db_info["table"]
+    database = db_info["database"]
+    driver = db_info["driver"]
+    cat_column = "cat"
+    sql = updates_as_transaction(
+        table=table,
+        cat_column=cat_column,
+        column=column_name,
+        cats=cats,
+        values=values,
+    )
+    gs.write_command(
+        "db.execute", input="-", database=database, driver=driver, stdin=sql
+    )
+
+
+@pytest.fixture(scope="module")
+def simple_dataset(tmp_path_factory):
+    """Creates a session with a mapset which has vector with a float column"""
+    tmp_path = tmp_path_factory.mktemp("simple_dataset")
+    location = "test"
+    map_name = "points"
+    column_name = "double_value"
+    num_points = 10
+    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
+    with grass_setup.init(tmp_path / location):
+        gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+        gs.run_command("v.random", output=map_name, npoints=num_points, seed=42)
+        gs.run_command(
+            "v.db.addtable",
+            map=map_name,
+            columns=f"{column_name} double precision",
+        )
+        cats = list(range(1, 1 + num_points))
+        values = [float(i) + 0.11 for i in range(100, 100 + num_points)]
+        value_update_by_category(
+            map_name=map_name,
+            layer=1,
+            column_name=column_name,
+            cats=cats,
+            values=values,
+        )
+        yield SimpleNamespace(
+            vector_name=map_name,
+            column_name=column_name,
+            values=values,
+        )

--- a/scripts/v.db.univar/tests/v_db_univar_test.py
+++ b/scripts/v.db.univar/tests/v_db_univar_test.py
@@ -1,0 +1,185 @@
+"""Tests of v.db.univar output statistics"""
+
+import json
+import statistics
+
+import pytest
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+import grass.script as gs
+
+
+def approx(x):
+    """Get an approximate value to test against"""
+    # Using absolute tolerance, but generally using relative too as pytest
+    # does by default would be an option here as well.
+    return pytest.approx(x, abs=1e-10)
+
+
+def numpy_percentiles(values, percentiles, method="lower"):
+    """Get list of percentiles using NumPy"""
+    # Lazy-importing to make the whole NumPy is optional for this test.
+    # Available since 1.9.0.
+    from numpy.lib import NumpyVersion  # pylint: disable=import-outside-toplevel
+
+    if NumpyVersion(np.__version__) < "1.22.0":
+        # Deprecated since 1.22.0.
+        kwargs = {"interpolation": method}
+    else:
+        kwargs = {"method": method}
+    return np.percentile(values, percentiles, **kwargs)
+
+
+def test_basic_stats(simple_dataset):
+    """Test basic statistics against the Python statistics package"""
+    data = json.loads(
+        gs.read_command(
+            "v.db.univar",
+            map=simple_dataset.vector_name,
+            column=simple_dataset.column_name,
+            format="json",
+        )
+    )
+    assert "statistics" in data
+    stats = data["statistics"]
+    assert stats["n"] == len(simple_dataset.values)
+    ref_min = min(simple_dataset.values)
+    ref_max = max(simple_dataset.values)
+    # Using approx for all computed values, but it is really needed only for
+    # stddev and variance.
+    assert stats["min"] == approx(ref_min)
+    assert stats["max"] == approx(ref_max)
+    assert stats["range"] == approx(ref_max - ref_min)
+    assert stats["sum"] == approx(sum(simple_dataset.values))
+    assert stats["mean"] == approx(statistics.mean(simple_dataset.values))
+    assert stats["mean_abs"] == approx(
+        statistics.mean(abs(i) for i in simple_dataset.values)
+    )
+    assert stats["stddev"] == approx(statistics.pstdev(simple_dataset.values))
+    assert stats["variance"] == approx(statistics.pvariance(simple_dataset.values))
+
+
+def test_extra_stats(simple_dataset):
+    """Test extended statistics against the Python statistics package"""
+    data = json.loads(
+        gs.read_command(
+            "v.db.univar",
+            map=simple_dataset.vector_name,
+            column=simple_dataset.column_name,
+            flags="e",
+            format="json",
+        )
+    )
+    stats = data["statistics"]
+    # Test some of the basic stats.
+    assert stats["n"] == len(simple_dataset.values)
+    assert stats["min"] == min(simple_dataset.values)
+    assert stats["max"] == max(simple_dataset.values)
+    # Test extra stats.
+    assert stats["median"] == statistics.median(simple_dataset.values)
+
+
+@pytest.mark.skipif(np is None, reason="NumPy package not available")
+def test_quartiles_default_percentile(simple_dataset):
+    """Test extended statistics including quantiles against NumPy"""
+    data = json.loads(
+        gs.read_command(
+            "v.db.univar",
+            map=simple_dataset.vector_name,
+            column=simple_dataset.column_name,
+            flags="e",
+            format="json",
+        )
+    )
+    assert "statistics" in data
+    stats = data["statistics"]
+    # Test some of the basic stats.
+    assert stats["n"] == len(simple_dataset.values)
+    assert stats["min"] == min(simple_dataset.values)
+    assert stats["max"] == max(simple_dataset.values)
+    assert stats["max"] == max(simple_dataset.values)
+    # Test percentiles.
+    # These work only for n=10. For other n, all methods are usually
+    # off by one at least for one of the values.
+    assert stats["median"] == numpy_percentiles(
+        simple_dataset.values, percentiles=50, method="midpoint"
+    )
+    assert stats["first_quartile"] == numpy_percentiles(
+        simple_dataset.values, percentiles=20, method="lower"
+    )
+    assert stats["third_quartile"] == numpy_percentiles(
+        simple_dataset.values, percentiles=75, method="higher"
+    )
+    assert len(stats["percentiles"]) == 1
+    precentile_90 = stats["percentiles"][0]["value"]
+    assert precentile_90 == numpy_percentiles(
+        simple_dataset.values, percentiles=90, method="lower"
+    )
+
+
+@pytest.mark.skipif(np is None, reason="NumPy package not available")
+def test_percentiles(simple_dataset):
+    """Test custom percentiles against NumPy"""
+    percentiles = range(10, 100, 10)
+    data = json.loads(
+        gs.read_command(
+            "v.db.univar",
+            map=simple_dataset.vector_name,
+            column=simple_dataset.column_name,
+            flags="e",
+            percentile=percentiles,
+            format="json",
+        )
+    )
+    stats = data["statistics"]
+    # Test some of the basic stats.
+    assert stats["n"] == len(simple_dataset.values)
+    assert stats["min"] == min(simple_dataset.values)
+    assert stats["max"] == max(simple_dataset.values)
+    # Test percentiles.
+    assert len(stats["percentiles"]) == len(percentiles)
+    ref_percentiles = numpy_percentiles(simple_dataset.values, percentiles)
+    assert len(stats["percentiles"]) == len(ref_percentiles)
+    for ref_percentile, percentile_result in zip(ref_percentiles, stats["percentiles"]):
+        assert percentile_result["percentile"]
+        # Same limitation as above: Works only for n=10.
+        assert percentile_result["value"] == ref_percentile
+
+
+def test_fixed_values(simple_dataset):
+    """Test against hardcoded values"""
+    percentiles = range(10, 100, 20)
+    data = json.loads(
+        gs.read_command(
+            "v.db.univar",
+            map=simple_dataset.vector_name,
+            column=simple_dataset.column_name,
+            flags="e",
+            percentile=percentiles,
+            format="json",
+        )
+    )
+    assert "statistics" in data
+    stats = data["statistics"]
+    assert stats["n"] == 10
+    assert stats["min"] == 100.11
+    assert stats["max"] == 109.11
+    assert stats["range"] == 9
+    assert stats["sum"] == approx(1046.1)
+    assert stats["mean"] == approx(104.61)
+    assert stats["mean_abs"] == approx(104.61)
+    assert stats["stddev"] == approx(2.87228132326952)
+    assert stats["variance"] == approx(8.25000000000291)
+    assert stats["coeff_var"] == approx(0.0274570435261402)
+    # Test percentiles.
+    assert len(stats["percentiles"]) == len(percentiles)
+    ref_percentiles = [100.11, 102.11, 104.11, 106.11, 108.11]
+    assert len(stats["percentiles"]) == len(ref_percentiles)
+    for ref_percentile, percentile_result in zip(ref_percentiles, stats["percentiles"]):
+        assert percentile_result["percentile"]
+        # Same limitation as above: Works only for n=10.
+        assert percentile_result["value"] == ref_percentile

--- a/scripts/v.db.univar/tests/v_db_univar_test.py
+++ b/scripts/v.db.univar/tests/v_db_univar_test.py
@@ -115,7 +115,8 @@ def test_quartiles_default_percentile(simple_dataset):
         simple_dataset.values, percentiles=75, method="higher"
     )
     assert len(stats["percentiles"]) == 1
-    precentile_90 = stats["percentiles"][0]["value"]
+    assert len(stats["percentile_values"]) == 1
+    precentile_90 = stats["percentile_values"][0]
     assert precentile_90 == numpy_percentiles(
         simple_dataset.values, percentiles=90, method="lower"
     )
@@ -124,7 +125,7 @@ def test_quartiles_default_percentile(simple_dataset):
 @pytest.mark.skipif(np is None, reason="NumPy package not available")
 def test_percentiles(simple_dataset):
     """Test custom percentiles against NumPy"""
-    percentiles = range(10, 100, 10)
+    percentiles = list(range(10, 100, 10))
     data = json.loads(
         gs.read_command(
             "v.db.univar",
@@ -141,18 +142,16 @@ def test_percentiles(simple_dataset):
     assert stats["min"] == min(simple_dataset.values)
     assert stats["max"] == max(simple_dataset.values)
     # Test percentiles.
-    assert len(stats["percentiles"]) == len(percentiles)
+    assert percentiles == stats["percentiles"]
     ref_percentiles = numpy_percentiles(simple_dataset.values, percentiles)
-    assert len(stats["percentiles"]) == len(ref_percentiles)
-    for ref_percentile, percentile_result in zip(ref_percentiles, stats["percentiles"]):
-        assert percentile_result["percentile"]
-        # Same limitation as above: Works only for n=10.
-        assert percentile_result["value"] == ref_percentile
+    assert len(percentiles) == len(ref_percentiles), "Error in the test itself"
+    # Same limitation as above: Works only for numbers with n=10.
+    assert list(ref_percentiles) == stats["percentile_values"]
 
 
 def test_fixed_values(simple_dataset):
     """Test against hardcoded values"""
-    percentiles = range(10, 100, 20)
+    percentiles = list(range(10, 100, 20))
     data = json.loads(
         gs.read_command(
             "v.db.univar",
@@ -176,10 +175,7 @@ def test_fixed_values(simple_dataset):
     assert stats["variance"] == approx(8.25000000000291)
     assert stats["coeff_var"] == approx(0.0274570435261402)
     # Test percentiles.
-    assert len(stats["percentiles"]) == len(percentiles)
+    assert stats["percentiles"] == percentiles
     ref_percentiles = [100.11, 102.11, 104.11, 106.11, 108.11]
-    assert len(stats["percentiles"]) == len(ref_percentiles)
-    for ref_percentile, percentile_result in zip(ref_percentiles, stats["percentiles"]):
-        assert percentile_result["percentile"]
-        # Same limitation as above: Works only for n=10.
-        assert percentile_result["value"] == ref_percentile
+    assert len(stats["percentiles"]) == len(ref_percentiles), "Error in the test itself"
+    assert stats["percentile_values"] == ref_percentiles

--- a/scripts/v.db.univar/v.db.univar.html
+++ b/scripts/v.db.univar/v.db.univar.html
@@ -54,6 +54,16 @@ v.db.select samples
 v.db.univar samples column=heights
 </pre></div>
 
+<h3>JSON output</h3>
+
+This uses the JSON output of the module which is passed using
+a pipe (in Bash or other unix-like shell) to the <em>jq</em> tool
+which selects just the relevant statistic.
+
+<div class="code"><pre>
+v.db.univar precip_30ynormals column=annual format=json | jq .statistics.mean
+</pre></div>
+
 <h2>SEE ALSO</h2>
 
 <em>

--- a/scripts/v.db.univar/v.db.univar.py
+++ b/scripts/v.db.univar/v.db.univar.py
@@ -42,6 +42,14 @@
 # % options: 0-100
 # % multiple: yes
 # %end
+# %option
+# % key: format
+# % type: string
+# % multiple: no
+# % options: plain,json,shell
+# % label: Output format
+# % descriptions: plain;Plain text output;json;JSON (JavaScript Object Notation);shell;Shell script style for Bash eval
+# %end
 # %flag
 # % key: e
 # % description: Extended statistics (quartiles and 90th percentile)
@@ -87,6 +95,7 @@ def main():
             passflags = "g"
         else:
             passflags = passflags + "g"
+    output_format = options["format"]
 
     try:
         gscript.run_command(
@@ -97,6 +106,7 @@ def main():
             driver=driver,
             perc=perc,
             where=where,
+            format=output_format,
             flags=passflags,
         )
     except CalledModuleError:


### PR DESCRIPTION
This adds JSON output for db.univar and v.db.univar.

```bash
v.db.univar map=roadsmajor column=SHAPE_LEN format=json -e percentile=80,90,95,99 | jq
```

```json
{
  "statistics": {
    "n": 355,
    "min": 20.359027,
    "max": 64177.255429,
    "range": 64156.896402,
    "mean": 4934.153557109861,
    "mean_abs": 4934.153557109861,
    "variance": 38328715.30867731,
    "stddev": 6191.0189233015035,
    "coeff_var": 1.254727655238975,
    "sum": 1751624.5127740006,
    "first_quartile": 761.180256,
    "median": 1601.228177,
    "third_quartile": 9527.487778,
    "percentiles": [
      {
        "percentile": 80,
        "value": 11737.529039
      },
      {
        "percentile": 90,
        "value": 13883.001283
      },
      {
        "percentile": 95,
        "value": 14711.484257
      },
      {
        "percentile": 99,
        "value": 14943.396283
      }
    ]
  }
}
```

The implementation introduces some more duplication (in addition to the existing duplicated code), but given that the computations are directly implemented in Python without any libraries and that the implemented method, even if implemented correctly, may need to be changed to a more standard one, I'm going with bad, but easier to write, code which brings less changes to the current code.

This also adds test, but the correctness checks against NumPy are limited, esp. due to different definitions of quartiles and percentiles.

See also #2108.