### PR TITLE
CI: Add test run for release workflow

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -49,9 +49,9 @@ jobs:
           cd utils
           # Git works without any special permissions.
           # Using current branch or the branch against the PR is open.
-          # Using last tag as start (works for release branches) or last 30 commits
-          # (for main and PRs). End is the current (latest) commit.
+          # Using the last 30 commits (for branches, tags, and PRs).
+          # End is the current (latest) commit.
           python ./generate_release_notes.py log \
               ${{ github.ref_name }} \
-              $(git describe --abbrev=0 --tags || git rev-parse HEAD~30) \
+              $(git rev-parse HEAD~30) \
               ""

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -2,8 +2,18 @@ name: Create a release draft
 
 on:
   push:
+    branches:
+      - main
+      - releasebranch_*
     tags:
       - '**'
+  pull_request:
+    branches:
+      - main
+      - releasebranch_*
+    paths:
+      - '.github/**'
+      - 'utils/**'
 
 jobs:
   build:
@@ -24,8 +34,9 @@ jobs:
           git add core_modules_with_last_commit.json
           git diff --cached > core_modules_with_last_commit.patch
 
-      - name: Create new release draft
+      - name: Create new release draft (for tags only)
         id: create_release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,9 +48,10 @@ jobs:
             - First change
             - Second change
           draft: true
-          prerelease: ${{ contains(github.ref, "RC") }}
+          prerelease: ${{ contains(github.ref, 'RC') }}
 
-      - name: Upload core_modules_with_last_commit.json file
+      - name: Upload core_modules_with_last_commit.json file (for tags only)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -49,7 +61,8 @@ jobs:
           asset_name: core_modules_with_last_commit.json
           asset_content_type: application/json
 
-      - name: Upload core_modules_with_last_commit.patch file
+      - name: Upload core_modules_with_last_commit.patch file (for tags only)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -59,9 +72,9 @@ jobs:
           asset_name: core_modules_with_last_commit.patch
           asset_content_type: text/plain
 
-      - name: On failure, make the created files available
+      - name: Make the created files available
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: artifacts
           path: |

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -1,4 +1,4 @@
-name: Create a release draft
+name: Create or check a release draft
 
 on:
   push:


### PR DESCRIPTION
* Run the create release workflow for PRs and on branches, too, for testing puproses, but exclude the release-only steps one by one. (Not even expression syntax is not checked when workflow does not run.)
* Upload artifacts always since now it runs for non-release commits as well.
* Fix expression syntax: Use single quotes for a string.
* Run only for selected paths for PRs, run always for selected branches and all tags.
* Don't use tags in the git log release notes test in additional checks because there for tags, this would be the same tag and so no difference (although the workflow now runs only for branches, not tags).
