### PR TITLE
contributing: Remove cd steps, assume utils subdir

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Generate release notes using git log
         run: |
           python -m pip install PyYAML
-          cd utils
           # Git works without any special permissions.
           # Using current branch or the branch against the PR is open.
           # Using the last 30 commits (for branches, tags, and PRs).

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -50,7 +50,7 @@ jobs:
           # Using current branch or the branch against the PR is open.
           # Using the last 30 commits (for branches, tags, and PRs).
           # End is the current (latest) commit.
-          python ./generate_release_notes.py log \
+          python ./utils/generate_release_notes.py log \
               ${{ github.ref_name }} \
               $(git rev-parse HEAD~30) \
               ""

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -84,6 +84,7 @@ Check that there is exactly one commit on your local branch and that it is the v
 ```bash
 git status
 git show
+```
 
 Push the tag to the upstream repo:
 
@@ -157,13 +158,9 @@ so that you can continue in the release process.
 
 ### Create release notes
 
-Generate a draft of release notes using a script. The script uses configuration files
-which are in the _utils_ directory and the script needs to run there,
-so change the current directory:
-
-```bash
-cd utils
-```
+Generate a draft of release notes using a script. The script the script needs to
+run from the top directory and will expect its configuration files
+to be in the _utils_ directory.
 
 For major and minor releases, GitHub API gives good results for the first
 release candidate because it contains contributor handles and can identify
@@ -196,12 +193,6 @@ However, these notes need to be manually edited to collapse related items into o
 Additionally, a _Highlights_ section needs to be added with manually identified new
 major features for major and minor releases. For all releases, a _Major_ section
 may need to be added showing critical fixes or breaking changes if there are any.
-
-Change directory back to the root directory of the repo:
-
-```bash
-cd ..
-```
 
 ### Modify the release draft
 

--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -181,19 +181,19 @@ def notes_from_git_log(start_tag, end_tag, categories, exclude):
     if not commits:
         raise RuntimeError("No commits retrieved from git log (try different tags)")
 
-    support_directory = Path("utils")
+    config_directory = Path("utils")
     svn_name_by_git_author = csv_to_dict(
-        support_directory / "svn_name_git_author.csv",
+        config_directory / "svn_name_git_author.csv",
         key="git_author",
         value="svn_name",
     )
     github_name_by_svn_name = csv_to_dict(
-        support_directory / "svn_name_github_name.csv",
+        config_directory / "svn_name_github_name.csv",
         key="svn_name",
         value="github_name",
     )
     github_name_by_git_author = csv_to_dict(
-        support_directory / "git_author_github_name.csv",
+        config_directory / "git_author_github_name.csv",
         key="git_author",
         value="github_name",
     )
@@ -248,7 +248,8 @@ def create_release_notes(args):
             check=True,
         ).stdout.strip()
 
-    with open("release.yml", encoding="utf-8") as file:
+    config_directory = Path("utils")
+    with open(config_directory / "release.yml", encoding="utf-8") as file:
         config = yaml.safe_load(file.read())["notes"]
 
     if args.backend == "api":

--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
+from pathlib import Path
 
 import yaml
 
@@ -180,14 +181,21 @@ def notes_from_git_log(start_tag, end_tag, categories, exclude):
     if not commits:
         raise RuntimeError("No commits retrieved from git log (try different tags)")
 
+    support_directory = Path("utils")
     svn_name_by_git_author = csv_to_dict(
-        "svn_name_git_author.csv", key="git_author", value="svn_name"
+        support_directory / "svn_name_git_author.csv",
+        key="git_author",
+        value="svn_name",
     )
     github_name_by_svn_name = csv_to_dict(
-        "svn_name_github_name.csv", key="svn_name", value="github_name"
+        support_directory / "svn_name_github_name.csv",
+        key="svn_name",
+        value="github_name",
     )
     github_name_by_git_author = csv_to_dict(
-        "git_author_github_name.csv", key="git_author", value="github_name"
+        support_directory / "git_author_github_name.csv",
+        key="git_author",
+        value="github_name",
     )
 
     lines = []


### PR DESCRIPTION
It is no longer necessary to cd to and from the utils directory. The script now assumes it is in the top directory and utils is a subdirectory with its config files.
