### PR TITLE
RFC: move adopted RFCs from trac wiki

### DIFF
--- a/doc/development/rfc/PSC_guidelines.md
+++ b/doc/development/rfc/PSC_guidelines.md
@@ -1,0 +1,122 @@
+# RFC 1: Project Steering Committee Guidelines
+
+Author: [GRASS PSC](https://trac.osgeo.org/grass/wiki/PSC)
+
+Contact: [grass-psc AT lists.osgeo.org](http://lists.osgeo.org/mailman/listinfo/grass-psc)
+
+Status: Adopted (6 April 2007)
+
+## Summary
+
+A GRASS Project Steering Committee ([PSC](https://trac.osgeo.org/grass/wiki/PSC)) is proposed to formalize control
+over the GRASS codebase and to facilitate GRASS project management issues.
+It is desired to keep the administrational overhead as low as possible.
+
+This document describes how the GRASS Project Steering Committee
+determines membership, and makes decisions on GRASS project issues.
+
+"The GRASS Project" is defined as the GPL-licenced GIS software known as the
+Geographic Resources Analysis Support System, together with the surrounding
+development, distribution and promotion infrastructure currently headquarted
+at OSGeo.
+
+## Terms of Reference
+
+The two primary functions of the PSC are:
+
+ 1. To enforce control over the GRASS codebase. This can be summarised as:
+     * Enforce mechanisms to ensure quality control.
+     * Ensure compliance with all required legal measures.
+ 2. Project Management and responsibility for the "public face" of GRASS.
+
+The PSC is expected to be able to speak and act on behalf of the GRASS
+project.
+
+## Codebase Control
+
+### Quality Control Mechanisms
+
+The quality control mechanisms, which are the responsibility of the PSC,
+currently include:
+
+ * Maintaining submitter guidelines and making all developers aware of them.
+ * Granting write access to the source code repository for new developers.
+ * Enforcing the submitter guidelines, with the ultimate sanction against non-compliance being removal of write access to the source code repository.
+
+In general, once write access has been granted, developers are allowed to
+make changes to the codebase as they see fit. For controversial or
+complicated changes consensus must be obtained on the developers' mailing
+list as far as reasonably practicable. It is recognised that the ultimate
+arbitration on technical issues should always lie with consensus on the
+developers' mailing list. Specifically, it is not the role of the PSC to
+impose technical solutions. Its role is in general limited to enforcing the
+quality control mechanisms outlined above.
+
+However, if consensus fails to emerge naturally, an issue can be
+referred to the PSC for more structured efforts to build consensus.
+As a last resort, if lack of consensus continues, the developer
+community can request the PSC to choose options best preserving the
+quality of the GRASS project.
+
+Removal of write access to the source code repository is handled as a
+proposal to the committee as described below in the [Operation of the PSC](#operation-of-the-psc) section.
+
+### Legal aspects
+
+Control over the codebase also extends to ensuring that it complies with
+all relevant legal requirements. This includes copyright and licensing
+amongst other issues. The PSC is responsible for developing rules and
+procedures to cover this. These are outlined in a separate document:
+[RFC 2: Legal aspects of code contributions](legal_aspects_of_code_contributions.md).
+This document will be updated and revised by the PSC as required.
+
+## Project Management
+
+The PSC will share responsibility and make decisions over issues related
+to the management of the overall direction of the GRASS project and
+external visibility, etc. These include, but are not limited to:
+
+ * Release Cycles
+ * Project infrastructure
+ * Website Maintenance
+ * Promotion and Public Relations
+ * Other issues as they become relevant
+
+It is the responsibility of the PSC to ensure that issues critical to the
+future of the GRASS project are adequately attended to. This may involve
+delegation to interested helpers.
+
+## Operation of the PSC
+
+A dedicated [mailing list](https://lists.osgeo.org/mailman/listinfo/grass-psc)
+exists for the purpose of PSC discussions. When a
+decision is required of the PSC, it will be presented by any member to the
+mailing list in the form of a proposal. A decision will then be achieved
+by discussion of the proposal on the mailing list until a consensus is
+reached. Voting on issues is also permissable and may be used as a means
+to reach a consensus or, only in case of extreme cases of disagreement, to
+force a decision. Any member may call a vote on any proposal. The voting
+procedure is outlined in a separate document:
+[RFC 3: PSC Voting Procedures](PSC_voting_procedures.md).
+
+The Chair is the ultimate adjudicator in case of deadlock or irretrievable
+break down of decision-making, or in case of disputes over voting.
+
+The following issue(s) *must* have a vote called before a
+decision is reached:
+
+ * Granting source code repository write access for new developers
+ * Selection of a committee Chair
+
+## Composition of the Committee
+
+Initial PSC membership was decided based on a nomination and informal voting
+period on the community's mailing lists.  Michael Barton, Dylan Beaudette,
+Hamish Bowman, Massimiliano Cannata, Brad Douglas, Paul Kelly, Helena Mitasova,
+Scott Mitchell, Markus Neteler, and Maciej Sieczka are declared to be the
+founding Project Steering Committee.
+
+Addition and removal of members from the committee, as well as selection
+of Chair is handled as a proposal to the committee as described above.
+
+The Chair is responsible for keeping track of the membership of the PSC.

--- a/doc/development/rfc/PSC_voting_procedures.md
+++ b/doc/development/rfc/PSC_voting_procedures.md
@@ -1,0 +1,30 @@
+# RFC 3: PSC Voting Procedures
+
+Author: [GRASS PSC](https://trac.osgeo.org/grass/wiki/PSC)
+
+Contact: [grass-psc AT lists.osgeo.org](http://lists.osgeo.org/mailman/listinfo/grass-psc)
+
+Status: Adopted (6 Oct 2014)
+
+## Introduction
+
+In brief, the PSC members vote on proposals on the dedicated [GRASS-PSC mailing list](http://lists.osgeo.org/mailman/listinfo/grass-psc).
+Proposals are available for review for at least seven calendar days, and a
+single veto is sufficient to delay progress although ultimately a majority
+of committee members can pass a proposal.
+
+## Detailed Process
+
+Proposals:
+ 1. Proposals are written up and submitted on the PSC mailing list for discussion. Any committee member may call a vote on any proposal, although it is normal practice for the proposer to call the vote. Any interested  party may subscribe to the list and join the discussion, but only [PSC committee members](https://trac.osgeo.org/grass/wiki/PSC) including the PSC Chair get a vote ("eligible voters").
+ 1. Proposals are available for review for at least seven calendar days before a vote can be closed. It is acknowledged that some more complex issues may require more time for discussion and deliberation: a vote should only be closed after the minimum time period (see above) has passed and sufficient discussion has taken place, or no more progress is being made. The PSC Chair may override this and prolong the discussion period or close a vote straight away if necessary (although the minimum time period for discussion/voting always applies).
+
+Voting:
+ 1. A voting procedure is started by the proposer. For a more visible communication, the word [MOTION] should be put into the subject of the email to the [GRASS-PSC mailing list](http://lists.osgeo.org/mailman/listinfo/grass-psc) along with a short title.
+ 1. Respondents may vote "+1" to indicate support for the proposal and a willingness to support implementation.
+ 1. Respondents may vote "-1" to veto a proposal, but must provide clear reasoning and alternative approaches to resolving the problem within the period the issue is open for discussion/voting. Otherwise the veto will be considered invalid.
+ 1. A vote of -0 indicates mild disagreement, but has no effect.  A 0 indicates no opinion.  A +0 indicate mild support, but has no effect.
+ 1. A proposal will be accepted if it receives majority (51% of all eligible voters including the proposer) of votes (+1) and no vetoes (-1).
+ 1. The committee member who called the vote (normally the proposer) is responsible for collating votes and presenting the result to the PSC after closing the vote.
+ 1. The Chair adjudicates in cases of disputes over voting.
+ 1. If a proposal is vetoed, and it cannot be revised to satisfy all parties, then it can be resubmitted for an override vote in which a majority of all eligible voters indicating +1 is sufficient to pass it. Note that this is a majority of all eligible voters, not just those who actively vote.

--- a/doc/development/rfc/language_standards_support.md
+++ b/doc/development/rfc/language_standards_support.md
@@ -1,0 +1,39 @@
+# RFC 7: Language Standards Support
+
+Author of the first draft: Nicklas Larsson
+
+Status: Motion passed, 29 March 2021
+
+## Introduction
+The code base of GRASS GIS consists today (Feb. 2021) of predominantly C code (ca 50 %), Python (ca 30 %) and a smaller amount of C++ (ca 5 %). Each of these languages have evolved significantly in the last 10–20 years. There is, however, no clearly stated policy of supported language standard(s), nor mechanism to update this policy when needed or wanted. This result in uncertainty for contributors for what may be allowed and solutions that may not be optimal.
+
+This RFC aims at setting a policy for GRASS GIS project regarding language standard support for C and C++.
+
+In addition, this is also intended to set a precedent for future updates on this subject.
+
+## Background
+Throughout its long history, soon 40 years, GRASS GIS has evolved and steps have been taken to adapt and modernize. The latest big modernization of the C code was done in 2002–2006 ([summary](https://lists.osgeo.org/pipermail/grass-dev/2021-February/094955.html)), when it was updated to conform to C89 (ANSI C) standard. A major job, which has payed-off well. However, during the years, language features of successive standards have slipped into the code base, which is no longer strictly C89 (nor C90) conformant. There are no compelling reasons to revert the existing code to strict C89, therefore the community has to decide which standard to adhere to.
+
+The small amount of C++ code in GRASS GIS has never been formalised and officially made to conform to any specific standard.
+
+See also the discussion leading to this RFC on the mailing list [thread](https://lists.osgeo.org/pipermail/grass-dev/2021-January/094899.html).
+
+## Discussion
+The advantage of having clearly stated policy on language standard requirements/support is important not only for contributors, but also sets the frame for supported platforms. For the latter, also the reverse is true: in deciding supported standard the community needs to consider the degree of support of standards for various platforms.
+
+It should be emphasized that existing GRASS GIS C and C++ code compiles also with C17 and C++17. There is therefore no need to modernize it the way it was done to C in the 2000’s. Nevertheless, conforming to newer standards may provide better cross platform support and possibly safer code.
+
+Regarding C, there are three standards that may be considered: C99, C11 and C17. C99 never really reached full support on key platforms, this is  particularly the case for Windows ([Visual Studio 2013](https://devblogs.microsoft.com/cppblog/c99-library-support-in-visual-studio-2013/)). Partly in consequence of this lack of support for some C99 features, the C11 standard was made less strict: making some C99 mandatory features optional. Thus, from autumn 2020 even [MSVC complies to C11](https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/) core feature support. Starting with [GCC 4.9](https://gcc.gnu.org/wiki/C11Status) it had “substantially complete” support for C11, Clang from [version 3.1](https://releases.llvm.org/3.1/docs/ClangReleaseNotes.html). [C17](https://en.wikipedia.org/wiki/C17_(C_standard_revision)), on the other hand, doesn’t add new features compared to C11. Its difference is more interesting from compiler point of view, whereas code “good for C11” is good for C17.
+
+Regarding C++, there are the C++98, C++03, C++11, C++14 and C++17 standards to consider. The platform and compiler support for all of these are significantly better. However, C++11 is at this date in general considered the standard and until compelling reasons argue otherwise, the C++11 standard should be policy of the GRASS GIS project.
+
+## Proposed Language Standards Support
+
+### C Language
+C11 with core (mandatory) features [brief summary](https://en.wikipedia.org/wiki/C11_(C_standard_revision))
+
+Optional features may be used if availability is tested with macro, and if not supported, alternative fallback code must be provided.
+
+### C++ Language
+C++11 [summary](https://en.wikipedia.org/wiki/C%2B%2B11)
+

--- a/doc/development/rfc/legal_aspects_of_code_contributions.md
+++ b/doc/development/rfc/legal_aspects_of_code_contributions.md
@@ -1,0 +1,82 @@
+# RFC 2: Legal aspects of code contributions
+
+Author: Markus Neteler (based on GDAL.org/RFC3)
+
+Contact: [grass-psc AT lists.osgeo.org](http://lists.osgeo.org/mailman/listinfo/grass-psc)
+
+Status: Adopted (8 Dec 2006)
+
+## Legal aspects
+
+GRASS developers have to keep the code base clear of improperly
+contributed code. It is important to the GRASS users, developers and
+the OSGeo foundation to avoid contributing any code to the project
+without it being clearly licensed under the project license or a
+compliant license. In this document, a "committer" is understood to be
+a developer with write access to the GRASS source code repository.
+
+Generally speaking, the key issues are that those individuals
+providing code to be included in the GRASS repository understand that
+the code will be released under the GPL >=2 license, and that the
+person providing the code has the right to contribute the code.  In
+order to verify this, the committer must have a clear understanding of
+the license themselves. When committing 3rd party contributions, the
+committer should verify the understanding unless the committer is very
+comfortable that the contributor understands the license (for instance
+frequent contributors).
+
+If the contribution was developed on behalf of an employer (on work
+time, as part of a work project, etc) then it is important that an
+appropriate representative of the employer understand that the code
+will be contributed under the GPL license. The arrangement should be
+cleared with an authorized supervisor/manager, etc.
+
+The code should be developed by the contributor, or the code should be
+from a source which can be rightfully contributed such as from the
+public domain, or from an open source project under a compatible
+license.
+
+All unusual situations need to be discussed and/or documented.
+
+Committers should adhere to the following guidelines, and may be
+personally legally liable for improperly contributing code to the
+source repository:
+
+ * Make sure the contributor (and possibly employer) is aware of the
+  contribution terms.
+ * Code coming from a source other than the contributor (such as
+  adapted from another project) should be clearly marked as to the
+  original source, copyright holders, license terms and so forth. This
+  information can be in the file headers, but should also be added to
+  the project licensing file if not exactly matching normal project
+  licensing (grass/COPYRIGHT.txt).
+ * Existing copyright headers and license text should never be stripped
+  from a file. If a copyright holder wishes to give up copyright they
+  must do so in writing to the GRASS [PSC](https://trac.osgeo.org/grass/wiki/PSC) before copyright messages
+  are removed. If license terms are changed, it has to be by agreement
+  (written in email is ok) of the copyright holders.
+ * When substantial contributions are added to a file (such as
+  substantial patches) the author/contributor should be added to the
+  list of copyright holders for the file in the file header.
+ * If there is uncertainty about whether a change is proper to
+  contribute to the code base, please seek more information from the
+  Project Steering Committee, other GRASS developers or the OSGeo
+  foundation legal counsel.
+
+Questions regarding GRASS GIS should be directed to the
+GRASS Development Team at the following address:
+
+Internet:
+  http://grass.osgeo.org/home/contact-us/
+
+Postal address:
+
+```
+ GRASS Development Team
+ c/o Dr Markus Neteler
+ Fondazione E. Mach - Research and Innovation Centre
+ GIS and Remote Sensing Unit
+ 38010 S. Michele all'Adige
+ Italy
+ email: neteler AT osgeo.org
+```

--- a/doc/development/rfc/legal_aspects_of_code_contributions.md
+++ b/doc/development/rfc/legal_aspects_of_code_contributions.md
@@ -69,14 +69,3 @@ GRASS Development Team at the following address:
 Internet:
   http://grass.osgeo.org/home/contact-us/
 
-Postal address:
-
-```
- GRASS Development Team
- c/o Dr Markus Neteler
- Fondazione E. Mach - Research and Innovation Centre
- GIS and Remote Sensing Unit
- 38010 S. Michele all'Adige
- Italy
- email: neteler AT osgeo.org
-```

--- a/doc/development/rfc/migration_github.md
+++ b/doc/development/rfc/migration_github.md
@@ -1,0 +1,136 @@
+# RFC 6: Migration from SVN to GitHub
+
+Authors of the first draft: Markus Neteler, Martin Landa
+
+Status: Motion passed Apr 22, 2019
+
+## Introduction
+
+GRASS GIS is an open source geoinformation system which is developed by a globally distributed team of developers. Besides the source code developers also message translators, people who write documentation, those who report bugs and wishes and more are involved.
+
+The centralized source code management system Subversion (SVN) has served the GRASS GIS project very well since 2007. The project has established routines and infrastructure (code repository, ticketing system, developer wiki) connected to SVN. However, with an increasing number of Open Source developers using git (and here especially the success of GitHub), time has come to migrate the source code base from SVN kindly hosted by OSGeo to GitHub.com, a widely adopted development platform.
+
+## Background information of git migration
+
+ * For background and aims, see
+   * https://trac.osgeo.org/grass/wiki/GitMigration
+ * Results of a survey performed in early 2019:
+   * https://docs.google.com/forms/d/1BoTFyZRNebqVX98A3rh5GpUS2gKFfmuim78gbradDjc/viewanalytics
+ * Technical discussions
+   * svn -> git test migration ongoing, see [#3722](https://trac.osgeo.org/grass/ticket/3722)
+   * trac -> github test issue migration ongoing, see [#3789](https://trac.osgeo.org/grass/ticket/3789)
+
+## New GitHub repositories
+
+Since migration is a huge effort, massive work on converting the existing source code (organized in branches) and the related trac tickets has been done. The main scope of weeks of efforts was to preserve as much information as possible by converting trac/svn references to full URLs pointing to the old system kept available in read-only mode.
+
+The following new GitHub repositories have been [created](https://github.com/grass-svn2git). Note that the "cut-off" date of the main **grass** repository does not correspond to the first upload to CSV which was then migrated to SVN. The repositories **grass** and **grass-legacy** overlap in time since they contain different branches:
+
+ * repository **grass**
+   * Source code from 2008 (as the starting commit r31142 was selected, i.e. "Welcome to GRASS 7.0.svn") to present day (SVN-trunk -> git-master)
+   * i.e., all 7.x and later release branches + master
+ * repository **grass-legacy**
+   * Source code from 1987 (pre-public internet times; manually reconstructed) - 2018 (r72361 - last commit to releasebranch_6_4)
+   * i.e., a separate repository for older GRASS GIS releases (3.2, 4.x, 5.x, 6.x)
+ * repository **grass-addons**
+   * repository for addons
+   * code re-organized from directory-like layout (grass6, grass7) into branches-like layout (master == grass7, grass6, ...)
+ * repository **grass-promo**
+   * repository for promotional material
+
+The final destination of these repositories will be under
+
+  https://github.com/OSGeo/
+
+## Authorship and SVN user name mapping to GitHub
+
+Given GRASS GIS’ history of 35+ years we had to invest major effort in identifying and mapping user names throughout the decades (CVS was used from 1999 to 2007; SVN has been used since 2007, see [history](https://grasswiki.osgeo.org/wiki/Bug_tracking)).
+
+The following circumstances could be identified:
+
+ * user present in CVS but not in SVN
+ * user present in SVN but not in CVS
+ * user present in both with identical name
+ * user present in both with different name as some were changed in the CVS to SVN migration in 2007, leading to colliding user names
+ * some users already having a GitHub account (with mostly different name again)
+   * see here for the [author mapping table](https://trac.osgeo.org/grass/browser/grass-addons/tools/svn2git/)
+
+**Important**: nothing is lost as contributions can be [claimed](https://help.github.com/en/articles/why-are-my-commits-linked-to-the-wrong-user) in GitHub.
+
+## Activating the GitHub issue tracker
+
+As the cut-off date for the trac migration we selected 2007-12-09 (r25479) as it was the first SVN commit (after the years in CVS).
+
+The tickets migrated from trac to GitHub contain updated links in the ticket texts:
+
+ * links to other tickets (closed now pointing to full trac URL, open pointing to a new github issues). Note that there were many styles of referring in the commit log message which had to be parsed accordingly.
+ * links to trac wiki (now pointing to full trac URL)
+ * links source code in SVN (now pointing to full trac URL)
+ * images and attachments (now pointing to full trac URL)
+
+Labels are preserved by transferring:
+
+ * "operating system" trac label into the GitHub issue text itself (following the new issue reporting template)
+ * converting milestones/tickets/comments/labels
+ * converting trac usernames to known GitHub usernames (those missing at time can [claim](https://help.github.com/en/articles/why-are-my-commits-linked-to-the-wrong-user) commits)
+ * setting assignees if possible; otherwise set new "grass-svn2git" an assignee
+
+**New labels in the GitHub issue tracker:**
+
+The trac component of the bug reports have been cleaned up following other OSGeo projects like GDAL and QGIS, leading to the following categories:
+
+ * **Issue category**:
+   * bug
+   * enhancement
+ * **Priority**:
+   * blocker
+   * critical
+   * feedback needed
+ * **Issue solution** (other than fixing and closing it normally):
+   * duplicate
+   * invalid
+   * wontfix
+   * worksforme
+ * **Components**:
+   * docs
+   * GUI
+   * libs
+   * modules
+   * packaging
+   * python
+   * translations
+   * unittests
+   * Windows specific
+
+Note that "normal" bugs reported will not carry a label in order to not overload the visual impact and readability.
+
+## Rules and best practices for using Git
+
+Before the new Git repository is open for writing, we need to have rules and best practices for dealing with the following:
+
+ * Policy for automatic merge commits due to un-synchronous nature of Git. Do we want to avoid those by `git pull --rebase`?
+ * How to do backports?
+ * A branch for every feature or bug fix in the main repo or is this done in the fork?
+ * _(add more)_
+
+## Turning SVN/trac into readonly mode
+
+As soon as the above listed repositories are stable and functional, SVN/trac (https://trac.osgeo.org/grass/) at OSGeo will be set into readonly mode. They will serve as a reference for existing links and also for the aforementioned converted commit messages and issues in the issue tracker.
+
+## Open issues
+
+ * Will be also Trac wiki migrated into GitHub?
+   * This can be decided at a later stage. Managed in [#3789](https://trac.osgeo.org/grass/ticket/3789)
+
+## Mirror or Exit strategy
+
+GitHub is a closed platform. In case it would be shutdown, closed or GitHub would start asking unreasonable fees, a backup strategy is needed.
+The proposed solution is
+   * GitLab has an import module from GitHub.
+     * implement a continuous mirror on GitLab.com including the issues and wiki.
+       * OSGeo-gitea code mirror: https://git.osgeo.org/gitea/grass_gis/grass
+     * See https://docs.gitlab.com/ee/workflow/repository_mirroring.html
+       * The mirroring is only for the repository, not the issues or wiki.
+
+
+

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -43,3 +43,4 @@ notes:
     regexp:
       - "[Hh]appy [Nn]ew [Yy]ear"
       - "version: "
+      - "RFC: "


### PR DESCRIPTION
As discussed during PSC call, let's move the already adopted RFCs to documentation (the same place as in #2357).
Original RFCs: https://trac.osgeo.org/grass/wiki/RFC

@neteler, I didn't update the physical address in the legal aspects RFC, should I update it to whatever we have in COPYING or remove entirely?