### PR TITLE
CI: Unique artifact name for Ubuntu tests

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: testreport-${{ matrix.os }}
+          name: testreport-${{ matrix.config }}
           path: testreport
           retention-days: 3
 


### PR DESCRIPTION
Now using config as the sufficiently unique name. This may be need to be changed in the future to something clearly unique like a new id variable. The name variable has spaces, so avoiding that for now.
