### PR TITLE
r.patch: fix race condition for CELL rasters

### DIFF
--- a/raster/r.patch/do_patch.c
+++ b/raster/r.patch/do_patch.c
@@ -21,7 +21,7 @@ int is_zero_value(void *rast, RASTER_MAP_TYPE data_type)
 }
 
 int do_patch(void *result, void *patch, struct Cell_stats *statf, int ncols,
-             RASTER_MAP_TYPE out_type, size_t out_cell_size, int use_zero)
+             RASTER_MAP_TYPE out_type, size_t out_cell_size, int use_zero, int no_support)
 {
     int more;
 
@@ -38,7 +38,7 @@ int do_patch(void *result, void *patch, struct Cell_stats *statf, int ncols,
                     if (is_zero_value(patch, out_type))
                         more = 1;
                     Rast_raster_cpy(result, patch, 1, out_type);
-                    if (out_type == CELL_TYPE)
+                    if (out_type == CELL_TYPE && !no_support)
                         Rast_update_cell_stats((CELL *) result, 1, statf);
                 }
             }    /* ZERO support */
@@ -49,7 +49,7 @@ int do_patch(void *result, void *patch, struct Cell_stats *statf, int ncols,
                     more = 1;
                 else {
                     Rast_raster_cpy(result, patch, 1, out_type);
-                    if (out_type == CELL_TYPE)
+                    if (out_type == CELL_TYPE && !no_support)
                         Rast_update_cell_stats((CELL *) result, 1, statf);
                 }
             } /* NULL support */

--- a/raster/r.patch/local_proto.h
+++ b/raster/r.patch/local_proto.h
@@ -1,6 +1,6 @@
 /* do_patch.c */
 int do_patch(void *result, void *, struct Cell_stats *, int, RASTER_MAP_TYPE,
-             size_t, int);
+             size_t, int, int);
 /* support.c */
 int support(char **, struct Cell_stats *, int, struct Categories *, int *,
             struct Colors *, int *, RASTER_MAP_TYPE);

--- a/raster/r.patch/main.c
+++ b/raster/r.patch/main.c
@@ -152,6 +152,10 @@ int main(int argc, char *argv[])
 
         Rast_get_cellhd(name, "", &cellhd[i]);
     }
+    if (!no_support && nprocs > 1 && out_type == CELL_TYPE) {
+        no_support = true;
+        G_warning(_("Creating support files (labels, color table) disabled for nprocs > 1"));
+    }
 
     out_cell_size = Rast_cell_size(out_type);
 
@@ -214,7 +218,7 @@ int main(int argc, char *argv[])
                 north_edge = Rast_row_to_northing(row, &window);
                 south_edge = north_edge - window.ns_res;
 
-                if (out_type == CELL_TYPE)
+                if (out_type == CELL_TYPE && !no_support)
                     Rast_update_cell_stats((CELL *) local_presult, ncols,
                                            &statf[0]);
                 for (i = 1; i < nfiles; i++) {
@@ -227,7 +231,7 @@ int main(int argc, char *argv[])
 
                     Rast_get_row(local_infd[i], local_patch, row, out_type);
                     if (!do_patch(local_presult, local_patch, &statf[i], ncols,
-                                  out_type, out_cell_size, use_zero))
+                                  out_type, out_cell_size, use_zero, no_support))
                         break;
                 }
                 void *p = G_incr_void_ptr(outbuf, out_cell_size *


### PR DESCRIPTION
Currently with nprocs > 1 and output CELL type, there is a race condition on line https://github.com/OSGeo/grass/blob/main/raster/r.patch/main.c#L218 (and in `do_patch` function as well). This is a quick fix that disables collecting and applying statistics from input for CELL type and nprocs > 1 (effectively activating -s flag).

A proper fix should create an array of the stats structures for each thread and then apply them all in `support` function, this requires more changes.