### PR TITLE
wxGUI/psmap: fix show correct error message if Ghostscript isn't installed (required for rendering output PDF file) on the OS MS Windows platform

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -433,12 +433,10 @@ class PsMapFrame(wx.Frame):
                     "-f",
                     event.userData["filename"],
                 ]
-                message = _(
-                    "Program {} is not available."
-                    " You can download {} version here"
-                    " https://www.ghostscript.com/releases/gsdnld.html."
-                    " Please install it to create PDF.\n\n "
-                ).format(pdf_rendering_prog, arch)
+                title = _("Program {} is not available.").format(pdf_rendering_prog)
+                message = _("{title} Please install it to create PDF.\n\n").format(
+                    title=title
+                )
             else:
                 pdf_rendering_prog = "ps2pdf"
                 command = [
@@ -464,6 +462,19 @@ class PsMapFrame(wx.Frame):
                 else:
                     self.SetStatusText(_("PDF generated"), 0)
             except OSError as e:
+                if sys.platform == "win32":
+                    dlg = HyperlinkDialog(
+                        self,
+                        title=title,
+                        message=message + str(e),
+                        hyperlink="https://www.ghostscript.com/releases/gsdnld.html.",
+                        hyperlinkLabel=_("You can download {} version here.").format(
+                            arch
+                        ),
+                    )
+                    dlg.ShowModal()
+                    dlg.Destroy()
+                    return
                 GError(parent=self, message=message + str(e))
 
         elif not event.userData["temp"]:

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -434,11 +434,11 @@ class PsMapFrame(wx.Frame):
                     event.userData["filename"],
                 ]
                 message = _(
-                    f"Program {pdf_rendering_prog} is not available."
-                    f" You can download {arch} version here"
+                    "Program {} is not available."
+                    " You can download {} version here"
                     " https://www.ghostscript.com/releases/gsdnld.html."
                     " Please install it to create PDF.\n\n "
-                )
+                ).format(pdf_rendering_prog, arch)
             else:
                 pdf_rendering_prog = "ps2pdf"
                 command = [
@@ -449,9 +449,9 @@ class PsMapFrame(wx.Frame):
                     event.userData["pdfname"],
                 ]
                 message = _(
-                    f"Program {pdf_rendering_prog} is not available."
+                    "Program {} is not available."
                     " Please install it to create PDF.\n\n "
-                )
+                ).format(pdf_rendering_prog)
             try:
                 proc = grass.Popen(command)
                 ret = proc.wait()

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -467,7 +467,7 @@ class PsMapFrame(wx.Frame):
                         self,
                         title=title,
                         message=message + str(e),
-                        hyperlink="https://www.ghostscript.com/releases/gsdnld.html.",
+                        hyperlink="https://www.ghostscript.com/releases/gsdnld.html",
                         hyperlinkLabel=_("You can download {} version here.").format(
                             arch
                         ),

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -404,8 +404,14 @@ class PsMapFrame(wx.Frame):
 
         if event.userData["pdfname"]:
             if sys.platform == "win32":
+                import platform
+
+                arch = platform.architecture()[0]
+                pdf_rendering_prog = "gswin64c"
+                if "32" in arch:
+                    pdf_rendering_prog = "gswin32c"
                 command = [
-                    "gswin32c",
+                    pdf_rendering_prog,
                     "-P-",
                     "-dSAFER",
                     "-dCompatibilityLevel=1.4",
@@ -427,14 +433,30 @@ class PsMapFrame(wx.Frame):
                     "-f",
                     event.userData["filename"],
                 ]
+                message = (
+                    "Program {} is not available."
+                    " You can donwload {} version here"
+                    " https://www.ghostscript.com/releases/gsdnld.html."
+                    " Please install it to create PDF.\n\n ".format(
+                        pdf_rendering_prog,
+                        arch,
+                    )
+                )
             else:
+                pdf_rendering_prog = "ps2pdf"
                 command = [
-                    "ps2pdf",
+                    pdf_rendering_prog,
                     "-dPDFSETTINGS=/prepress",
                     "-r1200",
                     event.userData["filename"],
                     event.userData["pdfname"],
                 ]
+                message = (
+                    "Program {} is not available."
+                    " Please install it to create PDF.\n\n ".format(
+                        pdf_rendering_prog,
+                    )
+                )
             try:
                 proc = grass.Popen(command)
                 ret = proc.wait()
@@ -447,13 +469,7 @@ class PsMapFrame(wx.Frame):
                 else:
                     self.SetStatusText(_("PDF generated"), 0)
             except OSError as e:
-                GError(
-                    parent=self,
-                    message=_(
-                        "Program ps2pdf is not available. Please install it to create PDF.\n\n %s"
-                    )
-                    % e,
-                )
+                GError(parent=self, message=_(message + str(e)))
 
         elif not event.userData["temp"]:
             self.SetStatusText(_("PostScript file generated"), 0)

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -433,14 +433,11 @@ class PsMapFrame(wx.Frame):
                     "-f",
                     event.userData["filename"],
                 ]
-                message = (
-                    "Program {} is not available."
-                    " You can donwload {} version here"
+                message = _(
+                    f"Program {pdf_rendering_prog} is not available."
+                    f" You can download {arch} version here"
                     " https://www.ghostscript.com/releases/gsdnld.html."
-                    " Please install it to create PDF.\n\n ".format(
-                        pdf_rendering_prog,
-                        arch,
-                    )
+                    " Please install it to create PDF.\n\n "
                 )
             else:
                 pdf_rendering_prog = "ps2pdf"
@@ -451,11 +448,9 @@ class PsMapFrame(wx.Frame):
                     event.userData["filename"],
                     event.userData["pdfname"],
                 ]
-                message = (
-                    "Program {} is not available."
-                    " Please install it to create PDF.\n\n ".format(
-                        pdf_rendering_prog,
-                    )
+                message = _(
+                    f"Program {pdf_rendering_prog} is not available."
+                    " Please install it to create PDF.\n\n "
                 )
             try:
                 proc = grass.Popen(command)
@@ -469,7 +464,7 @@ class PsMapFrame(wx.Frame):
                 else:
                     self.SetStatusText(_("PDF generated"), 0)
             except OSError as e:
-                GError(parent=self, message=_(message + str(e)))
+                GError(parent=self, message=message + str(e))
 
         elif not event.userData["temp"]:
             self.SetStatusText(_("PostScript file generated"), 0)

--- a/gui/wxpython/psmap/g.gui.psmap.html
+++ b/gui/wxpython/psmap/g.gui.psmap.html
@@ -196,7 +196,7 @@ Currently supported <em><a href="ps.map.html">ps.map</a></em> instructions:
   <dd> Generates hardcopy map output in PostScript/EPS file.</dd>
    <dt><img src="icons/pdf-export.png" alt="icon">&nbsp;
     <em>Generate hardcopy map output in PDF</em></dt>
-  <dd> Generates hardcopy map output in PDF using ps2pdf.</dd>
+  <dd> Generates hardcopy map output in PDF using ps2pdf or <a href="https://www.ghostscript.com/releases/gsdnld.html">Ghostscript gswin32c/gswin64c</a> (OS MS Windows platform only).</dd>
 
 </dl>
 


### PR DESCRIPTION
**Describe the bug**
Wrong error message if Ghostscript gswin32c/gswin64c isn't installed (required for rendering output PDF file) on the OS MS Windows platform

**To Reproduce**
Steps to reproduce the behavior:

1. Download and install e.g. [WinGRASS-8.3.dev ](https://wingrass.fsv.cvut.cz/grass83/WinGRASS-8.3.dev-c7495e2ef-123-Setup.exe)
1. Launch wxGUI Cartographic Composer `g.gui.psmap`
2. Add Map frame and choose some raster map e.g. elevation
3. Push toolbar Generate PDF output tool
4. See error

![wxGUI_psmap_error_message_dialog_def](https://user-images.githubusercontent.com/50632337/172553519-50683c4c-62f0-43ea-a63c-a6d3de4d61e1.png)

**Expected behavior**
If Ghostscript gswin32c/gswin64c isn't installed (required for rendering output PDF file), show correct error message.

![wxGUI_psmap_error_message_dialog_expected](https://user-images.githubusercontent.com/50632337/172553677-724c4800-53f8-40e6-94a4-19f15ebb4f6b.png)

**System description:**

- Operating System: MS Windows
- GRASS GIS version: all versions