### PR TITLE
wxGUI/dbmgr: fix removing map table layer and layer related Browse data and Manage tables page (tab)

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1023,13 +1023,16 @@ class DbMgrNotebookBase(GNotebook):
         if layer not in self.layers:
             return False
 
-        GNotebook.DeletePage(self, self.layers.index(layer))
+        GNotebook.DeleteNBPage(
+            self,
+            page=self._page_prefix_name.format(layer),
+        )
 
         self.layers.remove(layer)
         del self.layerPage[layer]
 
         if self.GetSelection() >= 0:
-            self.selLayer = self.layers[self.GetSelection()]
+            self.selLayer = self.layers[-1]
         else:
             self.selLayer = None
 
@@ -1108,6 +1111,8 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         DbMgrNotebookBase.__init__(self, parent=parent, parentDbMgrBase=parentDbMgrBase)
 
+        self._page_prefix_name = "browse-{}"
+
         #   for Sql Query notebook adaptation on current width
         self.sqlBestSize = None
 
@@ -1178,6 +1183,7 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
         self.InsertNBPage(
             index=pos,
             page=panel,
+            name=self._page_prefix_name.format(layer),
             text=" %d / %s %s"
             % (layer, label, self.dbMgrData["mapDBInfo"].layers[layer]["table"]),
         )
@@ -1360,6 +1366,9 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
     def OnSqlQuerySize(self, event, layer):
         """Adapts SQL Query Simple tab on current width"""
+
+        if not self.layerPage.get(layer):
+            return
 
         sqlNtb = event.GetEventObject()
         if not self.sqlBestSize:
@@ -2300,6 +2309,8 @@ class DbMgrTablesPage(DbMgrNotebookBase):
 
         DbMgrNotebookBase.__init__(self, parent=parent, parentDbMgrBase=parentDbMgrBase)
 
+        self._page_prefix_name = "table-{}"
+
         for layer in self.dbMgrData["mapDBInfo"].layers.keys():
             if onlyLayer > 0 and layer != onlyLayer:
                 continue
@@ -2335,6 +2346,7 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         self.InsertNBPage(
             index=pos,
             page=panel,
+            name=self._page_prefix_name.format(layer),
             text=" %d / %s %s"
             % (layer, label, self.dbMgrData["mapDBInfo"].layers[layer]["table"]),
         )

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1023,16 +1023,13 @@ class DbMgrNotebookBase(GNotebook):
         if layer not in self.layers:
             return False
 
-        GNotebook.DeleteNBPage(
-            self,
-            page=self._page_prefix_name.format(layer),
-        )
+        GNotebook.DeletePage(self, self.layers.index(layer))
 
         self.layers.remove(layer)
         del self.layerPage[layer]
 
         if self.GetSelection() >= 0:
-            self.selLayer = self.layers[-1]
+            self.selLayer = self.layers[self.GetSelection()]
         else:
             self.selLayer = None
 
@@ -1111,8 +1108,6 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         DbMgrNotebookBase.__init__(self, parent=parent, parentDbMgrBase=parentDbMgrBase)
 
-        self._page_prefix_name = "browse-{}"
-
         #   for Sql Query notebook adaptation on current width
         self.sqlBestSize = None
 
@@ -1183,7 +1178,6 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
         self.InsertNBPage(
             index=pos,
             page=panel,
-            name=self._page_prefix_name.format(layer),
             text=" %d / %s %s"
             % (layer, label, self.dbMgrData["mapDBInfo"].layers[layer]["table"]),
         )
@@ -1366,9 +1360,6 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
     def OnSqlQuerySize(self, event, layer):
         """Adapts SQL Query Simple tab on current width"""
-
-        if not self.layerPage.get(layer):
-            return
 
         sqlNtb = event.GetEventObject()
         if not self.sqlBestSize:
@@ -2309,8 +2300,6 @@ class DbMgrTablesPage(DbMgrNotebookBase):
 
         DbMgrNotebookBase.__init__(self, parent=parent, parentDbMgrBase=parentDbMgrBase)
 
-        self._page_prefix_name = "table-{}"
-
         for layer in self.dbMgrData["mapDBInfo"].layers.keys():
             if onlyLayer > 0 and layer != onlyLayer:
                 continue
@@ -2346,7 +2335,6 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         self.InsertNBPage(
             index=pos,
             page=panel,
-            name=self._page_prefix_name.format(layer),
             text=" %d / %s %s"
             % (layer, label, self.dbMgrData["mapDBInfo"].layers[layer]["table"]),
         )

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1023,7 +1023,7 @@ class DbMgrNotebookBase(GNotebook):
         if layer not in self.layers:
             return False
 
-        GNotebook.DeleteNBPage(self, self.layers.index(layer))
+        GNotebook.DeletePage(self, self.layers.index(layer))
 
         self.layers.remove(layer)
         del self.layerPage[layer]

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1023,13 +1023,13 @@ class DbMgrNotebookBase(GNotebook):
         if layer not in self.layers:
             return False
 
-        GNotebook.DeletePage(self, self.layers.index(layer))
+        GNotebook.DeleteNBPage(self, self.layers.index(layer))
 
         self.layers.remove(layer)
         del self.layerPage[layer]
 
         if self.GetSelection() >= 0:
-            self.selLayer = self.layers[self.GetSelection()]
+            self.selLayer = self.layers[-1]
         else:
             self.selLayer = None
 
@@ -1360,6 +1360,9 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
     def OnSqlQuerySize(self, event, layer):
         """Adapts SQL Query Simple tab on current width"""
+
+        if layer not in self.layers:
+            return
 
         sqlNtb = event.GetEventObject()
         if not self.sqlBestSize:

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -157,7 +157,11 @@ class NotebookController:
     def DeletePage(self, page):
         """Delete page
 
+        That method works correctly if AddPage() and InsertPage() method
+        was used with name parameter argument.
+
         :param page: name
+
         :return: True if page was deleted, False if not exists
         """
         delPageIndex = self.GetPageIndexByName(page)

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -132,7 +132,17 @@ class NotebookController:
         self.widget.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self.OnRemoveHighlight)
 
     def AddPage(self, *args, **kwargs):
-        """Add a new page"""
+        """Add a new page
+
+        :param str name: use this param if notebooks has ability to
+                         change position and then you must use page name
+                         param arg to correctly delete notebook page.
+                         If you do not use this parameter, make sure that
+                         the notebooks does not have the ability to change
+                         position, because in that case the deletion of
+                         the page based on the position index would not
+                         work correctly.
+        """
         if "name" in kwargs:
             self.notebookPages[kwargs["name"]] = kwargs["page"]
             del kwargs["name"]
@@ -140,7 +150,17 @@ class NotebookController:
         self.classObject.AddPage(self.widget, *args, **kwargs)
 
     def InsertPage(self, *args, **kwargs):
-        """Insert a new page"""
+        """Insert a new page
+
+        :param str name: use this param if notebooks has ability to
+                         change position and then you must use page name
+                         param arg to correctly delete notebook page.
+                         If you do not use this parameter, make sure that
+                         the notebooks does not have the ability to change
+                         position, because in that case the deletion of
+                         the page based on the position index would not
+                         work correctly.
+        """
         if "name" in kwargs:
             self.notebookPages[kwargs["name"]] = kwargs["page"]
             del kwargs["name"]
@@ -157,12 +177,9 @@ class NotebookController:
     def DeletePage(self, page):
         """Delete page
 
-        That method works correctly if AddPage() and InsertPage() method
-        was used with name parameter argument.
+        :param str|int page: page name or page index position
 
-        :param page: name
-
-        :return: True if page was deleted, False if not exists
+        :return bool: True if page was deleted, False if not exists
         """
         delPageIndex = self.GetPageIndexByName(page)
         if delPageIndex != -1:
@@ -219,8 +236,12 @@ class NotebookController:
     def GetPageIndexByName(self, page):
         """Get notebook page index
 
-        :param page: name
+        :param str|int page: page name or page index position
+
+        :return int: page index
         """
+        if not self.notebookPages:
+            return page
         if page not in self.notebookPages:
             return -1
         for pageIndex in range(self.classObject.GetPageCount(self.widget)):
@@ -263,8 +284,12 @@ class FlatNotebookController(NotebookController):
     def GetPageIndexByName(self, page):
         """Get notebook page index
 
-        :param page: name
+        :param str|int page: page name or page index position
+
+        :return int: page index
         """
+        if not self.notebookPages:
+            return page
         if page not in self.notebookPages:
             return -1
 


### PR DESCRIPTION
**Describe the bug**
Removing map table layer don't work and related layer page (tab) on the Browse data and Manage tables page (tab) aren't deleted too.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager e.g `g.gui.dbmgr geology`
2. Switch to Manage layers page (tab)
3. Create new table with name e.g. **test** (right side on the Add layer page (tab))
4. Add new layer with layer number 2, and choose **test** table from table choice widget and hit Add layer button
5. On the Manage layers page (tab) switch to Remove layer page (tab)
6. Choose layer 2 from Layer to remove ComboBox widget choices and hit Remove layer button
7. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass83/gui/wxpython/dbmgr/base.py", line 3815, in OnDeleteLayer
    self.parentDialog.parentDbMgrBase.UpdateDialog(layer=layer)
  File "/usr/lib64/grass83/gui/wxpython/dbmgr/manager.py", line 253, in UpdateDialog
    DbMgrBase.UpdateDialog(self, layer=layer)
  File "/usr/lib64/grass83/gui/wxpython/dbmgr/base.py", line 860, in UpdateDialog
    self.pages["browse"].DeletePage(layer)
  File "/usr/lib64/grass83/gui/wxpython/dbmgr/base.py", line 1037, in DeletePage
    self.selLayer = self.layers[self.GetSelection()]
IndexError: list index out of range
```

**Expected behavior**
Removing map table layer should be work without error message, and related layer page (tab) on the Browse data and Manage tables page (tab) be deleted too.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all
