### PR TITLE
v.db.addcolumn: Add error message for layer without a table

### DIFF
--- a/scripts/v.db.addcolumn/v.db.addcolumn.py
+++ b/scripts/v.db.addcolumn/v.db.addcolumn.py
@@ -60,10 +60,18 @@ def main():
     try:
         f = grass.vector_db(map)[int(layer)]
     except KeyError:
+        if grass.vector_db(map):
+            grass.fatal(
+                _(
+                    "There is no table connected to layer <{layer}> of <{name}>. "
+                    "Run v.db.connect or v.db.addtable first."
+                ).format(name=map, layer=layer)
+            )
         grass.fatal(
             _(
-                "There is no table connected to this map. Run v.db.connect or v.db.addtable first."
-            )
+                "There is no table connected to <{name}>. "
+                "Run v.db.connect or v.db.addtable first."
+            ).format(name=map)
         )
 
     table = f["table"]


### PR DESCRIPTION
* Layer without a table is reported with a specific message instead of the previous message which said there is no connection for the map.
* Message for no connection at all contains name of the map.
