### PR TITLE
wxGUI/dbmgr: show warning message dialog if new layer table link exists

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -3725,29 +3725,34 @@ class LayerBook(wx.Notebook):
             table=table,
             key=key,
             layer=layer,
+            getErrorMsg=True,
         )
 
-        # insert records into table if required
-        if self.addLayerWidgets["addCat"][0].IsChecked():
-            RunCommand(
-                "v.to.db",
-                parent=self,
-                quiet=True,
-                map=self.mapDBInfo.map,
-                layer=layer,
-                qlayer=layer,
-                option="cat",
-                columns=key,
-                overwrite=True,
-            )
-
-        if ret == 0:
+        if ret[0] == 0 and not ret[1]:
+            # insert records into table if required
+            if self.addLayerWidgets["addCat"][0].IsChecked():
+                RunCommand(
+                    "v.to.db",
+                    parent=self,
+                    quiet=True,
+                    map=self.mapDBInfo.map,
+                    layer=layer,
+                    qlayer=layer,
+                    option="cat",
+                    columns=key,
+                    overwrite=True,
+                )
             # update dialog (only for new layer)
             self.parentDialog.parentDbMgrBase.UpdateDialog(layer=layer)
             # update db info
             self.mapDBInfo = self.parentDialog.dbMgrData["mapDBInfo"]
             # increase layer number
             layerWin.SetValue(layer + 1)
+        elif ret[1]:
+            GWarning(
+                parent=self,
+                message=ret[1],
+            )
 
         if len(self.mapDBInfo.layers.keys()) == 1:
             # first layer add --- enable previously disabled widgets


### PR DESCRIPTION
**Describe the bug**
If layer table link exist, no warning message dialog is showed (Attribute table link exists), and Layer `SpinCtrl` widget (on the Manage layers page (tab)) increase value automatically.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager e.g `g.gui.dbmgr geology`
2. Switch to Manage layers page (tab)
3. From Table choice widget choose **geology** table
4. Hit Add layer button
7. Layer `SpinCtrl` widget automatically increase value (number 3), no warning message dialog is showed with message Attribute table link exists

**Expected behavior**
If layer table link exist, warning message dialog should be showed, and Layer `SpinCtrl` widget (on the Manage layers page (tab)) value should be not increased too.

![wxgui_dbmgr_layer_table_link_exists_exp](https://user-images.githubusercontent.com/50632337/173217495-ed4ded23-56d5-47ff-abad-ad88e646d7fa.png)

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all
