### PR TITLE
Add 'file_limit'  option to t.rast.series

### DIFF
--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -16,9 +16,9 @@ ordered by <b>start_time</b>.
 
 To avoid problems with too many open files, by default, the maximum 
 number of open files is set to 1000. If the number of input raster 
-files exceeds this number, the z-flag will be invoked. Because this 
+files exceeds this number, the <b>-z</b> flag will be invoked. Because this 
 will slow down processing, the user can set a higher limit with the 
-'open files' option. Note that 'open file' limit should not exceed the 
+<b>file_limit</b> parameter. Note that <b>file_limit</b> limit should not exceed the 
 user-specific limit on open files set by your operating system. See the 
 <a 
 href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing#Number_of_open_files_limitation">Wiki</a> 

--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -11,6 +11,18 @@ ordered by <b>start_time</b>.
 <em>t.rast.series</em> is a simple wrapper for the raster module
 <b>r.series</b>. It supports a subset of the aggregation methods of
 <b>r.series</b>.
+  
+<h2>NOTES</h2>
+
+To avoid problems with too many open files, by default, the maximum 
+number of open files is set to 1000. If the number of input raster 
+files exceeds this number, the z-flag will be invoked. Because this 
+will slow down processing, the user can set a higher limit with the 
+'open files' option. Note that 'open file' limit should not exceed the 
+user-specific limit on open files set by your operating system. See the 
+<a 
+href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing#Number_of_open_files_limitation">Wiki</a> 
+for more information. 
 
 <h2>EXAMPLES</h2>
 

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -68,6 +68,14 @@
 # %option G_OPT_R_OUTPUTS
 # %end
 
+# %option
+# % key: file_limit
+# % type: integer
+# % description: The maximum number of open files allowed for each r.series process
+# % required: no
+# % answer: 1000
+# %end
+
 # %flag
 # % key: t
 # % description: Do not assign the space time raster dataset start and end time to the output map
@@ -77,7 +85,6 @@
 # % key: n
 # % description: Propagate NULLs
 # %end
-
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError
@@ -96,6 +103,7 @@ def main():
     quantile = options["quantile"]
     order = options["order"]
     where = options["where"]
+    max_files_open = int(options["file_limit"])
     add_time = flags["t"]
     nulls = flags["n"]
 
@@ -129,10 +137,12 @@ def main():
         file.close()
 
         flag = ""
-        if len(rows) > 1000:
+        if len(rows) > max_files_open:
             grass.warning(
                 _(
-                    "Processing over 1000 maps: activating -z flag of r.series which slows down processing"
+                    "Processing over {} maps: activating -z flag of r.series which slows down processing.".format(
+                        max_files_open
+                    )
                 )
             )
             flag += "z"


### PR DESCRIPTION
Add the option to set the file_limit (the maximum number of open files allowed for each r.series process), like the same option in t.series.aggregate.