### PR TITLE
docker: update outdated release branch names

### DIFF
--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -34,7 +34,7 @@ __To build a stable version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_8_2
 ```
 
 and build and enter with:

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -21,7 +21,8 @@ docker build \
          --tag grass-py3-pdal:latest-debian .
 ```
 
-View the images available using `sudo docker images` and open a bash terminal with:
+View the images available using `sudo docker images` and open a bash terminal
+with:
 
 ```bash
 $ docker run -it grass-py3-pdal:latest-debian /bin/bash
@@ -33,7 +34,7 @@ __To build a stable version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_8_2
 ```
 
 and build and enter with:

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -36,7 +36,7 @@ __To build a stable version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_8_2
 ```
 
 and build and enter with:
@@ -73,7 +73,7 @@ __To build a latest version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_8_2
 ```
 
 and build and enter with:

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -24,17 +24,17 @@ __To build a stable version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout remotes/origin/releasebranch_7_8
+git checkout remotes/origin/releasebranch_8_2
 ```
 
 and build and enter with:
 
 ```bash
-sudo singularity build grass_7_8.simg singularity/debian/singularity_debian
+sudo singularity build grass_8_2.simg singularity/debian/singularity_debian
 ```
 
 The image can be used as:
 
 ```bash
-singularity exec containers/grass_7.8.simg grass --version
+singularity exec containers/grass_8.2.simg grass --version
 ```


### PR DESCRIPTION
- docker files: replaces `releasebranch_7_8` with `releasebranch_8_2`
- singularity: as above and build name update