### PR TITLE
v.info: Add vector name to no db connection message

### DIFF
--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -147,8 +147,9 @@ void print_columns(const struct Map_info *Map, const char *input_opt,
               field_opt);
 
     if ((fi = Vect_get_field2(Map, field_opt)) == NULL)
-        G_fatal_error(_("Database connection not defined for layer <%s> of <%s>"),
-                      field_opt, input_opt);
+        G_fatal_error(
+            _("Database connection not defined for layer <%s> of <%s>"),
+            field_opt, input_opt);
     driver = db_start_driver(fi->driver);
     if (driver == NULL)
         G_fatal_error(_("Unable to open driver <%s>"), fi->driver);

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -147,8 +147,8 @@ void print_columns(const struct Map_info *Map, const char *input_opt,
               field_opt);
 
     if ((fi = Vect_get_field2(Map, field_opt)) == NULL)
-        G_fatal_error(_("Database connection not defined for layer <%s>"),
-                      field_opt);
+        G_fatal_error(_("Database connection not defined for layer <%s> of <%s>"),
+                      field_opt, Vect_get_full_name(&In));
     driver = db_start_driver(fi->driver);
     if (driver == NULL)
         G_fatal_error(_("Unable to open driver <%s>"), fi->driver);

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -148,7 +148,7 @@ void print_columns(const struct Map_info *Map, const char *input_opt,
 
     if ((fi = Vect_get_field2(Map, field_opt)) == NULL)
         G_fatal_error(_("Database connection not defined for layer <%s> of <%s>"),
-                      field_opt, Vect_get_full_name(&In));
+                      field_opt, input_opt);
     driver = db_start_driver(fi->driver);
     if (driver == NULL)
         G_fatal_error(_("Unable to open driver <%s>"), fi->driver);


### PR DESCRIPTION
The error messegage about missing database connection for a given layer does not include vector name which may not be clear when scripting and an undelying function calls v.info.
