### PR TITLE
wxGUI/dbmgr: fix sorting newly added column values

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -556,18 +556,19 @@ class VirtualAttributeList(
     def OnColumnSort(self, event):
         """Column heading left mouse button -> sorting"""
         self._col = event.GetColumn()
-
+        self._updateColSortFlag()
         self.ColumnSort()
-
         event.Skip()
 
     def OnColumnSortAsc(self, event):
         """Sort values of selected column (ascending)"""
+        self._updateColSortFlag()
         self.SortListItems(col=self._col, ascending=True)
         event.Skip()
 
     def OnColumnSortDesc(self, event):
         """Sort values of selected column (descending)"""
+        self._updateColSortFlag()
         self.SortListItems(col=self._col, ascending=False)
         event.Skip()
 
@@ -713,6 +714,14 @@ class VirtualAttributeList(
             return False
 
         return True
+
+    def _updateColSortFlag(self):
+        """
+        Update listmix.ColumnSorterMixin class self._colSortFlag list
+        private variable for new column which was added (required for
+        sorting new added column values)
+        """
+        self._colSortFlag.extend([0] * (len(self.columns) - len(self._colSortFlag)))
 
 
 class DbMgrBase:


### PR DESCRIPTION
**Describe the bug**
Sorting (asc/desc) newly added column values via wxGUI dbmgr doesn't work.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager e.g `g.gui.dbmgr geology`
2. Switch to Manage tables page (tab)
3. Add new column e.g. **area** with double precision type
4. Switch to Browse data page (tab)
5. Right mouse click to the **area** column to invoke menu and choose Calculate (only numeric columns) -> Area size
6. Left mouse click on the **area** column to sorting values
7. See error

```
Traceback (most recent call last):
  File "/home/tomas/.local/lib/python3.9/site-packages/wx/lib/mixins/listctrl.py", line 129, in __OnColClick
    self._colSortFlag[col] = int(not self._colSortFlag[col])
IndexError: list index out of range
```

or
 
6. Right mouse click to the **area** column to invoke menu and choose Sort ascending or Sort descending
7. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass83/gui/wxpython/dbmgr/base.py", line 580, in OnColumnSortAsc
    self.SortListItems(col=self._col, ascending=True)
  File "/home/tomas/.local/lib/python3.9/site-packages/wx/lib/mixins/listctrl.py", line 88, in SortListItems
    self._colSortFlag[col] = ascending
IndexError: list assignment index out of range
```

**Expected behavior**
Sorting (asc/desc) newly added column values via wxGUI dbmgr should be work without error message.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all

**Additional context**

`VirtualAttributeList` class initialize private attribute `self._colSortFlag` inside [`listmix.ColumnSorterMixin.__init__()` ](https://github.com/wxWidgets/Phoenix/blob/7dafb83729711a834538de2faebfb42485dbece0/wx/lib/mixins/listctrl.py#L69) method, [`SetColumnCount()` ](https://github.com/wxWidgets/Phoenix/blob/7dafb83729711a834538de2faebfb42485dbece0/wx/lib/mixins/listctrl.py#L77) method during `VirtualAttributeList` class initialization, [`__init__()`](https://github.com/OSGeo/grass/blob/main/gui/wxpython/dbmgr/base.py#L102) method.

https://github.com/OSGeo/grass/blob/1e0f8882da51d682982d048bb9031aa2587c0377/gui/wxpython/dbmgr/base.py#L146

If **new column** is added, private attribute `self._colSortFlag` isn't updated.



