### PR TITLE
wxGUI/dbmgr: don't add new duplicated table col into table desc TableListCtrl widget

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2790,14 +2790,6 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             ).GetValue()
         )
 
-        # add item to the list of table columns
-        tlist = self.FindWindowById(self.layerPage[self.selLayer]["tableData"])
-
-        index = tlist.InsertItem(tlist.GetItemCount(), str(name))
-        tlist.SetItem(index, 0, str(name))
-        tlist.SetItem(index, 1, str(ctype))
-        tlist.SetItem(index, 2, str(length))
-
         self.AddColumn(name, ctype, length)
 
         # update widgets


### PR DESCRIPTION
**Describe the bug**
Duplicated column name  be added into table description `TableListCtrl` widget (see screenshot below).

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager e.g `g.gui.dbmgr geology`
2. Switch to Manage tables page (tab)
3. Add new column with same name as existed col name GEO_NAME
4. You see correct error dialog with message: Column <GEO_NAME> already exists in table <geology>.
7. Duplicated column name is added into table description `TableListCtrl` widget

![wxgui_dbmgr_add_duplicated_col_name_def](https://user-images.githubusercontent.com/50632337/173757947-194b2110-68f6-49d6-84f4-ac1cd5c575e1.png)

**Expected behavior**
Duplicated column name shouldn't be added into table description `TableListCtrl` widget

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all