### PR TITLE
wxGUI/dbmgr: update Browse data page Simple SQL Query WHERE ComboBox widget column names choices

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2732,6 +2732,12 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
+        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
+        self.FindWindowById(
+            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
+        ).SetItems(cols)
+        if self.pages["browse"].builder:
+            self.pages["browse"].builder.list_columns.Set(cols)
 
         event.Skip()
 

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2639,9 +2639,12 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
         self.FindWindowById(self.layerPage[self.selLayer]["renameColTo"]).SetValue("")
+        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
         self.FindWindowById(
             self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
-        ).SetItems(self.dbMgrData["mapDBInfo"].GetColumns(table))
+        ).SetItems(cols)
+        if self.pages["browse"].builder:
+            self.pages["browse"].builder.list_columns.Set(cols)
 
         event.Skip()
 
@@ -2811,9 +2814,12 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
+        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
         self.FindWindowById(
             self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
-        ).SetItems(self.dbMgrData["mapDBInfo"].GetColumns(table))
+        ).SetItems(cols)
+        if self.pages["browse"].builder:
+            self.pages["browse"].builder.list_columns.Set(cols)
 
         event.Skip()
 

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2639,6 +2639,9 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
         self.FindWindowById(self.layerPage[self.selLayer]["renameColTo"]).SetValue("")
+        self.FindWindowById(
+            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
+        ).SetItems(self.dbMgrData["mapDBInfo"].GetColumns(table))
 
         event.Skip()
 
@@ -2808,6 +2811,9 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
+        self.FindWindowById(
+            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
+        ).SetItems(self.dbMgrData["mapDBInfo"].GetColumns(table))
 
         event.Skip()
 

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2639,12 +2639,7 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
         self.FindWindowById(self.layerPage[self.selLayer]["renameColTo"]).SetValue("")
-        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
-        self.FindWindowById(
-            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
-        ).SetItems(cols)
-        if self.pages["browse"].builder:
-            self.pages["browse"].builder.list_columns.Set(cols)
+        self._updateTableColumnWidgetChoices(table=table)
 
         event.Skip()
 
@@ -2732,12 +2727,7 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
-        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
-        self.FindWindowById(
-            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
-        ).SetItems(cols)
-        if self.pages["browse"].builder:
-            self.pages["browse"].builder.list_columns.Set(cols)
+        self._updateTableColumnWidgetChoices(table=table)
 
         event.Skip()
 
@@ -2785,12 +2775,7 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
-        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
-        self.FindWindowById(
-            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
-        ).SetItems(cols)
-        if self.pages["browse"].builder:
-            self.pages["browse"].builder.list_columns.Set(cols)
+        self._updateTableColumnWidgetChoices(table=table)
 
         event.Skip()
 
@@ -2826,13 +2811,7 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
-        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
-        self.FindWindowById(
-            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
-        ).SetItems(cols)
-        if self.pages["browse"].builder:
-            self.pages["browse"].builder.list_columns.Set(cols)
-
+        self._updateTableColumnWidgetChoices(table=table)
         event.Skip()
 
     def UpdatePage(self, layer):
@@ -2846,6 +2825,26 @@ class DbMgrTablesPage(DbMgrNotebookBase):
                 columns=self.dbMgrData["mapDBInfo"].GetColumns(table),
             )
             self.OnTableReload(None)
+
+    def _updateTableColumnWidgetChoices(self, table):
+        """Update table column widget choices
+
+        :param str table: table name
+        """
+        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
+        # Browse data page SQL Query Simple page WHERE Combobox column names widget
+        self.FindWindowById(
+            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
+        ).SetItems(cols)
+        # Browse data page SQL Query Builder page SQL builder frame ListBox column names widget
+        if self.pages["browse"].builder:
+            self.pages["browse"].builder.list_columns.Set(cols)
+        # Browse data page column Field calculator frame ListBox column names widget
+        fieldCalc = self.FindWindowById(
+            self.pages["browse"].layerPage[self.selLayer]["data"],
+        ).fieldCalc
+        if fieldCalc:
+            fieldCalc.list_columns.Set(cols)
 
 
 class DbMgrLayersPage(wx.Panel):

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2779,6 +2779,12 @@ class DbMgrTablesPage(DbMgrNotebookBase):
             self.dbMgrData["mapDBInfo"].GetColumns(table)
         )
         self.FindWindowById(self.layerPage[self.selLayer]["renameCol"]).SetSelection(0)
+        cols = self.dbMgrData["mapDBInfo"].GetColumns(table)
+        self.FindWindowById(
+            self.pages["browse"].layerPage[self.selLayer]["whereColumn"]
+        ).SetItems(cols)
+        if self.pages["browse"].builder:
+            self.pages["browse"].builder.list_columns.Set(cols)
 
         event.Skip()
 


### PR DESCRIPTION
**Describe the bug**
When you add new table column or rename existed or delete, Browse data page Simple SQL Query WHERE `ComboBox` widget column names choices doesn't update. Same for SQL Builder frame (**must be opened before added/renamed/deleted table column**) `ListBox` widget table column names choices. Same for Field Calculator (**must be opened before added/renamed/deleted table column**) `ListBox` widget table column names choices.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager e.g `g.gui.dbmgr geology`
2. Switch to Manage tables page (tab)
3. Add new column e.g. **test** with double precision type or rename existed column e.g. **PERIMETER -> PERIMETER_NEW** or delete some existed table column e.g. **PERIMETER**
4. Switch to Browse data page (tab)
5. Check Simple SQL Query WHERE `ComboBox` widget column names choices
6. Newly added table column **test** or renamed column **PERIMETER_NEW** or deleted column **PERIMETER**  is missing from `ComboBox` widget choices

**Screenshots**

![wxgui_dbmgr_browse_data_page_simple_sql_query_where_combobox_widget_column_names_choices_def](https://user-images.githubusercontent.com/50632337/173865916-69dd2a2b-d172-4f88-9558-d8965cd1dcc9.png)

or 

2. On the Browse data page (tab) swich to Builder page (tab) and hit SQL Builder button to open SQL Builder frame
3. On The Attribute Table Manager frame switch to Manage tables page (tab)
4. Add new column e.g. **test** with double precision type or rename existed column e.g. **PERIMETER -> PERIMETER_NEW** or delete some existed table column e.g. **PERIMETER**
5. Switch to opened SQL Builder frame and check `ListBox` widget table column names choices
6. Newly added table column **test** or renamed column **PERIMETER_NEW** is missing from `ListBox` widget choices. Deleted column **PERIMETER** is still present in widget choices.

![wxgui_dbmgr_browse_data_page_sql_builder_listbox_widget_column_names_choices_def](https://user-images.githubusercontent.com/50632337/173860915-235953fd-4de0-4965-b882-f0bc1543c6a6.png)

or 

2. On the Browse data page (tab) right mouse click on the e.g. **PERIMETER** column to invoke menu and choose Field Calculator item
3. On The Attribute Table Manager frame switch to Manage tables page (tab)
4. Add new column e.g. **test** with double precision type or rename existed column e.g. **PERIMETER -> PERIMETER_NEW** or delete some existed table column e.g. **PERIMETER**
5. Switch to opened Field Calculator frame and check `ListBox` widget table column names choices
6. Newly added table column **test** or renamed column **PERIMETER_NEW**  is missing from `ListBox` widget choices.  Deleted column **PERIMETER** is still present in widget choices.

![wxgui_dbmgr_browse_data_page_field_calc_listbox_widget_column_names_choices_def](https://user-images.githubusercontent.com/50632337/173922983-51dc2b1e-ff42-4c28-9a22-6cd243907043.png)

**Expected behavior**
When you add new table column or rename existed or deleted, Browse data page Simple SQL Query WHERE `ComboBox` widget column names choices should be updated. If you have opened SQL Builder frame `ListBox` widget table column names choices should be updated too. If you have opened Field calculator frame `ListBox` widget table column names choices should be updated too.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all