### PR TITLE
wxGUI/psmap: Ghostscript HyperlinkDialog is needed

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -258,6 +258,15 @@ class PsMapFrame(wx.Frame):
         self.book.SetSelection(page_index)
         self.currentPage = page_index
 
+    def _getGhostscriptProgramName(self):
+        """Get Ghostscript program name
+
+        :return: Ghostscript program name
+        """
+        import platform
+
+        return "gswin64c" if "64" in platform.architecture()[0] else "gswin32c"
+
     def InstructionFile(self):
         """Creates mapping instructions"""
 
@@ -472,14 +481,20 @@ class PsMapFrame(wx.Frame):
                 im.save(self.imgName, format="PNG")
             except (IOError, OSError):
                 del busy
+                program = self._getGhostscriptProgramName()
                 dlg = HyperlinkDialog(
                     self,
                     title=_("Preview not available"),
                     message=_(
                         "Preview is not available probably because Ghostscript is not installed or not on PATH."
                     ),
-                    hyperlink="http://trac.osgeo.org/grass/wiki/CompileOnWindows#Ghostscript",
-                    hyperlinkLabel=_("Please follow instructions on GRASS Trac Wiki."),
+                    hyperlink="https://www.ghostscript.com/releases/gsdnld.html",
+                    hyperlinkLabel=_(
+                        "You can donwload {program} {arch} version here."
+                    ).format(
+                        program=program,
+                        arch="64bit" if "64" in program else "32Bit",
+                    ),
                 )
                 dlg.ShowModal()
                 dlg.Destroy()

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -493,7 +493,7 @@ class PsMapFrame(wx.Frame):
                         "You can donwload {program} {arch} version here."
                     ).format(
                         program=program,
-                        arch="64bit" if "64" in program else "32Bit",
+                        arch="64bit" if "64" in program else "32bit",
                     ),
                 )
                 dlg.ShowModal()


### PR DESCRIPTION
Revert back PR #2421.

**Describe the bug**
If Ghostscript program isn't available on the OS MS Windows, error is printed to the stdout.

**To Reproduce**
Steps to reproduce the behavior:

1. Download and install e.g. [WinGRASS-8.3.dev ](https://wingrass.fsv.cvut.cz/grass83/WinGRASS-8.3.dev-1e0f8882d-131-Setup.exe)
2. If you have installed Ghostscript, uninstall it
3. Launch wxGUI Cartographic Composer `g.gui.psmap`
4. Click on the Show preview toolbar tool (green "play button")
5. See error

```
Traceback (most recent call last):
  File "C:\Program Files\GRASS GIS 8.3\gui\wxpython\psmap\frame.py", line 484, in OnCmdDone
    im.save(self.imgName, format="PNG")
  File "C:\Program Files\GRASS GIS 8.3\Python39\lib\site-packages\PIL\Image.py", line 2117, in save
    self._ensure_mutable()
  File "C:\Program Files\GRASS GIS 8.3\Python39\lib\site-packages\PIL\Image.py", line 619, in _ensure_mutable
    self._copy()
  File "C:\Program Files\GRASS GIS 8.3\Python39\lib\site-packages\PIL\Image.py", line 612, in _copy
    self.load()
  File "C:\Program Files\GRASS GIS 8.3\Python39\lib\site-packages\PIL\EpsImagePlugin.py", line 332, in load
    self.im = Ghostscript(self.tile, self.size, self.fp, scale)
  File "C:\Program Files\GRASS GIS 8.3\Python39\lib\site-packages\PIL\EpsImagePlugin.py", line 134, in Ghostscript
    raise OSError("Unable to locate Ghostscript on paths")
OSError: Unable to locate Ghostscript on paths
```

**Expected behavior**
Show Hyperlink dialog with correct label and hyperlink if Ghostscript program isn't available.

![wxgui_psmap_ghostscript_hyperlinkdialog_exp](https://user-images.githubusercontent.com/50632337/174063375-da1947b8-647c-4e8d-9441-acb50672282d.png)

**System description (please complete the following information):**

- Operating System: MS Windows
- GRASS GIS version: all

**Additional context**
For reading EPS file, PIL require Ghostscript program to be installed.
