### PR TITLE
wxGUI/psmap: fix rendered preview page zoom

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -468,14 +468,14 @@ class PsMapFrame(wx.Frame):
                 im_array = np.array(im)
                 im = PILImage.fromarray(np.rot90(im_array, 3))
             im.save(self.imgName, format="PNG")
+            self.book.SetSelection(1)
+            self.currentPage = 1
             rect = self.previewCanvas.ImageRect()
             self.previewCanvas.image = wx.Image(self.imgName, wx.BITMAP_TYPE_PNG)
             self.previewCanvas.DrawImage(rect=rect)
 
             del busy
             self.SetStatusText(_("Preview generated"), 0)
-            self.book.SetSelection(1)
-            self.currentPage = 1
 
         grass.try_remove(event.userData["instrFile"])
         if event.userData["temp"]:


### PR DESCRIPTION
**Describe the bug**
Rendered preview page doesn't have same zoom as draft page and page isn't centered.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Cartographic Composer `g.gui.psmap`
2. Maximalize wxGUI Cartographic Composer window
3. Click on the Show preview toolbar tool (green "play button")
4. See rendered preview page

**Expected behavior**
Rendered preview page should be have same zoom as draft page and be centered.

**Screenshots**

Default:

![wxgui_psmap_rendered_preview_page_size_def](https://user-images.githubusercontent.com/50632337/174103125-41a52cef-c987-4ec4-bf59-b370a74b2364.png)

Expected:

![wxgui_psmap_rendered_preview_page_size_exp](https://user-images.githubusercontent.com/50632337/174103158-7c625b47-e4bf-4170-a419-70f5a3fce00b.png)

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all
