### PR TITLE
init: Add mapset and CRS to no CRS needed error

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1176,9 +1176,10 @@ def set_mapset(
                         if geofile:
                             fatal(
                                 _(
-                                    "No CRS is needed for creating mapset."
+                                    "No CRS is needed for creating mapset <{mapset}>, "
+                                    "but <{geofile}> was provided as CRS."
                                     " Did you mean to create a new location?"
-                                )
+                                ).format(mapset=mapset, geofile=geofile)
                             )
                         message(
                             _("Creating new GRASS GIS mapset <{}>...").format(mapset)


### PR DESCRIPTION
Although `grass -ec path/to/mapset`, `-e -c`, and `-c -e` work as expected when creating a new mapset, `-ce` leads to `e` being interpreted as CRS. This is a correct and common behavior which cannot be disabled in argparse. The new error message includes the mapset name and the parsed CRS to cover the `-ce` case while remaining focused on the location versus mapset case.

## Before

```bash
$ grass -ce ~/grassdata/nc_spm_08_grass7/test1
```

```
Starting GRASS GIS...
ERROR: No CRS is needed for creating mapset. Did you mean to create a new location?
Exiting...
```

## After

```bash
$ grass -ce ~/grassdata/nc_spm_08_grass7/test1
```

```
Starting GRASS GIS...
ERROR: No CRS is needed for creating mapset <test1>, but <e> was provided as CRS. Did you mean to create a new location?
Exiting...
```