### PR TITLE
t.unregister: add support to unregister maps from other mapsets

### DIFF
--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -50,7 +50,6 @@
 
 import grass.script as grass
 
-
 # lazy imports at the end of the file
 
 ############################################################################
@@ -76,6 +75,13 @@ def main():
 
     dbif = tgis.SQLDatabaseInterfaceConnection()
     dbif.connect()
+
+    # create new stds only in the current mapset
+    # remove all connections to any other mapsets
+    # ugly hack !
+    currcon = {}
+    currcon[mapset] = dbif.connections[mapset]
+    dbif.connections = currcon
 
     # In case a space time dataset is specified
     if input:
@@ -129,7 +135,7 @@ def main():
         map = tgis.dataset_factory(type, mapid)
 
         # Unregister map if in database
-        if map.is_in_db(dbif):
+        if map.is_in_db(dbif, mapset=mapset):
             # Unregister from a single dataset
             if input:
                 # Collect SQL statements

--- a/temporal/t.unregister/t.unregister.py
+++ b/temporal/t.unregister/t.unregister.py
@@ -76,7 +76,7 @@ def main():
     dbif = tgis.SQLDatabaseInterfaceConnection()
     dbif.connect()
 
-    # create new stds only in the current mapset
+    # modify a stds only if it is in the current mapset
     # remove all connections to any other mapsets
     # ugly hack !
     currcon = {}


### PR DESCRIPTION
By the try to unregister raster maps from a STRDS an error accured:
```
t.unregister input=test_strds@test_mapest maps=elevation@PERMANENT
Unregister maps
ERROR: Unable to execute sql statement. You have no permission to access
mapset <PERMANENT>, or mapset <PERMANENT> has no temporal database.
Accessible mapsets are: <test_mapset>
```
This changes fixes this bug and you can unregister raster maps from other mapset in the STRDS.