### PR TITLE
init: Remove automatic vacuum

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2111,10 +2111,6 @@ def clean_temp():
 
 
 def clean_all():
-    from grass.script import setup as gsetup
-
-    # clean default sqlite db
-    gsetup.clean_default_db()
     # remove leftover temp files
     clean_temp()
     # save 'last used' GISRC after removing variables which shouldn't

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -415,30 +415,6 @@ class SessionHandle:
         finish()
 
 
-# clean-up functions when terminating a GRASS session
-# these fns can only be called within a valid GRASS session
-def clean_default_db():
-    # clean the default db if it is sqlite
-    from grass.script import core as gcore
-    from grass.script import db as gdb
-
-    conn = gdb.db_connection()
-    if conn and conn["driver"] == "sqlite":
-        # check if db exists
-        gisenv = gcore.gisenv()
-        database = conn["database"]
-        database = database.replace("$GISDBASE", gisenv["GISDBASE"])
-        database = database.replace("$LOCATION_NAME", gisenv["LOCATION_NAME"])
-        database = database.replace("$MAPSET", gisenv["MAPSET"])
-        if os.path.exists(database):
-            gcore.message(_("Cleaning up default sqlite database ..."))
-            gcore.start_command("db.execute", sql="VACUUM")
-            # give it some time to start
-            import time
-
-            time.sleep(0.1)
-
-
 def call(cmd, **kwargs):
     """Wrapper for subprocess.call to deal with platform-specific issues"""
     if WINDOWS:
@@ -470,8 +446,6 @@ def finish():
     The function is not completely symmetrical with :func:`init` because it only
     closes the mapset, but doesn't undo the runtime environment setup.
     """
-
-    clean_default_db()
     clean_temp()
     # TODO: unlock the mapset?
     # unset the GISRC and delete the file


### PR DESCRIPTION
This removes automatic vacuum of SQLite database, i.e., reverts the addition of automatic vacuum when a session ends.

Doing vacuum can take long time which the current implementation hides by running the vacuum process in the background. The typical time is much longer than the 0.1 sec suggested by the sleep call.

Doing vacuum only sometimes would be less predictable for the users and doing it only for large database would mean that it will take really long time (with a lot of disk or memory usage) when it actually happens suggesting that that's something user may want to trigger manually.

Notably, SQLite doesn't do the vacuums automatically, although PostgreSQL has autovacuum on by default.

This is an alternative to #2377 which uses VACUUM for large, modified files only.
