### PR TITLE
wxGUI: fix error when starting profile tool

### DIFF
--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -182,8 +182,6 @@ class BasePlotFrame(wx.Frame):
 
         self.zoom = False  # zooming disabled
         self.drag = False  # draging disabled
-        # vertical and horizontal scrollbars
-        self.client.showScrollbars = True
 
         # x and y axis set to normal (non-log)
         self.client.logScale = (False, False)


### PR DESCRIPTION
Addresses #2418. Although part of the problem is probably in wxPython, we can avoid it by not using scrollbars, they don't seem to be needed, the plot scales based on the window.