### PR TITLE
grass.script: Make setup available without another import

### DIFF
--- a/doc/notebooks/scripting_example.ipynb
+++ b/doc/notebooks/scripting_example.ipynb
@@ -40,10 +40,9 @@
     "\n",
     "# Import the GRASS GIS packages we need.\n",
     "import grass.script as gs\n",
-    "import grass.script.setup as gsetup\n",
     "\n",
     "# Create a GRASS GIS session.\n",
-    "gsetup.init(\"~/data/grassdata/nc_basic_spm_grass7/user1\")\n",
+    "session = gs.setup.init(\"~/data/grassdata/nc_basic_spm_grass7/user1\")\n",
     "\n",
     "# We want functions to raise exceptions and see standard output of the modules in the notebook.\n",
     "gs.set_raise_on_error(True)\n",
@@ -168,7 +167,7 @@
    "outputs": [],
    "source": [
     "# Uncomment and run when done.\n",
-    "# gsetup.finish()"
+    "# session.finish()"
    ]
   }
  ],

--- a/lib/gis/tests/lib_gis_env_test.py
+++ b/lib/gis/tests/lib_gis_env_test.py
@@ -3,7 +3,6 @@
 import multiprocessing
 
 import grass.script as gs
-import grass.script.setup as grass_setup
 
 
 def run_in_subprocess(function):
@@ -39,7 +38,7 @@ def test_reading_respects_change_of_session(tmp_path):
         for location_name in ["test1", "test2", "abc"]:
             # pylint: disable=protected-access
             gs.core._create_location_xy(tmp_path, location_name)
-            with grass_setup.init(tmp_path / location_name):
+            with gs.setup.init(tmp_path / location_name):
                 libgis.G__read_gisrc_path()
                 libgis.G__read_gisrc_env()
                 names.append((pygrass_utils.getenv("LOCATION_NAME"), location_name))

--- a/lib/init/grass.html
+++ b/lib/init/grass.html
@@ -361,7 +361,6 @@ A very simple Python script ("test.py") may look like this:
 
 # import GRASS Python bindings (see also pygrass)
 import grass.script as gs
-import grass.script.setup as gsetup
 
 gs.message('Current GRASS GIS environment:')
 print(gs.gisenv())

--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -37,12 +37,6 @@ try:
 except ImportError:
     maketrans = str.maketrans
 
-# needed for write_gisrc
-# TODO: it would be good to find some way of writing rc without the need to
-# have GRASS proprly set (anything from grass.script requires translations to
-# be set, i.e. the GRASS environment properly set)
-import grass.script.setup as gsetup
-
 import collections
 
 
@@ -162,7 +156,7 @@ class GrassTestFilesInvoker(object):
         # TODO: put this to constructor and copy here again
         env = os.environ.copy()
         mapset, mapset_dir = self._create_mapset(gisdbase, location, module)
-        gisrc = gsetup.write_gisrc(gisdbase, location, mapset)
+        gisrc = gs.setup.write_gisrc(gisdbase, location, mapset)
 
         # here is special setting of environmental variables for running tests
         # some of them might be set from outside in the future and if the list

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -150,14 +150,14 @@ def main():
     os.environ["GISDBASE"] = text_to_string(gisdb)
 
     # import GRASS Python package for initialization
-    import grass.script.setup as gsetup
+    import grass.script as gs
 
     # launch session
     # we need some location and mapset here
     # TODO: can init work without it or is there some demo location in dist?
     location = locations[0].split(":")[0]
     mapset = "PERMANENT"
-    gsetup.init(gisbase, gisdb, location, mapset)
+    gs.setup.init(gisbase, gisdb, location, mapset)
 
     reports = []
     for location, location_type in zip(locations, locations_types):

--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -18,7 +18,6 @@ import os
 import weakref
 
 import grass.script as gs
-import grass.script.setup as gsetup
 
 
 def _set_notebook_defaults():
@@ -55,7 +54,7 @@ class _JupyterGlobalSession:
     """
 
     def __init__(self):
-        self._finalizer = weakref.finalize(self, gsetup.finish)
+        self._finalizer = weakref.finalize(self, gs.setup.finish)
 
     def switch_mapset(self, path, location=None, mapset=None):
         """Switch to a mapset provided as a name or path.
@@ -162,7 +161,7 @@ def init(path, location=None, mapset=None, grass_path=None):
     global _global_session_handle  # pylint: disable=global-statement,invalid-name
     if not _global_session_handle or not _global_session_handle.active:
         # Create a GRASS session.
-        gsetup.init(path, location=location, mapset=mapset, grass_path=grass_path)
+        gs.setup.init(path, location=location, mapset=mapset, grass_path=grass_path)
         # Set defaults for environmental variables and library.
         _set_notebook_defaults()
         _global_session_handle = _JupyterGlobalSession()

--- a/python/grass/jupyter/tests/conftest.py
+++ b/python/grass/jupyter/tests/conftest.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 import pytest
 
 import grass.script as gs
-import grass.script.setup as grass_setup
 
 
 @pytest.fixture(scope="module")
@@ -22,7 +21,7 @@ def space_time_raster_dataset(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("raster_time_series")
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         names = [f"precipitation_{i}" for i in range(1, 7)]
         max_values = [550, 450, 320, 510, 300, 650]
@@ -76,7 +75,7 @@ def simple_dataset(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("simple_dataset")
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.proj", flags="c", epsg=26917)
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         # Create Vector

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -5,7 +5,6 @@ import multiprocessing
 import pytest
 
 import grass.script as gs
-import grass.script.setup as grass_setup
 
 
 def max_processes():
@@ -28,7 +27,7 @@ def test_processes(tmp_path, processes):
     """Check that running with multiple processes works"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         surface = "surface"
@@ -66,7 +65,7 @@ def test_tiling_schemes(tmp_path, width, height):
     """Check that different shapes of tiles work"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         surface = "surface"
@@ -100,7 +99,7 @@ def test_overlaps(tmp_path, overlap):
     """Check that overlap accepts different values"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
         surface = "surface"
         gs.run_command("r.surf.fractal", output=surface)
@@ -134,7 +133,7 @@ def test_cleans(tmp_path, clean):
     location = "test"
     mapset_prefix = "abc"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
         surface = "surface"
         gs.run_command("r.surf.fractal", output=surface)
@@ -178,7 +177,7 @@ def test_patching_backend(tmp_path, patch_backend):
     """Check patching backend works"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         points = "points"
@@ -226,7 +225,7 @@ def test_tiling(tmp_path, width, height, processes):
     """Check auto adjusted tile size based on processes"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         surface = "surface"

--- a/python/grass/script/__init__.py
+++ b/python/grass/script/__init__.py
@@ -8,3 +8,4 @@ from .raster import *
 from .raster3d import *
 from .vector import *
 from .utils import *
+from . import setup

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -44,10 +44,9 @@ Usage::
 
     # import (some) GRASS Python bindings
     import grass.script as gs
-    import grass.script.setup as gsetup
 
     # launch session
-    rcfile = gsetup.init(gisdb, location, mapset)
+    session = gs.setup.init(gisdb, location, mapset)
 
     # example calls
     gs.message("Current GRASS GIS 8 environment:")
@@ -62,7 +61,7 @@ Usage::
         print(vect)
 
     # clean up at the end
-    gsetup.finish()
+    session.finish()
 
 
 (C) 2010-2021 by the GRASS Development Team
@@ -271,20 +270,22 @@ def init(path, location=None, mapset=None, grass_path=None):
     ValueError is raised. Exceptions from the underlying function are propagated.
 
     To create a GRASS session a session file (aka gisrc file) is created.
-    Caller is responsible for deleting the file which is normally done
-    with the function :func:`finish`.
+    The session object returned by this function will take care of deleting it
+    as long as the object is used as a context manager or the *finish* method
+    of the object is called explicitly. Using methods of the session object is
+    preferred over calling the function :func:`finish`.
 
     Basic usage::
 
         # ... setup GISBASE and sys.path before import
         import grass.script as gs
-        gs.setup.init(
+        session = gs.setup.init(
             "~/grassdata/nc_spm_08/user1",
             grass_path="/usr/lib/grass",
         )
         # ... use GRASS modules here
         # end the session
-        gs.setup.finish()
+        session.finish()
 
     The returned object is a context manager, so the ``with`` statement can be used to
     ensure that the session is finished (closed) at the end::
@@ -354,7 +355,6 @@ class SessionHandle:
         # ... setup sys.path before import as needed
 
         import grass.script as gs
-        import grass.script.setup
 
         session = gs.setup.init("~/grassdata/nc_spm_08/user1")
 
@@ -368,7 +368,6 @@ class SessionHandle:
         # ... setup sys.path before import as needed
 
         import grass.script as gs
-        import grass.script.setup
 
         with gs.setup.init("~/grassdata/nc_spm_08/user1"):
             # ... use GRASS modules here

--- a/python/grass/script/tests/grass_script_setup_test.py
+++ b/python/grass/script/tests/grass_script_setup_test.py
@@ -6,7 +6,6 @@ import os
 import pytest
 
 import grass.script as gs
-import grass.script.setup as grass_setup
 
 
 # All init tests change the global environment, but when it really matters,
@@ -31,7 +30,7 @@ def test_init_as_context_manager(tmp_path):
     """Check that init function return value works as a context manager"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", flags="p")
         session_file = os.environ["GISRC"]
     assert not os.path.exists(session_file)
@@ -41,7 +40,7 @@ def test_init_session_finish(tmp_path):
     """Check that init works with finish on the returned session object"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    session = grass_setup.init(tmp_path / location)
+    session = gs.setup.init(tmp_path / location)
     gs.run_command("g.region", flags="p")
     session_file = os.environ["GISRC"]
     session.finish()
@@ -55,10 +54,10 @@ def test_init_finish_global_functions(tmp_path):
     """Check that init and finish global functions work"""
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    grass_setup.init(tmp_path / location)
+    gs.setup.init(tmp_path / location)
     gs.run_command("g.region", flags="p")
     session_file = os.environ["GISRC"]
-    grass_setup.finish()
+    gs.setup.finish()
 
     assert not os.path.exists(session_file)
 
@@ -72,10 +71,10 @@ def test_init_finish_global_functions_capture_strerr(tmp_path):
         gs.core._create_location_xy(  # pylint: disable=protected-access
             tmp_path, location
         )
-        grass_setup.init(tmp_path / location)
+        gs.setup.init(tmp_path / location)
         gs.run_command("g.region", flags="p")
         queue.put(os.environ["GISRC"])
-        grass_setup.finish()
+        gs.setup.finish()
 
     session_file = run_in_subprocess(init_finish)
     assert session_file, "Expected file name from the subprocess"

--- a/scripts/v.db.univar/tests/conftest.py
+++ b/scripts/v.db.univar/tests/conftest.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import pytest
 
 import grass.script as gs
-import grass.script.setup as grass_setup
 
 
 def updates_as_transaction(table, cat_column, column, cats, values):
@@ -45,7 +44,7 @@ def simple_dataset(tmp_path_factory):
     column_name = "double_value"
     num_points = 10
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         gs.run_command("v.random", output=map_name, npoints=num_points, seed=42)
         gs.run_command(

--- a/temporal/t.rast.list/tests/conftest.py
+++ b/temporal/t.rast.list/tests/conftest.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 import pytest
 
 import grass.script as gs
-import grass.script.setup as grass_setup
 
 
 @pytest.fixture(scope="module")
@@ -18,7 +17,7 @@ def space_time_raster_dataset(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("raster_time_series")
     location = "test"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location):
+    with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         names = [f"precipitation_{i}" for i in range(1, 7)]
         max_values = [550, 450, 320, 510, 300, 650]


### PR DESCRIPTION
import grass.script.setup or similar was needed to get access to functions in the setup module. Now the module is imported in the init file which makes it available without an additional import in user code. gs.setup.init() is now an easy and clear way of getting access to the init function.

Most of the code using grass.script.setup was modified to the new style (except for grass.py and imports of specific functions).

Documentation related to the session returned from gs.setup.init updated as gs.setup.finish() call is not even needed when easier session.finish() call is used instead. (Using session.finish() leaves gs.setup.init() call to be the only one from setup for typical session handling code, so the previously required separate import would be for one call only; now there is no import except for grass.script.)

Alternatives to this implementation would be to import all functions (which would bring many symbols to grass.script) or importing specific functions (e.g., init only), but importing setup makes it most clear (all are available) while keeping them separate under setup. (There are other setup or session related functions in grass.script.core already available after importing grass.script, so there is still some confusion related to that. However, rather than mixing all together, it seems that these need to be separated from core or organized better in some other way.)