### PR TITLE
grass.jupyter: Support pathlib.Path in TimeSeriesMap.save

### DIFF
--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -70,9 +70,9 @@ def test_render_layers(space_time_raster_dataset, fill_gaps):
 
 @pytest.mark.skipif(IPython is None, reason="IPython package not available")
 @pytest.mark.skipif(ipywidgets is None, reason="ipywidgets package not available")
-def test_save(space_time_raster_dataset):
+def test_save(space_time_raster_dataset, tmp_path):
     """Test returns from animate and time_slider are correct object types"""
     img = gj.TimeSeriesMap()
     img.add_raster_series(space_time_raster_dataset.name)
-    gif_file = img.save("image.gif")
+    gif_file = img.save(tmp_path / "image.gif")
     assert Path(gif_file).is_file()

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -486,7 +486,7 @@ class TimeSeriesMap:
 
         # filepath to output GIF
         filename = Path(filename)
-        if not filename.suffix.lower() == ".gif":
+        if filename.suffix.lower() != ".gif":
             raise ValueError(_("filename must end in '.gif'"))
 
         images = []

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -16,6 +16,8 @@ import tempfile
 import os
 import weakref
 import shutil
+from pathlib import Path
+
 import grass.script as gs
 
 from .map import Map
@@ -483,7 +485,8 @@ class TimeSeriesMap:
             self.render()
 
         # filepath to output GIF
-        if not filename.endswith(".gif"):
+        filename = Path(filename)
+        if not filename.suffix.lower() == ".gif":
             raise ValueError(_("filename must end in '.gif'"))
 
         images = []


### PR DESCRIPTION
* API: TimeSeriesMap.save now supports pathlib.Path objects (and strings as before).
* tests: Use tmp_path, not current dir. Files generated by the tests should use tmp_path (or other pytest tmp dir ways), not the current directory.