### PR TITLE
init: Remove duplicate mapset cleaning code, use verbose

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2104,10 +2104,14 @@ def done_message():
 
 
 def clean_temp():
-    message(_("Cleaning up temporary files..."))
-    nul = open(os.devnull, "w")
-    call([gpath("etc", "clean_temp")], stdout=nul)
-    nul.close()
+    """Clean mapset temporary directory
+
+    Simple wrapper around the library function avoiding the need to solve imports at
+    the top level. This can hopefully be avoided in the future.
+    """
+    from grass.script import setup as gsetup
+
+    gsetup.clean_temp()
 
 
 def clean_all():

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -447,13 +447,14 @@ def call(cmd, **kwargs):
 
 
 def clean_temp():
-    from grass.script import core as gcore
+    """Clean mapset temporary directory"""
+    # Lazy-importing to reduce dependencies (this can be eventually removed).
+    # pylint: disable=import-outside-toplevel
+    import grass.script as gs
 
-    gcore.message(_("Cleaning up temporary files..."))
-    nul = open(os.devnull, "w")
+    gs.verbose(_("Cleaning up temporary files..."))
     gisbase = os.environ["GISBASE"]
-    call([os.path.join(gisbase, "etc", "clean_temp")], stdout=nul)
-    nul.close()
+    call([os.path.join(gisbase, "etc", "clean_temp")], stdout=subprocess.DEVNULL)
 
 
 def finish():


### PR DESCRIPTION
* Remove code duplication between init code in grass.py and grass.script.setup for mapset temporary directory cleaning.
* Simplify the code by using subprocess.DEVNULL instead of os.devnull.
* Change the cleaning message to verbose.
* Document both functions.
