### PR TITLE
wxGUI/vdigit: fix close frame if Vector Digitizer is run as standalone app g.gui.vdigit

### DIFF
--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -870,3 +870,6 @@ class FrameMixin:
 
     def SetSize(self, *args):
         self.GetParent().SetSize(*args)
+
+    def Close(self):
+        self.GetParent().Close()


### PR DESCRIPTION
**Describe the bug**
The standalone Vector Digitizer app window doesn't close after you hit "power off" toolbar.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Vector Digitizer as standalone app  e.g. `g.gui.vdigit map=geology`
2. Quit Vector Digitizer by click on the "power off" toolbar
3. The Vector Digitizer window doesn't close

**Expected behavior**
Standalone Vector Digitizer app window should be closed after you hit "power off" toolbar.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: 8.3.dev, 8.2