### PR TITLE
wxGUI/settings: fix hiding 'Tools' tab for single-window mode

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -673,9 +673,9 @@ class GMFrame(wx.Frame):
         self._auimgr.GetPane("toolbarNviz").Hide()
 
         # Set Tools as active tab
-        notebook = self._auimgr.GetNotebooks()
-        if notebook:
-            notebook = notebook[0]
+        notebooks = self._auimgr.GetNotebooks()
+        if notebooks:
+            notebook = notebooks[0]
             tools = self._auimgr.GetPane("tools")
             notebook.SetSelectionToPage(tools)
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -673,14 +673,16 @@ class GMFrame(wx.Frame):
         self._auimgr.GetPane("toolbarNviz").Hide()
 
         # Set Tools as active tab
-        tools = self._auimgr.GetPane("tools")
-        notebook = self._auimgr.GetNotebooks()[0]
-        notebook.SetSelectionToPage(tools)
+        notebook = self._auimgr.GetNotebooks()
+        if notebook:
+            notebook = notebook[0]
+            tools = self._auimgr.GetPane("tools")
+            notebook.SetSelectionToPage(tools)
 
-        # Set the size for automatic notebook
-        pane = self._auimgr.GetPane(notebook)
-        pane.BestSize(self.PANE_BEST_SIZE)
-        pane.MinSize(self.PANE_MIN_SIZE)
+            # Set the size for automatic notebook
+            pane = self._auimgr.GetPane(notebook)
+            pane.BestSize(self.PANE_BEST_SIZE)
+            pane.MinSize(self.PANE_MIN_SIZE)
 
         wx.CallAfter(self.datacatalog.LoadItems)
 


### PR DESCRIPTION
**Describe the bug**
When you check checkbox widget Hide 'Tools' tab (wxGUI settings dialog) for single-window mode, wxGUI doesn't launch.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI settings dialog and check checkbox widget Hide 'Tools' tab and Use single-windows mode.
2. Hit Save button
3. Restart wxGUI (close and launch wxGUI)
6. See error

```
Traceback (most recent call last):
  File "/home/tomas/.local/lib/python3.9/site-packages/wx/core.py", line 3285, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "/usr/lib64/grass83/gui/wxpython/wxgui.py", line 95, in show_main_gui
    mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
  File "/usr/lib64/grass83/gui/wxpython/main_window/frame.py", line 164, in __init__
    self.BuildPanes()
  File "/usr/lib64/grass83/gui/wxpython/main_window/frame.py", line 681, in BuildPanes
    notebook = self._auimgr.GetNotebooks()[0]
IndexError: list index out of range
```

**Expected behavior**
When you check checkbox widget Hide 'Tools' tab (wxGUI settings dialog) for single-window mode, wxGUI should be launch without error.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: 8.3.dev, 8.2