### PR TITLE
wxGUI: fix manual page "GUI index" link html file name

### DIFF
--- a/gui/wxpython/animation/g.gui.animation.html
+++ b/gui/wxpython/animation/g.gui.animation.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Animation tool -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>Animation Tool</b> is a <em><a href="wxGUI.html">wxGUI</a></em> component

--- a/gui/wxpython/datacatalog/g.gui.datacatalog.html
+++ b/gui/wxpython/datacatalog/g.gui.datacatalog.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Data Catalog -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>Data Catalog</b> is a <em><a href="wxGUI.html">wxGUI</a></em> component

--- a/gui/wxpython/dbmgr/g.gui.dbmgr.html
+++ b/gui/wxpython/dbmgr/g.gui.dbmgr.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Attribute Table Manager -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>Attribute Table Manager</b> is

--- a/gui/wxpython/gcp/g.gui.gcp.html
+++ b/gui/wxpython/gcp/g.gui.gcp.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI GCP Manager -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>GCP Manager</b> is a <em><a href="wxGUI.html">wxGUI</a></em>

--- a/gui/wxpython/gmodeler/g.gui.gmodeler.html
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Graphical Modeler -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 <p>

--- a/gui/wxpython/iclass/g.gui.iclass.html
+++ b/gui/wxpython/iclass/g.gui.iclass.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Supervised Classification Tool -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 
 <h2>KEYWORDS</h2>
 

--- a/gui/wxpython/image2target/g.gui.image2target.html
+++ b/gui/wxpython/image2target/g.gui.image2target.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI GCP Manager -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>GCP Manager</b> is a <em><a href="wxGUI.html">wxGUI</a></em>

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.html
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Map Swipe -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>Map Swipe</b> is a <em><a href="wxGUI.html">wxGUI</a></em> component

--- a/gui/wxpython/photo2image/g.gui.photo2image.html
+++ b/gui/wxpython/photo2image/g.gui.photo2image.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI GCP Manager for photo to image registration -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 This module is based on <b>g.gui.gcp</b>, the GCP manager of GRASS GIS.

--- a/gui/wxpython/psmap/g.gui.psmap.html
+++ b/gui/wxpython/psmap/g.gui.psmap.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Cartographic Composer -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 <p>

--- a/gui/wxpython/rdigit/g.gui.rdigit.html
+++ b/gui/wxpython/rdigit/g.gui.rdigit.html
@@ -1,4 +1,5 @@
 <!-- meta page description: wxGUI Raster Digitizer -->
+<!-- meta page index: topic_GUI|GUI -->
 <!-- meta page index: wxGUI -->
 
 <h2>KEYWORDS</h2>

--- a/gui/wxpython/rlisetup/g.gui.rlisetup.html
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI RLi Setup -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>g.gui.rlisetup</b> is a <em><a href="wxGUI.html">wxGUI</a></em>

--- a/gui/wxpython/timeline/g.gui.timeline.html
+++ b/gui/wxpython/timeline/g.gui.timeline.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Timeline Tool -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>Timeline Tool</b> is a <em><a href="wxGUI.html">wxGUI</a></em> component

--- a/gui/wxpython/tplot/g.gui.tplot.html
+++ b/gui/wxpython/tplot/g.gui.tplot.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Temporal Plot Tool -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>Temporal Plot Tool</b> is a <em><a href="wxGUI.html">wxGUI</a></em>

--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -1,5 +1,5 @@
 <!-- meta page description: wxGUI Vector Digitizer -->
-<!-- meta page index: topic_gui|GUI -->
+<!-- meta page index: topic_GUI|GUI -->
 <h2>DESCRIPTION</h2>
 
 The <b>vector digitizer</b> is a <em><a href="wxGUI.html">wxGUI</a></em>


### PR DESCRIPTION
**Describe the bug**
All wxGUI components manual page "GUI index" link redirection is not working.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch some wxGUI component e.g. `g.gui.psmap --ui`
2. Switch to the Manual page (tab)
4. Go to end of the manual page and click on the "GUI index"
5. Link redirection is not working

**Expected behavior**
GUI index link redirection should be working.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all