### PR TITLE
wxGUI/lmgr: fix launch GCP Manager if not map display is activated

### DIFF
--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -60,10 +60,11 @@ class LayerList(object):
 
     def __iter__(self):
         """Iterates over the contents of the list."""
-        item = self._tree.GetFirstChild(self._tree.root)[0]
-        while item and item.IsOk():
-            yield Layer(item, self._tree.GetPyData(item))
-            item = self._tree.GetNextItem(item)
+        if self._tree:
+            item = self._tree.GetFirstChild(self._tree.root)[0]
+            while item and item.IsOk():
+                yield Layer(item, self._tree.GetPyData(item))
+                item = self._tree.GetNextItem(item)
 
     def __getitem__(self, index):
         """Select a layer from the LayerList using the index."""


### PR DESCRIPTION
**Describe the bug**
When no map display is activated GCP Manager doesn't launch.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Close all activated map display
3. From the main wxGUI window toolbar launch GCP Manager 
4. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass83/gui/wxpython/lmgr/frame.py", line
737, in OnGCPManager

GCPWizard(self, self._giface)
  File "/usr/lib64/grass83/gui/wxpython/gcp/manager.py",
line 164, in __init__

self.mappage = DispMapPage(self.wizard, self)
  File "/usr/lib64/grass83/gui/wxpython/gcp/manager.py",
line 833, in __init__

extraItems=self.GetSelectTargetRasterExtraItems(),
  File "/usr/lib64/grass83/gui/wxpython/gcp/manager.py",
line 1037, in GetSelectTargetRasterExtraItems

return {self.web_servc_lyrs_root_node_name:
self.GetWebServiceLayers().keys()}
  File "/usr/lib64/grass83/gui/wxpython/gcp/manager.py",
line 1028, in GetWebServiceLayers

for layer in self.parent._giface.GetLayerList():
  File "/usr/lib64/grass83/gui/wxpython/lmgr/giface.py",
line 64, in __iter__

item = self._tree.GetFirstChild(self._tree.root)[0]
AttributeError
:
'NoneType' object has no attribute 'GetFirstChild'
```

**Expected behavior**
When no map display is activated GCP Manager should be launch without error.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all