### PR TITLE
wxGUI/gui_core: fix imagery create/edit group dialog deselect all maps

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -64,6 +64,7 @@ from gui_core.wrap import (
     StaticBox,
     StaticText,
     TextCtrl,
+    ListBox,
 )
 
 
@@ -870,7 +871,7 @@ class GroupDialog(wx.Dialog):
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.gLayerBox = wx.ListBox(
+        self.gLayerBox = ListBox(
             parent=self.gListPanel,
             id=wx.ID_ANY,
             size=(-1, 150),

--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -909,6 +909,10 @@ class ListBox(wx.ListBox):
         else:
             wx.ListBox.SetToolTipString(self, tip)
 
+    def DeselectAll(self):
+        for i in range(self.GetCount()):
+            self.Deselect(i)
+
 
 class HyperlinkCtrl(HyperlinkCtrl_):
     """Wrapper around HyperlinkCtrl to have more control


### PR DESCRIPTION
**Describe the bug**
Deselecting all maps from Image create/edit group dialog is not working.

**To Reproduce**
Steps to reproduce the behavior:

1. Launc wxGUI
2. From the main window menu choose Imagery -> Develop images and groups -> Create/edit group
3. Select some existed group e.g. nitrogen
4. Check Select all  checkbox widget 
5. Uncheck Select all checkbox widget 
6. See error

```
Traceback (most recent call last):
  File
"/usr/lib64/grass83/gui/wxpython/gui_core/dialogs.py", line
987, in OnGSelAll

self.gLayerBox.DeselectAll()
AttributeError
:
'ListBox' object has no attribute 'DeselectAll'
```

**Expected behavior**
Deselecting all maps from Image create/edit group dialog should be work without error.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all