### PR TITLE
libproj: fix area bbox for PROJ

### DIFF
--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -118,8 +118,8 @@ int get_pj_area(const struct pj_info *iproj, double *xmin, double *xmax,
 	}
 	G_free(indef);
 
-	estep = (window.west + window.east) / 21.;
-	nstep = (window.north + window.south) / 21.;
+	estep = (window.east - window.west) / 21.;
+	nstep = (window.north - window.south) / 21.;
 	for (i = 0; i < 20; i++) {
 	    x[i] = window.west + estep * (i + 1);
 	    y[i] = window.north;
@@ -692,7 +692,9 @@ int GPJ_init_transform(const struct pj_info *info_in,
 	    proj_list_destroy(op_list);
 
 	/* try proj_create_crs_to_crs() */
+	/*
 	G_debug(1, "trying %s to %s", indef, outdef);
+	*/
 
 	/* proj_create_crs_to_crs() does not work because it calls
 	 * proj_create_crs_to_crs_from_pj() which calls

--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -164,6 +164,17 @@ int get_pj_area(const struct pj_info *iproj, double *xmin, double *xmax,
 		*ymax = y[i];
 	}
 
+	/* The west longitude is generally lower than the east longitude,
+	 * except for areas of interest that go across the anti-meridian.
+	 */
+	if (x[80] > x[82] && x[81] > x[83]) {
+	    /* west > east, must be crossing the anti-meridian */
+	    double tmpx = *xmin;
+
+	    *xmin = *xmax;
+	    *xmax = tmpx;
+	}
+
 	G_debug(1, "input window north: %.8f", window.north);
 	G_debug(1, "input window south: %.8f", window.south);
 	G_debug(1, "input window east: %.8f", window.east);

--- a/vector/v.proj/main.c
+++ b/vector/v.proj/main.c
@@ -201,10 +201,6 @@ int main(int argc, char *argv[])
     info_out.srid = G_get_projsrid();
     info_out.wkt = G_get_projwkt();
 
-    if (G_verbose() == G_verbose_max()) {
-	pj_print_proj_params(&info_in, &info_out);
-    }
-
     info_trans.def = NULL;
 #ifdef HAVE_PROJ_H
     if (pipeline->answer) {
@@ -278,6 +274,10 @@ int main(int argc, char *argv[])
 
 	info_in.srid = G_get_projsrid();
 	info_in.wkt = G_get_projwkt();
+
+	if (G_verbose() == G_verbose_max()) {
+	    pj_print_proj_params(&info_in, &info_out);
+	}
 
 	Vect_set_open_level(1);
 	G_debug(1, "Open old: location: %s mapset : %s", G_location_path(),


### PR DESCRIPTION
The PJ_AREA has not been properly estimated. As a result, sometimes the wrong PROJ pipeline was chosen, or PROJ failed to find a pipeline at all.  