### PR TITLE
t.rast.series: pass n_procs and memory parameters to r.series

### DIFF
--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -12,6 +12,15 @@ ordered by <b>start_time</b>.
 <b>r.series</b>. It supports a subset of the aggregation methods of
 <b>r.series</b>.
 
+<h2>Performance</h2>
+To enable parallel processing, the user can specify the number of threads to be
+used with the <b>nprocs</b> parameter (default 1). The <b>memory</b> parameter
+(default 300 MB) can also be provided to determine the size of the buffer in MB for
+computation. Both parameters are passed to <a href="r.series.html">r.series</a>.
+To take advantage of the parallelization, GRASS GIS
+needs to compiled with OpenMP enabled.
+
+
 <h2>EXAMPLES</h2>
 
 <h3>Estimate the average temperature for the whole time series</h3>
@@ -43,7 +52,7 @@ t.rast.series input=tempmean_monthly \
     method=average output=tempmean_january \
     where="strftime('%m', start_time)='01'"
 
-# equivalently, we can use 
+# equivalently, we can use
 t.rast.series input=tempmean_monthly \
     output=tempmean_january method=average \
     where="start_time = datetime(start_time, 'start of year', '0 month')"
@@ -59,12 +68,12 @@ t.rast.series input=tempmean_monthly \
     where="start_time = datetime(start_time, 'start of year', '2 month')"
 </pre></div>
 
-Generalizing a bit, we can estimate monthly climatologies for all months 
+Generalizing a bit, we can estimate monthly climatologies for all months
 by means of different methods
 
 <div class="code"><pre>
-for i in `seq -w 1 12` ; do 
-  for m in average stddev minimum maximum ; do 
+for i in `seq -w 1 12` ; do
+  for m in average stddev minimum maximum ; do
     t.rast.series input=tempmean_monthly method=${m} output=tempmean_${m}_${i} \
     where="strftime('%m', start_time)='${i}'"
   done

--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -18,7 +18,7 @@ used with the <b>nprocs</b> parameter (default 1). The <b>memory</b> parameter
 (default 300 MB) can also be provided to determine the size of the buffer in MB for
 computation. Both parameters are passed to <a href="r.series.html">r.series</a>.
 To take advantage of the parallelization, GRASS GIS
-needs to compiled with OpenMP enabled.
+needs to be compiled with OpenMP enabled.
 
 
 <h2>EXAMPLES</h2>

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -63,12 +63,9 @@
 # %end
 
 # %option G_OPT_M_NPROCS
-# % description: Number of cores for multiprocessing in r.series
-# % answer: 1
 # %end
 
 # %option G_OPT_MEMORYMB
-# % description: Maximum memory to be used (in MB) by r.series
 # %end
 
 # %option G_OPT_T_WHERE

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -62,6 +62,15 @@
 # % answer: start_time
 # %end
 
+# %option G_OPT_M_NPROCS
+# % description: Number of cores for multiprocessing in r.series
+# % answer: 1
+# %end
+
+# %option G_OPT_MEMORYMB
+# % description: Maximum memory to be used (in MB) by r.series
+# %end
+
 # %option G_OPT_T_WHERE
 # %end
 
@@ -95,6 +104,8 @@ def main():
     method = options["method"]
     quantile = options["quantile"]
     order = options["order"]
+    memory = options["memory"]
+    nprocs = options["nprocs"]
     where = options["where"]
     add_time = flags["t"]
     nulls = flags["n"]
@@ -148,6 +159,8 @@ def main():
                 overwrite=grass.overwrite(),
                 method=method,
                 quantile=quantile,
+                memory=memory,
+                nprocs=nprocs
             )
         except CalledModuleError:
             grass.fatal(_("%s failed. Check above error messages.") % "r.series")

--- a/temporal/t.rast.series/t.rast.series.py
+++ b/temporal/t.rast.series/t.rast.series.py
@@ -160,7 +160,7 @@ def main():
                 method=method,
                 quantile=quantile,
                 memory=memory,
-                nprocs=nprocs
+                nprocs=nprocs,
             )
         except CalledModuleError:
             grass.fatal(_("%s failed. Check above error messages.") % "r.series")


### PR DESCRIPTION
This PR enables `t.rast.series` to pass the `n_procs` and `memory` parameters on to `r.series`