### PR TITLE
g.extension: Add details to URL error message

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2494,29 +2494,31 @@ def resolve_source_code(url=None, name=None, branch=None, fork=False):
     url = url[6:] if url.startswith("file://") else url
     if not os.path.exists(url):
         url_validated = False
+        message = None
         if url.startswith("http"):
             try:
                 open_url = urlopen(url)
                 open_url.close()
                 url_validated = True
-            except URLError:
-                pass
+            except URLError as error:
+                message = error
         else:
             try:
                 open_url = urlopen("http://" + url)
                 open_url.close()
                 url_validated = True
-            except URLError:
-                pass
+            except URLError as error:
+                message = error
             try:
                 open_url = urlopen("https://" + url)
                 open_url.close()
                 url_validated = True
-            except URLError:
-                pass
-
+            except URLError as error:
+                message = error
         if not url_validated:
-            grass.fatal(_("Cannot open URL: {}".format(url)))
+            grass.fatal(
+                _("Cannot open URL <{url}>: {error}").format(url=url, error=message)
+            )
 
     # Handle local URLs
     if os.path.isdir(url):


### PR DESCRIPTION
The URL validation introduced in 45ff0ead5acfbcb574a4326b54538b28821a2aea does not include the original error message details in the user-visible error message. This adds the details and also fixes the formatting which was done on the regular string literal instead of the translated string.
