### PR TITLE
r.watershed: Extend r.watershed test suite for differences between ram and seg versions

### DIFF
--- a/raster/r.watershed/testsuite/test_equal_ram_seg_output.py
+++ b/raster/r.watershed/testsuite/test_equal_ram_seg_output.py
@@ -137,19 +137,22 @@ class TestEqualRamSegOutput(TestCase):
 
         self.assertTrue(all(all(p) for p in passes), msg=msg)
 
+    @staticmethod
+    def columns(cells):
+        return "| " + (" | ".join(map(str, cells))) + " |"
+
     def md_table(self, passes):
-        columns = lambda l: "| " + (" | ".join(map(str, l))) + " |"
-        strinpts = columns(
+        strinpts = self.columns(
             [", ".join(["%s=%s" % kw for kw in d.items()]) for d in self.inputs]
         )
         for ir in self.tmp_input_rasters:
             strinpts = strinpts.replace("=" + ir, "")
         msg = "| Output " + strinpts + "\n"
-        msg += columns(["---"] * (len(self.inputs) + 1)) + "\n"
+        msg += self.columns(["---"] * (len(self.inputs) + 1)) + "\n"
         symbols = {True: ":white_check_mark:", False: ":red_circle:"}
-        for o, p in zip(self.outputs, zip(*passes)):
+        for o, p in zip(self.outputs, zip(*passes, strict=False), strict=False):
             sym = [symbols[b] for b in p]
-            msg += ("| %s " % o) + columns(sym) + "\n"
+            msg += ("| %s " % o) + self.columns(sym) + "\n"
         return msg
 
 


### PR DESCRIPTION
These tests are designed to give a comprehensive overview of matching output between the in-memory (ram) and segmentation library versions of `r.watershed` with different optional inputs. It relies on running the module with both versions and a random raster (n=10000) for the optional inputs. The min/max of the difference between output rasters are compared and tests pass if they do not exceed the following precisions/thresholds (open for suggestions):
 ```
    output_precision = {
        'accumulation': 1,
        'tci': 0.01,
        'spi': 0.01,
        'drainage': 0,
        'basin': 0,
        'stream': 0,
        'half_basin': 0,
        'length_slope': 0.01,
        'slope_steepness': 0.01,
    }
```

The current state of matches with optional input in columns:
| Output | _required_ | flags=s | flags=4 | depression | flow | disturbed_land | blocking | retention |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| accumulation | :white_check_mark: | :white_check_mark: | :white_check_mark: | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| tci | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| spi | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| drainage | :white_check_mark: | :red_circle: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :red_circle: | :white_check_mark: |
| basin | :white_check_mark: | :white_check_mark: | :red_circle: | :white_check_mark: | :red_circle: | :white_check_mark: | :red_circle: | :white_check_mark: |
| stream | :white_check_mark: | :white_check_mark: | :red_circle: | :white_check_mark: | :red_circle: | :white_check_mark: | :red_circle: | :white_check_mark: |
| half_basin | :white_check_mark: | :white_check_mark: | :red_circle: | :white_check_mark: | :red_circle: | :white_check_mark: | :red_circle: | :white_check_mark: |
| length_slope | :red_circle: | :white_check_mark: | :red_circle: | :red_circle: | :red_circle: | :red_circle: | :red_circle: | :red_circle: |
| slope_steepness | :red_circle: | :white_check_mark: | :red_circle: | :red_circle: | :red_circle: | :red_circle: | :red_circle: | :red_circle: |
 
I was not able to reproduce the mismatch in accumulation in the NC demo location reported by @HuidaeCho in #2222 with randomly assigned `flow` fractions (0-1), although other output does not match.