### PR TITLE
wxGUI/vselect: fix output fully qualified vector name

### DIFF
--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -358,6 +358,7 @@ class VectorSelectBase:
         if ret == 0:
             tree = self._giface.GetLayerTree()
             if tree:
+                outMap = f"{outMap}@{grass.gisenv()['MAPSET']}"
                 tree.AddLayer(
                     ltype="vector",
                     lname=outMap,


### PR DESCRIPTION
**Describe the bug**
When you created new vector map with Select vector feature(s) tool, map is added into Map Display layers tree. If you try delete this map from the Data Catalog Location current Mapset tree, map isn't deleted from the current Map Display layers tree.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some vector map e.g. `d.vect map=census`
3. From the Map Display layers tree select census vector map
4. From the Map Display Frame toolbars activate Select vector feature(s) tool
5. Select some area(s)
6. Hit Create new map button from the Select vector feature(s) dialog (new vector map is created e.g. **census_selectionW08** and is added into current Map Display layers tree)
7. Reload Data Catalog Location current Mapset tree (if you don't have installed Data Catalog watchdog Python package) via Data Catalog toolbar Reload current GRASS mapset only tool
8. From the Data Catalog Location current Mapset tree try delete newly created vector map **census_selectionW08**
9. Vector map  **census_selectionW08** is deleted from the Data Catalog Location current Mapset tree, but isn't deleted from the Map Display layers tree

**Expected behavior**
If vector map is deleted from the Data Catalog Location current Mapset tree should be deleted from the Map Display layers tree too.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all