### PR TITLE
wxGUI/psmap: don't set StatusBar widget text when frame is closed

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -513,7 +513,10 @@ class PsMapFrame(wx.Frame):
         if event.userData["temp"]:
             grass.try_remove(event.userData["filename"])
 
-        self.delayedCall = wx.CallLater(4000, lambda: self.SetStatusText("", 0))
+        self.delayedCall = wx.CallLater(
+            4000,
+            lambda: self.SetStatusText("", 0) if self else None,
+        )
 
     def getFile(self, wildcard):
         suffix = []


### PR DESCRIPTION
**Describe the bug**
When map preview is rendered and Cartographic Composer frame is closed, error message is printed.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI Cartographic Composer `g.gui.psmap`
2. From the toolbar activate Map frame tool and add raster map e.g. elevation
3. From the toolbar hit Show preview tool
4. From the toolbar hit Show preview tool again
5. Close the Cartographic Composer window
6. See error

```
Traceback (most recent call last):
  File "/home/tomas/.local/lib/python3.9/site-
packages/wx/core.py", line 2254, in Notify

self.notify()
  File "/home/tomas/.local/lib/python3.9/site-
packages/wx/core.py", line 3410, in Notify

self.result = self.callable(*self.args, **self.kwargs)
  File "/usr/lib64/grass83/gui/wxpython/psmap/frame.py",
line 517, in <lambda>

self.delayedCall = wx.CallLater(4000, lambda:
self.SetStatusText("", 0))
RuntimeError
:
wrapped C/C++ object of type PsMapFrame has been deleted
```

**Expected behavior**
When map preview is rendered and Cartographic Composer frame is closed, error message should not be printed.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all