### PR TITLE
wxGUI: do not crash on localized GUIs

### DIFF
--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -505,10 +505,10 @@ class WorkspaceManager:
         """
         if menu:
             file_menu = menu.GetMenu(
-                menuIndex=menu.FindMenu(title="File"),
+                menuIndex=menu.FindMenu(title=_("File")),
             )
             workspace_item = file_menu.FindItem(
-                id=file_menu.FindItem(itemString="Workspace"),
+                id=file_menu.FindItem(itemString=_("Workspace")),
             )[0]
             self._recent_files = RecentFilesMenu(
                 app_name="main",


### PR DESCRIPTION
PR #2469 (908c5e23bf8fc23f5a0602dd1cc03cab6bd4ad37) introduced a code that uses English UI strings to identify UI elements. In the case of a translated UI it fails to get element and then proceeds to manipulate with not existing element leading to an assert in C++ wx code.