### PR TITLE
wxGUI/modules: fix import PostGIS geometry data

### DIFF
--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -668,6 +668,7 @@ def _parseFormats(output, writableOnly=False):
             continue
         if name in (
             "PostgreSQL",
+            "PostgreSQL/PostGIS",
             "SQLite",
             "ODBC",
             "ESRI Personal GeoDatabase",

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2003,8 +2003,9 @@ class GdalSelect(wx.Panel):
         if sourceType == "db":
             self.dbWidgets["format"].SetItems(list(self.dbFormats.values()))
             if self.dbFormats:
-                if "PostgreSQL" in self.dbFormats.values():
-                    self.dbWidgets["format"].SetStringSelection("PostgreSQL")
+                formats = self.dbFormats.values()
+                if "PostgreSQL" in formats or "PostgreSQL/PostGIS" in formats:
+                    self.dbWidgets["format"].SetStringSelection("PostgreSQL/PostGIS")
                 else:
                     self.dbWidgets["format"].SetSelection(0)
             self.dbWidgets["format"].Enable()
@@ -2102,6 +2103,7 @@ class GdalSelect(wx.Panel):
         if self._sourceType == "db":
             if self.dbWidgets["format"].GetStringSelection() in (
                 "PostgreSQL",
+                "PostgreSQL/PostGIS",
                 "PostGIS Raster driver",
             ):
                 ret = RunCommand("db.login", read=True, quiet=True, flags="p")
@@ -2171,10 +2173,19 @@ class GdalSelect(wx.Panel):
         showDirbrowse = db in ("FileGDB")
         showChoice = db in (
             "PostgreSQL",
+            "PostgreSQL/PostGIS",
             "PostGIS WKT Raster driver",
             "PostGIS Raster driver",
         )
-        enableFeatType = self.dest and self.ogr and db in ("PostgreSQL")
+        enableFeatType = (
+            self.dest
+            and self.ogr
+            and db
+            in (
+                "PostgreSQL",
+                "PostgreSQL/PostGIS",
+            )
+        )
         showText = not (showBrowse or showChoice or showDirbrowse)
 
         sizer.Show(self.dbWidgets["browse"], show=showBrowse)

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2003,8 +2003,10 @@ class GdalSelect(wx.Panel):
         if sourceType == "db":
             self.dbWidgets["format"].SetItems(list(self.dbFormats.values()))
             if self.dbFormats:
-                formats = self.dbFormats.values()
-                if "PostgreSQL" in formats or "PostgreSQL/PostGIS" in formats:
+                db_formats = self.dbFormats.values()
+                if "PostgreSQL" in db_formats:
+                    self.dbWidgets["format"].SetStringSelection("PostgreSQL")
+                elif "PostgreSQL/PostGIS" in db_formats:
                     self.dbWidgets["format"].SetStringSelection("PostgreSQL/PostGIS")
                 else:
                     self.dbWidgets["format"].SetSelection(0)

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -613,13 +613,19 @@ class OgrImportDialog(ImportDialog):
             return
 
         dsn = self.dsnInput.GetDsn()
+        if not dsn:
+            return
         ext = self.dsnInput.GetFormatExt()
 
         # determine data driver for PostGIS links
         self.popOGR = False
         if (
             self.dsnInput.GetType() == "db"
-            and self.dsnInput.GetFormat() == "PostgreSQL"
+            and self.dsnInput.GetFormat()
+            in (
+                "PostgreSQL",
+                "PostgreSQL/PostGIS",
+            )
             and "GRASS_VECTOR_OGR" not in os.environ
         ):
             self.popOGR = True


### PR DESCRIPTION
**Describe the bug**
Import PostGIS geometry data via wxGUI Import vector data dialog doesn't work.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Set PostGIS connection via `db.login` module
3. From the Data catalog toolbar activate Import vector data tool
4. From the Import vector data dialog Source type choose Database RadioButton widget
5. Format ComboBox widget is not active

**Expected behavior**
Import PostGIS geometry data via wxGUI Import vector data dialog should be work.

**Screenshots**
![wxgui_import_dialog_def](https://user-images.githubusercontent.com/50632337/180305265-976c4572-3992-4896-9858-d4b9a89b4eac.png)

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all
- `ogr2ogr --version`: GDAL 3.4.2, released 2022/03/08

**Additional context**
```
GRASS nc_basic_spm_grass7/PERMANENT:~ > v.in.ogr -f | grep Postgre
Supported formats:
 PostgreSQL (rw+): PostgreSQL/PostGIS
 PGDUMP (rw+): PostgreSQL SQL dump
```
