### PR TITLE
wxGUI/modules: fix import SQLite geometry data

### DIFF
--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -669,6 +669,7 @@ def _parseFormats(output, writableOnly=False):
         if name in (
             "PostgreSQL",
             "SQLite",
+            "SQLite / Spatialite",
             "ODBC",
             "ESRI Personal GeoDatabase",
             "Rasterlite",

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2139,7 +2139,7 @@ class GdalSelect(wx.Panel):
     def SetDatabase(self, db):
         """Update database panel."""
         sizer = self.dbPanel.GetSizer()
-        showBrowse = db in ("SQLite", "Rasterlite")
+        showBrowse = db in ("SQLite", "SQLite / Spatialite", "Rasterlite")
         showDirbrowse = db in ("FileGDB")
         showChoice = db in (
             "PostgreSQL",


### PR DESCRIPTION
**Describe the bug**
Import SQLite geometry data via wxGUI Import vector data dialog doesn't work.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. From the Data catalog toolbar activate Import vector data tool
3. From the Import vector data dialog Source type choose Database RadioButton widget
4. Format ComboBox widget is not active

**Expected behavior**
Import SQLite geometry data via wxGUI Import vector data dialog should be work.

**Screenshots**
![wxgui_import_dialog_def](https://user-images.githubusercontent.com/50632337/180305265-976c4572-3992-4896-9858-d4b9a89b4eac.png)

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all
- `ogr2ogr --version`: GDAL 3.4.2, released 2022/03/08

**Additional context**
```
GRASS nc_basic_spm_grass7/PERMANENT:~ > v.in.ogr -f | grep SQLite
Supported formats:
 SQLite (rw+): SQLite / Spatialite
```
