### PR TITLE
wxGUI/forms: fix LayersList widget binding check/uncheck event method

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2262,7 +2262,7 @@ class CmdPanel(wx.Panel):
                         )
                         p["wxId"] = [self.win1.GetId()]
 
-                        def OnCheckItem(index, flag):
+                        def OnCheckItem(index=None, flag=None, event=None):
                             layers = list()
                             geometry = None
                             for layer, match, listId in self.win1.GetLayers():
@@ -2277,7 +2277,13 @@ class CmdPanel(wx.Panel):
                             # TODO: v.import has no geometry option
                             self.OnUpdateValues()  # TODO: replace by signal
 
-                        self.win1.OnCheckItem = OnCheckItem
+                        from core.globalvar import CheckWxVersion
+
+                        if CheckWxVersion([4, 1, 0]):
+                            self.win1.Bind(wx.EVT_LIST_ITEM_CHECKED, OnCheckItem)
+                            self.win1.Bind(wx.EVT_LIST_ITEM_UNCHECKED, OnCheckItem)
+                        else:
+                            self.win1.OnCheckItem = OnCheckItem
 
                 elif prompt == "sql_query":
                     win = gselect.SqlWhereSelect(parent=which_panel, param=p)


### PR DESCRIPTION
Fixes #2493. `CheckListCtrlMixin` class is [obsolete](https://docs.wxpython.org/wx.lib.mixins.listctrl.CheckListCtrlMixin.html) and `OnCheckItem` method doesn't work with wxPython 4.1.1 version. Instead of that, an event `wx.EVT_LIST_ITEM_CHECKED`,` wx.EVT_LIST_ITEM_UNCHECKED` is binded to the widget LayersList widget.