### PR TITLE
tests: Add timeout to pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r .github/workflows/python_requirements.txt
           pip install -r .github/workflows/optional_requirements.txt
-          pip install pytest
+          pip install pytest pytest-timeout
 
       - name: Create installation directory
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,4 @@ addopts = """
     --doctest-glob='*doctest*.txt'
     --ignore='raster/r.category/test_rcategory_doctest.txt'
 """
+timeout = 300


### PR DESCRIPTION
Now the individual pytest tests are terminated after 300 seconds just like the gunittest ones. New dependency pytest-timeout is needed for testing to use the timeout (or avoid the warning about unused configuration). In the future, individual tests can change the time if needed using the pytest.mark.timeout decorator.
