### PR TITLE
grass.jupyter: fix bbox reprojection for InteractiveMap

### DIFF
--- a/python/grass/jupyter/tests/reprojection_renderer_test.py
+++ b/python/grass/jupyter/tests/reprojection_renderer_test.py
@@ -1,6 +1,7 @@
 """Test ReprojectionRenderer functions"""
 
 from pathlib import Path
+from pytest import approx
 from grass.jupyter.reprojection_renderer import ReprojectionRenderer
 
 
@@ -20,7 +21,8 @@ def test_render_raster(simple_dataset):
     assert Path(filename).exists()
     # Test bounding box is correct
     # Raster is same extent as region so no need to test bbox for use_region=True
-    assert bbox == [["0.00072155", "-85.48874388"], ["0.00000000", "-85.48766880"]]
+    assert bbox[0] == approx([0.00072155, -85.48874388])
+    assert bbox[1] == approx([0.00000000, -85.48766880])
 
 
 # render_vector produces json

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -46,6 +46,7 @@ def reproject_region(region, from_proj, to_proj):
     """
     region = region.copy()
     # reproject all corners, otherwise reproj. region may be underestimated
+    # even better solution would be reprojecting vector region like in r.import
     proj_input = (
         f"{region['east']} {region['north']}\n"
         f"{region['west']} {region['north']}\n"
@@ -71,20 +72,20 @@ def reproject_region(region, from_proj, to_proj):
         raise RuntimeError(
             _("Encountered error while running m.proj: {}").format(stderr)
         )
-    enws = gs.decode(proj_output).splitlines()
+    output = gs.decode(proj_output).splitlines()
     # get the largest bbox
-    n = []
-    e = []
-    for each in enws:
-        elon, nlat, unused = each.split(" ")
-        e.append(float(elon))
-        n.append(float(nlat))
-    elon, wlon = max(e), min(e)
-    nlat, slat = max(n), min(n)
-    region["east"] = elon
-    region["north"] = nlat
-    region["west"] = wlon
-    region["south"] = slat
+    latitude_list = []
+    longitude_list = []
+    for row in output:
+        longitude, latitude, unused = row.split(" ")
+        longitude_list.append(float(longitude))
+        latitude_list.append(float(latitude))
+    east_longitude, west_longitude = max(longitude_list), min(longitude_list)
+    north_latitude, south_latitude = max(latitude_list), min(latitude_list)
+    region["east"] = east_longitude
+    region["north"] = north_latitude
+    region["west"] = west_longitude
+    region["south"] = south_latitude
     return region
 
 

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -80,12 +80,10 @@ def reproject_region(region, from_proj, to_proj):
         longitude, latitude, unused = row.split(" ")
         longitude_list.append(float(longitude))
         latitude_list.append(float(latitude))
-    east_longitude, west_longitude = max(longitude_list), min(longitude_list)
-    north_latitude, south_latitude = max(latitude_list), min(latitude_list)
-    region["east"] = east_longitude
-    region["north"] = north_latitude
-    region["west"] = west_longitude
-    region["south"] = south_latitude
+    region["east"] = max(longitude_list)
+    region["north"] = max(latitude_list)
+    region["west"] = min(longitude_list)
+    region["south"] = min(latitude_list)
     return region
 
 

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -11,8 +11,6 @@
 
 """Utility functions warpping existing processes in a suitable way"""
 
-import os
-
 import grass.script as gs
 
 


### PR DESCRIPTION
Region in pseudo mercator tmp location could be smaller than it was supposed to because only 2 corners of the region were reprojected. Now it reprojects all 4 corners and gets maximum bbox from them. 
