### PR TITLE
lib/parser: Apply standards to generated script

### DIFF
--- a/lib/gis/parser_script.c
+++ b/lib/gis/parser_script.c
@@ -56,6 +56,8 @@ void G__script(void)
     fprintf(fp,
 	    "############################################################################\n\n");
 
+    fprintf(fp, "\"\"\"Wraps %s to make it even better\"\"\"\n\n", G_program_name());
+
     fprintf(fp, "# %%module\n");
     if (st->module_info.label)
 	fprintf(fp, "# %% label: %s\n", st->module_info.label);
@@ -134,12 +136,12 @@ void G__script(void)
 	}
     }
 
-    fprintf(fp, "\nimport sys\n");
-    fprintf(fp, "\nimport grass.script as gs\n");
+    fprintf(fp, "\nimport grass.script as gs\n\n");
     fprintf(fp, "\ndef main():");
-    fprintf(fp, "\n    # put code here\n");
-    fprintf(fp, "\n    return 0\n");
-    fprintf(fp, "\nif __name__ == \"__main__\":");
+    fprintf(fp, "\n    \"\"\"Process command line parameters and run analysis\"\"\"");
     fprintf(fp, "\n    options, flags = gs.parser()");
-    fprintf(fp, "\n    sys.exit(main())\n");
+    fprintf(fp, "\n    # Put your code here.");
+    fprintf(fp, "\n\n");
+    fprintf(fp, "\nif __name__ == \"__main__\":");
+    fprintf(fp, "\n    main()\n");
 }


### PR DESCRIPTION
The --script now generates code which complies with Black, Flake8 (except long lines), and Pylint (except line-too-long and unused-variable).

The practice of calling main in sys.exit() and return 0 was removed (usually not needed in this context). Parser call is now in main, so the variables are not global anymore (and thus also follow the right naming practice).
