### PR TITLE
CI: introduce setup-msys2@v2 setup action

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -27,6 +27,11 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
 
       - name: Install OSGeo4W
         run: |
@@ -34,9 +39,6 @@ jobs:
           $url = 'http://download.osgeo.org/osgeo4w/v2/' + $exe
           (New-Object System.Net.WebClient).DownloadFile($url, $exe)
           Start-Process ('.\'+$exe) -ArgumentList '-A -g -k -q -s http://download.osgeo.org/osgeo4w/v2/ -P proj-devel,gdal-devel,geos-devel,libtiff-devel,libpng-devel,pdal-devel,netcdf-devel,cairo-devel,fftw,freetype-devel,gdal-ecw,gdal-mrsid,liblas-devel,libxdr,libpq-devel,pdcurses,python3-matplotlib,python3-numpy,python3-ply,python3-pywin32,python3-six,python3-wxpython,regex-devel,wxwidgets-devel,zstd-devel' -Wait
-
-      - name: Install MSYS2 packages
-        run: C:\msys64\usr\bin\pacman.exe --noconfirm -S tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
 
       - name: Compile GRASS GIS
         run: C:\msys64\usr\bin\bash.exe -l (''+(Get-Location)+'\.github\workflows\build_osgeo4w.sh') (Get-Location)

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          path-type: inherit
+          location: D:\
           update: true
           install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
 
@@ -41,13 +42,13 @@ jobs:
           Start-Process ('.\'+$exe) -ArgumentList '-A -g -k -q -s http://download.osgeo.org/osgeo4w/v2/ -P proj-devel,gdal-devel,geos-devel,libtiff-devel,libpng-devel,pdal-devel,netcdf-devel,cairo-devel,fftw,freetype-devel,gdal-ecw,gdal-mrsid,liblas-devel,libxdr,libpq-devel,pdcurses,python3-matplotlib,python3-numpy,python3-ply,python3-pywin32,python3-six,python3-wxpython,regex-devel,wxwidgets-devel,zstd-devel' -Wait
 
       - name: Compile GRASS GIS
-        run: C:\msys64\usr\bin\bash.exe -l (''+(Get-Location)+'\.github\workflows\build_osgeo4w.sh') (Get-Location)
+        run: D:\msys64\usr\bin\bash.exe -l (''+(Get-Location)+'\.github\workflows\build_osgeo4w.sh') (Get-Location)
 
       - name: Test executing of the grass command
         run: .github/workflows/test_simple.bat 'C:\OSGeo4W\opt\grass\grass83.bat'
 
       - name: Test executing of the grass command in bash
-        run: C:\msys64\usr\bin\bash.exe .github/workflows/test_simple.sh
+        run: D:\msys64\usr\bin\bash.exe .github/workflows/test_simple.sh
 
       - name: Run tests
         run: .github/workflows/test_thorough.bat 'C:\OSGeo4W\opt\grass\grass83.bat' 'C:\OSGeo4W\bin\python3'

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -32,7 +32,7 @@ jobs:
           path-type: inherit
           location: D:\
           update: true
-          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
+          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
 
       - name: Install OSGeo4W
         run: |

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -66,7 +66,7 @@ export ARCH=x86_64-w64-mingw32
     --with-zstd \
     --with-odbc \
     --with-cairo \
-    --with-cairo-includes=${SRC}/include \
+    --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
     --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
     --with-opengl=windows \
     --with-bzlib \

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -67,6 +67,7 @@ export ARCH=x86_64-w64-mingw32
     --with-odbc \
     --with-cairo \
     --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
+    --with-cairo-libs=$OSGEO4W_ROOT_MSYS/lib \
     --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
     --with-opengl=windows \
     --with-bzlib \

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -68,7 +68,7 @@ export ARCH=x86_64-w64-mingw32
     --with-cairo \
     --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
     --with-cairo-libs=$OSGEO4W_ROOT_MSYS/lib \
-    --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
+    --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo" \
     --with-opengl=windows \
     --with-bzlib \
     --with-liblas=${SRC}/mswindows/osgeo4w/liblas-config \

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -49,7 +49,7 @@ export ARCH=x86_64-w64-mingw32
     --with-blas \
     --with-lapack-includes=/mingw64/include/lapack \
     --with-freetype \
-    --with-freetype-includes=/mingw64/include/freetype2 \
+    --with-freetype-includes=${OSGEO4W_ROOT_MSYS}/include/freetype2 \
     --with-proj-share=${OSGEO4W_ROOT_MSYS}/share/proj \
     --with-proj-includes=${OSGEO4W_ROOT_MSYS}/include \
     --with-proj-libs=${OSGEO4W_ROOT_MSYS}/lib \
@@ -67,7 +67,7 @@ export ARCH=x86_64-w64-mingw32
     --with-odbc \
     --with-cairo \
     --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
-    --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo" # -lfontconfig" \ # temporary dectivate fontconfig on osgeo4w
+    --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
     --with-opengl=windows \
     --with-bzlib \
     --with-liblas=${SRC}/mswindows/osgeo4w/liblas-config \

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -67,7 +67,7 @@ export ARCH=x86_64-w64-mingw32
     --with-odbc \
     --with-cairo \
     --with-cairo-includes=${OSGEO4W_ROOT_MSYS}/include \
-    --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
+    --with-cairo-ldflags="-L${SRC}/mswindows/osgeo4w/lib -lcairo" # -lfontconfig" \ # temporary dectivate fontconfig on osgeo4w
     --with-opengl=windows \
     --with-bzlib \
     --with-liblas=${SRC}/mswindows/osgeo4w/liblas-config \


### PR DESCRIPTION
For using MSYS in CI (esp. github) it is recommended to use [msys2/setup-msys2@v2](https://github.com/msys2/setup-msys2) action. See also: https://www.msys2.org/docs/ci/

This PR introduces that action and should make the build pass again without errors.

Replaces #2468 

Should also speedup the test a few minutes and maybe simplifies to explore other possibilities (e.g. using UCRT)