### PR TITLE
GUI: wx.ListBox is dynamic – looping over GetSelections() results in removal of all list items

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1112,7 +1112,7 @@ class GroupDialog(wx.Dialog):
         # and thus adds a new item to GetSelections
         # Items are removed in reverse order to maintain positional number
         # of other selected items (ListBox is dynamic!)
-        selections = reversed(sorted(self.gLayerBox.GetSelections()))
+        selections = sorted(self.gLayerBox.GetSelections(), reverse=True)
         for sel in selections:
             m = self.gLayerBox.GetString(sel)
             self.gLayerBox.Delete(sel)

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1107,8 +1107,13 @@ class GroupDialog(wx.Dialog):
 
     def OnRemoveLayer(self, event):
         """Remove layer from listbox"""
-        while self.gLayerBox.GetSelections():
-            sel = self.gLayerBox.GetSelections()[0]
+        # After removal of last selected item by .Delete,
+        # ListBox selects the last of remaining items in the list
+        # and thus adds a new item to GetSelections
+        # Items are removed in reverse order to maintain positional number
+        # of other selected items (ListBox is dynamic!)
+        selections = reversed(sorted(self.gLayerBox.GetSelections()))
+        for sel in selections:
             m = self.gLayerBox.GetString(sel)
             self.gLayerBox.Delete(sel)
             self.gmaps.remove(m)


### PR DESCRIPTION
When the last item returned by GetSelections() has been .Delete()'d a new item is selected. The newly selected item is added to GetSelections(). If user selects the last item from a list, looping over GetSelections() output eventually will remove all list items not only ones selected by the user.
This is a workaround by freezing user selection in a list and iterating it in a reverse order as each .Delete() call updates the ListBox and thus changes positions of selected items. Reverse traversal ensures that no selected item gets a new position in the list.