### PR TITLE
wxGUI/gui_core: fix Create or edit image group dialog Select all CheckBox widget for selecting all items

### DIFF
--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -986,8 +986,7 @@ class GroupDialog(wx.Dialog):
         if not check:
             self.gLayerBox.DeselectAll()
         else:
-            for item in range(self.subgListBox.GetCount()):
-                self.gLayerBox.Select(item)
+            self.gLayerBox.SelectAll()
 
         event.Skip()
 

--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -913,6 +913,10 @@ class ListBox(wx.ListBox):
         for i in range(self.GetCount()):
             self.Deselect(i)
 
+    def SelectAll(self):
+        for i in range(self.GetCount()):
+            self.Select(i)
+
 
 class HyperlinkCtrl(HyperlinkCtrl_):
     """Wrapper around HyperlinkCtrl to have more control


### PR DESCRIPTION
**Describe the bug**
When you check Select all CheckBox widget from Create or edit image group dialog all added raster maps aren't selected.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
3. From the menu choose Imagery -> Develop images and groups -> Create/edit group
4. From the Create or edit image group dialog hit Add button widget and add some raster maps
5. From Create or edit image group dialog check Select all CheckBox widget
6. Added raster maps are not selected

or

3. From the Create or edit image group dialog Select existing group or enter name of new group ComboBox widget choose existed image group e.g. nitrogen.
4. From the Create or edit image group dialog hit Add button widget and add some raster maps
5. From Create or edit image group dialog check Select all CheckBox widget
6. Only raster maps which is currently in nitrogen group are selected

**Expected behavior**
When you check Select all CheckBox widget from Create or edit image group dialog all added raster maps should be selected.

**System description:**

- Operating System: all
- GRASS GIS version: all