### PR TITLE
wxGUI/gui_core: fix import PostGIS DB raster

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2264,7 +2264,7 @@ class GdalSelect(wx.Panel):
                                     dsn,
                                     conn_param="host",
                                 ),
-                                error=error,
+                                error=grass.utils.decode(error),
                             ),
                         ),
                     )
@@ -2527,7 +2527,7 @@ class GdalSelect(wx.Panel):
                             dsn,
                             conn_param="host",
                         ),
-                        error=error,
+                        error=grass.utils.decode(error),
                     ),
                 ),
             )
@@ -2619,7 +2619,7 @@ class GdalSelect(wx.Panel):
                                     dsn,
                                     conn_param="host",
                                 ),
-                                error=error,
+                                error=grass.utils.decode(error),
                             ),
                         ),
                     )

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2106,7 +2106,7 @@ class GdalSelect(wx.Panel):
             ):
                 ret = RunCommand("db.login", read=True, quiet=True, flags="p")
                 message = _(
-                    "PostgreSQL/PostGIS login was not setted."
+                    "PostgreSQL/PostGIS login was not set."
                     " Set it via <db.login> module, please."
                 )
                 if not ret:
@@ -2114,7 +2114,7 @@ class GdalSelect(wx.Panel):
                     return
 
                 connection_string = None
-                for conn in ret.split(os.linesep):
+                for conn in ret.splitlines():
                     db_login = conn.split("|")
                     if db_login[0] == "pg":
                         user, password, host, port = db_login[2:]

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -466,6 +466,8 @@ class GdalImportDialog(ImportDialog):
             return
 
         dsn = self.dsnInput.GetDsn()
+        if not dsn:
+            return
         ext = self.dsnInput.GetFormatExt()
 
         for layer, output, listId in data:
@@ -473,6 +475,9 @@ class GdalImportDialog(ImportDialog):
 
             if self.dsnInput.GetType() == "dir":
                 idsn = os.path.join(dsn, layer)
+            elif self.dsnInput.GetType() == "db":
+                if "PG:" in dsn:
+                    idsn = f"{dsn} table={layer}"
             else:
                 idsn = dsn
 


### PR DESCRIPTION
**Describe the bug**
Import PostGIS DB raster via wxGUI Import raster data dialog doesn't work.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Export some raster map into GTiff format e.g. `r.out.gdal input=elevation output=/tmp/elevation.tif` and import with `raster2pgsql -I -C -s 3358 /tmp/elevation.tif public.elevation | psql -d <YOUR_DATABASE> -U <YOUR_DATABASE_USER> -h <YOUR_DATABASE_HOST> -p <YOUR_DATABASE_PORT>` to PostGIS DB
3. Set PostGIS DB connection via `db.login` module
4. From the Data catalog toolbar activate Import raster data tool
5. From the Import raster data dialog Source type choose Database RadioButton widget
6. From the Source input Format ComboBox widget choose PostGIS Raster driver
7.  From the Name ComboBox widget choose your database name
8. List of raster layers ListCtrl widget is empty, no raster layers are loaded.

**Expected behavior**
Loading PostGIS DB raster layer and importing via wxGUI Import raster data dialog  should be work.

**Screenshots**

Current behavior:

![wxgui_import_raster_data_postgisdb_db_raster_current](https://user-images.githubusercontent.com/50632337/183481656-bb70de29-67c5-470c-9d3b-3569332d51b7.png)

Expected behavior:

![wxgui_import_raster_data_postgisdb_db_raster_exp](https://user-images.githubusercontent.com/50632337/183481625-425cf881-ada9-4947-bcd7-c1ba9795f091.png)


**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all