### PR TITLE
wxGUI: fix setting display size from workspace in multi-window mode

### DIFF
--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -863,3 +863,9 @@ class FrameMixin:
 
     def SetPosition(self, pt):
         self.GetParent().SetPosition(pt)
+
+    def GetSize(self):
+        return self.GetParent().GetSize()
+
+    def SetSize(self, *args):
+        self.GetParent().SetSize(*args)


### PR DESCRIPTION
Fixes setting display size when loading workspace in multi-window mode.