### PR TITLE
libproj: simple check for area of use

### DIFF
--- a/lib/proj/do_proj.c
+++ b/lib/proj/do_proj.c
@@ -167,6 +167,20 @@ int get_pj_area(const struct pj_info *iproj, double *xmin, double *xmax,
                 *ymax = y[i];
         }
 
+        /* detect an attempt to reproject outside the intended area of use */
+        if (*xmin < -180 && *xmax < -180) {
+            G_warning(_("The requested region seems to be outside the area of "
+                        "use of the target CRS"));
+            *xmin += 360;
+            *xmax += 360;
+        }
+        if (*xmin > 180 && *xmax > 180) {
+            G_warning(_("The requested region seems to be outside the area of "
+                        "use of the target CRS"));
+            *xmin -= 360;
+            *xmax -= 360;
+        }
+
         /* The west longitude is generally lower than the east longitude,
          * except for areas of interest that go across the anti-meridian.
          * do not reduce global coverage to a small north-south strip


### PR DESCRIPTION
This PR adds a simple check if reprojection would fall outside the intended area of use of the target CRS.

I would prefer to refuse reprojection in these extreme cases, but this might be too restrictive. If subsequent errors occur because reprojected coordinates are invalid, this can be changed accordingly to actually refuse reprojection which is the current behaviour, but without explanation why.