### PR TITLE
wxGUI/vdigit: fix keyboard shortcut for activating point/line tool

### DIFF
--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -84,12 +84,12 @@ from the background map.
   <dt><img src="icons/point-create.png" alt="icon">&nbsp;
     <em>Digitize new point</em></dt>
   <dd>Add new point to vector map and optionally define its
-    attributes.</dd>
+    attributes, Ctrl+P.</dd>
   
   <dt><img src="icons/line-create.png" alt="icon">&nbsp;
     <em>Digitize new line</em></dt>
   <dd>Add new line to vector map and optionally define its
-    attributes.</dd>
+    attributes, Ctrl+L.</dd>
 
   <dt><img src="icons/boundary-create.png" alt="icon">&nbsp;
     <em>Digitize new boundary</em></dt>

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -139,10 +139,10 @@ class VDigitWindow(BufferedMapWindow):
         event = None
         if not shift:
             if kc == ord("P"):
-                event = wx.CommandEvent(winid=self.toolbar.addPoint)
+                event = wx.CommandEvent(id=self.toolbar.addPoint)
                 tool = self.toolbar.OnAddPoint
             elif kc == ord("L"):
-                event = wx.CommandEvent(winid=self.toolbar.addLine)
+                event = wx.CommandEvent(id=self.toolbar.addLine)
                 tool = self.toolbar.OnAddLine
         if event:
             self.toolbar.OnTool(event)


### PR DESCRIPTION
**Describe the bug**
Vector Digitizer keyboard shortcut for activating point/line tool doesn't work.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Vector Digitizer `g.gui.vdigit -c map=vdigit`
2. Press keyboard shortcut Ctrl + P or Ctrl + L
3. See error

```
Traceback (most recent call last):
  File
"/usr/lib64/grass83/gui/wxpython/vdigit/mapwindow.py", line
142, in OnKeyDown

event = wx.CommandEvent(winid=self.toolbar.addPoint)
TypeError
:
CommandEvent(): arguments did not match any overloaded call:
  overload 1: 'winid' is not a valid keyword argument
  overload 2: 'winid' is not a valid keyword argument
```

**Expected behavior**
Vector Digitizer keyboard shortcut for activating point/line tool should be work without error message.

**System description:**

- Operating System: all
- GRASS GIS version: all