### PR TITLE
lib/parser: Add missing closing div tag

### DIFF
--- a/include/Make/HtmlRules.make
+++ b/include/Make/HtmlRules.make
@@ -1,7 +1,7 @@
 
 # common html rules (included by Html.make and GuiScript.make)
 
-htmldesc = $(call run_grass,$(1) --html-description < /dev/null | grep -v '</body>\|</html>' > $(2))
+htmldesc = $(call run_grass,$(1) --html-description < /dev/null | grep -v '</body>\|</html>\|</div> <!-- end container -->' > $(2))
 
 IMGSRC := $(wildcard *.png) $(wildcard *.jpg) $(wildcard *.gif)
 IMGDST := $(patsubst %,$(HTMLDIR)/%,$(IMGSRC))

--- a/lib/gis/parser_html.c
+++ b/lib/gis/parser_html.c
@@ -293,8 +293,8 @@ void G__usage_html(void)
 	fprintf(stdout, "</dl>\n");
     }
     fprintf(stdout, "</div>\n");
-    fprintf(stdout, "</div>\n");
 
+    fprintf(stdout, "</div> <!-- end container -->\n");
     fprintf(stdout, "</body>\n</html>\n");
 }
 

--- a/lib/gis/parser_html.c
+++ b/lib/gis/parser_html.c
@@ -293,6 +293,7 @@ void G__usage_html(void)
 	fprintf(stdout, "</dl>\n");
     }
     fprintf(stdout, "</div>\n");
+    fprintf(stdout, "</div>\n");
 
     fprintf(stdout, "</body>\n</html>\n");
 }

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -687,7 +687,10 @@ if not re.search("<html>", src_data, re.IGNORECASE):
         sys.stdout.write(header_tmpl.substitute(PGM=pgm, PGM_DESC=pgm_desc))
     if tmp_data:
         for line in tmp_data.splitlines(True):
-            if not re.search("</body>|</html>", line, re.IGNORECASE):
+            # The cleanup happens on Makefile level too.
+            if not re.search(
+                "</body>|</html>|</div> <!-- end container -->", line, re.IGNORECASE
+            ):
                 sys.stdout.write(line)
 
 # create TOC


### PR DESCRIPTION
End of file is being added both in parser and also in mkhtml because it is removed so that documentation can be just appended. This marks the closing tag with a comment so that the right line is removed.

(An ultimate solution is moving to more template-like replacement instead of the current file append.)