### PR TITLE
wxGUI/vdigit: extend tools keyboard shortcuts

### DIFF
--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -94,63 +94,63 @@ from the background map.
   <dt><img src="icons/boundary-create.png" alt="icon">&nbsp;
     <em>Digitize new boundary</em></dt>
   <dd>Add new boundary to vector map and optionally define its
-    attributes.</dd>
+    attributes, Ctrl+B.</dd>
   
   <dt><img src="icons/centroid-create.png" alt="icon">&nbsp;
     <em>Digitize new centroid</em></dt>
   <dd>Add new centroid to vector map and optionally define its
-    attributes.</dd>
+    attributes, Ctrl+C.</dd>
 
   <dt><img src="icons/polygon-create.png" alt="icon">&nbsp;
     <em>Digitize new area</em></dt>
   <dd>Add new area (closed boundary and one centroid inside) to vector
-    map and optionally define its attributes.</dd>
+    map and optionally define its attributes, Ctrl+A.</dd>
   
   <dt><img src="icons/vertex-move.png" alt="icon">&nbsp;
     <em>Move vertex</em></dt>
   <dd>Move selected vertex of linear feature. Thus shape of linear
-    feature is changed.</dd>
+    feature is changed, Ctrl+G.</dd>
 
   <dt><img src="icons/vertex-create.png" alt="icon">&nbsp;
     <em>Add vertex</em></dt>
   <dd>Add new vertex to selected linear feature (shape not
-    changed).</dd>
+    changed), Ctrl+V.</dd>
 
   <dt><img src="icons/vertex-delete.png" alt="icon">&nbsp;
     <em>Remove vertex</em></dt>
-  <dd>Remove selected vertex from linear feature. Thus shape of selected
+  <dd>Remove selected vertex from linear feature, Ctrl+X. Thus shape of selected
   feature can be changed.</dd>
   
   <dt><img src="icons/line-edit.png" alt="icon">&nbsp;
     <em>Edit line/boundary</em></dt>
   <dd>Edit selected linear feature, add new segments or remove
-  existing segments of linear feature.</dd>
+  existing segments of linear feature, Ctrl+E.</dd>
 
   <dt><img src="icons/line-move.png" alt="icon">&nbsp;
     <em>Move feature(s)</em></dt>
-  <dd>Move selected vector features. Selection can be done by mouse or
+  <dd>Move selected vector features, Ctrl+M. Selection can be done by mouse or
     by query.</dd>
 
   <dt><img src="icons/line-delete.png" alt="icon">&nbsp;
     <em>Delete feature(s)</em></dt>
   <dd>Delete selected vector features (point, line, centroid, or
-  boundary). Selection can be done by mouse or by query.</dd>
+  boundary), Ctrl+D. Selection can be done by mouse or by query.</dd>
 
   <dt><img src="icons/polygon-delete.png" alt="icon">&nbsp;
     <em>Delete areas(s)</em></dt>
-  <dd>Delete selected vector areas. Selection can be done by mouse
+  <dd>Delete selected vector areas, Ctrl+F. Selection can be done by mouse
   or by query.</dd>
 
   <dt><img src="icons/cats-display.png" alt="icon">&nbsp;
     <em>Display/update categories</em></dt>
-  <dd>Display categories of selected vector feature. Category settings
+  <dd>Display categories of selected vector feature, Ctrl+J. Category settings
   can be modified, new layer/category pairs added or already defined pairs
   removed.</dd>
 
   <dt><img src="icons/attributes-display.png" alt="icon">&nbsp;
     <em>Display/update attributes</em></dt>
   <dd>Display attributes of selected vector feature (based on its
-    category settings).  Attributes can be also modified. Same
+    category settings), Ctrl+K. Attributes can be also modified. Same
     functionality is accessible from Main toolbar "Query vector map
     (editable mode)".</dd>
 
@@ -224,11 +224,11 @@ from the background map.
 
   <dt><img src="icons/undo.png" alt="icon">&nbsp;
     <em>Undo</em></dt>
-  <dd>Undo previous operations.</dd>
+  <dd>Undo previous operations, Ctrl+Z.</dd>
 
   <dt><img src="icons/redo.png" alt="icon">&nbsp;
     <em>Redo</em></dt>
-  <dd>Redo previous operations.</dd>
+  <dd>Redo previous operations, Ctrl+Y.</dd>
 
   <dt><img src="icons/settings.png" alt="icon">&nbsp;
     <em>Settings</em></dt>

--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -84,73 +84,73 @@ from the background map.
   <dt><img src="icons/point-create.png" alt="icon">&nbsp;
     <em>Digitize new point</em></dt>
   <dd>Add new point to vector map and optionally define its
-    attributes, Ctrl+P.</dd>
+    attributes (Ctrl+P).</dd>
   
   <dt><img src="icons/line-create.png" alt="icon">&nbsp;
     <em>Digitize new line</em></dt>
   <dd>Add new line to vector map and optionally define its
-    attributes, Ctrl+L.</dd>
+    attributes (Ctrl+L).</dd>
 
   <dt><img src="icons/boundary-create.png" alt="icon">&nbsp;
     <em>Digitize new boundary</em></dt>
   <dd>Add new boundary to vector map and optionally define its
-    attributes, Ctrl+B.</dd>
+    attributes (Ctrl+B).</dd>
   
   <dt><img src="icons/centroid-create.png" alt="icon">&nbsp;
     <em>Digitize new centroid</em></dt>
   <dd>Add new centroid to vector map and optionally define its
-    attributes, Ctrl+C.</dd>
+    attributes (Ctrl+C).</dd>
 
   <dt><img src="icons/polygon-create.png" alt="icon">&nbsp;
     <em>Digitize new area</em></dt>
   <dd>Add new area (closed boundary and one centroid inside) to vector
-    map and optionally define its attributes, Ctrl+A.</dd>
+    map and optionally define its attributes (Ctrl+A).</dd>
   
   <dt><img src="icons/vertex-move.png" alt="icon">&nbsp;
     <em>Move vertex</em></dt>
   <dd>Move selected vertex of linear feature. Thus shape of linear
-    feature is changed, Ctrl+G.</dd>
+    feature is changed (Ctrl+G).</dd>
 
   <dt><img src="icons/vertex-create.png" alt="icon">&nbsp;
     <em>Add vertex</em></dt>
   <dd>Add new vertex to selected linear feature (shape not
-    changed), Ctrl+V.</dd>
+    changed) (Ctrl+V).</dd>
 
   <dt><img src="icons/vertex-delete.png" alt="icon">&nbsp;
     <em>Remove vertex</em></dt>
-  <dd>Remove selected vertex from linear feature, Ctrl+X. Thus shape of selected
+  <dd>Remove selected vertex from linear feature (Ctrl+X). Thus shape of selected
   feature can be changed.</dd>
   
   <dt><img src="icons/line-edit.png" alt="icon">&nbsp;
     <em>Edit line/boundary</em></dt>
   <dd>Edit selected linear feature, add new segments or remove
-  existing segments of linear feature, Ctrl+E.</dd>
+  existing segments of linear feature (Ctrl+E).</dd>
 
   <dt><img src="icons/line-move.png" alt="icon">&nbsp;
     <em>Move feature(s)</em></dt>
-  <dd>Move selected vector features, Ctrl+M. Selection can be done by mouse or
+  <dd>Move selected vector features (Ctrl+M.) Selection can be done by mouse or
     by query.</dd>
 
   <dt><img src="icons/line-delete.png" alt="icon">&nbsp;
     <em>Delete feature(s)</em></dt>
   <dd>Delete selected vector features (point, line, centroid, or
-  boundary), Ctrl+D. Selection can be done by mouse or by query.</dd>
+  boundary) (Ctrl+D). Selection can be done by mouse or by query.</dd>
 
   <dt><img src="icons/polygon-delete.png" alt="icon">&nbsp;
     <em>Delete areas(s)</em></dt>
-  <dd>Delete selected vector areas, Ctrl+F. Selection can be done by mouse
+  <dd>Delete selected vector areas (Ctrl+F). Selection can be done by mouse
   or by query.</dd>
 
   <dt><img src="icons/cats-display.png" alt="icon">&nbsp;
     <em>Display/update categories</em></dt>
-  <dd>Display categories of selected vector feature, Ctrl+J. Category settings
+  <dd>Display categories of selected vector feature (Ctrl+J). Category settings
   can be modified, new layer/category pairs added or already defined pairs
   removed.</dd>
 
   <dt><img src="icons/attributes-display.png" alt="icon">&nbsp;
     <em>Display/update attributes</em></dt>
   <dd>Display attributes of selected vector feature (based on its
-    category settings), Ctrl+K. Attributes can be also modified. Same
+    category settings) (Ctrl+K). Attributes can be also modified. Same
     functionality is accessible from Main toolbar "Query vector map
     (editable mode)".</dd>
 
@@ -224,24 +224,24 @@ from the background map.
 
   <dt><img src="icons/undo.png" alt="icon">&nbsp;
     <em>Undo</em></dt>
-  <dd>Undo previous operations, Ctrl+Z.</dd>
+  <dd>Undo previous operations (Ctrl+Z).</dd>
 
   <dt><img src="icons/redo.png" alt="icon">&nbsp;
     <em>Redo</em></dt>
-  <dd>Redo previous operations, Ctrl+Y.</dd>
+  <dd>Redo previous operations (Ctrl+Y).</dd>
 
   <dt><img src="icons/settings.png" alt="icon">&nbsp;
     <em>Settings</em></dt>
-  <dd>Digitizer settings, Ctrl+T.</dd>
+  <dd>Digitizer settings (Ctrl+T).</dd>
 
   <dt><img src="icons/help.png" alt="icon">&nbsp;
     <em>Show help</em></dt>
-  <dd>Show help page for the Digitizer, Ctrl+H.</dd>
+  <dd>Show help page for the Digitizer (Ctrl+H).</dd>
 
   <dt><img src="icons/quit.png" alt="icon">&nbsp;
     <em>Quit digitizing tool</em></dt>
   <dd>Changes in vector map can be optionally discarded when
-  digitizing session is quited, Ctrl+Q.</dd>
+  digitizing session is quited (Ctrl+Q).</dd>
 
 </dl>
 

--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -232,7 +232,7 @@ from the background map.
 
   <dt><img src="icons/settings.png" alt="icon">&nbsp;
     <em>Settings</em></dt>
-  <dd>Digitizer settings, Ctrl+S.</dd>
+  <dd>Digitizer settings, Ctrl+T.</dd>
 
   <dt><img src="icons/help.png" alt="icon">&nbsp;
     <em>Show help</em></dt>

--- a/gui/wxpython/vdigit/g.gui.vdigit.html
+++ b/gui/wxpython/vdigit/g.gui.vdigit.html
@@ -232,12 +232,16 @@ from the background map.
 
   <dt><img src="icons/settings.png" alt="icon">&nbsp;
     <em>Settings</em></dt>
-  <dd>Digitizer settings.</dd>
+  <dd>Digitizer settings, Ctrl+S.</dd>
+
+  <dt><img src="icons/help.png" alt="icon">&nbsp;
+    <em>Show help</em></dt>
+  <dd>Show help page for the Digitizer, Ctrl+H.</dd>
 
   <dt><img src="icons/quit.png" alt="icon">&nbsp;
     <em>Quit digitizing tool</em></dt>
   <dd>Changes in vector map can be optionally discarded when
-  digitizing session is quited.</dd>
+  digitizing session is quited, Ctrl+Q.</dd>
 
 </dl>
 

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -136,17 +136,78 @@ class VDigitWindow(BufferedMapWindow):
         shift = event.ShiftDown()
         kc = event.GetKeyCode()
 
-        event = None
+        tools = {
+            ord("P"): {
+                "event": wx.CommandEvent(id=self.toolbar.addPoint),
+                "tool": self.toolbar.OnAddPoint,
+            },
+            ord("L"): {
+                "event": wx.CommandEvent(id=self.toolbar.addLine),
+                "tool": self.toolbar.OnAddLine,
+            },
+            ord("A"): {
+                "event": wx.CommandEvent(id=self.toolbar.addArea),
+                "tool": self.toolbar.OnAddArea,
+            },
+            ord("B"): {
+                "event": None,
+                "tool": self.toolbar.OnAddBoundary,
+            },
+            ord("C"): {
+                "event": None,
+                "tool": self.toolbar.OnAddCentroid,
+            },
+            ord("V"): {
+                "event": wx.CommandEvent(id=self.toolbar.addVertex),
+                "tool": self.toolbar.OnAddVertex,
+            },
+            ord("X"): {
+                "event": wx.CommandEvent(id=self.toolbar.removeVertex),
+                "tool": self.toolbar.OnRemoveVertex,
+            },
+            ord("G"): {
+                "event": wx.CommandEvent(id=self.toolbar.moveVertex),
+                "tool": self.toolbar.OnMoveVertex,
+            },
+            ord("D"): {
+                "event": wx.CommandEvent(id=self.toolbar.deleteLine),
+                "tool": self.toolbar.OnDeleteLine,
+            },
+            ord("F"): {
+                "event": wx.CommandEvent(id=self.toolbar.deleteArea),
+                "tool": self.toolbar.OnDeleteArea,
+            },
+            ord("E"): {
+                "event": wx.CommandEvent(id=self.toolbar.editLine),
+                "tool": self.toolbar.OnEditLine,
+            },
+            ord("M"): {
+                "event": wx.CommandEvent(id=self.toolbar.moveLine),
+                "tool": self.toolbar.OnMoveLine,
+            },
+            ord("J"): {
+                "event": wx.CommandEvent(id=self.toolbar.displayCats),
+                "tool": self.toolbar.OnDisplayCats,
+            },
+            ord("K"): {
+                "event": wx.CommandEvent(id=self.toolbar.displayAttr),
+                "tool": self.toolbar.OnDisplayAttr,
+            },
+            ord("Z"): {
+                "event": wx.CommandEvent(id=self.toolbar.undo),
+                "tool": self.toolbar.OnUndo,
+            },
+            ord("Y"): {
+                "event": wx.CommandEvent(id=self.toolbar.redo),
+                "tool": self.toolbar.OnRedo,
+            },
+
+        }
         if not shift:
-            if kc == ord("P"):
-                event = wx.CommandEvent(id=self.toolbar.addPoint)
-                tool = self.toolbar.OnAddPoint
-            elif kc == ord("L"):
-                event = wx.CommandEvent(id=self.toolbar.addLine)
-                tool = self.toolbar.OnAddLine
-        if event:
-            self.toolbar.OnTool(event)
-            tool(event)
+            tool = tools.get(kc)
+            if tool:
+                event = self.toolbar.OnTool(tool["event"])
+                tool["tool"](event)
 
     def _updateMap(self):
         if not self.toolbar or not self.toolbar.GetLayer():

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -201,7 +201,7 @@ class VDigitWindow(BufferedMapWindow):
                 "event": wx.CommandEvent(id=self.toolbar.redo),
                 "tool": self.toolbar.OnRedo,
             },
-            ord("S"): {
+            ord("T"): {
                 "event": wx.CommandEvent(id=self.toolbar.settings),
                 "tool": self.toolbar.OnSettings,
             },

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -201,7 +201,6 @@ class VDigitWindow(BufferedMapWindow):
                 "event": wx.CommandEvent(id=self.toolbar.redo),
                 "tool": self.toolbar.OnRedo,
             },
-
         }
         if not shift:
             tool = tools.get(kc)

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -201,6 +201,18 @@ class VDigitWindow(BufferedMapWindow):
                 "event": wx.CommandEvent(id=self.toolbar.redo),
                 "tool": self.toolbar.OnRedo,
             },
+            ord("S"): {
+                "event": wx.CommandEvent(id=self.toolbar.settings),
+                "tool": self.toolbar.OnSettings,
+            },
+            ord("H"): {
+                "event": wx.CommandEvent(id=self.toolbar.help),
+                "tool": self.toolbar.OnHelp,
+            },
+            ord("Q"): {
+                "event": wx.CommandEvent(id=self.toolbar.quit),
+                "tool": self.toolbar.OnExit,
+            },
         }
         if not shift:
             tool = tools.get(kc)

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -436,7 +436,7 @@ class VDigitToolbar(BaseToolbar):
         toolbar"""
         Debug.msg(
             3,
-            f"VDigitToolbar.OnTool(): id = {event.GetId() if event else event}"
+            f"VDigitToolbar.OnTool(): id = {event.GetId() if event else event}",
         )
         # set cursor
         self.MapWindow.SetNamedCursor("cross")

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -144,63 +144,63 @@ class VDigitToolbar(BaseToolbar):
         self.icons = {
             "addPoint": MetaIcon(
                 img="point-create",
-                label=_("Digitize new point"),
+                label=_("Digitize new point, Ctrl+P"),
                 desc=_("Left: new point"),
             ),
             "addLine": MetaIcon(
                 img="line-create",
-                label=_("Digitize new line"),
+                label=_("Digitize new line, Ctrl+L"),
                 desc=_(
                     "Left: new point; Ctrl+Left: undo last point; Right: close line"
                 ),
             ),
             "addBoundary": MetaIcon(
                 img="boundary-create",
-                label=_("Digitize new boundary"),
+                label=_("Digitize new boundary, Ctrl+B"),
                 desc=_(
                     "Left: new point; Ctrl+Left: undo last point; Right: close line"
                 ),
             ),
             "addCentroid": MetaIcon(
                 img="centroid-create",
-                label=_("Digitize new centroid"),
+                label=_("Digitize new centroid, Ctrl+C"),
                 desc=_("Left: new point"),
             ),
             "addArea": MetaIcon(
                 img="polygon-create",
-                label=_("Digitize new area (boundary without category)"),
+                label=_("Digitize new area (boundary without category), Ctrl+A"),
                 desc=_("Left: new point"),
             ),
             "addVertex": MetaIcon(
                 img="vertex-create",
-                label=_("Add new vertex to line or boundary"),
+                label=_("Add new vertex to line or boundary, Ctrl+V"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "deleteLine": MetaIcon(
                 img="line-delete",
                 label=_(
-                    "Delete selected point(s), line(s), boundary(ies) or centroid(s)"
+                    "Delete selected point(s), line(s), boundary(ies) or centroid(s), Ctrl+D"
                 ),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "deleteArea": MetaIcon(
                 img="polygon-delete",
-                label=_("Delete selected area(s)"),
+                label=_("Delete selected area(s), Ctrl+F"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "displayAttr": MetaIcon(
                 img="attributes-display",
-                label=_("Display/update attributes"),
+                label=_("Display/update attributes, Ctrl+K"),
                 desc=_("Left: Select"),
             ),
             "displayCats": MetaIcon(
                 img="cats-display",
-                label=_("Display/update categories"),
+                label=_("Display/update categories, Ctrl+J"),
                 desc=_("Left: Select"),
             ),
             "editLine": MetaIcon(
                 img="line-edit",
-                label=_("Edit selected line/boundary"),
+                label=_("Edit selected line/boundary, Ctrl+E"),
                 desc=_(
                     "Left: new point; Ctrl+Left: undo last point; Right: close line"
                 ),
@@ -208,25 +208,29 @@ class VDigitToolbar(BaseToolbar):
             "moveLine": MetaIcon(
                 img="line-move",
                 label=_(
-                    "Move selected point(s), line(s), boundary(ies) or centroid(s)"
+                    "Move selected point(s), line(s), boundary(ies) or centroid(s), Ctrl+M"
                 ),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "moveVertex": MetaIcon(
                 img="vertex-move",
-                label=_("Move selected vertex"),
+                label=_("Move selected vertex, Ctrl+G"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "removeVertex": MetaIcon(
                 img="vertex-delete",
-                label=_("Remove selected vertex"),
+                label=_("Remove selected vertex, Ctrl+X"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
-            "settings": BaseIcons["settings"],
+            "settings": BaseIcons["settings"].SetLabel(
+                label=_("Settings, Ctrl+T"),
+            ),
             "quit": BaseIcons["quit"].SetLabel(
-                label=_("Quit"), desc=_("Quit digitizer and save changes")
+                label=_("Quit, Ctrl+Q"),
+                desc=_("Quit digitizer and save changes"),
             ),
             "help": BaseIcons["help"].SetLabel(
+                label=_("Show manual, Ctrl+H"),
                 desc=_("Show Vector Digitizer manual"),
             ),
             "additionalTools": MetaIcon(
@@ -235,10 +239,14 @@ class VDigitToolbar(BaseToolbar):
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "undo": MetaIcon(
-                img="undo", label=_("Undo"), desc=_("Undo previous change")
+                img="undo",
+                label=_("Undo, Ctrl+Z"),
+                desc=_("Undo previous change"),
             ),
             "redo": MetaIcon(
-                img="redo", label=_("Redo"), desc=_("Redo previous change")
+                img="redo",
+                label=_("Redo, Ctrl+Y"),
+                desc=_("Redo previous change"),
             ),
         }
 

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -434,14 +434,18 @@ class VDigitToolbar(BaseToolbar):
     def OnTool(self, event):
         """Tool selected -> untoggles previusly selected tool in
         toolbar"""
-        Debug.msg(3, "VDigitToolbar.OnTool(): id = %s" % event.GetId())
+        Debug.msg(
+            3,
+            f"VDigitToolbar.OnTool(): id = {event.GetId() if event else event}"
+        )
         # set cursor
         self.MapWindow.SetNamedCursor("cross")
         self.MapWindow.mouse["box"] = "point"
         self.MapWindow.mouse["use"] = "pointer"
 
         aId = self.action.get("id", -1)
-        BaseToolbar.OnTool(self, event)
+        if event:
+            BaseToolbar.OnTool(self, event)
 
         # clear tmp canvas
         if self.action["id"] != aId or aId == -1:
@@ -628,14 +632,16 @@ class VDigitToolbar(BaseToolbar):
         if self.digit:
             self.digit.Undo()
 
-        event.Skip()
+        if event:
+            event.Skip()
 
     def OnRedo(self, event):
         """Undo previous changes"""
         if self.digit:
             self.digit.Undo(level=1)
 
-        event.Skip()
+        if event:
+            event.Skip()
 
     def EnableUndo(self, enable=True):
         """Enable 'Undo' in toolbar

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -144,63 +144,63 @@ class VDigitToolbar(BaseToolbar):
         self.icons = {
             "addPoint": MetaIcon(
                 img="point-create",
-                label=_("Digitize new point, Ctrl+P"),
+                label=_("Digitize new point (Ctrl+P)"),
                 desc=_("Left: new point"),
             ),
             "addLine": MetaIcon(
                 img="line-create",
-                label=_("Digitize new line, Ctrl+L"),
+                label=_("Digitize new line (Ctrl+L)"),
                 desc=_(
                     "Left: new point; Ctrl+Left: undo last point; Right: close line"
                 ),
             ),
             "addBoundary": MetaIcon(
                 img="boundary-create",
-                label=_("Digitize new boundary, Ctrl+B"),
+                label=_("Digitize new boundary (Ctrl+B)"),
                 desc=_(
                     "Left: new point; Ctrl+Left: undo last point; Right: close line"
                 ),
             ),
             "addCentroid": MetaIcon(
                 img="centroid-create",
-                label=_("Digitize new centroid, Ctrl+C"),
+                label=_("Digitize new centroid (Ctrl+C)"),
                 desc=_("Left: new point"),
             ),
             "addArea": MetaIcon(
                 img="polygon-create",
-                label=_("Digitize new area (boundary without category), Ctrl+A"),
+                label=_("Digitize new area (boundary without category) (Ctrl+A)"),
                 desc=_("Left: new point"),
             ),
             "addVertex": MetaIcon(
                 img="vertex-create",
-                label=_("Add new vertex to line or boundary, Ctrl+V"),
+                label=_("Add new vertex to line or boundary (Ctrl+V)"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "deleteLine": MetaIcon(
                 img="line-delete",
                 label=_(
-                    "Delete selected point(s), line(s), boundary(ies) or centroid(s), Ctrl+D"
+                    "Delete selected point(s), line(s), boundary(ies) or centroid(s) (Ctrl+D)"
                 ),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "deleteArea": MetaIcon(
                 img="polygon-delete",
-                label=_("Delete selected area(s), Ctrl+F"),
+                label=_("Delete selected area(s) (Ctrl+F)"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "displayAttr": MetaIcon(
                 img="attributes-display",
-                label=_("Display/update attributes, Ctrl+K"),
+                label=_("Display/update attributes (Ctrl+K)"),
                 desc=_("Left: Select"),
             ),
             "displayCats": MetaIcon(
                 img="cats-display",
-                label=_("Display/update categories, Ctrl+J"),
+                label=_("Display/update categories (Ctrl+J)"),
                 desc=_("Left: Select"),
             ),
             "editLine": MetaIcon(
                 img="line-edit",
-                label=_("Edit selected line/boundary, Ctrl+E"),
+                label=_("Edit selected line/boundary (Ctrl+E)"),
                 desc=_(
                     "Left: new point; Ctrl+Left: undo last point; Right: close line"
                 ),
@@ -208,29 +208,29 @@ class VDigitToolbar(BaseToolbar):
             "moveLine": MetaIcon(
                 img="line-move",
                 label=_(
-                    "Move selected point(s), line(s), boundary(ies) or centroid(s), Ctrl+M"
+                    "Move selected point(s), line(s), boundary(ies) or centroid(s) (Ctrl+M)"
                 ),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "moveVertex": MetaIcon(
                 img="vertex-move",
-                label=_("Move selected vertex, Ctrl+G"),
+                label=_("Move selected vertex (Ctrl+G)"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "removeVertex": MetaIcon(
                 img="vertex-delete",
-                label=_("Remove selected vertex, Ctrl+X"),
+                label=_("Remove selected vertex (Ctrl+X)"),
                 desc=_("Left: Select; Ctrl+Left: Unselect; Right: Confirm"),
             ),
             "settings": BaseIcons["settings"].SetLabel(
-                label=_("Settings, Ctrl+T"),
+                label=_("Settings (Ctrl+T)"),
             ),
             "quit": BaseIcons["quit"].SetLabel(
-                label=_("Quit, Ctrl+Q"),
+                label=_("Quit (Ctrl+Q)"),
                 desc=_("Quit digitizer and save changes"),
             ),
             "help": BaseIcons["help"].SetLabel(
-                label=_("Show manual, Ctrl+H"),
+                label=_("Show manual (Ctrl+H)"),
                 desc=_("Show Vector Digitizer manual"),
             ),
             "additionalTools": MetaIcon(
@@ -240,12 +240,12 @@ class VDigitToolbar(BaseToolbar):
             ),
             "undo": MetaIcon(
                 img="undo",
-                label=_("Undo, Ctrl+Z"),
+                label=_("Undo (Ctrl+Z)"),
                 desc=_("Undo previous change"),
             ),
             "redo": MetaIcon(
                 img="redo",
-                label=_("Redo, Ctrl+Y"),
+                label=_("Redo (Ctrl+Y)"),
                 desc=_("Redo previous change"),
             ),
         }


### PR DESCRIPTION
Extend Vector Digitizer tools keyboard shortcuts.

- Digitize new boundary: **Ctrl+B**
- Digitize new centroid: **Ctrl+C**
- Digitize new area: **Ctrl+A**
- Move vertex: **Ctrl+G**
- Add vertex: **Ctrl+V**
- Remove vertex: **Ctrl+X**
- Edit line/boundary: **Ctrl+E**
- Move feature(s): **Ctrl+M.**
- Delete feature(s): **Ctrl+D**
- Delete areas(s): **Ctrl+F**
- Display/update categories: **Ctrl+J**
- Display/update attributes: **Ctrl+K**
- Undo: **Ctrl+Z**
- Redo: **Ctrl+Y**
- Settings: **Ctrl+S**
- Show help: **Ctrl+H**
- Quit digitizing tool: **Ctrl+Q**