### PR TITLE
wxGUI: remove unnecessary key press event handlers

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -2237,18 +2237,6 @@ class GMFrame(wx.Frame):
                 else:
                     self.notebook.SetSelectionByName("layers")
 
-        try:
-            ckc = chr(kc)
-        except ValueError:
-            event.Skip()
-            return
-
-        if event.CtrlDown():
-            if kc == "R":
-                self.OnAddRaster(None)
-            elif kc == "V":
-                self.OnAddVector(None)
-
         event.Skip()
 
     def OnCloseWindow(self, event):

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -694,7 +694,6 @@ class GMFrame(wx.Frame):
     def BindEvents(self):
         # bindings
         self.Bind(wx.EVT_CLOSE, self.OnCloseWindowOrExit)
-        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyDown)
 
     def _show_demo_map(self):
         """If in demolocation, add demo map to map display
@@ -2275,10 +2274,6 @@ class GMFrame(wx.Frame):
                 self.GetLayerTree().Delete(layer)
             except ValueError:
                 pass
-
-    def OnKeyDown(self, event):
-        """Key pressed"""
-        event.Skip()
 
     def OnCloseWindow(self, event):
         """Cleanup when wxGUI is quitted"""

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -2278,20 +2278,6 @@ class GMFrame(wx.Frame):
 
     def OnKeyDown(self, event):
         """Key pressed"""
-        kc = event.GetKeyCode()
-
-        try:
-            kc = chr(kc)
-        except ValueError:
-            event.Skip()
-            return
-
-        if event.CtrlDown():
-            if kc == "R":
-                self.OnAddRaster(None)
-            elif kc == "V":
-                self.OnAddVector(None)
-
         event.Skip()
 
     def OnCloseWindow(self, event):


### PR DESCRIPTION
**Describe the bug**
With pressing any key is printed error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Win GRASS GIS wxGUI (single or multi window mode)
2. Click on the main toolbar panel widget to get a focus
3. Press any key e.g. Shift
4. See error

Single window mode error:

```
Traceback (most recent call last):
  File "C:\Program Files\GRASS GIS
8.3\gui\wxpython\lmgr\frame.py", line 2243, in OnKeyDown

if event.CtrlDown():
AttributeError
:
'KeyEvent' object has no attribute 'CtrlDown'
```

Multi window mode error:

```
Traceback (most recent call last):
  File "C:\Program Files\GRASS GIS
8.3\gui\wxpython\main_window\frame.py", line 2284, in
OnKeyDown

if event.CtrlDown():
AttributeError
:
'KeyEvent' object has no attribute 'CtrlDown'
```

**Expected behavior**
With pressing any key should not be printed any error message.

**System description:**

- Operating System: MS Windows
- GRASS GIS version: all

**Additional context**
Keyboard shortcut for add raster map is **Ctrl + Shift +R** and for vector map is **Ctrl + Shift + V** defined here:

https://github.com/OSGeo/grass/blob/59e2974369a097e00837b2ee98fd70346fc60f73/gui/wxpython/xml/wxgui_items.xml#L157-L168