### PR TITLE
init: Fix sudo message on Ubuntu

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2032,7 +2032,7 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
     """.format(
             sh_history=sh_history
         )
-        # Ubuntu sudo creates a file .sudo_as_admin_successful and cbash checks
+        # Ubuntu sudo creates a file .sudo_as_admin_successful and bash checks
         # for this file in the home directory from /etc/bash.bashrc and prints a
         # message if it's not detected. This can be suppressed with either
         # creating the file ~/.sudo_as_admin_successful (it's always empty) or

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2039,6 +2039,12 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
     """.format(
             sh_history=sh_history
         )
+        sudo_success_file = ".sudo_as_admin_successful"
+        if os.path.exists(os.path.join(userhome, sudo_success_file)):
+            try:
+                fh = open(os.path.join(home, sudo_success_file), "a")
+            finally:
+                fh.close()
 
     # double curly brackets means single one for format function
     # setting LOCATION for backwards compatibility

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -645,11 +645,7 @@ def create_fallback_session(gisrc, tmpdir):
     """Creates fallback temporary session"""
     # Create temporary location
     set_mapset(
-        gisrc=gisrc,
-        geofile="XY",
-        create_new=True,
-        tmp_location=True,
-        tmpdir=tmpdir,
+        gisrc=gisrc, geofile="XY", create_new=True, tmp_location=True, tmpdir=tmpdir
     )
 
 
@@ -1757,9 +1753,7 @@ def run_batch_job(batch_job: list):
         script_in_addon_path = None
         if "GRASS_ADDON_BASE" in os.environ:
             script_in_addon_path = os.path.join(
-                os.environ["GRASS_ADDON_BASE"],
-                "scripts",
-                batch_job[0],
+                os.environ["GRASS_ADDON_BASE"], "scripts", batch_job[0]
             )
         if script_in_addon_path and os.path.exists(script_in_addon_path):
             batch_job[0] = script_in_addon_path
@@ -1772,8 +1766,7 @@ def run_batch_job(batch_job: list):
         proc = Popen(batch_job, shell=False, env=os.environ)
     except OSError as error:
         error_message = _("Execution of <{cmd}> failed:\n" "{error}").format(
-            cmd=batch_job_string,
-            error=error,
+            cmd=batch_job_string, error=error
         )
         # No such file or directory
         if error.errno == errno.ENOENT:
@@ -2565,8 +2558,7 @@ def main():
         from grass.grassdb.checks import can_start_in_mapset
 
         last_mapset_usable = can_start_in_mapset(
-            mapset_path=last_mapset_path,
-            ignore_lock=params.force_gislock_removal,
+            mapset_path=last_mapset_path, ignore_lock=params.force_gislock_removal
         )
         debug(f"last_mapset_usable: {last_mapset_usable}")
         if not last_mapset_usable:

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -2032,9 +2032,18 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
     """.format(
             sh_history=sh_history
         )
+        # Ubuntu sudo creates a file .sudo_as_admin_successful and cbash checks
+        # for this file in the home directory from /etc/bash.bashrc and prints a
+        # message if it's not detected. This can be suppressed with either
+        # creating the file ~/.sudo_as_admin_successful (it's always empty) or
+        # by creating a file ~/.hushlogin (also an empty file)
+        # Here we create the file in the Mapset directory if it exists in the
+        # user's home directory.
         sudo_success_file = ".sudo_as_admin_successful"
         if os.path.exists(os.path.join(userhome, sudo_success_file)):
             try:
+                # Open with append so that if the file already exists there
+                # isn't any error.
                 fh = open(os.path.join(home, sudo_success_file), "a")
             finally:
                 fh.close()


### PR DESCRIPTION
Fixes #753 by creating `<mapset>/.sudo_as_admin_successful` when `$HOME/.sudo_as_admin_successful` exists