### PR TITLE
grass.py: fix missing parameters in gettext.install()

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1560,10 +1560,7 @@ def set_language(grass_config_dir):
         del os.environ["LC_ALL"]  # Remove LC_ALL to not override LC_NUMERIC
 
     # From now on enforce the new language
-    if encoding:
-        gettext.install("grasslibs", gpath("locale"), codeset=encoding)
-    else:
-        gettext.install("grasslibs", gpath("locale"))
+    gettext.install("grasslibs", gpath("locale"))
 
 
 def lock_mapset(mapset_path, force_gislock_removal, user):


### PR DESCRIPTION
fix #2507