### PR TITLE
avoid using deprecated locale.getdefaultlocale()

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -783,7 +783,11 @@ def GetDefaultEncoding(forceUTF8=False):
 
     :return: system encoding (can be None)
     """
-    enc = locale.getdefaultlocale()[1]
+    try:
+        # Python >= 3.11
+        enc = locale.getencoding()
+    except AttributeError:
+        enc = locale.getdefaultlocale()[1]
     if forceUTF8 and (enc is None or enc == "UTF8"):
         return "UTF-8"
 

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -408,7 +408,11 @@ class GConsole(wx.EvtHandler):
             sys.stdout = self.cmdStdOut
             sys.stderr = self.cmdStdErr
         else:
-            enc = locale.getdefaultlocale()[1]
+            try:
+                # Python >= 3.11
+                enc = locale.getencoding()
+            except AttributeError:
+                enc = locale.getdefaultlocale()[1]
             if enc:
                 if sys.version_info.major == 2:
                     sys.stdout = codecs.getwriter(enc)(sys.__stdout__)

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2035,7 +2035,11 @@ class CmdPanel(wx.Panel):
                         )
                         if p.get("value", "") and os.path.isfile(p["value"]):
                             ifbb.Clear()
-                            enc = locale.getdefaultlocale()[1]
+                            try:
+                                # Python >= 3.11
+                                enc = locale.getencoding()
+                            except AttributeError:
+                                enc = locale.getdefaultlocale()[1]
                             with codecs.open(
                                 p["value"], encoding=enc, errors="ignore"
                             ) as f:
@@ -2588,7 +2592,11 @@ class CmdPanel(wx.Panel):
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
-            enc = locale.getdefaultlocale()[1]
+            try:
+                # Python >= 3.11
+                enc = locale.getencoding()
+            except AttributeError:
+                enc = locale.getdefaultlocale()[1]
             f = codecs.open(path, encoding=enc, mode="w", errors="replace")
             try:
                 f.write(text + os.linesep)
@@ -2612,7 +2620,11 @@ class CmdPanel(wx.Panel):
                 filename = grass.tempfile()
                 win.SetValue(filename)
 
-            enc = locale.getdefaultlocale()[1]
+            try:
+                # Python >= 3.11
+                enc = locale.getencoding()
+            except AttributeError:
+                enc = locale.getdefaultlocale()[1]
             f = codecs.open(filename, encoding=enc, mode="w", errors="replace")
             try:
                 f.write(text)

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -239,7 +239,11 @@ class AboutWindow(wx.Frame):
         if not self.langUsed:
             import locale
 
-            loc = locale.getdefaultlocale()
+            try:
+                # Python >= 3.11
+                loc = locale.getlocale()
+            except AttributeError:
+                loc = locale.getdefaultlocale()
             if loc == (None, None):
                 self.langUsed = _("unknown")
             else:

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -58,7 +58,11 @@ class ViewFrame(wx.Frame):
         self.btn_close.Bind(wx.EVT_BUTTON, self.OnClose)
         self.btn_ok.Bind(wx.EVT_BUTTON, self.OnOk)
         self._layout()
-        self.enc = locale.getdefaultlocale()[1]
+        try:
+            # Python >= 3.11
+            self.enc = locale.getencoding()
+        except AttributeError:
+            self.enc = locale.getdefaultlocale()[1]
 
     def _layout(self):
         """Set the layout"""

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -66,7 +66,11 @@ _DEBUG = None
 # for wxpath
 _WXPYTHON_BASE = None
 
-ENCODING = locale.getdefaultlocale()[1]
+try:
+    # Python >= 3.11
+    ENCODING = locale.getencoding()
+except AttributeError:
+    ENCODING = locale.getdefaultlocale()[1]
 if ENCODING is None:
     ENCODING = "UTF-8"
     print("Default locale not found, using UTF-8")  # intentionally not translatable
@@ -1418,7 +1422,11 @@ def set_language(grass_config_dir):
                 "Default locale settings are missing. GRASS running with C locale.\n"
             )
 
-        language, encoding = locale.getdefaultlocale()
+        try:
+            # Python >= 3.11
+            language, encoding = locale.getlocale()
+        except AttributeError:
+            language, encoding = locale.getdefaultlocale()
         if not language:
             sys.stderr.write(
                 "Default locale settings are missing. GRASS running with C locale.\n"

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -27,7 +27,11 @@ if sys.version_info.major >= 3:
 
 
 def _get_encoding():
-    encoding = locale.getdefaultlocale()[1]
+    try:
+        # Python >= 3.11
+        encoding = locale.getencoding()
+    except AttributeError:
+        encoding = locale.getdefaultlocale()[1]
     if not encoding:
         encoding = "UTF-8"
     return encoding

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -163,7 +163,11 @@ class KeyValue(dict):
 
 
 def _get_encoding():
-    encoding = locale.getdefaultlocale()[1]
+    try:
+        # Python >= 3.11
+        encoding = locale.getencoding()
+    except AttributeError:
+        encoding = locale.getdefaultlocale()[1]
     if not encoding:
         encoding = "UTF-8"
     return encoding

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -82,7 +82,11 @@ if grass_version != "unknown":
 
 
 def _get_encoding():
-    encoding = locale.getdefaultlocale()[1]
+    try:
+        # Python >= 3.11
+        encoding = locale.getencoding()
+    except AttributeError:
+        encoding = locale.getdefaultlocale()[1]
     if not encoding:
         encoding = "UTF-8"
     return encoding


### PR DESCRIPTION
* fix #2538
* Use `getencoding()` where only encoding is needed; `getlocale()` otherwise