### PR TITLE
manual: fix firedemo.sh URL

### DIFF
--- a/raster/r.ros/r.ros.html
+++ b/raster/r.ros/r.ros.html
@@ -141,7 +141,7 @@ r.ros -s model=fire_model moisture_1h=1hour_moisture moisture_live=live_moisture
 </em>
 
 Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
-(run this script within the "Fire simulation data set" location.
+(run this script within the "Fire simulation data set" location).
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.ros/r.ros.html
+++ b/raster/r.ros/r.ros.html
@@ -140,7 +140,7 @@ r.ros -s model=fire_model moisture_1h=1hour_moisture moisture_live=live_moisture
 <a href="r.spreadpath.html">r.spreadpath</a>
 </em>
 
-Sample data download: <a href="https://grass.osgeo.org/download/data/">firedemo.sh</a>
+Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
 (run this script within the "Fire simulation data set" location.
 
 <h2>AUTHOR</h2>

--- a/raster/r.spread/r.spread.html
+++ b/raster/r.spread/r.spread.html
@@ -132,7 +132,7 @@ Rutgers University, New Brunswick, New Jersey
 </em>
 
 Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
-(run this script within the "Fire simulation data set" location.
+(run this script within the "Fire simulation data set" location).
 
 <h2>AUTHORS</h2>
 

--- a/raster/r.spread/r.spread.html
+++ b/raster/r.spread/r.spread.html
@@ -131,7 +131,7 @@ Rutgers University, New Brunswick, New Jersey
 <a href="r.spreadpath.html">r.spreadpath</a>
 </em>
 
-Sample data download: <a href="https://grass.osgeo.org/download/data/">firedemo.sh</a>
+Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
 (run this script within the "Fire simulation data set" location.
 
 <h2>AUTHORS</h2>

--- a/raster/r.spreadpath/r.spreadpath.html
+++ b/raster/r.spreadpath/r.spreadpath.html
@@ -58,7 +58,7 @@ Rutgers University, New Brunswick, New Jersey
 <a href="r.ros.html">r.ros</a>
 </em>
 
-Sample data download: <a href="https://grass.osgeo.org/download/data/">firedemo.sh</a>
+Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
 (run this script within the "Fire simulation data set" location.
 
 <h2>AUTHORS</h2>

--- a/raster/r.spreadpath/r.spreadpath.html
+++ b/raster/r.spreadpath/r.spreadpath.html
@@ -59,7 +59,7 @@ Rutgers University, New Brunswick, New Jersey
 </em>
 
 Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
-(run this script within the "Fire simulation data set" location.
+(run this script within the "Fire simulation data set" location).
 
 <h2>AUTHORS</h2>
 


### PR DESCRIPTION
The script is currently stored in https://grass.osgeo.org/sampledata/.

Fixes #2565

TODO: Also add link to related dataset:
https://grass.osgeo.org/sampledata/fire_grass6data.tar.gz

(which should be updated as well - any volunteer?)