### PR TITLE
python/grass/pygrass: reset back MAPSET search path after GridModule class instance finish

### DIFF
--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -705,9 +705,6 @@ class GridModule(object):
     def patch(self):
         """Patch the final results."""
         bboxes = split_region_tiles(width=self.width, height=self.height)
-        loc = Location()
-        mset = loc[self.mset.name]
-        mset.visible.extend(loc.mapsets())
         noutputs = 0
         for otmap in self.module.outputs:
             otm = self.module.outputs[otmap]

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -93,10 +93,9 @@ def copy_mapset(mapset, path):
     >>> sorted(os.listdir(os.path.join(path, 'PERMANENT')))
     ['DEFAULT_WIND', 'PROJ_INFO', 'PROJ_UNITS', 'VAR', 'WIND']
     >>> sorted(os.listdir(os.path.join(path, mname)))   # doctest: +ELLIPSIS
-    [...'SEARCH_PATH',...'WIND']
+    [...'WIND'...]
     >>> import shutil
     >>> shutil.rmtree(path)
-
     """
     per_old = os.path.join(mapset.gisdbase, mapset.location, "PERMANENT")
     per_new = os.path.join(path, "PERMANENT")


### PR DESCRIPTION
**Describe the bug**
Python pygrass `GridModule` class instance change LOCATION MAPSET search path.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch GRASS GIS with **nc_spm_08_grass7** LOCATION and **landsat** MAPSET
2. Launch `g.mapsets operation=set mapset=landsat`

```
GRASS nc_spm_08_grass7/landsat:~ > g.mapsets -p
Accessible mapsets:
landsat
```
4. Launch this Python script

```python
#!/usr/bin/env python3

from grass.pygrass.modules.grid.grid import GridModule

def main():
    grd = GridModule("r.slope.aspect",
                    width=100, height=100, overlap=2,
                    processes=None, split=False, elevation="elevation", 
                    slope="slope", aspect="aspect", overwrite=True)
    grd.run()

if __name__ == '__main__':
    main()

```
5. Check output of `g.mapsets -p`

```
GRASS nc_spm_08_grass7/landsat:~ > g.mapsets -p
Accessible mapsets:
landsat PERMANENT climate_2000_2012
```

**Expected behavior**
Python pygrass `GridModule` class instance should not change LOCATION MAPSET search path.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all


**Additional context**

GRASS GIS Addons issue https://github.com/OSGeo/grass-addons/pull/787.