### PR TITLE
wxGUI: Fix behaviour of top Single-Window GUI toolbars

### DIFF
--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -304,8 +304,8 @@ class AuiToolbarController(ToolbarController):
     """Controller specialized for wx.lib.agw.aui.auibar.AuiToolBar subclass"""
 
     def _defineTool(self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL):
-        """Define tool.
-        Position is not needed since wx.lib.agw.aui.auibar.AuiToolBar does not have InsertTool method."""
+        """Define tool. Position is not needed since wx.lib.agw.aui.auibar.AuiToolBar
+        does not have InsertTool method."""
         if name:
             return (
                 name,

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -109,7 +109,7 @@ class ToolbarController:
         for tool in toolData:
             self.CreateTool(*tool)
 
-        self.widget._data = toolData
+        self.widget.setToolData(toolData)
 
     def CreateTool(self, label, bitmap, kind, shortHelp, longHelp, handler, pos=-1):
         """Add tool to the toolbar
@@ -166,7 +166,7 @@ class ToolbarController:
 
         :param enable: True for enable otherwise disable
         """
-        for tool in self.widget._data:
+        for tool in self.widget.getToolData():
             if isinstance(tool[0], tuple):
                 if tool[0][0] == "":  # separator
                     continue
@@ -301,7 +301,7 @@ class ToolbarController:
 
 
 class AuiToolbarController(ToolbarController):
-    """Provides handling for aui.AuiToolBar widget"""
+    """Provides handling for wx.lib.agw.aui.auibar.AuiToolBar widget"""
 
     def _defineTool(self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL):
         """Define tool"""
@@ -387,6 +387,12 @@ class BaseToolbar(ToolBar):
             toolSwitcher=toolSwitcher,
         )
 
+    def getToolData(self):
+        return self._data
+
+    def setToolData(self, data):
+        self._data = data
+
     def _toolbarData(self):
         """Toolbar data (virtual)"""
         return None
@@ -461,6 +467,12 @@ class AuiToolbar(aui.AuiToolBar):
             parent=self.parent,
             toolSwitcher=toolSwitcher,
         )
+
+    def getToolData(self):
+        return self._data
+
+    def setToolData(self, data):
+        self._data = data
 
     def _toolbarData(self):
         """Toolbar data (virtual)"""

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -91,7 +91,7 @@ BaseIcons = {
 
 
 class ToolbarController:
-    """Provides handling for wx.Toolbar widget"""
+    """Controller specialized for wx.ToolBar subclass."""
 
     def __init__(self, classObject, widget, parent, toolSwitcher):
         """
@@ -161,7 +161,7 @@ class ToolbarController:
 
         return tool
 
-    def EnableLongHelp(self, enable=True):
+    def EnableLongHelp(self, enable):
         """Enable/disable long help
 
         :param enable: True for enable otherwise disable
@@ -211,7 +211,7 @@ class ToolbarController:
             size = self.classObject.GetBestSize(self.widget)
             self.classObject.SetSize(self.widget, (size[0] + width, size[1]))
 
-    def Enable(self, tool, enable=True):
+    def Enable(self, tool, enable):
         """Enable/Disable defined tool
 
         :param str/tuple tool: name
@@ -230,7 +230,7 @@ class ToolbarController:
 
         self.classObject.EnableTool(self.widget, id, enable)
 
-    def EnableAll(self, enable=True):
+    def EnableAll(self, enable):
         """Enable/Disable all tools
 
         :param enable: True to enable otherwise disable tool
@@ -240,7 +240,7 @@ class ToolbarController:
                 continue
             self.Enable(item[0], enable)
 
-    def GetToolbarData(self, data):
+    def _getToolbarData(self, data):
         """Define tool"""
         retData = list()
         for args in data:
@@ -263,7 +263,7 @@ class ToolbarController:
             )
         return ("", "", "", "", "", "")  # separator
 
-    def OnMenu(self, data):
+    def _onMenu(self, data):
         """Toolbar pop-up menu"""
         menu = Menu()
 
@@ -276,7 +276,7 @@ class ToolbarController:
         self.classObject.PopupMenu(self.widget, menu)
         menu.Destroy()
 
-    def CreateSelectionButton(self, tooltip=_("Select graphics tool")):
+    def CreateSelectionButton(self, tooltip):
         """Add button to toolbar for selection of graphics drawing mode.
 
         Button must be custom (not toolbar tool) to set smaller width.
@@ -301,10 +301,11 @@ class ToolbarController:
 
 
 class AuiToolbarController(ToolbarController):
-    """Provides handling for wx.lib.agw.aui.auibar.AuiToolBar widget"""
+    """Controller specialized for wx.lib.agw.aui.auibar.AuiToolBar subclass"""
 
     def _defineTool(self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL):
-        """Define tool"""
+        """Define tool.
+        Position is not needed since wx.lib.agw.aui.auibar.AuiToolBar does not have InsertTool method."""
         if name:
             return (
                 name,
@@ -397,53 +398,32 @@ class BaseToolbar(ToolBar):
         """Toolbar data (virtual)"""
         return None
 
-    def _getToolbarData(self, data):
-        """@copydoc ToolbarController:_getToolbarData()"""
-        return self.controller.GetToolbarData(data)
-
-    def _onMenu(self, data):
-        """@copydoc ToolbarController:_onMenu()"""
-        self.controller.OnMenu(data)
-
-    def InitToolbar(self, toolData):
-        """@copydoc ToolbarController:InitToolbar()"""
-        self.controller.InitToolbar(toolData)
-
     def CreateTool(self, *args, **kwargs):
-        """@copydoc ToolbarController:CreateTool()"""
-        return self.controller.CreateTool(*args, **kwargs)
-
-    def EnableLongHelp(self, enable=True):
-        """@copydoc ToolbarController:EnableLongHelp()"""
-        self.controller.EnableLongHelp(enable)
-
-    def OnTool(self, event):
-        """@copydoc ToolbarController:OnTool()"""
-        self.controller.OnTool(event)
-
-    def SelectTool(self, id):
-        """@copydoc ToolbarController:SelectTool()"""
-        self.controller.SelectTool(id)
+        """@copydoc ToolbarController::CreateTool()"""
+        self.controller.CreateTool(*args, **kwargs)
 
     def SelectDefault(self):
-        """@copydoc ToolbarController:SelectDefault()"""
+        """@copydoc ToolbarController::SelectDefault()"""
         self.controller.SelectDefault(self._default)
 
-    def FixSize(self, width):
-        """@copydoc ToolbarController:FixSize()"""
-        self.controller.FixSize(width)
+    def EnableLongHelp(self, enable=True):
+        """@copydoc ToolbarController::EnableLongHelp()"""
+        self.controller.EnableLongHelp(enable)
 
     def Enable(self, tool, enable=True):
-        """@copydoc ToolbarController:Enable()"""
+        """@copydoc ToolbarController::Enable()"""
         self.controller.Enable(tool, enable)
 
     def EnableAll(self, enable=True):
-        """@copydoc ToolbarController:EnableAll()"""
+        """@copydoc ToolbarController::EnableAll()"""
         self.controller.EnableAll(enable)
 
     def CreateSelectionButton(self, tooltip=_("Select graphics tool")):
-        """@copydoc ToolbarController:CreateSelectionButton()"""
+        """@copydoc ToolbarController::CreateSelectionButton()"""
         return self.controller.CreateSelectionButton(tooltip)
+
+    def __getattr__(self, name):
+        return getattr(self.controller, name)
 
 
 class AuiToolbar(aui.AuiToolBar):
@@ -478,53 +458,28 @@ class AuiToolbar(aui.AuiToolBar):
         """Toolbar data (virtual)"""
         return None
 
-    def _getToolbarData(self, data):
-        """@copydoc ToolbarController:_getToolbarData()"""
-        return self.controller.GetToolbarData(data)
-
-    def _onMenu(self, data):
-        """@copydoc ToolbarController:_onMenu()"""
-        self.controller.OnMenu(data)
-
-    def InitToolbar(self, toolData):
-        """@copydoc ToolbarController:InitToolbar()"""
-        self.controller.InitToolbar(toolData)
-
-    def CreateTool(self, *args, **kwargs):
-        """@copydoc ToolbarController:CreateTool()"""
-        return self.controller.CreateTool(*args, **kwargs)
-
-    def EnableLongHelp(self, enable=True):
-        """@copydoc ToolbarController:EnableLongHelp()"""
-        self.controller.EnableLongHelp(enable)
-
-    def OnTool(self, event):
-        """@copydoc ToolbarController:OnTool()"""
-        self.controller.OnTool(event)
-
-    def SelectTool(self, id):
-        """@copydoc ToolbarController:SelectTool()"""
-        self.controller.SelectTool(id)
-
     def SelectDefault(self):
-        """@copydoc ToolbarController:SelectDefault()"""
+        """@copydoc ToolbarController::SelectDefault()"""
         self.controller.SelectDefault(self._default)
 
-    def FixSize(self, width):
-        """@copydoc ToolbarController:FixSize()"""
-        self.controller.FixSize(width)
+    def EnableLongHelp(self, enable=True):
+        """@copydoc ToolbarController::EnableLongHelp()"""
+        self.controller.EnableLongHelp(enable)
 
     def Enable(self, tool, enable=True):
-        """@copydoc ToolbarController:Enable()"""
+        """@copydoc ToolbarController::Enable()"""
         self.controller.Enable(tool, enable)
 
     def EnableAll(self, enable=True):
-        """@copydoc ToolbarController:EnableAll()"""
+        """@copydoc ToolbarController::EnableAll()"""
         self.controller.EnableAll(enable)
 
     def CreateSelectionButton(self, tooltip=_("Select graphics tool")):
-        """@copydoc ToolbarController:CreateSelectionButton()"""
+        """@copydoc ToolbarController::CreateSelectionButton()"""
         return self.controller.CreateSelectionButton(tooltip)
+
+    def __getattr__(self, name):
+        return getattr(self.controller, name)
 
 
 class ToolSwitcher:

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -303,13 +303,6 @@ class ToolbarController:
 class AuiToolbarController(ToolbarController):
     """Provides handling for aui.AuiToolBar widget"""
 
-    def __init__(self, classObject, widget, parent, toolSwitcher):
-        """
-        :param classObject: toolbar class name (object, i.e. wx.Toolbar)
-        :param widget: toolbar instance
-        """
-        super().__init__(classObject, widget, parent, toolSwitcher)
-
     def _defineTool(self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL):
         """Define tool"""
         if name:
@@ -476,10 +469,6 @@ class AuiToolbar(aui.AuiToolBar):
     def _getToolbarData(self, data):
         """@copydoc ToolbarController:_getToolbarData()"""
         return self.controller.GetToolbarData(data)
-
-    def _defineTool(self, *args, **kwargs):
-        """@copydoc ToolbarController:_defineTool()"""
-        self.controller.DefineTool(*args, **kwargs)
 
     def _onMenu(self, data):
         """@copydoc ToolbarController:_onMenu()"""

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -348,7 +348,7 @@ class AuiToolbarController(ToolbarController):
 
 
 class BaseToolbar(ToolBar):
-    """Abstract toolbar class.
+    """Abstract basic toolbar class.
 
     Following code shows how to create new basic toolbar:
 
@@ -427,7 +427,7 @@ class BaseToolbar(ToolBar):
 
 
 class AuiToolbar(aui.AuiToolBar):
-    """Abstract toolbar class.
+    """Abstract AUI toolbar class.
 
     Toolbar for integration with the AUI layout system."""
 

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -30,6 +30,11 @@ from gui_core.wrap import ToolBar, Menu, BitmapButton, NewId
 
 from grass.pydispatch.signal import Signal
 
+try:
+    from agw import aui
+except ImportError:
+    import wx.lib.agw.aui as aui
+
 
 BaseIcons = {
     "display": MetaIcon(
@@ -85,6 +90,269 @@ BaseIcons = {
 }
 
 
+class ToolbarController:
+    """Provides handling for wx.Toolbar widget"""
+
+    def __init__(self, classObject, widget, parent, toolSwitcher):
+        """
+        :param classObject: toolbar class name (object, i.e. wx.Toolbar)
+        :param widget: toolbar instance
+        """
+        self.classObject = classObject
+        self.widget = widget
+        self.parent = parent
+        self.toolSwitcher = toolSwitcher
+        self.handlers = {}
+
+    def InitToolbar(self, toolData):
+        """Initialize toolbar, add tools to the toolbar"""
+        for tool in toolData:
+            self.CreateTool(*tool)
+
+        self.widget._data = toolData
+
+    def CreateTool(self, label, bitmap, kind, shortHelp, longHelp, handler, pos=-1):
+        """Add tool to the toolbar
+
+        :param pos: if -1 add tool, if > 0 insert at given pos
+        :return: id of tool
+        """
+        bmpDisabled = wx.NullBitmap
+        tool = -1
+
+        if isinstance(label, tuple):
+            internal_label, label = label[0], label[1]
+        else:
+            internal_label = label
+
+        if label:
+            tool = vars(self.widget)[internal_label] = NewId()
+            Debug.msg(
+                3, "CreateTool(): tool=%d, label=%s bitmap=%s" % (tool, label, bitmap)
+            )
+            if pos < 0:
+                toolWin = self.classObject.AddLabelTool(
+                    self.widget,
+                    tool,
+                    label,
+                    bitmap,
+                    bmpDisabled,
+                    kind,
+                    shortHelp,
+                    longHelp,
+                )
+            else:
+                toolWin = self.classObject.InsertLabelTool(
+                    self.widget,
+                    pos,
+                    tool,
+                    label,
+                    bitmap,
+                    bmpDisabled,
+                    kind,
+                    shortHelp,
+                    longHelp,
+                )
+            self.handlers[tool] = handler
+            self.widget.Bind(wx.EVT_TOOL, handler, toolWin)
+            self.widget.Bind(wx.EVT_TOOL, self.OnTool, toolWin)
+        else:  # separator
+            self.classObject.AddSeparator(self.widget)
+
+        return tool
+
+    def EnableLongHelp(self, enable=True):
+        """Enable/disable long help
+
+        :param enable: True for enable otherwise disable
+        """
+        for tool in self.widget._data:
+            if isinstance(tool[0], tuple):
+                if tool[0][0] == "":  # separator
+                    continue
+                else:
+                    internal_label = tool[0][0]
+            else:
+                if tool[0] == "":  # separator
+                    continue
+                else:
+                    internal_label = tool[0]
+
+            label = vars(self.widget)[internal_label]
+            if enable:
+                self.classObject.SetToolLongHelp(self.widget, label, tool[4])
+            else:
+                self.classObject.SetToolLongHelp(self.widget, label, "")
+
+    def OnTool(self, event):
+        """Tool selected"""
+        if self.toolSwitcher:
+            Debug.msg(3, "BaseToolbar.OnTool(): id = %s" % event.GetId())
+            self.toolSwitcher.ToolChanged(event.GetId())
+        event.Skip()
+
+    def SelectTool(self, id):
+        self.classObject.ToggleTool(self.widget, id, True)
+        self.toolSwitcher.ToolChanged(id)
+
+        self.handlers[id](event=None)
+
+    def SelectDefault(self, default):
+        """Select default tool"""
+        self.SelectTool(default)
+
+    def FixSize(self, width):
+        """Fix toolbar width on Windows
+
+        .. todo::
+            Determine why combobox causes problems here
+        """
+        if platform.system() == "Windows":
+            size = self.classObject.GetBestSize(self.widget)
+            self.classObject.SetSize(self.widget, (size[0] + width, size[1]))
+
+    def Enable(self, tool, enable=True):
+        """Enable/Disable defined tool
+
+        :param str/tuple tool: name
+        :param enable: True to enable otherwise disable tool
+        """
+        try:
+            if isinstance(tool, tuple):
+                id = getattr(self.widget, tool[0])
+            else:
+                id = getattr(self.widget, tool)
+        except AttributeError:
+            # TODO: test everything that this is not raised
+            # this error was ignored for a long time
+            raise AttributeError("Toolbar does not have a tool %s." % tool)
+            return
+
+        self.classObject.EnableTool(self.widget, id, enable)
+
+    def EnableAll(self, enable=True):
+        """Enable/Disable all tools
+
+        :param enable: True to enable otherwise disable tool
+        """
+        for item in self.widget._toolbarData():
+            if not item[0]:
+                continue
+            self.Enable(item[0], enable)
+
+    def GetToolbarData(self, data):
+        """Define tool"""
+        retData = list()
+        for args in data:
+            retData.append(self._defineTool(*args))
+        return retData
+
+    def _defineTool(
+        self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL, pos=-1
+    ):
+        """Define tool"""
+        if name:
+            return (
+                name,
+                icon.GetBitmap(),
+                item,
+                icon.GetLabel(),
+                icon.GetDesc(),
+                handler,
+                pos,
+            )
+        return ("", "", "", "", "", "")  # separator
+
+    def OnMenu(self, data):
+        """Toolbar pop-up menu"""
+        menu = Menu()
+
+        for icon, handler in data:
+            item = wx.MenuItem(menu, wx.ID_ANY, icon.GetLabel())
+            item.SetBitmap(icon.GetBitmap(self.parent.iconsize))
+            menu.AppendItem(item)
+            self.widget.Bind(wx.EVT_MENU, handler, item)
+
+        self.classObject.PopupMenu(self.widget, menu)
+        menu.Destroy()
+
+    def CreateSelectionButton(self, tooltip=_("Select graphics tool")):
+        """Add button to toolbar for selection of graphics drawing mode.
+
+        Button must be custom (not toolbar tool) to set smaller width.
+        """
+        arrowPath = os.path.join(IMGDIR, "small_down_arrow.png")
+        if os.path.isfile(arrowPath) and os.path.getsize(arrowPath):
+            bitmap = wx.Bitmap(name=arrowPath)
+        else:
+            bitmap = wx.ArtProvider.GetBitmap(
+                id=wx.ART_MISSING_IMAGE, client=wx.ART_TOOLBAR
+            )
+        button = BitmapButton(
+            parent=self.widget,
+            id=wx.ID_ANY,
+            size=((-1, self.classObject.GetToolSize(self.widget)[1])),
+            bitmap=bitmap,
+            style=wx.NO_BORDER,
+        )
+        button.SetToolTip(tooltip)
+
+        return button
+
+
+class AuiToolbarController(ToolbarController):
+    """Provides handling for aui.AuiToolBar widget"""
+
+    def __init__(self, classObject, widget, parent, toolSwitcher):
+        """
+        :param classObject: toolbar class name (object, i.e. wx.Toolbar)
+        :param widget: toolbar instance
+        """
+        super().__init__(classObject, widget, parent, toolSwitcher)
+
+    def _defineTool(self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL):
+        """Define tool"""
+        if name:
+            return (
+                name,
+                icon.GetBitmap(),
+                item,
+                icon.GetLabel(),
+                icon.GetDesc(),
+                handler,
+            )
+        return ("", "", "", "", "", "")  # separator
+
+    def CreateTool(self, label, bitmap, kind, shortHelp, longHelp, handler):
+        """Add tool to the toolbar
+
+        :return: id of tool
+        """
+        bmpDisabled = wx.NullBitmap
+        tool = -1
+
+        if isinstance(label, tuple):
+            internal_label, label = label[0], label[1]
+        else:
+            internal_label = label
+
+        if label:
+            tool = vars(self.widget)[internal_label] = NewId()
+            Debug.msg(
+                3, "CreateTool(): tool=%d, label=%s bitmap=%s" % (tool, label, bitmap)
+            )
+            toolWin = self.classObject.AddTool(
+                self.widget, tool, label, bitmap, bmpDisabled, kind, shortHelp, longHelp
+            )
+            self.handlers[tool] = handler
+            self.widget.Bind(wx.EVT_TOOL, handler, toolWin)
+            self.widget.Bind(wx.EVT_TOOL, self.OnTool, toolWin)
+        else:  # separator
+            self.classObject.AddSeparator(self.widget)
+
+        return tool
+
+
 class BaseToolbar(ToolBar):
     """Abstract toolbar class.
 
@@ -119,189 +387,143 @@ class BaseToolbar(ToolBar):
         self.SetToolBitmapSize(globalvar.toolbarSize)
 
         self.toolSwitcher = toolSwitcher
-        self.handlers = {}
-
-    def InitToolbar(self, toolData):
-        """Initialize toolbar, add tools to the toolbar"""
-        for tool in toolData:
-            self.CreateTool(*tool)
-
-        self._data = toolData
+        self.controller = ToolbarController(
+            classObject=ToolBar,
+            widget=self,
+            parent=self.parent,
+            toolSwitcher=toolSwitcher,
+        )
 
     def _toolbarData(self):
         """Toolbar data (virtual)"""
         return None
 
-    def CreateTool(self, label, bitmap, kind, shortHelp, longHelp, handler, pos=-1):
-        """Add tool to the toolbar
-
-        :param pos: if -1 add tool, if > 0 insert at given pos
-        :return: id of tool
-        """
-        bmpDisabled = wx.NullBitmap
-        tool = -1
-
-        if isinstance(label, tuple):
-            internal_label, label = label[0], label[1]
-        else:
-            internal_label = label
-
-        if label:
-            tool = vars(self)[internal_label] = NewId()
-            Debug.msg(
-                3, "CreateTool(): tool=%d, label=%s bitmap=%s" % (tool, label, bitmap)
-            )
-            if pos < 0:
-                toolWin = self.AddLabelTool(
-                    tool, label, bitmap, bmpDisabled, kind, shortHelp, longHelp
-                )
-            else:
-                toolWin = self.InsertLabelTool(
-                    pos, tool, label, bitmap, bmpDisabled, kind, shortHelp, longHelp
-                )
-            self.handlers[tool] = handler
-            self.Bind(wx.EVT_TOOL, handler, toolWin)
-            self.Bind(wx.EVT_TOOL, self.OnTool, toolWin)
-        else:  # separator
-            self.AddSeparator()
-
-        return tool
-
-    def EnableLongHelp(self, enable=True):
-        """Enable/disable long help
-
-        :param enable: True for enable otherwise disable
-        """
-        for tool in self._data:
-            if isinstance(tool[0], tuple):
-                if tool[0][0] == "":  # separator
-                    continue
-                else:
-                    internal_label = tool[0][0]
-            else:
-                if tool[0] == "":  # separator
-                    continue
-                else:
-                    internal_label = tool[0]
-            if enable:
-                self.SetToolLongHelp(vars(self)[internal_label], tool[4])
-            else:
-                self.SetToolLongHelp(vars(self)[internal_label], "")
-
-    def OnTool(self, event):
-        """Tool selected"""
-        if self.toolSwitcher:
-            Debug.msg(3, "BaseToolbar.OnTool(): id = %s" % event.GetId())
-            self.toolSwitcher.ToolChanged(event.GetId())
-        event.Skip()
-
-    def SelectTool(self, id):
-        self.ToggleTool(id, True)
-        self.toolSwitcher.ToolChanged(id)
-
-        self.handlers[id](event=None)
-
-    def SelectDefault(self):
-        """Select default tool"""
-        self.SelectTool(self._default)
-
-    def FixSize(self, width):
-        """Fix toolbar width on Windows
-
-        .. todo::
-            Determine why combobox causes problems here
-        """
-        if platform.system() == "Windows":
-            size = self.GetBestSize()
-            self.SetSize((size[0] + width, size[1]))
-
-    def Enable(self, tool, enable=True):
-        """Enable/Disable defined tool
-
-        :param str/tuple tool: name
-        :param enable: True to enable otherwise disable tool
-        """
-        try:
-            if isinstance(tool, tuple):
-                id = getattr(self, tool[0])
-            else:
-                id = getattr(self, tool)
-        except AttributeError:
-            # TODO: test everything that this is not raised
-            # this error was ignored for a long time
-            raise AttributeError("Toolbar does not have a tool %s." % tool)
-            return
-
-        self.EnableTool(id, enable)
-
-    def EnableAll(self, enable=True):
-        """Enable/Disable all tools
-
-        :param enable: True to enable otherwise disable tool
-        """
-        for item in self._toolbarData():
-            if not item[0]:
-                continue
-            self.Enable(item[0], enable)
-
     def _getToolbarData(self, data):
-        """Define tool"""
-        retData = list()
-        for args in data:
-            retData.append(self._defineTool(*args))
-        return retData
-
-    def _defineTool(
-        self, name=None, icon=None, handler=None, item=wx.ITEM_NORMAL, pos=-1
-    ):
-        """Define tool"""
-        if name:
-            return (
-                name,
-                icon.GetBitmap(),
-                item,
-                icon.GetLabel(),
-                icon.GetDesc(),
-                handler,
-                pos,
-            )
-        return ("", "", "", "", "", "")  # separator
+        """@copydoc ToolbarController:_getToolbarData()"""
+        return self.controller.GetToolbarData(data)
 
     def _onMenu(self, data):
-        """Toolbar pop-up menu"""
-        menu = Menu()
+        """@copydoc ToolbarController:_onMenu()"""
+        self.controller.OnMenu(data)
 
-        for icon, handler in data:
-            item = wx.MenuItem(menu, wx.ID_ANY, icon.GetLabel())
-            item.SetBitmap(icon.GetBitmap(self.parent.iconsize))
-            menu.AppendItem(item)
-            self.Bind(wx.EVT_MENU, handler, item)
+    def InitToolbar(self, toolData):
+        """@copydoc ToolbarController:InitToolbar()"""
+        self.controller.InitToolbar(toolData)
 
-        self.PopupMenu(menu)
-        menu.Destroy()
+    def CreateTool(self, *args, **kwargs):
+        """@copydoc ToolbarController:CreateTool()"""
+        return self.controller.CreateTool(*args, **kwargs)
+
+    def EnableLongHelp(self, enable=True):
+        """@copydoc ToolbarController:EnableLongHelp()"""
+        self.controller.EnableLongHelp(enable)
+
+    def OnTool(self, event):
+        """@copydoc ToolbarController:OnTool()"""
+        self.controller.OnTool(event)
+
+    def SelectTool(self, id):
+        """@copydoc ToolbarController:SelectTool()"""
+        self.controller.SelectTool(id)
+
+    def SelectDefault(self):
+        """@copydoc ToolbarController:SelectDefault()"""
+        self.controller.SelectDefault(self._default)
+
+    def FixSize(self, width):
+        """@copydoc ToolbarController:FixSize()"""
+        self.controller.FixSize(width)
+
+    def Enable(self, tool, enable=True):
+        """@copydoc ToolbarController:Enable()"""
+        self.controller.Enable(tool, enable)
+
+    def EnableAll(self, enable=True):
+        """@copydoc ToolbarController:EnableAll()"""
+        self.controller.EnableAll(enable)
 
     def CreateSelectionButton(self, tooltip=_("Select graphics tool")):
-        """Add button to toolbar for selection of graphics drawing mode.
+        """@copydoc ToolbarController:CreateSelectionButton()"""
+        return self.controller.CreateSelectionButton(tooltip)
 
-        Button must be custom (not toolbar tool) to set smaller width.
-        """
-        arrowPath = os.path.join(IMGDIR, "small_down_arrow.png")
-        if os.path.isfile(arrowPath) and os.path.getsize(arrowPath):
-            bitmap = wx.Bitmap(name=arrowPath)
-        else:
-            bitmap = wx.ArtProvider.GetBitmap(
-                id=wx.ART_MISSING_IMAGE, client=wx.ART_TOOLBAR
-            )
-        button = BitmapButton(
-            parent=self,
-            id=wx.ID_ANY,
-            size=((-1, self.GetToolSize()[1])),
-            bitmap=bitmap,
-            style=wx.NO_BORDER,
+
+class AuiToolbar(aui.AuiToolBar):
+    """Abstract toolbar class.
+
+    Toolbar for integration with the AUI layout system."""
+
+    def __init__(
+        self, parent, toolSwitcher=None, style=wx.NO_BORDER | wx.TB_HORIZONTAL
+    ):
+        self.parent = parent
+        super().__init__(parent=self.parent, id=wx.ID_ANY, style=style)
+
+        self._default = None
+        self.SetToolBitmapSize(globalvar.toolbarSize)
+
+        self.toolSwitcher = toolSwitcher
+        self.controller = AuiToolbarController(
+            classObject=aui.AuiToolBar,
+            widget=self,
+            parent=self.parent,
+            toolSwitcher=toolSwitcher,
         )
-        button.SetToolTip(tooltip)
 
-        return button
+    def _toolbarData(self):
+        """Toolbar data (virtual)"""
+        return None
+
+    def _getToolbarData(self, data):
+        """@copydoc ToolbarController:_getToolbarData()"""
+        return self.controller.GetToolbarData(data)
+
+    def _defineTool(self, *args, **kwargs):
+        """@copydoc ToolbarController:_defineTool()"""
+        self.controller.DefineTool(*args, **kwargs)
+
+    def _onMenu(self, data):
+        """@copydoc ToolbarController:_onMenu()"""
+        self.controller.OnMenu(data)
+
+    def InitToolbar(self, toolData):
+        """@copydoc ToolbarController:InitToolbar()"""
+        self.controller.InitToolbar(toolData)
+
+    def CreateTool(self, *args, **kwargs):
+        """@copydoc ToolbarController:CreateTool()"""
+        return self.controller.CreateTool(*args, **kwargs)
+
+    def EnableLongHelp(self, enable=True):
+        """@copydoc ToolbarController:EnableLongHelp()"""
+        self.controller.EnableLongHelp(enable)
+
+    def OnTool(self, event):
+        """@copydoc ToolbarController:OnTool()"""
+        self.controller.OnTool(event)
+
+    def SelectTool(self, id):
+        """@copydoc ToolbarController:SelectTool()"""
+        self.controller.SelectTool(id)
+
+    def SelectDefault(self):
+        """@copydoc ToolbarController:SelectDefault()"""
+        self.controller.SelectDefault(self._default)
+
+    def FixSize(self, width):
+        """@copydoc ToolbarController:FixSize()"""
+        self.controller.FixSize(width)
+
+    def Enable(self, tool, enable=True):
+        """@copydoc ToolbarController:Enable()"""
+        self.controller.Enable(tool, enable)
+
+    def EnableAll(self, enable=True):
+        """@copydoc ToolbarController:EnableAll()"""
+        self.controller.EnableAll(enable)
+
+    def CreateSelectionButton(self, tooltip=_("Select graphics tool")):
+        """@copydoc ToolbarController:CreateSelectionButton()"""
+        return self.controller.CreateSelectionButton(tooltip)
 
 
 class ToolSwitcher:

--- a/gui/wxpython/iscatt/toolbars.py
+++ b/gui/wxpython/iscatt/toolbars.py
@@ -133,7 +133,7 @@ class MainToolbar(BaseToolbar):
     def SetPloltsMode(self, event, tool_name):
         self.scatt_mgr.modeSet.disconnect(self.ModeSet)
         if event.IsChecked():
-            for i_tool_data in self._data:
+            for i_tool_data in self.controller.data:
                 i_tool_name = i_tool_data[0]
                 if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
                     continue
@@ -159,7 +159,7 @@ class MainToolbar(BaseToolbar):
         self.UnsetMode()
 
     def UnsetMode(self):
-        for i_tool_data in self._data:
+        for i_tool_data in self.controller.data:
             i_tool_name = i_tool_data[0]
             if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
                 continue
@@ -281,7 +281,7 @@ class EditingToolbar(BaseToolbar):
     def SetMode(self, event, tool_name):
         self.scatt_mgr.modeSet.disconnect(self.ModeSet)
         if event.IsChecked():
-            for i_tool_data in self._data:
+            for i_tool_data in self.controller.data:
                 i_tool_name = i_tool_data[0]
                 if not i_tool_name:
                     continue
@@ -300,7 +300,7 @@ class EditingToolbar(BaseToolbar):
             self.UnsetMode()
 
     def UnsetMode(self):
-        for i_tool_data in self._data:
+        for i_tool_data in self.controller.data:
             i_tool_name = i_tool_data[0]
             if not i_tool_name:
                 continue

--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -24,15 +24,15 @@ This program is free software under the GNU General Public License
 """
 
 from core.gcmd import RunCommand
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseToolbar, AuiToolbar, BaseIcons
 from icons.icon import MetaIcon
 
 
-class LMWorkspaceToolbar(BaseToolbar):
+class LMWorkspaceToolbar(AuiToolbar):
     """Layer Manager `workspace` toolbar"""
 
     def __init__(self, parent):
-        BaseToolbar.__init__(self, parent)
+        AuiToolbar.__init__(self, parent)
 
         self.InitToolbar(self._toolbarData())
 
@@ -185,11 +185,11 @@ class DisplayPanelToolbar(BaseToolbar):
         )
 
 
-class LMToolsToolbar(BaseToolbar):
+class LMToolsToolbar(AuiToolbar):
     """Layer Manager `tools` toolbar"""
 
     def __init__(self, parent):
-        BaseToolbar.__init__(self, parent)
+        AuiToolbar.__init__(self, parent)
 
         self.InitToolbar(self._toolbarData())
 
@@ -259,11 +259,11 @@ class LMToolsToolbar(BaseToolbar):
         )
 
 
-class LMMiscToolbar(BaseToolbar):
+class LMMiscToolbar(AuiToolbar):
     """Layer Manager `misc` toolbar"""
 
     def __init__(self, parent):
-        BaseToolbar.__init__(self, parent)
+        AuiToolbar.__init__(self, parent)
 
         self.InitToolbar(self._toolbarData())
 
@@ -293,13 +293,13 @@ class LMMiscToolbar(BaseToolbar):
         )
 
 
-class LMNvizToolbar(BaseToolbar):
+class LMNvizToolbar(AuiToolbar):
     """Nviz toolbar"""
 
     def __init__(self, parent):
         self.lmgr = parent
 
-        BaseToolbar.__init__(self, parent)
+        AuiToolbar.__init__(self, parent)
 
         # only one dialog can be open
         self.settingsDialog = None

--- a/gui/wxpython/mapdisp/toolbars.py
+++ b/gui/wxpython/mapdisp/toolbars.py
@@ -280,12 +280,12 @@ class MapToolbar(BaseToolbar):
             icons = BaseIcons
         else:
             icons = NvizIcons
-        for i, data in enumerate(self._data):
+        for i, data in enumerate(self.controller.data):
             for tool in ("zoomIn", "zoomOut"):
                 if data[0] == tool:
                     tmp = list(data)
                     tmp[4] = icons[tool].GetDesc()
-                    self._data[i] = tuple(tmp)
+                    self.controller.data[i] = tuple(tmp)
 
     def OnSelectTool(self, event):
         """Select / enable tool available in tools list"""

--- a/gui/wxpython/psmap/toolbars.py
+++ b/gui/wxpython/psmap/toolbars.py
@@ -49,7 +49,7 @@ class PsMapToolbar(BaseToolbar):
 
         # custom button for graphics mode selection
         # TODO: could this be somehow generalized?
-        self.arrowButton = self.CreateSelectionButton()
+        self.arrowButton = self.CreateSelectionButton(tooltip=_("Select graphics tool"))
         self.arrowButtonId = self.InsertControl(18, self.arrowButton)
         self.arrowButton.Bind(wx.EVT_BUTTON, self.OnDrawGraphicsMenu)
 


### PR DESCRIPTION
Fixes the non-standard behavior of top Single-Window GUI toolbars.

**Bug:**
- bigger icons when undocking and docking the toolbar (takes into consideration that one does not drop a toolbar during that process)
![bigger icons](https://user-images.githubusercontent.com/49241681/188199474-7f763729-00d9-4fa9-ad95-fafa029989a5.PNG)
after redocking all toolbars were resized

- no toolbar name displayed after undocking
![no-name](https://user-images.githubusercontent.com/49241681/188199492-feb416b0-3354-466c-8bcc-0c91b7da2450.PNG)

**After fix:**
Now it inherits from AuiToolbar. This approach corresponds to the usage of aui agw library which is used for drawing the main window frame.

After conversion to AuiToolbar:

- sizes of toolbars are still the same
![toolbar](https://user-images.githubusercontent.com/49241681/188199576-3ad27d60-787d-40aa-9254-aad7fc877185.PNG)

- toolbar name is displayed after undock
![worrkspace_toolbar](https://user-images.githubusercontent.com/49241681/188199586-8f146eb1-4e48-4bb8-baba-71447668c9ea.PNG)

Potentially this PR could also fix some other related bugs  (probably different depending on OS) caused by inheriting from the inappropriate wx.Toolbar class.
