### PR TITLE
Fix i.evapo.pm disabled code for smooth indetation

### DIFF
--- a/imagery/i.evapo.pm/functions.c
+++ b/imagery/i.evapo.pm/functions.c
@@ -154,4 +154,5 @@ DCELL calc_openwaterETp(DCELL T, DCELL Z, DCELL u2, DCELL Rn, int day, DCELL Rh,
 
    /* calculus psichiometric constant gamma [hPa/degC] with cp=1.005[KJ/(Kg*K)] */
    gamma        = ((1.005*P)/(0.622*lambda))*0.001;
+   }
 #endif


### PR DESCRIPTION
Disabled code in i.evapo.pm missed one curly bracket which was confusing GNU indent.
