### PR TITLE
grass.pygrass: VisibleMapset: fix reading search path

### DIFF
--- a/python/grass/pygrass/gis/__init__.py
+++ b/python/grass/pygrass/gis/__init__.py
@@ -440,7 +440,7 @@ class VisibleMapset(object):
 
     def read(self):
         """Return the mapsets in the search path"""
-        with open(self.spath, "ab+") as f:
+        with open(self.spath, "rb") as f:
             lines = f.readlines()
             if lines:
                 return [decode(line.strip()) for line in lines]


### PR DESCRIPTION
VisibleMapset class was not reading search path properly, instead it was always just writing PERMANENT only into the path.