### PR TITLE
general/g.mapsets: fix write MAPSETs without additional empty new line

### DIFF
--- a/general/g.mapsets/main.c
+++ b/general/g.mapsets/main.c
@@ -297,7 +297,6 @@ int main(int argc, char *argv[])
      */
 
     no_tokens = G_number_of_tokens(tokens);
-
     for (n = 0; n < no_tokens; n++) {
         skip = 0;
         for (i = n; i < no_tokens; i++) {
@@ -331,9 +330,12 @@ void append_mapset(char **path, const char *mapset)
     int len = (*path == NULL ? 0 : strlen(*path));
 
     *path = (char *)G_realloc(*path, len + strlen(mapset) + 2);
-    if (!len)
+    if (!len) {
         *path[0] = '\0';
-    strcat(*path, mapset);
-    strcat(*path, " ");
+        strcat(*path, mapset);
+    } else {
+        strcat(*path, " ");
+        strcat(*path, mapset);
+    }
     return;
 }


### PR DESCRIPTION
**Describe the bug**
`g.mapsets` module writes to the file `$(g.gisenv get="GISDBASE")/$(g.gisenv get="LOCATION_NAME")/$(g.gisenv get="MAPSET")/SEARCH_PATH` additional empty new line.

**To Reproduce**
Steps to reproduce the behavior:

1. Lanch GG with **nc_spm_08_grass7** LOCATION and **landsat** MAPSET
2. Run `g.mapsets operation=set mapset=landsat`
3. Check the new line symbol `\n` in the file `cat -e "$(g.gisenv get="GISDBASE")/$(g.gisenv get="LOCATION_NAME")/$(g.gisenv get="MAPSET")/SEARCH_PATH"` and see additional new empty line.

```
GRASS nc_spm_08_grass7/landsat:~ > g.mapsets operation=set mapset=landsat
    
GRASS nc_spm_08_grass7/landsat:~ > cat -e "$(g.gisenv get="GISDBASE")/$(g.gisenv get="LOCATION_NAME")/$(g.gisenv get="MAPSET")/SEARCH_PATH"
landsat$
$
```

**Expected behavior**
`g.mapsets` module should  writes MAPSETs only without additional empty new line.

```
GRASS nc_spm_08_grass7/landsat:~ > g.mapsets operation=set mapset=landsat

GRASS nc_spm_08_grass7/landsat:~ > cat -e "$(g.gisenv get="GISDBASE")/$(g.gisenv get="LOCATION_NAME")/$(g.gisenv get="MAPSET")/SEARCH_PATH"
landsat$
```

**System description:**

- Operating System: all
- GRASS GIS version: all