### PR TITLE
SEO and manuals: add viewport and page language

### DIFF
--- a/REQUIREMENTS.html
+++ b/REQUIREMENTS.html
@@ -4,6 +4,8 @@
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
  <title>REQUIREMENTS to compile GRASS GIS 8</title>
  <link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body bgcolor="#FFFFFF">
 

--- a/db/drivers/mysql/grass-mesql.html
+++ b/db/drivers/mysql/grass-mesql.html
@@ -2,8 +2,10 @@
 <html>
 <head>
 <title>GRASS-MySQL embedded driver - GRASS GIS manual</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+ <link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body bgcolor="white">
 

--- a/general/g.setproj/g.setproj.html
+++ b/general/g.setproj/g.setproj.html
@@ -2,8 +2,10 @@
 <html>
 <head>
 <title>g.setproj - GRASS GIS manual</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+ <link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body bgcolor="white">
 

--- a/lib/gis/parser_html.c
+++ b/lib/gis/parser_html.c
@@ -3,7 +3,7 @@
 
    \brief GIS Library - Argument parsing functions (HTML output)
 
-   (C) 2001-2009, 2011-2020 by the GRASS Development Team
+   (C) 2001-2022 by the GRASS Development Team
 
    This program is free software under the GNU General Public License
    (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -45,6 +45,12 @@ void G__usage_html(void)
     fprintf(stdout, "<html>\n<head>\n");
     fprintf(stdout,
             " <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n");
+    fprintf(stdout,
+            " <meta name=\"Author\" content=\"GRASS Development Team\">\n");
+    fprintf(stdout,
+            " <meta http-equiv=\"content-language\" content=\"en-us\">\n");
+    fprintf(stdout,
+            " <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
     fprintf(stdout, " <title>%s - GRASS GIS manual</title>\n", st->pgm_name);
     fprintf(stdout, " <meta name=\"description\" content=\"%s", st->pgm_name);
     if (st->module_info.description)

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -39,6 +39,8 @@ header1_tmpl = string.Template(
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
  <title>${title} - GRASS GIS Manual</title>
  <meta name="Author" content="GRASS Development Team">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 """
 )
 

--- a/raster/r.li/r.li.html
+++ b/raster/r.li/r.li.html
@@ -2,8 +2,10 @@
 <html>
 <head>
 <title>r.li - GRASS GIS manual</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+ <link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body bgcolor="white">
 <div id="container">

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -375,6 +375,8 @@ header_base = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
  <meta name="Author" content="GRASS Development Team">
  <meta name="description" content="${PGM}: ${PGM_DESC}">
  <link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body bgcolor="white">
 <div id="container">

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -196,8 +196,10 @@ cat <<EOF >"${TMP}.html"
 <html>
 <head>
 <title>$(g.version | cut -f1 -d'(') Command list</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+ <link rel="stylesheet" href="grassdocs.css" type="text/css">
+ <meta http-equiv="content-language" content="en-us">
+ <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body bgcolor="white">
 


### PR DESCRIPTION
This PR addresses #2589 (SEO problems on mobile devices):
- Google: addresses "Page isn't usable on mobile" - "Viewport not set"
    - https://search.google.com/search-console/mobile-usability?resource_id=http%3A%2F%2Fgrass.osgeo.org%2F&hl=en
    - see: https://support.google.com/webmasters/answer/9063469#viewport_not_configured
- Bing: addresses "The page is missing meta language information"
    - https://www.bing.com/webmasters/seoreports?siteUrl=https%3A%2F%2Fgrass.osgeo.org%2F&ruleId=39

Manual pages generated with this PR applied are validated correctly at https://validator.w3.org/
