### PR TITLE
g.extension: use copytree from shutil for py >= 3.8

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -164,7 +164,13 @@ import zipfile
 import tempfile
 import json
 import xml.etree.ElementTree as etree
-from distutils.dir_util import copy_tree
+
+if sys.version_info.major == 3 and sys.version_info.minor < 8:
+    from distutils.dir_util import copy_tree
+else:
+    from functools import partial
+
+    copy_tree = partial(shutil.copytree, dirs_exist_ok=True)
 
 from six.moves.urllib import request as urlrequest
 from six.moves.urllib.error import HTTPError, URLError


### PR DESCRIPTION
Here is a suggestion to address #2016
Not sure if it needs to be backported all the way to 7.8 as people with such an old installation, probably do not have more recent Python anyway. So maybe 8.0 is a sufficient milestone.

An alternative implementation would be choose the function later in the code, like:
```
if sys.version_info.major == 3 and sys.version_info.minor < 8:
        from distutils.dir_util import copy_tree
```
And then here: https://github.com/OSGeo/grass/blob/82fb7b8e93a8b87f7de827c0b1f98992759ce7a1/scripts/g.extension/g.extension.py#L1582

```
if sys.version_info.major == 3 and sys.version_info.minor < 8:
    copy_tree(actual_file, os.path.join(target_dir, file_name))
else:
    shutil.copytree(actual_file, os.path.join(target_dir, file_name), dirs_exist_ok=True)
```
