### PR TITLE
utils: fix date and time format retrieved from the module source dir

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -26,7 +26,6 @@ import locale
 import json
 import pathlib
 import subprocess
-import time
 
 from html.parser import HTMLParser
 

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -152,18 +152,22 @@ def download_git_commit(url, response_format, *args, **kwargs):
         )
 
 
-def get_default_git_log(src_dir):
+def get_default_git_log(src_dir, datetime_format="%A %b %d %H:%M:%S %Y"):
     """Get default Git commit and commit date, when getting commit from
     local Git, local JSON file and remote GitHub REST API server wasn't
     successfull.
 
     :param str src_dir: addon source dir
+    :param str datetime_format: output commit datetime format
+                                e.g. Sunday Jan 16 23:09:35 2022
 
     :return dict: dict which store last commit and commnit date
     """
     return {
         "commit": "unknown",
-        "date": time.ctime(os.path.getmtime(src_dir)),
+        "date": datetime.fromtimestamp(os.path.getmtime(src_dir)).strftime(
+            datetime_format
+        ),
     }
 
 
@@ -266,7 +270,7 @@ def format_git_commit_date_from_rest_api(
 
     :param str commit_datetime: commit datetime
     :param str datetime_format: output commit datetime format
-                                e.g. Sun Jan 16 23:09:35 2022
+                                e.g. Sunday Jan 16 23:09:35 2022
 
     :return str: output formatted commit datetime
     """
@@ -283,7 +287,7 @@ def format_git_commit_date_from_local_git(
 
     :param str commit_datetime: commit datetime
     :param str datetime_format: output commit datetime format
-                                e.g. Sun Jan 16 23:09:35 2022
+                                e.g. Sunday Jan 16 23:09:35 2022
 
     :return str: output formatted commit datetime
     """


### PR DESCRIPTION
Same date and time format `"%A %b %d %H:%M:%S %Y"` (example Wednesday Oct 05 06:42:36 2022) inside manual page for all use cases:

1. Core modules compiled from Git repository, with date and time retrievied from the last commit.

2. Core modules compiled from tarball without Git repository and without applied official patch core_modules_with_last_commit.patch, with date and time retrievied from the module source directory.

3. Core modules compiled from tarball without Git repository and with applied official patch core_modules_with_last_commit.patch, with date and time retrievied from the core_modules_with_last_commit.json file.

4. Official addons with date and time retrievied from the last commit via GitHub REST API.

5. Unofficial addons with date and time retrievied from the module source directory.

This PR fix case no. **2** and **5**.

**Current date and time format** (inside core module / addon man page)**:**

Accessed: Sun Oct  9 12:16:03 2022

**Expected date and time format** (inside core module / addon man page)**:**

Accessed: Sunday Oct 09 12:16:03 2022 

**Additional context:**

After merging this PR, the `g.citation` addon will need to change regular expression for catch this date and time format.