### PR TITLE
r3.gwflow: Fix Rast3d_fatal_error() usage

### DIFF
--- a/raster3d/r3.gwflow/main.c
+++ b/raster3d/r3.gwflow/main.c
@@ -420,7 +420,7 @@ write_result(N_array_3d * status, N_array_3d * phead_start,
         Rast3d_fatal_error
             ("Error flushing tiles with Rast3d_flush_all_tiles");
     if (!Rast3d_close(map))
-        Rast3d_fatal_error(map, NULL, 0, _("Unable to close 3D raster map"));
+        Rast3d_fatal_error(_("Unable to close 3D raster map <%s>"), name);
 
     return;
 }


### PR DESCRIPTION
Fixes usage of Rast3d_fatal_error()