### PR TITLE
contributing: Enforce that duplicate files are the same

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Check that files with the same content are the same
+        run: |
+          diff Dockerfile docker/ubuntu/Dockerfile
+
       - name: Generate core modules with last commit JSON file and test it
         run: |
           python -m pip install pytest pytest-depends


### PR DESCRIPTION
Sometimes two files in the repo need to be the same. Various Dockerfiles are in docker directory, but having a (the one) Dockerfile in the main directly makes sense, too. A new check enforces that the file in synced with the other copy.
