### PR TITLE
nsis installer changed SID of grass82.py

### DIFF
--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -758,8 +758,8 @@ Section "GRASS" SecGRASS
 	Push 'config_projshare = "$INSTDIR\share\proj"' ; string to replace whole line with
 	Call ReplaceLineStr
 
-	;replace BU with numeric group name for local users
-        AccessControl::SetOnFile "$INSTDIR\etc\grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@.py" "(S-1-5-32-545)" "GenericRead + GenericExecute"                 
+	;replace BU with numeric group name for local users. Users  S-1-5-32-545 does not work for Windows Enterprise. Try Authenticated Users S-1-5-11
+        AccessControl::SetOnFile "$INSTDIR\etc\grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@.py" "(S-1-5-11)" "GenericRead + GenericExecute"                 
 SectionEnd
 
 ;--------------------------------------------------------------------------


### PR DESCRIPTION
In theory, this should fix [2603](https://github.com/OSGeo/grass/issues/2603). On Windows 10 Professional , the permissions are correct.  Will need to test on Windows 10 Enterprise 