### PR TITLE
lib config: create dynamic library of C++ libraries

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -448,6 +448,9 @@ AC_DEFUN([SC_ENABLE_SHARED], [
 #                       code, among other things).
 #       SHLIB_LD -      Base command to use for combining object files
 #                       into a shared library.
+#       SHLIB_LDX -     Base command to use for combining object files
+#                       into a shared C++ library.  Make sure "IS_CXX = yes"
+#                       is set in the library's Makefile.
 #       SHLIB_LD_FLAGS -Flags to pass when building a shared library. This
 #                       differes from the SHLIB_CFLAGS as it is not used
 #                       when building object files or executables.
@@ -473,6 +476,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
     SHLIB_LD_FLAGS=""
     SHLIB_SUFFIX=""
     SHLIB_LD=""
+    SHLIB_LDX=""
     STLIB_LD='${AR} cr'
     STLIB_SUFFIX='.a'
     GRASS_TRIM_DOTS='`echo ${LIB_VER} | tr -d .`'
@@ -487,6 +491,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
             SHLIB_LD_FLAGS="-Wl,-soname,\$(notdir \$[@])"
 	    SHLIB_SUFFIX=".so"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
             LDFLAGS="-Wl,--export-dynamic"
             LD_SEARCH_FLAGS='-Wl,-rpath-link,${LIB_RUNTIME_DIR} -Wl,-rpath,${INST_DIR}/lib'
             LD_LIBRARY_PATH_VAR="LD_LIBRARY_PATH"
@@ -500,6 +505,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
         *-pc-mingw32 | *-w64-mingw32 | *-pc-msys)
             SHLIB_SUFFIX=".dll"
             SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
             LDFLAGS="-Wl,--export-dynamic,--enable-runtime-pseudo-reloc"
             LD_LIBRARY_PATH_VAR="PATH"
             ;;
@@ -507,6 +513,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
             SHLIB_CFLAGS="-fno-common"
             SHLIB_SUFFIX=".dylib"
             SHLIB_LD="${CC} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name @rpath/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
+            SHLIB_LDX="${CXX} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name @rpath/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
             LDFLAGS="-Wl,-rpath,${INSTDIR}/lib,-rpath,\${GISBASE}/lib"
             LD_LIBRARY_PATH_VAR="LD_RUN_PATH"
             ;;
@@ -558,6 +565,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 	    SHLIB_CFLAGS="-fPIC"
 	    #SHLIB_LD="ld -Bshareable -x"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
             SHLIB_LD_FLAGS="-Wl,-soname,\$(notdir \$[@])"
 	    SHLIB_SUFFIX=".so"
 	    LDFLAGS="-Wl,--export-dynamic"
@@ -573,6 +581,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 	    # NetBSD has ELF.
 	    SHLIB_CFLAGS="-fPIC"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
 	    SHLIB_LD_LIBS="${LIBS}"
 	    LDFLAGS='-Wl,-rpath,${LIB_RUNTIME_DIR} -export-dynamic'
 	    SHLIB_LD_FLAGS='-Wl,-rpath,${LIB_RUNTIME_DIR} -export-dynamic'
@@ -620,6 +629,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
     AC_SUBST(LD_LIBRARY_PATH_VAR)
 
     AC_SUBST(SHLIB_LD)
+    AC_SUBST(SHLIB_LDX)
     AC_SUBST(SHLIB_LD_FLAGS)
     AC_SUBST(SHLIB_CFLAGS)
     AC_SUBST(SHLIB_SUFFIX)

--- a/configure
+++ b/configure
@@ -773,6 +773,7 @@ STLIB_LD
 SHLIB_SUFFIX
 SHLIB_CFLAGS
 SHLIB_LD_FLAGS
+SHLIB_LDX
 SHLIB_LD
 LD_LIBRARY_PATH_VAR
 LD_SEARCH_FLAGS
@@ -4012,6 +4013,7 @@ ac_save_ldflags="$LDFLAGS"
     SHLIB_LD_FLAGS=""
     SHLIB_SUFFIX=""
     SHLIB_LD=""
+    SHLIB_LDX=""
     STLIB_LD='${AR} cr'
     STLIB_SUFFIX='.a'
     GRASS_TRIM_DOTS='`echo ${LIB_VER} | tr -d .`'
@@ -4026,6 +4028,7 @@ ac_save_ldflags="$LDFLAGS"
             SHLIB_LD_FLAGS="-Wl,-soname,\$(notdir \$@)"
 	    SHLIB_SUFFIX=".so"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
             LDFLAGS="-Wl,--export-dynamic"
             LD_SEARCH_FLAGS='-Wl,-rpath-link,${LIB_RUNTIME_DIR} -Wl,-rpath,${INST_DIR}/lib'
             LD_LIBRARY_PATH_VAR="LD_LIBRARY_PATH"
@@ -4039,6 +4042,7 @@ ac_save_ldflags="$LDFLAGS"
         *-pc-mingw32 | *-w64-mingw32 | *-pc-msys)
             SHLIB_SUFFIX=".dll"
             SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
             LDFLAGS="-Wl,--export-dynamic,--enable-runtime-pseudo-reloc"
             LD_LIBRARY_PATH_VAR="PATH"
             ;;
@@ -4046,6 +4050,7 @@ ac_save_ldflags="$LDFLAGS"
             SHLIB_CFLAGS="-fno-common"
             SHLIB_SUFFIX=".dylib"
             SHLIB_LD="${CC} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name @rpath/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
+            SHLIB_LDX="${CXX} -dynamiclib -compatibility_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -current_version \${GRASS_VERSION_MAJOR}.\${GRASS_VERSION_MINOR} -install_name @rpath/lib\${LIB_NAME}\${SHLIB_SUFFIX}"
             LDFLAGS="-Wl,-rpath,${INSTDIR}/lib,-rpath,\${GISBASE}/lib"
             LD_LIBRARY_PATH_VAR="LD_RUN_PATH"
             ;;
@@ -4105,6 +4110,7 @@ $as_echo "#define _POSIX_PTHREAD_SEMANTICS 1" >>confdefs.h
 	    SHLIB_CFLAGS="-fPIC"
 	    #SHLIB_LD="ld -Bshareable -x"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
             SHLIB_LD_FLAGS="-Wl,-soname,\$(notdir \$@)"
 	    SHLIB_SUFFIX=".so"
 	    LDFLAGS="-Wl,--export-dynamic"
@@ -4120,6 +4126,7 @@ $as_echo "#define _POSIX_PTHREAD_SEMANTICS 1" >>confdefs.h
 	    # NetBSD has ELF.
 	    SHLIB_CFLAGS="-fPIC"
 	    SHLIB_LD="${CC} -shared"
+            SHLIB_LDX="${CXX} -shared"
 	    SHLIB_LD_LIBS="${LIBS}"
 	    LDFLAGS='-Wl,-rpath,${LIB_RUNTIME_DIR} -export-dynamic'
 	    SHLIB_LD_FLAGS='-Wl,-rpath,${LIB_RUNTIME_DIR} -export-dynamic'
@@ -4161,6 +4168,7 @@ $as_echo "#define _POSIX_PTHREAD_SEMANTICS 1" >>confdefs.h
             as_fn_error $? "***Unknown platform: $host***" "$LINENO" 5
             ;;
     esac
+
 
 
 

--- a/include/Make/Grass.make
+++ b/include/Make/Grass.make
@@ -261,11 +261,7 @@ $(1)LIB = -l$$($(1)_LIBNAME) $$($(1)DEPS)
 else
 $(1)LIB = -l$$($(1)_LIBNAME)
 endif
-ifneq ($(1),IOSTREAM)
 $(1)DEP = $$(BASE_LIBDIR)/$$(LIB_PREFIX)$$($(1)_LIBNAME)$$(LIB_SUFFIX)
-else
-$(1)DEP = $$(BASE_LIBDIR)/$$(STLIB_PREFIX)$$($(1)_LIBNAME)$$(STLIB_SUFFIX)
-endif
 endef
 
 $(foreach lib,$(libs),$(eval $(call lib_rules,$(firstword $(subst :, ,$(lib))),$(lastword $(subst :, ,$(lib))))))

--- a/include/Make/Platform.make.in
+++ b/include/Make/Platform.make.in
@@ -63,6 +63,7 @@ STLIB_SUFFIX        = @STLIB_SUFFIX@
 #shared libs
 SHLIB_PREFIX        = lib
 SHLIB_LD            = @SHLIB_LD@
+SHLIB_LDX           = @SHLIB_LDX@
 SHLIB_LDFLAGS       = @SHLIB_LD_FLAGS@
 SHLIB_CFLAGS        = @SHLIB_CFLAGS@
 SHLIB_SUFFIX        = @SHLIB_SUFFIX@

--- a/include/Make/Shlib.make
+++ b/include/Make/Shlib.make
@@ -6,8 +6,14 @@ CFLAGS += $(SHLIB_CFLAGS)
 CXXFLAGS += $(SHLIB_CFLAGS)
 LDFLAGS += $(SHLIB_LDFLAGS)
 
+ifndef IS_CXX
+SHL = $(SHLIB_LD)
+else
+SHL = $(SHLIB_LDX)
+endif
+
 $(SHLIB): $(SHLIB_OBJS)
-	$(SHLIB_LD) -o $@ $(LDFLAGS) $^ $(LIBES) $(EXTRA_LIBS) $(MATHLIB)
+	$(SHL) -o $@ $(LDFLAGS) $^ $(LIBES) $(EXTRA_LIBS) $(MATHLIB)
 ifndef MINGW
 	(cd $(ARCH_LIBDIR); ln -f -s $(notdir $@) $(patsubst %.$(GRASS_LIB_VERSION_NUMBER)$(SHLIB_SUFFIX),%$(SHLIB_SUFFIX),$@))
 endif

--- a/lib/iostream/Makefile
+++ b/lib/iostream/Makefile
@@ -2,9 +2,14 @@ MODULE_TOPDIR = ../..
 
 LIB = IOSTREAM
 
+IS_CXX = yes
+
 include $(MODULE_TOPDIR)/include/Make/Lib.make
 
-
 ifneq ($(strip $(CXX)),)
+ifneq ($(strip $(SHLIB_LDX)),)
+default: lib
+else
 default: stlib
+endif
 endif


### PR DESCRIPTION
Up till now linking C++ based libraries (at this point only the **iostream** library) was forced into creating a static library. This PR enables the possibility to create a dynamic library with the new configure flag 'SHLIB_LDX', which could use CXX instead of CC.

`IS_CXX = yes` must be set before including the 'Lib.make' file in the library's Makefile.