### PR TITLE
grass.pygrass: GridModule clean up temporary mapsets when exception occurs

### DIFF
--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -7,6 +7,7 @@ from __future__ import (
     print_function,
     unicode_literals,
 )
+import contextlib
 import os
 import sys
 import multiprocessing as mltp
@@ -647,17 +648,23 @@ class GridModule(object):
         """
         self.module.flags.overwrite = True
         self.define_mapset_inputs()
-        if self.debug:
-            for wrk in self.get_works():
-                cmd_exe(wrk)
-        else:
-            pool = mltp.Pool(processes=self.processes)
-            result = pool.map_async(cmd_exe, self.get_works())
-            result.wait()
-            pool.close()
-            pool.join()
-            if not result.successful():
-                raise RuntimeError(_("Execution of subprocesses was not successful"))
+
+        with contextlib.ExitStack() as stack:
+            if clean:
+                stack.callback(self._clean)
+            if self.debug:
+                for wrk in self.get_works():
+                    cmd_exe(wrk)
+            else:
+                pool = mltp.Pool(processes=self.processes)
+                result = pool.map_async(cmd_exe, self.get_works())
+                result.wait()
+                pool.close()
+                pool.join()
+                if not result.successful():
+                    raise RuntimeError(
+                        _("Execution of subprocesses was not successful")
+                    )
 
         if patch:
             if self.move:
@@ -689,17 +696,18 @@ class GridModule(object):
                     fil = open(os.path.join(dirpath, self.out_prefix + par.value), "w+")
                     fil.close()
 
-        if clean:
-            self.clean_location()
-            self.rm_tiles()
-            if self.n_mset:
-                gisdbase, location = os.path.split(self.move)
-                self.clean_location(Location(location, gisdbase))
-                # rm temporary gis_rc
-                os.remove(self.gisrc_dst)
-                self.gisrc_dst = None
-                sht.rmtree(os.path.join(self.move, "PERMANENT"))
-                sht.rmtree(os.path.join(self.move, self.mset.name))
+    def _clean(self):
+        """Cleanup temporary data"""
+        self.clean_location()
+        self.rm_tiles()
+        if self.n_mset:
+            gisdbase, location = os.path.split(self.move)
+            self.clean_location(Location(location, gisdbase))
+            # rm temporary gis_rc
+            os.remove(self.gisrc_dst)
+            self.gisrc_dst = None
+            sht.rmtree(os.path.join(self.move, "PERMANENT"))
+            sht.rmtree(os.path.join(self.move, self.mset.name))
 
     def patch(self):
         """Patch the final results."""

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -669,9 +669,7 @@ class GridModule(object):
             pool.close()
             pool.join()
             if not result.successful():
-                raise RuntimeError(
-                    _("Execution of subprocesses was not successful"),
-                )
+                raise RuntimeError(_("Execution of subprocesses was not successful"))
 
         if patch:
             if self.move:

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -406,6 +406,28 @@ def cmd_exe(args):
     os.remove(gisrc_dst)
 
 
+class CleanManager:
+    """Clean temporary files
+
+    :param bool clean: True if you want clean temporary files
+    :param function clean_func: clean function
+    """
+
+    def __init__(self, clean, clean_func):
+        self._clean = clean
+        self._clean_func = clean_func
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if exc_type:
+            self._clean_func()
+            return
+        if self._clean:
+            self._clean_func()
+
+
 class GridModule(object):
     # TODO maybe also i.* could be supported easily
     """Run GRASS raster commands in a multiprocessing mode.
@@ -645,61 +667,72 @@ class GridModule(object):
                       created by GridModule
         :type clean: bool
         """
-        self.module.flags.overwrite = True
-        self.define_mapset_inputs()
-        if self.debug:
-            for wrk in self.get_works():
-                cmd_exe(wrk)
-        else:
-            pool = mltp.Pool(processes=self.processes)
-            result = pool.map_async(cmd_exe, self.get_works())
-            result.wait()
-            pool.close()
-            pool.join()
-            if not result.successful():
-                raise RuntimeError(_("Execution of subprocesses was not successful"))
-
-        if patch:
-            if self.move:
-                os.environ["GISRC"] = self.gisrc_dst
-                self.n_mset.current()
-                self.patch()
-                os.environ["GISRC"] = self.gisrc_src
-                self.mset.current()
-                # copy the outputs from dst => src
-                routputs = [
-                    self.out_prefix + o for o in select(self.module.outputs, "raster")
-                ]
-                copy_rasters(routputs, self.gisrc_dst, self.gisrc_src)
+        with CleanManager(clean=clean, clean_func=self.clean):
+            self.module.flags.overwrite = True
+            self.define_mapset_inputs()
+            if self.debug:
+                for wrk in self.get_works():
+                    cmd_exe(wrk)
             else:
-                self.patch()
+                pool = mltp.Pool(processes=self.processes)
+                result = pool.map_async(cmd_exe, self.get_works())
+                result.wait()
+                pool.close()
+                pool.join()
+                if not result.successful():
+                    raise RuntimeError(
+                        _("Execution of subprocesses was not successful")
+                    )
 
-        if self.log:
-            # record in the temp directory
-            from grass.lib.gis import G_tempfile
+            if patch:
+                if self.move:
+                    os.environ["GISRC"] = self.gisrc_dst
+                    self.n_mset.current()
+                    self.patch()
+                    os.environ["GISRC"] = self.gisrc_src
+                    self.mset.current()
+                    # copy the outputs from dst => src
+                    routputs = [
+                        self.out_prefix + o
+                        for o in select(self.module.outputs, "raster")
+                    ]
+                    copy_rasters(routputs, self.gisrc_dst, self.gisrc_src)
+                else:
+                    self.patch()
 
-            tmp, dummy = os.path.split(G_tempfile())
-            tmpdir = os.path.join(tmp, self.module.name)
-            for k in self.module.outputs:
-                par = self.module.outputs[k]
-                if par.typedesc == "raster" and par.value:
-                    dirpath = os.path.join(tmpdir, par.name)
-                    if not os.path.isdir(dirpath):
-                        os.makedirs(dirpath)
-                    fil = open(os.path.join(dirpath, self.out_prefix + par.value), "w+")
-                    fil.close()
+            if self.log:
+                # record in the temp directory
+                from grass.lib.gis import G_tempfile
 
-        if clean:
-            self.clean_location()
-            self.rm_tiles()
-            if self.n_mset:
-                gisdbase, location = os.path.split(self.move)
-                self.clean_location(Location(location, gisdbase))
-                # rm temporary gis_rc
-                os.remove(self.gisrc_dst)
-                self.gisrc_dst = None
-                sht.rmtree(os.path.join(self.move, "PERMANENT"))
-                sht.rmtree(os.path.join(self.move, self.mset.name))
+                tmp, dummy = os.path.split(G_tempfile())
+                tmpdir = os.path.join(tmp, self.module.name)
+                for k in self.module.outputs:
+                    par = self.module.outputs[k]
+                    if par.typedesc == "raster" and par.value:
+                        dirpath = os.path.join(tmpdir, par.name)
+                        if not os.path.isdir(dirpath):
+                            os.makedirs(dirpath)
+                        fil = open(
+                            os.path.join(
+                                dirpath,
+                                self.out_prefix + par.value,
+                            ),
+                            "w+",
+                        )
+                        fil.close()
+
+    def clean(self):
+        """Cleanup temporary data"""
+        self.clean_location()
+        self.rm_tiles()
+        if self.n_mset:
+            gisdbase, location = os.path.split(self.move)
+            self.clean_location(Location(location, gisdbase))
+            # rm temporary gis_rc
+            os.remove(self.gisrc_dst)
+            self.gisrc_dst = None
+            sht.rmtree(os.path.join(self.move, "PERMANENT"))
+            sht.rmtree(os.path.join(self.move, self.mset.name))
 
     def patch(self):
         """Patch the final results."""

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -127,13 +127,8 @@ def test_overlaps(tmp_path, overlap):
         assert info["min"] > 0
 
 
-@pytest.mark.parametrize(
-    "clean, surface",
-    [
-        (True, False),
-        ("surface", "non_exist_surface"),
-    ],
-)
+@pytest.mark.parametrize("clean", [True, False])
+@pytest.mark.parametrize("surface", ["surface", "non_exist_surface"])
 def test_cleans(tmp_path, clean, surface):
     """Check that temporary mapsets are cleaned when appropriate"""
     location = "test"

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -127,16 +127,22 @@ def test_overlaps(tmp_path, overlap):
         assert info["min"] > 0
 
 
-@pytest.mark.parametrize("clean", [True, False])
-def test_cleans(tmp_path, clean):
+@pytest.mark.parametrize(
+    "clean, surface",
+    [
+        (True, False),
+        ("surface", "non_exist_surface"),
+    ],
+)
+def test_cleans(tmp_path, clean, surface):
     """Check that temporary mapsets are cleaned when appropriate"""
     location = "test"
     mapset_prefix = "abc"
     gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
     with gs.setup.init(tmp_path / location):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
-        surface = "surface"
-        gs.run_command("r.surf.fractal", output=surface)
+        if surface == "surface":
+            gs.run_command("r.surf.fractal", output=surface)
 
         def run_grid_module():
             # modules/shortcuts calls get_commands which requires GISBASE.


### PR DESCRIPTION
**Describe the bug**
`run()` method of the `GridModule` class instance doesn't clean up temporary MAPSETs when exception occurs (input raster map doesn't exists).

**To Reproduce**
Steps to reproduce the behavior:

1.  Launch GRASS GIS with **nc_spm_08_grass7** LOCATION and **PERMANENT** MAPSET
2.  Launch this Python script
```python
#!/usr/bin/env python3

from grass.pygrass.modules.grid.grid import GridModule

def main():
    grd = GridModule("r.slope.aspect",
                    width=100, height=100, overlap=2,
                    processes=None, split=False, elevation="non_exist_elevation", 
                    slope="slope", aspect="aspect", overwrite=True)
    grd.run()

if __name__ == '__main__':
    main()
```
3. See error
```
GRASS nc_spm_08_grass7/PERMANENT:grass > python /tmp/test.py 
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
ERROR: Raster map <non_exist_elevation> not found
Traceback (most recent call last):
  File "/tmp/test.py", line 13, in <module>
    main()
  File "/tmp/test.py", line 10, in main
    grd.run()
  File "/usr/lib64/grass83/etc/python/grass/pygrass/modules/grid/grid.py", line 675, in run
    self.patch()
  File "/usr/lib64/grass83/etc/python/grass/pygrass/modules/grid/grid.py", line 712, in patch
    rpatch_map(
  File "/usr/lib64/grass83/etc/python/grass/pygrass/modules/grid/patch.py", line 94, in rpatch_map
    rtype.open("r")
  File "/usr/lib64/grass83/etc/python/grass/pygrass/raster/__init__.py", line 218, in open
    raise OpenError(str_err)
grass.exceptions.OpenError: The map does not exist, I can't open in 'r' mode
```

5. Check the list of LOCATION MAPSETs

```
GRASS nc_spm_08_grass7/PERMANENT:grass > tree -d -L 1 $(g.gisenv get=GISDBASE)/$(g.gisenv get=LOCATION_NAME)
/home/tomas/grassdata/nc_spm_08_grass7
├── climate_2000_2012
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_000_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_000_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_000_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_000_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_000_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_000_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_001_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_001_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_001_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_001_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_001_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_001_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_002_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_002_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_002_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_002_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_002_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_002_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_003_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_003_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_003_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_003_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_003_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25275_003_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_000_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_000_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_000_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_000_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_000_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_000_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_001_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_001_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_001_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_001_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_001_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_001_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_002_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_002_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_002_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_002_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_002_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_002_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_003_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_003_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_003_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_003_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_003_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_003_005
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_004_000
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_004_001
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_004_002
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_004_003
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_004_004
├── grid_r_slope_aspect_gentoo_gnu_linux_25704_004_005
├── landsat
├── PERMANENT
└── tomas
```

**Expected behavior**
Clean up the temporary MAPSETs when an exception (input raster map does not exist) occurs during the `run()` method of an instance of the `GridModule` class.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all

