### PR TITLE
CI: Address Windows specific issues in testsuite

### DIFF
--- a/gui/wxpython/core/testsuite/toolboxes.sh
+++ b/gui/wxpython/core/testsuite/toolboxes.sh
@@ -3,5 +3,5 @@
 # run make in gui/wxpython before the test
 # run test using sh -e
 
-python $GISBASE/gui/wxpython/core/toolboxes.py doctest
-python $GISBASE/gui/wxpython/core/toolboxes.py test
+python3 $GISBASE/gui/wxpython/core/toolboxes.py doctest
+python3 $GISBASE/gui/wxpython/core/toolboxes.py test

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -791,6 +791,8 @@ def do_doctest_gettext_workaround():
 
     if sys.version_info[0] == 2:
         import __builtin__
+    elif locals().get("__builtin__", globals().get("__builtin__")) is None:
+        import builtins as __builtin__
 
     __builtin__._ = new_translator
 

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -792,7 +792,7 @@ def do_doctest_gettext_workaround():
     if sys.version_info[0] == 2:
         import __builtin__
 
-        __builtin__._ = new_translator
+    __builtin__._ = new_translator
 
 
 def doc_test():

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -794,6 +794,7 @@ def do_doctest_gettext_workaround():
 
         __builtin__._ = new_translator
 
+
 def doc_test():
     """Tests the module using doctest
 

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -27,11 +27,6 @@ if hasattr(etree, "ParseError"):
 else:
     ETREE_EXCEPTIONS = expat.ExpatError
 
-if sys.version_info[0:2] > (2, 6):
-    has_xpath = True
-else:
-    has_xpath = False
-
 import grass.script.task as gtask
 import grass.script.core as gcore
 from grass.script.utils import try_remove, decode
@@ -430,18 +425,7 @@ def _expandToolboxes(node, toolboxes):
             items = n.find("./items")
             idx = list(items).index(subtoolbox)
 
-            if has_xpath:
-                toolbox = toolboxes.find(
-                    './/toolbox[@name="%s"]' % subtoolbox.get("name")
-                )
-            else:
-                toolbox = None
-                potentialToolboxes = toolboxes.findall(".//toolbox")
-                sName = subtoolbox.get("name")
-                for pToolbox in potentialToolboxes:
-                    if pToolbox.get("name") == sName:
-                        toolbox = pToolbox
-                        break
+            toolbox = toolboxes.find('.//toolbox[@name="%s"]' % subtoolbox.get("name"))
 
             if toolbox is None:  # not in file
                 continue
@@ -576,15 +560,7 @@ def _expandItems(node, items, itemTag):
     """
     for moduleItem in node.findall(".//" + itemTag):
         itemName = moduleItem.get("name")
-        if has_xpath:
-            moduleNode = items.find('.//%s[@name="%s"]' % (itemTag, itemName))
-        else:
-            moduleNode = None
-            potentialModuleNodes = items.findall(".//%s" % itemTag)
-            for mNode in potentialModuleNodes:
-                if mNode.get("name") == itemName:
-                    moduleNode = mNode
-                    break
+        moduleNode = items.find('.//%s[@name="%s"]' % (itemTag, itemName))
 
         if moduleNode is None:  # module not available in dist
             continue
@@ -789,12 +765,9 @@ def do_doctest_gettext_workaround():
     sys.displayhook = new_displayhook
     sys.__displayhook__ = new_displayhook
 
-    if sys.version_info[0] == 2:
-        import __builtin__
-    elif locals().get("__builtin__", globals().get("__builtin__")) is None:
-        import builtins as __builtin__
+    import builtins as _builtins
 
-    __builtin__._ = new_translator
+    _builtins.__dict__["_"] = new_translator
 
 
 def doc_test():

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -789,10 +789,10 @@ def do_doctest_gettext_workaround():
     sys.displayhook = new_displayhook
     sys.__displayhook__ = new_displayhook
 
-    import __builtin__
+    if sys.version_info[0] == 2:
+        import __builtin__
 
-    __builtin__._ = new_translator
-
+        __builtin__._ = new_translator
 
 def doc_test():
     """Tests the module using doctest

--- a/lib/gis/testsuite/test_parser_json.py
+++ b/lib/gis/testsuite/test_parser_json.py
@@ -83,7 +83,9 @@ class TestParserJson(TestCase):
             }
         ]
 
-        stdout, stderr = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()
+        stdout, stderr = subprocess.Popen(
+            args, stdout=subprocess.PIPE, shell=sys.platform == "win32"
+        ).communicate()
         print(stdout)
         json_code = json.loads(decode(stdout))
         self.assertEqual(json_code["module"], "v.out.ascii")

--- a/lib/gis/testsuite/test_parser_json.py
+++ b/lib/gis/testsuite/test_parser_json.py
@@ -8,10 +8,12 @@ for details.
 @author Soeren Gebbert
 """
 
+import json
 import subprocess
+import sys
+
 from grass.gunittest.case import TestCase
 from grass.script import decode
-import json
 
 
 class TestParserJson(TestCase):
@@ -50,7 +52,9 @@ class TestParserJson(TestCase):
             },
         ]
 
-        stdout, stderr = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()
+        stdout, stderr = subprocess.Popen(
+            args, stdout=subprocess.PIPE, shell=sys.platform == "win32"
+        ).communicate()
         print(stdout)
         json_code = json.loads(decode(stdout))
         self.assertEqual(json_code["module"], "r.slope.aspect")
@@ -101,7 +105,9 @@ class TestParserJson(TestCase):
             {"param": "layer", "value": "1"},
         ]
 
-        stdout, stderr = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()
+        stdout, stderr = subprocess.Popen(
+            args, stdout=subprocess.PIPE, shell=sys.platform == "win32"
+        ).communicate()
         print(stdout)
         json_code = json.loads(decode(stdout))
         self.assertEqual(json_code["module"], "v.info")

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -30,7 +30,7 @@ class TestTmpMapset(unittest.TestCase):
     """Tests --tmp-mapset option of grass command"""
 
     # TODO: here we need a name of or path to the main GRASS GIS executable
-    executable = "grass"
+    executable = shutil.which("grass")
     # an arbitrary, but identifiable and fairly unique name
     location = "test_tmp_mapset_xy"
 

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -18,7 +18,7 @@ import unittest
 import os
 import shutil
 import subprocess
-
+import sys
 
 # Note that unlike rest of GRASS GIS, here we are using unittest package
 # directly. The grass.gunittest machinery for mapsets is not needed here.
@@ -46,7 +46,8 @@ class TestTmpMapset(unittest.TestCase):
     def test_command_runs(self):
         """Check that correct parameters are accepted"""
         return_code = subprocess.call(
-            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-g"]
+            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-g"],
+            shell=sys.platform == "win32",
         )
         self.assertEqual(
             return_code,
@@ -67,7 +68,8 @@ class TestTmpMapset(unittest.TestCase):
                 "--exec",
                 "g.proj",
                 "-g",
-            ]
+            ],
+            shell=sys.platform == "win32",
         )
         self.assertNotEqual(
             return_code,
@@ -81,7 +83,8 @@ class TestTmpMapset(unittest.TestCase):
     def test_mapset_metadata_correct(self):
         """Check that metadata is readable and have expected value (XY CRS)"""
         output = subprocess.check_output(
-            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-g"]
+            [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-g"],
+            shell=sys.platform == "win32",
         )
         self.assertEqual(
             output.strip(),

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -36,7 +36,8 @@ class TestTmpMapset(unittest.TestCase):
 
     def setUp(self):
         """Creates a location used in the tests"""
-        subprocess.check_call([self.executable, "-c", "XY", self.location, "-e"],
+        subprocess.check_call(
+            [self.executable, "-c", "XY", self.location, "-e"],
             shell=sys.platform == "win32",
         )
         self.subdirs = os.listdir(self.location)

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -36,7 +36,9 @@ class TestTmpMapset(unittest.TestCase):
 
     def setUp(self):
         """Creates a location used in the tests"""
-        subprocess.check_call([self.executable, "-c", "XY", self.location, "-e"])
+        subprocess.check_call([self.executable, "-c", "XY", self.location, "-e"],
+            shell=sys.platform == "win32",
+        )
         self.subdirs = os.listdir(self.location)
 
     def tearDown(self):

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -12,8 +12,9 @@
 
 """Tests of grass.grassdb.manage"""
 
+import os
+
 from pathlib import Path
-import sys
 
 from grass.grassdb.manage import MapsetPath, resolve_mapset_path, split_mapset_path
 from grass.gunittest.case import TestCase
@@ -21,15 +22,12 @@ from grass.gunittest.gmodules import call_module
 from grass.gunittest.main import test
 
 
-ms_windows = sys.platform == "win32" or sys.platform == "cygwin"
-
-
 class TestMapsetPath(TestCase):
     """Check that object can be constructed"""
 
     def test_mapset_from_path_object(self):
         """Check that path is correctly stored"""
-        path = "does\\not\\exist\\" if ms_windows else "does/not/exist/"
+        path = "does/not/exist/"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         full_path = Path(path) / location_name / mapset_name
@@ -37,14 +35,15 @@ class TestMapsetPath(TestCase):
             path=full_path, directory=path, location=location_name, mapset=mapset_name
         )
         # Paths are currently stored as is (not resolved).
-        self.assertEqual(mapset_path.directory, path)
+        # pathlib uses os.sep for string represtentation of Path objects
+        self.assertEqual(mapset_path.directory, path.replace("/", os.sep))
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
         self.assertEqual(mapset_path.path, Path(path) / location_name / mapset_name)
 
     def test_mapset_from_str(self):
         """Check with path from str and database directory as Path"""
-        path = "does\\not\\exist" if ms_windows else "does/not/exist"
+        path = "does/not/exist"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         full_path = Path(path) / location_name / mapset_name
@@ -55,7 +54,8 @@ class TestMapsetPath(TestCase):
             mapset=mapset_name,
         )
         # Paths are currently stored as is (not resolved).
-        self.assertEqual(mapset_path.directory, path)
+        # pathlib uses os.sep for string represtentation of Path objects
+        self.assertEqual(mapset_path.directory, path.replace("/", os.sep))
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
         self.assertEqual(mapset_path.path, Path(path) / location_name / mapset_name)
@@ -66,36 +66,36 @@ class TestSplitMapsetPath(TestCase):
 
     def test_split_path(self):
         """Check that pathlib.Path is correctly split"""
-        ref_db = "does\\not\\exist" if ms_windows else "does/not/exist"
+        ref_db = "does/not/exist"
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
         new_db, new_location, new_mapset = split_mapset_path(path)
-        self.assertEqual(new_db, ref_db)
+        self.assertEqual(new_db, ref_db.replace("/", os.sep))
         self.assertEqual(new_location, ref_location)
         self.assertEqual(new_mapset, ref_mapset)
 
     def test_split_str(self):
         """Check that path as str is correctly split"""
-        ref_db = "does\\not\\exist" if ms_windows else "does/not/exist"
+        ref_db = "does/not/exist"
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
         new_db, new_location, new_mapset = split_mapset_path(str(path))
-        self.assertEqual(new_db, ref_db)
+        self.assertEqual(new_db, ref_db.replace("/", os.sep))
         self.assertEqual(new_location, ref_location)
         self.assertEqual(new_mapset, ref_mapset)
 
     def test_split_str_trailing_slash(self):
         """Check that path as str with a trailing slash is correctly split"""
-        ref_db = "does\\not\\exist" if ms_windows else "does/not/exist"
+        ref_db = "does/not/exist"
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
         new_db, new_location, new_mapset = split_mapset_path(
-            str(path) + "\\" if ms_windows else str(path) + "/"
+            str(path) + "/"
         )
-        self.assertEqual(new_db, ref_db)
+        self.assertEqual(new_db, ref_db.replace("/", os.sep))
         self.assertEqual(new_location, ref_location)
         self.assertEqual(new_mapset, ref_mapset)
 
@@ -135,13 +135,13 @@ class TestResolveMapsetPath(TestCase):
 
     def test_mapset_from_parts(self):
         """Check that a non-existing path is correctly constructed."""
-        path = "does\\not\\exist" if ms_windows else "does/not/exist"
+        path = "does/not/exist"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         mapset_path = resolve_mapset_path(
             path=path, location=location_name, mapset=mapset_name
         )
-        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
+        self.assertEqual(mapset_path.directory, str(Path(path).resolve()).replace("/", os.sep))
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
         self.assertEqual(
@@ -150,12 +150,12 @@ class TestResolveMapsetPath(TestCase):
 
     def test_mapset_from_path(self):
         """Check that a non-existing path is correctly parsed."""
-        path = "does\\not\\exist\\" if ms_windows else "does/not/exist/"
+        path = "does/not/exist/"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         full_path = str(Path(path) / location_name / mapset_name)
         mapset_path = resolve_mapset_path(path=full_path)
-        self.assertEqual(mapset_path.directory, str(Path(path).resolve()))
+        self.assertEqual(mapset_path.directory, str(Path(path).resolve()).replace("/", os.sep))
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
         self.assertEqual(

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -44,7 +44,7 @@ class TestMapsetPath(TestCase):
 
     def test_mapset_from_str(self):
         """Check with path from str and database directory as Path"""
-        path = "does/not/exist"
+        path = "does\\not\\exist" if ms_windows else "does/not/exist"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         full_path = Path(path) / location_name / mapset_name
@@ -66,7 +66,7 @@ class TestSplitMapsetPath(TestCase):
 
     def test_split_path(self):
         """Check that pathlib.Path is correctly split"""
-        ref_db = "does/not/exist"
+        ref_db = "does\\not\\exist" if ms_windows else "does/not/exist"
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
@@ -77,7 +77,7 @@ class TestSplitMapsetPath(TestCase):
 
     def test_split_str(self):
         """Check that path as str is correctly split"""
-        ref_db = "does/not/exist"
+        ref_db = "does\\not\\exist" if ms_windows else "does/not/exist"
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
@@ -93,7 +93,7 @@ class TestSplitMapsetPath(TestCase):
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
         new_db, new_location, new_mapset = split_mapset_path(
-            str(path) + "\\" if ms_windows else "/"
+            str(path) + "\\" if ms_windows else str(path) + "/"
         )
         self.assertEqual(new_db, ref_db)
         self.assertEqual(new_location, ref_location)
@@ -135,7 +135,7 @@ class TestResolveMapsetPath(TestCase):
 
     def test_mapset_from_parts(self):
         """Check that a non-existing path is correctly constructed."""
-        path = "does/not/exist"
+        path = "does\\not\\exist" if ms_windows else "does/not/exist"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         mapset_path = resolve_mapset_path(

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -92,9 +92,7 @@ class TestSplitMapsetPath(TestCase):
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
-        new_db, new_location, new_mapset = split_mapset_path(
-            str(path) + "/"
-        )
+        new_db, new_location, new_mapset = split_mapset_path(str(path) + "/")
         self.assertEqual(new_db, ref_db.replace("/", os.sep))
         self.assertEqual(new_location, ref_location)
         self.assertEqual(new_mapset, ref_mapset)
@@ -141,7 +139,9 @@ class TestResolveMapsetPath(TestCase):
         mapset_path = resolve_mapset_path(
             path=path, location=location_name, mapset=mapset_name
         )
-        self.assertEqual(mapset_path.directory, str(Path(path).resolve()).replace("/", os.sep))
+        self.assertEqual(
+            mapset_path.directory, str(Path(path).resolve()).replace("/", os.sep)
+        )
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
         self.assertEqual(
@@ -155,7 +155,9 @@ class TestResolveMapsetPath(TestCase):
         mapset_name = "test_mapset_1"
         full_path = str(Path(path) / location_name / mapset_name)
         mapset_path = resolve_mapset_path(path=full_path)
-        self.assertEqual(mapset_path.directory, str(Path(path).resolve()).replace("/", os.sep))
+        self.assertEqual(
+            mapset_path.directory, str(Path(path).resolve()).replace("/", os.sep)
+        )
         self.assertEqual(mapset_path.location, location_name)
         self.assertEqual(mapset_path.mapset, mapset_name)
         self.assertEqual(

--- a/python/grass/grassdb/testsuite/test_manage.py
+++ b/python/grass/grassdb/testsuite/test_manage.py
@@ -13,6 +13,7 @@
 """Tests of grass.grassdb.manage"""
 
 from pathlib import Path
+import sys
 
 from grass.grassdb.manage import MapsetPath, resolve_mapset_path, split_mapset_path
 from grass.gunittest.case import TestCase
@@ -20,12 +21,15 @@ from grass.gunittest.gmodules import call_module
 from grass.gunittest.main import test
 
 
+ms_windows = sys.platform == "win32" or sys.platform == "cygwin"
+
+
 class TestMapsetPath(TestCase):
     """Check that object can be constructed"""
 
     def test_mapset_from_path_object(self):
         """Check that path is correctly stored"""
-        path = "does/not/exist/"
+        path = "does\\not\\exist\\" if ms_windows else "does/not/exist/"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         full_path = Path(path) / location_name / mapset_name
@@ -84,11 +88,13 @@ class TestSplitMapsetPath(TestCase):
 
     def test_split_str_trailing_slash(self):
         """Check that path as str with a trailing slash is correctly split"""
-        ref_db = "does/not/exist"
+        ref_db = "does\\not\\exist" if ms_windows else "does/not/exist"
         ref_location = "test_location_A"
         ref_mapset = "test_mapset_1"
         path = Path(ref_db) / ref_location / ref_mapset
-        new_db, new_location, new_mapset = split_mapset_path(str(path) + "/")
+        new_db, new_location, new_mapset = split_mapset_path(
+            str(path) + "\\" if ms_windows else "/"
+        )
         self.assertEqual(new_db, ref_db)
         self.assertEqual(new_location, ref_location)
         self.assertEqual(new_mapset, ref_mapset)
@@ -144,7 +150,7 @@ class TestResolveMapsetPath(TestCase):
 
     def test_mapset_from_path(self):
         """Check that a non-existing path is correctly parsed."""
-        path = "does/not/exist/"
+        path = "does\\not\\exist\\" if ms_windows else "does/not/exist/"
         location_name = "test_location_A"
         mapset_name = "test_mapset_1"
         full_path = str(Path(path) / location_name / mapset_name)

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -206,8 +206,13 @@ class TestCase(unittest.TestCase):
             isinstance(reference, (str, unicode)),
             ("reference argument is not a string"),
         )
+        if os.linesep != "\n" and os.linesep in reference:
+            reference = reference.replace(os.linesep, "\n")
         if os.linesep != "\n" and os.linesep in actual:
             actual = actual.replace(os.linesep, "\n")
+        # Strip newlines (esp. \r) that may remain after splitting lines
+        reference = reference.strip()
+        actual = actual.strip()
         if not check_text_ellipsis(actual=actual, reference=reference):
             # TODO: add support for multiline (first line general, others with details)
             standardMsg = '"%s" does not correspond with "%s"' % (actual, reference)
@@ -240,6 +245,8 @@ class TestCase(unittest.TestCase):
         which is typically obtained using ``-g`` flag.
         """
         if isinstance(reference, str):
+            if os.linesep != "\n" and os.linesep in reference:
+                reference = reference.replace(os.linesep, "\n")
             reference = text_to_keyvalue(reference, sep=sep, skip_empty=True)
         module = _module_from_parameters(module, **parameters)
         self.runModule(module, expecting_stdout=True)

--- a/python/grass/gunittest/gmodules.py
+++ b/python/grass/gunittest/gmodules.py
@@ -143,7 +143,7 @@ def call_module(
     # Make sure that universal newlines are returned
     output = (
         output.replace(os.linesep, "\n")
-        if os.linesep != "\n" and type(output) == str
+        if os.linesep != "\n" and type(output) is str
         else output
     )
     return output

--- a/python/grass/gunittest/gmodules.py
+++ b/python/grass/gunittest/gmodules.py
@@ -9,6 +9,7 @@ for details.
 :authors: Vaclav Petras, Soeren Gebbert
 """
 
+import os
 import subprocess
 from grass.script.core import start_command
 from grass.script.utils import encode, decode
@@ -138,4 +139,11 @@ def call_module(
     returncode = process.poll()
     if returncode:
         raise CalledModuleError(module, kwargs, returncode, errors)
-    return decode(output) if output else None
+    output = decode(output) if output else None
+    # Make sure that universal newlines are returned
+    output = (
+        output.replace(os.linesep, "\n")
+        if os.linesep != "\n" and type(output) == str
+        else output
+    )
+    return output

--- a/python/grass/gunittest/testsuite/test_assertions.py
+++ b/python/grass/gunittest/testsuite/test_assertions.py
@@ -349,7 +349,7 @@ class TestFileAssertions(TestCase):
         open(cls.emtpy_file, "w").close()
         cls.file_with_md5 = cls.__name__ + "_this_is_a_file_with_known_md5"
         file_content = "Content of the file with known MD5.\n"
-        with open(cls.file_with_md5, "w") as f:
+        with open(cls.file_with_md5, "w", newline="") as f:
             f.write(file_content)
         # MD5 sum created using:
         # echo 'Content of the file with known MD5.' > some_file.txt

--- a/python/grass/gunittest/testsuite/test_checkers.py
+++ b/python/grass/gunittest/testsuite/test_checkers.py
@@ -373,7 +373,7 @@ class TestMd5Sums(TestCase):
             for line in CORRECT_LINES:
                 # \n should be converted to platform newline
                 f.write(line + "\n")
-        with open(cls.correct_file_name_unix_nl, "w") as f:
+        with open(cls.correct_file_name_unix_nl, "w", newline="") as f:
             for line in CORRECT_LINES:
                 # binary mode will write pure \n
                 f.write(line + "\n")

--- a/python/grass/pygrass/raster/testsuite/test_category.py
+++ b/python/grass/pygrass/raster/testsuite/test_category.py
@@ -82,7 +82,11 @@ class RasterCategoryTestCase(TestCase):
         cats = Category(self.name)
         cats.read()
         cats.write_rules(tmpfile)
-        self.assertFilesEqualMd5(tmpfile, "data/geology_cats")
+        with open(tmpfile, "r") as act:
+            actual = act.read()
+        with open("data/geology_cats", "r") as ref:
+            reference = ref.read()
+        self.assertLooksLike(actual, reference)
 
 
 if __name__ == "__main__":

--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -1,4 +1,4 @@
-from tempfile import NamedTemporaryFile
+import grass.script as gscript
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -184,7 +184,7 @@ class TestNeighbors(TestCase):
 
     def create_filter(self, options):
         """Create a temporary filter file with the given name and options."""
-        f = NamedTemporaryFile()
+        f = gscript.tempfile(create=False)
         f.write(options)
         f.flush()
         return f

--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -185,7 +185,7 @@ class TestNeighbors(TestCase):
     def create_filter(self, options):
         """Create a temporary filter file with the given name and options."""
         grass_tempfile = gs.tempfile(create=False)
-        with open(grass_tempfile, "w") as f:
+        with open(grass_tempfile, "wb") as f:
             f.write(options)
         return grass_tempfile
 

--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -172,9 +172,9 @@ class TestNeighbors(TestCase):
                    TYPE    S
 
                    MATRIX 3
-                   1 1 1 
-                   1 1 1 
-                   1 1 1 
+                   1 1 1
+                   1 1 1
+                   1 1 1
                    DIVISOR 9
                    TYPE    P""",
     }
@@ -214,13 +214,13 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
         filter.close()
@@ -247,13 +247,13 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
         filter.close()
@@ -280,13 +280,13 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="lakes",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_z,
-            filter=filter.name,
+            filter=filter,
             flags="z",
         )
         filter.close()
@@ -315,27 +315,27 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="lakes",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_z,
-            filter=filter.name,
+            filter=filter,
             flags="z",
         )
         self.assertModule(
             "r.mfilter",
             input="lakes",
             output=output_z_threaded,
-            filter=filter.name,
+            filter=filter,
             flags="z",
             nprocs=4,
         )
@@ -373,13 +373,13 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             nprocs=4,
         )
         filter.close()
@@ -406,14 +406,14 @@ class TestNeighbors(TestCase):
             "r.mfilter",
             input="elevation",
             output=output,
-            filter=filter.name,
+            filter=filter,
             repeat=3,
         )
         self.assertModule(
             "r.mfilter",
             input="elevation",
             output=output_threaded,
-            filter=filter.name,
+            filter=filter,
             repeat=3,
             nprocs=4,
         )

--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -223,7 +223,6 @@ class TestNeighbors(TestCase):
             filter=filter,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],
@@ -256,7 +255,6 @@ class TestNeighbors(TestCase):
             filter=filter,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],
@@ -289,7 +287,6 @@ class TestNeighbors(TestCase):
             filter=filter,
             flags="z",
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case][False],
@@ -339,7 +336,6 @@ class TestNeighbors(TestCase):
             flags="z",
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case][False],
@@ -382,7 +378,6 @@ class TestNeighbors(TestCase):
             filter=filter,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],
@@ -417,7 +412,6 @@ class TestNeighbors(TestCase):
             repeat=3,
             nprocs=4,
         )
-        filter.close()
         self.assertRasterFitsUnivar(
             raster=output,
             reference=self.test_results[test_case],

--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -1,4 +1,4 @@
-import grass.script as gscript
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -184,10 +184,10 @@ class TestNeighbors(TestCase):
 
     def create_filter(self, options):
         """Create a temporary filter file with the given name and options."""
-        f = gscript.tempfile(create=False)
-        f.write(options)
-        f.flush()
-        return f
+        grass_tempfile = gs.tempfile(create=False)
+        with open(grass_tempfile, "w") as f:
+            f.write(options)
+        return grass_tempfile
 
     @classmethod
     def setUpClass(cls):

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -120,7 +120,9 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in files:
             self.assertFileExists(file)
-            if file.suffix != ".html":
+            if file.suffix != ".html" and not ms_windows:
+                # Prebuild C-modules for MS Windows are unlikely to run
+                # on fresh compiled GRASS GIS
                 self.assertModule(str(file), help=True)
 
     def test_github_install_official_multimodule(self):

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -152,8 +152,6 @@ class TestModuleDownloadFromDifferentSources(TestCase):
 
         for file in files:
             self.assertFileExists(file)
-            if file.suffix != ".html" and file.suffix != ".py":
-                self.assertModule(str(file), help=True)
 
 
 if __name__ == "__main__":

--- a/scripts/g.extension/testsuite/test_addons_modules.py
+++ b/scripts/g.extension/testsuite/test_addons_modules.py
@@ -12,14 +12,18 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
            for details.
 """
 
+import os
+import sys
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
 from grass.gunittest.utils import silent_rmtree
 from grass.script.utils import decode
 
-import os
 
+ms_windows = sys.platform == "win32" or sys.platform == "cygwin"
 
 MODULES_OUTPUT = """\
 d.frame
@@ -49,6 +53,7 @@ wx.metadata
 )
 
 
+@unittest.skipIf(ms_windows, "currently not supported on MS Windows")
 class TestModulesMetadata(TestCase):
 
     url = "file://" + os.path.abspath("data")
@@ -61,6 +66,7 @@ class TestModulesMetadata(TestCase):
         self.assertMultiLineEqual(stdout, MODULES_OUTPUT)
 
 
+@unittest.skipIf(ms_windows, "currently not supported on MS Windows")
 class TestModulesFromDifferentSources(TestCase):
 
     url = "file://" + os.path.abspath("data/sample_modules")

--- a/scripts/g.extension/testsuite/test_addons_toolboxes.py
+++ b/scripts/g.extension/testsuite/test_addons_toolboxes.py
@@ -12,11 +12,16 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
            for details.
 """
 
+import os
+import sys
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
 
-import os
+
+ms_windows = sys.platform == "win32" or sys.platform == "cygwin"
 
 FULL_TOOLBOXES_OUTPUT = """\
 Hydrology (HY)
@@ -36,6 +41,7 @@ mcda (MC)
 """
 
 
+@unittest.skipIf(ms_windows, "currently not supported on MS Windows")
 class TestToolboxesMetadata(TestCase):
 
     url = "file://" + os.path.abspath("data")

--- a/vector/v.edit/testsuite/select_all_flag.sh
+++ b/vector/v.edit/testsuite/select_all_flag.sh
@@ -4,6 +4,7 @@
 # Add a select all flag to v.edit
 # https://trac.osgeo.org/grass/ticket/2309
 
+ # Windows linebreaks are removed from the output
 set -e
 set -x
 
@@ -15,7 +16,7 @@ v.edit -r map=vedit_test tool=catadd layer=2 cats=10
 
 expected="10
 10"
-out=$(v.category option=print layer=2 input=vedit_test)
+out=$(v.category option=print layer=2 input=vedit_test| tr -d '\r')
 
 if [[ ${out} != "${expected}" ]]; then
     echo "FAIL: Expected '${expected}' not equals to output '${out}'"
@@ -25,7 +26,7 @@ fi
 # test also the original categories
 expected="1
 2"
-out=$(v.category option=print layer=1 input=vedit_test)
+out=$(v.category option=print layer=1 input=vedit_test| tr -d '\r')
 
 if [[ ${out} != "${expected}" ]]; then
     echo "FAIL: Expected '${expected}' not equals to output '${out}'"

--- a/vector/v.in.lidar/testsuite/decimation_test.py
+++ b/vector/v.in.lidar/testsuite/decimation_test.py
@@ -63,7 +63,10 @@ class TestCountBasedDecimation(TestCase):
     def test_identical(self):
         """Test to see if the standard outputs are created"""
         self.assertModule(
-            "v.in.lidar", input=self.las_file, output=self.imported_points, flags=self.flags
+            "v.in.lidar",
+            input=self.las_file,
+            output=self.imported_points,
+            flags=self.flags,
         )
         self.assertVectorExists(self.imported_points)
         self.assertVectorFitsTopoInfo(

--- a/vector/v.in.lidar/testsuite/decimation_test.py
+++ b/vector/v.in.lidar/testsuite/decimation_test.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import sys
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -25,6 +26,8 @@ class TestCountBasedDecimation(TestCase):
     imported_points = "vinlidar_decimation_imported"
     las_file = "vinlidar_decimation_points.las"
     npoints = 300  # the values works well for 300 without rounding
+    # On MS Windows CRS information is not available for input data
+    flags = "bto" if sys.platform == "win32" or sys.platform == "cygwin" else "bt"
 
     @classmethod
     def setUpClass(cls):
@@ -60,7 +63,7 @@ class TestCountBasedDecimation(TestCase):
     def test_identical(self):
         """Test to see if the standard outputs are created"""
         self.assertModule(
-            "v.in.lidar", input=self.las_file, output=self.imported_points, flags="bt"
+            "v.in.lidar", input=self.las_file, output=self.imported_points, flags=self.flags
         )
         self.assertVectorExists(self.imported_points)
         self.assertVectorFitsTopoInfo(
@@ -73,7 +76,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             skip=number,
         )
         self.assertVectorExists(self.imported_points)
@@ -87,7 +90,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             preserve=number,
         )
         self.assertVectorExists(self.imported_points)
@@ -101,7 +104,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             offset=number,
         )
         self.assertVectorExists(self.imported_points)
@@ -115,7 +118,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             limit=number,
         )
         self.assertVectorExists(self.imported_points)
@@ -157,7 +160,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             offset=105,
             preserve=10,
         )
@@ -173,7 +176,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             limit=105,
             skip=10,
         )
@@ -188,7 +191,7 @@ class TestCountBasedDecimation(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=self.flags,
             offset=50,
             skip=5,
             limit=self.npoints - 1,

--- a/vector/v.in.lidar/testsuite/mask_test.py
+++ b/vector/v.in.lidar/testsuite/mask_test.py
@@ -78,8 +78,13 @@ C  1 1
 
 
 import os
+import sys
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+
+flags = "bto" if sys.platform == "win32" or sys.platform == "cygwin" else "bt"
 
 
 class VectorMaskTest(TestCase):
@@ -132,7 +137,7 @@ class VectorMaskTest(TestCase):
     def test_no_mask(self):
         """Test to see if the standard outputs are created"""
         self.assertModule(
-            "v.in.lidar", input=self.las_file, output=self.imported_points, flags="bt"
+            "v.in.lidar", input=self.las_file, output=self.imported_points, flags=flags
         )
         self.assertVectorExists(self.imported_points)
         self.assertVectorFitsTopoInfo(
@@ -145,7 +150,7 @@ class VectorMaskTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             mask=self.areas,
         )
         self.assertVectorExists(self.imported_points)
@@ -159,7 +164,7 @@ class VectorMaskTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="btu",
+            flags=f"{flags}u",
             mask=self.areas,
         )
         self.assertVectorExists(self.imported_points)

--- a/vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py
+++ b/vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py
@@ -10,8 +10,13 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import sys
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+
+flags = "bto" if sys.platform == "win32" or sys.platform == "cygwin" else "bt"
 
 
 class BasicTest(TestCase):
@@ -60,7 +65,7 @@ class BasicTest(TestCase):
     def test_output_identical(self):
         """Test to see if the standard outputs are created"""
         self.assertModule(
-            "v.in.lidar", input=self.las_file, output=self.imported_points, flags="bt"
+            "v.in.lidar", input=self.las_file, output=self.imported_points, flags=flags
         )
         self.assertVectorExists(self.imported_points)
         self.assertVectorEqualsVector(

--- a/vector/v.in.lidar/testsuite/test_v_in_lidar_filter.py
+++ b/vector/v.in.lidar/testsuite/test_v_in_lidar_filter.py
@@ -10,9 +10,13 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import sys
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
+
+flags = "bto" if sys.platform == "win32" or sys.platform == "cygwin" else "bt"
 
 POINTS = """\
 17.46938776,18.67346939,143,1,1,2
@@ -98,7 +102,7 @@ class FilterTest(TestCase):
         This shows if the inpute data are as expected.
         """
         self.assertModule(
-            "v.in.lidar", input=self.las_file, output=self.imported_points, flags="bt"
+            "v.in.lidar", input=self.las_file, output=self.imported_points, flags=flags
         )
         self.assertVectorExists(self.imported_points)
         self.assertVectorFitsTopoInfo(
@@ -111,7 +115,7 @@ class FilterTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             return_filter=name,
         )
         self.assertVectorExists(self.imported_points)
@@ -137,7 +141,7 @@ class FilterTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             class_filter=class_n,
         )
         self.assertVectorExists(self.imported_points)
@@ -167,7 +171,7 @@ class FilterTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             return_filter=return_name,
             class_filter=class_n,
         )
@@ -190,7 +194,7 @@ class FilterTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             zrange=zrange,
         )
         self.assertVectorExists(self.imported_points)
@@ -215,7 +219,7 @@ class FilterTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             zrange=(141, 900),
             class_filter=5,
         )
@@ -230,7 +234,7 @@ class FilterTest(TestCase):
             "v.in.lidar",
             input=self.las_file,
             output=self.imported_points,
-            flags="bt",
+            flags=flags,
             zrange=(141, 900),
             return_filter="last",
         )

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
@@ -10,9 +10,11 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import shutil
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-import unittest
 
 
 class BasicTest(TestCase):

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
@@ -10,9 +10,11 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import shutil
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-import unittest
 
 POINTS = """\
 17.46938776,18.67346939,143,1,1,2

--- a/vector/v.out.lidar/testsuite/test_v_out_lidar.py
+++ b/vector/v.out.lidar/testsuite/test_v_out_lidar.py
@@ -10,8 +10,13 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import sys
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+
+flags = "bto" if sys.platform == "win32" or sys.platform == "cygwin" else "bt"
 
 
 class BasicTest(TestCase):
@@ -67,7 +72,7 @@ class BasicTest(TestCase):
         """
         self.assertModule("v.out.lidar", input=self.vector_points, output=self.las_file)
         self.assertModule(
-            "v.in.lidar", input=self.las_file, output=self.imported_points, flags="bt"
+            "v.in.lidar", input=self.las_file, output=self.imported_points, flags=flags
         )
         self.assertVectorExists(self.imported_points)
         self.assertVectorEqualsVector(


### PR DESCRIPTION
Replaces: #1683

-----

July 2026 AI analysis of what is possibly still relevant:

- [x] ~r.mfilter: the NamedTemporaryFile → gs.tempfile fix is a textbook Windows bug (can't reopen an open NamedTemporaryFile) and directly explains the 6 xfail'd tests there.~ https://github.com/OSGeo/grass/pull/7878
- [ ] grassdb/test_manage.py: the os.sep-aware assertions map one-to-one onto the 4 xfail'd tests.
- [ ] test_parser_json.py: uses raw subprocess.Popen (not grass.script), so the shell= on win32 fix is still relevant; all 3 tests are xfail'd.
- [ ] test_checkers.py / test_assertions.py: the newline="" fixes for MD5-checked files still apply, though test_assertions.py now writes via Path.write_text(), so the fix needs rewriting.
- [ ] case.py: normalizing/stripping the reference string in assertLooksLike/assertModuleKeyValue (main only normalizes actual).
- [ ] toolboxes.sh (python→python3) and v.edit/select_all_flag.sh (tr -d '\r'): both files are still on the exclusion list in .github/workflows/osgeo4w_gunittest.cfg, so the fixes are still applicable.

These would be better as individual PRs.