### PR TITLE
wxGUI: fix display of all single window mode main toolbar tools

### DIFF
--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -386,7 +386,7 @@ class AuiToolbar(aui.AuiToolBar):
         parent,
         toolSwitcher=None,
         style=wx.NO_BORDER | wx.TB_HORIZONTAL,
-        agwStyle=aui.AUI_TB_PLAIN_BACKGROUND,
+        agwStyle=aui.AUI_TB_PLAIN_BACKGROUND | aui.AUI_TB_GRIPPER,
     ):
         self.parent = parent
         super().__init__(


### PR DESCRIPTION
Current main toolbar tools layout (some tools are hidden): 

![wxgui_main_toolbars_tool_current](https://user-images.githubusercontent.com/50632337/198817230-e285dc18-073d-4c81-8f82-52a140080b0e.png)

Expected main toolbar tools layout:

![wxgui_main_toolbars_tool_expected](https://user-images.githubusercontent.com/50632337/198817254-c137ef7b-44a7-4f15-8ee6-529eb0fcd2de.png)

- Operating System: MS Windows, macOS
- GRASS GIS version: 8.3.dev

**Additional context**

Another solution is to set margins after this line: 
https://github.com/OSGeo/grass/blob/c492ae50bcb2f349bd64393ef85624b5b80c9e03/gui/wxpython/gui_core/toolbars.py#L392

```python
if platform.system() in ("Windows", "Darwin"):
    self.SetMargins(8, 8)
```

#2568 
