### PR TITLE
wxGUI: fix setting of user defined window position and size for single window mode

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -189,6 +189,8 @@ class GMFrame(wx.Frame):
             except Exception:
                 pass
             self.Layout()
+            if (w, h) <= globalvar.GM_WINDOW_SIZE:
+                self.Fit()
         else:
             self.Layout()
             self.Fit()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -189,7 +189,7 @@ class GMFrame(wx.Frame):
             except Exception:
                 pass
             self.Layout()
-            if (w, h) <= globalvar.GM_WINDOW_SIZE:
+            if w <= globalvar.GM_WINDOW_SIZE[0] or h <= globalvar.GM_WINDOW_SIZE[1]:
                 self.Fit()
         else:
             self.Layout()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -189,7 +189,6 @@ class GMFrame(wx.Frame):
             except Exception:
                 pass
             self.Layout()
-            self.Fit()
         else:
             self.Layout()
             self.Fit()


### PR DESCRIPTION
Fixes #2600.

How to test this PR:

1. Launch wxGUI with single window mode
2. Change and remember visually wxGUI window size and position 
3. Open wxGUI settings via menu Settings -> Preferences
4. On the General page (tab) from the Workspace setting **check Save current windows layout as default**
5. Hit Preferences dialog Save button
6. Close wxGUI
7. Launch wxGUI and check window position and size

If you want to change the wxGUI position and size again, you need to open the wxGUI preferences dialog again and press the Save button again.