### PR TITLE
t.rast.univar/t.rast3d.univar: add support for multiprocessing

### DIFF
--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -20,7 +20,6 @@ for details.
 """
 from __future__ import print_function
 from multiprocessing import Pool
-from copy import deepcopy
 from subprocess import PIPE
 
 from .core import SQLDatabaseInterfaceConnection, get_current_mapset

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -31,10 +31,10 @@ from grass.pygrass.modules import Module
 ###############################################################################
 
 
-def compute_univar_stats(row, stats_module, fs, rast_region=False):
+def compute_univar_stats(registered_map_info, stats_module, fs, rast_region=False):
     """Compute univariate statistics for a map of a space time raster or raster3d dataset
 
-    :param row: Must be "strds" or "str3ds"
+    :param registered_map_info: dict or db row with tgis info for a registered map
     :param stats_module: Pre-configured PyGRASS Module to compute univariate statistics with
     :param fs: Field separator
     :param rast_region: If set True ignore the current region settings
@@ -42,13 +42,13 @@ def compute_univar_stats(row, stats_module, fs, rast_region=False):
            Only available for strds.
     """
     string = ""
-    id = row["id"]
-    start = row["start_time"]
-    end = row["end_time"]
+    id = registered_map_info["id"]
+    start = registered_map_info["start_time"]
+    end = registered_map_info["end_time"]
     semantic_label = (
         ""
-        if stats_module.name == "r3.univar" or not row["semantic_label"]
-        else row["semantic_label"]
+        if stats_module.name == "r3.univar" or not registered_map_info["semantic_label"]
+        else registered_map_info["semantic_label"]
     )
 
     stats_module.inputs.map = id
@@ -115,7 +115,7 @@ def print_gridded_dataset_univar_statistics(
 ):
     """Print univariate statistics for a space time raster or raster3d dataset
 
-    :param type: Must be "strds" or "str3ds"
+    :param type: Type of Space-Time-Dataset, must be either strds or str3ds
     :param input: The name of the space time dataset
     :param output: Name of the optional output file, if None stdout is used
     :param where: A temporal database where statement
@@ -215,8 +215,6 @@ def print_gridded_dataset_univar_statistics(
             strings = pool.starmap(
                 compute_univar_stats, [(dict(row), univar_module, fs) for row in rows]
             )
-            pool.close()
-            pool.join()
 
     if output is None:
         print("\n".join(filter(None, strings)))

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -19,13 +19,87 @@ for details.
 :authors: Soeren Gebbert
 """
 from __future__ import print_function
+from multiprocessing import Pool
+from copy import deepcopy
+from subprocess import PIPE
 
 from .core import SQLDatabaseInterfaceConnection, get_current_mapset
 from .factory import dataset_factory
 from .open_stds import open_old_stds
-import grass.script as gscript
+import grass.script as gs
+from grass.pygrass.modules import Module
 
 ###############################################################################
+
+
+def compute_univar_stats(row, stats_module, fs, rast_region=False):
+    """Compute univariate statistics for a map of a space time raster or raster3d dataset
+
+    :param row: Must be "strds" or "str3ds"
+    :param stats_module: Pre-configured PyGRASS Module to compute univariate statistics with
+    :param fs: Field separator
+    :param rast_region: If set True ignore the current region settings
+           and use the raster map regions for univar statistical calculation.
+           Only available for strds.
+    """
+    string = ""
+    id = row["id"]
+    start = row["start_time"]
+    end = row["end_time"]
+    semantic_label = (
+        ""
+        if stats_module.name == "r3.univar" or not row["semantic_label"]
+        else row["semantic_label"]
+    )
+
+    stats_module.inputs.map = id
+    if rast_region:
+        stats_module.env = gs.region_env(raster=id)
+    stats_module.run()
+
+    univar_stats = stats_module.outputs.stdout
+
+    if not univar_stats:
+        gs.warning(
+            _(
+                "Unable to get statistics for {voxel}raster map "
+                "<{rmap}>".format(
+                    rmap=id, voxel="" if stats_module.name == "r.univar" else "3d "
+                )
+            )
+        )
+        return None
+    eol = ""
+
+    for idx, stats_kv in enumerate(univar_stats.split(";")):
+        stats = gs.utils.parse_key_val(stats_kv)
+        string += (
+            f"{id}{fs}{semantic_label}{fs}{start}{fs}{end}"
+            if stats_module.name == "r.univar"
+            else f"{id}{fs}{start}{fs}{end}"
+        )
+        if stats_module.inputs.zones:
+            if idx == 0:
+                zone = str(stats["zone"])
+                string = ""
+                continue
+            string += f"{fs}{zone}"
+            if "zone" in stats:
+                zone = str(stats["zone"])
+                eol = "\n"
+            else:
+                eol = ""
+        string += f'{fs}{stats["mean"]}{fs}{stats["min"]}'
+        string += f'{fs}{stats["max"]}{fs}{stats["mean_of_abs"]}'
+        string += f'{fs}{stats["stddev"]}{fs}{stats["variance"]}'
+        string += f'{fs}{stats["coeff_var"]}{fs}{stats["sum"]}'
+        string += f'{fs}{stats["null_cells"]}{fs}{stats["n"]}'
+        string += f'{fs}{stats["n"]}'
+        if "median" in stats:
+            string += f'{fs}{stats["first_quartile"]}{fs}{stats["median"]}'
+            string += f'{fs}{stats["third_quartile"]}{fs}{stats["percentile_90"]}'
+        string += eol
+    return string
 
 
 def print_gridded_dataset_univar_statistics(
@@ -38,6 +112,7 @@ def print_gridded_dataset_univar_statistics(
     fs="|",
     rast_region=False,
     zones=None,
+    nprocs=1,
 ):
     """Print univariate statistics for a space time raster or raster3d dataset
 
@@ -48,17 +123,12 @@ def print_gridded_dataset_univar_statistics(
     :param extended: If True compute extended statistics
     :param no_header: Suppress the printing of column names
     :param fs: Field separator
+    :param nprocs: Number of cores to use for processing
     :param rast_region: If set True ignore the current region settings
            and use the raster map regions for univar statistical calculation.
            Only available for strds.
     :param zones: raster map with zones to calculate statistics for
     """
-
-    stats_module = {
-        "strds": "r.univar",
-        "str3ds": "r3.univar",
-    }[type]
-
     # We need a database interface
     dbif = SQLDatabaseInterfaceConnection()
     dbif.connect()
@@ -80,7 +150,7 @@ def print_gridded_dataset_univar_statistics(
         err = "Space time %(sp)s dataset <%(i)s> is empty"
         if where:
             err += " or where condition is wrong"
-        gscript.fatal(
+        gs.fatal(
             _(err) % {"sp": sp.get_new_map_instance(None).get_type(), "i": sp.get_id()}
         )
 
@@ -116,73 +186,43 @@ def print_gridded_dataset_univar_statistics(
         else:
             out_file.write(string + "\n")
 
+    # Define flags
     flag = "g"
-
     if extended is True:
         flag += "e"
     if type == "strds" and rast_region is True:
         flag += "r"
 
-    for row in rows:
-        string = ""
-        id = row["id"]
-        start = row["start_time"]
-        end = row["end_time"]
-        semantic_label = (
-            ""
-            if type != "strds" or not row["semantic_label"]
-            else row["semantic_label"]
-        )
+    # Setup pygrass module to use for computation
+    univar_module = Module(
+        "r.univar" if type == "strds" else "r3.univar",
+        flags=flag,
+        zones=zones,
+        stdout_=PIPE,
+        run_=False,
+    )
 
-        univar_stats = gscript.read_command(
-            stats_module, map=id, flags=flag, zones=zones
-        ).rstrip()
-
-        if not univar_stats:
-            if type == "strds":
-                gscript.warning(
-                    _("Unable to get statistics for raster map " "<%s>") % id
-                )
-            elif type == "str3ds":
-                gscript.warning(
-                    _("Unable to get statistics for 3d raster map" " <%s>") % id
-                )
-            continue
-        eol = ""
-
-        for idx, stats_kv in enumerate(univar_stats.split(";")):
-            stats = gscript.utils.parse_key_val(stats_kv)
-            string += (
-                f"{id}{fs}{semantic_label}{fs}{start}{fs}{end}"
-                if type == "strds"
-                else f"{id}{fs}{start}{fs}{end}"
+    if nprocs == 1:
+        strings = [
+            compute_univar_stats(
+                row,
+                univar_module,
+                fs,
             )
-            if zones:
-                if idx == 0:
-                    zone = str(stats["zone"])
-                    string = ""
-                    continue
-                string += f"{fs}{zone}"
-                if "zone" in stats:
-                    zone = str(stats["zone"])
-                    eol = "\n"
-                else:
-                    eol = ""
-            string += f'{fs}{stats["mean"]}{fs}{stats["min"]}'
-            string += f'{fs}{stats["max"]}{fs}{stats["mean_of_abs"]}'
-            string += f'{fs}{stats["stddev"]}{fs}{stats["variance"]}'
-            string += f'{fs}{stats["coeff_var"]}{fs}{stats["sum"]}'
-            string += f'{fs}{stats["null_cells"]}{fs}{stats["n"]}'
-            string += f'{fs}{stats["n"]}'
-            if extended is True:
-                string += f'{fs}{stats["first_quartile"]}{fs}{stats["median"]}'
-                string += f'{fs}{stats["third_quartile"]}{fs}{stats["percentile_90"]}'
-            string += eol
+            for row in rows
+        ]
+    else:
+        with Pool(min(nprocs, len(rows))) as pool:
+            strings = pool.starmap(
+                compute_univar_stats, [(dict(row), univar_module, fs) for row in rows]
+            )
+            pool.close()
+            pool.join()
 
-        if output is None:
-            print(string)
-        else:
-            out_file.write(string + "\n")
+    if output is None:
+        print("\n".join(filter(None, strings)))
+    else:
+        out_file.write("\n".join(filter(None, strings)))
 
     dbif.close()
 
@@ -229,7 +269,7 @@ def print_vector_dataset_univar_statistics(
 
     if sp.is_in_db(dbif) is False:
         dbif.close()
-        gscript.fatal(
+        gs.fatal(
             _("Space time %(sp)s dataset <%(i)s> not found")
             % {"sp": sp.get_new_map_instance(None).get_type(), "i": id}
         )
@@ -242,7 +282,7 @@ def print_vector_dataset_univar_statistics(
 
     if not rows:
         dbif.close()
-        gscript.fatal(
+        gs.fatal(
             _("Space time %(sp)s dataset <%(i)s> is empty")
             % {"sp": sp.get_new_map_instance(None).get_type(), "i": id}
         )
@@ -316,7 +356,7 @@ def print_vector_dataset_univar_statistics(
         if not mylayer:
             mylayer = layer
 
-        stats = gscript.parse_command(
+        stats = gs.parse_command(
             "v.univar",
             map=id,
             where=where,
@@ -329,7 +369,7 @@ def print_vector_dataset_univar_statistics(
         string = ""
 
         if not stats:
-            gscript.warning(_("Unable to get statistics for vector map <%s>") % id)
+            gs.warning(_("Unable to get statistics for vector map <%s>") % id)
             continue
 
         string += str(id) + fs + str(start) + fs + str(end)

--- a/temporal/t.rast.univar/t.rast.univar.py
+++ b/temporal/t.rast.univar/t.rast.univar.py
@@ -26,6 +26,7 @@
 # % keyword: statistics
 # % keyword: raster
 # % keyword: time
+# % keyword: parallel
 # %end
 
 # %option G_OPT_STRDS_INPUT
@@ -34,6 +35,10 @@
 # %option G_OPT_R_INPUT
 # % key: zones
 # % description: Raster map used for zoning, must be of type CELL
+# % required: no
+# %end
+
+# %option G_OPT_M_NPROCS
 # % required: no
 # %end
 
@@ -82,6 +87,7 @@ def main():
     input = options["input"]
     zones = options["zones"]
     output = options["output"]
+    nprocs = int(options["nprocs"])
     where = options["where"]
     extended = flags["e"]
     no_header = flags["u"]
@@ -111,6 +117,7 @@ def main():
         fs=separator,
         rast_region=rast_region,
         zones=zones,
+        nprocs=nprocs,
     )
 
 

--- a/temporal/t.rast.univar/testsuite/test_t_rast_univar.py
+++ b/temporal/t.rast.univar/testsuite/test_t_rast_univar.py
@@ -317,6 +317,33 @@ b_4@PERMANENT|S2_B1|2001-10-01 00:00:00|2002-01-01 00:00:00|440|440|440|440|0|0|
                 res_line = res.split("|", 1)[1]
                 self.assertLooksLike(ref_line, res_line)
 
+    def test_with_semantic_label_parallel(self):
+        """Test semantic labels"""
+        t_rast_univar = SimpleModule(
+            "t.rast.univar",
+            input="B.S2_B1",
+            where="start_time >= '2001-01-01'",
+            nprocs=2,
+            overwrite=True,
+            verbose=True,
+        )
+        self.runModule("g.region", res=1)
+        self.assertModule(t_rast_univar)
+
+        univar_text = """id|semantic_label|start|end|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+b_1@PERMANENT|S2_B1|2001-01-01 00:00:00|2001-04-01 00:00:00|110|110|110|110|0|0|0|1056000|0|9600|9600
+b_2@PERMANENT|S2_B1|2001-04-01 00:00:00|2001-07-01 00:00:00|220|220|220|220|0|0|0|2112000|0|9600|9600
+b_3@PERMANENT|S2_B1|2001-07-01 00:00:00|2001-10-01 00:00:00|330|330|330|330|0|0|0|3168000|0|9600|9600
+b_4@PERMANENT|S2_B1|2001-10-01 00:00:00|2002-01-01 00:00:00|440|440|440|440|0|0|0|4224000|0|9600|9600
+"""
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast_univar.outputs.stdout.split("\n")
+        ):
+            if ref and res:
+                ref_line = ref.split("|", 1)[1]
+                res_line = res.split("|", 1)[1]
+                self.assertLooksLike(ref_line, res_line)
+
 
 if __name__ == "__main__":
     from grass.gunittest.main import test

--- a/temporal/t.rast3d.univar/t.rast3d.univar.py
+++ b/temporal/t.rast3d.univar/t.rast3d.univar.py
@@ -28,6 +28,7 @@
 # % keyword: raster3d
 # % keyword: voxel
 # % keyword: time
+# % keyword: parallel
 # %end
 
 # %option G_OPT_STR3DS_INPUT
@@ -37,6 +38,10 @@
 # % key: zones
 # % label: Raster map withh zones to compute statistics for
 # % description: Raster map withh zones to compute statistics for (needs to be CELL)
+# % required: no
+# %end
+
+# %option G_OPT_M_NPROCS
 # % required: no
 # %end
 
@@ -81,6 +86,7 @@ def main():
     input = options["input"]
     zones = options["zones"]
     output = options["output"]
+    nprocs = int(options["nprocs"])
     where = options["where"]
     extended = flags["e"]
     no_header = flags["s"]
@@ -105,6 +111,7 @@ def main():
         fs=separator,
         rast_region=False,
         zones=zones,
+        nprocs=nprocs,
     )
 
 

--- a/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
+++ b/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
@@ -206,6 +206,43 @@ a_4@PERMANENT|2001-10-01 00:00:00|2002-01-01 00:00:00|3|400|400|400|400|0|0|0|14
                 res_line = res.split("|", 1)[1]
                 self.assertLooksLike(ref_line, res_line)
 
+    def test_with_zones_parallel(self):
+        """Test use of zones"""
+
+        t_rast_univar_zones = SimpleModule(
+            "t.rast3d.univar",
+            input="A",
+            where="start_time >= '2001-01-01'",
+            zones="zones",
+            nprocs=2,
+            overwrite=True,
+            verbose=True,
+        )
+        self.runModule("g.region", res=1)
+        self.assertModule(t_rast_univar_zones)
+
+        univar_text = """id|start|end|zone|mean|min|max|mean_of_abs|stddev|variance|coeff_var|sum|null_cells|cells|non_null_cells
+a_1@PERMANENT|2001-01-01 00:00:00|2001-04-01 00:00:00|1|100|100|100|100|0|0|0|3000000|0|30000|30000
+a_1@PERMANENT|2001-01-01 00:00:00|2001-04-01 00:00:00|2|100|100|100|100|0|0|0|8400000|0|84000|84000
+a_1@PERMANENT|2001-01-01 00:00:00|2001-04-01 00:00:00|3|100|100|100|100|0|0|0|36600000|0|366000|366000
+a_2@PERMANENT|2001-04-01 00:00:00|2001-07-01 00:00:00|1|200|200|200|200|0|0|0|6000000|0|30000|30000
+a_2@PERMANENT|2001-04-01 00:00:00|2001-07-01 00:00:00|2|200|200|200|200|0|0|0|16800000|0|84000|84000
+a_2@PERMANENT|2001-04-01 00:00:00|2001-07-01 00:00:00|3|200|200|200|200|0|0|0|73200000|0|366000|366000
+a_3@PERMANENT|2001-07-01 00:00:00|2001-10-01 00:00:00|1|300|300|300|300|0|0|0|9000000|0|30000|30000
+a_3@PERMANENT|2001-07-01 00:00:00|2001-10-01 00:00:00|2|300|300|300|300|0|0|0|25200000|0|84000|84000
+a_3@PERMANENT|2001-07-01 00:00:00|2001-10-01 00:00:00|3|300|300|300|300|0|0|0|109800000|0|366000|366000
+a_4@PERMANENT|2001-10-01 00:00:00|2002-01-01 00:00:00|1|400|400|400|400|0|0|0|12000000|0|30000|30000
+a_4@PERMANENT|2001-10-01 00:00:00|2002-01-01 00:00:00|2|400|400|400|400|0|0|0|33600000|0|84000|84000
+a_4@PERMANENT|2001-10-01 00:00:00|2002-01-01 00:00:00|3|400|400|400|400|0|0|0|146400000|0|366000|366000
+"""
+
+        for ref, res in zip(
+            univar_text.split("\n"), t_rast_univar_zones.outputs.stdout.split("\n")
+        ):
+            if ref and res:
+                ref_line = ref.split("|", 1)[1]
+                res_line = res.split("|", 1)[1]
+                self.assertLooksLike(ref_line, res_line)
 
 if __name__ == "__main__":
     from grass.gunittest.main import test

--- a/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
+++ b/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
@@ -244,6 +244,7 @@ a_4@PERMANENT|2001-10-01 00:00:00|2002-01-01 00:00:00|3|400|400|400|400|0|0|0|14
                 res_line = res.split("|", 1)[1]
                 self.assertLooksLike(ref_line, res_line)
 
+
 if __name__ == "__main__":
     from grass.gunittest.main import test
 


### PR DESCRIPTION
This PR adds support for multiprocessing to `python/grass/temporal/univar_statistics.py` and ultimately to `t.rast.univar` and `t.rast3d.univar`.

A parallel testcase is added. However, thorough testing would be great!

Fixes #2590