### PR TITLE
wxGUI: fix map display combobox option after switching between toolbars

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -621,6 +621,11 @@ class MapPanel(SingleMapPanel):
                 .BestSize((self.toolbars["map"].GetBestSize())),
             )
 
+        # nviz
+        elif name == "nviz":
+            self.toolbars["map"].combo.SetValue(_("3D View"))
+            self.AddNviz()
+
         # vector digitizer
         elif name == "vdigit":
             self.toolbars["map"].combo.SetValue(_("Vector digitizer"))

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -623,7 +623,7 @@ class MapPanel(SingleMapPanel):
 
         # nviz
         elif name == "nviz":
-            self.toolbars["map"].combo.SetValue(_("3D View"))
+            self.toolbars["map"].combo.SetValue(_("3D view"))
             self.AddNviz()
 
         # vector digitizer

--- a/gui/wxpython/mapdisp/toolbars.py
+++ b/gui/wxpython/mapdisp/toolbars.py
@@ -294,12 +294,14 @@ class MapToolbar(BaseToolbar):
         if tool == self.toolId["2d"]:
             self.ExitToolbars()
             self.Enable2D(True)
+            self.parent.MapWindow.SetFocus()
 
         elif tool == self.toolId["3d"] and not (
             self.parent.MapWindow3D and self.parent.IsPaneShown("3d")
         ):
             self.ExitToolbars()
-            self.parent.AddNviz()
+            self.parent.AddToolbar("nviz")
+            self.parent.MapWindow.SetFocus()
 
         elif tool == self.toolId["vdigit"] and not self.parent.GetToolbar("vdigit"):
             self.ExitToolbars()
@@ -308,7 +310,8 @@ class MapToolbar(BaseToolbar):
 
         elif tool == self.toolId["rdigit"]:
             self.ExitToolbars()
-            self.parent.AddRDigit()
+            self.parent.AddToolbar("rdigit")
+            self.parent.MapWindow.SetFocus()
 
     def OnAnalyze(self, event):
         """Analysis tools menu"""


### PR DESCRIPTION
**Describe the bug**
Switch between Vector digitizer and Raster digitizer or Vector digitizer  and 3D view or Raster digitizer and 3D view sets wrong  Map Display combobox option.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some raster map e.g. `d.rast elevation`
3. Activate Vector digitizer via Map Display combobox widget choose Vector digitizer option
4. Switch to the Raster digitizer via Map Display combobox widget choose Raster digitizer option
5. See Map display combobox widget setted option which is **2D view** instead of the correct option **Raster digitizer**

or 

4. Switch to the 3D view via Map Display combobox widget choose 3D view option
5. See Map display combobox widget setted option which is **2D view** instead of the correct option **3D view**

or 

3. Activate Raster digitizer via Map Display combobox widget choose Raster digitizer option
4. Switch to the 3D view via Map Display combobox widget choose 3D view option
5. See Map display combobox widget setted option which is **2D view** instead of the correct option **3D view**

**Expected behavior**
Map Display combobox option should be set correctly after switching between toolbars.

**Screenshots**

![wxgui_switch_between_toolbars](https://user-images.githubusercontent.com/50632337/199916652-3400e634-a0be-4c6b-8ca9-e898c19218f6.png)


**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all