### PR TITLE
wxGUI/vdigit: fix activate Vector digitizer toolbar tools by keyboard shortcut

### DIFF
--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -217,7 +217,7 @@ class VDigitWindow(BufferedMapWindow):
         if not shift:
             tool = tools.get(kc)
             if tool:
-                event = self.toolbar.OnTool(tool["event"])
+                event = self.toolbar.controller.OnTool(tool["event"])
                 tool["tool"](event)
 
     def _updateMap(self):


### PR DESCRIPTION
 **Describe the bug**
Activate Vector digitizer toolbar tools by keyboard shortcut doesn't work.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Activate Vector digitizer via Map Display combobox widget
3. Try activate Vector digitizer Digitize new point tool by keyboard shortcut Ctrl + P
4. See error

```
Traceback (most recent call last):
  File
"/usr/lib64/grass83/gui/wxpython/vdigit/mapwindow.py", line
220, in OnKeyDown

event = self.toolbar.OnTool(tool["event"])
  File "/usr/lib64/grass83/gui/wxpython/vdigit/toolbars.py",
line 456, in OnTool

BaseToolbar.OnTool(self, event)
AttributeError
:
type object 'BaseToolbar' has no attribute 'OnTool'
```

**Expected behavior**
Activate Vector digitizer toolbar tools by keyboard shortcut should work.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: 8.3.dev

**Additional context**
#2568