### PR TITLE
v.in.ogr: skip columns with unsupported data type instead of failing to import

### DIFF
--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -380,12 +380,6 @@ int main(int argc, char *argv[])
     flag.notab = G_define_standard_flag(G_FLG_V_TABLE);
     flag.notab->guisection = _("Attributes");
 
-    flag.drop = G_define_flag();
-    flag.drop->guisection = _("Attributes");
-    flag.drop->key = 'd';
-    flag.drop->description =
-        _("Drop columns with unsupported data type from import");
-
     flag.over = G_define_flag();
     flag.over->key = 'o';
     flag.over->label =

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1053,12 +1053,19 @@ int main(int argc, char *argv[])
                 if (key_idx[layer] > -1 && key_idx[layer] == i)
                     continue; /* skip defined key (FID column) */
 
-		i_out++;
-                
 		Ogr_field = OGR_FD_GetFieldDefn(Ogr_featuredefn, i);
 		Ogr_ftype = OGR_Fld_GetType(Ogr_field);
 
 		G_debug(3, "Ogr_ftype: %i", Ogr_ftype);	/* look up below */
+
+                /* skip columns with unsupported data type */
+                if (Ogr_ftype == OFTBinary) {
+                    G_warning(_("Datatype of column <%s> is not supported. "
+                    "Omitting that column."), OGR_Fld_GetNameRef(Ogr_field));
+                    ncols_out = ncols_out - 1;
+                    continue; /* skip defined key (FID column) */
+				}
+		i_out++;
 
 		if (i < ncnames - 1) {
 		    Ogr_fieldname = G_store(param.cnames->answers[i + 1]);

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1176,17 +1176,13 @@ int main(int argc, char *argv[])
 		}
 		else {
                 /* handle columns of unsupported data type */
-                G_warning(_("Column type (Ogr_ftype: %d) not supported (Ogr_fieldname: %s)\n"),
-                          Ogr_ftype, Ogr_fieldname);
-                if (flag.drop->answer) {
-                    col_info[i_out] = col_info[i_out + 1];
-                    i_out--;
-                    ncols_out--;
-                }
-                else {
-                    buf[0] = 0;
-                    col_info[i_out].type = G_store(buf);
-                }
+                G_warning(_("Column <%s> is of unsupported data type (Ogr_ftype: %d)\n"
+                           "It is omitted from import\n"), Ogr_fieldname,
+                          Ogr_ftype);
+                buf[0] = 0;
+                col_info[i_out].type = G_store(buf);
+                i_out--;
+                ncols_out--;
             }
             G_free(Ogr_fieldname);
         }
@@ -1395,10 +1391,6 @@ int main(int argc, char *argv[])
 			    db_set_string(&strval, (char *)Ogr_fstring);
 			    db_double_quote_string(&strval);
 			    G_rasprintf(&sqlbuf, &sqlbufsize, ", '%s'", db_get_string(&strval));
-			}
-			else {
-			    /* column type not supported */
-			    G_rasprintf(&sqlbuf, &sqlbufsize, "%c", '\0');
 			}
 		    }
 		    else {

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1058,14 +1058,14 @@ int main(int argc, char *argv[])
 
 		G_debug(3, "Ogr_ftype: %i", Ogr_ftype);	/* look up below */
 
-                /* skip columns with unsupported data type */
-                if (Ogr_ftype == OFTBinary) {
-                    G_warning(_("Datatype of column <%s> is not supported. "
-                    "Omitting that column."), OGR_Fld_GetNameRef(Ogr_field));
-                    ncols_out = ncols_out - 1;
-                    continue;
-				}
-		i_out++;
+            /* skip columns with unsupported data type */
+            if (Ogr_ftype == OFTBinary) {
+                G_warning(_("Column <%s> is omitted, binary data type is not supported."),
+                          OGR_Fld_GetNameRef(Ogr_field));
+                ncols_out = ncols_out - 1;
+                continue;
+            }
+            i_out++;
 
 		if (i < ncnames - 1) {
 		    Ogr_fieldname = G_store(param.cnames->answers[i + 1]);

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1176,8 +1176,7 @@ int main(int argc, char *argv[])
 		}
 		else {
                 /* handle columns of unsupported data type */
-                G_warning(_("Column <%s> is of unsupported \"%s\" data type, "
-                            "it is omitted from import."),
+                G_warning(_("Column <%s> of unsupported data type \"%s\" is omitted from import"),
                           Ogr_fieldname, OGR_GetFieldTypeName(Ogr_ftype));
                 i_out--;
                 ncols_out--;

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1063,7 +1063,7 @@ int main(int argc, char *argv[])
                     G_warning(_("Datatype of column <%s> is not supported. "
                     "Omitting that column."), OGR_Fld_GetNameRef(Ogr_field));
                     ncols_out = ncols_out - 1;
-                    continue; /* skip defined key (FID column) */
+                    continue;
 				}
 		i_out++;
 

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1188,8 +1188,6 @@ int main(int argc, char *argv[])
                     col_info[i_out] = col_info[i_out + 1];
                     i_out--;
                     ncols_out--;
-                    G_warning(_("Column <%s> will be omitted from import"),
-                              Ogr_fieldname);
                 }
                 else {
                     buf[0] = 0;

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
         struct Option *snap, *type, *outloc, *cnames, *encoding, *key, *geom;
     } param;
     struct _flag {
-	struct Flag *list, *no_clean, *force2d, *notab, *drop,
+	struct Flag *list, *no_clean, *force2d, *notab,
 	    *region, *over, *extend, *formats, *tolower, *no_import,
             *proj;
     } flag;
@@ -1053,7 +1053,7 @@ int main(int argc, char *argv[])
                 if (key_idx[layer] > -1 && key_idx[layer] == i)
                     continue; /* skip defined key (FID column) */
 
-        i_out++;
+                i_out++;
 
 		Ogr_field = OGR_FD_GetFieldDefn(Ogr_featuredefn, i);
 		Ogr_ftype = OGR_Fld_GetType(Ogr_field);
@@ -1176,11 +1176,9 @@ int main(int argc, char *argv[])
 		}
 		else {
                 /* handle columns of unsupported data type */
-                G_warning(_("Column <%s> is of unsupported data type (Ogr_ftype: %d)\n"
-                           "It is omitted from import\n"), Ogr_fieldname,
-                          Ogr_ftype);
-                buf[0] = 0;
-                col_info[i_out].type = G_store(buf);
+                G_warning(_("Column <%s> is of unsupported \"%s\" data type, "
+                            "it is omitted from import."),
+                          Ogr_fieldname, OGR_GetFieldTypeName(Ogr_ftype));
                 i_out--;
                 ncols_out--;
             }


### PR DESCRIPTION
Before this PR, vector data failed to import if it contained columns in the attribute table that are of a data type that is not supported by GRASS\` s DBMI - like binary data (BLOB). This PR changes the behavior of `v.in.ogr` to drop such columns from import instead of failing to import the data in total.