### PR TITLE
wxGUI: BaseToolbar.OnTool needs to be explicitly defined

### DIFF
--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -87,7 +87,12 @@ BaseIcons = {
 
 
 class ToolbarController:
-    """Controller specialized for wx.ToolBar subclass."""
+    """Controller specialized for wx.ToolBar subclass.
+
+    Toolbar subclasses must delegate methods to controller.
+    Methods inherited from toolbar class must be delegated explicitly
+    and other methods can be delegated by @c __getattr__.
+    """
 
     def __init__(self, classObject, widget, parent, toolSwitcher):
         """
@@ -372,6 +377,10 @@ class BaseToolbar(ToolBar):
         """@copydoc ToolbarController::CreateTool()"""
         self.controller.CreateTool(*args, **kwargs)
 
+    def OnTool(self, event):
+        """@copydoc ToolbarController::OnTool()"""
+        self.controller.OnTool(event)
+
     def __getattr__(self, name):
         return getattr(self.controller, name)
 
@@ -415,6 +424,10 @@ class AuiToolbar(aui.AuiToolBar):
     def CreateTool(self, *args, **kwargs):
         """@copydoc ToolbarController::CreateTool()"""
         self.controller.CreateTool(*args, **kwargs)
+
+    def OnTool(self, event):
+        """@copydoc ToolbarController::OnTool()"""
+        self.controller.OnTool(event)
 
     def __getattr__(self, name):
         return getattr(self.controller, name)


### PR DESCRIPTION
Fixes #2626, seems `__getattr__` [doesn't work in this special case](https://stackoverflow.com/questions/12047847/super-object-not-calling-getattr).

I included a short documentation I forgot to push in #2568.