### PR TITLE
Use GRASS version for non-git builds.

### DIFF
--- a/configure
+++ b/configure
@@ -3845,7 +3845,7 @@ if test "$GIT" != "no" ; then
    fi
    GRASS_HEADERS_GIT_HASH=`$GIT log -1 --pretty=format:"%h" -- "${SRCDIR}/include" 2>/dev/null`
    if test -z "$GRASS_HEADERS_GIT_HASH"; then
-      GRASS_HEADERS_GIT_HASH=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
+      GRASS_HEADERS_GIT_HASH="${GRASS_VERSION_NUMBER}"
    fi
    GRASS_HEADERS_GIT_DATE=`date -d $($GIT log -1 --pretty=format:"%cI" -- "${SRCDIR}/include") -u +%FT%T%z | sed 's/\(..\)$/:\1/'` 2>/dev/null
    if test -z "$GRASS_HEADERS_GIT_DATE"; then

--- a/configure
+++ b/configure
@@ -3798,7 +3798,7 @@ LIB_VER=`echo ${GRASS_VERSION_NUMBER} | sed 's/^\([0-9.]*\).*$/\1/'`
 GRASS_VERSION_GIT="exported"
 # get git short hash + date of last change in GRASS headers
 # (and anything else in include)
-GRASS_HEADERS_GIT_HASH=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
+GRASS_HEADERS_GIT_HASH="${GRASS_VERSION_NUMBER}"
 GRASS_HEADERS_GIT_DATE=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
 # Extract the first word of "git", so it can be a program name with args.
 set dummy git; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -149,7 +149,7 @@ if test "$GIT" != "no" ; then
    fi
    GRASS_HEADERS_GIT_HASH=`$GIT log -1 --pretty=format:"%h" -- "${SRCDIR}/include" 2>/dev/null`
    if test -z "$GRASS_HEADERS_GIT_HASH"; then
-      GRASS_HEADERS_GIT_HASH=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
+      GRASS_HEADERS_GIT_HASH="${GRASS_VERSION_NUMBER}"
    fi
    GRASS_HEADERS_GIT_DATE=`date -d $($GIT log -1 --pretty=format:"%cI" -- "${SRCDIR}/include") -u +%FT%T%z | sed 's/\(..\)$/:\1/'` 2>/dev/null
    if test -z "$GRASS_HEADERS_GIT_DATE"; then

--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,7 @@ changequote([,])
 GRASS_VERSION_GIT="exported"
 # get git short hash + date of last change in GRASS headers
 # (and anything else in include)
-GRASS_HEADERS_GIT_HASH=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
+GRASS_HEADERS_GIT_HASH="${GRASS_VERSION_NUMBER}"
 GRASS_HEADERS_GIT_DATE=`date -u +%FT%T%z | sed 's/\(..\)$/:\1/'`
 AC_PATH_PROG(GIT, git, no)
 if test "$GIT" != "no" ; then


### PR DESCRIPTION
As reported in #2610, rebuilding the GRASS sources (from the release tarballs) with no changes break the gdal-grass plugins because the `GIS_H_VERSION` value changes.

Non-git builds use the current timestamp in `GRASS_HEADERS_GIT_HASH` which is also used for `GRASS_HEADERS_DATE`.

This PR uses `GRASS_VERSION_NUMBER` for `GRASS_HEADERS_GIT_HASH` as a better value for non-git builds, that value won't change for simple rebuilds of the source tree.