### PR TITLE
v.surf.rst: fix cross-validation and prevent running it multi-threaded 

### DIFF
--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -419,6 +419,10 @@ int main(int argc, char *argv[])
         G_warning(_("Parallel computation disabled when deviation output is required"));
         threads = 1;
     }
+    if (parm.cvdev->answer && threads > 1) {
+        G_warning(_("Parallel computation disabled when cross validation output is required"));
+        threads = 1;
+    }
 #if defined(_OPENMP)
     omp_set_num_threads(threads);
 #else
@@ -427,6 +431,7 @@ int main(int argc, char *argv[])
 #endif
 
     if (devi) {
+        create_devi = true;
         if (Vect_legal_filename(devi) == -1)
             G_fatal_error(_("Output vector map name <%s> is not valid map name"),
                           devi);
@@ -637,8 +642,6 @@ int main(int argc, char *argv[])
         }
         db_begin_transaction(driver2);
         count = 1;
-        create_devi = true;
-
     }
 
     ertot = 0.;


### PR DESCRIPTION
Bug introduced in #1271.

Unrelated, but this PR also disables threading when cross validation or deviation are set, they can't run multi-threaded due to several reasons (e.g. writing to db).