### PR TITLE
Fix -Wunused-but-set-variable compiler warnings, part 1

### DIFF
--- a/db/drivers/dbf/fetch.c
+++ b/db/drivers/dbf/fetch.c
@@ -26,7 +26,7 @@ int db__driver_fetch(dbCursor * cn, int position, int *more)
     dbColumn *column;
     dbValue *value;
     int col, ncols;
-    int htype, sqltype, ctype;
+    int sqltype, ctype;
     int dbfrow, dbfcol;
 
     /* get cursor token */
@@ -75,7 +75,6 @@ int db__driver_fetch(dbCursor * cn, int position, int *more)
 
         sqltype = db_get_column_sqltype(column);
         ctype = db_sqltype_to_Ctype(sqltype);
-        htype = db_get_column_host_type(column);
 
         if (db.tables[c->table].rows[dbfrow].values[dbfcol].is_null) {
             db_set_value_null(value);

--- a/db/drivers/dbf/table.c
+++ b/db/drivers/dbf/table.c
@@ -217,7 +217,7 @@ int load_table(int t)
 
 int save_table(int t)
 {
-    int i, j, ncols, nrows, ret, field, rec;
+    int i, j, ncols, nrows, field, rec;
     char name[2000], fname[20], element[100];
     DBFHandle dbf;
     ROW *rows;
@@ -286,17 +286,16 @@ int save_table(int t)
             else {
                 switch (db.tables[t].cols[j].type) {
                 case DBF_INT:
-                    ret = DBFWriteIntegerAttribute(dbf, rec, field, val->i);
+                    DBFWriteIntegerAttribute(dbf, rec, field, val->i);
                     break;
                 case DBF_CHAR:
                     if (val->c != NULL)
-                        ret =
-                            DBFWriteStringAttribute(dbf, rec, field, val->c);
+                        DBFWriteStringAttribute(dbf, rec, field, val->c);
                     else
-                        ret = DBFWriteStringAttribute(dbf, rec, field, "");
+                        DBFWriteStringAttribute(dbf, rec, field, "");
                     break;
                 case DBF_DOUBLE:
-                    ret = DBFWriteDoubleAttribute(dbf, rec, field, val->d);
+                    DBFWriteDoubleAttribute(dbf, rec, field, val->d);
                     break;
                 }
             }

--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -163,7 +163,7 @@ int describe_table(OGRLayerH hLayer, dbTable ** table, cursor * c)
 
     for (i = 0; i < ncols; i++, col++) {
         int sqlType = DB_SQL_TYPE_UNKNOWN;
-        int size = 0, precision = 0, scale;
+        int size = 0, precision = 0 /* , scale */ ;
 
         hFieldDefn = OGR_FD_GetFieldDefn(hFeatureDefn, i);
         ogrType = OGR_Fld_GetType(hFieldDefn);
@@ -225,9 +225,8 @@ int describe_table(OGRLayerH hLayer, dbTable ** table, cursor * c)
         db_set_column_length(column, size);
         db_set_column_precision(column, precision);
 
-        /* TODO */
-        scale = 0;
-        /*
+        /* TODO 
+           scale = 0;
            db_set_column_scale (column, scale);
          */
 

--- a/db/drivers/postgres/describe.c
+++ b/db/drivers/postgres/describe.c
@@ -53,7 +53,9 @@ int describe_table(PGresult * res, dbTable ** table, cursor * c)
     int i, ncols, kcols;
     int pgtype, gpgtype;
     char *fname;
-    int sqltype, fsize, precision, scale;
+    int sqltype, fsize;
+
+    /* TODO: int precision, scale; */
     dbColumn *column;
 
     G_debug(3, "describe_table()");
@@ -149,10 +151,10 @@ int describe_table(PGresult * res, dbTable ** table, cursor * c)
         db_set_column_host_type(column, gpgtype);
         db_set_column_sqltype(column, sqltype);
 
-        /* TODO */
-        precision = 0;
-        scale = 0;
-        /*
+        /* TODO:
+           precision = 0;
+           scale = 0;
+
            db_set_column_precision (column, precision);
            db_set_column_scale (column, scale);
          */

--- a/db/drivers/sqlite/describe.c
+++ b/db/drivers/sqlite/describe.c
@@ -182,7 +182,9 @@ int describe_table(sqlite3_stmt * statement, dbTable ** table, cursor * c)
     for (i = 0; i < ncols; i++) {
         const char *fname;
         dbColumn *column;
-        int litetype, sqltype, fsize, precision, scale;
+        int litetype, sqltype, fsize;
+
+        /* TODO: int precision, scale; */
 
         fname = sqlite3_column_name(statement, i);
 
@@ -241,10 +243,10 @@ int describe_table(sqlite3_stmt * statement, dbTable ** table, cursor * c)
         db_set_column_host_type(column, litetype);
         db_set_column_sqltype(column, sqltype);
 
-        /* TODO */
-        precision = 0;
-        scale = 0;
-        /*
+        /* TODO
+           precision = 0;
+           scale = 0;
+
            db_set_column_precision (column, precision);
            db_set_column_scale (column, scale);
          */

--- a/display/d.grid/plot.c
+++ b/display/d.grid/plot.c
@@ -16,15 +16,16 @@ int plot_grid(double grid_size, double east, double north, int do_text,
     double x, y, y0;
     double e1, e2;
     struct Cell_head window;
-    double row_dist, colm_dist;
+
+    /* double row_dist, colm_dist; */
     char text[128];
     double tx, ty, bt, bb, bl, br, w, h;
 
     G_get_set_window(&window);
 
     /* pull right and bottom edges back one pixel; display lib bug? */
-    row_dist = D_d_to_u_row(0.) - D_d_to_u_row(1.);
-    colm_dist = D_d_to_u_col(1.) - D_d_to_u_col(0.);
+    /* row_dist = D_d_to_u_row(0.) - D_d_to_u_row(1.);
+       colm_dist = D_d_to_u_col(1.) - D_d_to_u_col(0.); */
     /*    window.south += row_dist;
        window.east -= colm_dist;
      */

--- a/display/d.histogram/pie.c
+++ b/display/d.histogram/pie.c
@@ -66,7 +66,8 @@ int pie(struct stat_list *dist_stats,   /* list of distribution statistics */
     double y_box[6];
     double height, width;
     double xscale;              /* scaling factors */
-    double yscale;
+
+    /* double yscale; */
     char xlabel[1024];
     char txt[1024];
     char tic_name[80];
@@ -90,7 +91,7 @@ int pie(struct stat_list *dist_stats,   /* list of distribution statistics */
         dist_stats->mincat--;
     }
     xscale = ((double)(x_line[2] - x_line[1]) / ((double)num_cats));
-    yscale = ((double)(y_line[0] - y_line[1])) / dist_stats->maxstat;
+    /* yscale = ((double)(y_line[0] - y_line[1])) / dist_stats->maxstat; */
     yoffset = (long)(y_line[0]);
     if (num_cats >= x_line[2] - x_line[1])
         xoffset = (double)x_line[1];

--- a/display/d.path/main.c
+++ b/display/d.path/main.c
@@ -32,12 +32,12 @@ int main(int argc, char **argv)
 {
     struct Option *map, *afield_opt, *nfield_opt, *afcol, *abcol, *ncol,
         *type_opt;
-    struct Option *color_opt, *hcolor_opt, *bgcolor_opt, *coor_opt;
+    struct Option /* *color_opt, */ *hcolor_opt, /* *bgcolor_opt, */ *coor_opt;
     struct Flag *geo_f, *bold_f;
     struct GModule *module;
     struct Map_info Map;
     int type, afield, nfield, geo;
-    struct color_rgb color, hcolor, bgcolor;
+    struct color_rgb /* color, */ hcolor /*, bgcolor */ ;
     int r, g, b;
     double x1, y1, x2, y2;
 
@@ -93,6 +93,7 @@ int main(int argc, char **argv)
     ncol->required = NO;
     ncol->description = _("Node cost column");
 
+#if 0   /* unused */
     color_opt = G_define_option();
     color_opt->key = "color";
     color_opt->type = TYPE_STRING;
@@ -100,6 +101,7 @@ int main(int argc, char **argv)
     color_opt->description = _("Original line color");
     color_opt->gisprompt = "old_color,color,color";
     color_opt->guisection = _("Rendering");
+#endif
 
     hcolor_opt = G_define_option();
     hcolor_opt->key = "highlight_color";
@@ -109,6 +111,7 @@ int main(int argc, char **argv)
     hcolor_opt->gisprompt = "old_color,color,color";
     hcolor_opt->guisection = _("Rendering");
 
+#if 0   /* unused */
     bgcolor_opt = G_define_option();
     bgcolor_opt->key = "bgcolor";
     bgcolor_opt->type = TYPE_STRING;
@@ -116,6 +119,7 @@ int main(int argc, char **argv)
     bgcolor_opt->description = _("Background color");
     bgcolor_opt->gisprompt = "old_color,color,color";
     bgcolor_opt->guisection = _("Rendering");
+#endif
 
     geo_f = G_define_flag();
     geo_f->key = 'g';
@@ -152,12 +156,14 @@ int main(int argc, char **argv)
 
     D_open_driver();
 
+#if 0   /* unused */
     color = G_standard_color_rgb(BLACK);
     if (G_str_to_color(color_opt->answer, &r, &g, &b)) {
         color.r = r;
         color.g = g;
         color.b = b;
     }
+#endif
 
     hcolor = G_standard_color_rgb(RED);
     if (G_str_to_color(hcolor_opt->answer, &r, &g, &b)) {
@@ -166,12 +172,14 @@ int main(int argc, char **argv)
         hcolor.b = b;
     }
 
+#if 0   /* unused */
     bgcolor = G_standard_color_rgb(WHITE);
     if (G_str_to_color(bgcolor_opt->answer, &r, &g, &b)) {
         bgcolor.r = r;
         bgcolor.g = g;
         bgcolor.b = b;
     }
+#endif
 
     if (geo_f->answer) {
         geo = 1;

--- a/display/d.vect.thematic/display.c
+++ b/display/d.vect.thematic/display.c
@@ -147,14 +147,14 @@ int draw_line(int ltype, int line,
               int *n_points, int *n_lines, int *n_centroids,
               int *n_boundaries, int *n_faces, RGBA_Color * secondary_color)
 {
-    double var_size, rotation;
+    /* double var_size, rotation; */
     int i;
     double x0, y0;
     double *x, *y;
     int found, cat;
 
-    rotation = 0.0;
-    var_size = size;
+    /* rotation = 0.0;
+       var_size = size; */
     cat = -1;
 
     if (!ltype)

--- a/display/d.vect.thematic/plot1.c
+++ b/display/d.vect.thematic/plot1.c
@@ -46,9 +46,10 @@ int plot1(struct Map_info *Map, int type, int area, struct cat_list *Clist,
 {
     int i, ltype, nlines = 0, line, cat = -1;
     double *x, *y;
-    struct line_pnts *Points, *PPoints;
+    struct line_pnts *Points /* , *PPoints */ ;
     struct line_cats *Cats;
-    double msize;
+
+    /* double msize; */
     int x0, y0;
 
     struct field_info *fi = NULL;
@@ -91,10 +92,10 @@ int plot1(struct Map_info *Map, int type, int area, struct cat_list *Clist,
         fill_color->a = RGBA_COLOR_NONE;
 
 
-    msize = size * (D_d_to_u_col(2.0) - D_d_to_u_col(1.0));     /* do it better */
+    /* msize = size * (D_d_to_u_col(2.0) - D_d_to_u_col(1.0)); *//* do it better */
 
     Points = Vect_new_line_struct();
-    PPoints = Vect_new_line_struct();
+    /* PPoints = Vect_new_line_struct(); */
     Cats = Vect_new_cats_struct();
 
     open_db = table_colors_flag || width_column;

--- a/imagery/i.albedo/main.c
+++ b/imagery/i.albedo/main.c
@@ -59,7 +59,6 @@ int main(int argc, char *argv[])
     int nfiles;
     int infd[MAXFILES];
     int outfd;
-    char **names;
     char **ptr;
     int i = 0;
     int modis = 0, aster = 0, avhrr = 0;
@@ -78,9 +77,10 @@ int main(int argc, char *argv[])
     int bottom1a, bottom1b;
     int bottom2a, bottom2b;
     int bottom3a, bottom3b;
-    int i_bottom1a, i_bottom1b;
-    int i_bottom2a, i_bottom2b;
-    int i_bottom3a, i_bottom3b;
+    int i_bottom1a /*, i_bottom1b */ ;
+    int /* i_bottom2a, */ i_bottom2b;
+
+    /* int i_bottom3a, i_bottom3b; */
 
     /************************************/
     int histogram[100];
@@ -153,7 +153,6 @@ int main(int argc, char *argv[])
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    names = input->answers;
     ptr = input->answers;
 
     result = output->answer;
@@ -293,11 +292,11 @@ int main(int argc, char *argv[])
         bottom3a = 100000;
         bottom3b = 100000;
         i_bottom1a = 100;
-        i_bottom1b = 100;
-        i_bottom2a = 100;
+        /* i_bottom1b = 100; */
+        /* i_bottom2a = 100; */
         i_bottom2b = 100;
-        i_bottom3a = 100;
-        i_bottom3b = 100;
+        /* i_bottom3a = 100; */
+        /* i_bottom3b = 100; */
         /* Water histogram lower bound */
         for (i = 0; i < i_peak1; i++) {
             if (histogram[i] <= bottom1a) {
@@ -309,14 +308,14 @@ int main(int argc, char *argv[])
         for (i = i_peak2; i > i_peak1; i--) {
             if (histogram[i] <= bottom1b) {
                 bottom1b = histogram[i];
-                i_bottom1b = i;
+                /* i_bottom1b = i; */
             }
         }
         /* Land histogram lower bound */
         for (i = i_peak1; i < i_peak2; i++) {
             if (histogram[i] <= bottom2a) {
                 bottom2a = histogram[i];
-                i_bottom2a = i;
+                /* i_bottom2a = i; */
             }
         }
         /* Land histogram higher bound */
@@ -330,14 +329,14 @@ int main(int argc, char *argv[])
         for (i = i_peak2; i < i_peak3; i++) {
             if (histogram[i] < bottom3a) {
                 bottom3a = histogram[i];
-                i_bottom3a = i;
+                /* i_bottom3a = i; */
             }
         }
         /* Cloud/Snow histogram higher bound */
         for (i = 100; i > i_peak3; i--) {
             if (histogram[i] < bottom3b) {
                 bottom3b = histogram[i];
-                i_bottom3b = i;
+                /* i_bottom3b = i; */
             }
         }
         if (flag5->answer) {

--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     /*File Descriptors */
     int infd[MAXFILES];
     int outfd[MAXFILES];
-    char **names, **ptr;
+    char **ptr;
 
     /* For some strange reason infd[0] cannot be used later */
     /* So nfiles is initialized with nfiles = 1 */
@@ -153,7 +153,6 @@ int main(int argc, char *argv[])
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    names = input->answers;
     ptr = input->answers;
     doy = atof(input1->answer);
     sun_elevation = atof(input2->answer);

--- a/imagery/i.eb.netrad/r_net.c
+++ b/imagery/i.eb.netrad/r_net.c
@@ -15,7 +15,7 @@ double r_net(double bbalb, double ndvi, double tempk, double dtair,
     /* sunzangle = sun zenith angle at sat. overpass */
     /* tair = air temperature (approximative, or met.station) */
     double Kin = 0.0, Lin = 0.0, Lout = 0.0, Lcorr = 0.0, result = 0.0;
-    double ds = 0.0, e_atm = 0.0, delta = 0.0;
+    double ds = 0.0, e_atm = 0.0 /* , delta = 0.0 */ ;
 
     /* double tsw_for_e_atm = 0.7; *//* Special tsw, consider it a coefficient */
 
@@ -27,7 +27,7 @@ double r_net(double bbalb, double ndvi, double tempk, double dtair,
 
     /*      ds = 1.0 + 0.01672 * sin(2*PI*(doy-93.5)/365); */
     ds = 1.0 / pow((1 + 0.033 * cos(2 * PI * doy / 365)), 2);
-    delta = 0.4093 * sin((2 * PI * doy / 365) - 1.39);
+    /* delta = 0.4093 * sin((2 * PI * doy / 365) - 1.39); */
 
     /* Kin is the shortwave incoming radiation */
     Kin = 1358.0 * (cos(sunzangle * PI / 180) * tsw / (ds * ds));

--- a/imagery/i.evapo.time/main.c
+++ b/imagery/i.evapo.time/main.c
@@ -45,11 +45,8 @@ int main(int argc, char *argv[])
 
     /****************************************/
     /* Pointers for file names              */
-    char **names;
     char **ptr;
-    char **names1;
     char **ptr1;
-    char **names2;
     char **ptr2;
 
     /****************************************/
@@ -57,7 +54,6 @@ int main(int argc, char *argv[])
     int bfr, aft;
 
     /****************************************/
-    int ok;
     int i = 0, j = 0;
     double etodoy;              /*minimum ETo DOY */
     double startperiod, endperiod;      /*first and last days (DOYs) of the period studied */
@@ -128,12 +124,8 @@ int main(int argc, char *argv[])
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    ok = 1;
-    names = input->answers;
     ptr = input->answers;
-    names1 = input1->answers;
     ptr1 = input1->answers;
-    names2 = input2->answers;
     ptr2 = input2->answers;
     etodoy = atof(input3->answer);
     startperiod = atof(input4->answer);
@@ -141,14 +133,12 @@ int main(int argc, char *argv[])
     result = output->answer;
 
     /****************************************/
-    if (endperiod < startperiod) {
+    if (endperiod < startperiod)
         G_fatal_error(_("The DOY for end_period can not be smaller than start_period"));
-        ok = 0;
-    }
-    if (etodoy > startperiod) {
+
+    if (etodoy > startperiod)
         G_fatal_error(_("The DOY for start_period can not be smaller than eto_doy_min"));
-        ok = 0;
-    }
+
     for (; *ptr != NULL; ptr++) {
         if (nfiles > MAXFILES)
             G_fatal_error(_("Too many ETa files. Only %d allowed."),

--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -35,7 +35,6 @@ int main(int argc, char **argv)
     char *moduletorun;
     const char *grname;
     char tosystem[99];
-    int err = 0;
 
     /* initialize grass */
     G_gisinit(argv[0]);
@@ -99,11 +98,11 @@ int main(int argc, char **argv)
     /* run the program chosen */
     if (strcmp(moduletorun, "g.gui.photo2image") == 0) {
         strcpy(tosystem, "g.gui.photo2image");
-        err = system((const char *)tosystem);
+        return system((const char *)tosystem);
     }
     else if (strcmp(moduletorun, "g.gui.image2target") == 0) {
         strcpy(tosystem, "g.gui.image2target");
-        err = system((const char *)tosystem);
+        return system((const char *)tosystem);
     }
     else {
         if (strcmp(moduletorun, "i.group") == 0)
@@ -119,6 +118,6 @@ int main(int argc, char **argv)
         if (strcmp(moduletorun, "i.ortho.rectify") == 0)
             strcpy(tosystem, "i.ortho.rectify --ui group=");
         strcat(tosystem, grname);
-        err = system((const char *)tosystem);
+        return system((const char *)tosystem);
     }
 }

--- a/imagery/i.ortho.photo/lib/orthoref.c
+++ b/imagery/i.ortho.photo/lib/orthoref.c
@@ -65,7 +65,7 @@ int I_compute_ortho_equations(struct Ortho_Control_Points *cpz,
                               MATRIX * MO, MATRIX * MT)
 {
     MATRIX delta, epsilon, B, BT, C, E, N, CC, NN, UVW, XYZ, M, WT1;
-    double x, y, z, X, Y, Z, Xp, Yp, CFL;
+    double x, y, /* z, */ X, Y, Z, Xp, Yp, CFL;
     double lam, mu, nu, U, V, W;
     double xbar, ybar;
     double m11, m12, m13, m21, m22, m23, m31, m32, m33;
@@ -390,7 +390,7 @@ int I_compute_ortho_equations(struct Ortho_Control_Points *cpz,
 
             x = cpz->e1[i];
             y = cpz->n1[i];
-            z = cpz->z1[i];
+            /* z = cpz->z1[i]; */
             X = cpz->e2[i];
             Y = cpz->n2[i];
             Z = cpz->z2[i];
@@ -625,7 +625,7 @@ int I_ortho_ref(double e1, double n1, double z1,
 {
     MATRIX UVW, XYZ;
     double U, V, W;
-    double Xp, Yp, CFL;
+    double /* Xp, Yp, */ CFL;
     double dx, dy, dd;
 
     /*  Initialize and zero the matrices */
@@ -640,8 +640,8 @@ int I_ortho_ref(double e1, double n1, double z1,
 
     /************************ Start the work ******************************/
     /* Set Xp, Yp, and CFL from cam_info */
-    Xp = cam_info->Xp;
-    Yp = cam_info->Yp;
+    /* Xp = cam_info->Xp; */
+    /* Yp = cam_info->Yp; */
     CFL = cam_info->CFL;
 
     /* adjust for earth curvature */

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -201,13 +201,14 @@ int region_growing(struct globals *globals)
     struct reg_stats Ri_rs, Rk_rs, Rk_bestn_rs;
     double *dp;
     struct NB_TREE *tmpnbtree;
-    CELL cellmax;
+
+    /* CELL cellmax; */
     struct Cell_head cellhd;
 
     G_verbose_message("Running region growing algorithm");
 
-    cellmax = ((CELL) 1 << (sizeof(CELL) * 8 - 2)) - 1;
-    cellmax += ((CELL) 1 << (sizeof(CELL) * 8 - 2));
+    /* cellmax = ((CELL) 1 << (sizeof(CELL) * 8 - 2)) - 1;
+       cellmax += ((CELL) 1 << (sizeof(CELL) * 8 - 2)); */
 
     init_free_ids();
 
@@ -808,8 +809,7 @@ static int find_best_neighbor(struct ngbr_stats *Ri,
 
                                 tempsim =
                                     (globals->calculate_similarity) (Ri,
-                                                                     &globals->
-                                                                     ns,
+                                                                     &globals->ns,
                                                                      globals);
                                 candtmp =
                                     (FLAG_GET

--- a/lib/vector/dglib/edgemgmt-template.c
+++ b/lib/vector/dglib/edgemgmt-template.c
@@ -43,7 +43,7 @@ int DGL_ADD_EDGE_FUNC(dglGraph_s * pgraph,
 #if defined(_DGL_V2)
     dglInt32_t *pinEdgeset;
     dglTreeEdge_s *pEdgeItem;
-    dglTreeEdge_s findEdge;
+    /* dglTreeEdge_s findEdge; */
 #endif
 
     if (pgraph->Flags & DGL_GS_FLAT) {
@@ -204,7 +204,7 @@ int DGL_ADD_EDGE_FUNC(dglGraph_s * pgraph,
     /*
      * Set the edge-tree
      */
-    findEdge.nKey = nEdge;
+    /* findEdge.nKey = nEdge; */
 
     if ((pEdgeItem = dglTreeEdgeAdd(pgraph->pEdgeTree, nEdge)) == NULL) {
 	pgraph->iErrno = DGL_ERR_MemoryExhausted;

--- a/misc/m.nviz.image/args.c
+++ b/misc/m.nviz.image/args.c
@@ -960,7 +960,7 @@ void check_parameters(const struct GParams *params)
 
     int nvpoints, nvpoints_pos, nvpoints_layer;
 
-    int nvolumes, nisosurf, nslices;
+    int /* nvolumes, */ nisosurf, nslices;
 
     /* topography */
     nelev_map = opt_get_num_answers(params->elev_map);
@@ -1133,7 +1133,7 @@ void check_parameters(const struct GParams *params)
     /*
      * volumes
      */
-    nvolumes = opt_get_num_answers(params->volume);
+    /* nvolumes = opt_get_num_answers(params->volume); */
     nisosurf = opt_get_num_answers(params->isosurf_level);
     nslices = opt_get_num_answers(params->slice);
 

--- a/misc/m.nviz.script/main.c
+++ b/misc/m.nviz.script/main.c
@@ -45,9 +45,10 @@ int main(int argc, char *argv[])
 {
     const char *name;
     char outfile[GNAME_MAX];
-    int fd, projection;
+    int fd /*, projection */ ;
     char buf[512], buf1[1024], buf2[1024];
-    int screen_x, screen_y;
+
+    /* int screen_x, screen_y; */
     int i, k;
     int frame_start = 0;
     double e1, e2, n1, n2;
@@ -149,12 +150,12 @@ int main(int argc, char *argv[])
 
     /* get GRASS parameters */
     G_get_window(&window);
-    projection = G_projection();
+    /* projection = G_projection(); */
     D_do_conversions(&window, 0, 1, 0, 1);
 
     /* setup screen coords */
-    screen_x = ((int)D_get_d_west() + (int)D_get_d_east()) / 2;
-    screen_y = ((int)D_get_d_north() + (int)D_get_d_south()) / 2;
+    /* screen_x = ((int)D_get_d_west() + (int)D_get_d_east()) / 2;
+       screen_y = ((int)D_get_d_north() + (int)D_get_d_south()) / 2; */
 
     /* get camera parameters */
     DIST = atof(parm.dist->answer);

--- a/raster/r.in.ascii/gethead.c
+++ b/raster/r.in.ascii/gethead.c
@@ -31,8 +31,8 @@ int getgrdhead(FILE * fd, struct Cell_head *cellhd)
 
     /* read and check the flag on the first line */
     if (fgets(grd_flag, sizeof(grd_flag), fd) == NULL) {
-    	G_warning(_("failed to read the input file"));
-    	return 0;
+        G_warning(_("failed to read the input file"));
+        return 0;
     }
     if (strncmp(gs_ascii_flag, grd_flag, strlen(gs_ascii_flag))) {
         G_warning(_("input file is not a Surfer ascii grid file"));
@@ -90,7 +90,7 @@ int gethead(FILE * fd,
     int n, s, e, w, r, c;
     char label[100], value[100];
     char buf[1024];
-    int ret, len;
+    int ret;
 
     /* rsb fix */
     fpos_t p;
@@ -109,8 +109,6 @@ int gethead(FILE * fd,
 
         if (!G_getl2(buf, sizeof(buf), fd))
             break;
-
-        len = strlen(buf);
 
         *label = *value = '\0';
         if (NULL == strstr(buf, ":"))
@@ -247,7 +245,7 @@ static int extract(int count,
                    char *label, char *value,
                    void *data, int proj, int (*scanner)())
 {
-    if(count) {
+    if (count) {
         G_warning(_("Duplicate \"%s\" field in header"), label);
         return 0;
     }

--- a/raster/r.in.mat/main.c
+++ b/raster/r.in.mat/main.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 
     int i, row, col;            /* counters */
 
-    int machine_endianness, file_endianness, endian_mismatch;   /* 0=little, 1=big */
+    int machine_endianness, file_endianness /*, endian_mismatch */ ;    /* 0=little, 1=big */
     int data_format;            /* 0=double  1=float  2=32bit signed int  5=8bit unsigned int (ie text) */
     int data_type;              /* 0=numbers  1=text */
     int format_block;           /* combo of endianness, 0, data_format, and type */
@@ -133,10 +133,10 @@ int main(int argc, char *argv[])
     G_fseek(fp1, 0, SEEK_SET);  /* frewind() */
 
     file_endianness = format_block / 1000;      /* 0=little, 1=big */
-    if (file_endianness != machine_endianness)
-        endian_mismatch = 1;
-    else
-        endian_mismatch = 0;
+    /* if (file_endianness != machine_endianness)
+       endian_mismatch = 1;
+       else
+       endian_mismatch = 0; */
 
     G_debug(1, "File is %s endian.\n", file_endianness ? "big" : "little");
 
@@ -308,7 +308,8 @@ int main(int argc, char *argv[])
                 map_type = DCELL_TYPE;
                 array_data =
                     G_calloc(mrows * (ncols + 1), Rast_cell_size(map_type));
-                if (fread(array_data, sizeof(double), (size_t)mrows * ncols, fp1)
+                if (fread
+                    (array_data, sizeof(double), (size_t)mrows * ncols, fp1)
                     != (mrows * ncols))
                     G_fatal_error(_("Error reading data"));
                 break;
@@ -317,7 +318,8 @@ int main(int argc, char *argv[])
                 map_type = FCELL_TYPE;
                 array_data =
                     G_calloc(mrows * (ncols + 1), Rast_cell_size(map_type));
-                if (fread(array_data, sizeof(float), (size_t)mrows * ncols, fp1)
+                if (fread
+                    (array_data, sizeof(float), (size_t)mrows * ncols, fp1)
                     != (mrows * ncols))
                     G_fatal_error(_("Error reading data"));
                 break;

--- a/raster/r.kappa/calc_kappa.c
+++ b/raster/r.kappa/calc_kappa.c
@@ -10,7 +10,6 @@ void calc_kappa(void)
     int i, j;
     int a_i, b_i;
     int s, l;
-    int nl;
     size_t ns;
     double *pi, *pj, *pii, p0, pC;
     double kp, vkp, *kpp;
@@ -21,7 +20,6 @@ void calc_kappa(void)
     /* initialize */
     s = 0;
     l = -1;
-    nl = nlayers;
     ns = nstats;
     obs = 0;
     inter1 = inter2 = 0;

--- a/raster/r.kappa/prt2csv_mat.c
+++ b/raster/r.kappa/prt2csv_mat.c
@@ -21,7 +21,6 @@ void prn2csv_error_mat(int out_cols, int hdr)
     int thisone;
     long t_row, t_col;
     long t_rowcount;
-    const char *mapone;
     FILE *fd;
 
     long *cats;
@@ -106,7 +105,6 @@ void prn2csv_error_mat(int out_cols, int hdr)
         fprintf(fd, "RowSum");
         fprintf(fd, "\n");
         /* body of the matrix */
-        mapone = "MAP2";
         for (rndx = 0; rndx < ncat; rndx++) {
             cats = rlst;
             cl = Rast_get_c_cat((CELL *) & (cats[rndx]), &(layers[1].labels));

--- a/raster/r.li/r.li.daemon/daemon.c
+++ b/raster/r.li/r.li.daemon/daemon.c
@@ -35,8 +35,8 @@
 #include <grass/glocale.h>
 #include "daemon.h"
 
-int calculateIndex(char *file, rli_func *f,
-		   char **parameters, char *raster, char *output)
+int calculateIndex(char *file, rli_func * f,
+                   char **parameters, char *raster, char *output)
 {
 
     char pathSetup[GPATH_MAX], out[GPATH_MAX], parsed;
@@ -44,15 +44,15 @@ int calculateIndex(char *file, rli_func *f,
     struct History history;
     struct g_area *g;
     int res;
-    int i, doneDir, mv_fd, random_access;
+    int doneDir, mv_fd, random_access;
 
     /* int mv_rows, mv_cols; */
     struct list *l;
     msg m, doneJob;
 
-    g = (struct g_area *) G_malloc(sizeof(struct g_area));
+    g = (struct g_area *)G_malloc(sizeof(struct g_area));
     g->maskname = NULL;
-    l = (struct list*) G_malloc(sizeof(struct list));
+    l = (struct list *)G_malloc(sizeof(struct list));
     l->head = NULL;
     l->tail = NULL;
     l->size = 0;
@@ -67,12 +67,14 @@ int calculateIndex(char *file, rli_func *f,
     char rlipath[GPATH_MAX];
     char testpath[GPATH_MAX];
 
-	/* conf files go into ~/.grass8/r.li/ */
-    sprintf(rlipath, "%s%c%s%c", G_config_path(), HOST_DIRSEP, "r.li", HOST_DIRSEP);
+    /* conf files go into ~/.grass8/r.li/ */
+    sprintf(rlipath, "%s%c%s%c", G_config_path(), HOST_DIRSEP, "r.li",
+            HOST_DIRSEP);
 
-    sprintf(testpath, "%s%c%s%c", G_config_path(), HOST_DIRSEP, "r.li", HOST_DIRSEP);
+    sprintf(testpath, "%s%c%s%c", G_config_path(), HOST_DIRSEP, "r.li",
+            HOST_DIRSEP);
     if (strncmp(file, testpath, strlen(testpath)) == 0)
-	file += strlen(testpath);
+        file += strlen(testpath);
 
     /* TODO: check if this path is portable */
     /* TODO: use G_rc_path() */
@@ -86,45 +88,45 @@ int calculateIndex(char *file, rli_func *f,
        ####################################################### */
 
     if (parsed == MVWIN) {
-	/* struct Cell_head cellhd_r, cellhd_new;
-	   char *mapset; */
-	/*creating new raster file */
-	mv_fd = Rast_open_new(output, DCELL_TYPE);
+        /* struct Cell_head cellhd_r, cellhd_new;
+           char *mapset; */
+        /*creating new raster file */
+        mv_fd = Rast_open_new(output, DCELL_TYPE);
 
-	random_access_name = G_tempfile();
-	random_access = open(random_access_name, O_RDWR | O_CREAT, 0755);
-	if (random_access == -1)
-	    G_fatal_error(_("Cannot create random access file"));
+        random_access_name = G_tempfile();
+        random_access = open(random_access_name, O_RDWR | O_CREAT, 0755);
+        if (random_access == -1)
+            G_fatal_error(_("Cannot create random access file"));
     }
     else {
-	/* text file output */
-	/* check if ~/.grass8/ exists */
+        /* text file output */
+        /* check if ~/.grass8/ exists */
         sprintf(out, "%s", G_config_path());
-	doneDir = G_mkdir(out);
-	if (doneDir == -1 && errno != EEXIST)
-	    G_fatal_error(_("Cannot create %s directory"), out);
+        doneDir = G_mkdir(out);
+        if (doneDir == -1 && errno != EEXIST)
+            G_fatal_error(_("Cannot create %s directory"), out);
 
-	/* check if ~/.grass8/r.li/ exists */
-	sprintf(out, "%s", rlipath);
-	doneDir = G_mkdir(out);
-	if (doneDir == -1 && errno != EEXIST)
-	    G_fatal_error(_("Cannot create %s directory"), out);
+        /* check if ~/.grass8/r.li/ exists */
+        sprintf(out, "%s", rlipath);
+        doneDir = G_mkdir(out);
+        if (doneDir == -1 && errno != EEXIST)
+            G_fatal_error(_("Cannot create %s directory"), out);
 
-	/* check if ~/.grass7/r.li/output exists */
+        /* check if ~/.grass7/r.li/output exists */
         if (snprintf(out, GPATH_MAX, "%s%s", rlipath, "output") >= GPATH_MAX)
             G_fatal_error(_("Filepath '%s%s' exceeds max length"), rlipath,
                           "output");
-	doneDir = G_mkdir(out);
-	if (doneDir == -1 && errno != EEXIST)
-	    G_fatal_error(_("Cannot create %s directory"), out);
-        if (snprintf(out, GPATH_MAX, "%s%s%c%s", rlipath, "output", HOST_DIRSEP,
-                     output) >= GPATH_MAX)
-            G_fatal_error(_("Filepath '%s%s%c%s' exceeds max length"), rlipath,
-                          "output", HOST_DIRSEP, output);
+        doneDir = G_mkdir(out);
+        if (doneDir == -1 && errno != EEXIST)
+            G_fatal_error(_("Cannot create %s directory"), out);
+        if (snprintf
+            (out, GPATH_MAX, "%s%s%c%s", rlipath, "output", HOST_DIRSEP,
+             output) >= GPATH_MAX)
+            G_fatal_error(_("Filepath '%s%s%c%s' exceeds max length"),
+                          rlipath, "output", HOST_DIRSEP, output);
         if ((res = open(out, O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1)
             G_fatal_error(_("Cannot create %s output"), out);
     }
-    i = 0;
 
     /*#######################################################
        ------------------analysis loop----------------------
@@ -132,35 +134,35 @@ int calculateIndex(char *file, rli_func *f,
 
     /*body */
     while (next_Area(parsed, l, g, &m) != 0) {
-	worker_process(&doneJob, &m);
+        worker_process(&doneJob, &m);
 
-	/*perc++; */
-	/*G_percent (perc, WORKERS, 1); */
-	if (doneJob.type == DONE) {
-	    double result;
+        /*perc++; */
+        /*G_percent (perc, WORKERS, 1); */
+        if (doneJob.type == DONE) {
+            /* double result;
 
-	    result = doneJob.f.f_d.res;
-	    /* output */
-	    if (parsed != MVWIN) {
-		/* text file output */
-		print_Output(res, doneJob);
-	    }
-	    else {
-		/* raster output */
-		raster_Output(random_access, doneJob.f.f_d.aid, g,
-			      doneJob.f.f_d.res);
-	    }
-	}
-	else {
-	    if (parsed != MVWIN) {
-		/* text file output */
-		error_Output(res, doneJob);
-	    }
-	    else {
-		/* printf("todo"); fflush(stdout); */
-		/* TODO write to raster NULL ??? */
-	    }
-	}
+               result = doneJob.f.f_d.res; */
+            /* output */
+            if (parsed != MVWIN) {
+                /* text file output */
+                print_Output(res, doneJob);
+            }
+            else {
+                /* raster output */
+                raster_Output(random_access, doneJob.f.f_d.aid, g,
+                              doneJob.f.f_d.res);
+            }
+        }
+        else {
+            if (parsed != MVWIN) {
+                /* text file output */
+                error_Output(res, doneJob);
+            }
+            else {
+                /* printf("todo"); fflush(stdout); */
+                /* TODO write to raster NULL ??? */
+            }
+        }
     }
 
     worker_end();
@@ -170,17 +172,18 @@ int calculateIndex(char *file, rli_func *f,
        ################################################ */
 
     if (parsed == MVWIN) {
-	write_raster(mv_fd, random_access, g);
-	close(random_access);
-	unlink(random_access_name);
-	Rast_close(mv_fd);
-	Rast_short_history(output, "raster", &history);
-	Rast_command_history(&history);
-	Rast_write_history(output, &history);
-	G_done_msg(_("Raster map <%s> created."), output);
-    } else {
-	/* text file output */
-	G_done_msg("Result written to text file <%s>", out);
+        write_raster(mv_fd, random_access, g);
+        close(random_access);
+        unlink(random_access_name);
+        Rast_close(mv_fd);
+        Rast_short_history(output, "raster", &history);
+        Rast_command_history(&history);
+        Rast_write_history(output, &history);
+        G_done_msg(_("Raster map <%s> created."), output);
+    }
+    else {
+        /* text file output */
+        G_done_msg("Result written to text file <%s>", out);
     }
 
     /* This is only return in this function, so the documented 1 is
@@ -198,28 +201,29 @@ int parseSetup(char *path, struct list *l, struct g_area *g, char *raster)
     int setup;
     int letti;
     double rel_x, rel_y, rel_rl, rel_cl;
-    double sf_n, sf_s, sf_e, sf_w;
+
+    /* double sf_n, sf_s, sf_e, sf_w; */
     int sf_x, sf_y, sf_rl, sf_cl;
     int sa_x, sa_y, sa_rl, sa_cl;
     int size;
 
     if (stat(path, &s) != 0)
-	G_fatal_error(_("Cannot find configuration file <%s>"), path);
+        G_fatal_error(_("Cannot find configuration file <%s>"), path);
 
     size = s.st_size * sizeof(char);
     buf = G_malloc(size);
 
     setup = open(path, O_RDONLY, 0755);
     if (setup == -1)
-	G_fatal_error(_("Cannot read setup file"));
+        G_fatal_error(_("Cannot read setup file"));
 
     letti = read(setup, buf, s.st_size);
     if (letti < s.st_size)
-	G_fatal_error(_("Cannot read setup file"));
+        G_fatal_error(_("Cannot read setup file"));
 
     token = strtok(buf, " ");
     if (strcmp("SAMPLINGFRAME", token) != 0)
-	G_fatal_error(_("Unable to parse configuration file (sampling frame)"));
+        G_fatal_error(_("Unable to parse configuration file (sampling frame)"));
 
     rel_x = atof(strtok(NULL, "|"));
     rel_y = atof(strtok(NULL, "|"));
@@ -234,261 +238,261 @@ int parseSetup(char *path, struct list *l, struct g_area *g, char *raster)
     sf_y = (int)rint(cellhd.rows * rel_y);
     sf_rl = (int)rint(cellhd.rows * rel_rl);
     sf_cl = (int)rint(cellhd.cols * rel_cl);
-    
+
     /* sanity check */
     if (sf_x < 0)
-	sf_x = 0;
+        sf_x = 0;
     if (sf_y < 0)
-	sf_y = 0;
+        sf_y = 0;
     if (sf_x > cellhd.cols)
-	sf_x = cellhd.cols;
+        sf_x = cellhd.cols;
     if (sf_y > cellhd.rows)
-	sf_y = cellhd.rows;
+        sf_y = cellhd.rows;
     if (sf_rl > cellhd.rows - sf_y)
-	sf_rl = cellhd.rows - sf_y;
+        sf_rl = cellhd.rows - sf_y;
     if (sf_cl > cellhd.cols - sf_x)
-	sf_cl = cellhd.cols - sf_x;
+        sf_cl = cellhd.cols - sf_x;
 
     /* calculate sample frame boundaries */
-    sf_n = cellhd.north - (cellhd.ns_res * sf_y);
-    sf_s = sf_n - (cellhd.ns_res * sf_rl);
-    sf_w = cellhd.west + (cellhd.ew_res * sf_x);
-    sf_e = sf_w + (cellhd.ew_res * sf_cl);
+    /* sf_n = cellhd.north - (cellhd.ns_res * sf_y);
+       sf_s = sf_n - (cellhd.ns_res * sf_rl);
+       sf_w = cellhd.west + (cellhd.ew_res * sf_x);
+       sf_e = sf_w + (cellhd.ew_res * sf_cl); */
 
     /* parse configuration file */
     token = strtok(NULL, " ");
 
     if (strcmp("SAMPLEAREA", token) == 0) {
-	double rel_sa_x, rel_sa_y, rel_sa_rl, rel_sa_cl;
-	int aid = 1, toReturn;
+        double rel_sa_x, rel_sa_y, rel_sa_rl, rel_sa_cl;
+        int aid = 1, toReturn;
 
-	do {
-	    rel_sa_x = atof(strtok(NULL, "|"));
-	    rel_sa_y = atof(strtok(NULL, "|"));
-	    rel_sa_rl = atof(strtok(NULL, "|"));
-	    rel_sa_cl = atof(strtok(NULL, "\n"));
+        do {
+            rel_sa_x = atof(strtok(NULL, "|"));
+            rel_sa_y = atof(strtok(NULL, "|"));
+            rel_sa_rl = atof(strtok(NULL, "|"));
+            rel_sa_cl = atof(strtok(NULL, "\n"));
 
-	    if (rel_sa_x == -1.0 && rel_sa_y == -1.0) {
-		/* runtime disposition */
+            if (rel_sa_x == -1.0 && rel_sa_y == -1.0) {
+                /* runtime disposition */
 
-		sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
-		sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
+                sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
+                sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
 
-		/* sanity check */
-		if (sa_rl > cellhd.rows - sf_y)
-		    sa_rl = cellhd.rows - sf_y;
-		if (sa_cl > cellhd.cols - sf_x)
-		    sa_cl = cellhd.cols - sf_x;
+                /* sanity check */
+                if (sa_rl > cellhd.rows - sf_y)
+                    sa_rl = cellhd.rows - sf_y;
+                if (sa_cl > cellhd.cols - sf_x)
+                    sa_cl = cellhd.cols - sf_x;
 
-		/* total sample area */
-		g->rows = sf_rl;
-		g->cols = sf_cl;
-		g->x = sf_x;
-		g->y = sf_y;
-		/* current sample area (subset of total sample area) */
-		g->rl = sa_rl;
-		g->cl = sa_cl;
-		g->sf_x = sf_x;
-		g->sf_y = sf_y;
+                /* total sample area */
+                g->rows = sf_rl;
+                g->cols = sf_cl;
+                g->x = sf_x;
+                g->y = sf_y;
+                /* current sample area (subset of total sample area) */
+                g->rl = sa_rl;
+                g->cl = sa_cl;
+                g->sf_x = sf_x;
+                g->sf_y = sf_y;
 
-		g->count = 1;
-		g->maskname = NULL;
+                g->count = 1;
+                g->maskname = NULL;
 
-		return disposeAreas(l, g, strtok(NULL, "\n"));
-	    }
-	    else {
-		msg m;
+                return disposeAreas(l, g, strtok(NULL, "\n"));
+            }
+            else {
+                msg m;
 
-		toReturn = NORMAL;
-		/*read file and create list */
-		m.type = AREA;
-		/* current sample area (subset of total sample area) */
-		sa_x = (int)rint(cellhd.cols * rel_sa_x);
-		sa_y = (int)rint(cellhd.rows * rel_sa_y);
-		sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
-		sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
+                toReturn = NORMAL;
+                /*read file and create list */
+                m.type = AREA;
+                /* current sample area (subset of total sample area) */
+                sa_x = (int)rint(cellhd.cols * rel_sa_x);
+                sa_y = (int)rint(cellhd.rows * rel_sa_y);
+                sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
+                sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
 
-		/* sanity check */
-		if (sa_x < 0)
-		    sa_x = 0;
-		if (sa_y < 0)
-		    sa_y = 0;
-		if (sa_x > cellhd.cols)
-		    sa_x = cellhd.cols;
-		if (sa_y > cellhd.rows)
-		    sa_y = cellhd.rows;
-		if (sa_rl > cellhd.rows - sa_y)
-		    sa_rl = cellhd.rows - sa_y;
-		if (sa_cl > cellhd.cols - sa_x)
-		    sa_cl = cellhd.cols - sa_x;
+                /* sanity check */
+                if (sa_x < 0)
+                    sa_x = 0;
+                if (sa_y < 0)
+                    sa_y = 0;
+                if (sa_x > cellhd.cols)
+                    sa_x = cellhd.cols;
+                if (sa_y > cellhd.rows)
+                    sa_y = cellhd.rows;
+                if (sa_rl > cellhd.rows - sa_y)
+                    sa_rl = cellhd.rows - sa_y;
+                if (sa_cl > cellhd.cols - sa_x)
+                    sa_cl = cellhd.cols - sa_x;
 
-		m.f.f_a.x = sa_x;
-		m.f.f_a.y = sa_y;
-		m.f.f_a.rl = sa_rl;
-		m.f.f_a.cl = sa_cl;
-		m.f.f_a.aid = aid;
-		aid++;
-		insertNode(l, m);
-	    }
+                m.f.f_a.x = sa_x;
+                m.f.f_a.y = sa_y;
+                m.f.f_a.rl = sa_rl;
+                m.f.f_a.cl = sa_cl;
+                m.f.f_a.aid = aid;
+                aid++;
+                insertNode(l, m);
+            }
 
-	} while ((token = strtok(NULL, " ")) != NULL &&
-		 strcmp(token, "SAMPLEAREA") == 0);
+        } while ((token = strtok(NULL, " ")) != NULL &&
+                 strcmp(token, "SAMPLEAREA") == 0);
 
-	close(setup);
-	return toReturn;
+        close(setup);
+        return toReturn;
     }
     else if (strcmp("MASKEDSAMPLEAREA", token) == 0) {
-	double rel_sa_x, rel_sa_y, rel_sa_rl, rel_sa_cl;
-	int aid = 1;
-	char maskname[GNAME_MAX] = {'\0'};
+        double rel_sa_x, rel_sa_y, rel_sa_rl, rel_sa_cl;
+        int aid = 1;
+        char maskname[GNAME_MAX] = { '\0' };
 
-	do {
-	    rel_sa_x = atof(strtok(NULL, "|"));
-	    rel_sa_y = atof(strtok(NULL, "|"));
-	    rel_sa_rl = atof(strtok(NULL, "|"));
-	    rel_sa_cl = atof(strtok(NULL, "|"));
-	    strcpy(maskname, strtok(NULL, "\n"));
+        do {
+            rel_sa_x = atof(strtok(NULL, "|"));
+            rel_sa_y = atof(strtok(NULL, "|"));
+            rel_sa_rl = atof(strtok(NULL, "|"));
+            rel_sa_cl = atof(strtok(NULL, "|"));
+            strcpy(maskname, strtok(NULL, "\n"));
 
-	    if (rel_sa_x == -1 && rel_sa_y == -1) {
-		/* runtime disposition */
+            if (rel_sa_x == -1 && rel_sa_y == -1) {
+                /* runtime disposition */
 
-		sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
-		sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
+                sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
+                sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
 
-		/* sanity check */
-		if (sa_rl > cellhd.rows - sf_y)
-		    sa_rl = cellhd.rows - sf_y;
-		if (sa_cl > cellhd.cols - sf_x)
-		    sa_cl = cellhd.cols - sf_x;
+                /* sanity check */
+                if (sa_rl > cellhd.rows - sf_y)
+                    sa_rl = cellhd.rows - sf_y;
+                if (sa_cl > cellhd.cols - sf_x)
+                    sa_cl = cellhd.cols - sf_x;
 
-		/* total sample area */
-		g->rows = sf_rl;
-		g->cols = sf_cl;
-		g->x = sf_x;
-		g->y = sf_y;
-		/* current sample area (subset of total sample area) */
-		g->rl = sa_rl;
-		g->cl = sa_cl;
-		g->count = 1;
-		g->maskname = maskname;
-		return disposeAreas(l, g, strtok(NULL, "\n"));
-	    }
-	    else {
-		/*read file and create list */
-		msg m;
+                /* total sample area */
+                g->rows = sf_rl;
+                g->cols = sf_cl;
+                g->x = sf_x;
+                g->y = sf_y;
+                /* current sample area (subset of total sample area) */
+                g->rl = sa_rl;
+                g->cl = sa_cl;
+                g->count = 1;
+                g->maskname = maskname;
+                return disposeAreas(l, g, strtok(NULL, "\n"));
+            }
+            else {
+                /*read file and create list */
+                msg m;
 
-		m.type = MASKEDAREA;
-		/* current sample area (subset of total sample area) */
-		sa_x = (int)rint(cellhd.cols * rel_sa_x);
-		sa_y = (int)rint(cellhd.rows * rel_sa_y);
-		sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
-		sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
+                m.type = MASKEDAREA;
+                /* current sample area (subset of total sample area) */
+                sa_x = (int)rint(cellhd.cols * rel_sa_x);
+                sa_y = (int)rint(cellhd.rows * rel_sa_y);
+                sa_rl = (int)rint(cellhd.rows * rel_sa_rl);
+                sa_cl = (int)rint(cellhd.cols * rel_sa_cl);
 
-		/* sanity check */
-		if (sa_x < 0)
-		    sa_x = 0;
-		if (sa_y < 0)
-		    sa_y = 0;
-		if (sa_x > cellhd.cols)
-		    sa_x = cellhd.cols;
-		if (sa_y > cellhd.rows)
-		    sa_y = cellhd.rows;
-		if (sa_rl > cellhd.rows - sa_y)
-		    sa_rl = cellhd.rows - sa_y;
-		if (sa_cl > cellhd.cols - sa_x)
-		    sa_cl = cellhd.cols - sa_x;
+                /* sanity check */
+                if (sa_x < 0)
+                    sa_x = 0;
+                if (sa_y < 0)
+                    sa_y = 0;
+                if (sa_x > cellhd.cols)
+                    sa_x = cellhd.cols;
+                if (sa_y > cellhd.rows)
+                    sa_y = cellhd.rows;
+                if (sa_rl > cellhd.rows - sa_y)
+                    sa_rl = cellhd.rows - sa_y;
+                if (sa_cl > cellhd.cols - sa_x)
+                    sa_cl = cellhd.cols - sa_x;
 
-		m.f.f_ma.x = sa_x;
-		m.f.f_ma.y = sa_y;
-		m.f.f_ma.rl = sa_rl;
-		m.f.f_ma.cl = sa_cl;
-		m.f.f_ma.aid = aid;
-		strcpy(m.f.f_ma.mask, maskname);
-		aid++;
-		insertNode(l, m);
-	    }
-	}
+                m.f.f_ma.x = sa_x;
+                m.f.f_ma.y = sa_y;
+                m.f.f_ma.rl = sa_rl;
+                m.f.f_ma.cl = sa_cl;
+                m.f.f_ma.aid = aid;
+                strcpy(m.f.f_ma.mask, maskname);
+                aid++;
+                insertNode(l, m);
+            }
+        }
 
-	while ((token = strtok(NULL, " ")) != NULL &&
-	       strcmp(token, "MASKEDSAMPLEAREA") == 0);
+        while ((token = strtok(NULL, " ")) != NULL &&
+               strcmp(token, "MASKEDSAMPLEAREA") == 0);
 
-	close(setup);
-	return NORMAL;
+        close(setup);
+        return NORMAL;
     }
     else if (strcmp("MASKEDOVERLAYAREA", token) == 0) {
-	double sa_n, sa_s, sa_w, sa_e;
-	int aid = 1;
-	char maskname[GNAME_MAX] = {'\0'};
-	msg m;
+        double sa_n, sa_s, sa_w, sa_e;
+        int aid = 1;
+        char maskname[GNAME_MAX] = { '\0' };
+        msg m;
 
-	/* Get the window setting. g.region raster=<input raster> */
-	/*   ? same as cellhd above ? */
-	/* no. the current window might be different */
+        /* Get the window setting. g.region raster=<input raster> */
+        /*   ? same as cellhd above ? */
+        /* no. the current window might be different */
 
-	do {
-	    strcpy(maskname, strtok(NULL, "|"));
-	    sa_n = atof(strtok(NULL, "|"));
-	    sa_s = atof(strtok(NULL, "|"));
-	    sa_e = atof(strtok(NULL, "|"));
-	    sa_w = atof(strtok(NULL, "\n"));
+        do {
+            strcpy(maskname, strtok(NULL, "|"));
+            sa_n = atof(strtok(NULL, "|"));
+            sa_s = atof(strtok(NULL, "|"));
+            sa_e = atof(strtok(NULL, "|"));
+            sa_w = atof(strtok(NULL, "\n"));
 
-	    m.type = MASKEDAREA;
+            m.type = MASKEDAREA;
 
-	    /* Each input overlay area from input vector are converted to
-		raster via v.to.rast. See r.li.setup/sample_area_vector.sh.
-		This is used only for reading the region (NS, EW). */
+            /* Each input overlay area from input vector are converted to
+               raster via v.to.rast. See r.li.setup/sample_area_vector.sh.
+               This is used only for reading the region (NS, EW). */
 
-	    /* current sample area (subset of total sample area) */
+            /* current sample area (subset of total sample area) */
 
-	    /* Get start x and y position of masked overlay raster with
-		respect to current region.
-		sa_n, sa_w are read from configuration file. */
-	    sa_x = (int)rint((sa_w - cellhd.west) / cellhd.ew_res);
-	    sa_y = (int)rint((cellhd.north - sa_n) / cellhd.ns_res);
+            /* Get start x and y position of masked overlay raster with
+               respect to current region.
+               sa_n, sa_w are read from configuration file. */
+            sa_x = (int)rint((sa_w - cellhd.west) / cellhd.ew_res);
+            sa_y = (int)rint((cellhd.north - sa_n) / cellhd.ns_res);
 
-	    /* Get row count and column count of overlay raster */
-	    sa_rl = (int)rint((sa_n - sa_s) / cellhd.ns_res);
-	    sa_cl = (int)rint((sa_e - sa_w) / cellhd.ew_res);
+            /* Get row count and column count of overlay raster */
+            sa_rl = (int)rint((sa_n - sa_s) / cellhd.ns_res);
+            sa_cl = (int)rint((sa_e - sa_w) / cellhd.ew_res);
 
-	    /* sanity check */
-	    if (sa_x < 0)
-		sa_x = 0;
-	    if (sa_y < 0)
-		sa_y = 0;
-	    if (sa_x > cellhd.cols)
-		sa_x = cellhd.cols;
-	    if (sa_y > cellhd.rows)
-		sa_y = cellhd.rows;
-	    if (sa_rl > cellhd.rows - sa_y)
-		sa_rl = cellhd.rows - sa_y;
-	    if (sa_cl > cellhd.cols - sa_x)
-		sa_cl = cellhd.cols - sa_x;
+            /* sanity check */
+            if (sa_x < 0)
+                sa_x = 0;
+            if (sa_y < 0)
+                sa_y = 0;
+            if (sa_x > cellhd.cols)
+                sa_x = cellhd.cols;
+            if (sa_y > cellhd.rows)
+                sa_y = cellhd.rows;
+            if (sa_rl > cellhd.rows - sa_y)
+                sa_rl = cellhd.rows - sa_y;
+            if (sa_cl > cellhd.cols - sa_x)
+                sa_cl = cellhd.cols - sa_x;
 
-	    m.f.f_ma.x = sa_x;
-	    m.f.f_ma.y = sa_y;
-	    m.f.f_ma.rl = sa_rl;
-	    m.f.f_ma.cl = sa_cl;
-	    m.f.f_ma.aid = aid;
-	    strcpy(m.f.f_ma.mask, maskname);
-	    aid++;
-	    insertNode(l, m);
-	}
+            m.f.f_ma.x = sa_x;
+            m.f.f_ma.y = sa_y;
+            m.f.f_ma.rl = sa_rl;
+            m.f.f_ma.cl = sa_cl;
+            m.f.f_ma.aid = aid;
+            strcpy(m.f.f_ma.mask, maskname);
+            aid++;
+            insertNode(l, m);
+        }
 
-	while ((token = strtok(NULL, " ")) != NULL &&
-	       (strcmp(token, "MASKEDOVERLAYAREA") == 0));
+        while ((token = strtok(NULL, " ")) != NULL &&
+               (strcmp(token, "MASKEDOVERLAYAREA") == 0));
 
-	if (strcmp(token, "RASTERMAP") != 0)
-	    G_fatal_error(_("Irregular MASKEDOVERLAY areas definition"));
+        if (strcmp(token, "RASTERMAP") != 0)
+            G_fatal_error(_("Irregular MASKEDOVERLAY areas definition"));
 
-	token = strtok(NULL, "\n");
-	if (strcmp(token, raster) != 0)
-	    G_fatal_error(_("The configuration file can only be used "
-			    "with the <%s> raster map"), token);
-	close(setup);
-	return NORMAL;
+        token = strtok(NULL, "\n");
+        if (strcmp(token, raster) != 0)
+            G_fatal_error(_("The configuration file can only be used "
+                            "with the <%s> raster map"), token);
+        close(setup);
+        return NORMAL;
     }
     else
-	G_fatal_error(_("Unable to parse configuration file (sample area)"));
+        G_fatal_error(_("Unable to parse configuration file (sample area)"));
 
     close(setup);
     return ERROR;
@@ -500,134 +504,134 @@ int disposeAreas(struct list *l, struct g_area *g, char *def)
 
     token = strtok(def, " \n");
     if (strcmp(token, "MOVINGWINDOW") == 0) {
-	g->count = 0;
-	g->dist = 0;
-	g->add_row = 1;
-	g->add_col = 1;
-	if (g->rl != 1)
-	    g->rows = g->rows - g->rl + 1;
-	else
-	    g->rows = g->rows;
-	if (g->cl != 1)
-	    g->cols = g->cols - g->cl + 1;
-	return MVWIN;
+        g->count = 0;
+        g->dist = 0;
+        g->add_row = 1;
+        g->add_col = 1;
+        if (g->rl != 1)
+            g->rows = g->rows - g->rl + 1;
+        else
+            g->rows = g->rows;
+        if (g->cl != 1)
+            g->cols = g->cols - g->cl + 1;
+        return MVWIN;
     }
     else if (strcmp(token, "RANDOMNONOVERLAPPING") == 0) {
-	int units, sf_rl, sf_cl, sa_rl, sa_cl, max_units, i;
-	int *assigned;
+        int units, sf_rl, sf_cl, sa_rl, sa_cl, max_units, i;
+        int *assigned;
 
-	sscanf(strtok(NULL, "\n"), "%i", &units);
-	sf_rl = g->rows;
-	sf_cl = g->cols;
-	sa_rl = g->rl;
-	sa_cl = g->cl;
-	max_units = (int)rint((sf_rl / sa_rl) * (sf_cl / sa_cl));
-	if (units > max_units)
-	    G_fatal_error(_("Too many units to place"));
-	assigned = G_malloc(units * sizeof(int));
-	i = 0;
-	G_srand48(0);
-	while (i < units) {
-	    int j, position, found = FALSE;
+        sscanf(strtok(NULL, "\n"), "%i", &units);
+        sf_rl = g->rows;
+        sf_cl = g->cols;
+        sa_rl = g->rl;
+        sa_cl = g->cl;
+        max_units = (int)rint((sf_rl / sa_rl) * (sf_cl / sa_cl));
+        if (units > max_units)
+            G_fatal_error(_("Too many units to place"));
+        assigned = G_malloc(units * sizeof(int));
+        i = 0;
+        G_srand48(0);
+        while (i < units) {
+            int j, position, found = FALSE;
 
-	    position = G_lrand48() % max_units;
-	    for (j = 0; j < i; j++) {
-		if (assigned[j] == position)
-		    found = TRUE;
-	    }
-	    if (!found) {
-		msg m;
+            position = G_lrand48() % max_units;
+            for (j = 0; j < i; j++) {
+                if (assigned[j] == position)
+                    found = TRUE;
+            }
+            if (!found) {
+                msg m;
 
-		assigned[i] = position;
-		i++;
-		if (g->maskname == NULL) {
-		    int n_col = rint(sf_cl / sa_cl);
+                assigned[i] = position;
+                i++;
+                if (g->maskname == NULL) {
+                    int n_col = rint(sf_cl / sa_cl);
 
-		    m.type = AREA;
-		    m.f.f_a.aid = i;
-		    m.f.f_a.x = g->sf_x + (position % n_col) * sa_cl;
-		    m.f.f_a.y = g->sf_y + (position / n_col) * sa_rl;
-		    m.f.f_a.rl = sa_rl;
-		    m.f.f_a.cl = sa_cl;
-		    insertNode(l, m);
-		}
-		else {
-		    int n_col = sf_cl / sa_cl;
+                    m.type = AREA;
+                    m.f.f_a.aid = i;
+                    m.f.f_a.x = g->sf_x + (position % n_col) * sa_cl;
+                    m.f.f_a.y = g->sf_y + (position / n_col) * sa_rl;
+                    m.f.f_a.rl = sa_rl;
+                    m.f.f_a.cl = sa_cl;
+                    insertNode(l, m);
+                }
+                else {
+                    int n_col = sf_cl / sa_cl;
 
-		    m.type = MASKEDAREA;
-		    m.f.f_ma.aid = i;
-		    m.f.f_a.x = g->sf_x + (position % n_col) * sa_cl;
-		    m.f.f_a.y = g->sf_y + (position / n_col) * sa_rl;
-		    m.f.f_ma.rl = sa_rl;
-		    m.f.f_ma.cl = sa_cl;
-		    strcpy(m.f.f_ma.mask, g->maskname);
-		    insertNode(l, m);
-		}
-	    }
-	}
-	return NORMAL;
+                    m.type = MASKEDAREA;
+                    m.f.f_ma.aid = i;
+                    m.f.f_a.x = g->sf_x + (position % n_col) * sa_cl;
+                    m.f.f_a.y = g->sf_y + (position / n_col) * sa_rl;
+                    m.f.f_ma.rl = sa_rl;
+                    m.f.f_ma.cl = sa_cl;
+                    strcpy(m.f.f_ma.mask, g->maskname);
+                    insertNode(l, m);
+                }
+            }
+        }
+        return NORMAL;
     }
     else if (strcmp(token, "SYSTEMATICCONTIGUOUS") == 0) {
-	g->dist = 0;
-	g->add_row = g->rl;
-	g->add_col = g->cl;
-	return GEN;
+        g->dist = 0;
+        g->add_row = g->rl;
+        g->add_col = g->cl;
+        return GEN;
     }
     else if (strcmp(token, "SYSTEMATICNONCONTIGUOUS") == 0) {
-	int dist;
+        int dist;
 
-	dist = atoi(strtok(NULL, "\n"));
-	g->dist = dist;
-	g->add_row = g->rl + dist;
-	g->add_col = g->cl + dist;
-	g->x = g->sf_x + dist;
-	g->y = g->sf_y + dist;
-	return GEN;
+        dist = atoi(strtok(NULL, "\n"));
+        g->dist = dist;
+        g->add_row = g->rl + dist;
+        g->add_col = g->cl + dist;
+        g->x = g->sf_x + dist;
+        g->y = g->sf_y + dist;
+        return GEN;
     }
     else if (strcmp(token, "STRATIFIEDRANDOM") == 0) {
-	int r_strat, c_strat, r_strat_len, c_strat_len, loop, i;
+        int r_strat, c_strat, r_strat_len, c_strat_len, loop, i;
 
-	r_strat = atoi(strtok(NULL, "|"));
-	c_strat = atoi(strtok(NULL, "\n"));
-	r_strat_len = (int)rint(g->rows / r_strat);
-	c_strat_len = (int)rint(g->cols / c_strat);
-	if (r_strat_len < g->rl || c_strat_len < g->cl)
-	    G_fatal_error(_("Too many stratified random sample for raster map"));
-	loop = r_strat * c_strat;
-	G_srand48(0);
-	for (i = 0; i < loop; i++) {
-	    msg m;
+        r_strat = atoi(strtok(NULL, "|"));
+        c_strat = atoi(strtok(NULL, "\n"));
+        r_strat_len = (int)rint(g->rows / r_strat);
+        c_strat_len = (int)rint(g->cols / c_strat);
+        if (r_strat_len < g->rl || c_strat_len < g->cl)
+            G_fatal_error(_("Too many stratified random sample for raster map"));
+        loop = r_strat * c_strat;
+        G_srand48(0);
+        for (i = 0; i < loop; i++) {
+            msg m;
 
-	    if (g->maskname == NULL) {
-		m.type = AREA;
-		m.f.f_a.aid = i;
-		m.f.f_a.x = (int)g->sf_x + ((i % c_strat) * c_strat_len) +
-		    (G_lrand48() % (c_strat_len - g->cl));
-		m.f.f_a.y = (int)g->sf_y + (rint(i / c_strat) * r_strat_len) +
-		    (G_lrand48() % (r_strat_len - g->rl));
-		m.f.f_a.rl = g->rl;
-		m.f.f_a.cl = g->cl;
-		insertNode(l, m);
-	    }
-	    else {
-		m.type = MASKEDAREA;
-		m.f.f_ma.aid = i;
-		m.f.f_ma.x = (int)g->sf_x + ((i % c_strat) * c_strat_len) +
-		    (G_lrand48() % (c_strat_len - g->cl));
-		m.f.f_ma.y =
-		    (int)g->sf_y + (rint(i / c_strat) * r_strat_len) +
-		    (G_lrand48() % (r_strat_len - g->rl));
-		m.f.f_ma.rl = g->rl;
-		m.f.f_ma.cl = g->cl;
-		strcpy(m.f.f_ma.mask, g->maskname);
-		insertNode(l, m);
-	    }
-	}
-	return NORMAL;
+            if (g->maskname == NULL) {
+                m.type = AREA;
+                m.f.f_a.aid = i;
+                m.f.f_a.x = (int)g->sf_x + ((i % c_strat) * c_strat_len) +
+                    (G_lrand48() % (c_strat_len - g->cl));
+                m.f.f_a.y = (int)g->sf_y + (rint(i / c_strat) * r_strat_len) +
+                    (G_lrand48() % (r_strat_len - g->rl));
+                m.f.f_a.rl = g->rl;
+                m.f.f_a.cl = g->cl;
+                insertNode(l, m);
+            }
+            else {
+                m.type = MASKEDAREA;
+                m.f.f_ma.aid = i;
+                m.f.f_ma.x = (int)g->sf_x + ((i % c_strat) * c_strat_len) +
+                    (G_lrand48() % (c_strat_len - g->cl));
+                m.f.f_ma.y =
+                    (int)g->sf_y + (rint(i / c_strat) * r_strat_len) +
+                    (G_lrand48() % (r_strat_len - g->rl));
+                m.f.f_ma.rl = g->rl;
+                m.f.f_ma.cl = g->cl;
+                strcpy(m.f.f_ma.mask, g->maskname);
+                insertNode(l, m);
+            }
+        }
+        return NORMAL;
     }
     else {
-	G_fatal_error(_("Illegal areas disposition"));
-	return NORMAL;
+        G_fatal_error(_("Illegal areas disposition"));
+        return NORMAL;
     }
     return ERROR;
 }
@@ -636,19 +640,19 @@ int disposeAreas(struct list *l, struct g_area *g, char *def)
 int next_Area(int parsed, struct list *l, struct g_area *g, msg * m)
 {
     if (parsed == NORMAL) {
-	if (l->size == 0)
-	    return 0;
-	else {
-	    msg tmp;
+        if (l->size == 0)
+            return 0;
+        else {
+            msg tmp;
 
-	    memcpy(&tmp, l->head->m, sizeof(msg));
-	    *m = tmp;
-	    removeNode(l);
-	    return 1;
-	}
+            memcpy(&tmp, l->head->m, sizeof(msg));
+            *m = tmp;
+            removeNode(l);
+            return 1;
+        }
     }
     else {
-	return next(g, m);
+        return next(g, m);
     }
 }
 
@@ -656,21 +660,21 @@ int next_Area(int parsed, struct list *l, struct g_area *g, msg * m)
 int print_Output(int out, msg m)
 {
     if (m.type != DONE)
-	return 0;
+        return 0;
     else {
-	char s[100];
-	int len;
+        char s[100];
+        int len;
 
-	if (Rast_is_d_null_value(&m.f.f_d.res))
-	    sprintf(s, "RESULT %i|NULL\n", m.f.f_d.aid);
-	else
-	    sprintf(s, "RESULT %i|%.15g\n", m.f.f_d.aid, m.f.f_d.res);
-	len = strlen(s);
+        if (Rast_is_d_null_value(&m.f.f_d.res))
+            sprintf(s, "RESULT %i|NULL\n", m.f.f_d.aid);
+        else
+            sprintf(s, "RESULT %i|%.15g\n", m.f.f_d.aid, m.f.f_d.res);
+        len = strlen(s);
 
-	if (write(out, s, len) == len)
-	    return 1;
-	else
-	    return 0;
+        if (write(out, s, len) == len)
+            return 1;
+        else
+            return 0;
     }
 }
 
@@ -678,16 +682,16 @@ int print_Output(int out, msg m)
 int error_Output(int out, msg m)
 {
     if (m.type != ERROR)
-	return 0;
+        return 0;
     else {
-	char s[100];
+        char s[100];
 
-	sprintf(s, "ERROR %i", m.f.f_d.aid);
+        sprintf(s, "ERROR %i", m.f.f_d.aid);
 
-	if (write(out, s, strlen(s)) == strlen(s))
-	    return 1;
-	else
-	    return 0;
+        if (write(out, s, strlen(s)) == strlen(s))
+            return 1;
+        else
+            return 0;
     }
 }
 
@@ -698,14 +702,14 @@ int raster_Output(int fd, int aid, struct g_area *g, double res)
     off_t offset = (off_t) aid * sizeof(double);
 
     if (lseek(fd, offset, SEEK_SET) != offset) {
-	G_message(_("Cannot make lseek"));
-	return -1;
+        G_message(_("Cannot make lseek"));
+        return -1;
     }
 
     if (write(fd, &toPut, sizeof(double)) == 0)
-	return 1;
+        return 1;
     else
-	return 0;
+        return 0;
 }
 
 
@@ -727,27 +731,28 @@ int write_raster(int mv_fd, int random_access, struct g_area *g)
     Rast_set_d_null_value(cell_buf, Rast_window_cols() + 1);
 
     for (i = 0; i < g->sf_y + ((int)g->rl / 2); i++) {
-	Rast_put_row(mv_fd, cell_buf, DCELL_TYPE);
+        Rast_put_row(mv_fd, cell_buf, DCELL_TYPE);
     }
 
     for (i = 0; i < rows; i++) {
-	letti = read(random_access, file_buf, (cols * sizeof(double)));
+        letti = read(random_access, file_buf, (cols * sizeof(double)));
 
-	if (letti == -1)
-	    G_message("%s", strerror(errno));
+        if (letti == -1)
+            G_message("%s", strerror(errno));
 
-	for (j = 0; j < cols; j++) {
-	    cell_buf[j + center] = file_buf[j];
-	}
+        for (j = 0; j < cols; j++) {
+            cell_buf[j + center] = file_buf[j];
+        }
 
-	Rast_put_row(mv_fd, cell_buf, DCELL_TYPE);
+        Rast_put_row(mv_fd, cell_buf, DCELL_TYPE);
 
     }
 
     Rast_set_d_null_value(cell_buf, Rast_window_cols() + 1);
 
-    for (i = 0; i < Rast_window_rows() - g->sf_y - ((int)g->rl / 2) - g->rows; i++) {
-	Rast_put_row(mv_fd, cell_buf, DCELL_TYPE);
+    for (i = 0; i < Rast_window_rows() - g->sf_y - ((int)g->rl / 2) - g->rows;
+         i++) {
+        Rast_put_row(mv_fd, cell_buf, DCELL_TYPE);
     }
 
     G_free(file_buf);

--- a/raster/r.out.png/main.c
+++ b/raster/r.out.png/main.c
@@ -170,9 +170,9 @@ int main(int argc, char *argv[])
 
     png_compr = atoi(compr->answer);
 
-#if 0                           /* unused */
 #ifdef MAYBE_LATER
     /* ... if at all */
+    int ret;
     ret = G_str_to_color(bgcolor->answer, &def_red, &def_grn, &def_blu);
     if (ret == 0)
         G_fatal_error(_("[%s]: No such color"), bgcolor->answer);
@@ -181,9 +181,8 @@ int main(int argc, char *argv[])
             do_alpha = TRUE;
     }
 #else
-    ret = G_str_to_color(DEFAULT_BG_COLOR, &def_red, &def_grn, &def_blu);
+    G_str_to_color(DEFAULT_BG_COLOR, &def_red, &def_grn, &def_blu);
 #endif
-#endif /* unused */
 
     /*G_get_set_window (&win); *//* 10/99 MN: check for current region */
     G_get_window(&win);

--- a/raster/r.out.png/main.c
+++ b/raster/r.out.png/main.c
@@ -52,7 +52,8 @@ int main(int argc, char *argv[])
     struct GModule *module;
     struct Option *rast, *png_file, *compr;     /* , *bgcolor; */
     struct Flag *alpha, *wld_flag;
-    char *rastermap;
+
+    /* char *rastermap; */
     char *basename = NULL, *outfile = NULL;
     unsigned char *set, *ored, *ogrn, *oblu;
     int def_red, def_grn, def_blu;
@@ -62,7 +63,7 @@ int main(int argc, char *argv[])
     void *voidc;
     int rtype, row, col, do_stdout = 0;
     size_t rsize;
-    int png_compr, ret, do_alpha;
+    int png_compr, /* ret, */ do_alpha;
     struct Cell_head win;
     FILEDESC cellfile = 0;
     FILE *fp;
@@ -97,13 +98,13 @@ int main(int argc, char *argv[])
      * about "variable XXX might be clobbered by `longjmp' or `vfork'"
      * (stack corruption observed on Solaris 2.6 with gcc 2.8.1, even
      * in the absence of any other error condition) */
-    static xelval maxmaxval;
+    /* static xelval maxmaxval; */
 
     static int depth;
     static int filter;
 
     /* these guys are initialized to quiet compiler warnings: */
-    maxmaxval = 255;
+    /* maxmaxval = 255; */
     depth = 0;
 
     G_gisinit(argv[0]);
@@ -152,7 +153,7 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
 
 
-    rastermap = rast->answer;
+    /* rastermap = rast->answer; */
 
     do_alpha = alpha->answer ? TRUE : FALSE;
 
@@ -169,6 +170,7 @@ int main(int argc, char *argv[])
 
     png_compr = atoi(compr->answer);
 
+#if 0                           /* unused */
 #ifdef MAYBE_LATER
     /* ... if at all */
     ret = G_str_to_color(bgcolor->answer, &def_red, &def_grn, &def_blu);
@@ -181,6 +183,7 @@ int main(int argc, char *argv[])
 #else
     ret = G_str_to_color(DEFAULT_BG_COLOR, &def_red, &def_grn, &def_blu);
 #endif
+#endif /* unused */
 
     /*G_get_set_window (&win); *//* 10/99 MN: check for current region */
     G_get_window(&win);

--- a/raster/r.out.pov/main.c
+++ b/raster/r.out.pov/main.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     FILE *outf;
     char *outfilename;
 
-    CELL *cell;
+    /* CELL *cell; */
     char *name;
     int fd;
     int nrows, ncols;
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
     if (NULL == (outf = fopen(outfilename, "wb")))
         G_fatal_error(_("Unable to open output file <%s>"), outfilename);
 
-    cell = Rast_allocate_c_buf();
+    /* cell = Rast_allocate_c_buf(); */
 
     nrows = Rast_window_rows();
     ncols = Rast_window_cols();

--- a/raster/r.random.cells/init.c
+++ b/raster/r.random.cells/init.c
@@ -17,7 +17,8 @@ void Init()
     struct Cell_head Region;
     int Count;
     int FD, row, col;
-    double MinRes;
+
+    /* double MinRes; */
 
     G_debug(2, "Init()");
 
@@ -26,10 +27,10 @@ void Init()
     G_get_set_window(&Region);
     EW = Region.ew_res;
     NS = Region.ns_res;
-    if (EW < NS)
-        MinRes = EW;
-    else
-        MinRes = NS;
+    /* if (EW < NS)
+       MinRes = EW;
+       else
+       MinRes = NS; */
     CellBuffer = Rast_allocate_c_buf();
 
     /* Out = FlagCreate( Rs, Cs); */

--- a/raster/r.random.surface/calcsurf.c
+++ b/raster/r.random.surface/calcsurf.c
@@ -9,7 +9,7 @@ void CalcSurface(void)
 {
     int Count, OutRows, OutCols;
     int Row, Row2, Col, Col2, RanRows, RanCols;
-    int owC, oeC, onR, osR, wC, eC, nR, sR;
+    int /* owC, */ oeC, onR, /* osR, */ wC, eC, nR, sR;
     double **Randoms;
 
     G_debug(2, "CalcSurface()");
@@ -18,7 +18,7 @@ void CalcSurface(void)
     OutCols = BigF.ColPlus;
     RanRows = (2 * OutRows + Rs);
     RanCols = (2 * OutCols + Cs);
-    owC = osR = 0;
+    /* owC = osR = 0; */
     wC = OutCols;
     sR = OutRows;
     oeC = RanCols - 1;

--- a/raster/r.regression.multi/main.c
+++ b/raster/r.regression.multi/main.c
@@ -101,20 +101,21 @@ static int solvemat(struct MATRIX *m, double a[], double B[])
 
 int main(int argc, char *argv[])
 {
-    unsigned int r, c, rows, cols, n_valid;     /*  totals  */
+    unsigned int r, c, rows, cols;      /*  totals  */
     int *mapx_fd, mapy_fd, mapres_fd, mapest_fd;
     int i, j, k, n_predictors;
     double *sumX, sumY, *sumsqX, sumsqY, *sumXY;
     double *meanX, meanY, *varX, varY, *sdX, sdY;
     double yest, yres;          /* estimated y, residual */
-    double sumYest, *SSerr_without;
-    double SE;
-    double meanYest, meanYres, varYest, varYres, sdYest, sdYres;
+    double /* sumYest, */ *SSerr_without;
+
+    /* double SE; */
+    /* double meanYest, meanYres, varYest, varYres, sdYest, sdYres; */
     double SStot, SSerr, SSreg;
     double SAE;
     double **a;
     struct MATRIX *m, *m_all;
-    double **B, Rsq, Rsqadj, F, t, AIC, AICc, BIC;
+    double **B, Rsq, Rsqadj, F, /* t, */ AIC, AICc, BIC;
     unsigned int count = 0;
     DCELL **mapx_buf, *mapy_buf, *mapx_val, mapy_val, *mapres_buf,
         *mapest_buf;
@@ -246,12 +247,11 @@ int main(int argc, char *argv[])
         SSerr_without[i] = 0.0;
     }
     sumY = sumsqY = meanY = varY = sdY = 0.0;
-    sumYest = meanYest = varYest = sdYest = 0.0;
-    meanYres = varYres = sdYres = 0.0;
+    /* sumYest = meanYest = varYest = sdYest = 0.0; */
+    /* meanYres = varYres = sdYres = 0.0; */
 
     /* read input maps */
     G_message(_("First pass..."));
-    n_valid = 0;
     mapx_val[0] = 1.0;
     for (r = 0; r < rows; r++) {
         G_percent(r, rows, 2);
@@ -468,7 +468,7 @@ int main(int argc, char *argv[])
     /* constant aka estimate for intercept in R */
     fprintf(stdout, "b%d=%f\n", i, B[0][i]);
     /* t score for R squared of the full model, unused */
-    t = sqrt(Rsq) * sqrt((count - 2) / (1 - Rsq));
+    /* t = sqrt(Rsq) * sqrt((count - 2) / (1 - Rsq)); */
     /*
        fprintf(stdout, "t%d=%f\n", i, t);
      */
@@ -484,7 +484,7 @@ int main(int argc, char *argv[])
     fprintf(stdout, "BIC=%f\n", BIC);
 
     /* error variance of the model, identical to R */
-    SE = SSerr / (count - n_predictors - 1);
+    /* SE = SSerr / (count - n_predictors - 1); */
     /*
        fprintf(stdout, "SE=%f\n", SE);
        fprintf(stdout, "SSerr=%f\n", SSerr);
@@ -495,11 +495,11 @@ int main(int argc, char *argv[])
         fprintf(stdout, "\npredictor%d=%s\n", i + 1, input_mapx->answers[i]);
         fprintf(stdout, "b%d=%f\n", i + 1, B[0][i + 1]);
         if (n_predictors > 1) {
-            double Rsqi, SEi, sumsqX_corr;
+            /* double Rsqi, SEi, sumsqX_corr; */
 
             /* corrected sum of squares for predictor [i] */
-            sumsqX_corr =
-                sumsqX[i] - sumX[i] * sumX[i] / (count - n_predictors - 1);
+            /* sumsqX_corr =
+               sumsqX[i] - sumX[i] * sumX[i] / (count - n_predictors - 1); */
 
             /* standard error SE for predictor [i] */
 
@@ -510,7 +510,7 @@ int main(int argc, char *argv[])
              * resvar = rss / rdf = SE global
              * rss = sum of squares of the residuals
              * rdf = residual degrees of freedom = count - n_predictors - 1 */
-            SEi = sqrt(SE / (Rsq * sumsqX_corr));
+            /* SEi = sqrt(SE / (Rsq * sumsqX_corr)); */
             /*
                fprintf(stdout, "SE%d=%f\n", i + 1, SEi);
              */
@@ -525,11 +525,11 @@ int main(int argc, char *argv[])
             /* the additional amount of variance explained
              * when including predictor [i] :
              * Rsq - Rsqi */
-            Rsqi = (SSerr_without[i] - SSerr) / SStot;
-            fprintf(stdout, "Rsq%d=%f\n", i + 1, Rsqi);
+            /* Rsqi = (SSerr_without[i] - SSerr) / SStot;
+               fprintf(stdout, "Rsq%d=%f\n", i + 1, Rsqi); */
 
             /* t score for Student's t distribution, unused */
-            t = (B[0][i + 1]) / SEi;
+            /* t = (B[0][i + 1]) / SEi; */
             /*
                fprintf(stdout, "t%d=%f\n", i + 1, t);
              */

--- a/raster/r.report/format.c
+++ b/raster/r.report/format.c
@@ -15,9 +15,8 @@
 int format_parms(double v, int *n, int *dp, int *eformat, int e_option)
 {
     char buf[50];
-    int orig_length, scient_dp;
+    int scient_dp;
 
-    orig_length = *n;
     scient_dp = *dp;
     for (;;) {
         if (!*eformat)

--- a/raster/r.report/prt_report.c
+++ b/raster/r.report/prt_report.c
@@ -260,7 +260,6 @@ int print_report(int unit1, int unit2)
 int construct_val_str(int nl, CELL * pval, char *str)
 {
     char str1[50], str2[50];
-    char *descr;
     DCELL dLow, dHigh;
 
     if (Rast_is_c_null_value(pval))
@@ -270,8 +269,7 @@ int construct_val_str(int nl, CELL * pval, char *str)
     else {                      /* find out which floating point range to print */
 
         if (cat_ranges)
-            descr = Rast_get_ith_d_cat(&layers[nl].labels, *pval,
-                                       &dLow, &dHigh);
+            Rast_get_ith_d_cat(&layers[nl].labels, *pval, &dLow, &dHigh);
         else {
             dLow = (DMAX[nl] - DMIN[nl]) / nsteps *
                 (double)(*pval - 1) + DMIN[nl];

--- a/raster/r.ros/main.c
+++ b/raster/r.ros/main.c
@@ -152,8 +152,8 @@ int main(int argc, char *argv[])
     float R0,                   /*base ROS (w/out wind/slope) */
       Rdir, sin_fac, cos_fac, Ffactor_all[4][14],       /*in all fuel subclasses by sigma/WO */
       Ffactor_in_dead[3][14],   /*in dead fuel subclasses by sigma/WO */
-      Ffactor_dead[14],         /*dead fuel weight by sigma/WO */
-      Ffactor_live[14],         /*live fuel weight by sigma/WO */
+      /* Ffactor_dead[14], */   /*dead fuel weight by sigma/WO */
+      /* Ffactor_live[14], */   /*live fuel weight by sigma/WO */
       Gfactor_in_dead[3][14],   /*in dead fuel by the 6 classes */
       G1, G2, G3, G4, G5, wo_dead[14],  /*dead fuel total load */
       wn_dead,                  /*net dead fuel total load */
@@ -577,9 +577,9 @@ int main(int argc, char *argv[])
                 Gfactor_in_dead[class][model] = 0.0;
         }
 
-        Ffactor_dead[model] =
-            class_sum / (class_sum + WO[3][model] * SIGMA[3][model]);
-        Ffactor_live[model] = 1 - Ffactor_dead[model];
+        /* Ffactor_dead[model] =
+            class_sum / (class_sum + WO[3][model] * SIGMA[3][model]); */
+        /* Ffactor_live[model] = 1 - Ffactor_dead[model]; */
     }
 
     /*if considering spotting, read elevation map into an array */

--- a/raster/r.series/main.c
+++ b/raster/r.series/main.c
@@ -126,13 +126,13 @@ int main(int argc, char *argv[])
     } flag;
     int i, t;
     int nprocs;
-    bool threaded;
     int num_inputs;
     struct input **inputs = NULL;
     int bufrows;
 
 #if defined(_OPENMP)
     omp_lock_t fd_lock;
+    bool threaded;
 #endif
 
     int num_outputs;
@@ -224,13 +224,13 @@ int main(int argc, char *argv[])
     }
 #if defined(_OPENMP)
     omp_set_num_threads(nprocs);
+    threaded = nprocs > 1;
 #else
     if (nprocs != 1)
         G_warning(_("GRASS is compiled without OpenMP support. Ignoring "
                     "threads setting."));
     nprocs = 1;
 #endif
-    threaded = nprocs > 1;
 
     lo = -1.0 / 0.0;            /* -inf */
     hi = 1.0 / 0.0;             /* inf */

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -98,7 +98,8 @@ int main(int argc, char *argv[])
 {
     int threads;
     int ret_val;
-    double x_orig, y_orig;
+
+    /* double x_orig, y_orig; */
     struct GModule *module;
     struct Cell_head cellhd;
     struct WaterParams wp;
@@ -361,8 +362,8 @@ int main(int argc, char *argv[])
     wp.step = (wp.stepx + wp.stepy) / 2.;
     wp.mx = cellhd.cols;
     wp.my = cellhd.rows;
-    x_orig = cellhd.west * wp.conv;
-    y_orig = cellhd.south * wp.conv;    /* do we need this? */
+    /* x_orig = cellhd.west * wp.conv;
+       y_orig = cellhd.south * wp.conv; *//* do we need this? */
     wp.xmin = 0.;
     wp.ymin = 0.;
     wp.xp0 = wp.xmin + wp.stepx / 2.;

--- a/raster/r.sim/simlib/hydro.c
+++ b/raster/r.sim/simlib/hydro.c
@@ -122,13 +122,15 @@ void main_loop(void)
 {
 
     int i, ii, l, k;
-    int icoub, nmult;
+    int icoub /*, nmult */ ;
     int iw, iblock, lw;
     int itime, iter1;
-    int nfiterh, nfiterw;
-    int mgen, mgen2, mgen3;
+
+    /* int nfiterh, nfiterw; */
+    int mgen /* , mgen2, mgen3 */ ;
     int nblock;
-    int icfl;
+
+    /* int icfl; */
     int mitfac;
 
     /*  int mitfac, p; */
@@ -137,12 +139,12 @@ void main_loop(void)
     double factor, conn, gaux, gauy;
     double d1, addac, decr;
     double barea, sarea, walkwe;
-    double gen, gen2, wei2, wei3, wei, weifac;
+    double gen, gen2, /* wei2, wei3, */ wei /* , weifac */ ;
     float eff;
 
     nblock = 1;
     icoub = 0;
-    icfl = 0;
+    /* icfl = 0; */
     nstack = 0;
 
     if (maxwa > (MAXW - mx * my)) {
@@ -185,13 +187,13 @@ void main_loop(void)
                         (double)maxwab *si[k][l] / (si0 *
                                                     (double)(mx2o * my2o));
                     gen2 = gen2 * (barea / sarea);
-                    mgen2 = (int)gen2;
-                    wei2 = gen2 / (double)(mgen2 + 1);
-                    mgen3 =
-                        (int)((double)mgen2 * wei2 / ((double)mgen * wei));
-                    nmult = mgen3 + 1;
-                    wei3 = gen2 / (double)((mgen + 1) * (mgen2 + 1));
-                    weifac = wei3 / wei;
+                    /* mgen2 = (int)gen2;
+                       wei2 = gen2 / (double)(mgen2 + 1);
+                       mgen3 =
+                       (int)((double)mgen2 * wei2 / ((double)mgen * wei)); */
+                    /* nmult = mgen3 + 1;
+                       wei3 = gen2 / (double)((mgen + 1) * (mgen2 + 1)); */
+                    /* weifac = wei3 / wei; */
                     /*              } else {
                        nmult = 1;
                        weifac = 1.;
@@ -248,8 +250,8 @@ void main_loop(void)
             iter1 = i / iterout;
             iter1 *= iterout;
             if (iter1 == i) {
-                nfiterw = i / iterout + 10;
-                nfiterh = i / iterout + 40;
+                /* nfiterw = i / iterout + 10;
+                   nfiterh = i / iterout + 40; */
                 G_debug(2, "iblock=%d i=%d miter=%d nwalk=%d nwalka=%d",
                         iblock, i, miter, nwalk, nwalka);
             }

--- a/raster/r.solute.transport/main.c
+++ b/raster/r.solute.transport/main.c
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
     N_array_2d *hc_y = NULL;
     N_array_2d *phead = NULL;
 
-    double time_step, cfl, length, time_loops, time_sum;
+    double time_step, cfl, length, time_loops /* , time_sum */ ;
 
     /* Initialize GRASS */
     G_gisinit(argv[0]);
@@ -377,7 +377,7 @@ int main(int argc, char *argv[])
     /*Set the number of inner loops and the time step */
     if (data->dt > time_step && param.cfl->answer) {
         /*safe the user time step */
-        time_sum = data->dt;
+        /* time_sum = data->dt; */
         time_loops = data->dt / time_step;
         time_loops = floor(time_loops) + 1;
         data->dt = data->dt / time_loops;

--- a/raster/r.spread/select_linksB.c
+++ b/raster/r.spread/select_linksB.c
@@ -42,7 +42,8 @@ void select_linksB(struct costHa *pres_cell, int least, float comp_dens)
     extern struct cell_ptrHa *front_cell, *rear_cell;
     float angle;                /*that of a link cell to spread cell */
     float dir_angle;            /*that of the maximum ROS */
-    float cos_dir_angle, sin_dir_angle;
+
+    /* float cos_dir_angle, sin_dir_angle; */
     float polar_len;            /*polar distance of the ellipse */
     float distance;
     int n = 0, s = 0, e = 0, w = 0;     /*parameters defining a rectangule */
@@ -65,8 +66,8 @@ void select_linksB(struct costHa *pres_cell, int least, float comp_dens)
     dir = DATA(map_dir, pres_cell->row, pres_cell->col);
 
     dir_angle = dir % 360 * PI / 180;
-    sin_dir_angle = sin(dir_angle);
-    cos_dir_angle = cos(dir_angle);
+    /* sin_dir_angle = sin(dir_angle);
+       cos_dir_angle = cos(dir_angle); */
 
     /* identifies a rectangular just enclosing the ellipse,
      * thus avoiding redundant work in selection */

--- a/raster/r.univar/r3.univar_main.c
+++ b/raster/r.univar/r3.univar_main.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     unsigned int rows, cols, depths;
     unsigned int x, y, z;
     double dmin, dmax;
-    int zone, n_zones, use_zone = 0;
+    int zone, n_zones /* , use_zone = 0 */ ;
     const char *mapset, *name;
 
     struct GModule *module;
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
         G_debug(1, "min: %d, max: %d", zone_info.min, zone_info.max);
         zone_info.n_zones = zone_info.max - zone_info.min + 1;
 
-        use_zone = 1;
+        /* use_zone = 1; */
     }
 
     /* Open 3D input raster with default region */

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -458,7 +458,6 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
     Rast_set_null_value(inrast[2], ncols, data_type);
 
     /*scan through the raster data */
-    int isnull = 0;
     dimensionType i, j;
     double ax, ay;
     AEvent e;
@@ -492,7 +491,7 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
 	    e.col = j;
 
 	    /*read the elevation value into the event */
-	    isnull = Rast_is_null_value(&(inrast[1][j]), data_type);
+	    Rast_is_null_value(&(inrast[1][j]), data_type);
 	    e.elev[1] = inrast[1][j];
 
 	    /* adjust for curvature */
@@ -980,19 +979,18 @@ save_io_vis_and_elev_to_GRASS(IOVisibilityGrid * visgrid, char *elevfname,
 	for (j = 0; j < Rast_window_cols(); j++) {
 
 	    /* read the current elevation value */
-	    int isNull = 0;
 
 	    switch (elev_data_type) {
 	    case CELL_TYPE:
-		isNull = Rast_is_c_null_value(&((CELL *) elevrast)[j]);
+		Rast_is_c_null_value(&((CELL *) elevrast)[j]);
 		elev = (double)(((CELL *) elevrast)[j]);
 		break;
 	    case FCELL_TYPE:
-		isNull = Rast_is_f_null_value(&((FCELL *) elevrast)[j]);
+		Rast_is_f_null_value(&((FCELL *) elevrast)[j]);
 		elev = (double)(((FCELL *) elevrast)[j]);
 		break;
 	    case DCELL_TYPE:
-		isNull = Rast_is_d_null_value(&((DCELL *) elevrast)[j]);
+		Rast_is_d_null_value(&((DCELL *) elevrast)[j]);
 		elev = (double)(((DCELL *) elevrast)[j]);
 		break;
 	    }

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -219,6 +219,8 @@ init_event_list_in_memory(AEvent * eventList, char *rastName,
     G_SURFACE_T **inrast;
     int nrows = Rast_window_rows();
     int ncols = Rast_window_cols();
+    assert(nrows <= maxDimension);
+    assert(ncols <= maxDimension);    
 
     inrast = (G_SURFACE_T **)G_malloc(3 * sizeof(G_SURFACE_T *));
     assert(inrast);
@@ -247,7 +249,7 @@ init_event_list_in_memory(AEvent * eventList, char *rastName,
     Rast_get_row(infd, inrast[2], 0, data_type);
 
     e.angle = -1;
-    for (i = 0; i < nrows; i++) {
+    for (i = 0; i < (dimensionType)nrows; i++) {
 	/*read in the raster row */
 	
 	G_SURFACE_T *tmprast = inrast[0];
@@ -263,7 +265,7 @@ init_event_list_in_memory(AEvent * eventList, char *rastName,
 	G_percent(i, nrows, 2);
 
 	/*fill event list with events from this row */
-	for (j = 0; j < Rast_window_cols(); j++) {
+	for (j = 0; j < (dimensionType)ncols; j++) {
 	    e.row = i;
 	    e.col = j;
 
@@ -443,6 +445,8 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
     G_SURFACE_T **inrast;
     int nrows = Rast_window_rows();
     int ncols = Rast_window_cols();
+    assert(nrows <= maxDimension);
+    assert(ncols <= maxDimension);
 
     inrast = (G_SURFACE_T **)G_malloc(3 * sizeof(G_SURFACE_T *));
     assert(inrast);
@@ -468,7 +472,7 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
     e.angle = -1;
 
     /*start scanning through the grid */
-    for (i = 0; i < nrows; i++) {
+    for (i = 0; i < (dimensionType)nrows; i++) {
 	
 	G_percent(i, nrows, 2);
 
@@ -485,7 +489,7 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
 	    Rast_set_null_value(inrast[2], ncols, data_type);
 
 	/*fill event list with events from this row */
-	for (j = 0; j < ncols; j++) {
+	for (j = 0; j < (dimensionType)ncols; j++) {
 
 	    e.row = i;
 	    e.col = j;
@@ -641,11 +645,16 @@ save_grid_to_GRASS(Grid * grid, char *filename, RASTER_MAP_TYPE type,
     outrast = Rast_allocate_buf(type);
     assert(outrast);
 
+    int nrows = Rast_window_rows();
+    int ncols = Rast_window_cols();
+    assert(nrows <= maxDimension);
+    assert(ncols <= maxDimension);
+
     dimensionType i, j;
 
-    for (i = 0; i < Rast_window_rows(); i++) {
-        G_percent(i, Rast_window_rows(), 5);
-	for (j = 0; j < Rast_window_cols(); j++) {
+    for (i = 0; i < (dimensionType)nrows; i++) {
+        G_percent(i, nrows, 5);
+	for (j = 0; j < (dimensionType)ncols; j++) {
 	    if (is_invisible_nodata(grid->grid_data[i][j])) {
 		writeNodataValue(outrast, j, type);
 	    }
@@ -722,14 +731,19 @@ save_vis_elev_to_GRASS(Grid * visgrid, char *elevfname, char *visfname,
     visrast = Rast_allocate_buf(elev_data_type);
     assert(visrast);
 
+    int nrows = Rast_window_rows();
+    int ncols = Rast_window_cols();
+    assert(nrows <= maxDimension);
+    assert(ncols <= maxDimension);
+
     dimensionType i, j;
     double elev = 0, viewshed_value;
 
-    for (i = 0; i < Rast_window_rows(); i++) {
+    for (i = 0; i < (dimensionType)nrows; i++) {
 	/* get the row from elevation */
 	Rast_get_row(elevfd, elevrast, i, elev_data_type);
 
-	for (j = 0; j < Rast_window_cols(); j++) {
+	for (j = 0; j < (dimensionType)ncols; j++) {
 
 	    /* read the current elevation value */
 	    int isNull = 0;
@@ -864,10 +878,15 @@ save_io_visibilitygrid_to_GRASS(IOVisibilityGrid * visgrid,
 	counter++;
     }
 
+    int nrows = Rast_window_rows();
+    int ncols = Rast_window_cols();
+    assert(nrows <= maxDimension);
+    assert(ncols <= maxDimension);
+
     dimensionType i, j;
 
-    for (i = 0; i < Rast_window_rows(); i++) {
-	for (j = 0; j < Rast_window_cols(); j++) {
+    for (i = 0; i < (dimensionType)nrows; i++) {
+	for (j = 0; j < (dimensionType)ncols; j++) {
 
 	    if (curResult->row == i && curResult->col == j) {
 		/*cell is recodred in the visibility stream: it must be
@@ -971,12 +990,17 @@ save_io_vis_and_elev_to_GRASS(IOVisibilityGrid * visgrid, char *elevfname,
 
     dimensionType i, j;
     double elev = 0;
+    int nrows = Rast_window_rows();
+    int ncols = Rast_window_cols();
+    assert(nrows <= maxDimension);
+    assert(ncols <= maxDimension);
+    
 
-    for (i = 0; i < Rast_window_rows(); i++) {
+    for (i = 0; i < (dimensionType)nrows; i++) {
 
 	Rast_get_row(elevfd, elevrast, i, elev_data_type);
 
-	for (j = 0; j < Rast_window_cols(); j++) {
+	for (j = 0; j < (dimensionType)ncols; j++) {
 
 	    /* read the current elevation value */
 

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -219,8 +219,6 @@ init_event_list_in_memory(AEvent * eventList, char *rastName,
     G_SURFACE_T **inrast;
     int nrows = Rast_window_rows();
     int ncols = Rast_window_cols();
-    assert(nrows <= maxDimension);
-    assert(ncols <= maxDimension);    
 
     inrast = (G_SURFACE_T **)G_malloc(3 * sizeof(G_SURFACE_T *));
     assert(inrast);
@@ -249,7 +247,7 @@ init_event_list_in_memory(AEvent * eventList, char *rastName,
     Rast_get_row(infd, inrast[2], 0, data_type);
 
     e.angle = -1;
-    for (i = 0; i < (dimensionType)nrows; i++) {
+    for (i = 0; i < nrows; i++) {
 	/*read in the raster row */
 	
 	G_SURFACE_T *tmprast = inrast[0];
@@ -265,7 +263,7 @@ init_event_list_in_memory(AEvent * eventList, char *rastName,
 	G_percent(i, nrows, 2);
 
 	/*fill event list with events from this row */
-	for (j = 0; j < (dimensionType)ncols; j++) {
+	for (j = 0; j < Rast_window_cols(); j++) {
 	    e.row = i;
 	    e.col = j;
 
@@ -445,8 +443,6 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
     G_SURFACE_T **inrast;
     int nrows = Rast_window_rows();
     int ncols = Rast_window_cols();
-    assert(nrows <= maxDimension);
-    assert(ncols <= maxDimension);
 
     inrast = (G_SURFACE_T **)G_malloc(3 * sizeof(G_SURFACE_T *));
     assert(inrast);
@@ -472,7 +468,7 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
     e.angle = -1;
 
     /*start scanning through the grid */
-    for (i = 0; i < (dimensionType)nrows; i++) {
+    for (i = 0; i < nrows; i++) {
 	
 	G_percent(i, nrows, 2);
 
@@ -489,7 +485,7 @@ AMI_STREAM < AEvent > *init_event_list(char *rastName, Viewpoint * vp,
 	    Rast_set_null_value(inrast[2], ncols, data_type);
 
 	/*fill event list with events from this row */
-	for (j = 0; j < (dimensionType)ncols; j++) {
+	for (j = 0; j < ncols; j++) {
 
 	    e.row = i;
 	    e.col = j;
@@ -645,16 +641,11 @@ save_grid_to_GRASS(Grid * grid, char *filename, RASTER_MAP_TYPE type,
     outrast = Rast_allocate_buf(type);
     assert(outrast);
 
-    int nrows = Rast_window_rows();
-    int ncols = Rast_window_cols();
-    assert(nrows <= maxDimension);
-    assert(ncols <= maxDimension);
-
     dimensionType i, j;
 
-    for (i = 0; i < (dimensionType)nrows; i++) {
-        G_percent(i, nrows, 5);
-	for (j = 0; j < (dimensionType)ncols; j++) {
+    for (i = 0; i < Rast_window_rows(); i++) {
+        G_percent(i, Rast_window_rows(), 5);
+	for (j = 0; j < Rast_window_cols(); j++) {
 	    if (is_invisible_nodata(grid->grid_data[i][j])) {
 		writeNodataValue(outrast, j, type);
 	    }
@@ -731,19 +722,14 @@ save_vis_elev_to_GRASS(Grid * visgrid, char *elevfname, char *visfname,
     visrast = Rast_allocate_buf(elev_data_type);
     assert(visrast);
 
-    int nrows = Rast_window_rows();
-    int ncols = Rast_window_cols();
-    assert(nrows <= maxDimension);
-    assert(ncols <= maxDimension);
-
     dimensionType i, j;
     double elev = 0, viewshed_value;
 
-    for (i = 0; i < (dimensionType)nrows; i++) {
+    for (i = 0; i < Rast_window_rows(); i++) {
 	/* get the row from elevation */
 	Rast_get_row(elevfd, elevrast, i, elev_data_type);
 
-	for (j = 0; j < (dimensionType)ncols; j++) {
+	for (j = 0; j < Rast_window_cols(); j++) {
 
 	    /* read the current elevation value */
 	    int isNull = 0;
@@ -878,15 +864,10 @@ save_io_visibilitygrid_to_GRASS(IOVisibilityGrid * visgrid,
 	counter++;
     }
 
-    int nrows = Rast_window_rows();
-    int ncols = Rast_window_cols();
-    assert(nrows <= maxDimension);
-    assert(ncols <= maxDimension);
-
     dimensionType i, j;
 
-    for (i = 0; i < (dimensionType)nrows; i++) {
-	for (j = 0; j < (dimensionType)ncols; j++) {
+    for (i = 0; i < Rast_window_rows(); i++) {
+	for (j = 0; j < Rast_window_cols(); j++) {
 
 	    if (curResult->row == i && curResult->col == j) {
 		/*cell is recodred in the visibility stream: it must be
@@ -990,17 +971,12 @@ save_io_vis_and_elev_to_GRASS(IOVisibilityGrid * visgrid, char *elevfname,
 
     dimensionType i, j;
     double elev = 0;
-    int nrows = Rast_window_rows();
-    int ncols = Rast_window_cols();
-    assert(nrows <= maxDimension);
-    assert(ncols <= maxDimension);
-    
 
-    for (i = 0; i < (dimensionType)nrows; i++) {
+    for (i = 0; i < Rast_window_rows(); i++) {
 
 	Rast_get_row(elevfd, elevrast, i, elev_data_type);
 
-	for (j = 0; j < (dimensionType)ncols; j++) {
+	for (j = 0; j < Rast_window_cols(); j++) {
 
 	    /* read the current elevation value */
 

--- a/raster/r.watershed/ram/close_maps2.c
+++ b/raster/r.watershed/ram/close_maps2.c
@@ -8,23 +8,24 @@ int close_array_seg(void)
     int incr, max, red, green, blue, rd, gr, bl, flag;
     int c, r, map_fd;
     CELL *cellrow, value;
-    CELL *theseg;
-    RAMSEG thesegseg;
+
+    /* CELL *theseg;
+       RAMSEG thesegseg; */
 
     cellrow = Rast_allocate_c_buf();
     if (seg_flag || bas_flag || haf_flag) {
-        if (seg_flag) {
-            theseg = bas;
-            thesegseg = bas_seg;
-        }
-        else if (bas_flag) {
-            theseg = bas;
-            thesegseg = bas_seg;
-        }
-        else {
-            theseg = haf;
-            thesegseg = haf_seg;
-        }
+        /* if (seg_flag) {
+           theseg = bas;
+           thesegseg = bas_seg;
+           }
+           else if (bas_flag) {
+           theseg = bas;
+           thesegseg = bas_seg;
+           }
+           else {
+           theseg = haf;
+           thesegseg = haf_seg;
+           } */
         max = n_basins;
         G_debug(1, "%d basins created", max);
         Rast_init_colors(&colors);

--- a/raster/r.watershed/ram/do_cum.c
+++ b/raster/r.watershed/ram/do_cum.c
@@ -271,7 +271,7 @@ int do_cum_mfd(void)
     /* MFD */
     int mfd_cells, stream_cells, swale_cells, astar_not_set, is_null;
     double *dist_to_nbr, *contour, *weight, sum_weight, max_weight;
-    int r_nbr, c_nbr, r_max, c_max, ct_dir, np_side, max_side;
+    int r_nbr, c_nbr, r_max, c_max, ct_dir, np_side /*, max_side */ ;
     CELL ele, ele_nbr, aspect, is_worked;
     double prop, max_val;
     int workedon, edge, flat;
@@ -290,8 +290,8 @@ int do_cum_mfd(void)
      *       5   X   1
      *       4   3   2
      */
-    int nextmfd[8] = { 3, 7, 5, 1, 0, 4, 2, 6 };
-    int mfdir;
+    /* int nextmfd[8] = { 3, 7, 5, 1, 0, 4, 2, 6 }; */
+    /* int mfdir; */
 
     G_message(_("SECTION 3a: Accumulating Surface Flow with MFD."));
     G_debug(1, "MFD convergence factor set to %d.", c_fac);
@@ -528,9 +528,9 @@ int do_cum_mfd(void)
 
             /* get max flow accumulation */
             max_val = -1;
-            max_side = 0;
+            /* max_side = 0; */
             mfd_cells = 0;
-            mfdir = 0;
+            /* mfdir = 0; */
             stream_cells = 0;
             swale_cells = 0;
             ele = alt[this_index];
@@ -569,10 +569,10 @@ int do_cum_mfd(void)
                             max_val = ABS(valued);
                             r_max = r_nbr;
                             c_max = c_nbr;
-                            max_side = ct_dir;
+                            /* max_side = ct_dir; */
                         }
                         if (!is_null && ele_nbr <= ele) {
-                            mfdir |= (1 << nextmfd[ct_dir]);
+                            /* mfdir |= (1 << nextmfd[ct_dir]); */
                             mfd_cells++;
                         }
                     }
@@ -600,9 +600,9 @@ int do_cum_mfd(void)
                 asp[this_index] = aspect;
             }
             if (mfd_cells == 1)
-                mfdir = (1 << nextmfd[max_side]);
+                /* mfdir = (1 << nextmfd[max_side]); */
 
-            is_swale = FLAG_GET(swale, r, c);
+                is_swale = FLAG_GET(swale, r, c);
             /* start new stream */
             value = ABS(value) + 0.5;
             if (!is_swale && (int)value >= threshold && stream_cells < 1 &&

--- a/raster/r.watershed/ram/over_cells.c
+++ b/raster/r.watershed/ram/over_cells.c
@@ -6,11 +6,11 @@ overland_cells_recursive(int row, int col, CELL basin_num, CELL haf_num,
                          CELL * hih_ele)
 {
     int r, rr, c, cc;
-    CELL new_ele, new_max_ele, value;
+    CELL new_ele, /* new_max_ele, */ value;
 
     bas[SEG_INDEX(bas_seg, row, col)] = basin_num;
     haf[SEG_INDEX(haf_seg, row, col)] = haf_num;
-    new_max_ele = BIGNEG;
+    /* new_max_ele = BIGNEG; */
     for (r = row - 1, rr = 0; r <= row + 1; r++, rr++) {
         for (c = col - 1, cc = 0; c <= col + 1; c++, cc++) {
             if (r >= 0 && c >= 0 && r < nrows && c < ncols) {

--- a/raster/r.watershed/seg/close_maps2.c
+++ b/raster/r.watershed/seg/close_maps2.c
@@ -9,16 +9,17 @@ int close_array_seg(void)
     int incr, max, red, green, blue, rd, gr, bl, flag;
     int c, r, map_fd;
     CELL *cellrow;
-    CSEG *theseg;
+
+    /* CSEG *theseg; */
     ASP_FLAG af;
 
     if (seg_flag || bas_flag || haf_flag) {
-        if (seg_flag)
-            theseg = &bas;
-        else if (bas_flag)
-            theseg = &bas;
-        else
-            theseg = &haf;
+        /* if (seg_flag)
+           theseg = &bas;
+           else if (bas_flag)
+           theseg = &bas;
+           else
+           theseg = &haf; */
         max = -9;
         /*
            for (r = 0; r < nrows; r++) {

--- a/raster/r.watershed/seg/do_cum.c
+++ b/raster/r.watershed/seg/do_cum.c
@@ -290,7 +290,7 @@ int do_cum_mfd(void)
     /* MFD */
     int mfd_cells, stream_cells, swale_cells, astar_not_set, is_null;
     double *dist_to_nbr, *contour, *weight, sum_weight, max_weight;
-    int r_nbr, c_nbr, r_max, c_max, ct_dir, np_side, max_side;
+    int r_nbr, c_nbr, r_max, c_max, ct_dir, np_side /* , max_side */ ;
     CELL ele, *ele_nbr;
     double prop, max_val;
     int workedon, edge, is_swale, flat;
@@ -309,8 +309,8 @@ int do_cum_mfd(void)
      *       5   X   1
      *       4   3   2
      */
-    int nextmfd[8] = { 3, 7, 5, 1, 0, 4, 2, 6 };
-    int mfdir;
+    /* int nextmfd[8] = { 3, 7, 5, 1, 0, 4, 2, 6 }; */
+    /* int mfdir; */
 
     G_message(_("SECTION 3a: Accumulating Surface Flow with MFD."));
     G_debug(1, "MFD convergence factor set to %d.", c_fac);
@@ -585,9 +585,9 @@ int do_cum_mfd(void)
 
             /* get max flow accumulation */
             max_val = -1;
-            max_side = 0;
+            /* max_side = 0; */
             mfd_cells = 0;
-            mfdir = 0;
+            /* mfdir = 0; */
             stream_cells = 0;
             swale_cells = 0;
             ele = wa.ele;
@@ -634,10 +634,10 @@ int do_cum_mfd(void)
                             max_val = ABS(wa.wat);
                             r_max = r_nbr;
                             c_max = c_nbr;
-                            max_side = ct_dir;
+                            /* max_side = ct_dir; */
                         }
                         if (!is_null && ele_nbr[ct_dir] <= ele) {
-                            mfdir |= (1 << nextmfd[ct_dir]);
+                            /* mfdir |= (1 << nextmfd[ct_dir]); */
                             mfd_cells++;
                         }
                     }
@@ -665,9 +665,9 @@ int do_cum_mfd(void)
                     af.asp = drain[r - r_max + 1][c - c_max + 1];
             }
             if (mfd_cells == 1)
-                mfdir = (1 << nextmfd[max_side]);
+                /* mfdir = (1 << nextmfd[max_side]); */
 
-            is_swale = FLAG_GET(af.flag, SWALEFLAG);
+                is_swale = FLAG_GET(af.flag, SWALEFLAG);
             /* start new stream */
             if (!is_swale && fabs(value) >= threshold && stream_cells < 1 &&
                 swale_cells < 1 && !flat) {

--- a/raster/r.watershed/seg/init_vars.c
+++ b/raster/r.watershed/seg/init_vars.c
@@ -16,7 +16,6 @@ int init_vars(int argc, char *argv[])
     double memory_divisor, heap_mem, seg_factor, disk_space;
 
     /* int page_block, num_cseg; */
-    int max_bytes;
     CELL *buf, alt_value, *alt_value_buf, block_value;
     char asp_value;
     DCELL wat_value;
@@ -46,7 +45,6 @@ int init_vars(int argc, char *argv[])
     d_one = 1.0;
     ril_value = -1.0;
     /* dep_slope = 0.0; */
-    max_bytes = 0;
     sides = 8;
     mfd = 1;
     c_fac = 5;

--- a/raster/r.watershed/seg/over_cells.c
+++ b/raster/r.watershed/seg/over_cells.c
@@ -6,13 +6,13 @@ overland_cells_recursive(int row, int col, CELL basin_num, CELL haf_num,
                          CELL * hih_ele)
 {
     int r, rr, c, cc;
-    CELL new_ele, new_max_ele;
+    CELL new_ele /*, new_max_ele */ ;
     char aspect;
     ASP_FLAG af;
 
     cseg_put(&bas, &basin_num, row, col);
     cseg_put(&haf, &haf_num, row, col);
-    new_max_ele = BIGNEG;
+    /* new_max_ele = BIGNEG; */
     for (r = row - 1, rr = 0; r <= row + 1; r++, rr++) {
         for (c = col - 1, cc = 0; c <= col + 1; c++, cc++) {
             if (r >= 0 && c >= 0 && r < nrows && c < ncols) {

--- a/raster3d/r3.cross.rast/main.c
+++ b/raster3d/r3.cross.rast/main.c
@@ -120,7 +120,7 @@ void rast3d_cross_section(void *map, RASTER3D_Region region, int elevfd,
                           int outfd)
 {
     int col, row;
-    int rows, cols, depths, typeIntern;
+    int rows, cols, /* depths, */ typeIntern;
     FCELL *fcell = NULL;
     DCELL *dcell = NULL;
     void *elevrast;
@@ -136,7 +136,7 @@ void rast3d_cross_section(void *map, RASTER3D_Region region, int elevfd,
 
     rows = region.rows;
     cols = region.cols;
-    depths = region.depths;
+    /* depths = region.depths; */
 
     /*Typ of the RASTER3D Tile */
     typeIntern = Rast3d_tile_type_map(map);

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -105,12 +105,15 @@ void convert(char *fileout, int rows, int cols, int depths, int trueCoords)
     char VarName[MAXVARS][10];  /* names of variables */
     int TimeStamp[MAXTIMES];    /* real times for each time step */
     int DateStamp[MAXTIMES];    /* real dates for each time step */
+
+#if 0                           /* unused */
     float NorthLat;             /* latitude of north bound of box */
     float LatInc;               /* spacing between rows in degrees */
     float WestLon;              /* longitude of west bound of box */
     float LonInc;               /* spacing between columns in degs */
     float BottomHgt;            /* height of bottom of box in km */
     float HgtInc;               /* spacing between grid levels in km */
+#endif
     int Projection;
     float ProjArgs[100];
     int Vertical;
@@ -181,6 +184,7 @@ void convert(char *fileout, int rows, int cols, int depths, int trueCoords)
     }
 
 
+#if 0                           /* unused */
     /* put here some g3d functions */
     /* required ? */
     LatInc = 1.0;
@@ -189,6 +193,7 @@ void convert(char *fileout, int rows, int cols, int depths, int trueCoords)
     NorthLat = 50.0;
     WestLon = 90.0;
     BottomHgt = 0.0;
+#endif
 
 /****************/
 

--- a/vector/v.hull/chull.c
+++ b/vector/v.hull/chull.c
@@ -384,7 +384,8 @@ vertices are those in the list marked as onhull.
 void ConstructHull(void)
 {
     tVertex v, vnext;
-    bool changed;               /* T if addition changes hull; not used. */
+
+    /* bool changed; *//* T if addition changes hull; not used. */
     int i;
     int numVertices;
 
@@ -406,7 +407,7 @@ void ConstructHull(void)
         vnext = v->next;
         if (!v->mark) {
             v->mark = PROCESSED;
-            changed = AddOne(v);
+            /* changed = */ AddOne(v);
             CleanUp();
         }
         v = vnext;

--- a/vector/v.in.dxf/add_3dface.c
+++ b/vector/v.in.dxf/add_3dface.c
@@ -8,7 +8,8 @@ void add_3dface(struct dxf_file *dxf, struct Map_info *Map)
     char handle[DXF_BUF_SIZE];  /* entity handle, 16 hexadecimal digits */
     char layer[DXF_BUF_SIZE];   /* layer name */
     int layer_flag = 0;         /* indicates if a layer name has been found */
-    int dface_flag = 0;         /* indicates if a edge is invisible */
+
+    /* int dface_flag = 0; *//* indicates if a edge is invisible */
     int xflag = 0;              /* indicates if a x value has been found */
     int yflag = 0;              /* indicates if a y value has been found */
     int zflag = 0;              /* indicates if a z value has been found */
@@ -93,7 +94,7 @@ void add_3dface(struct dxf_file *dxf, struct Map_info *Map)
             zflag = 1;
             break;
         case 70:               /* 3dface flag */
-            dface_flag = atoi(dxf_buf);
+            /* dface_flag = atoi(dxf_buf); */
             /* TODO: what does 'invisible' mean here? */
 
             /*******************************************************************

--- a/vector/v.in.dxf/add_text.c
+++ b/vector/v.in.dxf/add_text.c
@@ -10,8 +10,9 @@ void add_text(struct dxf_file *dxf, struct Map_info *Map)
     int layer_flag = 0;         /* indicates if a layer name has been found */
     int xflag = 0;              /* indicates if a x value has been found */
     int yflag = 0;              /* indicates if a y value has been found */
-    double height = 1.0;        /* read in from dxf file */
-    double angle = 0.0;         /* read in from dxf file */
+
+    /* double height = 1.0; *//* read in from dxf file */
+    /* double angle = 0.0; *//* read in from dxf file */
     char label[DXF_BUF_SIZE];   /* read in from dxf file */
     int label_len = 0;
 
@@ -62,10 +63,10 @@ void add_text(struct dxf_file *dxf, struct Map_info *Map)
             zpnts[0] = atof(dxf_buf);
             break;
         case 40:               /* text height */
-            height = atof(dxf_buf);
+            /* height = atof(dxf_buf); */
             break;
         case 50:               /* text angle */
-            angle = atof(dxf_buf);
+            /* angle = atof(dxf_buf); */
             break;
 
         case 7:                /* text style name */

--- a/vector/v.info/parse.c
+++ b/vector/v.info/parse.c
@@ -9,8 +9,6 @@ void parse_args(int argc, char **argv,
                 char **input, char **field,
                 int *history, int *columns, int *shell)
 {
-    int i;
-
     struct Option *input_opt, *field_opt;
     struct Flag *hist_flag, *col_flag, *shell_flag, *region_flag, *topo_flag;
 
@@ -52,7 +50,6 @@ void parse_args(int argc, char **argv,
     *field = G_store(field_opt->answer);
     *history = hist_flag->answer ? TRUE : FALSE;
     *columns = col_flag->answer ? TRUE : FALSE;
-    i = 0;
     *shell = SHELL_NO;
     if (shell_flag->answer)
         *shell |= SHELL_BASIC;

--- a/vector/v.kernel/main.c
+++ b/vector/v.kernel/main.c
@@ -40,11 +40,11 @@ static double dimension = 2.;
 double L(double smooth)
 {
     int ii;
-    double resL, n, term;
+    double resL, n /*, term */ ;
 
     n = npoints;
     resL = 0.;
-    term = 1. / pow((2. * M_PI), dimension / 2.);
+    /* term = 1. / pow((2. * M_PI), dimension / 2.); */
 
     for (ii = 0; ii < ndists; ii++) {
         /*    resL+= gaussianFunction(dists[ii]/smooth,2.,dimension) - 2. * gaussianKernel(dists[ii]/smooth,term); */
@@ -826,9 +826,9 @@ void compute_net_distance(double x, double y, struct Map_info *In,
     G_debug(3, "  %d points in box", PointsList->n_values);
 
     for (i = 0; i < PointsList->n_values; i++) {
-        int line, ret;
+        int /* line, */ ret;
 
-        line = PointsList->id[i];
+        /* line = PointsList->id[i]; */
 
         G_debug(3, "  SP: %f %f -> %f %f", x, y, PointsList->box[i].E,
                 PointsList->box[i].N);

--- a/vector/v.label.sa/labels.c
+++ b/vector/v.label.sa/labels.c
@@ -993,7 +993,6 @@ static double label_pointover(label_t * label, label_candidate_t * candidate)
     double pointover;
     struct ilist *il;
     struct line_pnts *trbb;
-    int n;
 
     il = Vect_new_list();
 
@@ -1001,7 +1000,7 @@ static double label_pointover(label_t * label, label_candidate_t * candidate)
        candidate->rotation);
      */
     trbb = box_trans_rot(&label->bb, &candidate->point, candidate->rotation);
-    n = Vect_select_lines_by_polygon(&Map, trbb, 0, NULL, GV_POINT, il);
+    Vect_select_lines_by_polygon(&Map, trbb, 0, NULL, GV_POINT, il);
 
     pointover = (double)il->n_values;
     Vect_destroy_list(il);

--- a/vector/v.out.vtk/main.c
+++ b/vector/v.out.vtk/main.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
 {
     FILE *ascii;
     struct Option *input, *output, *type_opt, *dp_opt, *layer_opt, *scale;
-    struct Flag *coorcorr, *numatts, *labels;
+    struct Flag *coorcorr, *numatts /* , *labels */ ;
     int itype, *types = NULL, typenum = 0, dp, i;
     struct Map_info Map;
     struct bound_box box;
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
     numatts->description =
         _("Export numeric attribute table fields as VTK scalar variables");
 
-    labels = NULL;              /* to avoid compiler warning about "unused variable" */
     /* not yet supported
+       labels = NULL;
        labels = G_define_flag();
        labels->key = 'l';
        labels->description = _("Export text attribute table fields as VTK labels");

--- a/vector/v.overlay/line_area.c
+++ b/vector/v.overlay/line_area.c
@@ -55,7 +55,7 @@ static int compare_cats(struct line_cats *ACats, struct line_cats *BCats)
 static int merge_line(struct Map_info *Map, int line,
                       struct line_pnts *MPoints, struct line_cats *MCats)
 {
-    int nlines, i, first, last, next_line, curr_line;
+    int i, first, last, next_line, curr_line;
     int merged = 0, newl = 0;
     int next_node, direction, node_n_lines, type, ltype, lines_type;
     static struct ilist *List = NULL;
@@ -63,8 +63,6 @@ static int merge_line(struct Map_info *Map, int line,
     static struct line_cats *Cats = NULL;
 
     type = GV_LINE;
-
-    nlines = Vect_get_num_lines(Map);
 
     if (!Points)
         Points = Vect_new_line_struct();

--- a/vector/v.to.rast/vect2rast.c
+++ b/vector/v.to.rast/vect2rast.c
@@ -19,7 +19,7 @@ int vect_to_rast(const char *vector_map, const char *raster_map,
     struct cat_list *cat_list = NULL;
     int fd;                     /* for raster map */
     int nareas, nlines;         /* number of converted features */
-    int nareas_all, nplines_all;        /* number of all areas, points/lines */
+    int /* nareas_all, */ nplines_all;  /* number of all areas, points/lines */
     int stat;
     int format;
     int pass, npasses;
@@ -154,7 +154,7 @@ int vect_to_rast(const char *vector_map, const char *raster_map,
     npasses = begin_rasterization(cache_mb, format, dense);
     pass = 0;
 
-    nareas_all = Vect_get_num_areas(&Map);
+    /* nareas_all = Vect_get_num_areas(&Map); */
 
     do {
         pass++;

--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -77,7 +77,7 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
     struct field_info *Fi;
     dbDriver *Driver;
     dbCatValArray cvarr, sarray;
-    int nrec, nrec1, ctype, sctype;
+    int nrec, /* nrec1, */ ctype, sctype;
     struct line_pnts *Points;
     struct line_cats *Cats;
 
@@ -113,9 +113,9 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
 
     if (scol != NULL) {
 
-        nrec1 =
-            db_select_CatValArray(Driver, Fi->table, Fi->key, scol, wheresql,
-                                  &sarray);
+        /* nrec1 =
+           db_select_CatValArray(Driver, Fi->table, Fi->key, scol, wheresql,
+           &sarray); */
         sctype = cvarr.ctype;
 
         if (sctype == -1)

--- a/vector/v.vol.rst/user2.c
+++ b/vector/v.vol.rst/user2.c
@@ -94,12 +94,12 @@ int interp_call(struct octtree *root, struct octtree *tree)
 {
     /*    double          xmn,xmx,ymn,ymx,zmn,zmx; */
     double distx, disty, distz, distxp, distyp, distzp, temp1, temp2, temp3;
-    int i, npt, nptprev, MAXENC, k, j;
+    int i, npt, /* nptprev, */ MAXENC, k, j;
     static struct quadruple *points = NULL;
     struct point_3d skip_point;
     struct point_3d *point = NULL;
     int skip_index, segtest;
-    double xx, yy, zz, ww;
+    double xx, yy, zz /*, ww */ ;
 
     if (tree == NULL)
         return -1;
@@ -156,7 +156,7 @@ int interp_call(struct octtree *root, struct octtree *tree)
             i++;
             if (npt > KMAX2) {
                 MAXENC = 1;
-                nptprev = npt;
+                /* nptprev = npt; m */
                 temp1 = distxp;
                 distxp = distx;
                 distx = distxp - fabs(distx - temp1) * 0.5;
@@ -170,7 +170,7 @@ int interp_call(struct octtree *root, struct octtree *tree)
                    ymx+disty,zmn-distz,zmx+distz,points, KMAX2); */
             }
             else {
-                nptprev = npt;
+                /* nptprev = npt; */
                 temp1 = distyp;
                 distyp = disty;
                 temp2 = distxp;
@@ -248,7 +248,7 @@ int interp_call(struct octtree *root, struct octtree *tree)
                 xx = point[skip_index].x;
                 yy = point[skip_index].y;
                 zz = point[skip_index].z;
-                ww = point[skip_index].w;
+                /* ww = point[skip_index].w; */
                 if (xx >= xmn && xx <= xmx && yy >= ymn && yy <= ymx &&
                     zz >= zmn && zz <= zmx) {
                     segtest = 1;

--- a/vector/v.vol.rst/user3.c
+++ b/vector/v.vol.rst/user3.c
@@ -242,7 +242,7 @@ COGRR1(double x_or, double y_or, double z_or, int n_rows, int n_cols,
         etarcell, rcell, wwcell, zzcell;
     double x_crs, x_crsd, x_crsdd, x_crsdr2;
     int n1, k1, k2, k, i1, l, l1, n4, n5, m, i;
-    int NGST, LSIZE, ngstc, nszc, ngstr, nszr, ngstl, nszl;
+    int /* NGST, */ LSIZE, ngstc, nszc, ngstr, nszr, ngstl, nszl;
     int POINT();
     int ind, ind1;
     static int first_time_z = 1;
@@ -394,7 +394,7 @@ COGRR1(double x_or, double y_or, double z_or, int n_rows, int n_cols,
            C         INTERPOLATION   *  MOST INNER LOOPS !
            C
          */
-        NGST = 1;
+        /* NGST = 1; */
         LSIZE = 0;
 
         ngstc = (int)(x_or / ew_res + 0.5) + 1;
@@ -687,7 +687,7 @@ int POINT(int n_points, struct quadruple *points, struct point_3d skip_point)
  */
 {
     double errmax, h, xx, yy, r2, hz, zz, ww, err, xmm, ymm,
-        zmm, wmm, r, etar;
+        zmm, /* wmm, */ r, etar;
     int n1, mm, m, mmax, inside;
 
     errmax = .0;
@@ -743,7 +743,7 @@ int POINT(int n_points, struct quadruple *points, struct point_3d skip_point)
                 ((struct octdata *)(root->data))->y_orig;
             zmm = (points[mmax - 1].z * dnorm) +
                 ((struct octdata *)(root->data))->z_orig;
-            wmm = points[mmax - 1].w + wmin;
+            /* wmm = points[mmax - 1].w + wmin; */
             /*      printf (" max. error = %f at point i = %d \n", errmax, mmax);
                printf (" x(i) = %f  y(i) = %f \n", xmm, ymm);
                printf (" z(i) = %f  w(i) = %f \n", zmm, wmm); */


### PR DESCRIPTION
Compiling with -Wall using Clang 14 throws some 150 `-Wunused-but-set-variable` warnings. Fixing them are in the majority of cases just spring-cleaning. Here is the first batch of two, addressing them. Now affecting following parts:

**db/drivers**
dbf
ogr
postgres
sqlite

**display**
d.grid
d.histogram
d.path
d.vect.thematic

**imagery**
i.albedo
i.aster.toar
i.eb.netrad
i.evapo.time
i.ortho.photo
i.segment

**mics**
m.nviz.image
m.nviz.script

**raster**
r.in.ascii
r.in.mat
r.kappa
r.kappa
r.li/r.li.daemon
r.out.png
r.out.pov
r.random.cells
r.random.surface
r.regression.multi
r.report
r.ros
r.series
r.sim/r.sim.water
r.sim/simlib
r.solute.transport
r.spread
r.univar
r.viewshed
r.watershed/ram
r.watershed/seg

**raster3d**
r3.cross.rast
r3.out.v5d

**vector**
v.hull
v.in.dxf
v.info
v.kernel
v.label.sa
v.out.vtk
v.overlay
v.to.rast
v.vol.rst

**lib**
vector/dglib

Reported in #2156. Accompanied by #2650.