### PR TITLE
Fix -Wunused-but-set-variable compiler warnings, part 2

### DIFF
--- a/lib/arraystats/class.c
+++ b/lib/arraystats/class.c
@@ -271,13 +271,13 @@ double AS_class_discont(double *data, int count, int nbreaks,
                         double *classbreaks)
 {
     int *num, nbclass;
-    double *no, *zz, *nz, *xn, *co;
+    double *no, *zz, /* *nz, */ *xn, *co;
     double *x;                  /* Vector standardized observations */
     int i, j, k;
     double min = 0, max = 0, rangemax = 0;
     int n = 0;
     double rangemin = 0, xlim = 0;
-    double dmax = 0.0, d2 = 0.0, dd = 0.0, p = 0.0;
+    double dmax = 0.0 /*, d2 = 0.0, dd = 0.0, p = 0.0 */ ;
     int nf = 0, nmax = 0;
     double *abc;
     int nd = 0;
@@ -296,7 +296,7 @@ double AS_class_discont(double *data, int count, int nbreaks,
     num = G_malloc((nbclass + 1) * sizeof(int));
     no = G_malloc((nbclass + 1) * sizeof(double));
     zz = G_malloc((nbclass + 1) * sizeof(double));
-    nz = G_malloc(3 * sizeof(double));
+    /* nz = G_malloc(3 * sizeof(double)); */
     xn = G_malloc((n + 1) * sizeof(double));
     co = G_malloc((nbclass + 1) * sizeof(double));
 
@@ -336,7 +336,7 @@ double AS_class_discont(double *data, int count, int nbreaks,
     for (i = 1; i <= nbclass; i++) {
         nmax = 0;
         dmax = 0.0;
-        d2 = 0.0;
+        /* d2 = 0.0; */
         nf = 0;                 /*End number */
 
         /*           Loop through classes */
@@ -353,7 +353,7 @@ double AS_class_discont(double *data, int count, int nbreaks,
                     d = fabs((-1.0 * abc[1] * x[k]) + xn[k] - abc[0]) / den;
                 else
                     d = fabs(x[k] - abc[2]);
-                d2 += pow(d, 2);
+                /* d2 += pow(d, 2); */
                 if (x[k] - x[nd] < xlim)
                     continue;
                 if (x[nf] - x[k] < xlim)
@@ -371,9 +371,9 @@ double AS_class_discont(double *data, int count, int nbreaks,
                     co[j] = (xn[nf]) / (x[nf]); /* A VERIFIER! */
             }
         }
-        if (i == 1)
-            dd = d2;
-        p = d2 / dd;
+        /* if (i == 1)
+           dd = d2;
+           p = d2 / dd; */
         for (j = 1; j <= i; j++) {
             no[j] = num[j];
             zz[j] = x[num[j]] * rangemax + min;
@@ -451,10 +451,9 @@ int AS_class_frequencies(double *data, int count, int nbreaks,
                          double *classbreaks, int *frequencies)
 {
     int i, j;
-    double min, max;
 
-    min = data[0];
-    max = data[count - 1];
+    /* min = data[0];
+       max = data[count - 1]; */
     /* count cases in all classes, except for last class */
     i = 0;
     for (j = 0; j < nbreaks; j++) {

--- a/lib/cairodriver/graph.c
+++ b/lib/cairodriver/graph.c
@@ -115,7 +115,10 @@ static void fini_xlib(void)
 static void init_file(void)
 {
     int is_vector = 0;
+
+#if CAIRO_HAS_XLIB_XRENDER_SURFACE
     int is_xlib = 0;
+#endif
     int do_read = 0;
     int do_map = 0;
     char *p;
@@ -168,9 +171,11 @@ static void init_file(void)
     case FTYPE_SVG:
         is_vector = 1;
         break;
+#if CAIRO_HAS_XLIB_XRENDER_SURFACE
     case FTYPE_X11:
         is_xlib = 1;
         break;
+#endif
     }
 
     p = getenv("GRASS_RENDER_FILE_MAPPED");
@@ -341,8 +346,7 @@ static void init_cairo(void)
                                                                     CAIRO_FORMAT_ARGB32,
                                                                     ca.width,
                                                                     ca.height,
-                                                                    ca.
-                                                                    stride);
+                                                                    ca.stride);
         break;
 #if CAIRO_HAS_PDF_SURFACE
     case FTYPE_PDF:
@@ -370,8 +374,7 @@ static void init_cairo(void)
 #endif
 #if CAIRO_HAS_XLIB_XRENDER_SURFACE
     case FTYPE_X11:
-        surface =
-            (cairo_surface_t *)
+        surface = (cairo_surface_t *)
             cairo_xlib_surface_create_with_xrender_format(ca.dpy, ca.win,
                                                           ca.screen,
                                                           ca.format, ca.width,

--- a/lib/cdhc/andrsnde.c
+++ b/lib/cdhc/andrsnde.c
@@ -7,15 +7,13 @@
 double *Cdhc_anderson_darling_exp(double *x, int n)
 {
     static double y[2];
-    double sqrt2, mean = 0.0, *xcopy, fx, sum3 = 0.0;
+    double mean = 0.0, *xcopy, fx, sum3 = 0.0;
     int i;
 
     if ((xcopy = (double *)malloc(n * sizeof(double))) == NULL) {
         fprintf(stderr, "Memory error in Cdhc_anderson_darling\n");
         exit(EXIT_FAILURE);
     }
-
-    sqrt2 = sqrt((double)2.0);
 
     for (i = 0; i < n; ++i) {
         xcopy[i] = x[i];

--- a/lib/cdhc/dmax.c
+++ b/lib/cdhc/dmax.c
@@ -7,7 +7,7 @@
 double *Cdhc_dmax(double *x, int n)
 {
     static double y[2];
-    double *xcopy, sqrt2, sqrtn, mean = 0.0, sdx = 0.0, fx;
+    double *xcopy, sqrt2, mean = 0.0, sdx = 0.0, fx;
     double dp, dp_max, dm, dm_max;
     int i;
 
@@ -17,7 +17,6 @@ double *Cdhc_dmax(double *x, int n)
     }
 
     sqrt2 = sqrt((double)2.0);
-    sqrtn = sqrt((double)n);
 
     for (i = 0; i < n; ++i) {
         xcopy[i] = x[i];

--- a/lib/cdhc/kotz.c
+++ b/lib/cdhc/kotz.c
@@ -6,15 +6,13 @@ double *Cdhc_kotz_families(double *x, int n)
 {
     static double y[2];
     int i;
-    double a1, b1, a2, b3, c1, c2, c3, c4, c5, c6, lx;
-    double sum1 = 0.0, sum2 = 0.0, sum4 = 0.0;
+    double a1, a2, b3, c1, c2, c3, c4, c5, c6, lx;
+    double sum2 = 0.0, sum4 = 0.0;
 
     for (i = 0; i < n; ++i) {
-        sum1 += x[i];
         sum2 += log(x[i]);
     }
 
-    b1 = sum1 / n;
     a1 = sum2 / n;
 
     for (i = 0; i < n; ++i) {

--- a/lib/db/dbmi_base/table.c
+++ b/lib/db/dbmi_base/table.c
@@ -428,7 +428,7 @@ int db_table_to_sql(dbTable * table, dbString * sql)
     int col, ncols;
     dbColumn *column;
     const char *colname;
-    int sqltype, ctype;
+    int sqltype;
     char buf[500];
 
     db_set_string(sql, "create table ");
@@ -442,7 +442,6 @@ int db_table_to_sql(dbTable * table, dbString * sql)
         colname = db_get_column_name(column);
         sqltype = db_get_column_sqltype(column);
 
-        ctype = db_sqltype_to_Ctype(sqltype);
         G_debug(3, "%s (%s)", colname, db_sqltype_name(sqltype));
 
         if (col > 0)

--- a/lib/dspf/dspf_header.c
+++ b/lib/dspf/dspf_header.c
@@ -11,7 +11,6 @@ int dfwrite_header(file_info * headp)
     cmndln_info *linep;
     FILE *fp;
     long Where_dataoff;
-    long Where_lookoff;
 
     linep = &(headp->linefax);
     fp = headp->dspfoutfp;
@@ -53,7 +52,6 @@ int dfwrite_header(file_info * headp)
     /* the first time this number is set to 0 */
     /*this information will be overwritten after dspf is done */
     /* G_ftell keeps track of where this information is to be placed */
-    Where_lookoff = G_ftell(fp);
     headp->Lookoff = 0;
     if (1 != fwrite(&headp->Lookoff, sizeof(long), 1, fp))
         return (-1);

--- a/lib/external/shapelib/shpopen.c
+++ b/lib/external/shapelib/shpopen.c
@@ -473,8 +473,9 @@ void SHPAPI_CALL SHPWriteHeader(SHPHandle psSHP)
             SwapWord(4, panSHX + i * 2 + 1);
     }
 
-    if ((int)psSHP->sHooks.
-        FWrite(panSHX, sizeof(int32) * 2, psSHP->nRecords, psSHP->fpSHX)
+    if ((int)psSHP->
+        sHooks.FWrite(panSHX, sizeof(int32) * 2, psSHP->nRecords,
+                      psSHP->fpSHX)
         != psSHP->nRecords) {
         psSHP->sHooks.Error("Failure writing .shx contents");
     }
@@ -890,7 +891,6 @@ SHPRestoreSHX(const char *pszLayer, const char *pszAccess, SAHooks * psHooks)
     size_t nMessageLen;
     char *pszMessage;
 
-    unsigned int nCurrentRecordOffset = 0;
     unsigned int nCurrentSHPOffset = 100;
     size_t nRealSHXContentSize = 100;
 
@@ -1023,7 +1023,6 @@ SHPRestoreSHX(const char *pszLayer, const char *pszAccess, SAHooks * psHooks)
             if (!bBigEndian)
                 SwapWord(4, &nRecordLength);
             nRecordOffset += nRecordLength + 4;
-            nCurrentRecordOffset += 8;
             nCurrentSHPOffset += 8 + nRecordLength * 2;
 
             psHooks->FSeek(fpSHP, nCurrentSHPOffset, 0);
@@ -1850,15 +1849,13 @@ SHPWriteObject(SHPHandle psSHP, int nShapeId, SHPObject * psObject)
     /*      Write out record.                                               */
     /* -------------------------------------------------------------------- */
     if (psSHP->sHooks.FSeek(psSHP->fpSHP, nRecordOffset, 0) != 0) {
-        psSHP->sHooks.
-            Error
+        psSHP->sHooks.Error
             ("Error in psSHP->sHooks.FSeek() while writing object to .shp file.");
         free(pabyRec);
         return -1;
     }
     if (psSHP->sHooks.FWrite(pabyRec, nRecordSize, 1, psSHP->fpSHP) < 1) {
-        psSHP->sHooks.
-            Error
+        psSHP->sHooks.Error
             ("Error in psSHP->sHooks.Fwrite() while writing object to .shp file.");
         free(pabyRec);
         return -1;

--- a/lib/gis/parser_wps.c
+++ b/lib/gis/parser_wps.c
@@ -154,7 +154,8 @@ void G__wps_print_process_description(void)
     const char *value = NULL;
     int i;
     const char *encoding;
-    int new_prompt = 0;
+
+    /* int new_prompt = 0; */
     int store = 1;
     int status = 1;
     const char *identifier = NULL;
@@ -172,7 +173,7 @@ void G__wps_print_process_description(void)
     int is_tuple;               /* Checks the key_descr for comma separated values */
     int num_tuples;             /* Counts the "," in key_descr */
 
-    new_prompt = G__uses_new_gisprompt();
+    /* new_prompt = G__uses_new_gisprompt(); */
 
     /* gettext converts strings to encoding returned by nl_langinfo(CODESET) */
 

--- a/lib/gpde/n_arrays_io.c
+++ b/lib/gpde/n_arrays_io.c
@@ -173,7 +173,7 @@ N_array_2d *N_read_rast_to_array_2d(char *name, N_array_2d * array)
 void N_write_array_2d_to_rast(N_array_2d * array, char *name)
 {
     int map;                    /*The rastermap */
-    int x, y, cols, rows, count, type;
+    int x, y, cols, rows, type;
     CELL *rast = NULL;
     FCELL *frast = NULL;
     DCELL *drast = NULL;
@@ -201,7 +201,6 @@ void N_write_array_2d_to_rast(N_array_2d * array, char *name)
 
     G_message(_("Write 2d array to raster map <%s>"), name);
 
-    count = 0;
     for (y = 0; y < rows; y++) {
         G_percent(y, rows - 1, 10);
         for (x = 0; x < cols; x++) {
@@ -388,7 +387,7 @@ void N_write_array_3d_to_rast3d(N_array_3d * array, char *name, int mask)
 {
     void *map = NULL;           /*The 3D Rastermap */
     int changemask = 0;
-    int x, y, z, cols, rows, depths, count, type;
+    int x, y, z, cols, rows, depths, type;
     double d1 = 0.0, f1 = 0.0;
     N_array_3d *data = array;
     RASTER3D_Region region;
@@ -438,7 +437,6 @@ void N_write_array_3d_to_rast3d(N_array_3d * array, char *name, int mask)
         }
     }
 
-    count = 0;
     for (z = 0; z < depths; z++) {      /*From the bottom to the top */
         G_percent(z, depths - 1, 10);
         for (y = 0; y < rows; y++) {

--- a/lib/gpde/n_gwflow.c
+++ b/lib/gpde/n_gwflow.c
@@ -269,7 +269,7 @@ N_data_star *N_callback_gwflow_3d(void *gwdata, N_geom_data * geom, int col,
     double hc_xw, hc_yn, hc_zt;
     double hc_xe, hc_ys, hc_zb;
     double hc_start;
-    double Ss, r, nf, q;
+    double Ss, r, /* nf, */ q;
     double C, W, E, N, S, T, B, V;
     N_data_star *mat_pos;
     N_gwflow_data3d *data;
@@ -310,7 +310,7 @@ N_data_star *N_callback_gwflow_3d(void *gwdata, N_geom_data * geom, int col,
     /*storativity */
     Ss = N_get_array_3d_d_value(data->s, col, row, depth);
     /*porosity */
-    nf = N_get_array_3d_d_value(data->nf, col, row, depth);
+    /* nf = N_get_array_3d_d_value(data->nf, col, row, depth); */
 
     /*mass balance center cell to western cell */
     W = -1 * Ax * hc_w / dx;

--- a/lib/gpde/n_solute_transport.c
+++ b/lib/gpde/n_solute_transport.c
@@ -35,7 +35,7 @@ N_data_star *N_callback_solute_transport_3d(void *solutedata,
     double diff_xw, diff_yn;
     double diff_xe, diff_ys;
     double diff_zt, diff_zb;
-    double cin = 0, cg, cg_start;
+    double cin = 0, /* cg, */ cg_start;
     double R, nf, cs, q;
     double C, W, E, N, S, T, B, V;
     double vw = 0, ve = 0, vn = 0, vs = 0, vt = 0, vb = 0;
@@ -59,7 +59,7 @@ N_data_star *N_callback_solute_transport_3d(void *solutedata,
 
     /*read the data from the arrays */
     cg_start = N_get_array_3d_d_value(data->c_start, col, row, depth);
-    cg = N_get_array_3d_d_value(data->c, col, row, depth);
+    /* cg = N_get_array_3d_d_value(data->c, col, row, depth); */
 
     /*get the surrounding diffusion tensor entries */
     diff_x = N_get_array_3d_d_value(data->diff_x, col, row, depth);
@@ -197,7 +197,7 @@ N_data_star *N_callback_solute_transport_2d(void *solutedata,
     double diff_xe, diff_ys;
     double disp_xe, disp_ys;
     double z_xe, z_ys;
-    double cin = 0, cg, cg_start;
+    double cin = 0, /* cg, */ cg_start;
     double R, nf, cs, q;
     double C, W, E, N, S, V, NE, NW, SW, SE;
     double vw = 0, ve = 0, vn = 0, vs = 0;
@@ -220,7 +220,7 @@ N_data_star *N_callback_solute_transport_2d(void *solutedata,
 
     /*read the data from the arrays */
     cg_start = N_get_array_2d_d_value(data->c_start, col, row);
-    cg = N_get_array_2d_d_value(data->c, col, row);
+    /* cg = N_get_array_2d_d_value(data->c, col, row); */
 
     /* calculate the cell height */
     z = N_get_array_2d_d_value(data->top, col,

--- a/lib/imagery/georef_tps.c
+++ b/lib/imagery/georef_tps.c
@@ -311,7 +311,8 @@ static int calcls(struct Control_Points *cp, struct MATRIX *m, double a[], doubl
     )
 {
     int i, j, n, o, numactive = 0;
-    double dist = 0.0, dx, dy, regularization;
+
+    /* double dist = 0.0, dx, dy, regularization; */
 
     /* INITIALIZE THE MATRIX AND THE TWO COLUMN VECTORS */
 
@@ -362,17 +363,17 @@ static int calcls(struct Control_Points *cp, struct MATRIX *m, double a[], doubl
                     if (i != j)
                         M(j + 3, i + 3) = M(i + 3, j + 3);
 
-                    dx = cp->e1[n] - cp->e1[o];
-                    dy = cp->n1[n] - cp->n1[o];
-                    dist += sqrt(dx * dx + dy * dy);
+                    /* dx = cp->e1[n] - cp->e1[o];
+                       dy = cp->n1[n] - cp->n1[o];
+                       dist += sqrt(dx * dx + dy * dy); */
                 }
             }
         }
     }
 
     /* regularization */
-    dist /= (numactive * numactive);
-    regularization = 0.01 * dist * dist;
+    /* dist /= (numactive * numactive);
+       regularization = 0.01 * dist * dist; */
 
     /* set diagonal to regularization, but not the first 3x3 (global affine) */
 

--- a/lib/lidar/zones.c
+++ b/lib/lidar/zones.c
@@ -569,7 +569,7 @@ P_Aux_to_Vector(struct Map_info *Map, struct Map_info *Out, dbDriver * driver,
                 char *tab_name)
 {
 
-    int more, line_num, type, count = 0;
+    int more, type, count = 0;
     double coordX, coordY, coordZ;
 
     struct line_pnts *point;
@@ -604,7 +604,6 @@ P_Aux_to_Vector(struct Map_info *Map, struct Map_info *Out, dbDriver * driver,
             value = db_get_column_value(column);
         else
             continue;
-        line_num = db_get_value_int(value);
 
         column = db_get_table_column(table, 1);
         type = db_sqltype_to_Ctype(db_get_column_sqltype(column));

--- a/lib/ogsf/gsd_fringe.c
+++ b/lib/ogsf/gsd_fringe.c
@@ -51,18 +51,19 @@ float Nbottom[] = { 0.0, 0.0, -1.0 };
 void gsd_display_fringe(geosurf * surf, unsigned long clr, float elev,
                         int where[4])
 {
-    float bot, xres, yres;      /* world size of view cell */
+    float bot /*, xres, yres */ ;       /* world size of view cell */
     int ycnt, xcnt;             /* number of view cells across */
-    float xmax, ymax;
 
-    xres = surf->x_mod * surf->xres;
-    yres = surf->y_mod * surf->yres;
+    /* float xmax, ymax; */
+
+    /* xres = surf->x_mod * surf->xres; */
+    /* yres = surf->y_mod * surf->yres; */
 
     xcnt = VCOLS(surf);
     ycnt = VROWS(surf);
 
-    xmax = surf->xmax;
-    ymax = surf->ymax;
+    /* xmax = surf->xmax; */
+    /* ymax = surf->ymax; */
 
     /* 
        bot = surf->zmin - ((surf->zrange/4.) * surf->z_exag);

--- a/lib/ogsf/gsd_img_tif.c
+++ b/lib/ogsf/gsd_img_tif.c
@@ -55,7 +55,7 @@ int GS_write_tif(const char *name)
     TIFF *out;
     unsigned int y, x;
     unsigned int xsize, ysize;
-    int mapsize, linebytes;
+    int linebytes;
     unsigned char *buf, *tmpptr;
     unsigned char *pixbuf;
 
@@ -78,7 +78,6 @@ int GS_write_tif(const char *name)
     TIFFSetField(out, TIFFTAG_SAMPLESPERPIXEL, 24 > 8 ? 3 : 1);
     TIFFSetField(out, TIFFTAG_BITSPERSAMPLE, 24 > 1 ? 8 : 1);
     TIFFSetField(out, TIFFTAG_PLANARCONFIG, config);
-    mapsize = 1 << 24;
 
     TIFFSetField(out, TIFFTAG_PHOTOMETRIC, 24 > 8 ?
                  PHOTOMETRIC_RGB : PHOTOMETRIC_MINISBLACK);

--- a/lib/ogsf/gsd_surf.c
+++ b/lib/ogsf/gsd_surf.c
@@ -1092,7 +1092,7 @@ int gsd_surf_const(geosurf * surf, float k)
 int gsd_surf_func(geosurf * gs, int (*user_func)())
 {
 
-    return(1);
+    return (1);
 }
 
 /*!
@@ -1809,15 +1809,20 @@ int gsd_wall(float *bgn, float *end, float *norm)
  */
 int gsd_norm_arrows(geosurf * surf)
 {
-    typbuff *buff, *cobuff;
-    int check_mask, check_color;
+    typbuff *buff;
+    int check_mask;
     int xmod, ymod, row, col, cnt, xcnt, ycnt;
     long offset, y1off, y2off;
-    float x1, x2, y1, y2, tx, ty, tz, sz;
+    float /* x1, */ x2, y1, y2, tx, ty, tz, sz;
     float n[3], pt[4], xres, yres, ymax, zexag;
-    int col_src, curcolor;
-    gsurf_att *coloratt;
 
+#ifdef DO_ARROW_SOLID
+    int col_src;
+    typbuff *cobuff;
+    gsurf_att *coloratt;
+    int curcolor;
+    int check_color = 1;
+#endif
     int zeros, dr1, dr2, dr3, dr4;
     int datarow1, datacol1, datarow2, datacol2;
 
@@ -1839,7 +1844,7 @@ int gsd_norm_arrows(geosurf * surf)
     gs_update_curmask(surf);
     check_mask = surf->curmask ? 1 : 0;
 
-    check_color = 1;
+#ifdef DO_ARROW_SOLID
     coloratt = &(surf->att[ATT_COLOR]);
     col_src = surf->att[ATT_COLOR].att_src;
 
@@ -1850,12 +1855,13 @@ int gsd_norm_arrows(geosurf * surf)
         else {
             curcolor = surf->wire_color;
         }
-
         check_color = 0;
     }
 
-    buff = gs_get_att_typbuff(surf, ATT_TOPO, 0);
     cobuff = gs_get_att_typbuff(surf, ATT_COLOR, 0);
+#endif
+
+    buff = gs_get_att_typbuff(surf, ATT_TOPO, 0);
 
     xmod = surf->x_mod;
     ymod = surf->y_mod;
@@ -1919,11 +1925,11 @@ int gsd_norm_arrows(geosurf * surf)
             GET_MAPATT(buff, offset, pt[Z]);
             pt[Z] *= zexag;
 
+#ifdef DO_ARROW_SOLID
             if (check_color) {
                 curcolor = gs_mapcolor(cobuff, coloratt, offset);
             }
 
-#ifdef DO_ARROW_SOLID
             gsd_3darrow(pt, curcolor, xres * 2, xres / 2, n, sz);
 #else
             if (DEBUG_ARROW) {
@@ -1940,11 +1946,11 @@ int gsd_norm_arrows(geosurf * surf)
             GET_MAPATT(buff, offset, pt[Z]);
             pt[Z] *= zexag;
 
+#ifdef DO_ARROW_SOLID
             if (check_color) {
                 curcolor = gs_mapcolor(cobuff, coloratt, offset);
             }
 
-#ifdef DO_ARROW_SOLID
             gsd_3darrow(pt, curcolor, xres * 2, xres / 2, n, sz);
 #else
             if (DEBUG_ARROW) {
@@ -1959,7 +1965,7 @@ int gsd_norm_arrows(geosurf * surf)
             datacol1 = col * xmod;
             datacol2 = (col + 1) * xmod;
 
-            x1 = col * xres;
+            /* x1 = col * xres; */
             x2 = (col + 1) * xres;
 
             zeros = 0;
@@ -2001,11 +2007,11 @@ int gsd_norm_arrows(geosurf * surf)
                 GET_MAPATT(buff, offset, pt[Z]);
                 pt[Z] *= zexag;
 
+#ifdef DO_ARROW_SOLID
                 if (check_color) {
                     curcolor = gs_mapcolor(cobuff, coloratt, offset);
                 }
 
-#ifdef DO_ARROW_SOLID
                 gsd_3darrow(pt, curcolor, xres * 2, xres / 2, n, sz);
 #else
                 if (DEBUG_ARROW) {
@@ -2024,11 +2030,11 @@ int gsd_norm_arrows(geosurf * surf)
                 GET_MAPATT(buff, offset, pt[Z]);
                 pt[Z] *= zexag;
 
+#ifdef DO_ARROW_SOLID
                 if (check_color) {
                     curcolor = gs_mapcolor(cobuff, coloratt, offset);
                 }
 
-#ifdef DO_ARROW_SOLID
                 gsd_3darrow(pt, curcolor, xres * 2, xres / 2, n, sz);
 #else
                 if (DEBUG_ARROW) {
@@ -2061,11 +2067,11 @@ int gsd_norm_arrows(geosurf * surf)
  */
 int gsd_surf_map(geosurf * surf)
 {
-    int check_mask, check_color, check_transp;
+    int /* check_mask, */ check_color, check_transp;
     int check_material, check_emis, check_shin;
     typbuff *buff, *cobuff, *trbuff, *embuff, *shbuff;
     int xmod, ymod;
-    int row, col, cnt, xcnt, ycnt;
+    int row, col, xcnt, ycnt;
     long y1off, y2off, y3off;
     long offset2[10];
     float pt2[10][2];
@@ -2082,7 +2088,9 @@ int gsd_surf_map(geosurf * surf)
     GLint window[4];
     int cnt1 = 0, cnt2 = 0;
 
-    int datarow1, datacol1, datarow2, datacol2, datarow3, datacol3;
+    int datacol1, datacol2, datacol3;
+
+    /* int datarow1, datarow2, datarow3; */
 
     float kem, ksh, pkem, pksh;
     unsigned int ktrans;
@@ -2106,7 +2114,7 @@ int gsd_surf_map(geosurf * surf)
     cobuff = gs_get_att_typbuff(surf, ATT_COLOR, 0);
 
     gs_update_curmask(surf);
-    check_mask = surf->curmask ? 1 : 0;
+    /* check_mask = surf->curmask ? 1 : 0; */
 
     /*
        checks ATT_TOPO & ATT_COLOR no_zero flags, make a mask from each,
@@ -2210,7 +2218,6 @@ int gsd_surf_map(geosurf * surf)
 
     /* would also be good to check if colormap == surfmap, to increase speed */
     /* will also need to set check_transp, check_shine, etc & fix material */
-    cnt = 0;
 
     for (row = start_val; row < ycnt; row += step_val) {
         if (GS_check_cancel()) {
@@ -2233,10 +2240,11 @@ int gsd_surf_map(geosurf * surf)
            row /= 2;
            }
          */
-        datarow1 = row * ymod;
-        datarow2 = (row - (step_val / 2)) * ymod;
-        datarow3 = (row + (step_val / 2)) * ymod;
-
+        /*
+           datarow1 = row * ymod;
+           datarow2 = (row - (step_val / 2)) * ymod;
+           datarow3 = (row + (step_val / 2)) * ymod;
+         */
 
         y1 = ymax - row * yres;
         y2 = ymax - (row - (step_val / 2)) * yres;

--- a/lib/ogsf/gsd_wire.c
+++ b/lib/ogsf/gsd_wire.c
@@ -441,7 +441,7 @@ int gsd_wire_surf_const(geosurf * surf, float k)
  */
 int gsd_wire_surf_func(geosurf * gs, int (*user_func)())
 {
-    return(1);
+    return (1);
 }
 
 /*!
@@ -571,7 +571,7 @@ int gsd_wire_arrows(geosurf * surf)
  */
 int gsd_coarse_surf_map(geosurf * surf)
 {
-    int check_mask, check_color, check_transp;
+    int /* check_mask, */ check_color, check_transp;
     int check_material, check_emis, check_shin;
     typbuff *buff, *cobuff, *trbuff, *embuff, *shbuff;
     int xmod, ymod;
@@ -586,7 +586,9 @@ int gsd_coarse_surf_map(geosurf * surf)
     gsurf_att *ematt, *shatt, *tratt, *coloratt;
 
 
-    int datarow1, datacol1, datarow2, datacol2, datarow3, datacol3;
+    int datacol1, datacol2, datacol3;
+
+    /* int datarow1, datarow2, datarow3; */
 
     float kem, ksh, pkem, pksh;
     unsigned int ktrans;
@@ -613,7 +615,7 @@ int gsd_coarse_surf_map(geosurf * surf)
     cobuff = gs_get_att_typbuff(surf, ATT_COLOR, 0);
 
     gs_update_curmask(surf);
-    check_mask = surf->curmask ? 1 : 0;
+    /* check_mask = surf->curmask ? 1 : 0; */
 
     /*
        checks ATT_TOPO & ATT_COLOR no_zero flags, make a mask from each,
@@ -712,10 +714,11 @@ int gsd_coarse_surf_map(geosurf * surf)
     /* will also need to set check_transp, check_shine, etc & fix material */
     for (row = start_val; row <= ycnt - start_val; row += step_val) {
 
-        datarow1 = row * ymod;
-        datarow2 = (row - (step_val / 2)) * ymod;
-        datarow3 = (row + (step_val / 2)) * ymod;
-
+        /*
+           datarow1 = row * ymod;
+           datarow2 = (row - (step_val / 2)) * ymod;
+           datarow3 = (row + (step_val / 2)) * ymod;
+         */
 
         y1 = ymax - row * yres;
         y2 = ymax - (row - (step_val / 2)) * yres;

--- a/lib/ogsf/gsdrape.c
+++ b/lib/ogsf/gsdrape.c
@@ -883,10 +883,9 @@ int get_vert_intersects(geosurf * gs, float *bgn, float *end, float *dir)
 {
     int fcol, lcol, incr, hits, num, offset, drow1, drow2;
     float xl, yb, xr, yt, z1, z2, alpha;
-    float xres, yres, xi, yi;
+    float yres, xi, yi;
     int bgncol, endcol, cols, rows;
 
-    xres = VXRES(gs);
     yres = VYRES(gs);
     cols = VCOLS(gs);
     rows = VROWS(gs);
@@ -979,11 +978,10 @@ int get_horz_intersects(geosurf * gs, float *bgn, float *end, float *dir)
 {
     int frow, lrow, incr, hits, num, offset, dcol1, dcol2;
     float xl, yb, xr, yt, z1, z2, alpha;
-    float xres, yres, xi, yi;
+    float xres, xi, yi;
     int bgnrow, endrow, rows, cols;
 
     xres = VXRES(gs);
-    yres = VYRES(gs);
     cols = VCOLS(gs);
     rows = VROWS(gs);
 
@@ -1212,7 +1210,7 @@ int segs_intersect(float x1, float y1, float x2, float y2, float x3, float y3,
 {
     float a1, a2, b1, b2, c1, c2;       /* Coefficients of line eqns. */
     float r1, r2, r3, r4;       /* 'Sign' values */
-    float denom, offset, num;   /* Intermediate values */
+    float denom, /* offset, */ num;     /* Intermediate values */
 
     /* Compute a1, b1, c1, where line joining points 1 and 2
      * is "a1 x  +  b1 y  +  c1  =  0".
@@ -1260,7 +1258,7 @@ int segs_intersect(float x1, float y1, float x2, float y2, float x3, float y3,
         return (COLLINEAR);
     }
 
-    offset = denom < 0 ? -denom / 2 : denom / 2;
+    /* offset = denom < 0 ? -denom / 2 : denom / 2; */
 
     /* The denom/2 is to get rounding instead of truncating.  It
      * is added or subtracted to the numerator, depending upon the

--- a/lib/proj/convert.c
+++ b/lib/proj/convert.c
@@ -183,7 +183,7 @@ OGRSpatialReferenceH GPJ_grass_to_osr(const struct Key_Value *proj_info,
     const char *ellpskv, *unit, *unfact;
     char *ellps, *ellpslong, *datum, *params, *towgs84, *datumlongname,
         *start, *end;
-    const char *sysname, *osrunit, *osrunfact;
+    const char *sysname, *osrunit;
     double a, es, rf;
     int haveparams = 0;
 
@@ -302,7 +302,6 @@ OGRSpatialReferenceH GPJ_grass_to_osr(const struct Key_Value *proj_info,
             start = G_store(wkt);
 
         osrunit = OSRGetAttrValue(hSRS, "UNIT", 0);
-        osrunfact = OSRGetAttrValue(hSRS, "UNIT", 1);
 
         if ((unfact == NULL) || (G_strcasecmp(osrunit, "unknown") != 0))
             end = G_store("");

--- a/lib/raster/cats.c
+++ b/lib/raster/cats.c
@@ -812,7 +812,6 @@ int Rast_set_d_cat(const DCELL * rast1, const DCELL * rast2,
     long len;
     DCELL dtmp1, dtmp2;
     int i;
-    char *descr;
 
     /* DEBUG fprintf(stderr,"Rast_set_d_cat(rast1 = %p,rast2 = %p,label = '%s',pcats = %p)\n",
        rast1,rast2,label,pcats); */
@@ -830,7 +829,7 @@ int Rast_set_d_cat(const DCELL * rast1, const DCELL * rast2,
        the label for this range has been sen, and if it has, overwrite it */
 
     for (i = 0; i < pcats->ncats; i++) {
-        descr = Rast_get_ith_d_cat(pcats, i, &dtmp1, &dtmp2);
+        Rast_get_ith_d_cat(pcats, i, &dtmp1, &dtmp2);
         if ((dtmp1 == *rast1 && dtmp2 == *rast2)
             || (dtmp1 == *rast2 && dtmp2 == *rast1)) {
             if (pcats->labels[i] != NULL)

--- a/lib/raster/open.c
+++ b/lib/raster/open.c
@@ -158,7 +158,6 @@ int Rast__open_old(const char *name, const char *mapset)
     const char *r_mapset;
     struct Cell_head cellhd;
     int CELL_nbytes = 0;        /* bytes per cell in CELL map */
-    int INTERN_SIZE;
     int reclass_flag;
     int MAP_NBYTES;
     RASTER_MAP_TYPE MAP_TYPE;
@@ -256,17 +255,14 @@ int Rast__open_old(const char *name, const char *mapset)
     /* record number of bytes per cell */
     if (MAP_TYPE == FCELL_TYPE) {
         cell_dir = "fcell";
-        INTERN_SIZE = sizeof(FCELL);
         MAP_NBYTES = XDR_FLOAT_NBYTES;
     }
     else if (MAP_TYPE == DCELL_TYPE) {
         cell_dir = "fcell";
-        INTERN_SIZE = sizeof(DCELL);
         MAP_NBYTES = XDR_DOUBLE_NBYTES;
     }
     else {                      /* integer */
         cell_dir = "cell";
-        INTERN_SIZE = sizeof(CELL);
         MAP_NBYTES = CELL_nbytes;
     }
 

--- a/lib/raster3d/rle.c
+++ b/lib/raster3d/rle.c
@@ -177,13 +177,12 @@ int Rast3d_rle_count_only(char *src, int nofElts, int eltLength)
 
 void Rast3d_rle_encode(char *src, char *dst, int nofElts, int eltLength)
 {
-    int length, nofEqual;
+    int nofEqual;
     char *head, *tail, *headStop, *headStop2;
 
     if (nofElts <= 0)
         Rast3d_fatal_error("trying to encode 0-length list");
 
-    length = 0;
     nofEqual = 1;
     head = src + eltLength;
     tail = src;
@@ -201,7 +200,6 @@ void Rast3d_rle_encode(char *src, char *dst, int nofElts, int eltLength)
                 /*      printf ("equal %d char %d\n", nofEqual, *tail); */
                 while (tail != head)
                     *dst++ = *tail++;
-                length += G_rle_codeLength(nofEqual) + eltLength;
                 nofEqual = 1;
                 tail = headStop2 - eltLength;
                 break;
@@ -223,9 +221,7 @@ void Rast3d_rle_encode(char *src, char *dst, int nofElts, int eltLength)
     head = tail + eltLength;
     while (tail != head)
         *dst++ = *tail++;
-    length += G_rle_codeLength(nofEqual) + eltLength;
     dst = rle_length2code(-1, dst);
-    length += G_rle_codeLength(-1);
     rle_code2length(dst - 2, &nofEqual);
 }
 

--- a/lib/rst/interp_float/interp2d.c
+++ b/lib/rst/interp_float/interp2d.c
@@ -90,10 +90,10 @@ int IL_grid_calc_2d(struct interp_params *params, struct quaddata *data,        
     int cond1, cond2;
     double r;
     double stepix, stepiy, xx, xg, yg, xx2;
-    double rfsta2, /* cons, cons1, */ wm, dx, dy, dxx, dyy, dxy, h, bmgd1,
+    double /* rfsta2, cons, cons1, */ wm, dx, dy, dxx, dyy, dxy, h, bmgd1,
         bmgd2;
     double r2, gd1, gd2;        /* for interpder() */
-    int n1, k, l, m;
+    int /* n1, */ k, l, m;
     int ngstc, nszc, ngstr, nszr;
     double zz;
     int bmask = 1;
@@ -145,7 +145,7 @@ int IL_grid_calc_2d(struct interp_params *params, struct quaddata *data,        
             return -1;
         }
     }
-    n1 = n_points + 1;
+    /* n1 = n_points + 1; */
     /*
      * C C         INTERPOLATION   *  MOST INNER LOOPS ! C
      */
@@ -188,13 +188,13 @@ int IL_grid_calc_2d(struct interp_params *params, struct quaddata *data,        
                         w2[m] = yyr * yyr;
                         r2 = scale * xx2 + w2[m];
                         r = r2;
-                        rfsta2 = scale * xx2 + w2[m];
+                        /* rfsta2 = scale * xx2 + w2[m]; */
                     }
                     else {
                         xx2 = xx * xx;
                         r2 = xx2 + w2[m];
                         r = r2;
-                        rfsta2 = xx2 + w2[m];
+                        /* rfsta2 = xx2 + w2[m]; */
                     }
 
                     h = h + b[m] * params->interp(r, params->fi);

--- a/lib/rst/interp_float/point2d.c
+++ b/lib/rst/interp_float/point2d.c
@@ -62,10 +62,11 @@ int IL_check_at_points_2d(struct interp_params *params, struct quaddata *data,  
     double west = data->x_orig;
     double north = data->ymax;
     double south = data->y_orig;
-    double rfsta2, errmax, h, xx, yy, r2, hz, zz, err, xmm, ymm, r;
+    double /* rfsta2, errmax, */ h, xx, yy, r2, hz, zz, err, xmm, ymm, r;
     double skip_err;
-    int n1, mm, m, cat;
-    double fstar2;
+    int /* n1, */ mm, m, cat;
+
+    /* double fstar2; */
     int inside;
 
     /*  Site *site; */
@@ -75,9 +76,9 @@ int IL_check_at_points_2d(struct interp_params *params, struct quaddata *data,  
     /*  if ((site = G_site_new_struct (-1, 2, 0, 1)) == NULL)
        G_fatal_error ("Memory error for site struct"); */
 
-    fstar2 = params->fi * params->fi / 4.;
-    errmax = .0;
-    n1 = n_points + 1;
+    /* fstar2 = params->fi * params->fi / 4.; */
+    /* errmax = .0; */
+    /* n1 = n_points + 1; */
     for (mm = 1; mm <= n_points; mm++) {
         h = b[0];
         for (m = 1; m <= n_points; m++) {
@@ -85,7 +86,7 @@ int IL_check_at_points_2d(struct interp_params *params, struct quaddata *data,  
             yy = points[mm - 1].y - points[m - 1].y;
             r2 = yy * yy + xx * xx;
             if (r2 != 0.) {
-                rfsta2 = fstar2 * r2;
+                /* rfsta2 = fstar2 * r2; */
                 r = r2;
                 h = h + b[m] * params->interp(r, params->fi);
             }
@@ -148,7 +149,7 @@ int IL_check_at_points_2d(struct interp_params *params, struct quaddata *data,  
             yy = points[m - 1].y - skip_point.y;
             r2 = yy * yy + xx * xx;
             if (r2 != 0.) {
-                rfsta2 = fstar2 * r2;
+                /* rfsta2 = fstar2 * r2; */
                 r = r2;
                 h = h + b[m] * params->interp(r, params->fi);
             }

--- a/lib/rst/interp_float/ressegm2d.c
+++ b/lib/rst/interp_float/ressegm2d.c
@@ -54,14 +54,13 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
     int i, j, k, l, m, m1, i1;  /* loop coounters */
     int cursegm = 0;
     int new_comp = 0;
-    int n_rows, n_cols, inp_r, inp_c;
+    int n_rows, n_cols /*, inp_r, inp_c */ ;
     double x_or, y_or, xm, ym;
     static int first = 1, new_first = 1;
     double **matrix = NULL, **new_matrix = NULL, *b = NULL;
     int *indx = NULL, *new_indx = NULL;
     static struct fcell_triple *in_points = NULL;       /* input points */
-    int inp_check_rows, inp_check_cols, /* total input rows/cols */
-      out_check_rows, out_check_cols;   /* total output rows/cols */
+    int out_check_rows, out_check_cols; /* total output rows/cols */
     int first_row, last_row;    /* first and last input row of segment */
     int first_col, last_col;    /* first and last input col of segment */
     int num, prev;
@@ -125,8 +124,6 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
     overlap1 = min1(overlap1, inp_seg_r - 1);
     out_check_rows = 0;
     out_check_cols = 0;
-    inp_check_rows = 0;
-    inp_check_cols = 0;
 
     if (div == 1) {
         p_size = inp_seg_c * inp_seg_r;
@@ -236,8 +233,6 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
     overlap1 = min1(overlap1, inp_seg_r - 1);
     out_check_rows = 0;
     out_check_cols = 0;
-    inp_check_rows = 0;
-    inp_check_cols = 0;
 
     totsegm = div * div;
 
@@ -247,9 +242,8 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
             n_rows = out_seg_r;
         else
             n_rows = out_seg_r + 1;
-        inp_r = inp_seg_r;
+        /* inp_r = inp_seg_r; */
         out_check_cols = 0;
-        inp_check_cols = 0;
         ngstr = out_check_rows + 1;     /* first output row of the segment */
         nszr = ngstr + n_rows - 1;      /* last output row of the segment */
         y_or = (ngstr - 1) * ns_res;    /* y origin of the segment */
@@ -282,7 +276,7 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
                 n_cols = out_seg_c;
             else
                 n_cols = out_seg_c + 1;
-            inp_c = inp_seg_c;
+            /* inp_c = inp_seg_c; */
 
             ngstc = out_check_cols + 1; /* first output col of the segment */
             nszc = ngstc + n_cols - 1;  /* last output col of the segment */
@@ -349,7 +343,6 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
             else
                 data->n_points = params->KMAX2;
             out_check_cols += n_cols;
-            inp_check_cols += inp_c;
             cursegm = (i - 1) * div + j - 1;
 
             /* show before to catch 0% */
@@ -466,8 +459,6 @@ int IL_resample_interp_segments_2d(struct interp_params *params, struct BM *bitm
              * cursegm++;
              */
         }
-
-        inp_check_rows += inp_r;
         out_check_rows += n_rows;
     }
 

--- a/lib/rst/interp_float/segmen2d.c
+++ b/lib/rst/interp_float/segmen2d.c
@@ -58,7 +58,7 @@ int IL_interp_segments_2d(struct interp_params *params, struct tree_info *info, 
                           double dnorm)
 {
     double xmn, xmx, ymn, ymx, distx, disty, distxp, distyp, temp1, temp2;
-    int i, npt, nptprev, MAXENC;
+    int i, npt, MAXENC;
     struct quaddata *data;
     static int cursegm = 0;
     static double *b = NULL;
@@ -72,7 +72,7 @@ int IL_interp_segments_2d(struct interp_params *params, struct tree_info *info, 
     struct triple *point;
     struct triple skip_point;
     int m_skip, skip_index, j, k, segtest;
-    double xx, yy, zz;
+    double xx, yy /*, zz */ ;
 
     /* find the size of the smallest segment once */
     if (first_time) {
@@ -139,7 +139,6 @@ int IL_interp_segments_2d(struct interp_params *params, struct tree_info *info, 
                 /* decrease window */
             {
                 MAXENC = 1;
-                nptprev = npt;
                 temp1 = distxp;
                 distxp = distx;
                 distx = distxp - fabs(distx - temp1) * 0.5;
@@ -149,7 +148,6 @@ int IL_interp_segments_2d(struct interp_params *params, struct tree_info *info, 
                 /* decrease by 50% of a previous change in window */
             }
             else {
-                nptprev = npt;
                 temp1 = distyp;
                 distyp = disty;
                 temp2 = distxp;
@@ -261,7 +259,7 @@ int IL_interp_segments_2d(struct interp_params *params, struct tree_info *info, 
                     params->x_orig;
                 yy = point[skip_index].y * dnorm + data->y_orig +
                     params->y_orig;
-                zz = point[skip_index].z;
+                /* zz = point[skip_index].z; */
                 if (xx >= data->x_orig + params->x_orig &&
                     xx <= data->xmax + params->x_orig &&
                     yy >= data->y_orig + params->y_orig &&

--- a/lib/rst/interp_float/segmen2d_parallel.c
+++ b/lib/rst/interp_float/segmen2d_parallel.c
@@ -118,14 +118,14 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
 
             double xmn, xmx, ymn, ymx, distx, disty, distxp, distyp, temp1,
                 temp2;
-            int npt, nptprev, MAXENC;
+            int npt, MAXENC;
             double ew_res, ns_res;
             int MINPTS;
             double pr;
             struct triple *point;
             struct triple skip_point;
             int m_skip, skip_index, k, segtest;
-            double xx, yy, zz;
+            double xx, yy /*, zz */ ;
 
 
             //struct quaddata *data_local;
@@ -195,7 +195,6 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
                         /* decrease window */
                     {
                         MAXENC = 1;
-                        nptprev = npt;
                         temp1 = distxp;
                         distxp = distx;
                         distx = distxp - fabs(distx - temp1) * 0.5;
@@ -205,7 +204,6 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
                         /* decrease by 50% of a previous change in window */
                     }
                     else {
-                        nptprev = npt;
                         temp1 = distyp;
                         distyp = disty;
                         temp2 = distxp;
@@ -310,7 +308,7 @@ int IL_interp_segments_2d_parallel(struct interp_params *params, struct tree_inf
                             data_local[tid]->x_orig + params->x_orig;
                         yy = point[skip_index].y * dnorm +
                             data_local[tid]->y_orig + params->y_orig;
-                        zz = point[skip_index].z;
+                        /* zz = point[skip_index].z; */
                         if (xx >= data_local[tid]->x_orig + params->x_orig &&
                             xx <= data_local[tid]->xmax + params->x_orig &&
                             yy >= data_local[tid]->y_orig + params->y_orig &&

--- a/lib/rst/interp_float/vinput2d.c
+++ b/lib/rst/interp_float/vinput2d.c
@@ -60,7 +60,7 @@ int IL_vector_input_data_2d(struct interp_params *params,       /*!< interpolati
 {
     double dmax2;               /* max distance between points squared */
     double c1, c2, c3, c4;
-    int i, line, k = 0;
+    int i, k = 0;
     double ns_res, ew_res;
     int npoint, OUTRANGE;
     int totsegm;
@@ -140,7 +140,6 @@ int IL_vector_input_data_2d(struct interp_params *params,       /*!< interpolati
     /* Lines without nodes */
     G_message(_("Reading features from vector map ..."));
     sm = 0;
-    line = 1;
     while ((ltype = Vect_read_next_line(Map, Points, Cats)) != -2) {
 
         if (!(ltype & (GV_POINT | GV_LINE | GV_BOUNDARY)))
@@ -149,7 +148,6 @@ int IL_vector_input_data_2d(struct interp_params *params,       /*!< interpolati
         if (field > 0) {        /* use cat or attribute */
             Vect_cat_get(Cats, field, &cat);
 
-            /*    line++; */
             if (zcol == NULL) { /* use categories */
                 z = (double)cat;
             }

--- a/lib/vector/Vlib/remove_duplicates.c
+++ b/lib/vector/Vlib/remove_duplicates.c
@@ -71,7 +71,7 @@ void Vect_remove_duplicates(struct Map_info *Map, int type,
 {
     struct line_pnts *APoints, *BPoints;
     struct line_cats *ACats, *BCats;
-    int i, c, atype, btype, aline, bline;
+    int i, c, atype, aline, bline;
     int nlines, nacats_orig, npoints;
     int na1, na2, nb1, nb2, nodelines, nline;
     struct bound_box ABox;
@@ -162,7 +162,7 @@ void Vect_remove_duplicates(struct Map_info *Map, int type,
                     continue;
             }
 
-            btype = Vect_read_line(Map, BPoints, BCats, bline);
+            Vect_read_line(Map, BPoints, BCats, bline);
             Vect_line_prune(BPoints);
 
             /* check for duplicate */

--- a/lib/vector/Vlib/simple_features.c
+++ b/lib/vector/Vlib/simple_features.c
@@ -243,15 +243,17 @@ int Vect_sfa_line_astext(const struct line_pnts *Points, int type, int with_z,
    \return 1  feature simple
    \return 0  feature not simple
    \return -1 feature type not supported (GV_POINT, GV_CENTROID, ...)
+   \note Implementation is pending, now always returns 0
  */
 int Vect_sfa_is_line_simple(const struct line_pnts *Points, int type,
                             int with_z)
 {
-    SF_FeatureType sftype;
+    /* TODO:
+       SF_FeatureType sftype;
 
-    sftype = Vect_sfa_get_line_type(Points, type, with_z);
+       Vect_sfa_get_line_type(Points, type, with_z);
 
-    /* TODO */
+     */
 
     return 0;
 }

--- a/lib/vector/dglib/misc-template.c
+++ b/lib/vector/dglib/misc-template.c
@@ -362,7 +362,9 @@ int DGL_FLATTEN_FUNC(dglGraph_s * pgraph)
     register dglInt32_t *pnode;
     register dglInt32_t *pnodescan;
     dglInt32_t *pOutEdgeset;
+#if !defined(_DGL_V1)
     dglInt32_t *pInEdgeset;
+#endif
     int cOutEdgeset;
     int cInEdgeset;
 
@@ -421,7 +423,9 @@ int DGL_FLATTEN_FUNC(dglGraph_s * pgraph)
 	) {
 	pnode = DGL_T_NODEITEM_NodePTR(ptreenode);
 	pOutEdgeset = DGL_T_NODEITEM_OutEdgesetPTR(ptreenode);
+#if !defined(_DGL_V1)
 	pInEdgeset = DGL_T_NODEITEM_InEdgesetPTR(ptreenode);
+#endif
 
 	if (!(DGL_NODE_STATUS(pnode) & DGL_NS_ALONE)) {
 	    cOutEdgeset = (pOutEdgeset) ?

--- a/lib/vector/diglib/plus_area.c
+++ b/lib/vector/diglib/plus_area.c
@@ -456,7 +456,7 @@ int dig_del_area(struct Plus_head *plus, int area)
  * \param[in] current_line current line id, negative if request for end node
  * \param[in] side side GV_RIGHT or GV_LEFT
  * \param[in] type line type (GV_LINE, GV_BOUNDARY or both)
- * \param[in] angle
+ * \param[out] angle
  *
  * \return line number of next angle to follow a line (negative if connected by end node)
  *               (number of current line may be returned if dangle - this is used in build)
@@ -665,7 +665,7 @@ int dig_node_angle_check(struct Plus_head *plus, plus_t line, int type)
     if (angle1 == angle2) {
         G_debug(3,
                 "  The line to the left has the same angle: node = %d, line = %d",
-                node, next);
+                node, prev);
         return 0;
     }
 

--- a/lib/vector/neta/flow.c
+++ b/lib/vector/neta/flow.c
@@ -274,10 +274,9 @@ int NetA_split_vertices(dglGraph_s * in, dglGraph_s * out, int *node_costs)
     dglInt32_t opaqueset[16] =
         { 360000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     dglNodeTraverser_s nt;
-    dglInt32_t nnodes, edge_cnt;
+    dglInt32_t edge_cnt;
     dglInt32_t *cur_node;
 
-    nnodes = dglGet_NodeCount(in);
     dglInitialize(out, (dglByte_t) 1, (dglInt32_t) 0, (dglInt32_t) 0,
                   opaqueset);
     dglNode_T_Initialize(&nt, in);


### PR DESCRIPTION
Continuation of #2648.

As reported with #2156.

Following lib parts are affected:
- arraystats
- cairodriver
- cdhc
- db/dbmi_base
- dspf
- external/shapelib
- gis
- gpde
- imagery
- lidar
- ogsf
- proj
- raster
- rst/interp_float
- vector/Vlib
- vector/dglib
- vector/neta

