### PR TITLE
toolboxes.xml: add r.path

### DIFF
--- a/gui/wxpython/xml/toolboxes.xml
+++ b/gui/wxpython/xml/toolboxes.xml
@@ -807,6 +807,9 @@
       <module-item name="r.cost">
         <label>Cost surface</label>
       </module-item>
+      <module-item name="r.path">
+        <label>Trace a path</label>
+      </module-item>
       <module-item name="r.walk">
         <label>Cumulative movement costs</label>
       </module-item>


### PR DESCRIPTION
So far, it was impossible to find module `r.path` through GUI. This PR fixes it. 