### PR TITLE
v.in.ogr: handle skipped, not empty columns

### DIFF
--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1389,6 +1389,10 @@ int main(int argc, char *argv[])
 			    db_double_quote_string(&strval);
 			    G_rasprintf(&sqlbuf, &sqlbufsize, ", '%s'", db_get_string(&strval));
 			}
+                else {
+                    /* column type not supported (thus skiped) and not empty */
+                    G_rasprintf(&sqlbuf, &sqlbufsize, "%c", '\0');
+                }
 		    }
 		    else {
 			/* G_warning (_("Column value not set" )); */

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1390,7 +1390,7 @@ int main(int argc, char *argv[])
 			    G_rasprintf(&sqlbuf, &sqlbufsize, ", '%s'", db_get_string(&strval));
 			}
                 else {
-                    /* column type not supported (thus skiped) and not empty */
+                    /* column type not supported (thus skipped) and not empty */
                     G_rasprintf(&sqlbuf, &sqlbufsize, "%c", '\0');
                 }
 		    }


### PR DESCRIPTION
There was a glitch in #2630 that values from skipped but not empty columns of unsupported data types were still tried to insert into the table in the GRASS DB.
This PR skips also to INSERT values from those columns, using the same logic as for the columns themself.