### PR TITLE
lib/imagery: fix -Wfortify-source warning

### DIFF
--- a/lib/imagery/sigset.c
+++ b/lib/imagery/sigset.c
@@ -238,7 +238,7 @@ static int get_title(FILE * fd, struct SigSet *S)
     char title[1024];
 
     *title = 0;
-    if (fscanf(fd, "%1024[^\n]", title) != 1)
+    if (fscanf(fd, "%1023[^\n]", title) != 1)
         return -1;
     G_strip(title);
     I_SetSigTitle(S, title);
@@ -293,7 +293,7 @@ static int get_classtitle(FILE * fd, struct ClassSig *C)
     char title[1024];
 
     *title = 0;
-    if (fscanf(fd, "%1024[^\n]", title) != 1)
+    if (fscanf(fd, "%1023[^\n]", title) != 1)
         return -1;
     G_strip(title);
     I_SetClassTitle(C, title);


### PR DESCRIPTION
This addresses following warning message:
> warning: 'fscanf' may overflow; destination buffer in argument 3 has size 1024, but the corresponding specifier may require size 1025

Found working on #2661.