### PR TITLE
manual: add functionality to handle line breaks in dt tag

### DIFF
--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -209,7 +209,7 @@ class Formatter:
         elif tag in formats:
             spec = formats[tag]
             if is_string(spec):
-                if "\n.br\n" == spec:
+                if spec == "\n.br\n":
                     spec = ".br "
                 self.fmt(spec, content)
             else:

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -209,6 +209,8 @@ class Formatter:
         elif tag in formats:
             spec = formats[tag]
             if is_string(spec):
+                if "\n.br\n" == spec:
+                    spec = ".br "
                 self.fmt(spec, content)
             else:
                 (fmt, var) = spec


### PR DESCRIPTION
Changes has been done in `ggroff.py` file in order to fix the issue #2129. Inserted a condition which checks if `.br` is present in string format (spec) with `\n` and replacing the format (spec) with simple space `("\n.br\n" to ".br ")`  
