### PR TITLE
gunittest: remove deprecated 'U'-mode for open()

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1239,9 +1239,8 @@ class TestCase(unittest.TestCase):
         """
         import difflib
 
-        # 'U' taken from difflib documentation
-        fromlines = open(actual, "U").readlines()
-        tolines = open(reference, "U").readlines()
+        fromlines = open(actual).readlines()
+        tolines = open(reference).readlines()
         context_lines = 3  # number of context lines
         # TODO: filenames are set to "actual" and "reference", isn't it too general?
         # it is even more useful if map names or file names are some generated


### PR DESCRIPTION
'U'-mode was deprecated since Python 3.4, it is removed in Python 3.11.

Fixes #2670 