### PR TITLE
cmake support preparation: use of INFINITY and NAN

### DIFF
--- a/general/g.region/printwindow.c
+++ b/general/g.region/printwindow.c
@@ -469,7 +469,7 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag)
         double convergence;
 
         if (G_projection() == PROJECTION_XY)
-            convergence = 0. / 0.;
+            convergence = NAN;
         else if (G_projection() == PROJECTION_LL)
             convergence = 0.0;
         else {

--- a/lib/btree2/kdtree.c
+++ b/lib/btree2/kdtree.c
@@ -531,7 +531,7 @@ int kdtree_knn(struct kdtree *t, double *c, int *uid, double *d, int k,
     if (skip)
         sn.uid = *skip;
 
-    maxdist = 1.0 / 0.0;
+    maxdist = INFINITY;
     found = 0;
 
     /* go down */

--- a/lib/gmath/la.c
+++ b/lib/gmath/la.c
@@ -1291,7 +1291,7 @@ double G_vector_norm1(vec_struct *vc)
 
     if (!vc->is_init) {
         G_warning(_("Matrix is not initialised"));
-        return 0.0 / 0.0; /* NaN */
+        return NAN;
     }
 
     idx = (vc->v_indx > 0) ? vc->v_indx : 0;

--- a/lib/vector/Vlib/box.c
+++ b/lib/vector/Vlib/box.c
@@ -248,7 +248,7 @@ int Vect_get_line_box(const struct Map_info *Map, int line,
 
     Line = Plus->Line[line];
     if (Line == NULL) { /* dead */
-        Box->N = Box->S = Box->E = Box->W = Box->T = Box->B = 0. / 0.;
+        Box->N = Box->S = Box->E = Box->W = Box->T = Box->B = NAN;
         return 0;
     }
 
@@ -313,7 +313,7 @@ int Vect_get_area_box(const struct Map_info *Map, int area,
     Area = Plus->Area[area];
 
     if (Area == NULL) { /* dead */
-        Box->N = Box->S = Box->E = Box->W = Box->T = Box->B = 0. / 0.;
+        Box->N = Box->S = Box->E = Box->W = Box->T = Box->B = NAN;
         return 0;
     }
 
@@ -360,7 +360,7 @@ int Vect_get_isle_box(const struct Map_info *Map, int isle,
     Isle = Plus->Isle[isle];
 
     if (Isle == NULL) { /* dead */
-        Box->N = Box->S = Box->E = Box->W = Box->T = Box->B = 0. / 0.;
+        Box->N = Box->S = Box->E = Box->W = Box->T = Box->B = NAN;
         return 0;
     }
 

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -754,7 +754,7 @@ double horizon_height(void)
 {
     double height;
 
-    tanh0 = -1.0 / 0.0; /* -inf */
+    tanh0 = -INFINITY;
     length = 0;
 
     height = searching();

--- a/raster/r.in.bin/main.c
+++ b/raster/r.in.bin/main.c
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
     const char *outpre;
     char output[GNAME_MAX];
     const char *title;
-    double null_val = 0.0 / 0.0;
+    double null_val = NAN;
     int is_fp;
     int is_signed;
     int bytes, hbytes;

--- a/raster/r.in.lidar/info.c
+++ b/raster/r.in.lidar/info.c
@@ -12,11 +12,9 @@
  */
 
 #include <string.h>
-
+#include <math.h>
 #include <grass/glocale.h>
-
 #include <liblas/capi/liblas.h>
-
 #include "local_proto.h"
 
 void print_lasinfo(LASHeaderH LAS_header, LASSRSH LAS_srs)
@@ -99,7 +97,7 @@ int scan_bounds(LASReaderH LAS_reader, int shell_style, int extents, int update,
     first = TRUE;
 
     /* init to nan in case no points are found */
-    min_x = max_x = min_y = max_y = min_z = max_z = 0.0 / 0.0;
+    min_x = max_x = min_y = max_y = min_z = max_z = NAN;
 
     G_verbose_message(_("Scanning data ..."));
 

--- a/raster/r.in.pdal/info.cpp
+++ b/raster/r.in.pdal/info.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "info.h"
+#include <cmath>
 
 void get_extent(struct StringList *infiles, double *min_x, double *max_x,
                 double *min_y, double *max_y, double *min_z, double *max_z)
@@ -17,7 +18,7 @@ void get_extent(struct StringList *infiles, double *min_x, double *max_x,
     pdal::StageFactory factory;
     bool first = 1;
 
-    *min_x = *max_x = *min_y = *max_y = *min_z = *max_z = 0.0 / 0.0;
+    *min_x = *max_x = *min_y = *max_y = *min_z = *max_z = NAN;
 
     for (int i = 0; i < infiles->num_items; i++) {
         const char *infile = infiles->items[i];

--- a/raster/r.in.xyz/main.c
+++ b/raster/r.in.xyz/main.c
@@ -124,8 +124,8 @@ int main(int argc, char *argv[])
     int arr_row, arr_col;
     unsigned long count, count_total;
 
-    double min = 0.0 / 0.0; /* init as nan */
-    double max = 0.0 / 0.0; /* init as nan */
+    double min = NAN;
+    double max = NAN;
     double zscale = 1.0;
     double vscale = 1.0;
     size_t offset, n_offset;

--- a/raster/r.li/r.li.padrange/padrange.c
+++ b/raster/r.li/r.li.padrange/padrange.c
@@ -312,8 +312,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                       (((NS_DIST1 + NS_DIST2) / 2) / hd.rows);
 
         /* get min and max patch size */
-        min = 1.0 / 0.0;  /* inf */
-        max = -1.0 / 0.0; /* -inf */
+        min = INFINITY;
+        max = -INFINITY;
         for (old_pid = 1; old_pid <= pid; old_pid++) {
             if (pst[old_pid].count > 0) {
                 area_p = cell_size_m * pst[old_pid].count / 10000;
@@ -549,8 +549,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                       (((NS_DIST1 + NS_DIST2) / 2) / hd.rows);
 
         /* get min and max patch size */
-        min = 1.0 / 0.0;  /* inf */
-        max = -1.0 / 0.0; /* -inf */
+        min = INFINITY;
+        max = -INFINITY;
         for (old_pid = 1; old_pid <= pid; old_pid++) {
             if (pst[old_pid].count > 0) {
                 area_p = cell_size_m * pst[old_pid].count / 10000;
@@ -786,8 +786,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                       (((NS_DIST1 + NS_DIST2) / 2) / hd.rows);
 
         /* get min and max patch size */
-        min = 1.0 / 0.0;  /* inf */
-        max = -1.0 / 0.0; /* -inf */
+        min = INFINITY;
+        max = -INFINITY;
         for (old_pid = 1; old_pid <= pid; old_pid++) {
             if (pst[old_pid].count > 0) {
                 area_p = cell_size_m * pst[old_pid].count / 10000;

--- a/raster/r.out.gdal/main.c
+++ b/raster/r.out.gdal/main.c
@@ -1047,11 +1047,11 @@ double set_default_nodata_value(GDALDataType datatype, double min, double max)
 
     case GDT_Float32:
     case GDT_CFloat32:
-        return 0.0 / 0.0;
+        return NAN;
 
     case GDT_Float64:
     case GDT_CFloat64:
-        return 0.0 / 0.0;
+        return NAN;
 
     default:
         return 0;

--- a/raster/r.series.accumulate/main.c
+++ b/raster/r.series.accumulate/main.c
@@ -171,9 +171,8 @@ int main(int argc, char *argv[])
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    lo = -1.0 / 0.0; /* -inf */
-    hi = 1.0 / 0.0;  /* inf */
-
+    lo = -INFINITY;
+    hi = INFINITY;
     method = METHOD_GDD;
     if (G_strncasecmp(parm.method->answer, "gdd", 3) == 0)
         method = METHOD_GDD;

--- a/raster/r.series/main.c
+++ b/raster/r.series/main.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <math.h>
 
 #include <grass/gis.h>
 #include <grass/glocale.h>
@@ -226,8 +227,8 @@ int main(int argc, char *argv[])
     nprocs = 1;
 #endif
 
-    lo = -1.0 / 0.0; /* -inf */
-    hi = 1.0 / 0.0;  /* inf */
+    lo = -INFINITY;
+    hi = INFINITY;
     if (parm.range->answer) {
         lo = atof(parm.range->answers[0]);
         hi = atof(parm.range->answers[1]);

--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -170,8 +170,8 @@ int main(int argc, char *argv[])
     /* table field separator */
     zone_info.sep = G_option_to_separator(param.separator);
 
-    zone_info.min = 0.0 / 0.0; /* set to nan as default */
-    zone_info.max = 0.0 / 0.0; /* set to nan as default */
+    zone_info.min = 0;
+    zone_info.max = 0;
     zone_info.n_zones = 0;
 
     fdz = NULL;

--- a/raster/r.univar/r3.univar_main.c
+++ b/raster/r.univar/r3.univar_main.c
@@ -132,10 +132,10 @@ int main(int argc, char *argv[])
     /* table field separator */
     zone_info.sep = G_option_to_separator(param.separator);
 
-    dmin = 0.0 / 0.0;          /* set to nan as default */
-    dmax = 0.0 / 0.0;          /* set to nan as default */
-    zone_info.min = 0.0 / 0.0; /* set to nan as default */
-    zone_info.max = 0.0 / 0.0; /* set to nan as default */
+    dmin = NAN;
+    dmax = NAN;
+    zone_info.min = 0;
+    zone_info.max = 0;
     zone_info.n_zones = 0;
 
     /* open 3D zoning raster with default region */

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -30,8 +30,8 @@ univar_stat *create_univar_stat_struct(int map_type, int n_perc)
     for (i = 0; i < n_zones; i++) {
         stats[i].sum = 0.0;
         stats[i].sumsq = 0.0;
-        stats[i].min = 0.0 / 0.0; /* set to nan as default */
-        stats[i].max = 0.0 / 0.0; /* set to nan as default */
+        stats[i].min = NAN;
+        stats[i].max = NAN;
         stats[i].n_perc = n_perc;
         if (n_perc > 0)
             stats[i].perc = (double *)G_malloc(n_perc * sizeof(double));
@@ -127,7 +127,7 @@ int print_stats(univar_stat *stats)
         var_coef = (stdev / mean) * 100.; /* perhaps stdev/fabs(mean) ? */
 
         if (stats[z].n == 0)
-            stats[z].sum = stats[z].sum_abs = 0.0 / 0.0;
+            stats[z].sum = stats[z].sum_abs = NAN;
         sprintf(sum_str, "%.15g", stats[z].sum);
         G_trim_decimal(sum_str);
 
@@ -186,9 +186,9 @@ int print_stats(univar_stat *stats)
             quartile_perc = (double *)G_calloc(stats[z].n_perc, sizeof(double));
 
             if (stats[z].n == 0) {
-                quartile_25 = median = quartile_75 = 0.0 / 0.0;
+                quartile_25 = median = quartile_75 = NAN;
                 for (i = 0; i < stats[z].n_perc; i++)
-                    quartile_perc[i] = 0.0 / 0.0;
+                    quartile_perc[i] = NAN;
             }
             else {
                 for (i = 0; i < stats[z].n_perc; i++) {
@@ -398,7 +398,7 @@ int print_stats_table(univar_stat *stats)
         var_coef = (stdev / mean) * 100.; /* perhaps stdev/fabs(mean) ? */
 
         if (stats[z].n == 0)
-            stats[z].sum = stats[z].sum_abs = 0.0 / 0.0;
+            stats[z].sum = stats[z].sum_abs = NAN;
 
         if (zone_info.n_zones) {
             int z_cat = z + zone_info.min;
@@ -446,9 +446,9 @@ int print_stats_table(univar_stat *stats)
             quartile_perc = (double *)G_calloc(stats[z].n_perc, sizeof(double));
 
             if (stats[z].n == 0) {
-                quartile_25 = median = quartile_75 = 0.0 / 0.0;
+                quartile_25 = median = quartile_75 = NAN;
                 for (i = 0; i < stats[z].n_perc; i++)
-                    quartile_perc[i] = 0.0 / 0.0;
+                    quartile_perc[i] = NAN;
             }
             else {
                 for (i = 0; i < stats[z].n_perc; i++) {

--- a/raster3d/r3.in.lidar/info.c
+++ b/raster3d/r3.in.lidar/info.c
@@ -13,6 +13,7 @@
  */
 
 #include <string.h>
+#include <math.h>
 
 #include <grass/glocale.h>
 
@@ -100,7 +101,7 @@ int scan_bounds(LASReaderH LAS_reader, int shell_style, int extents, int update,
     first = TRUE;
 
     /* init to nan in case no points are found */
-    min_x = max_x = min_y = max_y = min_z = max_z = 0.0 / 0.0;
+    min_x = max_x = min_y = max_y = min_z = max_z = NAN;
 
     G_verbose_message(_("Scanning data ..."));
 

--- a/vector/v.cluster/main.c
+++ b/vector/v.cluster/main.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
             c[2] = 0.0;
             n = 0;
             sum = sumsq = 0;
-            min = 1.0 / 0.0;
+            min = INFINITY;
             max = 0;
             kd = G_malloc(minpnts * sizeof(double));
             ki = G_malloc(minpnts * sizeof(int));
@@ -463,7 +463,7 @@ int main(int argc, char *argv[])
             c[2] = 0.0;
             n = 0;
             sum = sumsq = 0;
-            min = 1.0 / 0.0;
+            min = INFINITY;
             max = 0;
             kd = G_malloc(minpnts * sizeof(double));
             ki = G_malloc(minpnts * sizeof(int));

--- a/vector/v.distance/distance.c
+++ b/vector/v.distance/distance.c
@@ -11,7 +11,7 @@ int get_line_box(const struct line_pnts *Points, struct bound_box *box)
     int i;
 
     if (Points->n_points == 0) {
-        box->E = box->W = box->N = box->S = box->T = box->B = 0.0 / 0.0;
+        box->E = box->W = box->N = box->S = box->T = box->B = NAN;
         return 0;
     }
 

--- a/vector/v.univar/main.c
+++ b/vector/v.univar/main.c
@@ -71,13 +71,8 @@ double sumsq = 0.0;
 double sumcb = 0.0;
 double sumqt = 0.0;
 double sum_abs = 0.0;
-<<<<<<< HEAD
-double min = 0.0 / 0.0; /* init as nan */
-double max = 0.0 / 0.0;
-=======
 double min = NAN;
 double max = NAN;
->>>>>>> 78245fdb1d (cmake support preparation: use of INFINITY and NAN)
 double mean, mean_abs, pop_variance, sample_variance, pop_stdev, sample_stdev,
     pop_coeff_variation, kurtosis, skewness;
 double total_size = 0.0; /* total size: length/area */

--- a/vector/v.univar/main.c
+++ b/vector/v.univar/main.c
@@ -71,8 +71,13 @@ double sumsq = 0.0;
 double sumcb = 0.0;
 double sumqt = 0.0;
 double sum_abs = 0.0;
+<<<<<<< HEAD
 double min = 0.0 / 0.0; /* init as nan */
 double max = 0.0 / 0.0;
+=======
+double min = NAN;
+double max = NAN;
+>>>>>>> 78245fdb1d (cmake support preparation: use of INFINITY and NAN)
 double mean, mean_abs, pop_variance, sample_variance, pop_stdev, sample_stdev,
     pop_coeff_variation, kurtosis, skewness;
 double total_size = 0.0; /* total size: length/area */

--- a/vector/v.voronoi/skeleton.c
+++ b/vector/v.voronoi/skeleton.c
@@ -528,7 +528,7 @@ int tie_up(void)
                                  IPoints[i]);
         }
 
-        distmin = 1. / 0.; /* +inf */
+        distmin = INFINITY;
         xmin = x;
         ymin = y;
 


### PR DESCRIPTION
- use of `INFINITY` (1/0 = INFINITY) rather than only division by zero (this is supported by gcc and other compilers but not on Windows)
- use of `NAN` (0/0 = NAN) rather than only division by zero

Extracted from WIP PR #289

TODO: not sure about the changes in "raster/r.in.lidar/point_binning.c", taken from #289