### PR TITLE
wxGUI: Console: Export history of executed commands

### DIFF
--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -466,7 +466,7 @@ class GConsoleWindow(wx.SplitterWindow):
         event.Skip()
 
     def OnCmdExportHistory(self, event):
-        """Export history of executed commands into a file"""
+        """Export the history of executed commands stored in a .wxgui_history file to a selected file."""
         dlg = wx.FileDialog(
             self,
             message=_("Save file as..."),

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -480,10 +480,10 @@ class GConsoleWindow(wx.SplitterWindow):
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
-            self.cmdPrompt.CopyHistory(path)
-            self.showNotification.emit(
-                message=_("Command history saved to '{}'".format(path))
-            )
+            if self.cmdPrompt.CopyHistory(path):
+                self.showNotification.emit(
+                    message=_("Command history saved to '{}'".format(path))
+                )
 
         dlg.Destroy()
         event.Skip()

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -480,15 +480,7 @@ class GConsoleWindow(wx.SplitterWindow):
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
-            try:
-                self.cmdPrompt.CopyHistory(path)
-            except IOError as e:
-                GError(
-                    _(
-                        "Unable to copy .wxgui_history file to {}'.\n\nDetails: {}"
-                    ).format(path, e)
-                )
-
+            self.cmdPrompt.CopyHistory(path)
             self.showNotification.emit(
                 message=_("Command history saved to '{}'".format(path))
             )

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -471,8 +471,9 @@ class GConsoleWindow(wx.SplitterWindow):
             self,
             message=_("Save file as..."),
             defaultFile="grass_cmd_log.txt",
-            wildcard=_("%(txt)s (*.txt)|*.txt|%(files)s (*)|*")
-            % {"txt": _("Text files"), "files": _("Files")},
+            wildcard=_("{txt} (*.txt)|*.txt|{files} (*)|*").format(
+                txt=_("Text files"), files=_("Files")
+            ),
             style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
         )
 

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -466,7 +466,8 @@ class GConsoleWindow(wx.SplitterWindow):
         event.Skip()
 
     def OnCmdExportHistory(self, event):
-        """Export the history of executed commands stored in a .wxgui_history file to a selected file."""
+        """Export the history of executed commands stored
+        in a .wxgui_history file to a selected file."""
         dlg = wx.FileDialog(
             self,
             message=_("Save file as..."),
@@ -484,8 +485,8 @@ class GConsoleWindow(wx.SplitterWindow):
             except IOError as e:
                 GError(
                     _(
-                        "Unable to copy .wxgui_history file to '{filePath}'.\n\nDetails: {error}"
-                    ).format(filePath=path, error=e)
+                        "Unable to copy .wxgui_history file to {}'.\n\nDetails: {}"
+                    ).format(path, e)
                 )
 
             self.showNotification.emit(

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -43,7 +43,7 @@ from core.gconsole import (
 )
 from core.globalvar import CheckWxVersion, wxPythonPhoenix
 from gui_core.prompt import GPromptSTC
-from gui_core.wrap import Button, ClearButton, ToggleButton, StaticText, StaticBox
+from gui_core.wrap import Button, ClearButton, StaticText, StaticBox
 from core.settings import UserSettings
 
 

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -483,9 +483,9 @@ class GConsoleWindow(wx.SplitterWindow):
                 self.cmdPrompt.CopyHistory(path)
             except IOError as e:
                 GError(
-                    _("Unable to copy .wxgui_history file to '{filePath}'.\n\nDetails: {error}").format(
-                        filePath=path, error=e
-                    )
+                    _(
+                        "Unable to copy .wxgui_history file to '{filePath}'.\n\nDetails: {error}"
+                    ).format(filePath=path, error=e)
                 )
 
             self.showNotification.emit(

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -480,14 +480,10 @@ class GConsoleWindow(wx.SplitterWindow):
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             try:
-                with open(path, "w") as output:
-                    cmds = self.cmdPrompt.GetCommands()
-                    output.write("\n".join(cmds))
-                    if len(cmds) > 0:
-                        output.write("\n")
+                self.cmdPrompt.CopyHistory(path)
             except IOError as e:
                 GError(
-                    _("Unable to write file '{filePath}'.\n\nDetails: {error}").format(
+                    _("Unable to copy .wxgui_history file to '{filePath}'.\n\nDetails: {error}").format(
                         filePath=path, error=e
                     )
                 )

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -141,7 +141,7 @@ class GPrompt(object):
         self.ShowStatusText("")
 
     def CopyHistory(self, targetFile):
-        """Copy history file"""
+        """Copy history file to the target location"""
         env = grass.gisenv()
         historyFile = os.path.join(
             env["GISDBASE"],

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -151,7 +151,7 @@ class GPrompt(object):
         )
         try:
             shutil.copyfile(historyFile, targetFile)
-        except Exception as e:
+        except (IOError, OSError) as e:
             GError(
                 _("Unable to copy .wxgui_history file to {}'.\n\nDetails: {}").format(
                     historyFile, e

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -141,7 +141,8 @@ class GPrompt(object):
         self.ShowStatusText("")
 
     def CopyHistory(self, targetFile):
-        """Copy history file to the target location"""
+        """Copy history file to the target location.
+        Returns True if file is successfully copied."""
         env = grass.gisenv()
         historyFile = os.path.join(
             env["GISDBASE"],
@@ -153,10 +154,12 @@ class GPrompt(object):
             shutil.copyfile(historyFile, targetFile)
         except (IOError, OSError) as e:
             GError(
-                _("Unable to copy .wxgui_history file to {}'.\n\nDetails: {}").format(
-                    historyFile, e
+                _("Unable to copy file {} to {}'.\n\nDetails: {}").format(
+                    historyFile, targetFile, e
                 )
             )
+            return False
+        return True
 
     def GetCommands(self):
         """Get list of launched commands"""

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -34,7 +34,7 @@ from grass.pydispatch.signal import Signal
 
 from core import globalvar
 from core import utils
-from core.gcmd import EncodeString, DecodeString
+from core.gcmd import EncodeString, DecodeString, GError
 
 
 class GPrompt(object):
@@ -149,7 +149,14 @@ class GPrompt(object):
             env["MAPSET"],
             ".wxgui_history",
         )
-        shutil.copyfile(historyFile, targetFile)
+        try:
+            shutil.copyfile(historyFile, targetFile)
+        except Exception as e:
+            GError(
+                _("Unable to copy .wxgui_history file to {}'.\n\nDetails: {}").format(
+                    historyFile, e
+                )
+            )
 
     def GetCommands(self):
         """Get list of launched commands"""

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -22,6 +22,7 @@ import os
 import difflib
 import codecs
 import sys
+import shutil
 
 import wx
 import wx.stc
@@ -138,6 +139,17 @@ class GPrompt(object):
 
         self.OnCmdErase(None)
         self.ShowStatusText("")
+
+    def CopyHistory(self, targetFile):
+        """Copy history file"""
+        env = grass.gisenv()
+        historyFile = os.path.join(
+            env["GISDBASE"],
+            env["LOCATION_NAME"],
+            env["MAPSET"],
+            ".wxgui_history",
+        )
+        shutil.copyfile(historyFile, targetFile)
 
     def GetCommands(self):
         """Get list of launched commands"""

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -2257,10 +2257,6 @@ class GMFrame(wx.Frame):
 
     def _closeWindow(self, event):
         """Close wxGUI"""
-        # save command protocol if actived
-        if self.goutput.btnCmdProtocol.GetValue():
-            self.goutput.CmdProtocolSave()
-
         if not self.currentPage:
             self._auimgr.UnInit()
             self.Destroy()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -2296,10 +2296,6 @@ class GMFrame(wx.Frame):
 
     def _closeWindow(self, event):
         """Close wxGUI"""
-        # save command protocol if actived
-        if self.goutput.btnCmdProtocol.GetValue():
-            self.goutput.CmdProtocolSave()
-
         if not self.currentPage:
             self._auimgr.UnInit()
             self.Destroy()


### PR DESCRIPTION
This PR changes the way how the **Log file** button works. In this PR it is renamed to **Export history** because it better reflects what it newly does.

Original behavior (the button Log file is togglable):
1) Press the button Log file in the Console
2) Choose where you want to store executed commands
3) Starting this moment, all executed commands are stored to this file
4) Press the button Log file again and stop storing executed commands to the defined file

New behavior (the button Export History is not togglable):
1) Press the button Export History in the Console
2) Choose where you want to store executed commands
3) Store the whole history of executed commands (content of .wxgui_history file which is a part of a mapset)

All executed command history related to particular mapset environment can be automatically saved by clicking on the Export history button:
![Screenshot from 2022-12-04 16-46-45](https://user-images.githubusercontent.com/49241681/205500457-81453173-55d3-4901-b041-554bc4c96ec1.png)
