### PR TITLE
startup: catch errors in build_modules_xml.py, grass.py

### DIFF
--- a/gui/wxpython/tools/build_modules_xml.py
+++ b/gui/wxpython/tools/build_modules_xml.py
@@ -18,6 +18,7 @@ import sys
 
 import grass.script.core as gcore
 import grass.script.task as gtask
+from grass.exceptions import ScriptError
 
 
 def escapeXML(text):
@@ -80,11 +81,11 @@ def get_module_metadata(name):
     """
     try:
         task = gtask.parse_interface(name)
-    except:
+    except ScriptError as exc:
         sys.stderr.write(
             "Cannot parse interface for module %s. Empty strings"
             " will be placed instead of description and keywords."
-            "\n" % name
+            " Reason: %s\n" % (name, str(exc))
         )
         return "", ""
 

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -769,7 +769,7 @@ def set_paths(grass_config_dir):
 
     # Set LD_LIBRARY_PATH (etc) to find GRASS shared libraries
     # this works for subprocesses but won't affect the current process
-    if not LD_LIBRARY_PATH_VAR == "":
+    if LD_LIBRARY_PATH_VAR:
         path_prepend(gpath("lib"), LD_LIBRARY_PATH_VAR)
 
 

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -769,7 +769,8 @@ def set_paths(grass_config_dir):
 
     # Set LD_LIBRARY_PATH (etc) to find GRASS shared libraries
     # this works for subprocesses but won't affect the current process
-    path_prepend(gpath("lib"), LD_LIBRARY_PATH_VAR)
+    if not LD_LIBRARY_PATH_VAR == "":
+        path_prepend(gpath("lib"), LD_LIBRARY_PATH_VAR)
 
 
 def find_exe(pgm):


### PR DESCRIPTION
This PR is an extract from #348 (extracted and updated with `black`):

- gui/wxpython/tools/build_modules_xml.py edits:
    - https://github.com/OSGeo/grass/pull/348/files#diff-11ca77721b6d009b6537c54be4172efed843021797676258ad1141a6c63e6fd1
- lib/init/grass.py edit:
   - https://github.com/OSGeo/grass/pull/348/files#diff-647be4ef599868c33f2f69f0d899f79f0aee8d75d1db74f523268c1ac94cddf7

Not sure if we want these changes but just to avoid to see them lost when closing #348 in favour of #2684.