### PR TITLE
Add packaging status info widget across various GNU/Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ this issue, clean all the compiled files from the source code:
 ```bash
 make distclean
 ```
+
+## Packages
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/grass.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion=8.2.0)](https://repology.org/project/grass/versions)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ this issue, clean all the compiled files from the source code:
 make distclean
 ```
 
-## Packages
+## Available GNU/Linux and Unix-like OS packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/grass.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion=8.2.0)](https://repology.org/project/grass/versions)


### PR DESCRIPTION
Add [packaging status info widget](https://repology.org/badge/vertical-allrepos/grass.svg?exclude_unsupported=1&exclude_sources=modules,site&minversion=8.2.0)  (use https://repology.org/project/grass/badges) across various GNU/Linux distributions.