### PR TITLE
wxpyimgview: explicit conversion to int

### DIFF
--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -78,14 +78,14 @@ class Frame(wx.Frame):
     def draw(self):
         app = self.app
         size = self.GetSize()
-        x0 = (size.GetWidth() - app.i_width) / 2
-        y0 = (size.GetHeight() - app.i_height) / 2
+        x0 = (size.GetWidth() - app.i_width) // 2
+        y0 = (size.GetHeight() - app.i_height) // 2
         dc = wx.PaintDC(self)
         data = app.imgbuf.reshape((app.i_height, app.i_width, 4))
         data = data[::, ::, 2::-1]
         fn = getattr(data, "tobytes", getattr(data, "tostring"))
         image = wx.Image(app.i_width, app.i_height, fn())
-        dc.DrawBitmap(BitmapFromImage(image), int(x0), int(y0), False)
+        dc.DrawBitmap(BitmapFromImage(image), x0, y0, False)
 
     def redraw(self, ev):
         if self.app.fraction > 0.001:

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -85,7 +85,7 @@ class Frame(wx.Frame):
         data = data[::, ::, 2::-1]
         fn = getattr(data, "tobytes", getattr(data, "tostring"))
         image = wx.Image(app.i_width, app.i_height, fn())
-        dc.DrawBitmap(BitmapFromImage(image), x0, y0, False)
+        dc.DrawBitmap(BitmapFromImage(image), int(x0), int(y0), False)
 
     def redraw(self, ev):
         if self.app.fraction > 0.001:


### PR DESCRIPTION
Fixes `wxpyimgview` failure to run with Python 3.10:

```bash
wxpyimgview image=map.bmp percent=50
Traceback (most recent call last):
  File "/dev/grass/dist.aarch64-apple-darwin21.6.0/etc/wxpyimgview_gui.py", line 93, in redraw
    self.draw()
  File "/dev/grass/dist.aarch64-apple-darwin21.6.0/etc/wxpyimgview_gui.py", line 88, in draw
    dc.DrawBitmap(BitmapFromImage(image), x0, y0, False)
TypeError: DC.DrawBitmap(): arguments did not match any overloaded call:
  overload 1: argument 2 has unexpected type 'float'
  overload 2: argument 2 has unexpected type 'float'
```

Using:
Python 3.10.7 (v3.10.7:6cc6b13308, Sep  5 2022, 14:02:52) [Clang 13.0.0 (clang-1300.0.29.30)]
wxPython 4.2.0 osx-cocoa (phoenix) wxWidgets 3.2.0

