### PR TITLE
CI: add ClangFormat check

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,22 @@
+---
+name: ClangFormat Check
+on:
+  push:
+    branches:
+      - main
+      - releasebranch_*
+  pull_request:
+    branches:
+      - main
+      - releasebranch_*
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.9.0
+        with:
+          clang-format-version: "15"
+          check-path: .


### PR DESCRIPTION
This adds ClangFormat CI check.

To be merged after:

https://github.com/OSGeo/grass/pull/2272

https://github.com/OSGeo/grass/pull/2709
https://github.com/OSGeo/grass/pull/2710
https://github.com/OSGeo/grass/pull/2711
https://github.com/OSGeo/grass/pull/2712
https://github.com/OSGeo/grass/pull/2713
https://github.com/OSGeo/grass/pull/2714
https://github.com/OSGeo/grass/pull/2715
