### PR TITLE
r.proj: Fix a typo (lanzcos => lanczos)

### DIFF
--- a/raster/r.proj/r.proj.html
+++ b/raster/r.proj/r.proj.html
@@ -102,7 +102,7 @@ cells. The <b>method=bilinear</b> method determines the new value of
 the cell based on a weighted distance average of the 4 surrounding
 cells in the input map. The <b>method=bicubic</b> method determines the
 new value of the cell based on a weighted distance average of the 16
-surrounding cells in the input map. The <b>method=lanzcos</b> method
+surrounding cells in the input map. The <b>method=lanczos</b> method
 determines the new value of the cell based on a weighted distance
 average of the 25 surrounding cells in the input map. Compared to
 bicubic, lanczos puts a higher weight on cells close to the center and a


### PR DESCRIPTION
This PR fixes a typo in the r.proj manual. Corrects lan**zc**os to [lanczos](https://en.wikipedia.org/wiki/Lanczos_resampling).