### PR TITLE
i.maxlik: fix crash when classification result is NULL

### DIFF
--- a/imagery/i.maxlik/main.c
+++ b/imagery/i.maxlik/main.c
@@ -124,7 +124,8 @@ int main(int argc, char *argv[])
             for (int col = 0; col < ncols; col++) {
                 /* Predicted classes start at 1 but signature array is 0 based
                  */
-                class_cell[col] = S.sig[class_cell[col] - 1].oclass;
+                if (Rast_is_c_null_value(&class_cell[col]) == 0)
+                    class_cell[col] = S.sig[class_cell[col] - 1].oclass;
             }
         }
         Rast_put_row(class_fd, class_cell, CELL_TYPE);

--- a/imagery/i.maxlik/testsuite/test_i_maxlik.py
+++ b/imagery/i.maxlik/testsuite/test_i_maxlik.py
@@ -66,7 +66,7 @@ class SuccessTest(TestCase):
         )
         cls.runModule(
             "r.mapcalc",
-            expression=f"{cls.b2}=5.0+rand(-1.0,1.0)",
+            expression=f"{cls.b2}=if(row() == 3 && col() == 3, null(), 5.0+rand(-1.0,1.0))",
             flags="s",
             quiet=True,
         )


### PR DESCRIPTION
If any input cell from imagery group is NULL, the result of classification is also NULL. The implementation of original cat restoration (79f950095283fc351ecc83fc54b5cd7271101d21) did not check for this corner case and thus caused an out of bounds value access.