### PR TITLE
Close <li> and <p> tags in REQUIREMENTS.html

### DIFF
--- a/REQUIREMENTS.html
+++ b/REQUIREMENTS.html
@@ -19,6 +19,7 @@ depending on your platform and compiler flags. During a full compilation you may
 temporarily up to 550MB including the source code.
 <p>
 To enable and disable features please read the <a href="INSTALL.md">INSTALL.md</a> file.
+</p>
 
 <h3>General requirements:</h3>
 
@@ -96,6 +97,7 @@ to the v.select module<br>
 <a href="https://www.netlib.org/lapack">https://www.netlib.org/lapack</a> (usually available on Linux distros)
 <br>
 <i>Note:</i> LAPACK/BLAS support is at time only needed for selected Addons
+</li>
 
 <li><b>NetCDF</b> (for 3D raster netcdf export)<br>
 <a href="https://www.unidata.ucar.edu/software/netcdf/">https://www.unidata.ucar.edu/software/netcdf/</a>
@@ -214,6 +216,7 @@ newer versions are named "python-pillow"
  
 <li><b>Subversion</b> (svn in g.extension to fetch code selectively from grass-addons on GitHub)<br>
 <a href="https://subversion.apache.org/">https://subversion.apache.org/</a><br>
+</li>
 </ul>
 
 <h3>Note:</h3>
@@ -226,17 +229,21 @@ SUN Solaris users may go here to download precompiled libraries etc.:
 <!-- no longer supported: -->
 SGI IRIX users may go here to download precompiled libraries etc.:
 <br><a href="https://freeware.sgi.com">https://freeware.sgi.com</a>
+</p>
 
 <p>
 MacOSX users may go here to download precompiled libraries etc.:
 <br><a href="https://fink.sourceforge.net">https://fink.sourceforge.net</a>
+</p>
 
 <p>
+</p>
 
 <hr width="100%">
 <i>&copy; GRASS Development Team 1997-2023</i>
 
 <p>Please report bugs here:
 <br><a href="https://grass.osgeo.org/contribute/">https://grass.osgeo.org/contribute/</a>
+</p>
 </body>
 </html>


### PR DESCRIPTION
Any IDE with HTML support complains that the tags are unmatched in this file. It seems like a semi-dead file, but it is still under source control. 
I used a modern Chromium browser to place the closing tags at the sample place as the browser-parsed DOM.