### PR TITLE
Fix Wstringop-overflow and -Warray-parameter compiler warnings

### DIFF
--- a/imagery/i.ortho.photo/lib/orthophoto.h
+++ b/imagery/i.ortho.photo/lib/orthophoto.h
@@ -117,8 +117,8 @@ int I_put_con_points(char *, struct Ortho_Control_Points *);
 int I_convert_con_points(char *, struct Ortho_Control_Points *,
                          struct Ortho_Control_Points *, double[3], double[3]);
 /* georef.c */
-int I_compute_ref_equations(struct Ortho_Photo_Points *, double *, double *,
-                            double *, double *);
+int I_compute_ref_equations(struct Ortho_Photo_Points *, double[3], double[3],
+                            double[3], double[3]);
 /* orthoref.c */
 int I_compute_ortho_equations(struct Ortho_Control_Points *,
                               struct Ortho_Camera_File_Ref *,
@@ -140,7 +140,7 @@ int I_put_ref_points(char *, struct Ortho_Photo_Points *);
 
 /* cam_info.h */
 int I_read_cam_info(FILE *, struct Ortho_Camera_File_Ref *);
-int I_new_fid_point(struct Ortho_Camera_File_Ref *, char *, double, double);
+int I_new_fid_point(struct Ortho_Camera_File_Ref *, char[30], double, double);
 int I_write_cam_info(FILE *, struct Ortho_Camera_File_Ref *);
 int I_get_cam_info(char *, struct Ortho_Camera_File_Ref *);
 int I_put_cam_info(char *, struct Ortho_Camera_File_Ref *);

--- a/imagery/i.segment/iseg.h
+++ b/imagery/i.segment/iseg.h
@@ -141,7 +141,7 @@ int open_files(struct globals *);
 
 /* create_isegs.c */
 int create_isegs(struct globals *);
-void find_four_neighbors(int, int, int[][2]);
+void find_four_neighbors(int, int, int[8][2]);
 void find_eight_neighbors(int, int, int[8][2]);
 double calculate_euclidean_similarity(struct ngbr_stats *, struct ngbr_stats *,
                                       struct globals *);

--- a/include/grass/defs/ogsf.h
+++ b/include/grass/defs/ogsf.h
@@ -517,7 +517,7 @@ void gsd_scale(float, float, float);
 void gsd_translate(float, float, float);
 void gsd_rot(float, char);
 void gsd_checkwindow(int *, int *, double *, double *);
-int gsd_checkpoint(float *, int *, int *, double *, double *);
+int gsd_checkpoint(float[4], int[4], int[4], double[16], double[16]);
 void gsd_litvert_func(float *, unsigned long, float *);
 void gsd_litvert_func2(float *, unsigned long, float *);
 void gsd_vert_func(float *);

--- a/lib/ogsf/gpd.c
+++ b/lib/ogsf/gpd.c
@@ -214,7 +214,7 @@ void gpd_obj(geosurf *gs, gvstyle *style, Point3 pt)
  */
 int gpd_2dsite(geosite *gp, geosurf *gs, int do_fast)
 {
-    float site[3], konst;
+    float site[4], konst;
     int src, check;
     geopoint *gpt;
     typbuff *buf;
@@ -311,7 +311,7 @@ int gpd_2dsite(geosite *gp, geosurf *gs, int do_fast)
  */
 int gpd_3dsite(geosite *gp, float xo, float yo, int do_fast)
 {
-    float site[3], tz;
+    float site[4], tz;
     int check;
     geopoint *gpt;
     GLdouble modelMatrix[16], projMatrix[16];

--- a/lib/ogsf/gs2.c
+++ b/lib/ogsf/gs2.c
@@ -3282,7 +3282,7 @@ int GS_get_distance_alongsurf(int hs, float x1, float y1, float x2, float y2,
                               float *dist, int use_exag)
 {
     geosurf *gs;
-    float p1[2], p2[2];
+    Point3 p1, p2;
 
     gs = gs_get_surf(hs);
     if (gs == NULL) {

--- a/raster/r.circle/main.c
+++ b/raster/r.circle/main.c
@@ -23,7 +23,7 @@
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
-static double distance(double *, double *, double, double, int);
+static double distance(double[2], double[2], double, double, int);
 
 #ifndef HUGE_VAL
 #define HUGE_VAL 1.7976931348623157e+308

--- a/raster/r.surf.area/local_proto.h
+++ b/raster/r.surf.area/local_proto.h
@@ -5,6 +5,6 @@
 void add_row_area(DCELL *, DCELL *, double, struct Cell_head *, double *,
                   double *);
 void add_null_area(DCELL *, struct Cell_head *, double *);
-void v3cross(double[], double[], double[]);
-void v3mag(double[], double *);
+void v3cross(double[3], double[3], double[3]);
+void v3mag(double[3], double *);
 double conv_value(double, int);

--- a/vector/v.to.rast/do_lines.c
+++ b/vector/v.to.rast/do_lines.c
@@ -8,7 +8,7 @@
 /* function prototypes */
 static int plot_line(double *, double *, int, int, int);
 static int plot_points(double *, double *, int);
-static double v2angle(double *, double *, double, double);
+static double v2angle(double[2], double[2], double, double);
 static double deg_angle(double, double, double, double);
 
 int do_lines(struct Map_info *Map, struct line_pnts *Points,


### PR DESCRIPTION
Fixes `-Wstringop-overflow=` and `-Warray-parameter=` warnings surfaced with #2730. They are very much interrelated, it is therefore better to handle them in one PR.