### PR TITLE
CI/gcc: remove compiler warning exceptions

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: "-std=${{ matrix.c }} -fPIC -Wall -Wno-error=maybe-uninitialized"
+          CFLAGS: "-std=${{ matrix.c }} -fPIC -Wall"
           # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: "-std=${{ matrix.cpp }} -fPIC -Wall -Wno-error=class-memaccess"
+          CXXFLAGS: "-std=${{ matrix.cpp }} -fPIC -Wall"
         run: .github/workflows/build_ubuntu-20.04.sh $HOME/install -Werror


### PR DESCRIPTION
Makes the "GCC C/C++ standards check" CIs compile with -Wall, without exceptions.