### PR TITLE
diglib: fix integer overflow

### DIFF
--- a/lib/vector/diglib/spindex_rw.c
+++ b/lib/vector/diglib/spindex_rw.c
@@ -64,10 +64,10 @@ int dig_Wr_spidx_head(struct gvfile *fp, struct Plus_head *ptr)
     /* use ptr->off_t_size = 4 if possible */
     if (sizeof(off_t) > 4) {
         size = 145; /* max header size, see below */
-        size += ptr->Node_spidx->n_nodes * ptr->Node_spidx->nodesize;
-        size += ptr->Line_spidx->n_nodes * ptr->Line_spidx->nodesize;
-        size += ptr->Area_spidx->n_nodes * ptr->Area_spidx->nodesize;
-        size += ptr->Isle_spidx->n_nodes * ptr->Isle_spidx->nodesize;
+        size += (size_t)ptr->Node_spidx->n_nodes * ptr->Node_spidx->nodesize;
+        size += (size_t)ptr->Line_spidx->n_nodes * ptr->Line_spidx->nodesize;
+        size += (size_t)ptr->Area_spidx->n_nodes * ptr->Area_spidx->nodesize;
+        size += (size_t)ptr->Isle_spidx->n_nodes * ptr->Isle_spidx->nodesize;
 
         if (size < PORT_INT_MAX)
             ptr->spidx_port.off_t_size = 4;
@@ -282,6 +282,7 @@ int dig_Rd_spidx_head(struct gvfile *fp, struct Plus_head *ptr)
         ptr->version.spidx.back_major, ptr->version.spidx.back_minor);
 
     G_debug(2, "  byte order %d", byte_order);
+    G_debug(2, "  off_t size %d", ptr->spidx_port.off_t_size);
 
     /* check version numbers */
     if (ptr->version.spidx.major > GV_SIDX_VER_MAJOR ||

--- a/lib/vector/diglib/spindex_rw.c
+++ b/lib/vector/diglib/spindex_rw.c
@@ -56,18 +56,19 @@ int dig_Wr_spidx_head(struct gvfile *fp, struct Plus_head *ptr)
     unsigned char buf[6];
     long length = 81; /* header length in bytes */
     struct RTree *t;
-    size_t size;
 
     dig_rewind(fp);
     dig_set_cur_port(&(ptr->spidx_port));
 
     /* use ptr->off_t_size = 4 if possible */
     if (sizeof(off_t) > 4) {
+        off_t size;
+
         size = 145; /* max header size, see below */
-        size += (size_t)ptr->Node_spidx->n_nodes * ptr->Node_spidx->nodesize;
-        size += (size_t)ptr->Line_spidx->n_nodes * ptr->Line_spidx->nodesize;
-        size += (size_t)ptr->Area_spidx->n_nodes * ptr->Area_spidx->nodesize;
-        size += (size_t)ptr->Isle_spidx->n_nodes * ptr->Isle_spidx->nodesize;
+        size += (off_t)ptr->Node_spidx->n_nodes * ptr->Node_spidx->nodesize;
+        size += (off_t)ptr->Line_spidx->n_nodes * ptr->Line_spidx->nodesize;
+        size += (off_t)ptr->Area_spidx->n_nodes * ptr->Area_spidx->nodesize;
+        size += (off_t)ptr->Isle_spidx->n_nodes * ptr->Isle_spidx->nodesize;
 
         if (size < PORT_INT_MAX)
             ptr->spidx_port.off_t_size = 4;
@@ -1159,9 +1160,9 @@ static void rtree_load_from_sidx(struct gvfile *fp, off_t rootpos,
                                  struct RTree *t, int off_t_size)
 {
     if (t->fd > -1)
-        return rtree_load_to_file(fp, rootpos, t, off_t_size);
+        rtree_load_to_file(fp, rootpos, t, off_t_size);
     else
-        return rtree_load_to_memory(fp, rootpos, t, off_t_size);
+        rtree_load_to_memory(fp, rootpos, t, off_t_size);
 }
 
 /*!


### PR DESCRIPTION
This PR fixes an integer overflow when writing out spatial index files (sidx) larger than 2GB. With the integer overflow, the resultant file size is underestimated, a wrong size for writing out file offsets is used and the spatial index file becomes unreadable. Other potentially large vector files (coordinates, topology, category index) are not affected.