### PR TITLE
manual backport of #2735

### DIFF
--- a/lib/vector/diglib/spindex_rw.c
+++ b/lib/vector/diglib/spindex_rw.c
@@ -58,18 +58,19 @@ int dig_Wr_spidx_head(struct gvfile * fp, struct Plus_head *ptr)
     unsigned char buf[6];
     long length = 81;		/* header length in bytes */
     struct RTree *t;
-    size_t size;
 
     dig_rewind(fp);
     dig_set_cur_port(&(ptr->spidx_port));
 
     /* use ptr->off_t_size = 4 if possible */
     if (sizeof(off_t) > 4) {
+	off_t size;
+
 	size = 145;	/* max header size, see below */
-	size += ptr->Node_spidx->n_nodes * ptr->Node_spidx->nodesize;
-	size += ptr->Line_spidx->n_nodes * ptr->Line_spidx->nodesize;
-	size += ptr->Area_spidx->n_nodes * ptr->Area_spidx->nodesize;
-	size += ptr->Isle_spidx->n_nodes * ptr->Isle_spidx->nodesize;
+	size += (off_t)ptr->Node_spidx->n_nodes * ptr->Node_spidx->nodesize;
+	size += (off_t)ptr->Line_spidx->n_nodes * ptr->Line_spidx->nodesize;
+	size += (off_t)ptr->Area_spidx->n_nodes * ptr->Area_spidx->nodesize;
+	size += (off_t)ptr->Isle_spidx->n_nodes * ptr->Isle_spidx->nodesize;
 
 	if (size < PORT_INT_MAX)
 	    ptr->spidx_port.off_t_size = 4;


### PR DESCRIPTION
Manual backport of #2735 to G78 to fix integer overflow in diglib (cherry-picking not possible due to reformatted G83+).