### PR TITLE
CI: set -Werror on ubuntu test builds

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash -el {0}
         run: |
           printenv | sort
-          $CC --version
+          gcc --version
           lld --version
       - name: Build
         env:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Set LD_LIBRARY_PATH for compilation
         run: |
           echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
+      - name: Print build environment variables
+        shell: bash -el {0}
+        run: |
+          printenv | sort
+          $CC --version
+          lld --version
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           printenv | sort
           gcc --version
-          lld --version
+          ldd --version
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -52,8 +52,15 @@ jobs:
         run: |
           echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
 
+      - name: Print build environment variables
+        shell: bash -el {0}
+        run: |
+          printenv | sort
+          $CC --version
+          lld --version
+
       - name: Build
-        run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install
+        run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install -Werror
 
       - name: Add the bin directory to PATH
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: "-std=${{ matrix.c }} -fPIC"
+          CFLAGS: "-fPIC"
           # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: "-std=${{ matrix.cpp }} -fPIC"
+          CXXFLAGS: "-fPIC"
         run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install -Werror
 
       - name: Add the bin directory to PATH

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           printenv | sort
           gcc --version
-          lld --version
+          ldd --version
 
       - name: Build
         run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install -Werror

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash -el {0}
         run: |
           printenv | sort
-          $CC --version
+          gcc --version
           lld --version
 
       - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -60,6 +60,11 @@ jobs:
           ldd --version
 
       - name: Build
+        env:
+          # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
+          CFLAGS: "-std=${{ matrix.c }} -fPIC"
+          # TODO: -pedantic-errors here won't compile
+          CXXFLAGS: "-std=${{ matrix.cpp }} -fPIC"
         run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install -Werror
 
       - name: Add the bin directory to PATH


### PR DESCRIPTION
This set `-Werror` on Ubuntu test builds and in addition adds build-env-variables print on ubuntu and gcc builds for debugging info.