### PR TITLE
libproj: Use PJ_TYPE_BOUND_CRS only if Proj version >= 6

### DIFF
--- a/lib/proj/get_proj.c
+++ b/lib/proj/get_proj.c
@@ -275,6 +275,7 @@ int pj_get_kv(struct pj_info *info, const struct Key_Value *in_proj_keys,
     if (perr)
         G_fatal_error("PROJ 5 error %d", perr);
 
+#if PROJ_VERSION_MAJOR >= 6
     if (proj_get_type(pj) == PJ_TYPE_BOUND_CRS) {
         PJ *source_crs = proj_get_source_crs(pjc, pj);
         if (source_crs) {
@@ -282,6 +283,7 @@ int pj_get_kv(struct pj_info *info, const struct Key_Value *in_proj_keys,
             pj = source_crs;
         }
     }
+#endif
 #endif
 
     info->pj = pj;
@@ -426,6 +428,7 @@ int pj_get_string(struct pj_info *info, char *str)
         return -1;
     }
 
+#if PROJ_VERSION_MAJOR >= 6
     if (proj_get_type(pj) == PJ_TYPE_BOUND_CRS) {
         PJ *source_crs = proj_get_source_crs(pjc, pj);
         if (source_crs) {
@@ -433,6 +436,7 @@ int pj_get_string(struct pj_info *info, char *str)
             pj = source_crs;
         }
     }
+#endif
 #else
     /* Set finder function for locating datum conversion tables PK */
     pj_set_finder(FINDERFUNC);


### PR DESCRIPTION
This PR fixes a compilation error with PROJ < 6.