### PR TITLE
wxGUI Console: Button reorganization

### DIFF
--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -345,7 +345,7 @@ class ModelSearchDialog(wx.Dialog):
         self.search.Reset()
         self.label.SetValue("")
         self.comment.SetValue("")
-        self.cmd_prompt.OnCmdErase(None)
+        self.cmd_prompt.CmdErase()
         self.cmd_prompt.SetFocus()
 
 

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -171,7 +171,6 @@ class GConsoleWindow(wx.SplitterWindow):
                 flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP,
                 border=3,
             )
-
             helpText = StaticText(
                 self.panelPrompt,
                 id=wx.ID_ANY,

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -43,7 +43,7 @@ from core.gconsole import (
 )
 from core.globalvar import CheckWxVersion, wxPythonPhoenix
 from gui_core.prompt import GPromptSTC
-from gui_core.wrap import Button, ClearButton, StaticText, StaticBox
+from gui_core.wrap import Button, ClearButton, StaticText
 from core.settings import UserSettings
 
 
@@ -135,36 +135,22 @@ class GConsoleWindow(wx.SplitterWindow):
         if not self._gcstyle & GC_PROMPT:
             self.cmdPrompt.Hide()
 
-        if self._gcstyle & GC_PROMPT:
-            cmdLabel = _("Command prompt")
-            self.outputBox = StaticBox(
-                parent=self.panelOutput, id=wx.ID_ANY, label=" %s " % _("Output window")
-            )
-
-            self.cmdBox = StaticBox(
-                parent=self.panelOutput, id=wx.ID_ANY, label=" %s " % cmdLabel
-            )
-
         # buttons
-        self.btnOutputClear = ClearButton(parent=self.panelOutput)
+        self.btnOutputClear = ClearButton(parent=self.panelPrompt)
         self.btnOutputClear.SetToolTip(_("Clear output window content"))
-        self.btnCmdClear = ClearButton(parent=self.panelOutput)
-        self.btnCmdClear.SetToolTip(_("Clear command prompt content"))
-        self.btnOutputSave = Button(parent=self.panelOutput, id=wx.ID_SAVE)
+        self.btnOutputSave = Button(parent=self.panelPrompt, id=wx.ID_SAVE)
         self.btnOutputSave.SetToolTip(_("Save output window content to the file"))
         self.btnCmdAbort = Button(parent=self.panelProgress, id=wx.ID_STOP)
         self.btnCmdAbort.SetToolTip(_("Abort running command"))
-        self.btnCmdExportHistory = Button(parent=self.panelOutput, id=wx.ID_ANY)
+        self.btnCmdExportHistory = Button(parent=self.panelPrompt, id=wx.ID_ANY)
         self.btnCmdExportHistory.SetLabel(_("&Export history"))
         self.btnCmdExportHistory.SetToolTip(
             _("Export history of executed commands to a file")
         )
 
         if not self._gcstyle & GC_PROMPT:
-            self.btnCmdClear.Hide()
             self.btnCmdExportHistory.Hide()
 
-        self.btnCmdClear.Bind(wx.EVT_BUTTON, self.cmdPrompt.OnCmdErase)
         self.btnOutputClear.Bind(wx.EVT_BUTTON, self.OnOutputClear)
         self.btnOutputSave.Bind(wx.EVT_BUTTON, self.OnOutputSave)
         self.btnCmdAbort.Bind(wx.EVT_BUTTON, self._gconsole.OnCmdAbort)
@@ -176,13 +162,6 @@ class GConsoleWindow(wx.SplitterWindow):
         """Do layout"""
         self.outputSizer = wx.BoxSizer(wx.VERTICAL)
         progressSizer = wx.BoxSizer(wx.HORIZONTAL)
-        btnSizer = wx.BoxSizer(wx.HORIZONTAL)
-        if self._gcstyle & GC_PROMPT:
-            outBtnSizer = wx.StaticBoxSizer(self.outputBox, wx.HORIZONTAL)
-            cmdBtnSizer = wx.StaticBoxSizer(self.cmdBox, wx.HORIZONTAL)
-        else:
-            outBtnSizer = wx.BoxSizer(wx.HORIZONTAL)
-            cmdBtnSizer = wx.BoxSizer(wx.HORIZONTAL)
 
         if self._gcstyle & GC_PROMPT:
             promptSizer = wx.BoxSizer(wx.VERTICAL)
@@ -192,6 +171,7 @@ class GConsoleWindow(wx.SplitterWindow):
                 flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP,
                 border=3,
             )
+
             helpText = StaticText(
                 self.panelPrompt,
                 id=wx.ID_ANY,
@@ -202,45 +182,27 @@ class GConsoleWindow(wx.SplitterWindow):
             )
             promptSizer.Add(helpText, proportion=0, flag=wx.EXPAND | wx.LEFT, border=5)
 
+            btnSizer = wx.BoxSizer(wx.HORIZONTAL)
+            btnSizer.Add(
+                self.btnOutputSave,
+                proportion=0,
+                flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
+                border=5,
+            )
+            btnSizer.Add(
+                self.btnCmdExportHistory,
+                proportion=0,
+                flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
+                border=5,
+            )
+            btnSizer.AddStretchSpacer()
+            btnSizer.Add(self.btnOutputClear, proportion=0, flag=wx.EXPAND, border=5)
+            promptSizer.Add(btnSizer, proportion=0, flag=wx.ALL | wx.EXPAND, border=5)
+
         self.outputSizer.Add(
             self.cmdOutput, proportion=1, flag=wx.EXPAND | wx.ALL, border=3
         )
-        if self._gcstyle & GC_PROMPT:
-            proportion = 1
-        else:
-            proportion = 0
-            outBtnSizer.AddStretchSpacer()
 
-        outBtnSizer.Add(
-            self.btnOutputClear,
-            proportion=proportion,
-            flag=wx.ALIGN_LEFT | wx.LEFT | wx.RIGHT | wx.BOTTOM,
-            border=5,
-        )
-
-        outBtnSizer.Add(
-            self.btnOutputSave,
-            proportion=proportion,
-            flag=wx.RIGHT | wx.BOTTOM,
-            border=5,
-        )
-
-        cmdBtnSizer.Add(
-            self.btnCmdExportHistory,
-            proportion=1,
-            flag=wx.ALIGN_CENTER
-            | wx.ALIGN_CENTER_VERTICAL
-            | wx.LEFT
-            | wx.RIGHT
-            | wx.BOTTOM,
-            border=5,
-        )
-        cmdBtnSizer.Add(
-            self.btnCmdClear,
-            proportion=1,
-            flag=wx.ALIGN_CENTER | wx.RIGHT | wx.BOTTOM,
-            border=5,
-        )
         progressSizer.Add(
             self.btnCmdAbort, proportion=0, flag=wx.ALL | wx.ALIGN_CENTER, border=5
         )
@@ -253,16 +215,7 @@ class GConsoleWindow(wx.SplitterWindow):
 
         self.panelProgress.SetSizer(progressSizer)
         progressSizer.Fit(self.panelProgress)
-
-        btnSizer.Add(outBtnSizer, proportion=1, flag=wx.ALL | wx.ALIGN_CENTER, border=5)
-        btnSizer.Add(
-            cmdBtnSizer,
-            proportion=1,
-            flag=wx.ALIGN_CENTER | wx.TOP | wx.BOTTOM | wx.RIGHT,
-            border=5,
-        )
         self.outputSizer.Add(self.panelProgress, proportion=0, flag=wx.EXPAND)
-        self.outputSizer.Add(btnSizer, proportion=0, flag=wx.EXPAND)
 
         self.outputSizer.Fit(self)
         self.outputSizer.SetSizeHints(self)
@@ -279,7 +232,7 @@ class GConsoleWindow(wx.SplitterWindow):
         else:
             self.SplitHorizontally(self.panelOutput, self.panelPrompt, -45)
             self.Unsplit()
-        self.SetMinimumPaneSize(self.btnCmdClear.GetSize()[1] + 25)
+        self.SetMinimumPaneSize(self.btnOutputClear.GetSize()[1] + 100)
 
         self.SetSashGravity(1.0)
 

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -137,9 +137,9 @@ class GConsoleWindow(wx.SplitterWindow):
 
         # buttons
         self.btnClear = ClearButton(parent=self.panelPrompt)
-        self.btnClear.SetToolTip(_("Clear content of output and command windows"))
+        self.btnClear.SetToolTip(_("Clear prompt and output window"))
         self.btnOutputSave = Button(parent=self.panelPrompt, id=wx.ID_SAVE)
-        self.btnOutputSave.SetToolTip(_("Save output window content to the file"))
+        self.btnOutputSave.SetToolTip(_("Save output to a file"))
         self.btnCmdAbort = Button(parent=self.panelProgress, id=wx.ID_STOP)
         self.btnCmdAbort.SetToolTip(_("Abort running command"))
         self.btnCmdExportHistory = Button(parent=self.panelPrompt, id=wx.ID_ANY)
@@ -231,7 +231,7 @@ class GConsoleWindow(wx.SplitterWindow):
             self.Unsplit()
         self.SetMinimumPaneSize(self.btnClear.GetSize()[1] + 100)
 
-        self.SetSashGravity(0.5)
+        self.SetSashGravity(1.0)
 
         self.outputSizer.Hide(self.panelProgress)
         # layout

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -226,10 +226,8 @@ class GConsoleWindow(wx.SplitterWindow):
             self.panelPrompt.SetSizer(promptSizer)
 
         # split window
-        if self._gcstyle & GC_PROMPT:
-            self.SplitHorizontally(self.panelOutput, self.panelPrompt, 0)
-        else:
-            self.SplitHorizontally(self.panelOutput, self.panelPrompt, 0)
+        self.SplitHorizontally(self.panelOutput, self.panelPrompt, 0)
+        if not (self._gcstyle & GC_PROMPT):
             self.Unsplit()
         self.SetMinimumPaneSize(self.btnClear.GetSize()[1] + 100)
 

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -227,13 +227,13 @@ class GConsoleWindow(wx.SplitterWindow):
 
         # split window
         if self._gcstyle & GC_PROMPT:
-            self.SplitHorizontally(self.panelOutput, self.panelPrompt, -50)
+            self.SplitHorizontally(self.panelOutput, self.panelPrompt, 0)
         else:
-            self.SplitHorizontally(self.panelOutput, self.panelPrompt, -45)
+            self.SplitHorizontally(self.panelOutput, self.panelPrompt, 0)
             self.Unsplit()
         self.SetMinimumPaneSize(self.btnClear.GetSize()[1] + 100)
 
-        self.SetSashGravity(1.0)
+        self.SetSashGravity(0.5)
 
         self.outputSizer.Hide(self.panelProgress)
         # layout

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -136,8 +136,8 @@ class GConsoleWindow(wx.SplitterWindow):
             self.cmdPrompt.Hide()
 
         # buttons
-        self.btnOutputClear = ClearButton(parent=self.panelPrompt)
-        self.btnOutputClear.SetToolTip(_("Clear output window content"))
+        self.btnClear = ClearButton(parent=self.panelPrompt)
+        self.btnClear.SetToolTip(_("Clear content of output and command windows"))
         self.btnOutputSave = Button(parent=self.panelPrompt, id=wx.ID_SAVE)
         self.btnOutputSave.SetToolTip(_("Save output window content to the file"))
         self.btnCmdAbort = Button(parent=self.panelProgress, id=wx.ID_STOP)
@@ -151,7 +151,7 @@ class GConsoleWindow(wx.SplitterWindow):
         if not self._gcstyle & GC_PROMPT:
             self.btnCmdExportHistory.Hide()
 
-        self.btnOutputClear.Bind(wx.EVT_BUTTON, self.OnOutputClear)
+        self.btnClear.Bind(wx.EVT_BUTTON, self.OnClear)
         self.btnOutputSave.Bind(wx.EVT_BUTTON, self.OnOutputSave)
         self.btnCmdAbort.Bind(wx.EVT_BUTTON, self._gconsole.OnCmdAbort)
         self.btnCmdExportHistory.Bind(wx.EVT_BUTTON, self.OnCmdExportHistory)
@@ -195,7 +195,7 @@ class GConsoleWindow(wx.SplitterWindow):
                 border=5,
             )
             btnSizer.AddStretchSpacer()
-            btnSizer.Add(self.btnOutputClear, proportion=0, flag=wx.EXPAND, border=5)
+            btnSizer.Add(self.btnClear, proportion=0, flag=wx.EXPAND, border=5)
             promptSizer.Add(btnSizer, proportion=0, flag=wx.ALL | wx.EXPAND, border=5)
 
         self.outputSizer.Add(
@@ -231,7 +231,7 @@ class GConsoleWindow(wx.SplitterWindow):
         else:
             self.SplitHorizontally(self.panelOutput, self.panelPrompt, -45)
             self.Unsplit()
-        self.SetMinimumPaneSize(self.btnOutputClear.GetSize()[1] + 100)
+        self.SetMinimumPaneSize(self.btnClear.GetSize()[1] + 100)
 
         self.SetSashGravity(1.0)
 
@@ -330,12 +330,13 @@ class GConsoleWindow(wx.SplitterWindow):
             notification=Notification.MAKE_VISIBLE,
         )
 
-    def OnOutputClear(self, event):
-        """Clear content of output window"""
+    def OnClear(self, event):
+        """Clear content of output window and command window"""
         self.cmdOutput.SetReadOnly(False)
         self.cmdOutput.ClearAll()
         self.cmdOutput.SetReadOnly(True)
         self.progressbar.SetValue(0)
+        self.cmdPrompt.CmdErase()
 
     def GetProgressBar(self):
         """Return progress bar widget"""

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -137,7 +137,7 @@ class GPrompt(object):
 
         self.promptRunCmd.emit(cmd=cmd)
 
-        self.OnCmdErase(None)
+        self.CmdErase()
         self.ShowStatusText("")
 
     def CopyHistory(self, targetFile):
@@ -703,7 +703,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             wx.TheClipboard.Flush()
         event.Skip()
 
-    def OnCmdErase(self, event):
+    def CmdErase(self):
         """Erase command prompt"""
         self.Home()
         self.DelLineRight()


### PR DESCRIPTION
This PR solves two things:
* reduces the number of Console buttons by removing the Clear prompt button
* removes bounding boxes around buttons
* moves buttons to the bottom of the Console pane

Before:
![Screenshot from 2023-01-13 16-00-36](https://user-images.githubusercontent.com/49241681/212351904-941feac5-02af-4479-a703-a4fd12815627.png)

The main problem was that the right part of the button line could be cut off in Single-Window GUI (simply by shrinking the side Console pane):
![Screenshot from 2023-01-13 16-00-58](https://user-images.githubusercontent.com/49241681/212351894-4ed9942b-b2e6-4558-86b0-220136068688.png)

After:
![Screenshot from 2023-01-13 15-45-19](https://user-images.githubusercontent.com/49241681/212350603-334d22d8-39f5-4565-aa54-1f3aaf0dfe25.png)
The suggestion is very similar to the solution in other panes (Tools, Python).
Follows the suggestion in https://github.com/OSGeo/grass/issues/2585#issuecomment-1333143997.
