### PR TITLE
r3.in.v5d: Fix -Wliteral-range compiler warning

### DIFF
--- a/raster3d/r3.in.v5d/main.c
+++ b/raster3d/r3.in.v5d/main.c
@@ -138,7 +138,7 @@ void convert(char *openFile, RASTER3D_Region *region, int convertNull,
                 for (y = 0; y < region->rows; y++) {
                     for (x = 0; x < region->cols; x++) {
                         value = data1[cnt++];
-                        if (convertNull && (value == MISSING))
+                        if (convertNull && IS_MISSING(value))
                             Rast3d_set_null_value(&value, 1, FCELL_TYPE);
                         Rast3d_put_float(map, x, y, z, value);
                     }


### PR DESCRIPTION
Addresses a `-Wliteral-range` compiler warning, with the message:

> floating-point comparison is always false; constant cannot be represented exactly in type 'float' 

Fixes partly #2747.