### PR TITLE
configure: remove pdal cppflags

### DIFF
--- a/configure
+++ b/configure
@@ -9400,7 +9400,6 @@ fi
 
   if test "$PDAL_CONFIG" != "" ; then
     PDAL_LIBS=`"$PDAL_CONFIG" --libs`
-    PDAL_CPPFLAGS=`"$PDAL_CONFIG" --cxxflags`
     PDAL_INC=`"$PDAL_CONFIG" --includes`
     USE_PDAL=1
   fi
@@ -9408,10 +9407,8 @@ fi
   PDAL=
   ac_save_libs="$LIBS"
   ac_save_cflags="$CFLAGS"
-  ac_save_cppflags="$CPPFLAGS"
   LIBS="$LIBS $PDAL_LIBS"
   CFLAGS="$CFLAGS $PDAL_CFLAGS"
-  CPPFLAGS="$CPPFLAGS $PDAL_CPPFLAGS $PDAL_INC"
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -9458,7 +9455,6 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   LIBS=${ac_save_libs}
   CFLAGS=${ac_save_cflags}
-  CPPFLAGS=${ac_save_cppflags}
 
 
 $as_echo "#define HAVE_PDAL 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -1059,7 +1059,6 @@ else
 
   if test "$PDAL_CONFIG" != "" ; then
     PDAL_LIBS=`"$PDAL_CONFIG" --libs`
-    PDAL_CPPFLAGS=`"$PDAL_CONFIG" --cxxflags`
     PDAL_INC=`"$PDAL_CONFIG" --includes`
     USE_PDAL=1
   fi
@@ -1067,10 +1066,8 @@ else
   PDAL=
   ac_save_libs="$LIBS"
   ac_save_cflags="$CFLAGS"
-  ac_save_cppflags="$CPPFLAGS"
   LIBS="$LIBS $PDAL_LIBS"
   CFLAGS="$CFLAGS $PDAL_CFLAGS"
-  CPPFLAGS="$CPPFLAGS $PDAL_CPPFLAGS $PDAL_INC"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/PointTable.hpp>
   #include <pdal/Streamable.hpp>
   class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],[],[
@@ -1082,7 +1079,6 @@ else
   ])
   LIBS=${ac_save_libs}
   CFLAGS=${ac_save_cflags}
-  CPPFLAGS=${ac_save_cppflags}
 
   AC_DEFINE(HAVE_PDAL, 1, [define if PDAL exists])
 fi

--- a/include/Make/Platform.make.in
+++ b/include/Make/Platform.make.in
@@ -181,7 +181,6 @@ USE_LIBLAS          = @USE_LIBLAS@
 
 #LAS LiDAR through PDAL
 PDALLIBS             = @PDAL_LIBS@
-PDALCPPFLAGS         = @PDAL_CPPFLAGS@
 PDALINC              = @PDAL_INC@
 USE_PDAL             = @USE_PDAL@
 

--- a/raster/r.in.pdal/Makefile
+++ b/raster/r.in.pdal/Makefile
@@ -10,12 +10,6 @@ EXTRA_CFLAGS = $(VECT_CFLAGS)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make
 
-$(OBJDIR)/main.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
-
-$(OBJDIR)/info.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
-
-$(OBJDIR)/grasslidarfilter.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
-
 LINK = $(CXX)
 
 ifneq ($(strip $(CXX)),)

--- a/vector/v.in.pdal/Makefile
+++ b/vector/v.in.pdal/Makefile
@@ -10,8 +10,6 @@ EXTRA_CFLAGS = $(VECT_CFLAGS)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make
 
-$(OBJDIR)/main.o : EXTRA_CFLAGS += $(PDALCPPFLAGS)
-
 LINK = $(CXX)
 
 ifneq ($(strip $(CXX)),)


### PR DESCRIPTION
GRASS configure now fails with PDAL 2.5, see current CI Mac builds. Upstream pdal-config is outdated returning `-std=c++11`, while C++17 is in fact needed.

From https://github.com/PDAL/PDAL/blob/master/RELEASENOTES.txt under "2.4.0":
> A compiler that supports C++17 is now required to build PDAL or include PDAL headers in your code.

This is the least invasive fix for this I could think of, and may be backported too.