### PR TITLE
ximgview: Fix -Wsometimes-uninitialized warning

### DIFF
--- a/visualization/ximgview/main.c
+++ b/visualization/ximgview/main.c
@@ -145,7 +145,7 @@ static void main_loop(void)
     for (;;) {
         fd_set waitset;
         struct timeval tv;
-        unsigned long delay;
+        unsigned long delay = 0;
 
         while (XPending(dpy) > 0) {
             XEvent event;


### PR DESCRIPTION
Fixes partly https://github.com/OSGeo/grass/issues/2747.