### PR TITLE
r.geomorphon: fix -Wextra compiler warning

### DIFF
--- a/raster/r.geomorphon/geom.c
+++ b/raster/r.geomorphon/geom.c
@@ -219,23 +219,23 @@ float variance(float *elevation, int pattern_size)
     return variance / (float)pattern_size;
 }
 
-int radial2cartesian(PATTERN *pattern)
+void radial2cartesian(PATTERN *pattern)
 {
     /* this function converts radial coordinates of geomorphon
      * (assuming center as 0,0) to cartezian coordinates
      * with the beginning in the central cell of geomorphon */
     int i;
 
-    for (i = 0; i < NUM_DIRS; ++i)
-        if (pattern->distance > 0) {
+    for (i = 0; i < NUM_DIRS; ++i) {
+        if (pattern->distance[0] > 0.) {
             pattern->x[i] = pattern->distance[i] * sins[i];
             pattern->y[i] = pattern->distance[i] * coss[i];
         }
         else {
-            pattern->x[i] = 0;
-            pattern->y[i] = 0;
+            pattern->x[i] = 0.;
+            pattern->y[i] = 0.;
         }
-    return 0;
+    }
 }
 
 /*

--- a/raster/r.geomorphon/local_proto.h
+++ b/raster/r.geomorphon/local_proto.h
@@ -108,7 +108,7 @@ double octa_perimeter(const PATTERN *);
 double octa_area(const PATTERN *);
 double mesh_perimeter(const PATTERN *);
 double mesh_area(const PATTERN *);
-int radial2cartesian(PATTERN *);
+void radial2cartesian(PATTERN *);
 
 /* profile */
 void prof_int(const char *, const int);


### PR DESCRIPTION
The warning issued:

> warning: ordered comparison of pointer with integer zero [-Wextra]

referring to `pattern->distance > 0`

In addition changes unused return type int to void for `radial2cartesian()`.

Fixes partly #2747.