### PR TITLE
Add pre-commit hook file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.33.0
+    hooks:
+      - id: markdownlint
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 ---
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        exclude: |
+          (?x)^(
+                python/libgrass_interface_generator/
+          )
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        exclude: |
+          (?x)^(
+                python/libgrass_interface_generator/
+          )
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.6
+    hooks:
+      - id: clang-format


### PR DESCRIPTION
This adds [pre-commit](https://pre-commit.com) hook file, which runs and checks black, flake8 and clang-format on staged files.


```bash
cd grass-source-dir
python -m pip install pre-commit
# following step once per repo
pre-commit install

# edit files ...

git add <modified_files>

# following step triggers the hook
git commit
```

This is by far the simplest way to keep the files in a good shape. Also it will save **a lot** of CI builds, with no need for correcting pushed and failed commits.

The black and flake8 part may be backported to 8.2.
