### PR TITLE
Replace sprintf() with snprintf() in C++ code

### DIFF
--- a/include/grass/iostream/ami_stream.h
+++ b/include/grass/iostream/ami_stream.h
@@ -652,7 +652,8 @@ template <class T>
 char *AMI_STREAM<T>::sprint()
 {
     static char desc[BUFSIZ + 256];
-    sprintf(desc, "[AMI_STREAM %s %ld]", path, (long)stream_len());
+    snprintf(desc, sizeof(desc), "[AMI_STREAM %s %ld]", path,
+             (long)stream_len());
     return desc;
 }
 

--- a/include/grass/iostream/embuffer.h
+++ b/include/grass/iostream/embuffer.h
@@ -414,28 +414,29 @@ em_buffer<T, Key>::em_buffer(const unsigned short i, const unsigned long bs,
     assert((level >= 1) && (basesize >= 0));
 
     char str[100];
-    sprintf(str, "em_buffer: allocate %d AMI_STREAM*, total %ld\n", arity,
-            (long)(arity * sizeof(AMI_STREAM<T> *)));
+    snprintf(str, sizeof(str),
+             "em_buffer: allocate %d AMI_STREAM*, total %ld\n", arity,
+             (long)(arity * sizeof(AMI_STREAM<T> *)));
     MEMORY_LOG(str);
     // allocate STREAM* array
     data = new AMI_STREAM<T> *[arity];
 
     // allocate deleted array
-    sprintf(str, "em_buffer: allocate deleted array: %ld\n",
-            (long)(arity * sizeof(long)));
+    snprintf(str, sizeof(str), "em_buffer: allocate deleted array: %ld\n",
+             (long)(arity * sizeof(long)));
     MEMORY_LOG(str);
     deleted = new long[arity];
 
     // allocate streamsize array
-    sprintf(str, "em_buffer: allocate streamsize array: %ld\n",
-            (long)(arity * sizeof(long)));
+    snprintf(str, sizeof(str), "em_buffer: allocate streamsize array: %ld\n",
+             (long)(arity * sizeof(long)));
     MEMORY_LOG(str);
     streamsize = new unsigned long[arity];
 
 #ifdef SAVE_MEMORY
     // allocate name array
-    sprintf(str, "em_buffer: allocate name array: %ld\n",
-            (long)(arity * sizeof(char *)));
+    snprintf(str, sizeof(str), "em_buffer: allocate name array: %ld\n",
+             (long)(arity * sizeof(char *)));
     MEMORY_LOG(str);
     name = new char *[arity];
     assert(name);
@@ -937,9 +938,9 @@ AMI_err em_buffer<T, Key>::substream_merge(AMI_STREAM<T> **instreams,
     AMI_err ami_err;
 
     char str[200];
-    sprintf(str,
-            "em_buffer::substream_merge: allocate keys array, total %ldB\n",
-            (long)((long)arity * sizeof(merge_key<Key>)));
+    snprintf(str, sizeof(str),
+             "em_buffer::substream_merge: allocate keys array, total %ldB\n",
+             (long)((long)arity * sizeof(merge_key<Key>)));
     MEMORY_LOG(str);
 
     // keys array is initialized with smallest key from each stream (only

--- a/include/grass/iostream/empq_impl.h
+++ b/include/grass/iostream/empq_impl.h
@@ -163,8 +163,9 @@ em_pqueue<T, Key>::em_pqueue(long pq_sz, long buf_sz, unsigned short nb_buf,
     assert(buff_0);
 
     char str[200];
-    sprintf(str, "em_pqueue: allocating array of %ld buff pointers\n",
-            (long)max_nbuf);
+    snprintf(str, sizeof(str),
+             "em_pqueue: allocating array of %ld buff pointers\n",
+             (long)max_nbuf);
     MEMORY_LOG(str);
 
     // allocate ext memory buffers array
@@ -317,8 +318,9 @@ em_pqueue<T, Key>::em_pqueue()
 
     // allocate ext memory buffers array
     char str[200];
-    sprintf(str, "em_pqueue: allocating array of %ld buff pointers\n",
-            (long)max_nbuf);
+    snprintf(str, sizeof(str),
+             "em_pqueue: allocating array of %ld buff pointers\n",
+             (long)max_nbuf);
     MEMORY_LOG(str);
     // allocate ext memory buffers array
     buff = new em_buffer<T, Key> *[max_nbuf];
@@ -445,8 +447,9 @@ em_pqueue<T, Key>::em_pqueue(MinMaxHeap<T> *im, AMI_STREAM<T> *amis)
 
     // allocate ext memory buffer array
     char str[200];
-    sprintf(str, "em_pqueue: allocating array of %ld buff pointers\n",
-            (long)max_nbuf);
+    snprintf(str, sizeof(str),
+             "em_pqueue: allocating array of %ld buff pointers\n",
+             (long)max_nbuf);
     MEMORY_LOG(str);
     buff = new em_buffer<T, Key> *[max_nbuf];
     assert(buff);
@@ -594,8 +597,9 @@ bool em_pqueue<T, Key>::fillpq()
     AMI_err ae;
     {
         char str[200];
-        sprintf(str, "em_pqueue::fillpq: allocate array of %hd AMI_STREAMs\n",
-                crt_buf);
+        snprintf(str, sizeof(str),
+                 "em_pqueue::fillpq: allocate array of %hd AMI_STREAMs\n",
+                 crt_buf);
         MEMORY_LOG(str);
     }
     // merge pqsize smallest elements from each buffer into a new stream
@@ -1178,8 +1182,8 @@ void em_pqueue<T, Key>::empty_buff(unsigned short i)
     if (!buff[i + 1]) {
         // create buff[i+1] as a level-(i+2) buffer
         char str[200];
-        sprintf(str, "em_pqueue::empty_buff( %hd ) allocate new em_buffer\n",
-                i);
+        snprintf(str, sizeof(str),
+                 "em_pqueue::empty_buff( %hd ) allocate new em_buffer\n", i);
         MEMORY_LOG(str);
         buff[i + 1] = new em_buffer<T, Key>(i + 2, bufsize, buf_arity);
     }

--- a/include/grass/iostream/imbuffer.h
+++ b/include/grass/iostream/imbuffer.h
@@ -91,7 +91,8 @@ public:
         assert(n >= 0);
 
         char str[100];
-        sprintf(str, "im_buffer: allocate %ld\n", (long)(maxsize * sizeof(T)));
+        snprintf(str, sizeof(str), "im_buffer: allocate %ld\n",
+                 (long)(maxsize * sizeof(T)));
         MEMORY_LOG(str);
 
         data = new T[maxsize];

--- a/include/grass/iostream/mem_stream.h
+++ b/include/grass/iostream/mem_stream.h
@@ -167,7 +167,7 @@ template <class T>
 char *MEM_STREAM<T>::sprint()
 {
     static char buf[BUFSIZ];
-    sprintf(buf, "[MEM_STREAM %d]", stream_len());
+    snprintf(buf, sizeof(buf), "[MEM_STREAM %d]", stream_len());
     return buf;
 }
 

--- a/include/grass/iostream/minmaxheap.h
+++ b/include/grass/iostream/minmaxheap.h
@@ -93,8 +93,8 @@ public:
     BasicMinMaxHeap(HeapIndex size) : maxsize(size)
     {
         char str[100];
-        sprintf(str, "BasicMinMaxHeap: allocate %ld\n",
-                (long)((size + 1) * sizeof(T)));
+        snprintf(str, sizeof(str), "BasicMinMaxHeap: allocate %ld\n",
+                 (long)((size + 1) * sizeof(T)));
         // MEMORY_LOG(str);
 
         lastindex = 0;

--- a/lib/iostream/ami_stream.cpp
+++ b/lib/iostream/ami_stream.cpp
@@ -81,7 +81,7 @@ int ami_single_temp_name(const std::string &base, char *tmp_path)
         assert(base_dir);
         exit(1);
     }
-    sprintf(tmp_path, "%s/%s_XXXXXX", base_dir, base.c_str());
+    snprintf(tmp_path, GPATH_MAX, "%s/%s_XXXXXX", base_dir, base.c_str());
 
     fd = G_mkstemp(tmp_path, O_RDWR, 0600);
 

--- a/lib/iostream/rtimer.cpp
+++ b/lib/iostream/rtimer.cpp
@@ -38,24 +38,25 @@
 #include <string.h>
 #include <strings.h>
 
-// #include <rtimer.h>
 #include <grass/iostream/rtimer.h>
+
+#define BUFMAX 256
 
 char *rt_sprint_safe(char *buf, Rtimer rt)
 {
     if (rt_w_useconds(rt) == 0) {
-        sprintf(buf, "[%4.2fu (%.0f%%) %4.2fs (%.0f%%) %4.2f %.1f%%]", 0.0, 0.0,
-                0.0, 0.0, 0.0, 0.0);
+        snprintf(buf, BUFMAX, "[%4.2fu (%.0f%%) %4.2fs (%.0f%%) %4.2f %.1f%%]",
+                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     }
     else {
-        sprintf(buf, "[%4.2fu (%.0f%%) %4.2fs (%.0f%%) %4.2f %.1f%%]",
-                rt_u_useconds(rt) / 1000000,
-                100.0 * rt_u_useconds(rt) / rt_w_useconds(rt),
-                rt_s_useconds(rt) / 1000000,
-                100.0 * rt_s_useconds(rt) / rt_w_useconds(rt),
-                rt_w_useconds(rt) / 1000000,
-                100.0 * (rt_u_useconds(rt) + rt_s_useconds(rt)) /
-                    rt_w_useconds(rt));
+        snprintf(buf, BUFMAX, "[%4.2fu (%.0f%%) %4.2fs (%.0f%%) %4.2f %.1f%%]",
+                 rt_u_useconds(rt) / 1000000,
+                 100.0 * rt_u_useconds(rt) / rt_w_useconds(rt),
+                 rt_s_useconds(rt) / 1000000,
+                 100.0 * rt_s_useconds(rt) / rt_w_useconds(rt),
+                 rt_w_useconds(rt) / 1000000,
+                 100.0 * (rt_u_useconds(rt) + rt_s_useconds(rt)) /
+                     rt_w_useconds(rt));
     }
     return buf;
 }

--- a/raster/r.in.pdal/main.cpp
+++ b/raster/r.in.pdal/main.cpp
@@ -870,8 +870,10 @@ int main(int argc, char *argv[])
     /* close raster file & write history */
     Rast_close(out_fd);
 
-    sprintf(title, "Raw X,Y,Z data binned into a raster grid by cell %s",
-            method_opt->answer);
+    snprintf(title, sizeof(title),
+             "Raw X,Y,Z data binned into a raster grid by cell %s",
+             method_opt->answer);
+
     Rast_put_cell_title(outmap, title);
 
     Rast_short_history(outmap, "raster", &history);
@@ -894,17 +896,17 @@ int main(int argc, char *argv[])
         G_put_window(&region);
 
     if (infiles.num_items > 1) {
-        sprintf(buff,
-                _("Raster map <%s> created."
-                  " " GPOINT_COUNT_FORMAT
-                  " points from %d files found in region."),
-                outmap, grass_filter.num_passed(), infiles.num_items);
+        snprintf(buff, BUFFSIZE,
+                 _("Raster map <%s> created."
+                   " " GPOINT_COUNT_FORMAT
+                   " points from %d files found in region."),
+                 outmap, grass_filter.num_passed(), infiles.num_items);
     }
     else {
-        sprintf(buff,
-                _("Raster map <%s> created."
-                  " " GPOINT_COUNT_FORMAT " points found in region."),
-                outmap, grass_filter.num_passed());
+        snprintf(buff, BUFFSIZE,
+                 _("Raster map <%s> created."
+                   " " GPOINT_COUNT_FORMAT " points found in region."),
+                 outmap, grass_filter.num_passed());
     }
 
     G_done_msg("%s", buff);

--- a/raster/r.terraflow/common.cpp
+++ b/raster/r.terraflow/common.cpp
@@ -93,8 +93,8 @@ void *LargeMemory::alloc(size_t leng)
     next++;
     if (stats) {
         char buf[BUFSIZ], buf2[32];
-        sprintf(buf, "allocated large memory: %s 0x%lX",
-                formatNumber(buf2, leng), (unsigned long)p);
+        snprintf(buf, BUFSIZ, "allocated large memory: %s 0x%lX",
+                 formatNumber(buf2, leng), (unsigned long)p);
         stats->comment(buf);
     }
     return p;
@@ -121,8 +121,8 @@ void LargeMemory::free(void *p)
 
     if (stats) {
         char buf[BUFSIZ], buf2[32];
-        sprintf(buf, "freed large memory: %s 0x%lX", formatNumber(buf2, len[i]),
-                (unsigned long)p);
+        snprintf(buf, BUFSIZ, "freed large memory: %s 0x%lX",
+                 formatNumber(buf2, len[i]), (unsigned long)p);
         stats->comment(buf);
     }
 

--- a/raster/r.terraflow/fill.cpp
+++ b/raster/r.terraflow/fill.cpp
@@ -73,7 +73,7 @@ public:
     char *operator()(const elevation_type &p)
     {
         static char buf[20];
-        sprintf(buf, "%.1f", (float)p);
+        snprintf(buf, sizeof(buf), "%.1f", (float)p);
         return buf;
     }
 };
@@ -83,13 +83,13 @@ public:
     char *operator()(const direction_type &p)
     {
         static char buf[20];
-        sprintf(buf, "%3d", p);
+        snprintf(buf, sizeof(buf), "%3d", p);
         return buf;
     }
     char *operator()(const waterWindowBaseType &p)
     {
         static char buf[20];
-        sprintf(buf, "%3d", p.dir);
+        snprintf(buf, sizeof(buf), "%3d", p.dir);
         return buf;
     }
 #if (0)
@@ -108,19 +108,19 @@ public:
     char *operator()(const labelElevType &p)
     {
         static char buf[8];
-        sprintf(buf, CCLABEL_FMT, p.getLabel());
+        snprintf(buf, sizeof(buf), CCLABEL_FMT, p.getLabel());
         return buf;
     }
     char *operator()(const waterGridType &p)
     {
         static char buf[8];
-        sprintf(buf, CCLABEL_FMT, p.getLabel());
+        snprintf(buf, sizeof(buf), CCLABEL_FMT, p.getLabel());
         return buf;
     }
     char *operator()(const waterType &p)
     {
         static char buf[8];
-        sprintf(buf, CCLABEL_FMT, p.getLabel());
+        snprintf(buf, sizeof(buf), CCLABEL_FMT, p.getLabel());
         return buf;
     }
 };
@@ -130,7 +130,7 @@ public:
     char *operator()(const waterGridType &p)
     {
         static char buf[3];
-        sprintf(buf, "%1u", p.depth);
+        snprintf(buf, sizeof(buf), "%1u", p.depth);
         return buf;
     }
 };
@@ -138,7 +138,7 @@ public:
 char *verbosedir(const std::string &s)
 {
     static char buf[BUFSIZ];
-    sprintf(buf, "dump/%s", s.c_str());
+    snprintf(buf, BUFSIZ, "dump/%s", s.c_str());
     return buf;
 }
 
@@ -365,7 +365,7 @@ computeFlowDirections(AMI_STREAM<elevation_type> *&elstr,
     char path[BUFSIZ];
     char *base_dir = getenv(STREAM_TMPDIR);
     assert(base_dir);
-    sprintf(path, "%s/flowStream", base_dir);
+    snprintf(path, BUFSIZ, "%s/flowStream", base_dir);
     flowStream = new AMI_STREAM<waterWindowBaseType>(path);
     /*flowStream->persist(PERSIST_PERSISTENT); */
     if (stats)

--- a/raster/r.terraflow/main.cpp
+++ b/raster/r.terraflow/main.cpp
@@ -331,13 +331,13 @@ void record_args(int argc, char **argv)
         stats->comment("MFD flow direction");
     }
 
-    sprintf(buf, "D8CUT=%f", opt->d8cut);
+    snprintf(buf, BUFSIZ, "D8CUT=%f", opt->d8cut);
     stats->comment(buf);
 
     size_t mm_size = (size_t)opt->mem << 20; /* (in bytes) */
     char tmp[100];
     formatNumber(tmp, mm_size);
-    sprintf(buf, "Memory size: %s bytes", tmp);
+    snprintf(buf, BUFSIZ, "Memory size: %s bytes", tmp);
     stats->comment(buf);
 }
 
@@ -488,7 +488,7 @@ int main(int argc, char *argv[])
     G_verbose_message(_("Region size is %d x %d"), nrows, ncols);
 
     /* check STREAM path (the place where intermediate STREAMs are placed) */
-    sprintf(buf, "%s=%s", STREAM_TMPDIR, opt->streamdir);
+    snprintf(buf, BUFSIZ, "%s=%s", STREAM_TMPDIR, opt->streamdir);
     /* don't pass an automatic variable; putenv() isn't guaranteed to make a
      * copy */
     putenv(G_store(buf));
@@ -584,7 +584,7 @@ int main(int argc, char *argv[])
     AMI_STREAM<waterWindowBaseType> *flowStream;
     char path[GPATH_MAX];
 
-    sprintf(path, "%s/flowStream", streamdir->answer);
+    snprintf(path, GPATH_MAX, "%s/flowStream", streamdir->answer);
     flowStream = new AMI_STREAM<waterWindowBaseType>(path);
   G_verbose_message(_("flowStream opened: len=%lld\n", flowStream->stream_len());
   G_verbose_message(_("jumping to flow accumulation computation\n");

--- a/raster/r.terraflow/nodata.h
+++ b/raster/r.terraflow/nodata.h
@@ -59,7 +59,7 @@ public:
     static char *printLabel(const nodataType &p)
     {
         static char buf[8];
-        sprintf(buf, CCLABEL_FMT, p.label);
+        snprintf(buf, sizeof(buf), CCLABEL_FMT, p.label);
         return buf;
     }
 

--- a/raster/r.terraflow/plateau.h
+++ b/raster/r.terraflow/plateau.h
@@ -48,7 +48,7 @@ public:
     static char *printLabel(const plateauType &p)
     {
         static char buf[8];
-        sprintf(buf, CCLABEL_FMT, p.cclabel);
+        snprintf(buf, sizeof(buf), CCLABEL_FMT, p.cclabel);
         return buf;
     }
 

--- a/raster/r.terraflow/stats.cpp
+++ b/raster/r.terraflow/stats.cpp
@@ -89,7 +89,7 @@ int noclobberFile(char *fname)
             else { /* file exists */
                 char buf[BUFSIZ];
                 G_debug(1, "file %s exists - renaming.\n", fname);
-                sprintf(buf, "%s.old", fname);
+                snprintf(buf, BUFSIZ, "%s.old", fname);
                 if (rename(fname, buf) != 0) {
                     G_fatal_error("%s", fname);
                 }
@@ -111,7 +111,7 @@ char *noclobberFileName(char *fname)
         else { /* file exists */
             char buf[BUFSIZ];
             G_debug(1, "file %s exists - renaming.\n", fname);
-            sprintf(buf, "%s.old", fname);
+            snprintf(buf, BUFSIZ, "%s.old", fname);
             if (rename(fname, buf) != 0) {
                 G_fatal_error("%s", fname);
             }
@@ -137,7 +137,7 @@ char *statsRecorder::timestamp()
 {
     static char buf[BUFSIZ];
     rt_stop(tm);
-    sprintf(buf, "[%.1f] ", rt_seconds(tm));
+    snprintf(buf, BUFSIZ, "[%.1f] ", rt_seconds(tm));
     return buf;
 }
 
@@ -159,30 +159,33 @@ void statsRecorder::comment(const char *s, const int verbose)
 void statsRecorder::comment(const char *s1, const char *s2)
 {
     char buf[BUFSIZ];
-    sprintf(buf, "%s%s", s1, s2);
+    snprintf(buf, BUFSIZ, "%s%s", s1, s2);
     comment(buf);
 }
 
 void statsRecorder::comment(const int n)
 {
     char buf[BUFSIZ];
-    sprintf(buf, "%d", n);
+    snprintf(buf, BUFSIZ, "%d", n);
     comment(buf);
 }
 
 char *formatNumber(char *buf, off_t val)
 {
     if (val > (1 << 30)) {
-        sprintf(buf, "%.2fG (%" PRI_OFF_T ")", (double)val / (1 << 30), val);
+        snprintf(buf, BUFSIZ, "%.2fG (%" PRI_OFF_T ")", (double)val / (1 << 30),
+                 val);
     }
     else if (val > (1 << 20)) {
-        sprintf(buf, "%.2fM (%" PRI_OFF_T ")", (double)val / (1 << 20), val);
+        snprintf(buf, BUFSIZ, "%.2fM (%" PRI_OFF_T ")", (double)val / (1 << 20),
+                 val);
     }
     else if (val > (1 << 10)) {
-        sprintf(buf, "%.2fK (%" PRI_OFF_T ")", (double)val / (1 << 10), val);
+        snprintf(buf, BUFSIZ, "%.2fK (%" PRI_OFF_T ")", (double)val / (1 << 10),
+                 val);
     }
     else {
-        sprintf(buf, "%" PRI_OFF_T, val);
+        snprintf(buf, BUFSIZ, "%" PRI_OFF_T, val);
     }
     return buf;
 }

--- a/raster/r.terraflow/sweep.cpp
+++ b/raster/r.terraflow/sweep.cpp
@@ -123,7 +123,8 @@ FLOW_DATASTR *initializePQ()
         stats->comment("FLOW_DATASTRUCTURE: in-memory pqueue");
     flowpq = new FLOW_DATASTR(PQ_SIZE);
     char buf[1024];
-    sprintf(buf, "initialized to %.2fMB\n", (float)PQ_SIZE / (1 << 20));
+    snprintf(buf, sizeof(buf), "initialized to %.2fMB\n",
+             (float)PQ_SIZE / (1 << 20));
     if (stats)
         *stats << buf;
 
@@ -271,7 +272,7 @@ AMI_STREAM<sweepOutput> *sweep(AMI_STREAM<sweepItem> *sweepstr,
     if (stats)
         *stats << "sweeping done\n";
     char buf[1024];
-    sprintf(buf, "pqsize = %ld \n", (long)flowpq->size());
+    snprintf(buf, sizeof(buf), "pqsize = %ld \n", (long)flowpq->size());
     if (stats)
         *stats << buf;
 

--- a/raster/r.terraflow/sweep.h
+++ b/raster/r.terraflow/sweep.h
@@ -94,7 +94,7 @@ public:
     char *operator()(const sweepOutput &p)
     {
         static char buf[20];
-        sprintf(buf, "%7.3f", p.accu);
+        snprintf(buf, sizeof(buf), "%7.3f", p.accu);
         return buf;
     }
 };
@@ -111,7 +111,7 @@ public:
     char *operator()(const sweepOutput &p)
     {
         static char buf[20];
-        sprintf(buf, "%7.3f", p.tci);
+        snprintf(buf, sizeof(buf), "%7.3f", p.tci);
         return buf;
     }
 };

--- a/raster/r.terraflow/water.cpp
+++ b/raster/r.terraflow/water.cpp
@@ -32,7 +32,7 @@
 char *labelElevType::printLabel(const labelElevType &p)
 {
     static char buf[8];
-    sprintf(buf, CCLABEL_FMT, p.label);
+    snprintf(buf, sizeof(buf), CCLABEL_FMT, p.label);
     return buf;
 }
 
@@ -175,7 +175,7 @@ ostream &operator<<(ostream &s, const labelElevType &p)
 char *waterType::printLabel(const waterType &p)
 {
     static char buf[8];
-    sprintf(buf, CCLABEL_FMT, p.label);
+    snprintf(buf, sizeof(buf), CCLABEL_FMT, p.label);
     return buf;
 }
 

--- a/raster/r.viewshed/main.cpp
+++ b/raster/r.viewshed/main.cpp
@@ -267,7 +267,8 @@ int main(int argc, char *argv[])
         }
         else {
             /*set it */
-            sprintf(buf, "%s=%s", STREAM_TMPDIR, viewOptions.streamdir);
+            snprintf(buf, sizeof(buf), "%s=%s", STREAM_TMPDIR,
+                     viewOptions.streamdir);
             G_debug(1, "setting %s ", buf);
             putenv(buf);
             if (getenv(STREAM_TMPDIR) == NULL) {
@@ -493,7 +494,7 @@ void parse_args(int argc, char *argv[], int *vpRow, int *vpCol,
         _("Maximum visibility radius. By default infinity (-1)");
     char infdist[10];
 
-    sprintf(infdist, "%d", INFINITY_DISTANCE);
+    snprintf(infdist, sizeof(infdist), "%d", INFINITY_DISTANCE);
     maxDistOpt->answer = infdist;
     maxDistOpt->guisection = _("Settings");
 

--- a/raster/r.watershed/front/main.c
+++ b/raster/r.watershed/front/main.c
@@ -34,7 +34,7 @@ static void do_opt(const struct Option *opt)
     if (!opt->answer)
         return;
     buf = G_malloc(strlen(opt->key) + 1 + strlen(opt->answer) + 1);
-    sprintf(buf, "%s=%s", opt->key, opt->answer);
+    snprintf(buf, GPATH_MAX, "%s=%s", opt->key, opt->answer);
     new_argv[new_argc++] = buf;
 }
 
@@ -261,8 +261,8 @@ int main(int argc, char *argv[])
     }
 
     /* Build command line */
-    sprintf(command, "%s/etc/r.watershed/%s", G_gisbase(),
-            flag_seg->answer ? "seg" : "ram");
+    snprintf(command, GPATH_MAX, "%s/etc/r.watershed/%s", G_gisbase(),
+             flag_seg->answer ? "seg" : "ram");
     new_argv[new_argc++] = command;
 
     if (flag_sfd->answer)

--- a/raster/r.watershed/shed/com_line.c
+++ b/raster/r.watershed/shed/com_line.c
@@ -44,7 +44,8 @@ int com_line_Gwater(INPUT *input, OUTPUT *output)
     G_message(_("will allow other processes to run concurrently with %s.\n"),
               NON_NAME);
 
-    sprintf(buf, "Do you want to use the fast mode of %s?", NON_NAME);
+    snprintf(buf, sizeof(buf), "Do you want to use the fast mode of %s?",
+             NON_NAME);
     input->com_line_ram = input->com_line_seg = NULL;
     input->fast = 0;
     input->slow = 0;
@@ -52,25 +53,26 @@ int com_line_Gwater(INPUT *input, OUTPUT *output)
         input->fast = 1;
         input->com_line_ram = (char *)G_calloc(400, sizeof(char));
         prog_name = G_store(RAM_NAME);
-        sprintf(input->com_line_ram, "\"%s/etc/water/%s\"", G_gisbase(),
-                RAM_NAME);
+        snprintf(input->com_line_ram, (400 * sizeof(char)),
+                 "\"%s/etc/water/%s\"", G_gisbase(), RAM_NAME);
         fprintf(stderr,
                 "\nIf there is not enough ram for the fast mode (%s) to run,\n",
                 RAM_NAME);
-        sprintf(buf, "should the slow mode (%s) be run instead?", SEG_NAME);
+        snprintf(buf, sizeof(buf), "should the slow mode (%s) be run instead?",
+                 SEG_NAME);
         if (G_yes(buf, 1)) {
             input->slow = 1;
             input->com_line_seg = (char *)G_calloc(400, sizeof(char));
-            sprintf(input->com_line_seg, "\"%s/etc/water/%s\"", G_gisbase(),
-                    SEG_NAME);
+            snprintf(input->com_line_seg, (400, sizeof(char)),
+                     "\"%s/etc/water/%s\"", G_gisbase(), SEG_NAME);
         }
     }
     else {
         input->slow = 1;
         prog_name = G_store(SEG_NAME);
         input->com_line_seg = (char *)G_calloc(400, sizeof(char));
-        sprintf(input->com_line_seg, "\"%s/etc/water/%s\"", G_gisbase(),
-                SEG_NAME);
+        snprintf(input->com_line_seg, (400, sizeof(char)),
+                 "\"%s/etc/water/%s\"", G_gisbase(), SEG_NAME);
     }
 
     G_message(_("\nIf you hit <return> by itself for the next question, this"));
@@ -319,7 +321,8 @@ int com_line_Gwater(INPUT *input, OUTPUT *output)
     G_message(
         _("Equation (Rusle): Slope Length (LS), and Slope Steepness (S).\n"));
 
-    sprintf(buf, "Would you like any of these maps to be created?");
+    snprintf(buf, sizeof(buf),
+             "Would you like any of these maps to be created?");
     if (G_yes(buf, 1)) {
         mapset = G_ask_new("", map_layer, "cell", "stream channel");
         if (mapset != NULL) {
@@ -479,7 +482,7 @@ int basin_com_add(char **com_line, double d, double modifier,
     i = (int)(.5 + modifier * d / window->ns_res / window->ew_res);
     if (i < 1)
         i = 1;
-    sprintf(buf, " t=%d", i);
+    snprintf(buf, sizeof(buf), " t=%d", i);
     strcat(*com_line, buf);
 
     return 0;
@@ -490,7 +493,7 @@ int com_add(char **com_line, char *prompt, int ril_value)
     char buf[20];
 
     strcat(*com_line, prompt);
-    sprintf(buf, "%d", ril_value);
+    snprintf(buf, sizeof(buf), "%d", ril_value);
     strcat(*com_line, buf);
 
     return 0;

--- a/raster/r.watershed/shed/print.c
+++ b/raster/r.watershed/shed/print.c
@@ -72,27 +72,27 @@ int print_output(OUTPUT *output)
                     Rast_get_c_cat(&(do_cat->cat_val), &(output->maps[b].cats));
                 switch (output->type_area) {
                 case 1:
-                    sprintf(area, "%.3f acres",
-                            METERSQ_TO_ACRE * cell_size * do_cat->num_cat);
+                    snprintf(area, sizeof(area), "%.3f acres",
+                             METERSQ_TO_ACRE * cell_size * do_cat->num_cat);
                     break;
                 case 2:
-                    sprintf(area, "%.2f sq. meters",
-                            cell_size * do_cat->num_cat);
+                    snprintf(area, sizeof(area), "%.2f sq. meters",
+                             cell_size * do_cat->num_cat);
                     break;
                 case 3:
-                    sprintf(area, "%.4f sq. miles",
-                            METERSQ_TO_MILESQ * cell_size * do_cat->num_cat);
+                    snprintf(area, sizeof(area), "%.4f sq. miles",
+                             METERSQ_TO_MILESQ * cell_size * do_cat->num_cat);
                     break;
                 case 4:
-                    sprintf(area, "%.3f hectacres",
-                            METERSQ_TO_HECTACRE * cell_size * do_cat->num_cat);
+                    snprintf(area, sizeof(area), "%.3f hectacres",
+                             METERSQ_TO_HECTACRE * cell_size * do_cat->num_cat);
                     break;
                 case 5:
-                    sprintf(area, "%.3f sq. km.",
-                            METERSQ_TO_KILOSQ * cell_size * do_cat->num_cat);
+                    snprintf(area, sizeof(area), "%.3f sq. km.",
+                             METERSQ_TO_KILOSQ * cell_size * do_cat->num_cat);
                     break;
                 case 6:
-                    sprintf(area, "%6d cells", do_cat->num_cat);
+                    snprintf(area, sizeof(area), "%6d cells", do_cat->num_cat);
                     break;
                 }
                 fprintf(output->out_file, "%3d %-43s %16s %-.4f\n",


### PR DESCRIPTION
Starting with Xcode 14.2 (and with the SDK following it), usage of sprintf() in C++ code issues a `-Wdeprecated-declarations` warning. This replaces it with the safer snprintf().

Fixes #2766