### PR TITLE
wxGUI: Save current Single-Window layout to workspace file

### DIFF
--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -58,6 +58,11 @@ class ProcessWorkspaceFile:
         }  # current working directory
 
         #
+        # perspective
+        #
+        self.perspective = None
+        #
+        #
         # list of mapdisplays
         #
         self.displays = []
@@ -127,6 +132,13 @@ class ProcessWorkspaceFile:
             cwdPath = self.__getNodeText(node_lm, "cwd")
             if cwdPath:
                 self.layerManager["cwd"] = cwdPath
+
+        #
+        # perspective
+        #
+        node_pr= self.root.find("perspective")
+        if node_pr is not None:
+            self.perspective = node_pr.get("value", "")
 
         #
         # displays
@@ -897,6 +909,19 @@ class WriteWorkspaceFile(object):
             file.write("%s<cwd>%s</cwd>\n" % (" " * self.indent, cwdPath))
         self.indent -= 4
         file.write("%s</layer_manager>\n" % (" " * self.indent))
+
+        # perspectives
+        if hasattr(self.lmgr.GetAuiNotebook(), "SavePerspective"):
+            perspective = self.lmgr.GetAuiNotebook().SavePerspective()
+            file.write(
+                '%s<perspective value="%s">\n'
+                % (
+                    " " * self.indent,
+                    perspective
+                )
+            )
+            self.indent += 4
+            file.write("%s</perspective>\n" % (" " * self.indent))
 
         # list of displays
         for page in range(0, self.lmgr.GetLayerNotebook().GetPageCount()):

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -920,7 +920,7 @@ class WriteWorkspaceFile(object):
         file.write("%s</layer_manager>\n" % (" " * self.indent))
 
         # layout
-        if UserSettings.Get(group="general", key="singleWindow", subkey="enabled"):
+        if UserSettings.Get(group="appearance", key="singleWindow", subkey="enabled"):
             layout_panes = self.lmgr.GetAuiManager().SavePerspective()
             layout_notebook = self.lmgr.GetAuiNotebook().SavePerspective()
             file.write("{indent}<layout>\n".format(indent=" " * self.indent))

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -141,7 +141,7 @@ class ProcessWorkspaceFile:
         # layout
         #
         layout = self.root.find("layout")
-        if layout is not None:
+        if layout:
             self.layout["panes"] = self.__filterValue(
                 self.__getNodeText(layout, "panes")
             )

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1029,6 +1029,13 @@ class GMFrame(wx.Frame):
         """Get Layers Notebook"""
         return self.notebookLayers
 
+    def GetAuiNotebook(self):
+        """Get aui notebook
+
+        :return: aui notebook instance
+        """
+        return self._auimgr
+
     def GetLayerTree(self):
         """Get current layer tree
 

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1029,13 +1029,6 @@ class GMFrame(wx.Frame):
         """Get Layers Notebook"""
         return self.notebookLayers
 
-    def GetAuiNotebook(self):
-        """Get aui notebook
-
-        :return: aui notebook instance
-        """
-        return self._auimgr
-
     def GetLayerTree(self):
         """Get current layer tree
 

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -347,8 +347,9 @@ class WorkspaceManager:
         # load layout
         #
         if UserSettings.Get(group="general", key="singleWindow", subkey="enabled"):
-            if gxwXml.layout:
+            if gxwXml.layout["panes"]:
                 self.lmgr.GetAuiManager().LoadPerspective(gxwXml.layout["panes"])
+            if gxwXml.layout["notebook"]:
                 self.lmgr.GetAuiNotebook().LoadPerspective(gxwXml.layout["notebook"])
 
         self.workspaceFile = filename

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -211,6 +211,12 @@ class WorkspaceManager:
                     os.chdir(self.lmgr.cwdPath)
 
         #
+        # load user-defined layout
+        #
+        if gxwXml.perspective and hasattr(self.lmgr.GetAuiNotebook(), "LoadPerspective"):
+            self.lmgr.GetAuiNotebook().LoadPerspective(gxwXml.perspective)
+
+        #
         # start map displays first (list of layers can be empty)
         #
         displayId = 0

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -211,12 +211,6 @@ class WorkspaceManager:
                     os.chdir(self.lmgr.cwdPath)
 
         #
-        # load user-defined layout
-        #
-        if gxwXml.perspective and hasattr(self.lmgr.GetAuiNotebook(), "LoadPerspective"):
-            self.lmgr.GetAuiNotebook().LoadPerspective(gxwXml.perspective)
-
-        #
         # start map displays first (list of layers can be empty)
         #
         displayId = 0
@@ -348,6 +342,14 @@ class WorkspaceManager:
                     self.lmgr.nvizUpdatePage(page)
                 self.lmgr.nvizUpdateSettings()
                 mapdisplay[i].toolbars["map"].combo.SetSelection(1)
+
+        #
+        # load layout
+        #
+        if UserSettings.Get(group="general", key="singleWindow", subkey="enabled"):
+            if gxwXml.layout:
+                self.lmgr.GetAuiManager().LoadPerspective(gxwXml.layout["panes"])
+                self.lmgr.GetAuiNotebook().LoadPerspective(gxwXml.layout["notebook"])
 
         self.workspaceFile = filename
         self.AddFileToHistory()

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -346,7 +346,7 @@ class WorkspaceManager:
         #
         # load layout
         #
-        if UserSettings.Get(group="general", key="singleWindow", subkey="enabled"):
+        if UserSettings.Get(group="appearance", key="singleWindow", subkey="enabled"):
             if gxwXml.layout["panes"]:
                 self.lmgr.GetAuiManager().LoadPerspective(gxwXml.layout["panes"])
             if gxwXml.layout["notebook"]:

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -1113,6 +1113,13 @@ class GMFrame(wx.Frame):
         """Get Layers Notebook"""
         return self.notebookLayers
 
+    def GetAuiNotebook(self):
+        """Get aui notebook
+
+        :return: aui notebook instance
+        """
+        return self._auimgr
+
     def GetLayerTree(self):
         """Get current layer tree
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -1109,16 +1109,23 @@ class GMFrame(wx.Frame):
                 lcmd=command,
             )
 
-    def GetLayerNotebook(self):
-        """Get Layers Notebook"""
-        return self.notebookLayers
+    def GetAuiManager(self):
+        """Get aui manager
+
+        :return: aui manager instance
+        """
+        return self._auimgr
 
     def GetAuiNotebook(self):
         """Get aui notebook
 
         :return: aui notebook instance
         """
-        return self._auimgr
+        return self.mapnotebook
+
+    def GetLayerNotebook(self):
+        """Get Layers Notebook"""
+        return self.notebookLayers
 
     def GetLayerTree(self):
         """Get current layer tree
@@ -1955,8 +1962,6 @@ class GMFrame(wx.Frame):
         # moved from mapdisp/frame.py
         # TODO: why it is called 3 times when getting focus?
         # and one times when loosing focus?
-        if self.workspace_manager.loadingWorkspace:
-            return
         pgnum = self.notebookLayers.GetPageIndex(notebookLayerPage)
         if pgnum > -1:
             self.notebookLayers.SetSelection(pgnum)


### PR DESCRIPTION
The layout of Aui Notebook as well as AuiManager panes is automatically saved into a workspace file.
When a workspace is loaded, the layout for both parts is adapted (rearranged) to its workspace definition.