### PR TITLE
docker: update of Ubuntu image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,11 +7,11 @@
 <!-- markdownlint-disable line-length -->
 | Base image   | Docker tag    | GRASS GIS  | PROJ  | GDAL  | PDAL  | Python | Image size |
 |--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 22.04 | latest-ubuntu | 8.3.dev    | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 1.20 GB    |
+| Ubuntu 22.04 | latest-ubuntu | 8.3.dev    | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
 | Debian 11    | latest-debian | 8.3.dev    | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
 | Alpine 3.12  | latest-alpine | 8.3.dev    | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
 |--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 22.04 | stable-ubuntu | 8.2 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 1.20 GB    |
+| Ubuntu 22.04 | stable-ubuntu | 8.2 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
 | Debian 11    | stable-debian | 8.2 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
 | Alpine 3.12  | stable-alpine | 8.2 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
 <!-- markdownlint-enable line-length -->

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,16 +7,16 @@
 <!-- markdownlint-disable line-length -->
 | Base image   | Docker tag    | GRASS GIS  | PROJ  | GDAL  | PDAL  | Python | Image size |
 |--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 20.04 | latest-ubuntu | 8.3.dev    | 6.3.1 | 3.0.4 | 2.2.0 | 3.8.10 | 1.20 GB    |
+| Ubuntu 22.04 | latest-ubuntu | 8.3.dev    | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 1.20 GB    |
 | Debian 11    | latest-debian | 8.3.dev    | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
 | Alpine 3.12  | latest-alpine | 8.3.dev    | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
 |--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 20.04 | stable-ubuntu | 8.2 branch | 6.3.1 | 3.0.4 | 2.2.0 | 3.8.10 | 1.20 GB    |
+| Ubuntu 22.04 | stable-ubuntu | 8.2 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 1.20 GB    |
 | Debian 11    | stable-debian | 8.2 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
 | Alpine 3.12  | stable-alpine | 8.2 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
 <!-- markdownlint-enable line-length -->
 
-Last update: 21 Jan 2023 (source: <https://github.com/OSGeo/grass/actions/workflows/docker.yml>
+Last update: 22 Jan 2023 (source: <https://github.com/OSGeo/grass/actions/workflows/docker.yml>
 and <https://hub.docker.com/r/mundialis/grass-py3-pdal/tags>)
 
 ## Requirements

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -5,11 +5,9 @@ LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,weinmann@mundialis.
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# define versions to be used
+# define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
 ARG PDAL_VERSION=2.4.3
-# https://github.com/hobuinc/laz-perf/releases
-ARG LAZ_PERF_VERSION=3.2.0
 
 SHELL ["/bin/bash", "-c"]
 
@@ -83,18 +81,6 @@ RUN apt-get update && apt-get upgrade -y && \
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
 
-## install laz-perf (missing from https://packages.ubuntu.com/)
-RUN apt-get install cmake
-WORKDIR /src
-RUN wget -q https://github.com/hobu/laz-perf/archive/${LAZ_PERF_VERSION}.tar.gz -O laz-perf-${LAZ_PERF_VERSION}.tar.gz && \
-    tar -zxf laz-perf-${LAZ_PERF_VERSION}.tar.gz && \
-    cd laz-perf-${LAZ_PERF_VERSION} && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install
-
 ## fetch vertical datums for PDAL and store into PROJ dir
 WORKDIR /src
 RUN mkdir vdatum && \
@@ -111,7 +97,7 @@ RUN mkdir vdatum && \
     cd .. && \
     rm -rf vdatum
 
-## install pdal
+## compile and install PDAL (not available on Debian/Ubuntu) with laz-perf enabled
 ENV NUMTHREADS=4
 WORKDIR /src
 RUN wget -q \
@@ -134,10 +120,10 @@ RUN wget -q \
       -DHEXER_INCLUDE_DIR=/usr/include/ \
       -DBUILD_PLUGIN_NITF=OFF \
       -DBUILD_PLUGIN_ICEBRIDGE=ON \
-      -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+      -DBUILD_PLUGIN_PGPOINTCLOUD=OFF \
       -DBUILD_PGPOINTCLOUD_TESTS=OFF \
       -DBUILD_PLUGIN_SQLITE=ON \
-      -DWITH_LASZIP=ON \
+      -DWITH_LASZIP=OFF \
       -DWITH_LAZPERF=ON \
       -DWITH_TESTS=ON && \
     make -j $NUMTHREADS && \
@@ -233,6 +219,7 @@ COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 # Not yet ready for GRASS GIS 8:
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
+# test LAZ file
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -5,11 +5,9 @@ LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,weinmann@mundialis.
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# define versions to be used
+# define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
 ARG PDAL_VERSION=2.4.3
-# https://github.com/hobuinc/laz-perf/releases
-ARG LAZ_PERF_VERSION=3.2.0
 
 SHELL ["/bin/bash", "-c"]
 
@@ -115,18 +113,6 @@ ENV NO_AT_BRIDGE=1
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
 
-## install laz-perf (missing from https://packages.ubuntu.com/)
-RUN apt-get install cmake
-WORKDIR /src
-RUN wget -q https://github.com/hobu/laz-perf/archive/${LAZ_PERF_VERSION}.tar.gz -O laz-perf-${LAZ_PERF_VERSION}.tar.gz && \
-    tar -zxf laz-perf-${LAZ_PERF_VERSION}.tar.gz && \
-    cd laz-perf-${LAZ_PERF_VERSION} && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install
-
 ## fetch vertical datums for PDAL and store into PROJ dir
 WORKDIR /src
 RUN mkdir vdatum && \
@@ -143,7 +129,7 @@ RUN mkdir vdatum && \
     cd .. && \
     rm -rf vdatum
 
-## install pdal
+## compile and install PDAL (not available on Debian/Ubuntu) with laz-perf enabled
 ENV NUMTHREADS=4
 WORKDIR /src
 RUN wget -q \
@@ -166,10 +152,10 @@ RUN wget -q \
       -DHEXER_INCLUDE_DIR=/usr/include/ \
       -DBUILD_PLUGIN_NITF=OFF \
       -DBUILD_PLUGIN_ICEBRIDGE=ON \
-      -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+      -DBUILD_PLUGIN_PGPOINTCLOUD=OFF \
       -DBUILD_PGPOINTCLOUD_TESTS=OFF \
       -DBUILD_PLUGIN_SQLITE=ON \
-      -DWITH_LASZIP=ON \
+      -DWITH_LASZIP=OFF \
       -DWITH_LAZPERF=ON \
       -DWITH_TESTS=ON && \
     make -j $NUMTHREADS && \
@@ -270,6 +256,7 @@ COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 # Not yet ready for GRASS GIS 8:
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
+# test LAZ file
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb


### PR DESCRIPTION
- Debian docker base image update
- PDAL compilation: WITH_LASZIP=OFF, keep only WITH_LAZPERF=ON
- new versions:

| Base image   | GRASS GIS  | PROJ  | GDAL  | PDAL  | Python | Image size |
|--------------|------------|-------|-------|-------|--------|------------|
| Ubuntu 22.04 | 8.3.dev    | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.92 GB    |

LAZ-perf is enabled in PDAL, hence both LAS and LAZ files can be imported into GRASS GIS.

TODO in a separate PR: reduce image size