### PR TITLE
pre-commit: handle only c and c++ files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,4 @@ repos:
     rev: v15.0.6
     hooks:
       - id: clang-format
+        types_or: [c, c++]


### PR DESCRIPTION
The pre-commit hook 'clang-format' can handle a range of files (c++, c, c#, cuda, java, javascript, json, objective-c, proto). Presently there is only settings for C/C++ in `.clang-format`.

This PR makes pre-commit handle only C/C++ files.