### PR TITLE
CI: improve PR titles of renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitTypeAll(CI)"
   ]
 }

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -34,7 +34,7 @@ notes:
       regexp: '[Ss]ingularity: '
 
     - title: Continuous Integration, Tests, Code Quality, and Checks
-      regexp: '(CI|ci|[Tt]ests|[Cc]hecks|pytest): '
+      regexp: '(CI|ci|CI\(deps\)|ci\(deps\)|[Tt]ests|[Cc]hecks|pytest): '
 
     - title: Contributing and Management
       regexp: '(contributing|CONTRIBUTING.md|contributors.csv): '


### PR DESCRIPTION
Use `CI: ` prefix for pull request titles in order to facilitate the automated creation of release notes.
THis is a followup PR to #2772.

Related docs: https://github.com/renovatebot/renovate/blob/main/docs/usage/semantic-commits.md