### PR TITLE
pre-commit: add yaml file lint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,6 @@
 ---
 BasedOnStyle: LLVM
 IndentWidth: 4
-
 ---
 Language: Cpp
 AccessModifierOffset: -4
@@ -23,13 +22,9 @@ IfMacros:
 MacroBlockBegin: GNO_BEGIN
 MacroBlockEnd: GNO_END
 SortIncludes: Never
-
 ---
 Language: ObjC
-
 ---
 Language: JavaScript
-
 ---
 Language: Json
-...

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+---
 open_collective: grass

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,8 @@
-name: "CodeQL config"
+---
+name: CodeQL config
 paths-ignore:
-  - "**/testsuite/**"
-  - "bin.*"
-  - "dist.*"
+  - '**/testsuite/**'
+  - bin.*
+  - dist.*
   - node_modules
   - python/grass/pygrass/tests

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -1,3 +1,4 @@
+---
 name: Additional Checks
 
 # Checks which are not in standardized tools such as custom checks by scripts
@@ -35,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Generate core modules with last commit JSON file and test it
         run: |

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,3 +1,4 @@
+---
 name: Python Black Formatting
 
 on:
@@ -20,8 +21,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: "3.10"
-            black-version: "22.3.0"
+            python-version: '3.10'
+            black-version: 22.3.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -1,3 +1,4 @@
+---
 name: CentOS
 
 on:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Run clang-format style check for C/C++/Protobuf programs.
         uses: jidicula/clang-format-action@v4.10.1
         with:
-          clang-format-version: "15"
+          clang-format-version: '15'
           check-path: .

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,5 @@
-name: "CodeQL"
+---
+name: CodeQL
 
 on:
   push:
@@ -8,12 +9,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - "**/*.html"
-      - "**/*.md"
-      - "**/*.txt"
+      - '**/*.html'
+      - '**/*.md'
+      - '**/*.txt'
   schedule:
     # Check every Saturday at 18:36
-    - cron: "36 18 * * 6"
+    - cron: 36 18 * * 6
 
 jobs:
   analyze:
@@ -55,8 +56,8 @@ jobs:
 
       - name: Build
         env:
-          CFLAGS: "-std=gnu11"
-          CXXFLAGS: "-std=c++11"
+          CFLAGS: -std=gnu11
+          CXXFLAGS: -std=c++11
         run: .github/workflows/build_ubuntu-22.04.sh $HOME/install
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -1,3 +1,4 @@
+---
 name: Create or check a release draft
 
 on:
@@ -12,8 +13,8 @@ on:
       - main
       - releasebranch_*
     paths:
-      - '.github/**'
-      - 'utils/**'
+      - .github/**
+      - utils/**
 
 jobs:
   build:
@@ -28,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Generate core modules with last commit JSON file and patch file
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,6 @@
+---
+name: Docker
+
 # This workflow builds and pushes docker images to dockerhub
 #
 # Summary
@@ -14,24 +17,22 @@
 # job docker-release-os-matrix:
 # * creates tags <version>-alpine, <version>-debian and <version>-ubuntu for each release
 
-name: Docker
-
 on:
   push:
     branches:
-      - 'main'
-      - 'releasebranch_*'
+      - main
+      - releasebranch_*
       - '!releasebranch_7_*'
-      - 'releasebranch_7_8'
+      - releasebranch_7_8
     tags: ['*.*.*']
-    paths-ignore: ['doc/**']
+    paths-ignore: [doc/**]
   release:
     types: [published]
 
 env:
-    # Additionally mentioned in docker-sha-release-latest
-    # as use of variable fails there
-    DOCKERHUB_REPOSITORY: mundialis/grass-py3-pdal
+  # Additionally mentioned in docker-sha-release-latest
+  # as use of variable fails there
+  DOCKERHUB_REPOSITORY: mundialis/grass-py3-pdal
 
 jobs:
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,3 +1,4 @@
+---
 name: Python Flake8 Code Quality
 
 on:
@@ -20,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Install
         run: |

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,3 +1,4 @@
+---
 name: GCC C/C++ standards check
 
 on:
@@ -54,7 +55,7 @@ jobs:
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: "-std=${{ matrix.c }} -fPIC -Wall"
+          CFLAGS: -std=${{ matrix.c }} -fPIC -Wall
           # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: "-std=${{ matrix.cpp }} -fPIC -Wall"
+          CXXFLAGS: -std=${{ matrix.cpp }} -fPIC -Wall
         run: .github/workflows/build_ubuntu-22.04.sh $HOME/install -Werror

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,6 @@
 ---
 name: macOS
+
 # Build and run tests on macOS
 
 on:
@@ -35,9 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/miniconda3/envs/grass-env
-          key: conda-macos-x86_64-${{steps.get-date.outputs.today
-            }}-${{hashFiles('.github/workflows/macos_dependencies.txt') }}-${{
-            env.CACHE_NUMBER}}
+          key: conda-macos-x86_64-${{steps.get-date.outputs.today }}-${{hashFiles('.github/workflows/macos_dependencies.txt') }}-${{ env.CACHE_NUMBER}}
         id: cache
       - name: Update environment
         run: mamba env update -n grass-env -f .github/workflows/macos_dependencies.txt
@@ -77,4 +76,3 @@ jobs:
           name: testreport-macOS
           path: testreport
           retention-days: 3
-...

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/miniconda3/envs/grass-env
-          key: conda-macos-x86_64-${{steps.get-date.outputs.today }}-${{hashFiles('.github/workflows/macos_dependencies.txt') }}-${{ env.CACHE_NUMBER}}
+          key: conda-macos-x86_64-${{
+            steps.get-date.outputs.today }}-${{
+            hashFiles('.github/workflows/macos_dependencies.txt') }}-${{
+            env.CACHE_NUMBER }}
         id: cache
       - name: Update environment
         run: mamba env update -n grass-env -f .github/workflows/macos_dependencies.txt
@@ -64,11 +67,14 @@ jobs:
         shell: bash -el {0}
         run: >
           grass --tmp-location XY --exec \
-              g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
+              g.download.location url=${{ env.SampleData }} path=$HOME
           grass --tmp-location XY --exec \
               python3 -m grass.gunittest.main \
               --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
               --min-success 100 --config .github/workflows/macos_gunittest.cfg
+        env:
+          SampleData: "https://grass.osgeo.org/sampledata/north_carolina/\
+                       nc_spm_full_v2alpha2.tar.gz"
       - name: Make HTML test report available
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -1,3 +1,4 @@
+---
 name: OSGeo4W
 
 on:
@@ -32,7 +33,9 @@ jobs:
           path-type: inherit
           location: D:\
           update: true
-          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
+          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext
+            mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
 
       - name: Install OSGeo4W
         run: |

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -33,16 +33,27 @@ jobs:
           path-type: inherit
           location: D:\
           update: true
-          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf
-            mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext
-            mingw-w64-x86_64-libsystre mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
+          install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv
+            mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre
+            mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng
+            mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
 
       - name: Install OSGeo4W
-        run: |
+        run: >
           $exe = 'osgeo4w-setup.exe'
+
           $url = 'http://download.osgeo.org/osgeo4w/v2/' + $exe
+
           (New-Object System.Net.WebClient).DownloadFile($url, $exe)
-          Start-Process ('.\'+$exe) -ArgumentList '-A -g -k -q -s http://download.osgeo.org/osgeo4w/v2/ -P proj-devel,gdal-devel,geos-devel,libtiff-devel,libpng-devel,pdal-devel,netcdf-devel,cairo-devel,fftw,freetype-devel,gdal-ecw,gdal-mrsid,liblas-devel,libxdr,libpq-devel,pdcurses,python3-matplotlib,python3-numpy,python3-ply,python3-pywin32,python3-six,python3-wxpython,regex-devel,zstd-devel' -Wait
+
+          Start-Process ('.\'+$exe) -ArgumentList '-A -g -k -q -s http://download.osgeo.org/osgeo4w/v2/ \
+            -P ${{ env.Deps }}' -Wait
+        env:
+          Deps: "proj-devel,gdal-devel,geos-devel,libtiff-devel,libpng-devel,pdal-devel,netcdf-devel,cairo-devel,\
+            fftw,freetype-devel,gdal-ecw,gdal-mrsid,liblas-devel,libxdr,libpq-devel,pdcurses,python3-matplotlib,\
+            python3-numpy,python3-ply,python3-pywin32,python3-six,python3-wxpython,regex-devel,zstd-devel"
 
       - name: Compile GRASS GIS
         run: D:\msys64\usr\bin\bash.exe -l (''+(Get-Location)+'\.github\workflows\build_osgeo4w.sh') (Get-Location)

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -86,7 +86,13 @@ jobs:
           pip install pytest pytest-pylint
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass83/lib:$LD_LIBRARY_PATH
-          pytest --pylint -m pylint --pylint-rcfile=.pylintrc --pylint-jobs=$(nproc) --pylint-ignore-patterns="python/.*,gui/wxpython/.*,doc/.*,man/.*,utils/.*,locale/.*,raster/.*,imagery/.*,scripts/r.in.wms/wms_drv.py,scripts/g.extension/g.extension.py,temporal/t.rast.accdetect/t.rast.accdetect.py,temporal/t.rast.accumulate/t.rast.accumulate.py,scripts/d.rast.edit/d.rast.edit.py"
+          pytest --pylint -m pylint --pylint-rcfile=.pylintrc --pylint-jobs=$(nproc) \
+            --pylint-ignore-patterns="${{ env.PylintIgnore }}"
+        env:
+          PylintIgnore: "python/.*,gui/wxpython/.*,doc/.*,man/.*,utils/.*,locale/.*,raster/.*,\
+            imagery/.*,scripts/r.in.wms/wms_drv.py,scripts/g.extension/g.extension.py,\
+            temporal/t.rast.accdetect/t.rast.accdetect.py,temporal/t.rast.accumulate/t.rast.accumulate.py,\
+            scripts/d.rast.edit/d.rast.edit.py"
 
       - name: Test compiling example modules
         run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,3 +1,4 @@
+---
 name: Python Pylint Code Quality
 
 on:
@@ -12,7 +13,7 @@ on:
 
 jobs:
   pylint:
-    name: "Pylint ${{ matrix.pylint-version }}"
+    name: Pylint ${{ matrix.pylint-version }}
 
     # Using matrix just to get variables which are not environmental variables
     # and also to sync with other workflows which use matrix.
@@ -20,9 +21,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: "3.10"
-            min-python-version: "3.7"
-            pylint-version: "2.12.2"
+            python-version: '3.10'
+            min-python-version: '3.7'
+            pylint-version: 2.12.2
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,3 +1,4 @@
+---
 name: pytest
 
 on:
@@ -17,8 +18,8 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
-          - "3.8"
-          - "3.10"
+          - '3.8'
+          - '3.10'
       fail-fast: true
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,3 +1,4 @@
+---
 name: General linting
 
 on:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,6 @@
+---
 name: Ubuntu
+
 # Build and run tests on Ubuntu
 
 on:
@@ -19,13 +21,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "22.04"
+          - name: '22.04'
             os: ubuntu-22.04
             config: ubuntu-22.04
           # This is without optional things but it still keeps things useful,
           # so, e.g., without OpenMP, but with PDAL. Code or tests should be written
           # so that test pass even when these optional things are not present.
-          - name: "minimum config"
+          - name: minimum config
             os: ubuntu-22.04
             config: ubuntu-22.04_without_x
       fail-fast: false
@@ -62,9 +64,9 @@ jobs:
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: "-fPIC"
+          CFLAGS: -fPIC
           # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: "-fPIC"
+          CXXFLAGS: -fPIC
         run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install -Werror
 
       - name: Add the bin directory to PATH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,9 +66,5 @@ repos:
     rev: v1.21.0
     hooks:
       - id: yamllint
-        args: [--format, parsable, --strict, -d, '{extends: default, rules: {truthy: disable, line-length: disable } }']
-  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-    rev: 0.2.1
-    hooks:
-      - id: yamlfmt
-        args: [--mapping, '2', --sequence, '4', --offset, '2']
+        args: [--format, parsable, --strict, -d,
+               '{extends: default, rules: {truthy: disable, line-length: {max: 120, allow-non-breakable-words: true}}}']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
                 man/jquery.fixedheadertable.min.js
           )
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.21.0
+    rev: v1.29.0
     hooks:
       - id: yamllint
         args: [--format, parsable, --strict, -d,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,13 @@ repos:
           (?x)^(
                 man/jquery.fixedheadertable.min.js
           )
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.21.0
+    hooks:
+      - id: yamllint
+        args: [--format, parsable, --strict, -d, '{extends: default, rules: {truthy: disable, line-length: disable } }']
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.1
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, '2', --sequence, '4', --offset, '2']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 # Author: Ivan Mincik, ivan.mincik@gmail.com (linux)
 #         Rainer M. Krug, Rainer@krugs.de (osx)
 
@@ -5,20 +6,18 @@ language: c
 cache: ccache
 
 matrix:
-   include:
-      - os: linux
-        dist: focal
-        compiler: gcc
-        sudo: required
-        env:
-            CC=gcc
+  include:
+    - os: linux
+      dist: focal
+      compiler: gcc
+      sudo: required
+      env: CC=gcc
 
-      - os: linux
-        dist: focal
-        compiler: clang
-        sudo: required
-        env:
-            CC=clang
+    - os: linux
+      dist: focal
+      compiler: clang
+      sudo: required
+      env: CC=clang
 
 env:
   global:
@@ -37,4 +36,4 @@ after_success:
   - bash < (curl -s https://codecov.io/bash)
 
 notifications:
-        irc: "chat.freenode.net#grass"
+  irc: chat.freenode.net#grass

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -1,3 +1,4 @@
+---
 notes:
   categories:
     - title: Modules
@@ -41,6 +42,6 @@ notes:
 
   exclude:
     regexp:
-      - "[Hh]appy [Nn]ew [Yy]ear"
-      - "version: "
-      - "RFC: "
+      - '[Hh]appy [Nn]ew [Yy]ear'
+      - 'version: '
+      - 'RFC: '


### PR DESCRIPTION
This adds yaml linter https://github.com/adrienverge/yamllint ~~and formatter https://github.com/jumanjihouse/pre-commit-hook-yamlfmt~~ to `.pre-commit-config.yaml`.

All .yml files have also been fixed to pass without warning and formatted (for unified standard).

With CI's super-linter testing for yaml files, it is preferable to pre-empt any failures.