### PR TITLE
iostream: fix -Werror=type-limits warnings

### DIFF
--- a/include/grass/iostream/embuffer.h
+++ b/include/grass/iostream/embuffer.h
@@ -411,7 +411,7 @@ em_buffer<T, Key>::em_buffer(const unsigned short i, const unsigned long bs,
     : arity(ar), level(i), basesize(bs)
 {
 
-    assert((level >= 1) && (basesize >= 0));
+    assert(level >= 1);
 
     char str[100];
     snprintf(str, sizeof(str),
@@ -564,7 +564,7 @@ template <class T, class Key>
 AMI_STREAM<T> *em_buffer<T, Key>::get_stream(unsigned int i)
 {
 
-    assert(i >= 0 && i < index);
+    assert(i < index);
 
 #ifdef SAVE_MEMORY
     MY_LOG_DEBUG_ID("em_buffer::get_stream");
@@ -623,7 +623,7 @@ template <class T, class Key>
 void em_buffer<T, Key>::put_stream(unsigned int i)
 {
 
-    assert(i >= 0 && i < index);
+    assert(i < index);
 
 #ifdef SAVE_MEMORY
     MY_LOG_DEBUG_ID("em_buffer::put_stream");

--- a/include/grass/iostream/imbuffer.h
+++ b/include/grass/iostream/imbuffer.h
@@ -134,7 +134,7 @@ public:
     // return i'th item in buffer
     T get_item(unsigned long i) const
     {
-        assert((i >= 0) && (i < size));
+        assert(i < size);
         return data[i];
     }
 
@@ -334,7 +334,7 @@ void im_buffer<T>::reset(unsigned long start, unsigned long n)
         sorted = false;
         return;
     }
-    assert((start >= 0) && (start + n <= size));
+    assert(start + n <= size);
     size = n;
     if (n) {
         memmove(data, data + start, n * sizeof(T));

--- a/include/grass/iostream/replacementHeap.h
+++ b/include/grass/iostream/replacementHeap.h
@@ -214,7 +214,7 @@ template <class T, class Compare>
 void ReplacementHeap<T, Compare>::deleteRun(size_t i)
 {
 
-    assert(i >= 0 && i < size && mergeHeap[i].run);
+    assert(i < size && mergeHeap[i].run);
 
     RHEAP_DEBUG
     {
@@ -321,7 +321,7 @@ void ReplacementHeap<T, Compare>::heapify(size_t i)
     size_t rc = rheap_rchild(i);
 
     Compare cmpobj;
-    assert(i >= 0 && i < size);
+    assert(i < size);
     if ((lc < size) && (cmpobj.compare(mergeHeap[lc].value,
                                        mergeHeap[min_index].value) == -1)) {
         min_index = lc;

--- a/include/grass/iostream/replacementHeapBlock.h
+++ b/include/grass/iostream/replacementHeapBlock.h
@@ -216,7 +216,7 @@ template <class T, class Compare>
 void ReplacementHeapBlock<T, Compare>::deleteRun(size_t i)
 {
 
-    assert(i >= 0 && i < size && mergeHeap[i].run);
+    assert(i < size && mergeHeap[i].run);
 
     RBHEAP_DEBUG
     {
@@ -294,7 +294,7 @@ void ReplacementHeapBlock<T, Compare>::heapify(size_t i)
     size_t rc = rheap_rchild(i);
 
     Compare cmpobj;
-    assert(i >= 0 && i < size);
+    assert(i < size);
     if ((lc < size) && (cmpobj.compare(mergeHeap[lc].value,
                                        mergeHeap[min_index].value) == -1)) {
         min_index = lc;


### PR DESCRIPTION
Combining compiler flags `-Wall -Wextra -Werror` produces some `-Werror=type-limits` warnings in addition to the ones fixed in #2756.