### PR TITLE
CI: add -Wextra with a few exceptions

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: -std=${{ matrix.c }} -fPIC -Wall
+          CFLAGS: -std=${{ matrix.c }} -fPIC -Wall -Wextra
+            -Wno-error=implicit-fallthrough -Wno-error=unused-parameter
           # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: -std=${{ matrix.cpp }} -fPIC -Wall
+          CXXFLAGS: -std=${{ matrix.cpp }} -fPIC -Wall -Wextra
+            -Wno-error=implicit-fallthrough -Wno-error=unused-parameter
         run: .github/workflows/build_ubuntu-22.04.sh $HOME/install -Werror

--- a/.github/workflows/macos_dependencies.txt
+++ b/.github/workflows/macos_dependencies.txt
@@ -35,3 +35,4 @@ postgresql
 postgis
 cmake
 llvm-openmp
+flex

--- a/.github/workflows/macos_install.sh
+++ b/.github/workflows/macos_install.sh
@@ -66,8 +66,8 @@ CONFIGURE_FLAGS="\
   --with-readline-libs=${CONDA_PREFIX}/lib
 "
 
-export CFLAGS="-O2 -pipe -arch ${CONDA_ARCH} -DGL_SILENCE_DEPRECATION -Wall"
-export CXXFLAGS="-O2 -pipe -stdlib=libc++ -arch ${CONDA_ARCH} -Wall"
+export CFLAGS="-O2 -pipe -arch ${CONDA_ARCH} -DGL_SILENCE_DEPRECATION -Wall -Wextra -Wno-error=unused-parameter"
+export CXXFLAGS="-O2 -pipe -stdlib=libc++ -arch ${CONDA_ARCH} -Wall -Wextra -Wno-error=unused-parameter"
 
 ./configure $CONFIGURE_FLAGS
 


### PR DESCRIPTION
This adds `-Wextra` compiler flag to the GCC and macOS CI runners. 

The `-Wimplicit-fallthrough` and `-Wunused-parameter` warnings are exempted (until #2760  and #2770 are merged).

(An update of flex on macOS is needed as the default was old enough to cause `-Wsign-compare` warnings.)