### PR TITLE
Use 'PRId64' from C99, instead of macro PRI_OFF_T

### DIFF
--- a/imagery/i.segment/iseg.h
+++ b/imagery/i.segment/iseg.h
@@ -21,10 +21,13 @@
 
 #ifdef HAVE_LONG_LONG_INT
 #define LARGEINT long long
+#define PRI_LONG "lld"
 #elif defined HAVE_LARGEFILES
 #define LARGEINT off_t
+#define PRI_LONG PRI_OFF_T
 #else
 #define LARGEINT long
+#define PRI_LONG "ld"
 #endif
 
 /* methods */

--- a/imagery/i.segment/iseg.h
+++ b/imagery/i.segment/iseg.h
@@ -11,6 +11,7 @@
  *
  *****************************************************************************/
 
+#include <inttypes.h>
 #include <grass/segment.h>
 #include <grass/imagery.h>
 #include "flag.h"
@@ -24,7 +25,7 @@
 #define PRI_LONG "lld"
 #elif defined HAVE_LARGEFILES
 #define LARGEINT off_t
-#define PRI_LONG PRI_OFF_T
+#define PRI_LONG PRId64
 #else
 #define LARGEINT long
 #define PRI_LONG "ld"

--- a/imagery/i.segment/iseg.h
+++ b/imagery/i.segment/iseg.h
@@ -21,13 +21,10 @@
 
 #ifdef HAVE_LONG_LONG_INT
 #define LARGEINT long long
-#define PRI_LONG "lld"
 #elif defined HAVE_LARGEFILES
 #define LARGEINT off_t
-#define PRI_LONG PRI_OFF_T
 #else
 #define LARGEINT long
-#define PRI_LONG "ld"
 #endif
 
 /* methods */

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -1,5 +1,6 @@
 /* PURPOSE:      Develop the image segments */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -1,6 +1,5 @@
 /* PURPOSE:      Develop the image segments */
 
-#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -210,7 +209,7 @@ int mean_shift(struct globals *globals)
         G_message(_("Range bandwidth: %g"), hspec);
     }
 
-    G_debug(4, "Starting to process %" PRId64 " candidate cells",
+    G_debug(4, "Starting to process %" PRI_LONG " candidate cells",
             globals->candidate_count);
 
     t = 0;
@@ -395,7 +394,7 @@ int mean_shift(struct globals *globals)
             }
         }
         G_percent(1, 1, 1);
-        G_message(_("Changes > threshold: %" PRId64 ", largest change: %g"),
+        G_message(_("Changes > threshold: %" PRI_LONG ", largest change: %g"),
                   n_changes, sqrt(maxdiff2));
     }
     if (n_changes > 1)

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -1,5 +1,6 @@
 /* PURPOSE:      Develop the image segments */
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -209,7 +210,7 @@ int mean_shift(struct globals *globals)
         G_message(_("Range bandwidth: %g"), hspec);
     }
 
-    G_debug(4, "Starting to process %" PRI_LONG " candidate cells",
+    G_debug(4, "Starting to process %" PRId64 " candidate cells",
             globals->candidate_count);
 
     t = 0;
@@ -394,7 +395,7 @@ int mean_shift(struct globals *globals)
             }
         }
         G_percent(1, 1, 1);
-        G_message(_("Changes > threshold: %" PRI_LONG ", largest change: %g"),
+        G_message(_("Changes > threshold: %" PRId64 ", largest change: %g"),
                   n_changes, sqrt(maxdiff2));
     }
     if (n_changes > 1)

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -394,8 +394,10 @@ int mean_shift(struct globals *globals)
             }
         }
         G_percent(1, 1, 1);
-        G_message(_("Changes > threshold: %" PRI_LONG ", largest change: %g"),
-                  n_changes, sqrt(maxdiff2));
+        char buf[100];
+        snprintf(buf, sizeof(buf), "%" PRI_LONG, n_changes);
+        G_message(_("Changes > threshold: %s, largest change: %g"), buf,
+                  sqrt(maxdiff2));
     }
     if (n_changes > 1)
         G_message(_("Mean shift stopped at %d due to reaching max iteration "

--- a/imagery/i.segment/open_files.c
+++ b/imagery/i.segment/open_files.c
@@ -1,6 +1,5 @@
 /* PURPOSE:      opening input rasters and creating segmentation files */
 
-#include <inttypes.h>
 #include <stdlib.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>
@@ -554,7 +553,7 @@ static int manage_memory(int srows, int scols, struct globals *globals)
         }
 
         G_verbose_message(
-            _("Regions with at least %" PRId64 " cells are stored in memory"),
+            _("Regions with at least %" PRI_LONG " cells are stored in memory"),
             globals->min_reg_size);
     }
 

--- a/imagery/i.segment/open_files.c
+++ b/imagery/i.segment/open_files.c
@@ -552,9 +552,10 @@ static int manage_memory(int srows, int scols, struct globals *globals)
                 segs_mb = 10;
         }
 
+        char buf[100];
+        snprintf(buf, sizeof(buf), "%" PRI_LONG, globals->min_reg_size);
         G_verbose_message(
-            _("Regions with at least %" PRI_LONG " cells are stored in memory"),
-            globals->min_reg_size);
+            _("Regions with at least %s cells are stored in memory"), buf);
     }
 
     /* calculate number of segments in memory */

--- a/imagery/i.segment/open_files.c
+++ b/imagery/i.segment/open_files.c
@@ -1,5 +1,6 @@
 /* PURPOSE:      opening input rasters and creating segmentation files */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>

--- a/imagery/i.segment/open_files.c
+++ b/imagery/i.segment/open_files.c
@@ -1,5 +1,6 @@
 /* PURPOSE:      opening input rasters and creating segmentation files */
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>
@@ -553,7 +554,7 @@ static int manage_memory(int srows, int scols, struct globals *globals)
         }
 
         G_verbose_message(
-            _("Regions with at least %" PRI_LONG " cells are stored in memory"),
+            _("Regions with at least %" PRId64 " cells are stored in memory"),
             globals->min_reg_size);
     }
 

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -996,8 +996,10 @@ int update_band_vals(int row, int col, struct reg_stats *rs,
     G_debug(4, "update_band_vals()");
 
     if (rs->count >= globals->min_reg_size) {
-        G_fatal_error(_("Region stats should go in tree, %d >= %" PRI_LONG ""),
-                      rs->count, globals->min_reg_size);
+        char buf[100];
+        snprintf(buf, sizeof(buf), "%" PRI_LONG, globals->min_reg_size);
+        G_fatal_error(_("Region stats should go in tree, %d >= %s"), rs->count,
+                      buf);
     }
 
     Segment_get(&globals->rid_seg, (void *)&rid, row, col);

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -2,6 +2,7 @@
 
 /* Currently only region growing is implemented */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -2,7 +2,6 @@
 
 /* Currently only region growing is implemented */
 
-#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -263,7 +262,7 @@ int region_growing(struct globals *globals)
             }
         }
 
-        G_debug(4, "Starting to process %" PRId64 " candidate cells",
+        G_debug(4, "Starting to process %" PRI_LONG " candidate cells",
                 globals->candidate_count);
 
         /*process candidate cells */
@@ -588,7 +587,7 @@ int region_growing(struct globals *globals)
             }
         }
 
-        G_debug(4, "Starting to process %" PRId64 " candidate cells",
+        G_debug(4, "Starting to process %" PRI_LONG " candidate cells",
                 globals->candidate_count);
 
         /* process candidate cells */
@@ -997,7 +996,7 @@ int update_band_vals(int row, int col, struct reg_stats *rs,
     G_debug(4, "update_band_vals()");
 
     if (rs->count >= globals->min_reg_size) {
-        G_fatal_error(_("Region stats should go in tree, %d >= %" PRId64 ""),
+        G_fatal_error(_("Region stats should go in tree, %d >= %" PRI_LONG ""),
                       rs->count, globals->min_reg_size);
     }
 

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -2,6 +2,7 @@
 
 /* Currently only region growing is implemented */
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -262,7 +263,7 @@ int region_growing(struct globals *globals)
             }
         }
 
-        G_debug(4, "Starting to process %" PRI_LONG " candidate cells",
+        G_debug(4, "Starting to process %" PRId64 " candidate cells",
                 globals->candidate_count);
 
         /*process candidate cells */
@@ -587,7 +588,7 @@ int region_growing(struct globals *globals)
             }
         }
 
-        G_debug(4, "Starting to process %" PRI_LONG " candidate cells",
+        G_debug(4, "Starting to process %" PRId64 " candidate cells",
                 globals->candidate_count);
 
         /* process candidate cells */
@@ -996,7 +997,7 @@ int update_band_vals(int row, int col, struct reg_stats *rs,
     G_debug(4, "update_band_vals()");
 
     if (rs->count >= globals->min_reg_size) {
-        G_fatal_error(_("Region stats should go in tree, %d >= %" PRI_LONG ""),
+        G_fatal_error(_("Region stats should go in tree, %d >= %" PRId64 ""),
                       rs->count, globals->min_reg_size);
     }
 

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -62,13 +62,6 @@ static const char *GRASS_copyright __attribute__((unused)) =
 #define FALSE false
 #endif
 
-#if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) || \
-    (__APPLE__ && __LP64__)
-#define PRI_OFF_T "lld"
-#else
-#define PRI_OFF_T "ld"
-#endif
-
 /*! \brief Cross-platform Newline Character */
 #define NEWLINE '\n'
 #ifdef __MINGW32__

--- a/lib/dspf/cube_io.c
+++ b/lib/dspf/cube_io.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdlib.h>
 #include <grass/gis.h>
 #include "viz.h"
@@ -197,14 +198,14 @@ int read_cube(Cube_data *Cube, file_info *headfax)
     size |= inchar;
 
     if (0 >= (ret = my_fread((char *)Buffer, 1, size, fp))) {
-        fprintf(stderr, "Error reading display file offset %" PRI_OFF_T "\n",
+        fprintf(stderr, "Error reading display file offset %" PRId64 "\n",
                 G_ftell(fp));
         return (-1);
     }
 
     if (ret != size) {
         fprintf(stderr,
-                "Error (size) reading display file offset %" PRI_OFF_T "\n",
+                "Error (size) reading display file offset %" PRId64 "\n",
                 G_ftell(fp));
         return (-1);
     }

--- a/lib/segment/format.c
+++ b/lib/segment/format.c
@@ -11,6 +11,7 @@
  * \date 2005-2018
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -108,7 +109,7 @@ static int seg_format(int fd, off_t nrows, off_t ncols, int srows, int scols,
     int spr, size;
 
     if (nrows <= 0 || ncols <= 0 || len <= 0 || srows <= 0 || scols <= 0) {
-        G_warning("Segment_format(fd,%" PRI_OFF_T ",%" PRI_OFF_T
+        G_warning("Segment_format(fd,%" PRId64 ",%" PRId64
                   ",%d,%d,%d): illegal value(s)",
                   nrows, ncols, srows, scols, len);
         return -3;

--- a/lib/vector/Vlib/open_nat.c
+++ b/lib/vector/Vlib/open_nat.c
@@ -14,6 +14,7 @@
    \author Update to GRASS 5.7 Radim Blazek and David D. Gray.
  */
 
+#include <inttypes.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -151,12 +152,12 @@ int check_coor(struct Map_info *Map)
     if (dif > 0) {
         G_warning(
             _("Coor file of vector map <%s@%s> is larger than it should be "
-              "(%" PRI_OFF_T " bytes excess)"),
+              "(%" PRId64 " bytes excess)"),
             Map->name, Map->mapset, dif);
     }
     else if (dif < 0) {
         G_warning(_("Coor file of vector <%s@%s> is shorter than it should be "
-                    "(%" PRI_OFF_T " bytes missing)."),
+                    "(%" PRId64 " bytes missing)."),
                   Map->name, Map->mapset, -dif);
     }
     return 1;

--- a/lib/vector/Vlib/read_pg.c
+++ b/lib/vector/Vlib/read_pg.c
@@ -21,6 +21,7 @@
    \author Martin Landa <landa.martin gmail.com>
  */
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -338,8 +339,8 @@ int V2_read_line_pg(struct Map_info *Map, struct line_pnts *line_p,
         return 0;
     }
 
-    G_debug(4, "V2_read_line_pg() line = %d type = %d offset = %" PRI_OFF_T,
-            line, Line->type, Line->offset);
+    G_debug(4, "V2_read_line_pg() line = %d type = %d offset = %" PRId64, line,
+            Line->type, Line->offset);
 
     if (!line_p && !line_c)
         return Line->type;

--- a/lib/vector/Vlib/write.c
+++ b/lib/vector/Vlib/write.c
@@ -21,6 +21,7 @@
    & PostGIS support)
  */
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <grass/glocale.h>
 #include <grass/vector.h>
@@ -239,7 +240,7 @@ off_t Vect_rewrite_line(struct Map_info *Map, off_t line, int type,
 
     G_debug(3,
             "Vect_rewrite_line(): name = %s, format = %d, level = %d, "
-            "line/offset = %" PRI_OFF_T,
+            "line/offset = %" PRId64,
             Map->name, Map->format, Map->level, line);
 
     if (!check_map(Map))
@@ -248,7 +249,7 @@ off_t Vect_rewrite_line(struct Map_info *Map, off_t line, int type,
     ret = (*Vect_rewrite_line_array[Map->format][Map->level])(Map, line, type,
                                                               points, cats);
     if (ret == -1)
-        G_warning(_("Unable to rewrite feature/offset %" PRI_OFF_T
+        G_warning(_("Unable to rewrite feature/offset %" PRId64
                     " in vector map <%s>"),
                   line, Vect_get_name(Map));
 
@@ -272,7 +273,7 @@ int Vect_delete_line(struct Map_info *Map, off_t line)
 {
     int ret;
 
-    G_debug(3, "Vect_delete_line(): name = %s, line/offset = %" PRI_OFF_T,
+    G_debug(3, "Vect_delete_line(): name = %s, line/offset = %" PRId64,
             Map->name, line);
 
     if (!check_map(Map))
@@ -281,7 +282,7 @@ int Vect_delete_line(struct Map_info *Map, off_t line)
     ret = (*Vect_delete_line_array[Map->format][Map->level])(Map, line);
 
     if (ret == -1)
-        G_warning(_("Unable to delete feature/offset %" PRI_OFF_T
+        G_warning(_("Unable to delete feature/offset %" PRId64
                     " from vector map <%s>"),
                   line, Vect_get_name(Map));
 
@@ -307,8 +308,8 @@ int Vect_restore_line(struct Map_info *Map, off_t offset, off_t line)
     int ret;
 
     G_debug(3,
-            "Vect_restore_line(): name = %s, level = %d, offset = %" PRI_OFF_T
-            ", line = %" PRI_OFF_T,
+            "Vect_restore_line(): name = %s, level = %d, offset = %" PRId64
+            ", line = %" PRId64,
             Map->name, Map->level, offset, line);
 
     if (!check_map(Map))
@@ -318,7 +319,7 @@ int Vect_restore_line(struct Map_info *Map, off_t offset, off_t line)
         (*Vect_restore_line_array[Map->format][Map->level])(Map, offset, line);
 
     if (ret == -1)
-        G_warning(_("Unable to restore feature/offset %" PRI_OFF_T
+        G_warning(_("Unable to restore feature/offset %" PRId64
                     " in vector map <%s>"),
                   offset, Vect_get_name(Map));
 

--- a/lib/vector/Vlib/write_nat.c
+++ b/lib/vector/Vlib/write_nat.c
@@ -15,6 +15,7 @@
    \author V*_restore_line() by Martin Landa <landa.martin gmail.com> (2008)
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -109,7 +110,7 @@ off_t V1_rewrite_line_nat(struct Map_info *Map, off_t offset, int type,
     static struct line_pnts *old_points = NULL;
     static struct line_cats *old_cats = NULL;
 
-    G_debug(3, "V1_rewrite_line_nat(): offset = %" PRI_OFF_T, offset);
+    G_debug(3, "V1_rewrite_line_nat(): offset = %" PRId64, offset);
 
     /* First compare numbers of points and cats with tha old one */
     if (!old_points) {
@@ -249,7 +250,7 @@ int V1_delete_line_nat(struct Map_info *Map, off_t offset)
     char rhead;
     struct gvfile *dig_fp;
 
-    G_debug(3, "V1_delete_line_nat(): offset = %" PRI_OFF_T, offset);
+    G_debug(3, "V1_delete_line_nat(): offset = %" PRId64, offset);
 
     dig_set_cur_port(&(Map->head.port));
     dig_fp = &(Map->dig_fp);
@@ -352,8 +353,8 @@ int V1_restore_line_nat(struct Map_info *Map, off_t offset, off_t line)
     struct gvfile *dig_fp;
 
     G_debug(3,
-            "V1_restore_line_nat(): offset = %" PRI_OFF_T
-            ", line (not used) = %" PRI_OFF_T,
+            "V1_restore_line_nat(): offset = %" PRId64
+            ", line (not used) = %" PRId64,
             offset, line);
 
     dig_set_cur_port(&(Map->head.port));
@@ -404,14 +405,12 @@ int V2_restore_line_nat(struct Map_info *Map, off_t offset, off_t line)
 
     plus = &(Map->plus);
 
-    G_debug(
-        3, "V2_restore_line_nat(): offset = %" PRI_OFF_T ", line = %" PRI_OFF_T,
-        offset, line);
+    G_debug(3, "V2_restore_line_nat(): offset = %" PRId64 ", line = %" PRId64,
+            offset, line);
 
     if (line < 1 || line > plus->n_lines) {
-        G_warning(
-            _("Attempt to access feature with invalid id (%" PRI_OFF_T ")"),
-            line);
+        G_warning(_("Attempt to access feature with invalid id (%" PRId64 ")"),
+                  line);
         return -1;
     }
 
@@ -484,7 +483,7 @@ off_t V1__write_line_nat(struct Map_info *Map, off_t offset, int type,
             return -1;
 
         offset = dig_ftell(&(Map->dig_fp));
-        G_debug(3, "V1__rewrite_line_nat(): offset = %" PRI_OFF_T, offset);
+        G_debug(3, "V1__rewrite_line_nat(): offset = %" PRId64, offset);
         if (offset == -1)
             return -1;
     }
@@ -924,7 +923,7 @@ int V2__add_line_to_topo_nat(struct Map_info *Map, off_t offset, int type,
     plus = &(Map->plus);
 
     G_debug(3,
-            "V2__add_line_to_topo_nat(): offset = %" PRI_OFF_T
+            "V2__add_line_to_topo_nat(): offset = %" PRId64
             " (build level = %d)",
             offset, plus->built);
 

--- a/lib/vector/Vlib/write_ogr.c
+++ b/lib/vector/Vlib/write_ogr.c
@@ -17,6 +17,7 @@
    \author Martin Landa <landa.martin gmail.com>
  */
 
+#include <inttypes.h>
 #include <grass/vector.h>
 #include <grass/dbmi.h>
 #include <grass/gprojects.h>
@@ -89,8 +90,7 @@ off_t V1_rewrite_line_ogr(struct Map_info *Map, off_t offset, int type,
                           const struct line_pnts *points,
                           const struct line_cats *cats)
 {
-    G_debug(3, "V1_rewrite_line_ogr(): type=%d offset=%" PRI_OFF_T, type,
-            offset);
+    G_debug(3, "V1_rewrite_line_ogr(): type=%d offset=%" PRId64, type, offset);
 #ifdef HAVE_OGR
     if (type != V1_read_line_ogr(Map, NULL, NULL, offset)) {
         G_warning(_("Unable to rewrite feature (incompatible feature types)"));
@@ -131,7 +131,7 @@ int V1_delete_line_ogr(struct Map_info *Map, off_t offset)
     }
 
     if (offset >= ogr_info->offset.array_num) {
-        G_warning(_("Invalid offset (%" PRI_OFF_T ")"), offset);
+        G_warning(_("Invalid offset (%" PRId64 ")"), offset);
         return -1;
     }
 

--- a/lib/vector/Vlib/write_pg.c
+++ b/lib/vector/Vlib/write_pg.c
@@ -19,6 +19,7 @@
    \author Martin Landa <landa.martin gmail.com>
  */
 
+#include <inttypes.h>
 #include <string.h>
 
 #include <grass/vector.h>
@@ -187,8 +188,7 @@ off_t V1_rewrite_line_pg(struct Map_info *Map, off_t offset, int type,
                          const struct line_pnts *points,
                          const struct line_cats *cats)
 {
-    G_debug(3, "V1_rewrite_line_pg(): type=%d offset=%" PRI_OFF_T, type,
-            offset);
+    G_debug(3, "V1_rewrite_line_pg(): type=%d offset=%" PRId64, type, offset);
 #ifdef HAVE_POSTGRES
     if (type != V1_read_line_pg(Map, NULL, NULL, offset)) {
         G_warning(_("Unable to rewrite feature (incompatible feature types)"));
@@ -288,7 +288,7 @@ off_t V2_rewrite_line_pg(struct Map_info *Map, off_t line, int type,
     geom_data = line_to_wkb(pg_info, &points, 1, type, Map->head.with_z);
     G_asprintf(&stmt,
                "UPDATE \"%s\".\"%s\" SET geom = '%s'::GEOMETRY WHERE %s_id = "
-               "%" PRI_OFF_T,
+               "%" PRId64,
                schema_name, table_name, geom_data, keycolumn, line);
     G_free(geom_data);
 
@@ -334,7 +334,7 @@ int V1_delete_line_pg(struct Map_info *Map, off_t offset)
     }
 
     if (offset >= pg_info->offset.array_num) {
-        G_warning(_("Invalid offset (%" PRI_OFF_T ")"), offset);
+        G_warning(_("Invalid offset (%" PRId64 ")"), offset);
         return -1;
     }
 

--- a/lib/vector/diglib/cindex_rw.c
+++ b/lib/vector/diglib/cindex_rw.c
@@ -14,6 +14,7 @@
  *
  *****************************************************************************/
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <string.h>
@@ -66,7 +67,7 @@ int dig_write_cidx_head(struct gvfile *fp, struct Plus_head *plus)
 
         ci = &(plus->cidx[i]);
 
-        G_debug(3, "cidx %d head offset: %" PRI_OFF_T, i, dig_ftell(fp));
+        G_debug(3, "cidx %d head offset: %" PRId64, i, dig_ftell(fp));
 
         /* Field number */
         if (0 >= dig__fwrite_port_I(&(ci->field), 1, fp))
@@ -101,10 +102,10 @@ int dig_write_cidx_head(struct gvfile *fp, struct Plus_head *plus)
         /* Offset */
         if (0 >= dig__fwrite_port_O(&(ci->offset), 1, fp, plus->off_t_size))
             return (0);
-        G_debug(3, "cidx %d offset: %" PRI_OFF_T, i, ci->offset);
+        G_debug(3, "cidx %d offset: %" PRId64, i, ci->offset);
     }
 
-    G_debug(3, "cidx body offset %" PRI_OFF_T, dig_ftell(fp));
+    G_debug(3, "cidx body offset %" PRId64, dig_ftell(fp));
 
     return (0);
 }

--- a/lib/vector/diglib/head.c
+++ b/lib/vector/diglib/head.c
@@ -15,6 +15,7 @@
  *
  *****************************************************************************/
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <string.h>
 #include <grass/vector.h>
@@ -52,7 +53,7 @@ int dig__write_head(struct Map_info *Map)
         return (0);
 
     /* bytes 11 - 18 : size of coordinate file */
-    G_debug(1, "write coor size (%" PRI_OFF_T ") to head", Map->head.size);
+    G_debug(1, "write coor size (%" PRId64 ") to head", Map->head.size);
     if (Map->head.head_size >= GV_COOR_HEAD_SIZE + 4) {
         if (Map->head.size > PORT_LONG_MAX) {
             /* can only happen when sizeof(off_t) == 8 */
@@ -78,7 +79,7 @@ int dig__write_head(struct Map_info *Map)
             return (0);
     }
 
-    G_debug(2, "coor body offset %" PRI_OFF_T, dig_ftell(&(Map->dig_fp)));
+    G_debug(2, "coor body offset %" PRId64, dig_ftell(&(Map->dig_fp)));
 
     return 1;
 }
@@ -159,7 +160,7 @@ int dig__read_head(struct Map_info *Map)
         if (0 >= dig__fread_port_O(&(Map->head.size), 1, &(Map->dig_fp), 4))
             return (0);
     }
-    G_debug(2, "  coor size %" PRI_OFF_T, Map->head.size);
+    G_debug(2, "  coor size %" PRId64, Map->head.size);
 
     /* Go to end of header, file may be written by new version of GRASS with
      * longer header */

--- a/lib/vector/diglib/plus_struct.c
+++ b/lib/vector/diglib/plus_struct.c
@@ -15,6 +15,7 @@
  *
  *****************************************************************************/
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <string.h>
 #include <grass/vector.h>
@@ -648,7 +649,7 @@ int dig_Rd_Plus_head(struct gvfile *fp, struct Plus_head *ptr)
     if (0 >= dig__fread_port_O(&(ptr->coor_size), 1, fp, ptr->off_t_size))
         return (-1);
 
-    G_debug(2, "  coor size %" PRI_OFF_T, ptr->coor_size);
+    G_debug(2, "  coor size %" PRId64, ptr->coor_size);
 
     dig_fseek(fp, ptr->head_size, SEEK_SET);
 
@@ -761,7 +762,7 @@ int dig_Wr_Plus_head(struct gvfile *fp, struct Plus_head *ptr)
     if (0 >= dig__fwrite_port_O(&(ptr->coor_size), 1, fp, ptr->off_t_size))
         return (-1);
 
-    G_debug(2, "topo body offset %" PRI_OFF_T, dig_ftell(fp));
+    G_debug(2, "topo body offset %" PRId64, dig_ftell(fp));
 
     return (0);
 }

--- a/lib/vector/diglib/spindex_rw.c
+++ b/lib/vector/diglib/spindex_rw.c
@@ -15,6 +15,7 @@
    \author Update to GRASS 7 Markus Metz
  */
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <stdlib.h>
 #include <string.h>
@@ -744,8 +745,8 @@ static off_t rtree_write_from_memory(struct gvfile *fp, off_t startpos,
             /* write node to sidx file */
             if (G_ftell(fp->file) != nextfreepos)
                 G_fatal_error("Unable to write spatial index. "
-                              "Wrong node position (%" PRI_OFF_T
-                              ") in file (should be %" PRI_OFF_T ").",
+                              "Wrong node position (%" PRId64
+                              ") in file (should be %" PRId64 ").",
                               G_ftell(fp->file), nextfreepos);
 
             /* write with dig__fwrite_port_* fns */
@@ -863,8 +864,8 @@ static off_t rtree_write_from_file(struct gvfile *fp, off_t startpos,
             /* write node to sidx file */
             if (G_ftell(fp->file) != nextfreepos)
                 G_fatal_error("Unable to write spatial index. "
-                              "Wrong node position (%" PRI_OFF_T
-                              ") in file (should be %" PRI_OFF_T ").",
+                              "Wrong node position (%" PRId64
+                              ") in file (should be %" PRId64 ").",
                               G_ftell(fp->file), nextfreepos);
 
             /* write with dig__fwrite_port_* fns */

--- a/raster/r.in.bin/main.c
+++ b/raster/r.in.bin/main.c
@@ -13,6 +13,7 @@
  *
  *****************************************************************************/
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -602,7 +603,7 @@ int main(int argc, char *argv[])
     expected = (off_t)ncols * nrows * bytes * nbands + hbytes;
 
     if (file_size != expected) {
-        G_warning(_("File Size %" PRI_OFF_T " ... Total Bytes %" PRI_OFF_T),
+        G_warning(_("File Size %" PRId64 " ... Total Bytes %" PRId64),
                   file_size, expected);
         G_fatal_error(_("Bytes do not match file size"));
     }

--- a/raster/r.stream.extract/close.c
+++ b/raster/r.stream.extract/close.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
 #include <grass/vector.h>
@@ -204,7 +205,7 @@ int close_streamvect(char *stream_vect)
     /* stream nodes */
     for (i = 1; i <= n_stream_nodes; i++) {
 
-        sprintf(buf, "insert into %s values ( %" PRI_OFF_T ", \'%s\', %d, %d )",
+        sprintf(buf, "insert into %s values ( %" PRId64 ", \'%s\', %d, %d )",
                 Fi->table, i,
                 (stream_node[i].n_trib > 0 ? "intermediate" : "start"),
                 (stream_node[i].n_trib > 0), network_id[i]);

--- a/raster/r.stream.extract/do_astar.c
+++ b/raster/r.stream.extract/do_astar.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdlib.h>
 #include <math.h>
 #include <grass/raster.h>
@@ -60,12 +61,12 @@ int do_astar(void)
     while (heap_size > 0) {
         G_percent(count++, n_points, 1);
         if (count > n_points)
-            G_fatal_error(_("%" PRI_OFF_T " surplus points"), heap_size);
+            G_fatal_error(_("%" PRId64 " surplus points"), heap_size);
 
         if (heap_size > n_points)
-            G_fatal_error(_("Too many points in heap %" PRI_OFF_T
-                            ", should be %" PRI_OFF_T ""),
-                          heap_size, n_points);
+            G_fatal_error(
+                _("Too many points in heap %" PRId64 ", should be %" PRId64 ""),
+                heap_size, n_points);
 
         heap_p = heap_drop();
 

--- a/raster/r.stream.extract/init_search.c
+++ b/raster/r.stream.extract/init_search.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
 #include "local_proto.h"
@@ -114,9 +115,9 @@ int init_search(int depr_fd)
         G_free(depr_buf);
     }
 
-    G_debug(1, "%" PRI_OFF_T " edge cells", heap_size - n_depr_cells);
+    G_debug(1, "%" PRId64 " edge cells", heap_size - n_depr_cells);
     if (n_depr_cells)
-        G_debug(1, "%" PRI_OFF_T " cells in depressions", n_depr_cells);
+        G_debug(1, "%" PRId64 " cells in depressions", n_depr_cells);
 
     return 1;
 }

--- a/raster/r.stream.extract/load.c
+++ b/raster/r.stream.extract/load.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
 #include "local_proto.h"
@@ -168,7 +169,7 @@ int load_maps(int ele_fd, int acc_fd)
         G_free(acc_buf);
     }
 
-    G_debug(1, "%" PRI_OFF_T " non-NULL cells", n_points);
+    G_debug(1, "%" PRId64 " non-NULL cells", n_points);
 
     return (n_points > 0);
 }

--- a/raster/r.stream.extract/streams.c
+++ b/raster/r.stream.extract/streams.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdlib.h>
 #include <math.h>
 #include <grass/raster.h>
@@ -67,7 +68,7 @@ static int continue_stream(CELL stream_id, int r_max, int c_max, int *stream_no)
         /* debug */
         if (n_stream_nodes != *stream_no)
             G_warning(
-                _("Stream_no %d and n_stream_nodes %" PRI_OFF_T " out of sync"),
+                _("Stream_no %d and n_stream_nodes %" PRId64 " out of sync"),
                 *stream_no, n_stream_nodes);
 
         stream_node[*stream_no].n_alloc += 2;
@@ -652,7 +653,7 @@ int extract_streams(double threshold, double mont_exp, int internal_acc)
 
             /* debug */
             if (n_stream_nodes != stream_no)
-                G_warning(_("Stream_no %d and n_stream_nodes %" PRI_OFF_T
+                G_warning(_("Stream_no %d and n_stream_nodes %" PRId64
                             " out of sync"),
                           stream_no, n_stream_nodes);
         }
@@ -686,7 +687,7 @@ int extract_streams(double threshold, double mont_exp, int internal_acc)
     G_percent(1, 1, 2);
     if (workedon)
         G_warning(_("MFD: A * path already processed when setting drainage "
-                    "direction: %" PRI_OFF_T " of %" PRI_OFF_T " cells"),
+                    "direction: %" PRId64 " of %" PRId64 " cells"),
                   workedon, n_points);
 
     G_free(dist_to_nbr);
@@ -694,8 +695,8 @@ int extract_streams(double threshold, double mont_exp, int internal_acc)
     G_free(ele_nbr);
     G_free(flag_nbr);
 
-    G_debug(1, "%" PRI_OFF_T " outlets", n_outlets);
-    G_debug(1, "%" PRI_OFF_T " nodes", n_stream_nodes);
+    G_debug(1, "%" PRId64 " outlets", n_outlets);
+    G_debug(1, "%" PRId64 " nodes", n_stream_nodes);
     G_debug(1, "%d streams", stream_no);
 
     return 1;

--- a/raster/r.stream.extract/thin.c
+++ b/raster/r.stream.extract/thin.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdlib.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>
@@ -163,7 +164,7 @@ int thin_streams(void)
 
     G_free(nodestack);
 
-    G_verbose_message(_("%d of %" PRI_OFF_T " stream segments were thinned"),
+    G_verbose_message(_("%d of %" PRId64 " stream segments were thinned"),
                       n_thinned, n_stream_nodes);
 
     return 1;

--- a/raster/r.terraflow/grass2str.h
+++ b/raster/r.terraflow/grass2str.h
@@ -19,6 +19,7 @@
 #ifndef _gras2str_H
 #define _gras2str_H
 
+#include <cinttypes>
 #include <grass/iostream/ami.h>
 #include <grass/glocale.h>
 #include "option.h"
@@ -135,7 +136,7 @@ AMI_STREAM<T> *cell2stream(char *cellname, elevation_type T_max_value,
     /* close map files */
     Rast_close(infd);
 
-    G_debug(1, "nrows=%d   ncols=%d    stream_len()=%" PRI_OFF_T, nrows, ncols,
+    G_debug(1, "nrows=%d   ncols=%d    stream_len()=%" PRId64, nrows, ncols,
             str->stream_len());
     assert((off_t)nrows * ncols == str->stream_len());
     rt_stop(rt);

--- a/raster/r.terraflow/main.cpp
+++ b/raster/r.terraflow/main.cpp
@@ -16,6 +16,7 @@
  *
  *****************************************************************************/
 
+#include <cinttypes>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -411,13 +412,13 @@ void printMaxSortSize(long nodata_count)
     off_t maxneed = (fillmaxsize > flowmaxsize) ? fillmaxsize : flowmaxsize;
     maxneed = 2 * maxneed; /* need 2*N to sort */
 
-    G_debug(1, "total elements=%" PRI_OFF_T ", nodata elements=%ld",
+    G_debug(1, "total elements=%" PRId64 ", nodata elements=%ld",
             (off_t)nrows * ncols, nodata_count);
     G_debug(1, "largest temporary files: ");
-    G_debug(1, "\t\t FILL: %s [%" PRI_OFF_T " elements, %ldB each]",
+    G_debug(1, "\t\t FILL: %s [%" PRId64 " elements, %ldB each]",
             formatNumber(buf, fillmaxsize), (off_t)nrows * ncols,
             sizeof(waterWindowType));
-    G_debug(1, "\t\t FLOW: %s [%" PRI_OFF_T " elements, %ldB each]",
+    G_debug(1, "\t\t FLOW: %s [%" PRId64 " elements, %ldB each]",
             formatNumber(buf, flowmaxsize), (off_t)nrows * ncols - nodata_count,
             sizeof(sweepItem));
     G_debug(1, "Will need at least %s space available in %s",

--- a/raster/r.terraflow/stats.cpp
+++ b/raster/r.terraflow/stats.cpp
@@ -16,6 +16,7 @@
  *
  *****************************************************************************/
 
+#include <cinttypes>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -173,19 +174,19 @@ void statsRecorder::comment(const int n)
 char *formatNumber(char *buf, off_t val)
 {
     if (val > (1 << 30)) {
-        snprintf(buf, BUFSIZ, "%.2fG (%" PRI_OFF_T ")", (double)val / (1 << 30),
+        snprintf(buf, BUFSIZ, "%.2fG (%" PRId64 ")", (double)val / (1 << 30),
                  val);
     }
     else if (val > (1 << 20)) {
-        snprintf(buf, BUFSIZ, "%.2fM (%" PRI_OFF_T ")", (double)val / (1 << 20),
+        snprintf(buf, BUFSIZ, "%.2fM (%" PRId64 ")", (double)val / (1 << 20),
                  val);
     }
     else if (val > (1 << 10)) {
-        snprintf(buf, BUFSIZ, "%.2fK (%" PRI_OFF_T ")", (double)val / (1 << 10),
+        snprintf(buf, BUFSIZ, "%.2fK (%" PRId64 ")", (double)val / (1 << 10),
                  val);
     }
     else {
-        snprintf(buf, BUFSIZ, "%" PRI_OFF_T, val);
+        snprintf(buf, BUFSIZ, "%" PRId64, val);
     }
     return buf;
 }

--- a/raster/r.terraflow/sweep.cpp
+++ b/raster/r.terraflow/sweep.cpp
@@ -16,6 +16,7 @@
  *
  *****************************************************************************/
 
+#include <cinttypes>
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
@@ -195,8 +196,8 @@ AMI_STREAM<sweepOutput> *sweep(AMI_STREAM<sweepItem> *sweepstr,
         /* read next sweepItem = (prio, elevwin, topoRankwin, dir) */
         ae = sweepstr->read_item(&crtpoint);
         if (ae != AMI_ERROR_NO_ERROR) {
-            fprintf(stderr,
-                    "sweep: k=%" PRI_OFF_T ": cannot read next item..\n", k);
+            fprintf(stderr, "sweep: k=%" PRId64 ": cannot read next item..\n",
+                    k);
             exit(1);
         }
         /* cout << "k=" << k << " prio =" << crtpoint->getPriority() << "\n"; */

--- a/raster/r.watershed/seg/do_astar.c
+++ b/raster/r.watershed/seg/do_astar.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>
 #include "Gwater.h"
@@ -47,8 +48,7 @@ int do_astar(void)
     if (heap_size == 0)
         G_fatal_error(_("No seeds for A* Search"));
 
-    G_debug(1, "heap size %" PRI_OFF_T ", points %" PRI_OFF_T, heap_size,
-            do_points);
+    G_debug(1, "heap size %" PRId64 ", points %" PRId64, heap_size, do_points);
 
     count = 0;
 
@@ -62,7 +62,7 @@ int do_astar(void)
 
         r = heap_p.pnt.r;
         c = heap_p.pnt.c;
-        G_debug(3, "heap size %" PRI_OFF_T ", r %d, c %d", heap_size, r, c);
+        G_debug(3, "heap size %" PRId64 ", r %d, c %d", heap_size, r, c);
 
         alt_val = heap_p.ele;
 
@@ -144,8 +144,8 @@ int do_astar(void)
         seg_put(&aspflag, (char *)&af, r, c);
     }
     if (doer != -1)
-        G_fatal_error(_("bug in A* Search: doer %" PRI_OFF_T
-                        " heap size %" PRI_OFF_T " count %" PRI_OFF_T),
+        G_fatal_error(_("bug in A* Search: doer %" PRId64 " heap size %" PRId64
+                        " count %" PRId64),
                       doer, heap_size, count);
 
     seg_close(&search_heap);

--- a/raster/r.watershed/seg/do_cum.c
+++ b/raster/r.watershed/seg/do_cum.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include "Gwater.h"
 #include <unistd.h>
 #include <grass/gis.h>
@@ -554,7 +555,7 @@ int do_cum_mfd(void)
 
     if (workedon)
         G_warning(_("MFD: A * path already processed when distributing flow: "
-                    "%d of %" PRI_OFF_T " cells"),
+                    "%d of %" PRId64 " cells"),
                   workedon, do_points);
 
     G_message(_("SECTION 3b: Adjusting drainage directions."));


### PR DESCRIPTION
Replace the macro `PRI_OFF_T` with the use of `PRId64`, which is a macro defined in the C99 `<inttypes.h>` file.

Fixes #2806
which reports that gettext cannot handle locally defined macros, whereas

https://www.gnu.org/software/gettext/manual/gettext.html#Preparing-Strings :

> The gettext tools and library have special support for these <inttypes.h> macros. You can therefore simply write
> printf (gettext ("The amount is %0" PRId64 "\n"), number);
> The PO file will contain the string "The amount is %0<PRId64>\n". The translators will provide a translation
> containing "%0<PRId64>" as well, and at runtime the gettext function’s result will contain the appropriate
> constant string, "d" or "ld" or "lld".




This was already discussed in: https://github.com/OSGeo/grass/pull/1256#issuecomment-775499164