### PR TITLE
wxGUI: make single-window default, put it under Appearance

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -153,7 +153,6 @@ class Settings:
                 "region": {
                     "resAlign": {"enabled": False},
                 },
-                "singleWindow": {"enabled": False},
             },
             #
             # datacatalog
@@ -191,6 +190,7 @@ class Settings:
                 "gSelectPopupHeight": {"value": 200},
                 "iconTheme": {"type": "grass"},
                 "commandNotebook": {"selection": 0},
+                "singleWindow": {"enabled": True},
             },
             #
             # language

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -405,19 +405,6 @@ class PreferencesDialog(PreferencesBaseDialog):
         gridSizer = wx.GridBagSizer(hgap=3, vgap=3)
 
         row = 0
-        singleWindow = wx.CheckBox(
-            parent=panel,
-            id=wx.ID_ANY,
-            label=_("Use single-window mode (experimental, requires GUI restart)"),
-            name="IsChecked",
-        )
-        singleWindow.SetValue(
-            self.settings.Get(group="general", key="singleWindow", subkey="enabled")
-        )
-        self.winId["general:singleWindow:enabled"] = singleWindow.GetId()
-        gridSizer.Add(singleWindow, pos=(row, 0), span=(1, 2))
-
-        row += 1
         posDisplay = wx.CheckBox(
             parent=panel,
             id=wx.ID_ANY,
@@ -515,6 +502,29 @@ class PreferencesDialog(PreferencesBaseDialog):
         notebook.AddPage(page=panel, text=_("Appearance"))
 
         border = wx.BoxSizer(wx.VERTICAL)
+
+        #
+        # single window settings
+        #
+        box = StaticBox(
+            parent=panel, id=wx.ID_ANY, label=" %s " % _("Window layout settings")
+        )
+        sizer = wx.StaticBoxSizer(box, wx.VERTICAL)
+        singleWindow = wx.CheckBox(
+            parent=panel,
+            id=wx.ID_ANY,
+            label=_("Use single-window mode (requires GUI restart)"),
+            name="IsChecked",
+        )
+        singleWindow.SetToolTip(
+            _("Use single-window mode instead of multi-window mode")
+        )
+        singleWindow.SetValue(
+            self.settings.Get(group="appearance", key="singleWindow", subkey="enabled")
+        )
+        self.winId["appearance:singleWindow:enabled"] = singleWindow.GetId()
+        sizer.Add(singleWindow, proportion=0, flag=wx.ALL | wx.EXPAND, border=5)
+        border.Add(sizer, proportion=0, flag=wx.ALL | wx.EXPAND, border=3)
 
         box = StaticBox(parent=panel, id=wx.ID_ANY, label=" %s " % _("Font settings"))
         sizer = wx.StaticBoxSizer(box, wx.VERTICAL)

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1249,7 +1249,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             vector/volume
         """
         if not UserSettings.Get(
-            group="general",
+            group="appearance",
             key="singleWindow",
             subkey="enabled",
         ):

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -85,7 +85,7 @@ class GMApp(wx.App):
         def show_main_gui():
             # create and show main frame
             single = UserSettings.Get(
-                group="general", key="singleWindow", subkey="enabled"
+                group="appearance", key="singleWindow", subkey="enabled"
             )
             if single:
                 from main_window.frame import GMFrame


### PR DESCRIPTION
This is making single window the default (checkbox is checked by default). The settings key has changed, so old settings of layout won't apply. I changed where the option is now, it's the first thing in Appearance tab, so hopefully it should be more visible here.

![Selection_261](https://user-images.githubusercontent.com/7494312/217586150-780c6de3-fad3-4633-95d7-4f56db03289b.png)
