### PR TITLE
CI: compile OSGeo4W-Windows build with clang

### DIFF
--- a/.github/workflows/build_osgeo4w.sh
+++ b/.github/workflows/build_osgeo4w.sh
@@ -17,6 +17,8 @@ test -d "$1" && cd "$1"
 export OSGEO4W_ROOT_MSYS=/c/OSGeo4W
 export SRC=$(pwd)
 export UNITTEST=1
+export CC=clang
+export CXX=clang++
 
 # Build according to OSGeo4W recipe
 ${SRC}/mswindows/osgeo4w/build_osgeo4w.sh

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -35,10 +35,10 @@ jobs:
           update: true
           install: tar libintl make bison flex diffutils git dos2unix zip mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-fftw mingw-w64-x86_64-lapack mingw-w64-x86_64-pkgconf
-            mingw-w64-x86_64-gcc mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv
+            mingw-w64-x86_64-clang mingw-w64-x86_64-ccache mingw-w64-x86_64-zlib mingw-w64-x86_64-libiconv
             mingw-w64-x86_64-bzip2 mingw-w64-x86_64-gettext mingw-w64-x86_64-libsystre
             mingw-w64-x86_64-libtre-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libpng
-            mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six
+            mingw-w64-x86_64-pcre mingw-w64-x86_64-python3-six mingw-w64-x86_64-lld mingw-w64-x86_64-openmp
 
       - name: Install OSGeo4W
         run: >

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -506,7 +506,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
             SHLIB_SUFFIX=".dll"
             SHLIB_LD="${CC} -shared"
             SHLIB_LDX="${CXX} -shared"
-            LDFLAGS="-Wl,--export-dynamic,--enable-runtime-pseudo-reloc"
+            LDFLAGS="-Wl,--enable-runtime-pseudo-reloc"
             LD_LIBRARY_PATH_VAR="PATH"
             ;;
         *-apple-darwin*)

--- a/configure
+++ b/configure
@@ -4325,7 +4325,7 @@ ac_save_ldflags="$LDFLAGS"
             SHLIB_SUFFIX=".dll"
             SHLIB_LD="${CC} -shared"
             SHLIB_LDX="${CXX} -shared"
-            LDFLAGS="-Wl,--export-dynamic,--enable-runtime-pseudo-reloc"
+            LDFLAGS="-Wl,--enable-runtime-pseudo-reloc"
             LD_LIBRARY_PATH_VAR="PATH"
             ;;
         *-apple-darwin*)


### PR DESCRIPTION
The last week the Windows CI runner failed with linking failure, the reason was reported here: https://github.com/msys2/MINGW-packages/issues/15469. Searching for a fix/alternative/solution I came up with this PR.

The original solution has now apparently been fixed, but I put this up as a "proof of concept".