### PR TITLE
grass.pygrass: Convert all values to string, not just numbers

### DIFF
--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -40,13 +40,13 @@ def _check_value(param, value):
     def check_string(value):
         """Function to check that a string parameter is already a string"""
         if param.type in string:
-            if type(value) in (int, float):
+            try:
                 value = str(value)
-            if type(value) not in string:
+            except TypeError as error:
                 msg = (
                     "The Parameter <%s> require a string," " %s instead is provided: %r"
                 )
-                raise ValueError(msg % (param.name, type(value), value))
+                raise ValueError(msg % (param.name, type(value), value)) from error
         return value
 
     # return None if None


### PR DESCRIPTION
pathlib.Path and decimal.Decimal should just work as is when calling a tool though pygrass. This converts the value to a string first, i.e., there is no type checking given that everything in Python coverts to a string.
