### PR TITLE
grass.script: Fix ignored superquiet (--qq) parameter

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -390,7 +390,15 @@ def start_command(
         else:
             options[opt] = val
 
-    args = make_command(prog, flags=flags, overwrite=overwrite, quiet=quiet, superquiet=superquiet, verbose=verbose, **options)
+    args = make_command(
+        prog,
+        flags=flags,
+        overwrite=overwrite,
+        quiet=quiet,
+        superquiet=superquiet,
+        verbose=verbose,
+        **options,
+    )
 
     if debug_level() > 0:
         sys.stderr.write(

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -232,6 +232,7 @@ def make_command(
     :param str flags: flags to be used (given as a string)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param bool quiet: True to run quietly (<tt>--q</tt>)
+    :param bool superquiet: True to run extra quietly (<tt>--qq</tt>)
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param options: module's parameters
 
@@ -375,6 +376,7 @@ def start_command(
     :param str flags: flags to be used (given as a string)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param bool quiet: True to run quietly (<tt>--q</tt>)
+    :param bool superquiet: True to run extra quietly (<tt>--qq</tt>)
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param kwargs: module's parameters
 
@@ -388,7 +390,7 @@ def start_command(
         else:
             options[opt] = val
 
-    args = make_command(prog, flags, overwrite, quiet, verbose, **options)
+    args = make_command(prog, flags=flags, overwrite=overwrite, quiet=quiet, superquiet=superquiet, verbose=verbose, **options)
 
     if debug_level() > 0:
         sys.stderr.write(
@@ -627,12 +629,13 @@ def exec_command(
     :param str flags: flags to be used (given as a string)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param bool quiet: True to run quietly (<tt>--q</tt>)
+    :param bool superquiet: True to run quietly (<tt>--qq</tt>)
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param env: directory with environmental variables
     :param list kwargs: module's parameters
 
     """
-    args = make_command(prog, flags, overwrite, quiet, verbose, **kwargs)
+    args = make_command(prog, flags, overwrite, quiet, superquiet, verbose, **kwargs)
 
     if env is None:
         env = os.environ

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -109,7 +109,14 @@ def raster_info(map, env=None):
 
 
 def mapcalc(
-    exp, quiet=False, superquiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
+    exp,
+    quiet=False,
+    superquiet=False,
+    verbose=False,
+    overwrite=False,
+    seed=None,
+    env=None,
+    **kwargs,
 ):
     """Interface to r.mapcalc.
 
@@ -147,7 +154,14 @@ def mapcalc(
 
 
 def mapcalc_start(
-    exp, quiet=False, superquiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
+    exp,
+    quiet=False,
+    superquiet=False,
+    verbose=False,
+    overwrite=False,
+    seed=None,
+    env=None,
+    **kwargs,
 ):
     """Interface to r.mapcalc, doesn't wait for it to finish, returns Popen object.
 

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -109,12 +109,13 @@ def raster_info(map, env=None):
 
 
 def mapcalc(
-    exp, quiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
+    exp, quiet=False, superquiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
 ):
     """Interface to r.mapcalc.
 
     :param str exp: expression
     :param bool quiet: True to run quietly (<tt>--q</tt>)
+    :param bool superquiet: True to run extra quietly (<tt>--qq</tt>)
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param seed: an integer used to seed the random-number generator for the
@@ -137,6 +138,7 @@ def mapcalc(
             env=env,
             seed=seed,
             quiet=quiet,
+            superquiet=superquiet,
             verbose=verbose,
             overwrite=overwrite,
         )
@@ -145,7 +147,7 @@ def mapcalc(
 
 
 def mapcalc_start(
-    exp, quiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
+    exp, quiet=False, superquiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
 ):
     """Interface to r.mapcalc, doesn't wait for it to finish, returns Popen object.
 
@@ -166,6 +168,7 @@ def mapcalc_start(
 
     :param str exp: expression
     :param bool quiet: True to run quietly (<tt>--q</tt>)
+    :param bool superquiet: True to run extra quietly (<tt>--qq</tt>)
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param seed: an integer used to seed the random-number generator for the
@@ -188,6 +191,7 @@ def mapcalc_start(
         env=env,
         seed=seed,
         quiet=quiet,
+        superquiet=superquiet,
         verbose=verbose,
         overwrite=overwrite,
     )

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -69,12 +69,13 @@ def raster3d_info(map, env=None):
 
 
 def mapcalc3d(
-    exp, quiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
+    exp, quiet=False, superquiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
 ):
     """Interface to r3.mapcalc.
 
     :param str exp: expression
     :param bool quiet: True to run quietly (<tt>--q</tt>)
+    :param bool superquiet: True to run extra quietly (<tt>--qq</tt>)
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param seed: an integer used to seed the random-number generator for the
@@ -97,6 +98,7 @@ def mapcalc3d(
             env=env,
             seed=seed,
             quiet=quiet,
+            superquiet=superquiet,
             verbose=verbose,
             overwrite=overwrite,
         )

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -69,7 +69,14 @@ def raster3d_info(map, env=None):
 
 
 def mapcalc3d(
-    exp, quiet=False, superquiet=False, verbose=False, overwrite=False, seed=None, env=None, **kwargs
+    exp,
+    quiet=False,
+    superquiet=False,
+    verbose=False,
+    overwrite=False,
+    seed=None,
+    env=None,
+    **kwargs,
 ):
     """Interface to r3.mapcalc.
 


### PR DESCRIPTION
The superquiet (--qq) parameter was ignored by the core functions and not supported in others. This adds superquiet=False to all relevant functions.
