### PR TITLE
grass.pygrass: Fix parameter range error reporting

### DIFF
--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -100,18 +100,18 @@ def _check_value(param, value):
             ):
                 if param.min is None:
                     err_str = (
-                        "The Parameter <%s>, must be lower than "
-                        "%g, %r is outside." % (param.name, param.max, newvalue)
+                        f"The Parameter <{param.name}> must be lower than "
+                        f"{param.max}, {newvalue} is outside."
                     )
                 elif param.max is None:
                     err_str = (
-                        "The Parameter <%s>, must be higher than "
-                        "%g, %r is out of range." % (param.name, param.min, newvalue)
+                        f"The Parameter <{param.name}> must be higher than "
+                        f"{param.min}, {newvalue} is out of range."
                     )
                 else:
                     err_str = (
-                        "The Parameter <%s>, must be between: "
-                        "%g<=value<=%g, %r is outside." % (param.name, param.min, param.max, newvalue)
+                        f"The Parameter <{param.name}> must be between: "
+                        f"{param.min}<=value<={param.max}, {newvalue} is outside."
                     )
                 raise ValueError(err_str)
         # check if value is in the list of valid values

--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -98,11 +98,22 @@ def _check_value(param, value):
             if (param.min is not None and newvalue < param.min) or (
                 param.max is not None and newvalue > param.max
             ):
-                err_str = (
-                    "The Parameter <%s>, must be between: "
-                    "%g<=value<=%g, %r is outside."
-                )
-                raise ValueError(err_str % (param.name, param.min, param.max, newvalue))
+                if param.min is None:
+                    err_str = (
+                        "The Parameter <%s>, must be lower than "
+                        "%g, %r is outside." % (param.name, param.max, newvalue)
+                    )
+                elif param.max is None:
+                    err_str = (
+                        "The Parameter <%s>, must be higher than "
+                        "%g, %r is out of range." % (param.name, param.min, newvalue)
+                    )
+                else:
+                    err_str = (
+                        "The Parameter <%s>, must be between: "
+                        "%g<=value<=%g, %r is outside." % (param.name, param.min, param.max, newvalue)
+                    )
+                raise ValueError(err_str)
         # check if value is in the list of valid values
         if param.values is not None and newvalue not in param.values:
             raise ValueError(must_val % (param.name, param.values))

--- a/python/grass/pygrass/modules/interface/testsuite/test_parameter.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_parameter.py
@@ -133,6 +133,84 @@ class TestCheckValueFunction(TestCase):
             with self.assertRaises(ValueError):
                 _check_value(param, 2.6)
 
+    def test_positive_min_float_double(self):
+        """Check range checking for a positive minimum.
+
+        Tests positive cases, type of exception, and content of the message.
+        """
+        name = "number"
+        for ptype in ("float", "double"):
+            param = Parameter(
+                diz=dict(
+                    name=name,
+                    required="yes",
+                    multiple="no",
+                    type=ptype,
+                    values=[
+                        "2-",
+                    ],
+                )
+            )
+            value = 2
+            self.assertTupleEqual((float(value), value), _check_value(param, value))
+            value = 2.2
+            self.assertTupleEqual((value, value), _check_value(param, value))
+            value = "2"
+            self.assertTupleEqual((float(value), value), _check_value(param, value))
+            value = "2.5"
+            self.assertTupleEqual((float(value), value), _check_value(param, value))
+
+            # test errors
+            with self.assertRaisesRegex(ValueError, f"{name}.+elev"):
+                _check_value(param, "elev")
+            with self.assertRaisesRegex(TypeError, name):
+                _check_value(param, (1.0, 2.0))
+            # Only the main parts of the message are checked,
+            # but the check is order-dependent.
+            with self.assertRaisesRegex(ValueError, f"{name}.+1.9"):
+                _check_value(param, 1.9)
+            with self.assertRaisesRegex(ValueError, f"{name}.+-1.0"):
+                _check_value(param, -1.0)
+
+    def test_positive_max_float_double(self):
+        """Check range checking for a positive maximum.
+
+        Tests positive cases, type of exception, and content of the message.
+        """
+        name = "number"
+        for ptype in ("float", "double"):
+            param = Parameter(
+                diz=dict(
+                    name=name,
+                    required="yes",
+                    multiple="no",
+                    type=ptype,
+                    values=[
+                        "-100",
+                    ],
+                )
+            )
+            value = 1
+            self.assertTupleEqual((float(value), value), _check_value(param, value))
+            value = 1.2
+            self.assertTupleEqual((value, value), _check_value(param, value))
+            value = "0"
+            self.assertTupleEqual((float(value), value), _check_value(param, value))
+            value = "2.5"
+            self.assertTupleEqual((float(value), value), _check_value(param, value))
+
+            # test errors
+            with self.assertRaisesRegex(ValueError, f"{name}.+elev"):
+                _check_value(param, "elev")
+            with self.assertRaisesRegex(TypeError, name):
+                _check_value(param, (1.0, 2.0))
+            # Only the main parts of the message are checked,
+            # but the check is order-dependent.
+            with self.assertRaisesRegex(ValueError, f"{name}.+100.1"):
+                _check_value(param, 100.1)
+            with self.assertRaisesRegex(ValueError, f"{name}.+200"):
+                _check_value(param, 200.0)
+
     def test_single_integer(self):
         param = Parameter(
             diz=dict(name="int_number", required="yes", multiple="no", type="integer")


### PR DESCRIPTION
For a parameter value which was out of range from key_desc specified as `0-`, grass.pygrass failed to construct the error message and resulting error message for the exception was:

```
TypeError: must be real number, not NoneType
```

This handles the cases with only min or max specified separately, fixes the error message and uses f-strings. The new message is:

```
ValueError: The Parameter <size> must be higher than 1.0, 0 is out of range.
```