### PR TITLE
docker: selective backport of cleanup and PROJ_NETWORK=ON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,weinmann@mundialis.
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# define versions to be used
+# define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
 ARG PDAL_VERSION=2.4.3
-# https://github.com/hobuinc/laz-perf/releases
-ARG LAZ_PERF_VERSION=3.2.0
 
 SHELL ["/bin/bash", "-c"]
 
@@ -78,22 +76,11 @@ RUN apt-get update && apt-get upgrade -y && \
     vim \
     wget \
     zip \
-    zlib1g-dev
+    zlib1g-dev \
+    && apt-get clean all && rm -rf /var/lib/apt/lists/*
 
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
-
-## install laz-perf (missing from https://packages.ubuntu.com/)
-RUN apt-get install cmake
-WORKDIR /src
-RUN wget -q https://github.com/hobu/laz-perf/archive/${LAZ_PERF_VERSION}.tar.gz -O laz-perf-${LAZ_PERF_VERSION}.tar.gz && \
-    tar -zxf laz-perf-${LAZ_PERF_VERSION}.tar.gz && \
-    cd laz-perf-${LAZ_PERF_VERSION} && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install
 
 ## fetch vertical datums for PDAL and store into PROJ dir
 WORKDIR /src
@@ -111,7 +98,7 @@ RUN mkdir vdatum && \
     cd .. && \
     rm -rf vdatum
 
-## install pdal
+## compile and install PDAL (not available on Debian/Ubuntu) with laz-perf enabled
 ENV NUMTHREADS=4
 WORKDIR /src
 RUN wget -q \
@@ -134,10 +121,10 @@ RUN wget -q \
       -DHEXER_INCLUDE_DIR=/usr/include/ \
       -DBUILD_PLUGIN_NITF=OFF \
       -DBUILD_PLUGIN_ICEBRIDGE=ON \
-      -DBUILD_PLUGIN_PGPOINTCLOUD=ON \
+      -DBUILD_PLUGIN_PGPOINTCLOUD=OFF \
       -DBUILD_PGPOINTCLOUD_TESTS=OFF \
       -DBUILD_PLUGIN_SQLITE=ON \
-      -DWITH_LASZIP=ON \
+      -DWITH_LASZIP=OFF \
       -DWITH_LAZPERF=ON \
       -DWITH_TESTS=ON && \
     make -j $NUMTHREADS && \
@@ -201,6 +188,8 @@ ENV CXXFLAGS ""
 ENV SHELL /bin/bash
 ENV LC_ALL "en_US.UTF-8"
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
+# https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
+ENV PROJ_NETWORK=ON
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass82 /usr/local/grass
@@ -220,9 +209,6 @@ WORKDIR /scripts
 # install external GRASS GIS session Python API
 RUN pip3 install grass-session
 
-# install GRASS GIS extensions
-RUN grass --tmp-location EPSG:4326 --exec g.extension extension=r.in.pdal
-
 # add GRASS GIS envs for python usage
 ENV GISBASE "/usr/local/grass/"
 ENV GRASSBIN "/usr/local/bin/grass"
@@ -236,7 +222,8 @@ COPY docker/testdata/test_grass_session.py .
 ## just scan the LAZ file
 # Not yet ready for GRASS GIS 8:
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -s
+# test LAZ file
+RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb
 VOLUME /grassdb

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="neteler@osgeo.org"
 # PACKAGES VERSIONS
 ARG PYTHON_VERSION=3
 
-# List of packages to be installed
+# List of packages to be installed (proj-data omitted: 570.04 MB)
 ENV PACKAGES="\
       attr \
       bash \
@@ -65,7 +65,7 @@ RUN echo "Install Python";\
     rm -r /usr/lib/python*/ensurepip && \
     pip$PYTHON_VERSION install --upgrade pip setuptools && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip$PYTHON_VERSION /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
+    if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
     rm -r /root/.cache
 
 # Add the packages
@@ -128,12 +128,12 @@ ENV GRASS_BUILD_PACKAGES="\
       libc6-compat \
       libjpeg-turbo-dev \
       libpng-dev \
+      libpq-dev \
       make \
       openjpeg-dev \
       openblas-dev \
       pdal \
       pdal-dev \
-      postgresql-dev \
       proj-dev \
       python3-dev \
       py3-numpy-dev \
@@ -185,7 +185,7 @@ COPY --from=build /usr/local/grass* /usr/local/grass/
 # install external Python API
 RUN pip3 install --upgrade pip six grass-session --ignore-installed six
 
-RUN ln -sf /usr/local/grass `grass --config path`
+RUN ln -sf /usr/local/grass $(grass --config path)
 RUN grass --tmp-location XY --exec g.version -rge && \
     pdal --version && \
     python3 --version
@@ -193,7 +193,7 @@ RUN grass --tmp-location XY --exec g.version -rge && \
 
 FROM grass as test
 
-RUN apk add make gcc
+RUN apk add --no-cache make gcc
 
 ## run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/simple.laz
@@ -207,7 +207,7 @@ RUN /usr/bin/python3 /scripts/test_grass_session.py
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 # Test addon installation
-RUN apk add py3-scikit-learn
+RUN apk add --no-cache py3-scikit-learn
 RUN grass --tmp-location XY --exec g.extension extension=r.learn.ml2
 
 
@@ -218,7 +218,9 @@ FROM grass as final
 ENV GRASSBIN="/usr/local/bin/grass" \
     GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     SHELL="/bin/bash"
-ENV PROJ_NETWORK="ON"
+
+# https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
+ENV PROJ_NETWORK=ON
 
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \
@@ -234,4 +236,4 @@ RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" out
 WORKDIR /grassdb
 VOLUME /grassdb
 
-CMD $GRASSBIN --version
+CMD ["$GRASSBIN", "--version"]

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -2,8 +2,8 @@ FROM alpine:latest
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile
-LABEL authors="Pietro Zambelli,Markus Neteler"
-LABEL maintainer="peter.zamb@gmail.com,neteler@osgeo.org"
+LABEL authors="Carmen Tawalika,Pietro Zambelli,Markus Neteler"
+LABEL maintainer="neteler@osgeo.org"
 
 # without PDAL
 
@@ -18,16 +18,15 @@ ARG PYTHON_VERSION=3
 ENV GRASS_CONFIG="\
       --enable-largefile \
       --with-cxx \
-      --with-proj --with-proj-share=/usr/share/proj \
+      --with-proj-share=/usr/share/proj \
       --with-gdal \
-      --with-python \
       --with-geos \
       --with-sqlite \
       --with-bzlib \
       --with-zstd \
       --with-cairo --with-cairo-ldflags=-lfontconfig \
       --with-fftw \
-      --with-postgres --with-postgres-includes='/usr/include/postgresql' \
+      --with-postgres --with-postgres-includes=/usr/include/postgresql \
       --without-freetype \
       --without-pdal \
       --without-openmp \
@@ -35,8 +34,6 @@ ENV GRASS_CONFIG="\
       --without-nls \
       --without-mysql \
       --without-odbc \
-      --without-openmp \
-      --without-ffmpeg \
       "
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols
@@ -50,7 +47,7 @@ ENV MYCFLAGS="-O2 -std=gnu99 -m64" \
     NUMTHREADS=2
 
 
-# List of packages to be installed
+# List of packages to be installed (proj-data omitted: 570.04 MB)
 ENV PACKAGES="\
       attr \
       bash \
@@ -76,7 +73,6 @@ ENV PACKAGES="\
       py3-pillow \
       py3-six \
       postgresql \
-      proj-datumgrid \
       proj-util \
       sqlite \
       sqlite-libs \
@@ -101,10 +97,10 @@ ENV PACKAGES="\
       libc6-compat \
       libjpeg-turbo-dev \
       libpng-dev \
+      libpq-dev \
       make \
       openjpeg-dev \
       openblas-dev \
-      postgresql-dev \
       proj-dev \
       python3-dev \
       py3-numpy-dev \
@@ -132,7 +128,7 @@ RUN echo "Install Python";\
     rm -r /usr/lib/python*/ensurepip && \
     pip$PYTHON_VERSION install --upgrade pip setuptools && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip$PYTHON_VERSION /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
+    if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
     rm -r /root/.cache
 
 # Add the packages
@@ -212,17 +208,19 @@ COPY docker/testdata/test_grass_session.py .
 # FINALIZE
 # ========
 
-# Data workdir
-WORKDIR /grassdb
-VOLUME /grassdb
-
 # GRASS GIS specific
 # allow work with MAPSETs that are not owned by current user
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8"
+# https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
+ENV PROJ_NETWORK=ON
 
 # show installed version
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-location XY --exec g.version -rge && \
     python3 --version
 
-CMD [$GRASSBIN, "--version"]
+# Data workdir
+WORKDIR /grassdb
+VOLUME /grassdb
+
+CMD ["$GRASSBIN", "--version"]

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -79,7 +79,8 @@ RUN apt-get update && apt-get upgrade -y && \
     vim \
     wget \
     zip \
-    zlib1g-dev
+    zlib1g-dev \
+    && apt-get clean all && rm -rf /var/lib/apt/lists/*
 
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
@@ -189,6 +190,8 @@ ENV CXXFLAGS ""
 ENV SHELL /bin/bash
 ENV LC_ALL "en_US.UTF-8"
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
+# https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
+ENV PROJ_NETWORK=ON
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass82 /usr/local/grass

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -76,7 +76,8 @@ RUN apt-get update && apt-get upgrade -y && \
     vim \
     wget \
     zip \
-    zlib1g-dev
+    zlib1g-dev \
+    && apt-get clean all && rm -rf /var/lib/apt/lists/*
 
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
@@ -187,6 +188,8 @@ ENV CXXFLAGS ""
 ENV SHELL /bin/bash
 ENV LC_ALL "en_US.UTF-8"
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
+# https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
+ENV PROJ_NETWORK=ON
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass82 /usr/local/grass


### PR DESCRIPTION
debian and ubuntu Dockerfiles (includes backport of #2822):
* sync `./Dockerfile` to `docker/ubuntu/Dockerfile` (backport of #2820)
* enable PROJ CDN support for grids (`PROJ_NETWORK=ON`): see https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
* more cleanup added: `apt-get clean all && rm -rf /var/lib/apt/lists/*`

alpine Dockerfile:
* Dockerfile linting with https://hadolint.github.io/hadolint/
* remove `libexecinfo` as no longer existing in alpine
* postgresql-dev -> libpq-dev
* Dockerfile_alpine_latest: sync to (alpine) Dockerfile