### PR TITLE
tests: Disable test of core.gcmd.recv_some

### DIFF
--- a/.github/workflows/macos_gunittest.cfg
+++ b/.github/workflows/macos_gunittest.cfg
@@ -4,6 +4,7 @@
 # space. This would be ideally empty or it would include just special cases,
 # but it includes mainly tests which can (and should) be fixed.
 exclude =
+    gui/wxpython/core/testsuite/test_gcmd.py
     gui/wxpython/core/testsuite/toolboxes.sh
     lib/init/testsuite/test_grass_tmp_mapset.py
     python/grass/gunittest/testsuite/test_assertions_rast3d.py

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -4,6 +4,7 @@
 # space. This would be ideally empty or it would include just special cases,
 # but it includes mainly tests which can (and should) be fixed.
 exclude =
+    gui/wxpython/core/testsuite/test_gcmd.py
     gui/wxpython/core/testsuite/toolboxes.sh
     lib/init/testsuite/test_grass_tmp_mapset.py
     python/grass/gunittest/testsuite/test_assertions_rast3d.py


### PR DESCRIPTION
Test of a known (unfixed) bug which is always failing the CI needs to be disabled in the config file.
