### PR TITLE
g.extension: Remove six dependency

### DIFF
--- a/scripts/g.extension.all/g.extension.all.py
+++ b/scripts/g.extension.all/g.extension.all.py
@@ -35,19 +35,16 @@
 # % key: f
 # % label: Force operation (required for removal)
 # % end
-from __future__ import print_function
+
 import http
 import os
 import re
 import sys
 
-try:
-    import xml.etree.ElementTree as etree
-except ImportError:
-    import elementtree.ElementTree as etree  # Python <= 2.4
+import xml.etree.ElementTree as etree
 
-from six.moves.urllib import request as urlrequest
-from six.moves.urllib.error import HTTPError, URLError
+from urllib import request as urlrequest
+from urllib.error import HTTPError, URLError
 
 import grass.script as gscript
 from grass.exceptions import CalledModuleError

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -150,8 +150,6 @@
 
 # TODO: solve addon-extension(-module) confusion
 
-
-from __future__ import print_function
 import fileinput
 import http
 import os
@@ -172,9 +170,9 @@ else:
 
     copy_tree = partial(shutil.copytree, dirs_exist_ok=True)
 
-from six.moves.urllib import request as urlrequest
-from six.moves.urllib.error import HTTPError, URLError
-from six.moves.urllib.parse import urlparse
+from urllib import request as urlrequest
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 
 # Get the XML parsing exceptions to catch. The behavior changed with Python 2.7
 # and ElementTree 1.3.


### PR DESCRIPTION
* Removes imports from six, uses standard Python 3 imports.
* Removes Python <=2.4 ElementTree import.
* Removes future print_function imports.
* Removes six from g.extension and g.extension.all. Leaves the rest as is.