### PR TITLE
r.profile: Fix typos in the manual

### DIFF
--- a/raster/r.profile/r.profile.html
+++ b/raster/r.profile/r.profile.html
@@ -60,7 +60,7 @@ the end point coordinates entered for the segmanet.
 r.profile input=dgm12.5 coordinates=3570631,5763556 2>/dev/null
 </pre></div>
 
-This filters out the everything except the numbers.
+This filters out everything except the numbers.
 
 <h2>EXAMPLES</h2>
 
@@ -111,7 +111,7 @@ d.where | r.profile elevation.dem
 
 <h3>Extraction of values along profile defined by coordinates (variant 2)</h3>
 
-Coordinate pairs can also being "piped" into <em>r.profile</em> (variant 2a):
+Coordinate pairs can also be "piped" into <em>r.profile</em> (variant 2a):
 
 <div class="code"><pre>
 r.profile elevation resolution=1000 file=- &lt;&lt; EOF
@@ -123,7 +123,7 @@ EOF
 </pre></div>
 
 <p>
-Coordinate pairs can also being "piped" into <em>r.profile</em> (variant 2b):
+Coordinate pairs can also be "piped" into <em>r.profile</em> (variant 2b):
 
 <div class="code"><pre>
 echo "641712,226095


### PR DESCRIPTION
This PR fixes some grammatical typos in the r.profile manual.