### PR TITLE
wxGUI Profile: Don't repeat the first profile point (0,elev) in output

### DIFF
--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -271,7 +271,9 @@ class ProfileFrame(BasePlotFrame):
             "r.profile",
             parent=self,
             input=raster,
-            coordinates=coords,
+            # since a transect "line" starts with two identical start points,
+            # don't repeat the first pair of coordinates in output
+            coordinates=",".join(coords.split(",")[2:]),
             resolution=transect_res,
             null="nan",
             quiet=True,


### PR DESCRIPTION
This PR removes the first pair of repeating coordinates from output. It happens because the geometry type of transect line is "line" and the first "line" always starts with two identical start points.