### PR TITLE
wxGUI: Change caption of Data Catalog to Data

### DIFF
--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -614,7 +614,7 @@ class GMFrame(wx.Frame):
             self.datacatalog,
             aui.AuiPaneInfo()
             .Name("datacatalog")
-            .Caption("Data Catalog")
+            .Caption("Data")
             .Left()
             .Layer(1)
             .Position(1)

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -614,7 +614,7 @@ class GMFrame(wx.Frame):
             self.datacatalog,
             aui.AuiPaneInfo()
             .Name("datacatalog")
-            .Caption("Data")
+            .Caption(_("Data"))
             .Left()
             .Layer(1)
             .Position(1)
@@ -629,7 +629,7 @@ class GMFrame(wx.Frame):
             self.notebookLayers,
             aui.AuiPaneInfo()
             .Name("layers")
-            .Caption("Layers")
+            .Caption(_("Layers"))
             .Left()
             .Layer(1)
             .Position(2)
@@ -644,7 +644,7 @@ class GMFrame(wx.Frame):
             self.search,
             aui.AuiPaneInfo()
             .Name("tools")
-            .Caption("Tools")
+            .Caption(_("Tools"))
             .Right()
             .Layer(1)
             .Position(1)
@@ -659,7 +659,7 @@ class GMFrame(wx.Frame):
             self.goutput,
             aui.AuiPaneInfo()
             .Name("console")
-            .Caption("Console")
+            .Caption(_("Console"))
             .Right()
             .BestSize(self.PANE_BEST_SIZE)
             .MinSize(self.PANE_MIN_SIZE)
@@ -673,7 +673,7 @@ class GMFrame(wx.Frame):
             self.pyshell,
             aui.AuiPaneInfo()
             .Name("python")
-            .Caption("Python")
+            .Caption(_("Python"))
             .Right()
             .BestSize(self.PANE_BEST_SIZE)
             .MinSize(self.PANE_MIN_SIZE)


### PR DESCRIPTION
The multi-window layout is/was using just Data which worked well, so this changes the label of the pane/panel to just Data for simplicity and consistency. Now both the top caption and notebook tab/page label (if in a notebook) are Data.

## Screenshot Before: Single-window layout

A layout similar to the multi-window interface - all floating panels placed together in one notebook.

![Screenshot from 2023-02-16 14-04-52](https://user-images.githubusercontent.com/5449060/219462889-baddcd1d-e466-4f86-a103-26f8f30b0f33.png)

## Screenshot After: Single-window layout

Same layout as above. Before this PR, the _Data_ tab would be _Data Catalog_.

![Screenshot from 2023-02-16 13-55-24](https://user-images.githubusercontent.com/5449060/219461143-d30b51e7-1cb5-4a97-b213-c6a40d843504.png)

## Screenshot for Comparison: Multi-window layout

Data catalog is under _Data_ tab (unchanged by this PR).

![Screenshot from 2023-02-16 14-01-32](https://user-images.githubusercontent.com/5449060/219462869-4fbf5251-6f36-47e9-be10-be4140205217.png)
