### PR TITLE
r.cost and r.walk: fix integer overflows

### DIFF
--- a/raster/r.cost/flag.c
+++ b/raster/r.cost/flag.c
@@ -20,7 +20,7 @@ FLAG *flag_create(int nrows, int ncols)
     if (!new_flag->array)
         G_fatal_error(_("Out of memory!"));
 
-    temp = (unsigned char *)G_malloc(nrows * new_flag->leng *
+    temp = (unsigned char *)G_malloc((size_t)nrows * new_flag->leng *
                                      sizeof(unsigned char));
 
     if (!temp)

--- a/raster/r.cost/main.c
+++ b/raster/r.cost/main.c
@@ -513,7 +513,7 @@ int main(int argc, char *argv[])
         costs.cost_out = dnullval;
         costs.nearest = 0;
 
-        total_cells = nrows * ncols;
+        total_cells = (long)nrows * ncols;
 
         skip_nulls = Rast_is_d_null_value(&null_cost);
 
@@ -815,7 +815,7 @@ int main(int argc, char *argv[])
      */
 
     G_debug(1, "total cells: %ld", total_cells);
-    G_debug(1, "nrows x ncols: %d", nrows * ncols);
+    G_debug(1, "nrows x ncols: %ld", (long)nrows * ncols);
     G_message(_("Finding cost path..."));
     n_processed = 0;
     visited = flag_create(nrows, ncols);

--- a/raster/r.walk/flag.c
+++ b/raster/r.walk/flag.c
@@ -20,7 +20,7 @@ FLAG *flag_create(int nrows, int ncols)
     if (!new_flag->array)
         G_fatal_error(_("Out of memory!"));
 
-    temp = (unsigned char *)G_malloc(nrows * new_flag->leng *
+    temp = (unsigned char *)G_malloc((size_t)nrows * new_flag->leng *
                                      sizeof(unsigned char));
 
     if (!temp)

--- a/raster/r.walk/main.c
+++ b/raster/r.walk/main.c
@@ -650,7 +650,7 @@ int main(int argc, char *argv[])
         costs.cost_out = dnullval;
         costs.nearest = 0;
 
-        total_cells = nrows * ncols;
+        total_cells = (long)nrows * ncols;
 
         skip_nulls = Rast_is_d_null_value(&null_cost);
 
@@ -976,7 +976,7 @@ int main(int argc, char *argv[])
      */
 
     G_debug(1, "total cells: %ld", total_cells);
-    G_debug(1, "nrows x ncols: %d", nrows * ncols);
+    G_debug(1, "nrows x ncols: %ld", (long)nrows * ncols);
     G_message(_("Finding cost path..."));
     n_processed = 0;
     visited = flag_create(nrows, ncols);


### PR DESCRIPTION
`r.cost` and `r.walk` do not report correct percentages on the progress of the actual cost analysis for regions larger than INT_MAX (at most 2³¹ - 1) cells. Further on, memory allocation for the flag structure may fail.

Needs to be backported to all maintained GRASS 8 branches.