### PR TITLE
Fix Travis: ModuleNotFoundError: No module named 'six' (G 8.2)

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -34,8 +34,12 @@ except ImportError:
     # Python 3 import
     from html.parser import HTMLParser
 
-from six.moves.urllib import request as urlrequest
-from six.moves.urllib.error import HTTPError, URLError
+try:
+    from six.moves.urllib import request as urlrequest
+    from six.moves.urllib.error import HTTPError, URLError
+except ImportError:
+    from urllib import request as urlrequest
+    from urllib.error import HTTPError, URLError
 
 try:
     import urlparse


### PR DESCRIPTION
At time Travis CI fails in `releasebranch_8_2` with:

```
Traceback (most recent call last):

  File "/home/travis/build/OSGeo/grass/dist.x86_64-pc-linux-gnu/utils/mkhtml.py", line 37, in <module>
    from six.moves.urllib import request as urlrequest

ModuleNotFoundError: No module named 'six'
```

(Example for a failed Travis run: https://github.com/OSGeo/grass/pull/2843/checks?check_run_id=11475577650)

This PR addresses the removal of `six` in a simple way.

Side note: Travis does not fail in `main` due to PR #2547, see
https://github.com/OSGeo/grass/commit/17fc1d8dfd5f07ac88611d22727dfd0e40cd646f#diff-3e1684c5c5d40b273b6488a9b5a5558f556d2bcf2973ba5106b6125e01aa6959