### PR TITLE
clang: suppress -Wunknown-pragmas warnings from PDAL 2.5.1 code

### DIFF
--- a/raster/r.in.pdal/grasslidarfilter.h
+++ b/raster/r.in.pdal/grasslidarfilter.h
@@ -27,6 +27,7 @@ extern "C" {
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #endif
 #include <pdal/Filter.hpp>
 #include <pdal/Streamable.hpp>

--- a/raster/r.in.pdal/info.h
+++ b/raster/r.in.pdal/info.h
@@ -16,6 +16,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #endif
 #include <pdal/PointTable.hpp>
 #include <pdal/StageFactory.hpp>

--- a/raster/r.in.pdal/main.cpp
+++ b/raster/r.in.pdal/main.cpp
@@ -20,6 +20,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #endif
 #include <pdal/PointTable.hpp>
 #include <pdal/PointLayout.hpp>

--- a/vector/v.in.pdal/main.cpp
+++ b/vector/v.in.pdal/main.cpp
@@ -17,6 +17,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #endif
 #include <pdal/PointTable.hpp>
 #include <pdal/PointLayout.hpp>


### PR DESCRIPTION
PDAL 2.5.1+ header files included in GRASS causes Clang to issue -Wunknown-pragmas compilation warnings.