### PR TITLE
r.in.xyz: fix integer overflow

### DIFF
--- a/raster/r.in.xyz/support.c
+++ b/raster/r.in.xyz/support.c
@@ -45,7 +45,10 @@ int blank_array(void *array, int nrows, int ncols, RASTER_MAP_TYPE map_type,
     case -1:
         /* fill with NULL */
         /* alloc for col+1, do we come up (nrows) short? no. */
-        Rast_set_null_value(array, nrows * ncols, map_type);
+        for (row = 0; row < nrows; row++) {
+            Rast_set_null_value(ptr, ncols, map_type);
+            ptr = G_incr_void_ptr(ptr, ncols * Rast_cell_size(map_type));
+        }
         break;
 
     default:


### PR DESCRIPTION
Mirrors fix in 75cb8f6e6fe863913e68418f40a62a58d067217e (#2844)
