### PR TITLE
r.in.pdal and r.in.xyz: manual backport of #2844 and #2847 (8.2)

### DIFF
--- a/raster/r.in.pdal/point_binning.c
+++ b/raster/r.in.pdal/point_binning.c
@@ -60,7 +60,10 @@ int blank_array(void *array, int nrows, int ncols, RASTER_MAP_TYPE map_type,
     case -1:
         /* fill with NULL */
         /* alloc for col+1, do we come up (nrows) short? no. */
-        Rast_set_null_value(array, nrows * ncols, map_type);
+        for (row = 0; row < nrows; row++) {
+            Rast_set_null_value(ptr, ncols, map_type);
+            ptr = G_incr_void_ptr(ptr, ncols * Rast_cell_size(map_type));
+        }
         break;
 
     default:

--- a/raster/r.in.xyz/support.c
+++ b/raster/r.in.xyz/support.c
@@ -46,8 +46,11 @@ int blank_array(void *array, int nrows, int ncols, RASTER_MAP_TYPE map_type,
     case -1:
 	/* fill with NULL */
 	/* alloc for col+1, do we come up (nrows) short? no. */
-	Rast_set_null_value(array, nrows * ncols, map_type);
-	break;
+        for (row = 0; row < nrows; row++) {
+            Rast_set_null_value(ptr, ncols, map_type);
+            ptr = G_incr_void_ptr(ptr, ncols * Rast_cell_size(map_type));
+        }
+        break;
 
     default:
 	return -1;


### PR DESCRIPTION
Combined backport of #2844 and #2847 to version 8.2.