### PR TITLE
configure: use pkg-config for PDAL configuration

### DIFF
--- a/.github/workflows/build_centos.sh
+++ b/.github/workflows/build_centos.sh
@@ -41,7 +41,8 @@ export CXXFLAGS="-std=gnu++11"
     --without-mysql \
     --without-postgres \
     --without-odbc \
-    --without-fftw
+    --without-fftw \
+    --without-pdal
 
 make
 make install

--- a/.github/workflows/macos_install.sh
+++ b/.github/workflows/macos_install.sh
@@ -60,7 +60,7 @@ CONFIGURE_FLAGS="\
   --with-nls \
   --with-libs=${CONDA_PREFIX}/lib \
   --with-includes=${CONDA_PREFIX}/include \
-  --with-pdal=${CONDA_PREFIX}/bin/pdal-config \
+  --with-pdal \
   --with-readline \
   --with-readline-includes=${CONDA_PREFIX}/include/readline \
   --with-readline-libs=${CONDA_PREFIX}/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       dist: focal
       compiler: gcc
       sudo: required
-      env: CC=gcc CXX=gcc++
+      env: CC=gcc CXX=g++
 
     - os: linux
       dist: focal

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
 env:
   global:
     - CFLAGS="-Werror=implicit-function-declaration"
+    - CXXFLAGS="-std=c++11"
 
 before_install:
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ matrix:
       dist: focal
       compiler: gcc
       sudo: required
-      env: CC=gcc
+      env: CC=gcc CXX=gcc++
 
     - os: linux
       dist: focal
       compiler: clang
       sudo: required
-      env: CC=clang
+      env: CC=clang CXX=clang++
 
 env:
   global:

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -4,6 +4,7 @@
 set -e
 
 export CC="ccache $CC"
+export CXX="ccache $CXX"
 ./configure --host=x86_64-linux-gnu \
             --build=x86_64-linux-gnu \
             --prefix=/usr/lib \

--- a/configure
+++ b/configure
@@ -696,7 +696,6 @@ USE_PDAL
 PDAL_INC
 PDAL_CPPFLAGS
 PDAL_LIBS
-PDAL_CONFIG
 USE_LIBLAS
 LIBLAS_INC
 LIBLAS_CFLAGS
@@ -886,10 +885,10 @@ with_openmp
 with_opencl
 with_bzlib
 with_zstd
+with_pdal
 with_libpng
 with_gdal
 with_liblas
-with_pdal
 with_netcdf
 with_geos
 with_includes
@@ -1609,6 +1608,7 @@ Optional Packages:
   --with-opencl           support OpenCL functionality (default: no)
   --with-bzlib            support BZIP2 functionality (default: no)
   --with-zstd             support Zstandard functionality (default: yes)
+  --with-pdal             support PDAL functionality (default: yes)
   --with-libpng=path/libpng-config
                           enable PNG support (libpng-config with path,
                           e.g. '--with-libpng=/usr/local/bin/libpng-config')
@@ -1618,10 +1618,6 @@ Optional Packages:
   --with-liblas=path/liblas-config
                           enable libLAS support (liblas-config with path,
                           e.g. '--with-liblas=/usr/local/bin/liblas-config',
-                          default: no)
-  --with-pdal=path/pdal-config
-                          enable PDAL support (pdal-config with path,
-                          e.g. '--with-pdal=/usr/local/bin/pdal-config',
                           default: no)
   --with-netcdf=path/nc-config
                           enable NetCDF support (nc-config with path,
@@ -4698,6 +4694,16 @@ fi
 
 
 
+# Check whether --with-pdal was given.
+if test "${with_pdal+set}" = set; then :
+  withval=$with_pdal;
+else
+  with_pdal=yes
+fi
+
+
+
+
 # Check whether --with-libpng was given.
 if test "${with_libpng+set}" = set; then :
   withval=$with_libpng;
@@ -4717,15 +4723,6 @@ if test "${with_liblas+set}" = set; then :
   withval=$with_liblas;
 else
   with_liblas="no"
-fi
-
-
-
-# Check whether --with-pdal was given.
-if test "${with_pdal+set}" = set; then :
-  withval=$with_pdal;
-else
-  with_pdal="no"
 fi
 
 
@@ -9344,10 +9341,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 PDAL_LIBS=
 PDAL_CPPFLAGS=
 USE_PDAL=
-
-if test "`basename xx/$with_pdal`" = "pdal-config" ; then
-  PDAL_CONFIG="$with_pdal"
-fi
+pdal="pdal"
 
 if test "$with_pdal" = "no" ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
@@ -9355,54 +9349,14 @@ $as_echo "no" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-  # Extract the first word of "pdal-config", so it can be a program name with args.
-set dummy pdal-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
 
-case $PDAL_CONFIG in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_PDAL_CONFIG="$PDAL_CONFIG" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_PDAL_CONFIG="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_PDAL_CONFIG" && ac_cv_path_PDAL_CONFIG="no"
-  ;;
-esac
-PDAL_CONFIG=$ac_cv_path_PDAL_CONFIG
-if test -n "$PDAL_CONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PDAL_CONFIG" >&5
-$as_echo "$PDAL_CONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-
-  if test "$PDAL_CONFIG" = "no" ; then
-    as_fn_error $? "*** could not find pdal-config" "$LINENO" 5
+  if test -s "${PKG_CONFIG} --exists ${pdal}" ; then
+    as_fn_error $? "*** Unable to locate PDAL package." "$LINENO" 5
   fi
 
-  if test "$PDAL_CONFIG" != "" ; then
-    PDAL_LIBS=`"$PDAL_CONFIG" --libs`
-    PDAL_INC=`"$PDAL_CONFIG" --includes`
-    USE_PDAL=1
-  fi
+  PDAL_LIBS=`${PKG_CONFIG} --libs "${pdal}"`
+  PDAL_INC=`${PKG_CONFIG} --cflags "${pdal}"`
+  USE_PDAL=1
 
   PDAL=
   ac_save_libs="$LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -307,6 +307,7 @@ LOC_ARG_WITH(openmp, OpenMP, no)
 LOC_ARG_WITH(opencl, OpenCL, no)
 LOC_ARG_WITH(bzlib, BZIP2, no)
 LOC_ARG_WITH(zstd, Zstandard)
+LOC_ARG_WITH(pdal, PDAL)
 
 AC_ARG_WITH(libpng,
 [  --with-libpng[=path/libpng-config]
@@ -323,12 +324,6 @@ AC_ARG_WITH(liblas,
                           enable libLAS support (liblas-config with path,
                           e.g. '--with-liblas=/usr/local/bin/liblas-config',
                           default: no)],, with_liblas="no")
-
-AC_ARG_WITH(pdal,
-[  --with-pdal[=path/pdal-config]
-                          enable PDAL support (pdal-config with path,
-                          e.g. '--with-pdal=/usr/local/bin/pdal-config',
-                          default: no)],, with_pdal="no")
 
 AC_ARG_WITH(netcdf,
 [  --with-netcdf[=path/nc-config]
@@ -1042,26 +1037,20 @@ AC_LANG_PUSH(C++)
 PDAL_LIBS=
 PDAL_CPPFLAGS=
 USE_PDAL=
-
-if test "`basename xx/$with_pdal`" = "pdal-config" ; then
-  PDAL_CONFIG="$with_pdal"
-fi
+pdal="pdal"
 
 if test "$with_pdal" = "no" ; then
   AC_MSG_RESULT(no)
 else
   AC_MSG_RESULT(yes)
-  AC_PATH_PROG(PDAL_CONFIG, pdal-config, no)
 
-  if test "$PDAL_CONFIG" = "no" ; then
-    AC_MSG_ERROR([*** could not find pdal-config])
+  if test -s "${PKG_CONFIG} --exists ${pdal}" ; then
+    AC_MSG_ERROR([*** Unable to locate PDAL package.])
   fi
 
-  if test "$PDAL_CONFIG" != "" ; then
-    PDAL_LIBS=`"$PDAL_CONFIG" --libs`
-    PDAL_INC=`"$PDAL_CONFIG" --includes`
-    USE_PDAL=1
-  fi
+  PDAL_LIBS=`${PKG_CONFIG} --libs "${pdal}"`
+  PDAL_INC=`${PKG_CONFIG} --cflags "${pdal}"`
+  USE_PDAL=1
 
   PDAL=
   ac_save_libs="$LIBS"
@@ -1080,7 +1069,7 @@ else
   LIBS=${ac_save_libs}
   CFLAGS=${ac_save_cflags}
 
-  AC_DEFINE(HAVE_PDAL, 1, [define if PDAL exists])
+  AC_DEFINE(HAVE_PDAL, 1, [Define to 1 if PDAL is to be used.])
 fi
 
 AC_SUBST(PDAL_LIBS)

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -152,7 +152,7 @@
 /* define if glXCreatePbuffer exists */
 #undef HAVE_PBUFFERS
 
-/* define if PDAL exists */
+/* Define to 1 if PDAL is to be used. */
 #undef HAVE_PDAL
 
 /* define if glXCreateGLXPixmap exists */

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -63,7 +63,8 @@ export ARCH=x86_64-w64-mingw32
     --with-opengl=windows \
     --with-bzlib \
     --with-liblas=${SRC}/mswindows/osgeo4w/liblas-config \
-    --with-netcdf=${OSGEO4W_ROOT_MSYS}/bin/nc-config
+    --with-netcdf=${OSGEO4W_ROOT_MSYS}/bin/nc-config \
+    --without-pdal
 
 make
 


### PR DESCRIPTION
Using pkg-config for PDAL configuration is more future proof solution than #2749.

The pdal-config, which we used so far, is not actively maintained and is considered to be removed: https://github.com/PDAL/PDAL/issues/3979.

Configure flags are simplified:

no more `--with-pdal=/opt/local/bin/pdal-config`

only `--with-pdal` or `--without-pdal`