### PR TITLE
r.neighbors: fix integer overflow

### DIFF
--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -532,7 +532,7 @@ int main(int argc, char *argv[])
                          * (eq. floor(neighborhood/2)) Thus original data start
                          * is shifted by ncb.dist! */
                         for (i = 0; i < num_outputs; i++)
-                            outputs[i].buf[brow_idx * ncols + col] =
+                            outputs[i].buf[(size_t)brow_idx * ncols + col] =
                                 ncb.buf[t][ncb.dist][col + ncb.dist];
                         continue;
                     }
@@ -544,7 +544,7 @@ int main(int argc, char *argv[])
 
                     for (i = 0; i < num_outputs; i++) {
                         struct output *out = &outputs[i];
-                        DCELL *rp = &out->buf[brow_idx * ncols + col];
+                        DCELL *rp = &out->buf[(size_t)brow_idx * ncols + col];
 
                         if (n == 0) {
                             Rast_set_d_null_value(rp, 1);

--- a/raster/r.resamp.filter/main.c
+++ b/raster/r.resamp.filter/main.c
@@ -385,8 +385,8 @@ static void filter(void)
 
                 num_rows = rows;
 
-                v_filter(&outbuf[(row - start) * dst_w.cols], bufs[t_id], row,
-                         rows);
+                v_filter(&outbuf[(size_t)(row - start) * dst_w.cols], bufs[t_id],
+                         row, rows);
 #pragma omp atomic update
                 computed_row++;
             }

--- a/raster/r.resamp.filter/main.c
+++ b/raster/r.resamp.filter/main.c
@@ -385,8 +385,8 @@ static void filter(void)
 
                 num_rows = rows;
 
-                v_filter(&outbuf[(size_t)(row - start) * dst_w.cols], bufs[t_id],
-                         row, rows);
+                v_filter(&outbuf[(size_t)(row - start) * dst_w.cols],
+                         bufs[t_id], row, rows);
 #pragma omp atomic update
                 computed_row++;
             }

--- a/raster/r.resamp.interp/main.c
+++ b/raster/r.resamp.interp/main.c
@@ -246,10 +246,10 @@ int main(int argc, char *argv[])
 
                         if (Rast_is_d_null_value(&c)) {
                             Rast_set_d_null_value(
-                                &outbuf[(row - start) * dst_w.cols + col], 1);
+                                &outbuf[(size_t)(row - start) * dst_w.cols + col], 1);
                         }
                         else {
-                            outbuf[(row - start) * dst_w.cols + col] = c;
+                            outbuf[(size_t)(row - start) * dst_w.cols + col] = c;
                         }
                     }
 
@@ -288,10 +288,10 @@ int main(int argc, char *argv[])
                             Rast_is_d_null_value(&c10) ||
                             Rast_is_d_null_value(&c11)) {
                             Rast_set_d_null_value(
-                                &outbuf[(row - start) * dst_w.cols + col], 1);
+                                &outbuf[(size_t)(row - start) * dst_w.cols + col], 1);
                         }
                         else {
-                            outbuf[(row - start) * dst_w.cols + col] =
+                            outbuf[(size_t)(row - start) * dst_w.cols + col] =
                                 Rast_interp_bilinear(u, v, c00, c01, c10, c11);
                         }
                     }
@@ -361,10 +361,10 @@ int main(int argc, char *argv[])
                             Rast_is_d_null_value(&c32) ||
                             Rast_is_d_null_value(&c33)) {
                             Rast_set_d_null_value(
-                                &outbuf[(row - start) * dst_w.cols + col], 1);
+                                &outbuf[(size_t)(row - start) * dst_w.cols + col], 1);
                         }
                         else {
-                            outbuf[(row - start) * dst_w.cols + col] =
+                            outbuf[(size_t)(row - start) * dst_w.cols + col] =
                                 Rast_interp_bicubic(u, v, c00, c01, c02, c03,
                                                     c10, c11, c12, c13, c20,
                                                     c21, c22, c23, c30, c31,
@@ -419,7 +419,7 @@ int main(int argc, char *argv[])
                         }
 
                         if (do_lanczos) {
-                            outbuf[(row - start) * dst_w.cols + col] =
+                            outbuf[(size_t)(row - start) * dst_w.cols + col] =
                                 Rast_interp_lanczos(u, v, c);
                         }
                     }
@@ -433,7 +433,7 @@ int main(int argc, char *argv[])
 
         /* write to output map */
         for (row = start; row < end; row++) {
-            Rast_put_d_row(outfile, &outbuf[(row - start) * dst_w.cols]);
+            Rast_put_d_row(outfile, &outbuf[(size_t)(row - start) * dst_w.cols]);
         }
         written = end;
     }

--- a/raster/r.resamp.interp/main.c
+++ b/raster/r.resamp.interp/main.c
@@ -246,10 +246,13 @@ int main(int argc, char *argv[])
 
                         if (Rast_is_d_null_value(&c)) {
                             Rast_set_d_null_value(
-                                &outbuf[(size_t)(row - start) * dst_w.cols + col], 1);
+                                &outbuf[(size_t)(row - start) * dst_w.cols +
+                                        col],
+                                1);
                         }
                         else {
-                            outbuf[(size_t)(row - start) * dst_w.cols + col] = c;
+                            outbuf[(size_t)(row - start) * dst_w.cols + col] =
+                                c;
                         }
                     }
 
@@ -288,7 +291,9 @@ int main(int argc, char *argv[])
                             Rast_is_d_null_value(&c10) ||
                             Rast_is_d_null_value(&c11)) {
                             Rast_set_d_null_value(
-                                &outbuf[(size_t)(row - start) * dst_w.cols + col], 1);
+                                &outbuf[(size_t)(row - start) * dst_w.cols +
+                                        col],
+                                1);
                         }
                         else {
                             outbuf[(size_t)(row - start) * dst_w.cols + col] =
@@ -361,7 +366,9 @@ int main(int argc, char *argv[])
                             Rast_is_d_null_value(&c32) ||
                             Rast_is_d_null_value(&c33)) {
                             Rast_set_d_null_value(
-                                &outbuf[(size_t)(row - start) * dst_w.cols + col], 1);
+                                &outbuf[(size_t)(row - start) * dst_w.cols +
+                                        col],
+                                1);
                         }
                         else {
                             outbuf[(size_t)(row - start) * dst_w.cols + col] =
@@ -433,7 +440,8 @@ int main(int argc, char *argv[])
 
         /* write to output map */
         for (row = start; row < end; row++) {
-            Rast_put_d_row(outfile, &outbuf[(size_t)(row - start) * dst_w.cols]);
+            Rast_put_d_row(outfile,
+                           &outbuf[(size_t)(row - start) * dst_w.cols]);
         }
         written = end;
     }


### PR DESCRIPTION
Fix integer overflow for regions with more than INT_MAX cells.

A very similar cast to `size_t` is already in `r.series`, but maybe other modules that were recently parallelized also need some attention. 