### PR TITLE
CI: add CI concurrency

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   additional-checks:

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -16,6 +16,10 @@ on:
       - main
       - releasebranch_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   additional-checks:
     name: Additional checks

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   run-black:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,6 +11,10 @@ on:
       - main
       - releasebranch_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-black:
     name: Black

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -11,6 +11,10 @@ on:
       - main
       - releasebranch_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.os }} build

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   build:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,7 +11,7 @@ on:
       - releasebranch_*
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
       - releasebranch_*
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   flake8:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,6 +11,10 @@ on:
       - main
       - releasebranch_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flake8:
     runs-on: ubuntu-22.04

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,6 +1,6 @@
 ---
 name: GCC C/C++ standards check
-# bogus comment
+
 on:
   push:
     branches:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -17,7 +17,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.c }}-${{ matrix.cpp }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,6 +1,6 @@
 ---
 name: GCC C/C++ standards check
-
+# bogus comment
 on:
   push:
     branches:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: ${{ matrix.c }} & ${{ matrix.cpp }}
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.c }}-${{ matrix.cpp }}
+      cancel-in-progress: true
+
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ env:
   CACHE_NUMBER: 0
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   macos_build:
     name: macOS build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,9 @@ on:
       - releasebranch_*
 env:
   CACHE_NUMBER: 0
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   macos_build:
     name: macOS build

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: ${{ matrix.os }} build and tests
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.os }}
+      cancel-in-progress: true
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -17,7 +17,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.os }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,6 +15,10 @@ jobs:
   pylint:
     name: Pylint ${{ matrix.pylint-version }}
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.pylint-version }}
+      cancel-in-progress: true
+
     # Using matrix just to get variables which are not environmental variables
     # and also to sync with other workflows which use matrix.
     strategy:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.pylint-version }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     # Using matrix just to get variables which are not environmental variables
     # and also to sync with other workflows which use matrix.

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,10 @@ on:
 
 jobs:
   pytest:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.os }}-${{ matrix.python-version }}
+      cancel-in-progress: true
+
     strategy:
       matrix:
         os:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
   pytest:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.os }}-${{ matrix.python-version }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     strategy:
       matrix:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -11,6 +11,10 @@ on:
       - main
       - releasebranch_*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   super-linter:
     name: GitHub Super Linter

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   super-linter:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.name }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,6 +17,10 @@ jobs:
   build-and-test:
     name: ${{ matrix.name }} tests
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.name }}
+      cancel-in-progress: true
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 name: Ubuntu
 
-# Build and run tests on Ubuntu
+# Build and run tests on Ubuntutu
 
 on:
   push:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 name: Ubuntu
 
-# Build and run tests on Ubuntutu
+# Build and run tests on Ubuntu
 
 on:
   push:


### PR DESCRIPTION
Enables CI concurrency setting `cancel-in-progress` for most of the workflows.

Liberates a huge amount of CI processing in situations with a lot of added commits "upon" each other, e.g. in pull requests that are in practice WIP.