### PR TITLE
find_file: translate more legacy elements

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1368,14 +1368,8 @@ def find_file(name, element="cell", mapset=None, env=None):
     }
 
     if element in element_translation:
-        element_in = element
         element = element_translation[element]
-        debug(
-            _('Element type should be "{element}" and not "{element_in}"').format(
-                element_in=element_in, element=element
-            ),
-            1,
-        )
+
     # g.findfile returns non-zero when file was not found
     # so we ignore return code and just focus on stdout
     process = start_command(

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1326,9 +1326,26 @@ def del_temp_region():
 
 def find_file(name, element="cell", mapset=None, env=None):
     """Returns the output from running g.findfile as a
-    dictionary. Example:
+    dictionary.
+
+    Elements in g.findfile refer to mapset directories. However, in
+    parts of the code, different element terms like rast, raster, or rast3d
+    are used. For convenience the function translates such element types
+    to respective mapset elements. Current translations are:
+    "rast": "cell",
+    "raster": "cell",
+    "rast3d": "grid3",
+    "raster3d": "grid3",
+    "raster_3d": "grid3",
+
+    Example:
 
     >>> result = find_file('elevation', element='cell')
+    >>> print(result['fullname'])
+    elevation@PERMANENT
+    >>> print(result['file'])  # doctest: +ELLIPSIS
+    /.../PERMANENT/cell/elevation
+    >>> result = find_file('elevation', element='raster')
     >>> print(result['fullname'])
     elevation@PERMANENT
     >>> print(result['file'])  # doctest: +ELLIPSIS
@@ -1342,11 +1359,25 @@ def find_file(name, element="cell", mapset=None, env=None):
 
     :return: parsed output of g.findfile
     """
-    if element == "raster" or element == "rast":
-        verbose(_('Element type should be "cell" and not "%s"') % element)
-        element = "cell"
+    element_translation = {
+        "rast": "cell",
+        "raster": "cell",
+        "rast3d": "grid3",
+        "raster3d": "grid3",
+        "raster_3d": "grid3",
+    }
+
+    if element in element_translation:
+        element_in = element
+        element = element_translation[element]
+        debug(
+            _('Element type should be "{element}" and not "{element_in}"').format(
+                element_in=element_in, element=element
+            ),
+            1,
+        )
     # g.findfile returns non-zero when file was not found
-    # se we ignore return code and just focus on stdout
+    # so we ignore return code and just focus on stdout
     process = start_command(
         "g.findfile",
         flags="n",


### PR DESCRIPTION
Currently, the `find_file` function in the grass.script.core lib replaces _rast_ / _raster_ elements with _cell. This PR implements a more comprehensive replacement of element types that are used in the code but do not represent mapset elements in the sense of `g.findfile`.

Also, the message level in the function is changed from verbose to debug as the current message is mostly useful for developers.

The change would remove messages from e.g. `t.register --v` that are rather cryptic for normal users. It is a precondition for #2863