### PR TITLE
winGRASS: exclude pdal as compilation dependency

### DIFF
--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -195,6 +195,7 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 		--with-cairo-ldflags="-L$PWD/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
 		--with-bzlib \
 		--with-liblas=$PWD/mswindows/osgeo4w/liblas-config
+		--without-pdal
 
 	touch mswindows/osgeo4w/configure-stamp
 fi

--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -194,7 +194,7 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 		--with-cairo-includes=$OSGEO4W_ROOT_MSYS/include \
 		--with-cairo-ldflags="-L$PWD/mswindows/osgeo4w/lib -lcairo -lfontconfig" \
 		--with-bzlib \
-		--with-liblas=$PWD/mswindows/osgeo4w/liblas-config
+		--with-liblas=$PWD/mswindows/osgeo4w/liblas-config \
 		--without-pdal
 
 	touch mswindows/osgeo4w/configure-stamp


### PR DESCRIPTION
as seen in the compilation logs of daily winGRASS builds (https://wingrass.fsv.cvut.cz/grass83/logs/): 

pdal is not available in OSGeo4W due to Mingw64/MSVSC incompatibility 

see also gh CI build recipe (https://github.com/OSGeo/grass/blob/main/mswindows/osgeo4w/build_osgeo4w.sh#L67)