### PR TITLE
CI: do not fail macOS on -Wdeprecated-non-prototype

### DIFF
--- a/.github/workflows/macos_install.sh
+++ b/.github/workflows/macos_install.sh
@@ -71,6 +71,8 @@ export CXXFLAGS="-O2 -pipe -stdlib=libc++ -arch ${CONDA_ARCH} -Wall -Wextra"
 
 ./configure $CONFIGURE_FLAGS
 
-make -j$(sysctl -n hw.ncpu) CFLAGS="$CFLAGS -Werror" CXXFLAGS="$CXXFLAGS -Werror"
+EXEMPT="-Wno-error=deprecated-non-prototype"
+make -j$(sysctl -n hw.ncpu) CFLAGS="$CFLAGS -Werror $EXEMPT" \
+  CXXFLAGS="$CXXFLAGS -Werror $EXEMPT"
 
 make install


### PR DESCRIPTION
The Clang version for macOS CI build just bumped to 15, which issues -Wdeprecated-non-prototype warnings and failed the build with -Werror. This was expected (https://github.com/OSGeo/grass/issues/2747#issuecomment-1429484028) and the underlying issues are non-trivial, so this PR is a temporary solution.