### PR TITLE
lib/raster3d: attempt to add prototype by removing const

### DIFF
--- a/include/grass/defs/raster3d.h
+++ b/include/grass/defs/raster3d.h
@@ -132,11 +132,11 @@ int Rast3d_key_get_double(struct Key_Value *, const char *, double *);
 int Rast3d_key_get_string(struct Key_Value *, const char *, char **);
 int Rast3d_key_get_value(struct Key_Value *, const char *, char *, char *, int,
                          int, int *);
-int Rast3d_key_set_int(struct Key_Value *, const char *, const int *);
-int Rast3d_key_set_double(struct Key_Value *, const char *, const double *);
-int Rast3d_key_set_string(struct Key_Value *, const char *, char *const *);
-int Rast3d_key_set_value(struct Key_Value *, const char *, const char *,
-                         const char *, int, int, const int *);
+int Rast3d_key_set_int(struct Key_Value *, const char *, int *);
+int Rast3d_key_set_double(struct Key_Value *, const char *, double *);
+int Rast3d_key_set_string(struct Key_Value *, const char *, char **);
+int Rast3d_key_set_value(struct Key_Value *, const char *, char *, char *, int,
+                         int, int *);
 /* long.c */
 int Rast3d_long_encode(long *, unsigned char *, int);
 void Rast3d_long_decode(unsigned char *, long *, int, int);

--- a/lib/raster3d/header.c
+++ b/lib/raster3d/header.c
@@ -42,8 +42,11 @@ static int Rast3d_readWriteHeader(
     int *vertical_unit, int *version)
 {
     int returnVal;
-    int (*headerInt)(), (*headerDouble)(), (*headerValue)();
-    int (*headerString)();
+    int (*headerInt)(struct Key_Value *, const char *, int *),
+        (*headerDouble)(struct Key_Value *, const char *, double *),
+        (*headerValue)(struct Key_Value *, const char *, char *, char *, int,
+                       int, int *);
+    int (*headerString)(struct Key_Value *, const char *, char **);
 
     if (doRead) {
         headerDouble = Rast3d_key_get_double;

--- a/lib/raster3d/keys.c
+++ b/lib/raster3d/keys.c
@@ -90,7 +90,7 @@ int Rast3d_key_get_value(struct Key_Value *keys, const char *key, char *val1,
 
 /*---------------------------------------------------------------------------*/
 
-int Rast3d_key_set_int(struct Key_Value *keys, const char *key, const int *i)
+int Rast3d_key_set_int(struct Key_Value *keys, const char *key, int *i)
 {
     char keyValStr[200];
 
@@ -101,8 +101,7 @@ int Rast3d_key_set_int(struct Key_Value *keys, const char *key, const int *i)
 
 /*---------------------------------------------------------------------------*/
 
-int Rast3d_key_set_double(struct Key_Value *keys, const char *key,
-                          const double *d)
+int Rast3d_key_set_double(struct Key_Value *keys, const char *key, double *d)
 {
     char keyValStr[200];
 
@@ -114,7 +113,7 @@ int Rast3d_key_set_double(struct Key_Value *keys, const char *key,
 /*---------------------------------------------------------------------------*/
 
 int Rast3d_key_set_string(struct Key_Value *keys, const char *key,
-                          char *const *keyValStr)
+                          char **keyValStr)
 {
     G_set_key_value(key, *keyValStr, keys);
     return 1;
@@ -122,9 +121,8 @@ int Rast3d_key_set_string(struct Key_Value *keys, const char *key,
 
 /*---------------------------------------------------------------------------*/
 
-int Rast3d_key_set_value(struct Key_Value *keys, const char *key,
-                         const char *val1, const char *val2, int keyval1,
-                         int keyval2, const int *keyvalVar)
+int Rast3d_key_set_value(struct Key_Value *keys, const char *key, char *val1,
+                         char *val2, int keyval1, int keyval2, int *keyvalVar)
 {
     if (*keyvalVar == keyval1) {
         G_set_key_value(key, val1, keys);

--- a/lib/raster3d/window.c
+++ b/lib/raster3d/window.c
@@ -62,7 +62,7 @@ void Rast3d_get_window(RASTER3D_Region *window)
 
 /*---------------------------------------------------------------------------*/
 
-RASTER3D_Region *Rast3d_window_ptr()
+RASTER3D_Region *Rast3d_window_ptr(void)
 {
     return &g3d_window;
 }

--- a/lib/raster3d/windowio.c
+++ b/lib/raster3d/windowio.c
@@ -17,7 +17,8 @@ static int Rast3d_readWriteWindow(struct Key_Value *windowKeys, int doRead,
                                   double *ns_res, double *tb_res)
 {
     int returnVal;
-    int (*windowInt)(), (*windowDouble)();
+    int (*windowInt)(struct Key_Value *, const char *, int *),
+        (*windowDouble)(struct Key_Value *, const char *, double *);
 
     if (doRead) {
         windowDouble = Rast3d_key_get_double;


### PR DESCRIPTION
The `Rast3d_readWriteWindow()`:

https://github.com/OSGeo/grass/blob/d10ac4f5e17bc6bcdbe97a2bce115bc49fc8761d/lib/raster3d/windowio.c#L12

function both reads and writes files using function pointers without function prototypes, which is deprecated in all versions of C and is not supported in C2x.

Adding missing prototype for this function causes incompatibility with the set functions defined with `const` whereas the get functions are not. This PR removes the const qualifier for the set functions, which are however correct, but leads to the least modification overall.

An alternative to this approach, would be to rewrite this and separate the read and write code all together.

Putting this up as a draft, as the solution to this may be up to discussion.