### PR TITLE
wxGUI: remove initial duplicate point when creating profile or measuring distance

### DIFF
--- a/gui/wxpython/mapwin/analysis.py
+++ b/gui/wxpython/mapwin/analysis.py
@@ -70,6 +70,11 @@ class AnalysisControllerBase:
 
         :param x,y: east north coordinates
         """
+        # avoid duplicating point in the beginning
+        begin = self._mapWindow.mouse["begin"]
+        end = self._mapWindow.mouse["end"]
+        if begin == end:
+            return
         # add new point and calculate distance
         item = self._registeredGraphics.GetItem(0)
         coords = item.GetCoords() + [[x, y]]


### PR DESCRIPTION
This fixes the problem described in #2832 with GUI Profile tool duplicating first point. Additionally, this improves GUI distance measurement, now it omits printing first zero-length segment (the distance between the first duplicate points).

I suggest to use this PR instead of #2832.