### PR TITLE
checks: suppress compiler warnings from GDAL

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -59,8 +59,6 @@ jobs:
           ldd --version
       - name: Build
         env:
-          # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: -std=${{ matrix.c }} -fPIC -Wall -Wextra
-          # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: -std=${{ matrix.cpp }} -fPIC -Wall -Wextra
+          CFLAGS: -std=${{ matrix.c }} -fPIC -Wall -Wextra -Wpedantic
+          CXXFLAGS: -std=${{ matrix.cpp }} -fPIC -Wall -Wextra -Wpedantic
         run: .github/workflows/build_ubuntu-22.04.sh $HOME/install -Werror

--- a/db/drivers/ogr/cursor.c
+++ b/db/drivers/ogr/cursor.c
@@ -17,7 +17,19 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/db.c
+++ b/db/drivers/ogr/db.c
@@ -18,7 +18,19 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -16,7 +16,19 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/driver.c
+++ b/db/drivers/ogr/driver.c
@@ -13,7 +13,20 @@
 
 #include <grass/dbmi.h>
 
-#include "ogr_api.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "globals.h"
 #include "proto.h"
 

--- a/db/drivers/ogr/error.c
+++ b/db/drivers/ogr/error.c
@@ -18,7 +18,19 @@
 #include <grass/gis.h>
 #include <grass/dbmi.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/execute.c
+++ b/db/drivers/ogr/execute.c
@@ -16,8 +16,20 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
 #include <cpl_error.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/fetch.c
+++ b/db/drivers/ogr/fetch.c
@@ -18,7 +18,19 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/listtab.c
+++ b/db/drivers/ogr/listtab.c
@@ -15,7 +15,19 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/db/drivers/ogr/main.c
+++ b/db/drivers/ogr/main.c
@@ -19,7 +19,19 @@
 
 #include <grass/dbmi.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "dbdriver.h"

--- a/db/drivers/ogr/select.c
+++ b/db/drivers/ogr/select.c
@@ -15,7 +15,19 @@
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "globals.h"
 #include "proto.h"

--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -24,9 +24,21 @@
 #include <grass/config.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <ogr_api.h>
 #include <cpl_csv.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #include "local_proto.h"

--- a/include/grass/gprojects.h
+++ b/include/grass/gprojects.h
@@ -54,7 +54,19 @@
 #define PROJ_VERSION_MAJOR 4
 #endif
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_srs_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #if PROJ_VERSION_MAJOR >= 6 && GDAL_VERSION_MAJOR < 3
 #error "PROJ 6+ requires GDAL 3+"
 #endif

--- a/include/grass/vect/dig_defines.h
+++ b/include/grass/vect/dig_defines.h
@@ -225,6 +225,13 @@ typedef enum overlay_operator OVERLAY_OPERATOR;
 /*! \brief GRASS ASCII vector format - well-known-text format */
 #define GV_ASCII_FORMAT_WKT   2
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 /*! \brief Simple feature types
 
    Taken from GDAL/OGR library (ogr/ogr_core.h)
@@ -252,6 +259,11 @@ typedef enum {
     SF_MULTIPOLYGON25D = 0x80000006,      /* 2.5D extension as per 99-402 */
     SF_GEOMETRYCOLLECTION25D = 0x80000007 /* 2.5D extension as per 99-402 */
 } SF_FeatureType;
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #define HEADSTR               50
 

--- a/include/grass/vect/dig_structs.h
+++ b/include/grass/vect/dig_structs.h
@@ -24,7 +24,19 @@
 #include <grass/dbmi.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #ifdef HAVE_POSTGRES

--- a/lib/raster/R.h
+++ b/lib/raster/R.h
@@ -1,7 +1,19 @@
 #include <grass/config.h>
 #include <grass/gis.h>
 #ifdef HAVE_GDAL
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #define XDR_FLOAT_NBYTES  4

--- a/lib/raster/gdal.c
+++ b/lib/raster/gdal.c
@@ -28,7 +28,19 @@
 #endif
 
 #ifdef GDAL_LINK
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 /*!

--- a/lib/vector/Vlib/build_ogr.c
+++ b/lib/vector/Vlib/build_ogr.c
@@ -24,8 +24,20 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
 #include <cpl_error.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #include "local_proto.h"

--- a/lib/vector/Vlib/build_sfa.c
+++ b/lib/vector/Vlib/build_sfa.c
@@ -55,7 +55,19 @@ static void build_pg(struct Map_info *, int);
 #endif
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 static int add_geometry_ogr(struct Plus_head *, struct Format_info_ogr *,
                             OGRGeometryH, int, int, struct geom_parts *);

--- a/lib/vector/Vlib/close_ogr.c
+++ b/lib/vector/Vlib/close_ogr.c
@@ -19,7 +19,19 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #include "local_proto.h"

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -34,7 +34,19 @@
 #endif                    /* HAVE_GDAL */
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #ifdef HAVE_POSTGRES

--- a/lib/vector/Vlib/open_ogr.c
+++ b/lib/vector/Vlib/open_ogr.c
@@ -25,7 +25,19 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 /*!

--- a/lib/vector/Vlib/read_ogr.c
+++ b/lib/vector/Vlib/read_ogr.c
@@ -18,7 +18,19 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 static int cache_feature(struct Map_info *, OGRGeometryH, int);
 static int read_line(const struct Map_info *, OGRGeometryH, long,

--- a/lib/vector/Vlib/rewind_ogr.c
+++ b/lib/vector/Vlib/rewind_ogr.c
@@ -17,7 +17,19 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 /*!

--- a/lib/vector/Vlib/simple_features.c
+++ b/lib/vector/Vlib/simple_features.c
@@ -38,7 +38,19 @@
 #endif
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 static int check_sftype(const struct line_pnts *, int, SF_FeatureType, int);

--- a/lib/vector/Vlib/write_ogr.c
+++ b/lib/vector/Vlib/write_ogr.c
@@ -24,8 +24,20 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
 #include <cpl_string.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 static dbDriver *create_table(OGRLayerH, const struct field_info *);
 static int create_ogr_layer(struct Map_info *, int);

--- a/raster/r.external.out/main.c
+++ b/raster/r.external.out/main.c
@@ -23,7 +23,19 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 
-#include "gdal.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 static void list_formats(void)
 {

--- a/raster/r.external/colors.c
+++ b/raster/r.external/colors.c
@@ -2,7 +2,19 @@
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* -------------------------------------------------------------------- */
 /*      Transfer colormap, if there is one.                             */

--- a/raster/r.external/link.c
+++ b/raster/r.external/link.c
@@ -1,7 +1,19 @@
 #include <grass/gis.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "proto.h"
 

--- a/raster/r.external/list.c
+++ b/raster/r.external/list.c
@@ -7,7 +7,19 @@
 #include <grass/gis.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "proto.h"
 

--- a/raster/r.external/main.c
+++ b/raster/r.external/main.c
@@ -26,9 +26,21 @@
 #include <grass/imagery.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <ogr_srs_api.h>
 #include <cpl_conv.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "proto.h"
 

--- a/raster/r.external/proj.c
+++ b/raster/r.external/proj.c
@@ -2,8 +2,20 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <ogr_srs_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* keep in sync with r.in.gdal, v.in.ogr, v.external */
 void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,

--- a/raster/r.external/window.c
+++ b/raster/r.external/window.c
@@ -1,7 +1,19 @@
 #include <grass/gis.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "proto.h"
 

--- a/raster/r.in.gdal/main.c
+++ b/raster/r.in.gdal/main.c
@@ -29,8 +29,20 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <cpl_conv.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
                       int create_only, int override, int check_only);

--- a/raster/r.in.gdal/proj.c
+++ b/raster/r.in.gdal/proj.c
@@ -2,8 +2,20 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <ogr_srs_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* keep in sync with r.external, v.in.ogr, v.external */
 void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,

--- a/raster/r.out.gdal/attr.c
+++ b/raster/r.out.gdal/attr.c
@@ -2,8 +2,21 @@
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
-#include "cpl_string.h"
-#include "gdal.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include <cpl_string.h>
+#include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "local_proto.h"
 
 int export_attr(GDALDatasetH hMEMDS, int band, const char *name,

--- a/raster/r.out.gdal/export_band.c
+++ b/raster/r.out.gdal/export_band.c
@@ -17,9 +17,22 @@
 #include <grass/raster.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <cpl_string.h>
 #include <cpl_port.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "local_proto.h"
 
 int exact_range_check(double, double, GDALDataType, const char *);

--- a/raster/r.out.gdal/local_proto.h
+++ b/raster/r.out.gdal/local_proto.h
@@ -1,7 +1,20 @@
 #ifndef __LOCAL_PROTO_H__
 #define __LOCAL_PROTO_H__
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <math.h>
 /* is it safe to #include <float.h> ? */
 

--- a/vector/v.external.out/format.c
+++ b/vector/v.external.out/format.c
@@ -5,8 +5,20 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
-#include "ogr_api.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
+#include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif /* HAVE_OGR */
 
 int is_ogr(const char *format)
 {

--- a/vector/v.external.out/list.c
+++ b/vector/v.external.out/list.c
@@ -4,7 +4,19 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
-#include "ogr_api.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif /* HAVE_OGR */
 
 static int cmp(const void *, const void *);

--- a/vector/v.external.out/main.c
+++ b/vector/v.external.out/main.c
@@ -23,8 +23,20 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
-#include "ogr_api.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
+#include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif /* HAVE_OGR */
 
 #include "local_proto.h"
 

--- a/vector/v.external/list.c
+++ b/vector/v.external/list.c
@@ -7,11 +7,25 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
-#include "ogr_api.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #endif
+#include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif /* HAVE_OGR */
+
 #ifdef HAVE_POSTGRES
 #include <libpq-fe.h>
-#endif
+#endif /* HAVE_POSTGRES */
+
 #include "local_proto.h"
 
 static int cmp(const void *, const void *);

--- a/vector/v.external/local_proto.h
+++ b/vector/v.external/local_proto.h
@@ -1,9 +1,21 @@
 #ifndef V_EXTERNAL_LOCAL_PROTO_H
 #define V_EXTERNAL_LOCAL_PROTO_H
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <gdal_version.h>
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* define type of input datasource
  * as of GDAL 2.2, all functions having as argument a GDAL/OGR dataset

--- a/vector/v.external/main.c
+++ b/vector/v.external/main.c
@@ -24,7 +24,19 @@
 #include <grass/glocale.h>
 
 #ifdef HAVE_OGR
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #include "local_proto.h"

--- a/vector/v.external/proj.c
+++ b/vector/v.external/proj.c
@@ -2,7 +2,20 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_srs_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "local_proto.h"
 
 /* get projection info of OGR layer in GRASS format

--- a/vector/v.in.ogr/geom.c
+++ b/vector/v.in.ogr/geom.c
@@ -21,7 +21,21 @@
 #include <grass/dbmi.h>
 #include <grass/vector.h>
 #include <grass/glocale.h>
-#include "ogr_api.h"
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "global.h"
 
 int split_line(struct Map_info *Map, int otype, struct line_pnts *Points,

--- a/vector/v.in.ogr/global.h
+++ b/vector/v.in.ogr/global.h
@@ -22,9 +22,21 @@
 #ifndef __GLOBAL_H__
 #define __GLOBAL_H__
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <gdal_version.h>
 #include <ogr_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* define type of input datasource
  * as of GDAL 2.2, all functions having as argument a GDAL/OGR dataset

--- a/vector/v.in.ogr/proj.c
+++ b/vector/v.in.ogr/proj.c
@@ -2,8 +2,21 @@
 #include <grass/gprojects.h>
 #include <grass/glocale.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_srs_api.h>
 #include <cpl_conv.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "global.h"
 
 /* get projection info of OGR layer in GRASS format

--- a/vector/v.out.ogr/list.c
+++ b/vector/v.out.ogr/list.c
@@ -1,4 +1,17 @@
-#include "gdal.h"
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+#include <gdal.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <grass/glocale.h>
 #include "local_proto.h"
 

--- a/vector/v.out.ogr/local_proto.h
+++ b/vector/v.out.ogr/local_proto.h
@@ -2,10 +2,22 @@
 #include <grass/vector.h>
 #include <grass/dbmi.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <gdal.h>
 #include <gdal_version.h>
 #include <ogr_api.h>
 #include <cpl_string.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* switch to new GDAL API with GDAL 2.2+ */
 #if GDAL_VERSION_NUM >= 2020000

--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -25,7 +25,19 @@
 
 #include "local_proto.h"
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <ogr_srs_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Enabling compiler flag `-Wpedantic` unleashes a great number of warnings originating from non-GRASS sources. They all (on GCC CI runners) come from ogr_core.h with non-iso compliant enum values, eg.

```
/opt/local/include/ogr_core.h:460:5: warning: ISO C restricts enumerator values to range of 'int' (2147483649 is too large) [-Wpedantic]
    wkbPoint25D = 0x80000001, /**< 2.5D extension as per 99-402 */
    ^             ~~~~~~~~~~
```

This is not likely to be addressed upstreams in the near future: https://github.com/OSGeo/gdal/issues/2322.

I'm not too happy for the required solution of adding 12 line of macro for each include, but I reckon this is the only way to assure good code (`-Wpedantic -Werror` in the CI runners) in the GRASS source.