### PR TITLE
CITATION.cff: added formatted citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -41,6 +41,8 @@ authors:
   - given-names: Caitlin
     family-names: Haedrich
     email: caitlin.haedrich@gmail.com
+    affiliation: North Carolina State University
+    orcid: https://orcid.org/0000-0003-4373-5691
   - given-names: Stefan
     family-names: Blumentrath
     email: stefan.blumentrath@gmx.de

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,121 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it using the metadata from this file.
+
+title: GRASS GIS
+version: 8.2.1
+abstract: GRASS GIS (Geographic Resources Analysis Support System) is a free and open source Geographic Information System (GIS) software used for geospatial data management and analysis, image processing, graphics and maps production, spatial modeling, and visualization.
+
+authors:
+  - name: GRASS Development Team
+    email: grass-dev@lists.osgeo.org
+    affiliation: Open Source Geospatial Foundation (OSGeo)
+  - name: Martin Landa
+    affiliation: Czech Technical University in Prague
+    orcid: https://orcid.org/0000-0001-6869-3542
+  - name: Markus Neteler
+    affiliation: mundialis GmbH & Co. KG
+    orcid: https://orcid.org/0000-0003-1916-1966
+  - given-names: Markus
+    family-names: Metz
+    email: metz@mundialis.de
+    affiliation: mundialis GmbH & Co. KG
+    orcid: https://orcid.org/0000-0002-4038-8754
+  - name: Anna Petrášová
+    affiliation: North Carolina State University
+    orcid: https://orcid.org/0000-0002-5120-5538
+  - name: Vaclav Petráš
+    affiliation: North Carolina State University
+    orcid: https://orcid.org/0000-0001-5566-9236
+  - given-names: Glynn
+    family-names: Clements
+    email: glynn@gclements.plus.com
+  - given-names: Tomáš
+    family-names: Zigo
+    email: tomas.zigo@slovanet.sk
+  - given-names: Nicklas
+    family-names: Larsson
+    email: n_larsson@yahoo.com
+  - given-names: Linda
+    family-names: Kladivová
+    email: L.Kladivova@seznam.cz
+  - given-names: Caitlin
+    family-names: Haedrich
+    email: caitlin.haedrich@gmail.com
+  - given-names: Stefan
+    family-names: Blumentrath
+    email: stefan.blumentrath@gmx.de
+    orcid: https://orcid.org/0000-0001-6675-1331
+  - given-names: Veronica
+    family-names: Andreo
+    email: veroandreo@gmail.com
+    orcid: https://orcid.org/0000-0002-4633-2161
+  - given-names: Huidae
+    family-names: Cho
+    email: grass4u@gmail.com
+    orcid: https://orcid.org/0000-0003-1878-1274
+  - given-names: Sören
+    family-names: Gebbert
+    email: soerengebbert@gmail.com
+  - given-names: Māris
+    family-names: Nartišs
+    email: maris.gis@gmail.com
+    orcid: https://orcid.org/0000-0002-3875-740X
+  - given-names: Helmut
+    family-names: Kudrnovsky
+    email: hellik@web.de
+    orcid: https://orcid.org/0000-0001-6622-7169
+  - given-names: Luca
+    family-names: Delucchi
+    affiliation: Fondazione Edmund Mach
+    email: lucadeluge@gmail.com
+    orcid: https://orcid.org/0000-0002-0493-3516
+  - given-names: Pietro
+    family-names: Zambelli
+    email: peter.zamb@gmail.com
+    orcid: https://orcid.org/0000-0002-6187-3572
+  - given-names: Moritz
+    family-names: Lennert
+    email: mlennert@club.worldonline.be
+    orcid: https://orcid.org/0000-0002-2870-4515
+  - given-names: Helena
+    family-names: Mitášová
+    affiliation: North Carolina State University
+    orcid: https://orcid.org/0000-0002-6906-3398
+  - given-names: Yann
+    family-names: Chemin
+    email: dr.yann.chemin@gmail.com
+    orcid: https://orcid.org/0000-0001-9232-5512
+  - given-names: Ondřej
+    family-names: Pešek
+    email: pesej.ondrek@gmail.com
+    orcid: https://orcid.org/0000-0002-2363-8002
+  - given-names: Michael
+    family-names: Barton
+    email: michael.barton@asu.edu
+    orcid: https://orcid.org/0000-0003-2561-1927
+  - given-names: Carmen
+    family-names: Tawalika
+    email: tawalika@mundialis.de
+  - given-names: Denis
+    family-names: Ovsienko
+    email: denis@ovsienko.info
+  - given-names: Hamish
+    family-names: Bowman
+    email: hamish_b@yahoo.com
+
+repository-code: https://github.com/OSGeo/grass
+license: GNU General Public License v2 or later
+doi: 10.5281/zenodo.4621728
+keywords: 
+  - GIS
+  - geospatial
+  - spatial analysis
+  - data management
+  - visualization
+  - open source
+  - free software
+  - GNU GPL v2
+
+citation:
+  - text: GRASS Development Team. (2021). Geographic Resources Analysis Support System (GRASS GIS) Software, Version 8.2.1. Open Source Geospatial Foundation. https://grass.osgeo.org
+    doi: 10.5281/zenodo.4621728

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 
 title: GRASS GIS
-version: 8.2.1
+version: 8.3.0
 abstract: GRASS GIS (Geographic Resources Analysis Support System) is a free and open source Geographic Information System (GIS) software used for geospatial data management and analysis, image processing, graphics and maps production, spatial modeling, and visualization.
 
 authors:
@@ -119,5 +119,5 @@ keywords:
   - GNU GPL v2
 
 citation:
-  - text: GRASS Development Team. (2021). Geographic Resources Analysis Support System (GRASS GIS) Software, Version 8.2.1. Open Source Geospatial Foundation. https://grass.osgeo.org
+  - text: GRASS Development Team. (2023). Geographic Resources Analysis Support System (GRASS GIS) Software, Version 8.3.0. Open Source Geospatial Foundation. https://grass.osgeo.org
     doi: 10.5281/zenodo.4621728


### PR DESCRIPTION
This PR suggests the CITATION.cff file for improved citation management (by Zenodo.org etc).

The content is based on the GRASS GIS 8.2.1 record: https://doi.org/10.5281/zenodo.7764250

TODO:

- add missing authors relevant for the GRASS 8.2/8.3 releases
- add more ORCID IDs (please verify)