### PR TITLE
docker/alpine: add C support for g.extension; enable PostgreSQL support

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -20,9 +20,11 @@ ENV PACKAGES="\
       flex \
       freetype \
       gdal \
+      gdal-dev \
       gdal-tools \
       gettext \
       geos \
+      geos-dev \
       gnutls \
       jsoncpp \
       laszip \
@@ -31,6 +33,7 @@ ENV PACKAGES="\
       libjpeg-turbo \
       libpng \
       libunwind \
+      make \
       musl \
       musl-utils \
       ncurses \
@@ -231,8 +234,12 @@ ENV PROJ_NETWORK=ON
 RUN apk add --no-cache $GRASS_RUN_PACKAGES
 
 # addon test in final stage: does g.extension install also C-extensions?
+# test raster C addon
 RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=add
 RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+# test vector C addon
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -192,8 +192,6 @@ RUN grass --tmp-location XY --exec g.version -rge && \
 
 FROM grass as test
 
-RUN apk add --no-cache make gcc
-
 ## run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/simple.laz
 COPY docker/testdata/test_grass_session.py /scripts/test_grass_session.py
@@ -212,6 +210,14 @@ RUN grass --tmp-location XY --exec g.extension extension=r.learn.ml2
 
 FROM grass as final
 
+# These packages are required to run g.extension in GRASS GIS.
+ENV GRASS_RUN_PACKAGES="\
+      build-base \
+      gcc \
+      libpq-dev \
+      make \
+    "
+
 # GRASS GIS specific
 # allow work with MAPSETs that are not owned by current user
 ENV GRASSBIN="/usr/local/bin/grass" \
@@ -221,6 +227,13 @@ ENV GRASSBIN="/usr/local/bin/grass" \
 # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
 ENV PROJ_NETWORK=ON
 
+# Add packages for fully enabling g.extension
+RUN apk add --no-cache $GRASS_RUN_PACKAGES
+
+# addon test in final stage: does g.extension install also C-extensions?
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=add
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \
     pdal --version && \
@@ -229,7 +242,6 @@ RUN grass --tmp-location XY --exec g.version -rge && \
 # test r.in.pdal in final image because test stage is not executed in github action
 COPY docker/testdata/simple.laz /tmp/simple.laz
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
-
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -224,8 +224,12 @@ ENV PROJ_NETWORK=ON
 RUN apk add --no-cache $GRASS_RUN_PACKAGES
 
 # addon test in final stage: does g.extension install also C-extensions?
+# test raster C addon
 RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=add
 RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+# test vector C addon
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -61,7 +61,8 @@ ENV PACKAGES="\
       freetype \
       g++ \
       gcc \
-      gdal \
+      gdal-dev \
+      geos-dev \
       gettext \
       geos \
       gnutls \
@@ -69,6 +70,7 @@ ENV PACKAGES="\
       libjpeg-turbo \
       libpng \
       libpq-dev \
+      make \
       musl \
       musl-utils \
       ncurses \
@@ -88,22 +90,15 @@ ENV PACKAGES="\
     " \
     # These packages are required to compile GRASS GIS.
     GRASS_BUILD_PACKAGES="\
-      build-base \
       bzip2-dev \
       cairo-dev \
       fftw-dev \
       freetype-dev \
-      g++ \
-      gcc \
-      gdal-dev \
-      geos-dev \
       git \
       gnutls-dev \
       libc6-compat \
       libjpeg-turbo-dev \
       libpng-dev \
-      libpq-dev \
-      make \
       openjpeg-dev \
       openblas-dev \
       proj-dev \

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -50,6 +50,8 @@ ENV MYCFLAGS="-O2 -std=gnu99 -m64" \
 # List of packages to be installed (proj-data omitted: 570.04 MB)
 ENV PACKAGES="\
       attr \
+      build-base \
+      make \
       bash \
       bison \
       bzip2 \
@@ -57,6 +59,7 @@ ENV PACKAGES="\
       fftw \
       flex \
       freetype \
+      gcc \
       gdal \
       gettext \
       geos \
@@ -64,6 +67,7 @@ ENV PACKAGES="\
       libbz2 \
       libjpeg-turbo \
       libpng \
+      libpq-dev \
       musl \
       musl-utils \
       ncurses \
@@ -215,6 +219,13 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
 
 # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
 ENV PROJ_NETWORK=ON
+
+# Add packages for fully enabling g.extension
+RUN apk add --no-cache $GRASS_RUN_PACKAGES
+
+# addon test in final stage: does g.extension install also C-extensions?
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=add
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
 
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -59,6 +59,7 @@ ENV PACKAGES="\
       fftw \
       flex \
       freetype \
+      g++ \
       gcc \
       gdal \
       gettext \


### PR DESCRIPTION
This PR add
- the needed gcc compiler for addons written in C language (g.extension)
- enables PostgreSQL (add header file)

Co-authored-by: @anikaweinmann