### PR TITLE
docker/alpine: add C support for g.extension; enable PostgreSQL support (backport)

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -20,9 +20,11 @@ ENV PACKAGES="\
       flex \
       freetype \
       gdal \
+      gdal-dev \
       gdal-tools \
       gettext \
       geos \
+      geos-dev \
       gnutls \
       jsoncpp \
       laszip \
@@ -32,6 +34,7 @@ ENV PACKAGES="\
       libjpeg-turbo \
       libpng \
       libunwind \
+      make \
       musl \
       musl-utils \
       ncurses \
@@ -193,8 +196,6 @@ RUN grass --tmp-location XY --exec g.version -rge && \
 
 FROM grass as test
 
-RUN apk add --no-cache make gcc
-
 ## run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/simple.laz
 COPY docker/testdata/test_grass_session.py /scripts/test_grass_session.py
@@ -212,6 +213,13 @@ RUN grass --tmp-location XY --exec g.extension extension=r.learn.ml2
 
 
 FROM grass as final
+# These packages are required to run g.extension in GRASS GIS.
+ENV GRASS_RUN_PACKAGES="\
+      build-base \
+      gcc \
+      libpq-dev \
+      make \
+    "
 
 # GRASS GIS specific
 # allow work with MAPSETs that are not owned by current user
@@ -221,6 +229,16 @@ ENV GRASSBIN="/usr/local/bin/grass" \
 
 # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
 ENV PROJ_NETWORK=ON
+# Add packages for fully enabling g.extension
+RUN apk add --no-cache $GRASS_RUN_PACKAGES
+
+# addon test in final stage: does g.extension install also C-extensions?
+# test raster C addon
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=add
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+# test vector C addon
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \

--- a/docker/alpine/Dockerfile_alpine_latest
+++ b/docker/alpine/Dockerfile_alpine_latest
@@ -50,6 +50,7 @@ ENV MYCFLAGS="-O2 -std=gnu99 -m64" \
 # List of packages to be installed (proj-data omitted: 570.04 MB)
 ENV PACKAGES="\
       attr \
+      build-base \
       bash \
       bison \
       bzip2 \
@@ -57,13 +58,18 @@ ENV PACKAGES="\
       fftw \
       flex \
       freetype \
-      gdal \
+      g++ \
+      gcc \
+      gdal-dev \
+      geos-dev \
       gettext \
       geos \
       gnutls \
       libbz2 \
       libjpeg-turbo \
       libpng \
+      libpq-dev \
+      make \
       musl \
       musl-utils \
       ncurses \
@@ -83,22 +89,15 @@ ENV PACKAGES="\
     " \
     # These packages are required to compile GRASS GIS.
     GRASS_BUILD_PACKAGES="\
-      build-base \
       bzip2-dev \
       cairo-dev \
       fftw-dev \
       freetype-dev \
-      g++ \
-      gcc \
-      gdal-dev \
-      geos-dev \
       git \
       gnutls-dev \
       libc6-compat \
       libjpeg-turbo-dev \
       libpng-dev \
-      libpq-dev \
-      make \
       openjpeg-dev \
       openblas-dev \
       proj-dev \
@@ -149,6 +148,7 @@ RUN echo "Install main packages";\
     echo "  => Downloading grass"
 
 COPY . /src/grass_build/
+WORKDIR /src/grass_build/
 
 # Configure compile and install GRASS GIS
 RUN echo "  => Configure and compile grass";\
@@ -158,7 +158,7 @@ RUN echo "  => Configure and compile grass";\
     make install && \
     ldconfig /etc/ld.so.conf.d; \
     #
-    # Reduce the image size
+    # Reduce the image size - Remove unnecessary grass files
     #
     rm -rf /src/*; \
     # remove build dependencies and any leftover apk cache
@@ -214,6 +214,16 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8"
 # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
 ENV PROJ_NETWORK=ON
+# Add packages for fully enabling g.extension
+RUN apk add --no-cache $GRASS_RUN_PACKAGES
+
+# addon test in final stage: does g.extension install also C-extensions?
+# test raster C addon
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=add
+RUN grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+# test vector C addon
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add
+RUN grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # show installed version
 RUN grass --tmp-location XY --exec g.version -rge && \


### PR DESCRIPTION
(backport of #2909)

This PR adds
- the needed gcc compiler for addons written in C language (g.extension)
- enables PostgreSQL (add header file)

Co-authored-by: @anikaweinmann