### PR TITLE
v.extrude: do not require height/height_column if elevation specified

### DIFF
--- a/vector/v.extrude/main.c
+++ b/vector/v.extrude/main.c
@@ -144,13 +144,10 @@ int main(int argc, char *argv[])
 
     G_gisinit(argv[0]);
 
+    G_option_required(opt.height, opt.hcolumn, opt.elevation, NULL);
+
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
-
-    if (!opt.height->answer && !opt.hcolumn->answer) {
-        G_fatal_error(_("One of '%s' or '%s' parameters must be set"),
-                      opt.height->key, opt.hcolumn->key);
-    }
 
     sscanf(opt.zshift->answer, "%lf", &voffset);
     G_debug(1, "voffset = %f", voffset);


### PR DESCRIPTION
Currently `v.extrude` requires `height` or `height_column` to be set even when `elevation` is specified:

```sh
v.extrude in=stream1 out=stream3d1 elevation=dem10m --o
ERROR: One of 'height' or 'height_column' parameters must be set
```

## Expected behaviour

```
v.extrude in=stream1 out=stream3d1 elevation=dem10m --o
WARNING: Vector map <stream3d1> already exists and will be overwritten
Extruding features...
 100%
Copying attribute table...
Building topology for vector map <stream3d1@test>...
Registering primitives...
v.extrude complete. T: 392.161499 B: 0.000000.
```

```
v.extrude in=stream1 out=stream3d1 --q

ERROR: At least one of the following options is required: <height>, <height_column> and <elevation>
```
