### PR TITLE
pygrass: retrieve 3D geometries for 3D vector maps

### DIFF
--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -450,6 +450,7 @@ class VectorTopo(Vector):
 
             >>> test_vect.close()
         """
+        is2D = bool(libvect.Vect_is_3d(self.c_mapinfo) != 1)
         if vtype in _GEOOBJ.keys():
             if _GEOOBJ[vtype] is not None:
                 ids = (indx for indx in range(1, self.number_of(vtype) + 1))
@@ -461,6 +462,7 @@ class VectorTopo(Vector):
                         c_mapinfo=self.c_mapinfo,
                         table=self.table,
                         writeable=self.writeable,
+                        is2D=is2D
                     )
                     for indx in ids
                 )

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -462,7 +462,7 @@ class VectorTopo(Vector):
                         c_mapinfo=self.c_mapinfo,
                         table=self.table,
                         writeable=self.writeable,
-                        is2D=is2D
+                        is2D=is2D,
                     )
                     for indx in ids
                 )

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -450,7 +450,7 @@ class VectorTopo(Vector):
 
             >>> test_vect.close()
         """
-        is2D = bool(libvect.Vect_is_3d(self.c_mapinfo) != 1)
+        is2D = not self.is_3D()
         if vtype in _GEOOBJ.keys():
             if _GEOOBJ[vtype] is not None:
                 ids = (indx for indx in range(1, self.number_of(vtype) + 1))


### PR DESCRIPTION
## Current behaviour

PyGRASS currently handles geometries for 3D vector maps as 2D

### Steps to reproduce

```sh
v.random out=p3d n=1 -z zmax=1
```

Sample PyGRASS script:

```py
from grass.pygrass.vector import VectorTopo

with VectorTopo('p3d') as vmap:
    print('Map 3D?', vmap.is_3D())
    for f in vmap.viter('points'):
        print('Point 3D?', not f.is2D)
        print('Z:', f.z)
```

Output:

```
Map 3D? True
Point 3D? False
Z: None
```

## Expected behaviour

```
Map 3D? True
Point 3D? True
Z: 0.4480268010321531
```
