### PR TITLE
g.extension: fix printing extension temporary directory to stderr for downloading extension source code only with -d flag

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1047,9 +1047,6 @@ def cleanup():
     """Cleanup after the downloads and copilation"""
     if REMOVE_TMPDIR:
         try_rmdir(TMPDIR)
-    else:
-        gs.message("\n%s\n" % _("Path to the source code:"))
-        sys.stderr.write("%s\n" % os.path.join(TMPDIR, options["extension"]))
 
 
 def write_xml_modules(name, tree=None):
@@ -1988,6 +1985,7 @@ def download_source_code(
 def install_extension_std_platforms(name, source, url, branch):
     """Install extension on standard platforms"""
     gisbase = os.getenv("GISBASE")
+    path_to_src_code_message = _("Path to the source code:")
 
     # to hide non-error messages from subprocesses
     if gs.verbosity() <= 2:
@@ -2047,16 +2045,16 @@ def install_extension_std_platforms(name, source, url, branch):
                 )
 
     dirs = {
-        "bin": os.path.join(TMPDIR, name, "bin"),
-        "docs": os.path.join(TMPDIR, name, "docs"),
-        "html": os.path.join(TMPDIR, name, "docs", "html"),
-        "rest": os.path.join(TMPDIR, name, "docs", "rest"),
-        "man": os.path.join(TMPDIR, name, "docs", "man"),
-        "script": os.path.join(TMPDIR, name, "scripts"),
+        "bin": os.path.join(srcdir, "bin"),
+        "docs": os.path.join(srcdir, "docs"),
+        "html": os.path.join(srcdir, "docs", "html"),
+        "rest": os.path.join(srcdir, "docs", "rest"),
+        "man": os.path.join(srcdir, "docs", "man"),
+        "script": os.path.join(srcdir, "scripts"),
         # TODO: handle locales also for addons
-        #             'string'  : os.path.join(TMPDIR, name, 'locale'),
-        "string": os.path.join(TMPDIR, name),
-        "etc": os.path.join(TMPDIR, name, "etc"),
+        #             'string'  : os.path.join(srcdir, 'locale'),
+        "string": srcdir,
+        "etc": os.path.join(srcdir, "etc"),
     }
 
     make_cmd = [
@@ -2076,7 +2074,7 @@ def install_extension_std_platforms(name, source, url, branch):
     install_cmd = [
         MAKE,
         "MODULE_TOPDIR=%s" % gisbase,
-        "ARCH_DISTDIR=%s" % os.path.join(TMPDIR, name),
+        "ARCH_DISTDIR=%s" % srcdir,
         "INST_DIR=%s" % options["prefix"],
         "install",
     ]
@@ -2086,6 +2084,8 @@ def install_extension_std_platforms(name, source, url, branch):
         sys.stderr.write(" ".join(make_cmd) + "\n")
         gs.message("\n%s\n" % _("To install run:"))
         sys.stderr.write(" ".join(install_cmd) + "\n")
+        gs.message(f"\n{path_to_src_code_message}\n")
+        sys.stderr.write(f"{srcdir}\n")
         return 0, None, None, None
 
     os.chdir(srcdir)
@@ -2098,6 +2098,8 @@ def install_extension_std_platforms(name, source, url, branch):
         gs.fatal(_("Compilation failed, sorry." " Please check above error messages."))
 
     if flags["i"]:
+        gs.message(f"\n{path_to_src_code_message}\n")
+        sys.stderr.write(f"{srcdir}\n")
         return 0, None, None, None
 
     # collect old files
@@ -2118,7 +2120,7 @@ def install_extension_std_platforms(name, source, url, branch):
             if fullname not in old_file_list:
                 file_list.append(fullname)
 
-    return ret, module_list, file_list, os.path.join(TMPDIR, name)
+    return ret, module_list, file_list, os.path.join(srcdir)
 
 
 def remove_extension(force=False):

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -176,12 +176,12 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         self.assertModule(gextension)
         self.assertTrue(gextension.outputs.stderr)
         ext_path_str = re.search(
-            rf"^{_('Path to the source code:')}\n(.+?)\n",
+            rf"^{_('Path to the source code:')}(\n|\n\n)(.+?)\n",
             gextension.outputs.stderr,
             re.MULTILINE,
         )
         self.assertTrue(ext_path_str)
-        ext_path = Path(ext_path_str.group(1))
+        ext_path = Path(ext_path_str.group(2))
         self.assertTrue(ext_path.exists())
         self.assertIn(ext_path / "Makefile", list(ext_path.iterdir()))
 

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -12,6 +12,7 @@ COPYRIGHT: (C) 2022 Stefan Blumentrath and by the GRASS Development Team
            for details.
 """
 
+import re
 import sys
 import unittest
 
@@ -163,6 +164,26 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         self.assertModuleFail(gextension)
         self.assertTrue(gextension.outputs.stderr)
         self.assertIn(extension, gextension.outputs.stderr)
+
+    def test_github_download_official_module_src_code_only(self):
+        """Test download extension source code only from official addons
+        repository and check extension temporary directory path"""
+        gextension = SimpleModule(
+            "g.extension",
+            extension="db.join",
+            flags="d",
+        )
+        self.assertModule(gextension)
+        self.assertTrue(gextension.outputs.stderr)
+        ext_path_str = re.search(
+            rf"^{_('Path to the source code:')}\n(.+?)\n",
+            gextension.outputs.stderr,
+            re.MULTILINE,
+        )
+        self.assertTrue(ext_path_str)
+        ext_path = Path(ext_path_str.group(1))
+        self.assertTrue(ext_path.exists())
+        self.assertIn(ext_path / "Makefile", list(ext_path.iterdir()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Describe the bug**
If you try download some extension source code only (-d flag), printed extension directory is not correct (check extension directory path on the To Compile/Install run and Path to the source line)

**To Reproduce**
Steps to reproduce the behavior:

1. Try download some extension source code only `g.extension -d r.accumulate`
2. Check downloaded extension source code path printed on stderr (line To Compile/Install run and Path to the source code)

```
GRASS nc_basic_spm_grass7/PERMANENT:grass > g.extension -d r.accumulate
WARNING: Extension <r.accumulate> already installed. Re-installing...
Fetching <r.accumulate> from <https://github.com/OSGeo/grass-addons> (be
patient)...
remote: Enumerating objects: 41, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 41 (delta 3), reused 13 (delta 2), pack-reused 13
Receiving objects: 100% (41/41), 1.63 MiB | 787.00 KiB/s, done.
Resolving deltas: 100% (3/3), done.
Updating files: 100% (41/41), done.
Already on 'grass8'
Your branch is up to date with 'origin/grass8'.

To compile run:
make MODULE_TOPDIR=/usr/lib64/grass83 RUN_GISRC=/tmp/grass8-tomas-32426/gisrc BIN=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/bin HTMLDIR=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/docs/html RESTDIR=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/docs/rest MANBASEDIR=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/docs/man SCRIPTDIR=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/scripts STRINGDIR=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate ETC=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/etc SOURCE_URL=https://github.com/OSGeo/grass-addons

To install run:
make MODULE_TOPDIR=/usr/lib64/grass83 ARCH_DISTDIR=/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate INST_DIR=/home/tomas/.grass8/addons install

Path to the source code:
/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate

GRASS nc_basic_spm_grass7/PERMANENT:grass > tree /tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate
/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate
└── grass_addons
    ├── CONTRIBUTING.md
    ├── contributors.csv
    ├── LICENSE
    ├── pyproject.toml
    ├── README.md
    ├── src
    │   ├── Makefile
    │   ├── raster
    │   │   ├── Makefile
    │   │   └── r.accumulate
    │   │       ├── accumulate_iterative.c
    │   │       ├── accumulate_recursive.c
    │   │       ├── calculate_lfp_iterative.c
    │   │       ├── calculate_lfp_recursive.c
    │   │       ├── delineate_streams.c
    │   │       ├── delineate_subwatersheds_iterative.c
    │   │       ├── delineate_subwatersheds_recursive.c
    │   │       ├── global.h
    │   │       ├── line_list.c
    │   │       ├── main.c
    │   │       ├── Makefile
    │   │       ├── point_list.c
    │   │       ├── r_accumulate_formats.png
    │   │       ├── r.accumulate.html
    │   │       ├── r_accumulate_nc_comparison.png
    │   │       ├── r_accumulate_nc_example.png
    │   │       ├── r_accumulate_nc_lfp_example_multiple.png
    │   │       ├── r_accumulate_nc_lfp_example_single.png
    │   │       ├── r_accumulate_nc_lfp_example_single_warning.png
    │   │       ├── r_accumulate_nc_lfp_example_subwatersheds.png
    │   │       ├── r_accumulate_nc_stream_comparison.png
    │   │       ├── r_accumulate_nc_stream_example.png
    │   │       ├── r_accumulate_nc_subwatersheds_example.png
    │   │       ├── r_accumulate_nc_watershed_example.png
    │   │       ├── r_accumulate_r_watershed_nc_example.png
    │   │       ├── raster.c
    │   │       └── subaccumulate.c
    │   └── toolboxes.xml
    └── SUBMITTING

4 directories, 36 files
```

**Expected behavior**
Correct printed downloaded extension source code directory path to stderr.

Instead of extension directory path

/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate

should be 

**/tmp/grass8-tomas-32426/tmp9uhgtrug/r.accumulate/grass_addons/src/raster/r.accumulate**

```
GRASS nc_basic_spm_grass7/PERMANENT:~ > g.extension -d r.accumulate
WARNING: Extension <r.accumulate> already installed. Re-installing...
Fetching <r.accumulate> from <https://github.com/OSGeo/grass-addons> (be
patient)...
remote: Enumerating objects: 41, done.
remote: Counting objects: 100% (28/28), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 41 (delta 3), reused 13 (delta 2), pack-reused 13
Receiving objects: 100% (41/41), 1.63 MiB | 615.00 KiB/s, done.
Resolving deltas: 100% (3/3), done.
Updating files: 100% (41/41), done.
Already on 'grass8'
Your branch is up to date with 'origin/grass8'.

To compile run:
make MODULE_TOPDIR=/usr/lib64/grass83 RUN_GISRC=/tmp/grass8-tomas-24553/gisrc BIN=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate/bin HTMLDIR=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate/docs/html RESTDIR=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate/docs/rest MANBASEDIR=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate/docs/man SCRIPTDIR=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate/scripts STRINGDIR=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate ETC=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate/etc SOURCE_URL=https://github.com/OSGeo/grass-addons

To install run:
make MODULE_TOPDIR=/usr/lib64/grass83 ARCH_DISTDIR=/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate INST_DIR=/home/tomas/.grass8/addons install

Path to the source code:
/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate

GRASS nc_basic_spm_grass7/PERMANENT:~ > tree /tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate 
/tmp/grass8-tomas-24553/tmp6676la82/r.accumulate/grass_addons/src/raster/r.accumulate
├── accumulate_iterative.c
├── accumulate_recursive.c
├── calculate_lfp_iterative.c
├── calculate_lfp_recursive.c
├── delineate_streams.c
├── delineate_subwatersheds_iterative.c
├── delineate_subwatersheds_recursive.c
├── global.h
├── line_list.c
├── main.c
├── Makefile
├── point_list.c
├── r_accumulate_formats.png
├── r.accumulate.html
├── r_accumulate_nc_comparison.png
├── r_accumulate_nc_example.png
├── r_accumulate_nc_lfp_example_multiple.png
├── r_accumulate_nc_lfp_example_single.png
├── r_accumulate_nc_lfp_example_single_warning.png
├── r_accumulate_nc_lfp_example_subwatersheds.png
├── r_accumulate_nc_stream_comparison.png
├── r_accumulate_nc_stream_example.png
├── r_accumulate_nc_subwatersheds_example.png
├── r_accumulate_nc_watershed_example.png
├── r_accumulate_r_watershed_nc_example.png
├── raster.c
└── subaccumulate.c

0 directories, 27 files
```

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: 8.3.dev


**Additional context**
To be backported with #2895.
