### PR TITLE
docker alpine: CI update for `set-output` command

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
             TAG_PREFIX=`echo $GITHUB_REF|cut -d '/' -f3`
           fi
           tag="${DOCKERHUB_REPOSITORY}:${TAG_PREFIX}-${{ matrix.os }}"
-          echo "::set-output name=tags::$tag"
+          echo "tags=$tag" >> $GITHUB_OUTPUT
       - name: Log
         run: |
           echo ${{ steps.meta.outputs.tags }}
@@ -118,7 +118,7 @@ jobs:
         name: Create tag name
         run: |
           tag=${DOCKERHUB_REPOSITORY}:latest
-          echo "::set-output name=tags::$tag"
+          echo "tags=$tag" >> $GITHUB_OUTPUT
       - name: Log
         run: echo ${{ steps.meta.outputs.tags }}
       - name: Set up QEMU
@@ -175,7 +175,7 @@ jobs:
         name: Update tag name
         run: |
           tag="${{ steps.meta.outputs.tags }}-${{ matrix.os }}"
-          echo "::set-output name=tags::$tag"
+          echo "tags=$tag" >> $GITHUB_OUTPUT
       - name: Log
         run: |
           echo ${{ steps.meta2.outputs.tags }}


### PR DESCRIPTION
Currently (e.g. https://github.com/OSGeo/grass/actions/runs/4718450552/jobs/8368064252#step:8:9512) the following warning shows up:

_build and push alpine for branch_
_The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see:_
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR attempts to update it accordingly.