### PR TITLE
temporal: do not show empty range file message with default logging level

### DIFF
--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -748,7 +748,7 @@ def _read_raster_info(name, mapset):
             kvp["min"] = None
             kvp["max"] = None
         elif ret == 2:
-            logging.warning(_("Raster range file is empty"))
+            logging.info(_("Raster range file is empty"))
             kvp["min"] = None
             kvp["max"] = None
         else:
@@ -766,7 +766,7 @@ def _read_raster_info(name, mapset):
             kvp["min"] = None
             kvp["max"] = None
         elif ret == 2:
-            logging.warning(_("Raster range file is empty"))
+            logging.info(_("Raster range file is empty"))
             kvp["min"] = None
             kvp["max"] = None
         else:


### PR DESCRIPTION
Addresses #2932.

By default, logging shows only messages of level warning and higher, so info is not printed.