### PR TITLE
wxGUI: fix wxAssertionError when opening tools from console

### DIFF
--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -348,7 +348,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             self.AutoCompCancel()
         # show hint
         if self.IsEmpty():
-            self._showHint()
+            wx.CallAfter(self._showHint)
         event.Skip()
 
     def OnSetFocus(self, event):


### PR DESCRIPTION
Since d657c9a9be sometimes when a tool is opened from GUI console a wxAssertionError appears:

```
wx._core
.
wxAssertionError
:
C++ assertion "nNew != dynamicEvents.size()" failed at /home
/wxpy/wxPython-4.2.0/ext/wxWidgets/src/common/event.cpp(1930
) in SearchDynamicEventTable():
The above exception was the direct cause of the following
exception:
SystemError
:
<class 'wx._core.ChildFocusEvent'> returned a result with an
error set
```

I don't fully understand why that happens, but I don't think there is anything wrong in our code. Writing the hint after the `OnKillFocus` event is resolved seems to fix the problem.