### PR TITLE
g.extension: fix addon SOURCE_URL env var value for official GitHub addons

### DIFF
--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -203,7 +203,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         )
         html_man_page = self.install_prefix / "docs" / "html" / "db.join.html"
         self.assertFileExists(str(html_man_page))
-        with open(str(html_man_page)) as f:
+        with open(html_man_page) as f:
             content = f.read()
         for link_name in [f"{extension} source code", "history"]:
             url = re.search(rf"<a href=\"(.*)\">{link_name}</a>", content).group(1)

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -17,6 +17,7 @@ import sys
 import unittest
 
 from pathlib import Path
+from urllib import request as urlrequest
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
@@ -40,6 +41,10 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         install_prefix / "scripts" / "r.example.plus",
         install_prefix / "docs" / "html" / "r.example.plus.html",
     ]
+
+    request_headers = {
+        "User-Agent": "Mozilla/5.0",
+    }
 
     def setUp(self):
         """Make sure we are not dealing with some old files"""
@@ -184,6 +189,33 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         ext_path = Path(ext_path_str.group(2))
         self.assertTrue(ext_path.exists())
         self.assertIn(ext_path / "Makefile", list(ext_path.iterdir()))
+
+    def test_github_official_module_man_page_src_code_links_exists(self):
+        """Test if the installed extension HTML manual page from the
+        official GitHub repository contains the source code link and
+        the source code history link and if they exists
+        """
+        extension = "db.join"
+        self.assertModule(
+            "g.extension",
+            extension=extension,
+            prefix=str(self.install_prefix),
+        )
+        html_man_page = self.install_prefix / "docs" / "html" / "db.join.html"
+        self.assertFileExists(str(html_man_page))
+        with open(str(html_man_page)) as f:
+            content = f.read()
+        for link_name in [f"{extension} source code", "history"]:
+            url = re.search(rf"<a href=\"(.*)\">{link_name}</a>", content).group(1)
+            self.assertTrue(url)
+            try:
+                request = urlrequest.Request(url, headers=self.request_headers)
+                response = urlrequest.urlopen(request).code
+            except urlrequest.HTTPError as e:
+                response = e.code
+            except urlrequest.URLError as e:
+                response = e.args
+            self.assertEqual(response, 200)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Describe the bug**
Installed extension HTML manual page has wrong source code and history GitHub URL link.

Wrong is `SOURCE_URL` env var value, which is for every official addon https://github.com/OSGeo/grass-addons (correct URL for e.g. db.join addon should be https://github.com/OSGeo/grass-addons/tree/grass8/src/db/db.join):

https://github.com/OSGeo/grass/blob/c0addd9acb44efd181e4c38fe428634e9feb83e7/scripts/g.extension/g.extension.py#L2091

which is used inside mkhtml.py file (line 802)

https://github.com/OSGeo/grass/blob/c0addd9acb44efd181e4c38fe428634e9feb83e7/utils/mkhtml.py#L791-L804

**To Reproduce**
Steps to reproduce the behavior:

1. Try install some extension e.g. `g.extension db.join` 
2. Check db.join HTML manual page with `$EDITOR $GRASS_ADDON_BASE/docs/html/db.join.html`
3. See SOURCE code section db.join source code and history link

```
<h2>SOURCE CODE</h2>
<p>
  Available at:
  <a href="https://github.com/OSGeo/src/db/db.join">db.join source code</a>
  (<a href="https://github.com/OSGeo/src/db/db.join">history</a>)
</p>
```
Check if these URLs exists:

```
test@test:~$ URL=https://github.com/OSGeo/src/db/db.join; if curl --output /dev/null --silent --head --fail "$URL"; then echo "URL exists: $URL"; else echo "URL does not exist: $URL"; fi
URL does not exist: https://github.com/OSGeo/src/db/db.join
```

**Expected behavior**
Installed extension HTML manual page should have correct source code and history GitHub URL link.

e.g. db.join addon

```
<h2>SOURCE CODE</h2>
<p>
  Available at:
  <a href="https://github.com/OSGeo/grass-addons/tree/grass8/src/db/db.join">db.join source code</a>
  (<a href="https://github.com/OSGeo/grass-addons/commits/grass8/src/db/db.join">history</a>)
</p>
```

Check if these URLs exists:

```
test@test:~$ URL=https://github.com/OSGeo/grass-addons/tree/grass8/src/db/db.join; if curl --output /dev/null --silent --head --fail "$URL"; then echo "URL exists: $URL"; else echo "URL does not exist: $URL"; fi
URL exists: https://github.com/OSGeo/grass-addons/tree/grass8/src/db/db.join

test@test:~$ URL=https://github.com/OSGeo/grass-addons/commits/grass8/src/db/db.join; if curl --output /dev/null --silent --head --fail "$URL"; then echo "URL exists: $URL"; else echo "URL does not exist: $URL"; fi
URL exists: https://github.com/OSGeo/grass-addons/commits/grass8/src/db/db.join
```

**System description (please complete the following information):**

- Operating System: UNIX like
- GRASS GIS version 8.3.dev

**Additional context**
To be backported with #2895.
