### PR TITLE
WIP: pygrass: add get_json_dict function

### DIFF
--- a/python/grass/pygrass/modules/interface/testsuite/test_modules.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_modules.py
@@ -5,18 +5,14 @@ Created on Tue Jun 24 09:43:53 2014
 """
 import sys
 from fnmatch import fnmatch
+from io import BytesIO as StringIO
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
 from grass.script.core import get_commands
 from grass.exceptions import ParameterError
 from grass.pygrass.modules.interface import Module
-
-PY2 = sys.version_info[0] == 2
-if PY2:
-    from StringIO import StringIO
-else:
-    from io import BytesIO as StringIO
 
 
 SKIP = [
@@ -69,6 +65,13 @@ class TestModulesPickability(TestCase):
         out = StringIO()
         pickle.dump(Module("r.sun"), out)
         out.close()
+
+
+class TestModulesJsonDictExport(TestCase):
+    def test_rsun(self):
+        """Test if a Module can be exported to json dict"""
+
+        Module("r.info", map="elevation", run_=False).get_json_dict()
 
 
 class TestModulesCheck(TestCase):


### PR DESCRIPTION
This PR adds a `get_json_dict` function to the pygrass Module interface.

Motivation is to make it easier to create JSON intput to the actinia REST API for GRASS GIS.

Here is a usage example:
```
import json
from grass.pygrass.modules.interface import Module

json.dumps(Module("r.info", map="elevation", run_=False).get_json_dict())
```

Suggestions for changes are most welcome...