### PR TITLE
contributing: Link Open Collective contribute page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 ---
-open_collective: grass
+open_collective: grass/contribute


### PR DESCRIPTION
Given how Open Collective page is organzied, the page with clear contributing options is contribute which has all the options and nothing else, not the home (index) page for a collective. GitHub support suggests to change the configuration by adding /contribute to make the change.
