### PR TITLE
v.clean threshold description: clarify map units

### DIFF
--- a/vector/v.clean/main.c
+++ b/vector/v.clean/main.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     opt.thresh->type = TYPE_DOUBLE;
     opt.thresh->required = NO;
     opt.thresh->multiple = YES;
-    opt.thresh->label = _("Threshold in map units, one value for each tool");
+    opt.thresh->label = _("One value for each tool; for threshold units, see each tool");
     opt.thresh->description = _("Default: 0.0[,0.0,...])");
 
     flag.no_build = G_define_flag();


### PR DESCRIPTION
This PR de-confuses the current description of `threshold` from the misleading

```
  threshold   Threshold in map units, one value for each tool
```

to

```
  threshold   One value for each tool; for threshold units, see each tool
```

The point is that users need to look it up in the manual page. Esp. in long-lat locations, map units for area based tools are to be given in sqm, see https://grass.osgeo.org/grass-stable/manuals/v.clean.html