### PR TITLE
r.horizon: revert back to positive values only

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -746,7 +746,7 @@ double horizon_height(void)
 {
     double height;
 
-    tanh0 = -INFINITY;
+    tanh0 = 0.;
     length = 0;
 
     height = searching();

--- a/raster/r.horizon/r.horizon.html
+++ b/raster/r.horizon/r.horizon.html
@@ -134,9 +134,10 @@ cardinal directions caused by the projection (see above).
 
 <p>
 The output with the <b>-d</b> flag is azimuth degree (-90 to 90, where
-0 is parallel with the focal cell). In case of negative horizon values
-obtained this indicates that the horizon height is below the cell it is
-computed from.
+0 is parallel with the focal cell).
+
+<p> All horizon values are positive (or zero). While negative values are
+in theory possible, <b>r.horizon</b> currently does not support them.
 
 <h2>EXAMPLES</h2>
 

--- a/raster/r.horizon/testsuite/test_r_horizon.py
+++ b/raster/r.horizon/testsuite/test_r_horizon.py
@@ -30,7 +30,7 @@ ref2 = """azimuth,horizon_height
 280.000000,0.039774
 300.000000,0.032360
 320.000000,0.014804
-340.000000,-0.001438
+340.000000,0.000000
 360.000000,0.004724
 20.000000,0.012612
 40.000000,0.015207
@@ -51,7 +51,7 @@ ref3 = """azimuth,horizon_height
 280.000000,0.039774
 300.000000,0.032360
 320.000000,0.014804
-340.000000,-0.001438
+340.000000,0.000000
 360.000000,0.004724
 20.000000,0.012612
 40.000000,0.015207
@@ -119,9 +119,9 @@ class TestHorizon(TestCase):
         )
         self.assertModule(module)
         ref = {
-            "min": -1.57079637050629,
+            "min": 0,
             "max": 0.70678365230560,
-            "stddev": 0.0708080140468585,
+            "stddev": 0.0360724286360789,
         }
         self.assertRasterFitsUnivar(
             raster="test_horizon_output_from_elevation_050",
@@ -145,7 +145,10 @@ class TestHorizon(TestCase):
         self.runModule(module_list)
         stdout = module_list.outputs.stdout.strip()
         self.assertMultiLineEqual(
-            first="test_horizon_output_from_elevation_010_000\ntest_horizon_output_from_elevation_025_512",
+            first=(
+                "test_horizon_output_from_elevation_010_000\n"
+                "test_horizon_output_from_elevation_025_512"
+            ),
             second=stdout,
         )
 
@@ -166,7 +169,10 @@ class TestHorizon(TestCase):
         self.runModule(module_list)
         stdout = module_list.outputs.stdout.strip()
         self.assertMultiLineEqual(
-            first="test_horizon_output_from_elevation_090_000\ntest_horizon_output_from_elevation_105_512",
+            first=(
+                "test_horizon_output_from_elevation_090_000\n"
+                "test_horizon_output_from_elevation_105_512"
+            ),
             second=stdout,
         )
 


### PR DESCRIPTION
Enabling negative angles in r.horizon requires more work, the current simple implementation has problems (e.g. flat areas). Also r.sun doesn't work well with negative horizon values. See #2935 for discussion. For now, reverting back to horizon values >= 0 seems best. Note was added to manual page.