### PR TITLE
r.univar: print correct cells value for zones in shell script style

### DIFF
--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -158,7 +158,7 @@ int print_stats(univar_stat *stats)
             }
             fprintf(stdout, "n=%lu\n", stats[z].n);
             fprintf(stdout, "null_cells=%lu\n", stats[z].size - stats[z].n);
-            fprintf(stdout, "cells=%lu\n", stats->size);
+            fprintf(stdout, "cells=%lu\n", stats[z].size);
             fprintf(stdout, "min=%.15g\n", stats[z].min);
             fprintf(stdout, "max=%.15g\n", stats[z].max);
             fprintf(stdout, "range=%.15g\n", stats[z].max - stats[z].min);

--- a/raster/r.univar/testsuite/test_r_univar.py
+++ b/raster/r.univar/testsuite/test_r_univar.py
@@ -243,7 +243,7 @@ class TestRasterUnivar(TestCase):
                         zone=2;
                         n=6390
                         null_cells=0
-                        cells=1710
+                        cells=6390
                         min=121
                         max=280
                         range=159
@@ -295,7 +295,7 @@ class TestRasterUnivar(TestCase):
                         zone=2;
                         n=12780
                         null_cells=0
-                        cells=3420
+                        cells=12780
                         min=121
                         max=380
                         range=259
@@ -353,7 +353,7 @@ class TestRasterUnivar(TestCase):
                         zone=2;
                         n=12780
                         null_cells=0
-                        cells=3420
+                        cells=12780
                         min=121
                         max=380
                         range=259
@@ -415,7 +415,7 @@ class TestRasterUnivar(TestCase):
                            zone=9;
                            n=3600
                            null_cells=0
-                           cells=12600
+                           cells=3600
                            min=102
                            max=310
                            range=208


### PR DESCRIPTION
Currently, the number of cells in the first zone is propagated to subsequent zones in r.univar (see: #2958)
This PR corrects the value printed and adjusts the tests accordingly.