### PR TITLE
contributing: Add suggest message to version script

### DIFF
--- a/utils/update_version.py
+++ b/utils/update_version.py
@@ -236,6 +236,28 @@ def status(args):
         status_as_yaml(version_info=version_info, today=today, version=version, tag=tag)
 
 
+def suggest_message(args):
+    """Print suggestion for a commit message
+
+    Assumes that the version file was changed, but not commited yet,
+    but it does not check that assumption.
+
+    This shows a wrong commit message if going back from RCs,
+    but it is not likely this is needed because the suggestion
+    will be part of the message for the switch and there is
+    no other work to do afterwards except for the commit
+    (unlike updating the version number).
+    """
+    version_info = read_version_file()
+    if not version_info.micro.endswith("dev"):
+        tag = construct_version(version_info)
+        action = "GRASS GIS"
+    else:
+        tag = None
+        action = "Start"
+    suggest_commit_from_version_file(action, tag=tag)
+
+
 def main():
     """Translate sub-commands to function calls"""
     parser = argparse.ArgumentParser(
@@ -284,6 +306,11 @@ def main():
         "--bash", action="store_true", help="format as Bash variables for eval"
     )
     subparser.set_defaults(func=status)
+
+    subparser = subparsers.add_parser(
+        "suggest", help="suggest a commit message for new version"
+    )
+    subparser.set_defaults(func=suggest_message)
 
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
The helper script for udpates of versions suggests a commit message right after the update, but when additional changes need to be done, the message from the script can be lost. This adds a subcommand which can generate the message anytime. The message only makes sense when doing the version update, but the script does not check that. It also does not check (does not know) if the RC was just released. We use different commit message after that, but in that case, the commit happens right after the change from RC to dev, so there is no need to use this subcommand.
