### PR TITLE
Docker: Update 8.3 and 8.4 versions in Docker readme table

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,16 +7,16 @@
 <!-- markdownlint-disable line-length -->
 | Base image   | Docker tag    | GRASS GIS  | PROJ  | GDAL  | PDAL  | Python | Image size |
 |--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 22.04 | latest-ubuntu | 8.3.dev    | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
-| Debian 11    | latest-debian | 8.3.dev    | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
-| Alpine 3.12  | latest-alpine | 8.3.dev    | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
+| Ubuntu 22.04 | latest-ubuntu | 8.4.0dev   | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
+| Debian 11    | latest-debian | 8.4.0dev   | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
+| Alpine 3.12  | latest-alpine | 8.4.0dev   | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
 |--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 22.04 | stable-ubuntu | 8.2 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
-| Debian 11    | stable-debian | 8.2 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
-| Alpine 3.12  | stable-alpine | 8.2 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
+| Ubuntu 22.04 | stable-ubuntu | 8.3 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
+| Debian 11    | stable-debian | 8.3 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
+| Alpine 3.12  | stable-alpine | 8.3 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
 <!-- markdownlint-enable line-length -->
 
-Last update: 22 Jan 2023 (source: <https://github.com/OSGeo/grass/actions/workflows/docker.yml>
+Last update: May 17 2023 (source: <https://github.com/OSGeo/grass/blob/main/.github/workflows/docker.yml>
 and <https://hub.docker.com/r/mundialis/grass-py3-pdal/tags>)
 
 ## Requirements

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,18 +5,18 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/mundialis/grass-py3-pdal.svg)](https://grass.osgeo.org/download/software/docker-images/)
 
 <!-- markdownlint-disable line-length -->
-| Base image   | Docker tag    | GRASS GIS  | PROJ  | GDAL  | PDAL  | Python | Image size |
-|--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 22.04 | latest-ubuntu | 8.4.0dev   | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
-| Debian 11    | latest-debian | 8.4.0dev   | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
-| Alpine 3.12  | latest-alpine | 8.4.0dev   | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
-|--------------|---------------|------------|-------|-------|-------|--------|------------|
-| Ubuntu 22.04 | stable-ubuntu | 8.3 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 | 2.89 GB    |
-| Debian 11    | stable-debian | 8.3 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  | 2.93 GB    |
-| Alpine 3.12  | stable-alpine | 8.3 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |  186 MB    |
+| Base image   | Docker tag    | GRASS GIS  | PROJ  | GDAL  | PDAL  | Python |
+|--------------|---------------|------------|-------|-------|-------|--------|
+| Ubuntu 22.04 | latest-ubuntu | 8.4.0dev   | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 |
+| Debian 11    | latest-debian | 8.4.0dev   | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  |
+| Alpine 3.12  | latest-alpine | 8.4.0dev   | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |
+|--------------|---------------|------------|-------|-------|-------|--------|
+| Ubuntu 22.04 | stable-ubuntu | 8.3 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 |
+| Debian 11    | stable-debian | 8.3 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  |
+| Alpine 3.12  | stable-alpine | 8.3 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |
 <!-- markdownlint-enable line-length -->
 
-Last update: May 17 2023 (source: <https://github.com/OSGeo/grass/blob/main/.github/workflows/docker.yml>
+Last update: May 17 2023 (source: <https://github.com/OSGeo/grass/actions/workflows/docker.yml>
 and <https://hub.docker.com/r/mundialis/grass-py3-pdal/tags>)
 
 ## Requirements

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,11 +9,11 @@
 |--------------|---------------|------------|-------|-------|-------|--------|
 | Ubuntu 22.04 | latest-ubuntu | 8.4.0dev   | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 |
 | Debian 11    | latest-debian | 8.4.0dev   | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  |
-| Alpine 3.12  | latest-alpine | 8.4.0dev   | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |
+| Alpine 3.17  | latest-alpine | 8.4.0dev   | 9.1.0 | 3.5.3 | 2.4.3| 3.10.11 |
 |--------------|---------------|------------|-------|-------|-------|--------|
 | Ubuntu 22.04 | stable-ubuntu | 8.3 branch | 8.2.1 | 3.4.1 | 2.4.3 | 3.10.6 |
 | Debian 11    | stable-debian | 8.3 branch | 7.2.1 | 3.2.2 | 2.4.3 | 3.9.2  |
-| Alpine 3.12  | stable-alpine | 8.3 branch | 7.0.1 | 3.1.4 | 2.1.0 | 3.8.10 |
+| Alpine 3.17  | stable-alpine | 8.3 branch | 9.1.0 | 3.5.3 | 2.4.3| 3.10.11 |
 <!-- markdownlint-enable line-length -->
 
 Last update: May 17 2023 (source: <https://github.com/OSGeo/grass/actions/workflows/docker.yml>


### PR DESCRIPTION
Besides versions, ~~update also link to workflows not to go latest executed actions but to file on the main branch.~~
