### PR TITLE
version: Replace references to 8.2

### DIFF
--- a/doc/notebooks/jupyter_example.ipynb
+++ b/doc/notebooks/jupyter_example.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "[<img src=\"../../gui/images/splash_screen.png\" alt=\"GRASS GIS\" style=\"height: 20ex;\"/>](https://grass.osgeo.org/)\n",
     "\n",
-    "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the [_grass.jupyter_](https://grass.osgeo.org/grass82/manuals/libpython/grass.jupyter.html) package and the *Python* scripting language. The _grass.jupyter_ package simplifies the launch of *GRASS GIS* in *Jupyter Notebook* and provides several useful classes for creating, displaying, and saving *GRASS GIS* maps.\n",
+    "This is a quick introduction to *GRASS GIS* in a *Jupyter Notebook* using the [_grass.jupyter_](https://grass.osgeo.org/grass-stable/manuals/libpython/grass.jupyter.html) package and the *Python* scripting language. The _grass.jupyter_ package simplifies the launch of *GRASS GIS* in *Jupyter Notebook* and provides several useful classes for creating, displaying, and saving *GRASS GIS* maps.\n",
     "\n",
     "The _grass.jupyter_ package was initially written as part of Google Summer of Code in 2021 by Caitlin Haedrich and was experimentally included in version 8.0.0. Caitlin further improved it thanks to the GRASS Mini Grant 2022. The package was officially released for the first time as part of version 8.2.0. If you are curious about how the package improves the integration of *GRASS GIS* and *Jupyter Notebooks*, compare it with [scripting_example.ipynb](scripting_example.ipynb). More features of the _grass.jupyter_ package are presented in [jupyter_tutorial.ipynb](jupyter_tutorial.ipynb).\n",
     "\n",

--- a/doc/notebooks/jupyter_tutorial.ipynb
+++ b/doc/notebooks/jupyter_tutorial.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# The grass.jupyter Package\n",
     "\n",
-    "This notebook introduces the [_grass.jupyter_](https://grass.osgeo.org/grass82/manuals/libpython/grass.jupyter.html) package which simplifies the usage of *GRASS GIS* in *Jupyter Notebook*.\n",
+    "This notebook introduces the [_grass.jupyter_](https://grass.osgeo.org/grass-stable/manuals/libpython/grass.jupyter.html) package which simplifies the usage of *GRASS GIS* in *Jupyter Notebook*.\n",
     "\n",
     "The _grass.jupyter_ package was initially written as part of [Google Summer of Code in 2021](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS) by Caitlin Haedrich and was experimentally included in version 8.0.0. Caitlin further improved it thanks to the [GRASS Mini Grant 2022](https://trac.osgeo.org/grass/wiki/GSoC/2021/JupyterAndGRASS/MiniGrant2022). The package was officially released for the first time as part of version 8.2.0. Credits for mentoring and additional development go to Vaclav Petras, Helena Mitasova, Stefan Blumentrath, and Anna Petrasova as well as to many members of the GRASS community who provided important feedback.\n",
     "\n",

--- a/general/g.version/g.version.html
+++ b/general/g.version/g.version.html
@@ -38,7 +38,7 @@ print gcore.version()
 <div class="code"><pre>
 g.version
 
-GRASS 8.2.0dev (2022)
+GRASS 8.4.0 (2024)
 </pre></div>
 
 <h3>GIS Library info</h3>
@@ -46,23 +46,23 @@ GRASS 8.2.0dev (2022)
 <div class="code"><pre>
 g.version -r
 
-GRASS 8.2.0dev (2022)
+GRASS 8.4.0 (2024)
 libgis revision: c9e8576cf
-libgis date: 2022-04-27T09:38:49+00:00
+libgis date: 2024-04-27T09:38:49+00:00
 </pre></div>
 
 <h3>Full info in shell script style</h3>
 <div class="code"><pre>
 g.version -rge
 
-version=8.2.0dev
-date=2022
+version=8.4.0
+date=2024
 revision=d57f40906
-build_date=2021-05-23
+build_date=2024-05-23
 build_platform=x86_64-pc-linux-gnu
 build_off_t_size=8
 libgis_revision=c9e8576cf
-libgis_date=2022-04-27T09:38:49+00:00
+libgis_date=2024-04-27T09:38:49+00:00
 proj=8.2.1
 gdal=3.4.3
 geos=3.9.2

--- a/lib/init/grass.html
+++ b/lib/init/grass.html
@@ -130,12 +130,12 @@ version parameters, with the options:
 <li><b>arch</b>: system architecture (e.g., <tt>x86_64-pc-linux-gnu</tt>)</li>
 <li><b>build</b>: (e.g., <tt>./configure --with-cxx --enable-largefile --with-proj [...]</tt>)</li>
 <li><b>compiler</b>: (e.g., <tt>gcc</tt>)</li>
-<li><b>date</b>: (e.g., <tt>Tue Mar 31 20:34:57 2020 +0200</tt>)</li>
+<li><b>date</b>: (e.g., <tt>2024-04-10T11:44:54+00:00</tt>)</li>
 <li><b>path</b>: (e.g., <tt>/usr/lib64/grass</tt>)</li>
 <li><b>python_path</b>: (e.g., <tt>/usr/lib64/grass/etc/python</tt>)</li>
 <li><b>revision</b>: (e.g., <tt>745ee7ec9</tt>)</li>
 <li><b>svn_revision</b>: (e.g., <tt>062bffc8</tt>)</li>
-<li><b>version</b>: (e.g., <tt>8.2.0dev</tt>)</li>
+<li><b>version</b>: (e.g., <tt>8.4.0</tt>)</li>
 </ul>
 
 <h2>SAMPLE DATA</h2>

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -16,7 +16,7 @@ cd grass
 __Build the singularity with__:
 
 ```bash
-sudo singularity build grass_development.simg singularity/debian/singularity_debian
+sudo singularity build grass_gis.simg singularity/debian/singularity_debian
 ```
 
 __To build a stable version__:
@@ -24,17 +24,17 @@ __To build a stable version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout remotes/origin/releasebranch_8_2
+git checkout 8.2.0
 ```
 
 and build and enter with:
 
 ```bash
-sudo singularity build grass_8_2.simg singularity/debian/singularity_debian
+sudo singularity build grass_gis.simg singularity/debian/singularity_debian
 ```
 
 The image can be used as:
 
 ```bash
-singularity exec containers/grass_8.2.simg grass --version
+singularity exec containers/grass_gis.simg grass --version
 ```

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -24,7 +24,7 @@ __To build a stable version__:
 change to the releasebranch or tag you want to build:
 
 ```bash
-git checkout 8.2.0
+git checkout {tag or branch}
 ```
 
 and build and enter with:


### PR DESCRIPTION
- [x] Links to latest (current) stable in notebooks use the grass-stable URL.
- [x] singularity: Use tag instead of branch. Use an old tag for the example. Avoid using version in the image name.

8.2 used in examples (no change needed?):

- [x] lib/init/grass.html

Fix based on updates to 8.3 branch (same text or same style):

- [x] general/g.version/g.version.html (example of an output; change needed?)
- [x] rpm/grass.spec (copy the updated file? what is the procedure for syncs or updates?) #2977 
- [x] doc/howto_release.md (code for copy-pasting; prepare for 8.4?) #2980
- [x] doc/development/submitting/general.md (instructions for contributors; generalize to avoid need for updates?) #2978 

