### PR TITLE
pre-commit-config.yaml: exclude README.md from markdown-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
     rev: v0.33.0
     hooks:
       - id: markdownlint
+        exclude: |
+          (?x)^(
+                README.md
+          )
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,10 +37,6 @@ repos:
     rev: v0.33.0
     hooks:
       - id: markdownlint
-        exclude: |
-          (?x)^(
-                README.md
-          )
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -111,4 +111,3 @@ make distclean
 ## Thanks to all contributors ❤
 
 [![GRASS contributors](https://contrib.rocks/image?repo=OSGeo/grass "GRASS contributors")](https://github.com/OSGeo/grass/graphs/contributors)
-   <img src = "https://contrib.rocks/image?repo=OSGeo/grass"/>

--- a/README.md
+++ b/README.md
@@ -108,10 +108,8 @@ this issue, clean all the compiled files from the source code:
 make distclean
 ```
 
-
 ## Thanks to all contributors ❤
 
- <a href = "https://github.com/OSGeo/grass/graphs/contributors">
+<a href = "https://github.com/OSGeo/grass/graphs/contributors">
    <img src = "https://contrib.rocks/image?repo=OSGeo/grass"/>
- </a>
-
+</a>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,5 @@ make distclean
 
 ## Thanks to all contributors ❤
 
-<a href = "https://github.com/OSGeo/grass/graphs/contributors">
+[![GRASS contributors](https://contrib.rocks/image?repo=OSGeo/grass "GRASS contributors")](https://github.com/OSGeo/grass/graphs/contributors)
    <img src = "https://contrib.rocks/image?repo=OSGeo/grass"/>
-</a>


### PR DESCRIPTION
markdown-lint: exclude README.md from 033-no-inline-html.md, i.e. allow inline HTML in README.md.

Addresses
https://github.com/OSGeo/grass/pull/2947#issuecomment-1553356145