### PR TITLE
init: Do not report creating new mapset for tmp mapset

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1185,9 +1185,12 @@ def set_mapset(
                                     " Did you mean to create a new location?"
                                 ).format(mapset=mapset, geofile=geofile)
                             )
-                        message(
-                            _("Creating new GRASS GIS mapset <{}>...").format(mapset)
-                        )
+                        if not tmp_mapset:
+                            message(
+                                _("Creating new GRASS GIS mapset <{}>...").format(
+                                    mapset
+                                )
+                            )
                         # create mapset directory
                         os.mkdir(path)
                         if tmp_mapset:


### PR DESCRIPTION
When running grass with --tmp-mapset, printing a message about mapset creation is not needed. Mapset is created and then deleted just as the user asked.
