### PR TITLE
contributing: Fix syntax in Flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,9 @@
 [flake8]
 ignore =
-    E203,  # whitespace before ':' (Black)
-    W503,  # line break before binary operator (Black)
+    # whitespace before ':' (Black)
+    E203,
+    # line break before binary operator (Black)
+    W503,
 
 per-file-ignores =
     # Files and directories which need fixes or specific exceptions


### PR DESCRIPTION
Flake8 config file does not allow inline comments. Previous versions did not enforce that (which lead to silent errors), but the new versions (v6) do.

Source: https://github.com/PyCQA/flake8/issues/1760
