### PR TITLE
contributing: Align backporting example with text

### DIFF
--- a/doc/development/submitting/general.md
+++ b/doc/development/submitting/general.md
@@ -147,11 +147,11 @@ available), and compilation of the whole source tree (ideally after the
 the original commit to "main". Also note that not all these steps have to be
 done manually, you can take an advantage of our [​CI](https://github.com/OSGeo/grass/actions).
 
-Often there is more than one active release branch, if you are backporting, make
-sure you always backport to all the branches between "main" and the furthest
-branch you are backporting to. For example, let's say we have "main" and release
-branches 3.5 and 3.6, if you backport to 3.5, you should backport to 3.6, too.
-You can also choose to backport only to the closest branch, in our example 3.6.
+Often there is more than one active release branch. You can also choose to backport
+only to the closest branch. If you are backporting to other release branches than
+just the closets one, make sure you always backport to all the branches between "main"
+and the furthest branch you are backporting to. For example, let's say we have
+release branches 3.6 and 3.5, if you backport to 3.5, you should backport to 3.6, too.
 
 Backport only complete fixes. When you are not sure if the fix is complete or if
 there is an possibility that some details such as wording will change, wait with

--- a/doc/development/submitting/general.md
+++ b/doc/development/submitting/general.md
@@ -149,9 +149,9 @@ done manually, you can take an advantage of our [​CI](https://github.com/OSGeo
 
 Often there is more than one active release branch, if you are backporting, make
 sure you always backport to all the branches between "main" and the furthest
-branch you are backporting to. For example, let's say we have "main" and branches
-8.2 and 7.8, if you backport to 8.2, you should also consider to backport to 7.8.
-You can also choose to backport only to the closest branch, in our example 8.2.
+branch you are backporting to. For example, let's say we have "main" and release
+branches 3.5 and 3.6, if you backport to 3.5, you should backport to 3.6, too.
+You can also choose to backport only to the closest branch, in our example 3.6.
 
 Backport only complete fixes. When you are not sure if the fix is complete or if
 there is an possibility that some details such as wording will change, wait with

--- a/rpm/grass.spec
+++ b/rpm/grass.spec
@@ -2,7 +2,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 Name:		grass
-Version:	8.2.1
+Version:	8.2.0
 Release:	1%{?dist}
 Summary:	GRASS GIS - Geographic Resources Analysis Support System
 
@@ -20,11 +20,7 @@ Summary:	GRASS GIS - Geographic Resources Analysis Support System
 # "%%bcond_without" means "ENABLE by default and create a --without option"
 %bcond_without python3
 
-# GRASS GIS addon reuses the compiler flags originating from rpmbuild environment,
-# hence disabling package-notes plugin
-%undefine _package_note_file
-
-License:	GPL-2.0-or-later
+License:	GPLv2+
 URL:		https://grass.osgeo.org
 Source0:	https://grass.osgeo.org/%{name}%{shortver}/source/%{name}-%{version}.tar.gz
 
@@ -193,8 +189,10 @@ sed -i -e 's/-lblas/-lflexiblas/g' -e 's/-llapack/-lflexiblas/g' configure
 find -name \*.pl | xargs sed -i -e 's,#!/usr/bin/env perl,#!%{__perl},'
 
 %build
+# Package is not ready for -Werror=format-security or the C++11 standard
+CFLAGS="$(echo ${RPM_OPT_FLAGS} | sed -e 's/ -Werror=format-security//')"
+CXXFLAGS="-std=c++98 ${CFLAGS}"
 %configure \
-	--prefix=%{_libdir} \
 	--with-cxx \
 	--with-tiff \
 	--with-png \
@@ -223,7 +221,6 @@ find -name \*.pl | xargs sed -i -e 's,#!/usr/bin/env perl,#!%{__perl},'
 	--with-regex \
 	--with-openmp \
 	--with-gdal=%{_bindir}/gdal-config \
-	--with-wxwidgets=%{_bindir}/wx-config \
 	--with-geos=%{_bindir}/geos-config \
 %if (0%{?rhel} > 6 || 0%{?fedora})
 	--with-netcdf=%{_bindir}/nc-config \
@@ -240,9 +237,6 @@ find -name \*.pl | xargs sed -i -e 's,#!/usr/bin/env perl,#!%{__perl},'
 	--with-bzlib \
 	--with-zstd \
 	--with-proj-share=%{_datadir}/proj
-
-# .package_note hack for RHBZ #2084342 and RHBZ #2102895
-sed -i "s+ -Wl,-dT,${RPM_BUILD_DIR}/grass-%{version}/.package_note-grass-%{version}-%{release}.%{_arch}.ld++g" include/Make/Platform.make
 
 make %{?_smp_mflags}
 
@@ -361,64 +355,13 @@ fi
 %{_libdir}/%{name}%{shortver}/gui
 
 %files devel
-%doc TODO doc/* CONTRIBUTING.md
+%doc TODO doc/* SUBMITTING
 %{macrosdir}/macros.%{name}
 %{_libdir}/pkgconfig/*
 %dir %{_libdir}/%{name}%{shortver}/lib
 %{_libdir}/%{name}%{shortver}/include
 
 %changelog
-* Sat Jan 21 2023 Markus Neteler <neteler@mundialis.de> 8.2.1-1
-- New upstream version GRASS GIS 8.2.1
-
-* Thu Jan 19 2023 Fedora Release Engineering <releng@fedoraproject.org> - 8.2.0-11
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_38_Mass_Rebuild
-
-* Mon Jan 16 2023 Markus Neteler <neteler@mundialis.de> 8.2.0-10
-- modify grass-pdal.patch for alternative C++ fix
-
-* Sat Jan 14 2023 Sandro Mani <manisandro@gmail.com> - 8.2.0-9
-- Rebuild (PDAL)
-
-* Sat Nov 12 2022 Sandro Mani <manisandro@gmail.com> - 8.2.0-8
-- Rebuild (gdal)
-
-* Wed Nov 09 2022 Markus Neteler <neteler@mundialis.de> 8.2.0-7
-- SPDX license tag update
-
-* Thu Nov 03 2022 Markus Neteler <neteler@mundialis.de> - 8.2.0-6
-- fix RPM ARCH not defined for GRASS GIS addon installation (RHBZ #2138373)
-
-* Sat Sep 17 2022 Markus Neteler <neteler@mundialis.de> - 8.2.0-5
-- fix unexpected keyword argument 'codeset' (Python 3.11) for RHBZ #2126608
-
-* Mon Aug 08 2022 Markus Neteler <neteler@mundialis.de> - 8.2.0-4
-- Rebuild for RHBZ #2107826 (PYC magic number has changed)
-
-* Thu Jul 21 2022 Fedora Release Engineering <releng@fedoraproject.org> - 8.2.0-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild
-
-* Mon Jul 11 2022 Markus Neteler <neteler@mundialis.de> - 8.2.0-2
-- .package_note hack for RHBZ #2084342 and RHBZ #2102895
-
-* Sat Jun 04 2022 Markus Neteler <neteler@mundialis.de> - 8.2.0-1
-- New upstream version GRASS GIS 8.2.0
-
-* Sat May 21 2022 Sandro Mani <manisandro@gmail.com> - 8.0.2-2
-- Rebuild for gdal-3.5.0 and/or openjpeg-2.5.0
-
-* Thu May 12 2022 Markus Neteler <neteler@mundialis.de> - 8.0.2-1
-- New upstream version GRASS GIS 8.0.2
-
-* Tue Mar 29 2022 Markus Neteler <neteler@mundialis.de> - 8.0.1-3
-- Rebuild for pdal-2.4.0
-
-* Thu Mar 10 2022 Sandro Mani <manisandro@gmail.com> - 8.0.1-2
-- Rebuild for proj-9.0.0
-
-* Thu Feb 24 2022 Markus Neteler <neteler@mundialis.de> - 8.0.1-1
-- New upstream version GRASS GIS 8.0.1
-
 * Fri Jan 28 2022 Markus Neteler <neteler@mundialis.de> - 8.0.0-1
 - New upstream version GRASS GIS 8.0.0
 


### PR DESCRIPTION
The first part of the paragraph talks about backporting to all branches in between main and furthest backport. However, the example pushed the idea of backport to the furthest instead. The new example is now only about backporting to the in-between branch while the paragraph addresses the backport in general and packport to the closest branch first.

The new example uses version numbers with the major version 3 because it is only an example, so it does not need to be updated.