### PR TITLE
wxGUI/vselect: fix BoxSizer widget Add method proportion param arg type

### DIFF
--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -132,7 +132,7 @@ class VectorSelectBase:
         if createButton:
             createMap = Button(self._dialog, wx.ID_ANY, _("Create a new map"))
             createMap.Bind(wx.EVT_BUTTON, self.OnExportMap)
-            self._dialog.AddWidget(createMap, proportion=0.1)
+            self._dialog.AddWidget(createMap, proportion=0)
         self.slist = VectorSelectList(self._dialog)
         self.slist.Bind(wx.EVT_LIST_KEY_DOWN, self.OnDelete)
         self.slist.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.OnDeleteRow)


### PR DESCRIPTION
**Describe the bug**
Activating wxGUI Select vector feature(s) tool fails.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI
2. Display some vector map `d.vect geology`
3. Try to activate wxGUI Select vector feature(s) tool
4. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass82/gui/wxpython/mapdisp/frame.py",
line 704, in OnSelect

self.dialogs["vselect"].CreateDialog(createButton=True)
  File
"/usr/lib64/grass82/gui/wxpython/gui_core/vselect.py", line
135, in CreateDialog

self._dialog.AddWidget(createMap, proportion=0.1)
  File
"/usr/lib64/grass82/gui/wxpython/gui_core/vselect.py", line
83, in AddWidget

self.mainSizer.Add(widget, proportion=proportion, flag=flag)
TypeError
:
Sizer.Add(): arguments did not match any overloaded call:
  overload 1: 'proportion' is not a valid keyword argument
  overload 2: argument 'proportion' has unexpected type
'float'
  overload 3: argument 1 has unexpected type 'Button'
  overload 4: argument 1 has unexpected type 'Button'
  overload 5: argument 1 has unexpected type 'Button'
  overload 6: argument 1 has unexpected type 'Button'
  overload 7: argument 1 has unexpected type 'Button'
  overload 8: argument 1 has unexpected type 'Button'
  overload 9: argument 1 has unexpected type 'Button'
```

**Expected behavior**
Activating wxGUI Select vector feature(s) tool should work without error message.

**System description:**

- Operating System: all
- GRASS GIS version: all

Python 3.10.11 
wxPython 4.2.0

Fixed #2982.