### PR TITLE
Check min required wx version when starting wxgui

### DIFF
--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -80,10 +80,12 @@ def CheckWxPhoenix():
 
 
 def CheckWxVersion(version):
-    """Check wx version"""
-    ver = wx.__version__
-    parsed_version = parse_version_string(ver)
+    """Check wx version.
 
+    :return: True if current wx version is greater or equal than
+    specifed version otherwise False
+    """
+    parsed_version = parse_version_string(wx.__version__)
     if parsed_version < version:
         return False
 

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -26,7 +26,7 @@ import getopt
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
 from grass.exceptions import Usage
-from grass.script.core import set_raise_on_error
+from grass.script.core import set_raise_on_error, warning
 
 from core import globalvar
 from core.utils import registerPid, unregisterPid
@@ -45,6 +45,11 @@ try:
 except ImportError:
     SC = None
 
+min_required_wx_version = [4, 2, 0]
+if not globalvar.CheckWxVersion(min_required_wx_version):
+    warning("!" * 50)
+    warning("Minimum required WxPython version: {}".format('.'.join(map(str, min_required_wx_version))))
+    warning("!" * 50)
 
 class GMApp(wx.App):
     def __init__(self, workspace=None):


### PR DESCRIPTION
Currently wxGUI fails on wxPython 4.0.x with non-clear traceback:

```
Launching <wxpython> GUI in the background, please wait...

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wx/core.py", line 3282, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/wxgui.py", line 100, in show_main_gui
    mainframe = GMFrame(parent=None, id=wx.ID_ANY, workspace=self.workspaceFile)
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/main_window/frame.py", line 167, in __init__
    self.BuildPanes()
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/main_window/frame.py", line 658, in BuildPanes
    self._auimgr.AddPane(
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/framemanager.py", line 4711, in AddPane
    return self.AddPane4(window, arg1, target)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/framemanager.py", line 4879, in AddPane4
    self.UpdateNotebook()
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/framemanager.py", line 6653, in UpdateNotebook
    notebook.AddPage(pane.window, title, True, pane.icon)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 3575, in AddPage
    return self.InsertPage(self.GetPageCount(), page, caption, select, bitmap, disabled_bitmap, control, tooltip)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 3653, in InsertPage
    self.SetSelectionToWindow(page)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 4410, in SetSelectionToWindow
    self.SetSelection(idx)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 4357, in SetSelection
    ctrl.MakeTabVisible(ctrl_idx, ctrl)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 1843, in MakeTabVisible
    if not self.IsTabVisible(tabPage, self.GetTabOffset(), dc, win):
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 1732, in IsTabVisible
    self.Render(dc, wnd)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/auibook.py", line 1687, in Render
    page.rect, tab_button.rect, x_extent = self._art.DrawTab(dc, wnd, page, rect, tab_button.cur_state)
  File "/usr/lib/python3/dist-packages/wx/lib/agw/aui/tabart.py", line 475, in DrawTab
    r.SetHeight(r.GetHeight()/2)
TypeError: Rect.SetHeight(): argument 1 has unexpected type 'float'
```

This PR adds a warning which informs user at least about minimal required wxPython version:

```
Launching <wxpython> GUI in the background, please wait...
WARNING: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: Minimum required WxPython version: 4.2.0
WARNING: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Traceback (most recent call last):
...
```