### PR TITLE
wxGUI/query: set region matching the raster for each raster queried

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1074,14 +1074,14 @@ class MapPanel(SingleMapPanel):
                 mapdisp=self._giface.GetMapDisplay(), giface=self._giface
             )
 
-        # use display region settings instead of computation region settings
-        self.tmpreg = os.getenv("GRASS_REGION")
-        os.environ["GRASS_REGION"] = self.Map.SetRegion(windres=False)
-
         rastQuery = []
         vectQuery = []
-        if rast:
-            rastQuery = grass.raster_what(map=rast, coord=(east, north), localized=True)
+        env = os.environ.copy()
+        for raster in rast:
+            env["GRASS_REGION"] = grass.region_env(raster=raster)
+            rastQuery += grass.raster_what(
+                map=raster, coord=(east, north), localized=True, env=env
+            )
         if vect:
             encoding = UserSettings.Get(group="atm", key="encoding", subkey="value")
             try:
@@ -1100,7 +1100,6 @@ class MapPanel(SingleMapPanel):
                         "Check database settings and topology."
                     ).format(maps=",".join(vect)),
                 )
-        self._QueryMapDone()
 
         self._highlighter_layer.Clear()
         if vectQuery and "Category" in vectQuery[0]:
@@ -1145,19 +1144,6 @@ class MapPanel(SingleMapPanel):
 
             self._highlighter_layer.SetCats(tmp)
             self._highlighter_layer.DrawSelected()
-
-    def _QueryMapDone(self):
-        """Restore settings after querying (restore GRASS_REGION)"""
-        if hasattr(self, "tmpreg"):
-            if self.tmpreg:
-                os.environ["GRASS_REGION"] = self.tmpreg
-            elif "GRASS_REGION" in os.environ:
-                del os.environ["GRASS_REGION"]
-        elif "GRASS_REGION" in os.environ:
-            del os.environ["GRASS_REGION"]
-
-        if hasattr(self, "tmpreg"):
-            del self.tmpreg
 
     def OnQuery(self, event):
         """Query tools menu"""

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -752,29 +752,32 @@ class SwipeMapPanel(DoubleMapPanel):
 
         east, north = self.GetFirstWindow().Pixel2Cell((x, y))
 
-        # use display region settings instead of computation region settings
-        self.tmpreg = os.getenv("GRASS_REGION")
-        os.environ["GRASS_REGION"] = self.GetFirstMap().SetRegion(windres=False)
-
         result = []
+        env = os.environ.copy()
         if rasters[0]:
-            result.extend(
-                grass.raster_what(map=rasters[0], coord=(east, north), localized=True)
-            )
+            for raster in rasters[0]:
+                env["GRASS_REGION"] = grass.region_env(raster=raster)
+                result.extend(
+                    grass.raster_what(
+                        map=raster, coord=(east, north), localized=True, env=env
+                    )
+                )
         if vectors[0]:
             result.extend(
                 grass.vector_what(map=vectors[0], coord=(east, north), distance=qdist)
             )
         if rasters[1]:
-            result.extend(
-                grass.raster_what(map=rasters[1], coord=(east, north), localized=True)
-            )
+            for raster in rasters[1]:
+                env["GRASS_REGION"] = grass.region_env(raster=raster)
+                result.extend(
+                    grass.raster_what(
+                        map=raster, coord=(east, north), localized=True, env=env
+                    )
+                )
         if vectors[1]:
             result.extend(
                 grass.vector_what(map=vectors[1], coord=(east, north), distance=qdist)
             )
-
-        self._QueryMapDone()
 
         result = PrepareQueryResults(coordinates=(east, north), result=result)
         if self._queryDialog:
@@ -791,19 +794,6 @@ class SwipeMapPanel(DoubleMapPanel):
     def _oncloseQueryDialog(self, event):
         self._queryDialog = None
         event.Skip()
-
-    def _QueryMapDone(self):
-        """Restore settings after querying (restore GRASS_REGION)"""
-        if hasattr(self, "tmpreg"):
-            if self.tmpreg:
-                os.environ["GRASS_REGION"] = self.tmpreg
-            elif "GRASS_REGION" in os.environ:
-                del os.environ["GRASS_REGION"]
-        elif "GRASS_REGION" in os.environ:
-            del os.environ["GRASS_REGION"]
-
-        if hasattr(self, "tmpreg"):
-            del self.tmpreg
 
     def GetMapToolbar(self):
         """Returns toolbar with zooming tools"""


### PR DESCRIPTION
Addresses #2973.

Interactive querying of rasters now uses region matching the raster to avoid discrepancies due to using display region.