### PR TITLE
wxGUI: exception in thread when switching to mapset

### DIFF
--- a/gui/wxpython/core/watchdog.py
+++ b/gui/wxpython/core/watchdog.py
@@ -18,6 +18,7 @@ This program is free software under the GNU General Public License
 """
 
 import os
+import time
 
 watchdog_used = True
 try:
@@ -63,6 +64,8 @@ class CurrentMapsetWatch(FileSystemEventHandler):
             if timestamp - self.modified_time < 0.5:
                 return
             self.modified_time = timestamp
+            # wait to make sure file writing is done
+            time.sleep(0.1)
             with open(event.src_path, "r") as f:
                 gisrc = {}
                 for line in f.readlines():


### PR DESCRIPTION
When switching to mapset, we can can encounter this error:

Exception in thread
Thread-4
:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in
_bootstrap_inner

self.run()
  File "/home/linduska/.local/lib/python3.10/site-
packages/watchdog/observers/api.py", line 205, in run

self.dispatch_events(self.event_queue)
  File "/home/linduska/.local/lib/python3.10/site-
packages/watchdog/observers/api.py", line 381, in
dispatch_events

handler.dispatch(event)
  File "/home/linduska/.local/lib/python3.10/site-
packages/watchdog/events.py", line 272, in dispatch

{
  File "/home/linduska/grass/dist.x86_64-pc-linux-
gnu/gui/wxpython/datacatalog/tree.py", line 179, in
on_modified

gisrc["GISDBASE"], gisrc["LOCATION_NAME"], gisrc["MAPSET"]
KeyError
:
'GISDBASE'

It is related to the fact that when accessing the GISRC file with Database/location/mapset info, at the same time  the GISRC file could be accessed by another process.

Fixed by waiting 0.1 sec before reading GISRC.