### PR TITLE
build: Remove compatibility to GDAL 1 and <2.2

### DIFF
--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -105,8 +105,7 @@ int describe_table(OGRLayerH hLayer, dbTable **table, cursor *c)
         ogrType = OGR_Fld_GetType(hFieldDefn);
         fieldName = OGR_Fld_GetNameRef(hFieldDefn);
 
-        if (ogrType != OFTInteger &&
-            ogrType != OFTInteger64 &&
+        if (ogrType != OFTInteger && ogrType != OFTInteger64 &&
             ogrType != OFTReal && ogrType != OFTString && ogrType != OFTDate &&
             ogrType != OFTTime && ogrType != OFTDateTime) {
             G_warning(

--- a/db/drivers/ogr/describe.c
+++ b/db/drivers/ogr/describe.c
@@ -106,9 +106,7 @@ int describe_table(OGRLayerH hLayer, dbTable **table, cursor *c)
         fieldName = OGR_Fld_GetNameRef(hFieldDefn);
 
         if (ogrType != OFTInteger &&
-#if GDAL_VERSION_NUM >= 2000000
             ogrType != OFTInteger64 &&
-#endif
             ogrType != OFTReal && ogrType != OFTString && ogrType != OFTDate &&
             ogrType != OFTTime && ogrType != OFTDateTime) {
             G_warning(
@@ -174,19 +172,15 @@ int describe_table(OGRLayerH hLayer, dbTable **table, cursor *c)
 
         switch (ogrType) {
         case OFTInteger:
-#if GDAL_VERSION_NUM >= 2000000
         case OFTInteger64:
-#endif
             sqlType = DB_SQL_TYPE_INTEGER;
             size = OGR_Fld_GetWidth(hFieldDefn); /* OK ? */
             precision = 0;
-#if GDAL_VERSION_NUM >= 2000000
             if (ogrType == OFTInteger64)
                 G_warning(_("Column '%s' : type int8 (bigint) is stored as "
                             "integer (4 bytes) "
                             "some data may be damaged"),
                           fieldName);
-#endif
             break;
 
         case OFTReal:

--- a/db/drivers/ogr/execute.c
+++ b/db/drivers/ogr/execute.c
@@ -98,9 +98,7 @@ int db__driver_execute_immediate(dbString *sql)
             }
             else {
                 if ((cols[i].type != OFTInteger ||
-#if GDAL_VERSION_NUM >= 2000000
                      cols[i].type != OFTInteger64 ||
-#endif
                      cols[i].type != OFTReal) &&
                     *(cols[i].value) == '\'') {
                     value = G_strchg(cols[i].value, '\'', ' ');

--- a/db/drivers/ogr/execute.c
+++ b/db/drivers/ogr/execute.c
@@ -98,8 +98,7 @@ int db__driver_execute_immediate(dbString *sql)
             }
             else {
                 if ((cols[i].type != OFTInteger ||
-                     cols[i].type != OFTInteger64 ||
-                     cols[i].type != OFTReal) &&
+                     cols[i].type != OFTInteger64 || cols[i].type != OFTReal) &&
                     *(cols[i].value) == '\'') {
                     value = G_strchg(cols[i].value, '\'', ' ');
                     G_strip(value);

--- a/db/drivers/ogr/fetch.c
+++ b/db/drivers/ogr/fetch.c
@@ -143,12 +143,10 @@ int db__driver_fetch(dbCursor *cn, int position, int *more)
             value->i = OGR_F_GetFieldAsInteger(c->hFeature, i);
             break;
 
-#if GDAL_VERSION_NUM >= 2000000
         case OFTInteger64:
             /* test for integer overflow ? */
             value->i = OGR_F_GetFieldAsInteger64(c->hFeature, i);
             break;
-#endif
 
         case OFTReal:
             value->d = OGR_F_GetFieldAsDouble(c->hFeature, i);

--- a/include/grass/defs/gis.h
+++ b/include/grass/defs/gis.h
@@ -72,25 +72,6 @@
 #define RELDIR "?"
 #endif
 
-/* GDAL < 2.3 does not define HAVE_LONG_LONG when compiled with
- * Visual Studio as for OSGeo4W, even though long long is available,
- * and GIntBig falls back to long which is on Windows always 4 bytes.
- * This patch ensures that GIntBig is defined as long long (8 bytes)
- * if GDAL is compiled with Visual Studio and GRASS is compiled with
- * MinGW. This patch must be applied before other GDAL/OGR headers are
- * included, as done by gprojects.h and vector.h */
-#if defined(__MINGW32__) && HAVE_GDAL
-#include <gdal_version.h>
-#if GDAL_VERSION_NUM < 2030000
-#include <cpl_config.h>
-/* HAVE_LONG_LONG_INT comes from GRASS
- * HAVE_LONG_LONG comes from GDAL */
-#if HAVE_LONG_LONG_INT && !defined(HAVE_LONG_LONG)
-#define HAVE_LONG_LONG 1
-#endif
-#endif
-#endif
-
 /* adj_cellhd.c */
 void G_adjust_Cell_head(struct Cell_head *, int, int);
 void G_adjust_Cell_head3(struct Cell_head *, int, int, int);

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -731,8 +731,6 @@ static int read_dblinks_ogr(struct Map_info *Map)
 #ifndef HAVE_OGR
     G_warning(_("GRASS is not compiled with OGR support"));
 #else
-#if GDAL_VERSION_NUM > 1320 && \
-    HAVE_OGR /* seems to be fixed after 1320 release */
     int nLayers;
     char *ogr_fid_col;
 
@@ -777,112 +775,6 @@ static int read_dblinks_ogr(struct Map_info *Map)
     Vect_add_dblink(dbl, 1, Map->fInfo.ogr.layer_name,
                     Map->fInfo.ogr.layer_name, ogr_fid_col, Map->fInfo.ogr.dsn,
                     "ogr");
-#else
-    dbDriver *driver;
-    dbCursor cursor;
-    dbString sql;
-    int FID = 0, OGC_FID = 0, OGR_FID = 0, GID = 0;
-
-    G_debug(3, "GDAL_VERSION_NUM: %d", GDAL_VERSION_NUM);
-
-    /* FID is not available for all OGR drivers */
-    db_init_string(&sql);
-
-    driver = db_start_driver_open_database("ogr", Map->fInfo.ogr.dsn);
-
-    if (driver == NULL) {
-        G_warning(_("Unable to open OGR DBMI driver"));
-        return -1;
-    }
-
-    /* this is a bit stupid, but above FID auto-detection doesn't work yet...:
-     */
-    db_auto_print_errors(0);
-    sprintf(buf, "select FID from %s where FID > 0", Map->fInfo.ogr.layer_name);
-    db_set_string(&sql, buf);
-
-    if (db_open_select_cursor(driver, &sql, &cursor, DB_SEQUENTIAL) != DB_OK) {
-        /* FID not available, so we try ogc_fid */
-        G_debug(3, "Failed. Now searching for ogc_fid column in OGR DB");
-        sprintf(buf, "select ogc_fid from %s where ogc_fid > 0",
-                Map->fInfo.ogr.layer_name);
-        db_set_string(&sql, buf);
-
-        if (db_open_select_cursor(driver, &sql, &cursor, DB_SEQUENTIAL) !=
-            DB_OK) {
-            /* Neither FID nor ogc_fid available, so we try ogr_fid */
-            G_debug(3, "Failed. Now searching for ogr_fid column in OGR DB");
-            sprintf(buf, "select ogr_fid from %s where ogr_fid > 0",
-                    Map->fInfo.ogr.layer_name);
-            db_set_string(&sql, buf);
-
-            if (db_open_select_cursor(driver, &sql, &cursor, DB_SEQUENTIAL) !=
-                DB_OK) {
-                /* Neither FID nor ogc_fid available, so we try gid */
-                G_debug(3, "Failed. Now searching for gid column in OGR DB");
-                sprintf(buf, "select gid from %s where gid > 0",
-                        Map->fInfo.ogr.layer_name);
-                db_set_string(&sql, buf);
-
-                if (db_open_select_cursor(driver, &sql, &cursor,
-                                          DB_SEQUENTIAL) != DB_OK) {
-                    /* neither FID nor ogc_fid nor ogr_fid nor gid available */
-                    G_warning(
-                        _("All FID tests failed. Neither 'FID' nor 'ogc_fid' "
-                          "nor 'ogr_fid' nor 'gid' available in OGR DB table"));
-                    db_close_database_shutdown_driver(driver);
-                    return 0;
-                }
-                else
-                    GID = 1;
-            }
-            else
-                OGR_FID = 1;
-        }
-        else
-            OGC_FID = 1;
-    }
-    else
-        FID = 1;
-
-    G_debug(3, "FID: %d, OGC_FID: %d, OGR_FID: %d, GID: %d", FID, OGC_FID,
-            OGR_FID, GID);
-
-    db_close_cursor(&cursor);
-    db_close_database_shutdown_driver(driver);
-    db_auto_print_errors(1);
-
-    if (FID) {
-        G_debug(3, "Using FID column in OGR DB");
-        Vect_add_dblink(dbl, 1, Map->fInfo.ogr.layer_name,
-                        Map->fInfo.ogr.layer_name, "FID", Map->fInfo.ogr.dsn,
-                        "ogr");
-    }
-    else {
-        if (OGC_FID) {
-            G_debug(3, "Using ogc_fid column in OGR DB");
-            Vect_add_dblink(dbl, 1, Map->fInfo.ogr.layer_name,
-                            Map->fInfo.ogr.layer_name, "ogc_fid",
-                            Map->fInfo.ogr.dsn, "ogr");
-        }
-        else {
-            if (OGR_FID) {
-                G_debug(3, "Using ogr_fid column in OGR DB");
-                Vect_add_dblink(dbl, 1, Map->fInfo.ogr.layer_name,
-                                Map->fInfo.ogr.layer_name, "ogr_fid",
-                                Map->fInfo.ogr.dsn, "ogr");
-            }
-            else {
-                if (GID) {
-                    G_debug(3, "Using gid column in OGR DB");
-                    Vect_add_dblink(dbl, 1, Map->fInfo.ogr.layer_name,
-                                    Map->fInfo.ogr.layer_name, "gid",
-                                    Map->fInfo.ogr.dsn, "ogr");
-                }
-            }
-        }
-    }
-#endif /* GDAL_VERSION_NUM > 1320 && HAVE_OGR */
     return 1;
 #endif /* HAVE_GDAL */
 }

--- a/raster/r.in.gdal/main.c
+++ b/raster/r.in.gdal/main.c
@@ -138,9 +138,6 @@ int main(int argc, char *argv[])
     parm.band->guisection = _("Bands");
 
     parm.memory = G_define_standard_option(G_OPT_MEMORYMB);
-#if GDAL_VERSION_NUM < 1800
-    parm.memory->options = "0-2047";
-#endif
 
     parm.target = G_define_option();
     parm.target->key = "target";

--- a/raster/r.in.gdal/main.c
+++ b/raster/r.in.gdal/main.c
@@ -48,12 +48,8 @@ static GDALDatasetH opends(char *dsname, const char **doo, GDALDriverH *hDriver)
 {
     GDALDatasetH hDS = NULL;
 
-#if GDAL_VERSION_NUM >= 2000000
     hDS =
         GDALOpenEx(dsname, GDAL_OF_RASTER | GDAL_OF_READONLY, NULL, doo, NULL);
-#else
-    hDS = GDALOpen(dsname, GA_ReadOnly);
-#endif
     if (hDS == NULL)
         G_fatal_error(_("Unable to open datasource <%s>"), dsname);
     G_add_error_handler(error_handler_ds, hDS);

--- a/vector/v.external/list.c
+++ b/vector/v.external/list.c
@@ -293,9 +293,6 @@ int list_layers_ogr(FILE *fd, const char *dsn, char **layer, int print_types)
     for (i = 0; i < nlayers; i++) {
         Ogr_layer = OGR_DS_GetLayer(Ogr_ds, i);
         Ogr_featuredefn = OGR_L_GetLayerDefn(Ogr_layer);
-#if GDAL_VERSION_NUM < 1110000
-        Ogr_geom_type = OGR_FD_GetGeomType(Ogr_featuredefn);
-#endif
         layer_name = (char *)OGR_FD_GetName(Ogr_featuredefn);
 
         if (fd) {
@@ -303,9 +300,7 @@ int list_layers_ogr(FILE *fd, const char *dsn, char **layer, int print_types)
                 int proj_same, igeom;
                 OGRSpatialReferenceH Ogr_projection;
 
-#if GDAL_VERSION_NUM >= 1110000
                 OGRGeomFieldDefnH Ogr_geomdefn;
-#endif
                 /* projection check */
                 Ogr_projection = OGR_L_GetSpatialRef(Ogr_layer);
                 proj_same = 0;
@@ -327,7 +322,6 @@ int list_layers_ogr(FILE *fd, const char *dsn, char **layer, int print_types)
                         proj_same = 0;
                 }
                 G_suppress_warnings(FALSE);
-#if GDAL_VERSION_NUM >= 1110000
                 for (igeom = 0;
                      igeom < OGR_FD_GetGeomFieldCount(Ogr_featuredefn);
                      igeom++) {
@@ -343,11 +337,6 @@ int list_layers_ogr(FILE *fd, const char *dsn, char **layer, int print_types)
                             feature_type(OGRGeometryTypeToName(Ogr_geom_type)),
                             proj_same, OGR_GFld_GetNameRef(Ogr_geomdefn));
                 }
-#else
-                fprintf(fd, "%s,%s,%d,\n", layer_name,
-                        feature_type(OGRGeometryTypeToName(Ogr_geom_type)),
-                        proj_same);
-#endif
             }
             else {
                 fprintf(fd, "%s\n", layer_name);

--- a/vector/v.external/local_proto.h
+++ b/vector/v.external/local_proto.h
@@ -5,11 +5,6 @@
 #include <gdal_version.h>
 #include <ogr_api.h>
 
-typedef GDALDatasetH ds_t;
-
-#define ds_getlayerbyindex(ds, i) GDALDatasetGetLayer((ds), (i))
-#define ds_close(ds)              GDALClose(ds)
-
 struct _options {
     struct Option *dsn, *output, *layer, *where;
 };
@@ -30,6 +25,6 @@ int list_layers(FILE *, const char *, char **, int, int);
 void get_table_name(const char *, char **, char **);
 
 /* proj.c */
-void check_projection(struct Cell_head *, ds_t, int, char *, char *, int, int,
-                      int);
+void check_projection(struct Cell_head *, GDALDatasetH, int, char *, char *,
+                      int, int, int);
 #endif

--- a/vector/v.external/local_proto.h
+++ b/vector/v.external/local_proto.h
@@ -5,20 +5,10 @@
 #include <gdal_version.h>
 #include <ogr_api.h>
 
-/* define type of input datasource
- * as of GDAL 2.2, all functions having as argument a GDAL/OGR dataset
- * must use the GDAL version, not the OGR version */
-#if GDAL_VERSION_NUM >= 2020000
 typedef GDALDatasetH ds_t;
 
 #define ds_getlayerbyindex(ds, i) GDALDatasetGetLayer((ds), (i))
 #define ds_close(ds)              GDALClose(ds)
-#else
-typedef OGRDataSourceH ds_t;
-
-#define ds_getlayerbyindex(ds, i) OGR_DS_GetLayer((ds), (i))
-#define ds_close(ds)              OGR_DS_Destroy(ds)
-#endif
 
 struct _options {
     struct Option *dsn, *output, *layer, *where;

--- a/vector/v.external/main.c
+++ b/vector/v.external/main.c
@@ -141,12 +141,8 @@ int main(int argc, char *argv[])
     /* open OGR DSN */
     Ogr_ds = NULL;
     if (strlen(options.dsn->answer) > 0) {
-#if GDAL_VERSION_NUM >= 2020000
         Ogr_ds =
             GDALOpenEx(options.dsn->answer, GDAL_OF_VECTOR, NULL, NULL, NULL);
-#else
-        Ogr_ds = OGROpen(dsn, FALSE, NULL);
-#endif
     }
     if (Ogr_ds == NULL)
         G_fatal_error(_("Unable to open data source <%s>"), dsn);

--- a/vector/v.external/main.c
+++ b/vector/v.external/main.c
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     char buf[GPATH_MAX], *dsn, *layer;
     const char *output;
     struct Cell_head cellhd;
-    ds_t Ogr_ds;
+    GDALDatasetH Ogr_ds;
 
     G_gisinit(argv[0]);
 
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
     /* check projection match */
     check_projection(&cellhd, Ogr_ds, ilayer, NULL, NULL, 0,
                      flags.override->answer, flags.proj->answer);
-    ds_close(Ogr_ds);
+    GDALClose(Ogr_ds);
 
     /* create new vector map */
     putenv("GRASS_VECTOR_EXTERNAL_IGNORE=1");

--- a/vector/v.external/proj.c
+++ b/vector/v.external/proj.c
@@ -23,7 +23,6 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
     *proj_wkt = NULL;
 
     /* Fetch input layer projection in GRASS form. */
-#if GDAL_VERSION_NUM >= 1110000
     if (geom_col) {
         int igeom;
         OGRGeomFieldDefnH Ogr_geomdefn;
@@ -41,9 +40,6 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
     else {
         hSRS = OGR_L_GetSpatialRef(Ogr_layer);
     }
-#else
-    hSRS = OGR_L_GetSpatialRef(Ogr_layer); /* should not be freed later */
-#endif
 
     /* verbose is used only when comparing input SRS to GRASS projection,
      * not when comparing SRS's of several input layers */

--- a/vector/v.external/proj.c
+++ b/vector/v.external/proj.c
@@ -127,7 +127,7 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
 }
 
 /* keep in sync with r.in.gdal, r.external, v.in.ogr */
-void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
+void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
                       char *geom_col, char *outloc, int create_only,
                       int override, int check_only)
 {
@@ -140,7 +140,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
     OGRLayerH Ogr_layer;
 
     /* Get first layer to be imported to use for projection check */
-    Ogr_layer = ds_getlayerbyindex(hDS, layer);
+    Ogr_layer = GDALDatasetGetLayer(hDS, layer);
 
     /* -------------------------------------------------------------------- */
     /*      Fetch the projection in GRASS form, SRID, and WKT.              */
@@ -179,7 +179,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
 
         /* If create only, clean up and exit here */
         if (create_only) {
-            ds_close(hDS);
+            GDALClose(hDS);
             exit(EXIT_SUCCESS);
         }
     }
@@ -201,7 +201,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
             }
             else {
                 msg_fn = G_fatal_error;
-                ds_close(hDS);
+                GDALClose(hDS);
             }
             msg_fn(error_msg);
             if (!override) {
@@ -370,7 +370,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
                 msg_fn = G_fatal_error;
             msg_fn("%s", error_msg);
             if (check_only) {
-                ds_close(hDS);
+                GDALClose(hDS);
                 exit(EXIT_FAILURE);
             }
         }
@@ -382,7 +382,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
             msg_fn(_("Projection of input dataset and current location "
                      "appear to match"));
             if (check_only) {
-                ds_close(hDS);
+                GDALClose(hDS);
                 exit(EXIT_SUCCESS);
             }
         }

--- a/vector/v.in.ogr/geom.c
+++ b/vector/v.in.ogr/geom.c
@@ -61,7 +61,6 @@ int centroid(OGRGeometryH hGeomAny, CENTR *Centr, struct spatial_index *Sindex,
 
     hGeom = hGeomAny;
 
-#if GDAL_VERSION_NUM >= 2000000
     if (OGR_G_HasCurveGeometry(hGeom, 0)) {
         G_debug(2, "Approximating curves in a '%s'",
                 OGR_G_GetGeometryName(hGeom));
@@ -69,7 +68,6 @@ int centroid(OGRGeometryH hGeomAny, CENTR *Centr, struct spatial_index *Sindex,
         /* The ownership of the returned geometry belongs to the caller. */
         hGeom = OGR_G_GetLinearGeometry(hGeom, 0, NULL);
     }
-#endif
 
     eType = wkbFlatten(OGR_G_GetGeometryType(hGeom));
 
@@ -196,7 +194,6 @@ int poly_count(OGRGeometryH hGeomAny, int line2boundary)
 
     hGeom = hGeomAny;
 
-#if GDAL_VERSION_NUM >= 2000000
     if (OGR_G_HasCurveGeometry(hGeom, 0)) {
         G_debug(2, "Approximating curves in a '%s'",
                 OGR_G_GetGeometryName(hGeom));
@@ -204,7 +201,6 @@ int poly_count(OGRGeometryH hGeomAny, int line2boundary)
         /* The ownership of the returned geometry belongs to the caller. */
         hGeom = OGR_G_GetLinearGeometry(hGeom, 0, NULL);
     }
-#endif
 
     eType = wkbFlatten(OGR_G_GetGeometryType(hGeom));
 
@@ -290,7 +286,6 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
 
     hGeom = hGeomAny;
 
-#if GDAL_VERSION_NUM >= 2000000
     if (OGR_G_HasCurveGeometry(hGeom, 0)) {
         G_debug(2, "Approximating curves in a '%s'",
                 OGR_G_GetGeometryName(hGeom));
@@ -298,7 +293,6 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
         /* The ownership of the returned geometry belongs to the caller. */
         hGeom = OGR_G_GetLinearGeometry(hGeom, 0, NULL);
     }
-#endif
 
     eType = wkbFlatten(OGR_G_GetGeometryType(hGeom));
 

--- a/vector/v.in.ogr/global.h
+++ b/vector/v.in.ogr/global.h
@@ -26,18 +26,9 @@
 #include <gdal_version.h>
 #include <ogr_api.h>
 
-/* define type of input datasource
- * as of GDAL 2.2, all functions having as argument a GDAL/OGR dataset
- * must use the GDAL version, not the OGR version */
-#if GDAL_VERSION_NUM >= 2020000
 typedef GDALDatasetH ds_t;
 #define ds_getlayerbyindex(ds, i) GDALDatasetGetLayer((ds), (i))
 #define ds_close(ds)              GDALClose(ds)
-#else
-typedef OGRDataSourceH ds_t;
-#define ds_getlayerbyindex(ds, i) OGR_DS_GetLayer((ds), (i))
-#define ds_close(ds)              OGR_DS_Destroy(ds)
-#endif
 
 extern int n_polygons;
 extern int n_polygon_boundaries;

--- a/vector/v.in.ogr/global.h
+++ b/vector/v.in.ogr/global.h
@@ -26,10 +26,6 @@
 #include <gdal_version.h>
 #include <ogr_api.h>
 
-typedef GDALDatasetH ds_t;
-#define ds_getlayerbyindex(ds, i) GDALDatasetGetLayer((ds), (i))
-#define ds_close(ds)              GDALClose(ds)
-
 extern int n_polygons;
 extern int n_polygon_boundaries;
 extern double split_distance;

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -549,7 +549,7 @@ int main(int argc, char *argv[])
     if (Ogr_ds == NULL)
         G_fatal_error(_("Unable to open data source <%s>"), dsn);
 
-        /* driver name */
+    /* driver name */
     ogr_driver_name = GDALGetDriverShortName(GDALGetDatasetDriver(Ogr_ds));
     G_verbose_message(_("Using OGR driver '%s/%s'"), ogr_driver_name,
                       GDALGetDriverLongName(GDALGetDatasetDriver(Ogr_ds)));
@@ -812,7 +812,7 @@ int main(int argc, char *argv[])
             if (ogr_feature_count <= 0)
                 n_features[layer]++;
 
-                /* Geometry */
+            /* Geometry */
             Ogr_featuredefn = OGR_iter.Ogr_featuredefn;
             for (i = 0; i < OGR_FD_GetGeomFieldCount(Ogr_featuredefn); i++) {
                 if (igeom > -1 && i != igeom)
@@ -934,9 +934,7 @@ int main(int argc, char *argv[])
                 Ogr_field =
                     OGR_FD_GetFieldDefn(Ogr_featuredefn, key_idx[layer]);
                 Ogr_ftype = OGR_Fld_GetType(Ogr_field);
-                if (!(Ogr_ftype == OFTInteger
-                      || Ogr_ftype == OFTInteger64
-                      )) {
+                if (!(Ogr_ftype == OFTInteger || Ogr_ftype == OFTInteger64)) {
                     G_fatal_error(
                         _("Key column '%s' in input layer <%s> is not integer"),
                         param.key->answer, layer_names[layer]);
@@ -1054,9 +1052,8 @@ int main(int argc, char *argv[])
                                       Ogr_fieldname);
                     }
                 }
-                else if (Ogr_ftype == OFTIntegerList
-                         || Ogr_ftype == OFTInteger64List
-                ) {
+                else if (Ogr_ftype == OFTIntegerList ||
+                         Ogr_ftype == OFTInteger64List) {
                     /* hack: treat as string */
                     sprintf(buf, "varchar ( %d )", OFTIntegerListlength);
                     col_info[i_out].type = G_store(buf);
@@ -1252,7 +1249,7 @@ int main(int argc, char *argv[])
                 /* Ogr_geometry from OGR_F_GetGeomFieldRef() should not be
                  * modified. */
                 Ogr_geometry = OGR_F_GetGeomFieldRef(Ogr_feature, i);
-            Ogr_geometry = OGR_F_GetGeometryRef(Ogr_feature);
+                Ogr_geometry = OGR_F_GetGeometryRef(Ogr_feature);
                 if (Ogr_geometry == NULL) {
                     nogeom++;
                 }
@@ -1285,8 +1282,7 @@ int main(int argc, char *argv[])
                         Ogr_fstring = OGR_F_GetFieldAsString(Ogr_feature, i);
                     if (Ogr_fstring && *Ogr_fstring) {
                         if (Ogr_ftype == OFTInteger ||
-                            Ogr_ftype == OFTInteger64 ||
-                            Ogr_ftype == OFTReal) {
+                            Ogr_ftype == OFTInteger64 || Ogr_ftype == OFTReal) {
                             G_rasprintf(&sqlbuf, &sqlbufsize, ", %s",
                                         Ogr_fstring);
                         }
@@ -1307,9 +1303,8 @@ int main(int argc, char *argv[])
                         }
                         else if (Ogr_ftype == OFTString ||
                                  Ogr_ftype == OFTStringList ||
-                                 Ogr_ftype == OFTIntegerList
-                                 || Ogr_ftype == OFTInteger64List
-                        ) {
+                                 Ogr_ftype == OFTIntegerList ||
+                                 Ogr_ftype == OFTInteger64List) {
                             db_set_string(&strval, (char *)Ogr_fstring);
                             db_double_quote_string(&strval);
                             G_rasprintf(&sqlbuf, &sqlbufsize, ", '%s'",
@@ -1324,8 +1319,7 @@ int main(int argc, char *argv[])
                     else {
                         /* G_warning (_("Column value not set" )); */
                         if (Ogr_ftype == OFTInteger ||
-                            Ogr_ftype == OFTInteger64 ||
-                            Ogr_ftype == OFTReal) {
+                            Ogr_ftype == OFTInteger64 || Ogr_ftype == OFTReal) {
                             G_rasprintf(&sqlbuf, &sqlbufsize, ", NULL");
                         }
                         else if (Ogr_ftype == OFTDate || Ogr_ftype == OFTTime ||
@@ -1334,9 +1328,8 @@ int main(int argc, char *argv[])
                         }
                         else if (Ogr_ftype == OFTString ||
                                  Ogr_ftype == OFTStringList ||
-                                 Ogr_ftype == OFTIntegerList
-                                 || Ogr_ftype == OFTInteger64List
-                        ) {
+                                 Ogr_ftype == OFTIntegerList ||
+                                 Ogr_ftype == OFTInteger64List) {
                             G_rasprintf(&sqlbuf, &sqlbufsize, ", NULL");
                         }
                         else {
@@ -1565,8 +1558,8 @@ int main(int argc, char *argv[])
             Ogr_featuredefn = OGR_L_GetLayerDefn(Ogr_layer);
 
             igeom = -1;
-                igeom = OGR_FD_GetGeomFieldIndex(Ogr_featuredefn,
-                                                 param.geom->answer);
+            igeom =
+                OGR_FD_GetGeomFieldIndex(Ogr_featuredefn, param.geom->answer);
 
             cat = 0; /* field = layer + 1 */
             feature_count = 0;
@@ -1613,7 +1606,7 @@ int main(int argc, char *argv[])
                         continue; /* use only geometry defined via param.geom */
 
                     Ogr_geometry = OGR_F_GetGeomFieldRef(Ogr_feature, i);
-                Ogr_geometry = OGR_F_GetGeometryRef(Ogr_feature);
+                    Ogr_geometry = OGR_F_GetGeometryRef(Ogr_feature);
                     if (Ogr_geometry != NULL) {
                         centroid(Ogr_geometry, Centr, &si, layer + 1, area_cat,
                                  min_area, type);

--- a/vector/v.in.ogr/main.c
+++ b/vector/v.in.ogr/main.c
@@ -1249,7 +1249,6 @@ int main(int argc, char *argv[])
                 /* Ogr_geometry from OGR_F_GetGeomFieldRef() should not be
                  * modified. */
                 Ogr_geometry = OGR_F_GetGeomFieldRef(Ogr_feature, i);
-                Ogr_geometry = OGR_F_GetGeometryRef(Ogr_feature);
                 if (Ogr_geometry == NULL) {
                     nogeom++;
                 }
@@ -1558,8 +1557,9 @@ int main(int argc, char *argv[])
             Ogr_featuredefn = OGR_L_GetLayerDefn(Ogr_layer);
 
             igeom = -1;
-            igeom =
-                OGR_FD_GetGeomFieldIndex(Ogr_featuredefn, param.geom->answer);
+            if (param.geom->answer)
+                igeom = OGR_FD_GetGeomFieldIndex(Ogr_featuredefn,
+                                                 param.geom->answer);
 
             cat = 0; /* field = layer + 1 */
             feature_count = 0;
@@ -1606,7 +1606,6 @@ int main(int argc, char *argv[])
                         continue; /* use only geometry defined via param.geom */
 
                     Ogr_geometry = OGR_F_GetGeomFieldRef(Ogr_feature, i);
-                    Ogr_geometry = OGR_F_GetGeometryRef(Ogr_feature);
                     if (Ogr_geometry != NULL) {
                         centroid(Ogr_geometry, Centr, &si, layer + 1, area_cat,
                                  min_area, type);

--- a/vector/v.in.ogr/proj.c
+++ b/vector/v.in.ogr/proj.c
@@ -129,8 +129,8 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
 /* compare projections of all OGR layers
  * return 0 if all layers have the same projection
  * return 1 if layer projections differ */
-int cmp_layer_srs(ds_t Ogr_ds, int nlayers, int *layers, char **layer_names,
-                  char *geom_col)
+int cmp_layer_srs(GDALDatasetH Ogr_ds, int nlayers, int *layers,
+                  char **layer_names, char *geom_col)
 {
     int layer;
     struct Key_Value *proj_info1, *proj_units1;
@@ -152,7 +152,7 @@ int cmp_layer_srs(ds_t Ogr_ds, int nlayers, int *layers, char **layer_names,
     layer = 0;
     do {
         /* Get first SRS */
-        Ogr_layer = ds_getlayerbyindex(Ogr_ds, layers[layer]);
+        Ogr_layer = GDALDatasetGetLayer(Ogr_ds, layers[layer]);
 
         if (get_layer_proj(Ogr_layer, &cellhd1, &proj_info1, &proj_units1,
                            &proj_srid1, &proj_wkt1, geom_col, 0) == 0) {
@@ -197,7 +197,7 @@ int cmp_layer_srs(ds_t Ogr_ds, int nlayers, int *layers, char **layer_names,
 
     for (layer = 1; layer < nlayers; layer++) {
         /* Get SRS of other layer(s) */
-        Ogr_layer = ds_getlayerbyindex(Ogr_ds, layers[layer]);
+        Ogr_layer = GDALDatasetGetLayer(Ogr_ds, layers[layer]);
         G_get_window(&cellhd2);
         if (get_layer_proj(Ogr_layer, &cellhd2, &proj_info2, &proj_units2,
                            &proj_srid2, &proj_wkt2, geom_col, 0) != 0) {
@@ -261,7 +261,7 @@ int cmp_layer_srs(ds_t Ogr_ds, int nlayers, int *layers, char **layer_names,
 }
 
 /* keep in sync with r.in.gdal, r.external, v.external */
-void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
+void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
                       char *geom_col, char *outloc, int create_only,
                       int override, int check_only)
 {
@@ -274,7 +274,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
     OGRLayerH Ogr_layer;
 
     /* Get first layer to be imported to use for projection check */
-    Ogr_layer = ds_getlayerbyindex(hDS, layer);
+    Ogr_layer = GDALDatasetGetLayer(hDS, layer);
 
     /* -------------------------------------------------------------------- */
     /*      Fetch the projection in GRASS form, SRID, and WKT.              */
@@ -313,7 +313,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
 
         /* If create only, clean up and exit here */
         if (create_only) {
-            ds_close(hDS);
+            GDALClose(hDS);
             exit(EXIT_SUCCESS);
         }
     }
@@ -335,7 +335,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
             }
             else {
                 msg_fn = G_fatal_error;
-                ds_close(hDS);
+                GDALClose(hDS);
             }
             msg_fn(error_msg);
             if (!override) {
@@ -502,7 +502,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
                 msg_fn = G_fatal_error;
             msg_fn("%s", error_msg);
             if (check_only) {
-                ds_close(hDS);
+                GDALClose(hDS);
                 exit(EXIT_FAILURE);
             }
         }
@@ -514,7 +514,7 @@ void check_projection(struct Cell_head *cellhd, ds_t hDS, int layer,
             msg_fn(_("Projection of input dataset and current location "
                      "appear to match"));
             if (check_only) {
-                ds_close(hDS);
+                GDALClose(hDS);
                 exit(EXIT_SUCCESS);
             }
         }

--- a/vector/v.in.ogr/proj.c
+++ b/vector/v.in.ogr/proj.c
@@ -24,7 +24,6 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
     *proj_wkt = NULL;
 
     /* Fetch input layer projection in GRASS form. */
-#if GDAL_VERSION_NUM >= 1110000
     if (geom_col) {
         int igeom;
         OGRGeomFieldDefnH Ogr_geomdefn;
@@ -42,9 +41,6 @@ int get_layer_proj(OGRLayerH Ogr_layer, struct Cell_head *cellhd,
     else {
         hSRS = OGR_L_GetSpatialRef(Ogr_layer);
     }
-#else
-    hSRS = OGR_L_GetSpatialRef(Ogr_layer); /* should not be freed later */
-#endif
 
     /* verbose is used only when comparing input SRS to GRASS projection,
      * not when comparing SRS's of several input layers */

--- a/vector/v.out.ogr/attrb.c
+++ b/vector/v.out.ogr/attrb.c
@@ -98,11 +98,7 @@ int mk_att(int cat, struct field_info *Fi, dbDriver *driver, int ncol,
                     if ((nocat && strcmp(Fi->key, colname[j]) == 0) == 0) {
                         /* if this is 'cat', then execute the following only if
                          * the '-s' flag was NOT given */
-#if GDAL_VERSION_NUM >= 2020000
                         OGR_F_SetFieldNull(Ogr_feature, ogrfieldnum);
-#else
-                        OGR_F_UnsetField(Ogr_feature, ogrfieldnum);
-#endif
                     }
 
                     /* prevent writing NULL values */
@@ -135,10 +131,8 @@ int mk_att(int cat, struct field_info *Fi, dbDriver *driver, int ncol,
                             }
                         }
                     }
-#if GDAL_VERSION_NUM >= 2020000
                     else
                         OGR_F_SetFieldNull(Ogr_feature, ogrfieldnum);
-#endif
                 }
             }
             db_close_cursor(&cursor);

--- a/vector/v.out.ogr/create.c
+++ b/vector/v.out.ogr/create.c
@@ -20,11 +20,7 @@ void create_ogr_layer(const char *dsn, const char *format, const char *layer,
     }
 
     /* create datasource */
-#if GDAL_VERSION_NUM >= 2020000
     hDS = GDALCreate(hDriver, dsn, 0, 0, 0, GDT_Unknown, papszDSCO);
-#else
-    hDS = OGR_Dr_CreateDataSource(hDriver, dsn, papszDSCO);
-#endif
     if (hDS == NULL) {
         G_fatal_error(_("Creation of output OGR datasource <%s> failed"), dsn);
     }
@@ -33,11 +29,7 @@ void create_ogr_layer(const char *dsn, const char *format, const char *layer,
 
     /* create layer */
     /* todo: SRS */
-#if GDAL_VERSION_NUM >= 2020000
     hLayer = GDALDatasetCreateLayer(hDS, layer, NULL, wkbtype, papszLCO);
-#else
-    hLayer = OGR_DS_CreateLayer(hDS, layer, NULL, wkbtype, papszLCO);
-#endif
     if (hLayer == NULL) {
         G_fatal_error(_("Creation of OGR layer <%s> failed"), layer);
     }

--- a/vector/v.out.ogr/create.c
+++ b/vector/v.out.ogr/create.c
@@ -6,15 +6,15 @@ void create_ogr_layer(const char *dsn, const char *format, const char *layer,
                       unsigned int wkbtype, char **papszDSCO, char **papszLCO)
 {
     char *pszDriverName;
-    dr_t hDriver;
-    ds_t hDS;
+    GDALDriverH hDriver;
+    GDALDatasetH hDS;
     OGRLayerH hLayer;
 
     pszDriverName = G_store(format);
     G_strchg(pszDriverName, '_', ' '); /* '_' -> ' ' */
 
     /* start driver */
-    hDriver = get_driver_by_name(pszDriverName);
+    hDriver = GDALGetDriverByName(pszDriverName);
     if (hDriver == NULL) {
         G_fatal_error(_("OGR driver <%s> not available"), pszDriverName);
     }
@@ -34,7 +34,7 @@ void create_ogr_layer(const char *dsn, const char *format, const char *layer,
         G_fatal_error(_("Creation of OGR layer <%s> failed"), layer);
     }
 
-    ds_close(hDS);
+    GDALClose(hDS);
 }
 
 OGRwkbGeometryType get_multi_wkbtype(OGRwkbGeometryType wkbtype)

--- a/vector/v.out.ogr/list.c
+++ b/vector/v.out.ogr/list.c
@@ -10,11 +10,7 @@ char *OGR_list_write_drivers(void)
     int i, count;
     size_t len;
 
-#if GDAL_VERSION_NUM >= 2000000
     GDALDriverH hDriver;
-#else
-    OGRSFDriverH Ogr_driver;
-#endif
     char buf[2000];
 
     char **list, *ret;
@@ -22,7 +18,6 @@ char *OGR_list_write_drivers(void)
     list = NULL;
     count = len = 0;
 
-#if GDAL_VERSION_NUM >= 2000000
     /* get GDAL driver names */
     GDALAllRegister();
     G_debug(2, "driver count = %d", GDALGetDriverCount());
@@ -47,28 +42,6 @@ char *OGR_list_write_drivers(void)
         list[count++] = G_store(buf);
         len += strlen(buf) + 1; /* + ',' */
     }
-#else
-    /* get OGR driver names */
-    OGRRegisterAll();
-    G_debug(2, "driver count = %d", OGRGetDriverCount());
-    for (i = 0; i < OGRGetDriverCount(); i++) {
-        /* only fetch read/write drivers */
-        if (!OGR_Dr_TestCapability(OGRGetDriver(i), ODrCCreateDataSource))
-            continue;
-
-        Ogr_driver = OGRGetDriver(i);
-        G_debug(2, "driver %d/%d : %s", i, OGRGetDriverCount(),
-                OGR_Dr_GetName(Ogr_driver));
-
-        list = G_realloc(list, (count + 1) * sizeof(char *));
-
-        /* chg white space to underscore in OGR driver names */
-        sprintf(buf, "%s", OGR_Dr_GetName(Ogr_driver));
-        G_strchg(buf, ' ', '_');
-        list[count++] = G_store(buf);
-        len += strlen(buf) + 1; /* + ',' */
-    }
-#endif
 
     qsort(list, count, sizeof(char *), cmp);
 
@@ -99,11 +72,7 @@ int cmp(const void *a, const void *b)
 
 char *default_driver(void)
 {
-#if GDAL_VERSION_NUM >= 2000000
     if (GDALGetDriverByName("GPKG")) {
-#else
-    if (OGRGetDriverByName("GPKG")) {
-#endif
         return G_store("GPKG");
     }
 
@@ -116,7 +85,6 @@ void list_formats(void)
 
     G_message(_("Supported formats:"));
 
-#if GDAL_VERSION_NUM >= 2000000
     for (iDriver = 0; iDriver < GDALGetDriverCount(); iDriver++) {
         GDALDriverH hDriver = GDALGetDriver(iDriver);
         const char *pszRWFlag;
@@ -134,19 +102,4 @@ void list_formats(void)
         fprintf(stdout, " %s (%s): %s\n", GDALGetDriverShortName(hDriver),
                 pszRWFlag, GDALGetDriverLongName(hDriver));
     }
-
-#else
-    for (iDriver = 0; iDriver < OGRGetDriverCount(); iDriver++) {
-        OGRSFDriverH poDriver = OGRGetDriver(iDriver);
-        const char *pszRWFlag;
-
-        if (OGR_Dr_TestCapability(poDriver, ODrCCreateDataSource))
-            pszRWFlag = "rw";
-        else
-            continue;
-
-        fprintf(stdout, " %s (%s): %s\n", OGR_Dr_GetName(poDriver), pszRWFlag,
-                OGR_Dr_GetName(poDriver));
-    }
-#endif
 }

--- a/vector/v.out.ogr/local_proto.h
+++ b/vector/v.out.ogr/local_proto.h
@@ -7,16 +7,8 @@
 #include <ogr_api.h>
 #include <cpl_string.h>
 
-typedef GDALDatasetH ds_t;
-typedef GDALDriverH dr_t;
-
-#define get_driver_by_name        GDALGetDriverByName
-#define get_driver                GDALGetDriver
-#define ds_getlayerbyindex(ds, i) GDALDatasetGetLayer((ds), (i))
-#define ds_close(ds)              GDALClose(ds)
-
 /* some hard limits */
-#define SQL_BUFFER_SIZE           2000
+#define SQL_BUFFER_SIZE 2000
 
 struct Options {
     struct Option *input, *dsn, *layer, *type, *format, *field, *dsco, *lco,

--- a/vector/v.out.ogr/local_proto.h
+++ b/vector/v.out.ogr/local_proto.h
@@ -16,7 +16,7 @@ typedef GDALDriverH dr_t;
 #define ds_close(ds)              GDALClose(ds)
 
 /* some hard limits */
-#define SQL_BUFFER_SIZE 2000
+#define SQL_BUFFER_SIZE           2000
 
 struct Options {
     struct Option *input, *dsn, *layer, *type, *format, *field, *dsco, *lco,

--- a/vector/v.out.ogr/local_proto.h
+++ b/vector/v.out.ogr/local_proto.h
@@ -7,8 +7,6 @@
 #include <ogr_api.h>
 #include <cpl_string.h>
 
-/* switch to new GDAL API with GDAL 2.2+ */
-#if GDAL_VERSION_NUM >= 2020000
 typedef GDALDatasetH ds_t;
 typedef GDALDriverH dr_t;
 
@@ -16,15 +14,6 @@ typedef GDALDriverH dr_t;
 #define get_driver                GDALGetDriver
 #define ds_getlayerbyindex(ds, i) GDALDatasetGetLayer((ds), (i))
 #define ds_close(ds)              GDALClose(ds)
-#else
-typedef OGRDataSourceH ds_t;
-typedef OGRSFDriverH dr_t;
-
-#define get_driver_by_name        OGRGetDriverByName
-#define get_driver                OGRGetDriver
-#define ds_getlayerbyindex(ds, i) OGR_DS_GetLayer((ds), (i))
-#define ds_close(ds)              OGR_DS_Destroy(ds)
-#endif
 
 /* some hard limits */
 #define SQL_BUFFER_SIZE 2000

--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
     /* OGR */
     int drn;
     OGRFieldType ogr_ftype = OFTInteger;
-    ds_t hDS;
-    dr_t hDriver;
+    GDALDatasetH hDS;
+    GDALDriverH hDriver;
     OGRLayerH Ogr_layer;
     OGRFieldDefnH Ogr_field;
     OGRFeatureDefnH Ogr_featuredefn;
@@ -529,7 +529,7 @@ int main(int argc, char *argv[])
     }
     if (drn == -1)
         G_fatal_error(_("OGR driver <%s> not found"), options.format->answer);
-    hDriver = get_driver(drn);
+    hDriver = GDALGetDriver(drn);
 
     if (flags.append->answer) {
         G_debug(1, "Append to OGR layer");
@@ -860,7 +860,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    ds_close(hDS);
+    GDALClose(hDS);
 
     Vect_close(&In);
 

--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -514,7 +514,6 @@ int main(int argc, char *argv[])
     G_debug(1, "Requested to export %d features", num_to_export);
 
     /* Open OGR DSN */
-#if GDAL_VERSION_NUM >= 2020000
     G_debug(2, "driver count = %d", GDALGetDriverCount());
     drn = -1;
     for (i = 0; i < GDALGetDriverCount(); i++) {
@@ -528,28 +527,12 @@ int main(int argc, char *argv[])
             G_debug(2, " -> driver = %d", drn);
         }
     }
-#else
-    G_debug(2, "driver count = %d", OGRGetDriverCount());
-    drn = -1;
-    for (i = 0; i < OGRGetDriverCount(); i++) {
-        hDriver = OGRGetDriver(i);
-        G_debug(2, "driver %d : %s", i, OGR_Dr_GetName(hDriver));
-        /* chg white space to underscore in OGR driver names */
-        sprintf(buf, "%s", OGR_Dr_GetName(hDriver));
-        G_strchg(buf, ' ', '_');
-        if (strcmp(buf, options.format->answer) == 0) {
-            drn = i;
-            G_debug(2, " -> driver = %d", drn);
-        }
-    }
-#endif
     if (drn == -1)
         G_fatal_error(_("OGR driver <%s> not found"), options.format->answer);
     hDriver = get_driver(drn);
 
     if (flags.append->answer) {
         G_debug(1, "Append to OGR layer");
-#if GDAL_VERSION_NUM >= 2020000
         hDS =
             GDALOpenEx(dsn, GDAL_OF_VECTOR | GDAL_OF_UPDATE, NULL, NULL, NULL);
 
@@ -557,17 +540,8 @@ int main(int argc, char *argv[])
             G_debug(1, "Create OGR data source");
             hDS = GDALCreate(hDriver, dsn, 0, 0, 0, GDT_Unknown, papszDSCO);
         }
-#else
-        hDS = OGR_Dr_Open(hDriver, dsn, TRUE);
-
-        if (hDS == NULL) {
-            G_debug(1, "Create OGR data source");
-            hDS = OGR_Dr_CreateDataSource(hDriver, dsn, papszDSCO);
-        }
-#endif
     }
     else {
-#if GDAL_VERSION_NUM >= 2020000
         if (flags.update->answer) {
             G_debug(1, "Update OGR data source");
             hDS = GDALOpenEx(dsn, GDAL_OF_VECTOR | GDAL_OF_UPDATE, NULL, NULL,
@@ -577,16 +551,6 @@ int main(int argc, char *argv[])
             G_debug(1, "Create OGR data source");
             hDS = GDALCreate(hDriver, dsn, 0, 0, 0, GDT_Unknown, papszDSCO);
         }
-#else
-        if (flags.update->answer) {
-            G_debug(1, "Update OGR data source");
-            hDS = OGR_Dr_Open(hDriver, dsn, TRUE);
-        }
-        else {
-            G_debug(1, "Create OGR data source");
-            hDS = OGR_Dr_CreateDataSource(hDriver, dsn, papszDSCO);
-        }
-#endif
     }
 
     CSLDestroy(papszDSCO);
@@ -597,14 +561,8 @@ int main(int argc, char *argv[])
     /* check if OGR layer exists */
     overwrite = G_check_overwrite(argc, argv);
     found = FALSE;
-#if GDAL_VERSION_NUM >= 2020000
     for (i = 0; i < GDALDatasetGetLayerCount(hDS); i++) {
         Ogr_layer = GDALDatasetGetLayer(hDS, i);
-#else
-    for (i = 0; i < OGR_DS_GetLayerCount(hDS); i++) {
-        Ogr_layer = OGR_DS_GetLayer(hDS, i);
-
-#endif
         Ogr_field = OGR_L_GetLayerDefn(Ogr_layer);
         if (G_strcasecmp(OGR_FD_GetName(Ogr_field), options.layer->answer))
             continue;
@@ -619,11 +577,7 @@ int main(int argc, char *argv[])
             G_warning(
                 _("OGR layer <%s> already exists and will be overwritten"),
                 options.layer->answer);
-#if GDAL_VERSION_NUM >= 2020000
             GDALDatasetDeleteLayer(hDS, i);
-#else
-            OGR_DS_DeleteLayer(hDS, i);
-#endif
             break;
         }
     }
@@ -704,19 +658,11 @@ int main(int argc, char *argv[])
     }
 
     G_debug(1, "Create OGR layer");
-#if GDAL_VERSION_NUM >= 2020000
     if (flags.append->answer)
         Ogr_layer = GDALDatasetGetLayerByName(hDS, options.layer->answer);
     else
         Ogr_layer = GDALDatasetCreateLayer(hDS, options.layer->answer,
                                            Ogr_projection, wkbtype, papszLCO);
-#else
-    if (flags.append->answer)
-        Ogr_layer = OGR_DS_GetLayerByName(hDS, options.layer->answer);
-    else
-        Ogr_layer = OGR_DS_CreateLayer(hDS, options.layer->answer,
-                                       Ogr_projection, wkbtype, papszLCO);
-#endif
 
     CSLDestroy(papszLCO);
     if (Ogr_layer == NULL) {
@@ -800,11 +746,7 @@ int main(int argc, char *argv[])
                     ogr_ftype = OFTString;
                     break;
                 case DB_C_TYPE_DATETIME:
-#if GDAL_VERSION_NUM >= 1320
                     ogr_ftype = OFTDateTime;
-#else
-                    ogr_ftype = OFTString;
-#endif
                     break;
                 }
                 G_debug(2, "ogr_ftype = %d", ogr_ftype);


### PR DESCRIPTION
This PR aims to cleanup grass code to remove "dead code" since most modern distribution/packaging have GDAL 3.

Fixes https://github.com/OSGeo/grass/issues/2645