### PR TITLE
Show ModelRelation in white on dark mode

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -1622,15 +1622,15 @@ class ModelRelation(ogl.LineShape):
         """Get list of control points"""
         return self._points
 
-    def _setPen(self):
+    def _setPen(self, bg_white=False):
         """Set pen"""
         self.SetPen(
-            wx.Pen(wx.WHITE if IsDark() else wx.BLACK, 1, wx.SOLID)
+            wx.Pen(wx.WHITE if IsDark() and not bg_white else wx.BLACK, 1, wx.SOLID)
         )
 
     def OnDraw(self, dc):
         """Draw relation"""
-        self._setPen()
+        self._setPen(dc.GetBackground() == wx.WHITE_BRUSH)
         ogl.LineShape.OnDraw(self, dc)
 
     def SetName(self, param):

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -60,7 +60,7 @@ from core.gcmd import (
 from core.settings import UserSettings
 from gui_core.forms import GUI, CmdPanel
 from gui_core.widgets import GNotebook
-from gui_core.wrap import Button
+from gui_core.wrap import Button, IsDark
 from gmodeler.giface import GraphicalModelerGrassInterface
 
 from grass.script import task as gtask
@@ -1624,8 +1624,9 @@ class ModelRelation(ogl.LineShape):
 
     def _setPen(self):
         """Set pen"""
-        pen = wx.Pen(wx.BLACK, 1, wx.SOLID)
-        self.SetPen(pen)
+        self.SetPen(
+            wx.Pen(wx.WHITE if IsDark() else wx.BLACK, 1, wx.SOLID)
+        )
 
     def OnDraw(self, dc):
         """Draw relation"""


### PR DESCRIPTION
## Before PR

![Screenshot from 2023-06-03 12-06-47](https://github.com/OSGeo/grass/assets/5683186/8c05ad66-173a-4cb7-b323-25881370a3f2)

## After PR

![Screenshot from 2023-06-03 12-06-05](https://github.com/OSGeo/grass/assets/5683186/67778640-6cca-4bab-abab-3e400752e6ee)

Note: Black brush is used in dark mode only when exporting model into image:

![dark_fixed](https://github.com/OSGeo/grass/assets/5683186/53c68a54-ca5d-48ee-b7c3-f0767bfad3c6)


