### PR TITLE
Update dockerhub organization

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ on:
 env:
   # Additionally mentioned in docker-sha-release-latest
   # as use of variable fails there
-  DOCKERHUB_REPOSITORY: mundialis/grass-py3-pdal
+  DOCKERHUB_REPOSITORY: osgeo/grass-gis
 
 jobs:
 
@@ -166,7 +166,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           # images: ${DOCKERHUB_REPOSITORY}
-          images: mundialis/grass-py3-pdal
+          images: osgeo/grass-gis
           tags: |
             type=ref,event=tag
           flavor: |


### PR DESCRIPTION
As now there exists [`osgeo/grass-gis`](https://hub.docker.com/repository/docker/osgeo/grass-gis/general) on dockerhub, the pipeline can publish the dockerimage there.

TODOs just before merging:
- update dockerhub credentials in this repo settings

open to discussion:
- keep `latest` tag?
- tags `stable-alpine`, `stable-debian` and `stable-ubuntu` are build upon `releasebranch_7_8` should we move it to 8_2?
- do we need to manually copy some images from the [old org](https://hub.docker.com/r/mundialis/grass-py3-pdal/tags)?
  - `mundialis/grass-py3-pdal:releasebranch_8_2-alpine`
  - `mundialis/grass-py3-pdal:stable-ubuntu`
