### PR TITLE
CI: Switch Travis to Ubuntu 22.04 and fix non-prototype in ODBC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,3 @@ install:
 
 script:
   - ./.travis/$TRAVIS_OS_NAME.script.sh
-
-notifications:
-  irc: chat.freenode.net#grass

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # Author: Ivan Mincik, ivan.mincik@gmail.com (linux)
 #         Rainer M. Krug, Rainer@krugs.de (osx)
 
+os: linux
+dist: jammy
 language: c
 cache: ccache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
 env:
   global:
     - CFLAGS="-Werror=implicit-function-declaration"
-    - CXXFLAGS="-std=c++11"
+    - CXXFLAGS="-std=c++17"
 
 before_install:
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: jammy
 language: c
 cache: ccache
 
-matrix:
+jobs:
   include:
     - os: linux
       dist: jammy

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,5 @@ install:
 script:
   - ./.travis/$TRAVIS_OS_NAME.script.sh
 
-after_success:
-  - bash < (curl -s https://codecov.io/bash)
-
 notifications:
   irc: chat.freenode.net#grass

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,10 @@ cache: ccache
 jobs:
   include:
     - os: linux
-      dist: jammy
       compiler: gcc
       env: CC=gcc CXX=g++
 
     - os: linux
-      dist: jammy
       compiler: clang
       env: CC=clang CXX=clang++
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ matrix:
     - os: linux
       dist: jammy
       compiler: gcc
-      sudo: required
       env: CC=gcc CXX=g++
 
     - os: linux
       dist: jammy
       compiler: clang
-      sudo: required
       env: CC=clang CXX=clang++
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ dist: jammy
 language: c
 cache: ccache
 
+# safelist
+branches:
+  only:
+  - main
+  - releasebranch*
+
 jobs:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ cache: ccache
 matrix:
   include:
     - os: linux
-      dist: focal
+      dist: jammy
       compiler: gcc
       sudo: required
       env: CC=gcc CXX=g++
 
     - os: linux
-      dist: focal
+      dist: jammy
       compiler: clang
       sudo: required
       env: CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
   global:
     - CFLAGS="-Werror=implicit-function-declaration"
     - CXXFLAGS="-std=c++17"
-    - GRASS_EXTRA_CFLAGS="-Werror -fPIC"
-    - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC"
+    - GRASS_EXTRA_CFLAGS="-Werror -fPIC -Wfatal-errors"
+    - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
   global:
     - CFLAGS="-Werror=implicit-function-declaration"
     - CXXFLAGS="-std=c++17"
+    - GRASS_EXTRA_CFLAGS="-Werror -fPIC"
+    - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC"
 
 before_install:
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh

--- a/.travis/linux.before_install.sh
+++ b/.travis/linux.before_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Author: Ivan Mincik, ivan.mincik@gmail.com
 
 set -e

--- a/.travis/linux.install.sh
+++ b/.travis/linux.install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Author: Ivan Mincik, ivan.mincik@gmail.com
 
 set -e

--- a/.travis/linux.install.sh
+++ b/.travis/linux.install.sh
@@ -3,52 +3,7 @@
 
 set -e
 
-sudo apt-get install --no-install-recommends \
-        libcairo2-dev \
-        libfftw3-dev \
-        libfreetype6-dev \
-        libgdal-dev \
-        libgeos-dev \
-        libglu1-mesa-dev \
-        libgsl-dev \
-        libjpeg-dev \
-        liblapack-dev \
-        libncurses5-dev \
-        libnetcdf-dev \
-        libopenjp2-7 \
-        libopenjp2-7-dev \
-        libpdal-dev \
-        libpdal-plugin-python \
-        libpng-dev \
-        libmysqlclient-dev \
-        libpq-dev \
-        libproj-dev \
-        libreadline-dev \
-        libsqlite3-dev \
-        libtiff-dev \
-        libxmu-dev \
-        libzstd-dev \
-        python3 \
-        python3-dateutil \
-        python3-dev \
-        python3-numpy \
-        python3-pil \
-        python3-pip \
-        python3-ply \
-        python3-six \
-        python-wxgtk4.0 \
-        unixodbc-dev \
-        libnetcdf-dev \
-        autoconf2.13 \
-        autotools-dev \
-        debhelper \
-        ccache \
-        fakeroot \
-        flex \
-        bison \
-        netcdf-bin \
-        dpatch \
-        libblas-dev \
-        pdal \
-        proj-bin \
-        proj-data
+sudo apt-get update -y
+    sudo apt-get install -y wget git gawk findutils
+    xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
+        sudo apt-get install -y --no-install-recommends --no-install-suggests

--- a/.travis/linux.install.sh
+++ b/.travis/linux.install.sh
@@ -35,9 +35,10 @@ sudo apt-get install --no-install-recommends \
         python3-pil \
         python3-pip \
         python3-ply \
-        python-wxgtk3.0 \
+        python3-six \
+        python-wxgtk4.0 \
         unixodbc-dev \
-        libnetcdf-dev   \
+        libnetcdf-dev \
         autoconf2.13 \
         autotools-dev \
         debhelper \
@@ -45,7 +46,7 @@ sudo apt-get install --no-install-recommends \
         fakeroot \
         flex \
         bison \
-       netcdf-bin \
+        netcdf-bin \
         dpatch \
         libblas-dev \
         pdal \

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Author: Ivan Mincik, ivan.mincik@gmail.com
 
 set -e

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -32,7 +32,6 @@ echo "MAKEFLAGS is '$MAKEFLAGS'"
             --with-freetype-includes=/usr/include/freetype2/ \
             --with-postgres-includes=/usr/include/postgresql/ \
             --with-proj-share=/usr/share/proj \
-            --with-python \
             --with-cairo \
             --with-pdal
 

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -29,6 +29,7 @@ export CXX="ccache $CXX"
             --with-postgres-includes=/usr/include/postgresql/ \
             --with-proj-share=/usr/share/proj \
             --with-python \
-            --with-cairo
+            --with-cairo \
+            --with-pdal
 
 make -j2

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -35,4 +35,4 @@ echo "MAKEFLAGS is '$MAKEFLAGS'"
             --with-cairo \
             --with-pdal
 
-make
+make CFLAGS="$CFLAGS $GRASS_EXTRA_CFLAGS" CXXFLAGS="$CXXFLAGS $GRASS_EXTRA_CXXFLAGS"

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -5,7 +5,7 @@ set -e
 
 export CC="ccache $CC"
 export CXX="ccache $CXX"
-export MAKEFLAGS="-j $(nproc)"
+export MAKEFLAGS="-j $(nproc) --no-keep-going"
 
 echo "MAKEFLAGS is '$MAKEFLAGS'"
 

--- a/.travis/linux.script.sh
+++ b/.travis/linux.script.sh
@@ -5,6 +5,10 @@ set -e
 
 export CC="ccache $CC"
 export CXX="ccache $CXX"
+export MAKEFLAGS="-j $(nproc)"
+
+echo "MAKEFLAGS is '$MAKEFLAGS'"
+
 ./configure --host=x86_64-linux-gnu \
             --build=x86_64-linux-gnu \
             --prefix=/usr/lib \
@@ -32,4 +36,4 @@ export CXX="ccache $CXX"
             --with-cairo \
             --with-pdal
 
-make -j2
+make

--- a/db/drivers/odbc/describe.c
+++ b/db/drivers/odbc/describe.c
@@ -9,9 +9,7 @@
 
 int set_column_type(dbColumn *column, int otype);
 
-int db__driver_describe_table(table_name, table)
-dbString *table_name;
-dbTable **table;
+int db__driver_describe_table(dbString *table_name, dbTable **table)
 {
     char *name = NULL;
     SQLINTEGER err;
@@ -60,9 +58,7 @@ dbTable **table;
     return DB_OK;
 }
 
-int describe_table(stmt, table)
-SQLHSTMT stmt;
-dbTable **table;
+int describe_table(SQLHSTMT stmt, dbTable **table)
 {
     dbColumn *column;
     int col;
@@ -143,9 +139,7 @@ dbTable **table;
     return DB_OK;
 }
 
-int set_column_type(column, otype)
-dbColumn *column;
-int otype;
+int set_column_type(dbColumn *column, int otype)
 {
     int dbtype;
 

--- a/db/drivers/odbc/fetch.c
+++ b/db/drivers/odbc/fetch.c
@@ -3,10 +3,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_fetch(cn, position, more)
-dbCursor *cn;
-int position;
-int *more;
+int db__driver_fetch(dbCursor *cn, int position, int *more)
 {
     cursor *c;
     dbToken token;
@@ -163,8 +160,7 @@ int *more;
     return DB_OK;
 }
 
-int db__driver_get_num_rows(cn)
-dbCursor *cn;
+int db__driver_get_num_rows(dbCursor *cn)
 {
     cursor *c;
     dbToken token;

--- a/db/drivers/odbc/listtab.c
+++ b/db/drivers/odbc/listtab.c
@@ -3,10 +3,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_list_tables(tlist, tcount, system)
-dbString **tlist;
-int *tcount;
-int system;
+int db__driver_list_tables(dbString **tlist, int *tcount, int system)
 {
     cursor *c;
     dbString *list;


### PR DESCRIPTION
Default Python version reported by Travis for 20.04 is 3.7.13. While that's still a supported version for 8.3 release if it would be released now, 2023-06-27 is end of support for 3.7, so it seems safe to not test the main branch with 3.7 at this point.

Ubuntu 22.04 in Travis uses Python 3.10 by default according to the documentation.
