### PR TITLE
grass.gunittest: Fix usage of assertEquals() removed from Python 3.12

### DIFF
--- a/python/grass/script/testsuite/test_script_raster.py
+++ b/python/grass/script/testsuite/test_script_raster.py
@@ -27,15 +27,15 @@ class TestRaster(TestCase):
 
     def test_raster_what(self):
         res = gs.raster_what(self.raster, [self.coords])[0]
-        self.assertEquals(int(res[self.raster]["value"]), 100)
+        self.assertEqual(int(res[self.raster]["value"]), 100)
 
         res = gs.raster_what(self.raster, [self.coords], localized=True)[0]
-        self.assertEquals(int(res[self.raster][_("value")]), 100)
+        self.assertEqual(int(res[self.raster][_("value")]), 100)
 
     def test_raster_info(self):
         res = gs.raster_info(self.raster)
-        self.assertEquals(str(res["cols"]), str(self.region["cols"]))
-        self.assertEquals(str(res["north"]), str(self.region["n"]))
+        self.assertEqual(str(res["cols"]), str(self.region["cols"]))
+        self.assertEqual(str(res["north"]), str(self.region["n"]))
 
 
 if __name__ == "__main__":

--- a/python/grass/script/testsuite/test_start_command_functions.py
+++ b/python/grass/script/testsuite/test_start_command_functions.py
@@ -38,7 +38,7 @@ class TestPythonKeywordsInParameters(TestCase):
         proc = start_command("g.region", _raster_=self.raster, stderr=PIPE)
         stderr = proc.communicate()[1]
         returncode = proc.poll()
-        self.assertEquals(returncode, 1)
+        self.assertEqual(returncode, 1)
         self.assertIn(b"raster", stderr)
 
 
@@ -96,7 +96,7 @@ class TestPythonModuleWithStdinStdout(TestCase):
             separator=":",
         )
         res = read_command("r.category", map=self.raster, separator=":").strip()
-        self.assertEquals(res, "1:kůň\n2:kráva\n3:ovečka\n4:býk")
+        self.assertEqual(res, "1:kůň\n2:kráva\n3:ovečka\n4:býk")
         self.assertIsInstance(res, str)
 
     def test_write_labels_bytes(self):
@@ -112,7 +112,7 @@ class TestPythonModuleWithStdinStdout(TestCase):
         res = read_command(
             "r.category", map=self.raster, separator=":", encoding=None
         ).strip()
-        self.assertEquals(res, encode("1:kůň\n2:kráva\n3:ovečka\n4:býk"))
+        self.assertEqual(res, encode("1:kůň\n2:kráva\n3:ovečka\n4:býk"))
         self.assertIsInstance(res, bytes)
 
 

--- a/python/grass/script/testsuite/test_start_command_functions_nc.py
+++ b/python/grass/script/testsuite/test_start_command_functions_nc.py
@@ -27,14 +27,14 @@ class TestPythonKeywordsInParameters(TestCase):
         proc = start_command("g.region", _raster=self.raster, stderr=PIPE)
         stderr = proc.communicate()[1]
         returncode = proc.poll()
-        self.assertEquals(returncode, 0, msg="Underscore as prefix was not accepted")
+        self.assertEqual(returncode, 0, msg="Underscore as prefix was not accepted")
         self.assertNotIn(b"_raster", stderr)
 
     def test_suffixed_underscore(self):
         proc = start_command("g.region", raster_=self.raster, stderr=PIPE)
         stderr = proc.communicate()[1]
         returncode = proc.poll()
-        self.assertEquals(
+        self.assertEqual(
             returncode,
             0,
             msg="Underscore as suffix was not accepted, stderr is:\n%s" % stderr,
@@ -45,7 +45,7 @@ class TestPythonKeywordsInParameters(TestCase):
         proc = start_command("g.region", _raster_=self.raster, stderr=PIPE)
         stderr = proc.communicate()[1]
         returncode = proc.poll()
-        self.assertEquals(returncode, 1, msg="Underscore at both sides was accepted")
+        self.assertEqual(returncode, 1, msg="Underscore at both sides was accepted")
         self.assertIn(b"raster", stderr)
 
 

--- a/raster3d/r3.to.rast/testsuite/test_a_b_coeff.py
+++ b/raster3d/r3.to.rast/testsuite/test_a_b_coeff.py
@@ -147,7 +147,7 @@ class TestR3ToRast(TestCase):
             pattern="%s_*" % self.rast2d,
             exclude="%s_*" % self.rast2d_ref,
         )
-        self.assertEquals(
+        self.assertEqual(
             len(rasts), 4, msg="Wrong number of 2D rasters present" " in the mapset"
         )
         ref_info = dict(cells=9)

--- a/raster3d/r3.to.rast/testsuite/test_integer_rounding.py
+++ b/raster3d/r3.to.rast/testsuite/test_integer_rounding.py
@@ -149,7 +149,7 @@ class TestR3ToRastIntegerRounding(TestCase):
             pattern="%s_*" % self.rast2d,
             exclude="%s_*" % self.rast2d_ref,
         )
-        self.assertEquals(
+        self.assertEqual(
             len(rasts), 4, msg="Wrong number of 2D rasters present" " in the mapset"
         )
         ref_info = dict(cells=9)

--- a/raster3d/r3.to.rast/testsuite/test_nulls.py
+++ b/raster3d/r3.to.rast/testsuite/test_nulls.py
@@ -148,7 +148,7 @@ class TestR3ToRastNulls(TestCase):
             pattern="%s_*" % self.rast2d,
             exclude="%s_*" % self.rast2d_ref,
         )
-        self.assertEquals(
+        self.assertEqual(
             len(rasts), 4, msg="Wrong number of 2D rasters present" " in the mapset"
         )
         ref_info = dict(cells=9)

--- a/raster3d/r3.to.rast/testsuite/test_small_data.py
+++ b/raster3d/r3.to.rast/testsuite/test_small_data.py
@@ -145,7 +145,7 @@ class TestR3ToRast(TestCase):
             pattern="%s_*" % self.rast2d,
             exclude="%s_*" % self.rast2d_ref,
         )
-        self.assertEquals(
+        self.assertEqual(
             len(rasts), 4, msg="Wrong number of 2D rasters present" " in the mapset"
         )
         ref_info = dict(cells=9)


### PR DESCRIPTION
`unittest.assertEquals()` deprecated in python 3.2, removed in python 3.12