### PR TITLE
unittest: fix assertNotRegexMatches() removed from python 3.12

### DIFF
--- a/scripts/db.dropcolumn/testsuite/test_db_dropcolumn.py
+++ b/scripts/db.dropcolumn/testsuite/test_db_dropcolumn.py
@@ -46,7 +46,7 @@ class TestDbDropColumn(TestCase):
 
         m = SimpleModule("db.columns", table=self.mapName)
         self.assertModule(m)
-        self.assertNotRegexpMatches(decode(m.outputs.stdout), self.colName)
+        self.assertNotRegex(decode(m.outputs.stdout), self.colName)
 
 
 if __name__ == "__main__":

--- a/scripts/db.droptable/testsuite/test_db_droptable.py
+++ b/scripts/db.droptable/testsuite/test_db_droptable.py
@@ -43,7 +43,7 @@ class TestDbDropTable(TestCase):
 
         m = SimpleModule("db.tables", flags="p")
         self.assertModule(m)
-        self.assertNotRegexpMatches(decode(m.outputs.stdout), self.mapName)
+        self.assertNotRegex(decode(m.outputs.stdout), self.mapName)
 
 
 if __name__ == "__main__":

--- a/scripts/v.db.addtable/testsuite/test_v_db_addtable.py
+++ b/scripts/v.db.addtable/testsuite/test_v_db_addtable.py
@@ -36,7 +36,7 @@ class TestVDbAddTable(TestCase):
 
         m = SimpleModule("v.info", map="myroads", flags="c")
         self.assertModule(m)
-        self.assertNotRegexpMatches(decode(m.outputs.stdout), "slope")
+        self.assertNotRegex(decode(m.outputs.stdout), "slope")
 
         m = SimpleModule("v.info", map="myroads", flags="c", layer=2)
         self.assertModule(m)

--- a/scripts/v.db.dropcolumn/testsuite/test_v_db_dropcolumn.py
+++ b/scripts/v.db.dropcolumn/testsuite/test_v_db_dropcolumn.py
@@ -32,7 +32,7 @@ class TestVDbDropColumn(TestCase):
 
         m = SimpleModule("v.info", map="myroads", flags="c")
         self.assertModule(m)
-        self.assertNotRegexpMatches(decode(m.outputs.stdout), "SHAPE_LEN")
+        self.assertNotRegex(decode(m.outputs.stdout), "SHAPE_LEN")
 
 
 if __name__ == "__main__":

--- a/scripts/v.db.droptable/testsuite/test_v_db_droptable.py
+++ b/scripts/v.db.droptable/testsuite/test_v_db_droptable.py
@@ -41,7 +41,7 @@ class TestVDbDropTable(TestCase):
 
         m = SimpleModule("db.tables", flags="p")
         self.assertModule(m)
-        self.assertNotRegexpMatches(decode(m.outputs.stdout), "myroads")
+        self.assertNotRegex(decode(m.outputs.stdout), "myroads")
 
 
 if __name__ == "__main__":

--- a/scripts/v.db.renamecolumn/testsuite/test_v_db_renamecolumn.py
+++ b/scripts/v.db.renamecolumn/testsuite/test_v_db_renamecolumn.py
@@ -35,7 +35,7 @@ class TestVDbRenameColumn(TestCase):
         m = SimpleModule("v.info", flags="c", map="myroads")
         self.assertModule(m)
         self.assertRegexpMatches(decode(m.outputs.stdout), "roadname")
-        self.assertNotRegexpMatches(decode(m.outputs.stdout), "ROAD_NAME")
+        self.assertNotRegex(decode(m.outputs.stdout), "ROAD_NAME")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`unittest.assertNotRegexMatches()` deprecated in python 3.2, removed in python 3.12