### PR TITLE
Graphical Modeler: fix command parsing in "add tool" dialog

### DIFF
--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -325,8 +325,8 @@ class ModelSearchDialog(wx.Dialog):
 
     def OnCommand(self, cmd):
         """Command in prompt confirmed"""
-        if self.ValidateCmd(cmd):
-            self._command = cmd
+        if self.ValidateCmd(cmd['cmd']):
+            self._command = cmd['cmd']
             self.EndModal(wx.ID_OK)
 
     def OnOk(self, event):

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -325,8 +325,8 @@ class ModelSearchDialog(wx.Dialog):
 
     def OnCommand(self, cmd):
         """Command in prompt confirmed"""
-        if self.ValidateCmd(cmd['cmd']):
-            self._command = cmd['cmd']
+        if self.ValidateCmd(cmd["cmd"]):
+            self._command = cmd["cmd"]
             self.EndModal(wx.ID_OK)
 
     def OnOk(self, event):


### PR DESCRIPTION
## Steps to reproduce a bug

1. Add new tool into model
2. Enter selected GRASS tool in `Command`
3. Press Enter

![image](https://github.com/OSGeo/grass/assets/5683186/ee8d0978-d248-4f70-a52f-764bb4e3325a)

It fails with

```py
Traceback (most recent call last):
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/prompt.py", line 490, in OnKeyPressed
    self._runCmd(self.GetCurLine()[0].strip())
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/prompt.py", line 138, in _runCmd
    self.promptRunCmd.emit(cmd={"cmd": cmd, "cmdString": str(cmdString)})
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pydispatch/signal.py", line 233, in emit
    dispatcher.send(signal=self, *args, **kwargs)
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pydispatch/dispatcher.py", line 344, in send
    response = robustapply.robustApply(
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/dialogs.py", line 328, in OnCommand
    if self.ValidateCmd(cmd):
  File "/home/landa/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/dialogs.py", line 314, in ValidateCmd
    if cmd[0] not in globalvar.grassCmd:
KeyError: 0
```

Reason of failure: GPromptSTC's returns dictionary instead of list (which is expected by Graphical Modeler): https://github.com/OSGeo/grass/blob/main/gui/wxpython/gui_core/prompt.py#L138