### PR TITLE
wxGUI/digitizer: fix digitizer - VDigitToolbar.OnTool method was not called

### DIFF
--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -187,11 +187,6 @@ class VDigitWindow(BufferedMapWindow):
                 "ord": ord("F"),
                 "tool": self.toolbar.OnDeleteArea,
             },
-            "deleteArea": {
-                "evt": True,
-                "ord": ord("F"),
-                "tool": self.toolbar.OnDeleteArea,
-            },
             "editLine": {
                 "evt": True,
                 "ord": ord("E"),
@@ -239,24 +234,17 @@ class VDigitWindow(BufferedMapWindow):
             },
         }
 
-        def update_actual_tools():
-            event = None
-            if default_tools[tool]["evt"]:
-                event = wx.CommandEvent(id=getattr(self.toolbar, tool))
-            actual_tools[default_tools[tool]["ord"]] = {
-                "event": event,
-                "tool": default_tools[tool]["tool"],
-            }
-
+        # Custom vdigit tools if VDigitToolbar class tool param arg was defined
         actual_tools = {}
         for tool in default_tools:
-            # Default vdigit tools
-            # handle addArea menu addBoundary, addCentroid tools
-            if not self.toolbar.tools:
-                update_actual_tools()
-            # Custom vdigit tools if VDigitToolbar class tool param arg was defined
-            if self.toolbar.tools and hasattr(self.toolbar, tool):
-                update_actual_tools()
+            if hasattr(self.toolbar, tool):
+                event = None
+                if default_tools[tool]["evt"]:
+                    event = wx.CommandEvent(id=getattr(self.toolbar, tool))
+                actual_tools[default_tools[tool]["ord"]] = {
+                    "event": event,
+                    "tool": default_tools[tool]["tool"],
+                }
 
         if not shift:
             tool = actual_tools.get(kc)

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -136,86 +136,130 @@ class VDigitWindow(BufferedMapWindow):
         shift = event.ShiftDown()
         kc = event.GetKeyCode()
 
-        tools = {
-            ord("P"): {
-                "event": wx.CommandEvent(id=self.toolbar.addPoint),
+        default_tools = {
+            "addPoint": {
+                "evt": True,
+                "ord": ord("P"),
                 "tool": self.toolbar.OnAddPoint,
             },
-            ord("L"): {
-                "event": wx.CommandEvent(id=self.toolbar.addLine),
+            "addLine": {
+                "evt": True,
+                "ord": ord("L"),
                 "tool": self.toolbar.OnAddLine,
             },
-            ord("A"): {
-                "event": wx.CommandEvent(id=self.toolbar.addArea),
+            "addArea": {
+                "evt": True,
+                "ord": ord("A"),
                 "tool": self.toolbar.OnAddArea,
             },
-            ord("B"): {
-                "event": None,
+            "addBoundary": {
+                "evt": False,
+                "ord": ord("B"),
                 "tool": self.toolbar.OnAddBoundary,
             },
-            ord("C"): {
-                "event": None,
+            "addCentroid": {
+                "evt": False,
+                "ord": ord("C"),
                 "tool": self.toolbar.OnAddCentroid,
             },
-            ord("V"): {
-                "event": wx.CommandEvent(id=self.toolbar.addVertex),
+            "addVertex": {
+                "evt": True,
+                "ord": ord("V"),
                 "tool": self.toolbar.OnAddVertex,
             },
-            ord("X"): {
-                "event": wx.CommandEvent(id=self.toolbar.removeVertex),
+            "removeVertex": {
+                "evt": True,
+                "ord": ord("X"),
                 "tool": self.toolbar.OnRemoveVertex,
             },
-            ord("G"): {
-                "event": wx.CommandEvent(id=self.toolbar.moveVertex),
+            "moveVertex": {
+                "evt": True,
+                "ord": ord("G"),
                 "tool": self.toolbar.OnMoveVertex,
             },
-            ord("D"): {
-                "event": wx.CommandEvent(id=self.toolbar.deleteLine),
+            "deleteLine": {
+                "evt": True,
+                "ord": ord("D"),
                 "tool": self.toolbar.OnDeleteLine,
             },
-            ord("F"): {
-                "event": wx.CommandEvent(id=self.toolbar.deleteArea),
+            "deleteArea": {
+                "evt": True,
+                "ord": ord("F"),
                 "tool": self.toolbar.OnDeleteArea,
             },
-            ord("E"): {
-                "event": wx.CommandEvent(id=self.toolbar.editLine),
+            "deleteArea": {
+                "evt": True,
+                "ord": ord("F"),
+                "tool": self.toolbar.OnDeleteArea,
+            },
+            "editLine": {
+                "evt": True,
+                "ord": ord("E"),
                 "tool": self.toolbar.OnEditLine,
             },
-            ord("M"): {
-                "event": wx.CommandEvent(id=self.toolbar.moveLine),
+            "moveLine": {
+                "evt": True,
+                "ord": ord("M"),
                 "tool": self.toolbar.OnMoveLine,
             },
-            ord("J"): {
-                "event": wx.CommandEvent(id=self.toolbar.displayCats),
+            "displayCats": {
+                "evt": True,
+                "ord": ord("J"),
                 "tool": self.toolbar.OnDisplayCats,
             },
-            ord("K"): {
-                "event": wx.CommandEvent(id=self.toolbar.displayAttr),
+            "displayAttr": {
+                "evt": True,
+                "ord": ord("K"),
                 "tool": self.toolbar.OnDisplayAttr,
             },
-            ord("Z"): {
-                "event": wx.CommandEvent(id=self.toolbar.undo),
+            "undo": {
+                "evt": True,
+                "ord": ord("Z"),
                 "tool": self.toolbar.OnUndo,
             },
-            ord("Y"): {
-                "event": wx.CommandEvent(id=self.toolbar.redo),
+            "redo": {
+                "evt": True,
+                "ord": ord("Y"),
                 "tool": self.toolbar.OnRedo,
             },
-            ord("T"): {
-                "event": wx.CommandEvent(id=self.toolbar.settings),
+            "settings": {
+                "evt": True,
+                "ord": ord("T"),
                 "tool": self.toolbar.OnSettings,
             },
-            ord("H"): {
-                "event": wx.CommandEvent(id=self.toolbar.help),
+            "help": {
+                "evt": True,
+                "ord": ord("H"),
                 "tool": self.toolbar.OnHelp,
             },
-            ord("Q"): {
-                "event": wx.CommandEvent(id=self.toolbar.quit),
+            "quit": {
+                "evt": True,
+                "ord": ord("Q"),
                 "tool": self.toolbar.OnExit,
             },
         }
+
+        def update_actual_tools():
+            event = None
+            if default_tools[tool]["evt"]:
+                event = wx.CommandEvent(id=getattr(self.toolbar, tool))
+            actual_tools[default_tools[tool]["ord"]] = {
+                "event": event,
+                "tool": default_tools[tool]["tool"],
+            }
+
+        actual_tools = {}
+        for tool in default_tools:
+            # Default vdigit tools
+            # handle addArea menu addBoundary, addCentroid tools
+            if not self.toolbar.tools:
+                update_actual_tools()
+            # Custom vdigit tools if VDigitToolbar class tool param arg was defined
+            if self.toolbar.tools and hasattr(self.toolbar, tool):
+                update_actual_tools()
+
         if not shift:
-            tool = tools.get(kc)
+            tool = actual_tools.get(kc)
             if tool:
                 event = self.toolbar.OnTool(tool["event"])
                 tool["tool"](event)

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -237,14 +237,16 @@ class VDigitWindow(BufferedMapWindow):
         # Custom vdigit tools if VDigitToolbar class tool param arg was defined
         actual_tools = {}
         for tool in default_tools:
-            if hasattr(self.toolbar, tool):
-                event = None
-                if default_tools[tool]["evt"]:
-                    event = wx.CommandEvent(id=getattr(self.toolbar, tool))
-                actual_tools[default_tools[tool]["ord"]] = {
-                    "event": event,
-                    "tool": default_tools[tool]["tool"],
-                }
+            # custom tools, e.g. in g.gui.iclass
+            if self.toolbar.tools and tool not in self.toolbar.tools:
+                continue
+            event = None
+            if default_tools[tool]["evt"] and hasattr(self.toolbar, tool):
+                event = wx.CommandEvent(id=getattr(self.toolbar, tool))
+            actual_tools[default_tools[tool]["ord"]] = {
+                "event": event,
+                "tool": default_tools[tool]["tool"],
+            }
 
         if not shift:
             tool = actual_tools.get(kc)

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -449,7 +449,7 @@ class VDigitToolbar(BaseToolbar):
             3,
             f"VDigitToolbar.OnTool(): id = {event.GetId() if event else event}",
         )
-        if self.toolSwitcher:
+        if self.toolSwitcher and event:
             self.toolSwitcher.ToolChanged(event.GetId())
 
         # set cursor
@@ -471,7 +471,8 @@ class VDigitToolbar(BaseToolbar):
         if self.action["id"] == -1:
             self.action = {"desc": "", "type": "", "id": -1}
 
-        event.Skip()
+        if event:
+            event.Skip()
 
     def OnAddPoint(self, event):
         """Add point to the vector map Laier"""

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -54,6 +54,9 @@ class VDigitToolbar(BaseToolbar):
             self.editingStopped.connect(layerTree.StopEditing)
             self.editingBgMap.connect(layerTree.SetBgMapForEditing)
 
+        # replace OnTool from controller
+        self.controller.OnTool = self.OnTool
+
         # bind events
         self.Bind(wx.EVT_SHOW, self.OnShow)
 
@@ -446,14 +449,15 @@ class VDigitToolbar(BaseToolbar):
             3,
             f"VDigitToolbar.OnTool(): id = {event.GetId() if event else event}",
         )
+        if self.toolSwitcher:
+            self.toolSwitcher.ToolChanged(event.GetId())
+
         # set cursor
         self.MapWindow.SetNamedCursor("cross")
         self.MapWindow.mouse["box"] = "point"
         self.MapWindow.mouse["use"] = "pointer"
 
         aId = self.action.get("id", -1)
-        if event:
-            BaseToolbar.OnTool(self, event)
 
         # clear tmp canvas
         if self.action["id"] != aId or aId == -1:
@@ -467,8 +471,7 @@ class VDigitToolbar(BaseToolbar):
         if self.action["id"] == -1:
             self.action = {"desc": "", "type": "", "id": -1}
 
-        # set focus
-        self.MapWindow.SetFocus()
+        event.Skip()
 
     def OnAddPoint(self, event):
         """Add point to the vector map Laier"""


### PR DESCRIPTION
The bug could be reproduced by:

1. Starting digitizer
2. Switch to panning
3. Switch to a digitizer tool -> doesn't work

Also g.gui.iclass doesn't work.

The toolbar tools were bound to the ToolbarController.OnTool method, this PR replaces the controller's method in runtime by the specific one in digitizer toolbar. Probably there could be a better solution, but this seems to work and the code is changed minimally.

Unrelated change is removing setting focus, seems to help with using keyboard shortcuts. 