### PR TITLE
contributing: release procedure updates (G83)

### DIFF
--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -71,14 +71,17 @@ Modify the VERSION file use the dedicated script, for RC1, e.g.:
 ```
 
 The script will compute the correct version string and print a message
-containing it into the terminal (e.g., "version: GRASS GIS 8.3.0RC1").
+containing it into the terminal (e.g., "version: GRASS GIS 3.5.0RC1").
 
 Commit with a commit message suggested by the script, e.g.:
 
 ```bash
 git diff
-git commit include/VERSION -m "version: GRASS GIS 8.3.0RC1"
+git commit include/VERSION -m "..."
 ```
+
+If you lost the script output with the suggested message use
+`./utils/update_version.py suggest` to get it.
 
 Check that there is exactly one commit on your local branch and that it is the
 version change:
@@ -139,7 +142,7 @@ Create an annotated tag (a lightweight tag is okay too, but there is more metada
 stored for annotated tags including a date; message is suggested by the version script):
 
 ```bash
-git tag $TAG -a -m "GRASS GIS 8.3.0RC1"
+git tag $TAG -a -m "..."
 ```
 
 List all tags (annotated will be at the top of both lists):
@@ -238,8 +241,16 @@ Commit with the suggested commit message and push, e.g.:
 
 ```bash
 git show
-git commit include/VERSION -m "version: Back to 8.3.0dev"
+git commit include/VERSION -m "..."
 git push upstream
+```
+
+The message was suggested by the script, but if you lost that output,
+you can get the same or similar message again using the script
+(the message provided this way is not precise after RCs):
+
+```bash
+./utils/update_version.py suggest
 ```
 
 ## Upload to OSGeo servers
@@ -256,7 +267,7 @@ First, update the repo to get the tag locally:
 git fetch upstream
 ```
 
-Get the tagged source code, e.g.:
+Get the tagged source code, e.g. (modify the tag as needed):
 
 ```bash
 git checkout 8.3.0RC1
@@ -392,7 +403,7 @@ Software pages:
 
 ### Only in case of new major release
 
-- update cronjob '[cron_grass8_main_src_snapshot.sh](https://github.com/OSGeo/grass-addons/tree/grass8/utils/cronjobs_osgeo_lxd/)'
+- update '[cronjob(s)](https://github.com/OSGeo/grass-addons/tree/grass8/utils/cronjobs_osgeo_lxd/)'
   on grass.osgeo.org to next but one release tag for the differences
 - wiki updates, only when new major release:
   - {{cmd|xxxx}} macro: <https://grasswiki.osgeo.org/wiki/Template:Cmd>
@@ -465,9 +476,13 @@ the dedicated script, e.g., for next micro version, run:
 ./utils/update_version.py status
 ```
 
-Now commit the change to the branch with the commit message generated above:
+Now commit the change to the branch with the commit message generated above
+by the script:
 
 ```bash
 git diff
-git commit include/VERSION -m "version: GRASS GIS 8.3.1"
+git commit include/VERSION -m "..."
 ```
+
+If you lost the script output with the suggested message use
+`./utils/update_version.py suggest` to get it.

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -167,7 +167,9 @@ Generate a draft of release notes using a script. The script the script needs to
 run from the top directory and will expect its configuration files
 to be in the *utils* directory.
 
-For **major and minor releases**, GitHub API gives good results for the first
+#### Major and minor releases
+
+For major and minor releases, GitHub API gives good results for the first
 release candidate because it contains contributor handles and can identify
 new contributors, so use with the *api* backend, e.g.:
 
@@ -175,7 +177,9 @@ new contributors, so use with the *api* backend, e.g.:
 python ./utils/generate_release_notes.py api releasebranch_8_3 8.2.0 $VERSION
 ```
 
-For **micro releases**, GitHub API does not give good results because it uses PRs
+#### Micro releases
+
+For micro releases, GitHub API does not give good results because it uses PRs
 while the backports are usually direct commits without PRs.
 The *git log* command operates on commits, so use use the *log* backend:
 
@@ -183,12 +187,16 @@ The *git log* command operates on commits, so use use the *log* backend:
 python ./utils/generate_release_notes.py log releasebranch_8_3 8.3.0 $VERSION
 ```
 
-In between **RCs** and between last RC and final release, the *log* backend is useful
+#### RCs
+
+In between RCs and between last RC and final release, the *log* backend is useful
 for showing updates since the last RC:
 
 ```bash
 python ./utils/generate_release_notes.py log releasebranch_8_3 8.3.0RC1 $VERSION
 ```
+
+#### Finalizing the release notes
 
 For the final release, the changes accumulated since the first RC need to be
 added manually to the result from the *api* backend.
@@ -227,7 +235,7 @@ After an RC, switch to development version:
 ./utils/update_version.py dev
 ```
 
-After a final release, switch to development version for the next micro, minor,
+Next switch back to the development version for the next micro, minor,
 or major version, e.g., for micro version, use:
 
 ```bash
@@ -252,6 +260,10 @@ you can get the same or similar message again using the script
 ```bash
 ./utils/update_version.py suggest
 ```
+## Publish release
+
+For the final release, edit the draft release again and publish it using the
+"Publish release" button.
 
 ## Upload to OSGeo servers
 

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -6,8 +6,8 @@
 - You have communicated with a development coordinator.
 - You have evaluated status of issues and PRs associated with the relevant milestone.
 - You have already cloned the repo with Git.
-- Your own fork is the remote called "origin".
 - The OSGeo repo is the remote called "upstream".
+- Your own fork is the remote called "origin" or "fork".
 - You don't have any local un-pushed or un-committed changes.
 - You are using Bash or a similar shell.
 
@@ -351,6 +351,23 @@ ssh $USER@$SERVER1 "cd $SERVER1DIR ; ln -s grass-$VERSION.tar.md5sum grass-$MAJO
 echo "https://grass.osgeo.org/grass$MAJOR$MINOR/source/"
 ```
 
+### Update redirects
+
+For final minor and major releases (not release candidates and micro releases),
+update `grass-stable` redirect at `osgeo7-grass`:
+
+```bash
+sudo vim /etc/apache2/sites-enabled/000-default.conf`
+```
+
+Load the new configuration:
+
+```bash
+sudo systemctl reload apache2`
+```
+
+For new branches: Update `grass-devel` using the steps above.
+
 ## Update winGRASS related files
 
 Update the winGRASS version at <https://github.com/landam/wingrass-maintenance-scripts/>:
@@ -362,7 +379,7 @@ vim wingrass-maintenance-scripts/grass_copy_wwwroot.sh
 vim wingrass-maintenance-scripts/cronjob.sh       # major/minor release only
 ```
 
-## Update addon builders
+## Update binary and addon builders
 
 Add the new version to repos which build or test addons:
 
@@ -388,8 +405,8 @@ Release is done.
 
 ## Improve release description
 
-For final releases only, go to Zenodo a get a Markdown badge for the release
-which Zenodo creates with a DOI for the published released.
+For final releases only, go to Zenodo.org a get a Markdown badge for the release
+which Zenodo creates with a DOI for the published release.
 
 For all releases, click the Binder badge to get Binder to build. Use it to test
 it and to cache the built image. Add more links to (or badges for) more notebooks
@@ -397,7 +414,7 @@ if there are any which show well specific features added or updated in the relea
 
 ## Create entries for the new release
 
-### Trac Wiki release page
+### Trac Wiki release page entry
 
 Add entry in <https://trac.osgeo.org/grass/wiki/Release>
 
@@ -434,6 +451,7 @@ Subsequently, verify the software pages:
 
 ### WinGRASS notes
 
+- Go to <https://github.com/landam/wingrass-maintenance-scripts/>
 - Update grass_packager_release.bat, eg.
 
 ```bash
@@ -467,21 +485,23 @@ Subsequently, verify the software pages:
 
 ## Tell others about release
 
-- If release candidate:
+- If release candidate (send just a short invitation to test):
   - <grass-announce@lists.osgeo.org>
   - <grass-dev@lists.osgeo.org>
-- If official release:
-  - publish related announcement press release at:
-- Our GRASS web site: /announces/
-  - Note: DON'T use relative links there
+
+If final release, send out an announcement (press release) which is a shortened
+version of release desciption and website news item (under `/announces/`).
+Note: Do not use relative links.
+
 - Our main mailing lists:
   - <https://lists.osgeo.org/mailman/listinfo/grass-announce> | <grass-announce@lists.osgeo.org>
+    (ask a development coordinator to be added)
   - <https://lists.osgeo.org/mailman/listinfo/grass-dev> | <grass-dev@lists.osgeo.org>
   - <https://lists.osgeo.org/mailman/listinfo/grass-user> | <grass-user@lists.osgeo.org>
-- FreeGIS: <freegis-list@intevation.de>
-- OSGeo.org: <news_item@osgeo.org>, <info@osgeo.org>
+- OSGeo.org: <news_item@osgeo.org>, <info@osgeo.org> (send an email, then it
+  will be approved)
 
-Via Web / Social media:
+Via web and social media:
 
 - See: <https://grass.osgeo.org/wiki/Contact_Databases>
 

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -319,13 +319,13 @@ md5sum grass-${VERSION}.tar.gz > grass-${VERSION}.md5sum
 
 ### Upload source code tarball to OSGeo servers
 
-Note: servers 'osgeo8-grass' and 'osgeo7-download' only reachable via
+Note: servers 'osgeo7-grass' and 'osgeo7-download' only reachable via
       jumphost (managed by OSGeo-SAC) - see <https://wiki.osgeo.org/wiki/SAC_Service_Status#grass>
 
 ```bash
 # Store the source tarball (twice) in (use scp -p FILES grass:):
 USER=neteler
-SERVER1=osgeo8-grass
+SERVER1=osgeo7-grass
 SERVER1DIR=/var/www/code_and_data/grass$MAJOR$MINOR/source/
 SERVER2=osgeo7-download
 SERVER2DIR=/osgeo/download/grass/grass$MAJOR$MINOR/source/

--- a/doc/howto_release.md
+++ b/doc/howto_release.md
@@ -227,7 +227,7 @@ Save the modified draft, but do not publish the release yet.
 
 ## Reset include/VERSION file to git development version
 
-Use a dedicated script to edit the VERSION file.
+Use the dedicated `update_version.py` script to edit the VERSION file.
 
 After an RC, switch to development version:
 
@@ -260,6 +260,7 @@ you can get the same or similar message again using the script
 ```bash
 ./utils/update_version.py suggest
 ```
+
 ## Publish release
 
 For the final release, edit the draft release again and publish it using the
@@ -375,7 +376,8 @@ Add the new version to repos which build or test addons:
 For a final release (not release candidate), close the related milestone at
 <https://github.com/OSGeo/grass/milestones>.
 If there are any open issues or PRs, move them to another milestone
-in the milestone view (all can be moved at once).
+in the milestone view (all can be moved at once by selecting the open
+issues and PRs and reassigning the next milestone).
 
 ## Publish the release
 
@@ -399,19 +401,24 @@ if there are any which show well specific features added or updated in the relea
 
 Add entry in <https://trac.osgeo.org/grass/wiki/Release>
 
-### Update Hugo web site to show new version
+### Update Hugo web site and other pages to show the new version
 
 For a (final) release (not release candidate), write announcement and publish it:
 
 - News section, <https://github.com/OSGeo/grass-website/tree/master/content/news>
 
-Software pages:
+Increment the GRASS GIS version in
+
+- <https://github.com/OSGeo/grass-website/blob/master/data/grass.json>
+- <https://github.com/OSGeo/grass-website/blob/master/content/about/history/releases.md>
+
+Update the version in the Wiki page: <https://grasswiki.osgeo.org/wiki/GRASS-Wiki>
+
+Subsequently, verify the software pages:
 
 - Linux: <https://github.com/OSGeo/grass-website/blob/master/content/download/linux.en.md>
 - Windows: <https://github.com/OSGeo/grass-website/blob/master/content/download/windows.en.md>
 - Mac: <https://github.com/OSGeo/grass-website/blob/master/content/download/mac.en.md>
-- Releases: <https://github.com/OSGeo/grass-website/blob/master/content/about/history/releases.md>
-- Wiki: <https://grasswiki.osgeo.org/wiki/GRASS-Wiki>
 
 ### Only in case of new major release
 

--- a/doc/infrastructure.md
+++ b/doc/infrastructure.md
@@ -1,7 +1,7 @@
 # How the GRASS GIS Webserver and related infrastructure works
 
 written by M. Neteler
-Last changed: July 2020
+Last changed: June 2023
 
 Related Wiki documents:
 
@@ -16,7 +16,7 @@ than in SVN).
 
 The GitHub repositories are:
 
-* GRASS GIS core (7.x): <https://github.com/OSGeo/grass>
+* GRASS GIS core (7+): <https://github.com/OSGeo/grass>
 * GRASS GIS legacy (3.x-6.x): <https://github.com/OSGeo/grass-legacy>
 * GRASS GIS Add-ons: <https://github.com/OSGeo/grass-addons>
 * GRASS GIS promotional material: <https://github.com/OSGeo/grass-promo>
@@ -56,11 +56,11 @@ Statistics:
 Maintainer: M. Neteler
 
 * <https://grass.osgeo.org>
-  * osgeo8-grass: LXD container on osgeo8 (<https://wiki.osgeo.org/wiki/SAC_Service_Status#osgeo_8>)
+  * osgeo7-grass: LXD container on osgeo7 (<https://wiki.osgeo.org/wiki/SAC_Service_Status#osgeo_7>)
     * OS: Debian Buster
     * Apache Server with hugo (<https://github.com/OSGeo/grass-website>)
   * for migration details (7/2020), see <https://github.com/OSGeo/grass-website/issues/180>
-  * ssh login: via jumphost hop.osgeo8.osgeo.org
+  * ssh login: via jumphost hop.osgeo7.osgeo.org
   * deployment via cronjob: <https://github.com/OSGeo/grass-addons/tree/grass8/utils/cronjobs_osgeo_lxd/>
 * <https://old.grass.osgeo.org> (CMSMS, replaced in 2020 by above hugo based solution)
   * Shared virtual OSGeo machine (osgeo6) hosted at Oregon State University
@@ -71,7 +71,7 @@ Maintainer: M. Neteler
     * Apache Server with PHP
   * Login: via OSGeo LDAP, there is a "grass" LDAP group
 * Backups:
-  * osgeo8-grass: container on osgeo8 is backup'ed, see <http://wiki.osgeo.org/wiki/SAC:Backups>
+  * osgeo7-grass: container on osgeo7 is backup'ed, see <http://wiki.osgeo.org/wiki/SAC:Backups>
 * Mirrors:
   * rsync, see <https://grass.osgeo.org/contribute/>  --> Mirror
   * mirror list, see <https://grass.osgeo.org/about/mirrors/>
@@ -79,15 +79,15 @@ Maintainer: M. Neteler
 
 * Weekly software snapshots (generated Saturday morning Portland (OR), US time):
   * Source code tarball of git (GitHub) <https://github.com/OSGeo/grass>
-  * Linux binary snapshot is compiled on osgeo8-grass
+  * Linux binary snapshot is compiled on osgeo7-grass
     * GRASS is compiled with GDAL, PROJ, SQLite, MySQL, PostgreSQL, FFTW, C++ support
     * binary tar.gz and manuals are moved into Web space
 
 * GRASS user manual HTML:
-  * generated during compilation of weekly Linux binary snapshot on osgeo8-grass
+  * generated during compilation of weekly Linux binary snapshot on osgeo7-grass
 
 * GRASS addons manual HTML:
-  * generated during compilation of weekly Linux binary snapshot on osgeo8-grass
+  * generated during compilation of weekly Linux binary snapshot on osgeo7-grass
 
 * GRASS programmer's manual (<https://grass.osgeo.org/programming8/>)
   * HTML: cronjob run Wednesday morning Portland (OR), US time


### PR DESCRIPTION
- partial sync to document version in `main`
- markdown linting fixes
- some outdated version numbers updated
- fix path to helper script

Note: PRs for the other branches will be created separately (do not back-/forward-port this PR).