### PR TITLE
contributing: Add empty line after heading in release notes

### DIFF
--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -64,6 +64,14 @@ def split_to_categories(changes, categories):
     return by_category
 
 
+def print_section_heading_2(text, file=None):
+    print(f"### {text}\n", file=file)
+
+
+def print_section_heading_3(text, file=None):
+    print(f"### {text}\n", file=file)
+
+
 def print_category(category, changes, file=None):
     """Print changes for one category from dictionary of changes
 
@@ -72,7 +80,7 @@ def print_category(category, changes, file=None):
     items = changes.get(category, None)
     if not items:
         return
-    print(f"### {category}", file=file)
+    print_section_heading_3(category, file=file)
     for item in sorted(items):
         print(f"* {item}", file=file)
     print("")
@@ -109,7 +117,7 @@ def print_notes(
 
     if before:
         print(before)
-    print("## What's Changed", file=file)
+    print_section_heading_2("What's Changed", file=file)
     changes_by_category = split_to_categories(changes, categories=categories)
     print_by_category(changes_by_category, categories=categories, file=file)
     if after:


### PR DESCRIPTION
Based on the issue reported on Gitter 'there must be an empty line after the section titles to be valid MD.' This adds an extra newline after the headings generated by the script. Some headings are generated by the GitHub API and they don't include the line. GitHub rendering works well for both versions.
