### PR TITLE
g.extension: if copied files exists do not print warning message

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2334,6 +2334,8 @@ def check_style_file(name):
 
     try:
         shutil.copyfile(dist_file, addons_file)
+    except shutil.SameFileError:
+        pass
     except OSError as error:
         gs.warning(
             _(


### PR DESCRIPTION
Fixes #3052.