### PR TITLE
Fix spelling errors.

### DIFF
--- a/scripts/g.extension/g.extension.html
+++ b/scripts/g.extension/g.extension.html
@@ -91,7 +91,7 @@ branch is downloaded, unless a specific branch is requested in the
 <em>branch</em> option.
 
 Of course, a user can still specify the full URL of a ZIP file e.g. for a
-specific release and install the achived code in this way (ZIP file mechanism
+specific release and install the archived code in this way (ZIP file mechanism
 will be applied).
 
 <p>


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * achived -> archived