### PR TITLE
Docker alpine: add additional GDAL driver

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -24,8 +24,10 @@ ENV GRASS_RUN_PACKAGES="\
       gcc \
       gdal \
       gdal-dev \
+      gdal-driver-GMLAS \
       gdal-driver-HDF5 \
       gdal-driver-JP2OpenJPEG \
+      gdal-driver-LIBKML \
       gdal-driver-netCDF \
       gdal-driver-PG \
       gdal-driver-PNG \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -24,6 +24,12 @@ ENV GRASS_RUN_PACKAGES="\
       gcc \
       gdal \
       gdal-dev \
+      gdal-driver-HDF5 \
+      gdal-driver-JP2OpenJPEG \
+      gdal-driver-netCDF \
+      gdal-driver-PG \
+      gdal-driver-PNG \
+      gdal-driver-WMS \
       gdal-tools \
       gettext \
       geos \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -28,7 +28,9 @@ ENV GRASS_RUN_PACKAGES="\
       gdal-driver-HDF5 \
       gdal-driver-JP2OpenJPEG \
       gdal-driver-LIBKML \
+      gdal-driver-MSSQLSpatial \
       gdal-driver-netCDF \
+      gdal-driver-ODBC \
       gdal-driver-PG \
       gdal-driver-PNG \
       gdal-driver-WMS \
@@ -183,6 +185,14 @@ RUN cp /usr/local/grass84/gui/wxpython/xml/module_items.xml module_items.xml; \
     mkdir -p /usr/local/grass84/gui/wxpython/xml/; \
     mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
 
+RUN git clone https://github.com/OSGeo/gdal-grass /src/gdal-grass
+WORKDIR /src/gdal-grass
+RUN ./configure \
+    --with-gdal=/usr/bin/gdal-config \
+    --with-grass=/usr/local/grass84 && \
+    make -j $NUMTHREADS && \
+    make install -j $NUMTHREADS
+
 
 FROM common as grass
 
@@ -196,9 +206,10 @@ ENV GRASSBIN="/usr/local/bin/grass" \
     GRASSBIN=grass \
     LC_ALL="en_US.UTF-8"
 
-# Copy GRASS GIS from build image
+# Copy GRASS GIS and GDAL GRASS driver from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
+COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
 # run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/
 COPY docker/testdata/test_grass_session.py docker/alpine/grass_tests.sh /scripts/


### PR DESCRIPTION
In `alpine:3.18` many GDAL drivers were removed from the base package to reduce package size [(see related alpine aports issue here)](https://gitlab.alpinelinux.org/alpine/aports/-/issues/14910). Instead they can be installed individually. A list of all available additional drivers can be found [here](https://pkgs.alpinelinux.org/packages?name=gdal-driver*&branch=v3.18&repo=&arch=x86_64&maintainer=). Few were already removed from 3.15 to 3.17. 

This PR suggests to add the possibly most common ones.
Following a list of which drivers were removed from `gdal-tools` package between `alpine:3.17` and `alpine 3.18` :
```
vector
  4   BAG -raster,multidimensional raster,vector- (rw+v): Bathymetry Attributed Grid
  5   CAD -raster,vector- (rovs): AutoCAD Driver
  8   Carto -vector- (rw+): Carto
 15   Elasticsearch -vector- (rw+): Elastic Search
 16   FITS -raster,vector- (rw+): Flexible Image Transport System
 19   GMLAS -vector- (rwv): Geography Markup Language (GML) driven by application schemas
 32   JP2OpenJPEG -raster,vector- (rwv): JPEG-2000 driver based on OpenJPEG library
 34   LIBKML -vector- (rw+v): Keyhole Markup Language (LIBKML)
 37   MSSQLSpatial -vector- (rw+): Microsoft SQL Server Spatial Database
 42   MySQL -vector- (rw+): MySQL
 46   ODBC -vector- (ro):
 50   OGR_OGDI -vector- (ro): OGDI Vectors (VPF, VMAP, DCW)
 56   PCIDSK -raster,vector- (rw+v): PCIDSK Database File
 57   PDF -raster,vector- (rw+vs): Geospatial PDF
 61   PLSCENES -raster,vector- (ro): Planet Labs Scenes API
 62   PostgreSQL -vector- (rw+): PostgreSQL/PostGIS
 72   VFK -vector- (ro): Czech Cadastral Exchange Data Format
 76   XLS -vector- (ro): MS Excel format
 78   netCDF -raster,multidimensional raster,vector- (rw+s): Network Common Data Format

raster
 87   BAG -raster,multidimensional raster,vector- (rw+v): Bathymetry Attributed Grid
 94   CAD -raster,vector- (rovs): AutoCAD Driver
119   EXR -raster- (rw+vs): Extended Dynamic Range Image File Format
122   FITS -raster,vector- (rw+): Flexible Image Transport System
136   HDF5 -raster,multidimensional raster- (rovs): Hierarchical Data Format Release 5
137   HDF5Image -raster- (rov): HDF5 Dataset
138   HEIF -raster- (rov): ISO/IEC 23008-12:2017 High Efficiency Image File Format
150   JP2OpenJPEG -raster,vector- (rwv): JPEG-2000 driver based on OpenJPEG library
152   KEA -raster- (rw+v): KEA Image Format (.kea)
177   PCIDSK -raster,vector- (rw+v): PCIDSK Database File
178   PCRaster -raster- (rw+): PCRaster Raster File
179   PDF -raster,vector- (rw+vs): Geospatial PDF
183   PLSCENES -raster,vector- (ro): Planet Labs Scenes API
184   PNG -raster- (rwv): Portable Network Graphics
187   PostGISRaster -raster- (rws): PostGIS Raster driver
218   WEBP -raster- (rwv): WEBP
219   WMS -raster- (rwvs): OGC Web Map Service
225   netCDF -raster,multidimensional raster,vector- (rw+s): Network Common Data Format
```

What do you think about the selection I made @wenzeslaus @pesekon2 @neteler ?
Anyones redundant or missing?
