### PR TITLE
Update v.reclass.html: either 'rules' or 'column' option must be specified

### DIFF
--- a/vector/v.reclass/v.reclass.html
+++ b/vector/v.reclass/v.reclass.html
@@ -27,6 +27,8 @@ order.
 <p>For dissolving common boundaries, see
 <em><a href="v.dissolve.html">v.dissolve</a></em>.
 
+<p>Either <b>rules</b> or <b>column</b> option must be specified.
+
 <h2>EXAMPLES</h2>
 
 <h3>Example 1: Reclass by rules</h3>

--- a/vector/v.reclass/v.reclass.html
+++ b/vector/v.reclass/v.reclass.html
@@ -27,7 +27,7 @@ order.
 <p>For dissolving common boundaries, see
 <em><a href="v.dissolve.html">v.dissolve</a></em>.
 
-<p>Either <b>rules</b> or <b>column</b> option must be specified.
+<p>Either the <b>rules</b> or <b>column</b> option must be specified.
 
 <h2>EXAMPLES</h2>
 
@@ -37,7 +37,7 @@ order.
 v.reclass input=land output=land_u type=boundary rules=land.rcl
 </pre></div>
 
-the rules file contains :
+The rules file contains:
 
 <div class="code"><pre>
 # land reclass file
@@ -73,7 +73,7 @@ cat|I_vs_P
 
 <h2>KNOWN ISSUES</h2>
 
-No table is created for reclassed layer if <b>rules</b> option is used.
+No table is created for reclassed layer if the <b>rules</b> option is used.
 
 <h2>SEE ALSO</h2>
 


### PR DESCRIPTION
Add a note about the fact that either 'rules' or 'column' option must be specified.

See https://github.com/OSGeo/grass/blob/5cb4e430b5e405bce4ab30e6d20c15222b10815f/vector/v.reclass/main.c#L103-L107.