### PR TITLE
r.resamp.bspline: fix memory leak

### DIFF
--- a/raster/r.resamp.bspline/main.c
+++ b/raster/r.resamp.bspline/main.c
@@ -718,6 +718,8 @@ int main(int argc, char *argv[])
             else {
                 if (observ)
                     G_free(observ);
+                if (observ_marked)
+                    G_free(observ_marked);
                 if (npoints == 0)
                     G_warning(_("No data within this subregion. "
                                 "Consider increasing the spline step."));


### PR DESCRIPTION
This PR fixes a memory leak in `r.resamp.bspline` that becomes apparent only with larger input raster maps