### PR TITLE
docker: CI update and simplification

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
             type=ref,event=tag
             type=ref,event=branch
             type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
-            type=raw,value=latest,event=tag,enable=${{ matrix.os == 'ubuntu' }},suffix=
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu' }},suffix=
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ on:
       - main
       - releasebranch_*
       - '!releasebranch_7_*'
-      - docker-workflow-update
+      - docker-gh-workflow-update
     # tags: ['*.*.*']
     paths-ignore: [doc/**]
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,6 @@ on:
       - main
       - releasebranch_*
       - '!releasebranch_7_*'
-      - docker-gh-workflow-update
     # tags: ['*.*.*']
     paths-ignore: [doc/**]
   release:
@@ -36,7 +35,7 @@ jobs:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu
   docker-os-matrix:
     name: build and push ${{ matrix.os }} for ${{ github.ref }}
-    if: github.repository_owner == 'mmacata'
+    if: github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
 
     strategy:
@@ -57,7 +56,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: mmacata/grass-gis
+          images: osgeo/grass-gis
           tags: |
             type=ref,event=tag
             type=ref,event=branch

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ on:
       - main
       - releasebranch_*
       - '!releasebranch_7_*'
+      - docker-workflow-update
     # tags: ['*.*.*']
     paths-ignore: [doc/**]
   release:
@@ -35,7 +36,7 @@ jobs:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu
   docker-os-matrix:
     name: build and push ${{ matrix.os }} for ${{ github.ref }}
-    if: github.repository_owner == 'OSGeo'
+    if: github.repository_owner == 'mmacata'
     runs-on: ubuntu-latest
 
     strategy:
@@ -56,13 +57,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: osgeo/grass-gis
+          images: mmacata/grass-gis
           tags: |
             type=ref,event=tag
             type=ref,event=branch
             type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}',
-                'main') && matrix.os == 'ubuntu' }},suffix=
+            type=raw,value=latest,event=tag,enable=${{ matrix.os == 'ubuntu' }},suffix=
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,6 @@ on:
       - main
       - releasebranch_*
       - '!releasebranch_7_*'
-      - docker-workflow-update
     # tags: ['*.*.*']
     paths-ignore: [doc/**]
   release:
@@ -36,7 +35,7 @@ jobs:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu
   docker-os-matrix:
     name: build and push ${{ matrix.os }} for ${{ github.ref }}
-    if: github.repository_owner == 'mmacata'
+    if: github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
 
     strategy:
@@ -57,15 +56,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: mmacata/grass-gis
+          images: osgeo/grass-gis
           tags: |
             type=ref,event=tag
             type=ref,event=branch
             type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
-            type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'docker-workflow-update') }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.os == 'ubuntu' }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}',
-                'docker-workflow-update') && matrix.os == 'ubuntu' }},suffix=
+                'main') && matrix.os == 'ubuntu' }},suffix=
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
             type=ref,event=tag
             type=ref,event=branch
             type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu' }},suffix=
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/8.3') && matrix.os == 'ubuntu' }},suffix=
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,16 +5,11 @@ name: Docker
 #
 # Summary
 #
-# job docker-branch-os-matrix:
-# * creates tags latest-alpine, latest-debian and latest-ubuntu for main branch
-# * creates tags stable-alpine, stable-debian and stable-ubuntu for releasebranch_8_2
-# * creates tags <branch_name>-alpine, <branch_name>-debian and <branch_name>-ubuntu for all triggered branches
-#
-# job docker-main-latest:
-# * creates tag latest for main branch
-#
-# job docker-release-os-matrix:
+# job docker-os-matrix:
 # * creates tags <version>-alpine, <version>-debian and <version>-ubuntu for each release
+# * creates tags <branch_name>-alpine, <branch_name>-debian and <branch_name>-ubuntu for all triggered branches
+# * creates tags current-alpine, current-debian and current-ubuntu for releasebranch_8_3
+# * creates tag latest for main branch with ubuntu os
 
 on:
   push:
@@ -22,26 +17,26 @@ on:
       - main
       - releasebranch_*
       - '!releasebranch_7_*'
-    tags: ['*.*.*']
+      - docker-workflow-update
+    # tags: ['*.*.*']
     paths-ignore: [doc/**]
   release:
     types: [published]
 
-env:
-  # Additionally mentioned in docker-sha-release-latest
-  # as use of variable fails there
-  DOCKERHUB_REPOSITORY: osgeo/grass-gis
-
 jobs:
 
-  # Only run for push to configured branches, do not run for releases.
-  # Take care of different os. For main branch, created tags are:
-  # latest-alpine, latest-debian, latest-ubuntu
-  # For releasebranch_8_2, created tags are:
-  # stable-alpine, stable-debian, stable-ubuntu
-  docker-branch-os-matrix:
-    name: build and push ${{ matrix.os }} for branch
-    if: startsWith(github.ref, 'refs/heads/') && github.repository_owner == 'OSGeo'
+  # Run for push to configured branches and all published releases.
+  # Take care of different os.
+  # For main branch, created tags are:
+  #     main-alpine, main-debian, main-ubuntu and latest (with ubuntu)
+  # For releasebranch_8_3, created tags are:
+  #     current-alpine, current-debian, current-ubuntu,
+  #     releasebranch_8_3-alpine, releasebranch_8_3-debian, releasebranch_8_3-ubuntu
+  # For a release, e.g. 8.3.0, created tags are:
+  #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu
+  docker-os-matrix:
+    name: build and push ${{ matrix.os }} for ${{ github.ref }}
+    if: github.repository_owner == 'mmacata'
     runs-on: ubuntu-latest
 
     strategy:
@@ -58,125 +53,22 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: meta
-        name: Create tag name
-        run: |
-          if [ "$GITHUB_REF" == "refs/heads/main" ]
-          then
-            TAG_PREFIX=latest
-          elif [ "$GITHUB_REF" == "refs/heads/releasebranch_8_2" ]
-          then
-            TAG_PREFIX=stable
-          else
-            # use branch name as TAG_PREFIX
-            TAG_PREFIX=`echo $GITHUB_REF|cut -d '/' -f3`
-          fi
-          tag="${DOCKERHUB_REPOSITORY}:${TAG_PREFIX}-${{ matrix.os }}"
-          echo "tags=$tag" >> $GITHUB_OUTPUT
-      - name: Log
-        run: |
-          echo ${{ steps.meta.outputs.tags }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN  }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          pull: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          file: docker/${{ matrix.os }}/Dockerfile
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-
-  # Only run for push to main branch
-  # Take care of tag latest
-  # This job needs to build the configured image (ubuntu)
-  # again for main branch to create latest tag.
-  docker-main-latest:
-    name: build and push latest for main branch
-    if: github.ref == 'refs/heads/main' && github.repository_owner == 'OSGeo'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - id: meta
-        name: Create tag name
-        run: |
-          tag=${DOCKERHUB_REPOSITORY}:latest
-          echo "tags=$tag" >> $GITHUB_OUTPUT
-      - name: Log
-        run: echo ${{ steps.meta.outputs.tags }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN  }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          pull: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          file: docker/ubuntu/Dockerfile
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
-
-
-  # run for releases, take care of release tags
-  docker-release-os-matrix:
-    name: build and push release for ${{ matrix.os }}
-    if: startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'OSGeo'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os:
-          - alpine
-          - debian
-          - ubuntu
-      fail-fast: false
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Create image and tag name
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          # images: ${DOCKERHUB_REPOSITORY}
-          images: osgeo/grass-gis
+          images: mmacata/grass-gis
           tags: |
             type=ref,event=tag
+            type=ref,event=branch
+            type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
+            type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'docker-workflow-update') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.os == 'ubuntu' }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}',
+                'docker-workflow-update') && matrix.os == 'ubuntu' }},suffix=
           flavor: |
             latest=false
-      - id: meta2
-        name: Update tag name
-        run: |
-          tag="${{ steps.meta.outputs.tags }}-${{ matrix.os }}"
-          echo "tags=$tag" >> $GITHUB_OUTPUT
-      - name: Log
-        run: |
-          echo ${{ steps.meta2.outputs.tags }}
+            suffix=-${{ matrix.os }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -193,7 +85,7 @@ jobs:
           push: true
           pull: true
           context: .
-          tags: ${{ steps.meta2.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ name: Docker
 # * creates tags <version>-alpine, <version>-debian and <version>-ubuntu for each release
 # * creates tags <branch_name>-alpine, <branch_name>-debian and <branch_name>-ubuntu for all triggered branches
 # * creates tags current-alpine, current-debian and current-ubuntu for releasebranch_8_3
-# * creates tag latest for main branch with ubuntu os
+# * creates tag latest for last stable release with ubuntu os
 
 on:
   push:
@@ -27,12 +27,12 @@ jobs:
   # Run for push to configured branches and all published releases.
   # Take care of different os.
   # For main branch, created tags are:
-  #     main-alpine, main-debian, main-ubuntu and latest (with ubuntu)
+  #     main-alpine, main-debian, main-ubuntu
   # For releasebranch_8_3, created tags are:
   #     current-alpine, current-debian, current-ubuntu,
   #     releasebranch_8_3-alpine, releasebranch_8_3-debian, releasebranch_8_3-ubuntu
   # For a release, e.g. 8.3.0, created tags are:
-  #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu
+  #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
     name: build and push ${{ matrix.os }} for ${{ github.ref }}
     if: github.repository_owner == 'OSGeo'


### PR DESCRIPTION
This PR simplifies the github workflow for docker build, tag and push.
Due to some tag restructuring and new features of [docker/metadata-action](https://github.com/docker/metadata-action) it now only uses one job and, depending on the trigger action, creates different tags. It will create four different types of tags:

- `latest` for main branch and with ubuntu os
- `{{ branch }}-{{ os }}` for all configured branches, e.g. `releasebranch_8_3-alpine`
- `{{ tag }}-{{ os }}` for all published releases. e.g. `8.3.0-alpine`
- `current-{{ os }}` for a still hard-coded branch, here update to releasebranch_8_3, e.g `current-alpine`

This new naming conforms more with the GRASS GIS naming style of versions. While naming of branches and tags and content of `latest` tag is still the same, it adds `current-{{ os }}` and abandons former naming style with `latest-{{ os }}` and `stable-{{ os }}` like `latest-alpine` and `stable-alpine` to avoid confusion.

The plain `latest` tag is still created because it is default for `docker pull osgeo/grass-gis` and would be nice to have, although usage of it is not recommended. No strong opinion if it should point to `main` branch or `releasebranch_8_3`. Open for discussion. See also https://github.com/OSGeo/grass-website/pull/371

As the action was triggered twice for a release, `on: [tags ](tags: ['*.*.*'])` was outcommented.

Whole thing was tested as can be seen in [first commit of this PR](https://github.com/OSGeo/grass/commit/18e7811f3aff7b40133efaff3cba8c8af9cada30) on a branch named `docker-workflow-update` with mmacata remote and dockerhub account. Created and pushed image tags can be seen [here on dockerhub](https://hub.docker.com/r/mmacata/grass-gis/tags).