### PR TITLE
wxGUI: initialize db connection when creating new mapset

### DIFF
--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -117,6 +117,13 @@ class LocationDialog(TextEntryDialog):
         return is_location_name_valid(self.database, text)
 
 
+def initialize_mapset(grassdb, location, mapset):
+    """Initialize mapset (database connection)"""
+    gisrc_file, env = create_environment(grassdb, location, mapset)
+    RunCommand("db.connect", flags="c", env=env)
+    try_remove(gisrc_file)
+
+
 def create_mapset_interactively(guiparent, grassdb, location):
     """
     Create new mapset
@@ -135,6 +142,7 @@ def create_mapset_interactively(guiparent, grassdb, location):
         mapset = dlg.GetValue()
         try:
             create_mapset(grassdb, location, mapset)
+            initialize_mapset(grassdb, location, mapset)
         except OSError as err:
             mapset = None
             GError(


### PR DESCRIPTION
When creating new mapset (through data catalog or menu settings), this PR initializes db connection. This would prevent problem in #3078 (although that needs to be fixed separately).