### PR TITLE
wxGUI/psmap: fix vector map properties dialog correct typing the name of the vector map

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -50,6 +50,7 @@ else:
     from wx import PyValidator as Validator
 
 import grass.script as grass
+from grass.pygrass.utils import findmaps
 
 from core.utils import PilImageToWxImage
 from dbmgr.vinfo import VectorDBInfo
@@ -1861,11 +1862,17 @@ class VectorPanel(Panel):
     def OnVector(self, event):
         """Gets info about toplogy and enables/disables choices point/line/area"""
         vmap = self.select.GetValue()
-        try:
-            topoInfo = grass.vector_info_topo(map=vmap)
-        except grass.ScriptError:
+        genv = grass.core.gisenv()
+        if not findmaps(
+            type="vector",
+            pattern=vmap,
+            mapset=genv["MAPSET"],
+            location=genv["LOCATION_NAME"],
+            gisdbase=genv["GISDBASE"],
+        ):
             return
 
+        topoInfo = grass.vector_info_topo(map=vmap)
         if topoInfo:
             self.vectorType.EnableItem(2, bool(topoInfo["areas"]))
             self.vectorType.EnableItem(

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -50,7 +50,6 @@ else:
     from wx import PyValidator as Validator
 
 import grass.script as grass
-from grass.pygrass.utils import findmaps
 
 from core.utils import PilImageToWxImage
 from dbmgr.vinfo import VectorDBInfo
@@ -1862,14 +1861,10 @@ class VectorPanel(Panel):
     def OnVector(self, event):
         """Gets info about toplogy and enables/disables choices point/line/area"""
         vmap = self.select.GetValue()
-        genv = grass.core.gisenv()
-        if not findmaps(
-            type="vector",
-            pattern=vmap,
-            mapset=genv["MAPSET"],
-            location=genv["LOCATION_NAME"],
-            gisdbase=genv["GISDBASE"],
-        ):
+        if not grass.find_file(
+            vmap,
+            element="vector",
+        )["name"]:
             return
 
         topoInfo = grass.vector_info_topo(map=vmap)


### PR DESCRIPTION
**Describe the bug**
Typing the name of the vector map by keyboard inside vector map properties dialog (Map TextCtrl widget) print error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Cartographic composer GUI `g.gui.psmap`
2. Add map frame with some raster map e.g. elevation
3. Add vector map layer by typing vector map name by keyboards e.g. streams 
4. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/psmap/dialogs.py",
line 1865, in OnVector

topoInfo = grass.vector_info_topo(map=vmap)
  File
"/usr/lib64/grass84/etc/python/grass/script/vector.py", line
185, in vector_info_topo

s = read_command("v.info", flags="t", layer=layer, map=map,
env=env)
  File "/usr/lib64/grass84/etc/python/grass/script/core.py",
line 533, in read_command

return handle_errors(returncode, stdout, args, kwargs)
  File "/usr/lib64/grass84/etc/python/grass/script/core.py",
line 345, in handle_errors

raise CalledModuleError(module=module, code=code,
returncode=returncode)
grass.exceptions
.
CalledModuleError
:
Module run `v.info -t layer=1 map=s` ended with an error.
The subprocess ended with a non-zero return code: 1. See
errors above the traceback or in the error output.
```
and inside GRASS GIS session emulator terminal is printed error message too:

```
GRASS_INFO_ERROR(17890,1): Vector map <s> not found
GRASS_INFO_END(17890,1)

GRASS_INFO_ERROR(17891,1): Vector map <st> not found
GRASS_INFO_END(17891,1)

GRASS_INFO_ERROR(17892,1): Vector map <str> not found
GRASS_INFO_END(17892,1)

GRASS_INFO_ERROR(17893,1): Vector map <stre> not found
GRASS_INFO_END(17893,1)

GRASS_INFO_ERROR(17894,1): Vector map <strea> not found
GRASS_INFO_END(17894,1)

GRASS_INFO_ERROR(17895,1): Vector map <stream> not found
GRASS_INFO_END(17895,1)
```

**Expected behavior**
Typing the name of the vector map by keyboard inside vector map properties dialog (Map TextCtrl widget) should not print error messages.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all