### PR TITLE
wxGUI/nviz: make tools panel verically and horizontally scrollable for Single Window Mode

### DIFF
--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -144,10 +144,6 @@ class NvizToolWindow(GNotebook):
 
         self.Update()
         wx.CallAfter(self.SetPage, "view")
-        wx.CallAfter(
-            self.UpdateScrolling,
-            (self.foldpanelData, self.foldpanelAppear, self.foldpanelAnalysis),
-        )
         wx.CallAfter(self.SetInitialMaps)
 
     def SetInitialMaps(self):
@@ -206,6 +202,10 @@ class NvizToolWindow(GNotebook):
     def OnPageChanged(self, event):
         new = event.GetSelection()
         # self.ChangeSelection(new)
+        # Data, Appearance, Analysis page
+        if new in (1, 2, 3):
+            foldpanel = self.GetPage(new).GetChildren()[0]
+            wx.CallLater(100, self.UpdateScrolling, (foldpanel,))
 
     def PostViewEvent(self, zExag=False):
         """Change view settings"""
@@ -243,7 +243,7 @@ class NvizToolWindow(GNotebook):
     def _createViewPage(self):
         """Create view settings page"""
         panel = SP.ScrolledPanel(parent=self, id=wx.ID_ANY)
-        panel.SetupScrolling(scroll_x=False)
+        panel.SetupScrolling()
         self.page["view"] = {"id": 0, "notebook": self.GetId()}
 
         pageSizer = wx.BoxSizer(wx.VERTICAL)
@@ -478,7 +478,7 @@ class NvizToolWindow(GNotebook):
     def _createAnimationPage(self):
         """Create view settings page"""
         panel = SP.ScrolledPanel(parent=self, id=wx.ID_ANY)
-        panel.SetupScrolling(scroll_x=False)
+        panel.SetupScrolling()
         self.page["animation"] = {"id": 0, "notebook": self.GetId()}
 
         pageSizer = wx.BoxSizer(wx.VERTICAL)
@@ -662,7 +662,6 @@ class NvizToolWindow(GNotebook):
 
     def _createDataPage(self):
         """Create data (surface, vector, volume) settings page"""
-
         self.mainPanelData = ScrolledPanel(parent=self)
         self.mainPanelData.SetupScrolling(scroll_x=False)
         try:  # wxpython <= 2.8.10
@@ -820,7 +819,7 @@ class NvizToolWindow(GNotebook):
 
     def _createSurfacePage(self, parent):
         """Create view settings page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
         self.page["surface"] = {"id": 0, "notebook": self.foldpanelData.GetId()}
         pageSizer = wx.BoxSizer(wx.VERTICAL)
 
@@ -1135,12 +1134,13 @@ class NvizToolWindow(GNotebook):
 
         panel.Layout()
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
     def _createCPlanePage(self, parent):
         """Create cutting planes page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
         self.page["cplane"] = {"id": 4, "notebook": self.foldpanelData.GetId()}
         self.win["cplane"] = {}
 
@@ -1379,12 +1379,13 @@ class NvizToolWindow(GNotebook):
 
         panel.SetSizer(pageSizer)
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
     def _createConstantPage(self, parent):
         """Create constant page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
         self.page["constant"] = {"id": 1, "notebook": self.foldpanelData.GetId()}
         self.win["constant"] = {}
 
@@ -1471,12 +1472,13 @@ class NvizToolWindow(GNotebook):
 
         panel.SetSizer(pageSizer)
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
     def _createVectorPage(self, parent):
         """Create view settings page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
         self.page["vector"] = {"id": 2, "notebook": self.foldpanelData.GetId()}
         pageSizer = wx.BoxSizer(wx.VERTICAL)
 
@@ -1903,6 +1905,7 @@ class NvizToolWindow(GNotebook):
 
         panel.SetSizer(pageSizer)
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
@@ -1915,7 +1918,7 @@ class NvizToolWindow(GNotebook):
 
     def _createVolumePage(self, parent):
         """Create view settings page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
         self.page["volume"] = {"id": 3, "notebook": self.foldpanelData.GetId()}
         pageSizer = wx.BoxSizer(wx.VERTICAL)
 
@@ -2117,12 +2120,13 @@ class NvizToolWindow(GNotebook):
         )
         panel.SetSizer(pageSizer)
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
     def _createLightPage(self, parent):
         """Create light page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
 
         self.page["light"] = {"id": 0, "notebook": self.foldpanelAppear.GetId()}
         self.win["light"] = {}
@@ -2298,12 +2302,13 @@ class NvizToolWindow(GNotebook):
         panel.SetSizer(pageSizer)
         panel.Layout()
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
     def _createFringePage(self, parent):
         """Create fringe page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
 
         self.page["fringe"] = {"id": 1, "notebook": self.foldpanelAppear.GetId()}
         self.win["fringe"] = {}
@@ -2394,12 +2399,13 @@ class NvizToolWindow(GNotebook):
         panel.SetSizer(pageSizer)
         panel.Layout()
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 
     def _createDecorationPage(self, parent):
         """Create decoration (north arrow, scalebar, legend) page"""
-        panel = wx.Panel(parent=parent, id=wx.ID_ANY)
+        panel = ScrolledPanel(parent=parent)
 
         self.page["decoration"] = {"id": 2, "notebook": self.foldpanelAppear.GetId()}
         self.win["decoration"] = {}
@@ -2528,6 +2534,7 @@ class NvizToolWindow(GNotebook):
         panel.SetSizer(pageSizer)
         panel.Layout()
         panel.Fit()
+        panel.SetupScrolling(scroll_y=False)
 
         return panel
 


### PR DESCRIPTION
**Describe the bug**
With Single Window Mode 3D view mode tools pane (default width) has missing horizontal scrollbar or horizontal and vertical scrollbar also.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI with Single Window Mode
2. Display some raster map e.g. elevation `d.rast elevation`
3. Switch from 2D view to 3D view
4. It is not possible change some 3D view settings on the pages View, Data, Appearance, Analysis, Animation with default pane width due tools panel has missing horizontal or vertical scrollbar **by default**.

**Expected behavior**
3D view settings pages View, Data, Appearance, Analysis, Animation with default pane width should have horizontal or  vertical scrollbar.

**Screenshots**

A. View page

| Default behavior|Expected behavior| 
|--------------|-----------|
| <img src="https://github.com/OSGeo/grass/assets/50632337/ab9ae89c-d845-4347-ba80-eeee87f7e7d7" width="250">|<img src="https://github.com/OSGeo/grass/assets/50632337/e73405d7-2795-4400-bca0-793e963d0af7)" width="250">|


B. Data page

| Default behavior|Expected behavior| 
|--------------|-----------|
|<img src="https://github.com/OSGeo/grass/assets/50632337/5f19b6b9-5527-47e0-9d39-87305d567616" width="250">|<img src="https://github.com/OSGeo/grass/assets/50632337/d8cb4836-58b5-4cf9-af22-a975c05337a4" width="250">|


C. Appearance page

| Default behavior|Expected behavior| 
|--------------|-----------|
|<img src="https://github.com/OSGeo/grass/assets/50632337/bc2c8cea-50a1-40d0-8763-ae4bd960ec7d" width="250">|<img src="https://github.com/OSGeo/grass/assets/50632337/5b94e644-0ab2-40ce-9a96-9e71659a3036" width="250">|


D. Analysis page

| Default behavior|Expected behavior| 
|--------------|-----------|
|<img src="https://github.com/OSGeo/grass/assets/50632337/c5f484f8-b6f6-4866-b88d-db9a5218c637" width="250">|<img src="https://github.com/OSGeo/grass/assets/50632337/b2af1a61-e3ce-40de-8798-21a16ef7c107" width="250">|


E. Animation page

| Default behavior|Expected behavior| 
|--------------|-----------|
|<img src="https://github.com/OSGeo/grass/assets/50632337/9757c36c-988c-4b30-b3e0-19f35e1c1ad5" width="250">|<img src="https://github.com/OSGeo/grass/assets/50632337/0b0f459a-1589-4cee-b828-cb86f13cd355" width="250">|

**System description:**

- Operating System: all
- GRASS GIS version: 8.2, 8.3, 8.4.dev