### PR TITLE
r.drain: fix for fully-qualified map names

### DIFF
--- a/scripts/r.drain/r.drain.py
+++ b/scripts/r.drain/r.drain.py
@@ -108,7 +108,6 @@
 # % required: start_coordinates, start_points
 # %end
 
-import os
 import sys
 import atexit
 
@@ -141,10 +140,11 @@ def main():
     atexit.register(cleanup)
 
     if not dirmap:
+        valmap_name = valmap.split("@")[0]
         # get directions with r.fill.dir, without sink filling
-        dirmap = "%s_tmp_%d" % (valmap, os.getpid())
-        fill_map = "%s_fill_%d" % (valmap, os.getpid())
-        area_map = "%s_area_%d" % (valmap, os.getpid())
+        dirmap = grass.append_node_pid(f"{valmap_name}_tmp")
+        fill_map = grass.append_node_pid(f"{valmap_name}_fill")
+        area_map = grass.append_node_pid(f"{valmap_name}_area")
         tmp_maps = dirmap + "," + fill_map + "," + area_map
         grass.run_command(
             "r.fill.dir",

--- a/scripts/r.drain/r.drain.py
+++ b/scripts/r.drain/r.drain.py
@@ -111,14 +111,13 @@
 import sys
 import atexit
 
-import grass.script as grass
 import grass.script as gs
 
 
 def cleanup():
     """Delete temporary direction map."""
     if tmp_maps:
-        grass.run_command(
+        gs.run_command(
             "g.remove",
             flags="f",
             quiet=True,
@@ -147,7 +146,7 @@ def main():
         fill_map = gs.append_node_pid(f"{valmap_name}_fill")
         area_map = gs.append_node_pid(f"{valmap_name}_area")
         tmp_maps = dirmap + "," + fill_map + "," + area_map
-        grass.run_command(
+        gs.run_command(
             "r.fill.dir",
             input=valmap,
             output=fill_map,
@@ -180,11 +179,11 @@ def main():
     if flags["n"]:
         pathflags += "n"
 
-    grass.run_command("r.path", flags=pathflags, **kwargs)
+    gs.run_command("r.path", flags=pathflags, **kwargs)
 
     return 0
 
 
 if __name__ == "__main__":
-    options, flags = grass.parser()
+    options, flags = gs.parser()
     sys.exit(main())

--- a/scripts/r.drain/r.drain.py
+++ b/scripts/r.drain/r.drain.py
@@ -112,6 +112,7 @@ import sys
 import atexit
 
 import grass.script as grass
+import grass.script as gs
 
 
 def cleanup():
@@ -140,11 +141,11 @@ def main():
     atexit.register(cleanup)
 
     if not dirmap:
-        valmap_name = valmap.split("@")[0]
+        valmap_name = valmap.split("@", maxsplit=1)[0]
         # get directions with r.fill.dir, without sink filling
-        dirmap = grass.append_node_pid(f"{valmap_name}_tmp")
-        fill_map = grass.append_node_pid(f"{valmap_name}_fill")
-        area_map = grass.append_node_pid(f"{valmap_name}_area")
+        dirmap = gs.append_node_pid(f"{valmap_name}_dir")
+        fill_map = gs.append_node_pid(f"{valmap_name}_fill")
+        area_map = gs.append_node_pid(f"{valmap_name}_area")
         tmp_maps = dirmap + "," + fill_map + "," + area_map
         grass.run_command(
             "r.fill.dir",


### PR DESCRIPTION
Running r.drain with map@mapset fails. This PR  fixes that and also makes tmp map names safe for parallelization on cluster (include also node in the name).