### PR TITLE
d.legend.vect: Initialize title size

### DIFF
--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -52,6 +52,7 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
 
     /* Draw title */
     title_h = 0;
+    title_w = 0;
     if (strlen(title) > 0) {
         D_font(tit_font);
         D_text_size(tit_size, tit_size);


### PR DESCRIPTION
Later test (line 270) uses title width to compute background size regardless of title presence, but original code initialized title_w only when title was set.

This fixes occasional extra wide legend background rectangle.

Identified by valgrind as: Conditional jump or move depends on uninitialised value(s).
