### PR TITLE
r.sun: fix -Wimplicit-int warnings

### DIFF
--- a/raster/r.sun/local_proto.h
+++ b/raster/r.sun/local_proto.h
@@ -44,7 +44,7 @@ void setHorizonInterval(double val);
 void setAngularLossDenominator();
 
 
-void cube(int, int);
+/* void cube(int, int); */
 
 double com_sol_const(int no_of_day);
 

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -118,8 +118,8 @@ int OUTGR(void);
 int min(int, int);
 int max(int, int);
 
-void cube(int, int);
-void (*func) (int, int);
+/* void cube(int, int);
+void (*func) (int, int); */
 
 void joules2(struct SunGeometryConstDay *sunGeom,
 	     struct SunGeometryVarDay *sunVarGeom,
@@ -1685,9 +1685,9 @@ void where_is_point(double *length, struct SunGeometryVarDay *sunVarGeom,
  * }
  */
 
-void cube(jmin, imin)
+/* void cube(jmin, imin)
 {
-}
+} */
 
 
 /*////////////////////////////////////////////////////////////////////// */
@@ -1837,7 +1837,7 @@ void calculate(double singleSlope, double singleAspect, double singleAlbedo,
 	}
 	sunVarGeom.zmax = zmax;
         shadowoffset_base = (j % (numRows)) * n * arrayNumInt;
-    #pragma omp parallel firstprivate(q1,tan_lam_l,z1,i,shadowoffset,longitTime,coslat,coslatsq,func,latitude,longitude,sin_phi_l,latid_l,sin_u,cos_u,sin_v,cos_v,lum,gridGeom,elevin,aspin,slopein,civiltime,linkein,albedo,latin,coefbh,coefdh,incidout,longin,horizon,beam_rad,insol_time,diff_rad,refl_rad,glob_rad,mapset,per,decimals,str_step)
+    #pragma omp parallel firstprivate(q1,tan_lam_l,z1,i,shadowoffset,longitTime,coslat,coslatsq,latitude,longitude,sin_phi_l,latid_l,sin_u,cos_u,sin_v,cos_v,lum,gridGeom,elevin,aspin,slopein,civiltime,linkein,albedo,latin,coefbh,coefdh,incidout,longin,horizon,beam_rad,insol_time,diff_rad,refl_rad,glob_rad,mapset,per,decimals,str_step)
     {
       #pragma omp for schedule(dynamic)                                                        \
                       firstprivate(sunGeom,sunVarGeom,sunSlopeGeom,sunRadVar)                  \
@@ -1862,7 +1862,7 @@ void calculate(double singleSlope, double singleAspect, double singleAlbedo,
 		coslatsq = coslat * coslat;
 	    }
 
-	    func = NULL;
+	    /* func = NULL; */
 
 	    sunVarGeom.z_orig = z1 = sunVarGeom.zp = z[arrayOffset][i];
 

--- a/raster/r.sun/rsunglobals.h
+++ b/raster/r.sun/rsunglobals.h
@@ -60,4 +60,4 @@ extern struct pj_info iproj;
 extern struct pj_info oproj;
 
 
-extern void (*func) (int, int);
+/* extern void (*func) (int, int); */

--- a/raster/r.sun/rsunlib.c
+++ b/raster/r.sun/rsunlib.c
@@ -300,11 +300,11 @@ int searching(double *length, struct SunGeometryVarDay *sunVarGeom,
 
     if (succes == 1) {
 	where_is_point(length, sunVarGeom, gridGeom);
-	if (func == NULL) {
+	/*if (func == NULL) {
 	    gridGeom->xx0 = gridGeom->xg0;
 	    gridGeom->yy0 = gridGeom->yg0;
 	    return (3);
-	}
+	}*/
 	curvature_diff = EARTHRADIUS * (1. - cos(*length / EARTHRADIUS));
 
 	z2 = sunVarGeom->z_orig + curvature_diff +
@@ -338,7 +338,7 @@ double lumcline2(struct SunGeometryConstDay *sungeom,
     double timeoffset, horizPos;
     double horizonHeight;
 
-    func = cube;
+    /* func = cube; */
     sunVarGeom->isShadow = 0;
 
     if (useShadow()) {


### PR DESCRIPTION
This is a partial, manual backport of https://github.com/OSGeo/grass/pull/1405.

The warning is treated as an error by Clang 16+ and the compilation fails.

Considering next 7.8 release likely will be the last, this should be a blocker.