### PR TITLE
wxGUI/dbmgr: fix showing attribute column menu

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -481,7 +481,6 @@ class VirtualAttributeList(
             self.popupId = {
                 "sortAsc": NewId(),
                 "sortDesc": NewId(),
-                "calculate": NewId(),
                 "area": NewId(),
                 "length": NewId(),
                 "compact": NewId(),
@@ -499,8 +498,9 @@ class VirtualAttributeList(
         popupMenu.Append(self.popupId["sortDesc"], _("Sort descending"))
         popupMenu.AppendSeparator()
         subMenu = Menu()
-        popupMenu.AppendMenu(
-            self.popupId["calculate"], _("Calculate (only numeric columns)"), subMenu
+        subMenuItem = popupMenu.AppendSubMenu(
+            subMenu,
+            _("Calculate (only numeric columns)"),
         )
         popupMenu.Append(self.popupId["calculator"], _("Field calculator"))
         popupMenu.AppendSeparator()
@@ -519,7 +519,7 @@ class VirtualAttributeList(
         if not self.dbMgrData["editable"] or self.columns[
             self.GetColumn(self._col).GetText()
         ]["ctype"] not in (int, float):
-            popupMenu.Enable(self.popupId["calculate"], False)
+            subMenuItem.Enable(False)
 
         subMenu.Append(self.popupId["area"], _("Area size"))
         subMenu.Append(self.popupId["length"], _("Line length"))


### PR DESCRIPTION
When right-clicking on a column header with non-numerical type in attribute table manager, an error appears:
```
"/home/vpetras/Projects/grass/code/grass/dist.x86_64-pc-
linux-gnu/gui/wxpython/dbmgr/base.py", line 522, in
OnColumnMenu

popupMenu.Enable(self.popupId["calculate"], False)
wx._core
.
wxAssertionError
:
C++ assertion ""item"" failed at /home/wxpy/wxPython-4.1.1/e
xt/wxWidgets/src/common/menucmn.cpp(793) in Enable():
wxMenu::Enable: no such item
```

This PR addresses that. The error probably appears only in the newer versions of wxPython, but I am not sure which one broke it.