### PR TITLE
wxGUI/lmgr: fix saving web service layer as raster map

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -70,10 +70,7 @@ from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
 from lmgr.statusbar import SbMain
 from lmgr.workspace import WorkspaceManager
 from lmgr.pyshell import PyShellWindow
-from lmgr.giface import (
-    LayerManagerGrassInterface,
-    LayerManagerGrassInterfaceForMapDisplay,
-)
+from lmgr.giface import LayerManagerGrassInterface
 from mapdisp.frame import MapDisplay
 from datacatalog.catalog import DataCatalog
 from gui_core.forms import GUI
@@ -484,10 +481,10 @@ class GMFrame(wx.Frame):
         self.notebookLayers.AddPage(page=self.pg_panel, text=name, select=True)
         self.currentPage = self.notebookLayers.GetCurrentPage()
 
-        def CreateNewMapDisplay(layertree):
+        def CreateNewMapDisplay(giface, layertree):
             """Callback function which creates a new Map Display window
+            :param giface: giface for map display
             :param layertree: layer tree object
-            :param name: name of new map display window
             :return: reference to mapdisplay instance
             """
             # count map display frame position
@@ -503,14 +500,10 @@ class GMFrame(wx.Frame):
                 title=name,
             )
 
-            # create instance of Map Display interface
-            self._gifaceForDisplay = LayerManagerGrassInterfaceForMapDisplay(
-                self._giface, layertree
-            )
             # create Map Display
             mapdisplay = MapDisplay(
                 parent=mapframe,
-                giface=self._gifaceForDisplay,
+                giface=giface,
                 id=wx.ID_ANY,
                 size=globalvar.MAP_WINDOW_SIZE,
                 tree=layertree,

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -859,7 +859,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         from web_services.dialogs import SaveWMSLayerDialog
 
         dlg = SaveWMSLayerDialog(
-            parent=self, layer=mapLayer, giface=self._gifaceForDisplay
+            parent=self, layer=mapLayer, giface=self.mapdisplay._giface
         )
         dlg.CentreOnScreen()
         dlg.Show()

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -45,6 +45,7 @@ from core.gcmd import GWarning, GError, RunCommand
 from icons.icon import MetaIcon
 from gui_core.widgets import MapValidator
 from gui_core.wrap import Menu, GenBitmapButton, TextCtrl, NewId
+from lmgr.giface import LayerManagerGrassInterfaceForMapDisplay
 
 
 TREE_ITEM_HEIGHT = 25
@@ -152,7 +153,9 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         self._setGradient()
 
         # init associated map display
-        self.mapdisplay = createNewMapDisplay(layertree=self)
+        # create instance of Map Display interface
+        self._gifaceForDisplay = LayerManagerGrassInterfaceForMapDisplay(giface, self)
+        self.mapdisplay = createNewMapDisplay(self._gifaceForDisplay, layertree=self)
 
         self.root = self.AddRoot(_("Map Layers"))
         self.SetPyData(self.root, (None, None))
@@ -859,7 +862,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         from web_services.dialogs import SaveWMSLayerDialog
 
         dlg = SaveWMSLayerDialog(
-            parent=self, layer=mapLayer, giface=self.mapdisplay._giface
+            parent=self, layer=mapLayer, giface=self._gifaceForDisplay
         )
         dlg.CentreOnScreen()
         dlg.Show()

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -76,10 +76,7 @@ from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
 from lmgr.statusbar import SbMain
 from lmgr.workspace import WorkspaceManager
 from lmgr.pyshell import PyShellWindow
-from lmgr.giface import (
-    LayerManagerGrassInterface,
-    LayerManagerGrassInterfaceForMapDisplay,
-)
+from lmgr.giface import LayerManagerGrassInterface
 from mapdisp.frame import MapPanel
 from datacatalog.catalog import DataCatalog
 from gui_core.forms import GUI
@@ -415,20 +412,17 @@ class GMFrame(wx.Frame):
         self.currentPageNum = self.notebookLayers.GetSelection()
         self.notebookLayers.EnsureVisible(self.currentPageNum)
 
-        def CreateNewMapDisplay(layertree):
+        def CreateNewMapDisplay(giface, layertree):
             """Callback function which creates a new Map Display window
+            :param giface: giface for map display
             :param layertree: layer tree object
             :return: reference to mapdisplay instance
             """
-            # create instance of Map Display interface
-            self._gifaceForDisplay = LayerManagerGrassInterfaceForMapDisplay(
-                self._giface, layertree
-            )
 
             # create Map Display
             mapdisplay = MapPanel(
                 parent=self.mapnotebook,
-                giface=self._gifaceForDisplay,
+                giface=giface,
                 id=wx.ID_ANY,
                 tree=layertree,
                 lmgr=self,


### PR DESCRIPTION
**Describe the bug**
Saving web service layer as raster map fail.

**To Reproduce**
Steps to reproduce the behavior:

1. From the GUI Layers pane toolbar launch Add web service map dialog
2. Hit Add default button
3. Choose OSM-WMS item from the load profiles ComboBox widget
4. Hit Connect button
5. From the tree list of layers choose some layer e.g. OpenStreetMap WMS - by terrestris
6. Hit Add layer button 
7.  From the Layers pane choose added web service layer OpenStreetMap WMS - by terrestris and by right mouse click invoke layer menu and choose Save web service layer menu item
8. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/lmgr/layertree.py",
line 862, in OnSaveWs

parent=self, layer=mapLayer, giface=self._gifaceForDisplay
AttributeError
:
'LayerTree' object has no attribute '_gifaceForDisplay'
```

**Expected behavior**
Saving web service layer as raster map should work.


**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: 8.4.0dev, 8.3, 8.2