### PR TITLE
r.texture manual: fix output parameter in example

### DIFF
--- a/lib/gis/renamed_options
+++ b/lib/gis/renamed_options
@@ -386,6 +386,7 @@ r.surf.area|input:map
 r.terraflow|stream_dir:directory
 # r.texture
 r.texture|measure:method
+r.texture|prefix:output
 # r.to.vect
 r.to.vect|feature:type
 # r.topmodel

--- a/raster/r.texture/r.texture.html
+++ b/raster/r.texture/r.texture.html
@@ -159,7 +159,7 @@ r.colors ortho_2001_t792_1m color=grey
 # extract grey levels
 r.mapcalc "ortho_2001_t792_1m.greylevel = ortho_2001_t792_1m"
 # texture analysis
-r.texture ortho_2001_t792_1m.greylevel prefix=ortho_texture method=asm -s
+r.texture ortho_2001_t792_1m.greylevel output=ortho_texture method=asm -s
 # display
 g.region n=221461 s=221094 w=638279 e=638694
 d.shade color=ortho_texture_ASM_0 shade=ortho_2001_t792_1m


### PR DESCRIPTION
Fixes example and registers old `prefix` in `lib/gis/renamed_options`.

(was missing in e212c96107110eb9d29f69e03c3ae226a928eefd)