### PR TITLE
wxGUI: Make GUI workspace part of mapset

### DIFF
--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -17,9 +17,12 @@ import os
 import tempfile
 
 import xml.etree.ElementTree as etree
+from pathlib import Path
 
 import wx
 import wx.aui
+
+import grass.script as gs
 
 from core.settings import UserSettings
 from core.gcmd import RunCommand, GError, GMessage
@@ -124,6 +127,17 @@ class WorkspaceManager:
         self.lmgr._setTitle()
 
     def _tryToSwitchMapsetFromWorkspaceFile(self, gxwXml):
+        gisenv = gs.gisenv()
+        grassdb = gisenv["GISDBASE"]
+        location = gisenv["LOCATION_NAME"]
+        mapset = gisenv["MAPSET"]
+        if (
+            grassdb == gxwXml.database
+            and location == gxwXml.location
+            and mapset == gxwXml.mapset
+        ):
+            # Positive result but no message to the user is needed.
+            return True
         returncode, errors = RunCommand(
             "g.mapset",
             dbase=gxwXml.database,
@@ -161,6 +175,34 @@ class WorkspaceManager:
                 % {"loc": gxwXml.location, "mapset": gxwXml.mapset},
             )
         return True
+
+    # No need for method here, could be a function.
+    def CurrentMapsetWorkspaceFile(self):
+        gisenv = gs.gisenv()
+        grassdb = gisenv["GISDBASE"]
+        location = gisenv["LOCATION_NAME"]
+        mapset = gisenv["MAPSET"]
+        default_workspace_name = f"{mapset}.gxw"
+        return Path(grassdb) / location / mapset / default_workspace_name
+
+    def IsCurrentMapsetWorkspaceFile(self):
+        if not self.workspaceFile:
+            return False
+        path = self.CurrentMapsetWorkspaceFile()
+        return Path(self.workspaceFile) == path
+
+    def AutoLoad(self, filename=None):
+        if not filename:
+            path = self.CurrentMapsetWorkspaceFile()
+            filename = str(path)
+            if path.is_file():
+                self.lmgr.DisplayCloseAll()
+                self.workspaceChanged = False
+            else:
+                self.workspaceFile = filename
+                self.SaveToFile(filename)
+                return True
+        return self.Load(filename)
 
     def Load(self, filename):
         """Load layer tree definition stored in GRASS Workspace XML file (gxw)
@@ -386,7 +428,7 @@ class WorkspaceManager:
                     "Do you want to overwrite this file?"
                 )
                 % filename,
-                caption=_("Save workspace"),
+                caption=_("Save workspace (SaveAs)"),
                 style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
             )
             if dlg.ShowModal() != wx.ID_YES:
@@ -401,6 +443,18 @@ class WorkspaceManager:
 
     def Save(self):
         """Save file with workspace definition"""
+        gisenv = gs.gisenv()
+        grassdb = gisenv["GISDBASE"]
+        location = gisenv["LOCATION_NAME"]
+        mapset = gisenv["MAPSET"]
+        default_workspace_name = f"{mapset}.gxw"
+        path = Path(grassdb) / location / mapset / default_workspace_name
+        if path == Path(self.workspaceFile):
+            self.SaveToFile(self.workspaceFile)
+            self.lmgr._setTitle()
+            self.workspaceChanged = False
+            return
+
         if self.workspaceFile:
             dlg = wx.MessageDialog(
                 self.lmgr,
@@ -409,7 +463,7 @@ class WorkspaceManager:
                     "Do you want to overwrite this file?"
                 )
                 % self.workspaceFile,
-                caption=_("Save workspace"),
+                caption=_("Save workspace (Save)"),
                 style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
             )
             if dlg.ShowModal() == wx.ID_NO:

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -205,9 +205,8 @@ class GMFrame(wx.Frame):
         self.Show()
 
         # load workspace file if requested
-        if workspace:
-            if self.workspace_manager.Load(workspace):
-                self._setTitle()
+        if self.workspace_manager.AutoLoad(workspace):
+            self._setTitle()
         else:
             # start default initial display
             self.NewDisplay(show=False)
@@ -250,6 +249,15 @@ class GMFrame(wx.Frame):
         location = gisenv["LOCATION_NAME"]
         mapset = gisenv["MAPSET"]
         if self.workspace_manager.workspaceFile:
+            if self.workspace_manager.IsCurrentMapsetWorkspaceFile():
+                # Be more verbose just for clarity during testing, but otherwise
+                # showing just location/mapset might be sufficient.
+                self.SetTitle(
+                    "{location}/{mapset} (workspace in mapset) - {program}".format(
+                        location=location, mapset=mapset, program=self.baseTitle
+                    )
+                )
+                return
             filename = os.path.splitext(
                 os.path.basename(self.workspace_manager.workspaceFile)
             )[0]
@@ -1416,12 +1424,13 @@ class GMFrame(wx.Frame):
         """Current mapset changed.
         If location is None, mapset changed within location.
         """
-        if not location:
-            self._setTitle()
-        else:
-            # close current workspace and create new one
-            self.OnWorkspaceClose()
+        if location:
+            # Close was probably wrong action even before because it saved wrong mapset.
+            # self.OnWorkspaceClose()
             self.OnWorkspaceNew()
+        self.workspace_manager.AutoLoad()
+        self._setTitle()
+        return
 
     def OnChangeCWD(self, event=None, cmd=None):
         """Change current working directory


### PR DESCRIPTION
- Automatically create workspace file in a mapset when GUI is notified about the change if it does not exist.
- If workspace exists in a mapset, open it.
- If workspace does not exists and but the previous mapset was in the same location, it keeps the open mapdisplays as before.
- The updates to workspace are not saved automatically (in time interval, before switch, or at exit), so user needs to save the workspace (Ctrl+S) in order to keep the state.

This is a proof of concept and not meant for merging. If someone wants to pick it up, I'm more than fine with that.
