### PR TITLE
CITATION.cff: make license entry SPDX conform

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -106,7 +106,7 @@ authors:
     email: hamish_b@yahoo.com
 
 repository-code: https://github.com/OSGeo/grass
-license: GNU General Public License v2 or later
+license: GPL-2.0-or-later
 doi: 10.5281/zenodo.4621728
 keywords:
   - GIS


### PR DESCRIPTION
Use proper short code from https://spdx.org:

https://spdx.org/licenses/GPL-2.0-or-later.html

Hopefully fixes automated Zenodo.org upload, see discussion at
https://lists.osgeo.org/pipermail/grass-dev/2023-August/095989.html