### PR TITLE
wxGUI/preferences: fix saving display dimensions

### DIFF
--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -833,7 +833,7 @@ class FrameMixin:
         return self.GetParent().IsFullScreen()
 
     def IsIconized(self):
-        self.GetParent().IsIconized()
+        return self.GetParent().IsIconized()
 
     def Maximize(self):
         self.GetParent().Maximize()

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -1850,10 +1850,9 @@ class PreferencesDialog(PreferencesBaseDialog):
             for mapdisp in self._giface.GetAllMapDisplays():
                 pos = mapdisp.GetPosition()
                 size = mapdisp.GetSize()
-
                 # window size must be larger than zero, not minimized
                 # do not save dim when mapdisp is docked within single window
-                if (not mapdisp.IsDockable() or not mapdisp.IsDocked()) and (
+                if (hasattr(mapdisp, "IsIconized") and not mapdisp.IsIconized()) and (
                     size[0] > 0 and size[1] > 0
                 ):
                     dim += f",{pos[0]},{pos[1]},{size[0]},{size[1]}"


### PR DESCRIPTION
Fixes #3112. The methods `IsDockable` were introduced in development branch as part of (un)docking map displays in single window layout, but not ported to 8.3.0 (intentionally). But then they were by mistake used in 8.3.0.  