### PR TITLE
RFC: Version Numbering is adopted

### DIFF
--- a/doc/development/rfc/version_numbering.md
+++ b/doc/development/rfc/version_numbering.md
@@ -2,7 +2,7 @@
 
 Author: Vaclav Petras
 
-Status: Draft
+Status: Adopted (5 June 2023)
 
 ## Summary
 


### PR DESCRIPTION
In May, several people agreed to merge the finalized RFC in #2357 before it was adopted in a face-to-face meeting. In the meantime, the RFC was adopted. This updates the status. 

Adoption email: https://lists.osgeo.org/pipermail/grass-psc/2023-June/002724.html