### PR TITLE
r.fillnulls: proceed if no holes present (RST method)

### DIFF
--- a/scripts/r.fillnulls/r.fillnulls.html
+++ b/scripts/r.fillnulls/r.fillnulls.html
@@ -27,7 +27,7 @@ ignore the warning. The interpolation will be continued. However, the user
 may pay attention to below notes.
 <p>
 If interpolation fails, temporary raster and vector maps are left in place to allow
-unfilled map hole (NULL area) identification and manual repair.
+unfilled map holes (NULL areas) to be identified and manually repaired.
 
 <p>
 When using the default RST method, the algorithm is based

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -296,7 +296,16 @@ def main():
         os.remove(cats_file_name)
 
         if len(cat_list) < 1:
-            grass.fatal(_("Input map has no holes. Check region settings."))
+            # no holes found in current region
+            grass.run_command(
+                "g.copy", raster="%s,%sfilled" % (input, prefix), overwrite=True
+            )
+            grass.warning(
+                _(
+                    "Input map <%s> has no holes. Copying to output without modification."
+                )
+                % (input,)
+            )
 
         # GTC Hole is NULL area in a raster map
         grass.message(_("Processing %d map holes") % len(cat_list))


### PR DESCRIPTION
Proceed if no holes present also for `rst` method - now all methods behave the same.

In case no holes are in the current region of the raster input map the map is copied over and no fatal error is issues (same for all methods).

Test case:

```bash
# GRASS nc_spm_08_grass7/user1
g.region raster=elevation -p
# bilinear
r.fillnulls input=elevation output=test method=bilinear
# rst: this should no longer end with fatal error
r.fillnulls input=elevation output=test method=rst
```

Fixes #2986