### PR TITLE
wxGUI/animation: fix exporting an animation overlaid with custom image

### DIFF
--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -582,8 +582,8 @@ class AnimationController(wx.EvtHandler):
             # paste decorations
             for decoration in decorations:
                 # add image
-                x = decoration["pos"][0] / 100.0 * size[0]
-                y = decoration["pos"][1] / 100.0 * size[1]
+                x = int(decoration["pos"][0] / 100.0 * size[0])
+                y = int(decoration["pos"][1] / 100.0 * size[1])
                 if decoration["name"] == "image":
                     decImage = wx.Image(decoration["file"])
                 elif decoration["name"] == "time":


### PR DESCRIPTION
**Describe the bug**
Exporting an animation overlaid with a custom image fails.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch animation tool wxGUI `g.gui.animation`
2. Add some raster map(s) for creating animation
3. Activate Export animation tool from the animation window toolbar
4. On the Export animation dialog default Format page (tab) set output directory path for exported animation
5. On the Export animation dialog switch to Decorations page (tab)
6. Try to add some custom image (choose image file path)
7. Hit Export button
8. See error

```python
Traceback (most recent call last):
  File
"/usr/lib64/grass84/gui/wxpython/animation/dialogs.py", line
1487, in OnExport

self.doExport.emit(
  File
"/usr/lib64/grass84/etc/python/grass/pydispatch/signal.py",
line 233, in emit

dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/dispa
tcher.py", line 343, in send

response = robustapply.robustApply(
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/robus
tapply.py", line 60, in robustApply

return receiver(*arguments, **named)
  File
"/usr/lib64/grass84/gui/wxpython/animation/controller.py",
line 618, in _export

image.Paste(decImage, x, y)
TypeError
:
Image.Paste(): argument 2 has unexpected type 'float'
```

**Expected behavior**
Exporting an animation overlaid with a custom image should work.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all

```
test@test-gnu-linux:~$ python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Aug 25 2023, 20:13:27) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```