### PR TITLE
m.nviz.image: fix checking if color raster map exists if color_map param arg was used

### DIFF
--- a/misc/m.nviz.image/surface.c
+++ b/misc/m.nviz.image/surface.c
@@ -99,14 +99,14 @@ int load_rasters(const struct GParams *params, nv_data *data)
 
     for (i = 0; i < nsurfs; i++) {
         id = surf_list[i];
-        mapset = G_find_raster2(params->color_map->answers[i], "");
-        if (mapset == NULL) {
-            G_fatal_error(_("Raster map <%s> not found"),
-                          params->color_map->answers[i]);
-        }
         /* color */
         /* check for color map */
         if (i < ncolor_map && strcmp(params->color_map->answers[i], "")) {
+            mapset = G_find_raster2(params->color_map->answers[i], "");
+            if (mapset == NULL) {
+                G_fatal_error(_("Raster map <%s> not found"),
+                              params->color_map->answers[i]);
+            }
             Nviz_set_attr(
                 id, MAP_OBJ_SURF, ATT_COLOR, MAP_ATT,
                 G_fully_qualified_name(params->color_map->answers[i], mapset),


### PR DESCRIPTION
**Describe the bug**
 Create output image with `m.nviz.image elevation_map=elevation perspective=15 output=/tmp/elevation` module fails if  `color_map` param arg is not used.

**To Reproduce**
Steps to reproduce the behavior:

1. Run `m.nviz.image elevation_map=elevation perspective=15 output=/tmp/elevation` from the emulator terminal
2. See error

```
GRASS nc_spm_08_grass7/PERMANENT:~ > m.nviz.image elevation_map=elevation perspective=15 output=/tmp/elevation
Loading raster map <elevation@PERMANENT>...
 100%
Segmentation fault
```

**Expected behavior**
 Create output image with `m.nviz.image elevation_map=elevation perspective=15 output=/tmp/elevation` module should work  if  `color_map` param arg is not used.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all


**Additional context**

GDB debug info:

```gdb
GRASS nc_spm_08_grass7/PERMANENT:~ > gdb `which m.nviz.image`
GNU gdb (Gentoo 13.2 vanilla) 13.2
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://bugs.gentoo.org/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/lib64/grass84/bin/m.nviz.image...
Reading symbols from /usr/lib/debug//usr/lib64/grass84/bin/m.nviz.image.debug...
(gdb) run  elevation_map=elevation perspective=15 output=/tmp/elevation
Starting program: /usr/lib64/grass84/bin/m.nviz.image elevation_map=elevation perspective=15 output=/tmp/elevation
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
If they do, bad things may happen!
[New Thread 0x7fffe7e7c6c0 (LWP 3602)]
[New Thread 0x7fffe753a6c0 (LWP 3603)]
[New Thread 0x7fffe6d396c0 (LWP 3604)]
[New Thread 0x7fffe65386c0 (LWP 3605)]
[New Thread 0x7fffe59376c0 (LWP 3606)]
[New Thread 0x7fffe51366c0 (LWP 3607)]
Loading raster map <elevation@PERMANENT>...
 100%

Thread 1 "m.nviz.image" received signal SIGSEGV, Segmentation fault.
0x000055555555c048 in load_rasters (params=params@entry=0x55555558f9f0, data=data@entry=0x7fffffffd2e0) at surface.c:102
102	        mapset = G_find_raster2(params->color_map->answers[i], "");
```

Checking if a color raster map exists should be done if the `color_map` parameter arg is used.