### PR TITLE
r.watershed: fix streams and basins

### DIFF
--- a/raster/r.watershed/ram/do_cum.c
+++ b/raster/r.watershed/ram/do_cum.c
@@ -600,10 +600,12 @@ int do_cum_mfd(void)
                     aspect = -aspect;
                 asp[this_index] = aspect;
             }
+            /*
             if (mfd_cells == 1)
-                /* mfdir = (1 << nextmfd[max_side]); */
+                mfdir = (1 << nextmfd[max_side]);
+            */
 
-                is_swale = FLAG_GET(swale, r, c);
+            is_swale = FLAG_GET(swale, r, c);
             /* start new stream */
             value = ABS(value) + 0.5;
             if (!is_swale && (int)value >= threshold && stream_cells < 1 &&

--- a/raster/r.watershed/seg/do_cum.c
+++ b/raster/r.watershed/seg/do_cum.c
@@ -664,10 +664,12 @@ int do_cum_mfd(void)
                 else
                     af.asp = drain[r - r_max + 1][c - c_max + 1];
             }
+            /*
             if (mfd_cells == 1)
-                /* mfdir = (1 << nextmfd[max_side]); */
+                mfdir = (1 << nextmfd[max_side]);
+            */
 
-                is_swale = FLAG_GET(af.flag, SWALEFLAG);
+            is_swale = FLAG_GET(af.flag, SWALEFLAG);
             /* start new stream */
             if (!is_swale && fabs(value) >= threshold && stream_cells < 1 &&
                 swale_cells < 1 && !flat) {

--- a/raster/r.watershed/testsuite/r_watershed_test.py
+++ b/raster/r.watershed/testsuite/r_watershed_test.py
@@ -163,7 +163,12 @@ class TestWatershed(TestCase):
         )
         # it is expected that 100k Threshold has a min=2 and max=12 for this
         # data
-        self.assertRasterMinMax(self.basin, 2, 12)
+        reference = "min=2\nmax=12"
+        self.assertRasterFitsUnivar(
+            self.basin,
+            reference=reference,
+            msg="Basin values must be in the range [2, 12]",
+        )
         # it is expected that 100k Threshold has a min=2 and max=256 for this
         # data
         self.assertModule(
@@ -173,7 +178,12 @@ class TestWatershed(TestCase):
             basin=self.basin,
             overwrite=True,
         )
-        self.assertRasterMinMax(self.basin, 2, 256)
+        reference = "min=2\nmax=256"
+        self.assertRasterFitsUnivar(
+            self.basin,
+            reference=reference,
+            msg="Basin values must be in the range [2, 256]",
+        )
 
     def test_drainageDirection(self):
         """Test if the drainage direction is between -8 and 8."""
@@ -198,11 +208,11 @@ class TestWatershed(TestCase):
         # TODO: test just min, max is theoretically unlimited
         # or set a lower value according to what is expected with this data
         # TODO: add test which tests that 'max basin id' == 'num of basins'
-        self.assertRasterMinMax(
+        reference = "min=2\nmax=256"
+        self.assertRasterFitsUnivar(
             self.basin,
-            0,
-            1000000,
-            msg="A basin value is less than 0 or greater than 1000000",
+            reference=reference,
+            msg="Basin values must be in the range [2, 256]",
         )
 
 


### PR DESCRIPTION
The PR #2648 introduced a bug in `r.watershed` such that streams and basins are no longer correctly calculated. This PR fixes calculation of streams and basins in `r.watershed`.