### PR TITLE
wxGUI/vdidit: fix opening Vector Digitizer settings dialog while editing vector map

### DIFF
--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1173,7 +1173,7 @@ class ColumnSelect(ComboCtrl):
                     if key in excludeCols:
                         self.columns.remove(key)
             if type:  # only selected column types
-                for key, value in columnchoices.item():
+                for key, value in columnchoices.items():
                     if value["type"] not in type:
                         try:
                             self.columns.remove(key)


### PR DESCRIPTION
**Describe the bug**
Opening vector digitizer settings dialog while editing vector map fails.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Vector Digitizer e.g. `g.gui.vdigit geology`
2. From the Vector Digitizer window main toolbar activate Settings tool
3. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/vdigit/toolbars.py", line 698, in OnSettings
    self.settingsDialog = VDigitSettingsDialog(
  File "/usr/lib64/grass84/gui/wxpython/vdigit/preferences.py", line 48, in __init__
    self._createAttributesPage(notebook)
  File "/usr/lib64/grass84/gui/wxpython/vdigit/preferences.py", line 638, in _createAttributesPage
    column.InsertColumns(
  File "/usr/lib64/grass84/gui/wxpython/gui_core/gselect.py", line 1176, in InsertColumns
    for key, value in columnchoices.item():
AttributeError: 'dict' object has no attribute 'item'. Did you mean: 'items'?
```

**Expected behavior**
Opening vector digitizer settings dialog while editing vector map should work.


**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_basic_spm_grass7/PERMANENT:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Aug 25 2023, 20:13:27) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```