### PR TITLE
wxGUI/dbmgr: do not modify layer settings if settings have not changed

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -3860,7 +3860,7 @@ class LayerBook(wx.Notebook):
         if (
             self.modifyLayerWidgets["driver"][1].GetStringSelection()
             != self.mapDBInfo.layers[layer]["driver"]
-            or self.modifyLayerWidgets["database"][1].GetStringSelection()
+            or self.modifyLayerWidgets["database"][1].GetValue()
             != self.mapDBInfo.layers[layer]["database"]
             or self.modifyLayerWidgets["table"][1].GetStringSelection()
             != self.mapDBInfo.layers[layer]["table"]


### PR DESCRIPTION
**Describe the bug**
The wxGUI Attribute Table Manager adjusts the layer settings even if the settings have not changed while pressing the Modify layer button.


**To Reproduce**
Steps to reproduce the behavior:

1. Launch Attribute Table Manager e.g. `g.gui.dbmgr geology`
2. On the Attribute Table Manager window switch to the Manage Layers page (tab)
3. On the Manage Layers page (tab) switch to the Modify layer  page (tab)
4. Do not change layer settings
5. Hit Modify layer button
6.  See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/dbmgr/base.py", line 3896, in OnModifyLayer
    self.parentDialog.parentDbMgrBase.UpdateDialog(layer=layer)
  File "/usr/lib64/grass84/gui/wxpython/dbmgr/manager.py", line 253, in UpdateDialog
    DbMgrBase.UpdateDialog(self, layer=layer)
  File "/usr/lib64/grass84/gui/wxpython/dbmgr/base.py", line 854, in UpdateDialog
    self.pages["browse"].DeletePage(layer)
  File "/usr/lib64/grass84/gui/wxpython/dbmgr/base.py", line 1023, in DeletePage
    self.selLayer = self.layers[self.GetSelection()]
IndexError: list index out of range
```

**Expected behavior**
The wxGUI Attribute Table Manager don't adjusts the layer settings  if the settings have not changed while pressing the Modify layer button.

**System description (please complete the following information):**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_basic_spm_grass7/PERMANENT:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Aug 25 2023, 20:13:27) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```

**Additional context**
Issue related to incorrectly evaluated if condition (layer settings changed), especially line 3863 `self.modifyLayerWidgets["database"][1].GetStringSelection()`. 

Layer Database setting is **TextCtrl widget** and `self.modifyLayerWidgets["database"][1].GetStringSelection()` code especially `GetStringSelection()` method return empty string. Correct method for return control value should be `GetValue()`.

https://github.com/OSGeo/grass/blob/db8c58f780c905f7e070d2f5a73fd8929f9ec8e9/gui/wxpython/dbmgr/base.py#L3860-L3870