### PR TITLE
wxGUI/psmap: fix vector line map props dialog PenStyleComboBox widget drawing items

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -182,13 +182,13 @@ class PenStyleComboBox(OwnerDrawnComboBox):
         dc.DrawText(
             self.GetString(item),
             r.x + 3,
-            (r.y + 0) + ((r.height / 2) - dc.GetCharHeight()) / 2,
+            int((r.y + 0) + ((r.height / 2) - dc.GetCharHeight()) / 2),
         )
         dc.DrawLine(
             r.x + 5,
-            r.y + ((r.height / 4) * 3) + 1,
+            int(r.y + ((r.height / 4) * 3) + 1),
             r.x + r.width - 5,
-            r.y + ((r.height / 4) * 3) + 1,
+            int(r.y + ((r.height / 4) * 3) + 1),
         )
 
     def OnDrawBackground(self, dc, rect, item, flags):


### PR DESCRIPTION
**Describe the bug**
Vector line map props dialog Choose line style (`PenStyleComboBox()` class) widget doesn't drawing items correctly.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Cartographic Composer `g.gui.psmap`
2. Add map frame (via activating map frame tool from main toolbar), choose **vector line map** e.g. streams and hit Ok button (important is choose vector line map)
3. Double left mouse click on the square map frame to opening map frame dialog and switch to Vector maps page (tab)
4. On the Vector maps page (tab) hit Properties button to opening vector line e.g. streams map props dialog
5. On the vector line e.g. streams map props dialog switch to Size and style page (tab)
6. On Size and style page (tab) try to change  line style (Choose line style widget)
7.  See error

```
TypeError: DC.DrawText(): arguments did not match any overloaded call:
  overload 1: argument 3 has unexpected type 'float'
  overload 2: argument 2 has unexpected type 'int'
```

**Expected behavior**
Vector line map props dialog Choose line style (`PenStyleComboBox()` class) widget should draw items correctly.

**Screenshots**

Default behavior:

<img src="https://github.com/OSGeo/grass/assets/50632337/361481b5-c55c-4b5d-989f-fc9a39007821" alt="default behavior" width="400"/> 

Expected behavior:

<img src="https://github.com/OSGeo/grass/assets/50632337/b4646ea2-c7a3-47bf-a263-55c012dc9adf" alt="expected behavior" width="400"/> 

**System description:**

- Operating System: GNU/Linux
- GRASS GIS version: all

```
GRASS nc_basic_spm_grass7/PERMANENT:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```

**Additional context**
Device context `DrawTex()` and `DrawLine()` method require input `x`, `y` parameter argument type as integer type.

Method doc:

https://docs.wxpython.org/wx.DC.html#wx.DC.DrawText
https://docs.wxpython.org/wx.DC.html#wx.DC.DrawLine