### PR TITLE
wxGUI/psmap: fix simple point graphic recalculate position

### DIFF
--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -2126,8 +2126,8 @@ class PsMapBufferedWindow(wx.Window):
                     rect=rect, canvasToPaper=True
                 )
                 rect.Offset(
-                    dx=rect.GetWidth() / 2,
-                    dy=rect.GetHeight() / 2,
+                    dx=int(rect.GetWidth() / 2),
+                    dy=int(rect.GetHeight() / 2),
                 )
                 self.instruction[id]["where"] = self.CanvasPaperCoordinates(
                     rect=rect, canvasToPaper=True


### PR DESCRIPTION
**Describe the bug**
Changing the position of the simple point graphic prints an error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch `g.gui.psmap`
2. Add one simple point graphic
3. Activate Pointer tool from the main toolbar
4. Try to interactively change simple point graphic position
5. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/psmap/frame.py", line 1605, in MouseActions
    self.OnLeftUp(event)
  File "/usr/lib64/grass84/gui/wxpython/psmap/frame.py", line 1849, in OnLeftUp
    self.RecalculatePosition(ids=[self.dragId])
  File "/usr/lib64/grass84/gui/wxpython/psmap/frame.py", line 2128, in RecalculatePosition
    rect.Offset(
TypeError: Rect.Offset(): arguments did not match any overloaded call:
  overload 1: argument 'dx' has unexpected type 'float'
  overload 2: 'dx' is not a valid keyword argument
```

**Expected behavior**
Changing the position of the simple point graphic should not prints an error message.

**System description:**

- Operating System: GNU/Linux
- GRASS GIS version: all

```
GRASS nc_basic_spm_grass7/PERMANENT:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```

**Additional context**
 Rectangle widget with integer coordinates ,`Offset()` method `dx`,`dy` parameters require integer argument type.

Method doc:
https://docs.wxpython.org/wx.Rect.html#wx.Rect.Offset
