### PR TITLE
grass.script: Add function for colored message

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -661,6 +661,30 @@ def message(msg, flag=None):
     run_command("g.message", flags=flag, message=msg, errors="ignore")
 
 
+def prRed(msg):
+    """Display a message in red to highlight error message
+
+    :param str msg: message to be displayed
+    """    
+    print("\033[91m {}\033[00m".format(msg))
+
+
+def prLightPurple(msg):
+    """Display a message in lightpurple to highlight warning message
+
+    :param str msg: message to be displayed
+    """     
+    print("\033[94m {}\033[00m" .format(msg))
+
+
+def prGreen(msg):
+    """Display a message in green to highlight tip/suggestion
+
+    :param str msg: message to be displayed
+    """    
+    print("\033[92m {}\033[00m".format(msg))
+
+
 def debug(msg, debug=1):
     """Display a debugging message using `g.message -d`.
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -665,7 +665,7 @@ def prRed(msg):
     """Display a message in red to highlight error message
 
     :param str msg: message to be displayed
-    """    
+    """
     print("\033[91m {}\033[00m".format(msg))
 
 
@@ -673,15 +673,15 @@ def prLightPurple(msg):
     """Display a message in lightpurple to highlight warning message
 
     :param str msg: message to be displayed
-    """     
-    print("\033[94m {}\033[00m" .format(msg))
+    """
+    print("\033[94m {}\033[00m".format(msg))
 
 
 def prGreen(msg):
     """Display a message in green to highlight tip/suggestion
 
     :param str msg: message to be displayed
-    """    
+    """
     print("\033[92m {}\033[00m".format(msg))
 
 


### PR DESCRIPTION
Functions to print colored messages to the screen. They can be used to print error messages in red, warning messages in light purple and tips in green.  More examples with different colors on https://www.geeksforgeeks.org/print-colors-python-terminal/, from where I got these functions. (p.s. a better option, perhaps, is to add a color option to g.message?)