### PR TITLE
g.extension: fix registration addon with module name start with 2 chars db.*, ps.*, r3.*, wx.* 

### DIFF
--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1630,10 +1630,13 @@ def install_extension_win(name):
 
     # collect module names and file names
     module_list = list()
+    module_name_pattern = re.compile(
+        r"^([d,g,i,m,p,r,s,t,v]|^db|^ps|^r3|^wx)\..*[\.py,\.exe]$"
+    )
     for r, d, f in os.walk(srcdir):
         for file in f:
             # Filter GRASS module name patterns
-            if re.search(r"^[d,db,g,i,m,p,ps,r,r3,s,t,v,wx]\..*[\.py,\.exe]$", file):
+            if re.search(module_name_pattern, file):
                 modulename = os.path.splitext(file)[0]
                 module_list.append(modulename)
     # remove duplicates in case there are .exe wrappers for python scripts


### PR DESCRIPTION
**Describe the bug**
Not all addon module are registered during installation on the OS MS Windows platform.

**To Reproduce**
Steps to reproduce the behavior:

1. Apply PR #3166 first please
2. Try install one of the addons which name start with two characters **\*db.\*, ps.\*, r3.\*, wx.\*** e.g. `g.extension db.join`
3. Check if installed addon module is registered  `g.extension -a`

**Expected behavior**
Addon module whose  name start with two characters **\*db.\*, ps.\*, r3.\*, wx.\*** should be registered during installation same as others addon module.

```
C:\Users\User>g.extension db.join
Downloading precompiled GRASS Addons <db.join>...
Fetching <db.join> from
<http://wingrass.fsv.cvut.cz/grass84/addons/grass-8.4.0dev/db.join.zip> (be
patient)...
Updating extension modules metadata file...
Installation of <db.join> successfully finished

C:\Users\User>g.extension -a
List of installed extensions (modules):
db.join
```

**System description:**

- Operating System: MS Windows
- GRASS GIS version: all

```
C:\Users\User>python3 -c "import sys, wx; print(sys.version); print(wx.version())
3.9.5 (tags/v3.9.5:0a7dcbd, May  3 2021, 17:27:52) [MSC v.1928 64 bit (AMD64)]
4.2.0 msw (phoenix) wxWidgets 3.2.1
```

**Additional context**
Problematic is regular expression which not catch addon module name which start with two character **\*db.\*, ps.\*, r3.\*, wx.\***.

https://github.com/OSGeo/grass/blob/6ffd18f8083c888fddfdae86ceb771e0e33cbb25/scripts/g.extension/g.extension.py#L1635-L1636

Expected behavior:

```python
In [1]: import re

In [2]: re.search(r"^([d,g,i,m,p,r,s,t,v]|^db|^ps|^r3|^wx)\..*[\.py,\.exe]$", "db.join.py")
Out[2]: <re.Match object; span=(0, 10), match='db.join.py'>
```