### PR TITLE
wxGUI/iclass: fix showing scatter plots

### DIFF
--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -1019,8 +1019,7 @@ def imshow(
     @author: Chris Beaumont <beaumont@hawaii.edu>
     """
 
-    if not axes._hold:
-        axes.cla()
+    axes.cla()
     if norm is not None:
         assert isinstance(norm, mcolors.Normalize)
     if aspect is None:
@@ -1069,7 +1068,7 @@ def imshow(
     # to tightly fit the image, regardless of dataLim.
     im.set_extent(im.get_extent())
 
-    axes.images.append(im)
+    axes.add_image(im)
     im._remove_method = lambda h: axes.images.remove(h)
 
     return im


### PR DESCRIPTION
**Describe the bug**
Supervised Classification Tool does not show scatter plots and prints error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Supervised Classification Tool wxGUI `g.gui.iclass`
2. On the left Plots pane combobox widget choose **Scatter plots** item
3. On the Scatter plots toolbar activate Add scatter plot tool
5. On the Select imagery group dialog from the name of imagery group listbox widget items choose **lsat7_2000**
6. Hit Create/edit group... button widget
7. On the Create or edit image group dialog, type into Select existing subgroup or enter name of new subgroup combobox widget new subgroup name e.g. **test** and select some maps from the list to be part of the new cretaed subgroup **test** (lsat7_2000_10, lsat7_2000_20, lsat7_2000_30, lsat7_2000_40) and hit OK button
8. Hit OK button on the Create or edit image group dialog
9. On the next Add scatter plots dialog choose from the x axis combobox widget items lsat7_2000_10 raster map, and from the y axis combobox widget items choose lsat7_2000_20 raster map and hit Add button
10.  Repeat point 9. but with another maps, from the x axis combobox widget items choose lsat7_2000_30 raster map, and from the y axis combobox widget items choose lsat7_2000_40 raster map and hit Add button
11. On the Add scatter plots dialog hit OK button
12. See error

First error:

```
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib64/grass84/gui/wxpython/core/gthread.py", line 151, in __run
    self.__run_backup()
  File "/usr/lib64/grass84/gui/wxpython/core/gthread.py", line 114, in run
    ret = vars()["callable"](*args, **kwds)
  File "/usr/lib64/grass84/gui/wxpython/iscatt/controllers.py", line 604, in _renderscattplts
    scatt["scatt"].Plot(
  File "/usr/lib64/grass84/gui/wxpython/iscatt/plots.py", line 234, in Plot
    img = imshow(
  File "/usr/lib64/grass84/gui/wxpython/iscatt/plots.py", line 1021, in imshow
    if not axes._hold:
AttributeError: 'Axes' object has no attribute '_hold'
```

Second error:

```
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib64/grass84/gui/wxpython/core/gthread.py", line 151, in __run
    self.__run_backup()
  File "/usr/lib64/grass84/gui/wxpython/core/gthread.py", line 114, in run
    ret = vars()["callable"](*args, **kwds)
  File "/usr/lib64/grass84/gui/wxpython/iscatt/controllers.py", line 604, in _renderscattplts
    scatt["scatt"].Plot(
  File "/usr/lib64/grass84/gui/wxpython/iscatt/plots.py", line 234, in Plot
    img = imshow(
  File "/usr/lib64/grass84/gui/wxpython/iscatt/plots.py", line 1070, in imshow
    axes.images.append(im)
AttributeError: 'ArtistList' object has no attribute 'append'
```
**Expected behavior**
Supervised Classification Tool should show scatter plots without error message.

**Screenshots**

Expected behavior:

<img src="https://github.com/OSGeo/grass/assets/50632337/8a7fc92e-7aee-4b8a-a14d-b341fd97791b" alt="wxgui iclass scatter plots expected behavior" width="400"/>

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, matplotlib, wx; print(sys.version); print(wx.version()); print(f'{matplotlib.__version__} matplotlib')"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
3.7.2 matplotlib
```

**Additional context**

Matplotlib v3.0 API changes:

`matplotlib.axes.Axes.hold` doc:

https://matplotlib.org/2.2.5/api/_as_gen/matplotlib.axes.Axes.hold.html
