### PR TITLE
docker: implement multi-stage-builds for ubuntu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ docker
 .github
 .travis
 .travis.yml
+# Do not copy files from previous compilations
+dist.*
 
 # The following git files are needed by GRASS GIS to extract the revision
 # during compilation. If you are not using one of the Dockerimages from this

--- a/docker/testdata/test_docker_image.sh
+++ b/docker/testdata/test_docker_image.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e
+
+# to be used in Dockerfile
+
+# Display environment
+printf "\n############\nPrinting defined environment variables:\n############\n"
+printenv
+
+# run simple LAZ test
+cp docker/testdata/simple.laz /tmp/
+cp docker/testdata/test_grass_session.py /tmp/
+cp docker/testdata/test_grass_python.py /tmp/
+cp -r demolocation /tmp/
+
+# Test grass-session
+printf "\n############\nTesting grass_session:\n############\n"
+/usr/bin/python3 /tmp/test_grass_session.py
+
+# Test grass-setup
+printf "\n############\nTesting grass script setup:\n############\n"
+export DEMOLOCATION=/tmp/demolocation/PERMANENT
+/usr/bin/python3 /tmp/test_grass_python.py
+
+# Test PDAL
+printf "\n############\nTesting PDAL with laz:\n############\n"
+grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+
+# Test GRASS GIS Python-addon installation
+# add dependency
+printf "\n############\nTesting GRASS GIS Python-addon installation:\n############\n"
+/usr/bin/python3 -m pip install --no-cache-dir scikit-learn
+
+grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add && \
+	   grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
+
+# cleanup dependency
+/usr/bin/python3 -m pip uninstall -y scikit-learn
+
+# Test GRASS GIS C-addon installation: raster and vector
+printf "\n############\nTesting GRASS GIS C-addon installation:\n############\n"
+grass --tmp-location XY --exec g.extension extension=r.gwr operation=add && \
+	   grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add && \
+	   grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
+
+# show GRASS GIS, PROJ, GDAL etc versions
+printf "\n############\nPrinting GRASS, PDAL and Python versions:\n############\n"
+grass --tmp-location EPSG:4326 --exec g.version -rge && \
+    pdal --version && \
+    python3 --version
+
+# Test presence of central python packages
+printf "\n############\nPrinting versions of central python packages:\n############\n"
+python3 -c "import psycopg2;import numpy as np;print(psycopg2.__version__);print(np.__version__)"
+
+# Run testsuite
+if [ $TESTSUITE ] ; then
+  printf "\n############\nRunning the testsuite:\n############\n"
+  bash /grassdb/.github/workflows/test_thorough.sh
+fi

--- a/docker/testdata/test_docker_image.sh
+++ b/docker/testdata/test_docker_image.sh
@@ -14,6 +14,10 @@ cp docker/testdata/test_grass_session.py /tmp/
 cp docker/testdata/test_grass_python.py /tmp/
 cp -r demolocation /tmp/
 
+# Test gdal-grass-plugin
+printf "\n############\nTesting the gdal_grass plugin:\n############\n"
+gdalinfo --formats | grep "GRASS -raster-"
+
 # Test grass-session
 printf "\n############\nTesting grass_session:\n############\n"
 /usr/bin/python3 /tmp/test_grass_session.py

--- a/docker/testdata/test_grass_python.py
+++ b/docker/testdata/test_grass_python.py
@@ -1,0 +1,22 @@
+# Import GRASS Python bindings
+import os
+import grass.script as gs
+
+# hint: do not use ~ as an alias for HOME
+with gs.setup.init(
+    # run in PERMANENT mapset of demolocation in GRASS GIS source
+    os.environ["DEMOLOCATION"] # "/grassdata/demolocation/PERMANENT",
+    ):
+    print("grass-setup: tests for PROJ, GDAL, PDAL, GRASS GIS")
+    print(gs.parse_command("g.gisenv", flags="s"))
+
+    # simple test: just scan the LAZ file
+    gs.run_command(
+        "r.in.pdal",
+        input="/tmp/simple.laz",
+        output="count_1",
+        method="n",
+        flags="g",
+        resolution=1,
+        overwrite=True,
+    )

--- a/docker/testdata/test_grass_python.py
+++ b/docker/testdata/test_grass_python.py
@@ -5,8 +5,8 @@ import grass.script as gs
 # hint: do not use ~ as an alias for HOME
 with gs.setup.init(
     # run in PERMANENT mapset of demolocation in GRASS GIS source
-    os.environ["DEMOLOCATION"] # "/grassdata/demolocation/PERMANENT",
-    ):
+    os.environ["DEMOLOCATION"]  # "/grassdata/demolocation/PERMANENT",
+):
     print("grass-setup: tests for PROJ, GDAL, PDAL, GRASS GIS")
     print(gs.parse_command("g.gisenv", flags="s"))
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 as common
 
 LABEL authors="Carmen Tawalika,Markus Neteler,Anika Weinmann"
 LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,weinmann@mundialis.de"
@@ -7,132 +7,162 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
-ARG PDAL_VERSION=2.4.3
 
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /tmp
 
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends --no-install-suggests \
+# Todo: re-consider required dev packages for addons (~400MB in dev packages)
+ENV GRASS_RUN_PACKAGES="\
     build-essential \
     bison \
     bzip2 \
-    cmake \
     curl \
     flex \
     g++ \
     gcc \
     gdal-bin \
+    geos-bin \
+    proj-bin \
+    netcdf-bin \
     git \
     language-pack-en-base \
-    libbz2-dev \
     libcairo2 \
-    libcairo2-dev \
     libcurl4-gnutls-dev \
     libfftw3-bin \
-    libfftw3-dev \
-    libfreetype6-dev \
+    libfreetype6 \
     libgdal-dev \
-    libgeos-dev \
-    libgsl0-dev \
-    libjpeg-dev \
+    libgsl27 \
+    libjpeg-turbo8 \
     libjsoncpp-dev \
-    libnetcdf-dev \
-    libncurses5-dev \
+    libncurses5 \
+    #libopenblas-dev \
     libopenblas-base \
-    libopenblas-dev \
     libopenjp2-7 \
-    libopenjp2-7-dev \
-    libpnglite-dev \
-    libpq-dev \
-    libproj-dev \
+    libomp5 \
+    libgeos-dev \
+    #libpdal-dev \
+    #libproj-dev \
+    #libpq-dev \
+    libgsl-dev \
+    libpdal-base13 \
+    libpdal-plugin-hdf \
+    libpdal-plugins \
+    libpdal-util13 \
+    libpnglite0 \
+    libpq5 \
     libpython3-all-dev \
-    libsqlite3-dev \
-    libtiff-dev \
-    libzstd-dev \
+    libreadline8 \
+    libsqlite3-0 \
+    libtiff-tools \
+    libzstd1 \
     locales \
     make \
-    mesa-common-dev \
+    mesa-utils \
     moreutils \
     ncurses-bin \
-    netcdf-bin \
-    proj-bin \
+    pdal \
     proj-data \
     python3 \
-    python3-dateutil \
     python3-dev \
-    python3-magic \
-    python3-numpy \
-    python3-pil \
-    python3-pip \
-    python3-ply \
-    python3-setuptools \
     python3-venv \
-    software-properties-common \
     sqlite3 \
-    subversion \
     unzip \
     vim \
     wget \
     zip \
-    zlib1g-dev \
-    && apt-get clean all && rm -rf /var/lib/apt/lists/*
+    zlib1g \
+    "
+
+# Add ubuntugis unstable and fetch packages
+RUN apt-get update \
+    && apt-get install  -y --no-install-recommends --no-install-suggests \
+    software-properties-common \
+    gpg \
+    gpg-agent \
+    && LC_ALL=C.UTF-8 add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable \
+    && apt-get update -y && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+    $GRASS_RUN_PACKAGES \
+    && apt-get remove -y gpg gpg-agent \
+    && apt-get autoremove -y \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
 
-## fetch vertical datums for PDAL and store into PROJ dir
-WORKDIR /src
-RUN mkdir vdatum && \
-    cd vdatum && \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
-    cd .. && \
-    rm -rf vdatum
+# Start build stage
+FROM common as build
 
-## compile and install PDAL (not available on Debian/Ubuntu) with laz-perf enabled
-ENV NUMTHREADS=4
-WORKDIR /src
-RUN wget -q \
- https://github.com/PDAL/PDAL/releases/download/${PDAL_VERSION}/PDAL-${PDAL_VERSION}-src.tar.gz && \
-    tar xfz PDAL-${PDAL_VERSION}-src.tar.gz && \
-    cd /src/PDAL-${PDAL_VERSION}-src && \
-    mkdir build && \
-    cd build && \
-    cmake .. \
-      -G "Unix Makefiles" \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=/usr \
-      -DCMAKE_C_COMPILER=gcc \
-      -DCMAKE_CXX_COMPILER=g++ \
-      -DCMAKE_MAKE_PROGRAM=make \
-      -DBUILD_PLUGIN_PYTHON=ON \
-      -DBUILD_PLUGIN_CPD=OFF \
-      -DBUILD_PLUGIN_GREYHOUND=ON \
-      -DBUILD_PLUGIN_HEXBIN=ON \
-      -DHEXER_INCLUDE_DIR=/usr/include/ \
-      -DBUILD_PLUGIN_NITF=OFF \
-      -DBUILD_PLUGIN_ICEBRIDGE=ON \
-      -DBUILD_PLUGIN_PGPOINTCLOUD=OFF \
-      -DBUILD_PGPOINTCLOUD_TESTS=OFF \
-      -DBUILD_PLUGIN_SQLITE=ON \
-      -DWITH_LASZIP=OFF \
-      -DWITH_LAZPERF=ON \
-      -DWITH_TESTS=ON && \
-    make -j $NUMTHREADS && \
-    make install
+# Define build packages
+ENV GRASS_BUILD_PACKAGES="\
+    cmake \
+    libbz2-dev \
+    libcairo2-dev \
+    libopenblas-dev \
+    libpdal-dev \
+    libproj-dev \
+    libpq-dev \
+    libfftw3-dev \
+    libfreetype6-dev \
+    libomp-dev \
+    zlib1g-dev \
+    libnetcdf-dev \
+    libopenjp2-7-dev \
+    libreadline-dev \
+    libjpeg-dev \
+    libpnglite-dev \
+    libsqlite3-dev \
+    libtiff-dev \
+    libzstd-dev \
+    libncurses5-dev \
+    mesa-common-dev \
+    zlib1g-dev \
+    "
+
+# Add build packages
+RUN apt-get update \
+    && apt-get install  -y --no-install-recommends --no-install-suggests \
+    $GRASS_BUILD_PACKAGES \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add pip and Python packages
+RUN (echo "Install Python" \
+    && wget https://bootstrap.pypa.io/pip/get-pip.py \
+    # && apt-get install -y python3-ensurepip \
+    && python3 get-pip.py \
+    # && python3 -m ensurepip --upgrade \
+    && rm -r get-pip.py \
+    && mkdir -p /src/site-packages \
+    && cd /src \
+    && python3 -m pip install --no-cache-dir -t /src/site-packages --upgrade \
+    pip \
+    setuptools \
+    grass-session \
+    python-dateutil \
+    python-magic \
+    numpy \
+    Pillow \
+    ply \
+    setuptools \
+    matplotlib \
+    psycopg2 \
+    && rm -r /root/.cache \
+    )
+
+# ers are encouraged to fetch vertical datums and store into PROJ dir, e.g.:
+# WORKDIR /src
+# RUN mkdir vdatum && \
+#     cd vdatum && \
+#     wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+#     cd .. && \
+#     rm -rf vdatum
 
 # copy grass gis source
-WORKDIR /src
 COPY . /src/grass_build/
+
 WORKDIR /src/grass_build
 
 # Cleanup potentially leftover GISRC file with wrong path to "demolocation"
@@ -143,7 +173,7 @@ RUN rm -f /src/grass_build/dist.*/demolocation/.grassrc*
 ENV MYCFLAGS "-O2 -std=gnu99 -m64"
 ENV MYLDFLAGS "-s"
 # CXX stuff:
-ENV LD_LIBRARY_PATH "/usr/local/lib"
+#ENV LD_LIBRARY_PATH "/usr/local/lib"
 ENV LDFLAGS "$MYLDFLAGS"
 ENV CFLAGS "$MYCFLAGS"
 ENV CXXFLAGS "$MYCXXFLAGS"
@@ -152,7 +182,7 @@ ENV CXXFLAGS "$MYCXXFLAGS"
 ENV GRASS_PYTHON=/usr/bin/python3
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
-RUN /src/grass_build/configure \
+RUN ./configure \
   --with-cxx \
   --enable-largefile \
   --with-proj-share=/usr/share/proj \
@@ -168,11 +198,33 @@ RUN /src/grass_build/configure \
   --with-bzlib \
   --with-pdal \
   --without-mysql \
-  --without-odbc \
-  --without-openmp \
+  --with-blas \
+  --with-lapack \
+  --with-readline \
+  --with-odbc \
+  --with-openmp \
   --without-opengl \
     && make -j $NUMTHREADS \
     && make install && ldconfig
+
+# Build the GDAL-GRASS plugin
+RUN git clone https://github.com/OSGeo/gdal-grass && \
+    cd "gdal-grass" && \
+    ./configure --with-gdal=/usr/bin/gdal-config \
+            --with-grass=/usr/local/grass84 && \
+    make -j $NUMTHREADS && \
+    make install -j $NUMTHREADS && \
+    cd /src && \
+    rm -rf "gdal-grass"
+
+# Reduce the image size - Remove unnecessary grass files
+RUN cp /usr/local/grass84/gui/wxpython/xml/module_items.xml module_items.xml; \
+    rm -rf /usr/local/grass84/demolocation; \
+    rm -rf /usr/local/grass84/fonts; \
+    rm -rf /usr/local/grass84/gui; \
+    rm -rf /usr/local/grass84/share; \
+    mkdir -p /usr/local/grass84/gui/wxpython/xml/; \
+    mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
 
 # Unset environmental variables to avoid later compilation issues
 ENV INTEL ""
@@ -184,47 +236,40 @@ ENV LDFLAGS ""
 ENV CFLAGS ""
 ENV CXXFLAGS ""
 
-# set SHELL var to avoid /bin/sh fallback in interactive GRASS GIS sessions
-ENV SHELL /bin/bash
-ENV LC_ALL "en_US.UTF-8"
-ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
+# Leave build stage
+FROM common as grass
 
-# https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
-ENV PROJ_NETWORK=ON
+# GRASS GIS specific
+# allow work with MAPSETs that are not owned by current user
+# add GRASS GIS envs for python usage
+ENV GRASSBIN="/usr/local/bin/grass" \
+    GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
+    SHELL="/bin/bash" \
+    # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
+    PROJ_NETWORK=ON \
+    # GRASSBIN=grass \
+    LC_ALL="en_US.UTF-8" \
+    GISBASE="/usr/local/grass/" \
+    GRASSBIN="/usr/local/bin/grass" \
+    PYTHONPATH="${PYTHONPATH}:/usr/local/grass/etc/python/" \
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/grass/lib"
+
+# Copy GRASS GIS from build image
+COPY --from=build /usr/local/bin/grass* /usr/local/bin/
+COPY --from=build /usr/local/grass84 /usr/local/grass84/
+COPY --from=build /src/site-packages /usr/lib/python3.10/
 
 # Create generic GRASS GIS lib name regardless of version number
-RUN ln -sf /usr/local/grass84 /usr/local/grass
+RUN ln -sf /usr/local/grass84 /usr/local/grass && \
+    ldconfig /etc/ld.so.conf.d
 
-# show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
-    pdal --version && \
-    python3 --version
+RUN ls "$GISBASE/etc/python/"
+# Reduce the image size (not sure this has any effect)
+#RUN apt-get autoremove -y && \
+#    apt-get clean
 
-# Reduce the image size
-RUN apt-get autoremove -y
-RUN apt-get clean -y
-RUN rm -r /src/grass_build/.git
-
-WORKDIR /scripts
-
-# install external GRASS GIS session Python API
-RUN pip3 install grass-session
-
-# add GRASS GIS envs for python usage
-ENV GISBASE "/usr/local/grass/"
-ENV GRASSBIN "/usr/local/bin/grass"
-ENV PYTHONPATH "${PYTHONPATH}:$GISBASE/etc/python/"
-ENV LD_LIBRARY_PATH "$LD_LIBRARY_PATH:$GISBASE/lib"
-
-WORKDIR /tmp
-COPY docker/testdata/simple.laz .
-WORKDIR /scripts
-COPY docker/testdata/test_grass_session.py .
-## just scan the LAZ file
-# Not yet ready for GRASS GIS 8:
-#RUN /usr/bin/python3 /scripts/test_grass_session.py
-# test LAZ file
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
-
+# Data workdir
 WORKDIR /grassdb
 VOLUME /grassdb
+
+CMD ["bash", "-c", "$GRASSBIN", "--version"]

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -98,18 +98,19 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
 ## fetch vertical datums for PDAL and store into PROJ dir
 WORKDIR /src
 
-# Get datum grids
-FROM ubuntu:22.04 as datum_grids
+# # Get datum grids
+# # Currently using https://proj.org/en/9.3/usage/network.html#how-to-enable-network-capabilities
+# FROM ubuntu:22.04 as datum_grids
 
-# See: https://github.com/OSGeo/PROJ-data
-RUN apt-get update \
-    && apt-get install  -y --no-install-recommends --no-install-suggests \
-    wget \
-    && apt-get clean all \
-    && rm -rf /var/lib/apt/lists/*
+# # See: https://github.com/OSGeo/PROJ-data
+# RUN apt-get update \
+#     && apt-get install  -y --no-install-recommends --no-install-suggests \
+#     wget \
+#     && apt-get clean all \
+#     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /tmp
-RUN wget --no-check-certificate -r -l inf -A tif https://cdn.proj.org/
+# WORKDIR /tmp
+# RUN wget --no-check-certificate -r -l inf -A tif https://cdn.proj.org/
 
 # Start build stage
 FROM common as build
@@ -250,7 +251,7 @@ COPY --link --from=build /usr/local/bin/* /usr/local/bin/
 COPY --link --from=build /usr/local/grass84 /usr/local/grass84/
 COPY --link --from=build /src/site-packages /usr/lib/python3.10/
 COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
-COPY --link --from=datum_grids /tmp/cdn.proj.org/*.tif /usr/share/proj/
+# COPY --link --from=datum_grids /tmp/cdn.proj.org/*.tif /usr/share/proj/
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass84 /usr/local/grass && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,19 +1,22 @@
 # syntax=docker/dockerfile:1.4
-FROM ubuntu:22.04 as common
+
+ARG GUI=without
+
+FROM ubuntu:22.04 as common_start
 
 LABEL authors="Carmen Tawalika,Markus Neteler,Anika Weinmann,Stefan Blumentrath"
 LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,weinmann@mundialis.de"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /tmp
 
+ARG GUI
+
 # Todo: re-consider required dev packages for addons (~400MB in dev packages)
-ENV GRASS_RUN_PACKAGES="\
-    build-essential \
+ARG GRASS_RUN_PACKAGES="build-essential \
     bison \
     bzip2 \
     curl \
@@ -77,6 +80,117 @@ ENV GRASS_RUN_PACKAGES="\
     zlib1g \
     "
 
+# Define build packages
+ARG GRASS_BUILD_PACKAGES="cmake \
+    libbz2-dev \
+    libcairo2-dev \
+    libfreetype6-dev \
+    zlib1g-dev \
+    libnetcdf-dev \
+    libopenjp2-7-dev \
+    libreadline-dev \
+    libjpeg-dev \
+    libpnglite-dev \
+    libsqlite3-dev \
+    libtiff-dev \
+    libzstd-dev \
+    libncurses5-dev \
+    mesa-common-dev \
+    zlib1g-dev \
+    "
+
+ARG GRASS_CONFIG="--with-cxx \
+  --enable-largefile \
+  --with-proj-share=/usr/share/proj \
+  --with-gdal=/usr/bin/gdal-config \
+  --with-geos \
+  --with-sqlite \
+  --with-cairo --with-cairo-ldflags=-lfontconfig \
+  --with-freetype --with-freetype-includes=/usr/include/freetype2/ \
+  --with-fftw \
+  --with-postgres --with-postgres-includes=/usr/include/postgresql \
+  --with-netcdf \
+  --with-zstd \
+  --with-bzlib \
+  --with-pdal \
+  --without-mysql \
+  --with-blas \
+  --with-lapack \
+  --with-readline \
+  --with-odbc \
+  --with-openmp \
+  "
+
+ARG GRASS_PYTHON_PACKAGES="pip \
+    setuptools \
+    grass-session \
+    python-dateutil \
+    python-magic \
+    numpy \
+    Pillow \
+    ply \
+    matplotlib \
+    psycopg2 \
+  "
+
+
+FROM common_start as grass_without_gui
+
+ARG GRASS_CONFIG="${GRASS_CONFIG} --without-opengl"
+
+
+FROM common_start as grass_with_gui
+
+ARG GRASS_RUN_PACKAGES="${GRASS_RUN_PACKAGES} adwaita-icon-theme-full \
+  libglu1-mesa \
+  libgtk-3-0 \
+  libnotify4 \
+  libsdl2-2.0-0 \
+  libxtst6 \
+  librsvg2-common \
+  gettext \
+  freeglut3 \
+  libgstreamer-plugins-base1.0 \
+  libjpeg8 \
+  libpng16-16 \
+  libsm6 \
+  libtiff5 \
+  libwebkit2gtk-4.0 \
+"
+# librsvg2-common \
+# (fix error (wxgui.py:7782): Gtk-WARNING **: 19:53:09.774:
+# Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
+# This may indicate that pixbuf loaders or the mime database could not be found.)
+
+ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} adwaita-icon-theme-full \
+  libgl1-mesa-dev \
+  libglu1-mesa-dev \
+  freeglut3-dev \
+  libgstreamer-plugins-base1.0-dev \
+  libgtk-3-dev \
+  libjpeg-dev \
+  libnotify-dev \
+  libpng-dev \
+  libsdl2-dev \
+  libsm-dev \
+  libtiff-dev \
+  libwebkit2gtk-4.0-dev \
+  libxtst-dev \
+"
+
+ARG GRASS_CONFIG="${GRASS_CONFIG} --with-opengl \
+  --with-x \
+  --with-nls \
+  --with-readline \
+  "
+ARG GRASS_PYTHON_PACKAGES="${GRASS_PYTHON_PACKAGES} wxPython"
+# If you do not use any Gnome Accessibility features, to suppress warning
+# WARNING **: Couldn't connect to accessibility bus:
+# execute programs with
+ENV NO_AT_BRIDGE=1
+
+
+FROM grass_${GUI}_gui as grass_gis
 # Add ubuntugis unstable and fetch packages
 RUN apt-get update \
     && apt-get install  -y --no-install-recommends --no-install-suggests \
@@ -92,8 +206,9 @@ RUN apt-get update \
     && apt-get clean all \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo LANG="en_US.UTF-8" > /etc/default/locale
-RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
+RUN echo LANG="en_US.UTF-8" > /etc/default/locale \
+    && echo en_US.UTF-8 UTF-8 >> /etc/locale.gen \
+    && locale-gen
 
 ## fetch vertical datums for PDAL and store into PROJ dir
 WORKDIR /src
@@ -113,27 +228,7 @@ WORKDIR /src
 # RUN wget --no-check-certificate -r -l inf -A tif https://cdn.proj.org/
 
 # Start build stage
-FROM common as build
-
-# Define build packages
-ENV GRASS_BUILD_PACKAGES="\
-    cmake \
-    libbz2-dev \
-    libcairo2-dev \
-    libfreetype6-dev \
-    zlib1g-dev \
-    libnetcdf-dev \
-    libopenjp2-7-dev \
-    libreadline-dev \
-    libjpeg-dev \
-    libpnglite-dev \
-    libsqlite3-dev \
-    libtiff-dev \
-    libzstd-dev \
-    libncurses5-dev \
-    mesa-common-dev \
-    zlib1g-dev \
-    "
+FROM grass_gis as build
 
 # Add build packages
 RUN apt-get update \
@@ -152,16 +247,7 @@ RUN (echo "Install Python" \
     && mkdir -p /src/site-packages \
     && cd /src \
     && python3 -m pip install --no-cache-dir -t /src/site-packages --upgrade \
-    pip \
-    setuptools \
-    grass-session \
-    python-dateutil \
-    python-magic \
-    numpy \
-    Pillow \
-    ply \
-    matplotlib \
-    psycopg2 \
+    $GRASS_PYTHON_PACKAGES \
     && rm -r /root/.cache \
     && rm -rf /tmp/pip-* \
     )
@@ -185,28 +271,7 @@ ENV CXXFLAGS "$MYCXXFLAGS"
 ENV GRASS_PYTHON=/usr/bin/python3
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
-RUN ./configure \
-  --with-cxx \
-  --enable-largefile \
-  --with-proj-share=/usr/share/proj \
-  --with-gdal=/usr/bin/gdal-config \
-  --with-geos \
-  --with-sqlite \
-  --with-cairo --with-cairo-ldflags=-lfontconfig \
-  --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
-  --with-fftw \
-  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
-  --with-netcdf \
-  --with-zstd \
-  --with-bzlib \
-  --with-pdal \
-  --without-mysql \
-  --with-blas \
-  --with-lapack \
-  --with-readline \
-  --with-odbc \
-  --with-openmp \
-  --without-opengl \
+RUN ./configure $GRASS_CONFIG \
     && make -j $NUMTHREADS \
     && make install && ldconfig \
     &&  cp /usr/local/grass84/gui/wxpython/xml/module_items.xml module_items.xml; \
@@ -218,17 +283,18 @@ RUN ./configure \
     mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
 
 # Build the GDAL-GRASS plugin
-RUN git clone https://github.com/OSGeo/gdal-grass && \
-    cd "gdal-grass" && \
-    ./configure --with-gdal=/usr/bin/gdal-config \
-            --with-grass=/usr/local/grass84 && \
-    make -j $NUMTHREADS && \
-    make install -j $NUMTHREADS && \
-    cd /src && \
-    rm -rf "gdal-grass"
+RUN git clone https://github.com/OSGeo/gdal-grass \
+    && cd "gdal-grass" \
+    && ./configure \
+      --with-gdal=/usr/bin/gdal-config \
+      --with-grass=/usr/local/grass84 \
+    && make -j $NUMTHREADS \
+    && make install -j $NUMTHREADS \
+    && cd /src \
+    && rm -rf "gdal-grass"
 
 # Leave build stage
-FROM common as grass
+FROM grass_gis as grass_gis_final
 
 # GRASS GIS specific
 # allow work with MAPSETs that are not owned by current user
@@ -254,8 +320,8 @@ COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 # COPY --link --from=datum_grids /tmp/cdn.proj.org/*.tif /usr/share/proj/
 
 # Create generic GRASS GIS lib name regardless of version number
-RUN ln -sf /usr/local/grass84 /usr/local/grass && \
-    ldconfig /etc/ld.so.conf.d
+RUN ln -sf /usr/local/grass84 /usr/local/grass \
+    && ldconfig /etc/ld.so.conf.d
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -150,7 +150,7 @@ RUN (echo "Install Python" \
     && rm -r /root/.cache \
     )
 
-# ers are encouraged to fetch vertical datums and store into PROJ dir, e.g.:
+# Users are encouraged to fetch vertical datums and store into PROJ dir, e.g.:
 # WORKDIR /src
 # RUN mkdir vdatum && \
 #     cd vdatum && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM ubuntu:22.04 as common
 
 LABEL authors="Carmen Tawalika,Markus Neteler,Anika Weinmann,Stefan Blumentrath"
@@ -28,20 +29,22 @@ ENV GRASS_RUN_PACKAGES="\
     libcairo2 \
     libcurl4-gnutls-dev \
     libfftw3-bin \
+    libfftw3-dev \
     libfreetype6 \
     libgdal-dev \
     libgsl27 \
     libjpeg-turbo8 \
     libjsoncpp-dev \
     libncurses5 \
-    #libopenblas-dev \
+    libopenblas-dev \
     libopenblas-base \
     libopenjp2-7 \
     libomp5 \
+    libomp-dev \
     libgeos-dev \
-    #libpdal-dev \
-    #libproj-dev \
-    #libpq-dev \
+    libpdal-dev \
+    libproj-dev \
+    libpq-dev \
     libgsl-dev \
     libpdal-base13 \
     libpdal-plugin-hdf \
@@ -90,6 +93,22 @@ RUN apt-get update \
 RUN echo LANG="en_US.UTF-8" > /etc/default/locale
 RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
 
+## fetch vertical datums for PDAL and store into PROJ dir
+WORKDIR /src
+RUN mkdir vdatum && \
+    cd vdatum && \
+    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
+    wget -q http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
+    cd .. && \
+    rm -rf vdatum
+
 # Start build stage
 FROM common as build
 
@@ -98,13 +117,7 @@ ENV GRASS_BUILD_PACKAGES="\
     cmake \
     libbz2-dev \
     libcairo2-dev \
-    libopenblas-dev \
-    libpdal-dev \
-    libproj-dev \
-    libpq-dev \
-    libfftw3-dev \
     libfreetype6-dev \
-    libomp-dev \
     zlib1g-dev \
     libnetcdf-dev \
     libopenjp2-7-dev \
@@ -144,27 +157,16 @@ RUN (echo "Install Python" \
     numpy \
     Pillow \
     ply \
-    setuptools \
     matplotlib \
     psycopg2 \
     && rm -r /root/.cache \
+    && rm -rf /tmp/pip-* \
     )
-
-# Users are encouraged to fetch vertical datums and store into PROJ dir, e.g.:
-# WORKDIR /src
-# RUN mkdir vdatum && \
-#     cd vdatum && \
-#     wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
-#     cd .. && \
-#     rm -rf vdatum
 
 # copy grass gis source
 COPY . /src/grass_build/
 
 WORKDIR /src/grass_build
-
-# Cleanup potentially leftover GISRC file with wrong path to "demolocation"
-RUN rm -f /src/grass_build/dist.*/demolocation/.grassrc*
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols
 # Set gcc/g++ environmental variables for GRASS GIS compilation, without debug symbols
@@ -203,7 +205,14 @@ RUN ./configure \
   --with-openmp \
   --without-opengl \
     && make -j $NUMTHREADS \
-    && make install && ldconfig
+    && make install && ldconfig \
+    &&  cp /usr/local/grass84/gui/wxpython/xml/module_items.xml module_items.xml; \
+    rm -rf /usr/local/grass84/demolocation; \
+    rm -rf /usr/local/grass84/fonts; \
+    rm -rf /usr/local/grass84/gui; \
+    rm -rf /usr/local/grass84/share; \
+    mkdir -p /usr/local/grass84/gui/wxpython/xml/; \
+    mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
 
 # Build the GDAL-GRASS plugin
 RUN git clone https://github.com/OSGeo/gdal-grass && \
@@ -214,25 +223,6 @@ RUN git clone https://github.com/OSGeo/gdal-grass && \
     make install -j $NUMTHREADS && \
     cd /src && \
     rm -rf "gdal-grass"
-
-# Reduce the image size - Remove unnecessary grass files
-RUN cp /usr/local/grass84/gui/wxpython/xml/module_items.xml module_items.xml; \
-    rm -rf /usr/local/grass84/demolocation; \
-    rm -rf /usr/local/grass84/fonts; \
-    rm -rf /usr/local/grass84/gui; \
-    rm -rf /usr/local/grass84/share; \
-    mkdir -p /usr/local/grass84/gui/wxpython/xml/; \
-    mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
-
-# Unset environmental variables to avoid later compilation issues
-ENV INTEL ""
-ENV MYCFLAGS ""
-ENV MYLDFLAGS ""
-ENV MYCXXFLAGS ""
-ENV LD_LIBRARY_PATH ""
-ENV LDFLAGS ""
-ENV CFLAGS ""
-ENV CXXFLAGS ""
 
 # Leave build stage
 FROM common as grass
@@ -250,19 +240,20 @@ ENV GRASSBIN="/usr/local/bin/grass" \
     GISBASE="/usr/local/grass/" \
     GRASSBIN="/usr/local/bin/grass" \
     PYTHONPATH="${PYTHONPATH}:/usr/local/grass/etc/python/" \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/grass/lib"
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/grass/lib" \
+    GDAL_DRIVER_PATH="/usr/lib/gdalplugins"
 
 # Copy GRASS GIS from build image
-COPY --from=build /usr/local/bin/grass* /usr/local/bin/
-COPY --from=build /usr/local/grass84 /usr/local/grass84/
-COPY --from=build /src/site-packages /usr/lib/python3.10/
-COPY --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
+COPY --link --from=build /usr/local/bin/* /usr/local/bin/
+COPY --link --from=build /usr/local/grass84 /usr/local/grass84/
+COPY --link --from=build /src/site-packages /usr/lib/python3.10/
+COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass84 /usr/local/grass && \
     ldconfig /etc/ld.so.conf.d
 
-ENV GDAL_DRIVER_PATH="/usr/lib/gdalplugins"
+RUN ls /usr/local/bin/
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -256,12 +256,13 @@ ENV GRASSBIN="/usr/local/bin/grass" \
 COPY --from=build /usr/local/bin/grass* /usr/local/bin/
 COPY --from=build /usr/local/grass84 /usr/local/grass84/
 COPY --from=build /src/site-packages /usr/lib/python3.10/
+COPY --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass84 /usr/local/grass && \
     ldconfig /etc/ld.so.conf.d
 
-RUN ls "$GISBASE/etc/python/"
+ENV GDAL_DRIVER_PATH="/usr/lib/gdalplugins"
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -35,6 +35,8 @@ ENV GRASS_RUN_PACKAGES="\
     libgsl27 \
     libjpeg-turbo8 \
     libjsoncpp-dev \
+    libmagic1 \
+    libmagic-mgc \
     libncurses5 \
     libopenblas-dev \
     libopenblas-base \
@@ -95,19 +97,19 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen && locale-gen
 
 ## fetch vertical datums for PDAL and store into PROJ dir
 WORKDIR /src
-RUN mkdir vdatum && \
-    cd vdatum && \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2012.zip && unzip -j -u usa_geoid2012.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2009.zip && unzip -j -u usa_geoid2009.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid2003.zip && unzip -j -u usa_geoid2003.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/usa_geoid1999.zip && unzip -j -u usa_geoid1999.zip -d /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertconc.gtx && mv vertconc.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertcone.gtx && mv vertcone.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/vertcon/vertconw.gtx && mv vertconw.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/egm96_15/egm96_15.gtx && mv egm96_15.gtx /usr/share/proj; \
-    wget -q http://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx && mv egm08_25.gtx /usr/share/proj; \
-    cd .. && \
-    rm -rf vdatum
+
+# Get datum grids
+FROM ubuntu:22.04 as datum_grids
+
+# See: https://github.com/OSGeo/PROJ-data
+RUN apt-get update \
+    && apt-get install  -y --no-install-recommends --no-install-suggests \
+    wget \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+RUN wget --no-check-certificate -r -l inf -A tif https://cdn.proj.org/
 
 # Start build stage
 FROM common as build
@@ -248,12 +250,11 @@ COPY --link --from=build /usr/local/bin/* /usr/local/bin/
 COPY --link --from=build /usr/local/grass84 /usr/local/grass84/
 COPY --link --from=build /src/site-packages /usr/lib/python3.10/
 COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
+COPY --link --from=datum_grids /tmp/cdn.proj.org/*.tif /usr/share/proj/
 
 # Create generic GRASS GIS lib name regardless of version number
 RUN ln -sf /usr/local/grass84 /usr/local/grass && \
     ldconfig /etc/ld.so.conf.d
-
-RUN ls /usr/local/bin/
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,12 +1,10 @@
 FROM ubuntu:22.04 as common
 
-LABEL authors="Carmen Tawalika,Markus Neteler,Anika Weinmann"
+LABEL authors="Carmen Tawalika,Markus Neteler,Anika Weinmann,Stefan Blumentrath"
 LABEL maintainer="tawalika@mundialis.de,neteler@mundialis.de,weinmann@mundialis.de"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
-# https://github.com/PDAL/PDAL/releases
 
 SHELL ["/bin/bash", "-c"]
 
@@ -264,9 +262,6 @@ RUN ln -sf /usr/local/grass84 /usr/local/grass && \
     ldconfig /etc/ld.so.conf.d
 
 RUN ls "$GISBASE/etc/python/"
-# Reduce the image size (not sure this has any effect)
-#RUN apt-get autoremove -y && \
-#    apt-get clean
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -86,3 +86,22 @@ $ docker build \
 $ docker run -it grass-py3-pdal:latest-ubuntu /bin/bash
 bash-5.0#
 ```
+
+## Test the docker image
+
+Note: Adjust the volume mount to the path of the GRASS GIS source code directory.
+
+```bash
+# Test basic functionality
+$ docker run -ti \
+         -v /opt/src/grass:/grassdb \
+         grass-py3-pdal:latest-ubuntu \
+         bash docker/testdata/test_docker_image.sh
+
+# Execute also the full test suite
+$ docker run -ti \
+         -e TESTSUITE=1 \
+         -v /opt/src/grass:/grassdb \
+         grass-py3-pdal:latest-ubuntu \
+         bash docker/testdata/test_docker_image.sh
+```

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -87,6 +87,18 @@ $ docker run -it grass-py3-pdal:latest-ubuntu /bin/bash
 bash-5.0#
 ```
 
+__To build a latest version with wxgui__:
+
+The `GUI` build argument allows to choose if the GUI should
+be included in the build (`GUI=with`) or not (`GUI=without`).
+
+```bash
+$ DOCKER_BUILDKIT=1 docker build  \
+    --file docker/ubuntu/Dockerfile \
+    --tag grass-main-ubuntu-wxgui:latest \
+    --build-arg GUI=with .
+```
+
 ## Test the docker image
 
 Note: Adjust the volume mount to the path of the GRASS GIS source code directory.


### PR DESCRIPTION
This PR implements multi-stage-builds for _ubuntu_, comparable to how they are set up for _alpine_. It also adds a test script for docker files, that should be usable across different distributions...

Image size is reduced to ~1.6 GB (from > 2GB), while some new features are added and datum grids are removed.

A major change is also that GIS packages now come from `ubuntugis-unstable`, so the image ships more recent versions of GDAL, GEOS. In addition, PDAL does not have to be compiled...

Some dev-packages (e.g. gdal-dev, geos-dev) are kept for addon installation, but they still take quite some space so, I am happy to remove some more, depending on what you consider a good size/functionality trade-off.

Adresses: #776