### PR TITLE
wxGUI/iclass: fix closing scatter plot pane via x button

### DIFF
--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -276,6 +276,7 @@ class ScatterPlotsPanel(scrolled.ScrolledPanel):
         del self.scatts[scatt_id]
 
         if pane.IsOk():
+            pane.DestroyOnClose()
             self._mgr.ClosePane(pane)
         self._mgr.Update()
 

--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -314,7 +314,6 @@ class ScatterPlotWidget(wx.Panel, ManageBusyCursorMixin):
 
     def CleanUp(self):
         self.plotClosed.emit(scatt_id=self.scatt_id)
-        self.Destroy()
 
     def ZoomWheel(self, event):
         # get the current x and y limits


### PR DESCRIPTION
**Describe the bug**
Supervised Classification Tool  scatter plots pane prints error message when closed.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Supervised Classification Tool wxGUI `g.gui.iclass`
2. On the left Plots pane combobox widget choose **Scatter plots** item
3. On the Scatter plots toolbar activate Add scatter plot tool
5. On the Select imagery group dialog from the name of imagery group listbox widget items choose **lsat7_2000**
6. Hit Create/edit group... button widget
7. On the Create or edit image group dialog, type into Select existing subgroup or enter name of new subgroup combobox widget new subgroup name e.g. **test** and select some maps from the list to be part of the new cretaed subgroup **test** (lsat7_2000_10, lsat7_2000_20, lsat7_2000_30, lsat7_2000_40) and hit OK button
8. Hit OK button on the Create or edit image group dialog
9. On the next Add scatter plots dialog choose from the x axis combobox widget items lsat7_2000_10 raster map, and from the y axis combobox widget items choose lsat7_2000_20 raster map and hit Add button
10.  Repeat point 9. but with another maps, from the x axis combobox widget items choose lsat7_2000_30 raster map, and from the y axis combobox widget items choose lsat7_2000_40 raster map and hit Add button
11. On the Add scatter plots dialog hit OK button
12. Try to **close scatter plot pane** via **x button**
13. See error

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 8448, in OnRender
    art.DrawCaption(dc, self._frame, part.pane.caption, part.rect, part.pane)
  File "/usr/lib/python3.10/site-packages/wx/lib/agw/aui/dockart.py", line 593, in DrawCaption
    btns = pane.CountButtons()
  File "/usr/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 1715, in CountButtons
    if isinstance(wx.GetTopLevelParent(self.window), AuiFloatingFrame):
RuntimeError: wrapped C/C++ object of type ScatterPlotWidget has been deleted
```

**Expected behavior**
Supervised Classification Tool scatter plots pane should not prints error message when closed.

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```