### PR TITLE
manual: i.ortho.* update broken module references

### DIFF
--- a/imagery/i.ortho.photo/i.ortho.camera/i.ortho.camera.html
+++ b/imagery/i.ortho.photo/i.ortho.camera/i.ortho.camera.html
@@ -98,8 +98,8 @@ is reached.
 
 <em>
 <a href="i.ortho.photo.html">i.ortho.photo</a>,
-<a href="i.photo.2image.html">i.photo.2image</a>,
-<a href="i.photo.2target.html">i.photo.2target</a>,
+<a href="g.gui.photo2image.html">g.gui.photo2image</a>,
+<a href="g.gui.image2target.html">g.gui.image2target</a>,
 <a href="i.ortho.init.html">i.ortho.init</a>
 </em>
 

--- a/imagery/i.ortho.photo/i.ortho.elev/i.ortho.elev.html
+++ b/imagery/i.ortho.photo/i.ortho.elev/i.ortho.elev.html
@@ -7,8 +7,8 @@
 <em>
 <a href="i.ortho.photo.html">i.ortho.photo</a><br>
 <a href="i.ortho.camera.html">i.ortho.camera</a><br>
-<a href="i.photo.2image.html">i.photo.2image</a><br>
-<a href="i.photo.2target.html">i.photo.2target</a><br>
+<a href="g.gui.photo2image.html">g.gui.photo2image</a><br>
+<a href="g.gui.image2target.html">g.gui.image2target</a><br>
 <a href="i.ortho.init.html">i.ortho.init</a><br>
 <a href="i.rectify.html">i.rectify</a>
 </em>

--- a/imagery/i.ortho.photo/i.ortho.init/i.ortho.init.html
+++ b/imagery/i.ortho.photo/i.ortho.init/i.ortho.init.html
@@ -20,7 +20,7 @@ parameters. During the imagery program, <em>i.photo.rectify</em>, the initial ca
 exposure station file is used for computation of the ortho-rectification
 parameters.  If no initial camera exposure station file exist, the default
 values are computed from the control points file created in <em><A
-HREF="i.photo.2target.html">i.photo.2target</a></em>.
+HREF="g.gui.image2target.html">g.gui.image2target</a></em>.
 
 
 <p>
@@ -103,8 +103,8 @@ values in this menu are not used.
 
 <em>
 <a href="i.ortho.photo.html">i.ortho.photo</a>,
-<a href="i.photo.2image.html">i.photo.2image</a>,
-<a href="i.photo.2target.html">i.photo.2target</a>,
+<a href="g.gui.photo2image.html">g.gui.photo2image</a>,
+<a href="g.gui.image2target.html">g.gui.image2target</a>,
 <a href="i.ortho.elev.html">i.ortho.elev</a>,
 <a href="i.ortho.camera.html">i.ortho.camera</a>,
 <a href="i.ortho.transform.html">i.ortho.transform</a>,

--- a/imagery/i.ortho.photo/i.ortho.rectify/i.ortho.rectify.html
+++ b/imagery/i.ortho.photo/i.ortho.rectify/i.ortho.rectify.html
@@ -1,13 +1,13 @@
 <H2>DESCRIPTION</H2>
 
 <em>i.photo.rectify</em> rectifies an image by using the image to photo
-coordinate transformation matrix created by <a href="i.photo.2image.html">i.photo.2image</a>
-and the rectification parameters created by <a href="i.photo.2target.html">i.photo.2target</a>.
+coordinate transformation matrix created by <a href="g.gui.photo2image.html">g.gui.photo2image</a>
+and the rectification parameters created by <a href="g.gui.image2target.html">g.gui.image2target</a>.
 Rectification is the process by which the geometry of an image is made
 planimetric.  This is accomplished by mapping an image from one coordinate
 system to another. In <em>i.photo.rectify</em> the parameters computed by
-<a href="i.photo.2image.html">i.photo.2image</a> and
-<a href="i.photo.2target.html">i.photo.2target</a> are used in equations to
+<a href="g.gui.photo2image.html">g.gui.photo2image</a> and
+<a href="g.gui.image2target.html">g.gui.image2target</a> are used in equations to
 convert x,y image coordinates to standard map coordinates for each pixel in
 the image.  The result is an image with a standard map coordinate system,
 compensated for relief distortions and photographic tilt. Upon completion of
@@ -94,8 +94,8 @@ The last prompt will ask you about the amount of memory to be used by
 <em>
 <a href="i.ortho.photo.html">i.ortho.photo</a><br>
 <a href="i.ortho.camera.html">i.ortho.camera</a><br>
-<a href="i.photo.2image.html">i.photo.2image</a><br>
-<a href="i.photo.2target.html">i.photo.2target</a><br>
+<a href="g.gui.photo2image.html">g.gui.photo2image</a><br>
+<a href="g.gui.image2target.html">g.gui.image2target</a><br>
 <a href="i.ortho.init.html">i.ortho.init</a><br>
 <a href="i.rectify.html">i.rectify</a>
 </em>

--- a/imagery/i.ortho.photo/i.ortho.target/i.ortho.target.html
+++ b/imagery/i.ortho.photo/i.ortho.target/i.ortho.target.html
@@ -9,8 +9,8 @@
 <a href="i.ortho.photo.html">i.ortho.photo</a><br>
 <a href="i.ortho.elev.html">i.ortho.elev</a><br>
 <a href="i.ortho.camera.html">i.ortho.camera</a><br>
-<a href="i.photo.2image.html">i.photo.2image</a><br>
-<a href="i.photo.2target.html">i.photo.2target</a><br>
+<a href="g.gui.photo2image.html">g.gui.photo2image</a><br>
+<a href="g.gui.image2target.html">g.gui.image2target</a><br>
 <a href="i.ortho.init.html">i.ortho.init</a><br>
 <a href="i.ortho.rectify.html">i.ortho.rectify</a>
 </em>

--- a/imagery/i.ortho.photo/lib/conz_points.c
+++ b/imagery/i.ortho.photo/lib/conz_points.c
@@ -5,7 +5,6 @@
 
 #define POINT_FILE "CONTROL_POINTS"
 
-/* This is used in i.image.2target */
 /* read the control points from group file "CONTROL_POINTS" into */
 /* the struct Con_Points */
 int I_read_con_points(FILE *fd, struct Ortho_Control_Points *cp)


### PR DESCRIPTION
Time ago some GRASS GIS 6 modules have been rewritten:

- `i.photo.2target` -> `g.gui.photo2image`
- `i.photo.2image` -> `g.gui.image2target`

This PR updates the references in the manual accordingly.