### PR TITLE
wxGUI/iclass: fix activating scatter plot pane toolbar tools

### DIFF
--- a/gui/wxpython/iscatt/toolbars.py
+++ b/gui/wxpython/iscatt/toolbars.py
@@ -5,6 +5,7 @@
 
 Classes:
  - toolbars::MainToolbar
+ - toolbars::GetToolNameMixin
 
 (C) 2013 by the GRASS Development Team
 
@@ -21,7 +22,24 @@ from core.gcmd import RunCommand
 from iscatt.dialogs import SettingsDialog
 
 
-class MainToolbar(BaseToolbar):
+class GetToolNameMixin:
+    """Get tool name"""
+
+    def _get_tool_name(self, tool_name, tool_name_type=tuple):
+        """Get tool name
+
+        :param str|tuple tool_name: tool name
+        :param type tool_name_type: tool name type with default
+                                    tuple type
+
+        :return str: tool name
+        """
+        if isinstance(tool_name, tool_name_type):
+            return tool_name[0]
+        return tool_name
+
+
+class MainToolbar(BaseToolbar, GetToolNameMixin):
     """Main toolbar"""
 
     def __init__(self, parent, scatt_mgr, opt_tools=None):
@@ -133,7 +151,7 @@ class MainToolbar(BaseToolbar):
         self.scatt_mgr.modeSet.disconnect(self.ModeSet)
         if event.IsChecked():
             for i_tool_data in self.controller.data:
-                i_tool_name = i_tool_data[0]
+                i_tool_name = self._get_tool_name(i_tool_data[0])
                 if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
                     continue
                 if i_tool_name == tool_name:
@@ -158,7 +176,7 @@ class MainToolbar(BaseToolbar):
 
     def UnsetMode(self):
         for i_tool_data in self.controller.data:
-            i_tool_name = i_tool_data[0]
+            i_tool_name = self._get_tool_name(i_tool_data[0])
             if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
                 continue
             i_tool_id = vars(self)[i_tool_name]
@@ -176,7 +194,7 @@ class MainToolbar(BaseToolbar):
         RunCommand("g.manual", entry="wxGUI.iscatt")
 
 
-class EditingToolbar(BaseToolbar):
+class EditingToolbar(BaseToolbar, GetToolNameMixin):
     """Main toolbar"""
 
     def __init__(self, parent, scatt_mgr):
@@ -280,7 +298,7 @@ class EditingToolbar(BaseToolbar):
         self.scatt_mgr.modeSet.disconnect(self.ModeSet)
         if event.IsChecked():
             for i_tool_data in self.controller.data:
-                i_tool_name = i_tool_data[0]
+                i_tool_name = self._get_tool_name(i_tool_data[0])
                 if not i_tool_name:
                     continue
                 if i_tool_name == tool_name:
@@ -298,7 +316,7 @@ class EditingToolbar(BaseToolbar):
 
     def UnsetMode(self):
         for i_tool_data in self.controller.data:
-            i_tool_name = i_tool_data[0]
+            i_tool_name = self._get_tool_name(i_tool_data[0])
             if not i_tool_name:
                 continue
             i_tool_id = vars(self)[i_tool_name]

--- a/gui/wxpython/iscatt/toolbars.py
+++ b/gui/wxpython/iscatt/toolbars.py
@@ -5,7 +5,6 @@
 
 Classes:
  - toolbars::MainToolbar
- - toolbars::GetToolNameMixin
 
 (C) 2013 by the GRASS Development Team
 
@@ -22,24 +21,21 @@ from core.gcmd import RunCommand
 from iscatt.dialogs import SettingsDialog
 
 
-class GetToolNameMixin:
-    """Get tool name"""
+def get_tool_name(tool_name, tool_name_type=tuple):
+    """Get tool name
 
-    def _get_tool_name(self, tool_name, tool_name_type=tuple):
-        """Get tool name
+    :param str|tuple tool_name: tool name
+    :param type tool_name_type: tool name type with default
+                                tuple type
 
-        :param str|tuple tool_name: tool name
-        :param type tool_name_type: tool name type with default
-                                    tuple type
-
-        :return str: tool name
-        """
-        if isinstance(tool_name, tool_name_type):
-            return tool_name[0]
-        return tool_name
+    :return str: tool name
+    """
+    if isinstance(tool_name, tool_name_type):
+        return tool_name[0]
+    return tool_name
 
 
-class MainToolbar(BaseToolbar, GetToolNameMixin):
+class MainToolbar(BaseToolbar):
     """Main toolbar"""
 
     def __init__(self, parent, scatt_mgr, opt_tools=None):
@@ -151,7 +147,7 @@ class MainToolbar(BaseToolbar, GetToolNameMixin):
         self.scatt_mgr.modeSet.disconnect(self.ModeSet)
         if event.IsChecked():
             for i_tool_data in self.controller.data:
-                i_tool_name = self._get_tool_name(i_tool_data[0])
+                i_tool_name = get_tool_name(i_tool_data[0])
                 if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
                     continue
                 if i_tool_name == tool_name:
@@ -176,7 +172,7 @@ class MainToolbar(BaseToolbar, GetToolNameMixin):
 
     def UnsetMode(self):
         for i_tool_data in self.controller.data:
-            i_tool_name = self._get_tool_name(i_tool_data[0])
+            i_tool_name = get_tool_name(i_tool_data[0])
             if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
                 continue
             i_tool_id = vars(self)[i_tool_name]
@@ -194,7 +190,7 @@ class MainToolbar(BaseToolbar, GetToolNameMixin):
         RunCommand("g.manual", entry="wxGUI.iscatt")
 
 
-class EditingToolbar(BaseToolbar, GetToolNameMixin):
+class EditingToolbar(BaseToolbar):
     """Main toolbar"""
 
     def __init__(self, parent, scatt_mgr):
@@ -298,7 +294,7 @@ class EditingToolbar(BaseToolbar, GetToolNameMixin):
         self.scatt_mgr.modeSet.disconnect(self.ModeSet)
         if event.IsChecked():
             for i_tool_data in self.controller.data:
-                i_tool_name = self._get_tool_name(i_tool_data[0])
+                i_tool_name = get_tool_name(i_tool_data[0])
                 if not i_tool_name:
                     continue
                 if i_tool_name == tool_name:
@@ -316,7 +312,7 @@ class EditingToolbar(BaseToolbar, GetToolNameMixin):
 
     def UnsetMode(self):
         for i_tool_data in self.controller.data:
-            i_tool_name = self._get_tool_name(i_tool_data[0])
+            i_tool_name = get_tool_name(i_tool_data[0])
             if not i_tool_name:
                 continue
             i_tool_id = vars(self)[i_tool_name]


### PR DESCRIPTION
**Describe the bug**
Activating Supervised Classification Tool window scatter plots pane toolbar tools prints an error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Supervised Classification Tool wxGUI `g.gui.iclass`
2. On the left Plots pane combobox widget choose **Scatter plots** item
3. On the Scatter plots toolbar activate Add scatter plot tool
5. On the Select imagery group dialog from the name of imagery group listbox widget items choose **lsat7_2000**
6. Hit Create/edit group... button widget
7. On the Create or edit image group dialog, type into Select existing subgroup or enter name of new subgroup combobox widget new subgroup name e.g. **test** and select some maps from the list to be part of the new cretaed subgroup **test** (lsat7_2000_10, lsat7_2000_20, lsat7_2000_30, lsat7_2000_40) and hit OK button
8. Hit OK button on the Create or edit image group dialog
9. On the next Add scatter plots dialog choose from the x axis combobox widget items lsat7_2000_10 raster map, and from the y axis combobox widget items choose lsat7_2000_20 raster map and hit Add button
10.  Repeat point 9. but with another maps, from the x axis combobox widget items choose lsat7_2000_30 raster map, and from the y axis combobox widget items choose lsat7_2000_40 raster map and hit Add button
11. On the Add scatter plots dialog hit OK button
12. **Try to activate some scatter plots toolbar tools** e.g. Pan mode
13. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/iscatt/toolbars.py", line 82, in <lambda>
    lambda event: self.SetPloltsMode(event, "pan"),
  File "/usr/lib64/grass84/gui/wxpython/iscatt/toolbars.py", line 141, in SetPloltsMode
    i_tool_id = vars(self)[i_tool_name]
KeyError: ('add_scatt', 'Add scatter plot')
```

**Expected behavior**
Activating Supervised Classification Tool window  scatter plots pane toolbar tools should working without prints an error message.

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```