### PR TITLE
wxGUI/iclass: fix zoom to scatter plot extend

### DIFF
--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -618,7 +618,8 @@ class ScatterPlotContextMenu:
     def ShowMenu(self, menu):
         self.plot.PopupMenu(menu)
         menu.Destroy()
-        self.plot.ReleaseMouse()
+        if self.plot.HasCapture():
+            self.plot.ReleaseMouse()
 
 
 class PolygonDrawer:


### PR DESCRIPTION
**Describe the bug**
Activating Supervised Classification Tool window scatter plots pane zoom to scatter plot extend menu item prints an error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Supervised Classification Tool wxGUI `g.gui.iclass`
2. On the left Plots pane combobox widget choose **Scatter plots** item
3. On the Scatter plots toolbar activate Add scatter plot tool
5. On the Select imagery group dialog from the name of imagery group listbox widget items choose **lsat7_2000**
6. Hit Create/edit group... button widget
7. On the Create or edit image group dialog, type into Select existing subgroup or enter name of new subgroup combobox widget new subgroup name e.g. **test** and select some maps from the list to be part of the new cretaed subgroup **test** (lsat7_2000_10, lsat7_2000_20, lsat7_2000_30, lsat7_2000_40) and hit OK button
8. Hit OK button on the Create or edit image group dialog
9. On the next Add scatter plots dialog choose from the x axis combobox widget items lsat7_2000_10 raster map, and from the y axis combobox widget items choose lsat7_2000_20 raster map and hit Add button
10.  Repeat point 9. but with another maps, from the x axis combobox widget items choose lsat7_2000_30 raster map, and from the y axis combobox widget items choose lsat7_2000_40 raster map and hit Add button
11. On the Add scatter plots dialog hit OK button
12.  Try right mouse click inside scatter plot pane to invoke menu and choose **Zoom to scatter plot extend** item
13. See error

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/wx/core.py", line 3427, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "/usr/lib64/grass84/gui/wxpython/iscatt/plots.py", line 621, in ShowMenu
    self.plot.ReleaseMouse()
wx._core.wxAssertionError: C++ assertion ""!wxMouseCapture::stack.empty()"" failed at /var/tmp/portage/x11-libs/wxGTK-3.2.2.1-r2/work/wxWidgets-3.2.2.1/src/common/wincmn.cpp(3425) in ReleaseMouse(): Releasing mouse capture but capture stack empty?
```

**Expected behavior**
Activating Supervised Classification Tool window scatter plots pane zoom to scatter plot extend menu item should not prints an error message.

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```