### PR TITLE
wxGUI/mapswipe: fix saving display to file

### DIFF
--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -511,9 +511,11 @@ class BufferedMapWindow(MapWindowBase, Window):
                 pdc.SetTextBackground(img["background"])
             coords, bbox = self.TextBounds(img)
             if rotation == 0:
-                pdc.DrawText(img["text"], coords[0], coords[1])
+                pdc.DrawText(img["text"], int(coords[0]), int(coords[1]))
             else:
-                pdc.DrawRotatedText(img["text"], coords[0], coords[1], rotation)
+                pdc.DrawRotatedText(
+                    img["text"], int(coords[0]), int(coords[1]), rotation
+                )
             pdc.SetIdBounds(drawid, bbox)
 
         pdc.EndDrawing()

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -2526,7 +2526,7 @@ class PsMapBufferedWindow(wx.Window):
         if rot == 0:
             pdc.DrawLabel(text=textDict["text"], rect=bounds)
         else:
-            pdc.DrawRotatedText(textDict["text"], coords[0], coords[1], rot)
+            pdc.DrawRotatedText(textDict["text"], int(coords[0]), int(coords[1]), rot)
 
         pdc.SetIdBounds(drawId, Rect(*bounds))
         self.Refresh()


### PR DESCRIPTION
**Describe the bug**
Map Swipe tool Save display to file tool doesn't work an prints an error message.


**To Reproduce**
Steps to reproduce the behavior:

1. Launch Map Swipe tool `g.gui.mapswipe`
2. Display some two comparable maps
3. Try activate  Save display to file tool from the main toolbar
4. Save display to file
5. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/core/gthread.py", line 138, in OnDone
    event.ondone(event)
  File "/usr/lib64/grass84/gui/wxpython/core/render.py", line 510, in OnRenderDone
    self.updateProgress.emit(env=event.userdata["env"], layer=self.layer)
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/signal.py", line 233, in emit
    dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/dispatcher.py", line 343, in send
    response = robustapply.robustApply(
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/usr/lib64/grass84/gui/wxpython/core/render.py", line 813, in ReportProgress
    self.renderDone.emit(env=env)
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/signal.py", line 233, in emit
    dispatcher.send(signal=self, *args, **kwargs)
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/dispatcher.py", line 343, in send
    response = robustapply.robustApply(
  File "/usr/lib64/grass84/etc/python/grass/pydispatch/robustapply.py", line 60, in robustApply
    return receiver(*arguments, **named)
  File "/usr/lib64/grass84/gui/wxpython/mapwin/buffered.py", line 772, in _saveToFileDone
    self.Draw(self.pdc, img=self.textdict[id], drawid=id, pdctype="text")
  File "/usr/lib64/grass84/gui/wxpython/mapswipe/mapwindow.py", line 137, in Draw
    return super(SwipeBufferedWindow, self).Draw(
  File "/usr/lib64/grass84/gui/wxpython/mapwin/buffered.py", line 514, in Draw
    pdc.DrawText(img["text"], coords[0], coords[1])
TypeError: PseudoDC.DrawText(): arguments did not match any overloaded call:
  overload 1: argument 2 has unexpected type 'float'
  overload 2: argument 2 has unexpected type 'float'
```

**Expected behavior**
Map Swipe tool Save display to file tool should work.

**System description:**

- Operating System: GNU/Linux
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```