### PR TITLE
wxGUI/preferences: fix setting command output font

### DIFF
--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -2035,7 +2035,6 @@ class PreferencesDialog(PreferencesBaseDialog):
         size = self.settings.Get(group="appearance", key="outputfont", subkey="size")
         if size is None or size == 0:
             size = 11
-        size = float(size)
         if type is None or type == "":
             type = "Courier"
 


### PR DESCRIPTION
**Describe the bug**
Setting wxGUI command output font fails and prints an error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch wxGUI `g.gui`
2. Open GUI settings dialog from main toolbar
4. On the GUI settings dialog switch to Appearance page (tab)
5.  Try to change command output font (Font settings), hit Set font button widget
6.  See error

```
Traceback (most recent call last):
  File
"/usr/lib64/grass84/gui/wxpython/gui_core/preferences.py",
line 2042, in OnSetOutputFont

outfont = wx.Font(
TypeError
:
Font(): arguments did not match any overloaded call:
  overload 1: too many arguments
  overload 2: argument 1 has unexpected type 'float'
  overload 3: argument 1 has unexpected type 'float'
  overload 4: argument 1 has unexpected type 'float'
  overload 5: argument 1 has unexpected type 'float'
  overload 6: argument 1 has unexpected type 'float'
  overload 7: argument 1 has unexpected type 'float'
```

**Expected behavior**
Setting wxGUI command output font should work without prints an error message.

**System description:**

- Operating System: GNU/Linux
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```