### PR TITLE
wxGUI/gmodeler: fix storing current model settings to model file

### DIFF
--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -353,7 +353,7 @@ class ModelFrame(wx.Frame):
                 message = _("Do you want to save changes in the model?")
             else:
                 message = _(
-                    "Do you want to store current model settings " "to model file?"
+                    "Do you want to store current model settings to model file?"
                 )
 
             # ask user to save current settings
@@ -370,7 +370,7 @@ class ModelFrame(wx.Frame):
             ret = dlg.ShowModal()
             if ret == wx.ID_YES:
                 if not self.modelFile:
-                    self.OnWorkspaceSaveAs()
+                    self.OnModelSaveAs()
                 else:
                     self.WriteModelFile(self.modelFile)
             elif ret == wx.ID_CANCEL:
@@ -559,9 +559,9 @@ class ModelFrame(wx.Frame):
                 self.SetStatusText(_("File <%s> saved") % self.modelFile, 0)
                 self.SetTitle(self.baseTitle + " - " + os.path.basename(self.modelFile))
         elif not self.modelFile:
-            self.OnModelSaveAs(None)
+            self.OnModelSaveAs()
 
-    def OnModelSaveAs(self, event):
+    def OnModelSaveAs(self, event=None):
         """Create model to file as"""
         filename = ""
         dlg = wx.FileDialog(


### PR DESCRIPTION
**Describe the bug**
Saving the Graphical Modeler current model settings to model file fails and prints an error message if Graphical Modeler window is closed.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch  Graphical Modeler `g.gui.gmodeler`
2. Add GRASS tool (module) to model e.g. simple module command `db.test test1`
3. Validate model
4. Run model
5. Close Graphical Modeler window by keyboard shortcut Alt + F4 or via toolbar Quit tool
6.  On the confirm save current model settings to model file dialog hit Yes button
7. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/gmodeler/frame.py", line 373, in OnCloseWindow
    self.OnWorkspaceSaveAs()
AttributeError: 'ModelFrame' object has no attribute 'OnWorkspaceSaveAs'
```
**Expected behavior**
Saving Graphical Modeler current model settings to model file should work and not printing an error message if Graphical Modeler window is closed.

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/PERMANENT:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```