### PR TITLE
wxGUI/image2target: fix showing Ground Control Points settings dialog

### DIFF
--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -3117,13 +3117,13 @@ class GrSettingsDialog(wx.Dialog):
                 parent=panel, id=wx.ID_ANY, label=_("Select source map to display:")
             ),
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         sizer.Add(
             self.srcselection,
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         self.srcselection.SetValue(src_map)
@@ -3134,13 +3134,13 @@ class GrSettingsDialog(wx.Dialog):
                 label=_("Select target raster map to display:"),
             ),
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         sizer.Add(
             self.tgtrastselection,
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         self.tgtrastselection.SetValue(tgt_map["raster"])
@@ -3151,13 +3151,13 @@ class GrSettingsDialog(wx.Dialog):
                 label=_("Select target vector map to display:"),
             ),
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         sizer.Add(
             self.tgtvectselection,
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         self.tgtvectselection.SetValue(tgt_map["vector"])
@@ -3223,7 +3223,7 @@ class GrSettingsDialog(wx.Dialog):
                 parent=panel, id=wx.ID_ANY, label=_("Extension for output maps:")
             ),
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
         self.ext_txt = TextCtrl(parent=panel, id=wx.ID_ANY, value="", size=(350, -1))
@@ -3231,7 +3231,7 @@ class GrSettingsDialog(wx.Dialog):
         sizer.Add(
             self.ext_txt,
             proportion=0,
-            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
+            flag=wx.ALIGN_LEFT | wx.ALL,
             border=5,
         )
 


### PR DESCRIPTION
**Describe the bug**
Showing Map Georectifier and Ground Control Points manager for 3D correction tool settings dialog fails and prints an error message.

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Map Georectifier and Ground Control Points manager for 3D correction tool window `g.gui.image2target`
2. From the Select source location combobox widget choose nc_spm_08_grass7 location
3. From the Select source mapset combobox widget choose landsat mapset
4. Hit Next > button widget
5. On the next wizard Select image/map group to georectify page choose from the Select group combobox widget lsat7_2000 group
6. On the next wizard Select maps to display for GCP creation page from the Select source map to display combobox widget choose lsat7_2000_10@landsat map
7. Hit Finish button widget
8.  Try open Settings dialog from the main toolbar
9. See error

```
Traceback (most recent call last):
  File "/usr/lib64/grass84/gui/wxpython/image2target/ii2t_manager.py", line 1869, in OnSettings
    dlg = GrSettingsDialog(
  File "/usr/lib64/grass84/gui/wxpython/image2target/ii2t_manager.py", line 2895, in __init__
    self.__CreateSymbologyPage(notebook)
  File "/usr/lib64/grass84/gui/wxpython/image2target/ii2t_manager.py", line 3115, in __CreateSymbologyPage
    sizer.Add(
wx._core.wxAssertionError: C++ assertion "CheckSizerFlags(!((flags) & (wxALIGN_CENTRE_VERTICAL)))" failed at /var/tmp/portage/x11-libs/wxGTK-3.2.2.1-r2/work/wxWidgets-3.2.2.1/src/common/sizer.cpp(2258) in DoInsert(): wxALIGN_CENTRE_VERTICAL will be ignored in this sizer: only horizontal alignment flags can be used in vertical sizers

DO NOT PANIC !!

If you're an end user running a program not developed by you, please ignore this message, it is harmless, and please try reporting the problem to the program developers.

You may also set WXSUPPRESS_SIZER_FLAGS_CHECK environment variable to suppress all such checks when running this program.

If you're the developer, simply remove this flag from your code to avoid getting this message. You can also call wxSizerFlags::DisableConsistencyChecks() to globally disable all such checks, but this is strongly not recommended.
```


**Expected behavior**
Showing Map Georectifier and Ground Control Points manager for 3D correction tool settings dialog should work and not printing an error message.

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/PERMANENT:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```

**Additional context**
Only horizontal alignment flags can be used in vertical sizers.