### PR TITLE
wxGUI/psmap: fix showing image map element preview

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -5971,10 +5971,10 @@ class ImageDialog(PsmapDialog):
             return img
         if w > h:
             newW = self.previewSize[0]
-            newH = self.previewSize[0] * h / w
+            newH = self.previewSize[0] * h // w
         else:
             newH = self.previewSize[0]
-            newW = self.previewSize[0] * w / h
+            newW = self.previewSize[0] * w // h
         return img.Scale(newW, newH, wx.IMAGE_QUALITY_HIGH)
 
     def DrawWarningText(self, warning):


### PR DESCRIPTION
**Describe the bug**
Map image element doesn't show preview on the Image settings dialog for adding map image element. 

**To Reproduce**
Steps to reproduce the behavior:

1. Launch Cartographic Composer `g.gui.psmap`
2. From the main toolbar activate Add map elements tool and choose Image
3. On the Image settings dialog select the directory where the EPS images are stored
4. Choose image from list of loaded images
5. See error

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/wx/lib/filebrowsebutton.py", line 140, in OnChanged
    self.changeCallback(evt)
  File "/usr/lib64/grass84/gui/wxpython/psmap/dialogs.py", line 5908, in OnDirChanged
    self.OnImageSelectionChanged(None)
  File "/usr/lib64/grass84/gui/wxpython/psmap/dialogs.py", line 5958, in OnImageSelectionChanged
    img = self.ScaleToPreview(img)
  File "/usr/lib64/grass84/gui/wxpython/psmap/dialogs.py", line 5978, in ScaleToPreview
    return img.Scale(newW, newH, wx.IMAGE_QUALITY_HIGH)
TypeError: Image.Scale(): argument 2 has unexpected type 'float
```

**Expected behavior**
Map image element should show preview on the Image settings dialog for adding map image element. 

**System description:**

- Operating System: all
- GRASS GIS version: all

```
GRASS nc_spm_08_grass7/landsat:~ > python3 -c "import sys, wx; print(sys.version); print(wx.version())"
3.10.13 (main, Sep 16 2023, 22:24:59) [GCC 12.3.1 20230526]
4.2.0 gtk3 (phoenix) wxWidgets 3.2.2.1
```