### PR TITLE
v.colors: do not compile thumbnails, r.colors is doing that already

### DIFF
--- a/vector/v.colors/Makefile
+++ b/vector/v.colors/Makefile
@@ -11,9 +11,4 @@ include $(MODULE_TOPDIR)/include/Make/Module.make
 
 default: cmd
 
-thumbnails: $(BIN)/r.mapcalc$(EXE)
-	-$(call run_grass, $(GRASS_HOME)/utils/thumbnails.py)
-
-.PHONY: thumbnails
-
 .INTERMEDIATE: v.colors.tmp.html


### PR DESCRIPTION
Addresses #3038 by removing the thumbnail compilation from v.colors, but it's difficult to be sure 100%, since the problem didn't occur every time. I marked it as backport to 8.3, but we can also just leave it for next time since we are close.