### PR TITLE
configure: remove or replace obsolete macros

### DIFF
--- a/configure
+++ b/configure
@@ -619,6 +619,7 @@ ac_includes_default="\
 # include <unistd.h>
 #endif"
 
+ac_header_list=
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 GRASS_HOME
@@ -2607,6 +2608,7 @@ See \`config.log' for more details" "$LINENO" 5; }
 done
 
 
+as_fn_append ac_header_list " sys/time.h"
 # Check that the precious variables saved in the cache have kept the same
 # value.
 ac_cache_corrupted=false
@@ -5766,6 +5768,7 @@ $as_echo "no" >&6; }
 fi
 
 
+
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -6134,7 +6137,6 @@ $as_echo "#define STDC_HEADERS 1" >>confdefs.h
 
 fi
 
-#AC_CHECK_HEADERS(curses.h limits.h termio.h termios.h unistd.h values.h)
 # On IRIX 5.3, sys/types and inttypes.h are conflicting.
 for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
 		  inttypes.h stdint.h unistd.h
@@ -6216,37 +6218,34 @@ fi
 
 done
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether time.h and sys/time.h may both be included" >&5
-$as_echo_n "checking whether time.h and sys/time.h may both be included... " >&6; }
 
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <sys/types.h>
-#include <sys/time.h>
-#include <time.h>
 
-int
-main ()
-{
-if ((struct tm *) 0)
-return 0;
-  ;
-  return 0;
-}
+
+  for ac_header in $ac_header_list
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
+"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_header_time=yes
-else
-  ac_cv_header_time=no
+
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_time" >&5
-$as_echo "$ac_cv_header_time" >&6; }
-if test $ac_cv_header_time = yes; then
+
+done
+
+
+
+
+# Obsolete code to be removed.
+if test $ac_cv_header_sys_time_h = yes; then
 
 $as_echo "#define TIME_WITH_SYS_TIME 1" >>confdefs.h
 
 fi
+# End of obsolete code.
+
 
 ac_fn_c_check_type "$LINENO" "off_t" "ac_cv_type_off_t" "$ac_includes_default"
 if test "x$ac_cv_type_off_t" = xyes; then :

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ $2
 AC_INIT
 AC_CONFIG_SRCDIR([configure.ac])
 AC_PREREQ([2.69])
-AC_CONFIG_HEADER(include/grass/config.h)
+AC_CONFIG_HEADERS([include/grass/config.h])
 AC_CANONICAL_HOST
 AC_PROG_CC
 
@@ -466,7 +466,7 @@ AC_SUBST(LIBRARY_DIRS)
 
 AC_PROG_INSTALL
 
-AC_PROG_LEX
+AC_PROG_LEX(noyywrap)
 if test "$LEX" = "lex"; then
     AC_PATH_PROG(LEXPATH, lex, no)
     if test "$LEXPATH" = "no"; then
@@ -486,14 +486,27 @@ AC_PROG_RANLIB
 AC_CHECK_PROGS(AR, ar)
 AC_CHECK_PROGS(ENV, env)
 AC_PATH_PROG(PERL, perl, no)
-AC_HEADER_STDC
-#AC_CHECK_HEADERS(curses.h limits.h termio.h termios.h unistd.h values.h)
+
 AC_CHECK_HEADERS(limits.h termio.h termios.h unistd.h values.h f2c.h g2c.h)
 AC_CHECK_HEADERS(sys/ioctl.h sys/mtio.h sys/resource.h sys/time.h)
 AC_CHECK_HEADERS(sys/timeb.h sys/types.h sys/utsname.h)
 AC_CHECK_HEADERS(libintl.h iconv.h)
 AC_CHECK_HEADERS(langinfo.h)
-AC_HEADER_TIME
+m4_warn([obsolete],
+[Update your code to rely only on HAVE_SYS_TIME_H,
+then remove this warning and the obsolete code below it.
+All current systems provide time.h; it need not be checked for.
+Not all systems provide sys/time.h, but those that do, all allow
+you to include it and time.h simultaneously.])dnl
+AC_CHECK_HEADERS_ONCE([sys/time.h])
+# Obsolete code to be removed.
+if test $ac_cv_header_sys_time_h = yes; then
+  AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
+	     and <time.h>.  This macro is obsolete.])
+fi
+# End of obsolete code.
+
+
 AC_TYPE_OFF_T
 AC_TYPE_UID_T
 
@@ -904,7 +917,7 @@ else
   CFLAGS="$CFLAGS $PNGINC"
 
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <png.h>]], [[png_read_image(NULL, NULL);]])],[],[
-  AC_TRY_LINK([#include <png.h>],[png_read_image(NULL, NULL);],PNGLIB="$PNGLIB",[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <png.h>]], [[png_read_image(NULL, NULL);]])],[PNGLIB="$PNGLIB"],[
   AC_MSG_ERROR([*** Unable to locate libpng library.])
   ])
   ])
@@ -959,7 +972,7 @@ else
   CFLAGS="$CFLAGS $GDAL_CFLAGS"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <gdal.h>]], [[GDALOpen("foo", GA_ReadOnly);]])],[],[
   LIBS="$LIBS $GDAL_DEP_LIBS"
-  AC_TRY_LINK([#include <gdal.h>],[GDALOpen("foo", GA_ReadOnly);],GDAL_LIBS="$GDAL_LIBS $GDAL_DEP_LIBS",[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <gdal.h>]], [[GDALOpen("foo", GA_ReadOnly);]])],[GDAL_LIBS="$GDAL_LIBS $GDAL_DEP_LIBS"],[
   AC_MSG_ERROR([*** Unable to locate GDAL library.])
   ])
   ])
@@ -1012,7 +1025,7 @@ else
   CPPFLAGS="$CPPFLAGS $LIBLAS_INC"
   AC_CHECK_HEADERS(liblas/capi/liblas.h)
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <liblas/capi/liblas.h>]], [[LASReader_Create("foo");]])],[],[
-  AC_TRY_LINK([#include <liblas/capi/liblas.h>],[LASReader_Create("foo");],LAS_LIBS="$LAS_LIBS",[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <liblas/capi/liblas.h>]], [[LASReader_Create("foo");]])],[LAS_LIBS="$LAS_LIBS"],[
   AC_MSG_ERROR([*** Unable to locate libLAS library.])
   ])
   ])
@@ -1060,9 +1073,9 @@ else
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/PointTable.hpp>
   #include <pdal/Streamable.hpp>
   class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],[],[
-  AC_TRY_LINK([#include <pdal/PointTable.hpp>
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/PointTable.hpp>
   #include <pdal/Streamable.hpp>
-  class St:public pdal::Streamable {};],[pdal::PointTable table;],PDAL_LIBS="$PDAL_LIBS",[
+  class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],[PDAL_LIBS="$PDAL_LIBS"],[
   AC_MSG_ERROR([*** Unable to locate suitable (>=1.7.1) PDAL library.])
   ])
   ])
@@ -1113,7 +1126,7 @@ else
   LIBS="$LIBS $NETCDF_LIBS"
   CFLAGS="$CFLAGS $NETCDF_CFLAGS"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <netcdf.h>]], [[nc_create("foo", NC_CLOBBER, NULL);]])],[],[
-  AC_TRY_LINK([#include <netcdf.h>],[nc_create("foo", NC_CLOBBER, NULL);],NETCDF_LIBS="$NETCDF_LIBS",[
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <netcdf.h>]], [[nc_create("foo", NC_CLOBBER, NULL);]])],[NETCDF_LIBS="$NETCDF_LIBS"],[
   AC_MSG_ERROR([*** Unable to locate NetCDF library.])
   ])
   ])

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -317,7 +317,8 @@
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. This
+   macro is obsolete. */
 #undef TIME_WITH_SYS_TIME
 
 /* define if NLS requested */


### PR DESCRIPTION
This eliminates warnings running autoconf with version 2.71. Note: the file 'configure' is still created by and fully compatible with version 2.69. This does **not** represent a change to generate the configure file by 2.71, but that change will eventually be merely formal. 

One issue involving <time.h> vs. <sys/time.h> remains and now issues a separate warning. Solving that includes changes in code and must be addressed separately.

The changes of this PR is in practice a subset of #2281, without the official move to 2.71.