### PR TITLE
grass.script: ensure memmap content is flushed before writing to a raster

### DIFF
--- a/python/grass/script/array.py
+++ b/python/grass/script/array.py
@@ -208,6 +208,9 @@ class array(numpy.memmap):
         else:
             raise ValueError(_("Invalid kind <%s>") % kind)
 
+        # ensure all array content is written to the file
+        self.flush()
+
         reg = gcore.region(env=self._env)
 
         try:
@@ -312,6 +315,9 @@ class array3d(numpy.memmap):
             flags = "i"
         else:
             raise ValueError(_("Invalid kind <%s>") % kind)
+
+        # ensure all array content is written to the file
+        self.flush()
 
         reg = gcore.region(True, env=self._env)
 


### PR DESCRIPTION
numpy.memap needs to be flushed so that grass.script.array.write() method writes correct content to a raster. The problem was found when running on an HPC with fairly large array that was being modified and then written to raster - only portion of it was being written correctly, the rest was empty.

May be worth including in 8.3.1 release.