### PR TITLE
v.db.connect: Replace -o flag with the standard --overwrite

### DIFF
--- a/lib/gis/renamed_options
+++ b/lib/gis/renamed_options
@@ -468,6 +468,8 @@ v.buffer|bufcolumn:column
 v.clean|thresh:threshold
 # v.colors
 v.colors|volume:raster_3d
+# v.db.connect
+v.db.connect|-o:--overwrite
 # v.db.join
 v.db.join|otable:other_table
 v.db.join|ocolumn:other_column

--- a/vector/v.db.connect/main.c
+++ b/vector/v.db.connect/main.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
     struct GModule *module;
     struct Option *inopt, *dbdriver, *dbdatabase, *dbtable, *field_opt, *dbkey,
         *sep_opt;
-    struct Flag *overwrite, *print, *columns, *delete, *shell_print;
+    struct Flag *print, *columns, *delete, *shell_print;
     dbDriver *driver;
     dbString table_name;
     dbTable *table;
@@ -100,11 +100,6 @@ int main(int argc, char **argv)
     columns->description = _("Print types/names of table columns for specified "
                              "layer and exit");
     columns->guisection = _("Print");
-
-    overwrite = G_define_flag();
-    overwrite->key = 'o';
-    overwrite->description =
-        _("Overwrite connection parameter for certain layer");
 
     delete = G_define_flag();
     delete->key = 'd';
@@ -271,9 +266,9 @@ int main(int argc, char **argv)
                 G_debug(3, "Vect_map_check_dblink = %d", ret);
                 if (ret == 1) {
                     /* field already defined */
-                    if (!overwrite->answer)
-                        G_fatal_error(_("Use -o to overwrite existing link "
-                                        "for layer <%d>"),
+                    if (!G_get_overwrite())
+                        G_fatal_error(_("Use --overwrite to overwrite "
+                                        "existing link for layer <%d>"),
                                       field);
                     else {
                         dbColumn *column;


### PR DESCRIPTION
This PR fixes #3149 by using the standard `--overwrite` flag.