### PR TITLE
lint: fix pre-commit warnings/errors

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -114,7 +114,10 @@ jobs:
       - name: Run Pylint on other files using pytest
         run: |
           pip install pytest pytest-pylint==0.19
-          echo "::warning file=.github/workflows/python-code-quality.yml,line=116,col=42,endColumn=48::Temporarily downgraded pytest-pylint to allow merging other PRs. The errors reported with a newer version seem legitimite and should be fixed (2023-10-18, see https://github.com/OSGeo/grass/pull/3205)"
+          echo "::warning file=.github/workflows/python-code-quality.yml,line=116,col=42,endColumn=48::\
+            Temporarily downgraded pytest-pylint to allow merging other PRs. The errors reported\
+            with a newer version seem legitimite and should be fixed (2023-10-18,\
+            see https://github.com/OSGeo/grass/pull/3205)"
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
           pytest --pylint -m pylint --pylint-rcfile=.pylintrc --pylint-jobs=$(nproc) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.6
 
 # Note: This file must be kept in sync in ./Dockerfile and ./docker/ubuntu/Dockerfile.
-#       Changes to this file must be copied over to the other file.  
+#       Changes to this file must be copied over to the other file.
 
 ARG GUI=without
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.6
 
 # Note: This file must be kept in sync in ./Dockerfile and ./docker/ubuntu/Dockerfile.
-#       Changes to this file must be copied over to the other file.  
+#       Changes to this file must be copied over to the other file.
 
 ARG GUI=without
 

--- a/locale/transifex/.tx/config
+++ b/locale/transifex/.tx/config
@@ -18,4 +18,3 @@ source_file = ../templates/grasswxpy.pot
 source_lang = en
 file_filter = ../po/grasswxpy_<lang>.po
 type        = PO
-

--- a/locale/transifex/transifex_merge_2.sh
+++ b/locale/transifex/transifex_merge_2.sh
@@ -7,7 +7,7 @@
 
 # Required installation:
 #  sudo pip3 install transifex-client
-# see also: https://grasswiki.osgeo.org/wiki/GRASS_messages_translation#Get_the_translated_po_files 
+# see also: https://grasswiki.osgeo.org/wiki/GRASS_messages_translation#Get_the_translated_po_files
 
 # Usage:
 # this script has to be launched in the `locale/` directory.
@@ -40,12 +40,12 @@ for fil in `ls $NEWLIBPODIR`;
 do
   # TODO: keep uppercase for pt_BR etc - rename in SVN as needed
   MYLANG=`echo $fil | sed 's+_translation++g'`
-  
+
   # LV is not translated in Tx thus skip it
   if [[ ${MYLANG} == "lv" ]]; then
     continue
   fi
-  
+
   # https://www.gnu.org/software/gettext/manual/html_node/msgmerge-Invocation.html#msgmerge-Invocation
   # if po file locally present, update it, otherwise copy over new file from transifex
   if [ -f grasslibs_${MYLANG}.po ]; then


### PR DESCRIPTION
Address pre-commit warnings and fixes. A majority of the issues originate from CI bot PRs, but not all.
This emphasises the need to explore the introduction of [pre-commit.ci](https://pre-commit.ci/).