### PR TITLE
pre-commit: set min-space to 1 for in-line comments in yaml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,4 +67,6 @@ repos:
     hooks:
       - id: yamllint
         args: [--format, parsable, --strict, -d,
-               '{extends: default, rules: {truthy: disable, line-length: {max: 120, allow-non-breakable-words: true}}}']
+               '{extends: default, rules: {truthy: disable,
+                 line-length: {max: 120, allow-non-breakable-words: true},
+                 comments: {min-spaces-from-content: 1}}}']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+ci:
+  skip: [flake8]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -60,7 +62,8 @@ repos:
         types_or: [c, c++, javascript, json, objective-c]
         exclude: |
           (?x)^(
-                man/jquery.fixedheadertable.min.js
+                man/jquery.fixedheadertable.min.js$|
+                .*\.ipynb$
           )
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.29.0


### PR DESCRIPTION
Renovate bot commit may contain trailing comments with 1 space from the content. This is caused by Renovate uses 'prettier' for formatting, which has a different default compared to yamllint, and that is not likely to change.

This is completely arbitrary, thus to avoid further linting issues cased by Renovate we can as well adapt to use 1 min-space from content.


Update: I added a commit which prepares pre-commit config for the use of `pre-commit.ci` if we choose do so. This part will otherwise make no difference.

- Skip flake8 for pre-commit.ci, as the '.flake8' file is ignored by pre-commit.ci.

- For some unknown reason the 'clang-format' of pre-commit.ci also formats ipynb files (being json files), but local use of pre-commit does not. Exclude ipynb files from clang-format.
