### PR TITLE
parser: Support renamed flags (flags/options to options/flags as well)

### DIFF
--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1027,7 +1027,6 @@ void set_flag(int f)
                                 "flag <%c> has been renamed to <%s>"),
                               G_program_name(), f, renamed_key);
                     st->overwrite = 1;
-                    return;
                 }
                 else {
                     /* long flags other than --overwrite are usually specific to
@@ -1038,8 +1037,8 @@ void set_flag(int f)
                                  "flag <%c> has been renamed to <%s>"),
                                G_program_name(), f, renamed_key);
                     append_error(err);
-                    return;
                 }
+                return;
             }
             /* if renamed to a short flag */
             for (flag = &st->first_flag; flag; flag = flag->next_flag) {

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1225,9 +1225,8 @@ void set_option(const char *string)
 
     /* First, check if key has been renamed */
     if (found == 0) {
-        const char *renamed_key = NULL;
+        const char *renamed_key = get_renamed_option(the_key);
 
-        renamed_key = get_renamed_option(the_key);
         if (renamed_key) {
             /* if renamed to a new flag (option value given but will be lost),
              * fatal error */

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1056,8 +1056,8 @@ void set_flag(int f)
             }
         }
         else {
-            /* if renamed to a new option (less information given), fatal error
-             */
+            /* if renamed to a new option (no option value given but will be
+             * required), fatal error */
             struct Option *opt = NULL;
             for (opt = &st->first_option; opt; opt = opt->next_opt) {
                 if (strcmp(renamed_key, opt->key) == 0) {
@@ -1229,8 +1229,8 @@ void set_option(const char *string)
 
         renamed_key = get_renamed_option(the_key);
         if (renamed_key) {
-            /* if renamed to a new flag (information loss occurs), fatal error
-             */
+            /* if renamed to a new flag (option value given but will be lost),
+             * fatal error */
             if (*renamed_key == '-') {
                 if (renamed_key[1] == '-')
                     G_asprintf(&err,

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1011,7 +1011,7 @@ void set_flag(int f)
         flag = flag->next_flag;
     }
 
-    /* First, check if key has been renamed in GRASS 7 */
+    /* First, check if key has been renamed */
     G_asprintf(&key, "-%c", f);
     renamed_key = get_renamed_option(key);
     G_free(key);
@@ -1223,7 +1223,7 @@ void set_option(const char *string)
     if (found)
         opt = matches[0];
 
-    /* First, check if key has been renamed in GRASS 7 */
+    /* First, check if key has been renamed */
     if (found == 0) {
         const char *renamed_key = NULL;
 

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1224,6 +1224,7 @@ void set_option(const char *string)
                                  "option <%s> has been renamed to flag <%c>"),
                                G_program_name(), the_key, renamed_key[1]);
                 append_error(err);
+                return;
             }
 
             /* if renamed to a new option */


### PR DESCRIPTION
This PR supports flag to flag, flag to option (fatal error), option to flag (fatal error) renaming.

https://github.com/OSGeo/grass/blob/816c25f62cd6723aa956939b157ac1f3da1c8f44/lib/gis/renamed_options#L453-L461

Above lines need a fix (2nd `|` => `:`). Fixed in #3260.