### PR TITLE
Speed up pytest workflow by 1min20 with pytest-xdist

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,7 +49,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r .github/workflows/python_requirements.txt
           pip install -r .github/workflows/optional_requirements.txt
-          pip install pytest pytest-timeout pytest-github-actions-annotate-failures
+          pip install pytest pytest-timeout pytest-github-actions-annotate-failures pytest-xdist
 
       - name: Create installation directory
         run: |
@@ -73,7 +73,7 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
-          pytest .
+          pytest --numprocesses auto .
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install non-Python dependencies
         run: |


### PR DESCRIPTION
Using pytest-xdist, it is possible to use multiple cores to run pytest, with many multiple options to manage the queue.
Since there isn’t many tests to run with pytest, only 100, the runtime for the complete pytest workflow goes from 532-537 seconds to 439-451 seconds (about 86-93 seconds faster). For each run. The pytest only part passed from 3:24-3:44 to 2:04-2:19.

Caching python packages doesn’t seem to help a lot, since only about 30 seconds is passed on this.


In my Megalinter repo, this had a bigger impact, cutting off ~10mins on our longest workflow, cutting the python tests time in half. (It automatically chose 4 workers for the 2 cores in CI, but a lot of time is idle depending on the linters to spin up)