### PR TITLE
added support for Darwin 64bit arch and for ASTER L1T data products

### DIFF
--- a/scripts/r.in.aster/r.in.aster.html
+++ b/scripts/r.in.aster/r.in.aster.html
@@ -2,12 +2,12 @@
 
 <em>r.in.aster</em> rectifies, georeferences, and imports Terra-ASTER imagery
 to current location using gdalwarp, hdf 4, and r.in.gdal, using projection parameters
-from g.proj. It can import Level 1A, Level 1B, and relative DEM products.
+from g.proj. It can import Level 1A, Level 1B, their relative DEM products, and Level 1T.
 <p>The program may be run interactively or non-interactively from the command
   line. In either case, the user must specify an <b>input</b> *.hdf file name,
   the <b>type</b> of processing used, the image <b>band</b> to import, and an
   <b>output</b> GRASS raster map name.
-<p>The <b>type</b> parameter can take values of L1A, L1B, or DEM.
+<p>The <b>type</b> parameter can take values of L1A, L1B, L1T or DEM.
 <p>The <b>band</b> parameter can take values of 1, 2, 3n, 3b, 4-14
 
 <h2>NOTES</h2>

--- a/scripts/r.in.aster/r.in.aster.py
+++ b/scripts/r.in.aster/r.in.aster.py
@@ -36,7 +36,7 @@
 # % key: proctype
 # % type: string
 # % description: ASTER imagery processing type (Level 1A, Level 1B, or relative DEM)
-# % options: L1A,L1B,DEM
+# % options: L1A,L1B,L1T,DEM
 # % answer: L1B
 # % required: yes
 # %end
@@ -82,6 +82,25 @@ bands = {
         "5": "SWIR_Swath:ImageData5",
         "6": "SWIR_Swath:ImageData6",
         "7": "SWIR_Swath:ImageData7",
+        "8": "SWIR_Swath:ImageData8",
+        "9": "SWIR_Swath:ImageData9",
+        "10": "TIR_Swath:ImageData10",
+        "11": "TIR_Swath:ImageData11",
+        "12": "TIR_Swath:ImageData12",
+        "13": "TIR_Swath:ImageData13",
+        "14": "TIR_Swath:ImageData14",
+    },
+    "L1T": {
+        "4": "SWIR_Swath:ImageData4",
+        "5": "SWIR_Swath:ImageData5",
+        "6": "SWIR_Swath:ImageData6",
+        "7": "SWIR_Swath:ImageData7",
+        "8": "SWIR_Swath:ImageData8",
+        "9": "SWIR_Swath:ImageData9",
+        "1": "VNIR_Swath:ImageData1",
+        "2": "VNIR_Swath:ImageData2",
+        "3n": "VNIR_Swath:ImageData3N",
+        "3b": "VNIR_Swath:ImageData3N", # A placeholder for consistency with other bands
         "8": "SWIR_Swath:ImageData8",
         "9": "SWIR_Swath:ImageData9",
         "10": "TIR_Swath:ImageData10",
@@ -138,8 +157,8 @@ def main():
     else:
         bandlist = band.split(",")
 
-    # initialize datasets for L1A and L1B
-    if proctype in ["L1A", "L1B"]:
+    # initialize datasets for L1A, L1B, L1T
+    if proctype in ["L1A", "L1B","L1T"]:
         for band in bandlist:
             if band in allbands:
                 dataset = bands[proctype][band]
@@ -166,7 +185,10 @@ def import_aster(proj, srcfile, tempfile, output, band):
     grass.debug("gdalwarp -t_srs %s %s %s" % (proj, srcfile, tempfile))
 
     if platform.system() == "Darwin":
-        cmd = ["arch", "-i386", "gdalwarp", "-t_srs", proj, srcfile, tempfile]
+        if platform.architecture()[0] == "32bit":
+            cmd = ["arch", "-i386", "gdalwarp", "-t_srs", proj, srcfile, tempfile]
+        if platform.architecture()[0] == "64bit":
+            cmd = ["arch", "-x86_64", "gdalwarp", "-t_srs", proj, srcfile, tempfile]
     else:
         cmd = ["gdalwarp", "-t_srs", proj, srcfile, tempfile]
     p = grass.call(cmd)


### PR DESCRIPTION

this adds to r.in.aster support for:

 1.  Darwin 64bit architecture
 2.  ATER Level 1 Precision Terrain Corrected Registered At-Sensor Radiance ([L1T](https://doi.org/10.5067/ASTER/AST_L1T.031)) containing calibrated at-sensor radiance, which corresponds with the ASTER Level 1B [(AST_L1B)](https://doi.org/10.5067/ASTER/AST_L1B.003), that has been geometrically corrected, and rotated to a north-up UTM projection.

updated code and manual.  

The code expects 15 bands, while The L1T dataset does not include the aft-looking VNIR band 3 (3b), so 3b is the copy of 3n.  Future improvements shall consider this aspect specific to L1T.

best,

Alessandro


