### PR TITLE
parser: Fix key-value pairs for t.* modules in renamed_options

### DIFF
--- a/lib/gis/renamed_options
+++ b/lib/gis/renamed_options
@@ -450,15 +450,15 @@ t.vect.import|extrdir:directory
 # t.vect.export
 t.vect.export|extrdir:directory
 # t.info
-t.info|-s|-d
+t.info|-s:-d
 # t.rast.list
-t.rast.list|-s|-u
+t.rast.list|-s:-u
 # t.rast.univar
-t.rast.univar|-s|-u
+t.rast.univar|-s:-u
 # t.vect.list
-t.vect.list|-s|-u
+t.vect.list|-s:-u
 # t.vect.univar
-t.vect.univar|-s|-u
+t.vect.univar|-s:-u
 #########################
 ### Vector module changes
 #########################


### PR DESCRIPTION
This PR fixes the key-value pairs for t.* modules in `etc/renamed_options`. Still, flag renaming is not support yet without #3256.