### PR TITLE
CI: fix Periodic update's cron and do not add labels

### DIFF
--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
   schedule:
     # At 10:32 on every first Wednesday of the month.
-    # See https://crontab.guru/#32_10_1-7_*_WED
-    - cron: "32 10 1-7 * WED"
+    # See https://crontab.guru/#32_10_*/100,1-7_*_WED
+    - cron: "32 10 */100,1-7 * WED"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -38,7 +38,6 @@ jobs:
           commit-message: "config.guess + config.sub: updated from http://git.savannah.gnu.org/cgit/config.git/plain/"
           branch: periodic/update-configure
           title: "configure: update to latest config.guess and config.sub"
-          labels: "CI,packaging,configure"
           body: |
             This updates config.guess and config.sub to their latest versions.
             If the two files are deleted in this PR, please check the logs of the workflow here:


### PR DESCRIPTION
Fixes the `Periodic update` workflow's cron settings to run the first Wednesday every month.
This also removes the setting of labels for the update PRs created by the bot.