### PR TITLE
db.dropcolumn: Circumvent length limit for sqlite3 SQL STDIN string

### DIFF
--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -80,30 +80,38 @@ def main():
         return 0
 
     if driver == "sqlite":
-        # echo "Using special trick for SQLite"
-        # http://www.sqlite.org/faq.html#q13
-        colnames = []
-        coltypes = []
-        for f in gscript.db_describe(table)["cols"]:
-            if f[0] != column:
-                colnames.append(f[0])
-                coltypes.append("%s %s" % (f[0], f[1]))
+        sqlite3_version = gscript.read_command("sqlite3", "version")
 
-        colnames = ", ".join(colnames)
-        coltypes = ", ".join(coltypes)
+        if sqlite3_version >= "3.35.0":
+            sql = "ALTER TABLE %s DROP COLUMN %s" % (table, column)
+            if column == "cat":
+                sql = "DROP INDEX %s_%s; %s" % (table, column, sql)
+        else:
+            # for older sqlite3 versions, use old way to remove column
+            # echo "Using special trick for SQLite"
+            # http://www.sqlite.org/faq.html#q13
+            colnames = []
+            coltypes = []
+            for f in gscript.db_describe(table)["cols"]:
+                if f[0] != column:
+                    colnames.append(f[0])
+                    coltypes.append("%s %s" % (f[0], f[1]))
 
-        cmds = [
-            "BEGIN TRANSACTION",
-            "CREATE TEMPORARY TABLE ${table}_backup(${coldef})",
-            "INSERT INTO ${table}_backup SELECT ${colnames} FROM ${table}",
-            "DROP TABLE ${table}",
-            "CREATE TABLE ${table}(${coldef})",
-            "INSERT INTO ${table} SELECT ${colnames} FROM ${table}_backup",
-            "DROP TABLE ${table}_backup",
-            "COMMIT",
-        ]
-        tmpl = string.Template(";\n".join(cmds))
-        sql = tmpl.substitute(table=table, coldef=coltypes, colnames=colnames)
+            colnames = ", ".join(colnames)
+            coltypes = ", ".join(coltypes)
+
+            cmds = [
+                "BEGIN TRANSACTION",
+                "CREATE TEMPORARY TABLE ${table}_backup(${coldef})",
+                "INSERT INTO ${table}_backup SELECT ${colnames} FROM ${table}",
+                "DROP TABLE ${table}",
+                "CREATE TABLE ${table}(${coldef})",
+                "INSERT INTO ${table} SELECT ${colnames} FROM ${table}_backup",
+                "DROP TABLE ${table}_backup",
+                "COMMIT",
+            ]
+            tmpl = string.Template(";\n".join(cmds))
+            sql = tmpl.substitute(table=table, coldef=coltypes, colnames=colnames)
     else:
         sql = "ALTER TABLE %s DROP COLUMN %s" % (table, column)
 

--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -94,8 +94,6 @@ def main():
                 sql = "DROP INDEX %s_%s; %s" % (table, column, sql)
         else:
             # for older sqlite3 versions, use old way to remove column
-            # echo "Using special trick for SQLite"
-            # http://www.sqlite.org/faq.html#q13
             colnames = []
             coltypes = []
             for f in gscript.db_describe(table)["cols"]:

--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -80,7 +80,13 @@ def main():
         return 0
 
     if driver == "sqlite":
-        sqlite3_version = gscript.read_command("sqlite3", "version")
+        sqlite3_version = gscript.read_command(
+            "db.select",
+            sql="SELECT sqlite_version();",
+            flags="c",
+            database=database,
+            driver=driver,
+        )
 
         if sqlite3_version >= "3.35.0":
             sql = "ALTER TABLE %s DROP COLUMN %s" % (table, column)

--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -86,9 +86,9 @@ def main():
             flags="c",
             database=database,
             driver=driver,
-        )
+        ).split(".")[0:2]
 
-        if sqlite3_version >= "3.35.0":
+        if [int(i) for i in sqlite3_version] >= [int(i) for i in "3.35".split(".")]:
             sql = "ALTER TABLE %s DROP COLUMN %s" % (table, column)
             if column == "cat":
                 sql = "DROP INDEX %s_%s; %s" % (table, column, sql)


### PR DESCRIPTION
This PR supports a more recent sqlite3 command to drop a column within db.dropcolumn.
In sqlite3 [3.35.0, the DROP COLUMN](https://www.sqlite.org/changes.html#version_3_35_0) command was added. This PR makes use of the command if the sqlite3 version is high enough.

Background is a failing `db.in.ogr` command for a CSV file containing many columns:

```bash
GRASS cttest/PERMANENT:~ > db.in.ogr input=migr_emi2_L0.csv output=migr_emi2_L0
Traceback (most recent call last):
  File "/usr/local/grass83/scripts/db.in.ogr", line 189, in <module>
    main()
  File "/usr/local/grass83/scripts/db.in.ogr", line 172, in main
    grass.run_command(
  File "/usr/local/grass83/etc/python/grass/script/core.py", line 466, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/grass83/etc/python/grass/script/core.py", line 345, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `db.dropcolumn --q -f table=migr_emi2_L0 column=cat` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
```
And with further debugging:
```bash
GRASS cttest/PERMANENT:~ > db.dropcolumn --q -f table=migr_emi2_L0 column=cat
WARNING: Deleting <cat> column which may be needed to keep table connected
         to a vector map
DBMI-SQLite driver error:
Error in sqlite3_prepare():
incomplete input

DBMI-SQLite driver error:
Error in sqlite3_prepare():
incomplete input

ERROR: Error while executing: 'CREATE TEMPORARY TABLE
       migr_emi2_L0_backup(NUTS_ID TEXT, TOTAL_COMPLET_NR_F_2021 DOUBLE
       PRECISION, TOTAL_COMPLET_NR_F_2020 DOUBLE PRECISION,
       TOTAL_COMPLET_NR_F_2019 DOUBLE PRECISION, TOTAL_COMPLET_NR_F_2018
       DOUBLE PRECISION, TOTAL_COMPLET_NR_F_2017 DOUBLE PRECISION,
...    
       Y43_REACH_NR_T_2017 DOUBLE PRECISION, Y43_REACH_NR_T_2016 DOUBLE
       PRECISION, Y43_REACH_NR_T_2015 DOUBLE PRECISION,
       Y44_COMPLET_NR_F_2021 DOUBLE PRECISION, Y4'
ERROR: Cannot continue (problem deleting column)
```
So the created SQL string becomes too long to be passed via stdin in ` "db.execute", input="-", database=database, driver=driver, stdin=sql` command. This PR circumvents this by using the newer sqlite3 syntax if available.