### PR TITLE
grass.pygrass: Support shortened parameter values

### DIFF
--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -143,7 +143,7 @@ class Parameter(object):
         >>> param.value = 3
         Traceback (most recent call last):
            ...
-        ValueError: The Parameter <int_number>, must be one of the following values: [2, 4, 6, 8]
+        ValueError: The Parameter <int_number>, must be one of the following values: [2, 4, 6, 8] not '3'
 
     ...
     """

--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -13,7 +13,6 @@ def _check_value(param, value):
     """Function to check the correctness of a value and
     return the checked value and the original.
     """
-    must_val = "The Parameter <%s>, must be one of the following values: %r"
     req = "The Parameter <%s>, require: %s, get: %s instead: %r\n%s"
     string = (type(b""), type(""))
 
@@ -107,7 +106,17 @@ def _check_value(param, value):
                 raise ValueError(err_str)
         # check if value is in the list of valid values
         if param.values is not None and newvalue not in param.values:
-            raise ValueError(must_val % (param.name, param.values))
+            good = False
+            if param.type == str:
+                for param_value in param.values:
+                    if param_value.startswith(newvalue):
+                        good = True
+                        break
+            if not good:
+                raise ValueError(
+                    f"The Parameter <{param.name}>, must be one of the following values:"
+                    f" {param.values!r} not '{newvalue}'"
+                )
     return (
         (
             [

--- a/vector/v.to.rast/testsuite/test_v_to_rast.py
+++ b/vector/v.to.rast/testsuite/test_v_to_rast.py
@@ -1,0 +1,58 @@
+"""
+Name:       v.to.rast test
+
+Purpose:    Test v.to.rast
+
+Author:     Vaclav Petras
+
+Copyright:  (C) 2023 by Vaclav Petras and the GRASS Development Team
+
+Licence:    This program is free software under the GNU General Public
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
+"""
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+class TestParameters(TestCase):
+    """Test v.to.rast"""
+
+    output = "roads"
+
+    @classmethod
+    def setUpClass(cls):
+        """Specify region for raster creation for this class"""
+        cls.use_temp_region()
+        cls.runModule("g.region", raster="roadsmajor", res=10, flags="a")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove temporary region"""
+        cls.del_temp_region()
+
+    def tearDown(self):
+        """Remove maps after each test method"""
+        self.runModule(
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=[self.output],
+        )
+
+    def test_legacy_use_interface(self):
+        """Check that a legacy value for use parameter works"""
+        self.assertModule(
+            "v.to.rast", input="roadsmajor", output=self.output, use="val", value=1
+        )
+
+    def test_use_interface(self):
+        """Check that use=value value=1 works"""
+        self.assertModule(
+            "v.to.rast", input="roadsmajor", output=self.output, use="value", value=1
+        )
+        self.assertRasterFitsInfo(raster=self.output, reference={"min": 1, "max": 1})
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
Command line interface parser allows parameter (option) values such as 'val' when full value should be 'value'. Parameter class from pygrass does the checking, but does not know about these rules. This addition covers the simple case of val-value which is not much work to implement and maintain. It does not cover more complex cases with underscores and legacy aliases.

The test covers the issue for use=value change in v.to.rast made in #3110.

Strict checking in pygrass is discussed in #3237.
