### PR TITLE
v.in.ogr: add fix for unclosed rings

### DIFF
--- a/vector/v.in.ogr/geom.c
+++ b/vector/v.in.ogr/geom.c
@@ -368,8 +368,9 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
             Points->z[0] != Points->z[lastidx]) {
             if (mk_centr) {
                 /* do not clean polygons */
-                G_fatal_error(_("Found unclosed outer polygon ring, can be "
-                                "closed when cleaning polygons is enabled"));
+                G_fatal_error(
+                    _("Found unclosed outer polygon ring, can be "
+                      "closed when cleaning polygons is not disabled"));
             }
             else {
                 G_warning(_("Closing unclosed outer polygon ring"));
@@ -435,7 +436,7 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
                         /* do not clean polygons */
                         G_fatal_error(
                             _("Found unclosed inner polygon ring, can be "
-                              "closed when cleaning polygons is enabled"));
+                              "closed when cleaning polygons is not disabled"));
                     }
                     else {
                         G_warning(_("Closing unclosed inner polygon ring"));

--- a/vector/v.in.ogr/geom.c
+++ b/vector/v.in.ogr/geom.c
@@ -274,6 +274,7 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
     OGRGeometryH hRing;
     double x, y;
     double size;
+    int lastidx;
 
     G_debug(3, "geom() cat = %d", cat);
 
@@ -361,6 +362,22 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
         }
         Vect_line_prune(Points);
 
+        lastidx = Points->n_points - 1;
+        if (Points->x[0] != Points->x[lastidx] ||
+            Points->y[0] != Points->y[lastidx] ||
+            Points->z[0] != Points->z[lastidx]) {
+            if (mk_centr) {
+                /* do not clean polygons */
+                G_fatal_error(_("Found unclosed outer polygon ring, can be "
+                                "closed when cleaning polygons is enabled"));
+            }
+            else {
+                G_warning(_("Closing unclosed outer polygon ring"));
+                Vect_append_point(Points, Points->x[0], Points->y[0],
+                                  Points->z[0]);
+            }
+        }
+
         /* Degenerate is not ignored because it may be useful to see where it
          * is, but may be eliminated by min_area option */
         if (Points->n_points < 4)
@@ -406,6 +423,28 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
                         OGR_G_GetY(hRing, j), OGR_G_GetZ(hRing, j));
                 }
                 Vect_line_prune(IPoints[valid_isles]);
+
+                lastidx = Points->n_points - 1;
+                if (IPoints[valid_isles]->x[0] !=
+                        IPoints[valid_isles]->x[lastidx] ||
+                    IPoints[valid_isles]->y[0] !=
+                        IPoints[valid_isles]->y[lastidx] ||
+                    IPoints[valid_isles]->z[0] !=
+                        IPoints[valid_isles]->z[lastidx]) {
+                    if (mk_centr) {
+                        /* do not clean polygons */
+                        G_fatal_error(
+                            _("Found unclosed inner polygon ring, can be "
+                              "closed when cleaning polygons is enabled"));
+                    }
+                    else {
+                        G_warning(_("Closing unclosed inner polygon ring"));
+                        Vect_append_point(IPoints[valid_isles],
+                                          IPoints[valid_isles]->x[0],
+                                          IPoints[valid_isles]->y[0],
+                                          IPoints[valid_isles]->z[0]);
+                    }
+                }
 
                 if (IPoints[valid_isles]->n_points < 4)
                     G_warning(_("Degenerate island (%d vertices)"),


### PR DESCRIPTION
Sometimes there are unclosed polygon rings in input vectors which is a violation of the OGR simple feature specification. `ogrinfo` reports in these cases:
```
Warning 1: Non closed ring detected. To avoid accepting it, set the OGR_GEOMETRY_ACCEPT_UNCLOSED_RING configuration option to NO
```
`ogr2ogr -makevalid` fails with
```
ERROR 1: IllegalArgumentException: Points of LinearRing do not form a closed linestring
```
This PR adds a fix by appending the first vertex to the end of an unclosed ring, thus closing it. It seems that this is usually the reason for unclosed rings: someone or some software forgot to append the first vertex as the last vertex.

This fix in `v.in.ogr` is only applied if polygon cleaning is not disabled with the `-c` flag, otherwise `v.in.ogr` will fail with a new fatal error: `Found unclosed [outer|inner] polygon ring, can be closed when cleaning polygons is enabled`

In the current behaviour, such unclosed rings will end up as invalid boundaries in the output or are removed altogether during cleaning, in the extreme case resulting in an empty output vector without any geometries.