### PR TITLE
v.out.ogr: fix append+overwrite mode

### DIFF
--- a/vector/v.out.ogr/main.c
+++ b/vector/v.out.ogr/main.c
@@ -615,7 +615,7 @@ int main(int argc, char *argv[])
                 _("Layer <%s> already exists in OGR data source '%s'"),
                 options.layer->answer, options.dsn->answer);
         }
-        else if (overwrite) {
+        else if (overwrite && !flags.append->answer) {
             G_warning(
                 _("OGR layer <%s> already exists and will be overwritten"),
                 options.layer->answer);


### PR DESCRIPTION
Currently, `v.out.ogr` deletes an existing OGR output layer in append+overwrite mode in [L618ff](https://github.com/OSGeo/grass/blob/main/vector/v.out.ogr/main.c#L618). This 

- deletion of an existing OGR output layer in append mode can be disastrous if it already contains valuable information and data that should definitively not be deleted
- causes an error because the layer to be appended has been deleted and can not be found in [L709](https://github.com/OSGeo/grass/blob/main/vector/v.out.ogr/main.c#L709), thus fatal error in [L724](https://github.com/OSGeo/grass/blob/main/vector/v.out.ogr/main.c#L724) 

In are more complex workflow, overwrite might be set to the whole workflow in order to overwrite previous interim GRASS results of an unsuccessful run. Once the processing finishes successfully, overwriting any previous interim GRASS data, the final result should be appended to an external OGR output layer without deleting this external OGR output layer. If anything went wrong previously, selected records in the external OGR output layer should be deleted, but not the complete external OGR output layer.