### PR TITLE
r.cross: fix outdated doc (max 10 changed to 30 layers)

### DIFF
--- a/raster/r.cross/r.cross.html
+++ b/raster/r.cross/r.cross.html
@@ -3,15 +3,11 @@
 <em>r.cross</em> creates an <em>output</em> raster map layer representing
 all unique combinations of category values in the raster input layers
 (<b>input=</b><em>name,name,name</em>, ...).  At least two, but not more than
-ten, <em>input</em> map layers must be specified.  The user must also
+30, <em>input</em> map layers must be specified.  The user must also
 specify a name to be assigned to the <em>output</em> raster map layer
 created by <em>r.cross</em>.
 
 <h2>OPTIONS</h2>
-
-The program will be run non-interactively if the user specifies
-the names of between 2-10 raster map layers be used as <em>input</em>,
-and the name of a raster map layer to hold program <em>output</em>.
 
 <p>
 With the <b>-z</b> flag NULL values are not crossed.


### PR DESCRIPTION
Reported in https://gis.stackexchange.com/questions/471574/r-cross-max-number-of-input-map-layers
Max number of layers changed in https://github.com/OSGeo/grass/commit/efd287950e7b777a05d93e4bee4b5689b08941cc.