### PR TITLE
CI: Add Python 3.12 to pytest's matrix

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,6 +25,7 @@ jobs:
         python-version:
           - '3.8'
           - '3.10'
+          - '3.12'
       fail-fast: true
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Contributes to https://github.com/OSGeo/grass/issues/3285
This is the second step of my PRs to modernize our Python code. It is the first bullet of #3285.

This PR simply adds Python 3.12 in our pytest workflows, in order to be able to see more warnings and deprecations. I chose this as it is a relatively fast workflow and the impact would be minimal. Of course, full coverage isn't there yet, as it only runs 103 tests, but at least some importing of our modules is done (grass.script and some grass.jupyter packages for now).

This doesn't mean for now that we support Python 3.12, but we should be for the next release, so work must start at some point.