### PR TITLE
Missing `shutil` import when used inside `@unittest.skipIf` condition

### DIFF
--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import shutil
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 import unittest

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+import shutil
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 import unittest


### PR DESCRIPTION
When trying to explore a bit more running unittest-based tests with pytest, discovering tests failed on this since shutils wasn’t imported in the file but used in the condition of `@unittest.skipIf`. Additionally found by a Python linter.

I don’t understand how the two test files could have run correctly and not fail yet with this missing import. Is it actually running in the test suite?