### PR TITLE
pre-commit: Update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
                 python/libgrass_interface_generator/
           )
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.6
+    rev: v15.0.7
     hooks:
       - id: clang-format
         types_or: [c, c++, javascript, json, objective-c]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,16 @@ repos:
     rev: v0.33.0
     hooks:
       - id: markdownlint
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.12.1
     hooks:
       - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        # language_version: python3.11
         exclude: |
           (?x)^(
                 python/libgrass_interface_generator/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
                 .*\.ipynb$
           )
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
         args: [--format, parsable, --strict, -d,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.12.1
     hooks:
-      - id: black
+      - id: black-jupyter
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,12 @@ repos:
                 lib/fonts/fonts/.*
           )
       - id: destroyed-symlinks
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-xml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: detect-private-key
   - repo: https://github.com/igorshubovych/markdownlint-cli
     # A DeprecationWarning for punycode exists after v0.33.0, at least until v0.38.0.
     # The issue has been resolved by the markdown-it, but markdownlint and

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
                 python/libgrass_interface_generator/
           )
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.1.0
     hooks:
       - id: flake8
         exclude: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
                 python/libgrass_interface_generator/ctypesgen/|
                 lib/fonts/fonts/.*
           )
+      - id: destroyed-symlinks
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.33.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   skip: [flake8]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
         exclude: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,13 @@ repos:
           )
       - id: destroyed-symlinks
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    # A DeprecationWarning for punycode exists after v0.33.0, at least until v0.38.0.
+    # The issue has been resolved by the markdown-it, but markdownlint and
+    # markdownlint-cli didn't release a new version yet.
+    # This check still works in the meantime.
+    # See https://github.com/DavidAnson/markdownlint/issues/1032
+    # See https://github.com/igorshubovych/markdownlint-cli/issues/437
+    rev: v0.38.0
     hooks:
       - id: markdownlint
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster


### PR DESCRIPTION
Multiple pre-commit tools were not up-to-date.

Most annoyingly, Flake8 didn't run at all with a Python 3.12 (by default) workspace, and had a version of a couple years ago.

Since we will be changing the black yearly version soon, I made a round of changes that should be integrated before this.


I added some additional tools from the https://github.com/pre-commit/pre-commit-hooks, and enabled black formatting for jupyter notebooks.


Someone with admin rights should enable the pre-commit checks from this issue https://github.com/OSGeo/grass/issues/3255 in the short-term, as there were already some files that were out of date. (Excluding jupyter notebooks). Should I do a separate PR for these 13 files?
If setting up pre-commit.ci is too complicated (meaning only one person can really administer the changes), I suggest their other way of running pre-commit, by GitHub Actions workflows so we could at least be able to do PR for improving the configuration.