### PR TITLE
CI: Add a verify-success reusable workflow to use for required checks

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -80,3 +80,11 @@ jobs:
       - name: Print installed versions
         if: always()
         run: .github/workflows/print_versions.sh
+  pytest-success:
+    name: pytest Result
+    needs:
+      - pytest
+    if: ${{ always() }}
+    uses: ./.github/workflows/verify-success.yml
+    with:
+      needs_context: ${{ toJson(needs) }}

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -13,11 +13,10 @@ on:
 
 jobs:
   python-checks:
-    name: Python Code Quality
+    name: Python Code Quality Checks
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
-        matrix.pylint-version }}
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{ matrix.pylint-version }}
       cancel-in-progress: true
 
     # Using matrix just to get variables which are not environmental variables
@@ -45,11 +44,11 @@ jobs:
           echo Pylint: ${{ matrix.pylint-version }}
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install non-Python dependencies
         run: |
@@ -146,3 +145,11 @@ jobs:
           name: sphinx-grass
           path: sphinx-grass
           retention-days: 3
+  python-success:
+    name: Python Code Quality Result
+    needs:
+      - python-checks
+    if: ${{ always() }}
+    uses: ./.github/workflows/verify-success.yml
+    with:
+      needs_context: ${{ toJson(needs) }}

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -16,7 +16,9 @@ jobs:
     name: Python Code Quality Checks
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{ matrix.pylint-version }}
+      group: ${{ github.workflow }}-${{ github.job }}-${{
+        github.event_name == 'pull_request' &&
+        github.head_ref || github.sha }}-${{ matrix.pylint-version }}
       cancel-in-progress: true
 
     # Using matrix just to get variables which are not environmental variables
@@ -55,7 +57,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y wget git gawk findutils
           xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
-              sudo apt-get install -y --no-install-recommends --no-install-suggests
+          sudo apt-get install -y --no-install-recommends --no-install-suggests
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -65,11 +65,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r .github/workflows/python_requirements.txt
           pip install -r .github/workflows/optional_requirements.txt
-          pip install pipx \
-            pylint==${{ matrix.pylint-version }} \
-            pytest-github-actions-annotate-failures
-          pipx install black[jupyter]==${{ matrix.black-version }}
-          pipx install flake8==${{ matrix.flake8-version }}
+          pip install black==${{ matrix.black-version }}
+          pip install flake8==${{ matrix.flake8-version }}
+          pip install pylint==${{ matrix.pylint-version }} pytest-github-actions-annotate-failures
 
       - name: Run Black
         run: |

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -27,11 +27,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: '3.10'
-            min-python-version: '3.7'
-            black-version: '23.1.0'
-            flake8-version: '3.9.2'
-            pylint-version: '2.12.2'
+            python-version: "3.10"
+            min-python-version: "3.7"
+            black-version: "23.1.0"
+            flake8-version: "3.9.2"
+            pylint-version: "2.12.2"
 
     runs-on: ${{ matrix.os }}
 
@@ -40,12 +40,13 @@ jobs:
         run: |
           echo OS: ${{ matrix.os }}
           echo Python: ${{ matrix.python-version }}
-          echo Minimimal Python version: ${{ matrix.min-python-version }}
+          echo Minimal Python version: ${{ matrix.min-python-version }}
           echo Black: ${{ matrix.black-version }}
           echo Flake8: ${{ matrix.flake8-version }}
           echo Pylint: ${{ matrix.pylint-version }}
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -64,9 +65,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r .github/workflows/python_requirements.txt
           pip install -r .github/workflows/optional_requirements.txt
-          pip install black==${{ matrix.black-version }}
-          pip install flake8==${{ matrix.flake8-version }}
-          pip install pylint==${{ matrix.pylint-version }} pytest-github-actions-annotate-failures
+          pip install pipx \
+            pylint==${{ matrix.pylint-version }} \
+            pytest-github-actions-annotate-failures
+          pipx install black[jupyter]==${{ matrix.black-version }}
+          pipx install flake8==${{ matrix.flake8-version }}
 
       - name: Run Black
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -14,7 +14,7 @@ on:
       - releasebranch_*
 
 jobs:
-  build-and-test:
+  ubuntu:
     name: ${{ matrix.name }} tests
 
     concurrency:
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: '22.04'
+          - name: "22.04"
             os: ubuntu-22.04
             config: ubuntu-22.04
           # This is without optional things but it still keeps things useful,
@@ -95,3 +95,11 @@ jobs:
       - name: Print installed versions
         if: always()
         run: .github/workflows/print_versions.sh
+  build-and-test-success:
+    name: Build & Test Result
+    needs:
+      - ubuntu
+    if: ${{ always() }}
+    uses: ./.github/workflows/verify-success.yml
+    with:
+      needs_context: ${{ toJson(needs) }}

--- a/.github/workflows/verify-success.yml
+++ b/.github/workflows/verify-success.yml
@@ -1,0 +1,121 @@
+---
+name: Verify Success reusable workflow
+
+# Use this reusable workflow as a job of workflow to check that
+# all jobs, including ones ran through a matrix, were successful.
+# This job can then be used as a required status check in the
+# repo's rulesets, that allows to change the required jobs or
+# the matrix values of a required job without needing to change
+# the rulesets settings. In the future, GitHub might have a
+# solution to this natively.
+
+# This reusable workflow has inputs to change what is required
+# to have this workflow pass. It handles the cases were there were
+# skipped jobs, and no successful jobs.
+
+# The jobs to check must set as the `needs` for the job calling this
+# reusable workflow. This also means that the job ids should be in the
+# same workflow file. The calling job must be set to always run to be
+# triggered when jobs are skipped or cancelled.
+# Then, set the `needs_context` input like:
+# `needs_context: ${{ toJson(needs) }}`
+
+# Example usage, as a job inside a workflow:
+# ```
+# jobs:
+#   a-job-id:
+#     ...
+#   another-job-id:
+#     ...
+#   some-job-success:
+#     name: Some Job Result
+#     needs:
+#       - a-job-id
+#       - another-job-id
+#     if: ${{ always() }}
+#     uses: ./.github/workflows/verify-success.yml
+#     with:
+#       needs_context: ${{ toJson(needs) }}
+# ```
+
+on:
+  workflow_call:
+    inputs:
+      needs_context:
+        type: string
+        required: true
+        # Can't escape the handlebars in the description
+        description: In the calling job that defines all the needed jobs, send `toJson(needs)` inside `$` followed by `{{ }}`.
+      fail_if_failure:
+        type: boolean
+        default: true
+        description: If true, this workflow will fail if any job from 'needs_context was failed
+      fail_if_cancelled:
+        type: boolean
+        default: true
+        description: If true, this workflow will fail if any job from 'needs_context' was cancelled
+      fail_if_skipped:
+        type: boolean
+        default: false
+        description: If true, this workflow will fail if any job from 'needs_context' was skipped
+      require_success:
+        type: boolean
+        default: true
+        description: If true, this workflow will fail if no job from 'needs_context' was successful
+
+jobs:
+  verify-success:
+    name: Success
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Set outputs for each job result type
+        id: has-result
+        run: |
+          echo "failure=${{ contains(env.NEEDS_RESULT, 'failure') }}" >> "$GITHUB_OUTPUT"
+          echo "cancelled=${{ contains(env.NEEDS_RESULT, 'cancelled') }}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${{ contains(env.NEEDS_RESULT, 'skipped') }}" >> "$GITHUB_OUTPUT"
+          echo "success=${{ contains(env.NEEDS_RESULT, 'success') }}" >> "$GITHUB_OUTPUT"
+        env:
+          NEEDS_RESULT: ${{ toJson(fromJson(inputs.needs_context).*.result) }}
+      - name: Set exit codes for each job result type
+        id: exit-code
+        run: |
+          echo "failure=${{ inputs.fail_if_failure && fromJson(steps.has-result.outputs.failure) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
+          echo "cancelled=${{ inputs.fail_if_cancelled && fromJson(steps.has-result.outputs.cancelled) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${{ inputs.fail_if_skipped && fromJson(steps.has-result.outputs.skipped) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
+          echo "success=${{ inputs.require_success && !fromJson(steps.has-result.outputs.success) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
+      - name: Set messages for each job result type
+        id: message
+        run: |
+          echo "failure=${{ format('{0}{1} were failed', 
+                              (steps.exit-code.outputs.failure == 1) && env.P1 || env.P2, 
+                              (steps.has-result.outputs.failure == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
+          echo "cancelled=${{ format('{0}{1} were cancelled', 
+                              (steps.exit-code.outputs.cancelled == 1) && env.P1 || env.P2, 
+                              (steps.has-result.outputs.cancelled == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${{ format('{0}{1} were skipped', 
+                              (steps.exit-code.outputs.skipped == 1) && env.P1 || env.P2, 
+                              (steps.has-result.outputs.skipped == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
+          echo "success=${{ format('{0}{1} were successful', 
+                              (steps.exit-code.outputs.success == 1) && env.P1 || env.P2, 
+                              (steps.has-result.outputs.success == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
+        env:
+          P1: "::error ::" # Common message prefix if step will fail
+          P2: "" # Common message prefix if step will not fail
+          M1: "Some jobs" # Common message if result is true
+          M2: "No jobs" # Common message if result is false
+
+      - name: Check for failed jobs
+        run: echo "${{ steps.message.outputs.failure }}" && exit ${{ steps.exit-code.outputs.failure }}
+      - name: Check for cancelled jobs
+        run: echo "${{ steps.message.outputs.cancelled }}" && exit ${{ steps.exit-code.outputs.cancelled }}
+      - name: Check for skipped jobs
+        run: echo "${{ steps.message.outputs.skipped }}" && exit ${{ steps.exit-code.outputs.skipped }}
+      - name: Check for successful jobs
+        run: echo "${{ steps.message.outputs.success }}" && exit ${{ steps.exit-code.outputs.success }}
+
+      - run: echo "Checks passed successfully"
+        if: ${{ success() }}
+      - run: echo "Checks failed"
+        if: ${{ !success() }}

--- a/.github/workflows/verify-success.yml
+++ b/.github/workflows/verify-success.yml
@@ -45,23 +45,33 @@ on:
         type: string
         required: true
         # Can't escape the handlebars in the description
-        description: In the calling job that defines all the needed jobs, send `toJson(needs)` inside `$` followed by `{{ }}`.
+        description:
+          In the calling job that defines all the needed jobs,
+          send `toJson(needs)` inside `$` followed by `{{ }}`
       fail_if_failure:
         type: boolean
         default: true
-        description: If true, this workflow will fail if any job from 'needs_context was failed
+        description:
+          If true, this workflow will fail if any job from 'needs_context was
+          failed
       fail_if_cancelled:
         type: boolean
         default: true
-        description: If true, this workflow will fail if any job from 'needs_context' was cancelled
+        description:
+          If true, this workflow will fail if any job from 'needs_context' was
+          cancelled
       fail_if_skipped:
         type: boolean
         default: false
-        description: If true, this workflow will fail if any job from 'needs_context' was skipped
+        description:
+          If true, this workflow will fail if any job from 'needs_context' was
+          skipped
       require_success:
         type: boolean
         default: true
-        description: If true, this workflow will fail if no job from 'needs_context' was successful
+        description:
+          If true, this workflow will fail if no job from 'needs_context' was
+          successful
 
 jobs:
   verify-success:
@@ -72,34 +82,50 @@ jobs:
       - name: Set outputs for each job result type
         id: has-result
         run: |
-          echo "failure=${{ contains(env.NEEDS_RESULT, 'failure') }}" >> "$GITHUB_OUTPUT"
-          echo "cancelled=${{ contains(env.NEEDS_RESULT, 'cancelled') }}" >> "$GITHUB_OUTPUT"
-          echo "skipped=${{ contains(env.NEEDS_RESULT, 'skipped') }}" >> "$GITHUB_OUTPUT"
-          echo "success=${{ contains(env.NEEDS_RESULT, 'success') }}" >> "$GITHUB_OUTPUT"
+          echo "failure=${{
+            contains(env.NEEDS_RESULT, 'failure') }}" >> "$GITHUB_OUTPUT"
+          echo "cancelled=${{
+            contains(env.NEEDS_RESULT, 'cancelled') }}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${{
+            contains(env.NEEDS_RESULT, 'skipped') }}" >> "$GITHUB_OUTPUT"
+          echo "success=${{
+            contains(env.NEEDS_RESULT, 'success') }}" >> "$GITHUB_OUTPUT"
         env:
           NEEDS_RESULT: ${{ toJson(fromJson(inputs.needs_context).*.result) }}
       - name: Set exit codes for each job result type
         id: exit-code
         run: |
-          echo "failure=${{ inputs.fail_if_failure && fromJson(steps.has-result.outputs.failure) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
-          echo "cancelled=${{ inputs.fail_if_cancelled && fromJson(steps.has-result.outputs.cancelled) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
-          echo "skipped=${{ inputs.fail_if_skipped && fromJson(steps.has-result.outputs.skipped) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
-          echo "success=${{ inputs.require_success && !fromJson(steps.has-result.outputs.success) && 1 || 0 }}" >> "$GITHUB_OUTPUT"
+          echo "failure=${{ inputs.fail_if_failure &&
+                  fromJson(steps.has-result.outputs.failure) && 1 || 0
+                  }}" >> "$GITHUB_OUTPUT"
+          echo "cancelled=${{ inputs.fail_if_cancelled &&
+                  fromJson(steps.has-result.outputs.cancelled) && 1 || 0
+                  }}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${{ inputs.fail_if_skipped && 
+                  fromJson(steps.has-result.outputs.skipped) && 1 || 0
+                  }}" >> "$GITHUB_OUTPUT"
+          echo "success=${{ inputs.require_success && 
+                  !fromJson(steps.has-result.outputs.success) && 1 || 0
+                  }}" >> "$GITHUB_OUTPUT"
       - name: Set messages for each job result type
         id: message
         run: |
-          echo "failure=${{ format('{0}{1} were failed', 
-                              (steps.exit-code.outputs.failure == 1) && env.P1 || env.P2, 
-                              (steps.has-result.outputs.failure == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
-          echo "cancelled=${{ format('{0}{1} were cancelled', 
-                              (steps.exit-code.outputs.cancelled == 1) && env.P1 || env.P2, 
-                              (steps.has-result.outputs.cancelled == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
-          echo "skipped=${{ format('{0}{1} were skipped', 
-                              (steps.exit-code.outputs.skipped == 1) && env.P1 || env.P2, 
-                              (steps.has-result.outputs.skipped == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
-          echo "success=${{ format('{0}{1} were successful', 
-                              (steps.exit-code.outputs.success == 1) && env.P1 || env.P2, 
-                              (steps.has-result.outputs.success == 'true') && env.M1 || env.M2) }}" >> "$GITHUB_OUTPUT"
+          echo "failure=${{ format('{0}{1} were failed',
+            (steps.exit-code.outputs.failure == 1) && env.P1 || env.P2,
+            (steps.has-result.outputs.failure == 'true') && env.M1 || env.M2)
+            }}" >> "$GITHUB_OUTPUT"
+          echo "cancelled=${{ format('{0}{1} were cancelled',
+            (steps.exit-code.outputs.cancelled == 1) && env.P1 || env.P2,
+            (steps.has-result.outputs.cancelled == 'true') && env.M1 || env.M2)
+            }}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${{ format('{0}{1} were skipped',
+            (steps.exit-code.outputs.skipped == 1) && env.P1 || env.P2,
+            (steps.has-result.outputs.skipped == 'true') && env.M1 || env.M2)
+            }}" >> "$GITHUB_OUTPUT"
+          echo "success=${{ format('{0}{1} were successful',
+            (steps.exit-code.outputs.success == 1) && env.P1 || env.P2,
+            (steps.has-result.outputs.success == 'true') && env.M1 || env.M2)
+            }}" >> "$GITHUB_OUTPUT"
         env:
           P1: "::error ::" # Common message prefix if step will fail
           P2: "" # Common message prefix if step will not fail
@@ -107,13 +133,21 @@ jobs:
           M2: "No jobs" # Common message if result is false
 
       - name: Check for failed jobs
-        run: echo "${{ steps.message.outputs.failure }}" && exit ${{ steps.exit-code.outputs.failure }}
+        run: |
+          echo "${{ steps.message.outputs.failure }}"
+          exit ${{ steps.exit-code.outputs.failure }}
       - name: Check for cancelled jobs
-        run: echo "${{ steps.message.outputs.cancelled }}" && exit ${{ steps.exit-code.outputs.cancelled }}
+        run: |
+          echo "${{ steps.message.outputs.cancelled }}"
+          exit ${{ steps.exit-code.outputs.cancelled }}
       - name: Check for skipped jobs
-        run: echo "${{ steps.message.outputs.skipped }}" && exit ${{ steps.exit-code.outputs.skipped }}
+        run: |
+          echo "${{ steps.message.outputs.skipped }}"
+          exit ${{ steps.exit-code.outputs.skipped }}
       - name: Check for successful jobs
-        run: echo "${{ steps.message.outputs.success }}" && exit ${{ steps.exit-code.outputs.success }}
+        run: |
+          echo "${{ steps.message.outputs.success }}"
+          exit ${{ steps.exit-code.outputs.success }}
 
       - run: echo "Checks passed successfully"
         if: ${{ success() }}


### PR DESCRIPTION
Since the issue might be a little weird to understand, let's go through the problem by stating individual facts, then explaining why the PR is needed and the changes to make.
1. The current repo's settings defines rulesets (or the older branch protection rules that now work similarly) that selects some required checks before merging. That is a good thing.
2. The current repo has multiple checks. That is also good.
3. Some background terminology:
   - A workflow is defined in a .yml file.
   - A workflow defines the triggers and filters that it is executed on.
   - A workflow contains one or more jobs.
   - A job can include a matrix strategy to create jobs for multiple combinations of variables using a single job definition.
   - A job contains steps to run, or can call a reusable workflow defined elsewhere, like another file or repo.
   - When a reusable workflow is used, the job has no other steps.
   - A job can depend on other jobs in the same workflow, using the `needs` property. This is what makes some pretty diagrams in the workflow summary when more than one rectangle is present. Usually, all jobs in `needs` have to be successfully complete before the dependant job starts, unless a conditional expression makes it continue.
   - The result of a job can either be `success`, `failure`, `cancelled`, or `skipped`.
   - A job can use conditions (by using `if` at the job-level) to control if it should be executed, or it should be skipped.
   - Skipped jobs due to a conditional will report its status as a success. (i.e. A job runs for the main repo, another for pull requests that come from a fork. A failure wouldn't be appropriate)
4. Some checks use a matrix strategy to run a (or multiple) job, specifying the variables there instead of all around the job. This is also not a problem.
5. Each job (normal or created from a matrix strategy) will create a status check. For matrix strategy jobs, they are named using the variables of the matrix strategy.
6. Required status checks are defined for a context that use the name of the status check.


Now the problematic part starts:
1. Since the required status checks depend on the name of the status check, 
2. and the name of the status check depend on the values of the matrix strategy variables,
3. then it is not possible to change a variable in a job's matrix strategy to another value if it is a required check. It is only possible to add a new value to an existing variable inside the matrix strategy, but that won't make this new strategy required too. It wouldn't be possible to add another variable to the matrix strategy, as it changes the name of the status check.


Examples of the problematic behaviour:
- Adding python 3.12 to the pytest versions tested in https://github.com/OSGeo/grass/pull/3314 was non-breaking. It is not a required check at the moment. It would not be possible, at the moment, to create a PR that changes either Python 3.8 or Python 3.10 from that workflow, for example when we change our supported python versions. Furthermore, it wouldn't even be possible to set `3.10.0` since the name would be different.
- Trying to sync the updated linter versions with an update of the pre-commit config in https://github.com/OSGeo/grass/pull/3318 waited indefinitely for a status check to be reported, but would never be satisfied since that combination wouldn't exist anymore. So the PR would remain unmergeable, deadlocked.


So the solution is to have the status checks defined on a job that can only complete successfully if the checks we want to be required are also successful. That is what I bring in this PR.

To make it possible to use the same logic multiple times, I created a reusable workflow called `verify-success.yml`, and call it from our existing workflows. In order to have the most flexibility to really create the outcomes that we want, I added inputs that allow to adjust for what types of job results that check should fail. That reusable workflow doesn't run my itself since it only has the `workflow_call` trigger.

In the future, I imagine that I might bring a PR that combines multiple workflow files (that have the same triggers) together to reuse some commonly built artifacts, or optimizations like that. But if some of the jobs shouldn't be required, but others do, the way I created the reusable workflow allows to group the non-required jobs or even cancelled jobs to make the result of that verify-success job successful, and that could be used a dependant job for another call of verify-success, along with other required jobs. That's why you already see that I set the job_id to `ubuntu` in the `ubuntu.yml` workflow. 

I tested out this with multiple smaller jobs with all statuses, and all 16 combinations of my input flags (boolean). It works correctly.

Some more info:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks
https://docs.github.com/en/actions/using-workflows/required-workflows
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview



Now, for the settings changes that an admin has to do to allow this PR to merge:
I made them all from rulesets. They are layered, and when more than one rule applies, the strictest setting is used.
I made screenshots of the configuration I think we need.

1. In the repo settings, open the **Rules > Rulesets tab**. Create a new ruleset.
     <details><summary>Image</summary>
      <p>
      
      ![Capture d’écran 2023-12-29 102912](https://github.com/OSGeo/grass/assets/27212526/b225642f-b1fe-4f17-967e-767d2db5cc56)
       
     ![Capture d’écran 2023-12-29 103016](https://github.com/OSGeo/grass/assets/27212526/1b953941-8b20-4f51-bddd-2cd30ed85c4f)

     </p>
     </details> 
1.  Add bypass to admin, it is sometimes needed. I selected for pull requests for now
     <details><summary>Image</summary>
      <p>
      
      ![Capture d’écran 2023-12-29 143606](https://github.com/OSGeo/grass/assets/27212526/ef502892-bb95-4c9c-b70d-6c3cd6a331b6)
       
      ![image](https://github.com/OSGeo/grass/assets/27212526/90b83c72-44a5-448e-b02d-9efacb761f8d)

     </p>
     </details> 
1. Choose the branches to target. The default branch, plus our `releasebranch_*`
     <details><summary>Image</summary>
      <p>
     
      ![image](https://github.com/OSGeo/grass/assets/27212526/f634df4c-ab2d-4d8e-ae85-efe8a511233b)
      
      ![image](https://github.com/OSGeo/grass/assets/27212526/42cc6059-e577-4726-93fe-a0f746e116ed)
      
      ![image](https://github.com/OSGeo/grass/assets/27212526/3245adf7-b2a0-4dcb-8845-33c275f1b928)

      Once saved, we see that it will apply correctly:
      ![image](https://github.com/OSGeo/grass/assets/27212526/80c56a4b-cbe6-442d-a3eb-3c330ceed7ab)

     </p>
     </details> 
1. For the next section of settings, we select the branch protection settings
     <details><summary>Image</summary>
      <p>
     
      I started by selecting at least to disallow deletions.
      ![image](https://github.com/OSGeo/grass/assets/27212526/b7d2d391-35e4-4b87-9178-df23c37e4406)
      
     Then, I selected the most basic settings concerning pull requests. Some of them have bigger quirks than others, and need some time getting used to. If we were to be more active on reviews, "Require approval of the most recent reviewable push" could be interesting in order to not allow someone to merge their own pull requests. I don't think we are ready for this yet.

      ![image](https://github.com/OSGeo/grass/assets/27212526/ce61d024-b621-490b-8f71-a3a6283494f8)

     </p>
     </details> 
1. Then the core part, specific for this PR, choosing the settings for "Require status checks to pass".
     <details><summary>Image</summary>
      <p>
     
      If the rules were configured as rulesets, make sure to remove the existing entries for Ubuntu (2 lines), Pytest (2 lines), and Python Code Quality (2 lines). If there is nothing there, we need to remove 

     Then, select all the following entries, to match the picture:
      ![image](https://github.com/OSGeo/grass/assets/27212526/5c60477f-573f-461b-8601-83a282f51b62)
     The newest checks that come from this PR might only show once they have run once for this PR (if they don't show yet, wait for the first round of CI checks since this PR was opened to complete first)

     </p>
     </details> 
1. Lastly, I selected to block force pushes to these 7 (for now) protected branches, enabled, and saved.
     <details><summary>Image</summary>
      <p>
     
      ![image](https://github.com/OSGeo/grass/assets/27212526/c8d948b2-af92-4fc7-8425-7b2aa8d88f3e)
      
      I saved the settings.
      Then back to the top, make sure that the ruleset is enabled:
      ![image](https://github.com/OSGeo/grass/assets/27212526/c161842a-6233-40c5-89fc-e6f84430b38a)
      
      Then save again.
     </p>
     </details> 
1. If there wasn't any required checks in the rulesets, then the configuration was through branch protection rules. They are found on the left, two tabs above rulesets. Make sure to disable any conflicting configuration from there. The functionality of the older branch protection rules was ported up to be essentially the same (user-interface - wise).
 
I exported my config, I'm joining it here. It might reference my repo though:
[Main and release branch rules.json](https://github.com/OSGeo/grass/files/13795868/Main.and.release.branch.rules.json)


