### PR TITLE
python: Remove Shortening messages in pygrass messages

### DIFF
--- a/python/grass/pygrass/messages/__init__.py
+++ b/python/grass/pygrass/messages/__init__.py
@@ -77,10 +77,6 @@ def message_server(lock, conn):
             sys.exit()
 
         message = data[1]
-        # libgis limitation
-        if isinstance(message, str):
-            if len(message) >= 2000:
-                message = message[:1999]
 
         if message_type == "PERCENT":
             n = int(data[1])


### PR DESCRIPTION
Was fixed in C code in https://github.com/OSGeo/grass/commit/9b61d2e668c82bd32b28aa560d70707b39cd2426

Addresses comment https://github.com/OSGeo/grass/pull/3316#issuecomment-1874837305