### PR TITLE
Use integer port argument with mysql_real_connect

### DIFF
--- a/db/drivers/mysql/db.c
+++ b/db/drivers/mysql/db.c
@@ -53,10 +53,9 @@ int db__driver_open_database(dbHandle *handle)
         db_get_login2("mysql", name, &user, &password, &host, &port);
 
         connection = mysql_init(NULL);
-        res = mysql_real_connect(connection, host, user, password,
-                                 connpar.dbname,
-                                 port != NULL ? atoi(port) : 0,
-                                 NULL, 0);
+        res =
+            mysql_real_connect(connection, host, user, password, connpar.dbname,
+                               port != NULL ? atoi(port) : 0, NULL, 0);
 
         if (res == NULL) {
             db_d_append_error("%s\n%s", _("Connection failed."),

--- a/db/drivers/mysql/db.c
+++ b/db/drivers/mysql/db.c
@@ -54,7 +54,9 @@ int db__driver_open_database(dbHandle *handle)
 
         connection = mysql_init(NULL);
         res = mysql_real_connect(connection, host, user, password,
-                                 connpar.dbname, port, NULL, 0);
+                                 connpar.dbname,
+                                 port != NULL ? atoi(port) : 0,
+                                 NULL, 0);
 
         if (res == NULL) {
             db_d_append_error("%s\n%s", _("Connection failed."),


### PR DESCRIPTION
The port argument is not a string, but a plain integer.  In the past, compilers ignore such type errors and produced a warning only, but this is changing, so this change also addresses a potential build failure.

Note that I can't really test this, but at least the compiler error is gone. Found as part of:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
