### PR TITLE
python: Replace usages of Python2-only `import __builtin__` with a Python 3 compatible equivalent

### DIFF
--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -757,9 +757,9 @@ def do_doctest_gettext_workaround():
     sys.displayhook = new_displayhook
     sys.__displayhook__ = new_displayhook
 
-    import __builtin__
+    import builtins as __builtin__
 
-    __builtin__._ = new_translator
+    __builtin__.__dict__["_"] = new_translator
 
 
 def doc_test():

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -757,9 +757,9 @@ def do_doctest_gettext_workaround():
     sys.displayhook = new_displayhook
     sys.__displayhook__ = new_displayhook
 
-    import builtins as __builtin__
+    import builtins
 
-    __builtin__.__dict__["_"] = new_translator
+    builtins.__dict__["_"] = new_translator
 
 
 def doc_test():

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -1134,9 +1134,9 @@ def do_doctest_gettext_workaround():
 
     sys.displayhook = new_displayhook
 
-    import __builtin__
+    import builtins as __builtin__
 
-    __builtin__._ = new_translator
+    __builtin__.__dict__["_"] = new_translator
 
 
 def doc_test():

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -1134,9 +1134,9 @@ def do_doctest_gettext_workaround():
 
     sys.displayhook = new_displayhook
 
-    import builtins as __builtin__
+    import builtins
 
-    __builtin__.__dict__["_"] = new_translator
+    builtins.__dict__["_"] = new_translator
 
 
 def doc_test():

--- a/gui/wxpython/tools/build_modules_xml.py
+++ b/gui/wxpython/tools/build_modules_xml.py
@@ -43,9 +43,9 @@ def do_doctest_gettext_workaround():
     sys.displayhook = new_displayhook
     sys.__displayhook__ = new_displayhook
 
-    import __builtin__
+    import builtins as __builtin__
 
-    __builtin__._ = new_translator
+    __builtin__.__dict__["_"] = new_translator
 
 
 def parse_modules(fd):

--- a/gui/wxpython/tools/build_modules_xml.py
+++ b/gui/wxpython/tools/build_modules_xml.py
@@ -43,9 +43,9 @@ def do_doctest_gettext_workaround():
     sys.displayhook = new_displayhook
     sys.__displayhook__ = new_displayhook
 
-    import builtins as __builtin__
+    import builtins
 
-    __builtin__.__dict__["_"] = new_translator
+    builtins.__dict__["_"] = new_translator
 
 
 def parse_modules(fd):

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -57,7 +57,7 @@ def do_doctest_gettext_workaround():
 
     import builtins as __builtin__
 
-    __builtin__._ = new_translator
+    __builtin__.__dict__["_"] = new_translator
 
 
 _MAX_LENGTH = 80

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -55,9 +55,9 @@ def do_doctest_gettext_workaround():
 
     sys.displayhook = new_displayhook
 
-    import builtins as __builtin__
+    import builtins
 
-    __builtin__.__dict__["_"] = new_translator
+    builtins.__dict__["_"] = new_translator
 
 
 _MAX_LENGTH = 80


### PR DESCRIPTION
Fixes #3328

I took the approach of setting in the dict, as tools like Pyright complain (rightfully), that `_` isn't a know builtin. It's true, its something a bit more dynamic. That's about what we use for the normal translations in

https://github.com/OSGeo/grass/blob/5e86482fd9ad7f1bdb874e23740e1ca6b0b9b896/python/grass/__init__.py#L19
https://github.com/OSGeo/grass/blob/5e86482fd9ad7f1bdb874e23740e1ca6b0b9b896/python/grass/__init__.py#L97-L101


