### PR TITLE
Update super-linter.yml to use super-linter/super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -21,11 +21,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Lint code base
-        uses: github/super-linter@v5
+        uses: super-linter/super-linter/slim@v5.7.2
         env:
+          DEFAULT_BRANCH: main
+          # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Listed but commented out linters would be nice to have.
           # (see https://github.com/github/super-linter#environment-variables)

--- a/doc/infrastructure.md
+++ b/doc/infrastructure.md
@@ -261,7 +261,7 @@ User settings:
 
 - The GRASS GIS CI user at Docker hub is "grassgis" (joined June 3, 2023),
   see also <https://hub.docker.com/u/grassgis>
-- Docker Hub access token are managed via grass-ci-admin@osgeo.org.
+- Docker Hub access token are managed via <grass-ci-admin@osgeo.org>.
 - The OSGeo Org membership is managed at <https://hub.docker.com/orgs>
   through OSGeo-SAC
 

--- a/macosx/ReadMe.md
+++ b/macosx/ReadMe.md
@@ -654,6 +654,6 @@ This program is free software under the GNU General Public License (>=v2).
 
 \- William Kyngesburye
 
-kyngchaos@kyngchaos.com
+<kyngchaos@kyngchaos.com>
 
 <http://www.kyngchaos.com/>


### PR DESCRIPTION
Super-linter is now in its own organization since April 26th, 2023. This updates the workflow to use newer releases.