### PR TITLE
r.in.gdal: fix and enable test

### DIFF
--- a/.github/workflows/macos_gunittest.cfg
+++ b/.github/workflows/macos_gunittest.cfg
@@ -16,7 +16,6 @@ exclude =
     python/grass/script/testsuite/test_script_doctests.py
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
     python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
-    raster/r.in.gdal/testsuite/test_r_in_gdal.py
     raster/r.in.lidar/testsuite/test_base_resolution.sh
     raster/r.in.lidar/testsuite/test_base_resolution.sh
     raster/r.in.pdal/testsuite/test_r_in_pdal_binning.py

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -16,7 +16,6 @@ exclude =
     python/grass/script/testsuite/test_script_doctests.py
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
     python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
-    raster/r.in.gdal/testsuite/test_r_in_gdal.py
     raster/r.in.lidar/testsuite/test_base_resolution.sh
     raster/r.in.lidar/testsuite/test_base_resolution.sh
     scripts/g.search.modules/testsuite/test_g_search_modules.py

--- a/raster/r.in.gdal/testsuite/test_r_in_gdal.py
+++ b/raster/r.in.gdal/testsuite/test_r_in_gdal.py
@@ -146,8 +146,8 @@ class TestGdalImport(TestCase):
         # Output of r.info
         info_string = """north=228500
                        south=215000
-                       east=644640
-                       west=629640
+                       east=645000
+                       west=630000
                        nsres=100
                        ewres=100
                        rows=135
@@ -186,8 +186,8 @@ class TestGdalImport(TestCase):
         # Output of r.info
         info_string = """north=228500
                        south=215000
-                       east=644640
-                       west=629640
+                       east=645000
+                       west=630000
                        nsres=100
                        ewres=100
                        rows=135
@@ -226,8 +226,8 @@ class TestGdalImport(TestCase):
         # Output of r.info
         info_string = """north=228500
                        south=215000
-                       east=644640
-                       west=629640
+                       east=645000
+                       west=630000
                        nsres=100
                        ewres=100
                        rows=135
@@ -266,8 +266,8 @@ class TestGdalImport(TestCase):
         # Output of r.info
         info_string = """north=228500
                        south=215000
-                       east=644640
-                       west=629640
+                       east=645000
+                       west=630000
                        nsres=100
                        ewres=100
                        rows=135


### PR DESCRIPTION
This should fix r.in.gdal test. I changed the expected east/west to match the actual imported data, which also matches what gdalinfo reports on the testdata. Why this wasn't the case before, I don't know.

Relevant output from gdalinfo on the test dataset:
```
Files: data/elevation3d.nc
Size is 150, 135
Origin = (630000.000000000000000,228500.000000000000000)
Pixel Size = (100.000000000000000,-100.000000000000000)
Corner Coordinates:
Upper Left  (  630000.000,  228500.000) 
Lower Left  (  630000.000,  215000.000) 
Upper Right (  645000.000,  228500.000) 
Lower Right (  645000.000,  215000.000) 
Center      (  637500.000,  221750.000) 

```