### PR TITLE
python: Add extract filter for tarfile.extractall

### DIFF
--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -277,7 +277,15 @@ def import_stds(
     # Extraction filters were added in Python 3.12,
     # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
     # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
-    tar.extractall(path=directory, filter="data")
+    # and https://peps.python.org/pep-0706/
+    # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
+    # and in Python 3.14, `filter='data'` will be the default
+    if hasattr(tarfile, "data_filter"):
+        tar.extractall(path=directory, filter="data")
+    else:
+        # Remove this when no longer needed
+        gscript.warning(_("Extracting may be unsafe; consider updating Python"))
+        tar.extractall(path=directory)
     tar.close()
 
     # We use a new list file name for map registration

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -274,7 +274,10 @@ def import_stds(
         gscript.fatal(_("Unable to find projection file <%s>") % proj_file_name)
 
     msgr.message(_("Extracting data..."))
-    tar.extractall(path=directory)
+    # Extraction filters were added in Python 3.12,
+    # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
+    # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
+    tar.extractall(path=directory, filter='data')
     tar.close()
 
     # We use a new list file name for map registration

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -277,7 +277,7 @@ def import_stds(
     # Extraction filters were added in Python 3.12,
     # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
     # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
-    tar.extractall(path=directory, filter='data')
+    tar.extractall(path=directory, filter="data")
     tar.close()
 
     # We use a new list file name for map registration

--- a/python/grass/utils/download.py
+++ b/python/grass/utils/download.py
@@ -52,7 +52,21 @@ def extract_tar(name, directory, tmpdir):
         tar = tarfile.open(name)
         extract_dir = os.path.join(tmpdir, "extract_dir")
         os.mkdir(extract_dir)
-        tar.extractall(path=extract_dir)
+
+        # Extraction filters were added in Python 3.12,
+        # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
+        # See
+        # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
+        # and https://peps.python.org/pep-0706/
+        # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
+        # and in Python 3.14, `filter='data'` will be the default
+        if hasattr(tarfile, "data_filter"):
+            tar.extractall(path=extract_dir, filter="data")
+        else:
+            # Remove this when no longer needed
+            debug(_("Extracting may be unsafe; consider updating Python"))
+            tar.extractall(path=extract_dir)
+
         files = os.listdir(extract_dir)
         _move_extracted_files(
             extract_dir=extract_dir, target_dir=directory, files=files

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -110,7 +110,18 @@ def main():
             )
 
     # extract data
-    tar.extractall()
+    # Extraction filters were added in Python 3.12,
+    # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
+    # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
+    # and https://peps.python.org/pep-0706/
+    # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
+    # and in Python 3.14, `filter='data'` will be the default
+    if hasattr(tarfile, "data_filter"):
+        tar.extractall(filter="data")
+    else:
+        # Remove this when no longer needed
+        grass.warning(_("Extracting may be unsafe; consider updating Python"))
+        tar.extractall()
     tar.close()
     os.chdir(data_names[0])
 

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -120,7 +120,18 @@ def main():
         shutil.rmtree(new_dir, True)
 
     # extract data
-    tar.extractall()
+    # Extraction filters were added in Python 3.12,
+    # and backported to 3.8.17, 3.9.17, 3.10.12, and 3.11.4
+    # See https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
+    # and https://peps.python.org/pep-0706/
+    # In Python 3.12, using `filter=None` triggers a DepreciationWarning,
+    # and in Python 3.14, `filter='data'` will be the default
+    if hasattr(tarfile, "data_filter"):
+        tar.extractall(filter="data")
+    else:
+        # Remove this when no longer needed
+        grass.warning(_("Extracting may be unsafe; consider updating Python"))
+        tar.extractall()
     tar.close()
     if os.path.exists(os.path.join(data_name, "coor")):
         pass


### PR DESCRIPTION
Fixed a CodeQL CWE-22 type issue (named Arbitrary file write during tarfile extraction), found when running an extended analysis (instead of only default).

The solution suggested in the alert didn’t seem appropriate (extracting files one by one), but I found that this issue was fixed in Python 3.12 and backported in the versions from 3.8 to 3.11.  The extraction filter chosen is the strictest, since the archives that are supposed to be extracted are purely data, we do not expect any rare or advanced behaviour.

https://docs.python.org/3/library/tarfile.html#extraction-filters

https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall