### PR TITLE
db/driver: fix MySQL driver compilation warnings

### DIFF
--- a/configure
+++ b/configure
@@ -12091,6 +12091,9 @@ fi
   fi
 
   if test "$MYSQLD_CONFIG" != "" ; then
+    mysql_version=`"$MYSQLD_CONFIG" --version`
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using MySQL/MariaDB version \"$mysql_version\"" >&5
+printf "%s\n" "using MySQL/MariaDB version \"$mysql_version\"" >&6; }
     ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -12104,10 +12107,10 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
     ac_fn_cxx_check_func "$LINENO" "mysql_server_init" "ac_cv_func_mysql_server_init"
 if test "x$ac_cv_func_mysql_server_init" = xyes
 then :
-
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: libmysqld found" >&5
+printf "%s\n" "libmysqld found" >&6; }
 else $as_nop
-  MYSQLDLIB="";
-                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: libmysqld not found" >&5
+  MYSQLDLIB=""; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: libmysqld not found" >&5
 printf "%s\n" "$as_me: WARNING: libmysqld not found" >&2;}
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1281,13 +1281,16 @@ if test -n "$USE_MYSQL"; then
   fi
 
   if test "$MYSQLD_CONFIG" != "" ; then
+    mysql_version=`"$MYSQLD_CONFIG" --version`
+    AC_MSG_RESULT([using MySQL/MariaDB version "$mysql_version"])
     AC_LANG_PUSH([C++])
     ac_save_libs="$LIBS"
     MYSQLDLIB=`"$MYSQLD_CONFIG" --libmysqld-libs`
 
     LIBS="$MYSQLDLIB $LIBS"
-    AC_CHECK_FUNC(mysql_server_init,,[MYSQLDLIB="";
-                  AC_MSG_WARN([libmysqld not found])] )
+    AC_CHECK_FUNC(mysql_server_init,
+                  AC_MSG_RESULT([libmysqld found]),
+                  [MYSQLDLIB=""; AC_MSG_WARN([libmysqld not found])])
     LIBS=$ac_save_libs
     AC_LANG_POP([C++])
   fi

--- a/db/drivers/mysql/driver.c
+++ b/db/drivers/mysql/driver.c
@@ -16,7 +16,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_init(int argc, char *argv[])
+int db__driver_init(int argc UNUSED, char *argv[] UNUSED)
 {
     init_error();
     return DB_OK;

--- a/db/drivers/mysql/fetch.c
+++ b/db/drivers/mysql/fetch.c
@@ -250,8 +250,7 @@ int db__driver_fetch(dbCursor *cn, int position, int *more)
     return DB_OK;
 }
 
-int db__driver_get_num_rows(cn)
-dbCursor *cn;
+int db__driver_get_num_rows(dbCursor *cn)
 {
     cursor *c;
     dbToken token;

--- a/db/drivers/mysql/listtab.c
+++ b/db/drivers/mysql/listtab.c
@@ -18,7 +18,7 @@
 #include "globals.h"
 #include "proto.h"
 
-int db__driver_list_tables(dbString **tlist, int *tcount, int system)
+int db__driver_list_tables(dbString **tlist, int *tcount, int system UNUSED)
 {
     int i;
     dbString *list;
@@ -32,7 +32,7 @@ int db__driver_list_tables(dbString **tlist, int *tcount, int system)
     res = mysql_list_tables(connection, NULL);
 
     if (res == NULL) {
-        db_d_append_error("%s\%s", _("Unable get list of tables:"),
+        db_d_append_error("%s\n%s", _("Unable get list of tables:"),
                           mysql_error(connection));
         db_d_report_error();
         return DB_FAILED;


### PR DESCRIPTION
Addresses a few compilation warnings with MySQL driver and in addition improves the configuration output.

(This does **not** add the driver to the CI tests; eg. PostgreSQL driver is also not included, thus that would be another issue.)