### PR TITLE
temporal: Update STDS metadata from DB

### DIFF
--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1533,44 +1533,46 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             # check keys in first row
             # note that 'if "bottom" in row' does not work
             # because row is not a dict but some db backend object
-            has_bt_columns = "bottom" in rows[0].keys() and "top" in rows[0].keys()
+            has_bt_columns = "bottom" in rows[0].keys()
             has_semantic_label = "semantic_label" in rows[0].keys()
+        else:
+            return obj_list
 
-            for row in rows:
-                map = self.get_new_map_instance(row["id"])
-                # time
-                if self.is_time_absolute():
-                    map.set_absolute_time(row["start_time"], row["end_time"])
-                elif self.is_time_relative():
-                    map.set_relative_time(
-                        row["start_time"],
-                        row["end_time"],
-                        self.get_relative_time_unit(),
-                    )
-                # space
-                # The fast way
-                if has_bt_columns:
-                    map.set_spatial_extent_from_values(
-                        west=row["west"],
-                        east=row["east"],
-                        south=row["south"],
-                        top=row["top"],
-                        north=row["north"],
-                        bottom=row["bottom"],
-                    )
-                # The slow work around
-                else:
-                    map.spatial_extent.select(dbif)
+        for row in rows:
+            map = self.get_new_map_instance(row["id"])
+            # time
+            if self.is_time_absolute():
+                map.set_absolute_time(row["start_time"], row["end_time"])
+            elif self.is_time_relative():
+                map.set_relative_time(
+                    row["start_time"],
+                    row["end_time"],
+                    self.get_relative_time_unit(),
+                )
+            # space
+            # The fast way
+            if has_bt_columns:
+                map.set_spatial_extent_from_values(
+                    west=row["west"],
+                    east=row["east"],
+                    south=row["south"],
+                    top=row["top"],
+                    north=row["north"],
+                    bottom=row["bottom"],
+                )
+            # The slow work around
+            else:
+                map.spatial_extent.select(dbif)
 
-                # labels
-                if (
-                    has_semantic_label
-                    and row["semantic_label"] is not None
-                    and row["semantic_label"] != "None"
-                ):
-                    map.metadata.set_semantic_label(row["semantic_label"])
+            # labels
+            if (
+                has_semantic_label
+                and row["semantic_label"] is not None
+                and row["semantic_label"] != "None"
+            ):
+                map.metadata.set_semantic_label(row["semantic_label"])
 
-                obj_list.append(copy.copy(map))
+            obj_list.append(copy.copy(map))
 
         if connection_state_changed:
             dbif.close()

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -24,9 +24,9 @@ from .core import (
 )
 from .abstract_dataset import (
     AbstractDataset,
-    AbstractMapDataset,
     AbstractDatasetComparisonKeyStartTime,
 )
+from .abstract_map_dataset import AbstractMapDataset
 from .temporal_granularity import (
     check_granularity_string,
     compute_absolute_time_granularity,

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -467,7 +467,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         def _get_row_time_tuple(sqlite_row):
             return sqlite_row["start_time"], sqlite_row["end_time"]
 
-        if issubclass(maps[0].__class__, tgis.AbstractMapDataset):
+        if issubclass(maps[0].__class__, self):
             get_time_tuple = _get_map_time_tuple
         else:
             get_time_tuple = _get_row_time_tuple

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1525,7 +1525,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             None, where, order, dbif, spatial_extent, spatial_relation
         )
 
-        if rows is not None:
+        if rows:
             # Older temporal databases have no bottom and top columns
             # in their views so we need a work around to set the full
             # spatial extent as well

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1513,7 +1513,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             "contains": maps that contain (fully cover) the provided spatial extent
 
         :return: The ordered map object list,
-                In case nothing found an empty list is returned
+                In case nothing is found, an empty list is returned
         """
 
         dbif, connection_state_changed = init_dbif(dbif)

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -455,9 +455,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         """
 
         if maps is None:
-            maps = self.get_registered_maps(
-                where=None, order="start_time", dbif=dbif
-            )
+            maps = self.get_registered_maps(where=None, order="start_time", dbif=dbif)
 
         def _get_map_time_tuple(map_object):
             if map_object.is_time_absolute():
@@ -465,6 +463,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             if map_object.is_time_relative():
                 time_tuple = map_object.get_relative_time()
             return time_tuple[0:2]
+
         def _get_row_time_tuple(sqlite_row):
             return sqlite_row["start_time"], sqlite_row["end_time"]
 
@@ -473,11 +472,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         else:
             get_time_tuple = _get_row_time_tuple
 
-        tcount = {
-            "point": 0,
-            "interval": 0,
-            "invalid": 0
-        }
+        tcount = {"point": 0, "interval": 0, "invalid": 0}
 
         for map_reference in maps:
             # Check for point and interval data

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -2,7 +2,7 @@
 The abstract_space_time_dataset module provides the AbstractSpaceTimeDataset
 class that is the base class for all space time datasets.
 
-(C) 2011-2013 by the GRASS Development Team
+(C) 2011-2024 by the GRASS Development Team
 This program is free software under the GNU General Public
 License (>=v2). Read the file COPYING that comes with GRASS
 for details.
@@ -26,11 +26,11 @@ from .abstract_dataset import (
     AbstractDataset,
     AbstractDatasetComparisonKeyStartTime,
 )
-from .abstract_map_dataset import AbstractMapDataset
 from .temporal_granularity import (
     check_granularity_string,
     compute_absolute_time_granularity,
     compute_relative_time_granularity,
+    get_time_tuple_function,
 )
 from .spatio_temporal_relationships import (
     count_temporal_topology_relationships,
@@ -466,25 +466,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         if not maps:
             return tcount
 
-        def _get_map_time_tuple(map_object):
-            """Helper function to return time tuple
-            from AbstractDataset object"""
-            if map_object.is_time_absolute():
-                time_tuple = map_object.get_absolute_time()
-            if map_object.is_time_relative():
-                time_tuple = map_object.get_relative_time()
-            return time_tuple[0:2]
-
-        def _get_row_time_tuple(sqlite_row):
-            """Helper function to return time tuple
-            from database row"""
-            return sqlite_row["start_time"], sqlite_row["end_time"]
-
-        # Check if input is list of MapDataset objects or SQLite rows
-        if issubclass(maps[0].__class__, AbstractMapDataset):
-            get_time_tuple = _get_map_time_tuple
-        else:
-            get_time_tuple = _get_row_time_tuple
+        get_time_tuple = get_time_tuple_function(maps)
 
         for map_reference in maps:
             # Check for point and interval data

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -463,7 +463,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         if maps is None:
             maps = self.get_registered_maps(where=None, order="start_time", dbif=dbif)
 
-        if maps is None:
+        if not maps:
             return tcount
 
         def _get_map_time_tuple(map_object):

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -352,9 +352,6 @@ class RasterMetadata(RasterMetadataBase):
             max,
         )
 
-        if get_tgis_db_version_from_metadata() > 2:
-            self.set_semantic_label(semantic_label)
-
     def set_semantic_label(self, semantic_label):
         """Set the semantic label identifier"""
         self.D["semantic_label"] = semantic_label

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -271,11 +271,10 @@ def compute_relative_time_granularity(maps):
             t = abs(end - start)
             delta.append(int(t))
 
-    # Compute the timedelta of the gaps
-    for i in range(len(maps)):
+        # Compute the timedelta of the gaps
         if i < len(maps) - 1:
             start2, end2 = get_time_tuple(maps[i + 1])
-            if _is_after(start, start2, end2):
+            if _is_after(start2, start, end):
                 # Gaps are between intervals, intervals and
                 # points, points and points
                 if end and start2:
@@ -405,7 +404,7 @@ def compute_absolute_time_granularity(maps):
         # Compute the timedelta of the gaps
         if i < len(maps) - 1:
             start2, end2 = get_time_tuple(maps[i + 1])
-            if _is_after(start, start2, end2):
+            if _is_after(start2, start, end):
                 # Gaps are between intervals, intervals and
                 # points, points and points
                 if end and start2:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -438,7 +438,7 @@ def compute_absolute_time_granularity(maps):
         elif time_detla["day"] > 0:
             has_unit_dict["days"] = True
             # print "has day"
-        elif time_detla["month"] > 0:
+        elif time_delta["month"] > 0:
             has_unit_dict["months"] = True
             # print "has month"
         elif time_detla["year"] > 0:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -253,6 +253,8 @@ def compute_relative_time_granularity(maps):
 
     """
 
+    if maps is None:
+        return None
     if issubclass(maps[0].__class__, AbstractMapDataset):
         get_time_tuple = _get_map_time_tuple
     else:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -386,7 +386,7 @@ def compute_absolute_time_granularity(maps):
     has_months = False
     has_years = False
 
-    if issubclass(maps[0].__class__, tgis.AbstractMapDataset):
+    if issubclass(maps[0].__class__, AbstractMapDataset):
         get_time_tuple = _get_map_time_tuple
     else:
         get_time_tuple = _get_row_time_tuple

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -253,8 +253,9 @@ def compute_relative_time_granularity(maps):
 
     """
 
-    if maps is None:
+    if not maps:
         return None
+
     if issubclass(maps[0].__class__, AbstractMapDataset):
         get_time_tuple = _get_map_time_tuple
     else:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -441,7 +441,7 @@ def compute_absolute_time_granularity(maps):
         elif time_delta["month"] > 0:
             has_unit_dict["months"] = True
             # print "has month"
-        elif time_detla["year"] > 0:
+        elif time_delta["year"] > 0:
             has_unit_dict["years"] = True
             # print "has year"
         return has_unit_dict

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -432,7 +432,7 @@ def compute_absolute_time_granularity(maps):
         elif time_delta["minute"] > 0:
             has_unit_dict["minutes"] = True
             # print "has minute"
-        elif time_detla["hour"] > 0:
+        elif time_delta["hour"] > 0:
             has_unit_dict["hours"] = True
             # print "has hour"
         elif time_detla["day"] > 0:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -423,13 +423,13 @@ def compute_absolute_time_granularity(maps):
 
     """
 
-    def _update_time_unit_dict(has_unit_dict, time_detla):
-        if time_detla["second"] > 0:
+    def _update_time_unit_dict(has_unit_dict, time_delta):
+        if time_delta["second"] > 0:
             has_unit_dict["seconds"] = True
             # "second" is the smallest supported unit
             # As soon as a time delta is found that contains seconds
             # no other time deltas need to be checked
-        elif time_detla["minute"] > 0:
+        elif time_delta["minute"] > 0:
             has_unit_dict["minutes"] = True
             # print "has minute"
         elif time_detla["hour"] > 0:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -469,7 +469,7 @@ def compute_absolute_time_granularity(maps):
         if end:
             map_datetime_delta = compute_datetime_delta(start, end)
             has_units = _update_time_unit_dict(has_units, map_datetime_delta)
-            datetime_delta.add(tuple(map_datetime_delta.items()))
+            datetime_delta.add(sorted(tuple(map_datetime_delta.items())))
         # Compute the timedelta of the gaps
         if _is_after(start, previous_start, previous_end):
             # Gaps are between intervals, intervals and
@@ -480,7 +480,7 @@ def compute_absolute_time_granularity(maps):
             else:
                 gap_datetime_delta = compute_datetime_delta(previous_start, start)
             has_units = _update_time_unit_dict(has_units, gap_datetime_delta)
-            datetime_delta.add(tuple(gap_datetime_delta.items()))
+            datetime_delta.add(sorted(tuple(gap_datetime_delta.items())))
         previous_start, previous_end = start, end
 
     # Create a list with a single time unit only

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -435,7 +435,7 @@ def compute_absolute_time_granularity(maps):
         elif time_delta["hour"] > 0:
             has_unit_dict["hours"] = True
             # print "has hour"
-        elif time_detla["day"] > 0:
+        elif time_delta["day"] > 0:
             has_unit_dict["days"] = True
             # print "has day"
         elif time_delta["month"] > 0:


### PR DESCRIPTION
After digging a bit I figured out that the bottleneck and reason for the very slow process for updating STDS metadata (see: #3136) is the _get_registered_maps_as_objects_ function.

Creating a map object takes 1/10 og 1/20 of a second, but with 100k maps that sums up to a quite a bit of time...

This PR is a work around for updating STDS metadata, that avoids using the slow function. But ideally, the function itself (_get_registered_maps_as_objects_) should be improved so it scales to larger STDS... I assume it is initilizing of DB interface that is most time consuming, but I did not investigate more deeply...