### PR TITLE
fix: duplicateExpression warnings in modules and libraries

### DIFF
--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -453,7 +453,7 @@ int draw_scale(double east, double north, int length, int seg, int units,
                 xarr[1] = seg_len;
                 yarr[1] = 0;
                 xarr[2] = 0;
-                yarr[2] = (i % 2 ? ysize_checker : +ysize_checker);
+                yarr[2] = (i % 2 ? -ysize_checker : +ysize_checker);
                 xarr[3] = -seg_len;
                 yarr[3] = 0;
                 xarr[4] = 0;

--- a/imagery/i.atcorr/altitude.cpp
+++ b/imagery/i.atcorr/altitude.cpp
@@ -187,7 +187,7 @@ void Altitude::presplane(AtmosModel &atms)
                                 (1013.25 * plane_sim.tpl[k]));
         rmwh[k] = atms.wh[k] / (roair * 1000);
         rmo3[k] = atms.wo[k] / (roair * 1000);
-        rt += (atms.p[k + 1] / atms.t[k + 1] + atms.p[k] / atms.p[k]) *
+        rt += (atms.p[k + 1] / atms.t[k + 1] + 1) *
               (atms.z[k + 1] - atms.z[k]);
         rp += (plane_sim.ppl[k + 1] / plane_sim.tpl[k + 1] +
                plane_sim.ppl[k] / plane_sim.tpl[k]) *

--- a/imagery/i.evapo.time/main.c
+++ b/imagery/i.evapo.time/main.c
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
                     /* do nothing        */
                 }
                 else {
-                    if (DOYbeforeETa[i] == 0 || DOYbeforeETa[i] == 0)
+                    if (DOYbeforeETa[i] == 0)
                         Rast_set_d_null_value(&outrast[col], 1);
                     else {
                         bfr = (int)DOYbeforeETa[i];
@@ -317,7 +317,7 @@ int main(int argc, char *argv[])
 
             d_out = 0.0;
             for (i = 0; i < nfiles1; i++) {
-                if (d_null == 1 || d_null == 1)
+                if (d_null == 1 || d1_null == 1)
                     Rast_set_d_null_value(&outrast[col], 1);
                 else {
                     d_out += d_ETrF[i] * sum[i];

--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -140,10 +140,9 @@ int D_open_driver(void)
           : (p && G_strcasecmp(p, "html") == 0) ? HTML_Driver()
           :
 #ifdef USE_CAIRO
-          (p && G_strcasecmp(p, "cairo") == 0) ? Cairo_Driver()
-                                               : Cairo_Driver();
+    Cairo_Driver();
 #else
-                                                PNG_Driver();
+    PNG_Driver();
 #endif
 
     if (p && G_strcasecmp(drv->name, p) != 0)

--- a/lib/imagery/group.c
+++ b/lib/imagery/group.c
@@ -261,8 +261,7 @@ int I_init_ref_color_nums(struct Ref *ref)
     ref->grn.index = NULL;
     ref->blu.index = NULL;
 
-    if (ref->nfiles <= 0 || ref->red.n >= 0 || ref->blu.n >= 0 ||
-        ref->blu.n >= 0)
+    if (ref->nfiles <= 0 || ref->red.n >= 0 || ref->blu.n >= 0)
         return 1;
     switch (ref->nfiles) {
     case 1:

--- a/lib/ogsf/gsd_surf.c
+++ b/lib/ogsf/gsd_surf.c
@@ -2237,22 +2237,24 @@ int gsd_surf_map(geosurf *surf)
            datarow3 = (row + (step_val / 2)) * ymod;
          */
 
+        double half_step_val = step_val / 2.0;
+
         y1 = ymax - row * yres;
-        y2 = ymax - (row - (step_val / 2)) * yres;
-        y3 = ymax - (row + (step_val / 2)) * yres;
+        y2 = ymax - (row - half_step_val) * yres;
+        y3 = ymax - (row + half_step_val) * yres;
 
         y1off = row * ymod * surf->cols;
-        y2off = (row - (step_val / 2)) * ymod * surf->cols;
-        y3off = (row + (step_val / 2)) * ymod * surf->cols;
+        y2off = (row - half_step_val) * ymod * surf->cols;
+        y3off = (row + half_step_val) * ymod * surf->cols;
 
         for (col = start_val; col < xcnt; col += step_val) {
             datacol1 = col * xmod;
-            datacol2 = (col - (step_val / 2)) * xmod;
-            datacol3 = (col + (step_val / 2)) * xmod;
+            datacol2 = (col - half_step_val) * xmod;
+            datacol3 = (col + half_step_val) * xmod;
 
             x1 = col * xres;
-            x2 = (col - (step_val / 2)) * xres;
-            x3 = (col + (step_val / 2)) * xres;
+            x2 = (col - half_step_val) * xres;
+            x3 = (col + half_step_val) * xres;
 
             /* 0 */
             /*

--- a/lib/raster/get_row.c
+++ b/lib/raster/get_row.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <errno.h>
+#include <math.h>
 
 #include <grass/config.h>
 #include <grass/raster.h>
@@ -992,7 +993,7 @@ static void get_null_value_row_gdal(int fd, char *flags, int row)
     for (i = 0; i < R__.rd_window.cols; i++)
         /* note: using == won't work if the null value is NaN */
         flags[i] = !fcb->col_map[i] || tmp_buf[i] == fcb->gdal->null_val ||
-                   tmp_buf[i] != tmp_buf[i];
+                   isnan(tmp_buf[i]);
 
     G_free(tmp_buf);
 }

--- a/lib/raster/null_val.c
+++ b/lib/raster/null_val.c
@@ -17,6 +17,7 @@
 
 /* System include files */
 #include <string.h>
+#include <math.h>
 
 /* Grass and local include files */
 #include <grass/gis.h>
@@ -238,7 +239,7 @@ int Rast_is_c_null_value(const CELL *cellVal)
 #ifndef Rast_is_f_null_value
 int Rast_is_f_null_value(const FCELL *fcellVal)
 {
-    return *fcellVal != *fcellVal;
+    return isnan(*fcellVal);
 }
 #endif
 
@@ -257,7 +258,7 @@ int Rast_is_f_null_value(const FCELL *fcellVal)
 #ifndef Rast_is_d_null_value
 int Rast_is_d_null_value(const DCELL *dcellVal)
 {
-    return *dcellVal != *dcellVal;
+    return isnan(*dcellVal);
 }
 #endif
 

--- a/lib/stats/c_reg.c
+++ b/lib/stats/c_reg.c
@@ -81,7 +81,7 @@ static void regression(DCELL *result, DCELL *values, int n, int which)
     }
 
     /* Check for NaN */
-    if (*result != *result)
+    if (isnan(*result))
         Rast_set_d_null_value(result, 1);
 }
 
@@ -175,7 +175,7 @@ static void regression_w(DCELL *result, DCELL (*values)[2], int n, int which)
     }
 
     /* Check for NaN */
-    if (*result != *result)
+    if (isnan(*result))
         Rast_set_d_null_value(result, 1);
 }
 

--- a/lib/vector/diglib/port_test.c
+++ b/lib/vector/diglib/port_test.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
     }
     tmp = tmp2 = 1;
     for (i = 0; i < nat_off_t; i++) {
-        if (off_t_cnvrt[i] != (i + (nat_off_t - nat_off_t)))
+        if (off_t_cnvrt[i] != i)
             tmp = 0;
         if (off_t_cnvrt[i] != (nat_off_t - i - 1))
             tmp2 = 0;

--- a/raster/r.surf.area/area.c
+++ b/raster/r.surf.area/area.c
@@ -66,7 +66,7 @@ void add_row_area(DCELL *top, DCELL *bottom, double sz, struct Cell_head *w,
             /* upper */
             tedge2[X] = -w->ew_res;
             tedge2[Y] = 0.0;
-            tedge2[Z] = sz * (top[col + 1] - top[col + 1]);
+            tedge2[Z] = sz * (top[col + 1] - top[col]);
 
             v3cross(tedge1, tedge2, crossp);
             v3mag(crossp, &mag);

--- a/raster/r.terraflow/unionFind.h
+++ b/raster/r.terraflow/unionFind.h
@@ -180,7 +180,7 @@ inline void unionFind<T>::makeUnion(T x, T y)
         /* hook setx onto sety */
         parent[setx] = sety;
         /* if equal increase rank */
-        if (sety == sety) {
+        if (setx == sety) {
             rank[sety]++;
         }
     }


### PR DESCRIPTION
The commit addresses duplicateExpression warnings detected by cppcheck in the following files:

Modules:

display/d.barscale/draw_scale.c
imagery/i.atcorr/altitude.cpp
imagery/i.evapo.time/main.c
raster/r.surf.area/area.c
raster/r.terraflow/unionFind.h
GRASS Library Parts:

lib/display/r_raster.c
lib/imagery/group.c
lib/ogsf/gsd_surf.c
lib/raster/get_row.c
lib/raster/null_val.c
lib/stats/c_reg.c
lib/vector/diglib/port_test.c

This commit is part of the effort to fix compiler warnings reported in issue #2164.
