### PR TITLE
CI(labeler): Fix RFC exclusion from docs, adjust other globs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -113,6 +113,7 @@ docker:
           - .dockerignore
 
 docs:
+- all:
   - changed-files:
       - any-glob-to-any-file:
           - doc/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,89 +2,88 @@
 libraries:
   - changed-files:
       - any-glob-to-any-file:
-          - lib/**/*
-          - include/grass/*
-          - include/grass/**/*
-          - python/**/*
+          - lib/**
+          - include/grass/**
+          - python/**
 module:
   - changed-files:
       - any-glob-to-any-file:
-          - db/**/*
-          - display/**/*
-          - general/**/*
-          - imagery/**/*
-          - misc/**/*
-          - ps/**/*
-          - raster/**/*
-          - raster3d/**/*
-          - scripts/**/*
-          - temporal/**/*
-          - vector/**/*
+          - db/**
+          - display/**
+          - general/**
+          - imagery/**
+          - misc/**
+          - ps/**
+          - raster/**
+          - raster3d/**
+          - scripts/**
+          - temporal/**
+          - vector/**
 
 # Module categories
 database:
   - changed-files:
       - any-glob-to-any-file:
-          - db/**/*
-          - lib/db/**/*
+          - db/**
+          - lib/db/**
           - scripts/db.*/**
 display:
   - changed-files:
       - any-glob-to-any-file:
-          - display/**/*
-          - lib/display/**/*
+          - display/**
+          - lib/display/**
           - scripts/d.*/**
 general:
   - changed-files:
       - any-glob-to-any-file:
-          - general/**/*
+          - general/**
           - scripts/g.*/**
 GUI:
   - changed-files:
       - any-glob-to-any-file:
-          - gui/**/*
+          - gui/**
 imagery:
   - changed-files:
       - any-glob-to-any-file:
-          - imagery/**/*
-          - lib/imagery/**/*
+          - imagery/**
+          - lib/imagery/**
           - scripts/i.*/**
 misc:
   - changed-files:
       - any-glob-to-any-file:
-          - misc/**/*
+          - misc/**
           - scripts/m.*/**
 raster:
   - changed-files:
       - any-glob-to-any-file:
-          - raster/**/*
-          - lib/raster/**/*
+          - raster/**
+          - lib/raster/**
           - scripts/r.*/**
 raster3d:
   - changed-files:
       - any-glob-to-any-file:
-          - raster3d/**/*
-          - lib/raster3d/**/*
+          - raster3d/**
+          - lib/raster3d/**
           - scripts/r3.*/**
 temporal:
   - changed-files:
       - any-glob-to-any-file:
-          - temporal/**/*
-          - lib/temporal/**/*
+          - temporal/**
+          - lib/temporal/**
           - scripts/t.*/**
 vector:
   - changed-files:
       - any-glob-to-any-file:
-          - vector/**/*
-          - lib/vector/**/*
+          - vector/**
+          - lib/vector/**
           - scripts/v.*/**
 
 # Build, packaging, or OS related
 CI:
   - changed-files:
       - any-glob-to-any-file:
-          - .github/**/*
-          - .travis/**/*
+          - .github/**
+          - .travis/**
           - binder/**
           - .travis.yml
           - renovate.json
@@ -92,32 +91,30 @@ CI:
 Windows:
   - changed-files:
       - any-glob-to-any-file:
-          - mswindows/**/*
+          - mswindows/**
 macOS:
   - changed-files:
       - any-glob-to-any-file:
-          - macosx/**/*
+          - macosx/**
 Linux:
   - changed-files:
       - any-glob-to-any-file:
-          - singularity/**/*
+          - singularity/**
           - rpm/** 
 docker:
   - changed-files:
       - any-glob-to-any-file:
-          - docker/**/*
+          - docker/**
           - '**/*Dockerfile*'
           - '**/*dockerfile*'
-          - '*Dockerfile*'
-          - '*dockerfile*'
           - .dockerignore
 
 docs:
 - all:
   - changed-files:
       - any-glob-to-any-file:
-          - doc/**/*
-          - man/**/*
+          - doc/**
+          - man/**
           - '**/*.md'
           - '**/*.rst'
           - '**/*.html'
@@ -130,14 +127,14 @@ docs:
           - NEWS
           - TODO
       - all-globs-to-all-files:
-          - '!doc/development/rfc/*'
+          - '!doc/development/rfc/**'
 RFC:
   - changed-files:
       - any-glob-to-any-file: 
-          - doc/development/rfc/*
+          - doc/development/rfc/**
 translation:
   - changed-files:
-      - any-glob-to-any-file: locale/**/*
+      - any-glob-to-any-file: locale/**
 
 # based on file types
 Python:
@@ -145,7 +142,6 @@ Python:
       - any-glob-to-any-file: 
         - '**/*.py'
         - '**/pyproject.toml'
-        - 'pyproject.toml'
 C:
   - changed-files:
       - any-glob-to-any-file: '**/*.c'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,7 @@ database:
           - db/**
           - lib/db/**
           - scripts/db.*/**
+          - '**.sql'
 display:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
A little tune up in three parts:

1.  I noticed in my fork that the docs label was added to every PR. I went and reread very very attentively the docs for the labeler action, and noticed I missed that in the example for exclusion, there was a top level key that wasn’t `any` but `all`. So, inside the `changed-files`, the  results of the options `any-glob-to-any-file`, `any-glob-to-all-files`, `all-globs-to-any-file` and `all-globs-to-all-files` were `OR`-ed together. That is because by default, if `any` or `all` is missing, `any` is used. I expected the results of the individual sections of globs to be `AND`-ed together, ie the behavior of `all`.
2. Since I reread so attentively the docs, I observed that `blabla/**/*` was redundant to `blabla/**`, as a single star matches everything except a slash, and a double star matches everything. Their examples also show it.
3. In the recent PRs of @ninsbl , I noticed that database wasn’t included as a label, and was in fact removed automatically even if it was added manually before the run of the labeller. It isn’t a surprise, as was explained as a potential shortcoming that I considered tolerable and isn’t enabled by default.  So I added sql files to the database label.


For both points 1 and 2, I « changed » my main branch with the changes one by one and I did PRs in my fork to be able to test that the behaviour is correct. (The trigger is at pull_request_target, so the workflow already needs to be in the target to run)

