### PR TITLE
CI(CodeQL): Improve run times and add concurrency groups

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,10 +47,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          cache: pip
-          cache-dependency-path: |
-            .github/workflows/python_requirements.txt
-            .github/workflows/optional_requirements.txt
       - name: Install non-Python dependencies
         if: ${{ matrix.language == 'c-cpp' }}
         run: |
@@ -58,15 +54,6 @@ jobs:
           sudo apt-get install -y wget git gawk findutils
           xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install \
-            -r .github/workflows/python_requirements.txt \
-            -r .github/workflows/optional_requirements.txt
-          # Set the `CODEQL-PYTHON` environment variable to the Python executable
-          # that includes the dependencies
-          echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,12 @@ jobs:
           - cpp
           - python
 
+    concurrency:
+      group: ${{ github.workflow }}-${{
+        github.event_name == 'pull_request' &&
+        github.head_ref || github.sha }}-${{ matrix.language }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
 
+      - name: Set number of cores for compilation
+        run: |
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
       - name: Build
         env:
           CFLAGS: -std=gnu11

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,17 +16,22 @@ on:
     # Check every Saturday at 18:36
     - cron: 36 18 * * 6
 
+permissions: {}
+
 jobs:
   analyze:
-    name: ${{ matrix.language }}
+    name: Analyze
     runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
 
     strategy:
       fail-fast: false
       matrix:
-        # C is included in cpp, no separate C language available on CodeQL
         language:
-          - cpp
+          - c-cpp
           - python
 
     concurrency:
@@ -38,37 +43,58 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: |
+            .github/workflows/python_requirements.txt
+            .github/workflows/optional_requirements.txt
+      - name: Install non-Python dependencies
+        if: ${{ matrix.language == 'c-cpp' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y wget git gawk findutils
+          xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
+              sudo apt-get install -y --no-install-recommends --no-install-suggests
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install \
+            -r .github/workflows/python_requirements.txt \
+            -r .github/workflows/optional_requirements.txt
+          # Set the `CODEQL-PYTHON` environment variable to the Python executable
+          # that includes the dependencies
+          echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Get dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y wget git gawk findutils
-          xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
-              sudo apt-get install -y --no-install-recommends --no-install-suggests
+          setup-python-dependencies: false
 
       - name: Create installation directory
         run: |
-          mkdir $HOME/install
+          mkdir "${HOME}/install"
 
       - name: Set LD_LIBRARY_PATH for compilation
         run: |
-          echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${HOME}/install/lib" >> $GITHUB_ENV
 
       - name: Set number of cores for compilation
         run: |
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
 
       - name: Build
+        if: ${{ matrix.language == 'c-cpp' }}
         env:
           CFLAGS: -std=gnu11
           CXXFLAGS: -std=c++11
-        run: .github/workflows/build_ubuntu-22.04.sh $HOME/install
+        run: .github/workflows/build_ubuntu-22.04.sh "${HOME}/install"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
During the last week or so, I explored many options and configuration possibilities to refresh our CodeQL jobs, starting from a new fresh advanced config and porting the new suggested practices one by one. This is the result of the most appropriate possibility.

1. First, the goal was to add a concurrency group for PRs, since even when exploring (for other things) in my fork, sometimes I was waiting on runners because a new push to a PR would not cancel CodeQL analysis like our other workflows.
2. Then, to improve build times, I added the number of jobs to the makeflags like our Ubuntu workflows.
3. ~CodeQL scanning for python doesn't need to have grass built to work. This wasn't the case before when CodeQL was introduced, lots have changed. It seems it is a static analysis, but still needs to see the code for the python dependencies. So, I didn't build grass for python language scans.~ Edit: I completly removed Python dependencies after the extra reference I found in 4, and retesting it out.
4. There's a weird background-compatibilty workaround CodeQL uses to try to autoinstall python dependencies if you ever used CodeQL with this enabled when it was the default. Now they prefer to not add them, but they go extra steps so you don't notice that default change (for new users) https://github.blog/changelog/2023-07-12-code-scanning-with-codeql-no-longer-installs-python-dependencies-automatically-for-new-users/. I thus removed any pip dependency installation, and it doesn't impact the C build either.
5. CodeQL prefers now to use `c-cpp`, others being an alias.
7. We could optionally remove to paths/paths ignore from `.github/codeql/codeql-config.yml`, but I didn't include them in this PR. It doesn't really change, C/C++ doesn't support it anyways, and without build

I also explored the possibility of running a single job that scans both languages, but after figuring out that building grass or not didn't seem to impact python scanning and after more exploration, then computing the run times vs runner usage didn't make it advantageous, especially with the MAKEFLAGS set.
