### PR TITLE
refactor: positioning of mixed_checker addressing duplicateExpression warning

### DIFF
--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -453,7 +453,7 @@ int draw_scale(double east, double north, int length, int seg, int units,
                 xarr[1] = seg_len;
                 yarr[1] = 0;
                 xarr[2] = 0;
-                yarr[2] = (i % 2 ? ysize_checker : +ysize_checker);
+                yarr[2] = +ysize_checker;
                 xarr[3] = -seg_len;
                 yarr[3] = 0;
                 xarr[4] = 0;


### PR DESCRIPTION
This pull request addresses a code clarity enhancement in the file `graphics.c` where the `yarr` array is utilized to store y-coordinates for drawing polygons. The modification aims to improve the understanding of the code by adjusting the assignment of values to `yarr[2]` based on the parity of the loop index.

Reasons:

Correction for Checkerboard Pattern: In the context of the surrounding code, this adjustment ensures the correct positioning of the checkerboard pattern by modifying the calculation of the y-coordinate.
Code Clarity: The change is made to address the `duplicateExpression` warning flagged by cppcheck and to enhance the clarity of the code.
Coding Standards: Additionally, the modified code adheres to the existing coding standards.

Testing:
Manual testing has been performed both before and after making the changes to ensure that the behavior of the code remains unchanged.
A screenshot of the changes made is attached to provide a visual reference for the modification.

![code](https://github.com/OSGeo/grass/assets/54804304/4b6f6c37-cecc-4919-ada0-c0f158d69813)

![IMG_20240113_184445](https://github.com/OSGeo/grass/assets/54804304/d4412e91-43a5-465a-a72a-5f2e8c528a95)

![IMG_20240113_184428](https://github.com/OSGeo/grass/assets/54804304/0bc48d97-cb31-400b-8b1e-32771b44a2b5)


