### PR TITLE
wxGUI/preferences: fix `PreferencesDialog` class `OnSave` method

### DIFF
--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -189,11 +189,11 @@ class PreferencesBaseDialog(wx.Dialog):
         """Button 'Cancel' pressed"""
         self.Close()
 
-    def OnSave(self, event):
+    def OnSave(self, event, force=False):
         """Button 'Save' pressed
         Emits signal settingsChanged.
         """
-        if self._updateSettings():
+        if force is True or self._updateSettings():
             self.settings.SaveToFile()
             Debug.msg(1, "Settings saved to file '%s'" % self.settings.filePath)
             self.settingsChanged.emit()
@@ -2210,6 +2210,50 @@ class PreferencesDialog(PreferencesBaseDialog):
         scrollId = self.winId["display:scrollDirection:selection"]
         self.FindWindowById(scrollId).Enable(enable)
 
+    def OnSave(self, event):
+        """Button 'Save' pressed
+        Emits signal settingsChanged.
+        """
+        if self._updateSettings():
+            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
+            if lang == "system":
+                # Most fool proof way to use system locale is to not provide
+                # any locale info at all
+                self.settings.Set(
+                    group="language", key="locale", subkey="lc_all", value=None
+                )
+                lang = None
+            env = grass.gisenv()
+
+            # Set gisenv MEMORYMB var value
+            memorydb_gisenv = "MEMORYMB"
+            memorymb = self.memorymb.GetValue()
+            if memorymb:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{memorydb_gisenv}={memorymb}",
+                )
+            elif env.get(memorydb_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=memorydb_gisenv,
+                )
+            # Set gisenv NPROCS var value
+            nprocs_gisenv = "NPROCS"
+            nprocs = self.nprocs.GetValue()
+            if nprocs:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{nprocs_gisenv}={nprocs}",
+                )
+            elif env.get(nprocs_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=nprocs_gisenv,
+                )
+
+        PreferencesBaseDialog.OnSave(self, event, force=True)
+
 
 class MapsetAccess(wx.Dialog):
     """Controls setting options and displaying/hiding map overlay
@@ -2340,45 +2384,3 @@ class CheckListMapset(ListCtrl, listmix.ListCtrlAutoWidthMixin, CheckListCtrlMix
         mapset = self.parent.all_mapsets_ordered[index]
         if mapset == self.parent.curr_mapset:
             self.CheckItem(index, True)
-
-    def OnSave(self, event):
-        """Button 'Save' pressed
-        Emits signal settingsChanged.
-        """
-        if self._updateSettings():
-            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
-            if lang == "system":
-                # Most fool proof way to use system locale is to not provide
-                # any locale info at all
-                self.settings.Set(
-                    group="language", key="locale", subkey="lc_all", value=None
-                )
-                lang = None
-            env = grass.gisenv()
-
-            # Set gisenv MEMORYMB var value
-            memorydb_gisenv = "MEMORYMB"
-            memorymb = self.memorymb.GetValue()
-            if memorymb:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{memorydb_gisenv}={memorymb}",
-                )
-            elif env.get(memorydb_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=memorydb_gisenv,
-                )
-            # Set gisenv NPROCS var value
-            nprocs_gisenv = "NPROCS"
-            nprocs = self.nprocs.GetValue()
-            if nprocs:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{nprocs_gisenv}={nprocs}",
-                )
-            elif env.get(nprocs_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=nprocs_gisenv,
-                )

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -194,41 +194,6 @@ class PreferencesBaseDialog(wx.Dialog):
         Emits signal settingsChanged.
         """
         if self._updateSettings():
-            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
-            if lang == "system":
-                # Most fool proof way to use system locale is to not provide
-                # any locale info at all
-                self.settings.Set(
-                    group="language", key="locale", subkey="lc_all", value=None
-                )
-                lang = None
-            env = grass.gisenv()
-            nprocs_gisenv = "NPROCS"
-            memorydb_gisenv = "MEMORYMB"
-            # Set gisenv MEMORYMB var value
-            memorymb = self.memorymb.GetValue()
-            if memorymb:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{memorydb_gisenv}={memorymb}",
-                )
-            elif env.get(memorydb_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=memorydb_gisenv,
-                )
-            # Set gisenv NPROCS var value
-            nprocs = self.nprocs.GetValue()
-            if nprocs:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{nprocs_gisenv}={nprocs}",
-                )
-            elif env.get(nprocs_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=nprocs_gisenv,
-                )
             self.settings.SaveToFile()
             Debug.msg(1, "Settings saved to file '%s'" % self.settings.filePath)
             self.settingsChanged.emit()
@@ -2375,3 +2340,45 @@ class CheckListMapset(ListCtrl, listmix.ListCtrlAutoWidthMixin, CheckListCtrlMix
         mapset = self.parent.all_mapsets_ordered[index]
         if mapset == self.parent.curr_mapset:
             self.CheckItem(index, True)
+
+    def OnSave(self, event):
+        """Button 'Save' pressed
+        Emits signal settingsChanged.
+        """
+        if self._updateSettings():
+            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
+            if lang == "system":
+                # Most fool proof way to use system locale is to not provide
+                # any locale info at all
+                self.settings.Set(
+                    group="language", key="locale", subkey="lc_all", value=None
+                )
+                lang = None
+            env = grass.gisenv()
+
+            # Set gisenv MEMORYMB var value
+            memorydb_gisenv = "MEMORYMB"
+            memorymb = self.memorymb.GetValue()
+            if memorymb:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{memorydb_gisenv}={memorymb}",
+                )
+            elif env.get(memorydb_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=memorydb_gisenv,
+                )
+            # Set gisenv NPROCS var value
+            nprocs_gisenv = "NPROCS"
+            nprocs = self.nprocs.GetValue()
+            if nprocs:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{nprocs_gisenv}={nprocs}",
+                )
+            elif env.get(nprocs_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=nprocs_gisenv,
+                )


### PR DESCRIPTION
Currently saving preferences in Graphical Modeler (same applies to Map Swipe) fails with:

```py
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/preferences.py", line 631, in OnSave
    PreferencesBaseDialog.OnSave(self, event)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/preferences.py", line 209, in OnSave
    memorymb = self.memorymb.GetValue()
               ^^^^^^^^^^^^^
AttributeError: 'PreferencesDialog' object has no attribute 'memorymb'
```

The variable `self.memorymb` is defined in `gui._core.preferences.PreferencesDialog`. This PR fixes this bug by moving relevant code from `gui._core.preferences.PreferencesBaseDialog.OnSave()` to a new method `gui._core.preferences.PreferencesBaseDialog.OnSave()` .