### PR TITLE
Graphical Modeler: add support for PyGRASS API

### DIFF
--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -733,6 +733,7 @@ class Settings:
                         "height": 100,
                     },
                 },
+                "grassAPI": {"selection": 0},  # script package
             },
             "mapswipe": {
                 "cursor": {
@@ -873,6 +874,11 @@ class Settings:
             _("cross"),
             _("box"),
             _("circle"),
+        )
+
+        self.internalSettings["modeler"]["grassAPI"]["choices"] = (
+            _("Script package"),
+            _("PyGRASS"),
         )
 
     def ReadSettingsFile(self, settings=None):

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -877,8 +877,8 @@ class Settings:
         )
 
         self.internalSettings["modeler"]["grassAPI"]["choices"] = (
-            _("Script package"),
             _("PyGRASS"),
+            _("Script package"),
         )
 
     def ReadSettingsFile(self, settings=None):

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -877,8 +877,8 @@ class Settings:
         )
 
         self.internalSettings["modeler"]["grassAPI"]["choices"] = (
-            _("PyGRASS"),
             _("Script package"),
+            _("PyGRASS"),
         )
 
     def ReadSettingsFile(self, settings=None):

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -2103,7 +2103,13 @@ class PythonPanel(wx.Panel):
                 return False
 
         fd = tempfile.TemporaryFile(mode="r+")
-        self.write_object(fd, self.parent.GetModel())  # TODO: grass_api
+        grassAPI = UserSettings.Get(group="modeler", key="grassAPI", subkey="selection")
+        self.write_object(
+            fd,
+            self.parent.GetModel(),
+            grassAPI="script" if grassAPI == 0 else "pygrass",
+        )
+
         fd.seek(0)
         self.body.SetText(fd.read())
         fd.close()

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -2107,7 +2107,7 @@ class PythonPanel(wx.Panel):
         self.write_object(
             fd,
             self.parent.GetModel(),
-            grassAPI="pygrass" if grassAPI == 0 else "script",
+            grassAPI="script" if grassAPI == 0 else "pygrass",
         )
 
         fd.seek(0)

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -2107,7 +2107,7 @@ class PythonPanel(wx.Panel):
         self.write_object(
             fd,
             self.parent.GetModel(),
-            grassAPI="script" if grassAPI == 0 else "pygrass",
+            grassAPI="pygrass" if grassAPI == 0 else "script",
         )
 
         fd.seek(0)

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -2103,7 +2103,7 @@ class PythonPanel(wx.Panel):
                 return False
 
         fd = tempfile.TemporaryFile(mode="r+")
-        self.write_object(fd, self.parent.GetModel())
+        self.write_object(fd, self.parent.GetModel())  # TODO: grass_api
         fd.seek(0)
         self.body.SetText(fd.read())
         fd.close()

--- a/gui/wxpython/gmodeler/g.gui.gmodeler.html
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.html
@@ -372,6 +372,12 @@ not to run it on itself.
 <i>Figure: Python editor in the wxGUI Graphical Modeler - set to PyWPS.</i>
 </center>
 
+<p>
+By default GRASS script package API is used
+(<tt>grass.script.core.run_command()</tt>). This can be changed in the
+settings. Alternatively also PyGRASS API is supported
+(<tt>grass.pygrass.modules.Module</tt>).
+
 <h3>Defining loops</h3>
 In the example below the <a href="https://e4ftl01.cr.usgs.gov/MOLT/MOD13Q1.006/">MODIS MOD13Q1</a>
 (NDVI) satellite data products are used in a loop. The original data are

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -19,7 +19,7 @@ Classes:
  - model::WritePythonFile
  - model::ModelParamDialog
 
-(C) 2010-2018 by the GRASS Development Team
+(C) 2010-2024 by the GRASS Development Team
 
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -2664,12 +2664,12 @@ class WriteScriptFile(ABC):
 class WritePyWPSFile(WriteScriptFile):
     """Class for exporting model to PyWPS script."""
 
-    def __init__(self, fd, model, grass_api="script"):
+    def __init__(self, fd, model, grassAPI="script"):
         """Class for exporting model to PyWPS script."""
         self.fd = fd
         self.model = model
         self.indent = 8
-        self.grass_api = grass_api
+        self.grassAPI = grassAPI
 
         self._writePyWPS()
 
@@ -2686,7 +2686,7 @@ import atexit
 import tempfile
 """
         )
-        if self.grass_api == "script":
+        if self.grassAPI == "script":
             self.fd.write("from grass.script import run_command\n")
         else:
             self.fd.write("from grass.pygrass.modules import Module\n")
@@ -2878,7 +2878,7 @@ if __name__ == "__main__":
         task = GUI(show=None).ParseCommand(cmd=item.GetLog(string=False))
         strcmd = "\n%s%s(" % (
             " " * self.indent,
-            "run_command" if self.grass_api == "script" else "Module",
+            "run_command" if self.grassAPI == "script" else "Module",
         )
         self.fd.write(
             strcmd + self._getPythonActionCmd(item, task, len(strcmd) - 1, variables)
@@ -3072,17 +3072,17 @@ if __name__ == "__main__":
 
 
 class WritePythonFile(WriteScriptFile):
-    def __init__(self, fd, model, grass_api="script"):
+    def __init__(self, fd, model, grassAPI="script"):
         """Class for exporting model to Python script
 
         :param fd: file descriptor
         :param model: model to translate
-        :param grass_api: script or pygrass
+        :param grassAPI: script or pygrass
         """
         self.fd = fd
         self.model = model
         self.indent = 4
-        self.grass_api = grass_api
+        self.grassAPI = grassAPI
 
         self._writePython()
 
@@ -3205,7 +3205,7 @@ import atexit
 from grass.script import parser
 """
         )
-        if self.grass_api == "script":
+        if self.grassAPI == "script":
             self.fd.write("from grass.script import run_command\n")
         else:
             self.fd.write("from grass.pygrass.modules import Module\n")
@@ -3217,7 +3217,7 @@ from grass.script import parser
 def cleanup():
 """
         )
-        run_command = "run_command" if self.grass_api == "script" else "Module"
+        run_command = "run_command" if self.grassAPI == "script" else "Module"
         if rast:
             self.fd.write(
                 r"""    %s("g.remove", flags="f", type="raster",
@@ -3281,7 +3281,7 @@ if __name__ == "__main__":
         task = GUI(show=None).ParseCommand(cmd=item.GetLog(string=False))
         strcmd = "%s%s(" % (
             " " * self.indent,
-            "run_command" if self.grass_api == "script" else "Module",
+            "run_command" if self.grassAPI == "script" else "Module",
         )
         self.fd.write(
             strcmd + self._getPythonActionCmd(item, task, len(strcmd), variables) + "\n"

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -2928,6 +2928,7 @@ if __name__ == "__main__":
                 else:
                     overwrite_string = ""
 
+                strcmd_len = len(strcmd.strip())
                 self.fd.write(
                     """
 {run_command}"{cmd}",
@@ -2939,14 +2940,14 @@ if __name__ == "__main__":
 """.format(
                         run_command=strcmd,
                         cmd=command,
-                        indent1=" " * (self.indent + 12),
+                        indent1=" " * (self.indent + strcmd_len),
                         input=param_request,
-                        indent2=" " * (self.indent + 12),
-                        indent3=" " * (self.indent + 16),
-                        indent4=" " * (self.indent + 16),
+                        indent2=" " * (self.indent + strcmd_len),
+                        indent3=" " * (self.indent * 2 + strcmd_len),
+                        indent4=" " * (self.indent * 2 + strcmd_len),
                         out=param_request,
                         format_ext=extension,
-                        indent5=" " * (self.indent + 12),
+                        indent5=" " * (self.indent + strcmd_len),
                         format=format,
                         overwrite_string=overwrite_string,
                     )

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -3299,7 +3299,10 @@ if __name__ == "__main__":
 
         for p in opts["params"]:
             name = p.get("name", None)
-            value = p.get("value", None)
+            if self.grassAPI == "script" or p.get("multiple", False) is False:
+                value = p.get("value", None)
+            else:
+                value = str(p.get("values", []))
 
             if (name and value) or (name in parameterizedParams):
                 ptype = p.get("type", "string")

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -3299,10 +3299,13 @@ if __name__ == "__main__":
 
         for p in opts["params"]:
             name = p.get("name", None)
-            if self.grassAPI == "script" or p.get("multiple", False) is False:
-                value = p.get("value", None)
-            else:
-                value = str(p.get("values", []))
+            value = p.get("value", None)
+            if (
+                self.grassAPI == "pygrass"
+                and p.get("multiple", False) is True
+                and "," in value
+            ):
+                value = value.split(",")
 
             if (name and value) or (name in parameterizedParams):
                 ptype = p.get("type", "string")
@@ -3312,7 +3315,7 @@ if __name__ == "__main__":
                     foundVar = True
                     value = 'options["{}"]'.format(self._getParamName(name, item))
 
-                if foundVar or ptype != "string":
+                if foundVar or ptype != "string" or isinstance(value, list):
                     params.append("{}={}".format(name, value))
                 else:
                     params.append('{}="{}"'.format(name, value))

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -3300,22 +3300,31 @@ if __name__ == "__main__":
         for p in opts["params"]:
             name = p.get("name", None)
             value = p.get("value", None)
+            ptype = p.get("type", "string")
+
             if (
                 self.grassAPI == "pygrass"
-                and p.get("multiple", False) is True
+                and (p.get("multiple", False) is True or len(p.get("key_desc", [])) > 1)
                 and "," in value
             ):
                 value = value.split(",")
+                if ptype == "integer":
+                    value = list(map(int, value))
+                elif ptype == "float":
+                    value = list(map(float, value))
 
             if (name and value) or (name in parameterizedParams):
-                ptype = p.get("type", "string")
                 foundVar = False
 
                 if name in parameterizedParams:
                     foundVar = True
                     value = 'options["{}"]'.format(self._getParamName(name, item))
 
-                if foundVar or ptype != "string" or isinstance(value, list):
+                if (
+                    foundVar
+                    or isinstance(value, list)
+                    or (ptype != "string" and len(p.get("key_desc", [])) < 2)
+                ):
                     params.append("{}={}".format(name, value))
                 else:
                     params.append('{}="{}"'.format(name, value))

--- a/gui/wxpython/gmodeler/preferences.py
+++ b/gui/wxpython/gmodeler/preferences.py
@@ -7,7 +7,7 @@ Classes:
  - preferences::PreferencesDialog
  - preferences::PropertiesDialog
 
-(C) 2010-2013 by the GRASS Development Team
+(C) 2010-2024 by the GRASS Development Team
 
 This program is free software under the GNU General Public License
 (>=v2). Read the file COPYING that comes with GRASS for details.
@@ -48,9 +48,9 @@ class PreferencesDialog(PreferencesBaseDialog):
         """Create notebook page for action settings"""
         panel = wx.Panel(parent=notebook, id=wx.ID_ANY)
         notebook.AddPage(page=panel, text=_("General"))
+        border = wx.BoxSizer(wx.VERTICAL)
 
         # colors
-        border = wx.BoxSizer(wx.VERTICAL)
         box = StaticBox(parent=panel, id=wx.ID_ANY, label=" %s " % _("Item properties"))
         sizer = wx.StaticBoxSizer(box, wx.VERTICAL)
 
@@ -73,6 +73,48 @@ class PreferencesDialog(PreferencesBaseDialog):
 
         gridSizer.Add(
             rColor, flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, pos=(row, 1)
+        )
+
+        gridSizer.AddGrowableCol(0)
+        sizer.Add(gridSizer, proportion=1, flag=wx.ALL | wx.EXPAND, border=5)
+        border.Add(
+            sizer,
+            proportion=0,
+            flag=wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            border=3,
+        )
+
+        # Python editor
+        box = StaticBox(parent=panel, id=wx.ID_ANY, label=" %s " % _("Python editor"))
+        sizer = wx.StaticBoxSizer(box, wx.VERTICAL)
+
+        gridSizer = wx.GridBagSizer(hgap=3, vgap=3)
+
+        row = 0
+        gridSizer.Add(
+            StaticText(parent=panel, id=wx.ID_ANY, label=_("GRASS API:")),
+            flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL,
+            pos=(row, 0),
+        )
+        grassAPI = wx.Choice(
+            parent=panel,
+            id=wx.ID_ANY,
+            size=(150, -1),
+            choices=self.settings.Get(
+                group="modeler",
+                key="grassAPI",
+                subkey="choices",
+                settings_type="internal",
+            ),
+            name="GetSelection",
+        )
+        grassAPI.SetSelection(
+            self.settings.Get(group="modeler", key="grassAPI", subkey="selection")
+        )
+        self.winId["modeler:grassAPI:selection"] = grassAPI.GetId()
+
+        gridSizer.Add(
+            grassAPI, flag=wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, pos=(row, 1)
         )
 
         gridSizer.AddGrowableCol(0)

--- a/gui/wxpython/gmodeler/preferences.py
+++ b/gui/wxpython/gmodeler/preferences.py
@@ -21,6 +21,7 @@ import wx.lib.colourselect as csel
 from core import globalvar
 from gui_core.preferences import PreferencesBaseDialog
 from core.settings import UserSettings
+from core.debug import Debug
 from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
 
 
@@ -670,7 +671,11 @@ class PreferencesDialog(PreferencesBaseDialog):
 
     def OnSave(self, event):
         """Button 'Save' pressed"""
-        PreferencesBaseDialog.OnSave(self, event)
+        if self._updateSettings():
+            self.settings.SaveToFile()
+            Debug.msg(1, "Settings saved to file '%s'" % self.settings.filePath)
+            self.settingsChanged.emit()
+            self.Close()
 
         self.parent.GetModel().Update()
         self.parent.GetCanvas().Refresh()

--- a/gui/wxpython/gmodeler/preferences.py
+++ b/gui/wxpython/gmodeler/preferences.py
@@ -21,7 +21,6 @@ import wx.lib.colourselect as csel
 from core import globalvar
 from gui_core.preferences import PreferencesBaseDialog
 from core.settings import UserSettings
-from core.debug import Debug
 from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
 
 
@@ -671,11 +670,7 @@ class PreferencesDialog(PreferencesBaseDialog):
 
     def OnSave(self, event):
         """Button 'Save' pressed"""
-        if self._updateSettings():
-            self.settings.SaveToFile()
-            Debug.msg(1, "Settings saved to file '%s'" % self.settings.filePath)
-            self.settingsChanged.emit()
-            self.Close()
+        PreferencesBaseDialog.OnSave(self, event)
 
         self.parent.GetModel().Update()
         self.parent.GetCanvas().Refresh()

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -189,11 +189,11 @@ class PreferencesBaseDialog(wx.Dialog):
         """Button 'Cancel' pressed"""
         self.Close()
 
-    def OnSave(self, event):
+    def OnSave(self, event, force=False):
         """Button 'Save' pressed
         Emits signal settingsChanged.
         """
-        if self._updateSettings():
+        if force is True or self._updateSettings():
             self.settings.SaveToFile()
             Debug.msg(1, "Settings saved to file '%s'" % self.settings.filePath)
             self.settingsChanged.emit()
@@ -2210,6 +2210,50 @@ class PreferencesDialog(PreferencesBaseDialog):
         scrollId = self.winId["display:scrollDirection:selection"]
         self.FindWindowById(scrollId).Enable(enable)
 
+    def OnSave(self, event):
+        """Button 'Save' pressed
+        Emits signal settingsChanged.
+        """
+        if self._updateSettings():
+            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
+            if lang == "system":
+                # Most fool proof way to use system locale is to not provide
+                # any locale info at all
+                self.settings.Set(
+                    group="language", key="locale", subkey="lc_all", value=None
+                )
+                lang = None
+            env = grass.gisenv()
+
+            # Set gisenv MEMORYMB var value
+            memorydb_gisenv = "MEMORYMB"
+            memorymb = self.memorymb.GetValue()
+            if memorymb:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{memorydb_gisenv}={memorymb}",
+                )
+            elif env.get(memorydb_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=memorydb_gisenv,
+                )
+            # Set gisenv NPROCS var value
+            nprocs_gisenv = "NPROCS"
+            nprocs = self.nprocs.GetValue()
+            if nprocs:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{nprocs_gisenv}={nprocs}",
+                )
+            elif env.get(nprocs_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=nprocs_gisenv,
+                )
+
+        PreferencesBaseDialog.OnSave(self, event, force=True)
+
 
 class MapsetAccess(wx.Dialog):
     """Controls setting options and displaying/hiding map overlay
@@ -2340,45 +2384,3 @@ class CheckListMapset(ListCtrl, listmix.ListCtrlAutoWidthMixin, CheckListCtrlMix
         mapset = self.parent.all_mapsets_ordered[index]
         if mapset == self.parent.curr_mapset:
             self.CheckItem(index, True)
-
-    def OnSave(self, event):
-        """Button 'Save' pressed
-        Emits signal settingsChanged.
-        """
-        if self._updateSettings():
-            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
-            if lang == "system":
-                # Most fool proof way to use system locale is to not provide
-                # any locale info at all
-                self.settings.Set(
-                    group="language", key="locale", subkey="lc_all", value=None
-                )
-                lang = None
-            env = grass.gisenv()
-
-            # Set gisenv MEMORYMB var value
-            memorydb_gisenv = "MEMORYMB"
-            memorymb = self.memorymb.GetValue()
-            if memorymb:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{memorydb_gisenv}={memorymb}",
-                )
-            elif env.get(memorydb_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=memorydb_gisenv,
-                )
-            # Set gisenv NPROCS var value
-            nprocs_gisenv = "NPROCS"
-            nprocs = self.nprocs.GetValue()
-            if nprocs:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{nprocs_gisenv}={nprocs}",
-                )
-            elif env.get(nprocs_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=nprocs_gisenv,
-                )

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -194,41 +194,6 @@ class PreferencesBaseDialog(wx.Dialog):
         Emits signal settingsChanged.
         """
         if self._updateSettings():
-            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
-            if lang == "system":
-                # Most fool proof way to use system locale is to not provide
-                # any locale info at all
-                self.settings.Set(
-                    group="language", key="locale", subkey="lc_all", value=None
-                )
-                lang = None
-            env = grass.gisenv()
-            nprocs_gisenv = "NPROCS"
-            memorydb_gisenv = "MEMORYMB"
-            # Set gisenv MEMORYMB var value
-            memorymb = self.memorymb.GetValue()
-            if memorymb:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{memorydb_gisenv}={memorymb}",
-                )
-            elif env.get(memorydb_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=memorydb_gisenv,
-                )
-            # Set gisenv NPROCS var value
-            nprocs = self.nprocs.GetValue()
-            if nprocs:
-                grass.run_command(
-                    "g.gisenv",
-                    set=f"{nprocs_gisenv}={nprocs}",
-                )
-            elif env.get(nprocs_gisenv):
-                grass.run_command(
-                    "g.gisenv",
-                    unset=nprocs_gisenv,
-                )
             self.settings.SaveToFile()
             Debug.msg(1, "Settings saved to file '%s'" % self.settings.filePath)
             self.settingsChanged.emit()
@@ -2375,3 +2340,45 @@ class CheckListMapset(ListCtrl, listmix.ListCtrlAutoWidthMixin, CheckListCtrlMix
         mapset = self.parent.all_mapsets_ordered[index]
         if mapset == self.parent.curr_mapset:
             self.CheckItem(index, True)
+
+    def OnSave(self, event):
+        """Button 'Save' pressed
+        Emits signal settingsChanged.
+        """
+        if self._updateSettings():
+            lang = self.settings.Get(group="language", key="locale", subkey="lc_all")
+            if lang == "system":
+                # Most fool proof way to use system locale is to not provide
+                # any locale info at all
+                self.settings.Set(
+                    group="language", key="locale", subkey="lc_all", value=None
+                )
+                lang = None
+            env = grass.gisenv()
+
+            # Set gisenv MEMORYMB var value
+            memorydb_gisenv = "MEMORYMB"
+            memorymb = self.memorymb.GetValue()
+            if memorymb:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{memorydb_gisenv}={memorymb}",
+                )
+            elif env.get(memorydb_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=memorydb_gisenv,
+                )
+            # Set gisenv NPROCS var value
+            nprocs_gisenv = "NPROCS"
+            nprocs = self.nprocs.GetValue()
+            if nprocs:
+                grass.run_command(
+                    "g.gisenv",
+                    set=f"{nprocs_gisenv}={nprocs}",
+                )
+            elif env.get(nprocs_gisenv):
+                grass.run_command(
+                    "g.gisenv",
+                    unset=nprocs_gisenv,
+                )


### PR DESCRIPTION
Currently the Graphical Modeler is using GRASS script API (`grass.script.core.run_command()`) when converting model into Python code. This cannot be changed by the user.

This PR adds support for PyGRASS API (`grass.pygrass.modules.Module`). GRASS script package is still default. This can be changed in the settings.

![image](https://github.com/OSGeo/grass/assets/5683186/df7ff32e-1433-45b8-b59c-a20b7cd3ead5)

Compare sample model:

1) GRASS script package (default):

```py
from grass.script import run_command
...
    run_command("v.rast.stats",
                flags='c',
                map="zipcodes_wake",
                layer="1",
                type="point,line,boundary,centroid,area",
                raster="elevation",
                column_prefix="rst",
                method="average",
                percentile=90)
...
```

2) and PyGRASS:

```py
from grass.pygrass.modules import Module
...
    Module("v.rast.stats",
           flags='c',
           map="zipcodes_wake",
           layer="1",
           type=['point', 'line', 'boundary', 'centroid', 'area'],
           raster="elevation",
           column_prefix="rst",
           method="average",
           percentile=90)
...
```