### PR TITLE
db.execute: fix duplicated word in in docs

### DIFF
--- a/db/db.execute/db.execute.html
+++ b/db/db.execute/db.execute.html
@@ -12,7 +12,7 @@ If parameters for database connection are already set with
 <em><a href="db.connect.html">db.connect</a></em>, they are taken as default
 values and do not need to be specified each time.
 <p>
-If you have a large number of SQL commands to process, it is much much
+If you have a large number of SQL commands to process, it is much
 faster to place all the SQL statements into a text file and
 use <b>input</b> file parameter than it is to process each statement
 individually in a loop. If multiple instruction lines are given, each


### PR DESCRIPTION
Although repeating the word `much` creates an undeniable emphasis on the user, I find its added value purely sentimental and consider it a mistake.