### PR TITLE
SearchModuleWidget: show module description also for first match

### DIFF
--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1250,7 +1250,7 @@ class SearchModuleWidget(wx.Panel):
 
         if self._showTip:
             self._searchTip = StaticWrapText(
-                parent=self, id=wx.ID_ANY, label="Choose a tool", size=(-1, 35)
+                parent=self, id=wx.ID_ANY, label="Choose a tool", size=(-1, 40)
             )
 
         if self._showChoice:
@@ -1315,9 +1315,9 @@ class SearchModuleWidget(wx.Panel):
                 self._searchChoice.SetSelection(0)
                 self.OnSelectModule()
 
-        label = _("%d tools match") % len(commands)
+        label = _("{} tools matched").format(len(commands))
         if self._showTip:
-            self._searchTip.SetLabel(label)
+            self._searchTip.SetLabel(self._searchTip.GetLabel() + " [{}]".format(label))
 
         self.showNotification.emit(message=label)
 
@@ -1347,7 +1347,6 @@ class SearchModuleWidget(wx.Panel):
         """Module selected from choice, update command prompt"""
         cmd = self._searchChoice.GetStringSelection()
         self.moduleSelected.emit(name=cmd)
-
         if self._showTip:
             for module in self._results:
                 if cmd == module.data["command"]:

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1347,6 +1347,7 @@ class SearchModuleWidget(wx.Panel):
         """Module selected from choice, update command prompt"""
         cmd = self._searchChoice.GetStringSelection()
         self.moduleSelected.emit(name=cmd)
+
         if self._showTip:
             for module in self._results:
                 if cmd == module.data["command"]:


### PR DESCRIPTION
# Current behaviour

Module description is not show for first match automatically, only number of matches.

[Screencast from 2024-01-22 15-34-47.webm](https://github.com/OSGeo/grass/assets/5683186/6ae263ee-f158-43cc-8146-de31deecc103)

# New behaviour

Module description shown including number of matches:

[Screencast from 2024-01-22 15-49-14.webm](https://github.com/OSGeo/grass/assets/5683186/308ec121-4147-405f-8b69-d475d6bacd06)
