### PR TITLE
Graphical Modeler: fix UI produced by Python export

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -3120,9 +3120,9 @@ class WritePythonFile(WriteScriptFile):
         # UI
         self.fd.write(
             r"""
-# %module
-# % description: {description}
-# %end
+#% module
+#% description: {description}
+#% end
 """.format(
                 description=" ".join(properties["description"].splitlines())
             )
@@ -3136,23 +3136,23 @@ class WritePythonFile(WriteScriptFile):
                 else:
                     desc = flag["description"]
                 self.fd.write(
-                    r"""# %option
-# % key: {flag_name}
-# % description: {description}
-# % required: yes
-# % type: string
-# % options: True, False
-# % guisection: Flags
+                    r"""#% option
+#% key: {flag_name}
+#% description: {description}
+#% required: yes
+#% type: string
+#% options: True, False
+#% guisection: Flags
 """.format(
                         flag_name=self._getParamName(flag["name"], item),
                         description=desc,
                     )
                 )
                 if flag["value"]:
-                    self.fd.write("# % answer: {}\n".format(flag["value"]))
+                    self.fd.write("#% answer: {}\n".format(flag["value"]))
                 else:
-                    self.fd.write("# % answer: False\n")
-                self.fd.write("# %end\n")
+                    self.fd.write("#% answer: False\n")
+                self.fd.write("#% end\n")
 
             for param in item.GetParameterizedParams()["params"]:
                 if param["label"]:
@@ -3160,26 +3160,26 @@ class WritePythonFile(WriteScriptFile):
                 else:
                     desc = param["description"]
                 self.fd.write(
-                    r"""# %option
-# % key: {param_name}
-# % description: {description}
-# % required: yes
+                    r"""#% option
+#% key: {param_name}
+#% description: {description}
+#% required: yes
 """.format(
                         param_name=self._getParamName(param["name"], item),
                         description=desc,
                     )
                 )
                 if param["type"] != "float":
-                    self.fd.write("# % type: {}\n".format(param["type"]))
+                    self.fd.write("#% type: {}\n".format(param["type"]))
                 else:
-                    self.fd.write("# % type: double\n")
+                    self.fd.write("#% type: double\n")
                 if param["key_desc"]:
-                    self.fd.write("# % key_desc: ")
+                    self.fd.write("#% key_desc: ")
                     self.fd.write(", ".join(param["key_desc"]))
                     self.fd.write("\n")
                 if param["value"]:
-                    self.fd.write("# % answer: {}\n".format(param["value"]))
-                self.fd.write("# %end\n")
+                    self.fd.write("#% answer: {}\n".format(param["value"]))
+                self.fd.write("#% end\n")
 
         # import modules
         self.fd.write(


### PR DESCRIPTION
Python scripts generated by Graphical Modeler (`Python editor -> Save As`) contain broken UI definition. Sample model attached: 
[buffer.gxm.zip](https://github.com/OSGeo/grass/files/14039187/buffer.gxm.zip)


```py
# %module
# % description: Script generated by wxGUI Graphical Modeler.
# %end
...
```

Extra space between `#` and `%` causes that `GConsole` skips interface completely: https://github.com/OSGeo/grass/blob/main/gui/wxpython/core/gconsole.py#L641

[Screencast from 2024-01-24 14-37-48.webm](https://github.com/OSGeo/grass/assets/5683186/592a45d2-9da4-4cfa-a118-448a6e7e9a84)

The PR fixes this bug:

[Screencast from 2024-01-24 14-45-45.webm](https://github.com/OSGeo/grass/assets/5683186/70512ee8-2036-4c56-93f2-5e943988fbf4)

