### PR TITLE
python: Remove Python 2-only `-t` CLI flag in makefile

### DIFF
--- a/include/Make/Python.make
+++ b/include/Make/Python.make
@@ -2,4 +2,4 @@
 PY_SOURCES := $(wildcard *.py)
 
 %.pyc: %.py
-	$(PYTHON) -t -m py_compile $<
+	$(PYTHON) -m py_compile $<


### PR DESCRIPTION
`-t` was used in Python 2 to warn if a file was mixing spaces and tabs such as a valid syntax would depend on the number of spaces a tab is worth. It doesn’t exist anymore since Python 3.0

https://docs.python.org/2.7/using/cmdline.html#cmdoption-t
https://docs.python.org/3/using/cmdline.html
https://docs.python.org/3.0/using/cmdline.html

