### PR TITLE
libgis: allow bypass of compatibility test

### DIFF
--- a/lib/gis/gisinit.c
+++ b/lib/gis/gisinit.c
@@ -50,12 +50,27 @@ void G__gisinit(const char *version, const char *pgm)
     G_set_program_name(pgm);
 
     /* verify version of GRASS headers (and anything else in include) */
-    if (strcmp(version, GIS_H_VERSION) != 0)
-        G_fatal_error(_("Module built against version %s but "
+    if (strcmp(version, GIS_H_VERSION) != 0) {
+        char *envstr;
+        char *answer = "0";
+
+        envstr = getenv("GRASS_COMPATIBILITY_TEST");
+        if (envstr && *envstr && strcmp(envstr, answer) == 0) {
+            G_warning(_("Module built against version %s but "
                         "trying to use version %s. "
-                        "You need to rebuild GRASS GIS or untangle multiple "
-                        "installations."),
-                      version, GIS_H_VERSION);
+                        "In case of errors you need to rebuild the module "
+                        "against GRASS GIS version %s."),
+                      version, GIS_H_VERSION, GRASS_VERSION_STRING);
+        }
+        else {
+            G_fatal_error(
+                _("Module built against version %s but "
+                  "trying to use version %s. "
+                  "You need to rebuild GRASS GIS or untangle multiple "
+                  "installations."),
+                version, GIS_H_VERSION);
+        }
+    }
 
     /* Make sure location and mapset are set */
     G_location_path();
@@ -86,12 +101,27 @@ void G__no_gisinit(const char *version)
         return;
 
     /* verify version of GRASS headers (and anything else in include) */
-    if (strcmp(version, GIS_H_VERSION) != 0)
-        G_fatal_error(_("Module built against version %s but "
+    if (strcmp(version, GIS_H_VERSION) != 0) {
+        char *envstr;
+        char *answer = "0";
+
+        envstr = getenv("GRASS_COMPATIBILITY_TEST");
+        if (envstr && *envstr && strcmp(envstr, answer) == 0) {
+            G_warning(_("Module built against version %s but "
                         "trying to use version %s. "
-                        "You need to rebuild GRASS GIS or untangle multiple "
-                        "installations."),
-                      version, GIS_H_VERSION);
+                        "In case of errors you need to rebuild the module "
+                        "against GRASS GIS version %s."),
+                      version, GIS_H_VERSION, GRASS_VERSION_STRING);
+        }
+        else {
+            G_fatal_error(
+                _("Module built against version %s but "
+                  "trying to use version %s. "
+                  "You need to rebuild GRASS GIS or untangle multiple "
+                  "installations."),
+                version, GIS_H_VERSION);
+        }
+    }
     gisinit();
 }
 


### PR DESCRIPTION
The compatibility test for C modules in https://github.com/OSGeo/grass/blob/main/lib/gis/gisinit.c is stricter than it needs to be, because GRASS has versioned shared libraries including major and minor version. That means, a C module compiled against an older version will not run simply because it will not find the old shared libraries.

With a bugfix release, binary compatibility is preserved and the test is not needed. This PR introduces a mechanism to bypass the shared libs compatibility test if the env var `GRASS_COMPATIBILITY_TEST` is set to 0 (zero). In this case a warning is issued and the module is allowed to execute. If this new env var is not set, the default behaviour with fatal error in case of different `GIS_H_VERSION`s is preserved.

The motivation for this new mechanism is that for many users it might not be easy to reinstall or recompile addons written in C for each new bugfix release.