### PR TITLE
CI: Split Ubuntu tests into jobs to reduce each job's execution time

### DIFF
--- a/.github/workflows/test_thorough.sh
+++ b/.github/workflows/test_thorough.sh
@@ -9,4 +9,4 @@ grass --tmp-location XY --exec \
 grass --tmp-location XY --exec \
     python3 -m grass.gunittest.main \
     --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
-    --min-success 100
+    --min-success 100 $@

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - releasebranch_*
+      - '*'
 
 jobs:
   ubuntu:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,16 +16,38 @@ on:
 
 jobs:
   ubuntu:
-    name: ${{ matrix.name }} tests
-
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
-        matrix.name }}
+        matrix.name }}-${{ matrix.os }}-${{ matrix.extra-include }}
       cancel-in-progress: true
 
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        name:
+          - "22.04"
+          - minimum config
+
+        # Only run tests for these folders in this matrix job.
+        extra-include:
+          # All root folders that could contain tests are:
+          #   db display doc docker general gui
+          #   imagery lib misc ps python raster raster3d scripts
+          #   temporal testsuite utils vector visualization
+          #
+          # In order to split test executions, all these root folders are
+          # added as excluded folders, then items included for this matrix
+          # job are removed from that exclusion list.
+          #
+          # Using folded YAML multiline string block chomping (>-) to replace
+          # newlines with spaces, and strip newline at end.
+          # See https://yaml-multiline.info/
+          - temporal
+          - >-
+            db display doc docker general gui
+            imagery lib misc ps python raster raster3d scripts
+            testsuite utils vector visualization
+
         include:
           - name: "22.04"
             os: ubuntu-22.04
@@ -40,6 +62,44 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Invert inclusion list to an exclusion list
+        id: get-exclude
+        run: |
+          array=(db display doc docker general gui \
+          imagery lib misc ps python raster raster3d scripts \
+          temporal testsuite utils vector visualization)
+          echo "Complete set of folders that can be included:"
+          echo "${array[@]}"
+          delete=( ${{ env.DELETE_ARRAY }} )
+          echo "Included folders to remove from the complete set:"
+          echo "${delete[@]}"
+          for target in "${delete[@]}"; do
+            for i in "${!array[@]}"; do
+              if [[ ${array[i]} = $target ]]; then
+                unset 'array[i]'
+              fi
+            done
+          done
+          unset new_array
+          for i in "${!array[@]}"; do
+              new_array+=( "${array[i]}" )
+          done
+          echo "Excluded folders:"
+          echo "${new_array[@]}"
+          printf -v extra_exclude './%s/* ' "${new_array[@]}"
+          echo "Exclusion string to add to gunittest config"
+          echo "${extra_exclude}"
+          echo "extra-exclude=${extra_exclude}" >> "${GITHUB_OUTPUT}"
+        env:
+          DELETE_ARRAY: ${{ matrix.extra-include }}
+
+      - name: Add extra exclusions to a gunittest config file
+        run: |
+          sed 's:exclude =:exclude = ${{ 
+            steps.get-exclude.outputs.extra-exclude
+          }}:g' .gunittest.cfg > .gunittest.extra.cfg
+          cat .gunittest.extra.cfg
 
       - name: Get dependencies
         run: |
@@ -87,13 +147,13 @@ jobs:
         run: .github/workflows/test_simple.sh
 
       - name: Run tests
-        run: .github/workflows/test_thorough.sh
+        run: .github/workflows/test_thorough.sh --config .gunittest.extra.cfg
 
       - name: Make HTML test report available
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: testreport-${{ matrix.config }}
+          name: testreport-${{ matrix.os }}-${{ matrix.config }}-${{ matrix.extra-include }}
           path: testreport
           retention-days: 3
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -78,6 +78,10 @@ jobs:
         run: |
           echo "$HOME/install/bin" >> $GITHUB_PATH
 
+      - name: Print installed versions
+        if: always()
+        run: .github/workflows/print_versions.sh
+
       - name: Test executing of the grass command
         run: .github/workflows/test_simple.sh
 
@@ -92,9 +96,6 @@ jobs:
           path: testreport
           retention-days: 3
 
-      - name: Print installed versions
-        if: always()
-        run: .github/workflows/print_versions.sh
   build-and-test-success:
     name: Build & Test Result
     needs:


### PR DESCRIPTION
This **cuts CI time in half** for Ubuntu jobs.

Unit tests in the temporal folder take a little bit more time than the tests in all other folders. So this split of two jobs is the fairest.

I extracted my changes from a bigger set of changes to have it easier to review.

Splitting this way costs an overhead of about 5 minutes to build, but saves more than 30 minutes in the test step.
I tried using only one common build and using `make bindist` like the linux builds that can be downloaded, but once installed, extensions cannot be compiled properly, since the makefiles assume a dist.x86_64-pc-linux-gnu folder that doesn't exist, thus failing tests that compile addons.