### PR TITLE
CI: Downgrade pytest for pylint job to allow time to fix breaking changes in pytest 8

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -115,11 +115,12 @@ jobs:
 
       - name: Run Pylint on other files using pytest
         run: |
-          pip install pytest pytest-pylint==0.19
+          pip install pytest==7.4.4 pytest-pylint==0.19
           echo "::warning file=.github/workflows/python-code-quality.yml,line=116,col=42,endColumn=48::\
-            Temporarily downgraded pytest-pylint to allow merging other PRs. The errors reported\
-            with a newer version seem legitimite and should be fixed (2023-10-18,\
-            see https://github.com/OSGeo/grass/pull/3205)"
+            Temporarily downgraded pytest-pylint and pytest to allow merging other PRs.\
+            The errors reported with a newer version seem legitimite and should be fixed \
+            (2023-10-18, see https://github.com/OSGeo/grass/pull/3205)\
+            (2024-01-28, see https://github.com/OSGeo/grass/issues/3380)"
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
           pytest --pylint -m pylint --pylint-rcfile=.pylintrc --pylint-jobs=$(nproc) \


### PR DESCRIPTION
Contributes to #3380

HIGH PRIORITY FIX to not fail every job that will run python code quality and fail.

It pins pytest to 7.4.4, the latest release before 8.