### PR TITLE
db.connect: update GRASS version defaults in docs

### DIFF
--- a/db/db.connect/db.connect.html
+++ b/db/db.connect/db.connect.html
@@ -4,8 +4,8 @@
 These parameters are then taken as default values by modules so that the
 user does not need to enter the parameters each time.
 <p>
-The default database backend in GRASS GIS 7
-is <a href="grass-sqlite.html">SQLite</a>.
+The default database backend in GRASS GIS
+is <a href="grass-sqlite.html">SQLite</a> (since version 7).
 
 <h2>NOTES</h2>
 


### PR DESCRIPTION
it used to say that SQLite is default in GRASS GIS 7, but it is default in any version since GRASS GIS 7