### PR TITLE
v.in.ogr: fix bug from PR #3282

### DIFF
--- a/vector/v.in.ogr/geom.c
+++ b/vector/v.in.ogr/geom.c
@@ -419,7 +419,7 @@ int geom(OGRGeometryH hGeomAny, struct Map_info *Map, int field, int cat,
                 }
                 Vect_line_prune(IPoints[valid_isles]);
 
-                lastidx = Points->n_points - 1;
+                lastidx = IPoints[valid_isles]->n_points - 1;
                 if (IPoints[valid_isles]->x[0] !=
                         IPoints[valid_isles]->x[lastidx] ||
                     IPoints[valid_isles]->y[0] !=


### PR DESCRIPTION
The PR #3282 introduced a mostly harmless bug where incorrect warnings `WARNING: Closing unclosed inner polygon ring` are issued. Vector import succeeds anyway. This PR fixes this bug. 