### PR TITLE
v.to.db: add h-flag to write header

### DIFF
--- a/vector/v.to.db/global.h
+++ b/vector/v.to.db/global.h
@@ -26,9 +26,10 @@ struct options {
     char *qcol;
     int type;
     int option;
-    int print; /* print only */
-    int sql;   /* print only sql statements */
-    int total; /* print totals */
+    int print;        /* print only */
+    int print_header; /* print only */
+    int sql;          /* print only sql statements */
+    int total;        /* print totals */
     int units;
     int qfield; /* query field */
     char *fs;

--- a/vector/v.to.db/global.h
+++ b/vector/v.to.db/global.h
@@ -27,7 +27,7 @@ struct options {
     int type;
     int option;
     int print;        /* print only */
-    int print_header; /* print only */
+    int print_header; /* print header for print and total */
     int sql;          /* print only sql statements */
     int total;        /* print totals */
     int units;

--- a/vector/v.to.db/parse.c
+++ b/vector/v.to.db/parse.c
@@ -126,8 +126,7 @@ int parse_command_line(int argc, char *argv[])
     flags.h->key = 'h';
     flags.h->description = _("Print header");
     flags.h->guisection = _("Print");
-    flags.h->suppress_required = YES;
-
+    
     flags.s = G_define_flag();
     flags.s->key = 's';
     flags.s->description = _("Only print SQL statements");
@@ -140,6 +139,8 @@ int parse_command_line(int argc, char *argv[])
     flags.t->guisection = _("Print");
     flags.t->suppress_required = YES;
 
+    G_option_requires(flags.h, flags.p, flags.t, NULL);
+    
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 

--- a/vector/v.to.db/parse.c
+++ b/vector/v.to.db/parse.c
@@ -24,7 +24,7 @@ int parse_command_line(int argc, char *argv[])
         struct Option *fs;
     } parms;
     struct {
-        struct Flag *p, *s, *t;
+        struct Flag *h, *p, *s, *t;
     } flags;
     char *desc;
 
@@ -122,6 +122,12 @@ int parse_command_line(int argc, char *argv[])
     flags.p->guisection = _("Print");
     flags.p->suppress_required = YES;
 
+    flags.h = G_define_flag();
+    flags.h->key = 'h';
+    flags.h->description = _("Print header");
+    flags.h->guisection = _("Print");
+    flags.h->suppress_required = YES;
+
     flags.s = G_define_flag();
     flags.s->key = 's';
     flags.s->description = _("Only print SQL statements");
@@ -146,6 +152,7 @@ int parse_command_line(int argc, char *argv[])
                       parms.option->key, parms.option->description);
 
     options.print = flags.p->answer;
+    options.print_header = flags.h->answer;
     options.sql = flags.s->answer;
     options.total = flags.t->answer;
 

--- a/vector/v.to.db/parse.c
+++ b/vector/v.to.db/parse.c
@@ -126,7 +126,7 @@ int parse_command_line(int argc, char *argv[])
     flags.h->key = 'h';
     flags.h->description = _("Print header");
     flags.h->guisection = _("Print");
-    
+
     flags.s = G_define_flag();
     flags.s->key = 's';
     flags.s->description = _("Only print SQL statements");
@@ -140,7 +140,7 @@ int parse_command_line(int argc, char *argv[])
     flags.t->suppress_required = YES;
 
     G_option_requires(flags.h, flags.p, flags.t, NULL);
-    
+
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 

--- a/vector/v.to.db/report.c
+++ b/vector/v.to.db/report.c
@@ -17,7 +17,7 @@ int report(void)
 
     switch (options.option) {
     case O_CAT:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat\n");
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d\n", Values[i].cat);
@@ -25,7 +25,7 @@ int report(void)
 
     case O_COUNT:
         if (options.print) {
-            if (G_verbose() > G_verbose_min())
+            if (G_verbose() > G_verbose_min() || options.print_header)
                 fprintf(stdout, "cat%scount\n", options.fs);
             for (i = 0; i < vstat.rcat; i++)
                 fprintf(stdout, "%d%s%d\n", Values[i].cat, options.fs,
@@ -43,7 +43,7 @@ int report(void)
 
     case O_AREA:
         if (options.print) {
-            if (G_verbose() > G_verbose_min())
+            if (G_verbose() > G_verbose_min() || options.print_header)
                 fprintf(stdout, "cat%sarea\n", options.fs);
             for (i = 0; i < vstat.rcat; i++)
                 fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -62,7 +62,7 @@ int report(void)
     case O_COMPACT:
         /* perimeter / perimeter of equivalent circle
          *   perimeter of equivalent circle: 2.0 * sqrt(M_PI * area) */
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%scompact\n", options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             Values[i].d1 = Values[i].d2 / (2.0 * sqrt(M_PI * Values[i].d1));
@@ -82,7 +82,7 @@ int report(void)
          *
          * avoid division by zero:
          * 2.0 * log(1 + perimeter) / log(1 + area) */
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sfd\n", options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             if (Values[i].d1 == 1) /* log(1) == 0 */
@@ -94,7 +94,7 @@ int report(void)
         break;
 
     case O_PERIMETER:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sperimeter\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -102,7 +102,7 @@ int report(void)
         break;
 
     case O_BBOX:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sN%sS%sE%sW\n", options.fs, options.fs,
                     options.fs, options.fs);
         for (i = 0; i < vstat.rcat; i++) {
@@ -114,7 +114,7 @@ int report(void)
 
     case O_LENGTH:
         if (options.print) {
-            if (G_verbose() > G_verbose_min())
+            if (G_verbose() > G_verbose_min() || options.print_header)
                 fprintf(stdout, "cat%slength\n", options.fs);
             for (i = 0; i < vstat.rcat; i++)
                 fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -130,7 +130,7 @@ int report(void)
         }
         break;
     case O_SLOPE:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sslope\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -138,7 +138,7 @@ int report(void)
 
         break;
     case O_SINUOUS:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%ssinuous\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -147,7 +147,7 @@ int report(void)
     case O_COOR:
     case O_START:
     case O_END:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sx%sy%sz\n", options.fs, options.fs,
                     options.fs);
         for (i = 0; i < vstat.rcat; i++) {
@@ -159,7 +159,7 @@ int report(void)
         break;
 
     case O_SIDES:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sleft%sright\n", options.fs, options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             if (Values[i].count1 == 1) {
@@ -197,7 +197,7 @@ int report(void)
         break;
 
     case O_QUERY:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%squery\n", options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             if (Values[i].null) {
@@ -222,7 +222,7 @@ int report(void)
         }
         break;
     case O_AZIMUTH:
-        if (G_verbose() > G_verbose_min())
+        if (G_verbose() > G_verbose_min() || options.print_header)
             fprintf(stdout, "cat%sazimuth\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,

--- a/vector/v.to.db/report.c
+++ b/vector/v.to.db/report.c
@@ -5,7 +5,7 @@
 
 int report(void)
 {
-    int i;
+    int i, print_header = G_verbose() > G_verbose_min() || options.print_header;
     char left[20], right[20];
 
     if (!options.print &&
@@ -17,7 +17,7 @@ int report(void)
 
     switch (options.option) {
     case O_CAT:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat\n");
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d\n", Values[i].cat);
@@ -25,7 +25,7 @@ int report(void)
 
     case O_COUNT:
         if (options.print) {
-            if (G_verbose() > G_verbose_min() || options.print_header)
+            if (print_header)
                 fprintf(stdout, "cat%scount\n", options.fs);
             for (i = 0; i < vstat.rcat; i++)
                 fprintf(stdout, "%d%s%d\n", Values[i].cat, options.fs,
@@ -43,7 +43,7 @@ int report(void)
 
     case O_AREA:
         if (options.print) {
-            if (G_verbose() > G_verbose_min() || options.print_header)
+            if (print_header)
                 fprintf(stdout, "cat%sarea\n", options.fs);
             for (i = 0; i < vstat.rcat; i++)
                 fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -62,7 +62,7 @@ int report(void)
     case O_COMPACT:
         /* perimeter / perimeter of equivalent circle
          *   perimeter of equivalent circle: 2.0 * sqrt(M_PI * area) */
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%scompact\n", options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             Values[i].d1 = Values[i].d2 / (2.0 * sqrt(M_PI * Values[i].d1));
@@ -82,7 +82,7 @@ int report(void)
          *
          * avoid division by zero:
          * 2.0 * log(1 + perimeter) / log(1 + area) */
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sfd\n", options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             if (Values[i].d1 == 1) /* log(1) == 0 */
@@ -94,7 +94,7 @@ int report(void)
         break;
 
     case O_PERIMETER:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sperimeter\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -102,7 +102,7 @@ int report(void)
         break;
 
     case O_BBOX:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sN%sS%sE%sW\n", options.fs, options.fs,
                     options.fs, options.fs);
         for (i = 0; i < vstat.rcat; i++) {
@@ -114,7 +114,7 @@ int report(void)
 
     case O_LENGTH:
         if (options.print) {
-            if (G_verbose() > G_verbose_min() || options.print_header)
+            if (print_header)
                 fprintf(stdout, "cat%slength\n", options.fs);
             for (i = 0; i < vstat.rcat; i++)
                 fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -130,7 +130,7 @@ int report(void)
         }
         break;
     case O_SLOPE:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sslope\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -138,7 +138,7 @@ int report(void)
 
         break;
     case O_SINUOUS:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%ssinuous\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,
@@ -147,7 +147,7 @@ int report(void)
     case O_COOR:
     case O_START:
     case O_END:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sx%sy%sz\n", options.fs, options.fs,
                     options.fs);
         for (i = 0; i < vstat.rcat; i++) {
@@ -159,7 +159,7 @@ int report(void)
         break;
 
     case O_SIDES:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sleft%sright\n", options.fs, options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             if (Values[i].count1 == 1) {
@@ -197,7 +197,7 @@ int report(void)
         break;
 
     case O_QUERY:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%squery\n", options.fs);
         for (i = 0; i < vstat.rcat; i++) {
             if (Values[i].null) {
@@ -222,7 +222,7 @@ int report(void)
         }
         break;
     case O_AZIMUTH:
-        if (G_verbose() > G_verbose_min() || options.print_header)
+        if (print_header)
             fprintf(stdout, "cat%sazimuth\n", options.fs);
         for (i = 0; i < vstat.rcat; i++)
             fprintf(stdout, "%d%s%.15g\n", Values[i].cat, options.fs,


### PR DESCRIPTION
v.to.db currently prints column headers only when verbosity level is above _quiet_. Other tools (e.g. _v.db.select_ have a specific flag to print column headers in output. v.to.db should use the same approach, as verbosity level should control user messages, and not the actual data output.

This PR adds a `h-flag` for printing a header. Current behavior is unaltered otherwise.