### PR TITLE
wxGUI/history: Move Export History button to history pane

### DIFF
--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -194,13 +194,13 @@ class GConsoleWindow(wx.SplitterWindow):
             promptSizer.Add(helpText, proportion=0, flag=wx.EXPAND | wx.LEFT, border=5)
 
             btnSizer = wx.BoxSizer(wx.HORIZONTAL)
+            btnSizer.AddStretchSpacer()
             btnSizer.Add(
                 self.btnOutputSave,
                 proportion=0,
                 flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
                 border=5,
             )
-            btnSizer.AddStretchSpacer()
             btnSizer.Add(self.btnClear, proportion=0, flag=wx.EXPAND, border=5)
             promptSizer.Add(btnSizer, proportion=0, flag=wx.ALL | wx.EXPAND, border=5)
 

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -29,7 +29,6 @@ from grass.pydispatch.signal import Signal
 from grass.grassdb.history import (
     read_history,
     create_history_file,
-    copy_history,
     get_current_mapset_gui_history_path,
 )
 
@@ -164,19 +163,10 @@ class GConsoleWindow(wx.SplitterWindow):
         self.btnOutputSave.SetToolTip(_("Save output to a file"))
         self.btnCmdAbort = Button(parent=self.panelProgress, id=wx.ID_STOP)
         self.btnCmdAbort.SetToolTip(_("Abort running command"))
-        self.btnCmdExportHistory = Button(parent=self.panelPrompt, id=wx.ID_ANY)
-        self.btnCmdExportHistory.SetLabel(_("&Export history"))
-        self.btnCmdExportHistory.SetToolTip(
-            _("Export history of executed commands to a file")
-        )
-
-        if not self._gcstyle & GC_PROMPT:
-            self.btnCmdExportHistory.Hide()
 
         self.btnClear.Bind(wx.EVT_BUTTON, self.OnClear)
         self.btnOutputSave.Bind(wx.EVT_BUTTON, self.OnOutputSave)
         self.btnCmdAbort.Bind(wx.EVT_BUTTON, self._gconsole.OnCmdAbort)
-        self.btnCmdExportHistory.Bind(wx.EVT_BUTTON, self.OnCmdExportHistory)
 
         self._layout()
 
@@ -206,12 +196,6 @@ class GConsoleWindow(wx.SplitterWindow):
             btnSizer = wx.BoxSizer(wx.HORIZONTAL)
             btnSizer.Add(
                 self.btnOutputSave,
-                proportion=0,
-                flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
-                border=5,
-            )
-            btnSizer.Add(
-                self.btnCmdExportHistory,
                 proportion=0,
                 flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
                 border=5,
@@ -447,33 +431,6 @@ class GConsoleWindow(wx.SplitterWindow):
     def OnCmdProgress(self, event):
         """Update progress message info"""
         self.progressbar.SetValue(event.value)
-        event.Skip()
-
-    def OnCmdExportHistory(self, event):
-        """Export the history of executed commands stored
-        in a .wxgui_history file to a selected file."""
-        dlg = wx.FileDialog(
-            self,
-            message=_("Save file as..."),
-            defaultFile="grass_cmd_log.txt",
-            wildcard=_("{txt} (*.txt)|*.txt|{files} (*)|*").format(
-                txt=_("Text files"), files=_("Files")
-            ),
-            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
-        )
-
-        if dlg.ShowModal() == wx.ID_OK:
-            path = dlg.GetPath()
-            history_path = get_current_mapset_gui_history_path()
-            try:
-                copy_history(path, history_path)
-                self.showNotification.emit(
-                    message=_("Command history saved to '{}'".format(path))
-                )
-            except OSError as e:
-                GError(str(e))
-
-        dlg.Destroy()
         event.Skip()
 
     def OnCmdRun(self, event):

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -89,13 +89,13 @@ class HistoryBrowser(wx.Panel):
             border=5,
         )
         btnSizer = wx.BoxSizer(wx.HORIZONTAL)
+        btnSizer.AddStretchSpacer()
         btnSizer.Add(
             self.btnCmdExportHistory,
             proportion=0,
             flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
             border=5,
         )
-        btnSizer.AddStretchSpacer()
         sizer.Add(
             self.tree, proportion=1, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5
         )

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -19,10 +19,16 @@ for details.
 
 import wx
 
-from gui_core.wrap import SearchCtrl
+from gui_core.wrap import SearchCtrl, Button
 from history.tree import HistoryBrowserTree
 
 from grass.pydispatch.signal import Signal
+from grass.grassdb.history import (
+    copy_history,
+    get_current_mapset_gui_history_path,
+)
+
+from core.gcmd import GError
 
 
 class HistoryBrowser(wx.Panel):
@@ -57,6 +63,14 @@ class HistoryBrowser(wx.Panel):
         self.search.Bind(wx.EVT_TEXT, lambda evt: self.tree.Filter(evt.GetString()))
         self.search.Bind(wx.EVT_SEARCHCTRL_CANCEL_BTN, lambda evt: self.tree.Filter(""))
 
+        # buttons
+        self.btnCmdExportHistory = Button(parent=self, id=wx.ID_ANY)
+        self.btnCmdExportHistory.SetLabel(_("&Export history"))
+        self.btnCmdExportHistory.SetToolTip(
+            _("Export history of executed commands to a file")
+        )
+        self.btnCmdExportHistory.Bind(wx.EVT_BUTTON, self.OnCmdExportHistory)
+
         # tree with layers
         self.tree = HistoryBrowserTree(self, giface=giface)
         self.tree.SetToolTip(_("Double-click to run selected tool"))
@@ -68,12 +82,11 @@ class HistoryBrowser(wx.Panel):
     def _layout(self):
         """Dialog layout"""
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(
-            self.search,
-            proportion=0,
-            flag=wx.ALL | wx.EXPAND,
-            border=5,
-        )
+        searchSizer = wx.BoxSizer(wx.HORIZONTAL)
+        searchSizer.Add(self.search, proportion=1, flag=wx.EXPAND | wx.RIGHT, border=5)
+        searchSizer.Add(self.btnCmdExportHistory, proportion=0, flag=wx.EXPAND)
+
+        sizer.Add(searchSizer, proportion=0, flag=wx.EXPAND | wx.ALL, border=5)
         sizer.Add(
             self.tree, proportion=1, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5
         )
@@ -81,3 +94,30 @@ class HistoryBrowser(wx.Panel):
         self.SetSizerAndFit(sizer)
         self.SetAutoLayout(True)
         self.Layout()
+
+    def OnCmdExportHistory(self, event):
+        """Export the history of executed commands stored
+        in a .wxgui_history file to a selected file."""
+        dlg = wx.FileDialog(
+            self,
+            message=_("Save file as..."),
+            defaultFile="grass_cmd_log.txt",
+            wildcard=_("{txt} (*.txt)|*.txt|{files} (*)|*").format(
+                txt=_("Text files"), files=_("Files")
+            ),
+            style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+        )
+
+        if dlg.ShowModal() == wx.ID_OK:
+            path = dlg.GetPath()
+            history_path = get_current_mapset_gui_history_path()
+            try:
+                copy_history(path, history_path)
+                self.showNotification.emit(
+                    message=_("Command history saved to '{}'".format(path))
+                )
+            except OSError as e:
+                GError(str(e))
+
+        dlg.Destroy()
+        event.Skip()

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -82,14 +82,24 @@ class HistoryBrowser(wx.Panel):
     def _layout(self):
         """Dialog layout"""
         sizer = wx.BoxSizer(wx.VERTICAL)
-        searchSizer = wx.BoxSizer(wx.HORIZONTAL)
-        searchSizer.Add(self.search, proportion=1, flag=wx.EXPAND | wx.RIGHT, border=5)
-        searchSizer.Add(self.btnCmdExportHistory, proportion=0, flag=wx.EXPAND)
-
-        sizer.Add(searchSizer, proportion=0, flag=wx.EXPAND | wx.ALL, border=5)
+        sizer.Add(
+            self.search,
+            proportion=0,
+            flag=wx.ALL | wx.EXPAND,
+            border=5,
+        )
+        btnSizer = wx.BoxSizer(wx.HORIZONTAL)
+        btnSizer.Add(
+            self.btnCmdExportHistory,
+            proportion=0,
+            flag=wx.EXPAND | wx.LEFT | wx.RIGHT,
+            border=5,
+        )
+        btnSizer.AddStretchSpacer()
         sizer.Add(
             self.tree, proportion=1, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5
         )
+        sizer.Add(btnSizer, proportion=0, flag=wx.EXPAND | wx.ALL, border=5)
 
         self.SetSizerAndFit(sizer)
         self.SetAutoLayout(True)


### PR DESCRIPTION
This PR relocates the Export History button placed at the bottom of the Console pane to the History pane at the top.

Before:
![Screenshot from 2024-02-04 20-05-23](https://github.com/OSGeo/grass/assets/49241681/25fdeea3-1099-4b65-8f12-5ad62c6ecade)


After:
![Screenshot from 2024-02-04 20-02-08](https://github.com/OSGeo/grass/assets/49241681/02f502ec-1c3c-40e7-b680-07770f93e190)

