### PR TITLE
r.horizon: use absolute value for angles < GRASS_EPSILON

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -718,7 +718,7 @@ int max(int arg1, int arg2)
 
 /**********************************************************/
 
-void com_par()
+void com_par(void)
 {
     if (fabs(sinangle) < 0.0000001) {
         sinangle = 0.;
@@ -844,6 +844,8 @@ void calculate_shadow(void)
             shadow_angle *= rad2deg;
         }
         printangle = angle * rad2deg - 90.;
+        if (fabs(printangle) < GRASS_EPSILON)
+            printangle = fabs(printangle);
         if (printangle < 0.)
             printangle += 360;
         else if (printangle >= 360.)

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -790,6 +790,7 @@ void calculate_shadow(void)
     yp = ymin + yy0;
 
     angle = (single_direction * deg2rad) + pihalf;
+    printangle = single_direction;
 
     maxlength = fixedMaxLength;
     fprintf(fp, "azimuth,horizon_height\n");
@@ -843,13 +844,6 @@ void calculate_shadow(void)
         if (degreeOutput) {
             shadow_angle *= rad2deg;
         }
-        printangle = angle * rad2deg - 90.;
-        if (fabs(printangle) < GRASS_EPSILON)
-            printangle = fabs(printangle);
-        if (printangle < 0.)
-            printangle += 360;
-        else if (printangle >= 360.)
-            printangle -= 360;
 
         if (compassOutput) {
             double tmpangle;
@@ -864,11 +858,17 @@ void calculate_shadow(void)
         }
 
         angle += dfr_rad;
+        printangle += step;
 
         if (angle < 0.)
             angle += twopi;
         else if (angle > twopi)
             angle -= twopi;
+
+        if (printangle < 0.)
+            printangle += 360;
+        else if (printangle > 360.)
+            printangle -= 360;
     } /* end of for loop over angles */
 }
 

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -790,6 +790,7 @@ void calculate_shadow(void)
     yp = ymin + yy0;
 
     angle = (single_direction * deg2rad) + pihalf;
+    printangle = single_direction;
 
     maxlength = fixedMaxLength;
     fprintf(fp, "azimuth,horizon_height\n");
@@ -843,9 +844,6 @@ void calculate_shadow(void)
         if (degreeOutput) {
             shadow_angle *= rad2deg;
         }
-        printangle = angle * rad2deg - 90.;
-        if (fabs(printangle) < GRASS_EPSILON)
-            printangle = fabs(printangle);
         if (printangle < 0.)
             printangle += 360;
         else if (printangle >= 360.)
@@ -864,6 +862,7 @@ void calculate_shadow(void)
         }
 
         angle += dfr_rad;
+        printangle += step;
 
         if (angle < 0.)
             angle += twopi;

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -790,7 +790,6 @@ void calculate_shadow(void)
     yp = ymin + yy0;
 
     angle = (single_direction * deg2rad) + pihalf;
-    printangle = single_direction;
 
     maxlength = fixedMaxLength;
     fprintf(fp, "azimuth,horizon_height\n");
@@ -844,6 +843,9 @@ void calculate_shadow(void)
         if (degreeOutput) {
             shadow_angle *= rad2deg;
         }
+        printangle = angle * rad2deg - 90.;
+        if (fabs(printangle) < GRASS_EPSILON)
+            printangle = fabs(printangle);
         if (printangle < 0.)
             printangle += 360;
         else if (printangle >= 360.)
@@ -862,7 +864,6 @@ void calculate_shadow(void)
         }
 
         angle += dfr_rad;
-        printangle += step;
 
         if (angle < 0.)
             angle += twopi;


### PR DESCRIPTION
Use absolute value for r.horizon print angles < GRASS_EPSILON.

Apple ARM processor results :

https://github.com/OSGeo/grass/blob/76c1ac531f69c80f88de127fb38819123e9e4784/raster/r.horizon/main.c#L846


with a `printangle == -0.`  to which is added 360 in the next lines:

https://github.com/OSGeo/grass/blob/76c1ac531f69c80f88de127fb38819123e9e4784/raster/r.horizon/main.c#L847-L848

Closes  #3397