### PR TITLE
r.horizon: address incorrect number of rasters created

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -1115,7 +1115,9 @@ void calculate(double xcoord, double ycoord, int buffer_e, int buffer_w,
         }
         else {
             dfr_rad = step * deg2rad;
-            arrayNumInt = (int)((end - start) / fabs(step));
+            arrayNumInt = 0;
+            for (double tmp = 0; tmp < end - start; tmp += fabs(step))
+                ++arrayNumInt;
         }
 
         decimals = G_get_num_decimals(str_step);

--- a/raster/r.horizon/testsuite/test_r_horizon.py
+++ b/raster/r.horizon/testsuite/test_r_horizon.py
@@ -176,6 +176,7 @@ class TestHorizon(TestCase):
         )
 
     def test_raster_mode_multiple_direction(self):
+        self.runModule("g.region", raster="elevation", res=100)
         module = SimpleModule(
             "r.horizon",
             elevation="elevation",
@@ -193,12 +194,14 @@ class TestHorizon(TestCase):
         self.assertMultiLineEqual(
             first=(
                 "test_horizon_output_from_elevation_010_000\n"
-                "test_horizon_output_from_elevation_025_512"
+                "test_horizon_output_from_elevation_025_512\n"
+                "test_horizon_output_from_elevation_041_024"
             ),
             second=stdout,
         )
 
     def test_raster_mode_multiple_direction_offset(self):
+        self.runModule("g.region", raster="elevation", res=100)
         module = SimpleModule(
             "r.horizon",
             elevation="elevation",
@@ -217,7 +220,8 @@ class TestHorizon(TestCase):
         self.assertMultiLineEqual(
             first=(
                 "test_horizon_output_from_elevation_090_000\n"
-                "test_horizon_output_from_elevation_105_512"
+                "test_horizon_output_from_elevation_105_512\n"
+                "test_horizon_output_from_elevation_121_024"
             ),
             second=stdout,
         )


### PR DESCRIPTION
Fixes #2582.
E.g. for start=0, end=12, step=5, three rasters are now generated (0, 5, 10) and not only 2 (because 12/5 = 2...) as was the case before. 
Documentation is still valid, the interval is [start, end) as described there. Not sure if this should be backported, it is a bugfix, but it could break things (e.g. in QGIS, see the link in #2582).

This also speeds up the test significantly, there was no need to run r.horizon with full resolution if we are checking only the created raster names.


