### PR TITLE
v.clip: do not fail when clip map has no table connected

### DIFF
--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -563,7 +563,8 @@ def main():
         user_aggregate_methods, aggregate_backend, provide_defaults=not result_columns
     )
     if not result_columns:
-        aggregate_columns_exist_or_fatal(input_vector, layer, columns_to_aggregate)
+        if columns_to_aggregate:
+            aggregate_columns_exist_or_fatal(input_vector, layer, columns_to_aggregate)
         columns_to_aggregate, user_aggregate_methods = match_columns_and_methods(
             columns_to_aggregate, user_aggregate_methods
         )


### PR DESCRIPTION
In GRASS 8.4 `v.clip` fails when `clip` map has no table connected. Steps to reproduce in NC location:

```
v.extract input=boundary_county cat=1 output=aoi
v.db.connect aoi -d
v.clip input=geology clip=aoi output=geology_clip --o
```

`v.clip` currently fails with:

```
ERROR: Database connection for map <aoi> is not defined in DB file
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/v.dissolve", line 686, in <module>
    main()
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/v.dissolve", line 566, in main
    aggregate_columns_exist_or_fatal(input_vector, layer, columns_to_aggregate)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/v.dissolve", line 265, in aggregate_columns_exist_or_fatal
    column_names = gs.vector_columns(vector, layer).keys()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/vector.py", line 128, in vector_columns
    s = read_command(
        ^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 532, in read_command
    return handle_errors(returncode, stdout, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 344, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `v.info --q -c map=aoi layer=1` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/v.clip", line 226, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/scripts/v.clip", line 150, in main
    grass.run_command("v.dissolve", input=clip_map, output=temp_clip_map)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 465, in run_command
    return handle_errors(returncode, result=None, args=args, kwargs=kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/etc/python/grass/script/core.py", line 344, in handle_errors
    raise CalledModuleError(module=module, code=code, returncode=returncode)
grass.exceptions.CalledModuleError: Module run `v.dissolve input=aoi output=temp_20535` ended with an error.
The subprocess ended with a non-zero return code: 1. See errors above the traceback or in the error output.
```

It is regression, in GRASS 8.3 `v.clip` module works as expected.