### PR TITLE
NSIS3: fix untgz command

### DIFF
--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -800,7 +800,7 @@ Function DownloadInstallMSRuntime
 		
 	download_ok:	
 	InitPluginsDir
-	untgz::extract "-d" "$TEMP\$ORIGINAL_UNTAR_FOLDER" "-zbz2" "$TEMP\$ARCHIVE_NAME"
+	untgz::extract -d "$TEMP\$ORIGINAL_UNTAR_FOLDER" -zbz2 "$TEMP\$ARCHIVE_NAME"
 	Pop $0
 	StrCmp $0 "success" untar_ok untar_failed
 	
@@ -872,7 +872,7 @@ Function DownloadDataSet
 		
 	download_ok:	
 	InitPluginsDir
-	untgz::extract "-d" "$GIS_DATABASE" "$TEMP\$ARCHIVE_NAME"
+	untgz::extract -d "$GIS_DATABASE" "$TEMP\$ARCHIVE_NAME"
 	Pop $0
 	StrCmp $0 "success" untar_ok untar_failed
 	


### PR DESCRIPTION
After upgrading to NSIS3 on the build server a new problem appear. Installers produced by NSIS version 3.09 (eg. https://grass.osgeo.org/grass83/binary/mswindows/native/WinGRASS-8.3.1-2-Setup.exe or https://wingrass.fsv.cvut.cz/grass84/WinGRASS-8.4.0dev-76c1ac531f-121-Setup.exe) fail to uncompress MSVCRT archive: 

![image](https://github.com/OSGeo/grass/assets/5683186/850ffa49-9796-4512-a6ec-8b8b9c2ce378)

 This PR modifies slightly syntax of `untgz` based on examples found in https://github.com/tpn/nsis-untgz/blob/master/examples/example.nsi.