### PR TITLE
wxGUI/history: New button for setting current computational region based on executed commands

### DIFF
--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -135,6 +135,11 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.sizer_region_settings_grid.SetCols(2)
         self.sizer_region_settings_grid.SetRows(9)
 
+        self.sizer_region_settings_text = wx.BoxSizer(wx.VERTICAL)
+        self.region_settings_box_sizer.Add(
+            self.sizer_region_settings_text, proportion=0, flag=wx.EXPAND, border=5
+        )
+
         self.region_settings_box_sizer.Add(
             self.sizer_region_settings_grid,
             proportion=1,
@@ -143,12 +148,6 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         )
 
         self.sizer_region_settings_grid.AddGrowableCol(1)
-
-        self.sizer_region_settings_text = wx.BoxSizer(wx.VERTICAL)
-        self.region_settings_box_sizer.Add(
-            self.sizer_region_settings_text, proportion=0, flag=wx.EXPAND, border=5
-        )
-
         self.region_settings_box.Hide()
 
     def _general_info_filter(self, key, value):
@@ -244,7 +243,7 @@ class HistoryInfoPanel(SP.ScrolledPanel):
             )
 
             btnSetRegion = Button(parent=self.region_settings_box, id=wx.ID_ANY)
-            btnSetRegion.SetLabel(_("&Set as current region"))
+            btnSetRegion.SetLabel(_("&Set current region to following values"))
             btnSetRegion.SetToolTip(
                 _("Set current computational region to the region of executed command")
             )

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -107,8 +107,8 @@ class HistoryInfoPanel(SP.ScrolledPanel):
     def _initImages(self):
         bmpsize = (16, 16)
         self.icons = {
-            "check": MetaIcon(img="grassdb").GetBitmap(bmpsize),
-            "cross": MetaIcon(img="location").GetBitmap(bmpsize),
+            "check": MetaIcon(img="check").GetBitmap(bmpsize),
+            "cross": MetaIcon(img="check").GetBitmap(bmpsize),
         }
 
     def _createGeneralInfoBox(self):
@@ -145,7 +145,7 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.sizer_region_settings_grid.SetCols(2)
         self.sizer_region_settings_grid.SetRows(9)
 
-        self.sizer_region_settings_match = wx.BoxSizer(wx.VERTICAL)
+        self.sizer_region_settings_match = wx.BoxSizer(wx.HORIZONTAL)
         self.region_settings_box_sizer.Add(
             self.sizer_region_settings_match, proportion=0, flag=wx.EXPAND, border=5
         )
@@ -237,23 +237,14 @@ class HistoryInfoPanel(SP.ScrolledPanel):
 
         self.sizer_region_settings_match.Clear(True)
 
+        status_text = _("Region match")
+
         if self.region_settings != self._get_current_region():
-            status_text = _("Region does not match current region")
             icon = self.icons["cross"]
             button_label = _("Update current region")
         else:
-            status_text = _("Region match current region")
             icon = self.icons["check"]
             button_label = None
-
-        # Sizer for text and icon
-        text_icon_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.sizer_region_settings_match.Add(
-            text_icon_sizer,
-            proportion=0,
-            flag=wx.ALL | wx.EXPAND,
-            border=5,
-        )
 
         # Static text
         textRegionMatch = StaticText(
@@ -261,16 +252,16 @@ class HistoryInfoPanel(SP.ScrolledPanel):
             id=wx.ID_ANY,
             label=status_text,
         )
-        text_icon_sizer.Add(
+        self.sizer_region_settings_match.Add(
             textRegionMatch,
             proportion=0,
             flag=wx.ALL | wx.EXPAND,
-            border=5,
+            border=15,
         )
 
         # Static bitmap for icon
         iconRegionMatch = wx.StaticBitmap(self.region_settings_box, bitmap=icon)
-        text_icon_sizer.Add(
+        self.sizer_region_settings_match.Add(
             iconRegionMatch,
             proportion=0,
             flag=wx.ALL | wx.EXPAND,
@@ -278,19 +269,11 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         )
 
         if button_label:
-            button_sizer = wx.BoxSizer(wx.HORIZONTAL)
-            self.sizer_region_settings_match.Add(
-                button_sizer,
-                proportion=0,
-                flag=wx.ALL | wx.EXPAND,
-                border=5,
-            )
-
             buttonUpdateRegion = wx.Button(self.region_settings_box, label=button_label)
             buttonUpdateRegion.Bind(wx.EVT_BUTTON, self.OnUpdateRegion)
-            button_sizer.Add(
+            self.sizer_region_settings_match.Add(
                 buttonUpdateRegion,
-                proportion=0,
+                proportion=1,
                 flag=wx.ALL | wx.EXPAND,
                 border=5,
             )

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -107,8 +107,8 @@ class HistoryInfoPanel(SP.ScrolledPanel):
     def _initImages(self):
         bmpsize = (16, 16)
         self.icons = {
-            "check": MetaIcon(img="check").GetBitmap(bmpsize),
-            "cross": MetaIcon(img="check").GetBitmap(bmpsize),
+            "check": MetaIcon(img="success").GetBitmap(bmpsize),
+            "cross": MetaIcon(img="cross").GetBitmap(bmpsize),
         }
 
     def _createGeneralInfoBox(self):
@@ -141,14 +141,17 @@ class HistoryInfoPanel(SP.ScrolledPanel):
             self.region_settings_box, wx.VERTICAL
         )
 
+        self.sizer_region_settings_match = wx.BoxSizer(wx.HORIZONTAL)
+        self.region_settings_box_sizer.Add(
+            self.sizer_region_settings_match,
+            proportion=0,
+            flag=wx.ALL | wx.EXPAND,
+            border=5,
+        )
+
         self.sizer_region_settings_grid = wx.GridBagSizer(hgap=0, vgap=0)
         self.sizer_region_settings_grid.SetCols(2)
         self.sizer_region_settings_grid.SetRows(9)
-
-        self.sizer_region_settings_match = wx.BoxSizer(wx.HORIZONTAL)
-        self.region_settings_box_sizer.Add(
-            self.sizer_region_settings_match, proportion=0, flag=wx.EXPAND, border=5
-        )
 
         self.region_settings_box_sizer.Add(
             self.sizer_region_settings_grid,
@@ -237,26 +240,30 @@ class HistoryInfoPanel(SP.ScrolledPanel):
 
         self.sizer_region_settings_match.Clear(True)
 
-        status_text = _("Region match")
+        # Region condition
+        history_region = self.region_settings
+        current_region = self._get_current_region()
+        region_matches = history_region == current_region
 
-        if self.region_settings != self._get_current_region():
-            icon = self.icons["cross"]
-            button_label = _("Update current region")
-        else:
+        # Icon and button according to the condition
+        if region_matches:
             icon = self.icons["check"]
             button_label = None
+        else:
+            icon = self.icons["cross"]
+            button_label = _("Update current region")
 
         # Static text
         textRegionMatch = StaticText(
             parent=self.region_settings_box,
             id=wx.ID_ANY,
-            label=status_text,
+            label=_("Region match"),
         )
         self.sizer_region_settings_match.Add(
             textRegionMatch,
             proportion=0,
-            flag=wx.ALL | wx.EXPAND,
-            border=15,
+            flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            border=10,
         )
 
         # Static bitmap for icon
@@ -264,18 +271,23 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.sizer_region_settings_match.Add(
             iconRegionMatch,
             proportion=0,
-            flag=wx.ALL | wx.EXPAND,
-            border=5,
+            flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            border=10,
         )
 
         if button_label:
-            buttonUpdateRegion = wx.Button(self.region_settings_box, label=button_label)
+            # Button for region update
+            buttonUpdateRegion = Button(self.region_settings_box, id=wx.ID_ANY)
+            buttonUpdateRegion.SetLabel(_("Update current region"))
+            buttonUpdateRegion.SetToolTip(
+                _("Set current computational region to the region of executed command")
+            )
             buttonUpdateRegion.Bind(wx.EVT_BUTTON, self.OnUpdateRegion)
             self.sizer_region_settings_match.Add(
                 buttonUpdateRegion,
                 proportion=1,
-                flag=wx.ALL | wx.EXPAND,
-                border=5,
+                flag=wx.ALIGN_CENTER_VERTICAL,
+                border=10,
             )
 
         self.region_settings_box.Layout()

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -27,7 +27,6 @@ from gui_core.wrap import SearchCtrl, StaticText, StaticBox, Button
 from history.tree import HistoryBrowserTree
 
 import grass.script as gs
-from grass.script.utils import parse_key_val
 
 from grass.grassdb import history
 
@@ -229,21 +228,21 @@ class HistoryInfoPanel(SP.ScrolledPanel):
 
         self.sizer_region_settings_text.Clear(True)
 
-        textSetRegion = StaticText(
-            parent=self.region_settings_box,
-            id=wx.ID_ANY,
-            label=_("Region is same as the current region"),
-        )
-        textSetRegion.Wrap(self.GetSize()[0])
-        self.sizer_region_settings_text.Add(
-            textSetRegion,
-            proportion=1,
-            flag=wx.ALL | wx.EXPAND,
-            border=5,
-        )
-
         if self.region_settings != self._get_current_region():
-            textSetRegion.SetLabel(_("Region is different from the current region"))
+            textSetRegion = StaticText(
+                parent=self.region_settings_box,
+                id=wx.ID_ANY,
+                label=_("Region is different from the current region"),
+            )
+            textSetRegion.Wrap(self.GetSize()[0])
+
+            self.sizer_region_settings_text.Add(
+                textSetRegion,
+                proportion=1,
+                flag=wx.ALL | wx.EXPAND,
+                border=5,
+            )
+
             btnSetRegion = Button(parent=self.region_settings_box, id=wx.ID_ANY)
             btnSetRegion.SetLabel(_("&Set as current region"))
             btnSetRegion.SetToolTip(
@@ -282,12 +281,7 @@ class HistoryInfoPanel(SP.ScrolledPanel):
 
     def _get_current_region(self):
         """Get current computational region settings."""
-        current_region = dict(
-            parse_key_val(gs.read_command("g.region", flags="g"), val_type=float)
-        )
-        for key, value in current_region.items():
-            current_region[key] = int(value) if value.is_integer() else value
-        return current_region
+        return gs.region()
 
     def _get_history_region(self):
         """Get computational region settings of executed command."""

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -126,7 +126,7 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         self.region_settings_box = StaticBox(
             parent=self,
             id=wx.ID_ANY,
-            label=_("Computational region upon command execution"),
+            label=_("Computational region during command execution"),
         )
         self.region_settings_box_sizer = wx.StaticBoxSizer(
             self.region_settings_box, wx.VERTICAL

--- a/python/grass/grassdb/history.py
+++ b/python/grass/grassdb/history.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 from datetime import datetime
 import grass.script as gs
-from grass.script.utils import parse_key_val
 
 
 class Status(Enum):
@@ -274,15 +273,7 @@ def get_initial_command_info(env_run):
     mask3d_present = (mapset_path / "grid3" / "RASTER3D_MASK").exists()
 
     # Computational region settings
-    region_settings = dict(
-        parse_key_val(
-            gs.read_command("g.region", flags="g", env=env_run), val_type=float
-        )
-    )
-
-    # Convert floats to integers if possible
-    for key, value in region_settings.items():
-        region_settings[key] = int(value) if value.is_integer() else value
+    region_settings = gs.region(env=env_run)
 
     # Finalize the command info dictionary
     cmd_info = {


### PR DESCRIPTION
This PR enhances the history command info panel by adding the option for setting the current computational region settings to the one active upon the history command execution.

The original command info has only information about the computational region settings:
![Screenshot from 2024-03-19 14-16-47](https://github.com/OSGeo/grass/assets/49241681/460a3cef-5178-4f61-bd41-3597d8a21191)


The new proposal adds information on whether the current region is equal to the region from the history or not. In the case that the two settings are not equal, the new button "Set as current region" is added:
![Screenshot from 2024-03-19 14-05-38](https://github.com/OSGeo/grass/assets/49241681/5de19620-56c9-4452-9f2e-42c2b870685e)

If settings are equal the panel shows just the info message:
![Screenshot from 2024-03-19 14-06-00](https://github.com/OSGeo/grass/assets/49241681/578e1ae5-362d-4c0c-93e1-df032b94843a)

