### PR TITLE
grass.script: Create new location without a session

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1733,9 +1733,20 @@ def create_location(
     if datum_trans:
         kwargs["datum_trans"] = datum_trans
 
+    # Lazy-importing to avoid circular dependencies.
+    # pylint: disable=import-outside-toplevel
+    if os.environ.get("GISBASE"):
+        env = os.environ
+    else:
+        from grass.script.setup import setup_runtime_env
+
+        env = setup_runtime_env(env=os.environ)
+
     if epsg or proj4 or filename or wkt:
         # The names don't really matter here.
-        tmp_gisrc, env = create_environment(dbase, "<placeholder>", "<placeholder>")
+        tmp_gisrc, env = create_environment(
+            dbase, "<placeholder>", "<placeholder>", env=env
+        )
 
     if epsg:
         ps = pipe_command(

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1740,7 +1740,8 @@ def create_location(
     else:
         from grass.script.setup import setup_runtime_env
 
-        env = setup_runtime_env(env=os.environ)
+        env = os.environ.copy()
+        setup_runtime_env(env=env)
 
     if epsg or proj4 or filename or wkt:
         # The names don't really matter here.

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -192,15 +192,29 @@ def get_install_path(path=None):
     return None
 
 
-def setup_runtime_env(gisbase):
+def setup_runtime_env(gisbase=None, env=None):
     """Setup the runtime environment.
 
-    Modifies the global environment (os.environ) so that GRASS modules can run.
+    Modifies environment so that GRASS modules can run. It does not setup a session,
+    but only the system environment to execute commands.
+
+    Returns modified copy of the environment provided with _env_. If _env_ is not
+    provided, modifies the global environment (os.environ).
     """
+    if not gisbase:
+        gisbase = get_install_path()
+
     # Accept Path objects.
     gisbase = os.fspath(gisbase)
+
+    # If environment is not provided, use the global one.
+    if env:
+        env = env.copy()
+    else:
+        env = os.environ
+
     # Set GISBASE
-    os.environ["GISBASE"] = gisbase
+    env["GISBASE"] = gisbase
 
     # define PATH
     path_addition = os.pathsep + os.path.join(gisbase, "bin")
@@ -210,46 +224,48 @@ def setup_runtime_env(gisbase):
 
     # add addons to the PATH, use GRASS_ADDON_BASE if set
     # copied and simplified from lib/init/grass.py
-    addon_base = os.getenv("GRASS_ADDON_BASE")
+    addon_base = env.get("GRASS_ADDON_BASE")
     if not addon_base:
         if WINDOWS:
             config_dirname = f"GRASS{VERSION_MAJOR}"
-            addon_base = os.path.join(os.getenv("APPDATA"), config_dirname, "addons")
+            addon_base = os.path.join(env.get("APPDATA"), config_dirname, "addons")
         elif MACOS:
             version = f"{VERSION_MAJOR}.{VERSION_MINOR}"
             addon_base = os.path.join(
-                os.getenv("HOME"), "Library", "GRASS", version, "Addons"
+                env.get("HOME"), "Library", "GRASS", version, "Addons"
             )
         else:
             config_dirname = f".grass{VERSION_MAJOR}"
-            addon_base = os.path.join(os.getenv("HOME"), config_dirname, "addons")
-        os.environ["GRASS_ADDON_BASE"] = addon_base
+            addon_base = os.path.join(env.get("HOME"), config_dirname, "addons")
+        env["GRASS_ADDON_BASE"] = addon_base
 
     if not WINDOWS:
         path_addition += os.pathsep + os.path.join(addon_base, "scripts")
     path_addition += os.pathsep + os.path.join(addon_base, "bin")
 
-    os.environ["PATH"] = path_addition + os.pathsep + os.getenv("PATH")
+    env["PATH"] = path_addition + os.pathsep + env.get("PATH")
 
     # define LD_LIBRARY_PATH
-    if "@LD_LIBRARY_PATH_VAR@" not in os.environ:
-        os.environ["@LD_LIBRARY_PATH_VAR@"] = ""
-    os.environ["@LD_LIBRARY_PATH_VAR@"] += os.pathsep + os.path.join(gisbase, "lib")
+    if "@LD_LIBRARY_PATH_VAR@" not in env:
+        env["@LD_LIBRARY_PATH_VAR@"] = ""
+    env["@LD_LIBRARY_PATH_VAR@"] += os.pathsep + os.path.join(gisbase, "lib")
 
     # Set GRASS_PYTHON and PYTHONPATH to find GRASS Python modules
-    if not os.getenv("GRASS_PYTHON"):
+    if not env.get("GRASS_PYTHON"):
         if WINDOWS:
-            os.environ["GRASS_PYTHON"] = "python3.exe"
+            env["GRASS_PYTHON"] = "python3.exe"
         else:
-            os.environ["GRASS_PYTHON"] = "python3"
+            env["GRASS_PYTHON"] = "python3"
 
-    path = os.getenv("PYTHONPATH")
+    path = env.get("PYTHONPATH")
     etcpy = os.path.join(gisbase, "etc", "python")
     if path:
         path = etcpy + os.pathsep + path
     else:
         path = etcpy
-    os.environ["PYTHONPATH"] = path
+    env["PYTHONPATH"] = path
+
+    return env
 
 
 def init(path, location=None, mapset=None, grass_path=None):

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -192,14 +192,18 @@ def get_install_path(path=None):
     return None
 
 
-def setup_runtime_env(gisbase=None, env=None):
+def setup_runtime_env(gisbase=None, *, env=None):
     """Setup the runtime environment.
 
     Modifies environment so that GRASS modules can run. It does not setup a session,
     but only the system environment to execute commands.
 
-    Returns modified copy of the environment provided with _env_. If _env_ is not
-    provided, modifies the global environment (os.environ).
+    Modifies the environment provided with _env_. If _env_ is not
+    provided, modifies the global environment (os.environ). Pass a copy of the
+    environment if you don't want the source environment modified.
+
+    If _gisbase_ is not provided, a heuristic is used to find the path to GRASS
+    installation (see the :func:`get_install_path` function for details).
     """
     if not gisbase:
         gisbase = get_install_path()
@@ -208,9 +212,7 @@ def setup_runtime_env(gisbase=None, env=None):
     gisbase = os.fspath(gisbase)
 
     # If environment is not provided, use the global one.
-    if env:
-        env = env.copy()
-    else:
+    if not env:
         env = os.environ
 
     # Set GISBASE
@@ -264,8 +266,6 @@ def setup_runtime_env(gisbase=None, env=None):
     else:
         path = etcpy
     env["PYTHONPATH"] = path
-
-    return env
 
 
 def init(path, location=None, mapset=None, grass_path=None):

--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -58,6 +58,25 @@ def test_with_init_in_subprocess(tmp_path):
     assert epsg == "EPSG:3358"
 
 
+def test_without_session(tmp_path):
+    """Check that creation works outside of session.
+
+    Assumes that there is no session for the test. This can be ensured by running only
+    this test with pylint outside a session.
+    """
+    name = "desired"
+    gs.create_location(tmp_path, name, epsg="3358")
+    assert (tmp_path / name).exists()
+    wkt_file = tmp_path / name / "PERMANENT" / "PROJ_WKT"
+    assert wkt_file.exists()
+    with gs.setup.init(tmp_path / name):
+        gs.run_command("g.gisenv", set=f"GISDBASE={tmp_path}")
+        gs.run_command("g.gisenv", set=f"LOCATION_NAME={name}")
+        gs.run_command("g.gisenv", set="MAPSET=PERMANENT")
+        epsg = gs.parse_command("g.proj", flags="g")["srid"]
+        assert epsg == "EPSG:3358"
+
+
 def test_with_different_path(tmp_path):
     """Check correct EPSG is created with different path"""
     bootstrap_location = "bootstrap"


### PR DESCRIPTION
The function create_location now works without a full session. Internally, it sets up a runtime environment to execute tools (modules) without the connection to a location (project) which is sufficient for executing g.proj.

The new test covers the new functionality, but to actually test it, the test needs to run by itself because grass.script.setup.init (still) creates a global session.
