### PR TITLE
r.horizon: variable needs to be reset for point mode

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -757,6 +757,7 @@ double horizon_height(void)
 
     tanh0 = 0.;
     length = 0;
+    zp = z_orig;
 
     height = searching();
 

--- a/raster/r.horizon/testsuite/test_r_horizon.py
+++ b/raster/r.horizon/testsuite/test_r_horizon.py
@@ -144,6 +144,12 @@ class TestHorizon(TestCase):
         stdout = module.outputs.stdout
         self.assertMultiLineEqual(first=ref2, second=stdout)
 
+        # include nulls along the edge
+        self.runModule("g.region", raster="elevation", w="w-100")
+        self.assertModule(module)
+        stdout = module.outputs.stdout
+        self.assertMultiLineEqual(first=ref2, second=stdout)
+
     def test_point_mode_multiple_direction_artificial(self):
         """Test mode with 1 point and multiple directions with artificial surface"""
         module = SimpleModule(


### PR DESCRIPTION
Another bug coming from using global variables in r.horizon. Reported by a user, can be reproduced with https://www.datigeo-piem-download.it/static/regp01/DTM5_ICE/RIPRESA_AEREA_ICE_2009_2011_DTM-SDO_CTR_FOGLI50-172-EPSG32632-TIF.zip:
```
r.horizon elevation=DTM5_172 direction=0 step=1 coordinates=350089,4979561 -d file=horizon.csv
```
The bug is that for part of the angles it results in zeros. It comes up when there are nulls at the edge of the raster, test was added.

This bug is not present in #3346, there it was (accidentally) fixed.