### PR TITLE
wxGUI: fix URL to Piemonte (Italy) dataset

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -57,7 +57,7 @@ LOCATIONS = [
     },
     {
         "label": "Piemonte, Italy data set",
-        "url": "http://geodati.fmach.it/gfoss_geodata/libro_gfoss/grassdata_piemonte_utm32n_wgs84_grass7.tar.gz",
+        "url": "https://grass.osgeo.org/sampledata/grassdata_piemonte_utm32n_wgs84_grass7.tar.gz",
     },
     {
         "label": "Slovakia 3D precipitation voxel data set",


### PR DESCRIPTION
The dataset belongs to the book

L. Casagrande, P. Cavallini, A. Frigeri, A. Furieri, I. Marchesini, M. Neteler, 2012: _GIS Open Source. GRASS GIS, Quantum GIS e Spatialite_. ISBN 9788857901497. 224 pages, Dario Flaccovio Editore S.r.l.

The dataset URL is now updated to the new download space:

https://grass.osgeo.org/sampledata/grassdata_piemonte_utm32n_wgs84_grass7.tar.gz

(size: 291MB)

Fixes #3292