### PR TITLE
script: Change insecure mktemp to NamedTemporaryFile

### DIFF
--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -97,8 +97,8 @@ VERSION_MINOR = "@GRASS_VERSION_MINOR@"
 
 def write_gisrc(dbase, location, mapset):
     """Write the ``gisrc`` file and return its path."""
-    gisrc = tmpfile.mktemp()
-    with open(gisrc, "w") as rc:
+    with tmpfile.NamedTemporaryFile(mode="w", delete=False) as rc:
+        gisrc = rc.name
         rc.write("GISDBASE: %s\n" % dbase)
         rc.write("LOCATION_NAME: %s\n" % location)
         rc.write("MAPSET: %s\n" % mapset)


### PR DESCRIPTION
Removed use of deprecated 'tempfile.mktemp' and replaced it with 'NamedTemporaryFile'.

Deprecated mktemp function returns an arbitrary file name to use for a temporary file. However, the application does not immediately create/open this file.

This introduces an opportunity for an attacker to interfere with the file to be created. [Documentation on tempfile](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) recommends replacing mktemp with NamedTemporaryFile. By doing this, there is no window between getting the temporary file name and opening it.

Following up on echoix's comment on PR #3436, This was the only instance of `tempfile.mktemp` I found in this project. There are other uses of a function `tmp_path_factory.mktemp` in various conftest files, but that is different in that it instantly creates a directory and does not pose the risk `tempfile.mktemp` does. Additionally `tempfile.mkstemp` which is occasionally used is safe as the file is automatically created with secure permissions by default.


