### PR TITLE
utils: fixed shell vulnerability in mkrest.py

### DIFF
--- a/utils/mkrest.py
+++ b/utils/mkrest.py
@@ -81,10 +81,8 @@ tmp_data = read_file(tmp_file)
 if tmp_data:
     sys.stdout.write(tmp_data)
 
-arguments = ['pandoc', '-s', '-r', 'html', src_file, '-w', 'rst']
-process = subprocess.Popen(
-    arguments, stdout=subprocess.PIPE
-)
+arguments = ["pandoc", "-s", "-r", "html", src_file, "-w", "rst"]
+process = subprocess.Popen(arguments, stdout=subprocess.PIPE)
 html_text = process.communicate()[0]
 if html_text:
     for k, v in replacement.iteritems():

--- a/utils/mkrest.py
+++ b/utils/mkrest.py
@@ -81,8 +81,9 @@ tmp_data = read_file(tmp_file)
 if tmp_data:
     sys.stdout.write(tmp_data)
 
+arguments = ['pandoc', '-s', '-r', 'html', src_file, '-w', 'rst']
 process = subprocess.Popen(
-    "pandoc -s -r html %s -w rst" % src_file, shell=True, stdout=subprocess.PIPE
+    arguments, stdout=subprocess.PIPE
 )
 html_text = process.communicate()[0]
 if html_text:


### PR DESCRIPTION
I found a vulnerability in this mkrest.py utilities file, where malformed input in the src_file variable could give an attacker a shell if they escaped the rest of the command. This fix restructures the Popen call to not use shell=True while still retaining the same functionality.