### PR TITLE
grass Python package: hide windows triggered by subprocess.Popen on MS Windows

### DIFF
--- a/lib/init/variables.html
+++ b/lib/init/variables.html
@@ -262,16 +262,6 @@ PERMANENT
   of G_fatal_error() will end in a segmentation violation. GDB can be used
   to trace the source of the error.</dd>
 
-  <dt>GRASS_SUBPROCESS_CREATE_NEW_CONSOLE</dt>
-  <dd>[Python grass package]<br>
-  This variable affects GRASS commands invoked in Python using
-  grass.script.core.Popen class. If this environment variable is defined
-  (and set to any value) a new console window is opened for each
-  command. This behavior was defaulted to GRASS GIS 8.3. Since version
-  8.4, new console windows are not automatically opened. Relevant only
-  for MS Windows operating system.
-  </dd>
-
   <dt>GRASS_PYTHON</dt>
   <dd>[wxGUI, Python Ctypes]<br>
     set to override Python executable.<br>

--- a/lib/init/variables.html
+++ b/lib/init/variables.html
@@ -262,6 +262,16 @@ PERMANENT
   of G_fatal_error() will end in a segmentation violation. GDB can be used
   to trace the source of the error.</dd>
 
+  <dt>GRASS_SUBPROCESS_CREATE_NEW_CONSOLE</dt>
+  <dd>[Python grass package]<br>
+  This variable affects GRASS commands invoked in Python using
+  grass.script.core.Popen class. If this environment variable is defined
+  (and set to any value) a new console window is opened for each
+  command. This behavior was defaulted to GRASS GIS 8.3. Since version
+  8.4, new console windows are not automatically opened. Relevant only
+  for MS Windows operating system.
+  </dd>
+
   <dt>GRASS_PYTHON</dt>
   <dd>[wxGUI, Python Ctypes]<br>
     set to override Python executable.<br>

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -128,7 +128,8 @@ class Popen(subprocess.Popen):
                 kwargs["shell"] = True
                 args = [self._escape_for_shell(arg) for arg in args]
 
-            if env.subprocess.show_window:
+            if env.subprocess.show_window is False:
+                # do not show new window on MS Windows
                 si = subprocess.STARTUPINFO()
                 si.dwFlags = (
                     subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -130,6 +130,7 @@ class Popen(subprocess.Popen):
 
             if env.subprocess.show_window is False or "--interface-description" in args:
                 # do not show new window on MS Windows
+                # always hide on "--interface-description" to avoid fast pop-up windows
                 si = subprocess.STARTUPINFO()
                 si.dwFlags = (
                     subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -57,6 +57,15 @@ class Popen(subprocess.Popen):
             if ext.lower() not in self._builtin_exts:
                 kwargs["shell"] = True
                 args = [self._escape_for_shell(arg) for arg in args]
+
+            if os.environ.get("GRASS_SUBPROCESS_CREATE_NEW_CONSOLE", None) is None:
+                si = subprocess.STARTUPINFO()
+                si.dwFlags = (
+                    subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
+                )
+                si.wShowWindow = subprocess.SW_HIDE
+                kwargs["startupinfo"] = si
+
         subprocess.Popen.__init__(self, args, **kwargs)
 
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -128,7 +128,7 @@ class Popen(subprocess.Popen):
                 kwargs["shell"] = True
                 args = [self._escape_for_shell(arg) for arg in args]
 
-            if env.subprocess.show_window is False:
+            if env.subprocess.show_window is False or "--interface-description" in args:
                 # do not show new window on MS Windows
                 si = subprocess.STARTUPINFO()
                 si.dwFlags = (


### PR DESCRIPTION
When running Python script using GRASS Python API in third party environments (like QGIS) on MS Windows for every command triggered by `script.core.Popen()` a new window pops up. This can be very frustrating when running multiple GRASS modules in sequence. See short example below:

[Screencast_02_26_2024_06:28:46_AM.webm](https://github.com/OSGeo/grass/assets/5683186/a45d095e-74db-40cf-a31a-6264a2c3f4b4)

# How to tests

Run script below in QGIS:

```py
import os

import grass.script.setup as gsetup
from grass.pygrass.modules import Module

gisdb = f"{os.environ['HOMEPATH']}\\Documents\\grassdata"
gsetup.init(gisdb, "world_latlong_wgs84", 'PERMANENT')

Module("g.region", n=90, s=0, w=0, e=100, res=0.02, flags="p")
Module("r.random.surface", output="x", overwrite=True)
print("done")
```

# New behaviour

The PR changes this behaviour. No pop-up windows are show.

[Screencast_02_26_2024_06:31:13_AM.webm](https://github.com/OSGeo/grass/assets/5683186/3406f3c7-b046-42ad-901b-14c03b8c136c)

Windows can be show by setting a new environmental variable globally:

```py
from grass.script import env
env.subprocess.show_window = True
```

Or just for selected commands (see below):

```py
from grass.script import Env
with Env() as env:
    env.subprocess.show_window = True
    Module("r.random.surface", output="x", overwrite=True)
```

[Screencast_02_26_2024_06:39:18_AM.webm](https://github.com/OSGeo/grass/assets/5683186/b53ff1dd-3cac-4a24-932d-5fb1ab0f812c)


# Side effect

New concept of `Env` class allows to add new variables in the future, eg.

```py
env.output.overwrite = True
```

or similar.
