### PR TITLE
lib/vector/Vlib: always write out topo files in update mode

### DIFF
--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -572,6 +572,7 @@ int Vect__open_old(struct Map_info *Map, const char *name, const char *mapset,
             if (access(file_path, F_OK) == 0) /* fidx file exists? */
                 unlink(file_path);
         }
+        Map->support_updated = TRUE;
     }
 
     return level;

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -550,9 +550,30 @@ int Vect__open_old(struct Map_info *Map, const char *name, const char *mapset,
         Vect_rewind(Map);
     }
 
-    /* DO NOT delete support files topo, sidx, cidx, fidx if native format
-     * was opened for update (not head_only)
-     * they will be deleted by Vect_close() if the map was actually updated */
+    /* delete support files if native format was opened for update (not
+     * head_only) */
+    if (update && !head_only) {
+        char file_path[GPATH_MAX];
+
+        Vect__get_element_path(file_path, Map, GV_TOPO_ELEMENT);
+        if (access(file_path, F_OK) == 0) /* topo file exists? */
+            unlink(file_path);
+
+        Vect__get_element_path(file_path, Map, GV_SIDX_ELEMENT);
+        if (access(file_path, F_OK) == 0) /* sidx file exists? */
+            unlink(file_path);
+
+        Vect__get_element_path(file_path, Map, GV_CIDX_ELEMENT);
+        if (access(file_path, F_OK) == 0) /* cidx file exists? */
+            unlink(file_path);
+
+        if (format == GV_FORMAT_OGR || format == GV_FORMAT_POSTGIS) {
+            Vect__get_element_path(file_path, Map, GV_FIDX_ELEMENT);
+            if (access(file_path, F_OK) == 0) /* fidx file exists? */
+                unlink(file_path);
+        }
+        Map->support_updated = TRUE;
+    }
 
     return level;
 }

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -550,30 +550,9 @@ int Vect__open_old(struct Map_info *Map, const char *name, const char *mapset,
         Vect_rewind(Map);
     }
 
-    /* delete support files if native format was opened for update (not
-     * head_only) */
-    if (update && !head_only) {
-        char file_path[GPATH_MAX];
-
-        Vect__get_element_path(file_path, Map, GV_TOPO_ELEMENT);
-        if (access(file_path, F_OK) == 0) /* topo file exists? */
-            unlink(file_path);
-
-        Vect__get_element_path(file_path, Map, GV_SIDX_ELEMENT);
-        if (access(file_path, F_OK) == 0) /* sidx file exists? */
-            unlink(file_path);
-
-        Vect__get_element_path(file_path, Map, GV_CIDX_ELEMENT);
-        if (access(file_path, F_OK) == 0) /* cidx file exists? */
-            unlink(file_path);
-
-        if (format == GV_FORMAT_OGR || format == GV_FORMAT_POSTGIS) {
-            Vect__get_element_path(file_path, Map, GV_FIDX_ELEMENT);
-            if (access(file_path, F_OK) == 0) /* fidx file exists? */
-                unlink(file_path);
-        }
-        Map->support_updated = TRUE;
-    }
+    /* DO NOT delete support files topo, sidx, cidx, fidx if native format
+     * was opened for update (not head_only)
+     * they will be delted by Vect_close() if the map was actually updated */
 
     return level;
 }

--- a/lib/vector/Vlib/open.c
+++ b/lib/vector/Vlib/open.c
@@ -552,7 +552,7 @@ int Vect__open_old(struct Map_info *Map, const char *name, const char *mapset,
 
     /* DO NOT delete support files topo, sidx, cidx, fidx if native format
      * was opened for update (not head_only)
-     * they will be delted by Vect_close() if the map was actually updated */
+     * they will be deleted by Vect_close() if the map was actually updated */
 
     return level;
 }

--- a/python/grass/pygrass/vector/abstract.py
+++ b/python/grass/pygrass/vector/abstract.py
@@ -458,14 +458,14 @@ class Info:
         if hasattr(self, "table") and self.table is not None:
             self.table.conn.close()
         if self.is_open():
-            if libvect.Vect_close(self.c_mapinfo) != 0:
-                str_err = "Error when trying to close the map with Vect_close"
-                raise GrassError(str_err)
             if (
                 self.c_mapinfo.contents.mode
                 in {libvect.GV_MODE_RW, libvect.GV_MODE_WRITE}
             ) and build:
                 self.build()
+            if libvect.Vect_close(self.c_mapinfo) != 0:
+                str_err = "Error when trying to close the map with Vect_close"
+                raise GrassError(str_err)
 
     def remove(self):
         """Remove vector map"""
@@ -475,16 +475,11 @@ class Info:
 
     def build(self):
         """Close the vector map and build vector Topology"""
-        self.close()
-        libvect.Vect_set_open_level(1)
-        if libvect.Vect_open_old2(self.c_mapinfo, self.name, self.mapset, "0") != 1:
-            str_err = "Error when trying to open the vector map."
-            raise GrassError(str_err)
-        # Vect_build returns 1 on success and 0 on error (bool approach)
-        if libvect.Vect_build(self.c_mapinfo) != 1:
-            str_err = "Error when trying build topology with Vect_build"
-            raise GrassError(str_err)
-        libvect.Vect_close(self.c_mapinfo)
+        if self.is_open():
+            # Vect_build returns 1 on success and 0 on error (bool approach)
+            if libvect.Vect_build(self.c_mapinfo) != 1:
+                str_err = "Error when trying build topology with Vect_build"
+                raise GrassError(str_err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a vector with topology is opened in update mode, but nothing is changed, topology info (topo, cidx, sidx) is not written out. This PR fixes this.

I am not sure if this is a bug or an enhancement.