### PR TITLE
script.core.Popen: do not show new window on MS Windows

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -58,9 +58,9 @@ class Popen(subprocess.Popen):
                 kwargs["shell"] = True
                 args = [self._escape_for_shell(arg) for arg in args]
 
-            # do not show new window on MS Windows
+            # hides the window on MS Windows - another window will be activated
             si = subprocess.STARTUPINFO()
-            si.dwFlags = subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
+            si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             si.wShowWindow = subprocess.SW_HIDE
             kwargs["startupinfo"] = si
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -57,6 +57,13 @@ class Popen(subprocess.Popen):
             if ext.lower() not in self._builtin_exts:
                 kwargs["shell"] = True
                 args = [self._escape_for_shell(arg) for arg in args]
+
+            # do not show new window on MS Windows
+            si = subprocess.STARTUPINFO()
+            si.dwFlags = subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
+            si.wShowWindow = subprocess.SW_HIDE
+            kwargs["startupinfo"] = si
+
         subprocess.Popen.__init__(self, args, **kwargs)
 
 


### PR DESCRIPTION
See original #3457. When running Python script using GRASS Python API in third party environments (like QGIS) on MS Windows for every command triggered by `script.core.Popen` a new window pops up. This can be very frustrating when running multiple GRASS modules in sequence. See short example below:

[Screencast_02_27_2024_11:43:41_AM.webm](https://github.com/OSGeo/grass/assets/5683186/f3722036-9769-47ad-a60f-885a0b67b967)

And if you can really enjoy terminal windows poping-up. Than here is real example of [SMODERP2D](https://github.com/storm-fsv-cvut/smoderp2d) QGIS Plugin :-)

[Screencast_02_27_2024_11:44:43_AM.webm](https://github.com/OSGeo/grass/assets/5683186/a8cee2a2-4711-425b-b8e7-ac8398e80351)

# How to tests

Run script below in QGIS:

```py
import os

import grass.script.setup as gsetup
from grass.pygrass.modules import Module

gisdb = f"{os.environ['HOMEPATH']}\\Documents\\grassdata"
gsetup.init(gisdb, "world_latlong_wgs84", 'PERMANENT')

Module("g.region", n=90, s=0, w=0, e=100, res=0.02, flags="p")
Module("r.random.surface", output="x", overwrite=True)
print("done")
```

# New behaviour

The PR changes this behaviour. No pop-up windows are show.

[Screencast_02_27_2024_11:50:25_AM.webm](https://github.com/OSGeo/grass/assets/5683186/212fd082-e605-4308-bf82-8f14e03371e0)
