### PR TITLE
vector: use full db connection settings for db.describe

### DIFF
--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -35,6 +35,13 @@
 # % required : yes
 # %end
 
+# %option G_OPT_DB_DATABASE
+# %end
+
+# %option G_OPT_DB_DRIVER
+# % options: dbf,odbc,ogr,sqlite,pg
+# %end
+
 import sys
 import string
 
@@ -45,14 +52,19 @@ import grass.script as gscript
 def main():
     table = options["table"]
     column = options["column"]
+    database = options["database"]
+    driver = options["driver"]
     force = flags["f"]
 
     # check if DB parameters are set, and if not set them.
     gscript.run_command("db.connect", flags="c")
 
-    kv = gscript.db_connection()
-    database = kv["database"]
-    driver = kv["driver"]
+    if not database or not driver:
+        kv = gscript.db_connection()
+        if not database:
+            database = kv["database"]
+        if not driver:
+            driver = kv["driver"]
     # schema needed for PG?
 
     if force:
@@ -67,7 +79,10 @@ def main():
             % column
         )
 
-    cols = [f[0] for f in gscript.db_describe(table)["cols"]]
+    cols = [
+        f[0]
+        for f in gscript.db_describe(table, database=database, driver=driver)["cols"]
+    ]
     if column not in cols:
         gscript.fatal(_("Column <%s> not found in table") % column)
 

--- a/scripts/db.in.ogr/db.in.ogr.py
+++ b/scripts/db.in.ogr/db.in.ogr.py
@@ -143,6 +143,13 @@ def main():
         else:
             grass.fatal(_("Input DSN <%s> not found or not readable") % input)
 
+    # save db connection settings of the output
+    f = grass.vector_layer_db(output, "1")
+
+    table = f["table"]
+    database = f["database"]
+    driver = f["driver"]
+
     # rename ID col if requested from cat to new name
     if key:
         grass.write_command(
@@ -173,14 +180,16 @@ def main():
         "db.dropcolumn",
         quiet=True,
         flags="f",
-        table=output,
+        table=table,
+        database=database,
+        driver=driver,
         column="cat",
         stdout=nuldev,
         stderr=nuldev,
     )
     nuldev.close()
 
-    records = grass.db_describe(output)["nrows"]
+    records = grass.db_describe(table, database=database, driver=driver)["nrows"]
     grass.message(_("Imported table <%s> with %d rows") % (output, records))
 
 

--- a/scripts/v.db.renamecolumn/v.db.renamecolumn.py
+++ b/scripts/v.db.renamecolumn/v.db.renamecolumn.py
@@ -90,7 +90,7 @@ def main():
 
     # describe old col
     oldcoltype = None
-    for f in grass.db_describe(table)["cols"]:
+    for f in grass.db_describe(table, database=database, driver=driver)["cols"]:
         if f[0] != oldcol:
             continue
         oldcoltype = f[1]


### PR DESCRIPTION
Some scripts did not specify database and driver when calling `grass.db_describe()`, causing errors if vector maps use non-standard db connections. This PR queries actual db connection settings for affected modules and passes these to `grass.db_describe()`