### PR TITLE
Docker alpine: Fix for PEP-668

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -79,7 +79,7 @@ RUN echo "Install Python";\
     apk add --no-cache $PYTHONBIN && \
     $PYTHONBIN -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
-    pip$PYTHON_VERSION install --upgrade pip setuptools && \
+    pip$PYTHON_VERSION install --no-cache-dir --upgrade pip setuptools && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip$PYTHON_VERSION /usr/bin/pip ; fi && \
     if [ ! -e /usr/bin/python ]; then ln -sf /usr/bin/$PYTHONBIN /usr/bin/python; fi && \
     rm -r /root/.cache; \
@@ -219,7 +219,7 @@ COPY docker/testdata/test_grass_session.py docker/alpine/grass_tests.sh /scripts
 COPY docker/testdata/test_grass_session.py /scripts/
 
 # install external Python API
-RUN pip3 install --upgrade pip six grass-session --ignore-installed six; \
+RUN pip3 install --no-cache-dir --upgrade pip six grass-session --ignore-installed six; \
     ln -sf /usr/local/grass $(grass --config path); \
     # run some tests and cleanup
     $SHELL /scripts/grass_tests.sh \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 as common
+FROM python:3-alpine3.19 as common
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -206,7 +206,8 @@ ENV GRASSBIN="/usr/local/bin/grass" \
     # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
     PROJ_NETWORK=ON \
     GRASSBIN=grass \
-    LC_ALL="en_US.UTF-8"
+    LC_ALL="en_US.UTF-8" \
+    PYTHONPATH="/usr/local/grass/etc/python:$PYTHONPATH"
 
 # Copy GRASS GIS and GDAL GRASS driver from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass


### PR DESCRIPTION
After alpine docker image was updated to alpine 3.19, it uses PEP 668 and cannot use `pip` as is anymore:

```
pip3 install --upgrade pip setuptools
...
#8 3.927 error: externally-managed-environment
#8 3.927 
#8 3.927 × This environment is externally managed
#8 3.927 ╰─> 
#8 3.927     The system-wide python installation should be maintained using the system
#8 3.927     package manager (apk) only.
#8 3.927     
#8 3.927     If the package in question is not packaged already (and hence installable via
#8 3.927     "apk add py3-somepackage"), please consider installing it inside a virtual
#8 3.927     environment, e.g.:
#8 3.927     
#8 3.927     python3 -m venv /path/to/venv
#8 3.927     . /path/to/venv/bin/activate
#8 3.927     pip install mypackage
#8 3.927     
#8 3.927     To exit the virtual environment, run:
#8 3.927     
#8 3.927     deactivate
#8 3.927     
#8 3.927     The virtual environment is not deleted, and can be re-entered by re-sourcing
#8 3.927     the activate file.
#8 3.927     
#8 3.927     To automatically manage virtual environments, consider using pipx (from the
#8 3.927     pipx package).
#8 3.927 
#8 3.927 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#8 3.927 hint: See PEP 668 for the detailed specification.
```
This can be seen in e.g. [this job](https://github.com/OSGeo/grass/actions/runs/8079109763/job/22072802665). The alpine job runs successful but log states the same error as above.
The current docker image on dockerhub does not contain e.g. six and grass_session. With this PR it works again.

Background is that Pip and others are not allowed to interfere with system python packages.
For the docker builds it is possible to simply use the official python images. Else virtual python environments are required.

Here is a nice blog post about the topic and possible solutions: 
https://pythonspeed.com/articles/externally-managed-environment-pep-668/

The same type of fix might be necessary for the other docker flavours.
