### PR TITLE
makefile: Remove doxygen from temporal and python/grass/exceptions that is unused

### DIFF
--- a/python/grass/exceptions/Makefile
+++ b/python/grass/exceptions/Makefile
@@ -2,7 +2,6 @@ MODULE_TOPDIR=../../..
 
 include $(MODULE_TOPDIR)/include/Make/Other.make
 include $(MODULE_TOPDIR)/include/Make/Python.make
-include $(MODULE_TOPDIR)/include/Make/Doxygen.make
 
 PYDIR = $(ETC)/python
 GDIR = $(PYDIR)/grass
@@ -25,6 +24,3 @@ $(DSTDIR): | $(GDIR)
 
 $(DSTDIR)/%: % | $(DSTDIR)
 	$(INSTALL_DATA) $< $@
-
-#doxygen:
-DOXNAME = exceptions

--- a/python/grass/temporal/Makefile
+++ b/python/grass/temporal/Makefile
@@ -2,7 +2,6 @@ MODULE_TOPDIR = ../../..
 
 include $(MODULE_TOPDIR)/include/Make/Other.make
 include $(MODULE_TOPDIR)/include/Make/Python.make
-include $(MODULE_TOPDIR)/include/Make/Doxygen.make
 
 PYDIR = $(ETC)/python
 GDIR = $(PYDIR)/grass
@@ -26,6 +25,3 @@ $(DSTDIR): | $(GDIR)
 
 $(DSTDIR)/%: % | $(DSTDIR)
 	$(INSTALL_DATA) $< $@
-
-#doxygen:
-DOXNAME = pythontemporal


### PR DESCRIPTION
It seems that the makefile in `python/grass/temporal/Makefile` has had some merge conflicts 10 years ago. 
Looking at the history, after the single change that changed the file structure in 2021, there were two commits about 1 month apart in 2014. 

![image](https://github.com/OSGeo/grass/assets/27212526/e2b33911-0a67-407e-983d-a5a839e830a2)
![image](https://github.com/OSGeo/grass/assets/27212526/b5881f42-72bc-413b-a093-5458bb00af5c)

https://github.com/OSGeo/grass/commits/0c83c976b2312e7cb586265a3927a321a1a27d63/lib/python/temporal/Makefile?browsing_rename_history=true&new_path=python/grass/temporal/Makefile&original_branch=main

One where doxygen documentation was changed to sphinx, removing lines in Makefiles and the `*lib.dox` files, commit https://github.com/OSGeo/grass/commit/74221f332eefd309c0ef97b1b2b7a5eaf43c5bd5.
Then, an `temporal_operator` module was added that replaced `temporal_vector_operator` and `temporal_raster_operator` in commit https://github.com/OSGeo/grass/commit/aab579233e579256e575c8ca4ec285418fdc3dd3.

I'm almost convinced it is an error in resolving a merge conflict, since all the changes from https://github.com/OSGeo/grass/commit/74221f332eefd309c0ef97b1b2b7a5eaf43c5bd5 this file were readded in https://github.com/OSGeo/grass/commit/aab579233e579256e575c8ca4ec285418fdc3dd3, but not the `pythontemporallib.dox` file. There are no other references of `pythontemporallib.dox`, `pythontemporallib`, or `pythontemporal` in the repo.

The doxygen docs, the programmer's manual https://grass.osgeo.org/programming8/index.html, refer to https://grass.osgeo.org/grass-devel/manuals/libpython/temporal_framework.html for TGIS,
![image](https://github.com/OSGeo/grass/assets/27212526/0233b02c-dd47-4b7e-9c6a-43f032c3fab5)

Am I right with this PR?