### PR TITLE
Remove libexpat-1.dll from package.sh 

### DIFF
--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -110,7 +110,6 @@ DLLS="
 	/mingw64/bin/zlib1.dll
 	/mingw64/bin/libbz2-1.dll
 	/mingw64/bin/libiconv-2.dll
-	/mingw64/bin/libexpat-1.dll
 	/mingw64/bin/libfontconfig-1.dll
 	/mingw64/bin/libgfortran-5.dll
 	/mingw64/bin/libbrotlidec.dll


### PR DESCRIPTION
This PR replaces https://github.com/OSGeo/grass/pull/3476 (base branch changed from `releasebranch_8_3` to `main`)