### PR TITLE
CI(clang-format): Run faster and post fixes as code suggestions if possible when running on a PR

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -6,20 +6,88 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
+  workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_protected != true }}
+permissions: {}
 jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: jidicula/clang-format-action@v4.11.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          clang-format-version: '15'
-          check-path: .
+          persist-credentials: false
+      - uses: DoozyX/clang-format-lint-action@11b773b1598aa4ae3b32f023701bca5201c3817d # v0.17
+        with:
+          source: "."
+          clangFormatVersion: 15
+          inplace: True
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@d774a4c7ebe335445d79c7b44138f56a76058ba0 # v19.0.0
+        id: verify-changed-files
+      - id: git-changed-files
+        run: |
+          {
+            echo 'CHANGED_FILES<<EOF'
+            git ls-files --other --modified --exclude-standard
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: List all changed files tracked and untracked files
+        run: |
+          echo "Changed files: ${{ steps.git-changed-files.outputs.CHANGED_FILES }}"
+      - name: Add job summary without changed files
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'false' }}
+        run: |
+          {
+            echo "### Changed files:"
+            echo "No files were changed by clang-format"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Add job summary with changed files
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
+        run: |
+          {
+            echo '### Changed files:'
+            echo '```'
+            echo "${CHANGED_FILES}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          CHANGED_FILES: ${{ steps.git-changed-files.outputs.CHANGED_FILES }}
+      - name: Create unified diff of changes
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
+        run: git diff --unified=0 --no-color --output=diff-clang-format.patch
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
+        with:
+          name: diff
+          if-no-files-found: ignore
+          retention-days: 1
+          path: |
+            diff-clang-format.patch
+      - name: Add note to summary explaining that code suggestions will be applied if it is a PR
+        if: ${{ (github.event_name == 'pull_request') && (steps.verify-changed-files.outputs.files_changed == 'true') }}
+        run: |
+          {
+            echo ''
+            echo 'Suggestions can only be added near to lines changed in this PR.'
+            echo 'If any fixes can be added as code suggestions, they will be added shortly from another workflow.'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: always()
+        with:
+          name: formatted-clang-format
+          retention-days: 10
+          path: |
+            .clang-format
+            ${{ steps.git-changed-files.outputs.CHANGED_FILES }}
+      - name: Explain that more files need to be fixed
+        if: ${{ steps.verify-changed-files.outputs.files_changed == 'true' }}
+        run: |
+          {
+            echo ''
+            # shellcheck disable=SC2016
+            echo 'All fixed files are included in the `formatted-*` artifact. This artifact can be downloaded and copied to the repository to replace unformatted files with the formatted files.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -1,0 +1,45 @@
+---
+name: Post PR code suggestions
+
+on:
+  workflow_run:
+    workflows: ["ClangFormat Check"]
+    types:
+      - completed
+permissions: {}
+jobs:
+  post-suggestions:
+    runs-on: ubuntu-latest
+    # Only run on failures, since no changes are needed on success
+    if: >
+      (github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure')
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create a .git directory needed by reviewdog
+        run: git init
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        id: diff
+        continue-on-error: true
+        with:
+          name: diff
+          github-token: ${{ github.token }}
+          run-id: ${{github.event.workflow_run.id }}
+      - uses: reviewdog/action-setup@1d18b2938261447f64c39f831d7395e90ef5a40e # v1.2.1
+      - run: |
+          GITHUB_ACTIONS="" reviewdog \
+              -name="${INPUT_TOOL_NAME:-reviewdog-suggester}" \
+              -f=diff \
+              -f.diff.strip=1 \
+              -filter-mode=nofilter \
+              -guess \
+              -reporter="github-pr-review" < "${TMPFILE}"
+        env:
+          TMPFILE: diff-clang-format.patch
+          INPUT_TOOL_NAME: clang-format
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get


### PR DESCRIPTION
Replaces #3284
Closes #3284

This PR replaces #3284.
It is an adaptation of https://github.com/OSGeo/grass-addons/pull/1038.

This integrates the ideas of #3284, which is to run clang-format way faster, in the 30-second range. It also sets the infrastructure needed to post code suggestions to the PRs of linter fixes. Clang-format is now the first here to have it. It is designed, and planned, to have some of our other tools add code suggestions as fixes to PRs to facilitate completing them and applying small fixes without a full round of feedback from the author.

Here is what I wrote for https://github.com/OSGeo/grass-addons/pull/1038:
> After a hundred iterations or so, I've got a solution that I'm satisfied with. This allows linter formatting in a PR from a forked pull request to do so without any special secret access, and also be able to add PR review comments, that need pull-request: write permissions. These permissions cannot be granted for PRs coming from forks. Since all the PRs come from forks, we could never use any write permissions from our forks. It also avoids using pull_request_target with a checkout of the external code, which is something that should never be done.
> 
> Instead, it runs another workflow triggered by the completion of another workflow, through the workflow_run trigger. That second workflow takes 3 seconds, max 10 including startup. It won't appear as a check for a PR, but still manages to use the event's payload information available to apply to the PR. The fixes that need to be added as code suggestion comments are fed through the upload of a diff artifact. It is then easily downloaded in the second workflow.
> 
> Note that PR review comments can only be added to lines in the diff context, that is 3 lines above or below the changed lines of a PR, just like the web interface: the API isn't different. The code suggestion comments are added on a best-effort basis to facilitate contributors to finish a PR. So only upgrading the clang-format version in a PR won't be able to post suggestions on all changes in the repo, since the affected lines aren't changed in that PR.
> 
> I designed this solution to be able to accept and post code suggestions for other tools in the near future. Other workflows could upload diffs from multiple tools in the same artifact, and only the tool name and the file name needs to be handled by conditional expressions (if: ...) or a bash loop (careful to not inject the file names from the artifact, as it is untrusted inputs; prefer whitelisting the expected file names to match to). For now, it is implemented for clang-format.
> 
> This time, I created a new organization, so I could develop with the forked-repo situation from the start. Once this PR is merged, the "callback" workflow that post code suggestions will be enabled, and will work right away.


Examples (when intentionally creating formatting errors):
![image](https://github.com/OSGeo/grass/assets/27212526/6a16fea9-672b-4460-922d-67d2e2964fc4)
They can be batch committed as always by going to the files changed tab and adding the suggestions to a batch, and creating one commit. 

![image](https://github.com/OSGeo/grass/assets/27212526/7f30e8ef-a6bc-42c4-b207-1d2a0972da12)
![image](https://github.com/OSGeo/grass/assets/27212526/55dadb23-63ad-4221-bb2c-42cc45b39e58)

