### PR TITLE
d.rast.num: Constrain rendering within the current display extent in the wx monitor

### DIFF
--- a/display/d.rast.num/main.c
+++ b/display/d.rast.num/main.c
@@ -138,13 +138,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
 
     /* Setup driver and check important information */
-    if (D_open_driver() == -1) {
-        /* don't render the entire raster region; this module will be rerun by
-         * the monitor with the display extent (D_open_driver() will return 0
-         * then) and use that information to constrain rendering */
-        D_close_driver();
-        exit(EXIT_SUCCESS);
-    }
+    D_open_driver();
 
     map_name = opt.map->answer;
 

--- a/display/d.rast.num/main.c
+++ b/display/d.rast.num/main.c
@@ -137,6 +137,15 @@ int main(int argc, char **argv)
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
+    /* Setup driver and check important information */
+    if (D_open_driver() < 0) {
+        /* don't render the entire raster region; this module will be rerun by
+         * the monitor with the display extent (D_open_driver() will return 0
+         * then) and use that information to constrain rendering */
+        D_close_driver();
+        exit(EXIT_SUCCESS);
+    }
+
     map_name = opt.map->answer;
 
     if (strcmp("none", opt.grid_color->answer) == 0)
@@ -220,10 +229,6 @@ int main(int argc, char **argv)
         G_fatal_error(_("Aborting (region larger then 200 rows X 200 cols is "
                         "not allowed)"));
     }
-
-    /* Setup driver and check important information */
-
-    D_open_driver();
 
     if (opt.font->answer)
         D_font(opt.font->answer);

--- a/display/d.rast.num/main.c
+++ b/display/d.rast.num/main.c
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
 
     /* Setup driver and check important information */
-    if (D_open_driver() < 0) {
+    if (D_open_driver() == -1) {
         /* don't render the entire raster region; this module will be rerun by
          * the monitor with the display extent (D_open_driver() will return 0
          * then) and use that information to constrain rendering */


### PR DESCRIPTION
This PR uses #3482 to allow displaying raster numbers for a smaller **display extent** (not computational region) than the suggested 200x200. Do we still want this limitation when `d.rast.arrow` doesn't have any or should we add the same limit to `d.rast.arrow`?