### PR TITLE
d.rast: Use new D_open_driver() return value to constrain rendering

### DIFF
--- a/display/d.rast/main.c
+++ b/display/d.rast/main.c
@@ -93,7 +93,13 @@ int main(int argc, char **argv)
     overlay = !flag_n->answer;
     invert = flag_i->answer;
 
-    D_open_driver();
+    if (D_open_driver() == -1) {
+        /* don't render the entire raster region; this module will be rerun by
+         * the monitor with the display extent (D_open_driver() will return 0
+         * then) and use that information to constrain rendering */
+        D_close_driver();
+        exit(EXIT_SUCCESS);
+    }
 
     fp = Rast_map_is_fp(name, "");
     if (vallist->answer) {


### PR DESCRIPTION
This PR uses #3482 to allow rendering raster maps within the display extent on the monitor, instead of the entire computational region.