### PR TITLE
d.rast.arrow: Use new D_open_driver() return value to constrain rendering

### DIFF
--- a/display/d.rast.arrow/main.c
+++ b/display/d.rast.arrow/main.c
@@ -220,7 +220,13 @@ int main(int argc, char **argv)
         G_warning(_("Scale option requires magnitude_map"));
 
     /* Setup driver and check important information */
-    D_open_driver();
+    if (D_open_driver() == -1) {
+        /* don't render the entire raster region; this module will be rerun by
+         * the monitor with the display extent (D_open_driver() will return 0
+         * then) and use that information to constrain rendering */
+        D_close_driver();
+        exit(EXIT_SUCCESS);
+    }
 
     D_setup(0);
 


### PR DESCRIPTION
This PR uses https://github.com/OSGeo/grass/pull/3482 to allow rendering raster arrows within the display extent on the monitor, instead of the entire computational region. It addresses #3481.