### PR TITLE
CI: add libsvm to full Ubuntu builds

### DIFF
--- a/.github/workflows/apt.txt
+++ b/.github/workflows/apt.txt
@@ -13,6 +13,7 @@ libpdal-dev
 libpng-dev
 libproj-dev
 libreadline-dev
+libsvm-dev
 libzstd-dev
 pdal
 proj-bin

--- a/.github/workflows/build_ubuntu-22.04.sh
+++ b/.github/workflows/build_ubuntu-22.04.sh
@@ -38,6 +38,7 @@ export INSTALL_PREFIX=$1
     --with-bzlib \
     --with-blas \
     --with-lapack \
+    --with-libsvm \
     --with-readline \
     --with-openmp \
     --with-pdal \


### PR DESCRIPTION
Following https://github.com/OSGeo/grass-addons/pull/1040, I'm suggesting to integrate this flag to the bigger Ubuntu builds.

I want to tend towards continuously testing a "full" and "minimal" configuration, to at least know that the optional components remain actually optional (still works without), but that optional components do actually still build. This is one more flag that is being added towards the "full" configuration.
