### PR TITLE
CI(labeler): Disable sync-labels that removes labels and pin action

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -20,6 +20,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
-          sync-labels: true
+          sync-labels: false


### PR DESCRIPTION
When this workflow was introduced, I suggested we try using the sync-labels option, that removes labels if files that were previously matching filters aren't matching anymore, like when some changes are reverted. We would have the time to refine our label-matching rules after merging. After a couple months of using this action (since end of December/beginning of January), I didn't see as much of pull requests where files were initially changed and were finally reverted and that it would have changed the labels of the PR. However, I saw multiple times PRs where manually added labels were removed, sometimes multiple times after each commit, which is a bit less intuitive. Each time I saw labels removed, I tried to think if an adjustment to the label matching patterns would do the trick, but most often not. A recent example is with the recent @HuidaeCho's PRs: a GUI and raster specific bug that needs to be fixed in files that match another section, like display.

So, for the time being, I suggest to turn that option back off, its default value. I left the line there set to false instead of removing it as a reminder that we tried it, in case the default changes in the future. (If in the future the behaviour is more adapted, we could try it again).

It is now our job (us PR reviewers) to remove unnecessary labels if less files are changed in a PR than it has previously had when the labeler workflow ran.



