### PR TITLE
CI(labeler): Match notebook label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -143,6 +143,11 @@ Python:
       - any-glob-to-any-file:
         - '**/*.py'
         - '**/pyproject.toml'
+notebook:
+  - changed-files:
+      - any-glob-to-any-file:
+        - '**/*.ipynb'
+        - doc/notebooks/**
 C:
   - changed-files:
       - any-glob-to-any-file: '**/*.c'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -148,6 +148,7 @@ notebook:
       - any-glob-to-any-file:
         - '**/*.ipynb'
         - doc/notebooks/**
+        - python/grass/jupyter/**
 C:
   - changed-files:
       - any-glob-to-any-file: '**/*.c'


### PR DESCRIPTION
PRs and issues relating to notebooks (for now only Python, but others exists) sometimes require a different skill set to review or resolve.

This PR configures matching the `notebook` label https://github.com/OSGeo/grass/labels/notebook in PRs with notebooks, as long as for the supporting code in the python/grass/jupyter folder.

By having the matching apply to PRs, a reviewer can filter by a label matching his skills to open PRs waiting to be merged (still in the hundreds)

I already started using that label in issues when triaging.