### PR TITLE
d.mon: Delegate rendering to wx monitors

### DIFF
--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
             mapfile += ".ppm"
         # to force rendering by wx monitors, but don't create a map file for
         # non-rendering modules
-        if cmd[0] not in ("d.redraw",) + non_rendering_modules:
+        if cmd[0] not in non_rendering_modules:
             Path(mapfile).touch()
     else:
         mapfile = None

--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import tempfile
+from pathlib import Path
 
 from grass.script import core as grass
 from grass.script import task as gtask
@@ -56,7 +57,6 @@ def update_cmd_file(cmd_file, cmd, mapfile):
         "d.info",
         "d.mon",
         "d.out.file",
-        "d.redraw",
         "d.to.rast",
         "d.what.rast",
         "d.what.vect",
@@ -157,13 +157,18 @@ if __name__ == "__main__":
             mapfile += ".png"
         else:
             mapfile += ".ppm"
+        # to force rendering by wx monitors
+        Path(mapfile).touch()
     else:
         mapfile = None
         adjust_region(width, height)
 
     read_stdin(cmd)
 
-    render(cmd, mapfile)
+    # wx monitors will render new layers internally
+    if not mon.startswith("wx"):
+        render(cmd, mapfile)
+
     update_cmd_file(os.path.join(path, "cmd"), cmd, mapfile)
     if cmd[0] == "d.erase" and os.path.exists(legfile):
         os.remove(legfile)

--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -8,6 +8,20 @@ from grass.script import core as grass
 from grass.script import task as gtask
 from grass.exceptions import CalledModuleError
 
+non_rendering_modules = (
+    "d.colorlist",
+    "d.font",
+    "d.fontlist",
+    "d.frame",
+    "d.info",
+    "d.mon",
+    "d.out.file",
+    "d.to.rast",
+    "d.what.rast",
+    "d.what.vect",
+    "d.where",
+)
+
 
 # read environment variables from file
 def read_env_file(env_file):
@@ -49,19 +63,7 @@ def render(cmd, mapfile):
 
 # update cmd file
 def update_cmd_file(cmd_file, cmd, mapfile):
-    if cmd[0] in (
-        "d.colorlist",
-        "d.font",
-        "d.fontlist",
-        "d.frame",
-        "d.info",
-        "d.mon",
-        "d.out.file",
-        "d.to.rast",
-        "d.what.rast",
-        "d.what.vect",
-        "d.where",
-    ):
+    if cmd[0] in non_rendering_modules:
         return
 
     mode = "w" if cmd[0] == "d.erase" else "a"
@@ -165,8 +167,10 @@ if __name__ == "__main__":
 
     read_stdin(cmd)
 
-    # wx monitors will render new layers internally
-    if not mon.startswith("wx"):
+    # wx monitors will render new layers internally so don't render them here;
+    # also, some display modules print information to the terminal rather than
+    # rendering any contents on the monitor so allow them to run here
+    if not mon.startswith("wx") or cmd[0] in non_rendering_modules:
         render(cmd, mapfile)
 
     update_cmd_file(os.path.join(path, "cmd"), cmd, mapfile)


### PR DESCRIPTION
This PR is another attempt to address https://github.com/OSGeo/grass/issues/3481. It should replace
* #3482
* #3491
* #3492

How it works:
1. `d.mon start=wx0`
2. Run a display module from the terminal
3. `D_open_setup()` from the module spawns the monitor's `render.py` and exits
4. `render.py` touches a temp map file for the wx monitor so the monitor can force rendering non-existing layers; without this empty file, the monitor won't render them (`Layer.IsRendered()` and `RenderMapMgr._checkRenderedSizes()` in `gui/wxpython/core/render.py`)
5. `render.py` doesn't `render()` for the wx monitor because the monitor is watching the `cmd` file and will render any new layers; existing layers won't be re-rendered (`exists` in `GetLayersFromCmdFile()` in `gui/wxpython/mapdisp/main.py`
6. `render.py` adds the new command line to the `cmd` file
7. The monitor catches a change in the `cmd` file from step 6 and calls the display module for actual rendering (`RenderLayerMgr.Render()` in `gui/wxpython/core/render.py`)

A display module is called twice by the user from the terminal and by the wx monitor or `render.py` for non-wx monitors.