### PR TITLE
v.patch: Continuous cats with -e

### DIFF
--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -416,7 +416,7 @@ int main(int argc, char *argv[])
             Vect_copy_head_data(&InMap, &OutMap);
 
         if (do_table) {
-            add_cat = maxcat + 1;
+            add_cat = maxcat;
         }
         else {
             add_cat = 0;

--- a/vector/v.patch/main.c
+++ b/vector/v.patch/main.c
@@ -8,7 +8,7 @@
  *               Markus Neteler <neteler itc.it>,
  *               Martin Landa <landa.martin gmail.com> (bbox)
  * PURPOSE:
- * COPYRIGHT:    (C) 2002-2006 by the GRASS Development Team
+ * COPYRIGHT:    (C) 2002-2024 by the GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS


### PR DESCRIPTION
This PR makes patched categories continuous. Without this PR:
```bash
v.random tmp100 npoints=100 seed=100
v.db.addtable tmp100 col="id varchar(20)"
v.db.update tmp100 col=id qcol="'tmp100_' || cat"

v.random tmp10 npoints=10 seed=10
v.db.addtable tmp10 col="id varchar(20)"
v.db.update tmp10 col=id qcol="'tmp10_' || cat"

v.patch tmp100,tmp10 out=tmp110 -e

v.category tmp110 op=report
Layer/table: 1/tmp110
type       count        min        max
point        110          2        112
line           0          0          0
boundary       0          0          0
centroid       0          0          0
area           0          0          0
face           0          0          0
kernel         0          0          0
all          110          2        112 # 2-101, 103-112
```

With this PR:
```bash
v.category tmp110 op=report
Layer/table: 1/tmp110
type       count        min        max
point        110          1        110
line           0          0          0
boundary       0          0          0
centroid       0          0          0
area           0          0          0
face           0          0          0
kernel         0          0          0
all          110          1        110 # 1-110
```