### PR TITLE
grass.script: add create_project() with same functionality as create_location()

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1700,12 +1700,15 @@ def mapsets(search_path=False, env=None):
 
 
 def create_location(*args, **kwargs):
+    if "location" in kwargs:
+        kwargs["name"] = kwargs["location"]
+        del kwargs["location"]
     return create_project(*args, **kwargs)
 
 
 def create_project(
     path,
-    location=None,
+    name=None,
     epsg=None,
     proj4=None,
     filename=None,
@@ -1720,7 +1723,7 @@ def create_project(
     Raise ScriptError on error.
 
     :param str path: path to GRASS database
-    :param str location: project name to create
+    :param str name: project name to create
     :param str mapset: mapset within given project (default: 'PERMANENT')
     :param epsg: if given create new project based on EPSG code
     :param proj4: if given create new project based on Proj4 definition
@@ -1736,13 +1739,13 @@ def create_project(
     # Support ~ in the path for user home directory.
     path = Path(path).expanduser()
 
-    if location:
+    if name:
         mapset = "PERMANENT"
     else:
         path = path / "PERMANENT"
         mapset = None
 
-    mapset_path = resolve_mapset_path(path=path, location=location, mapset=mapset)
+    mapset_path = resolve_mapset_path(path=path, location=name, mapset=mapset)
 
     # create dbase if not exists
     if not os.path.exists(mapset_path.directory):

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1736,16 +1736,12 @@ def create_project(
     :param bool overwrite: True to overwrite project if exists (WARNING:
                            ALL DATA from existing project ARE DELETED!)
     """
-    # Support ~ in the path for user home directory.
-    path = Path(path).expanduser()
+    # Add default mapset to project path if needed
+    if not name:
+        path = os.path.join(path, "PERMANENT")
 
-    if name:
-        mapset = "PERMANENT"
-    else:
-        path = path / "PERMANENT"
-        mapset = None
-
-    mapset_path = resolve_mapset_path(path=path, location=name, mapset=mapset)
+    # resolve dbase, location and mapset
+    mapset_path = resolve_mapset_path(path=path, location=name)
 
     # create dbase if not exists
     if not os.path.exists(mapset_path.directory):

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1766,19 +1766,18 @@ def create_project(
     # check if location already exists
     if Path(mapset_path.directory, mapset_path.location).exists():
         if not overwrite:
-            warning(
+            fatal(
                 _("Location <%s> already exists. Operation canceled.")
                 % mapset_path.location,
                 env=env,
             )
             return
-        else:
-            warning(
-                _("Location <%s> already exists and will be overwritten")
-                % mapset_path.location,
-                env=env,
-            )
-            shutil.rmtree(os.path.join(mapset_path.directory, mapset_path.location))
+        warning(
+            _("Location <%s> already exists and will be overwritten")
+            % mapset_path.location,
+            env=env,
+        )
+        shutil.rmtree(os.path.join(mapset_path.directory, mapset_path.location))
 
     stdin = None
     kwargs = dict()

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -28,9 +28,11 @@ import string
 import random
 import shlex
 from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 from .utils import KeyValue, parse_key_val, basename, encode, decode, try_remove
 from grass.exceptions import ScriptError, CalledModuleError
+from grass.grassdb.manage import resolve_mapset_path
 
 
 # subprocess wrapper that uses shell on Windows
@@ -1697,9 +1699,13 @@ def mapsets(search_path=False, env=None):
 # interface to `g.proj -c`
 
 
-def create_location(
-    dbase,
-    location,
+def create_location(*args, **kwargs):
+    return create_project(*args, **kwargs)
+
+
+def create_project(
+    path,
+    location=None,
     epsg=None,
     proj4=None,
     filename=None,
@@ -1709,44 +1715,38 @@ def create_location(
     desc=None,
     overwrite=False,
 ):
-    """Create new location
+    """Create new project
 
     Raise ScriptError on error.
 
-    :param str dbase: path to GRASS database
-    :param str location: location name to create
-    :param epsg: if given create new location based on EPSG code
-    :param proj4: if given create new location based on Proj4 definition
-    :param str filename: if given create new location based on georeferenced file
-    :param str wkt: if given create new location based on WKT definition
+    :param str path: path to GRASS database
+    :param str location: project name to create
+    :param str mapset: mapset within given project (default: 'PERMANENT')
+    :param epsg: if given create new project based on EPSG code
+    :param proj4: if given create new project based on Proj4 definition
+    :param str filename: if given create new project based on georeferenced file
+    :param str wkt: if given create new project based on WKT definition
                     (can be path to PRJ file or WKT string)
     :param datum: GRASS format datum code
     :param datum_trans: datum transformation parameters (used for epsg and proj4)
-    :param desc: description of the location (creates MYNAME file)
-    :param bool overwrite: True to overwrite location if exists(WARNING:
-                           ALL DATA from existing location ARE DELETED!)
+    :param desc: description of the project (creates MYNAME file)
+    :param bool overwrite: True to overwrite project if exists(WARNING:
+                           ALL DATA from existing project ARE DELETED!)
     """
+    # Support ~ in the path for user home directory.
+    path = Path(path).expanduser()
+
+    if location:
+        mapset = "PERMANENT"
+    else:
+        path = path / "PERMANENT"
+        mapset = None
+
+    mapset_path = resolve_mapset_path(path=path, location=location, mapset=mapset)
+
     # create dbase if not exists
-    if not os.path.exists(dbase):
-        os.mkdir(dbase)
-
-    # check if location already exists
-    if os.path.exists(os.path.join(dbase, location)):
-        if not overwrite:
-            warning(_("Location <%s> already exists. Operation canceled.") % location)
-            return
-        else:
-            warning(
-                _("Location <%s> already exists and will be overwritten") % location
-            )
-            shutil.rmtree(os.path.join(dbase, location))
-
-    stdin = None
-    kwargs = dict()
-    if datum:
-        kwargs["datum"] = datum
-    if datum_trans:
-        kwargs["datum_trans"] = datum_trans
+    if not os.path.exists(mapset_path.directory):
+        os.mkdir(mapset_path.directory)
 
     # Lazy-importing to avoid circular dependencies.
     # pylint: disable=import-outside-toplevel
@@ -1761,8 +1761,32 @@ def create_location(
     if epsg or proj4 or filename or wkt:
         # The names don't really matter here.
         tmp_gisrc, env = create_environment(
-            dbase, "<placeholder>", "<placeholder>", env=env
+            mapset_path.directory, mapset_path.location, mapset_path.mapset, env=env
         )
+
+    # check if location already exists
+    if os.path.exists(os.path.join(mapset_path.directory, mapset_path.location)):
+        if not overwrite:
+            warning(
+                _("Location <%s> already exists. Operation canceled.")
+                % mapset_path.location,
+                env=env,
+            )
+            return
+        else:
+            warning(
+                _("Location <%s> already exists and will be overwritten")
+                % mapset_path.location,
+                env=env,
+            )
+            shutil.rmtree(os.path.join(mapset_path.directory, mapset_path.location))
+
+    stdin = None
+    kwargs = dict()
+    if datum:
+        kwargs["datum"] = datum
+    if datum_trans:
+        kwargs["datum_trans"] = datum_trans
 
     if epsg:
         ps = pipe_command(
@@ -1770,7 +1794,7 @@ def create_location(
             quiet=True,
             flags="t",
             epsg=epsg,
-            location=location,
+            location=mapset_path.location,
             stderr=PIPE,
             env=env,
             **kwargs,
@@ -1781,7 +1805,7 @@ def create_location(
             quiet=True,
             flags="t",
             proj4=proj4,
-            location=location,
+            location=mapset_path.location,
             stderr=PIPE,
             env=env,
             **kwargs,
@@ -1791,28 +1815,33 @@ def create_location(
             "g.proj",
             quiet=True,
             georef=filename,
-            location=location,
+            location=mapset_path.location,
             stderr=PIPE,
             env=env,
         )
     elif wkt:
         if os.path.isfile(wkt):
             ps = pipe_command(
-                "g.proj", quiet=True, wkt=wkt, location=location, stderr=PIPE, env=env
+                "g.proj",
+                quiet=True,
+                wkt=wkt,
+                location=mapset_path.location,
+                stderr=PIPE,
+                env=env,
             )
         else:
             ps = pipe_command(
                 "g.proj",
                 quiet=True,
                 wkt="-",
-                location=location,
+                location=mapset_path.location,
                 stderr=PIPE,
                 stdin=PIPE,
                 env=env,
             )
             stdin = encode(wkt)
     else:
-        _create_location_xy(dbase, location)
+        _create_location_xy(mapset_path.directory, mapset_path.location)
 
     if epsg or proj4 or filename or wkt:
         error = ps.communicate(stdin)[1]
@@ -1821,7 +1850,7 @@ def create_location(
         if ps.returncode != 0 and error:
             raise ScriptError(repr(error))
 
-    _set_location_description(dbase, location, desc)
+    _set_location_description(mapset_path.directory, mapset_path.location, desc)
 
 
 def _set_location_description(path, location, text):

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1771,7 +1771,6 @@ def create_project(
                 % mapset_path.location,
                 env=env,
             )
-            return
         warning(
             _("Location <%s> already exists and will be overwritten")
             % mapset_path.location,

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1722,9 +1722,9 @@ def create_project(
 
     Raise ScriptError on error.
 
-    :param str path: path to GRASS database
+    :param str path: path to GRASS database or project; if path to database, project
+                     name must be specified with name parameter
     :param str name: project name to create
-    :param str mapset: mapset within given project (default: 'PERMANENT')
     :param epsg: if given create new project based on EPSG code
     :param proj4: if given create new project based on Proj4 definition
     :param str filename: if given create new project based on georeferenced file
@@ -1733,7 +1733,7 @@ def create_project(
     :param datum: GRASS format datum code
     :param datum_trans: datum transformation parameters (used for epsg and proj4)
     :param desc: description of the project (creates MYNAME file)
-    :param bool overwrite: True to overwrite project if exists(WARNING:
+    :param bool overwrite: True to overwrite project if exists (WARNING:
                            ALL DATA from existing project ARE DELETED!)
     """
     # Support ~ in the path for user home directory.
@@ -1768,7 +1768,7 @@ def create_project(
         )
 
     # check if location already exists
-    if os.path.exists(os.path.join(mapset_path.directory, mapset_path.location)):
+    if Path(mapset_path.directory, mapset_path.location).exists():
         if not overwrite:
             warning(
                 _("Location <%s> already exists. Operation canceled.")

--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -99,6 +99,37 @@ def test_with_different_path(tmp_path):
         assert epsg == "EPSG:3358"
 
 
+def test_path_only(tmp_path):
+    desired_location = "desired"
+    full_path = tmp_path / desired_location
+    gs.create_location(full_path, epsg="3358")
+    mapset_path = full_path / "PERMANENT"
+    wkt_file = mapset_path / "PROJ_WKT"
+    assert full_path.exists()
+    assert mapset_path.exists()
+    assert wkt_file.exists()
+    with gs.setup.init(full_path):
+        gs.run_command("g.gisenv", set=f"GISDBASE={tmp_path}")
+        gs.run_command("g.gisenv", set=f"LOCATION_NAME={desired_location}")
+        gs.run_command("g.gisenv", set="MAPSET=PERMANENT")
+        epsg = gs.parse_command("g.proj", flags="g")["srid"]
+        assert epsg == "EPSG:3358"
+
+
+def test_create_project(tmp_path):
+    name = "desired"
+    gs.create_project(tmp_path / name, epsg="3358")
+    assert (tmp_path / name).exists()
+    wkt_file = tmp_path / name / "PERMANENT" / "PROJ_WKT"
+    assert wkt_file.exists()
+    with gs.setup.init(tmp_path / name):
+        gs.run_command("g.gisenv", set=f"GISDBASE={tmp_path}")
+        gs.run_command("g.gisenv", set=f"LOCATION_NAME={name}")
+        gs.run_command("g.gisenv", set="MAPSET=PERMANENT")
+        epsg = gs.parse_command("g.proj", flags="g")["srid"]
+        assert epsg == "EPSG:3358"
+
+
 def test_files(tmp_path):
     """Check expected files are created"""
     bootstrap_location = "bootstrap"


### PR DESCRIPTION
As we begin renaming location to project, it would be nice to have a `create_project()` function that works the same as `create_location`.

This is particularly nice in notebooks because these function work without an active GRASS session so users can use a work flow that I think is very intuitive:
1. `import grass.script` and `grass.jupyter`
2. `create_project()` to make a new project 
3. `gj.init()` to start the session in the new project

This PR also includes additional path support. For example, all the following lines will create a new project:
```
# just project name (creates project in current working directory)
gs.create_project("nags_head", epsg="32119") 

# grassdata path and name of project
gs.create_project("~/grassdata", name="nags_head", epsg="32119") 

# full path to new project
gs.create_project("~/grassdata/nags_head", epsg="32119") # full path to new project
```