### PR TITLE
Add Automated Coverity Scanning

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,7 +4,7 @@ name: CI-Coverity-Basic
 on:
   workflow_dispatch: # run whenever a contributor calls it
   schedule: 
-    - cron: '48 5 * * 6' # Run at 05:48 on Saturdays
+    - cron: '48 5 * * *' # Run at 05:48
   
 jobs:
   build:
@@ -16,16 +16,6 @@ jobs:
         uses: synopsys-sig/synopsys-action@v1.6.0
         with:
           ### SCANNING: Required fields
-          coverity_url: ${{ secrets.COVERITY_URL }}
-          coverity_user: ${{ secrets.COVERITY_USER }}
-          coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }}
-          
-          ### Coverity Connect users - Uncomment below
-          # coverity_local: true
-        
-          ### POLICY ENFORCEMENT: Uncomment to break build on policy
-          # coverity_policy_view: 'Outstanding Issues' 
-        
-          ### PULL REQUEST COMMENTS: Uncomment below to enable
-          # coverity_prComment_enabled: true
-          # github_token: ${{ secrets.GITHUB_TOKEN }} # Required when PR comments is enabled  
+          coverity_url: ${{ secrets.COVERITY_URL }}               # The URL to Coverity
+          coverity_user: ${{ secrets.COVERITY_USER }}             # The user for the Coverity project
+          coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }} # The password for the Coverity user

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,10 +1,9 @@
 name: Coverity Scan
-# Created using https://sig-product-docs.synopsys.com/bundle/bridge/page/documentation/c_github-coverity.html as a template
-# Author: Jaden Abrams <jadenabrams100@gmail.com>
 on:
   workflow_dispatch: # run whenever a contributor calls it
   schedule: 
     - cron: '48 5 * * *' # Run at 05:48
+    # Coverity will let GRASS do a scan a maximum of twice per day, so this schedule will help GRASS fit within that limit with some additional space for manual runs
   
 jobs:
   build:
@@ -13,7 +12,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v3
       - name: Coverity Scan
-        uses: synopsys-sig/synopsys-action@v1.6.0
+        uses: synopsys-sig/synopsys-action@45ec794c72a1dff9baba58ff356386bbbfeb32c7 #v1.6.0
         with:
           ### SCANNING: Required fields
           coverity_url: ${{ secrets.COVERITY_URL }}               # The URL to Coverity

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.0.0
       - name: Coverity Scan
         uses: synopsys-sig/synopsys-action@45ec794c72a1dff9baba58ff356386bbbfeb32c7 #v1.6.0
         with:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,31 @@
+name: CI-Coverity-Basic
+# Created using https://sig-product-docs.synopsys.com/bundle/bridge/page/documentation/c_github-coverity.html as a template
+# Author: Jaden Abrams <jadenabrams100@gmail.com>
+on:
+  workflow_dispatch: # run whenever a contributor calls it
+  schedule: 
+    - cron: '48 5 * * 6' # Run at 05:48 on Saturdays
+  
+jobs:
+  build:
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+      - name: Coverity Scan
+        uses: synopsys-sig/synopsys-action@v1.6.0
+        with:
+          ### SCANNING: Required fields
+          coverity_url: ${{ secrets.COVERITY_URL }}
+          coverity_user: ${{ secrets.COVERITY_USER }}
+          coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }}
+          
+          ### Coverity Connect users - Uncomment below
+          # coverity_local: true
+        
+          ### POLICY ENFORCEMENT: Uncomment to break build on policy
+          # coverity_policy_view: 'Outstanding Issues' 
+        
+          ### PULL REQUEST COMMENTS: Uncomment below to enable
+          # coverity_prComment_enabled: true
+          # github_token: ${{ secrets.GITHUB_TOKEN }} # Required when PR comments is enabled  

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,4 +1,4 @@
-name: CI-Coverity-Basic
+name: Coverity Scan
 # Created using https://sig-product-docs.synopsys.com/bundle/bridge/page/documentation/c_github-coverity.html as a template
 # Author: Jaden Abrams <jadenabrams100@gmail.com>
 on:


### PR DESCRIPTION
This PR adds automatic Coverity functionality to the GRASS GIS repository. This action will (should) tell the Synopsys Coverity action to run the scan, with the results being posted on the Coverity Website. The following things will be needed in secrets for the action to work:

* COVERITY_URL: the URL for Coverity
* COVERITY_USER: the Coverity username
* COVERITY_PASSPHRASE: the Coverity passphrase

This action is based off of https://sig-product-docs.synopsys.com/bundle/bridge/page/documentation/c_github-coverity.html and will be worked on with @wenzeslaus 