### PR TITLE
CI(windows): Increase required passing tests percentage to 80%

### DIFF
--- a/.github/workflows/test_thorough.bat
+++ b/.github/workflows/test_thorough.bat
@@ -2,4 +2,4 @@ set grass=%1
 set python=%2
 
 call %grass% --tmp-location XY --exec g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=%USERPROFILE%
-call %grass% --tmp-location XY --exec %python% -m grass.gunittest.main --grassdata %USERPROFILE% --location nc_spm_full_v2alpha2 --location-type nc --min-success 60
+call %grass% --tmp-location XY --exec %python% -m grass.gunittest.main --grassdata %USERPROFILE% --location nc_spm_full_v2alpha2 --location-type nc --min-success 80


### PR DESCRIPTION
Currently, the number of test files on windows is 295, and 238 files pass. That is a little over 80% (80.677966%), and the results at the end of the test runs mention 81% passes.

This PR raises the minimum percent of passing files to the current state, so that we can become more aware of changes in the test suite. It still allows for 2 files to fail before it becomes under 80%: 236/295=0.8, but 235/295=0.796610.

There’s no magic with this PR, since number of test files isn’t a very good measure to determine if a regression has occurred inside an already failing file, but it’s still better than nothing.