### PR TITLE
CI: Use Renovate best-practices preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:base",
+        "config:best-practices",
         ":semanticCommitTypeAll(CI)"
     ]
 }


### PR DESCRIPTION
See docs here: https://docs.renovatebot.com/presets-config/#configbest-practices

Among others, it will pin GitHub Actions to digests (ie: will convert the `@v2` of https://github.com/OSGeo/grass/pull/3532 to the digest we use elsewhere). Same for docker images.
