### PR TITLE
Fix flake8 F401 imported but unused

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,6 @@ per-file-ignores =
     # F821 undefined name 'unicode'
     # F841 local variable assigned to but never used
     # E741 ambiguous variable name 'l'
-    __init__.py: F401
     lib/init/grass.py: E501, E722, F821, F841, W605
     utils/mkrest.py: E501, W605
     utils/gitlog2changelog.py: E722, E712, W605

--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,7 @@ per-file-ignores =
     # F821 undefined name 'unicode'
     # F841 local variable assigned to but never used
     # E741 ambiguous variable name 'l'
+    __init__.py: F401
     lib/init/grass.py: E501, E722, F821, F841, W605
     utils/mkrest.py: E501, W605
     utils/gitlog2changelog.py: E722, E712, W605

--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,7 @@ per-file-ignores =
     # F821 undefined name 'unicode'
     # F841 local variable assigned to but never used
     # E741 ambiguous variable name 'l'
-    __init__.py: F401
+    __init__.py: F401, F403
     lib/init/grass.py: E501, E722, F821, F841, W605
     utils/mkrest.py: E501, W605
     utils/gitlog2changelog.py: E722, E712, W605

--- a/python/grass/pygrass/tests/benchmark.py
+++ b/python/grass/pygrass/tests/benchmark.py
@@ -21,7 +21,6 @@ sys.path.append("%s/.." % (os.getcwd()))
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster
 import grass.script as core
-import grass.pygrass
 import ctypes
 
 


### PR DESCRIPTION
F401 errors are most often caused by ```__init__.py```, except one. The line ```--per-file-ignores=__init__.py:F401``` has been added to the .flake8 file to ignore ```__init__.py```. 