### PR TITLE
CI(black): Post black code suggestions as PR review comments

### DIFF
--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -3,7 +3,7 @@ name: Post PR code suggestions
 
 on:
   workflow_run:
-    workflows: ["ClangFormat Check"]
+    workflows: ["ClangFormat Check", "Python Code Quality"]
     types:
       - completed
 permissions: {}
@@ -27,7 +27,30 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{github.event.workflow_run.id }}
       - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
-      - run: |
+      - name: Check what tools have suggestions to post
+        # Using this pattern to have expected file names explicitly named
+        id: tools
+        run: |
+          for tool_name in $INPUT_TOOL_NAMES
+          do
+            INPUT_TOOL_NAME_FILE="diff-${tool_name}.patch"
+            echo "Checking if tool ${tool_name} left suggestions in ${INPUT_TOOL_NAME_FILE}..."
+            if [[ -f "${INPUT_TOOL_NAME_FILE}" ]]; then
+              echo "   ${INPUT_TOOL_NAME_FILE} was found for tool ${tool_name}"
+              echo "$tool_name=true" >> "${GITHUB_OUTPUT}"
+            else
+              echo "   ${INPUT_TOOL_NAME_FILE} was not found for tool ${tool_name}"
+              echo "$tool_name=false" >> "${GITHUB_OUTPUT}"
+            fi
+          done
+        env:
+          INPUT_TOOL_NAMES: >-
+            black
+            clang-format
+      - name: Post Black suggestions
+        if: ${{ steps.tools.outputs.black == 'true' }}
+        run: |
+          TMPFILE="diff-${INPUT_TOOL_NAME}.patch"
           GITHUB_ACTIONS="" reviewdog \
               -name="${INPUT_TOOL_NAME:-reviewdog-suggester}" \
               -f=diff \
@@ -36,7 +59,24 @@ jobs:
               -guess \
               -reporter="github-pr-review" < "${TMPFILE}"
         env:
-          TMPFILE: diff-clang-format.patch
+          INPUT_TOOL_NAME: black
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get
+      - name: Post ClangFormat suggestions
+        if: ${{ steps.tools.outputs.clang-format == 'true' }}
+        run: |
+          TMPFILE="diff-${INPUT_TOOL_NAME}.patch"
+          GITHUB_ACTIONS="" reviewdog \
+              -name="${INPUT_TOOL_NAME:-reviewdog-suggester}" \
+              -f=diff \
+              -f.diff.strip=1 \
+              -filter-mode=nofilter \
+              -guess \
+              -reporter="github-pr-review" < "${TMPFILE}"
+        env:
           INPUT_TOOL_NAME: clang-format
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_COMMIT: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -56,6 +56,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install Black only
+        run: pip install black==${{ matrix.black-version }}
+
+      - name: Run Black
+        run: black .
+
+      - name: Create and uploads code suggestions to apply for Black
+        # Will fail fast here if there are changes required
+        id: diff-black
+        uses: ./.github/actions/create-upload-suggestions
+        with:
+          tool-name: black
+          # To keep repo's file structure in formatted changes artifact
+          extra-upload-changes: .clang-format
 
       - name: Install non-Python dependencies
         run: |
@@ -66,25 +83,11 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r .github/workflows/python_requirements.txt
           pip install -r .github/workflows/optional_requirements.txt
-          pip install black==${{ matrix.black-version }}
           pip install flake8==${{ matrix.flake8-version }}
           pip install pylint==${{ matrix.pylint-version }} pytest-github-actions-annotate-failures
           pip install bandit[sarif]==${{matrix.bandit-version}}
-
-      - name: Run Black
-        run: black .
-
-      - name: Create and uploads code suggestions to apply for black
-        # Will fail fast here if there are changes required
-        id: diff-black
-        uses: ./.github/actions/create-upload-suggestions
-        with:
-          tool-name: black
-          # To keep repo's file structure in formatted changes artifact
-          extra-upload-changes: .clang-format
 
       - name: Run Flake8
         run: |

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -75,8 +75,16 @@ jobs:
           pip install bandit[sarif]==${{matrix.bandit-version}}
 
       - name: Run Black
-        run: |
-          black --check --diff .
+        run: black .
+
+      - name: Create and uploads code suggestions to apply for black
+        # Will fail fast here if there are changes required
+        id: diff-black
+        uses: ./.github/actions/create-upload-suggestions
+        with:
+          tool-name: black
+          # To keep repo's file structure in formatted changes artifact
+          extra-upload-changes: .clang-format
 
       - name: Run Flake8
         run: |


### PR DESCRIPTION
Since #3527 is merged, I rebased my implementation of posting code suggestions for Black formatting.
I have implemented a pattern to handle multiple tools in the workflow_run triggered workflow (the one called when a workflow is completed, and that runs with write permissions, and from the context of the default branch->main). 

I wrote the workflow with a whitelisting approach in mind, to only allow continuing on the expected file names, in case the workflow is triggered on a file that wasn’t supposed to.
That’s why it’s not a simple loop, that would execute shell scripts on untrusted inputs/interpolation.
