### PR TITLE
utils(dep_tree2sql): Update to valid syntax, address shellcheck warnings

### DIFF
--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -125,42 +125,42 @@ find . -type f -perm +111 \! -name '*.so' -print0 \
 
 )
 
-find * -type f -name 'lib?*.a' -print0 \
+find ./* -type f -name 'lib?*.a' -print0 \
 	| xargs -0 nm -A \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$5}' \
 	> "$tmpdir/stlib_exp.lst"
 
-find * -type f -name 'lib?*.so' -print0 \
+find ./* -type f -name 'lib?*.so' -print0 \
 	| xargs -0 nm -AD \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
 	> "$tmpdir/shlib_exp.lst"
 
-find * -type f -name '*.o' -print0 \
+find ./* -type f -name '*.o' -print0 \
 	| xargs -0 nm -A \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print $1,$4}' \
 	> "$tmpdir/obj_exp.lst"
 
-find * -type f -name 'lib?*.a' -print0 \
+find ./* -type f -name 'lib?*.a' -print0 \
 	| xargs -0 nm -A \
 	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$4}' \
 	> "$tmpdir/stlib_imp.lst"
 
-find * -type f -name 'lib?*.so' -print0 \
+find ./* -type f -name 'lib?*.so' -print0 \
 	| xargs -0 nm -AD \
 	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$3}' \
 	> "$tmpdir/shlib_imp.lst"
 
-find * -type f -name '*.o' -print0 \
+find ./* -type f -name '*.o' -print0 \
 	| xargs -0 nm -A \
 	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -86,10 +86,10 @@ tmpdir=/tmp/sql-grass
 dbname=grass
 
 if [ -n "$1" ]; then
-	builddir="$1"
+    builddir="$1"
 else
-	echo "Usage: del_tree2sql.sh <source directory>" >&2
-	exit 1
+    echo "Usage: del_tree2sql.sh <source directory>" >&2
+    exit 1
 fi
 
 rm -rf "$tmpdir"
@@ -97,85 +97,86 @@ mkdir -m 711 "$tmpdir" || exit 1
 
 cd "$builddir" || exit 1
 
-( cd dist.* || exit 1
+(
+    cd dist.* || exit 1
 
-#LD_LIBRARY_PATH=`pwd`/lib
-#export LD_LIBRARY_PATH
+    #LD_LIBRARY_PATH=`pwd`/lib
+    #export LD_LIBRARY_PATH
 
-find . -type f -perm /a+x \! -name '*.so.*' \
-	| while read -r file ; do ldd "$file" | sed 's!^!'"$file"'!' ; done 2>/dev/null \
-	| sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
-	| grep -F -v 'not a dynamic executable' \
-	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \
-	> "$tmpdir/ldd.lst"
+    find . -type f -perm /a+x \! -name '*.so.*' \
+        | while read -r file; do ldd "$file" | sed 's!^!'"$file"'!'; done 2> /dev/null \
+        | sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
+        | grep -F -v 'not a dynamic executable' \
+        | awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \
+            > "$tmpdir/ldd.lst"
 
-find . -type f -perm /a+x \! -name '*.so' -print0 \
-	| xargs -0 nm -AD 2>/dev/null \
-	| grep -E ': {8}{1,2} U ' \
-	| sed -e 's/:/ /g' -e 's/\.\///' \
-	| awk -vOFS='\t' '{print $1,$3}' \
-	> "$tmpdir/prog_imp.lst"
+    find . -type f -perm /a+x \! -name '*.so' -print0 \
+        | xargs -0 nm -AD 2> /dev/null \
+        | grep -E ': {8}{1,2} U ' \
+        | sed -e 's/:/ /g' -e 's/\.\///' \
+        | awk -vOFS='\t' '{print $1,$3}' \
+            > "$tmpdir/prog_imp.lst"
 
-find . -type f -perm /a+x \! -name '*.so' -print0 \
-	| xargs -0 nm -AD 2>/dev/null \
-	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
-	| sed -e 's/:/ /g' -e 's/\.\///' \
-	| awk -vOFS='\t' '{print $1,$4}' \
-	> "$tmpdir/prog_exp.lst"
+    find . -type f -perm /a+x \! -name '*.so' -print0 \
+        | xargs -0 nm -AD 2> /dev/null \
+        | grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+        | sed -e 's/:/ /g' -e 's/\.\///' \
+        | awk -vOFS='\t' '{print $1,$4}' \
+            > "$tmpdir/prog_exp.lst"
 
 )
 
 find ./* -type f -name 'lib?*.a' -print0 \
-	| xargs -0 nm -A \
-	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$5}' \
-	> "$tmpdir/stlib_exp.lst"
+    | xargs -0 nm -A \
+    | grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$5}' \
+        > "$tmpdir/stlib_exp.lst"
 
 find ./* -type f -name 'lib?*.so' -print0 \
-	| xargs -0 nm -AD \
-	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
-	> "$tmpdir/shlib_exp.lst"
+    | xargs -0 nm -AD \
+    | grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
+        > "$tmpdir/shlib_exp.lst"
 
 find ./* -type f -name '*.o' -print0 \
-	| xargs -0 nm -A \
-	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print $1,$4}' \
-	> "$tmpdir/obj_exp.lst"
+    | xargs -0 nm -A \
+    | grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print $1,$4}' \
+        > "$tmpdir/obj_exp.lst"
 
 find ./* -type f -name 'lib?*.a' -print0 \
-	| xargs -0 nm -A \
-	| grep -E ': {8}{1,2} U ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$4}' \
-	> "$tmpdir/stlib_imp.lst"
+    | xargs -0 nm -A \
+    | grep -E ': {8}{1,2} U ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$4}' \
+        > "$tmpdir/stlib_imp.lst"
 
 find ./* -type f -name 'lib?*.so' -print0 \
-	| xargs -0 nm -AD \
-	| grep -E ': {8}{1,2} U ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$3}' \
-	> "$tmpdir/shlib_imp.lst"
+    | xargs -0 nm -AD \
+    | grep -E ': {8}{1,2} U ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$3}' \
+        > "$tmpdir/shlib_imp.lst"
 
 find ./* -type f -name '*.o' -print0 \
-	| xargs -0 nm -A \
-	| grep -E ': {8}{1,2} U ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print $1,$3}' \
-	> "$tmpdir/obj_imp.lst"
+    | xargs -0 nm -A \
+    | grep -E ': {8}{1,2} U ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print $1,$3}' \
+        > "$tmpdir/obj_imp.lst"
 
 mapfile -t libs < <(awk '{print $3}' "$tmpdir/ldd.lst" | uniq | sort | uniq)
 
 nm -AD "${libs[@]}" \
-	| grep -E ':[0-9a-f]{8}{1,2} [TWDRC] ' \
-	| sed 's/:/ /g' \
-	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
-	> "$tmpdir/libs.lst"
+    | grep -E ':[0-9a-f]{8}{1,2} [TWDRC] ' \
+    | sed 's/:/ /g' \
+    | awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
+        > "$tmpdir/libs.lst"
 
-cat > "$tmpdir/ansi.lst" <<EOF
+cat > "$tmpdir/ansi.lst" << EOF
 abort
 asctime
 atexit
@@ -281,7 +282,7 @@ EOF
 dropdb --if-exists "$dbname"
 createdb "$dbname"
 
-psql -n -q -d "$dbname" <<EOF
+psql -n -q -d "$dbname" << EOF
 
 -- ----------------------------------------------------------------------
 

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -103,7 +103,7 @@ cd "$builddir" || exit 1
 #export LD_LIBRARY_PATH
 
 find . -type f -perm +111 \! -name '*.so.*' \
-	| while read file ; do ldd "$file" | sed 's!^!'"$file"'!' ; done 2>/dev/null \
+	| while read -r file ; do ldd "$file" | sed 's!^!'"$file"'!' ; done 2>/dev/null \
 	| sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
 	| grep -F -v 'not a dynamic executable' \
 	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -105,7 +105,7 @@ cd "$builddir" || exit 1
 find . -type f -perm +111 \! -name '*.so.*' \
 	| while read file ; do ldd "$file" | sed 's!^!'$file'!' ; done 2>/dev/null \
 	| sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
-	| fgrep -v 'not a dynamic executable' \
+	| grep -F -v 'not a dynamic executable' \
 	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \
 	> "$tmpdir/ldd.lst"
 

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -167,7 +167,7 @@ find * -type f -name '*.o' \
 	| awk -vOFS='\t' '{print $1,$3}' \
 	> "$tmpdir/obj_imp.lst"
 
-libs=`awk '{print $3}' "$tmpdir/ldd.lst" | uniq | sort | uniq`
+libs=$(awk '{print $3}' "$tmpdir/ldd.lst" | uniq | sort | uniq)
 
 nm -AD $libs \
 	| egrep ':[0-9a-f]{8}{1,2} [TWDRC] ' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -111,14 +111,14 @@ find . -type f -perm +111 \! -name '*.so.*' \
 
 find . -type f -perm +111 \! -name '*.so' \
 	| xargs nm -AD 2>/dev/null \
-	| egrep ': {8}{1,2} U ' \
+	| grep -E ': {8}{1,2} U ' \
 	| sed -e 's/:/ /g' -e 's/\.\///' \
 	| awk -vOFS='\t' '{print $1,$3}' \
 	> "$tmpdir/prog_imp.lst"
 
 find . -type f -perm +111 \! -name '*.so' \
 	| xargs nm -AD 2>/dev/null \
-	| egrep ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed -e 's/:/ /g' -e 's/\.\///' \
 	| awk -vOFS='\t' '{print $1,$4}' \
 	> "$tmpdir/prog_exp.lst"
@@ -127,42 +127,42 @@ find . -type f -perm +111 \! -name '*.so' \
 
 find * -type f -name 'lib?*.a' \
 	| xargs nm -A \
-	| egrep ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$5}' \
 	> "$tmpdir/stlib_exp.lst"
 
 find * -type f -name 'lib?*.so' \
 	| xargs nm -AD \
-	| egrep ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
 	> "$tmpdir/shlib_exp.lst"
 
 find * -type f -name '*.o' \
 	| xargs nm -A \
-	| egrep ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
+	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print $1,$4}' \
 	> "$tmpdir/obj_exp.lst"
 
 find * -type f -name 'lib?*.a' \
 	| xargs nm -A \
-	| egrep ': {8}{1,2} U ' \
+	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$4}' \
 	> "$tmpdir/stlib_imp.lst"
 
 find * -type f -name 'lib?*.so' \
 	| xargs nm -AD \
-	| egrep ': {8}{1,2} U ' \
+	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$3}' \
 	> "$tmpdir/shlib_imp.lst"
 
 find * -type f -name '*.o' \
 	| xargs nm -A \
-	| egrep ': {8}{1,2} U ' \
+	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print $1,$3}' \
 	> "$tmpdir/obj_imp.lst"
@@ -170,7 +170,7 @@ find * -type f -name '*.o' \
 libs=$(awk '{print $3}' "$tmpdir/ldd.lst" | uniq | sort | uniq)
 
 nm -AD $libs \
-	| egrep ':[0-9a-f]{8}{1,2} [TWDRC] ' \
+	| grep -E ':[0-9a-f]{8}{1,2} [TWDRC] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
 	> "$tmpdir/libs.lst"

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -102,21 +102,21 @@ cd "$builddir" || exit 1
 #LD_LIBRARY_PATH=`pwd`/lib
 #export LD_LIBRARY_PATH
 
-find . -type f -perm +111 \! -name '*.so.*' \
+find . -type f -perm /a+x \! -name '*.so.*' \
 	| while read -r file ; do ldd "$file" | sed 's!^!'"$file"'!' ; done 2>/dev/null \
 	| sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
 	| grep -F -v 'not a dynamic executable' \
 	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \
 	> "$tmpdir/ldd.lst"
 
-find . -type f -perm +111 \! -name '*.so' -print0 \
+find . -type f -perm /a+x \! -name '*.so' -print0 \
 	| xargs -0 nm -AD 2>/dev/null \
 	| grep -E ': {8}{1,2} U ' \
 	| sed -e 's/:/ /g' -e 's/\.\///' \
 	| awk -vOFS='\t' '{print $1,$3}' \
 	> "$tmpdir/prog_imp.lst"
 
-find . -type f -perm +111 \! -name '*.so' -print0 \
+find . -type f -perm /a+x \! -name '*.so' -print0 \
 	| xargs -0 nm -AD 2>/dev/null \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed -e 's/:/ /g' -e 's/\.\///' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -167,9 +167,9 @@ find ./* -type f -name '*.o' -print0 \
 	| awk -vOFS='\t' '{print $1,$3}' \
 	> "$tmpdir/obj_imp.lst"
 
-libs=$(awk '{print $3}' "$tmpdir/ldd.lst" | uniq | sort | uniq)
+mapfile -t libs < <(awk '{print $3}' "$tmpdir/ldd.lst" | uniq | sort | uniq)
 
-nm -AD $libs \
+nm -AD "${libs[@]}" \
 	| grep -E ':[0-9a-f]{8}{1,2} [TWDRC] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -109,15 +109,15 @@ find . -type f -perm +111 \! -name '*.so.*' \
 	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \
 	> "$tmpdir/ldd.lst"
 
-find . -type f -perm +111 \! -name '*.so' \
-	| xargs nm -AD 2>/dev/null \
+find . -type f -perm +111 \! -name '*.so' -print0 \
+	| xargs -0 nm -AD 2>/dev/null \
 	| grep -E ': {8}{1,2} U ' \
 	| sed -e 's/:/ /g' -e 's/\.\///' \
 	| awk -vOFS='\t' '{print $1,$3}' \
 	> "$tmpdir/prog_imp.lst"
 
-find . -type f -perm +111 \! -name '*.so' \
-	| xargs nm -AD 2>/dev/null \
+find . -type f -perm +111 \! -name '*.so' -print0 \
+	| xargs -0 nm -AD 2>/dev/null \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed -e 's/:/ /g' -e 's/\.\///' \
 	| awk -vOFS='\t' '{print $1,$4}' \
@@ -125,43 +125,43 @@ find . -type f -perm +111 \! -name '*.so' \
 
 )
 
-find * -type f -name 'lib?*.a' \
-	| xargs nm -A \
+find * -type f -name 'lib?*.a' -print0 \
+	| xargs -0 nm -A \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$5}' \
 	> "$tmpdir/stlib_exp.lst"
 
-find * -type f -name 'lib?*.so' \
-	| xargs nm -AD \
+find * -type f -name 'lib?*.so' -print0 \
+	| xargs -0 nm -AD \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$4}' \
 	> "$tmpdir/shlib_exp.lst"
 
-find * -type f -name '*.o' \
-	| xargs nm -A \
+find * -type f -name '*.o' -print0 \
+	| xargs -0 nm -A \
 	| grep -E ':[0-9a-f]{8}{1,2} [BCDGRSTW] ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print $1,$4}' \
 	> "$tmpdir/obj_exp.lst"
 
-find * -type f -name 'lib?*.a' \
-	| xargs nm -A \
+find * -type f -name 'lib?*.a' -print0 \
+	| xargs -0 nm -A \
 	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$2,$4}' \
 	> "$tmpdir/stlib_imp.lst"
 
-find * -type f -name 'lib?*.so' \
-	| xargs nm -AD \
+find * -type f -name 'lib?*.so' -print0 \
+	| xargs -0 nm -AD \
 	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print gensub("^[^ ]*/","",1,$1),$3}' \
 	> "$tmpdir/shlib_imp.lst"
 
-find * -type f -name '*.o' \
-	| xargs nm -A \
+find * -type f -name '*.o' -print0 \
+	| xargs -0 nm -A \
 	| grep -E ': {8}{1,2} U ' \
 	| sed 's/:/ /g' \
 	| awk -vOFS='\t' '{print $1,$3}' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -95,9 +95,9 @@ fi
 rm -rf "$tmpdir"
 mkdir -m 711 "$tmpdir" || exit 1
 
-cd $builddir
+cd $builddir || exit 1
 
-( cd dist.*
+( cd dist.* || exit 1
 
 #LD_LIBRARY_PATH=`pwd`/lib
 #export LD_LIBRARY_PATH

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -95,7 +95,7 @@ fi
 rm -rf "$tmpdir"
 mkdir -m 711 "$tmpdir" || exit 1
 
-cd $builddir || exit 1
+cd "$builddir" || exit 1
 
 ( cd dist.* || exit 1
 
@@ -103,7 +103,7 @@ cd $builddir || exit 1
 #export LD_LIBRARY_PATH
 
 find . -type f -perm +111 \! -name '*.so.*' \
-	| while read file ; do ldd $file | sed 's!^!'$file'!' ; done 2>/dev/null \
+	| while read file ; do ldd "$file" | sed 's!^!'$file'!' ; done 2>/dev/null \
 	| sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
 	| fgrep -v 'not a dynamic executable' \
 	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -103,7 +103,7 @@ cd "$builddir" || exit 1
 #export LD_LIBRARY_PATH
 
 find . -type f -perm +111 \! -name '*.so.*' \
-	| while read file ; do ldd "$file" | sed 's!^!'$file'!' ; done 2>/dev/null \
+	| while read file ; do ldd "$file" | sed 's!^!'"$file"'!' ; done 2>/dev/null \
 	| sed -e 's/^\.\///' -e 's/ (0x.*)$//' -e 's/ => \(.*\)$/	\1/' -e 's/ => .*$//' \
 	| grep -F -v 'not a dynamic executable' \
 	| awk -vOFS='\t' '{print $1,$2,$3 ? $3 : $2}' \

--- a/utils/dep_tree2sql.sh
+++ b/utils/dep_tree2sql.sh
@@ -278,7 +278,7 @@ fsetpos64
 tmpfile64
 EOF
 
-dropdb "$dbname"
+dropdb --if-exists "$dbname"
 createdb "$dbname"
 
 psql -n -q -d "$dbname" <<EOF


### PR DESCRIPTION
I incrementally updated the utils/dep_tree2sql.sh script first to address some easy shellcheck suggestions, but it ended up being a bit more touchy, so I made this a PR by itself.

The initial state of this script was that it wasn't completely working anymore in modern shells (bash in Ubuntu 22.04).
The way I proceeded: I made a single change, dumped the database to a SQL script (`pg_dump grass > dumpfile.sql`), checked the diff, and continued to a further change. I also explored the various example queries in the file at first, plus exploring the tables (since I was surprised some were empty tables, 16 in this case (see below)).
Hence, it might be easier to review by checking each commit one by one instead of understanding the complete diff all at once.

The couple first commits didn't change the resulting database, as the first three find commands were erroring out because of the long deprecated find test `-perm +111`. Once I transformed it to the equivalent `-perm /a+x` ("any file that has the executable bit set for anybody"), the resulting SQL dump grew from 4.93 MB to 7.27 MB, since more deps were found. The number of empty tables is now 11.

There is only one commit that effectively makes a small difference in the results outputted: replacing `find *` with `find ./*`. This makes all the paths for the `.a`, `.o`, and `.so` found with `find` start with `./` instead of nothing.[ I found the difference between `find .` and `find *`](https://stackoverflow.com/a/62292764), but couldn't find the reason why 20 years ago (the furthest I could go back with the grass-legacy repo https://github.com/OSGeo/grass-legacy/blob/66914c9eb661b32031f493845c6694819cd41f89/tools/sql.sh) the author chose `find .` for the first 3, and `find *` for the others. `find .` looks for hidden files, while `find *` looks for visible contents. So I kept the `*`.

A remaining change that I intentionally left out, is the subshell surrounding the first three finds. I assume it was there since the LD_LIBRARY_PATH was assigned to, so to prevent affecting the current shell. But it has been commented out 

The last commit of all is uniformizing the shell formatting with 
```shell
shfmt -w -s -i 4 -ci -bn -sr utils/dep_tree2sql.sh
``` 
My couple last shell contributions were made with that too, and some other PR is coming too.

In the end of this PR, I get the following output
```shell
gitpod /workspace/grass (dep_tree2sql_shell_fixes) $ utils/dep_tree2sql.sh `pwd`
nm: 'a.out': No such file
nm: 'a.out': No such file
nm: 'linux-vdso.so.1': No such file
nm: 'not': No such file
``` 
```shell
gitpod /workspace/grass (dep_tree2sql_shell_fixes) $ psql -d grass
grass=# \dt+
                            List of relations
 Schema |        Name         | Type  | Owner  |    Size    | Description 
--------+---------------------+-------+--------+------------+-------------
 public | ansi                | table | gitpod | 8192 bytes | 
 public | defined             | table | gitpod | 256 kB     | 
 public | depends             | table | gitpod | 160 kB     | 
 public | duplicates          | table | gitpod | 8192 bytes | 
 public | duplicates2         | table | gitpod | 8192 bytes | 
 public | imports             | table | gitpod | 224 kB     | 
 public | ldd                 | table | gitpod | 288 kB     | 
 public | lib_deps            | table | gitpod | 16 kB      | 
 public | lib_deps_1          | table | gitpod | 24 kB      | 
 public | lib_deps_2          | table | gitpod | 32 kB      | 
 public | lib_deps_trans      | table | gitpod | 24 kB      | 
 public | lib_exp             | table | gitpod | 376 kB     | 
 public | lib_imp             | table | gitpod | 224 kB     | 
 public | libc                | table | gitpod | 0 bytes    | 
 public | libs                | table | gitpod | 1488 kB    | 
 public | nonansi             | table | gitpod | 0 bytes    | 
 public | nonansi_counts      | table | gitpod | 0 bytes    | 
 public | nonansi_lib_counts  | table | gitpod | 0 bytes    | 
 public | nonansi_libs        | table | gitpod | 0 bytes    | 
 public | nonansi_prog_counts | table | gitpod | 0 bytes    | 
 public | nonansi_progs       | table | gitpod | 0 bytes    | 
 public | obj_exp             | table | gitpod | 1728 kB    | 
 public | obj_imp             | table | gitpod | 4272 kB    | 
 public | prog_exp            | table | gitpod | 912 kB     | 
 public | prog_imp            | table | gitpod | 1392 kB    | 
 public | prog_libs           | table | gitpod | 88 kB      | 
 public | shlib_exp           | table | gitpod | 400 kB     | 
 public | shlib_imp           | table | gitpod | 248 kB     | 
 public | stlib_exp           | table | gitpod | 0 bytes    | 
 public | stlib_imp           | table | gitpod | 0 bytes    | 
 public | undefined           | table | gitpod | 32 kB      | 
 public | undefined_1         | table | gitpod | 32 kB      | 
 public | undefined_2         | table | gitpod | 0 bytes    | 
 public | used                | table | gitpod | 80 kB      | 
(34 rows)

grass=# select n.nspname as table_schema,
grass-#        c.relname as table_name,
grass-#        c.reltuples as rows
grass-# from pg_class c
grass-# join pg_namespace n on n.oid = c.relnamespace
grass-# where c.relkind = 'r'
grass-#       and n.nspname not in ('information_schema','pg_catalog')
grass-# order by c.reltuples desc;
 table_schema |     table_name      | rows  
--------------+---------------------+-------
 public       | obj_imp             | 43843
 public       | prog_imp            | 21704
 public       | libs                | 18156
 public       | obj_exp             | 15247
 public       | prog_exp            | 12008
 public       | lib_exp             |  5350
 public       | shlib_exp           |  5350
 public       | defined             |  5288
 public       | shlib_imp           |  3126
 public       | imports             |  3126
 public       | lib_imp             |  3126
 public       | ldd                 |  3045
 public       | depends             |  1730
 public       | used                |  1511
 public       | prog_libs           |  1207
 public       | undefined           |   560
 public       | undefined_1         |   465
 public       | lib_deps_trans      |   251
 public       | lib_deps_1          |   217
 public       | lib_deps_2          |   213
 public       | lib_deps            |   113
 public       | ansi                |   100
 public       | duplicates2         |    70
 public       | nonansi_counts      |     0
 public       | stlib_imp           |     0
 public       | duplicates          |     0
 public       | undefined_2         |     0
 public       | libc                |     0
 public       | nonansi             |     0
 public       | nonansi_progs       |     0
 public       | nonansi_libs        |     0
 public       | nonansi_prog_counts |     0
 public       | nonansi_lib_counts  |     0
 public       | stlib_exp           |     0
(34 rows)

grass=# 
``` 


Before this PR, I get the following:
```shell
gitpod /workspace/grass (dep_tree2sql_shell_fixes) $ psql -d grass
psql (12.18 (Ubuntu 12.18-1.pgdg22.04+1))
Type "help" for help.

grass=# \dt+
                            List of relations
 Schema |        Name         | Type  | Owner  |    Size    | Description 
--------+---------------------+-------+--------+------------+-------------
 public | ansi                | table | gitpod | 8192 bytes | 
 public | defined             | table | gitpod | 256 kB     | 
 public | depends             | table | gitpod | 160 kB     | 
 public | duplicates          | table | gitpod | 8192 bytes | 
 public | duplicates2         | table | gitpod | 8192 bytes | 
 public | imports             | table | gitpod | 224 kB     | 
 public | ldd                 | table | gitpod | 8192 bytes | 
 public | lib_deps            | table | gitpod | 16 kB      | 
 public | lib_deps_1          | table | gitpod | 24 kB      | 
 public | lib_deps_2          | table | gitpod | 32 kB      | 
 public | lib_deps_trans      | table | gitpod | 24 kB      | 
 public | lib_exp             | table | gitpod | 376 kB     | 
 public | lib_imp             | table | gitpod | 224 kB     | 
 public | libc                | table | gitpod | 0 bytes    | 
 public | libs                | table | gitpod | 8192 bytes | 
 public | nonansi             | table | gitpod | 0 bytes    | 
 public | nonansi_counts      | table | gitpod | 0 bytes    | 
 public | nonansi_lib_counts  | table | gitpod | 0 bytes    | 
 public | nonansi_libs        | table | gitpod | 0 bytes    | 
 public | nonansi_prog_counts | table | gitpod | 0 bytes    | 
 public | nonansi_progs       | table | gitpod | 0 bytes    | 
 public | obj_exp             | table | gitpod | 1696 kB    | 
 public | obj_imp             | table | gitpod | 4184 kB    | 
 public | prog_exp            | table | gitpod | 0 bytes    | 
 public | prog_imp            | table | gitpod | 0 bytes    | 
 public | prog_libs           | table | gitpod | 0 bytes    | 
 public | shlib_exp           | table | gitpod | 400 kB     | 
 public | shlib_imp           | table | gitpod | 248 kB     | 
 public | stlib_exp           | table | gitpod | 0 bytes    | 
 public | stlib_imp           | table | gitpod | 0 bytes    | 
 public | undefined           | table | gitpod | 32 kB      | 
 public | undefined_1         | table | gitpod | 40 kB      | 
 public | undefined_2         | table | gitpod | 0 bytes    | 
 public | used                | table | gitpod | 80 kB      | 
(34 rows)

grass=# select n.nspname as table_schema,
grass-#        c.relname as table_name,
grass-#        c.reltuples as rows
grass-# from pg_class c
grass-# join pg_namespace n on n.oid = c.relnamespace
grass-# where c.relkind = 'r'
grass-#       and n.nspname not in ('information_schema','pg_catalog')
grass-# order by c.reltuples desc;
 table_schema |     table_name      | rows  
--------------+---------------------+-------
 public       | obj_imp             | 43843
 public       | obj_exp             | 15247
 public       | shlib_exp           |  5350
 public       | lib_exp             |  5350
 public       | defined             |  5288
 public       | shlib_imp           |  3126
 public       | imports             |  3126
 public       | lib_imp             |  3126
 public       | depends             |  1730
 public       | used                |  1511
 public       | undefined_1         |   560
 public       | undefined           |   560
 public       | lib_deps_trans      |   251
 public       | lib_deps_1          |   217
 public       | lib_deps_2          |   213
 public       | lib_deps            |   113
 public       | ansi                |   100
 public       | duplicates2         |    70
 public       | nonansi_counts      |     0
 public       | stlib_imp           |     0
 public       | prog_imp            |     0
 public       | prog_exp            |     0
 public       | libs                |     0
 public       | ldd                 |     0
 public       | duplicates          |     0
 public       | undefined_2         |     0
 public       | prog_libs           |     0
 public       | libc                |     0
 public       | nonansi             |     0
 public       | nonansi_progs       |     0
 public       | nonansi_libs        |     0
 public       | nonansi_prog_counts |     0
 public       | nonansi_lib_counts  |     0
 public       | stlib_exp           |     0
(34 rows)

grass=# 
```