### PR TITLE
Shell: Shellcheck fix

### DIFF
--- a/.github/workflows/build_osgeo4w.sh
+++ b/.github/workflows/build_osgeo4w.sh
@@ -15,8 +15,9 @@ set -e
 test -d "$1" && cd "$1"
 
 export OSGEO4W_ROOT_MSYS=/c/OSGeo4W
-export SRC=$(pwd)
+SRC="$(pwd)"
+export SRC
 export UNITTEST=1
 
 # Build according to OSGeo4W recipe
-${SRC}/mswindows/osgeo4w/build_osgeo4w.sh
+"${SRC}"/mswindows/osgeo4w/build_osgeo4w.sh

--- a/.github/workflows/build_ubuntu-22.04.sh
+++ b/.github/workflows/build_ubuntu-22.04.sh
@@ -19,10 +19,10 @@ fi
 # Adding -Werror to make's CFLAGS is a workaround for configuring with
 # an old version of configure, which issues compiler warnings and
 # errors out. This may be removed with upgraded configure.in file.
-makecmd="make"
-if [[ "$#" -ge 2 ]]; then
+makecmd=("make")
+if [[ $# -ge 2 ]]; then
     ARGS=("$@")
-    makecmd="make CFLAGS='$CFLAGS ${ARGS[@]:1}' CXXFLAGS='$CXXFLAGS ${ARGS[@]:1}'"
+    makecmd=("make" "CFLAGS=$CFLAGS ${ARGS[@]:1}" "CXXFLAGS=$CXXFLAGS ${ARGS[@]:1}")
 fi
 
 # non-existent variables as an errors
@@ -52,5 +52,5 @@ export INSTALL_PREFIX=$1
     --with-fftw \
     --with-netcdf
 
-eval $makecmd
+"${makecmd[@]}"
 make install

--- a/.github/workflows/build_ubuntu-22.04_without_x.sh
+++ b/.github/workflows/build_ubuntu-22.04_without_x.sh
@@ -19,9 +19,10 @@ fi
 # Adding -Werror to make's CFLAGS is a workaround for configuring with
 # an old version of configure, which issues compiler warnings and
 # errors out. This may be removed with upgraded configure.in file.
-makecmd="make"
-if [[ "$#" -eq 2 ]]; then
-    makecmd="make CFLAGS='$CFLAGS $2' CXXFLAGS='$CXXFLAGS $2'"
+makecmd=("make")
+if [[ $# -ge 2 ]]; then
+    ARGS=("$@")
+    makecmd=("make" "CFLAGS=$CFLAGS ${ARGS[@]:1}" "CXXFLAGS=$CXXFLAGS ${ARGS[@]:1}")
 fi
 
 # non-existent variables as an errors
@@ -50,5 +51,5 @@ export INSTALL_PREFIX=$1
     --with-fftw \
     --with-netcdf
 
-eval $makecmd
+"${makecmd[@]}"
 make install

--- a/.github/workflows/macos_install.sh
+++ b/.github/workflows/macos_install.sh
@@ -70,7 +70,7 @@ export CPPFLAGS="-isystem${CONDA_PREFIX}/include"
 ./configure $CONFIGURE_FLAGS
 
 EXEMPT="-Wno-error=deprecated-non-prototype -Wno-error=strict-prototypes"
-make -j$(sysctl -n hw.ncpu) CFLAGS="$CFLAGS -Werror $EXEMPT" \
-  CXXFLAGS="$CXXFLAGS -Werror $EXEMPT"
+make -j"$(sysctl -n hw.ncpu)" CFLAGS="$CFLAGS -Werror $EXEMPT" \
+    CXXFLAGS="$CXXFLAGS -Werror $EXEMPT"
 
 make install

--- a/.github/workflows/macos_install.sh
+++ b/.github/workflows/macos_install.sh
@@ -39,7 +39,7 @@ CONFIGURE_FLAGS="\
   --with-cairo \
   --with-cairo-includes=${CONDA_PREFIX}/include/cairo \
   --with-cairo-libs=${CONDA_PREFIX}/lib \
-  --with-cairo-ldflags="-lcairo" \
+  --with-cairo-ldflags=-lcairo \
   --with-zstd \
   --with-zstd-libs=${CONDA_PREFIX}/lib \
   --with-zstd-includes=${CONDA_PREFIX}/include \

--- a/.github/workflows/test_thorough.sh
+++ b/.github/workflows/test_thorough.sh
@@ -4,9 +4,9 @@
 set -e
 
 grass --tmp-location XY --exec \
-    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
+    g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path="$HOME"
 
 grass --tmp-location XY --exec \
     python3 -m grass.gunittest.main \
-    --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
-    --min-success 100 $@
+    --grassdata "$HOME" --location nc_spm_full_v2alpha2 --location-type nc \
+    --min-success 100 "$@"

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -20,9 +20,9 @@ make
 
 # put command on path
 # ensure the user specific bin dir exists (already on path)
-mkdir -p $HOME/.local/bin/
+mkdir -p "$HOME/.local/bin/"
 # create link to build
-ln -s $HOME/bin.*/grass* $HOME/.local/bin/grass
+ln -s "$HOME"/bin.*/grass* "$HOME/.local/bin/grass"
 
 # download a sample dataset
 mkdir -p data/grassdata \

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -26,7 +26,7 @@ ln -s "$HOME"/bin.*/grass* "$HOME/.local/bin/grass"
 
 # download a sample dataset
 mkdir -p data/grassdata \
-  && curl -SL https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip > nc_basic_spm_grass7.zip \
-  && unzip -qq nc_basic_spm_grass7.zip \
-  && mv nc_basic_spm_grass7 data/grassdata \
-  && rm nc_basic_spm_grass7.zip
+    && curl -SL https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip > nc_basic_spm_grass7.zip \
+    && unzip -qq nc_basic_spm_grass7.zip \
+    && mv nc_basic_spm_grass7 data/grassdata \
+    && rm nc_basic_spm_grass7.zip

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -11,14 +11,14 @@ apk add --no-cache py3-scikit-learn
 grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 # Test GRASS GIS Python-addon installation
-grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add && \
-   grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
+grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add \
+    && grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
 
 # Test GRASS GIS C-addon installation: raster and vector
-grass --tmp-location XY --exec g.extension extension=r.gwr operation=add && \
-   grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
-grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add && \
-   grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
+grass --tmp-location XY --exec g.extension extension=r.gwr operation=add \
+    && grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add \
+    && grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # cleanup dependency
 apk del py3-scikit-learn

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # to be used in alpine Dockerfile
 

--- a/docker/testdata/test_docker_image.sh
+++ b/docker/testdata/test_docker_image.sh
@@ -36,31 +36,31 @@ grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output=
 printf "\n############\nTesting GRASS GIS Python-addon installation:\n############\n"
 /usr/bin/python3 -m pip install --no-cache-dir scikit-learn
 
-grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add && \
-	   grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
+grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add \
+    && grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
 
 # cleanup dependency
 /usr/bin/python3 -m pip uninstall -y scikit-learn
 
 # Test GRASS GIS C-addon installation: raster and vector
 printf "\n############\nTesting GRASS GIS C-addon installation:\n############\n"
-grass --tmp-location XY --exec g.extension extension=r.gwr operation=add && \
-	   grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
-grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add && \
-	   grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
+grass --tmp-location XY --exec g.extension extension=r.gwr operation=add \
+    && grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
+grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add \
+    && grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # show GRASS GIS, PROJ, GDAL etc versions
 printf "\n############\nPrinting GRASS, PDAL and Python versions:\n############\n"
-grass --tmp-location EPSG:4326 --exec g.version -rge && \
-    pdal --version && \
-    python3 --version
+grass --tmp-location EPSG:4326 --exec g.version -rge \
+    && pdal --version \
+    && python3 --version
 
 # Test presence of central python packages
 printf "\n############\nPrinting versions of central python packages:\n############\n"
 python3 -c "import psycopg2;import numpy as np;print(psycopg2.__version__);print(np.__version__)"
 
 # Run testsuite
-if [ $TESTSUITE ] ; then
-  printf "\n############\nRunning the testsuite:\n############\n"
-  bash /grassdb/.github/workflows/test_thorough.sh
+if [ "$TESTSUITE" ]; then
+    printf "\n############\nRunning the testsuite:\n############\n"
+    bash /grassdb/.github/workflows/test_thorough.sh
 fi

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -54,7 +54,7 @@ g.message "Generating module synopsis (writing to \$GISBASE/etc/) ..."
 SYNOP="$GISBASE/etc/module_synopsis.txt"
 
 OLDDIR="$(pwd)"
-cd "$GISBASE"
+cd "$GISBASE" || exit 1
 
 ### generate menu hierarchy
 
@@ -97,7 +97,7 @@ find_menu_hierarchy()
 
 ### execute the loop for all modules
 for DIR in bin scripts ; do
-  cd $DIR
+  cd $DIR || exit 1
 
   for MODULE in ?\.* db.* r3.* ; do
     unset label
@@ -482,7 +482,7 @@ done
 
 TMPDIR="$(dirname "$TMP")"
 cp "$OLDDIR/../man/grasslogo_vector.pdf" "$TMPDIR"
-cd "$TMPDIR"
+cd "$TMPDIR" || exit 1
 
 #once working nicely make it quieter
 #pdflatex --interaction batchmode "$GISBASE/etc/module_synopsis.tex"

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -18,37 +18,36 @@
 #   (TeX needs to be able to find grasslogo_vector.pdf)
 #
 
-if  [ -z "$GISBASE" ] ; then
+if [ -z "$GISBASE" ]; then
     echo "You must be in GRASS GIS to run this program." 1>&2
     exit 1
 fi
 
-for FILE in txt tex ; do
-    if [ -e "$GISBASE/etc/module_synopsis.$FILE" ] ; then
-    #  echo "ERROR: module_synopsis.$FILE already exists" 1>&2
-    #  exit 1
-       #blank it
-       g.message -w "Overwriting \"\$GISBASE/etc/module_synopsis.$FILE\""
-       \rm "$GISBASE/etc/module_synopsis.$FILE"
+for FILE in txt tex; do
+    if [ -e "$GISBASE/etc/module_synopsis.$FILE" ]; then
+        #  echo "ERROR: module_synopsis.$FILE already exists" 1>&2
+        #  exit 1
+        #blank it
+        g.message -w "Overwriting \"\$GISBASE/etc/module_synopsis.$FILE\""
+        \rm "$GISBASE/etc/module_synopsis.$FILE"
     fi
 done
-for FILE in html pdf ; do
-    if [ -e "$GISBASE/docs/$FILE/module_synopsis.$FILE" ] ; then
-    #  echo "ERROR: module_synopsis.$FILE already exists" 1>&2
-    #  exit 1
-       #blank it
-       g.message -w "Overwriting \"\$GISBASE/docs/$FILE/module_synopsis.$FILE\""
-       \rm "$GISBASE/docs/$FILE/module_synopsis.$FILE"
+for FILE in html pdf; do
+    if [ -e "$GISBASE/docs/$FILE/module_synopsis.$FILE" ]; then
+        #  echo "ERROR: module_synopsis.$FILE already exists" 1>&2
+        #  exit 1
+        #blank it
+        g.message -w "Overwriting \"\$GISBASE/docs/$FILE/module_synopsis.$FILE\""
+        \rm "$GISBASE/docs/$FILE/module_synopsis.$FILE"
     fi
 done
 
-
-if ! TMP="$(g.tempfile pid=$$)" || [ -z "$TMP" ] ; then
+if ! TMP="$(g.tempfile pid=$$)" || [ -z "$TMP" ]; then
     g.message -e "Unable to create temporary files"
     exit 1
 fi
 
-g.message "Generating module synopsis (writing to \$GISBASE/etc/) ..."
+g.message 'Generating module synopsis (writing to $GISBASE/etc/) ...'
 
 SYNOP="$GISBASE/etc/module_synopsis.txt"
 
@@ -64,105 +63,104 @@ MDPY="$GISBASE/etc/wxpython/gui_modules/menudata.py"
 # python menudata.py tree
 # python menudata.py strings
 python "$MDPY" commands | sed -e 's/ | /|/' -e 's/[ -].*|/|/' \
-  | sort -u > "$TMP.menu_hierarchy"
+    | sort -u > "$TMP.menu_hierarchy"
 
 # for running with GRASS 6.4 after generating with GRASS 6.5.
 #\cp "$TMP.menu_hierarchy" "$GISBASE/etc/gui/menu_hierarchy.txt"
 #\cp "$GISBASE/etc/gui/menu_hierarchy.txt" "$TMP.menu_hierarchy"
 
 ### given a module name return where it is in the menu tree
-find_menu_hierarchy()
-{
-  MODL=$1
+find_menu_hierarchy() {
+    MODL=$1
 
-  # unwrap wrapper scripts
-  if [ "$MODL" = "g.gui" ] ; then
-    MODL="g.change.gui.py"
-  elif  [ "$MODL" = "v.type" ] ; then
-    MODL="v.type_wrapper.py"
-  fi
+    # unwrap wrapper scripts
+    if [ "$MODL" = "g.gui" ]; then
+        MODL="g.change.gui.py"
+    elif [ "$MODL" = "v.type" ]; then
+        MODL="v.type_wrapper.py"
+    fi
 
-  PLACEMENT=$(grep "^$MODL|" "$TMP.menu_hierarchy" | cut -f2 -d'|' | head -n 1)
+    PLACEMENT=$(grep "^$MODL|" "$TMP.menu_hierarchy" | cut -f2 -d'|' | head -n 1)
 
-  # combine some modules which are listed twice
-  if [ "$MODL" = "g.region" ] ; then
-      PLACEMENT=$(echo "$PLACEMENT" | sed -e 's/Display/Set or Display/')
-  elif  [ "$MODL" = "r.reclass" ] || [ "$MODL" = "v.reclass" ] ; then
-      PLACEMENT=$(echo "$PLACEMENT" | sed -e 's/Reclassify.*$/Reclassify/')
-  fi
+    # combine some modules which are listed twice
+    if [ "$MODL" = "g.region" ]; then
+        PLACEMENT=$(echo "$PLACEMENT" | sed -e 's/Display/Set or Display/')
+    elif [ "$MODL" = "r.reclass" ] || [ "$MODL" = "v.reclass" ]; then
+        PLACEMENT=$(echo "$PLACEMENT" | sed -e 's/Reclassify.*$/Reclassify/')
+    fi
 
-  echo "$PLACEMENT"
+    echo "$PLACEMENT"
 }
 
 ### execute the loop for all modules
-for DIR in bin scripts ; do
-  cd $DIR || exit 1
+for DIR in bin scripts; do
+    cd $DIR || exit 1
 
-  for MODULE in ?\.* db.* r3.* ; do
-    unset label
-    unset desc
-#    echo "[$MODULE]"
+    for MODULE in ?\.* db.* r3.*; do
+        unset label
+        unset desc
+        #    echo "[$MODULE]"
 
-    case "$MODULE" in
-      g.parser | "r3.*" | g.module_to_skip)
-	continue
-	;;
-    esac
+        case "$MODULE" in
+            g.parser | "r3.*" | g.module_to_skip)
+                continue
+                ;;
+        esac
 
-    eval "$($MODULE --interface-description | head -n 5 | tail -n 1 | \
-        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')"
+        eval "$($MODULE --interface-description | head -n 5 | tail -n 1 \
+            | tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')"
 
-    if [ -z "$label" ] && [ -z "$desc" ] ; then
-	continue
-    fi
+        if [ -z "$label" ] && [ -z "$desc" ]; then
+            continue
+        fi
 
-    MODULE_MENU_LOC=$(find_menu_hierarchy "$MODULE")
+        MODULE_MENU_LOC=$(find_menu_hierarchy "$MODULE")
 
-    BUFF=""
-    if [ -z "$label" ] ; then
-	BUFF="$MODULE: $desc"
-    else
-	BUFF="$MODULE: $label"
-    fi
-    if [ -n "$MODULE_MENU_LOC" ] ; then
-        BUFF="$BUFF {$MODULE_MENU_LOC}"
-    fi
-    if [ -n "$BUFF" ] ; then
-       #echo "$BUFF"
-       echo "$BUFF" >> "$TMP"
-    fi
-  done
+        BUFF=""
+        if [ -z "$label" ]; then
+            BUFF="$MODULE: $desc"
+        else
+            BUFF="$MODULE: $label"
+        fi
+        if [ -n "$MODULE_MENU_LOC" ]; then
+            BUFF="$BUFF {$MODULE_MENU_LOC}"
+        fi
+        if [ -n "$BUFF" ]; then
+            #echo "$BUFF"
+            echo "$BUFF" >> "$TMP"
+        fi
+    done
 
-  cd ..
+    cd ..
 done
 
 # ps.map doesn't jive with the above loop.
 # shellcheck disable=SC2043
-for MODULE in ps.map ; do
+for MODULE in ps.map; do
     unset label
     unset desc
 
-    eval "$($MODULE --interface-description | head -n 5 | tail -n 1 | \
-        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')"
+    eval "$($MODULE --interface-description | head -n 5 | tail -n 1 \
+        | tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')"
 
-    if [ -z "$label" ] && [ -z "$desc" ] ; then
-	continue
+    if [ -z "$label" ] && [ -z "$desc" ]; then
+        continue
     fi
 
     MODULE_MENU_LOC=$(find_menu_hierarchy "$MODULE")
 
     BUFF=""
-    if [ -z "$label" ] ; then
-	BUFF="$MODULE: $desc"
+    if [ -z "$label" ]; then
+        BUFF="$MODULE: $desc"
     else
-	BUFF="$MODULE: $label"
+        BUFF="$MODULE: $label"
     fi
-    if [ -n "$MODULE_MENU_LOC" ] ; then
+    if [ -n "$MODULE_MENU_LOC" ]; then
         BUFF="$BUFF {$MODULE_MENU_LOC}"
     fi
-    if [ -n "$BUFF" ] ; then
-       #echo "$BUFF"
-       echo "$BUFF" >> "$TMP"
+    if [ -n "$BUFF" ]; then
+        #echo "$BUFF"
+        echo "$BUFF" >> "$TMP"
     fi
 done
 
@@ -188,10 +186,10 @@ cp "$SYNOP" "${TMP}.txt"
 ####### create HTML source #######
 # poor cousin to full_index.html from build_html_index.sh
 # todo $MODULE.html links
-g.message "Generating HTML (writing to \$GISBASE/docs/html/) ..."
+g.message 'Generating HTML (writing to $GISBASE/docs/html/) ...'
 
 #### write header
-cat <<EOF >"${TMP}.html"
+cat << EOF > "${TMP}.html"
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
@@ -247,33 +245,40 @@ sed -i -e 's+\(a href="\)\([^#\.h]\)+\1../../grass64/manuals/html64_user/\2+'
   <li> <a href="nviz.html">NVIZ</a> - <i>n</i>-dimensional visualization suite
 EOF
 
-
 #### fill in module entries
 
-for SECTION in d db g i m ps r r3 v ; do
+for SECTION in d db g i m ps r r3 v; do
     SEC_TYPE="commands"
     case $SECTION in
-      d)
-	SEC_NAME="Display" ;;
-      db)
-	SEC_NAME="Database management" ;;
-      g)
-	SEC_NAME="General GIS management" ;;
-      i)
-	SEC_NAME="Imagery" ;;
-      m)
-	SEC_NAME="Miscellaneous"
-	SEC_TYPE="tools" ;;
-      ps)
-	SEC_NAME="PostScript" ;;
-      r)
-	SEC_NAME="Raster" ;;
-      r3)
-	SEC_NAME="Raster 3D" ;;
-      v)
-	SEC_NAME="Vector" ;;
+        d)
+            SEC_NAME="Display"
+            ;;
+        db)
+            SEC_NAME="Database management"
+            ;;
+        g)
+            SEC_NAME="General GIS management"
+            ;;
+        i)
+            SEC_NAME="Imagery"
+            ;;
+        m)
+            SEC_NAME="Miscellaneous"
+            SEC_TYPE="tools"
+            ;;
+        ps)
+            SEC_NAME="PostScript"
+            ;;
+        r)
+            SEC_NAME="Raster"
+            ;;
+        r3)
+            SEC_NAME="Raster 3D"
+            ;;
+        v)
+            SEC_NAME="Vector"
+            ;;
     esac
-
 
     cat << EOF >> "${TMP}.html"
 </ul>
@@ -285,17 +290,17 @@ for SECTION in d db g i m ps r r3 v ; do
 <ul>
 EOF
 
-    grep "^${SECTION}\." "${TMP}.txt" | \
-      sed -e 's/: /| /' -e 's/^.*|/<li> <a href="&.html">&<\/a>:/' \
-	  -e 's/|.html">/.html">/' -e 's+|</a>:+</a>:+' \
-	  -e 's/&/\&amp;/g' \
-	  -e 's+ {+\n     <BR><font size="-2" color="#778877"><i>+' \
-	  -e 's+}+</i></font>+' \
-	  -e 's+ > + \&rarr; +g'  >> "${TMP}.html"
+    grep "^${SECTION}\." "${TMP}.txt" \
+        | sed -e 's/: /| /' -e 's/^.*|/<li> <a href="&.html">&<\/a>:/' \
+            -e 's/|.html">/.html">/' -e 's+|</a>:+</a>:+' \
+            -e 's/&/\&amp;/g' \
+            -e 's+ {+\n     <BR><font size="-2" color="#778877"><i>+' \
+            -e 's+}+</i></font>+' \
+            -e 's+ > + \&rarr; +g' >> "${TMP}.html"
 
-    if [ "$SECTION" = "i" ] ; then
-	# include imagery photo subsection
-	cat << EOF >> "${TMP}.html"
+    if [ "$SECTION" = "i" ]; then
+        # include imagery photo subsection
+        cat << EOF >> "${TMP}.html"
 </ul>
 
 <h4>Imagery photo.* commands:</h4>
@@ -303,17 +308,16 @@ EOF
 <ul>
 EOF
 
-	grep "^photo\." "${TMP}.txt" | \
-	  sed -e 's/: /| /' -e 's/^.*|/<li> <a href="&.html">&<\/a>:/' \
-	      -e 's/|.html">/.html">/' -e 's+|</a>:+</a>:+' \
-	      -e 's/&/\&amp;/g' \
-	      -e 's+ {+\n     <BR><font size="-2" color="#778877"><i>+' \
-	      -e 's+}+</i></font>+' \
-	      -e 's+ > + \&rarr; +g'  >> "${TMP}.html"
+        grep "^photo\." "${TMP}.txt" \
+            | sed -e 's/: /| /' -e 's/^.*|/<li> <a href="&.html">&<\/a>:/' \
+                -e 's/|.html">/.html">/' -e 's+|</a>:+</a>:+' \
+                -e 's/&/\&amp;/g' \
+                -e 's+ {+\n     <BR><font size="-2" color="#778877"><i>+' \
+                -e 's+}+</i></font>+' \
+                -e 's+ > + \&rarr; +g' >> "${TMP}.html"
     fi
 
 done
-
 
 #### save footer
 cat << EOF >> "${TMP}.html"
@@ -331,10 +335,8 @@ EOF
 
 \mv "${TMP}.html" "$GISBASE/docs/html/module_synopsis.html"
 
-
-
 ####### create LaTeX source #######
-g.message "Generating LaTeX source (writing to \$GISBASE/etc/) ..."
+g.message 'Generating LaTeX source (writing to $GISBASE/etc/) ...'
 
 #### write header
 # shellcheck disable=SC2154 # $n$ is latex syntax
@@ -388,33 +390,40 @@ cat << EOF > "${TMP}.tex"
 \item [NVIZ]$n$-dimensional visualization suite
 EOF
 
-
 #### fill in module entries
 
-for SECTION in d db g i m ps r r3 v ; do
+for SECTION in d db g i m ps r r3 v; do
     SEC_TYPE="commands"
     case $SECTION in
-      d)
-	SEC_NAME="Display" ;;
-      db)
-	SEC_NAME="Database management" ;;
-      g)
-	SEC_NAME="General GIS management" ;;
-      i)
-	SEC_NAME="Imagery" ;;
-      m)
-	SEC_NAME="Miscellaneous"
-	SEC_TYPE="tools" ;;
-      ps)
-	SEC_NAME="PostScript" ;;
-      r)
-	SEC_NAME="Raster" ;;
-      r3)
-	SEC_NAME="Raster 3D" ;;
-      v)
-	SEC_NAME="Vector" ;;
+        d)
+            SEC_NAME="Display"
+            ;;
+        db)
+            SEC_NAME="Database management"
+            ;;
+        g)
+            SEC_NAME="General GIS management"
+            ;;
+        i)
+            SEC_NAME="Imagery"
+            ;;
+        m)
+            SEC_NAME="Miscellaneous"
+            SEC_TYPE="tools"
+            ;;
+        ps)
+            SEC_NAME="PostScript"
+            ;;
+        r)
+            SEC_NAME="Raster"
+            ;;
+        r3)
+            SEC_NAME="Raster 3D"
+            ;;
+        v)
+            SEC_NAME="Vector"
+            ;;
     esac
-
 
     cat << EOF >> "${TMP}.tex"
 \end{lyxlist}
@@ -425,12 +434,12 @@ for SECTION in d db g i m ps r r3 v ; do
 \begin{lyxlist}{00.00.0000}
 EOF
 
-    grep "^${SECTION}\." "${TMP}.txt" | \
-      sed -e 's/^/\\item [/' -e 's/: /]/' \
-          -e 's+ {+ \\\\\n$+' -e 's/}$/$/' \
-	  -e 's+ > +\\,\\triangleright\\,|+g' \
-          -e 's/\*/{*}/g' -e 's/_/\\_/g' -e 's/&/\\\&/g' \
-	| awk '/^\$/ { STR=$0; \
+    grep "^${SECTION}\." "${TMP}.txt" \
+        | sed -e 's/^/\\item [/' -e 's/: /]/' \
+            -e 's+ {+ \\\\\n$+' -e 's/}$/$/' \
+            -e 's+ > +\\,\\triangleright\\,|+g' \
+            -e 's/\*/{*}/g' -e 's/_/\\_/g' -e 's/&/\\\&/g' \
+        | awk '/^\$/ { STR=$0; \
 		       gsub(" ", "\\: ", STR); \
 		       gsub(/\|/, " ", STR); \
 		       sub(/^/, "  \\textcolor{DarkSeaGreen3}{\\footnotesize ", STR); \
@@ -439,9 +448,9 @@ EOF
 		     } ;
 	       /^\\/ {print}' >> "${TMP}.tex"
 
-    if [ "$SECTION" = "i" ] ; then
-	# include imagery photo subsection
-	cat << EOF >> "${TMP}.tex"
+    if [ "$SECTION" = "i" ]; then
+        # include imagery photo subsection
+        cat << EOF >> "${TMP}.tex"
 \end{lyxlist}
 
 \subsubsection*{Imagery photo.{*} commands:}
@@ -449,8 +458,8 @@ EOF
 \begin{lyxlist}{00.00.0000}
 EOF
 
-	grep "^photo\." "${TMP}.txt" | \
-	  sed -e 's/^/\\item [/' -e 's/: /]/' >> "${TMP}.tex"
+        grep "^photo\." "${TMP}.txt" \
+            | sed -e 's/^/\\item [/' -e 's/: /]/' >> "${TMP}.tex"
     fi
 
 done
@@ -471,15 +480,15 @@ EOF
 #     fix: *.univar.sh, r.surf.idw2, v.to.rast3, r.out.ppm3, others..
 #####
 
-g.message "Converting LaTeX to PDF (writing to \$GISBASE/docs/pdf/) ..."
+g.message 'Converting LaTeX to PDF (writing to $GISBASE/docs/pdf/) ...'
 
 # shellcheck disable=SC2043
-for PGM in pdflatex ; do
-   if [ ! -x "$(which $PGM)" ] ; then
-	g.message -e "pdflatex needed for this PDF conversion."
-	g.message "Done."
-	exit 1
-   fi
+for PGM in pdflatex; do
+    if [ ! -x "$(which $PGM)" ]; then
+        g.message -e "pdflatex needed for this PDF conversion."
+        g.message "Done."
+        exit 1
+    fi
 done
 
 TMPDIR="$(dirname "$TMP")"
@@ -491,9 +500,9 @@ cd "$TMPDIR" || exit 1
 pdflatex "$GISBASE/etc/module_synopsis.tex"
 
 \rm -f module_synopsis.dvi module_synopsis.ps \
-       module_synopsis_2.ps grasslogo_vector.pdf
+    module_synopsis_2.ps grasslogo_vector.pdf
 
-if [ ! -d "$GISBASE/docs/pdf" ] ; then
+if [ ! -d "$GISBASE/docs/pdf" ]; then
     mkdir "$GISBASE/docs/pdf"
 fi
 \mv module_synopsis.pdf "$GISBASE/docs/pdf/"

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -43,7 +43,7 @@ for FILE in html pdf ; do
 done
 
 
-TMP="`g.tempfile pid=$$`"
+TMP="$(g.tempfile pid=$$)"
 if [ $? -ne 0 ] || [ -z "$TMP" ] ; then
     g.message -e "Unable to create temporary files"
     exit 1
@@ -83,13 +83,13 @@ find_menu_hierarchy()
     MODL="v.type_wrapper.py"
   fi
 
-  PLACEMENT=`grep "^$MODL|" "$TMP.menu_hierarchy" | cut -f2 -d'|' | head -n 1`
+  PLACEMENT=$(grep "^$MODL|" "$TMP.menu_hierarchy" | cut -f2 -d'|' | head -n 1)
 
   # combine some modules which are listed twice
   if [ "$MODL" = "g.region" ] ; then
-      PLACEMENT=`echo "$PLACEMENT" | sed -e 's/Display/Set or Display/'`
+      PLACEMENT=$(echo "$PLACEMENT" | sed -e 's/Display/Set or Display/')
   elif  [ "$MODL" = "r.reclass" ] || [ "$MODL" = "v.reclass" ] ; then
-      PLACEMENT=`echo "$PLACEMENT" | sed -e 's/Reclassify.*$/Reclassify/'`
+      PLACEMENT=$(echo "$PLACEMENT" | sed -e 's/Reclassify.*$/Reclassify/')
   fi
 
   echo "$PLACEMENT"
@@ -110,14 +110,14 @@ for DIR in bin scripts ; do
 	;;
     esac
 
-    eval `$MODULE --interface-description | head -n 5 | tail -n 1 | \
-        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./'`
+    eval $($MODULE --interface-description | head -n 5 | tail -n 1 | \
+        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')
 
     if [ -z "$label" ] && [ -z "$desc" ] ; then
 	continue
     fi
 
-    MODULE_MENU_LOC=`find_menu_hierarchy "$MODULE"`
+    MODULE_MENU_LOC=$(find_menu_hierarchy "$MODULE")
 
     BUFF=""
     if [ -z "$label" ] ; then
@@ -142,14 +142,14 @@ for MODULE in ps.map ; do
     unset label
     unset desc
 
-    eval `$MODULE --interface-description | head -n 5 | tail -n 1 | \
-        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./'`
+    eval $($MODULE --interface-description | head -n 5 | tail -n 1 | \
+        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')
 
     if [ -z "$label" ] && [ -z "$desc" ] ; then
 	continue
     fi
 
-    MODULE_MENU_LOC=`find_menu_hierarchy "$MODULE"`
+    MODULE_MENU_LOC=$(find_menu_hierarchy "$MODULE")
 
     BUFF=""
     if [ -z "$label" ] ; then
@@ -473,14 +473,14 @@ EOF
 g.message "Converting LaTeX to PDF (writing to \$GISBASE/docs/pdf/) ..."
 
 for PGM in pdflatex ; do
-   if [ ! -x `which $PGM` ] ; then
+   if [ ! -x $(which $PGM) ] ; then
 	g.message -e "pdflatex needed for this PDF conversion."
 	g.message "Done."
 	exit 1
    fi
 done
 
-TMPDIR="`dirname "$TMP"`"
+TMPDIR="$(dirname "$TMP")"
 cp "$OLDDIR/../man/grasslogo_vector.pdf" "$TMPDIR"
 cd "$TMPDIR"
 

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -47,6 +47,7 @@ if ! TMP="$(g.tempfile pid=$$)" || [ -z "$TMP" ]; then
     exit 1
 fi
 
+# shellcheck disable=SC2016 # Expressions don't expand in single quotes.
 g.message 'Generating module synopsis (writing to $GISBASE/etc/) ...'
 
 SYNOP="$GISBASE/etc/module_synopsis.txt"
@@ -186,6 +187,7 @@ cp "$SYNOP" "${TMP}.txt"
 ####### create HTML source #######
 # poor cousin to full_index.html from build_html_index.sh
 # todo $MODULE.html links
+# shellcheck disable=SC2016 # Expressions don't expand in single quotes.
 g.message 'Generating HTML (writing to $GISBASE/docs/html/) ...'
 
 #### write header
@@ -336,6 +338,7 @@ EOF
 \mv "${TMP}.html" "$GISBASE/docs/html/module_synopsis.html"
 
 ####### create LaTeX source #######
+# shellcheck disable=SC2016 # Expressions don't expand in single quotes.
 g.message 'Generating LaTeX source (writing to $GISBASE/etc/) ...'
 
 #### write header
@@ -480,6 +483,7 @@ EOF
 #     fix: *.univar.sh, r.surf.idw2, v.to.rast3, r.out.ppm3, others..
 #####
 
+# shellcheck disable=SC2016 # Expressions don't expand in single quotes.
 g.message 'Converting LaTeX to PDF (writing to $GISBASE/docs/pdf/) ...'
 
 # shellcheck disable=SC2043

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -138,6 +138,7 @@ for DIR in bin scripts ; do
 done
 
 # ps.map doesn't jive with the above loop.
+# shellcheck disable=SC2043
 for MODULE in ps.map ; do
     unset label
     unset desc
@@ -337,6 +338,7 @@ EOF
 g.message "Generating LaTeX source (writing to \$GISBASE/etc/) ..."
 
 #### write header
+# shellcheck disable=SC2154 # $n$ is latex syntax
 cat << EOF > "${TMP}.tex"
 %% Adapted from LyX 1.3 LaTeX export. (c) 2009 The GRASS Development Team
 \documentclass[a4paper]{article}
@@ -472,6 +474,7 @@ EOF
 
 g.message "Converting LaTeX to PDF (writing to \$GISBASE/docs/pdf/) ..."
 
+# shellcheck disable=SC2043
 for PGM in pdflatex ; do
    if [ ! -x "$(which $PGM)" ] ; then
 	g.message -e "pdflatex needed for this PDF conversion."

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -43,8 +43,7 @@ for FILE in html pdf ; do
 done
 
 
-TMP="$(g.tempfile pid=$$)"
-if [ $? -ne 0 ] || [ -z "$TMP" ] ; then
+if ! TMP="$(g.tempfile pid=$$)" || [ -z "$TMP" ] ; then
     g.message -e "Unable to create temporary files"
     exit 1
 fi

--- a/utils/module_synopsis.sh
+++ b/utils/module_synopsis.sh
@@ -110,8 +110,8 @@ for DIR in bin scripts ; do
 	;;
     esac
 
-    eval $($MODULE --interface-description | head -n 5 | tail -n 1 | \
-        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')
+    eval "$($MODULE --interface-description | head -n 5 | tail -n 1 | \
+        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')"
 
     if [ -z "$label" ] && [ -z "$desc" ] ; then
 	continue
@@ -142,8 +142,8 @@ for MODULE in ps.map ; do
     unset label
     unset desc
 
-    eval $($MODULE --interface-description | head -n 5 | tail -n 1 | \
-        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')
+    eval "$($MODULE --interface-description | head -n 5 | tail -n 1 | \
+        tr '"' "'" | sed -e 's/^[ \t]./desc="/' -e 's/$/"/' -e 's/[^\."]"$/&./')"
 
     if [ -z "$label" ] && [ -z "$desc" ] ; then
 	continue
@@ -473,7 +473,7 @@ EOF
 g.message "Converting LaTeX to PDF (writing to \$GISBASE/docs/pdf/) ..."
 
 for PGM in pdflatex ; do
-   if [ ! -x $(which $PGM) ] ; then
+   if [ ! -x "$(which $PGM)" ] ; then
 	g.message -e "pdflatex needed for this PDF conversion."
 	g.message "Done."
 	exit 1


### PR DESCRIPTION
This is the original work that #3547 spun off from.

My end goal with this series is to be able to enable shell script linting with shellcheck. It is also the shell-backing linter in actionlint, which can lint GitHub Action .yml files (using shellcheck for the run step), and Hadolint, that can lint Dockerfiles (using shellcheck for the RUN instructions). It can catch a lot of cases that we aren’t always aware of the problems, adapts the rules according to the interpreter used (sh/bash/dash/ksh), has many great long-form error descriptions (that make it easy to understand the issue), and some of the detections have suggested fixes when they are appropriate.



So here are a couple of changes, starting with the .github folder, binder, docker, and utils. In utils, the dep_tree2sql.sh is in another PR. The fix_typos.sh isn’t yet completed, as it will take more than just trivial fixes, it doesn’t run at all and both files that need to be download don’t exist at these locations anymore. I found the new directory for the QGIS one, but didn’t check for the rest. It will be for another time, as even if the file count is small, it’s not obvious for everyone to review if you don’t remember the subtleties between syntaxes (or have some reference nearby).


The majority of the changes are in regards to double quoting to prevent globing and word splitting. There is also the use of arrays and referring to all of them instead of an unquoted string.

I didn’t go all in for the macOS script changes, as I wasn’t so confident enough on what macOS would support, even as a posix-/bin/sh shell. So instead I simply removed the double quotes inside the quotes of the configure flags, and kept the unquoted use of the variable when calling configure. POSIX sh has more limited features.

Like mentioned in the other PR, I finished these files by uniformizing shell scripts formatting with `shfmt -w -s -i 4 -ci -bn -sr`.  Between files, and sometimes in the same file, tabs vs spaces, number of tabs were different, and spaces before and after different constructs were different. These options are just to have a more complete, readable style rather than the minimal changes. The w flag writes the file in place, s is to simplify (it can also minify, but not our goal here), sets indent as 4 spaces, ci is for indenting the "case" switches, sr for space redirects, and bn for binary operations can start on a new line.
Overall it makes the final touch up of the file easier to read through properly indented (at least for me, as I already find that reading a complete shell script is mentally harder than just code and functions, because of all the different syntax packed together for a same goal).

The explanations for each change are by each commit. Each single type of change, by file, is made separately, with the justification in the commit message. Each of these separate changes aren’t worth a PR by themselves, but together they do.

There is also many more scripts in the tests to go through, and other parts of the repo, but I’m starting with this for now.



