### PR TITLE
lib raster: fixed security vulnerabilities and weaknesses

### DIFF
--- a/lib/gis/error.c
+++ b/lib/gis/error.c
@@ -368,7 +368,7 @@ void G_init_logging(void)
 
     logfile = getenv("GIS_ERROR_LOG");
     if (!logfile) {
-        char buf[GPATH_MAX + 1];
+        char buf[GPATH_MAX];
 
         snprintf(buf, GPATH_MAX, "%s/GIS_ERROR_LOG", G__home());
         logfile = G_store(buf);

--- a/lib/gis/error.c
+++ b/lib/gis/error.c
@@ -368,9 +368,9 @@ void G_init_logging(void)
 
     logfile = getenv("GIS_ERROR_LOG");
     if (!logfile) {
-        char buf[GPATH_MAX];
+        char buf[GPATH_MAX + 1];
 
-        sprintf(buf, "%s/GIS_ERROR_LOG", G__home());
+        snprintf(buf, GPATH_MAX, "%s/GIS_ERROR_LOG", G__home());
         logfile = G_store(buf);
     }
 

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -186,7 +186,6 @@ int make_mapset_element_impl(const char *p_path, const char *p_element,
     char path[GPATH_MAX] = {'\0'};
     char *p;
     const char *element;
-    path[GPATH_MAX] = '\0';
 
     element = p_element;
     if (*element == 0)

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -183,8 +183,9 @@ int G_make_mapset_object_group_basedir(const char *type, const char *basedir)
 int make_mapset_element_impl(const char *p_path, const char *p_element,
                              bool race_ok)
 {
-    char path[GPATH_MAX], *p;
+    char path[GPATH_MAX + 1], *p;
     const char *element;
+    path[GPATH_MAX] = 0;
 
     element = p_element;
     if (*element == 0)

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -183,7 +183,8 @@ int G_make_mapset_object_group_basedir(const char *type, const char *basedir)
 int make_mapset_element_impl(const char *p_path, const char *p_element,
                              bool race_ok)
 {
-    char path[GPATH_MAX + 1], *p;
+    char path[GPATH_MAX] = {'\0'};
+    char *p;
     const char *element;
     path[GPATH_MAX] = '\0';
 
@@ -191,7 +192,7 @@ int make_mapset_element_impl(const char *p_path, const char *p_element,
     if (*element == 0)
         return 0;
 
-    strncpy(path, p_path, GPATH_MAX);
+    strncpy(path, p_path, GPATH_MAX - 1);
     p = path;
     while (*p)
         p++;

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -185,7 +185,7 @@ int make_mapset_element_impl(const char *p_path, const char *p_element,
 {
     char path[GPATH_MAX + 1], *p;
     const char *element;
-    path[GPATH_MAX] = 0;
+    path[GPATH_MAX] = '\0';
 
     element = p_element;
     if (*element == 0)

--- a/raster/r.gwflow/main.c
+++ b/raster/r.gwflow/main.c
@@ -212,7 +212,6 @@ int main(int argc, char *argv[])
     N_gradient_field_2d *field = NULL;
     N_array_2d *xcomp = NULL;
     N_array_2d *ycomp = NULL;
-    char *buff = NULL;
     int with_river = 0, with_drain = 0;
 
     /* Initialize GRASS */
@@ -460,9 +459,6 @@ int main(int argc, char *argv[])
 
         N_write_array_2d_to_rast(xcomp, param.vector_x->answer);
         N_write_array_2d_to_rast(ycomp, param.vector_y->answer);
-        if (buff)
-            G_free(buff);
-
         if (xcomp)
             N_free_array_2d(xcomp);
         if (ycomp)


### PR DESCRIPTION
This PR fixes three vulnerabilities/weaknesses found with older scans of Coverity. 

Issue 1208372 in error.c concerns an unbounded read of an environment variable into memory. An attacker could overwrite the environment variable that is accessed by G__home() and exploit it to overflow the buf array.

Issue 1501330 in mapset_msc.c concerns writing into an array that is not null terminated. If the path variable was not null terminated, the write could fill the whole array with data without a null terminator, causing trouble down the line.

Issue 1207344 in raster/r.gwflow/main.c concerns a constant variable guarding dead code. This is not exactly a security vulnerability, but is a code quality issue I was able to easily fix.