### PR TITLE
Update Bandit to ignore secure random warning (Rule B311)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,4 @@ timeout = 300
 
 [tool.bandit]
 exclude_dirs = ["./testsuite", "*/tests/*", "*/testsuite/*", "utils/test_generate_last_commit_file.py"]
-skips = ["B324","B110", "B101", "B112", "B404"]
+skips = ["B324","B110", "B101", "B112", "B311", "B404"]


### PR DESCRIPTION
@wenzeslaus has indicated that all use of random generators are not for cryptographic purposes in issue #3553 . Knowing this, these alerts are false positives and can be safely ignored. 

This PR adds in a skip to the bandit configuration in pyproject.toml for rule B311. This rule searches for instances of randomizers used for potential cryptography.
