### PR TITLE
CI: specify coverity version in coverity.yml

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,3 +18,4 @@ jobs:
           coverity_url: ${{ secrets.COVERITY_URL }}               # The URL to Coverity
           coverity_user: ${{ secrets.COVERITY_USER }}             # The user for the Coverity project
           coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }} # The password for the Coverity user
+          coverity_version: '2023.6.2'                            # The version for Coverity Scan


### PR DESCRIPTION
The Coverity Scan GitHub action is failing due to [not being able to find the supported Coverity version](https://github.com/OSGeo/grass/actions/runs/8533866655/job/23377252411#step:3:71). This fix attempts to fix the error by adding in the version of Coverity specified in the Coverity defects dashboard.