### PR TITLE
Adding a dismissal workflow to code scanning alerts

### DIFF
--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -126,8 +126,7 @@ jobs:
               -d "$json_data" \
             https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
           fi
-          
-
+           #make sure there is no double issue
 
           done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text, .[].dismissed_comment]  | @tsv' )"
           

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -91,17 +91,8 @@ jobs:
        
      - name: Download alerts artifacts
        uses: actions/download-artifact@v4
-       with:
-         name: workflow-data 
-
-         
-     - name: Use downloaded artifact
-       run: |
-         # Access the downloaded artifact
-         #if the discription, prepended with #DISMISSED in alerts.json match the title of an issue, remove from alerts.json
-         jq 'reduce inputs as $in (.; if .title == ("#DISMISSED " + $in.description) then empty else . end)' alerts.json issues.json > filtered_alerts.json
-
-         cat filtered_alerts.json
+       with:    
+          name: workflow-data 
 
      - name: Filter alerts and create issues
        run: |

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -118,11 +118,12 @@ jobs:
           else
             echo "Alert $number is not an issue"
             #create an issue
+            json_data="{\"title\": \"DISMISSED $number $message\", \"body\": \"$dismissed_comment\"}"
             curl -L \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              -d '{"title": "DISMISSED $number $message", "body": "$dismissed_comment"}' \
+              -d "$json_data" \
             https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
           fi
           

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -108,8 +108,8 @@ jobs:
           alertsArray+=($(cat alerts.json | jq -r .[].most_recent_instance.message.text))
        
           # print out alertsArray to the console
-          echo "Alerts: ${alertsArray[@]}"
-          
+          echo "Alerts: ${alertsArray[0]}"
+
          #append the alert id number to each alert array
           alertsID+=($(cat alerts.json | jq .[].number))
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -27,10 +27,10 @@ jobs:
              run: |
              
               curl -L \
+              -F "state=fixed" \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              -F "state=fixed" \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/ > alerts.json  
 
               # remember to change the path above before uploading to grass!

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -114,23 +114,24 @@ jobs:
 
             #check if the alert is already an issue
             if grep -q "DISMISSED $number $message" issues.json; then
-              echo "Alert DISMISSED $number $message is already an issue"
-            else
-              echo "Alert $number is not an issue"
-              #create an issue
-              curl -L \
+            echo "Alert DISMISSED $number $message is already an issue"
+          else
+            echo "Alert $number is not an issue"
+            #create an issue
+            curl -L \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               -d "$(cat <<EOF
               {
                 "title": "DISMISSED $number $message",
-                "body": $dismissed_comment
+                "body": "$dismissed_comment"
               }
               EOF
-              )" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
-            fi
+            )" \
+            https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+          fi
+          
 
 
           done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text, .[].dismissed_comment]  | @tsv' )"

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -133,4 +133,4 @@ jobs:
  
 
           
-  
+       #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -113,4 +113,4 @@ jobs:
         path: dismissed.json
         
           
-       #trigger a rerun
+       #trigger a reru

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -3,8 +3,8 @@ name: Track Dismissed Code Scanning Alerts
 on:
   push:
     branches: 
-     - main
      - dismissalCheckout   # Trigger only test branch, remember to remove before PRing to grass
+                           # in the grass repo this will be changed to a scheduled event (e.g., every 24 hours)
 
 jobs:
     get-dismissals-data:
@@ -13,7 +13,7 @@ jobs:
 
         steps:
      
-     
+             # will remove this step once some testing has been done to make sure it is unnecessary
            - uses: actions/checkout@v4 # Checkout repository code
     
            - name: Install dependencies (if needed for parsing security tool response)
@@ -23,10 +23,10 @@ jobs:
                  
    
            - name: Get Security Alerts
-          
              run: |
 
                #get only dismissed alerts using curl
+               # path to local repo will be changed to the path to the repo in grass
 
                curl -L \
                 -H "Accept: application/vnd.github+json" \
@@ -36,12 +36,9 @@ jobs:
                 echo "alerts retrieved successfully!"
 
 
-              # remember to change the path above before uploading to grass!
-
          
 
-              #trigger a rerun
-
+             #trigger a rerun
            - name: Upload the coding alerts as artifact
              uses: actions/upload-artifact@v4
              with:
@@ -49,7 +46,7 @@ jobs:
               path: alerts.json
 
 
-# get the repository issues 
+             # get the repository issues 
            - name: Get Current Issues        
              run: |
               
@@ -70,6 +67,7 @@ jobs:
                  name: issues-data
                  path: issues.json
 
+    #track the dismissed alerts in github issues             
     track-dismissals:
      runs-on: ubuntu-latest  
      permissions: write-all
@@ -114,7 +112,9 @@ jobs:
 
             #check if the alert is already an issue
             if grep -q "DISMISSED $number $message" issues.json; then
-            echo "Alert DISMISSED $number $message is already an issue"
+            echo "Alert DISMISSED $number $message is already a github issue"
+
+            # path to local repo will be changed to the path to the repo in grass
           else
             echo "Alert $number is not an issue"
             #create an issue
@@ -126,7 +126,7 @@ jobs:
               -d "$json_data" \
             https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
           fi
-           #make sure there is no double issue
+     
 
           done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text, .[].dismissed_comment]  | @tsv' )"
           

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -46,9 +46,8 @@ jobs:
 
 
 # get the repository issues 
-           - name: Get Current Issues
-          
-            run: |
+           - name: Get Current Issues        
+             run: |
               
                curl -L \
                -H "Accept: application/vnd.github+json" \
@@ -63,8 +62,8 @@ jobs:
                #trigger a rerun
  
            - name: Upload the issues as artifact
-            uses: actions/upload-artifact@v4
-            with:
-                name: workflow-data
-                path: issues.json
+             uses: actions/upload-artifact@v4
+             with:
+                 name: workflow-data
+                 path: issues.json
        

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -8,10 +8,13 @@ on:
 jobs:
     track-dismissals:
         runs-on: ubuntu-latest  # Replace with your preferred runner
-     
+        permissions: write-all
+        
         steps:
-           - uses: actions/checkout@v4 # Checkout repository code
      
+     
+           - uses: actions/checkout@v4 # Checkout repository code
+    
            - name: Install dependencies (if needed for parsing security tool response)
              run: |
                 # Add any package installation commands here (e.g., pip install requests)
@@ -19,6 +22,7 @@ jobs:
                  
    
            - name: Get Security Alerts
+          
              run: |
              
               curl -L \

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -79,6 +79,11 @@ jobs:
                    
      - uses: actions/checkout@v4 # Checkout repository code
 
+     - name: Install dependencies (if needed for parsing security tool response)
+       run: |
+        # Add any package installation commands here (e.g., pip install requests)
+          sudo apt-get install jq  # Install jq for parsing JSON
+
      - name: Download inssues artifacts
        uses: actions/download-artifact@v4
        with:
@@ -92,23 +97,28 @@ jobs:
          
      - name: Use downloaded artifact
        run: |
-         ls # Access the downloaded artifact
+         # Access the downloaded artifact
+         #if the discription, prepended with #DISMISSED in alerts.json match the title of an issue, remove from alerts.json
+         jq 'reduce inputs as $in (.; if .title == ("#DISMISSED " + $in.description) then empty else . end)' alerts.json issues.json > filtered_alerts.json
 
-         touch dismissed.json
-         jq -c '.[]' alerts.json | while read i; do
-          alert_name=$(echo $i | jq -r '.rule.id')
-          issue_name="${alert_name}_DISMISSED"
-          if grep -q "$issue_name" issues.json; then
-            echo $i >> dismissed.json
-          fi
-         done
-         echo "Dismissed alerts saved to dismissed.json!"
+         cat filtered_alerts.json
 
-     - name: Upload the issues as artifact
-       uses: actions/upload-artifact@v4
-       with:
-        name: dismissed-data
-        path: dismissed.json
+     - name: Create GitHub issues for dismissed alerts
+       run: |
+          jq -c '.[]' filtered_alerts.json | while read i; do
+            description=$(echo "$i" | jq -r '.description')
+            title="#DISMISSED $description"
+            curl -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -d '{"title": "'"$title"'", "body": "'"$description"'"}' \
+                https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+            done
+         
+
+
+
         
           
-       #trigger a reru
+       #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -29,7 +29,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/analyses
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts
               echo "Security Alerts retrieved successfully!"
 
               #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -16,7 +16,7 @@ jobs:
              run: |
                 # Add any package installation commands here (e.g., pip install requests)
                  echo "Installing dependencies..."  # Placeholder
-                 apt-get install curl
+                 
    
            - name: Get Security Alerts
              run: |

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -30,7 +30,8 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/?query=fixed > alerts.json  
+              -F "state=fixed" \
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/ > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -35,12 +35,12 @@ jobs:
               # remember to change the path above before uploading to grass!
 
 
-              jq '[.[] | select(.state == "dismissed")]' alerts.json > dismissed_alerts.json
-              echo "Filtered dismissed alerts!"
-              rm alerts.json
-              mv dismissed_alerts.json alerts.json
+            #  jq '[.[] | select(.state == "dismissed")]' alerts.json > dismissed_alerts.json
+            #  echo "Filtered dismissed alerts!"
+         #     rm alerts.json
+          #    mv dismissed_alerts.json alerts.json
 
-              echo "Security Alerts retrieved successfully!"
+         
 
               #trigger a rerun
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -122,12 +122,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              -d "$(cat <<EOF
-              {
-                "title": "DISMISSED $number $message",
-                "body": "$dismissed_comment"
-              }
-              EOF)" \
+              -d '{"title": "DISMISSED $number $message", "body": "$dismissed_comment"}' \
             https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
           fi
           

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -97,66 +97,16 @@ jobs:
      - name: Filter alerts and create issues
        run: |
         # make an array of strings to store the alerts
-          alertsArray=()
 
-        #make an array of strings to store the alert id numbers
-
-          alertsID=()
-
-
-          #for every alert in alerts.json, append the alert to the alertsArray
-          alertsArray+=($(cat alerts.json | jq -r .[].most_recent_instance.message.text))
-       
-          # print out alertsArray to the console
-          echo "Alerts: ${alertsArray[0]}"
-
-         #append the alert id number to each alert array
-          alertsID+=($(cat alerts.json | jq .[].number))
-
-         #append the alert id number to each alert in alertsArray
-          for i in ${!alertsArray[@]}
-          do
-            alertsArray[$i]="${alertsArray[$i]} ID: ${alertsID[$i]}"
-          done
-
-         #append the string "DISMISSED: " to each alert in alertsArray
-          alerts=()
-          for alert in $alertsArray
-          do
-            alerts+=("DISMISSED: $alert")
-          done
+                  
+          while IFS= read -r line; do
+            # Process each line (string) here
+            echo "Processing: $line dismissed"
 
 
-          #print alerts to the console
-          echo "Alerts: ${alerts[@]}"
-
-
-  
-
-
-         #if the alert in alerts has no issue because of it, create a new issue with that title
-        
-          for alert in $alerts
-          do
-            if [[ ! "issues.json" == *"$alert"* ]]; then
-              echo "Creating issue for $alert"
-              curl -L \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              -X POST \
-              -d "{\"title\":\"$alert\ because of this alert, please check the code and fix it.\",\"body\":\"This issue was created because of the alert: $alert\"}" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
-            fi
-          done
-
-          #trigger a rerun
-
-
-
-        
-
+          done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text] | @sh' )"
+          
  
-        
+
           
        #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -27,7 +27,7 @@ jobs:
              run: |
              
                curl --request GET \
-               --url "https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=fixed" \
+               --url "https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed" \
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -120,23 +120,31 @@ jobs:
             alerts+=("DISMISSED: $alert")
           done
 
+
+          #print alerts to the console
+          echo "Alerts: ${alerts[@]}"
+
+
   
 
 
-         #if the alert in alerts is not a title in issues.json, create a new issue with that title
+         #if the alert in alerts has no issue because of it, create a new issue with that title
+        
           for alert in $alerts
           do
-            if ! grep -q "$alert" issues.json
-            then
+            if [[ ! "issues.json" == *"$alert"* ]]; then
+              echo "Creating issue for $alert"
               curl -L \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               -X POST \
-              -d "{\"title\":\"$alert\",\"body\":\"This issue was created because the alert was dismissed.\"}" \
+              -d "{\"title\":\"$alert\",\"body\":\"This alert has been dismissed\"}" \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
             fi
           done
+
+          #trigger a rerun
 
 
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -7,7 +7,7 @@ on:
      - dismissalCheckout   # Trigger only test branch, remember to remove before PRing to grass
 
 jobs:
-    track-dismissals:
+    get-dismissals-data:
         runs-on: ubuntu-latest  
         permissions: write-all
 
@@ -66,4 +66,28 @@ jobs:
              with:
                  name: issues-data
                  path: issues.json
+
+    track-dismissals:
+     runs-on: ubuntu-latest  
+     permissions: write-all
+              
+     steps:
+                   
+
+     - name: Download artifacts
+       uses: actions/download-artifact@v3
+       with:
+         name: issues-data  # Match the name used for upload
+       
+     - name: Download artifacts
+       uses: actions/download-artifact@v3
+       with:
+         name: workflow-data
+
+         
+     - name: Use downloaded artifact
+       run: |
+         cat issues.json # Access the downloaded artifact
+         cat alerts.json
+          
        

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -101,7 +101,7 @@ jobs:
           alertsID=()
 
 
-          for every alert in alerts.json, append the alert to the alertsArray
+          #for every alert in alerts.json, append the alert to the alertsArray
           alertsArray+=($(cat alerts.json | jq .[].most_recent_instance.message.text))
        
          #append the alert id number to each alert array
@@ -112,7 +112,7 @@ jobs:
           do
             alertsArray[$i]="${alertsArray[$i]} ID: ${alertsID[$i]}"
           done
-          
+
          #append the string "DISMISSED: " to each alert in alertsArray
           alerts=()
           for alert in $alertsArray

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -99,40 +99,27 @@ jobs:
          # Parse the alerts and issues
          alerts=$( cat alerts.json | jq .[].most_recent_instance.message.text )
 
-         #get alert id
-         alert_id=$( cat alerts.json | jq .[].number )
+         #append the id of the alert to each alert
+          alerts=$( echo $alerts | jq '.[].number' )
+
+         #append the string "DISMISSED: " to each alert
+          alerts=$( echo $alerts | sed 's/^/DISMISSED: /' )
 
 
-          #get the issue title
-
-          issue_title=$( cat issues.json | jq .[].title )
-
-          #if the issue title matches a dismissed alert, remove the dismissed alert from alerts.json
-
-
-          for i in $issue_title
+         #if the alert is not in the issues, create a new issue
+          for alert in $alerts
           do
-            for j in $alerts
-            do
-              if [ "DISSMISSED" + "$i" == "$j" ]
-              then
-                #remove the alert from alerts.json
-                jq 'del(.[].number == $alert_id)' alerts.json > alerts.json
-              fi
-            done
-          done
-
-
-          #make a new issue for each alert in alerts.json
-          for i in $alerts
-
-          do
-            curl -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d '{"title": "DISMISSED $i", "body": "This alert was dismissed"}' \
-            https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+            if ! grep -q $alert issues.json
+            then
+              echo "Creating new issue for alert: $alert"
+              curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -X POST \
+              -d "{\"title\":\"$alert\",\"body\":\"This alert was dismissed and needs to be addressed.\"}" \
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+            fi
           done
 
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -19,14 +19,12 @@ jobs:
            - name: Install dependencies (if needed for parsing security tool response)
              run: |
                 # Add any package installation commands here (e.g., pip install requests)
-                 echo "Installing dependencies..."  # Placeholder
+                  sudo apt-get install jq  # Install jq for parsing JSON
                  
    
            - name: Get Security Alerts
           
              run: |
-             
-
 
                #get only dismissed alerts using curl
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -37,6 +37,7 @@ jobs:
 
               jq '[.[] | select(.state == "dismissed")]' alerts.json > dismissed_alerts.json
               echo "Filtered dismissed alerts!"
+              rm alerts.json
               mv dismissed_alerts.json alerts.json
 
               echo "Security Alerts retrieved successfully!"

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -77,12 +77,12 @@ jobs:
      - name: Download artifacts
        uses: actions/download-artifact@v3
        with:
-         name: issues-data  # Match the name used for upload
+         name: issues.json  # Match the name used for upload
        
      - name: Download artifacts
        uses: actions/download-artifact@v3
        with:
-         name: workflow-data
+         name: alerts.json
 
          
      - name: Use downloaded artifact

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -74,15 +74,15 @@ jobs:
      steps:
                    
      - uses: actions/checkout@v4 # Checkout repository code
-     - name: Download artifacts
+     - name: Download inssues artifacts
        uses: actions/download-artifact@v3
        with:
-         name: issues.json  # Match the name used for upload
+         name: issues-data  # Match the name used for upload
        
-     - name: Download artifacts
+     - name: Download alerts artifacts
        uses: actions/download-artifact@v3
        with:
-         name: alerts.json
+         name: workflow-data
 
          
      - name: Use downloaded artifact

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -97,28 +97,50 @@ jobs:
      - name: Filter alerts and create issues
        run: |
          # Parse the alerts and issues
-         alerts=$(jq -c '.[]' alerts.json)
-         issues=$(jq -c '.[]' issues.json)
+         alerts=$( cat alerts.json | jq .[].most_recent_instance.message.text )
 
-         # For each alert, check if a corresponding issue exists
-         for alert in ${alerts[@]}; do
-           alert_title=$(echo "$alert" | jq -r '.description')
-           dismissed_title="#DISMISSED $alert_title"
+         #get alert id
+         alert_id=$( cat alerts.json | jq .[].number )
 
-           # Check if an issue with the dismissed title exists
-           issue_exists=$(echo "$issues" | jq -r "select(.title == \"$dismissed_title\")")
 
-           # If no issue exists, create a new one
-           if [ -z "$issue_exists" ]; then
-             curl -X POST \
-               -H "Accept: application/vnd.github+json" \
-               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-               -H "X-GitHub-Api-Version: 2022-11-28" \
-               -d '{"title": "'"$dismissed_title"'", "body": "'"$alert_title"'"}' \
-               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
-           fi
-         done
-         
+          #get the issue title
+
+          issue_title=$( cat issues.json | jq .[].title )
+
+          #if the issue title matches a dismissed alert, remove the dismissed alert from alerts.json
+
+
+          for i in $issue_title
+          do
+            for j in $alerts
+            do
+              if [ "DISSMISSED" + "$i" == "$j" ]
+              then
+                #remove the alert from alerts.json
+                jq 'del(.[].number == $alert_id)' alerts.json > alerts.json
+              fi
+            done
+          done
+
+
+          #make a new issue for each alert in alerts.json
+          for i in $alerts
+
+          do
+            curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d '{"title": "DISMISSED $i", "body": "This alert was dismissed"}' \
+            https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+          done
+
+
+          echo "Alerts filtered and new issues created successfully!"
+
+
+
+ 
         
           
        #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -26,8 +26,7 @@ jobs:
           
              run: |
              
-              curl -L \
-            
+              curl -L \      
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -30,16 +30,9 @@ jobs:
                --url "https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed" \
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-               --header "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json  
+               --header "X-GitHub-Api-Version: 2022-11-28" \ > alerts.json  
 
               # remember to change the path above before uploading to grass!
-
-
-            #  jq '[.[] | select(.state == "dismissed")]' alerts.json > dismissed_alerts.json
-            #  echo "Filtered dismissed alerts!"
-         #     rm alerts.json
-          #    mv dismissed_alerts.json alerts.json
 
          
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -30,7 +30,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json  
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/?query=fixed > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -82,7 +82,7 @@ jobs:
         # Add any package installation commands here (e.g., pip install requests)
           sudo apt-get install jq  # Install jq for parsing JSON
 
-     - name: Download inssues artifacts
+     - name: Download issues artifacts
        uses: actions/download-artifact@v4
        with:
          name: issues-data   # Match the name used for upload
@@ -127,5 +127,4 @@ jobs:
             https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
           fi
      
-
           done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text, .[].dismissed_comment]  | @tsv' )"

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -26,11 +26,12 @@ jobs:
           
              run: |
              
-              curl -L \      
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=fixed > alerts.json  
+               curl --request GET \
+               --url "https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=fixed" \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -96,14 +96,20 @@ jobs:
 
      - name: Filter alerts and create issues
        run: |
-        #make an array called alertsArray
+        # make an array of strings to store the alerts
           alertsArray=()
+
+        #make an array of strings to store the alert id numbers
+
           alertsID=()
 
 
           #for every alert in alerts.json, append the alert to the alertsArray
-          alertsArray+=($(cat alerts.json | jq .[].most_recent_instance.message.text))
+          alertsArray+=($(cat alerts.json | jq -r .[].most_recent_instance.message.text))
        
+          # print out alertsArray to the console
+          echo "Alerts: ${alertsArray[@]}"
+          
          #append the alert id number to each alert array
           alertsID+=($(cat alerts.json | jq .[].number))
 
@@ -139,7 +145,7 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               -X POST \
-              -d "{\"title\":\"$alert\",\"body\":\"This alert has been dismissed\"}" \
+              -d "{\"title\":\"$alert\ because of this alert, please check the code and fix it.\",\"body\":\"This issue was created because of the alert: $alert\"}" \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
             fi
           done

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -74,20 +74,21 @@ jobs:
      steps:
                    
      - uses: actions/checkout@v4 # Checkout repository code
+
      - name: Download inssues artifacts
        uses: actions/download-artifact@v3
        with:
-         name: issues-data  # Match the name used for upload
+         name: issues-data.zip  # Match the name used for upload
        
      - name: Download alerts artifacts
        uses: actions/download-artifact@v3
        with:
-         name: workflow-data
+         name: workflow-data.zip
 
          
      - name: Use downloaded artifact
        run: |
-         cat issues.json # Access the downloaded artifact
-         cat alerts.json
+         ls # Access the downloaded artifact
+        
           
        

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -103,11 +103,11 @@ jobs:
 
          cat filtered_alerts.json
 
-     - name: Create GitHub issues for dismissed alerts
+     - name: Create GitHub issues for each alert in filtered alerts
        run: |
           jq -c '.[]' filtered_alerts.json | while read i; do
             description=$(echo "$i" | jq -r '.description')
-            title="#DISMISSED $description"
+            title="#ALERT $description"
             curl -X POST \
                 -H "Accept: application/vnd.github+json" \
                 -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
@@ -115,9 +115,6 @@ jobs:
                 -d '{"title": "'"$title"'", "body": "'"$description"'"}' \
                 https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
             done
-         
-
-
 
         
           

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -3,7 +3,8 @@ name: Track Dismissed Code Scanning Alerts
 on:
   push:
     branches: 
-     - dismissalCheckout   # Trigger only test branch
+     - main
+     - dismissalCheckout   # Trigger only test branch, remember to remove before PRing to grass
 
 jobs:
     track-dismissals:
@@ -29,13 +30,16 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json  
+
+              # remember to change the path above before uploading to grass!
+
               echo "Security Alerts retrieved successfully!"
 
               #trigger a rerun
 
            - name: Upload the coding alerts as artifact
-             uses: actions/upload-artifact@v3
+             uses: actions/upload-artifact@v4
              with:
               name: workflow-data
               path: alerts.json

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -120,7 +120,7 @@ jobs:
             alerts+=("DISMISSED: $alert")
           done
 
-          echo "Alerts filtered successfully!
+  
 
 
          #if the alert in alerts is not a title in issues.json, create a new issue with that title
@@ -138,9 +138,6 @@ jobs:
             fi
           done
 
-
-
-          echo "Alerts filtered and new issues created successfully!"
 
 
         

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -122,7 +122,13 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              -d '{"title": "DISMISSED $(echo $message)", "body": "Alert $(echo $number) was dismissed with the comment: $(echo $dismissed_comment)"}' \
+              -d "$(cat <<EOF
+              {
+                "title": "DISMISSED $number $message",
+                "body": $dismissed_comment
+              }
+              EOF
+              )" \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
             fi
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -103,8 +103,31 @@ jobs:
             # Process each line (string) here
             echo "Processing: $line dismissed"
 
+          
 
-          done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text] | @sh' )"
+           #seperate $title into variables for number, message, and dismissed_comment seperated by tab
+            IFS=$'\t' read -r number message dismissed_comment <<< "$line"
+            echo "number: $number"
+            echo "message: $message"
+            echo "dismissed_comment: $dismissed_comment"
+
+
+            #check if the alert is already an issue
+            if grep -q "$number" issues.json; then
+              echo "Alert $number is already an issue"
+            else
+              echo "Alert $number is not an issue"
+              #create an issue
+              curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -d '{"title": "Alert $number", "body": "Alert $number was dismissed with the comment: $dismissed_comment"}' \
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+            fi
+
+
+          done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text, .[].dismissed_comment]  | @tsv' )"
           
  
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -112,4 +112,4 @@ jobs:
         path: dismissed.json
         
           
-       
+       #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -31,8 +31,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              -F state='fixed' \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/ > alerts.json  
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/events?state=fixed > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -129,8 +129,3 @@ jobs:
      
 
           done <<< "$(cat alerts.json | jq -r '[.[].number, .[].most_recent_instance.message.text, .[].dismissed_comment]  | @tsv' )"
-          
- 
-
-          
-       #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -133,4 +133,4 @@ jobs:
  
 
           
-       #trigger a rerun
+  

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -127,8 +127,7 @@ jobs:
                 "title": "DISMISSED $number $message",
                 "body": "$dismissed_comment"
               }
-              EOF
-            )" \
+              EOF)" \
             https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
           fi
           

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -31,7 +31,7 @@ jobs:
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed" > alerts.json  
+               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -30,7 +30,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/events?state=fixed > alerts.json  
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/?state=fixed > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -9,7 +9,7 @@ jobs:
     track-dismissals:
         runs-on: ubuntu-latest  # Replace with your preferred runner
         permissions: write-all
-        
+
         steps:
      
      
@@ -31,4 +31,5 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/analyses
               echo "Security Alerts retrieved successfully!"
-   
+
+              #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -27,10 +27,11 @@ jobs:
              run: |
              
               curl -L \
-              -F "state=fixed" \
+            
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
+              -F state='fixed' \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/ > alerts.json  
 
               # remember to change the path above before uploading to grass!

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -96,38 +96,54 @@ jobs:
 
      - name: Filter alerts and create issues
        run: |
-         # Parse the alerts and issues
-         alerts=$( cat alerts.json | jq .[].most_recent_instance.message.text )
-
-    
-
-         #append the id of the alert from at alerts.json | jq .[].number to each alert
-          alerts=$( echo $alerts | sed 's/^/ID: $(cat alerts.json | jq .[].number) /' )
-
-         #append the string "DISMISSED: " to each alert
-          alerts=$( echo $alerts | sed 's/^/DISMISSED: /' )
+        #make an array called alertsArray
+          alertsArray=()
+          alertsID=()
 
 
-         #if the alert is not in the issues, create a new issue
+          for every alert in alerts.json, append the alert to the alertsArray
+          alertsArray+=($(cat alerts.json | jq .[].most_recent_instance.message.text))
+       
+         #append the alert id number to each alert array
+          alertsID+=($(cat alerts.json | jq .[].number))
+
+         #append the alert id number to each alert in alertsArray
+          for i in ${!alertsArray[@]}
+          do
+            alertsArray[$i]="${alertsArray[$i]} ID: ${alertsID[$i]}"
+          done
+          
+         #append the string "DISMISSED: " to each alert in alertsArray
+          alerts=()
+          for alert in $alertsArray
+          do
+            alerts+=("DISMISSED: $alert")
+          done
+
+          echo "Alerts filtered successfully!
+
+
+         #if the alert in alerts is not a title in issues.json, create a new issue with that title
           for alert in $alerts
           do
-            if ! grep -q $alert issues.json
+            if ! grep -q "$alert" issues.json
             then
-              echo "Creating new issue for alert: $alert"
               curl -L \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               -X POST \
-              -d "{\"title\":\"$alert\",\"body\":\"This alert was dismissed and needs to be addressed.\"}" \
+              -d "{\"title\":\"$alert\",\"body\":\"This issue was created because the alert was dismissed.\"}" \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
             fi
           done
 
 
+
           echo "Alerts filtered and new issues created successfully!"
 
 
+        
 
  
         

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -70,6 +70,7 @@ jobs:
     track-dismissals:
      runs-on: ubuntu-latest  
      permissions: write-all
+     needs: get-dismissals-data
     
      steps:
                    

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     track-dismissals:
-        runs-on: ubuntu-latest  # Replace with your preferred runner
+        runs-on: ubuntu-latest  
         permissions: write-all
 
         steps:
@@ -29,7 +29,14 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json
               echo "Security Alerts retrieved successfully!"
 
               #trigger a rerun
+
+           - name: Upload the coding alerts as artifact
+             uses: actions/upload-artifact@v3
+             with:
+              name: workflow-data
+              path: alerts.json
+      

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -30,7 +30,8 @@ jobs:
                --url "https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed" \
                --header "Accept: application/vnd.github+json" \
                --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-               --header "X-GitHub-Api-Version: 2022-11-28" \ > alerts.json  
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed" > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -70,10 +70,10 @@ jobs:
     track-dismissals:
      runs-on: ubuntu-latest  
      permissions: write-all
-              
+    
      steps:
                    
-
+     - uses: actions/checkout@v4 # Checkout repository code
      - name: Download artifacts
        uses: actions/download-artifact@v3
        with:

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -95,7 +95,7 @@ jobs:
        run: |
          ls # Access the downloaded artifact
 
-
+         touch dismissed.json
          jq -c '.[]' alerts.json | while read i; do
           alert_name=$(echo $i | jq -r '.rule.id')
           issue_name="${alert_name}_DISMISSED"

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -34,6 +34,11 @@ jobs:
 
               # remember to change the path above before uploading to grass!
 
+
+              jq '[.[] | select(.state == "dismissed")]' alerts.json > dismissed_alerts.json
+              echo "Filtered dismissed alerts!"
+              mv dismissed_alerts.json alerts.json
+
               echo "Security Alerts retrieved successfully!"
 
               #trigger a rerun
@@ -56,7 +61,6 @@ jobs:
                https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues > issues.json  
  
                # remember to change the path above before uploading to grass!
- 
                echo "issues retrieved successfully!"
  
                #trigger a rerun
@@ -90,6 +94,22 @@ jobs:
      - name: Use downloaded artifact
        run: |
          ls # Access the downloaded artifact
+
+
+         jq -c '.[]' alerts.json | while read i; do
+          alert_name=$(echo $i | jq -r '.rule.id')
+          issue_name="${alert_name}_DISMISSED"
+          if grep -q "$issue_name" issues.json; then
+            echo $i >> dismissed.json
+          fi
+         done
+         echo "Dismissed alerts saved to dismissed.json!"
+
+     - name: Upload the issues as artifact
+       uses: actions/upload-artifact@v4
+       with:
+        name: dismissed-data
+        path: dismissed.json
         
           
        

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -43,4 +43,28 @@ jobs:
              with:
               name: workflow-data
               path: alerts.json
-      
+
+
+# get the repository issues 
+           - name: Get Current Issues
+          
+            run: |
+              
+               curl -L \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               -H "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues > issues.json  
+ 
+               # remember to change the path above before uploading to grass!
+ 
+               echo "issues retrieved successfully!"
+ 
+               #trigger a rerun
+ 
+           - name: Upload the issues as artifact
+            uses: actions/upload-artifact@v4
+            with:
+                name: workflow-data
+                path: issues.json
+       

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -64,6 +64,6 @@ jobs:
            - name: Upload the issues as artifact
              uses: actions/upload-artifact@v4
              with:
-                 name: workflow-data
+                 name: issues-data
                  path: issues.json
        

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -76,14 +76,14 @@ jobs:
      - uses: actions/checkout@v4 # Checkout repository code
 
      - name: Download inssues artifacts
-       uses: actions/download-artifact@v3
+       uses: actions/download-artifact@v4
        with:
-         name: issues-data.zip  # Match the name used for upload
+         name: issues-data   # Match the name used for upload
        
      - name: Download alerts artifacts
-       uses: actions/download-artifact@v3
+       uses: actions/download-artifact@v4
        with:
-         name: workflow-data.zip
+         name: workflow-data 
 
          
      - name: Use downloaded artifact

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -26,12 +26,17 @@ jobs:
           
              run: |
              
-               curl --request GET \
-               --url "https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed" \
-               --header "Accept: application/vnd.github+json" \
-               --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-               --header "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts > alerts.json  
+
+
+               #get only dismissed alerts using curl
+
+               curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=dismissed > alerts.json
+                echo "alerts retrieved successfully!"
+
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -30,7 +30,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts/?state=fixed > alerts.json  
+              https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/code-scanning/alerts?state=fixed > alerts.json  
 
               # remember to change the path above before uploading to grass!
 

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -99,8 +99,10 @@ jobs:
          # Parse the alerts and issues
          alerts=$( cat alerts.json | jq .[].most_recent_instance.message.text )
 
-         #append the id of the alert to each alert
-          alerts=$( echo $alerts | jq '.[].number' )
+    
+
+         #append the id of the alert from at alerts.json | jq .[].number to each alert
+          alerts=$( echo $alerts | sed 's/^/ID: $(cat alerts.json | jq .[].number) /' )
 
          #append the string "DISMISSED: " to each alert
           alerts=$( echo $alerts | sed 's/^/DISMISSED: /' )

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -103,19 +103,31 @@ jobs:
 
          cat filtered_alerts.json
 
-     - name: Create GitHub issues for each alert in filtered alerts
+     - name: Filter alerts and create issues
        run: |
-          jq -c '.[]' filtered_alerts.json | while read i; do
-            description=$(echo "$i" | jq -r '.description')
-            title="#ALERT $description"
-            curl -X POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                -d '{"title": "'"$title"'", "body": "'"$description"'"}' \
-                https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
-            done
+         # Parse the alerts and issues
+         alerts=$(jq -c '.[]' alerts.json)
+         issues=$(jq -c '.[]' issues.json)
 
+         # For each alert, check if a corresponding issue exists
+         for alert in ${alerts[@]}; do
+           alert_title=$(echo "$alert" | jq -r '.description')
+           dismissed_title="#DISMISSED $alert_title"
+
+           # Check if an issue with the dismissed title exists
+           issue_exists=$(echo "$issues" | jq -r "select(.title == \"$dismissed_title\")")
+
+           # If no issue exists, create a new one
+           if [ -z "$issue_exists" ]; then
+             curl -X POST \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+               -H "X-GitHub-Api-Version: 2022-11-28" \
+               -d '{"title": "'"$dismissed_title"'", "body": "'"$alert_title"'"}' \
+               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
+           fi
+         done
+         
         
           
        #trigger a rerun

--- a/.github/workflows/security_dismissal.yml
+++ b/.github/workflows/security_dismissal.yml
@@ -113,8 +113,8 @@ jobs:
 
 
             #check if the alert is already an issue
-            if grep -q "$number" issues.json; then
-              echo "Alert $number is already an issue"
+            if grep -q "DISMISSED $number $message" issues.json; then
+              echo "Alert DISMISSED $number $message is already an issue"
             else
               echo "Alert $number is not an issue"
               #create an issue
@@ -122,7 +122,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              -d '{"title": "Alert $number", "body": "Alert $number was dismissed with the comment: $dismissed_comment"}' \
+              -d '{"title": "DISMISSED $(echo $message)", "body": "Alert $(echo $number) was dismissed with the comment: $(echo $dismissed_comment)"}' \
               https://api.github.com/repos/ncsu-csc472-spring2024/grass-CI-playground/issues
             fi
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "github.copilot.editor.enableAutoCompletions": true
+}


### PR DESCRIPTION
The issue this is trying to solve: Many code dismissals removed from one person dismisses the alert for the entire repository without discussion. what this would do would be that on a scheduled time (Its currently works on push to a local test branch, but this would be changed to a scheduled time)  the workflow will check for new dismissals and make a github issue for it.  This will allow community input on whether or not a certain security alert truly is invalid before dismissing.

this is an example of what the action currently does:
![image](https://github.com/OSGeo/grass/assets/42349380/f8094b14-bf15-4336-b37c-3d11166ef3e4). I have tested that it does resist on making multiple issues for the same coding alert, but more thorough testing will be done to make sure the following additions to be made as the grass would need it to be on their end. 

adding additional information to the title/body of the issue (such as location of the bug and the person who dismissed it)  would be easy.

likewise, we are also looking into filtering out dismissals that were dismissed too long ago (these dates would change if they were reopened, and  so this method allows for revisions) so the run doesn't flood issues on the first go.  

an additional feature we would like to implement is to not make an issue for coding alerts that are dismissed for it being part of tests. 