### PR TITLE
raster: disable parallelization when MASK active

### DIFF
--- a/raster/r.mfilter/main.c
+++ b/raster/r.mfilter/main.c
@@ -132,7 +132,10 @@ int main(int argc, char **argv)
                     "threads setting."));
     nprocs = 1;
 #endif
-
+    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        nprocs = 1;
+    }
     out_name = opt2->answer;
     filt_name = opt3->answer;
 

--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -310,7 +310,10 @@ int main(int argc, char *argv[])
                     "threads setting."));
     ncb.threads = 1;
 #endif
-
+    if (ncb.threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        ncb.threads = 1;
+    }
     if (strcmp(parm.weighting_function->answer, "none") && flag.circle->answer)
         G_fatal_error(_("-%c and %s= are mutually exclusive"), flag.circle->key,
                       parm.weighting_function->answer);

--- a/raster/r.resamp.filter/main.c
+++ b/raster/r.resamp.filter/main.c
@@ -494,7 +494,10 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-
+    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        nprocs = 1;
+    }
     if (parm.radius->answer) {
         if (parm.x_radius->answer || parm.y_radius->answer)
             G_fatal_error(_("%s= and %s=/%s= are mutually exclusive"),

--- a/raster/r.resamp.interp/main.c
+++ b/raster/r.resamp.interp/main.c
@@ -132,7 +132,10 @@ int main(int argc, char *argv[])
                     "threads setting."));
     threads = 1;
 #endif
-
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        threads = 1;
+    }
     bufrows = atoi(memory->answer) * (((1 << 20) / sizeof(DCELL)) / dst_w.cols);
     /* set the output buffer rows to be at most covering the entire map */
     if (bufrows > dst_w.rows) {

--- a/raster/r.series/main.c
+++ b/raster/r.series/main.c
@@ -227,7 +227,10 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-
+    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        nprocs = 1;
+    }
     lo = -INFINITY;
     hi = INFINITY;
     if (parm.range->answer) {

--- a/raster/r.sim/r.sim.sediment/main.c
+++ b/raster/r.sim/r.sim.sediment/main.c
@@ -380,6 +380,10 @@ int main(int argc, char *argv[])
 #else
     threads = 1;
 #endif
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        threads = 1;
+    }
     G_message(_("Number of threads: %d"), threads);
 
     /*      sscanf(parm.nwalk->answer, "%d", &wp.maxwa); */

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -407,6 +407,10 @@ int main(int argc, char *argv[])
 #else
     threads = 1;
 #endif
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        threads = 1;
+    }
     G_message(_("Number of threads: %d"), threads);
 
     /* if no rain map input, then: */

--- a/raster/r.slope.aspect/main.c
+++ b/raster/r.slope.aspect/main.c
@@ -305,7 +305,10 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-
+    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        nprocs = 1;
+    }
     radians_to_degrees = 180.0 / M_PI;
     degrees_to_radians = M_PI / 180.0;
 

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -591,6 +591,10 @@ int main(int argc, char *argv[])
 #else
     threads = 1;
 #endif
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        threads = 1;
+    }
     G_message(_("Number of threads <%d>"), threads);
 
     if (civiltime != NULL) {

--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -188,7 +188,10 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-
+    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        nprocs = 1;
+    }
     /* table field separator */
     zone_info.sep = G_option_to_separator(param.separator);
 

--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -429,7 +429,10 @@ int main(int argc, char *argv[])
         G_warning(_("GRASS GIS is not compiled with OpenMP support, parallel "
                     "computation is disabled."));
 #endif
-
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        threads = 1;
+    }
     if (devi) {
         create_devi = true;
         if (Vect_legal_filename(devi) == -1)


### PR DESCRIPTION
Similarly to #2829, this PR disables parallelization when MASK is active for parallelized tools. Fixes #3560.