### PR TITLE
r.univar: add note that parallelization is disabled if mask is set

### DIFF
--- a/raster/r.univar/r.univar.html
+++ b/raster/r.univar/r.univar.html
@@ -54,7 +54,7 @@ map and uploads statistics to new attribute columns, see
 <em>r.univar</em> supports parallel processing using OpenMP. The user
 can specify the number of threads to be used with the <b>nprocs</b> parameter.
 However, parallelization is disabled when the <b>-e</b> extended statistics
-flag is used.
+flag is used. Parallelization is furthermore disabled when the MASK is set.
 
 <p>
 Due to the differences in summation order, users may encounter small floating points

--- a/raster/r.univar/r.univar.html
+++ b/raster/r.univar/r.univar.html
@@ -53,8 +53,7 @@ map and uploads statistics to new attribute columns, see
 <p>
 <em>r.univar</em> supports parallel processing using OpenMP. The user
 can specify the number of threads to be used with the <b>nprocs</b> parameter.
-However, parallelization is disabled when the <b>-e</b> extended statistics
-flag is used. Parallelization is furthermore disabled when the MASK is set.
+However, parallelization is disabled when the MASK is set.
 
 <p>
 Due to the differences in summation order, users may encounter small floating points


### PR DESCRIPTION
Given #3561 I think it is good to add the note that parallelization does not work (or is disabled) when the mask is set to the modules that allow parallelization.