### PR TITLE
grass.jupyter: fix reinitializing session

### DIFF
--- a/python/grass/jupyter/setup.py
+++ b/python/grass/jupyter/setup.py
@@ -16,6 +16,7 @@
 
 import os
 import weakref
+from pathlib import Path
 
 import grass.script as gs
 
@@ -87,6 +88,7 @@ class _JupyterGlobalSession:
         if (
             not location
             and not mapset
+            and len(Path(path).parts) == 1
             and mapset_exists(
                 path=gisenv["GISDBASE"], location=gisenv["LOCATION_NAME"], mapset=path
             )


### PR DESCRIPTION
When running `gj.init(/path/to/project)` in already active session, the paths got all mixed up. Problem was that `mapset_exists` was getting `mapset="/tmp/someting/project_name"` and because of a somewhat unexpected (but documented) behavior of `os.path.join` when merging absolute paths, this end up as an existing directory, while the expectation was it would fail. So this change adds the check that mapset is a name, not a path.