### PR TITLE
CI: Overhaul Coverity Scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir cov-analysis-linux64
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
         env:
-          TOKEN: ${{ secrets.COVERITY_PASSPHRASE }} # this is the token that admins use to upload builds
+          TOKEN: ${{ secrets.COVERITY_PASSPHRASE }}
       - name: Set number of cores for compilation
         run: |
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -58,11 +58,12 @@ jobs:
           curl \
             --form project=grass \
             --form token=$TOKEN \
-            --form email=wenzeslaus@gmail.com \
+            --form email=$EMAIL \
             --form file=@grass.tgz \
             --form version=master \
             --form description="`git rev-parse --abbrev-ref HEAD` `git rev-parse --short HEAD`" \
             https://scan.coverity.com/builds?project=grass
         env:
           TOKEN: ${{ secrets.COVERITY_PASSPHRASE }}
+          EMAIL: ${{ secrets.COVERITY_USER }}
                                   

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   # action based off of https://github.com/OSGeo/PROJ/blob/905c9a6c2da3dc6b7aa2c89d3ab78d9d1a9cd070/.github/workflows/coverity-scan.yml
-  # and https://github.com/OSGeo/grass/blob/2aa98a166d8f50aa1491908401205962fa1d70fb/.github/workflows/ubuntu.yml
 jobs:
   coverity:
     runs-on: ubuntu-22.04

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           pwd
           export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
-          cov-build --dir cov-int .github/workflows/build_ubuntu-22.04_without_x.sh $HOME/install -Werror
+          cov-build --dir cov-int .github/workflows/build_ubuntu-22.04_without_x.sh $HOME/install
       - name: Submit to Coverity Scan
         run: |
           tar czvf proj.tgz cov-int

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -60,7 +60,7 @@ jobs:
             --form token=$TOKEN \
             --form email=$EMAIL \
             --form file=@grass.tgz \
-            --form version=master \
+            --form version=main \
             --form description="`git rev-parse --abbrev-ref HEAD` `git rev-parse --short HEAD`" \
             https://scan.coverity.com/builds?project=grass
         env:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -62,7 +62,7 @@ jobs:
             --form project=grass \
             --form token=$TOKEN \
             --form email=wenzeslaus@gmail.com \
-            --form file=@proj.tgz \
+            --form file=@grass.tgz \
             --form version=master \
             --form description="`git rev-parse --abbrev-ref HEAD` `git rev-parse --short HEAD`" \
             https://scan.coverity.com/builds?project=grass

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -57,7 +57,7 @@ jobs:
           cov-build --dir cov-int .github/workflows/build_ubuntu-22.04_without_x.sh $HOME/install
       - name: Submit to Coverity Scan
         run: |
-          tar czvf proj.tgz cov-int
+          tar czvf grass.tgz cov-int
           curl \
             --form project=grass \
             --form token=$TOKEN \

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,18 +4,56 @@ on:
   schedule:
     - cron: '48 5 * * *' # Run at 05:48
     # Coverity will let GRASS do a scan a maximum of twice per day, so this schedule will help GRASS fit within that limit with some additional space for manual runs
-
+permissions:
+  contents: read
 jobs:
-  build:
-    runs-on: [ ubuntu-latest ]
+  coverity:
+    runs-on: ubuntu-22.04
+    # if: github.repository == 'OSGeo/grass' TODO: uncomment this line when it is deployed
     steps:
-      - name: Checkout Source
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Coverity Scan
-        uses: synopsys-sig/synopsys-action@cef5e38596faf5d2787bbff78a5d7255a9f7682b # v1.8.0
-        with:
-          ### SCANNING: Required fields
-          coverity_url: ${{ secrets.COVERITY_URL }}               # The URL to Coverity
-          coverity_user: ${{ secrets.COVERITY_USER }}             # The user for the Coverity project
-          coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }} # The password for the Coverity user
-          coverity_version: '2023.6.2'                            # The version for Coverity Scan
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y wget git gawk findutils
+          xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
+              sudo apt-get install -y --no-install-recommends --no-install-suggests
+      - name: Create installation directory
+        run: |
+          mkdir $HOME/install
+
+      - name: Set number of cores for compilation
+        run: |
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+
+      - name: Set LD_LIBRARY_PATH for compilation
+        run: |
+          echo "LD_LIBRARY_PATH=$HOME/install/lib" >> $GITHUB_ENV
+
+      - name: Print build environment variables
+        run: |
+          printenv | sort
+          gcc --version
+          ldd --version
+      - name: Build
+        env:
+          # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
+          CFLAGS: -fPIC -Wvla
+          # TODO: -pedantic-errors here won't compile
+          CXXFLAGS: -fPIC
+        run: .github/workflows/build_ubuntu-22.04_without_x.sh $HOME/install -Werror
+          
+  # build:
+  #   runs-on: [ ubuntu-latest ]
+  #   steps:
+  #     - name: Checkout Source
+  #       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  #     - name: Coverity Scan
+  #       uses: synopsys-sig/synopsys-action@cef5e38596faf5d2787bbff78a5d7255a9f7682b # v1.8.0
+  #       with:
+  #         ### SCANNING: Required fields
+  #         coverity_url: ${{ secrets.COVERITY_URL }}               # The URL to Coverity
+  #         coverity_user: ${{ secrets.COVERITY_USER }}             # The user for the Coverity project
+  #         coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }} # The password for the Coverity user
+  #         coverity_version: '2023.6.2'                          

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -6,10 +6,12 @@ on:
     # Coverity will let GRASS do a scan a maximum of twice per day, so this schedule will help GRASS fit within that limit with some additional space for manual runs
 permissions:
   contents: read
+  # action based off of https://github.com/OSGeo/PROJ/blob/905c9a6c2da3dc6b7aa2c89d3ab78d9d1a9cd070/.github/workflows/coverity-scan.yml
+  # and https://github.com/OSGeo/grass/blob/2aa98a166d8f50aa1491908401205962fa1d70fb/.github/workflows/ubuntu.yml
 jobs:
   coverity:
     runs-on: ubuntu-22.04
-    # if: github.repository == 'OSGeo/grass' TODO: uncomment this line when it is deployed
+    if: github.repository == 'OSGeo/grass' # make sure that it only runs for GRASS
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -22,7 +24,14 @@ jobs:
       - name: Create installation directory
         run: |
           mkdir $HOME/install
-
+          
+      - name: Download Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=grass" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+        env:
+          TOKEN: ${{ secrets.COVERITY_PASSPHRASE }} # this is the token that admins use to upload builds
       - name: Set number of cores for compilation
         run: |
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
@@ -36,24 +45,27 @@ jobs:
           printenv | sort
           gcc --version
           ldd --version
-      - name: Build
+      - name: Build with cov-build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
           CFLAGS: -fPIC -Wvla
           # TODO: -pedantic-errors here won't compile
           CXXFLAGS: -fPIC
-        run: .github/workflows/build_ubuntu-22.04_without_x.sh $HOME/install -Werror
-          
-  # build:
-  #   runs-on: [ ubuntu-latest ]
-  #   steps:
-  #     - name: Checkout Source
-  #       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-  #     - name: Coverity Scan
-  #       uses: synopsys-sig/synopsys-action@cef5e38596faf5d2787bbff78a5d7255a9f7682b # v1.8.0
-  #       with:
-  #         ### SCANNING: Required fields
-  #         coverity_url: ${{ secrets.COVERITY_URL }}               # The URL to Coverity
-  #         coverity_user: ${{ secrets.COVERITY_USER }}             # The user for the Coverity project
-  #         coverity_passphrase: ${{ secrets.COVERITY_PASSPHRASE }} # The password for the Coverity user
-  #         coverity_version: '2023.6.2'                          
+        run: |
+          pwd
+          export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
+          cov-build --dir cov-int .github/workflows/build_ubuntu-22.04_without_x.sh $HOME/install -Werror
+      - name: Submit to Coverity Scan
+        run: |
+          tar czvf proj.tgz cov-int
+          curl \
+            --form project=grass \
+            --form token=$TOKEN \
+            --form email=wenzeslaus@gmail.com \
+            --form file=@proj.tgz \
+            --form version=master \
+            --form description="`git rev-parse --abbrev-ref HEAD` `git rev-parse --short HEAD`" \
+            https://scan.coverity.com/builds?project=grass
+        env:
+          TOKEN: ${{ secrets.COVERITY_PASSPHRASE }}
+                                  

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   coverity:
     runs-on: ubuntu-22.04
-    if: github.repository == 'OSGeo/grass' # make sure that it only runs for GRASS
+    if: github.repository == 'OSGeo/grass'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -46,9 +46,7 @@ jobs:
           ldd --version
       - name: Build with cov-build
         env:
-          # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
           CFLAGS: -fPIC -Wvla
-          # TODO: -pedantic-errors here won't compile
           CXXFLAGS: -fPIC
         run: |
           pwd


### PR DESCRIPTION
This PR attempts to fix the problems with the previously submitted Coverity Scanning action. Basic building functionality is borrowed from [our ubuntu.yml](https://github.com/OSGeo/grass/blob/2aa98a166d8f50aa1491908401205962fa1d70fb/.github/workflows/ubuntu.yml), and Coverity functionality is borrowed from [PROJ's coverity-scan.yml](https://github.com/OSGeo/PROJ/blob/905c9a6c2da3dc6b7aa2c89d3ab78d9d1a9cd070/.github/workflows/coverity-scan.yml).  

The needed secrets are:
* COVERITY_PASSPHRASE: the token used to submit builds.

