### PR TITLE
r.in.pdal: use NoFileWriter class for PDAL > 2.7.0 (fixes #3552)

### DIFF
--- a/configure
+++ b/configure
@@ -10473,24 +10473,6 @@ pdal::PointTable table;
 _ACEOF
 if ac_fn_cxx_try_link "$LINENO"
 then :
-
-else $as_nop
-
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <pdal/PointTable.hpp>
-  #include <pdal/Streamable.hpp>
-  class St:public pdal::Streamable {};
-int
-main (void)
-{
-pdal::PointTable table;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
   PDAL_LIBS="$PDAL_LIBS"
 else $as_nop
 
@@ -10500,15 +10482,44 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-  LIBS=${ac_save_libs}
-  CFLAGS=${ac_save_cflags}
-
 
 printf "%s\n" "#define HAVE_PDAL 1" >>confdefs.h
 
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to use PDAL NoFilenameWriter" >&5
+printf %s "checking whether to use PDAL NoFilenameWriter... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <pdal/Writer.hpp>
+  class St:public pdal::NoFilenameWriter {};
+int
+main (void)
+{
+
+  class NFWTest : public pdal::NoFilenameWriter {};
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+
+
+printf "%s\n" "#define HAVE_PDAL_NOFILENAMEWRITER 1" >>confdefs.h
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+  LIBS=${ac_save_libs}
+  CFLAGS=${ac_save_cflags}
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1076,17 +1076,25 @@ else
   CFLAGS="$CFLAGS $PDAL_CFLAGS"
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/PointTable.hpp>
   #include <pdal/Streamable.hpp>
-  class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],[],[
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/PointTable.hpp>
-  #include <pdal/Streamable.hpp>
-  class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],[PDAL_LIBS="$PDAL_LIBS"],[
+  class St:public pdal::Streamable {};]], [[pdal::PointTable table;]])],
+  [PDAL_LIBS="$PDAL_LIBS"],[
   AC_MSG_ERROR([*** Unable to locate suitable (>=1.7.1) PDAL library.])
   ])
-  ])
-  LIBS=${ac_save_libs}
-  CFLAGS=${ac_save_cflags}
 
   AC_DEFINE(HAVE_PDAL, 1, [Define to 1 if PDAL exists.])
+
+  AC_MSG_CHECKING(whether to use PDAL NoFilenameWriter)
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/Writer.hpp>
+  class St:public pdal::NoFilenameWriter {};]], [[
+  class NFWTest : public pdal::NoFilenameWriter {};
+  ]])],
+  [
+    AC_DEFINE(HAVE_PDAL_NOFILENAMEWRITER, 1, [Define to 1 if PDAL NoFilenameWriter is present.])
+    AC_MSG_RESULT(yes)
+  ],[AC_MSG_RESULT(no)])
+
+  LIBS=${ac_save_libs}
+  CFLAGS=${ac_save_cflags}
 fi
 
 AC_SUBST(PDAL_LIBS)

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -158,6 +158,9 @@
 /* Define to 1 if PDAL exists. */
 #undef HAVE_PDAL
 
+/* Define to 1 if PDAL >2.7.0 Writters should be used */
+#undef HAVE_PDAL_NOFILENAMEWRITER
+
 /* Define to 1 if glXCreateGLXPixmap exists. */
 #undef HAVE_PIXMAPS
 

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -158,7 +158,7 @@
 /* Define to 1 if PDAL exists. */
 #undef HAVE_PDAL
 
-/* Define to 1 if PDAL >2.7.0 Writters should be used */
+/* Define to 1 if PDAL NoFilenameWriter is present. */
 #undef HAVE_PDAL_NOFILENAMEWRITER
 
 /* Define to 1 if glXCreateGLXPixmap exists. */

--- a/raster/r.in.pdal/grassrasterwriter.h
+++ b/raster/r.in.pdal/grassrasterwriter.h
@@ -32,7 +32,12 @@ extern "C" {
 #include <pdal/Writer.hpp>
 
 /* Binning code wrapped as a PDAL Writer class */
+#ifdef HAVE_PDAL_NOFILENAMEWRITER
+class GrassRasterWriter : public pdal::NoFilenameWriter,
+                          public pdal::Streamable {
+#else
 class GrassRasterWriter : public pdal::Writer, public pdal::Streamable {
+#endif
 public:
     GrassRasterWriter() : n_processed(0) {}
 


### PR DESCRIPTION
Starting from PDAL 2.7.0 filename is mandatory for Writer class, but there is a NoFileWriter class that maintains old behaviour. https://github.com/PDAL/PDAL/pull/4342