### PR TITLE
doc: continue renaming location to project in documentation

### DIFF
--- a/display/d.barscale/d.barscale.html
+++ b/display/d.barscale/d.barscale.html
@@ -10,8 +10,8 @@ parameter for their previews).
 
 <h2>NOTE</h2>
 
-<em>d.barscale</em> will not work in Lat/Lon locations as the horizontal
-scale distance changes with latitude.
+<em>d.barscale</em> will not work with Lat/Lon coordinate reference system
+as the horizontal scale distance changes with latitude.
 Try <em><a href="d.grid.html">d.grid</a></em> instead.
 
 <h2>SEE ALSO</h2>

--- a/display/d.geodesic/d.geodesic.html
+++ b/display/d.geodesic/d.geodesic.html
@@ -39,7 +39,7 @@ d.geodesic coordinates=55:58W,33:18S,26:43E,60:37N \
 
 <h2>NOTES</h2>
 
-This program works only in GRASS locations with longitude/latitude
+This program works only with longitude/latitude
 coordinate system.
 
 <h2>SEE ALSO</h2>

--- a/display/d.labels/d.labels.html
+++ b/display/d.labels/d.labels.html
@@ -6,7 +6,7 @@ which determine the text, the location of the text on the image, its
 size, and the background for the text. This file can be generated with
 the <em><a href="v.label.html">v.label</a></em> program or simply created
 by the user as an ASCII file (using a text editor) and placed in the
-appropriate directory under the user's current mapset and location
+appropriate directory under the user's current mapset and project
 (i.e. <tt>$MAPSET/paint/labels/</tt>).
 
 <h2>NOTES</h2>

--- a/display/d.legend.vect/d.legend.vect.html
+++ b/display/d.legend.vect/d.legend.vect.html
@@ -50,7 +50,7 @@ This file is automatically created and updated whenever
 User can create custom legend file and then use
 <em>export GRASS_LEGEND_FILE=path/to/file</em> in shell.
 GRASS GUI and MONITORS create the legend file automatically.
-By default the legend file is stored in grassdata/location/mapset/.tmp/user
+By default the legend file is stored in grassdata/project/mapset/.tmp/user
 directory (in case of d.mon deeper in /monitor_name directory).<br>
 <p>
 Legend file has this format:

--- a/display/d.rhumbline/d.rhumbline.html
+++ b/display/d.rhumbline/d.rhumbline.html
@@ -40,7 +40,7 @@ d.grid 10
 
 <h2>NOTES</h2>
 
-This program works only in GRASS locations with longitude/latitude
+This program works only with longitude/latitude
 coordinate system.
 
 <h2>SEE ALSO</h2>

--- a/display/d.where/d.where.html
+++ b/display/d.where/d.where.html
@@ -32,7 +32,7 @@ It is not necessary, although useful, to have displayed a map in the current
 frame before running <em>d.where</em>. The <b>-d</b> flag allows the user to
 optionally output latitude/longitude coordinates pair(s) in decimal degree
 rather than DD:MM:SS format. The <b>-w</b> flag is only valid
-if a datum is defined for the current location.
+if a datum is defined for the current coordinate reference system.
 
 If the <b>-f</b> flag is given the x,y frame coordinates of the active display
 monitor will be returned (as a percentage, 0,0 is bottom left).

--- a/general/g.access/g.access.html
+++ b/general/g.access/g.access.html
@@ -19,7 +19,7 @@ the mapset to personal use only.
 
 <p> Under GRASS, access to the mapset PERMANENT must be open to
 all users.  This is because GRASS looks for the user's default geographic
-region definition settings and the location TITLE in files that are stored
+region definition settings and the project TITLE in files that are stored
 under the PERMANENT mapset directory.  The <em>g.access</em> command,
 therefore, will not allow you to restrict access to the PERMANENT mapset.
 

--- a/general/g.copy/g.copy.html
+++ b/general/g.copy/g.copy.html
@@ -20,7 +20,7 @@ mapset search path. However, the user may only modify data stored
 under their own current mapset. <em>g.copy</em> allows the user to copy
 existing data files <b>from</b> other mapsets <b>to</b> the user's
 current mapset (<code>g.mapset -p</code>). The files to be copied must exist in the
-user's current mapset search path (<code>g.mapsets -p</code>) and location;
+user's current mapset search path (<code>g.mapsets -p</code>) and project;
 output is sent to the
 relevant data element directory(ies) under the user's current mapset.
 

--- a/general/g.gisenv/g.gisenv.html
+++ b/general/g.gisenv/g.gisenv.html
@@ -1,7 +1,7 @@
 <h2>DESCRIPTION</h2>
 
 When a user runs GRASS, certain variables are set specifying the GRASS
-data base, location, mapset, peripheral device drivers, etc., being
+data base, project, mapset, peripheral device drivers, etc., being
 used in the current GRASS session. These variable name settings are
 recognized as long as the user is running a GRASS session.
 
@@ -41,9 +41,9 @@ are essential.
 <dt><em>GISDBASE</em>
 <dd>The <em>GISDBASE</em> is a directory in which all users' GRASS
 data are stored. Within the <em>GISDBASE</em>, data are segregated
-into subdirectories (called &quot;locations&quot;) based on the map
+into subdirectories (called &quot;projects&quot;) based on the map
 coordinate system used and the geographic extent of the data.  Each
-&quot;location&quot; directory itself contains subdirectories called
+&quot;project&quot; directory itself contains subdirectories called
 &quot;mapsets&quot;; each &quot;mapset&quot; stores &quot;data base
 elements&quot; - the directories (e.g.,
 the <tt>cell</tt>, <tt>cellhd</tt>, <tt>vector</tt>, etc., directories)
@@ -52,17 +52,18 @@ in which GRASS data files are actually stored.
 <dt><em>LOCATION_NAME</em>
 
 <dd>The user must choose to work with the data under a single GRASS
-location within any given GRASS session; this location is then called
-the <em>current GRASS location</em>, and is specified by the variable
+project (previously called &quot;location&quot;) within any given
+GRASS session; this project is then called
+the <em>current GRASS project</em>, and is specified by the variable
 <em>LOCATION_NAME</em>. The <em>LOCATION_NAME</em> is the GRASS data
 base location whose data will be affected by any GRASS commands issued
 during the user's current GRASS session, and is a subdirectory of the
-current <em>GISDBASE</em>. Each &quot;location&quot; directory can
+current <em>GISDBASE</em>. Each &quot;project&quot; directory can
 contain multiple &quot;mapset&quot; directories (including the special
 mapset <em>PERMANENT</em>).  Maps stored under the same
 GRASS <em>LOCATION_NAME</em> (and/or within the same <em>MAPSET</em>)
 must use the same coordinate system and typically fall within the
-boundaries of the same geographic region (aka, &quot;location&quot;).
+boundaries of the same geographic region.
 
 <dt><em>MAPSET</em>
 
@@ -98,7 +99,7 @@ working under each <em>LOCATION_NAME</em>.
 Once within a GRASS session, GRASS users have access only to the data
 under a single GRASS data base directory (the <em>current GRASS data
 base</em>, specified by the variable <em>GISDBASE</em>), and to a
-single GRASS location directory (the <em>current location</em>,
+single GRASS project directory (the <em>current project</em>,
 specified by the variable <em>LOCATION_NAME</em>).  Within a single
 session, the user may only <em>modify</em> the data in the
 <em>current mapset</em> (specified by the variable
@@ -145,7 +146,7 @@ compatible with some other UNIX shells.
 By default the GRASS variables are stored in <em>gisrc</em> file
 (defined by environmental
 variable <em>GISRC</em>). If <b>store=mapset</b> is given then the
-variables are stored in <tt>&lt;gisdbase&gt;/&lt;location&gt;/&lt;mapset&gt;/VAR</tt>
+variables are stored in <tt>&lt;gisdbase&gt;/&lt;project&gt;/&lt;mapset&gt;/VAR</tt>
 after the current GRASS session is closed.
 
 <h3>GRASS Debugging</h3>

--- a/general/g.list/g.list.html
+++ b/general/g.list/g.list.html
@@ -172,7 +172,7 @@ g.list -r type=vector pattern='^tmp[0-9]$' region=.
 </pre></div>
 
 List all raster and vector maps whose region overlaps with the default region
-of the PERMANENT mapset in the current location (DEFAULT_WIND):
+of the PERMANENT mapset in the current project (DEFAULT_WIND):
 <div class="code"><pre>
 g.list type=rast,vect region=*
 </pre></div>

--- a/general/g.mapset/g.mapset.html
+++ b/general/g.mapset/g.mapset.html
@@ -2,11 +2,10 @@
 
 <em>g.mapset</em> changes the current working mapset, project (formerly known
 as location), or GISDBASE (directory with one or more projects).
-This is a fairly radical maneuver to run mid-session, take care when running
-the GUI at the same time.
+
 <p>
 With <em>g.mapset</em>, the shell history (i.e. <tt>.bash_history</tt> file
-of the initial location will be used to record the command history.
+of the initial project will be used to record the command history.
 
 <h2>NOTES</h2>
 

--- a/general/g.mapsets/g.mapsets.html
+++ b/general/g.mapsets/g.mapsets.html
@@ -1,6 +1,6 @@
 <h2>DESCRIPTION</h2>
 
-For basic information about GRASS <em>mapset</em>, <em>location</em>
+For basic information about GRASS <em>mapset</em>, <em>project</em>
 and <em>data base</em> refer to <a href="helptext.html">GRASS
 Quickstart</a>.
 
@@ -8,9 +8,10 @@ Quickstart</a>.
 A <em>mapset</em> holds a distinct set of data layers, each relevant
 to the same (or a subset of the same) geographic region, and each
 drawn in the same map coordinate system.  At the outset of every GRASS
-session, the user identifies a GRASS data base, location, and mapset
+session, the user identifies a GRASS data base, project (previosuly
+called location), and mapset
 that are to be the user's <em>current data base</em>, <em>current
-location</em>, and <em>current mapset</em> for the duration of the
+project</em>, and <em>current mapset</em> for the duration of the
 session; any maps created by the user during the session will be
 stored under the <em>current mapset</em> set at the session's outset
 (see <em><a href="g.mapset.html">g.mapset</a></em> [without an "s"]
@@ -21,12 +22,12 @@ mapset with a session).
 The user can add, modify, and delete data layers that exist under
 their <em>current mapset</em>. Although the user can
 also <em>access</em> (i.e., use) data that are stored under
-<em>other</em> mapsets in the same GRASS location using the
+<em>other</em> mapsets in the same GRASS project using the
 <tt>mapname@mapsetname</tt> notation or mapset search path, the user
 can only make permanent changes (create or modify data)
 located in the <em>current mapset</em>.  The user's
 <em>mapset search path</em> lists the order in which other mapsets in
-the same GRASS location can be searched and their data accessed by the
+the same GRASS project can be searched and their data accessed by the
 user. The user can modify the listing and order in which these mapsets
 are accessed by modifying the mapset search path; this can be done
 using the <em>g.mapsets</em> command. This program allows the user to
@@ -39,7 +40,7 @@ may be called in such a manner.
 
 <p>
 <em>g.mapsets</em> shows the user available mapsets under the current
-GRASS location, lists mapsets to which the user currently has access,
+GRASS project, lists mapsets to which the user currently has access,
 and lists the order in which accessible mapsets will be accessed by
 GRASS programs searching for data files.  The user is then given the
 opportunity to add or delete mapset names from the search path, or
@@ -63,7 +64,7 @@ ensures that a new file named <tt>my_soils</tt> is to be a copy of
 the file <tt>soils</tt> from the mapset PERMANENT.
 
 <p>
-In each location there is the special mapset <b>PERMANENT</b> included
+In each project there is the special mapset <b>PERMANENT</b> included
 in the mapset search path, as this mapset typically contains base maps
 relevant to many applications. Often, other mapsets which contain sets
 of interpreted maps will be likewise included in the user's mapset search path.
@@ -109,7 +110,7 @@ g.mapsets -s
 </center>
 
 <h3>Print available mapsets</h3>
-All available mapsets in the current location can be printed out by
+All available mapsets in the current project can be printed out by
 
 <div class="code"><pre>
 g.mapsets -l

--- a/general/g.proj/g.proj.html
+++ b/general/g.proj/g.proj.html
@@ -11,17 +11,18 @@ For an introduction to map projections (with PROJ),see the manual page of
 If compiled without <a href="https://gdal.org/">OGR</a> present, the
 functionality is limited to:
 <ul>
-<li>Reporting the projection information for the current location,
+<li>Reporting the projection information for the current project
+(previously called location),
 either in conventional GRASS (-p flag) or PROJ (-j flag) format</li>
 <li>Changing the datum, or reporting and modifying the datum transformation
-parameters, for the current location</li>
+parameters, for the current project</li>
 </ul>
 
 <p>When compiled with OGR, functionality is increased and allows output of
 the projection information in the Well-Known Text (WKT) format popularised
 by proprietary GIS. In addition, if one of the parameters <em>georef</em>,
 <em>wkt</em>, <em>proj4</em> or <em>epsg</em> is specified, rather than the
-projection information being read from the current location it is imported
+projection information being read from the current project it is imported
 from an external source as follows:
 
 <dl>
@@ -72,9 +73,9 @@ format.
 
 <p>In addition however, if the -c flag is specified, <em>g.proj</em> will
 create new GRASS projection files (PROJ_INFO, PROJ_UNITS, WIND and
-DEFAULT_WIND) based on the imported information. If the <em>location</em>
-parameter is specified in addition to -c, then a new location will be created.
-Otherwise the projection information files in the current location will be
+DEFAULT_WIND) based on the imported information. If the <em>project</em>
+parameter is specified in addition to -c, then a new project will be created.
+Otherwise the projection information files in the current project will be
 overwritten. The program will <strong>not</strong> warn before doing this.
 
 <p>The final mode of operation of g.proj is to report on the datum
@@ -92,7 +93,7 @@ the <em>datumtrans</em> option and act according to the following:<br>
 <strong>-1:</strong> List available parameter sets in a GUI-parsable (but also
 human-readable) format and exit.<br>
 <strong>0 (default):</strong> Continue without specifying parameters - if
-used when creating a location, other GRASS modules will use the "default"
+used when creating a project, other GRASS modules will use the "default"
 (likely non-optimum) parameters for this datum if necessary in the future.<br>
 <strong>Any other number less than or equal to the number of parameter sets
 available for this datum:</strong> Choose this parameter set and add it to the
@@ -101,7 +102,7 @@ If the <em>-t</em> flag is specified, the module will attempt to change the
 datum transformation parameters using one of the above two methods
 <strong>even if</strong> a valid parameter set is already specified in the
 input co-ordinate system. This can be useful to change the datum information
-for an existing location.
+for an existing project.
 
 <p>Output is simply based on the input projection information. g.proj does
 <strong>not</strong> attempt to verify that the co-ordinate system thus
@@ -118,14 +119,14 @@ limited to 8000 bytes.
 
 <h3>Print information</h3>
 
-Print the projection information for the current location:<br>
+Print the projection information for the current project:<br>
 
 <div class="code"><pre>
 g.proj -p
 </pre></div>
 
 <p>
-List the possible datum transformation parameters for the current location:<br>
+List the possible datum transformation parameters for the current project:<br>
 
 <div class="code"><pre>
 g.proj -t datumtrans=-1
@@ -133,7 +134,7 @@ g.proj -t datumtrans=-1
 
 <h3>Create projection (PRJ) file</h3>
 
-Create a '.prj' file in ESRI format corresponding to the current location:<br>
+Create a '.prj' file in ESRI format corresponding to the current project:<br>
 
 <div class="code"><pre>
 g.proj -wef > irish_grid.prj
@@ -155,9 +156,9 @@ format:<br>
 cat proj4.description | g.proj -w proj4=-
 </pre></div>
 
-<h3>Create new location</h3>
+<h3>Create new project</h3>
 
-<p>Create a new location with the co-ordinate system referred to by EPSG code
+<p>Create a new project with the co-ordinate system referred to by EPSG code
 4326 (Latitude-Longitude/WGS84), without explicitly specifying datum
 transformation parameters:<br>
 
@@ -165,14 +166,14 @@ transformation parameters:<br>
 g.proj -c epsg=4326 location=latlong
 </pre></div>
 
-<p>Create a new location with the co-ordinate system referred to by ESRI-EPSG code
+<p>Create a new project with the co-ordinate system referred to by ESRI-EPSG code
 900913 (<a href="http://spatialreference.org/ref/user/6/">Google Mercator Projection</a>)<br>
 
 <div class="code"><pre>
 g.proj -c epsg=900913 location=google
 </pre></div>
 
-<p>Create a new location with the co-ordinate system referred to by EPSG code
+<p>Create a new project with the co-ordinate system referred to by EPSG code
 29900 (Irish Grid), selecting datum transformation parameter set no. 2:<br>
 
 <div class="code"><pre>
@@ -181,21 +182,21 @@ g.proj -t datumtrans=-1 epsg=29900
 g.proj -c epsg=29900 datumtrans=2 location=irish_grid
 </pre></div>
 
-<p>Create a new location with the same co-ordinate system as the current
-location, but forcing a change to datum transformation parameter set no. 1:<br>
+<p>Create a new project with the same co-ordinate system as the current
+project, but forcing a change to datum transformation parameter set no. 1:<br>
 
 <div class="code"><pre>
 g.proj -c location=newloc -t datumtrans=1
 </pre></div>
 
-<p>Create a new location with the co-ordinate system from a WKT definition
+<p>Create a new project with the co-ordinate system from a WKT definition
 stored in a text file:<br>
 
 <div class="code"><pre>
 g.proj -c wkt=irish_grid.prj location=irish_grid
 </pre></div>
 
-<p>Create a new location from a PROJ description, explicitly
+<p>Create a new project from a PROJ description, explicitly
 specifying a datum and using the default datum transformation
 parameters:<br>
 

--- a/general/g.region/g.region.html
+++ b/general/g.region/g.region.html
@@ -48,7 +48,7 @@ modules and <em>v.in.region</em>.
 
 <dt><b>Default Region:</b>
 
-<dd>Each GRASS LOCATION has a fixed
+<dd>Each GRASS project (previously called location) has a fixed
 geographic region, called the default geographic region
 (stored in the region file <kbd>DEFAULT_WIND</kbd> under
 the special mapset <kbd>PERMANENT</kbd>), that defines the
@@ -57,7 +57,7 @@ point for defining new geographic regions, user-defined
 geographic regions need not fall within this geographic
 region. The current region can be reset to the default region
 with the <b>-d</b> flag. The default region is initially set
-when the location is first created and can be reset using the
+when the project is first created and can be reset using the
 <b>-s</b> flag.
 
 <dt><b>Current Region:</b>
@@ -78,7 +78,7 @@ referred to as the user's saved region definitions).
 Any of these pre-defined geographic regions
 may be selected, by name, to become the current geographic
 region.  Users may also access saved region definitions
-stored under other mapsets in the current location, if
+stored under other mapsets in the current project, if
 these mapsets are included in the user's mapset search
 path or the '@' operator is used (<tt>region_name@mapset</tt>).
 </dl>
@@ -283,7 +283,7 @@ g.region -pm
 </tt></span>
 
 <dd> This will print the current region in the format
- (latitude-longitude location):
+ (latitude-longitude project):
 
 <div class="code"><pre>
 projection: 3 (Latitude-Longitude)
@@ -326,7 +326,7 @@ g.region -dp s=698000
 </tt></span>
 
 <dd> will set the current region from the default region
-for the GRASS data base location, reset the south edge to
+for the GRASS project, reset the south edge to
 698000, and then print the result.
 
 <p>
@@ -438,7 +438,7 @@ eval `g.region -g`
 ogr2ogr -spat $w $s $e $n soils_cut.shp soils.shp
 </pre></div>
 
-This requires that the location/SHAPE file projection match.
+This requires that the project/SHAPE file projection match.
 
 <h3>Using g.region in a shell in combination with GDAL</h3>
 
@@ -454,7 +454,7 @@ gdalwarp -t_srs "`g.proj -wf`" -te $w $s $e $n \
          p016r035_7t20020524_nc_spm_wake_nn30.tif
 </pre></div>
 
-Here the input raster map does not have to match the location
+Here the input raster map does not have to match the project
 projection since it is reprojected on the fly.
 
 <h2>SEE ALSO</h2>

--- a/general/g.setproj/g.setproj.html
+++ b/general/g.setproj/g.setproj.html
@@ -15,7 +15,7 @@
 
 <em><b>g.setproj</b></em> allows the user to create the PROJ_INFO and the
 PROJ_UNITS files to record the projection information associated with a
-current location.
+current project (previously called location).
 <br>
 
 <h2>SYNOPSIS</h2>
@@ -25,7 +25,7 @@ current location.
 <h2>DESCRIPTION</h2>
 
 Allows a user to create a PROJ_INFO file in the PERMANENT mapset of the
-current location. PROJ_INFO file is used to record the projection information
+current project. PROJ_INFO file is used to record the projection information
 associated with the specified mapset.
 
 <h2>NOTES</h2>
@@ -33,7 +33,7 @@ associated with the specified mapset.
 The user running <em>g.setproj</em> must own the PERMANENT
 mapset and it must be currently selected.
 It is highly recommended to run <em>g.setproj</em> after
-creating a new location so that conversion programs (such
+creating a new project so that conversion programs (such
 as <em>v.proj</em>) can be run.
 
 <p>The user will be prompted for the projection name.

--- a/gui/wxpython/image2target/g.gui.image2target.html
+++ b/gui/wxpython/image2target/g.gui.image2target.html
@@ -15,8 +15,8 @@ to POINTS file). This guarantees that accidental changes are not
 permanent and can be undone by reloading the Ground Control Points.
 
 <p>
-The GCP Manager must be started in the target location, not in the
-source location.
+The GCP Manager must be started in the target project, not in the
+source project (project used to be called location).
 
 <p>
 The GCP Manager is structured into three panels:
@@ -28,8 +28,8 @@ The GCP Manager is structured into three panels:
   caption or by clicking on the pin button on the right in the caption.
   This panel can also be placed below the map displays by dragging.
   <li>The two panels in the lower part are used for map and GCP display,
-  the left pane showing a map from the source location and the right
-  pane showing a reference map from the target location. Numbered Ground
+  the left pane showing a map from the source project and the right
+  pane showing a reference map from the target project. Numbered Ground
   Control Points are shown on both map displays.
 </ul>
 
@@ -63,8 +63,8 @@ unused GCP).
 <p>
 <em>Two panels for map display</em>
 <p>
-The left panel is used to display a map from the source location, the
-right panel to display a map from the target location. Zooming in and
+The left panel is used to display a map from the source project, the
+right panel to display a map from the target project. Zooming in and
 out is always possible with the mouse wheel and done for each map canvas
 separately.
 <p>
@@ -213,9 +213,9 @@ canvas (source or target).</dd>
         <dt><em>Select rectification method</em></dt>
           <dd>Set the polynomial order for georectification. This order will
           also be used for RMS error calculation.</dd>
-        <dt><em>Clip to computational region in target location</em></dt>
+        <dt><em>Clip to computational region in target project</em></dt>
           <dd>Clip raster maps to the current computational region in the
-          target location when georectifying.</dd>
+          target project when georectifying.</dd>
         <dt><em>Extension for output maps</em></dt>
           <dd>Change the extension for output map names when doing the actual
           georectification.</dd>

--- a/gui/wxpython/photo2image/g.gui.photo2image.html
+++ b/gui/wxpython/photo2image/g.gui.photo2image.html
@@ -22,7 +22,7 @@ are the order of rectification (1 if no of Fiducials is 4, 2 if no of Fiducials 
 an extension file (if not given, defaults to \$filename_ip2i_out)
 
 <p>
-An example for Location <b>imagery60</b>:
+An example for project <b>imagery60</b>:
 
 <div class="code"><pre>
 g.gui.photo2image group=aerial@PERMANENT raster=gs13.1@PERMANENT camera=gscamera order=2 extension=try --o

--- a/imagery/i.atcorr/i.atcorr.html
+++ b/imagery/i.atcorr/i.atcorr.html
@@ -810,13 +810,13 @@ but step by step output will be printed.</td>
 
 <h3>Atmospheric correction of a Sentinel-2 band</h3>
 <p>This example illustrates how to perform atmospheric correction of a
-Sentinel-2 scene in the North Carolina location.
+Sentinel-2 scene in the North Carolina project.
 
 <p>Let's assume that the Sentinel-2 L1C scene
 <em>S2A_OPER_PRD_MSIL1C_PDMC_20161029T092602_R054_V20161028T155402_20161028T155402</em>
 was downloaded and imported with region cropping
 (see <a href="r.import.html">r.import</a>)
-into the <em>PERMANENT</em> mapset of the North Carolina location. The
+into the <em>PERMANENT</em> mapset of the North Carolina project. The
 computational region was set to the extent of the <em>elevation</em>
 map in the North Carolina dataset. Now, we have 13 individual bands
 (<em>B01-B12</em>) that we want to apply the atmospheric correction to.

--- a/imagery/i.cluster/i.cluster.html
+++ b/imagery/i.cluster/i.cluster.html
@@ -263,7 +263,7 @@ over, whichever comes first.
 <h2>EXAMPLE</h2>
 
 Preparing the statistics for unsupervised classification of
-a LANDSAT scene within North Carolina location:
+a LANDSAT scene within North Carolina project:
 
 <div class="code"><pre>
 # Set computational region to match the scene

--- a/imagery/i.rectify/i.rectify.html
+++ b/imagery/i.rectify/i.rectify.html
@@ -20,33 +20,33 @@ If no ground control points are available, the
 <a href="wxGUI.gcp.html">Ground Control Points Manager</a>
 must be run before <em>i.rectify</em>. An image must be
 georeferences before it can reside in a standard coordinate
-LOCATION, and therefore be analyzed with the other map
-layers in the standard coordinate LOCATION. Upon
+project, and therefore be analyzed with the other map
+layers in the standard coordinate project. Upon
 completion of <em>i.rectify</em>, the rectified image is
-deposited in the target standard coordinate LOCATION. This
-LOCATION is selected using
+deposited in the target standard coordinate project. This
+project is selected using
 
 <em><a href="i.target.html">i.target</a></em>.
 
 <p>More than one raster map may be rectified at a time. Each cell file
 should be given a unique output file name. The rectified image or
-rectified raster maps will be located in the target LOCATION when the
+rectified raster maps will be located in the target project when the
 program is completed. The original unrectified files are not modified
 or removed.
 
 <p>If the <b>-c</b> flag is used, <em>i.rectify</em> will only rectify that
 portion of the image or raster map that occurs within the chosen window
-region in the target location, and only that portion of the cell
+region in the target project, and only that portion of the cell
 file will be relocated in the target database. It is
 important therefore, to check the current mapset window in
-the target LOCATION if the <b>-c</b> flag is used.
+the target project if the <b>-c</b> flag is used.
 
 <p>
 If you are rectifying a file with plans to patch it to
 another file using the GRASS program <em>r.patch</em>,
 choose option number one, the current window in the target
-location. This window, however, must be the default window
-for the target LOCATION. When a file being rectified is
+project. This window, however, must be the default window
+for the target project. When a file being rectified is
 smaller than the default window in which it is being
 rectified, NULLs are added to the rectified file. Patching
 files of the same size that contain NULL data,

--- a/imagery/i.smap/i.smap.html
+++ b/imagery/i.smap/i.smap.html
@@ -136,7 +136,7 @@ r.mapcalc "MASKed_map = classification_results"
 
 <h2>EXAMPLE</h2>
 
-Supervised classification of LANDSAT scene (complete NC location)
+Supervised classification of LANDSAT scene (complete NC dataset)
 
 <div class="code"><pre>
 # Align computation region to the scene

--- a/imagery/i.svm.train/i.svm.train.html
+++ b/imagery/i.svm.train/i.svm.train.html
@@ -50,7 +50,7 @@ utilized on an as-needed basis, so it's unlikely to reach the specified value.</
 
 <p>Train a SVM to identify land use classes according to the 1996 land
 use map <em>landuse96_28m</em> and then classify a LANDSAT scene from
-October of 2002. Example requires the nc_spm_08 location.</p>
+October of 2002. Example requires the nc_spm_08 dataset.</p>
 <div class="code"><pre>
 # Align computation region to the scene
 g.region raster=lsat7_2002_10 -p

--- a/imagery/i.target/i.target.html
+++ b/imagery/i.target/i.target.html
@@ -1,12 +1,12 @@
 <h2>DESCRIPTION</h2>
 
 <em>i.target</em> targets an <a href="i.group.html">imagery
-group</a> to a GRASS data base location name and mapset.
+group</a> to a GRASS data base project name and mapset.
 
-A location name and mapset are required for the
+A project name and mapset are required for the
 <em><a href="i.rectify.html">i.rectify</a></em> imagery module, into which
 to write the rectified map just prior to completion of the program;
-<em>i.target</em> enables the user to specify this location.
+<em>i.target</em> enables the user to specify this project.
 
 <em>i.target</em> must be run before
 <em><a href="g.gui.gcp.html">g.gui.gcp</a></em> and
@@ -19,7 +19,7 @@ to write the rectified map just prior to completion of the program;
 The imagery group must be present in the user's current mapset.
 
 An <a href="i.group.html">imagery group</a> may be targeted to any GRASS
-location.
+project.
 <p>If a group name is given without setting options, the currently targeted
 group will be displayed.
 

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -73,14 +73,14 @@ As a general rule in GRASS:
 The module <a href="r.in.gdal.html">r.in.gdal</a> offers a common
 interface for many different raster and satellite image
 formats. Additionally, it also offers options such as on-the-fly
-location creation or extension of the default region to match the
+project creation or extension of the default region to match the
 extent of the imported raster map.  For special cases, other import
 modules are available. Always the full map is imported. Imagery data
 can be group (e.g. channel-wise) with <a href="i.group.html">i.group</a>.
 
 <p>
 For importing scanned maps, the user will need to create a
-x,y-location, scan the map in the desired resolution and save it into
+x,y-project, scan the map in the desired resolution and save it into
 an appropriate raster format (e.g. tiff, jpeg, png, pbm) and then use
 <a href="r.in.gdal.html">r.in.gdal</a> to import it. Based on
 reference points the scanned map can be rectified to obtain geocoded

--- a/lib/init/helptext.html
+++ b/lib/init/helptext.html
@@ -2,7 +2,7 @@
 
 <p>
 When <a href="grass.html">launching</a> GRASS GIS for the first time, you will open a
-<b>default Location</b> "world_latlog_wgs84" where you can find a map layer
+<b>default project</b> "world_latlog_wgs84" where you can find a map layer
 called "country_boundaries" showing a world map in the WGS84 coordinate system.
 </p>
 
@@ -14,24 +14,24 @@ called "country_boundaries" showing a world map in the WGS84 coordinate system.
 <p>
 The main component of the Data tab is the <em>Data Catalog</em>
 which shows the GRASS GIS hierarchical structure consisting of
-Database <img src="grassdb.png" alt="[GRASS Database]">,
-Location <img src="location.png" alt="[Location]"> and
-Mapset <img src="mapset.png" alt="[Mapset]">.
+database <img src="grassdb.png" alt="[GRASS Database]">,
+project <img src="location.png" alt="[project]"> and
+mapset <img src="mapset.png" alt="[mapset]">.
 </p>
 <dl>
-  <dt><img src="grassdb.png" alt="[GRASS Database]">&nbsp;<b>GRASS Database</b> (directory with projects)</dt>
+  <dt><img src="grassdb.png" alt="[GRASS Database]">&nbsp;<b>GRASS database</b> (directory with projects)</dt>
   <dd>Running GRASS GIS for the first time, a folder named "grassdata" is automatically
     created. Depending on your operating system, you can find it in your $HOME
     directory (*nix) or My Documents (MS Windows).</dd>
-  <dt><img src="location.png" alt="[Location]">&nbsp;<b>Location</b> (a project)</dt>
-  <dd>A Location is defined by its coordinate reference system (CRS).
-    In the case of the default Location, it is a geographic coordinate reference system
+  <dt><img src="location.png" alt="[project]">&nbsp;<b>project</b> (previously called location)</dt>
+  <dd>A project is defined by its coordinate reference system (CRS).
+    In the case of the default project, it is a geographic coordinate reference system
     WGS84 (EPSG:4326). If you have data in another CRS than WGS84, you should create
-    a new Location corresponding to your system.</dd>
-  <dt><img src="mapset.png" alt="[Mapset]">&nbsp;<b>Mapset</b> (a subproject)</dt>
-  <dd>Each Location can have many Mapsets for managing different aspects of
-    a project or project's subregions. When creating a new Location, GRASS GIS
-    automatically creates a special Mapset called PERMANENT where the core
+    a new project corresponding to your system.</dd>
+  <dt><img src="mapset.png" alt="[mapset]">&nbsp;<b>mapset</b> (a subproject)</dt>
+  <dd>Each project can have many mapsets for managing different aspects of
+    a project or project's subregions. When creating a new project, GRASS GIS
+    automatically creates a special mapset called PERMANENT where the core
     data for the project can be stored.</dd>
 </dl>
 
@@ -40,30 +40,30 @@ For more info about data hierarchy, see
 <a href="grass_database.html">GRASS GIS Database</a> page.
 </p>
 
-<h2>GRASS started in the default Location, now what?</h2>
+<h2>GRASS started in the default project, now what?</h2>
 
 <p>
 First, if you would like to get to know GRASS better before importing your own data,
 please download provided samples such as the &quot;North Carolina&quot; dataset.
 You can simply reach them through
-&quot;Download sample location to current database&quot; management icon
-<img src="location-download.png" alt="[Download Location]">.
+&quot;Download sample project to current database&quot; management icon
+<img src="location-download.png" alt="[Download project]">.
 </p>
 
 <p>
-To work with your own data, you typically want to first create a new Location
+To work with your own data, you typically want to first create a new project
 with a <a href="https://en.wikipedia.org/wiki/Spatial_reference_system">
 coordinate reference system (CRS)</a> suitable for your study area or one that
-matches your data's CRS. The Location Wizard <img src="location-add.png" alt="[Add Location]">
+matches your data's CRS. The Project Wizard <img src="location-add.png" alt="[Add project]">
 will help you with that by guiding you through a series of dialogs to browse
 and select predefined projections (also via EPSG code) or to define individual
 projections.
 
-<h3>Creating a New Location with the Location Wizard</h3>
+<h3>Creating a New project with the Project Wizard</h3>
 <p>
 If you know the CRS of your data or study area,
 you can fill <a href="https://epsg.io">EPSG code</a>
-or description and Location Wizard finds appropriate CRS from a predefined list
+or description and Project Wizard finds appropriate CRS from a predefined list
 of projections.
 
 If you do not know CRS of you data, you can read it from your georeferenced
@@ -72,16 +72,16 @@ included).
 </p>
 
 <h3>Importing data</h3>
-After creating a new Location, you are ready to import your data. You can use
+After creating a new project, you are ready to import your data. You can use
 simple raster or vector data import <img src="raster-import.png" alt="[Raster import]">,
 <img src="vector-import.png" alt="[Vector import]"> or a variety of more specialized tools.
-If the data's CRS does not match your Location's CRS, data will be automatically reprojected.
+If the data's CRS does not match your project's CRS, data will be automatically reprojected.
 
 After import your raster or vector data are added as a layer to Map Display.
 To change layer properties, go to Display tab.
 To analyze your data, search for a tool in the Modules tab.
 
-<h2>Text-based startup and Location creation</h2>
+<h2>Text-based startup and project creation</h2>
 
 GRASS GIS can be run entirely without using the graphical user interface.
 See <a href="grass.html">examples</a> of running GRASS GIS from a command line.

--- a/lib/init/variables.html
+++ b/lib/init/variables.html
@@ -532,10 +532,10 @@ g.gisenv set=DEBUG=0
   <dd>See <tt>GRASS_GUI</tt> environmental variable for details.</dd>
 
   <dt>LOCATION</dt>
-  <dd>full path to location directory</dd>
+  <dd>full path to project (previously called location) directory</dd>
 
   <dt>LOCATION_NAME</dt>
-  <dd>initial location name</dd>
+  <dd>initial project name</dd>
 
   <dt>MAPSET</dt>
   <dd>initial mapset</dd>

--- a/misc/m.measure/m.measure.html
+++ b/misc/m.measure/m.measure.html
@@ -6,7 +6,8 @@ hectares, square miles, square feet, square meters and square kilometers.
 
 <h2>EXAMPLES</h2>
 
-Distance example in a latitude-longitude location (on great circle, i.e. an orthodrome):
+Distance example in a latitude-longitude coordinate reference system
+(on great circle, i.e. an orthodrome):
 
 <div class="code"><pre>
 Bonn_DE="7.09549,50.73438"

--- a/ps/ps.map/ps.map.html
+++ b/ps/ps.map/ps.map.html
@@ -520,7 +520,7 @@ USAGE:	<b>header</b>
 </pre></div>
 If the <em>file</em> sub-instruction is absent the header will consist
 of the map's title <!-- from hist file -->
-and the location's description.<!-- PERMANENT/MYNAME -->
+and the project's description.<!-- PERMANENT/MYNAME -->
 The text will be centered on the page above the map.
 The default text color is black.
 <p>If the <em>file</em> sub-instruction is given the header will consist
@@ -532,8 +532,8 @@ of the text in the text file specified, with some special formatting keys:
 <li><tt>%_</tt>  - horizontal bar
 <li><tt>%c</tt>  - "&lt;raster name&gt; in mapset &lt;mapset name&gt;"
 <li><tt>%d</tt>  - today's date
-<li><tt>%l</tt>  - location name
-<li><tt>%L</tt>  - Location's text description
+<li><tt>%l</tt>  - project name
+<li><tt>%L</tt>  - project's text description
 <li><tt>%m</tt>  - mapset name
 <li><tt>%u</tt>  - user name
 <li><tt>%x</tt>  - mask info

--- a/raster/r.buffer/r.buffer.html
+++ b/raster/r.buffer/r.buffer.html
@@ -51,8 +51,8 @@ category values of interest spread throughout the area.
 <p>
 <em>r.buffer</em> measures distances from center of cell to
 center of cell using Euclidean distance measure for
-planimetric locations (like UTM) and using ellipsoidal
-geodesic distance measure for latitude/longitude locations.
+planimetric coordinate reference systems (like UTM) and using ellipsoidal
+geodesic distance measure for latitude/longitude CRS.
 <p>
 <em>r.buffer</em> calculates distance zones from all cells having
 non-NULL category values in the <b>input</b> map. If the user wishes

--- a/raster/r.carve/r.carve.html
+++ b/raster/r.carve/r.carve.html
@@ -112,7 +112,7 @@ d.rast accum_diff
 <h2>KNOWN ISSUES</h2>
 
 <!-- Is this still the case as of Jan 11, 2008? - EP -->
-The module does not operate yet in latitude-longitude locations.  It
+The module does not operate yet in latitude-longitude coordinate reference system.  It
 has not been thoroughly tested, so not all options may work properly -
 but this was the intention.
 

--- a/raster/r.contour/r.contour.html
+++ b/raster/r.contour/r.contour.html
@@ -27,7 +27,7 @@ vector map. It acts like a filter, omitting spurs, single points, etc., making t
 
 <h2>EXAMPLES</h2>
 
-In the Spearfish location, produce a vector contour map from input raster <i>elevation.dem</i>
+In the Spearfish dataset, produce a vector contour map from input raster <i>elevation.dem</i>
 with contour levels from 1000m to 2000m, 100m contour step, and a minimum of 200 input raster
 points contributing to the contour line:
 

--- a/raster/r.describe/r.describe.html
+++ b/raster/r.describe/r.describe.html
@@ -40,7 +40,7 @@ extent of the input raster map.
 
 <h2>EXAMPLES</h2>
 
-The following examples are from the Spearfish60 sample Location:
+The following examples are from the Spearfish60 sample dataset:
 
 <p>
 # Print the full list of raster map categories:

--- a/raster/r.fill.stats/r.fill.stats.html
+++ b/raster/r.fill.stats/r.fill.stats.html
@@ -97,9 +97,9 @@ The most critical user-provided settings are the interpolation/gap
 filling method (<b>mode</b>) and the maximum distance, up to which
 <em>r.fill.stats</em> will scan for cells with values (<b>distance</b>).
 The distance can be expressed as a number of cells (default) or in the
-current GRASS location's units (if the <b>-m</b> flag is given). The latter
-are typically meters, but can be any other units of a <em>planar</em>
-coordinate system.
+current coordinate reference system's units (if the <b>-m</b> flag is given).
+The latter are typically meters, but can be any other units of a
+<em>planar</em> coordinate system.
 
 <p>
 
@@ -466,7 +466,7 @@ d.mon stop=cairo
 <h3>Outlier removal and gap-filling of SRTM elevation data</h3>
 
 In this example, the SRTM elevation map in the
-North Carolina sample dataset location is filtered for outlier
+North Carolina sample dataset is filtered for outlier
 elevation values; missing pixels are then re-interpolated to obtain
 a complete elevation map:
 

--- a/raster/r.grow.distance/r.grow.distance.html
+++ b/raster/r.grow.distance/r.grow.distance.html
@@ -60,7 +60,7 @@ where the isolines of distance from a point are squares.
 
 <p>
 The <i>Geodesic metric</i> is calculated as geodesic distance, to
-be used only in latitude-longitude locations. It is recommended
+be used only in latitude-longitude coordinate reference system. It is recommended
 to use it along with the <em>-m</em> flag in order to output
 distances in meters instead of map units.
 
@@ -101,7 +101,7 @@ r.colors map=dist_from_streams color=rainbow
    with d.rast.num)</i>
 </div>
 
-<h3>Distance from sea in meters in latitude-longitude location</h3>
+<h3>Distance from sea in meters in latitude-longitude CRS</h3>
 
 <div class="code"><pre>
 g.region raster=sea -p

--- a/raster/r.gwflow/r.gwflow.html
+++ b/raster/r.gwflow/r.gwflow.html
@@ -4,7 +4,7 @@ This numerical program calculates implicit transient, confined and
 unconfined groundwater flow in two dimensions based on
 raster maps and the current region settings.
 All initial and boundary conditions must be provided as
-raster maps. The unit in the location must be meters.
+raster maps. The unit of the current coordinate reference system must be meters.
 <p>This module is sensitive to mask settings. All cells which are outside the mask
 are ignored and handled as no flow boundaries.
 <p><center>

--- a/raster/r.horizon/r.horizon.html
+++ b/raster/r.horizon/r.horizon.html
@@ -23,7 +23,7 @@ geographic projection and not the coordinate system given by the rows
 and columns of the raster map. This correction implies that the
 resulting cardinal directions represent true orientation towards the
 East, North, West and South. The only exception of this feature is
-LOCATION with x,y coordinate system, where this correction is
+x,y coordinate system, where this correction is
 not applied.
 
 <p>
@@ -116,7 +116,7 @@ you use <b>r.horizon</b> in the raster map mode this option will be ignored.
 even if you use geographical coordinates (longitude/latitude). If your
 projection is based on distance (easting and northing), these too must
 be in meters. The buffer parameters must be in the same units as the
-raster coordinates (e.g., for latitude-longitude locations buffers are
+raster coordinates (e.g., for latitude-longitude buffers are
 measured in degree unit).
 
 <h2>METHOD</h2>

--- a/raster/r.in.gdal/r.in.gdal.html
+++ b/raster/r.in.gdal/r.in.gdal.html
@@ -2,7 +2,8 @@
 
 <em>r.in.gdal</em> allows a user to create a GRASS GIS raster map layer,
 or imagery group, from any GDAL supported raster map format, with an optional
-title. The imported file may also be optionally used to create a new location.
+title. The imported file may also be optionally used to create a new project
+(previously called location).
 
 <!--
 Extended explanations:
@@ -125,27 +126,27 @@ WEBP                                          WEBP              Yes      No     
 WMO GRIB1/GRIB2 (.grb)                        GRIB              No       Yes          2GB
 </pre></div>
 
-<h3>Location Creation</h3>
+<h3>Project Creation</h3>
 
 <em>r.in.gdal</em> attempts to preserve projection information when importing
 datasets if the source format includes projection information, and if
 the GDAL driver supports it.  If the projection of the source dataset does
-not match the projection of the current location <em>r.in.gdal</em> will
+not match the projection of the current project <em>r.in.gdal</em> will
 report an error message (<tt>Projection of dataset does not appear to
-match current location</tt>) and then report the PROJ_INFO parameters of
+match current project</tt>) and then report the PROJ_INFO parameters of
 the source dataset.
 
 <p>
 If the user wishes to ignore the difference between the apparent coordinate
-system of the source data and the current location, they may pass the
+system of the source data and the current project, they may pass the
 <b>-o</b> flag to override the projection check.
 
 <p>
 If the user wishes to import the data with the full projection definition,
-it is possible to have r.in.gdal automatically create a new location based
+it is possible to have r.in.gdal automatically create a new project based
 on the projection and extents of the file being read.  This is accomplished
-by passing the name to be used for the new location via the <b>location</b>
-parameter.  Upon completion of the command, a new location will have been
+by passing the name to be used for the new project via the <b>location</b>
+parameter.  Upon completion of the command, a new project will have been
 created (with only a PERMANENT mapset), and the raster will have been
 imported with the indicated <b>output</b> name into the PERMANENT mapset.
 
@@ -156,11 +157,11 @@ POINTS file within an imagery group. They can directly be used for
 <p>
 The <b>target</b> option allows you to automatically re-project the GCPs
 from their own projection into another projection read from the
-PROJ_INFO file of the location name <b>target</b>.
+PROJ_INFO file of the project name <b>target</b>.
 <p>
-If the <b>target</b> location does not exist, a new location will be
+If the <b>target</b> project does not exist, a new project will be
 created matching the projection definition of the GCPs. The target of
-the output group will be set to the new location, and
+the output group will be set to the new project, and
 <a href=i.rectify.html>i.rectify</a> can now be used without any further
 preparation.
 <p>
@@ -212,8 +213,8 @@ to set the north, south, east and west edges.  Rotational coefficients will
 be ignored, resulting in incorrect positioning for rotated datasets.<br>
 
 <dt> Projection
-<dd> The dataset's projection will be used to compare to the current location
-or to define a new location.  Internally GDAL represents projections in
+<dd> The dataset's projection will be used to compare to the current project
+or to define a new project.  Internally GDAL represents projections in
 OpenGIS Well Known Text format.  A large subset of the total set of GRASS
 projections are supported.<br>
 
@@ -230,7 +231,7 @@ a POINTS file associated with the imagery group.  Datasets with only one
 band that would otherwise have been translated as a simple raster map
 will also have an associated imagery group if there are ground control points.
 The coordinate system of the ground control points is reported by r.in.gdal
-but not preserved.  It is up to the user to ensure that the location
+but not preserved.  It is up to the user to ensure that the project
 established with i.target has a compatible coordinate system before using
 the points with i.rectify.<br>
 
@@ -260,23 +261,23 @@ gdalwarp rotated.tif northup.tif
 </pre></div>
 
 <p>
-<i>"ERROR: Projection of dataset does not appear to match the current location."</i><br>
+<i>"ERROR: Projection of dataset does not appear to match the current project."</i><br>
 
-You need to create a location whose projection matches the data you
+You need to create a project whose projection matches the data you
 wish to import. Try using <b>location</b> parameter to create a new
-location based upon the projection information in the file. If desired,
-you can then re-project it to another location with <em>r.proj</em>.
+project based upon the projection information in the file. If desired,
+you can then re-project it to another project with <em>r.proj</em>.
 Alternatively you can override this error by using the <b>-o</b> flag.
 
 <p>
 <i>"WARNING: G_set_window(): Illegal latitude for North"</i><br>
 
-Latitude/Longitude locations in GRASS can not have regions which exceed
+Latitude/Longitude project in GRASS can not have regions which exceed
 90&deg; North or South. Non-georeferenced imagery will have coordinates
 based on the images's number of pixels: 0,0 in the bottom left; cols,rows
 in the top right. Typically imagery will be much more than 90 pixels tall
 and so the GIS refuses to import it. If you are sure that the data is
-appropriate for your Lat/Lon location and intentd to reset the map's
+appropriate for your Lat/Lon project and intend to reset the map's
 bounds with the <em>r.region</em> module directly after import you may
 use the <b>-l</b> flag to constrain the map coordinates to legal values.
 
@@ -285,8 +286,8 @@ map the map's data will be unaltered and safe. After resetting to known
 bounds with <em>r.region</em> you should double check them with
 <em>r.info</em>, paying special attention to the map resolution. In most
 cases you will want to import into the datafile's native projection, or
-into a simple XY location and use the Georectifaction tools
-(<em>i.rectify</em> et al.) to properly project into the target location.
+into a simple XY project and use the Georectifaction tools
+(<em>i.rectify</em> et al.) to properly project into the target project.
 The <b>-l</b> flag should <i>only</i> be used if you know the projection
 is correct but the internal georeferencing has gotten lost, and you know
 the what the map's bounds and resolution should be beforehand.
@@ -302,7 +303,7 @@ To import the different chunks of data provided by the project as netCDF files,
 the offset parameter can be used to properly assign numbers to the series
 of daily raster maps from 1st Jan 1950 (in case of importing the ECAD data
 split into multi-annual chunks). The ECAD data must be imported into a
-LatLong location.
+LatLong project.
 <p>
 By using the <em>num_digits</em> parameter leading zeros are added to the
 map name numbers, allowing for chronological numbering of the imported raster

--- a/raster/r.in.lidar/r.in.lidar.html
+++ b/raster/r.in.lidar/r.in.lidar.html
@@ -301,7 +301,7 @@ The typical file extensions for the LAS format are .las and .laz
 (compressed). The compressed LAS (.laz) format can be imported only if
 libLAS has been compiled with LASzip support. It is also recommended to
 compile libLAS with GDAL which is used to test if the LAS projection
-matches that of the GRASS location.
+matches that of the GRASS project (previously called location).
 
 <h3>LAS file import preparations</h3>
 
@@ -367,7 +367,7 @@ Attempt to use it with other statistical methods will result in an error.
 <h2>EXAMPLES</h2>
 
 Simple example of binning of point from a LAS file into a newly created
-raster map in an existing location/mapset (using metric units):
+raster map in an existing project/mapset (using metric units):
 
 <div class="code"><pre>
 # set the computational region automatically, resol. for binning is 5m
@@ -443,10 +443,10 @@ r.in.lidar input=points.las output=lidar_dem_percentile_95 \
 Further hints: how to calculate number of LiDAR points/square meter:
 <div class="code"><pre>
 g.region -e
-  # Metric location:
+  # Metric project:
   # points_per_sq_m = n_points / (ns_extent * ew_extent)
 
-  # Lat/Lon location:
+  # Lat/Lon project:
   # points_per_sq_m = n_points / (ns_extent * ew_extent*cos(lat) * (1852*60)^2)
 </pre></div>
 
@@ -462,11 +462,11 @@ available at
 # print LAS file info
 r.in.lidar -p input="Serpent Mound Model LAS Data.las"
 
-# using v.in.lidar to create a new location
-# create location with projection information of the LAS data
+# using v.in.lidar to create a new project
+# create project with projection information of the LAS data
 v.in.lidar -i input="Serpent Mound Model LAS Data.las" location=Serpent_Mound
 
-# quit and restart GRASS in the newly created location "Serpent_Mound"
+# quit and restart GRASS in the newly created project "Serpent_Mound"
 
 # scan the extents of the LAS data
 r.in.lidar -sg input="Serpent Mound Model LAS Data.las"

--- a/raster/r.in.mat/r.in.mat.html
+++ b/raster/r.in.mat/r.in.mat.html
@@ -30,7 +30,7 @@ exists.
 <br>
 <br>
 The '<b>map_northern_edge</b>' and like variables are mandatory unless the
-user is importing to a "XY" non-georeferenced location
+user is importing to a "XY" non-georeferenced project
 (e.g. imagery data). Latitude and longitude values should be in decimal form.
 
 <h2>NOTES</h2>

--- a/raster/r.in.pdal/r.in.pdal.html
+++ b/raster/r.in.pdal/r.in.pdal.html
@@ -361,7 +361,7 @@ The typical file extensions for the LAS format are .las and .laz
 (compressed). The compressed LAS (.laz) format can be imported only if
 libLAS has been compiled with LASzip support. It is also recommended to
 compile libLAS with GDAL which is used to test if the LAS projection
-matches that of the GRASS location.
+matches that of the GRASS project (previously called location).
 
 <!--
 <h3>LAS file import preparations</h3>
@@ -438,7 +438,7 @@ result in an empty map.
 <h2>EXAMPLES</h2>
 
 Simple example of binning of point from a LAS file into a newly created
-raster map in an existing location/mapset (using metric units):
+raster map in an existing project/mapset (using metric units):
 
 <div class="code"><pre>
 # set the computational region automatically, resol. for binning is 5m
@@ -501,10 +501,10 @@ r.in.pdal input=points.las output=lidar_dem_percentile_95 \
 Further hints: how to calculate number of LiDAR points/square meter:
 <div class="code"><pre>
 g.region -e
-  # Metric location:
+  # Metric project:
   # points_per_sq_m = n_points / (ns_extent * ew_extent)
 
-  # Lat/Lon location:
+  # Lat/Lon project:
   # points_per_sq_m = n_points / (ns_extent * ew_extent*cos(lat) * (1852*60)^2)
 </pre></div>
 
@@ -520,11 +520,11 @@ available at
 # print LAS file info
 r.in.pdal -p input="Serpent Mound Model LAS Data.las"
 
-# using v.in.lidar to create a new location
-# create location with projection information of the LAS data
+# using v.in.lidar to create a new project
+# create project with projection information of the LAS data
 v.in.lidar -i input="Serpent Mound Model LAS Data.las" location=Serpent_Mound
 
-# quit and restart GRASS in the newly created location "Serpent_Mound"
+# quit and restart GRASS in the newly created project "Serpent_Mound"
 
 # scan the extents of the LAS data
 r.in.pdal -g input="Serpent Mound Model LAS Data.las"

--- a/raster/r.in.xyz/r.in.xyz.html
+++ b/raster/r.in.xyz/r.in.xyz.html
@@ -111,10 +111,10 @@ g.region -p
 # points_per_cell = n_points / (rows * cols)
 
 g.region -e
-# UTM location:
+# UTM project:
 # points_per_sq_m = n_points / (ns_extent * ew_extent)
 
-# Lat/Lon location:
+# Lat/Lon project:
 # points_per_sq_m = n_points / (ns_extent * ew_extent*cos(lat) * (1852*60)^2)
 </pre></div>
 

--- a/raster/r.out.png/r.out.png.html
+++ b/raster/r.out.png/r.out.png.html
@@ -13,7 +13,7 @@ the world file will be called <tt>png_map.wld</tt>.
 
 <h2>EXAMPLE</h2>
 
-The example is based on the North Carolina sample data location.
+The example is based on the North Carolina sample data.
 <p>
 Export of the soil map to PNG format with world file:
 

--- a/raster/r.out.vrml/r.out.vrml.html
+++ b/raster/r.out.vrml/r.out.vrml.html
@@ -33,7 +33,7 @@ platforms, see:<p><a href="http://www.w3.org/MarkUp/VRML/">VRML Virtual Reality 
 <h2>BUGS</h2>
 
 Currently the region is transformed to a unit size, so real geographic
-location is lost.  Side effects when working in a lat-lon location are
+location is lost.  Side effects when working in a lat-lon project are
 that besides general distortion due to projection, a very small
 exaggeration factor (on order of .001) must be used to compensate for
 vertical units expected to be the same as map units.

--- a/raster/r.profile/r.profile.html
+++ b/raster/r.profile/r.profile.html
@@ -45,8 +45,8 @@ The optional RGB output provides the associated GRASS colour value for
 each profile point.
 
 <p>Option <b>units</b> enables to set units of the profile length output.
-If the units are not specified, current location units will be used.
-In case of geographic locations (latitude/longitude), meters are used as default unit.
+If the units are not specified, current coordinate reference system's units will be used.
+In case of geographic CRS (latitude/longitude), meters are used as default unit.
 
 <h2>NOTES</h2>
 

--- a/raster/r.proj/r.proj.html
+++ b/raster/r.proj/r.proj.html
@@ -1,8 +1,9 @@
 <h2>DESCRIPTION</h2>
 
 <em>r.proj</em> projects a raster map in a specified mapset of a
-specified location from the projection of the input location to a raster map
-in the current location. The projection information is taken from the
+specified project  (previously called location) from the projection
+of the input project to a raster map
+in the current project. The projection information is taken from the
 current PROJ_INFO files, as set and viewed with
 <em><a href="g.proj.html">g.proj</a></em>.
 
@@ -79,7 +80,7 @@ GIS the
 vector maps, transferring topology and attributes as well as node coordinates.
 This program uses the projection definition and parameters which are stored in
 the PROJ_INFO and PROJ_UNITS files in the PERMANENT mapset directory for every
-GRASS location.
+GRASS project.
 
 <h3>Design of r.proj</h3>
 
@@ -89,8 +90,8 @@ intersections of a grid in the target projection. The basic procedure
 for accomplishing this, therefore, is as follows:
 <p>
 <em>r.proj</em> converts a map to a new geographic projection. It
-reads a map from a different location, projects it and write it out to
-the current location. The projected data is resampled with one of four
+reads a map from a different project, projects it and write it out to
+the current project. The projected data is resampled with one of four
 different methods: nearest neighbor, bilinear, bicubic interpolation or
 lanczos.
 <p>
@@ -156,16 +157,16 @@ as the current mapset's name.
 <br>
 If <b>dbase</b> is not specified it is assumed to be the current
 database. The user only has to specify <b>dbase</b> if the source
-location is stored in another separate GRASS database.
+project is stored in another separate GRASS database.
 
 <p>
 To avoid excessive time consumption when reprojecting a map the region
-and resolution of the target location should be set appropriately
+and resolution of the target project should be set appropriately
 beforehand.
 
 <p>
 A simple way to do this is to check the projected bounds of the input
-map in the current location's projection using the <b>-p</b>
+map in the current project's projection using the <b>-p</b>
 flag. The <b>-g</b> flag reports the same thing, but in a form which
 can be directly cut and pasted into
 a <em><a href="g.region.html">g.region</a></em> command. After setting
@@ -177,14 +178,14 @@ flag. E.g.
 
 <p>
 A more involved, but more accurate, way to do this is to generate a
-vector "box" map of the region in the source location using
+vector "box" map of the region in the source project using
  <em><a href="v.in.region.html">v.in.region -d</a></em>.
-This "box" map is then reprojected into the target location with
+This "box" map is then reprojected into the target project with
 <em><a href="v.proj.html">v.proj</a></em>. Next the region in the
-target location is set to the extent of the new vector map
+target project is set to the extent of the new vector map
 with <em><a href="g.region.html">g.region</a></em> along with the
 desired raster resolution (<em>g.region -m</em> can be used in
-Latitude/Longitude locations to measure the geodetic length of a
+Latitude/Longitude projects to measure the geodetic length of a
 pixel).
 <em>r.proj</em> is then run for the raster map the user wants to
 reproject.  In this case a little preparation goes a long way.
@@ -199,7 +200,7 @@ than latitude-longitude so results may be odd with trimming.
 
 <h3>Inline method</h3>
 
-With GRASS running in the destination location use the <b>-g</b> flag
+With GRASS running in the destination project use the <b>-g</b> flag
 to show the input map's bounds once projected into the current working
 projection, then use that to set the region bounds before performing
 the reprojection:
@@ -258,26 +259,26 @@ r.proj input=elevation project=ll_wgs84 mapset=user1 memory=800
 
 <div class="code"><pre>
 
-# In the source location, use v.in.region to generate a bounding box around the
+# In the source project, use v.in.region to generate a bounding box around the
 # region of interest:
 
 v.in.region -d output=bounds type=area
 
-# Now switch to the target location and import the vector bounding box
-# (you can run v.proj -l to get a list of vector maps in the source location):
+# Now switch to the target project and import the vector bounding box
+# (you can run v.proj -l to get a list of vector maps in the source project):
 
-v.proj input=bounds project=source_location_name output=bounds_reprojected
+v.proj input=bounds project=source_project_name output=bounds_reprojected
 
-# Set the region in the target location with that of the newly-imported vector
+# Set the region in the target project with that of the newly-imported vector
 # bounds map, and align the resolution to the desired cell resolution of the
 # final, reprojected raster map:
 
 g.region vector=bounds_reprojected res=5 -a
 
-# Now reproject the raster into the target location
+# Now reproject the raster into the target project
 
 r.proj input=elevation.dem output=elevation.dem.reproj \
-  project=source_location_name mapset=PERMANENT res=5 method=bicubic
+  project=source_project_name mapset=PERMANENT res=5 method=bicubic
 </pre></div>
 
 <h2>REFERENCES</h2>

--- a/raster/r.relief/r.relief.html
+++ b/raster/r.relief/r.relief.html
@@ -54,7 +54,7 @@ The current mask is ignored.
 <h3>Shaded relief map</h3>
 
 In this example, the aspect map in the North Carolina sample
-dataset location is used to hillshade the elevation map:
+dataset is used to hillshade the elevation map:
 
 <div class="code"><pre>
 g.region raster=elevation -p
@@ -79,7 +79,8 @@ r.shade shade=elevation_shade color=elevation output=elevation_shaded
 
 <h3>Using the scale factor in Latitude-Longitude</h3>
 
-In Latitude-Longitude locations (or other non-metric locations), the
+In Latitude-Longitude coordinate reference systems
+(or other non-metric systems), the
 <em>scale</em> factor has to be used:
 
 <div class="code"><pre>

--- a/raster/r.report/r.report.html
+++ b/raster/r.report/r.report.html
@@ -11,7 +11,7 @@ body of the report.
 
 <p>
 The header section of the report identifies the raster map(s) (by map
-name and title), location, mapset, report date, and the region of
+name and title), project, mapset, report date, and the region of
 interest. The area of interest is described in two parts: the user's
 current geographic region is presented, and the mask is presented (if
 any is used).

--- a/raster/r.resamp.bspline/r.resamp.bspline.html
+++ b/raster/r.resamp.bspline/r.resamp.bspline.html
@@ -81,7 +81,7 @@ r.patch input=input_raster,interpolated_nulls output=input_raster_gapfilled
 <h3>Interpolation of NULL cells and patching (NC data)</h3>
 
 In this example, the SRTM elevation map in the
-North Carolina sample dataset location is filtered for outlier
+North Carolina sample dataset is filtered for outlier
 elevation values; missing pixels are then re-interpolated to obtain
 a complete elevation map:
 

--- a/raster/r.resamp.filter/r.resamp.filter.html
+++ b/raster/r.resamp.filter/r.resamp.filter.html
@@ -70,7 +70,8 @@ tail. By scaling the axes to the same width, the a=3 window has a narrower
 central lobe.
 
 <p>
-For longitude-latitude locations, the interpolation algorithm is based on
+For longitude-latitude coordinate reference systems,
+the interpolation algorithm is based on
 degree fractions, not on the absolute distances between cell centers.  Any
 attempt to implement the latter would violate the integrity of the
 interpolation method.

--- a/raster/r.resamp.interp/r.resamp.interp.html
+++ b/raster/r.resamp.interp/r.resamp.interp.html
@@ -31,7 +31,8 @@ of input cell centers are set to NULL (NULL propagation). This could occur
 due to the input cells being outside the current region, being NULL or MASKed.
 
 
-<p>For longitude-latitude locations, the interpolation algorithm is based on
+<p>For longitude-latitude coordinate reference systems,
+the interpolation algorithm is based on
 degree fractions, not on the absolute distances between cell centers.  Any
 attempt to implement the latter would violate the integrity of the
 interpolation method.

--- a/raster/r.ros/r.ros.html
+++ b/raster/r.ros/r.ros.html
@@ -141,7 +141,7 @@ r.ros -s model=fire_model moisture_1h=1hour_moisture moisture_live=live_moisture
 </em>
 
 Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
-(run this script within the "Fire simulation data set" location).
+(run this script within the "Fire simulation data set" project).
 
 <h2>AUTHOR</h2>
 

--- a/raster/r.solute.transport/r.solute.transport.html
+++ b/raster/r.solute.transport/r.solute.transport.html
@@ -3,7 +3,7 @@
 This numerical program calculates numerical implicit transient and steady state
 solute transport in porous media in the saturated zone of an aquifer. The computation is based on
 raster maps and the current region settings. All initial- and boundary-conditions must be provided as
-raster maps. The unit in the location must be meters.
+raster maps. The unit of the coordinate reference system must be meters.
 <br>
 <p>This module is sensitive to mask settings. All cells which are outside the mask
 are ignored and handled as no flow boundaries.

--- a/raster/r.spread/r.spread.html
+++ b/raster/r.spread/r.spread.html
@@ -132,7 +132,7 @@ Rutgers University, New Brunswick, New Jersey
 </em>
 
 Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
-(run this script within the "Fire simulation data set" location).
+(run this script within the "Fire simulation data set" project).
 
 <h2>AUTHORS</h2>
 

--- a/raster/r.spreadpath/r.spreadpath.html
+++ b/raster/r.spreadpath/r.spreadpath.html
@@ -59,7 +59,7 @@ Rutgers University, New Brunswick, New Jersey
 </em>
 
 Sample data download: <a href="https://grass.osgeo.org/sampledata/firedemo_grass7.sh">firedemo.sh</a>
-(run this script within the "Fire simulation data set" location).
+(run this script within the "Fire simulation data set" project).
 
 <h2>AUTHORS</h2>
 

--- a/raster/r.sun/r.sun.html
+++ b/raster/r.sun/r.sun.html
@@ -48,7 +48,7 @@ with the <a href="r.info.html">r.info</a> command.
 The solar incidence angle raster map <i>incidout</i> is computed specifying
 elevation raster map <i>elevation</i>, aspect raster map <i>aspect</i>, slope
 steepness raster map <i>slope,</i> given the day <i>day</i> and local time
-<i>time</i>. There is no need to define latitude for locations with known
+<i>time</i>. There is no need to define latitude for projects with known
 and defined projection/coordinate system (check it with the <a href="g.proj.html">
 g.proj</a>
  command). If you have undefined projection, (x,y) system, etc. then the latitude

--- a/raster/r.sunmask/r.sunmask.html
+++ b/raster/r.sunmask/r.sunmask.html
@@ -50,7 +50,7 @@ winter and summer), s/he would have to change the Time Zone parameter in
 <p>
 
 <p>
-Note: In latitude/longitude locations the position coordinates pair
+Note: In latitude/longitude projects the position coordinates pair
 (east/west) has to be specified in decimal degree (not DD:MM:SS). If
 not specified, the map center's coordinates will be used.
 Also <em>g.region -l</em> displays the map center's coordinates in

--- a/raster/r.to.rast3/r.to.rast3.html
+++ b/raster/r.to.rast3/r.to.rast3.html
@@ -31,7 +31,7 @@ This example shows how to convert 6 maps into one 3D map with 6 layers.
 <br>
 
 <div class="code"><pre>
-# Mapset data in Location slovakia3d
+# Mapset data in dataset slovakia3d
 g.region raster=prec_1,prec_2,prec_3,prec_4,prec_5,prec_6 -p
 g.region b=0 t=600 tbres=100 res3=100 -p3
 r.to.rast3 input=prec_1,prec_2,prec_3,prec_4,prec_5,prec_6 output=new_3dmap
@@ -42,7 +42,7 @@ This example shows how to convert 3 maps into one 3D map with 6 layers.
 <br>
 
 <div class="code"><pre>
-# Mapset data in Location slovakia3d
+# Mapset data in dataset slovakia3d
 g.region b=0 t=600 tbres=100 res3=100 -p3
 r.to.rast3 input=prec_1,prec_2,prec_3 output=new_3dmap
 </pre></div>

--- a/raster/r.topidx/r.topidx.html
+++ b/raster/r.topidx/r.topidx.html
@@ -19,10 +19,10 @@ r.mapcalc "belev = if(isnull(basin), basin, elev)"
 <p>
 <em>r.stats -Anc</em> prints out averaged statistics for topographic index.
 
-<p>Unprojected lat/long locations are not supported. If data is not projected
-in a lat/long location, please create a new location in a projected coordinate
-system and reproject the data into the new projected location. Please run
-<em>r.topidx</em> from that location.
+<p>Unprojected lat/long projects are not supported. If data is not projected,
+please create a new project in a projected coordinate
+system and reproject the data into the new project. Please run
+<em>r.topidx</em> from that project.
 
 <h2>EXAMPLE</h2>
 

--- a/raster/rasterintro.html
+++ b/raster/rasterintro.html
@@ -30,7 +30,7 @@ There are a few exceptions to this:
 
 <tt>r.in.*</tt> programs read the data cell-for-cell, with no resampling. When
 reading non-georeferenced data, the imported map will usually have its
-lower-left corner at (0,0) in the location's coordinate system; the user
+lower-left corner at (0,0) in the project's coordinate system; the user
 needs to use <a href="r.region.html">r.region</a> to "place" the imported map.
 <p>
 Some programs which need to perform specific types of resampling (e.g.
@@ -45,13 +45,13 @@ final result.
 
 The module <a href="r.in.gdal.html">r.in.gdal</a> offers a common
 interface for many different raster formats. Additionally, it also
-offers options such as on-the-fly location creation or extension of
+offers options such as on-the-fly project creation or extension of
 the default region to match the extent of the imported raster map.
 For special cases, other import modules are available. The full map
 is always imported.
 <p>
 For importing scanned maps, the user will need to create a
-x,y-location, scan the map in the desired resolution and save it into
+x,y-project, scan the map in the desired resolution and save it into
 an appropriate raster format (e.g. tiff, jpeg, png, pbm) and then use
 <a href="r.in.gdal.html">r.in.gdal</a> to import it. Based on
 reference points the scanned map can be recified to obtain geocoded
@@ -73,7 +73,7 @@ first change the region, then explicitly resample the map with e.g.
 <a href="r.resamp.stats.html">r.resamp.stats</a>, then export the
 resampled map.
 <p>
-GRASS GIS raster map exchange between different locations (same projection)
+GRASS GIS raster map exchange between different projects (same projection)
 can be done in a lossless way using the <a href="r.pack.html">r.pack</a>
 and <a href="r.unpack.html">r.unpack</a> modules.
 


### PR DESCRIPTION
Some cases are simply replaced (location to project), in some cases 'coordinate reference system' or 'dataset' are better replacements.