### PR TITLE
mkhtml: check for addon_path

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -398,7 +398,7 @@ def get_last_git_commit(src_dir, addon_path, is_addon):
             src_dir=src_dir,
         )
     else:
-        if gs:
+        if gs and addon_path is not None:
             # Addons installation
             return get_git_commit_from_rest_api_for_addon_repo(
                 addon_path=addon_path,

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -291,25 +291,26 @@ def get_git_commit_from_rest_api_for_addon_repo(
     # Accessed date time if getting commit from GitHub REST API wasn't successful
     if not git_log:
         git_log = get_default_git_log(src_dir=src_dir)
-    grass_addons_url = (
-        "https://api.github.com/repos/osgeo/grass-addons/commits?"
-        "path={path}&page=1&per_page=1&sha=grass{major}".format(
-            path=addon_path,
-            major=major,
-        )
-    )  # sha=git_branch_name
-
-    response = download_git_commit(
-        url=grass_addons_url,
-        response_format="application/json",
-    )
-    if response:
-        commit = json.loads(response.read())
-        if commit:
-            git_log["commit"] = commit[0]["sha"]
-            git_log["date"] = format_git_commit_date_from_rest_api(
-                commit_datetime=commit[0]["commit"]["author"]["date"],
+    if addon_path is not None:
+        grass_addons_url = (
+            "https://api.github.com/repos/osgeo/grass-addons/commits?"
+            "path={path}&page=1&per_page=1&sha=grass{major}".format(
+                path=addon_path,
+                major=major,
             )
+        )  # sha=git_branch_name
+
+        response = download_git_commit(
+            url=grass_addons_url,
+            response_format="application/json",
+        )
+        if response:
+            commit = json.loads(response.read())
+            if commit:
+                git_log["commit"] = commit[0]["sha"]
+                git_log["date"] = format_git_commit_date_from_rest_api(
+                    commit_datetime=commit[0]["commit"]["author"]["date"],
+                )
     return git_log
 
 
@@ -398,7 +399,7 @@ def get_last_git_commit(src_dir, addon_path, is_addon):
             src_dir=src_dir,
         )
     else:
-        if gs and addon_path is not None:
+        if gs:
             # Addons installation
             return get_git_commit_from_rest_api_for_addon_repo(
                 addon_path=addon_path,


### PR DESCRIPTION
This PR suggests to add a check for an empty addon_path.
The default value is set to `addon_path = None` in [L889](https://github.com/osgeo/grass/blob/main/utils/mkhtml.py#L889) and there are circumstances where it is not overwritten. As far as I see it, this would prevent the code from requesting a wrong path in the [following method](https://github.com/osgeo/grass/blob/main/utils/mkhtml.py#L297) returning the latest commit of the whole addon repository instead of the latest commit for the addon.

Manual page generation here is really new to me so I am not sure about all the different variations in which this script might be called and if I oversee something. Background is that I am using the script to generate manual pages for addons not in the official addon repository and this PR would prevent multiple unneccessary requests to the github API.