### PR TITLE
grassTask.get_param(): full match also for strings

### DIFF
--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -148,9 +148,6 @@ class grassTask:
             if isinstance(val, (list, tuple)):
                 if value in val:
                     return p
-            elif isinstance(val, (bytes, str)):
-                if p[element][: len(value)] == value:
-                    return p
             else:
                 if p[element] == value:
                     return p

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -1,0 +1,10 @@
+import pytest
+from grass.script.task import grassTask as gtask
+
+def test_mapcalc_simple_e_name():
+    gt = gtask("r.mapcalc.simple")
+    assert gt.get_param('e')['name'] == 'e'
+
+def test_mapcalc_simple_expession_name():
+    gt = gtask("r.mapcalc.simple")
+    assert gt.get_param('expression')['name'] == 'expression'

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -4,7 +4,8 @@ from grass.script.task import grassTask as gtask
 
 def test_mapcalc_simple_e_name():
     gt = gtask("r.mapcalc.simple")
-    assert gt.get_param('e')['name'] == 'e'
+    assert gt.get_param("e")["name"] == "e"
+
 
 def test_mapcalc_simple_expession_name():
     gt = gtask("r.mapcalc.simple")

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -9,4 +9,4 @@ def test_mapcalc_simple_e_name():
 
 def test_mapcalc_simple_expession_name():
     gt = gtask("r.mapcalc.simple")
-    assert gt.get_param('expression')['name'] == 'expression'
+    assert gt.get_param("expression")["name"] == "expression"

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -1,4 +1,3 @@
-import pytest
 from grass.script.task import grassTask as gtask
 
 

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -1,6 +1,7 @@
 import pytest
 from grass.script.task import grassTask as gtask
 
+
 def test_mapcalc_simple_e_name():
     gt = gtask("r.mapcalc.simple")
     assert gt.get_param('e')['name'] == 'e'


### PR DESCRIPTION
`grassTask.get_param()` does not perform full match on string data type, see https://github.com/OSGeo/grass/blob/main/python/grass/script/task.py#L151

This may lead to buggy behaviour as explained below.

Sample code:

```py
from grass.script.task import grassTask

print(grassTask("r.mapcalc.simple").get_param('e')['name'])
```

returns `expression` instead of `e`.
