### PR TITLE
CI(windows): Set number of cores for compilation

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -59,6 +59,11 @@ jobs:
             python3-matplotlib,python3-numpy,python3-ply,python3-pywin32,\
             python3-wxpython,regex-devel,zstd-devel"
 
+      - name: Set number of cores for compilation
+        run: |
+          echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
+        shell: msys2 {0}
+
       - name: Compile GRASS GIS
         run: D:\msys64\usr\bin\bash.exe -l (''+(Get-Location)+'\.github\workflows\build_osgeo4w.sh') (Get-Location)
 


### PR DESCRIPTION
Saves at least 10 minutes on compilation, for every run. 

This is the low hanging fruit I was able to quickly fix.

Windows runners (and Linux runners) all use 4 cores for public repos since January when they completed the upgrade of the runners.

I was tracing the builds with an ETW trace (xperf), and analyzing with Windows Performance Analyzer (really cool, even down to the context switches per process and priority if needed). I see that with that, most of the time if compilation uses all of the 4 CPU cores. Using 3 jobs makes the build step last 11min18sec for the run I made. Using 4 jobs is about at 10min-10min30sec. Using 1 job like currently is more than 20 minutes.

It is still 2 times slower than I expected, and I didn’t find an obvious reason for now. I expected to see an IO issue, but it didn’t seem like it (for the compilation step). The OSGeo4W installation step though is not optimal from the traces I saw.


