### PR TITLE
wxGUI: fix animation/nviz animation tool play/record animation

### DIFF
--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -92,7 +92,7 @@ class AnimationController(wx.EvtHandler):
         self._timeTick = value
         if self.timer.IsRunning():
             self.timer.Stop()
-            self.timer.Start(self._timeTick)
+            self.timer.Start(int(self._timeTick))
         self.DisableSliderIfNeeded()
 
     timeTick = property(fget=GetTimeTick, fset=SetTimeTick)
@@ -110,7 +110,7 @@ class AnimationController(wx.EvtHandler):
                 anim.NextFrameIndex()
             anim.Start()
         if not self.timer.IsRunning():
-            self.timer.Start(self.timeTick)
+            self.timer.Start(int(self.timeTick))
             self.DisableSliderIfNeeded()
 
     def PauseAnimation(self, paused):
@@ -120,7 +120,7 @@ class AnimationController(wx.EvtHandler):
                 self.DisableSliderIfNeeded()
         else:
             if not self.timer.IsRunning():
-                self.timer.Start(self.timeTick)
+                self.timer.Start(int(self.timeTick))
                 self.DisableSliderIfNeeded()
 
         for anim in self.animations:

--- a/gui/wxpython/nviz/animation.py
+++ b/gui/wxpython/nviz/animation.py
@@ -59,7 +59,7 @@ class Animation:
 
     def Start(self):
         """Start recording/playing"""
-        self.timer.Start(self.GetInterval())
+        self.timer.Start(int(self.GetInterval()))
 
     def Pause(self):
         """Pause recording/playing"""

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -564,7 +564,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                     self.fly["pos"]["x"] = sx / 2
                     self.fly["pos"]["y"] = sy / 2
                     self.fly["mouseControl"] = False  # controlled by keyboard
-                    self.timerFly.Start(self.fly["interval"])
+                    self.timerFly.Start(int(self.fly["interval"]))
 
                 self.ProcessFlyByArrows(keyCode=key)
 
@@ -712,7 +712,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
 
         if self.mouse["use"] == "fly":
             if not self.timerFly.IsRunning():
-                self.timerFly.Start(self.fly["interval"])
+                self.timerFly.Start(int(self.fly["interval"]))
                 self.fly["mouseControl"] = True
 
         event.Skip()


### PR DESCRIPTION
Fixes #3580.

`wx.Timer` class `Start()` method `milliseconds` param arg should by integer type, [doc](https://docs.wxpython.org/wx.Timer.html#wx.Timer.Start). 