### PR TITLE
g.mapsets: add missing declared or defined argument type

### DIFF
--- a/general/g.mapsets/list.c
+++ b/general/g.mapsets/list.c
@@ -6,7 +6,7 @@
 #include <grass/parson.h>
 
 // Function to initialize a JSON object with a mapsets array
-static JSON_Object *initialize_json_object()
+static JSON_Object *initialize_json_object(void)
 {
     JSON_Value *root_value = json_value_init_object();
     if (!root_value) {
@@ -70,7 +70,7 @@ void list_accessible_mapsets(const char *fs)
 }
 
 // Lists all accessible mapsets in JSON format
-void list_accessible_mapsets_json()
+void list_accessible_mapsets_json(void)
 {
     const char *name;
     JSON_Object *root_object = initialize_json_object();

--- a/general/g.mapsets/local_proto.h
+++ b/general/g.mapsets/local_proto.h
@@ -6,4 +6,4 @@ const char *substitute_mapset(const char *);
 void list_available_mapsets(const char **, int, const char *);
 void list_accessible_mapsets(const char *);
 void list_avaliable_mapsets_json(const char **, int);
-void list_accessible_mapsets_json();
+void list_accessible_mapsets_json(void);


### PR DESCRIPTION
Add missing declaration/definition of argument type. 

Log extract:

```
/usr/bin/clang -I/opt/local/include -isystem/opt/local/include -isystem/opt/local/include/libomp -std=c11 -I/opt/local/include -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk -arch arm64 -O0 --debug -Wall -Wextra -Wpedantic -Wno-error=deprecated-non-prototype -D_FORTIFY_SOURCE=3 -Wvla -Wno-error=strict-prototypes -DGL_SILENCE_DEPRECATION   -I/dev/grass/dist.aarch64-apple-darwin23.4.0/include -I/dev/grass/dist.aarch64-apple-darwin23.4.0/include    -DPACKAGE=\""grassmods"\"   -I/dev/grass/dist.aarch64-apple-darwin23.4.0/include -I/dev/grass/dist.aarch64-apple-darwin23.4.0/include -DRELDIR=\"general/g.mapsets\" -o OBJ.aarch64-apple-darwin23.4.0/get_maps.o -c get_maps.c
In file included from get_maps.c:5:
./local_proto.h:9:34: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
void list_accessible_mapsets_json();
                                 ^
                                  void
1 warning generated.
```