### PR TITLE
libvector: add destructor function to the struct field_info

### DIFF
--- a/include/grass/defs/vector.h
+++ b/include/grass/defs/vector.h
@@ -108,6 +108,7 @@ void Vect_set_db_updated(struct Map_info *);
 const char *Vect_get_column_names(struct Map_info *, int);
 const char *Vect_get_column_types(struct Map_info *, int);
 const char *Vect_get_column_names_types(struct Map_info *, int);
+void Vect_destroy_field_info(struct field_info *);
 
 /* List of FID (feature ID) (integers) */
 struct ilist *Vect_new_list(void);

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -625,6 +625,25 @@ int Vect_get_field_number(struct Map_info *Map, const char *field)
     return atoi(field);
 }
 
+/*!
+   \brief Frees all memory associated with a struct field_info
+
+   \param[in,out] fi pointer to field_info structure
+ */
+void Vect_destroy_field_info(struct field_info *fi)
+{
+    if (!fi)
+        return;
+    if (fi->name)
+        G_free(fi->name);
+    G_free(fi->driver);
+    G_free(fi->database);
+    G_free(fi->table);
+    G_free(fi->key);
+    G_free(fi);
+    fi = NULL;
+}
+
 static int read_dblinks_nat(struct Map_info *Map)
 {
     FILE *fd;

--- a/lib/vector/Vlib/field.c
+++ b/lib/vector/Vlib/field.c
@@ -626,7 +626,7 @@ int Vect_get_field_number(struct Map_info *Map, const char *field)
 }
 
 /*!
-   \brief Frees all memory associated with a struct field_info
+   \brief Free a struct field_info and all memory associated with it.
 
    \param[in,out] fi pointer to field_info structure
  */


### PR DESCRIPTION
Add a missing destructor function to the struct `field_info`.  This enables to free memory, which now is being leaked.