### PR TITLE
windows: use Python 3.12 with updated OSGeo4W

### DIFF
--- a/mswindows/GRASS-Packager.bat.tmpl
+++ b/mswindows/GRASS-Packager.bat.tmpl
@@ -89,9 +89,9 @@ xcopy %OSGEO4W_PKG_DIR%\share\gdal %PACKAGE_DIR%\share\gdal /S/V/F/I
 @echo -----------------------------------------------------------------------------------------------------------------------
 @echo.
 
-mkdir %PACKAGE_DIR%\Python39
+mkdir %PACKAGE_DIR%\Python312
 
-xcopy %OSGEO4W_PKG_DIR%\apps\Python39\* %PACKAGE_DIR%\Python39 /S/V/F/I
+xcopy %OSGEO4W_PKG_DIR%\apps\Python312\* %PACKAGE_DIR%\Python312 /S/V/F/I
 
 @echo.
 @echo -----------------------------------------------------------------------------------------------------------------------

--- a/mswindows/crosscompile.sh
+++ b/mswindows/crosscompile.sh
@@ -350,10 +350,10 @@ if defined GRASS_PYTHON (
 ) else (
 	rem Change this variable to override auto-detection of python.exe in
 	rem PATH
-	set GRASS_PYTHON=C:\Python39\python.exe
+	set GRASS_PYTHON=C:\Python312\python.exe
 
 	rem For portable installation, use %~d0 for the changing drive letter
-	rem set GRASS_PYTHON=%~d0\Python39\python.exe
+	rem set GRASS_PYTHON=%~d0\Python312\python.exe
 
 	if not exist "%GRASS_PYTHON%" (
 		set GRASS_PYTHON=

--- a/mswindows/env.bat
+++ b/mswindows/env.bat
@@ -3,7 +3,7 @@ REM Environmental variables for GRASS stand-alone installer
 REM
 
 set GRASS_PYTHON=%GISBASE%\extrabin\python3.exe
-set PYTHONHOME=%GISBASE%\Python39
+set PYTHONHOME=%GISBASE%\Python312
 
 set GRASS_PROJSHARE=%GISBASE%\share\proj
 

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -18,7 +18,7 @@ set -e
 # compile
 export PATH=${OSGEO4W_ROOT_MSYS}/bin:/usr/bin:/mingw64/bin
 export C_INCLUDE_PATH=".:${OSGEO4W_ROOT_MSYS}/include:${SRC}/dist.${ARCH}/include:/c/msys64/mingw64/include"
-export PYTHONHOME=${OSGEO4W_ROOT_MSYS}/apps/Python39
+export PYTHONHOME=${OSGEO4W_ROOT_MSYS}/apps/Python312
 export ARCH=x86_64-w64-mingw32
 
 ./configure \


### PR DESCRIPTION
Update Windows builds to use Python 3.12 with [updated OSGeo4W](https://lists.osgeo.org/pipermail/grass-dev/2024-April/096269.html).

Closes: #3596.