### PR TITLE
db/drivers/mysql: set SQL ANSI_QUOTES MODE

### DIFF
--- a/db/drivers/mysql/db.c
+++ b/db/drivers/mysql/db.c
@@ -63,6 +63,14 @@ int db__driver_open_database(dbHandle *handle)
             db_d_report_error();
             return DB_FAILED;
         }
+        /* Set SQL ANSI_QUOTES MODE which allow to use double quotes instead of
+         * backticks */
+        if (mysql_query(connection, "SET SQL_MODE=ANSI_QUOTES") != 0) {
+            db_d_append_error("%s %s", _("Unable to set SQL ANSI_QUOTES mode:"),
+                              mysql_error(connection));
+            db_d_report_error();
+            return DB_FAILED;
+        }
     }
 
     return DB_OK;


### PR DESCRIPTION
Which allow to use SQL standard double quotes instead of backticks for escaping column name.

Successfully tested with MySQL DB backend.

[Example](https://github.com/OSGeo/grass/issues/3604#issuecomment-2058805737) for testing purpose.