### PR TITLE
v.db.select: fix escaping SQL columns names with SQL standard double quotes

### DIFF
--- a/vector/v.db.select/main.c
+++ b/vector/v.db.select/main.c
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
         char *buf = NULL;
 
         buf = G_malloc((strlen(options.group->answer) + 8));
-        sprintf(buf, " GROUP BY %s", options.group->answer);
+        sprintf(buf, " GROUP BY \"%s\"", options.group->answer);
         db_append_string(&sql, buf);
         G_free(buf);
     }

--- a/vector/v.db.select/main.c
+++ b/vector/v.db.select/main.c
@@ -289,17 +289,19 @@ int main(int argc, char **argv)
 
     if (options.cols->answer) {
         char col_sep[] = ",";
-        char *token = strtok(options.cols->answer, col_sep);
+        char **tokens;
+        int i, ntokens;
 
         sprintf(query, "SELECT ");
-
-        while (token != NULL) {
-            sprintf(query + strlen(query), "\"%s\"", token);
-            token = strtok(NULL, col_sep);
-            if (token)
-                sprintf(query + strlen(query), "%c", *col_sep);
+        tokens = G_tokenize(options.cols->answer, col_sep);
+        ntokens = G_number_of_tokens(tokens);
+        for (i = 0; i < ntokens; i++) {
+            if (i < ntokens - 1)
+                sprintf(query + strlen(query), "\"%s\"%c", tokens[i], *col_sep);
+            else
+                sprintf(query + strlen(query), "\"%s\"", tokens[i]);
         }
-
+        G_free_tokens(tokens);
         sprintf(query + strlen(query), " FROM ");
     }
     else

--- a/vector/v.db.select/main.c
+++ b/vector/v.db.select/main.c
@@ -287,8 +287,21 @@ int main(int argc, char **argv)
                       Fi->database, Fi->driver);
     db_set_error_handler_driver(driver);
 
-    if (options.cols->answer)
-        sprintf(query, "SELECT %s FROM ", options.cols->answer);
+    if (options.cols->answer) {
+        char col_sep[] = ",";
+        char *token = strtok(options.cols->answer, col_sep);
+
+        sprintf(query, "SELECT ");
+
+        while (token != NULL) {
+            sprintf(query + strlen(query), "\"%s\"", token);
+            token = strtok(NULL, col_sep);
+            if (token)
+                sprintf(query + strlen(query), "%c", *col_sep);
+        }
+
+        sprintf(query + strlen(query), " FROM ");
+    }
     else
         sprintf(query, "SELECT * FROM ");
 

--- a/vector/v.db.select/testsuite/test_v_db_select_reserved_db_keyword_col_name.py
+++ b/vector/v.db.select/testsuite/test_v_db_select_reserved_db_keyword_col_name.py
@@ -1,0 +1,65 @@
+############################################################################
+#
+# MODULE:       Test of v.db.select
+# AUTHOR(S):    Tomas Zigo <tomas zigo slovanet sk>
+# PURPOSE:      Test query with defined columns (column name is reserved DB
+#               keyword)
+# COPYRIGHT:    (C) 2021-2024 by Tomas Zigo the GRASS Development Team
+#
+#               This program is free software under the GNU General Public
+#               License (>=v2). Read the file COPYING that comes with GRASS
+#               for details.
+#
+#############################################################################
+
+"""Test query with defined columns (column name is reserved DB keyword)"""
+
+import grass.script as gs
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+POINTS = """\
+17.46938776,18.67346939,1
+20.93877551,17.44897959,2
+"""
+
+
+class QueryWithDefinedColumnsTest(TestCase):
+    """Test case for query with defined columns (column name is reserved
+    DB keyword)
+    """
+
+    # Setup variables to be used for outputs
+    vector_points = "points"
+
+    @classmethod
+    def setUpClass(cls):
+        """Create points with reserved DB keyword column name"""
+        cls.runModule(
+            "v.in.ascii",
+            input="-",
+            stdin_=POINTS,
+            cat=0,
+            separator="comma",
+            output=cls.vector_points,
+            columns='x double precision, y double precision, "order" integer',
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove the test data"""
+        cls.runModule("g.remove", flags="f", type="vector", name=cls.vector_points)
+
+    def test_query_with_defined_columns(self):
+        """Test query with defined columns param arg"""
+        data = gs.read_command(
+            "v.db.select",
+            map=self.vector_points,
+            columns="cat,order",
+        )
+        self.assertEqual(data, "cat|order\n1|1\n2|2\n")
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
Fix escaping SQL columns names with SQL standard double quotes if v.db.select module `columns` param arg is used.


[Example](https://github.com/OSGeo/grass/issues/3604#issuecomment-2058805737) for testing purpose.

v.db.select module with `columns` param arg should sucessfully return columns data in the case when column name **order** is DB reserved keyword:

```
GRASS hybas/PERMANENT:~ > v.db.select hybas_lake_eu_lev01_v1c column=cat,order
cat|order
1|0
```

