### PR TITLE
CI: revert coverity to simple submitting method, temporary disable cron

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,11 +3,11 @@ name: Coverity Scan
 
 on:
   workflow_dispatch: # run whenever a contributor calls it
-  schedule:
-    - cron: '48 5 * * *' # Run at 05:48
-    # Coverity will let GRASS do a scan a maximum of twice per day, so this
-    # schedule will help GRASS fit within that limit with some additional space
-    # for manual runs
+#  schedule:
+#    - cron: '48 5 * * *' # Run at 05:48
+#    # Coverity will let GRASS do a scan a maximum of twice per day, so this
+#    # schedule will help GRASS fit within that limit with some additional space
+#    # for manual runs
 permissions:
   contents: read
   # action based off of
@@ -33,7 +33,7 @@ jobs:
       - name: Download Coverity Build Tool
         run: |
           wget -q https://scan.coverity.com/download/cxx/linux64 \
-            --post-data "token=$TOKEN&project=grass" -O cov-analysis-linux64.tar.gz
+            --post-data "token=${TOKEN}&project=grass" -O cov-analysis-linux64.tar.gz
           mkdir cov-analysis-linux64
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
         env:
@@ -84,7 +84,7 @@ jobs:
       - name: Build with cov-build
         run: |
           pwd
-          export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
+          export PATH="$(pwd)/cov-analysis-linux64/bin:${PATH}"
           cov-build --dir cov-int make
 
       - name: Put results into Tarball
@@ -97,36 +97,21 @@ jobs:
           name: grass.tgz
           path: grass.tgz
 
-      - name: Initialize Build in Coverity Cloud
+      - name: Submit to Coverity Scan
         run: |
-          curl -X POST \
-          -d version="main" \
-          -d description="$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short HEAD)" \
-          -d email=$EMAIL \
-          -d token=$TOKEN \
-          -d file_name="grass.tgz" \
-          https://scan.coverity.com/projects/1038/builds/init \
-          | tee response
+          version=$(head -n 3 include/VERSION | xargs | sed 's/ /./g')
+          commit=$(git rev-parse --short HEAD)
+          branch=$(git rev-parse --abbrev-ref HEAD)
+          desc="Version%3A${version}%2C%20commit%3${commit}%2C%20branch%3A${branch}."
+          echo "Submitting ${desc}"
+          tar czvf grass.tgz cov-int
+          curl \
+            --form "token=${TOKEN}" \
+            --form "email=${EMAIL}" \
+            --form "file=@grass.tgz" \
+            --form "version=${version}-${commit}" \
+            --form "description=${desc}" \
+            'https://scan.coverity.com/builds?project=grass'
         env:
           TOKEN: ${{ secrets.COVERITY_PASSPHRASE }}
           EMAIL: ${{ secrets.COVERITY_USER }}
-
-      - name: Save Upload URL and Build ID from Initialization Response
-        run: |
-          echo "UPLOAD_URL=$(jq -r '.url' response)" >> $GITHUB_ENV
-          echo "BUILD_ID=$(jq -r '.build_id' response)" >> $GITHUB_ENV
-
-      - name: Upload the tarball to the Cloud
-        run: |
-          export COV_RES_PATH="$(pwd)/grass.tgz"
-          curl -X PUT \
-            --header 'Content-Type: application/json' \
-            --upload-file $COV_RES_PATH \
-            $UPLOAD_URL
-      - name: Trigger the build on Scan
-        run: |
-          curl -X PUT \
-          -d token=$TOKEN \
-          https://scan.coverity.com/projects/1038/builds/$BUILD_ID/enqueue
-        env:
-          TOKEN: ${{ secrets.COVERITY_PASSPHRASE }}


### PR DESCRIPTION
Revert Coverity Scan workflow to the simple (one-step) submitting method, with some minor moderations. The multi-step version was not needed nor was the solution to fix the problem we have getting this to work.

I manually submitted the runner build artifact online and it started the analysis. I later tried a second time to submit the same build file now via command line (using the same curl command as in this PR), again successful. So this _should_ work.

I did notice a message online after the first online submission, that the analysis was put in queue with three jobs ahead. I don't know if those jobs were ours, or for the system in total. Anyways, with the two submissions, the daily quota was reached, only in ~16 hrs from now will the next one be permitted. As long as we're working this out, I disabled the cron, to be able to chose the time of submission.

With the successful submission, we have a fresh and up-to-date analysis online. It is now possible to work with that data as of now (no need to wait for this CI runner to work as expected).