### PR TITLE
r.horizon: address coverity scan 'Null pointer dereferences'

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -1271,7 +1271,6 @@ void calculate_raster_mode(const Settings *settings, const Geometry *geometry,
             angle * rad2deg);
 
         Rast_write_history(shad_filename, &history);
-        if (shad_filename)
-            G_free(shad_filename);
+        G_free(shad_filename);
     }
 }


### PR DESCRIPTION
This should address this (I think)
```
*** CID 1543994:  Null pointer dereferences  (REVERSE_INULL)
/raster/r.horizon/main.c: 1274 in calculate_raster_mode()
1268             Rast_append_format_history(
1269                 &history,
1270                 "Horizon view from azimuth angle %.2f degrees CCW from East",
1271                 angle * rad2deg);
1272     
1273             Rast_write_history(shad_filename, &history);
>>>     CID 1543994:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "shad_filename" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
1274             if (shad_filename)
1275                 G_free(shad_filename);
1276         }
```