### PR TITLE
doc: renaming location to project continued

### DIFF
--- a/general/g.mapsets/tests/conftest.py
+++ b/general/g.mapsets/tests/conftest.py
@@ -28,7 +28,7 @@ def simple_dataset(tmp_path_factory):
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         # Create Mock Mapsets
         for mapset in TEST_MAPSETS:
-            gs.run_command("g.mapset", location=location, mapset=mapset, flags="c")
+            gs.run_command("g.mapset", project=location, mapset=mapset, flags="c")
 
         yield SimpleNamespace(
             mapsets=TEST_MAPSETS, accessible_mapsets=ACCESSIBLE_MAPSETS

--- a/raster/r.external/main.c
+++ b/raster/r.external/main.c
@@ -98,10 +98,9 @@ int main(int argc, char *argv[])
 
     flag.o = G_define_flag();
     flag.o->key = 'o';
-    flag.o->label =
-        _("Override projection check (use current location's projection)");
-    flag.o->description = _(
-        "Assume that the dataset has same projection as the current location");
+    flag.o->label = _("Override projection check (use current project's CRS)");
+    flag.o->description = _("Assume that the dataset has the same coordinate "
+                            "reference system as the current project");
 
     flag.j = G_define_flag();
     flag.j->key = 'j';

--- a/raster/r.external/proj.c
+++ b/raster/r.external/proj.c
@@ -130,15 +130,16 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
     if (outloc != NULL) {
         /* do not create a xy location if an existing SRS was unreadable */
         if (proj_trouble == 2) {
-            G_fatal_error(_("Unable to convert input map projection to GRASS "
-                            "format; cannot create new location."));
+            G_fatal_error(
+                _("Unable to convert input map coordinate reference "
+                  "system to GRASS format; cannot create new project."));
         }
         else {
             if (0 != G_make_location_crs(outloc, cellhd, proj_info, proj_units,
                                          srid, wkt)) {
-                G_fatal_error(_("Unable to create new location <%s>"), outloc);
+                G_fatal_error(_("Unable to create new project <%s>"), outloc);
             }
-            G_message(_("Location <%s> created"), outloc);
+            G_message(_("Project <%s> created"), outloc);
 
             G_unset_window(); /* new location, projection, and window */
             G_get_window(cellhd);
@@ -195,14 +196,15 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
                                               proj_info, proj_units)) != 1) {
             int i_value;
 
-            strcpy(error_msg, _("Projection of dataset does not"
-                                " appear to match current location.\n\n"));
+            strcpy(error_msg,
+                   _("Coordinate reference system of dataset does not"
+                     " appear to match current project.\n\n"));
 
             /* TODO: output this info sorted by key: */
             if (loc_wind.proj != cellhd->proj || err != -2) {
                 /* error in proj_info */
                 if (loc_proj_info != NULL) {
-                    strcat(error_msg, _("Location PROJ_INFO is:\n"));
+                    strcat(error_msg, _("Project PROJ_INFO is:\n"));
                     for (i_value = 0; i_value < loc_proj_info->nitems;
                          i_value++)
                         sprintf(error_msg + strlen(error_msg), "%s: %s\n",
@@ -211,22 +213,22 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
                     strcat(error_msg, "\n");
                 }
                 else {
-                    strcat(error_msg, _("Location PROJ_INFO is:\n"));
+                    strcat(error_msg, _("Project PROJ_INFO is:\n"));
                     if (loc_wind.proj == PROJECTION_XY)
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (unreferenced/unknown)\n",
+                                "Project proj = %d (unreferenced/unknown)\n",
                                 loc_wind.proj);
                     else if (loc_wind.proj == PROJECTION_LL)
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (lat/long)\n",
+                                "Project proj = %d (lat/long)\n",
                                 loc_wind.proj);
                     else if (loc_wind.proj == PROJECTION_UTM)
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (UTM), zone = %d\n",
+                                "Project proj = %d (UTM), zone = %d\n",
                                 loc_wind.proj, cellhd->zone);
                     else
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (unknown), zone = %d\n",
+                                "Project proj = %d (unknown), zone = %d\n",
                                 loc_wind.proj, cellhd->zone);
                 }
 
@@ -300,7 +302,7 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
             else {
                 /* error in proj_units */
                 if (loc_proj_units != NULL) {
-                    strcat(error_msg, "Location PROJ_UNITS is:\n");
+                    strcat(error_msg, "Project PROJ_UNITS is:\n");
                     for (i_value = 0; i_value < loc_proj_units->nitems;
                          i_value++)
                         sprintf(error_msg + strlen(error_msg), "%s: %s\n",
@@ -318,13 +320,14 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
                 }
             }
             if (!check_only) {
-                strcat(error_msg, _("\nIn case of no significant differences "
-                                    "in the projection definitions,"
-                                    " use the -o flag to ignore them and use"
-                                    " current location definition.\n"));
-                strcat(error_msg, _("Consider generating a new location from "
+                strcat(error_msg,
+                       _("\nIn case of no significant differences "
+                         "in the coordinate reference system definitions,"
+                         " use the -o flag to ignore them and use"
+                         " current project definition.\n"));
+                strcat(error_msg, _("Consider generating a new project from "
                                     "the input dataset using "
-                                    "the 'location' parameter.\n"));
+                                    "the 'project' parameter.\n"));
             }
 
             if (check_only)
@@ -342,8 +345,8 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, char *outloc,
                 msg_fn = G_message;
             else
                 msg_fn = G_verbose_message;
-            msg_fn(_("Projection of input dataset and current location "
-                     "appear to match"));
+            msg_fn(_("Coordinate reference system of input dataset and current "
+                     "project appear to match"));
             if (check_only) {
                 GDALClose(hDS);
                 exit(EXIT_SUCCESS);

--- a/raster/r.in.lidar/main.c
+++ b/raster/r.in.lidar/main.c
@@ -300,9 +300,10 @@ int main(int argc, char *argv[])
     over_flag = G_define_flag();
     over_flag->key = 'o';
     over_flag->label =
-        _("Override projection check (use current location's projection)");
-    over_flag->description = _(
-        "Assume that the dataset has same projection as the current location");
+        _("Override projection check (use current project's CRS)");
+    over_flag->description =
+        _("Assume that the dataset has the same coordinate reference system as "
+          "the current project");
 
     scan_flag = G_define_flag();
     scan_flag->key = 's';

--- a/raster/r.in.lidar/projection.c
+++ b/raster/r.in.lidar/projection.c
@@ -29,8 +29,8 @@ void projection_mismatch_report(struct Cell_head cellhd,
     int i_value;
     char error_msg[8192];
 
-    strcpy(error_msg, _("Projection of dataset does not"
-                        " appear to match current location.\n\n"));
+    strcpy(error_msg, _("Coordinate reference system of dataset does not"
+                        " appear to match current project.\n\n"));
 
     /* TODO: output this info sorted by key: */
     if (loc_wind.proj != cellhd.proj || err != -2) {
@@ -86,12 +86,12 @@ void projection_mismatch_report(struct Cell_head cellhd,
         }
     }
     sprintf(error_msg + strlen(error_msg),
-            _("\nIn case of no significant differences in the projection "
-              "definitions,"
+            _("\nIn case of no significant differences"
+              " in the coordinate reference system definitions,"
               " use the -o flag to ignore them and use"
-              " current location definition.\n"));
+              " current project definition.\n"));
     strcat(error_msg,
-           _("Consider generating a new location with 'location' parameter"
+           _("Consider generating a new project with 'project' parameter"
              " from input data set.\n"));
     G_fatal_error("%s", error_msg);
 }
@@ -132,7 +132,8 @@ void projection_check_wkt(struct Cell_head cellhd, struct Cell_head loc_wind,
                                    loc_proj_units, proj_info, proj_units, err);
     }
     else if (verbose) {
-        G_message(_("Projection of input dataset and current location "
-                    "appear to match"));
+        G_message(_(
+            "Coordinate reference system of input dataset and current project "
+            "appear to match"));
     }
 }

--- a/raster/r.in.lidar/r.in.lidar.html
+++ b/raster/r.in.lidar/r.in.lidar.html
@@ -464,7 +464,7 @@ r.in.lidar -p input="Serpent Mound Model LAS Data.las"
 
 # using v.in.lidar to create a new project
 # create project with CRS information of the LAS data
-v.in.lidar -i input="Serpent Mound Model LAS Data.las" location=Serpent_Mound
+v.in.lidar -i input="Serpent Mound Model LAS Data.las" project=Serpent_Mound
 
 # quit and restart GRASS in the newly created project "Serpent_Mound"
 

--- a/raster/r.in.pdal/main.cpp
+++ b/raster/r.in.pdal/main.cpp
@@ -248,10 +248,10 @@ int main(int argc, char *argv[])
 
     reproject_flag->key = 'w';
     reproject_flag->label =
-        _("Reproject to location's coordinate system if needed");
+        _("Reproject to project's coordinate system if needed");
     reproject_flag->description =
         _("Reprojects input dataset to the coordinate system of"
-          " the GRASS location (by default only datasets with the"
+          " the GRASS project (by default only datasets with the"
           " matching coordinate system can be imported");
     reproject_flag->guisection = _("Projection");
 
@@ -393,9 +393,10 @@ int main(int argc, char *argv[])
 
     over_flag->key = 'o';
     over_flag->label =
-        _("Override projection check (use current location's projection)");
-    over_flag->description = _(
-        "Assume that the dataset has same projection as the current location");
+        _("Override projection check (use current project's CRS)");
+    over_flag->description =
+        _("Assume that the dataset has the same coordinate reference system as "
+          "the current project");
     over_flag->guisection = _("Projection");
 
     Flag *base_rast_res_flag = G_define_flag();
@@ -731,7 +732,7 @@ int main(int argc, char *argv[])
 
     // we reproject when requested regardless of the input projection
     if (reproject_flag->answer) {
-        G_message(_("Reprojecting the input to the location projection"));
+        G_message(_("Reprojecting the input to the project's CRS"));
         char *proj_wkt = location_projection_as_wkt(false);
 
         pdal::Options o4;
@@ -781,8 +782,8 @@ int main(int argc, char *argv[])
     // getting projection is possible only after prepare
     if (over_flag->answer) {
         G_important_message(_("Overriding projection check and assuming"
-                              " that the projection of input matches"
-                              " the location projection"));
+                              " that the CRS of input matches"
+                              " the project's CRS"));
     }
     else if (!reproject_flag->answer) {
         pdal::SpatialReference spatial_reference =

--- a/raster/r.in.pdal/projection.c
+++ b/raster/r.in.pdal/projection.c
@@ -27,8 +27,8 @@ void projection_mismatch_report(struct Cell_head cellhd,
     int i_value;
     char error_msg[8192];
 
-    strcpy(error_msg, _("Projection of dataset does not"
-                        " appear to match current location.\n\n"));
+    strcpy(error_msg, _("Coordinate reference system of dataset does not"
+                        " appear to match current project.\n\n"));
 
     /* TODO: output this info sorted by key: */
     if (loc_wind.proj != cellhd.proj || err != -2) {
@@ -84,12 +84,12 @@ void projection_mismatch_report(struct Cell_head cellhd,
         }
     }
     sprintf(error_msg + strlen(error_msg),
-            _("\nIn case of no significant differences in the projection "
-              "definitions,"
+            _("\nIn case of no significant differences"
+              " in the coordinate reference system definitions,"
               " use the -o flag to ignore them and use"
-              " current location definition.\n"));
+              " current project definition.\n"));
     strcat(error_msg,
-           _("Consider generating a new location with 'location' parameter"
+           _("Consider generating a new project with 'project' parameter"
              " from input data set.\n"));
     G_fatal_error("%s", error_msg);
 }
@@ -131,8 +131,8 @@ void projection_check_wkt(struct Cell_head cellhd, struct Cell_head loc_wind,
     }
     else {
         if (verbose) {
-            G_message(_("Projection of input dataset and current location "
-                        "appear to match"));
+            G_message(_("Coordinate reference system of input dataset and "
+                        "current project appear to match"));
         }
     }
 }

--- a/raster/r.in.pdal/r.in.pdal.html
+++ b/raster/r.in.pdal/r.in.pdal.html
@@ -522,7 +522,7 @@ r.in.pdal -p input="Serpent Mound Model LAS Data.las"
 
 # using v.in.lidar to create a new project
 # create a project with CRS information of the LAS data
-v.in.lidar -i input="Serpent Mound Model LAS Data.las" location=Serpent_Mound
+v.in.lidar -i input="Serpent Mound Model LAS Data.las" project=Serpent_Mound
 
 # quit and restart GRASS in the newly created project "Serpent_Mound"
 

--- a/raster3d/r3.in.lidar/main.c
+++ b/raster3d/r3.in.lidar/main.c
@@ -287,9 +287,9 @@ int main(int argc, char *argv[])
     over_flag = G_define_flag();
     over_flag->key = 'o';
     over_flag->label =
-        _("Override projection check (use current location's projection)");
-    over_flag->description = _(
-        "Assume that the dataset has same projection as the current location");
+        _("Override projection check (use current projects's CRS)");
+    over_flag->description = _("Assume that the dataset has same coordinate "
+                               "reference system as the current project");
 
     print_flag = G_define_flag();
     print_flag->key = 'p';

--- a/raster3d/r3.in.lidar/projection.c
+++ b/raster3d/r3.in.lidar/projection.c
@@ -30,8 +30,8 @@ void projection_mismatch_report(struct Cell_head cellhd,
     int i_value;
     char error_msg[8192];
 
-    strcpy(error_msg, _("Projection of dataset does not"
-                        " appear to match current location.\n\n"));
+    strcpy(error_msg, _("Coordinate reference system of dataset does not"
+                        " appear to match current project.\n\n"));
 
     /* TODO: output this info sorted by key: */
     if (loc_wind.proj != cellhd.proj || err != -2) {
@@ -87,12 +87,12 @@ void projection_mismatch_report(struct Cell_head cellhd,
         }
     }
     sprintf(error_msg + strlen(error_msg),
-            _("\nIn case of no significant differences in the projection "
-              "definitions,"
+            _("\nIn case of no significant differences in the"
+              " coordinate reference system definitions,"
               " use the -o flag to ignore them and use"
-              " current location definition.\n"));
+              " current project definition.\n"));
     strcat(error_msg,
-           _("Consider generating a new location with 'location' parameter"
+           _("Consider generating a new project with 'project' parameter"
              " from input data set.\n"));
     G_fatal_error("%s", error_msg);
 }
@@ -133,7 +133,8 @@ void projection_check_wkt(struct Cell_head cellhd, struct Cell_head loc_wind,
                                    loc_proj_units, proj_info, proj_units, err);
     }
     else if (verbose) {
-        G_message(_("Projection of input dataset and current location "
-                    "appear to match"));
+        G_message(_(
+            "Coordinate reference system of input dataset and current project "
+            "appear to match"));
     }
 }

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -30,8 +30,8 @@
 # %end
 # %flag
 # % key: o
-# % label: Override projection check (use current location's projection)
-# % description: Assume that the dataset has same projection as the current location
+# % label: Override projection check (use current projects's CRS)
+# % description: Assume that the dataset has same coordinate reference system as the current project
 # % guisection: Output settings
 # %end
 # %flag
@@ -140,9 +140,7 @@ def main():
     # check projection compatibility in a rather crappy way
 
     if flags["o"]:
-        grass.warning(
-            _("Overriding projection check (using current location's projection).")
-        )
+        grass.warning(_("Overriding projection check (using current project's CRS)."))
 
     else:
         diff_result_1 = diff_result_2 = None
@@ -155,7 +153,7 @@ def main():
             if os.path.exists(proj_info_file_2):
                 grass.fatal(
                     _(
-                        "PROJ_INFO file is missing, unpack raster map in XY (unprojected) location."
+                        "PROJ_INFO file is missing, unpack raster map in XY (unprojected) project."
                     )
                 )
             skip_projection_check = True  # XY location
@@ -179,22 +177,23 @@ def main():
                     grass.warning(
                         _(
                             "Difference between PROJ_INFO file of packed map "
-                            "and of current location:\n{diff}"
+                            "and of current project:\n{diff}"
                         ).format(diff="".join(diff_result_1))
                     )
                 if diff_result_2:
                     grass.warning(
                         _(
                             "Difference between PROJ_UNITS file of packed map "
-                            "and of current location:\n{diff}"
+                            "and of current project:\n{diff}"
                         ).format(diff="".join(diff_result_2))
                     )
                 grass.fatal(
                     _(
-                        "Projection of dataset does not appear to match current location."
-                        " In case of no significant differences in the projection definitions,"
+                        "Coordinate reference system of dataset does"
+                        " not appear to match current project."
+                        " In case of no significant differences in the CRS definitions,"
                         " use the -o flag to ignore them and use"
-                        " current location definition."
+                        " current project definition."
                     )
                 )
 

--- a/scripts/v.import/v.import.html
+++ b/scripts/v.import/v.import.html
@@ -64,46 +64,6 @@ refer to the <em>v.clean</em> manual page.
 v.import input=research_area.shp output=research_area extent=input
 </pre></div>
 
-<h2>ERROR MESSAGES</h2>
-
-<h3>SQL syntax errors</h3>
-
-Depending on the currently selected SQL driver, error messages such as follows may arise:
-
-<div class="code"><pre>
-DBMI-SQLite driver error:
-Error in sqlite3_prepare():
-near "ORDER": syntax error
-</pre></div>
-
-Or:
-
-<div class="code"><pre>
-DBMI-DBF driver error:
-SQL parser error:
-syntax error, unexpected DESC, expecting NAME processing 'DESC
-</pre></div>
-
-This indicates that a column name in the input dataset corresponds to a reserved
-SQL word (here: 'ORDER' and 'DESC' respectively). A different column name has to be
-used in this case. The <b>columns</b> parameter can be used to assign different
-column names on the fly in order to avoid using reserved SQL words.
-
-For a list of SQL reserved words for SQLite (the default driver),
-see <a href="https://www.sqlite.org/lang_keywords.html">here</a>.
-
-<h3>Projection errors</h3>
-
-<div class="code"><pre>
-Projection of dataset does not appear to match the current project.
-</pre></div>
-
-Here you need to create or use a project whose CRS matches that
-of the vector data you wish to import. Try using <b>location</b> parameter to
-create a new project based upon the CRS information in the file. If
-desired, you can then re-project it to another project
-with <em><a href="v.proj.html">v.proj</a></em>.
-
 <h2>SEE ALSO</h2>
 
 <em>

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -32,8 +32,8 @@
 # %end
 # %flag
 # % key: o
-# % label: Override projection check (use current location's projection)
-# % description: Assume that the dataset has same projection as the current location
+# % label: Override projection check (use current projects's CRS)
+# % description: Assume that the dataset has same coordinate reference system as the current project
 # % guisection: Output settings
 # %end
 # %flag
@@ -154,7 +154,7 @@ def main():
         if os.path.exists(loc_proj):
             grass.fatal(
                 _(
-                    "PROJ_INFO file is missing, unpack vector map in XY (unprojected) location."
+                    "PROJ_INFO file is missing, unpack vector map in XY (unprojected) project."
                 )
             )
         skip_projection_check = True  # XY location
@@ -185,22 +185,23 @@ def main():
                     grass.warning(
                         _(
                             "Difference between PROJ_INFO file of packed map "
-                            "and of current location:\n{diff}"
+                            "and of current project:\n{diff}"
                         ).format(diff="".join(diff_result_1))
                     )
                 if diff_result_2:
                     grass.warning(
                         _(
                             "Difference between PROJ_UNITS file of packed map "
-                            "and of current location:\n{diff}"
+                            "and of current project:\n{diff}"
                         ).format(diff="".join(diff_result_2))
                     )
                 grass.fatal(
                     _(
-                        "Projection of dataset does not appear to match current location."
-                        " In case of no significant differences in the projection definitions,"
+                        "Coordinate reference system of dataset does not"
+                        " appear to match current project."
+                        " In case of no significant differences in the CRS definitions,"
                         " use the -o flag to ignore them and use"
-                        " current location definition."
+                        " current project definition."
                     )
                 )
 

--- a/vector/v.external/args.c
+++ b/vector/v.external/args.c
@@ -46,9 +46,10 @@ void parse_args(int argc, char **argv, struct _options *options,
     flags->override = G_define_flag();
     flags->override->key = 'o';
     flags->override->label =
-        _("Override projection check (use current location's projection)");
-    flags->override->description = _("Assume that the dataset has the same "
-                                     "projection as the current location");
+        _("Override projection check (use current project's CRS)");
+    flags->override->description =
+        _("Assume that the dataset has the same "
+          "coordinate reference system as the current project");
 
     flags->proj = G_define_flag();
     flags->proj->key = 'j';

--- a/vector/v.external/proj.c
+++ b/vector/v.external/proj.c
@@ -163,15 +163,15 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
         /* do not create a xy location because this can mean that the
          * real SRS has not been recognized or is missing */
         if (proj_trouble) {
-            G_fatal_error(_("Unable to convert input map projection to GRASS "
-                            "format; cannot create new location."));
+            G_fatal_error(_("Unable to convert input map CRS to GRASS "
+                            "format; cannot create new project."));
         }
         else {
             if (0 != G_make_location_crs(outloc, cellhd, proj_info, proj_units,
                                          srid, wkt)) {
-                G_fatal_error(_("Unable to create new location <%s>"), outloc);
+                G_fatal_error(_("Unable to create new project <%s>"), outloc);
             }
-            G_message(_("Location <%s> created"), outloc);
+            G_message(_("Project <%s> created"), outloc);
 
             G_unset_window(); /* new location, projection, and window */
             G_get_window(cellhd);
@@ -232,14 +232,15 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
                                               proj_info, proj_units)) != 1) {
             int i_value;
 
-            strcpy(error_msg, _("Projection of dataset does not"
-                                " appear to match current location.\n\n"));
+            strcpy(error_msg,
+                   _("Coordinate reference system of dataset does not"
+                     " appear to match current project.\n\n"));
 
             /* TODO: output this info sorted by key: */
             if (loc_wind.proj != cellhd->proj || err != -2) {
                 /* error in proj_info */
                 if (loc_proj_info != NULL) {
-                    strcat(error_msg, _("Location PROJ_INFO is:\n"));
+                    strcat(error_msg, _("Project PROJ_INFO is:\n"));
                     for (i_value = 0; i_value < loc_proj_info->nitems;
                          i_value++)
                         sprintf(error_msg + strlen(error_msg), "%s: %s\n",
@@ -248,22 +249,22 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
                     strcat(error_msg, "\n");
                 }
                 else {
-                    strcat(error_msg, _("Location PROJ_INFO is:\n"));
+                    strcat(error_msg, _("Project PROJ_INFO is:\n"));
                     if (loc_wind.proj == PROJECTION_XY)
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (unreferenced/unknown)\n",
+                                "Project proj = %d (unreferenced/unknown)\n",
                                 loc_wind.proj);
                     else if (loc_wind.proj == PROJECTION_LL)
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (lat/long)\n",
+                                "Project proj = %d (lat/long)\n",
                                 loc_wind.proj);
                     else if (loc_wind.proj == PROJECTION_UTM)
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (UTM), zone = %d\n",
+                                "Project proj = %d (UTM), zone = %d\n",
                                 loc_wind.proj, cellhd->zone);
                     else
                         sprintf(error_msg + strlen(error_msg),
-                                "Location proj = %d (unknown), zone = %d\n",
+                                "Project proj = %d (unknown), zone = %d\n",
                                 loc_wind.proj, cellhd->zone);
                 }
 
@@ -337,7 +338,7 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
             else {
                 /* error in proj_units */
                 if (loc_proj_units != NULL) {
-                    strcat(error_msg, "Location PROJ_UNITS is:\n");
+                    strcat(error_msg, "Project PROJ_UNITS is:\n");
                     for (i_value = 0; i_value < loc_proj_units->nitems;
                          i_value++)
                         sprintf(error_msg + strlen(error_msg), "%s: %s\n",
@@ -355,13 +356,14 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
                 }
             }
             if (!check_only) {
-                strcat(error_msg, _("\nIn case of no significant differences "
-                                    "in the projection definitions,"
-                                    " use the -o flag to ignore them and use"
-                                    " current location definition.\n"));
-                strcat(error_msg, _("Consider generating a new location from "
+                strcat(error_msg,
+                       _("\nIn case of no significant differences "
+                         "in the coordinate reference system definitions,"
+                         " use the -o flag to ignore them and use"
+                         " current project definition.\n"));
+                strcat(error_msg, _("Consider generating a new project from "
                                     "the input dataset using "
-                                    "the 'location' parameter.\n"));
+                                    "the 'project' parameter.\n"));
             }
 
             if (check_only)
@@ -379,8 +381,8 @@ void check_projection(struct Cell_head *cellhd, GDALDatasetH hDS, int layer,
                 msg_fn = G_message;
             else
                 msg_fn = G_verbose_message;
-            msg_fn(_("Projection of input dataset and current location "
-                     "appear to match"));
+            msg_fn(_("Coordinate reference system of input dataset and current "
+                     "project appear to match"));
             if (check_only) {
                 GDALClose(hDS);
                 exit(EXIT_SUCCESS);

--- a/vector/v.in.lidar/main.c
+++ b/vector/v.in.lidar/main.c
@@ -270,10 +270,10 @@ int main(int argc, char *argv[])
     limit_opt->guisection = _("Decimation");
 
     outloc_opt = G_define_option();
-    outloc_opt->key = "location";
+    outloc_opt->key = "project";
     outloc_opt->type = TYPE_STRING;
     outloc_opt->required = NO;
-    outloc_opt->description = _("Name for new location to create");
+    outloc_opt->description = _("Name for new project (location) to create");
     outloc_opt->key_desc = "name";
 
     print_flag = G_define_flag();
@@ -319,15 +319,16 @@ int main(int argc, char *argv[])
     over_flag = G_define_flag();
     over_flag->key = 'o';
     over_flag->label =
-        _("Override projection check (use current location's projection)");
-    over_flag->description = _(
-        "Assume that the dataset has same projection as the current location");
+        _("Override projection check (use current project's CRS)");
+    over_flag->description =
+        _("Assume that the dataset has the same coordinate reference system as "
+          "the current project");
 
     no_import_flag = G_define_flag();
     no_import_flag->key = 'i';
-    no_import_flag->description = _(
-        "Create the location specified by the \"location\" parameter and exit."
-        " Do not import the vector data.");
+    no_import_flag->description =
+        _("Create the project specified by the \"project\" parameter and exit."
+          " Do not import the vector data.");
     no_import_flag->suppress_required = YES;
 
     G_option_exclusive(skip_opt, preserve_opt, NULL);
@@ -512,16 +513,16 @@ int main(int argc, char *argv[])
          * assume the user has a terminal open */
         if (GPJ_wkt_to_grass(&cellhd, &proj_info, &proj_units, projstr, 0) <
             0) {
-            G_fatal_error(_("Unable to convert input map projection to GRASS "
-                            "format; cannot create new location."));
+            G_fatal_error(_("Unable to convert input map CRS to GRASS "
+                            "format; cannot create new project."));
         }
         else {
             if (0 != G_make_location(outloc_opt->answer, &cellhd, proj_info,
                                      proj_units)) {
-                G_fatal_error(_("Unable to create new location <%s>"),
+                G_fatal_error(_("Unable to create new project <%s>"),
                               outloc_opt->answer);
             }
-            G_message(_("Location <%s> created"), outloc_opt->answer);
+            G_message(_("Project <%s> created"), outloc_opt->answer);
         }
 
         /* If the i flag is set, clean up? and exit here */
@@ -529,7 +530,7 @@ int main(int argc, char *argv[])
             exit(EXIT_SUCCESS);
 
         /*  TODO: */
-        G_warning("Import into new location not yet implemented");
+        G_warning("Import into new project not yet implemented");
         /* at this point the module should be using G_create_alt_env()
            to change context to the newly created location; once done
            it should switch back with G_switch_env(). See r.in.gdal */

--- a/vector/v.in.lidar/projection.c
+++ b/vector/v.in.lidar/projection.c
@@ -27,8 +27,8 @@ void projection_mismatch_report(struct Cell_head cellhd,
     int i_value;
     char error_msg[8192];
 
-    strcpy(error_msg, _("Projection of dataset does not"
-                        " appear to match current location.\n\n"));
+    strcpy(error_msg, _("Coordinate reference system of dataset does not"
+                        " appear to match current project.\n\n"));
 
     /* TODO: output this info sorted by key: */
     if (loc_wind.proj != cellhd.proj || err != -2) {
@@ -84,12 +84,12 @@ void projection_mismatch_report(struct Cell_head cellhd,
         }
     }
     sprintf(error_msg + strlen(error_msg),
-            _("\nIn case of no significant differences in the projection "
-              "definitions,"
+            _("\nIn case of no significant differences"
+              " in the coordinate reference system definitions,"
               " use the -o flag to ignore them and use"
-              " current location definition.\n"));
+              " current project definition.\n"));
     strcat(error_msg,
-           _("Consider generating a new location with 'location' parameter"
+           _("Consider generating a new project with 'project' parameter"
              " from input data set.\n"));
     G_fatal_error("%s", error_msg);
 }
@@ -130,7 +130,8 @@ void projection_check_wkt(struct Cell_head cellhd, struct Cell_head loc_wind,
                                    loc_proj_units, proj_info, proj_units, err);
     }
     else if (verbose) {
-        G_message(_("Projection of input dataset and current location "
-                    "appear to match"));
+        G_message(_(
+            "Coordinate reference system of input dataset and current project "
+            "appear to match"));
     }
 }

--- a/vector/v.in.lidar/v.in.lidar.html
+++ b/vector/v.in.lidar/v.in.lidar.html
@@ -91,7 +91,7 @@ system of the source data and the current project, they may pass the
 <p>If the user wishes to import the data with the full CRS definition,
 it is possible to have <em>v.in.lidar</em> automatically create a new project based
 on the CRS and extents of the file being read.  This is accomplished
-by passing the name to be used for the new project via the <b>location</b>
+by passing the name to be used for the new project via the <b>project</b>
 parameter.  Upon completion of the command, a new project will have been
 created (with only a PERMANENT mapset), and the vector map will have been
 imported with the indicated <b>output</b> name into the PERMANENT mapset.
@@ -116,7 +116,7 @@ available at
   v.in.lidar -p input="Serpent Mound Model LAS Data.las"
 
   # create a project with CRS information of the LAS data
-  v.in.lidar -i input="Serpent Mound Model LAS Data.las" location=Serpent_Mound
+  v.in.lidar -i input="Serpent Mound Model LAS Data.las" project=Serpent_Mound
 
   # quit and restart GRASS in the newly created project "Serpent_Mound"
   # real import of LiDAR LAS data, without topology and without attribute table

--- a/vector/v.in.pdal/main.cpp
+++ b/vector/v.in.pdal/main.cpp
@@ -212,19 +212,20 @@ int main(int argc, char *argv[])
     Flag *reproject_flag = G_define_flag();
     reproject_flag->key = 'w';
     reproject_flag->label =
-        _("Reproject to location's coordinate system if needed");
+        _("Reproject to projects's coordinate system if needed");
     reproject_flag->description =
         _("Reprojects input dataset to the coordinate system of"
-          " the GRASS location (by default only datasets with the"
+          " the GRASS project (by default only datasets with the"
           " matching coordinate system can be imported");
     reproject_flag->guisection = _("Projection");
 
     Flag *over_flag = G_define_flag();
     over_flag->key = 'o';
     over_flag->label =
-        _("Override projection check (use current location's projection)");
-    over_flag->description = _(
-        "Assume that the dataset has same projection as the current location");
+        _("Override projection check (use current project's CRS)");
+    over_flag->description =
+        _("Assume that the dataset has the same coordinate reference system as "
+          "the current project");
     over_flag->guisection = _("Projection");
 
     // TODO: from the API it seems that also prj file path and proj string will
@@ -347,7 +348,7 @@ int main(int argc, char *argv[])
 
     // we reproject when requested regardless the input projection
     if (reproject_flag->answer) {
-        G_message(_("Reprojecting the input to the location projection"));
+        G_message(_("Reprojecting the input to the project's CRS"));
         char *proj_wkt = location_projection_as_wkt(false);
         pdal::Options o4;
         // TODO: try catch for user input error
@@ -370,8 +371,8 @@ int main(int argc, char *argv[])
     // getting projection is possible only after prepare
     if (over_flag->answer) {
         G_important_message(_("Overriding projection check and assuming"
-                              " that the projection of input matches"
-                              " the location projection"));
+                              " that the CRS of input matches"
+                              " the project's CRS"));
     }
     else if (!reproject_flag->answer) {
         pdal::SpatialReference spatial_reference =

--- a/vector/v.in.pdal/projection.c
+++ b/vector/v.in.pdal/projection.c
@@ -27,8 +27,8 @@ void projection_mismatch_report(struct Cell_head cellhd,
     int i_value;
     char error_msg[8192];
 
-    strcpy(error_msg, _("Projection of dataset does not"
-                        " appear to match current location.\n\n"));
+    strcpy(error_msg, _("Coordinate reference system of the dataset does not"
+                        " appear to match current project.\n\n"));
 
     /* TODO: output this info sorted by key: */
     if (loc_wind.proj != cellhd.proj || err != -2) {
@@ -84,12 +84,12 @@ void projection_mismatch_report(struct Cell_head cellhd,
         }
     }
     sprintf(error_msg + strlen(error_msg),
-            _("\nIn case of no significant differences in the projection "
-              "definitions,"
+            _("\nIn case of no significant differences"
+              " in the coordinate reference system definitions,"
               " use the -o flag to ignore them and use"
-              " current location definition.\n"));
+              " current project definition.\n"));
     strcat(error_msg,
-           _("Consider generating a new location with 'location' parameter"
+           _("Consider generating a new project with 'project' parameter"
              " from input data set.\n"));
     G_fatal_error("%s", error_msg);
 }
@@ -131,8 +131,8 @@ void projection_check_wkt(struct Cell_head cellhd, struct Cell_head loc_wind,
     }
     else {
         if (verbose) {
-            G_message(_("Projection of input dataset and current location "
-                        "appear to match"));
+            G_message(_("Coordinate reference system of the input dataset and "
+                        "current project appear to match"));
         }
     }
 }


### PR DESCRIPTION
This PR replaces location with project (and projection with CRS in certain places) in documentation and messages for r/r3/v.in.lidar, r/v.external, r/v.in.pdal, r/v.unpack and v.import.