### PR TITLE
pytest: Enhance logging output with colors and summary

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - releasebranch_*
+      - "*"
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,9 +8,6 @@ on:
       - releasebranch_*
   pull_request:
     branches:
-      - main
-      - releasebranch_*
-      - "*"
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -66,7 +66,7 @@ jobs:
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
 
       - name: Build
-        run: .github/workflows/build_${{ matrix.os }}.sh $HOME/install -fdiagnostics-color
+        run: .github/workflows/build_${{ matrix.os }}.sh $HOME/install
 
       - name: Add the bin directory to PATH
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --numprocesses auto .
+          pytest --verbose --color=yes --numprocesses auto -ra .
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
-          pytest -ra --verbose --color=yes --numprocesses auto --dist worksteal .
+          pytest --verbose --color=yes --numprocesses auto .
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --numprocesses auto -ra .
+          pytest --verbose --color=yes --durations=50 --numprocesses auto -ra .
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=50 --numprocesses auto -ra .
+          pytest --verbose --color=yes --durations=0 --durations-min=0.5 --numprocesses auto -ra .
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
-          pytest --numprocesses auto .
+          pytest -ra --verbose --color=yes --numprocesses auto --dist worksteal .
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,9 @@ jobs:
       fail-fast: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      FORCE_COLOR: 1 # for software including pip: https://force-color.org/
+      CLICOLOR_FORCE: 1 # for other software including ninja: https://bixense.com/clicolors/
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -63,7 +66,7 @@ jobs:
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
 
       - name: Build
-        run: .github/workflows/build_${{ matrix.os }}.sh $HOME/install
+        run: .github/workflows/build_${{ matrix.os }}.sh $HOME/install -fdiagnostics-color
 
       - name: Add the bin directory to PATH
         run: |


### PR DESCRIPTION
To help read CI logs more easily, enabled colored output where possible (in CI only, for pytest workflow).

For pytest itself:
- added verbose output so we can see what test is running
- added colors so error results are WAY easier to read through (it even has syntax highlighting for python code)
- added a short summary of passed/skipped/failed/xfailed tests
- added the display of top durations for the test or the setup (I finally chose to not limit the number of items to output, but to raise the minimum duration for that list to ignore all durations under 0.5 sec instead of the default of 0.005s. 0.5s seems reasonable for what a slow unit test should be in my opinion. We have setup and test steps that take over 9 seconds as we can see from that)


<details><summary>Images</summary>
<p>

Colored pip with cache misses:
![image](https://github.com/OSGeo/grass/assets/27212526/62fa8a07-066b-42fd-a11d-7f61c380603d)

For errors/warnings, some I intentionnaly added to see how it looked
Colored gcc:
![image](https://github.com/OSGeo/grass/assets/27212526/986882d7-5f92-43ac-a6be-c85de7f471d4)

Colored pytest:
![image](https://github.com/OSGeo/grass/assets/27212526/5e176377-5e39-477f-a930-cd49c0a5a102)
![image](https://github.com/OSGeo/grass/assets/27212526/e273c06e-8f40-41ed-9aaf-4bf9748d936f)
![image](https://github.com/OSGeo/grass/assets/27212526/ae535244-acf7-4e80-8bca-5df2b01349b8)
![image](https://github.com/OSGeo/grass/assets/27212526/4d0b39c0-de6a-4409-a7d5-76134407408d)
![image](https://github.com/OSGeo/grass/assets/27212526/fe062f83-9fb0-4389-98ef-e21efa38b003)


</p>
</details> 
