### PR TITLE
v.db.renamecolumn: fix enclosing column name with SQL standard double quotes

### DIFF
--- a/scripts/v.db.renamecolumn/v.db.renamecolumn.py
+++ b/scripts/v.db.renamecolumn/v.db.renamecolumn.py
@@ -103,9 +103,9 @@ def main():
     # some tricks
     if driver in ["sqlite", "dbf"]:
         if oldcoltype.upper() == "CHARACTER":
-            colspec = f'"{newcol}" varchar({oldcollength})'
+            colspec = f"{newcol} varchar({oldcollength})"
         else:
-            colspec = f'"{newcol}" {oldcoltype}'
+            colspec = f"{newcol} {oldcoltype}"
 
         grass.run_command("v.db.addcolumn", map=map, layer=layer, column=colspec)
         sql = f'UPDATE {table} SET "{newcol}"="{oldcol}"'
@@ -119,7 +119,7 @@ def main():
         else:
             newcoltype = oldcoltype
 
-        sql = f'ALTER TABLE {table} CHANGE "{oldcol}" "{newcol}" "{newcoltype}"'
+        sql = f'ALTER TABLE {table} CHANGE "{oldcol}" "{newcol}" {newcoltype}'
         grass.write_command(
             "db.execute", input="-", database=database, driver=driver, stdin=sql
         )

--- a/scripts/v.db.renamecolumn/v.db.renamecolumn.py
+++ b/scripts/v.db.renamecolumn/v.db.renamecolumn.py
@@ -103,12 +103,12 @@ def main():
     # some tricks
     if driver in ["sqlite", "dbf"]:
         if oldcoltype.upper() == "CHARACTER":
-            colspec = "%s varchar(%s)" % (newcol, oldcollength)
+            colspec = f'"{newcol}" varchar({oldcollength})'
         else:
-            colspec = "%s %s" % (newcol, oldcoltype)
+            colspec = f'"{newcol}" {oldcoltype}'
 
         grass.run_command("v.db.addcolumn", map=map, layer=layer, column=colspec)
-        sql = "UPDATE %s SET %s=%s" % (table, newcol, oldcol)
+        sql = f'UPDATE {table} SET "{newcol}"="{oldcol}"'
         grass.write_command(
             "db.execute", input="-", database=database, driver=driver, stdin=sql
         )
@@ -119,12 +119,12 @@ def main():
         else:
             newcoltype = oldcoltype
 
-        sql = "ALTER TABLE %s CHANGE %s %s %s" % (table, oldcol, newcol, newcoltype)
+        sql = f'ALTER TABLE {table} CHANGE "{oldcol}" "{newcol}" "{newcoltype}"'
         grass.write_command(
             "db.execute", input="-", database=database, driver=driver, stdin=sql
         )
     else:
-        sql = "ALTER TABLE %s RENAME %s TO %s" % (table, oldcol, newcol)
+        sql = f'ALTER TABLE {table} RENAME "{oldcol}" TO "{newcol}"'
         grass.write_command(
             "db.execute", input="-", database=database, driver=driver, stdin=sql
         )


### PR DESCRIPTION
Enable to use column name which is reserved DB backend keyword.