### PR TITLE
v.db.dropcolumn: fix enclosing column name with SQL standard double quotes

### DIFF
--- a/scripts/v.db.dropcolumn/v.db.dropcolumn.py
+++ b/scripts/v.db.dropcolumn/v.db.dropcolumn.py
@@ -96,11 +96,11 @@ def main():
                 # see db_sqltype_name() for type names
                 if f[1] == "CHARACTER":
                     # preserve field length for sql type "CHARACTER"
-                    coltypes.append("%s %s(%s)" % (f[0], f[1], f[2]))
+                    coltypes.append(f'"{f[0]}" {f[1]}({f[2]})')
                 else:
-                    coltypes.append("%s %s" % (f[0], f[1]))
+                    coltypes.append(f'"{f[0]}" {f[1]}')
 
-            colnames = ", ".join(colnames)
+            colnames = ", ".join([f'"{col}"' for col in colnames])
             coltypes = ", ".join(coltypes)
 
             cmds = [

--- a/scripts/v.db.dropcolumn/v.db.dropcolumn.py
+++ b/scripts/v.db.dropcolumn/v.db.dropcolumn.py
@@ -119,7 +119,7 @@ def main():
                 table=table, coldef=coltypes, colnames=colnames, keycol=keycol
             )
         else:
-            sql = "ALTER TABLE %s DROP COLUMN %s" % (table, column)
+            sql = f'ALTER TABLE {table} DROP COLUMN "{column}"'
 
         try:
             grass.write_command(


### PR DESCRIPTION
Enable to use column name which is reserved DB backend keyword.