### PR TITLE
v.db.addcolumn: fix enclosing column name with SQL standard double quotes

### DIFF
--- a/python/grass/script/testsuite/test_names.py
+++ b/python/grass/script/testsuite/test_names.py
@@ -109,7 +109,11 @@ class TestLegalizeVectorName(TestCase):
         try:
             gs.run_command("v.edit", map=name, tool="create")
             gs.run_command("v.db.addtable", map=name)
-            gs.run_command("v.db.addcolumn", map=name, columns=name)
+            gs.run_command(
+                "v.db.addcolumn",
+                map=name,
+                columns=f"{name} integer",
+            )
             works = True
         except gs.CalledModuleError:
             works = False

--- a/scripts/v.db.addcolumn/v.db.addcolumn.py
+++ b/scripts/v.db.addcolumn/v.db.addcolumn.py
@@ -112,7 +112,7 @@ def main():
                     " <'name type [,name type, ...]'> format, please."
                 )
             )
-        col_name, col_type = col.split(whitespace.group(0))
+        col_name, col_type = col.split(whitespace.group(0), 1)
         if col_name in column_existing:
             grass.error(
                 _("Column <{}> is already in the table. Skipping.").format(col_name)

--- a/scripts/v.db.addcolumn/v.db.addcolumn.py
+++ b/scripts/v.db.addcolumn/v.db.addcolumn.py
@@ -42,6 +42,8 @@
 
 import atexit
 import os
+import re
+
 from grass.exceptions import CalledModuleError
 import grass.script as grass
 
@@ -98,17 +100,23 @@ def main():
     column_existing = grass.vector_columns(map, int(layer)).keys()
 
     add_str = "BEGIN TRANSACTION\n"
+    pattern = re.compile(r"\s+")
     for col in columns:
         if not col:
             grass.fatal(_("There is an empty column. Did you leave a trailing comma?"))
-        col_name = col.split(" ")[0].strip()
+        whitespace = re.search(pattern, col)
+        if not whitespace:
+            grass.fatal(
+                _("Incorrect new column(s) format <'name type [,name type, ...]'>")
+            )
+        col_name, col_type = col.split(whitespace.group(0))
         if col_name in column_existing:
             grass.error(
                 _("Column <{}> is already in the table. Skipping.").format(col_name)
             )
             continue
         grass.verbose(_("Adding column <{}> to the table").format(col_name))
-        add_str += f"ALTER TABLE {table} ADD COLUMN {col};\n"
+        add_str += f'ALTER TABLE {table} ADD COLUMN "{col_name}" {col_type};\n'
     add_str += "END TRANSACTION"
     sql_file = grass.tempfile()
     rm_files.append(sql_file)

--- a/scripts/v.db.addcolumn/v.db.addcolumn.py
+++ b/scripts/v.db.addcolumn/v.db.addcolumn.py
@@ -107,7 +107,10 @@ def main():
         whitespace = re.search(pattern, col)
         if not whitespace:
             grass.fatal(
-                _("Incorrect new column(s) format <'name type [,name type, ...]'>")
+                _(
+                    "Incorrect new column(s) format, use"
+                    " <'name type [,name type, ...]'> format, please."
+                )
             )
         col_name, col_type = col.split(whitespace.group(0))
         if col_name in column_existing:


### PR DESCRIPTION
Enable to use column name which is reserved DB backend keyword.