### PR TITLE
wxGUI/dbmgr: fix enclosing column name with SQL standard double quotes

### DIFF
--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -237,7 +237,10 @@ class VirtualAttributeList(
             self.sqlFilter = {"where": where}
 
             if columns:
-                cmdParams.update(dict(columns=",".join(columns)))
+                # Enclose column name with SQL standard double quotes
+                cmdParams.update(
+                    dict(columns=",".join([f'"{col}"' for col in columns]))
+                )
 
             ret = RunCommand("v.db.select", **cmdParams)
 
@@ -2103,8 +2106,9 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
             try:
                 if len(whereVal) > 0:
                     showSelected = True
+                    # Enclose column name with SQL standard double quotes
                     keyColumn = listWin.LoadData(
-                        self.selLayer, where=whereCol + whereOpe + whereVal
+                        self.selLayer, where=f'"{whereCol}"' + whereOpe + whereVal
                     )
                 else:
                     keyColumn = listWin.LoadData(self.selLayer)

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -364,8 +364,8 @@ class SQLBuilder(wx.Frame):
             return
 
         self.list_values.Clear()
-
-        sql = "SELECT DISTINCT {column} FROM {table} ORDER BY {column}".format(
+        # Enclose column name with SQL standard double quotes
+        sql = 'SELECT DISTINCT "{column}" FROM {table} ORDER BY "{column}"'.format(
             column=column, table=self.tablename
         )
         if justsample:
@@ -398,7 +398,8 @@ class SQLBuilder(wx.Frame):
         idx = self.list_columns.GetSelections()
         for i in idx:
             column = self.list_columns.GetString(i)
-            self._add(element="column", value=column)
+            # Enclose column name with SQL standard double quotes
+            self._add(element="column", value=f'"{column}"')
 
         if not self.btn_uniquesample.IsEnabled():
             self.btn_uniquesample.Enable(True)


### PR DESCRIPTION
Enable to use (show/add/delete/rename/query) column name which is reserved DB backend keyword.

Requires these PR #3631, #3632, #3633  to be applied for proper functionality.