### PR TITLE
gmath: Include only one header for FFTW

### DIFF
--- a/lib/gmath/fft.c
+++ b/lib/gmath/fft.c
@@ -29,13 +29,9 @@
 
 #ifdef HAVE_FFTW_H
 #include <fftw.h>
-#endif
-
-#ifdef HAVE_DFFTW_H
+#elifdef HAVE_DFFTW_H
 #include <dfftw.h>
-#endif
-
-#ifdef HAVE_FFTW3_H
+#elifdef HAVE_FFTW3_H
 #include <fftw3.h>
 #define c_re(c) ((c)[0])
 #define c_im(c) ((c)[1])

--- a/lib/gmath/fft.c
+++ b/lib/gmath/fft.c
@@ -25,16 +25,16 @@
 
 #include <grass/config.h>
 
-#if defined(HAVE_FFTW_H) || defined(HAVE_DFFTW_H) || defined(HAVE_FFTW3_H)
+#if defined(HAVE_FFTW3_H) || defined(HAVE_DFFTW_H) || defined(HAVE_FFTW_H)
 
-#ifdef HAVE_FFTW_H
-#include <fftw.h>
-#elifdef HAVE_DFFTW_H
-#include <dfftw.h>
-#elifdef HAVE_FFTW3_H
+#ifdef HAVE_FFTW3_H
 #include <fftw3.h>
 #define c_re(c) ((c)[0])
 #define c_im(c) ((c)[1])
+#elifdef HAVE_DFFTW_H
+#include <dfftw.h>
+#elifdef HAVE_FFTW_H
+#include <fftw.h>
 #endif
 
 #include <stdlib.h>

--- a/lib/gmath/fft.c
+++ b/lib/gmath/fft.c
@@ -25,16 +25,16 @@
 
 #include <grass/config.h>
 
-#if defined(HAVE_FFTW3_H) || defined(HAVE_DFFTW_H) || defined(HAVE_FFTW_H)
+#if defined(HAVE_FFTW3_H) || defined(HAVE_FFTW_H) || defined(HAVE_DFFTW_H)
 
-#ifdef HAVE_FFTW3_H
+#if defined(HAVE_FFTW3_H)
 #include <fftw3.h>
 #define c_re(c) ((c)[0])
 #define c_im(c) ((c)[1])
-#elifdef HAVE_DFFTW_H
-#include <dfftw.h>
-#elifdef HAVE_FFTW_H
+#elif defined(HAVE_FFTW_H)
 #include <fftw.h>
+#elif defined(HAVE_DFFTW_H)
+#include <dfftw.h>
 #endif
 
 #include <stdlib.h>


### PR DESCRIPTION
This PR addresses https://github.com/OSGeo/grass/pull/3621#issuecomment-2069764116 by including only one header for FFTW when there are multiple versions.