### PR TITLE
g.mkfontcap: Replace -o with --overwrite; Add a renamed flag warning

### DIFF
--- a/binaryInstall.src
+++ b/binaryInstall.src
@@ -319,7 +319,7 @@ echo""
 
 echo "Generating display font configuration file..."
 
-GISBASE="$DESTDIR" GISRC=junk LD_LIBRARY_PATH_VAR="${DESTDIR}/lib:$LD_LIBRARY_PATH_VAR" "${DESTDIR}/bin/g.mkfontcap" -o
+GISBASE="$DESTDIR" GISRC=junk LD_LIBRARY_PATH_VAR="${DESTDIR}/lib:$LD_LIBRARY_PATH_VAR" "${DESTDIR}/bin/g.mkfontcap" --overwrite
 
 echo""
 

--- a/general/g.mkfontcap/main.c
+++ b/general/g.mkfontcap/main.c
@@ -5,7 +5,7 @@
  * PURPOSE:      Generates the font configuration file by scanning various
  *               directories for GRASS stroke and Freetype-compatible fonts.
  *
- * COPYRIGHT:    (C) 2007-2015 by the GRASS Development Team
+ * COPYRIGHT:    (C) 2007-2024 by the GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS
@@ -47,7 +47,7 @@ static int compare_fonts(const void *, const void *);
 
 int main(int argc, char *argv[])
 {
-    struct Flag *tostdout, *overwrite;
+    struct Flag *tostdout;
     struct Option *extradirs;
     struct GModule *module;
 
@@ -64,11 +64,6 @@ int main(int argc, char *argv[])
     module->description = _(
         "Generates the font configuration file by scanning various directories "
         "for fonts.");
-
-    overwrite = G_define_flag();
-    overwrite->key = 'o';
-    overwrite->description =
-        _("Overwrite font configuration file if already existing");
 
     tostdout = G_define_flag();
     tostdout->key = 's';
@@ -99,11 +94,11 @@ int main(int argc, char *argv[])
             G_asprintf(&fontcapfile, "%s/etc/fontcap", gisbase);
 
         if (!access(fontcapfile, F_OK)) { /* File exists? */
-            if (!overwrite->answer)
-                G_fatal_error(
-                    _("Fontcap file %s already exists; use -%c flag if you "
-                      "wish to overwrite it"),
-                    fontcapfile, overwrite->key);
+            if (!G_get_overwrite())
+                G_fatal_error(_("Fontcap file %s already exists; use "
+                                "--overwrite flag if you "
+                                "wish to overwrite it"),
+                              fontcapfile);
         }
     }
 

--- a/lib/driver/font2.c
+++ b/lib/driver/font2.c
@@ -146,7 +146,7 @@ static void read_fontmap(const char *name)
     fp = fopen(buf, "r");
     if (!fp) {
         G_warning("Unable to open font map '%s': %s. "
-                  "Try running 'g.mkfontcap -o'",
+                  "Try running 'g.mkfontcap --overwrite'",
                   buf, strerror(errno));
         return;
     }

--- a/lib/gis/renamed_options
+++ b/lib/gis/renamed_options
@@ -95,6 +95,8 @@ g.mapset|gisdbase:dbase
 g.mapsets|addmapset:operation
 g.mapsets|removemapset:operation
 g.mapsets|measure:method
+# g.mkfontcap
+g.mkfontcap|-o:--overwrite
 # g.pnmcomp
 g.pnmcomp|background:bgcolor
 ###################################

--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -557,7 +557,7 @@ Section "GRASS" SecGRASS
 	FileWrite $0 'set GISRC=dummy$\r$\n'
 	FileWrite $0 '$\r$\n'
 	FileWrite $0 'rem run g.mkfontcap outside a grass session$\r$\n'
-	FileWrite $0 '"%GISBASE%\bin\g.mkfontcap.exe" -o$\r$\n'
+	FileWrite $0 '"%GISBASE%\bin\g.mkfontcap.exe" --overwrite$\r$\n'
 	FileWrite $0 'exit$\r$\n'
 	FileClose $0
 	done_create_run_gmkfontcap.bat:

--- a/mswindows/osgeo4w/postinstall.bat
+++ b/mswindows/osgeo4w/postinstall.bat
@@ -24,6 +24,6 @@ rem GISRC must be set
 set GISRC=dummy
 
 rem run g.mkfontcap outside a GRASS session
-"%GISBASE%\bin\g.mkfontcap.exe" -o
+"%GISBASE%\bin\g.mkfontcap.exe" --overwrite
 
 del "%BATCH%.tmpl


### PR DESCRIPTION
This PR replaces `-o` with standard `--overwrite` and adds a warning.