### PR TITLE
checks: add configuration files for yamllint and markdownlint

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,3 @@
+---
+
+default: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,3 @@ repos:
     rev: v1.29.0
     hooks:
       - id: yamllint
-        args: [--format, parsable, --strict, -d,
-               '{extends: default, rules: {truthy: disable,
-                 line-length: {max: 120, allow-non-breakable-words: true},
-                 comments: {min-spaces-from-content: 1}}}']

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+---
+
+extends: default
+
+rules:
+  comments:
+    level: error
+    min-spaces-from-content: 1
+  document-start:
+    level: error
+  line-length:
+    level: error
+    max: 120
+    allow-non-breakable-inline-mappings: true
+  truthy: disable


### PR DESCRIPTION
Avoid discrepancy between super-linter and pre-commit settings.

I couldn't find a way to avoid this problem without adding yet another two files in an already cluttered top-level repo, but current situation is not sustainable, so...