### PR TITLE
CI: Use faster mold linker to reduce build time by ≈>30 sec

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '**/*.html'
       - '**/*.md'
@@ -54,6 +52,8 @@ jobs:
           sudo apt-get install -y wget git gawk findutils
           xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
+      - uses: rui314/setup-mold@6bebc01caac32fb5251ee64f60cea0322d0e6574 # v1
+        if: ${{ matrix.language == 'c-cpp' }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,6 +47,8 @@ jobs:
           xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
 
+      - uses: rui314/setup-mold@6bebc01caac32fb5251ee64f60cea0322d0e6574 # v1
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -7,9 +7,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
 
 jobs:
   python-checks:
@@ -120,6 +117,7 @@ jobs:
         run: |
           echo "MAKEFLAGS=-j$(nproc)" >> $GITHUB_ENV
 
+      - uses: rui314/setup-mold@6bebc01caac32fb5251ee64f60cea0322d0e6574 # v1
       - name: Build
         run: .github/workflows/build_${{ matrix.os }}.sh $HOME/install
 


### PR DESCRIPTION
I’ve known about the mold linker for years now. It is a drop in replacement for Unix linkers, but several times faster. The design goal was to be able to link chromium in the one second range, with speeds approaching `cp`. 

https://github.com/rui314/mold has a graph and table of the performance. Phoronix has multiple articles on the subject, that’s where I first learned about it.

The author is the same that created LLVM’s lld linker at the time, and that is still several times faster than what existed before.

I’ve initially wanted to speed up the
CodeQL c-cpp build, as since this build is profiled, it is already slower than normal builds. It still saves about 30 seconds.

I have chosen to not use the mold linker everywhere, to keep the usual linker in the Ubuntu build where most tests are done. For other workflows where a build is needed, but only for using the compiled binaries, like the Pylint workflow.

I’ve made at least 3 reruns of the same commits before and after to get an estimate of the build times (across different hardware allocated by GitHub Actions).


I don’t know why I didn’t think about this, as I already knew that build times were still too long when using ccache (I have been exploring using it on a couple of occasions), and one of the factors in play is that ccache can accelerate compilation, not linking. So the remaining time attributed to the linker could be reduced, and it represents 30 secs. That also means that the remaining time would be attributed to the various Python scripts used during the build, that could be further optimized.




