### PR TITLE
grass.script: Fix missing passing of env parameter

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -766,7 +766,7 @@ def fatal(msg, env=None):
     if raise_on_error:
         raise ScriptError(msg)
 
-    error(msg, env=None)
+    error(msg, env=env)
     sys.exit(1)
 
 


### PR DESCRIPTION
The original change in PR #3439 has None instead of env passed to the error function in the fatal function. This passes the env parameter.