### PR TITLE
grass.script: Always use full env in create_project

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1760,11 +1760,11 @@ def create_project(
         env = os.environ.copy()
         setup_runtime_env(env=env)
 
-    if epsg or proj4 or filename or wkt:
-        # The names don't really matter here.
-        tmp_gisrc, env = create_environment(
-            mapset_path.directory, mapset_path.location, mapset_path.mapset, env=env
-        )
+    # Even g.proj and g.message need GISRC to be present.
+    # The names don't really matter here.
+    tmp_gisrc, env = create_environment(
+        mapset_path.directory, mapset_path.location, mapset_path.mapset, env=env
+    )
 
     # check if location already exists
     if Path(mapset_path.directory, mapset_path.location).exists():


### PR DESCRIPTION
For reporting errors the g.message tool is called, so the environment setup is always needed (except when doing XY without errors).