### PR TITLE
g.message: Do not require full gisinit

### DIFF
--- a/general/g.message/main.c
+++ b/general/g.message/main.c
@@ -26,7 +26,12 @@ int main(int argc, char *argv[])
     struct GModule *module;
     int debug_level;
 
-    G_gisinit(argv[0]);
+    /* We don't call G_gisinit() here because it validates the
+     * mapset, whereas this module may legitimately be even
+     * without a valid mapset. */
+    G_set_program_name(argv[0]);
+    G_no_gisinit();
+    G_set_gisrc_mode(G_GISRC_MODE_MEMORY);
 
     module = G_define_module();
     G_add_keyword(_("general"));

--- a/general/g.proj/main.c
+++ b/general/g.proj/main.c
@@ -59,10 +59,11 @@ int main(int argc, char *argv[])
     int formats;
     const char *epsg = NULL;
 
+    /* We don't call G_gisinit() here because it validates the
+     * mapset, whereas this module may legitimately be used
+     * (to create a new location) when none exists. */
     G_set_program_name(argv[0]);
-    G_no_gisinit(); /* We don't call G_gisinit() here because it validates the
-                     * mapset, whereas this module may legitmately be used
-                     * (to create a new location) when none exists */
+    G_no_gisinit();
 
     module = G_define_module();
     G_add_keyword(_("general"));


### PR DESCRIPTION
The g.message does not need any of the session setup and it can be used during a setup process to report standardized messages to the user. This removes the need to have a full session before running g.message. GISRC is still needed, but the data (file) structures for mapset don't need to exist.

The code is combination of what is in g.proj (the 'no init' call and comment) and g.dirseps (memory mode for GISRC). It is also syncing the corresponding lines in g.proj.