### PR TITLE
grass.script: Automatically parse JSON and CSV in parse_command

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -573,7 +573,7 @@ def parse_command(*args, **kwargs):
     """
 
     def parse_csv(result):
-        return list(csv.reader(io.StringIO(result)))
+        return list(csv.DictReader(io.StringIO(result)))
 
     parse = None
     parse_args = {}

--- a/python/grass/script/testsuite/test_start_command_functions_nc.py
+++ b/python/grass/script/testsuite/test_start_command_functions_nc.py
@@ -73,7 +73,6 @@ class TestParseCommand(TestCase):
             isinstance(result, list)
             and isinstance(result[0].get("easting"), (int, float))
         )
-        result = parse_command("v.db.select", map="zipcodes", format="json")
 
     def test_parse_format_csv(self):
         reference = parse_command("v.db.select", map="zipcodes", format="json")[

--- a/python/grass/script/testsuite/test_start_command_functions_nc.py
+++ b/python/grass/script/testsuite/test_start_command_functions_nc.py
@@ -3,7 +3,8 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-from grass.script.core import start_command, PIPE
+from grass.script.core import parse_command, start_command, PIPE
+from grass.script.utils import parse_key_val
 
 LOCATION = "nc"
 
@@ -47,6 +48,39 @@ class TestPythonKeywordsInParameters(TestCase):
         returncode = proc.poll()
         self.assertEqual(returncode, 1, msg="Underscore at both sides was accepted")
         self.assertIn(b"raster", stderr)
+
+
+class TestParseCommand(TestCase):
+    """Tests parse_command"""
+
+    def test_parse_default(self):
+        result = parse_command("r.info", map="elevation", flags="g")
+        self.assertTrue(
+            isinstance(result, dict) and isinstance(result.get("north"), str)
+        )
+        result_2 = parse_command("r.info", map="elevation", flags="g", delimiter="=")
+        self.assertDictEqual(result, result_2)
+        result_3 = parse_command(
+            "r.info", map="elevation", flags="g", parse=(parse_key_val, {"sep": "="})
+        )
+        self.assertDictEqual(result, result_3)
+
+    def test_parse_format_json(self):
+        result = parse_command(
+            "r.what", map="elevation", coordinates=(640000, 220000), format="json"
+        )
+        self.assertTrue(
+            isinstance(result, list)
+            and isinstance(result[0].get("easting"), (int, float))
+        )
+        result = parse_command("v.db.select", map="zipcodes", format="json")
+
+    def test_parse_format_csv(self):
+        reference = parse_command("v.db.select", map="zipcodes", format="json")[
+            "records"
+        ]
+        result = parse_command("v.db.select", map="zipcodes", format="csv")
+        self.assertListEqual(list(reference[0].keys()), list(result[0].keys()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Given several tools have options `format`, this adds automatic parsing to `parse_command`:
```
>>> data = gs.parse_command("r.what", map='elevation@PERMANENT', coordinates=[641567, 223962], format='json')
[{'easting': 641567, 'northing': 223962, 'site_name': '', 'elevation@PERMANENT': {'value': 75.82444763183594}}]

>>> data = gs.parse_command("v.db.select", map='busroute1@PERMANENT', format='csv')
[{'cat': '1', 'ROUTE': '1'}, {'cat': '2', 'ROUTE': '1'}]
>>> pd.DataFrame(data)
  cat ROUTE
0   1     1
1   2     1

```
For csv, I use DictReader, which makes sense only when the csv has a header, but that seems like reasonable assumption, and then it works nicely with pandas.

Option delimiter does not fit well into it conceptually, so I deprecated it. Also, it's now taken into account only when parameter `parse` is not specified, it assumed that anyway.

