### PR TITLE
grass.pygrass: Lazy load list of commands for module shortcuts

### DIFF
--- a/python/grass/pygrass/modules/shortcuts.py
+++ b/python/grass/pygrass/modules/shortcuts.py
@@ -1,11 +1,23 @@
 import fnmatch
 
-
-from grass.script.core import get_commands
 from grass.pygrass.modules.interface import Module
 
-_CMDS = list(get_commands()[0])
-_CMDS.sort()
+
+def _get_commands():
+    """Get a list of commands (tool names)"""
+    if _get_commands.list_of_commands is None:
+        # Retrieve and store the list during the the first call of the function.
+        # pylint: disable=import-outside-toplevel
+        from grass.script.core import get_commands
+
+        _get_commands.list_of_commands = list(get_commands()[0])
+        _get_commands.list_of_commands.sort()
+    return _get_commands.list_of_commands
+
+
+# Initialize the attribute of the function to indicate
+# that the data is not initialized.
+_get_commands.list_of_commands = None
 
 
 class MetaModule:
@@ -52,7 +64,7 @@ class MetaModule:
     def __dir__(self):
         return [
             mod[(len(self.prefix) + 1) :].replace(".", "_")
-            for mod in fnmatch.filter(_CMDS, "%s.*" % self.prefix)
+            for mod in fnmatch.filter(_get_commands(), "%s.*" % self.prefix)
         ]
 
     def __getattr__(self, name):

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -5,6 +5,7 @@ import multiprocessing
 import pytest
 
 import grass.script as gs
+from grass.pygrass.modules.grid import GridModule
 
 
 def max_processes():
@@ -34,10 +35,6 @@ def test_processes(tmp_path, processes):
         gs.run_command("r.surf.fractal", output=surface)
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "r.slope.aspect",
                 width=10,
@@ -72,10 +69,6 @@ def test_tiling_schemes(tmp_path, width, height):
         gs.run_command("r.surf.fractal", output=surface)
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "r.slope.aspect",
                 width=width,
@@ -105,10 +98,6 @@ def test_overlaps(tmp_path, overlap):
         gs.run_command("r.surf.fractal", output=surface)
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "r.slope.aspect",
                 width=10,
@@ -140,10 +129,6 @@ def test_cleans(tmp_path, clean, surface):
             gs.run_command("r.surf.fractal", output=surface)
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "r.slope.aspect",
                 width=10,
@@ -189,10 +174,6 @@ def test_patching_backend(tmp_path, patch_backend):
         )
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "v.to.rast",
                 width=10,
@@ -233,10 +214,6 @@ def test_tiling(tmp_path, width, height, processes):
         gs.run_command("r.surf.fractal", output=surface)
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "r.slope.aspect",
                 width=width,
@@ -274,10 +251,6 @@ def test_patching_error(tmp_path, processes, backend):
         surface = "fractal"
 
         def run_grid_module():
-            # modules/shortcuts calls get_commands which requires GISBASE.
-            # pylint: disable=import-outside-toplevel
-            from grass.pygrass.modules.grid import GridModule
-
             grid = GridModule(
                 "r.surf.fractal",
                 overlap=0,


### PR DESCRIPTION
Importing _grass.pygrass.modules_ required the list to be loaded because the _shortcuts_ module is loaded by the _modules_ module. Now the list is loaded only when the _dir_ function is called for the first time.

This is using the technique from grass init file for lazy loading translations.

This allows grass.pygrass.modules to be imported without an active session, so this simplifies the GridModule tests (and its imports in general).
