### PR TITLE
grass.script: Make grass_path keyword only in init

### DIFF
--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -268,7 +268,7 @@ def setup_runtime_env(gisbase=None, *, env=None):
     env["PYTHONPATH"] = path
 
 
-def init(path, location=None, mapset=None, grass_path=None):
+def init(path, location=None, mapset=None, *, grass_path=None):
     """Initialize system variables to run GRASS modules
 
     This function is for running GRASS GIS without starting it with the


### PR DESCRIPTION
This makes the grass_path parameter a keyword-only argument (PEP 3102). While this technically breaks the 8.0 API for 8.4, the documentation only shows grass_path as a keyword argument, grass_path is required to be a keyword argument when location and mapset are omitted, and given the automation triggered by grass_path=None, any usage of grass_path is likely limited (the usage would have to be as positional argument to trigger the incompatibility).

## API

Originally posted as [a comment in #3438](https://github.com/OSGeo/grass/pull/3438#discussion_r1591003832):

Worked in 8.0-8.3:

```python
gs.setup.init("~/data/nc_spm/new_highway")
gs.setup.init("~/data/nc_spm/new_highway", grass_path="/opt/grass/bin/grass")
gs.setup.init("~/data", "nc_spm", "new_highway")
gs.setup.init("~/data", "nc_spm", "new_highway", "/opt/grass/bin/grass")
```

With this PR:

```python
gs.setup.init("~/data/nc_spm/new_highway")
gs.setup.init("~/data/nc_spm/new_highway", grass_path="/opt/grass/bin/grass")
gs.setup.init("~/data", "nc_spm", "new_highway")
gs.setup.init("~/data/nc_spm/new_highway", env=env)
gs.setup.init("~/data/nc_spm/new_highway", grass_path="/opt/grass/bin/grass", env=env)
gs.setup.init("~/data", "nc_spm", "new_highway", env=env)
```

Never possible:


```python
gs.setup.init("~/data/nc_spm/new_highway", "/opt/grass/bin/grass")
```

With this PR, code without an explicit _grass_path_ working in 8.0-8.3 needs to be rewritten:

```diff
- gs.setup.init("~/data", "nc_spm", "new_highway", "/opt/grass/bin/grass")
+ gs.setup.init("~/data", "nc_spm", "new_highway", grass_path="/opt/grass/bin/grass")
```

Back to my earlier comment, the usage which is no longer available with this PR was never promoted. Instead, the documentation for _grass.script.setup.init_ shows:

```python
import grass.script as gs
session = gs.setup.init(
    "~/grassdata/nc_spm_08/user1",
    grass_path="/usr/lib/grass",
)
```

There is a heuristic in the function which determines the path automatically, so the idea is that in most cases, _grass_path_ does not have to be supplied at all. (For example, I don't see any usages in this repo or [on GitHub](https://github.com/search?q=%22grass_path%3D%22&type=code).) Having _grass_path_ passed as a keyword argument (with explicit name), rather than a positional one, is the intended usage (based on the example, number and type of parameters and my judgement of what I intended back in 8.0 times).

One can say that this PR limits the usage to intended usage by fixing bug in the function specification.