### PR TITLE
CI: Remove simple test from Python Code Quality

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -125,9 +125,6 @@ jobs:
         run: |
           echo "$HOME/install/bin" >> $GITHUB_PATH
 
-      - name: Test executing of the grass command
-        run: .github/workflows/test_simple.sh
-
       - name: Run Pylint on grass package
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH


### PR DESCRIPTION
With an error in the code which prevents the simple test of the main executable to run, the Pylint check does not run. While it requires some functionality from the grass executable, it does not require everything to work. This removes the step with the explicit test of the grass executable and relies on other workflows to do that test and provide a reasonable message there. This workflow now hopes to get to Pylint and report an issue with Pylint.

The motivation is #3694 where I would expect to see a Pylint error, but get a traceback from the grass executable in the simple test. (The executable partially works, but not enough for the simple test.)
