### PR TITLE
lib: Add a standard parser option for JSON formatting

### DIFF
--- a/general/g.mapsets/main.c
+++ b/general/g.mapsets/main.c
@@ -105,15 +105,7 @@ int main(int argc, char *argv[])
     opt.op->description = _("Operation to be performed");
     opt.op->answer = "add";
 
-    opt.format = G_define_option();
-    opt.format->key = "format";
-    opt.format->type = TYPE_STRING;
-    opt.format->required = YES;
-    opt.format->label = _("Output format for printing (-l and -p flags)");
-    opt.format->options = "plain,json";
-    opt.format->descriptions = "plain;Configurable plain text output;"
-                               "json;JSON (JavaScript Object Notation);";
-    opt.format->answer = "plain";
+    opt.format = G_define_standard_option(G_OPT_F_FORMAT);
     opt.format->guisection = _("Print");
 
     opt.fsep = G_define_standard_option(G_OPT_F_SEP);

--- a/imagery/i.signatures/main.c
+++ b/imagery/i.signatures/main.c
@@ -118,15 +118,7 @@ int main(int argc, char *argv[])
     parms.type->description = _("Type of signature file");
     parms.type->guisection = _("Main");
 
-    parms.format = G_define_option();
-    parms.format->key = "format";
-    parms.format->type = TYPE_STRING;
-    parms.format->required = NO;
-    parms.format->label = _("Output format");
-    parms.format->options = "plain,json";
-    parms.format->descriptions = "plain;Plain text output;"
-                                 "json;JSON (JavaScript Object Notation);";
-    parms.format->answer = "plain";
+    parms.format = G_define_standard_option(G_OPT_F_FORMAT);
     parms.format->guisection = _("Print");
 
     parms.mapset = G_define_standard_option(G_OPT_M_MAPSET);

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -352,7 +352,9 @@ typedef enum {
     G_OPT_MAP_TYPE,  /*!< The type of an input map: raster, vect, rast3d */
     G_OPT_T_TYPE,    /*!< The temporal type of a space time dataset */
     G_OPT_T_WHERE,   /*!< A temporal GIS framework SQL WHERE statement */
-    G_OPT_T_SAMPLE   /*!< Temporal sample methods */
+    G_OPT_T_SAMPLE,  /*!< Temporal sample methods */
+
+    G_OPT_F_FORMAT, /*!< set output format to JSON */
 } STD_OPT;
 
 /*!

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -354,7 +354,7 @@ typedef enum {
     G_OPT_T_WHERE,   /*!< A temporal GIS framework SQL WHERE statement */
     G_OPT_T_SAMPLE,  /*!< Temporal sample methods */
 
-    G_OPT_F_FORMAT, /*!< set output format to JSON */
+    G_OPT_F_FORMAT, /*!< set output format to plain text or JSON */
 } STD_OPT;
 
 /*!

--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -943,6 +943,17 @@ struct Option *G_define_standard_option(int opt)
         Opt->description =
             _("The method to be used for sampling the input dataset");
         break;
+    case G_OPT_F_FORMAT:
+        Opt->key = "format";
+        Opt->type = TYPE_STRING;
+        Opt->key_desc = "name";
+        Opt->required = YES;
+        Opt->label = _("Output format");
+        Opt->answer = "plain";
+        Opt->options = "plain,json";
+        Opt->descriptions = _("plain;Plain text output;"
+                              "json;JSON (JavaScript Object Notation);");
+        break;
     }
 
     return Opt;

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -298,15 +298,8 @@ int main(int argc, char *argv[])
     parm.dist->description = _("Sampling distance step coefficient (0.5-1.5)");
     parm.dist->guisection = _("Optional");
 
-    parm.format = G_define_option();
-    parm.format->key = "format";
-    parm.format->type = TYPE_STRING;
+    parm.format = G_define_standard_option(G_OPT_F_FORMAT);
     parm.format->required = YES;
-    parm.format->label = _("Output format used for point mode");
-    parm.format->options = "plain,json";
-    parm.format->descriptions = "plain;Plain text output;"
-                                "json;JSON (JavaScript Object Notation);";
-    parm.format->answer = "plain";
     parm.format->guisection = _("Point mode");
 
     parm.output = G_define_standard_option(G_OPT_F_OUTPUT);

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -299,7 +299,6 @@ int main(int argc, char *argv[])
     parm.dist->guisection = _("Optional");
 
     parm.format = G_define_standard_option(G_OPT_F_FORMAT);
-    parm.format->required = YES;
     parm.format->guisection = _("Point mode");
 
     parm.output = G_define_standard_option(G_OPT_F_OUTPUT);

--- a/raster/r.kappa/main.c
+++ b/raster/r.kappa/main.c
@@ -97,15 +97,8 @@ int main(int argc, char **argv)
     parms.titles->answer = "ACCURACY ASSESSMENT";
     parms.titles->guisection = _("Output settings");
 
-    parms.format = G_define_option();
-    parms.format->key = "format";
-    parms.format->type = TYPE_STRING;
+    parms.format = G_define_standard_option(G_OPT_F_FORMAT);
     parms.format->required = YES;
-    parms.format->label = _("Output format");
-    parms.format->options = "plain,json";
-    parms.format->descriptions = "plain;Plain text output;"
-                                 "json;JSON (JavaScript Object Notation);";
-    parms.format->answer = "plain";
     parms.format->guisection = _("Output settings");
 
     flags.w = G_define_flag();

--- a/raster/r.kappa/main.c
+++ b/raster/r.kappa/main.c
@@ -98,7 +98,6 @@ int main(int argc, char **argv)
     parms.titles->guisection = _("Output settings");
 
     parms.format = G_define_standard_option(G_OPT_F_FORMAT);
-    parms.format->required = YES;
     parms.format->guisection = _("Output settings");
 
     flags.w = G_define_flag();

--- a/raster/r.what/main.c
+++ b/raster/r.what/main.c
@@ -140,15 +140,7 @@ int main(int argc, char *argv[])
     opt.fs = G_define_standard_option(G_OPT_F_SEP);
     opt.fs->guisection = _("Print");
 
-    opt.format = G_define_option();
-    opt.format->key = "format";
-    opt.format->type = TYPE_STRING;
-    opt.format->required = NO;
-    opt.format->label = _("Output format");
-    opt.format->options = "plain,json";
-    opt.format->descriptions = "plain;Plain text output;"
-                               "json;JSON (JavaScript Object Notation);";
-    opt.format->answer = "plain";
+    opt.format = G_define_standard_option(G_OPT_F_FORMAT);
     opt.format->guisection = _("Print");
 
     opt.cache = G_define_option();

--- a/vector/v.db.select/main.c
+++ b/vector/v.db.select/main.c
@@ -119,18 +119,13 @@ int main(int argc, char **argv)
         _("GROUP BY conditions of SQL statement without 'group by' keyword");
     options.group->guisection = _("Selection");
 
-    options.format = G_define_option();
-    options.format->key = "format";
-    options.format->type = TYPE_STRING;
-    options.format->required = YES;
-    options.format->label = _("Output format");
+    options.format = G_define_standard_option(G_OPT_F_FORMAT);
     options.format->options = "plain,csv,json,vertical";
     options.format->descriptions =
         "plain;Configurable plain text output;"
         "csv;CSV (Comma Separated Values);"
         "json;JSON (JavaScript Object Notation);"
         "vertical;Plain text vertical output (instead of horizontal)";
-    options.format->answer = "plain";
     options.format->guisection = _("Format");
 
     options.fsep = G_define_standard_option(G_OPT_F_SEP);


### PR DESCRIPTION
As a part of https://github.com/OSGeo/grass/discussions/3019, JSON format support will be added to multiple modules. By default, modules output in existing plain format. If the format=json option is provided, modules will output in JSON format instead. To avoid duplication of code across several modules, define a standard parser option.