### PR TITLE
wxGUI: fix displaying layer from different project

### DIFF
--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -307,7 +307,6 @@ class HistoryInfoPanel(SP.ScrolledPanel):
         """Clear command info."""
         self.sizer_general_info.Clear(True)
         self.sizer_region_settings_grid.Clear(True)
-        self.sizer_region_settings_text.Clear(True)
         self._createGeneralInfoBox()
         self._createRegionSettingsBox()
         self._layout()


### PR DESCRIPTION
Fixes #3711. Looks like some leftover code, there are no other references to `sizer_region_settings_text`.