### PR TITLE
CI: Print Python version first

### DIFF
--- a/.github/workflows/print_versions.sh
+++ b/.github/workflows/print_versions.sh
@@ -2,12 +2,14 @@
 
 # Print versions, esp. versions of dependencies.
 
-# fail on non-zero return code from a subprocess
-set -e
+python --version
+python3 --version
 
+# We use Git during build.
+git --version
+
+# This will fail if the build failed.
 grass --version
 grass --tmp-location XY --exec g.version -e
 # Detailed Python version info (in one line thanks to echo)
 grass --tmp-location XY --exec bash -c "echo Python: \$(\$GRASS_PYTHON -c 'import sys; print(sys.version)')"
-python3 --version
-python --version


### PR DESCRIPTION
* Print first version of Python.
* Print also Git version which we use during build (when available and it is available in the CI).
* Print GRASS versions last because they actually need the build to be successful and this purposefully runs even for failures.
