### PR TITLE
deps: Set min Python version to 3.8

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             python-version: "3.10"
-            min-python-version: "3.7"
+            min-python-version: "3.8"
             black-version: "24.4.0"
             flake8-version: "3.9.2"
             pylint-version: "2.12.2"

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -33,7 +33,7 @@ for other platforms you may have to install some of them.
   PROJ: [https://proj.org/](https://proj.org/)
 - **GDAL/OGR** for import and export of most external raster and vector map formats
   GDAL: [https://gdal.org](https://gdal.org)
-- **Python >= 3.7** (for temporal framework, scripts, wxGUI, and ctypes interface)
+- **Python >= 3.8** (for temporal framework, scripts, wxGUI, and ctypes interface)
   [https://www.python.org](https://www.python.org)
 
 ## Optional packages


### PR DESCRIPTION
Python 3.7 is end-of-life. Version 3.8 is in security (fixes) status till 2024-10. Changing version in code quality check (for Pylint) and in requirements file.

Minimum version of Python is now specified as 3.8.
