### PR TITLE
build: Help older Python parse new Git dates

### DIFF
--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -342,9 +342,18 @@ def format_git_commit_date_from_local_git(
 
     :return str: output formatted commit datetime
     """
-    return datetime.fromisoformat(
-        commit_datetime,
-    ).strftime(datetime_format)
+    try:
+        date = datetime.fromisoformat(
+            commit_datetime,
+        )
+    except ValueError:
+        if commit_datetime.endswith("Z"):
+            # Python 3.10 and older does not support Z in time, while recent versions
+            # of Git (2.45.1) use it. Try to help the parsing if Z is in the string.
+            date = datetime.fromisoformat(commit_datetime[:-1] + "+00:00")
+        else:
+            raise
+    return date.strftime(datetime_format)
 
 
 def has_src_code_git(src_dir, is_addon):


### PR DESCRIPTION
Current Git (2.45.1) produces strict ISO dates with Z for any time with +00:00 time zone offest. Python prior to 3.11 does not understand these dates. This trunkes the Z in case of ValueError which is what old Python throws. The +00:00 offset is placed in the input string for fromisoformat instead.