### PR TITLE
CI: Allow workflows running on pull request to run for any target branch

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -12,9 +12,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -9,9 +9,6 @@ on:
     tags:
       - '**'
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
     paths:
       - .github/**
       - utils/**

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -7,9 +7,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,9 +9,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
 env:
   CACHE_NUMBER: 0
 concurrency:

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -7,9 +7,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
 
 jobs:
   pytest:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,9 +7,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,10 +9,6 @@ on:
       - main
       - releasebranch_*
   pull_request:
-    branches:
-      - main
-      - releasebranch_*
-      - '*'
 
 jobs:
   ubuntu:


### PR DESCRIPTION
Following a discussion a couple weeks ago, this removes the `branches` filtering on pull requests, so it can be easier to test out pull requests on our forks (like me). Since we use rulesets in the repo that prevents branch creation, this additional filtering doesn't filter out any runs at all. Even if rulesets didn't prevent the workflows from creating branches in this repo, we might have wanted to have the workflows run on any such PR that targeted a branch that wasn't called `main` or didn't start with `releasebranch_`.

If ever the situation changes, the branches filter can be added back easily.