### PR TITLE
CI(windows): Upload test report artifact

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -78,3 +78,11 @@ jobs:
 
       - name: Run tests
         run: .github/workflows/test_thorough.bat 'C:\OSGeo4W\opt\grass\grass84.bat' 'C:\OSGeo4W\bin\python3'
+
+      - name: Make HTML test report available
+        if: ${{ always() }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: testreport-${{ matrix.os }}
+          path: testreport
+          retention-days: 3


### PR DESCRIPTION
This uploads the test report for gunittest tests. It is almost exactly the same step as the Ubuntu workflow, but changes were made for the name of the artifact since no config matrix strategy exists here.

I didn’t find another PR or issue for this. It is different from #1212, that tried to have the compiled grass uploaded as a osgeo4w-compatible package.