### PR TITLE
CI: Print more version information, for all platforms

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Add the bin directory to PATH
         run: echo "$HOME/install/bin" >> $GITHUB_PATH
       - name: Check installed version
+        if: always()
         shell: bash -l {0}
         run: source ./.github/workflows/print_versions.sh
       - name: Run tests

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -66,6 +66,11 @@ jobs:
         shell: msys2 {0}
         run: .github/workflows/build_osgeo4w.sh
 
+      - name: Print installed versions
+        if: always()
+        shell: msys2 {0}
+        run: .github/workflows/print_versions.sh
+
       - name: Test executing of the grass command
         run: .github/workflows/test_simple.bat 'C:\OSGeo4W\opt\grass\grass84.bat'
 

--- a/.github/workflows/print_versions.sh
+++ b/.github/workflows/print_versions.sh
@@ -10,6 +10,6 @@ git --version
 
 # This will fail if the build failed.
 grass --version
-grass --tmp-location XY --exec g.version -e
+grass --tmp-location XY --exec g.version -ecxrgb
 # Detailed Python version info (in one line thanks to echo)
 grass --tmp-location XY --exec bash -c "echo Python: \$(\$GRASS_PYTHON -c 'import sys; print(sys.version)')"

--- a/.github/workflows/print_versions.sh
+++ b/.github/workflows/print_versions.sh
@@ -10,6 +10,6 @@ git --version
 
 # This will fail if the build failed.
 grass --version
-grass --tmp-location XY --exec g.version -ecxrgb
+grass --tmp-location XY --exec g.version -ergb
 # Detailed Python version info (in one line thanks to echo)
 grass --tmp-location XY --exec bash -c "echo Python: \$(\$GRASS_PYTHON -c 'import sys; print(sys.version)')"


### PR DESCRIPTION
This was an exploratory branch I made in my fork to confirm another potential bug in the OSGeo4W packages, ie the nightlies, filed as https://github.com/OSGeo/grass/issues/3739. When filing in my recent bugs reports on Windows, I observed that the libgis_date, libgis_revision, revision, build_date fields don't seem updated, and mention 2024-04-14 or in the 2024-04-13 day (when there were big changes in the build environment). Assuming that this April 14, 2024, is after the changes in configure to use the git dates (https://github.com/OSGeo/grass/pull/3435, March 24, 2024), I expect that these would be up to date.

This PR adds all the flags of g.version to the call in the print_versions.sh file, and makes sure it runs on builds of our three platforms. It shows that the build information here is up to date, but not on OSGeo4W (nightly) packages
