### PR TITLE
DataCatalog: different message for moving and copying

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1339,9 +1339,7 @@ class DataCatalogTree(TreeView):
                 if pasted == 0:
                     Debug.msg(1, "COPIED TO: " + new_name)
                     if self.copy_mode:
-                        self.showNotification.emit(message=_("g.copy completed"))
-                    else:
-                        self.showNotification.emit(message=_("g.copy completed"))
+                        self.showNotification.emit(message=_("Copying completed"))
                     self._giface.grassdbChanged.emit(
                         grassdb=self.selected_grassdb[0].data["name"],
                         location=self.selected_location[0].data["name"],
@@ -1355,6 +1353,7 @@ class DataCatalogTree(TreeView):
                         self._removeMapAfterCopy(
                             self.copy_layer[i], self.copy_mapset[i], env2
                         )
+                        self.showNotification.emit(message=_("Moving completed"))
 
                 gscript.try_remove(gisrc)
                 gscript.try_remove(gisrc2)


### PR DESCRIPTION
Minor fix changing the messages for copying and moving, when pasting DataCatalog elements.

Fix #1095