### PR TITLE
grass.jupyter: update r.proj call to use project instead of location

### DIFF
--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -104,7 +104,7 @@ def estimate_resolution(raster, mapset, location, dbase, env):
         flags="g",
         input=raster,
         mapset=mapset,
-        location=location,
+        project=location,
         dbase=dbase,
         env=env,
     ).strip()


### PR DESCRIPTION
Somehow, this one got forgotten during location to project renaming.