### PR TITLE
r.horizon: always include distance output in JSON output

### DIFF
--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -312,7 +312,7 @@ int main(int argc, char *argv[])
     flag.horizonDistance = G_define_flag();
     flag.horizonDistance->key = 'l';
     flag.horizonDistance->description =
-        _("Include horizon distance in the output");
+        _("Include horizon distance in the plain output");
     flag.horizonDistance->guisection = _("Point mode");
 
     flag.degreeOutput = G_define_flag();
@@ -889,8 +889,7 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
             case JSON:
                 json_array_append_number(azimuths, tmpangle);
                 json_array_append_number(horizons, shadow_angle);
-                if (settings->horizonDistance)
-                    json_array_append_number(distances, horizon.length);
+                json_array_append_number(distances, horizon.length);
                 break;
             }
         }
@@ -905,8 +904,7 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
             case JSON:
                 json_array_append_number(azimuths, printangle);
                 json_array_append_number(horizons, shadow_angle);
-                if (settings->horizonDistance)
-                    json_array_append_number(distances, horizon.length);
+                json_array_append_number(distances, horizon.length);
                 break;
             }
         }
@@ -928,9 +926,7 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
     if (format == JSON) {
         json_object_set_value(json_origin, "azimuth", azimuths_value);
         json_object_set_value(json_origin, "horizon_height", horizons_value);
-        if (settings->horizonDistance)
-            json_object_set_value(json_origin, "horizon_distance",
-                                  distances_value);
+        json_object_set_value(json_origin, "horizon_distance", distances_value);
     }
 }
 

--- a/raster/r.horizon/testsuite/test_r_horizon.py
+++ b/raster/r.horizon/testsuite/test_r_horizon.py
@@ -108,6 +108,27 @@ ref5 = """azimuth,horizon_height,horizon_distance
 340.000000,0.196863,5004.018385
 """
 
+ref6 = """azimuth,horizon_height,horizon_distance
+180.000000,0.023101,420.000000
+200.000000,0.034850,436.577599
+220.000000,0.050549,184.390889
+240.000000,0.048211,197.230829
+260.000000,0.053101,162.788206
+280.000000,0.039774,253.179778
+300.000000,0.032360,277.848880
+320.000000,0.014804,262.488095
+340.000000,0.000000,0.000000
+360.000000,0.004724,2780.017986
+20.000000,0.012612,1148.259553
+40.000000,0.015207,1334.166406
+60.000000,0.014344,1867.966809
+80.000000,0.011044,2964.203097
+100.000000,0.012192,1828.223181
+120.000000,0.007462,4270.667395
+140.000000,0.004071,5659.231397
+160.000000,0.015356,1666.883319
+"""
+
 
 class TestHorizon(TestCase):
     circle = "circle"
@@ -206,16 +227,18 @@ class TestHorizon(TestCase):
         stdout = json.loads(module.outputs.stdout)
         azimuths = []
         horizons = []
+        distances = []
         reference = {}
-        for line in ref2.splitlines()[1:]:
-            azimuth, horizon = line.split(",")
+        for line in ref6.splitlines()[1:]:
+            azimuth, horizon, distance = line.split(",")
             azimuths.append(float(azimuth))
             horizons.append(float(horizon))
+            distances.append(float(distance))
         reference["x"] = 634720.0
         reference["y"] = 216180.0
         reference["azimuth"] = azimuths
         reference["horizon_height"] = horizons
-        stdout[0].pop("horizon_distance", None)
+        reference["horizon_distance"] = distances
 
         self.assertListEqual([reference], stdout)
 
@@ -234,17 +257,18 @@ class TestHorizon(TestCase):
         stdout = json.loads(module.outputs.stdout)
         azimuths = []
         horizons = []
+        distances = []
         reference = {}
-        for line in ref2.splitlines()[1:]:
-            azimuth, horizon = line.split(",")
+        for line in ref6.splitlines()[1:]:
+            azimuth, horizon, distance = line.split(",")
             azimuths.append(float(azimuth))
             horizons.append(float(horizon))
+            distances.append(float(distance))
         reference["x"] = 634720.0
         reference["y"] = 216180.0
         reference["azimuth"] = azimuths
         reference["horizon_height"] = horizons
-        stdout[0].pop("horizon_distance", None)
-        stdout[1].pop("horizon_distance", None)
+        reference["horizon_distance"] = distances
 
         self.assertListEqual([reference, reference], stdout)
 

--- a/raster/r.horizon/testsuite/test_r_horizon.py
+++ b/raster/r.horizon/testsuite/test_r_horizon.py
@@ -215,6 +215,7 @@ class TestHorizon(TestCase):
         reference["y"] = 216180.0
         reference["azimuth"] = azimuths
         reference["horizon_height"] = horizons
+        stdout[0].pop("horizon_distance", None)
 
         self.assertListEqual([reference], stdout)
 
@@ -242,6 +243,8 @@ class TestHorizon(TestCase):
         reference["y"] = 216180.0
         reference["azimuth"] = azimuths
         reference["horizon_height"] = horizons
+        stdout[0].pop("horizon_distance", None)
+        stdout[1].pop("horizon_distance", None)
 
         self.assertListEqual([reference, reference], stdout)
 


### PR DESCRIPTION
Given the [discussion](https://github.com/OSGeo/grass/pull/3744#issuecomment-2135488969) about what should be part of JSON output, I changed the behavior to include the distance whether or not the -l flag is used. There is no computational reason not to.