### PR TITLE
CI: split files from revisions in git diff command

### DIFF
--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -28,7 +28,7 @@ jobs:
           wget http://git.savannah.gnu.org/cgit/config.git/plain/config.guess && chmod +x config.guess
           wget http://git.savannah.gnu.org/cgit/config.git/plain/config.sub && chmod +x config.sub
       # Display changes, only to follow along in the logs.
-      - run: git diff config.guess config.sub
+      - run: git diff -- config.guess config.sub
       - name: Double check if files are modified
         run: git status --ignored
       - name: Create Pull Request


### PR DESCRIPTION
The latest invocation of the periodic update workflow failed to compare the differences in the config files, as the two files were ambiguous from the revisions in the call to hit diff. The suggestion is to use -- to separate the revisions from the files. 

This PR does that. 

Fixes the failure in https://github.com/OSGeo/grass/actions/runs/9382599049