### PR TITLE
contributing: Add more known authors to release notes

### DIFF
--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -219,10 +219,7 @@ def notes_from_git_log(start_tag, end_tag, categories, exclude):
             # Emails are stored with @ replaced by a space.
             email = commit["author_email"].replace("@", " ")
             git_author = f"{commit['author_name']} <{email}>"
-            if (
-                git_author not in svn_name_by_git_author
-                and git_author in github_name_by_git_author
-            ):
+            if git_author in github_name_by_git_author:
                 github_name = github_name_by_git_author[git_author]
                 github_name = f"@{github_name}"
             else:

--- a/utils/git_author_github_name.csv
+++ b/utils/git_author_github_name.csv
@@ -1,15 +1,29 @@
 git_author,github_name
+Alberto Paradís Llop <albertoparadisllop gmail.com>,albertoparadisllop
+Alessandro Frigeri <alessandro.frigeri gmail.com>,afrigeri
+Alexandre Detiste <alexandre.detiste gmail.com>,a-detiste
+Andrea Giudiceandrea <andreaerdna libero.it>,agiudiceandrea
+Anna Petrasova <kratochanna gmail.com>,petrasovaa
+Bas Couwenberg <sebastic xs4all.nl>,sebastic
+Bernhard M. Wiedemann <bwiedemann suse.de>,bmwiedemann
+Brendan Harmon <brendan.harmon gmail.com>,baharmon
+Christoph Reiter <reiter.christoph gmail.com>,lazka
+Corey White <smortopahri gmail.com>,cwhite911
+Florian Weimer <fweimer redhat.com>,fweimer-rh
+Hamed Elgizery <hamedashraf2004 gmail.com>,HamedElgizery
 Jürgen Fischer <jef norbit.de>,jef-n
-Owen Smith <ocsmit protonmail.com>,ocsmit
+Ken Mankoff <mankoff gmail.com>,mankoff
+Luís de Sousa <luis.de.sousa protonmail.ch>,ldesousa
+Māris Nartišs <maris.gis gmail.com>,marisn
+Markus Neteler <neteler osgeo.org>,neteler
+Maximilian Stahlberg <viech unvanquished.net>,Viech
 Nicklas Larsson <n_larsson yahoo.com>,nilason
 nilason <n_larsson yahoo.com>,nilason
-Stefan Blumentrath <stefan.blumentrath gmx.de>,ninsbl
-Anna Petrasova <kratochanna gmail.com>,petrasovaa
-Māris Nartišs <maris.gis gmail.com>,marisn
 Ondrej Pesek <pesej.ondrek gmail.com>,pesekon2
-Bas Couwenberg <sebastic xs4all.nl>,sebastic
-積丹尼 Dan Jacobson <jidanni jidanni.org>,jidanni
+Owen Smith <ocsmit protonmail.com>,ocsmit
+Paulo van Breugel <paulo ecodiv.earth>,ecodiv
+Stefan Blumentrath <stefan.blumentrath gmx.de>,ninsbl
+Yann Chemin <dr.yann.chemin gmail.com>,YannChemin
 Yann Chemin <ychemin gmail.com>,YannChemin
-Alberto Paradís Llop <albertoparadisllop gmail.com>,albertoparadisllop
-Andrea Giudiceandrea <andreaerdna libero.it>,agiudiceandrea
-Maximilian Stahlberg <viech unvanquished.net>,Viech
+ymdatta <ymdatta.work gmail.com>,ymdatta
+積丹尼 Dan Jacobson <jidanni jidanni.org>,jidanni


### PR DESCRIPTION
To match the commits to their GitHub names, we need to translate some of the names and emails to GitHub names. Some of these were missing. Now the script also generates a list of authors who need that update.

There is still some names which are not recognized and we need to have another mechanism to ignore bots, so this is a draft.
