### PR TITLE
CI(python): Keep tools versions updated with env vars and renovate

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -15,21 +15,26 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{
         github.event_name == 'pull_request' &&
-        github.head_ref || github.sha }}-${{ matrix.pylint-version }}
+        github.head_ref || github.sha }}
       cancel-in-progress: true
 
-    # Using matrix just to get variables which are not environmental variables
-    # and also to sync with other workflows which use matrix.
     strategy:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: "3.10"
-            min-python-version: "3.8"
-            black-version: "24.4.0"
-            flake8-version: "3.9.2"
-            pylint-version: "2.12.2"
-            bandit-version: "1.7.8"
+
+    env:
+      # renovate: datasource=python-version depName=python
+      PYTHON_VERSION: "3.10"
+      MIN_PYTHON_VERSION: "3.8"
+      # renovate: datasource=pypi depName=black
+      BLACK_VERSION: "24.4.0"
+      # renovate: datasource=pypi depName=flake8
+      FLAKE8_VERSION: "3.9.2"
+      # renovate: datasource=pypi depName=pylint
+      PYLINT_VERSION: "2.12.2"
+      # renovate: datasource=pypi depName=bandit
+      BANDIT_VERSION: "1.7.8"
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -39,25 +44,25 @@ jobs:
       - name: Versions
         run: |
           echo OS: ${{ matrix.os }}
-          echo Python: ${{ matrix.python-version }}
-          echo Minimal Python version: ${{ matrix.min-python-version }}
-          echo Black: ${{ matrix.black-version }}
-          echo Flake8: ${{ matrix.flake8-version }}
-          echo Pylint: ${{ matrix.pylint-version }}
-          echo Bandit: ${{matrix.bandit-version}}
+          echo Python: ${{ env.PYTHON_VERSION }}
+          echo Minimal Python version: ${{ env.MIN_PYTHON_VERSION }}
+          echo Black: ${{ env.BLACK_VERSION }}
+          echo Flake8: ${{ env.FLAKE8_VERSION }}
+          echo Pylint: ${{ env.PYLINT_VERSION }}
+          echo Bandit: ${{ env.BANDIT_VERSION }}
 
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Set up Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
       - name: Install Black only
-        run: pip install black[jupyter]==${{ matrix.black-version }}
+        run: pip install black[jupyter]==${{ env.BLACK_VERSION }}
 
       - name: Run Black
         run: black .
@@ -82,9 +87,9 @@ jobs:
         run: |
           pip install -r .github/workflows/python_requirements.txt
           pip install -r .github/workflows/optional_requirements.txt
-          pip install flake8==${{ matrix.flake8-version }}
-          pip install pylint==${{ matrix.pylint-version }} pytest-github-actions-annotate-failures
-          pip install bandit[sarif]==${{matrix.bandit-version}}
+          pip install flake8==${{ env.FLAKE8_VERSION }}
+          pip install pylint==${{ env.PYLINT_VERSION }} pytest-github-actions-annotate-failures
+          pip install bandit[sarif]==${{ env.BANDIT_VERSION }}
 
       - name: Run Flake8
         run: |
@@ -130,19 +135,19 @@ jobs:
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
           cd python
-          pylint --persistent=no --py-version=${{ matrix.min-python-version }} --jobs=$(nproc) grass
+          pylint --persistent=no --py-version=${{ env.MIN_PYTHON_VERSION }} --jobs=$(nproc) grass
 
       - name: Run Pylint on wxGUI
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$HOME/install/grass84/lib:$LD_LIBRARY_PATH
           cd gui/wxpython
-          pylint --persistent=no --py-version=${{ matrix.min-python-version }} --jobs=$(nproc) *
+          pylint --persistent=no --py-version=${{ env.MIN_PYTHON_VERSION }} --jobs=$(nproc) *
 
       - name: Run Pylint on other files using pytest
         run: |
           pip install pytest==7.4.4 pytest-pylint==0.19
-          echo "::warning file=.github/workflows/python-code-quality.yml,line=116,col=42,endColumn=48::\
+          echo "::warning file=.github/workflows/python-code-quality.yml,line=149,col=42,endColumn=48::\
             Temporarily downgraded pytest-pylint and pytest to allow merging other PRs.\
             The errors reported with a newer version seem legitimite and should be fixed \
             (2023-10-18, see https://github.com/OSGeo/grass/pull/3205)\

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:best-practices",
-        ":semanticCommits",
-        ":semanticCommitTypeAll(CI)"
-    ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices",
+        ":semanticCommits",
+        ":semanticCommitTypeAll(CI)",
+ 
+        // allows to use comments starting with 
+        // "# renovate: " to update _VERSION 
+        // environment variables in GitHub Action files.
+        "customManagers:githubActionsVersions"
+    ]
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,9 @@
         // allows to use comments starting with 
         // "# renovate: " to update _VERSION 
         // environment variables in GitHub Action files.
-        "customManagers:githubActionsVersions"
+        "customManagers:githubActionsVersions",
+        
+        // when a dependency is really out of date, this will prevent to skip directly to the latest version.
+        ":separateMultipleMajorReleases",
     ]
 }


### PR DESCRIPTION
This PR sets up the tools versions in the Python code quality workflow as such that Renovate can pick these up.

It gets rid of the matrix strategy variables and uses global env vars, which is a good thing. The matrix strategy variables had drawbacks that made the code scanning configurations get a new key each time these changed.

On the renovate part, the feature used is the regex custom managers. But some configuration presets exists for that, and allow to use a standardized comment line above to insert many required and optional info to link any dependency to where the update info is. It allows to avoid writing a custom regex, and use a widely used one.

You may also notice the renovate config file uses json5; it simply allows trailing comma (to reduce diff for next change) and add comments. It is a supported renovate file format.

I also used the preset to separate multiple major versions in separate PRs: flake8 is very outdated, and bumping straight from v3.9.2 to v7.0.0 wasn’t smooth, but v4 was. It might be taken out later on if we feel it is too much.