### PR TITLE
docker: Use debian:bookworm-slim image, with date suffix instead of debian:stable

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,7 +1,5 @@
-FROM debian:stable@sha256:82f8da149d6d567c74564cccd6f355fb5ade42a958e4cde10a1100eaeb24d42e
-# currently Debian 12
+FROM debian:bookworm-20240612-slim@sha256:67f3931ad8cb1967beec602d8c0506af1e37e8d73c2a0b38b181ec5d8560d395
 
-# docker run -it --rm debian:stable bash
 # apt-get update && apt-get install lsb-release -y && lsb_release -a
 
 LABEL authors="Carmen Tawalika,Markus Neteler,Anika Weinmann"


### PR DESCRIPTION
Renovate has a special [handling of Debian versioning ](https://docs.renovatebot.com/modules/versioning/debian/) and should keep them updated with the digest pinned.