### PR TITLE
docker: Configure renovate updates for PDAL in Dockerfiles

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # define versions to be used (PDAL is not available on Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
+# renovate: datasource=github-tags depName=PDAL/PDAL
 ARG PDAL_VERSION=2.5.5
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
+# renovate: datasource=github-tags depName=PDAL/PDAL
 ARG PDAL_VERSION=2.4.3
 
 SHELL ["/bin/bash", "-c"]

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,10 @@
         // "# renovate: " to update _VERSION 
         // environment variables in GitHub Action files.
         "customManagers:githubActionsVersions",
+        // allows to use comments starting with
+        // "# renovate: " to update _VERSION
+        // ENV or ARG in a Dockerfile.
+        "customManagers:dockerfileVersions",
         
         // when a dependency is really out of date, this will prevent to skip directly to the latest version.
         ":separateMultipleMajorReleases",


### PR DESCRIPTION
Docker images for debian and ubuntu_wxgui use a build argument to get PDAL and compile it from source.

This PR uses the same pattern as https://github.com/OSGeo/grass/pull/3799 (using https://docs.renovatebot.com/presets-customManagers/#custommanagersdockerfileversions) to keep PDAL versions updated.