### PR TITLE
docker: Use only native Python API, set only necessary variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -323,7 +323,7 @@ RUN ln -sf /usr/local/grass85 /usr/local/grass
 # show GRASS GIS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
-    python3 --version
+    python --version
 
 # Reduce the image size
 RUN apt-get autoremove -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -321,7 +321,7 @@ COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
@@ -347,7 +347,7 @@ COPY docker/testdata/test_grass_session.py .
 RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 WORKDIR /grassdb
 VOLUME /grassdb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,12 +245,12 @@ RUN apt-get update \
 RUN (echo "Install Python" \
     && wget https://bootstrap.pypa.io/pip/get-pip.py \
     # && apt-get install -y python3-ensurepip \
-    && python3 get-pip.py \
+    && python get-pip.py \
     # && python3 -m ensurepip --upgrade \
     && rm -r get-pip.py \
     && mkdir -p /src/site-packages \
     && cd /src \
-    && python3 -m pip install --no-cache-dir -t /src/site-packages --upgrade \
+    && python -m pip install --no-cache-dir -t /src/site-packages --upgrade \
     $GRASS_PYTHON_PACKAGES \
     && rm -r /root/.cache \
     && rm -rf /tmp/pip-* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     zip \
     zlib1g \
     "
+ENV GRASS_RUN_PACKAGES=${GRASS_RUN_PACKAGES}
 
 # Define build packages
 ARG GRASS_BUILD_PACKAGES="cmake \
@@ -102,6 +103,7 @@ ARG GRASS_BUILD_PACKAGES="cmake \
     mesa-common-dev \
     zlib1g-dev \
     "
+ENV GRASS_BUILD_PACKAGES=${GRASS_BUILD_PACKAGES}
 
 ARG GRASS_CONFIG="--with-cxx \
   --enable-largefile \
@@ -135,12 +137,13 @@ ARG GRASS_PYTHON_PACKAGES="pip \
     matplotlib \
     psycopg2 \
   "
+ENV GRASS_PYTHON_PACKAGES=${GRASS_PYTHON_PACKAGES}
 
 
 FROM common_start as grass_without_gui
 
 ARG GRASS_CONFIG="${GRASS_CONFIG} --without-opengl"
-
+ENV GRASS_CONFIG=${GRASS_CONFIG}
 
 FROM common_start as grass_with_gui
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,6 @@ ARG GRASS_CONFIG="--with-cxx \
 
 ARG GRASS_PYTHON_PACKAGES="pip \
     setuptools \
-    grass-session \
     python-dateutil \
     python-magic \
     numpy \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -191,12 +191,10 @@ FROM common as grass
 
 # GRASS GIS specific
 # allow work with MAPSETs that are not owned by current user
-ENV GRASSBIN="/usr/local/bin/grass" \
-    GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
+ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     SHELL="/bin/bash" \
     # https://proj.org/usage/environmentvars.html#envvar-PROJ_NETWORK
     PROJ_NETWORK=ON \
-    GRASSBIN=grass \
     LC_ALL="en_US.UTF-8" \
     PYTHONPATH="/usr/local/grass/etc/python:$PYTHONPATH"
 
@@ -206,17 +204,17 @@ COPY --from=build /usr/local/grass* /usr/local/grass/
 COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
 # run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/
-COPY docker/testdata/test_grass_python.py docker/alpine/grass_tests.sh /scripts/
-COPY docker/testdata/test_grass_python.py /scripts/
+COPY docker/testdata/test_grass_python.py docker/testdata/test_grass_session.py docker/alpine/grass_tests.sh /scripts/
 
-# install external Python API
+# run GRASS GIS python session and scan the test LAZ file; some cleanup
+# also show installed version
 RUN ln -sf /usr/local/grass $(grass --config path); \
-    # run some tests and cleanup
-    $SHELL /scripts/grass_tests.sh \
+    rm -rf /tmp/grasstest_epsg_25832; \
+    $SHELL /scripts/grass_tests.sh; \
+    python /scripts/test_grass_session.py && rm -rf /tmp/grasstest_epsg_25832; \
+    grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g \
     && rm -f /scripts/grass_tests.sh /tmp/simple.laz /scripts/test_grass_python.py; \
-    # delete unused packages
     apk del --no-cache gettext pdal-dev; \
-    # show installed version
     grass --tmp-location XY --exec g.version -rge \
     && pdal --version \
     && python3 --version

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -217,7 +217,7 @@ RUN ln -sf /usr/local/grass $(grass --config path); \
     apk del --no-cache gettext pdal-dev; \
     grass --tmp-project XY --exec g.version -rge \
     && pdal --version \
-    && python3 --version
+    && python --version
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -212,7 +212,7 @@ RUN ln -sf /usr/local/grass $(grass --config path); \
     rm -rf /tmp/grasstest_epsg_25832; \
     $SHELL /scripts/grass_tests.sh; \
     python /scripts/test_grass_session.py && rm -rf /tmp/grasstest_epsg_25832; \
-    grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g \
+    grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g \
     && rm -f /scripts/grass_tests.sh /tmp/simple.laz /scripts/test_grass_python.py; \
     apk del --no-cache gettext pdal-dev; \
     grass --tmp-project XY --exec g.version -rge \

--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -1,8 +1,7 @@
 # Docker GRASS GIS (alpine linux)
 
 Dockerfile with an [Alpine Linux](https://www.alpinelinux.org/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
-[grass-session](https://github.com/zarch/grass-session/).
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is only approximately 80 MB.
 

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -5,7 +5,7 @@
 # add dependency
 apk add --no-cache py3-scikit-learn
 
-# Test grass-session:
+# Test grass-session
 /usr/bin/python3 /scripts/test_grass_session.py
 # Test PDAL
 grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update && apt-get upgrade -y && \
     netcdf-bin \
     proj-bin \
     proj-data \
+    python-is-python3 \
     python3 \
     python3-dateutil \
     python3-dev \
@@ -148,7 +149,6 @@ ENV CFLAGS "$MYCFLAGS"
 ENV CXXFLAGS "$MYCXXFLAGS"
 
 # Configure compile and install GRASS GIS
-ENV GRASS_PYTHON=/usr/bin/python3
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
@@ -197,7 +197,7 @@ RUN ln -sf /usr/local/grass85 /usr/local/grass
 # show GRASS GIS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
-    python3 --version
+    python --version
 
 # Reduce the image size
 RUN apt-get autoremove -y

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -208,24 +208,23 @@ RUN rm -r /src/grass_build/.git
 
 WORKDIR /scripts
 
-# install external GRASS GIS session Python API
-RUN pip3 install grass-session --break-system-packages
-
-# add GRASS GIS envs for python usage
-ENV GISBASE "/usr/local/grass/"
-ENV GRASSBIN "/usr/local/bin/grass"
-ENV PYTHONPATH "${PYTHONPATH}:$GISBASE/etc/python/"
-ENV LD_LIBRARY_PATH "$LD_LIBRARY_PATH:$GISBASE/lib"
+# enable GRASS GIS Python session support
+## grass --config python-path
+ENV PYTHONPATH "/usr/local/grass/etc/python:${PYTHONPATH}"
+# enable GRASS GIS ctypes imports
+## grass --config path
+ENV LD_LIBRARY_PATH "/usr/local/grass/lib:$LD_LIBRARY_PATH"
 
 WORKDIR /tmp
 COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## just scan the LAZ file
-# Not yet ready for GRASS GIS 8:
-#RUN /usr/bin/python3 /scripts/test_grass_session.py
+## run GRASS GIS python session and scan the test LAZ file
+RUN python3 /scripts/test_grass_session.py
+RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb
 VOLUME /grassdb
+CMD ["$GRASSBIN", "--version"]

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -218,7 +218,7 @@ COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
 ## run GRASS GIS python session and scan the test LAZ file
-RUN python3 /scripts/test_grass_session.py
+RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file
 RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g

--- a/docker/debian/README.md
+++ b/docker/debian/README.md
@@ -1,8 +1,7 @@
 # Docker GRASS GIS (Debian Linux)
 
 Dockerfile with an [Debian Linux](https://www.debian.org/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
-[grass-session](https://github.com/zarch/grass-session/).
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 2.6 GB.
 

--- a/docker/testdata/test_grass_session.py
+++ b/docker/testdata/test_grass_session.py
@@ -1,4 +1,4 @@
-# Import GRASS GIS Python bindings (requires 8-4+) and test r.in.pdal
+# Import GRASS GIS Python bindings (requires 8.4+) and test r.in.pdal
 
 # PYTHONPATH=$(grass --config python-path) python
 

--- a/docker/testdata/test_grass_session.py
+++ b/docker/testdata/test_grass_session.py
@@ -1,18 +1,16 @@
-# Import GRASS Python bindings
-# https://github.com/zarch/grass-session
-# pip install grass-session
+# Import GRASS GIS Python bindings (requires 8-4+) and test r.in.pdal
 
-from grass_session import Session
+# PYTHONPATH=$(grass --config python-path) python
+
 import grass.script as gs
 
+# full path to new project
+project = "/tmp/grasstest_epsg_25832"
+gs.create_project(project, epsg="25832")
+
 # hint: do not use ~ as an alias for HOME
-with Session(
-    # run in PERMANENT mapset after creation of location "test"
-    gisdb="/grassdata/",
-    location="test",
-    create_opts="EPSG:25832",
-):
-    print("grass-session: tests for PROJ, GDAL, PDAL, GRASS GIS")
+with gs.setup.init(project):
+    print("GRASS GIS session: tests for PROJ, GDAL, PDAL, GRASS GIS")
     print(gs.parse_command("g.gisenv", flags="s"))
 
     # simple test: just scan the LAZ file

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -323,7 +323,7 @@ RUN ln -sf /usr/local/grass85 /usr/local/grass
 # show GRASS GIS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
-    python3 --version
+    python --version
 
 # Reduce the image size
 RUN apt-get autoremove -y

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -321,7 +321,7 @@ COPY --link --from=build /usr/lib/gdalplugins /usr/lib/gdalplugins
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
@@ -347,7 +347,7 @@ COPY docker/testdata/test_grass_session.py .
 RUN python /scripts/test_grass_session.py
 RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 WORKDIR /grassdb
 VOLUME /grassdb
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -245,12 +245,12 @@ RUN apt-get update \
 RUN (echo "Install Python" \
     && wget https://bootstrap.pypa.io/pip/get-pip.py \
     # && apt-get install -y python3-ensurepip \
-    && python3 get-pip.py \
+    && python get-pip.py \
     # && python3 -m ensurepip --upgrade \
     && rm -r get-pip.py \
     && mkdir -p /src/site-packages \
     && cd /src \
-    && python3 -m pip install --no-cache-dir -t /src/site-packages --upgrade \
+    && python -m pip install --no-cache-dir -t /src/site-packages --upgrade \
     $GRASS_PYTHON_PACKAGES \
     && rm -r /root/.cache \
     && rm -rf /tmp/pip-* \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -83,6 +83,7 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     zip \
     zlib1g \
     "
+ENV GRASS_RUN_PACKAGES=${GRASS_RUN_PACKAGES}
 
 # Define build packages
 ARG GRASS_BUILD_PACKAGES="cmake \
@@ -102,6 +103,7 @@ ARG GRASS_BUILD_PACKAGES="cmake \
     mesa-common-dev \
     zlib1g-dev \
     "
+ENV GRASS_BUILD_PACKAGES=${GRASS_BUILD_PACKAGES}
 
 ARG GRASS_CONFIG="--with-cxx \
   --enable-largefile \
@@ -135,12 +137,13 @@ ARG GRASS_PYTHON_PACKAGES="pip \
     matplotlib \
     psycopg2 \
   "
+ENV GRASS_PYTHON_PACKAGES=${GRASS_PYTHON_PACKAGES}
 
 
 FROM common_start as grass_without_gui
 
 ARG GRASS_CONFIG="${GRASS_CONFIG} --without-opengl"
-
+ENV GRASS_CONFIG=${GRASS_CONFIG}
 
 FROM common_start as grass_with_gui
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -127,7 +127,6 @@ ARG GRASS_CONFIG="--with-cxx \
 
 ARG GRASS_PYTHON_PACKAGES="pip \
     setuptools \
-    grass-session \
     python-dateutil \
     python-magic \
     numpy \

--- a/docker/ubuntu/README.md
+++ b/docker/ubuntu/README.md
@@ -1,8 +1,7 @@
 # Docker GRASS GIS (Ubuntu Linux)
 
 Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
-[grass-session](https://github.com/zarch/grass-session/).
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 2.6 GB.
 

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -244,24 +244,23 @@ RUN rm -r /src/grass_build/.git
 
 WORKDIR /scripts
 
-# install external GRASS GIS session Python API
-RUN pip3 install grass-session
-
-# add GRASS GIS envs for python usage
-ENV GISBASE "/usr/local/grass/"
-ENV GRASSBIN "/usr/local/bin/grass"
-ENV PYTHONPATH "${PYTHONPATH}:$GISBASE/etc/python/"
-ENV LD_LIBRARY_PATH "$LD_LIBRARY_PATH:$GISBASE/lib"
+# enable GRASS GIS Python session support
+## grass --config python-path
+ENV PYTHONPATH "/usr/local/grass/etc/python:${PYTHONPATH}"
+# enable GRASS GIS ctypes imports
+## grass --config path
+ENV LD_LIBRARY_PATH "/usr/local/grass/lib:$LD_LIBRARY_PATH"
 
 WORKDIR /tmp
 COPY docker/testdata/simple.laz .
 WORKDIR /scripts
 COPY docker/testdata/test_grass_session.py .
-## just scan the LAZ file
-# Not yet ready for GRASS GIS 8:
-#RUN /usr/bin/python3 /scripts/test_grass_session.py
+## run GRASS GIS python session and scan the test LAZ file
+RUN python /scripts/test_grass_session.py
+RUN rm -rf /tmp/grasstest_epsg_25832
 # test LAZ file
 RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb
 VOLUME /grassdb
+CMD ["$GRASSBIN", "--version"]

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && apt-get upgrade -y && \
     netcdf-bin \
     proj-bin \
     proj-data \
+    python-is-python3 \
     python3 \
     python3-dateutil \
     python3-dev \
@@ -184,7 +185,6 @@ ENV CXXFLAGS "$MYCXXFLAGS"
 # wxGUI require
 # --with-x
 # --with-nls
-ENV GRASS_PYTHON=/usr/bin/python3
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
@@ -235,7 +235,7 @@ RUN ln -sf /usr/local/grass85 /usr/local/grass
 # show GRASS GIS, PROJ, GDAL etc versions
 RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
-    python3 --version
+    python --version
 
 # Reduce the image size
 RUN apt-get autoremove -y

--- a/docker/ubuntu_wxgui/README.md
+++ b/docker/ubuntu_wxgui/README.md
@@ -1,8 +1,7 @@
 # Docker GRASS GIS (Ubuntu Linux)
 
 Dockerfile with an [Ubuntu Linux](https://ubuntu.com/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
-[grass-session](https://github.com/zarch/grass-session/).
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 2.6 GB.
 

--- a/singularity/debian/README_debian.md
+++ b/singularity/debian/README_debian.md
@@ -1,8 +1,7 @@
 # Singularity GRASS GIS (Debian Linux)
 
 Singularityfile with an [Debian Linux](https://www.debian.org/) image with
-[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support and
-[grass-session](https://github.com/zarch/grass-session/).
+[GRASS GIS](https://grass.osgeo.org/), [PDAL](https://pdal.io) support.
 
 Download size of this image is of approximately 560 MB.
 

--- a/singularity/debian/singularityfile_debian
+++ b/singularity/debian/singularityfile_debian
@@ -137,9 +137,6 @@ Singularity container for GRASS GIS to be run into GRASS main directory
     #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=v.clip
     #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=v.strds.stats
 
-    # Add Python GRASS session
-    pip3 install grass-session
-
 %environment
     export LANG=C.UTF-8
     export LC_ALL=C.UTF-8


### PR DESCRIPTION
- Rewrite `testdata/test_grass_session.py`, replacing the `pip install grass-session` approach by native solution (now fully functional).
- Remove unneeded environmental variables from images (setting GISBASE without the rest of variables may be harmful because internal mechanisms use it to determine if there is an existing session or not).
- Update tests for all Dockerfiles.

Co-authored-by: Vaclav Petras <wenzeslaus@gmail.com>