### PR TITLE
docker: replace --tmp-location with --tmp-project

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@
 Find out included version of GDAL, GEOS, PROJ, PDAL, Python and GRASS GIS using
 
 ```bash
-grass --tmp-location XY --exec g.version -rge \
+grass --tmp-project XY --exec g.version -rge \
     && pdal --version \
     && python3 --version
 ```

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -217,7 +217,7 @@ RUN ln -sf /usr/local/grass $(grass --config path); \
     # delete unused packages
     apk del --no-cache gettext pdal-dev; \
     # show installed version
-    grass --tmp-location XY --exec g.version -rge \
+    grass --tmp-project XY --exec g.version -rge \
     && pdal --version \
     && python3 --version
 

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -8,17 +8,17 @@ apk add --no-cache py3-scikit-learn
 # Test grass-session:
 /usr/bin/python3 /scripts/test_grass_session.py
 # Test PDAL
-grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 # Test GRASS GIS Python-addon installation
-grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add && \
-   grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
+grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=add && \
+   grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=remove -f
 
 # Test GRASS GIS C-addon installation: raster and vector
-grass --tmp-location XY --exec g.extension extension=r.gwr operation=add && \
-   grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
-grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add && \
-   grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
+grass --tmp-project XY --exec g.extension extension=r.gwr operation=add && \
+   grass --tmp-project XY --exec g.extension extension=r.gwr operation=remove -f
+grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=add && \
+   grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # cleanup dependency
 apk del py3-scikit-learn

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -195,7 +195,7 @@ ENV PROJ_NETWORK=ON
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
@@ -223,7 +223,7 @@ COPY docker/testdata/test_grass_session.py .
 # Not yet ready for GRASS GIS 8:
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
 # test LAZ file
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb
 VOLUME /grassdb

--- a/docker/testdata/test_docker_image.sh
+++ b/docker/testdata/test_docker_image.sh
@@ -29,29 +29,29 @@ export DEMOLOCATION=/tmp/demolocation/PERMANENT
 
 # Test PDAL
 printf "\n############\nTesting PDAL with laz:\n############\n"
-grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 # Test GRASS GIS Python-addon installation
 # add dependency
 printf "\n############\nTesting GRASS GIS Python-addon installation:\n############\n"
 /usr/bin/python3 -m pip install --no-cache-dir scikit-learn
 
-grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=add && \
-	   grass --tmp-location XY --exec g.extension extension=r.learn.ml2 operation=remove -f
+grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=add && \
+	   grass --tmp-project XY --exec g.extension extension=r.learn.ml2 operation=remove -f
 
 # cleanup dependency
 /usr/bin/python3 -m pip uninstall -y scikit-learn
 
 # Test GRASS GIS C-addon installation: raster and vector
 printf "\n############\nTesting GRASS GIS C-addon installation:\n############\n"
-grass --tmp-location XY --exec g.extension extension=r.gwr operation=add && \
-	   grass --tmp-location XY --exec g.extension extension=r.gwr operation=remove -f
-grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=add && \
-	   grass --tmp-location XY --exec g.extension extension=v.centerpoint operation=remove -f
+grass --tmp-project XY --exec g.extension extension=r.gwr operation=add && \
+	   grass --tmp-project XY --exec g.extension extension=r.gwr operation=remove -f
+grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=add && \
+	   grass --tmp-project XY --exec g.extension extension=v.centerpoint operation=remove -f
 
 # show GRASS GIS, PROJ, GDAL etc versions
 printf "\n############\nPrinting GRASS, PDAL and Python versions:\n############\n"
-grass --tmp-location EPSG:4326 --exec g.version -rge && \
+grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -233,7 +233,7 @@ ENV PROJ_NETWORK=ON
 RUN ln -sf /usr/local/grass85 /usr/local/grass
 
 # show GRASS GIS, PROJ, GDAL etc versions
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
@@ -261,7 +261,7 @@ COPY docker/testdata/test_grass_session.py .
 # Not yet ready for GRASS GIS 8:
 #RUN /usr/bin/python3 /scripts/test_grass_session.py
 # test LAZ file
-RUN grass --tmp-location EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
+RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" output="count_1" method="n" resolution=1 -g
 
 WORKDIR /grassdb
 VOLUME /grassdb

--- a/singularity/debian/singularityfile_debian
+++ b/singularity/debian/singularityfile_debian
@@ -128,14 +128,14 @@ Singularity container for GRASS GIS to be run into GRASS main directory
     cd /tmp
     rm -rf /tmp/grass_build
     # Add useful GRASS addons
-    grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=i.modis
-    grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=i.sentinel
-    grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=r.in.pdal
-    #grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=i.wi
-    #grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=r.bioclim
-    #grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=r.series.lwr
-    #grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=v.clip
-    #grass -c EPSG:4326 --tmp-location --exec g.extension -s ext=v.strds.stats
+    grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=i.modis
+    grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=i.sentinel
+    grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=r.in.pdal
+    #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=i.wi
+    #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=r.bioclim
+    #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=r.series.lwr
+    #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=v.clip
+    #grass -c EPSG:4326 --tmp-project --exec g.extension -s ext=v.strds.stats
 
     # Add Python GRASS session
     pip3 install grass-session


### PR DESCRIPTION
Option `--tmp-location` is deprecated, use `--tmp-project` flag instead