### PR TITLE
contributing: Add more prefixes

### DIFF
--- a/utils/release.yml
+++ b/utils/release.yml
@@ -29,10 +29,10 @@ notes:
       regexp: '(packaging|pkg|rpm|deb|pkg-config|configure|config|[Mm]ake|build): '
 
     - title: Docker
-      regexp: '[Dd]ocker(/[^ ]+)?(\(\w[\w.]*\))?: '
+      regexp: '[Dd]ocker(/[^ ]+)?(\(\w[\w.-]*\))?: '
 
     - title: Singularity
-      regexp: '[Ss]ingularity: '
+      regexp: '[Ss]ingularity(\(\w[\w.-]*\))?: '
 
     - title: Continuous Integration, Infrastructure, Tests and Code Quality
       regexp: '(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest)(\(\w[\w.-]*\))?: '

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -2,7 +2,7 @@
 notes:
   categories:
     - title: Modules
-      regexp: '((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools): '
+      regexp: '((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools|temporal): '
 
     - title: Graphical User Interface
       regexp: '(wxGUI.*|gui|GUI): '
@@ -29,13 +29,13 @@ notes:
       regexp: '(packaging|pkg|rpm|deb|pkg-config|configure|config|[Mm]ake|build): '
 
     - title: Docker
-      regexp: '[Dd]ocker(/[^ ]+)?: '
+      regexp: '[Dd]ocker(/[^ ]+)?(\(\w[\w.]*\))?: '
 
     - title: Singularity
       regexp: '[Ss]ingularity: '
 
-    - title: Continuous Integration, Tests, Code Quality, and Checks
-      regexp: '(CI|ci|CI\(deps\)|ci\(deps\)|[Tt]ests|[Cc]hecks|pytest): '
+    - title: Continuous Integration, Infrastructure, Tests and Code Quality
+      regexp: '(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest)(\(\w[\w.-]*\))?: '
 
     - title: Contributing and Management
       regexp: '(contributing|CONTRIBUTING.md|contributors|contributors.csv): '


### PR DESCRIPTION
Add prefixes temporal (a lot of temporal tools are often changed together). Docker and CI et al. can have subcategories or scopes. General style and perf are recognized. unittest (as in Python unittest) is recognized together with pytest. Refactoring is added as reaction to a specific change. utils is based on existing commits which are hard to categorize otherwise.
