### PR TITLE
CI: replace --tmp-location with --tmp-project

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,9 +61,9 @@ jobs:
       - name: Run tests
         shell: bash -el {0}
         run: >
-          grass --tmp-location XY --exec \
+          grass --tmp-project XY --exec \
               g.download.location url=${{ env.SampleData }} path=$HOME
-          grass --tmp-location XY --exec \
+          grass --tmp-project XY --exec \
               python3 -m grass.gunittest.main \
               --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
               --min-success 100 --config .github/workflows/macos_gunittest.cfg

--- a/.github/workflows/print_versions.sh
+++ b/.github/workflows/print_versions.sh
@@ -10,6 +10,6 @@ git --version
 
 # This will fail if the build failed.
 grass --version
-grass --tmp-location XY --exec g.version -ergb
+grass --tmp-project XY --exec g.version -ergb
 # Detailed Python version info (in one line thanks to echo)
-grass --tmp-location XY --exec bash -c "echo Python: \$(\$GRASS_PYTHON -c 'import sys; print(sys.version)')"
+grass --tmp-project XY --exec bash -c "echo Python: \$(\$GRASS_PYTHON -c 'import sys; print(sys.version)')"

--- a/.github/workflows/test_simple.bat
+++ b/.github/workflows/test_simple.bat
@@ -1,8 +1,8 @@
 set grass=%1
 
 rem Test execution of binary command
-call %grass% --tmp-location EPSG:4326 --exec g.region res=0.1 -p
+call %grass% --tmp-project EPSG:4326 --exec g.region res=0.1 -p
 rem Test if batch-wrapper-scripts without extension are found
-call %grass% --tmp-location EPSG:4326 --exec C:/Windows/System32/where.exe t.create
+call %grass% --tmp-project EPSG:4326 --exec C:/Windows/System32/where.exe t.create
 rem Test if python-scripts can be called
-call %grass% --tmp-location EPSG:4326 --exec t.create --help
+call %grass% --tmp-project EPSG:4326 --exec t.create --help

--- a/.github/workflows/test_simple.sh
+++ b/.github/workflows/test_simple.sh
@@ -4,8 +4,8 @@
 set -e
 
 # Test execution of binary command
-grass --tmp-location EPSG:4326 --exec g.region res=0.1 -p
+grass --tmp-project EPSG:4326 --exec g.region res=0.1 -p
 # Test if python modules without extension are found
-grass --tmp-location EPSG:4326 --exec which t.create
+grass --tmp-project EPSG:4326 --exec which t.create
 # Test if python modules can be called
-grass --tmp-location EPSG:4326 --exec t.create --help
+grass --tmp-project EPSG:4326 --exec t.create --help

--- a/.github/workflows/test_thorough.bat
+++ b/.github/workflows/test_thorough.bat
@@ -1,5 +1,5 @@
 set grass=%1
 set python=%2
 
-call %grass% --tmp-location XY --exec g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=%USERPROFILE%
-call %grass% --tmp-location XY --exec %python% -m grass.gunittest.main --grassdata %USERPROFILE% --location nc_spm_full_v2alpha2 --location-type nc --min-success 80
+call %grass% --tmp-project XY --exec g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=%USERPROFILE%
+call %grass% --tmp-project XY --exec %python% -m grass.gunittest.main --grassdata %USERPROFILE% --location nc_spm_full_v2alpha2 --location-type nc --min-success 80

--- a/.github/workflows/test_thorough.sh
+++ b/.github/workflows/test_thorough.sh
@@ -3,10 +3,10 @@
 # fail on non-zero return code from a subprocess
 set -e
 
-grass --tmp-location XY --exec \
+grass --tmp-project XY --exec \
     g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 
-grass --tmp-location XY --exec \
+grass --tmp-project XY --exec \
     python3 -m grass.gunittest.main \
     --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc \
     --min-success 100 $@


### PR DESCRIPTION
Option `--tmp-location` is deprecated, use `--tmp-project` flag instead