### PR TITLE
docker: Revert failing cleaning steps in Ubuntu Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -327,11 +327,6 @@ RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python --version
 
-# Reduce the image size
-RUN apt-get autoremove -y
-RUN apt-get clean -y
-RUN rm -r /src/grass_build/.git
-
 WORKDIR /scripts
 
 # enable GRASS GIS Python session support

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -327,11 +327,6 @@ RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python --version
 
-# Reduce the image size
-RUN apt-get autoremove -y
-RUN apt-get clean -y
-RUN rm -r /src/grass_build/.git
-
 WORKDIR /scripts
 
 # enable GRASS GIS Python session support


### PR DESCRIPTION
Built both on a fresh cloud IDE, and also finishing building the untouched ubuntu_wxgui Dockerfile

This fixes only the failures introduced in https://github.com/OSGeo/grass/commit/9f7ecdc31044b64794f35491093ffb8e336c22b4, but nothing else