### PR TITLE
python(flake8): Add excluded pattern from .flake8 to .pre-commit-config.yaml

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -196,6 +196,7 @@ per-file-ignores =
 
 
 max-line-length = 88
+# Remember to remove the exclusions from .pre-commit-config.yaml when removing here
 exclude =
     .git,
     __pycache__,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,8 @@ repos:
       - id: flake8
         exclude: |
           (?x)^(
-                python/libgrass_interface_generator/
+                python/libgrass_interface_generator/|
+                .*/testsuite/.*
           )
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v15.0.6


### PR DESCRIPTION
This PR was the cause of the failures preventing upgrading to flake8 version 7.0.0, especially using Python 3.12.

Before dropping all the other commits, I successfully tested in CI that flake8 7.0 works with pre-commit with python 3.12 and that the python-code-quality workflow, can be upgraded to python 3.12 and flake8 7.0.0. See https://github.com/echoix/grass/actions/runs/9528534271/job/26266309879?pr=116, and an equivalent code here (backup of the rebase) https://github.com/echoix/grass/pull/118. Updates might need to be batched together.


The issue here, was that pre-commit calls the tools with a list of files, and flake8 lints them regardless of whether the .flake8 config excludes them or not. Calling `pre-commit run --all-files` sends a list of all files, and get linted. Other projects have had this problem with flake8 and pre-commit, the solution is to replicate the exclusions in the .pre-commit-config.yaml file. Here, only the testsuite folder was needed.


Flake8 failures with python 3.12 needs newer flake8 versions than the ones currently used, that these allow to unblock.

Once merged, https://github.com/OSGeo/grass/pull/3818 should be retried (but might need a newer python version too).