### PR TITLE
CI: Run pre-commit on all files on pre-commit config changes

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -28,6 +28,14 @@ jobs:
         with:
           fetch-depth: 31
 
+      - name: Check what files were changed
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            precommit:
+              - '.pre-commit-config.yaml'
+
       - name: Check for CRLF endings
         uses: erclu/check-crlf@94acb86c2a41b0a46bd8087b63a06f0457dd0c6c # v1.2.0
         with:
@@ -60,3 +68,6 @@ jobs:
               ${{ github.ref_name }} \
               $(git rev-parse HEAD~30) \
               ""
+
+      - run: pip install pre-commit && pre-commit run -a
+        if: ${{ steps.changes.outputs.precommit == 'true' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 ---
 ci:
   skip: [flake8]
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ---
 ci:
   skip: [flake8]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
In order to be able to review automated pre-commit hooks PRs from renovate, we need to be able to test if pre-commit the new config file works correctly.

This PR adds a step to run pre-commit on all files ONLY IF the .pre-commit-config.yaml file is updated.

I kept the commit that is later reverted on purpose to be able to show the workflow run results, and show that it was tested. Feel free to clear these two when squashing.

See:
* Step not running since file not changed: https://github.com/echoix/grass/actions/runs/9528895290/job/26267060588?pr=120
* Step running when the file is changed: https://github.com/echoix/grass/actions/runs/9529084450/job/26267443677?pr=120
* Step now not running since the full PR diff doesn't change .pre-commit-config.yaml anymore: https://github.com/echoix/grass/actions/runs/9529105603/job/26267485089?pr=120

A PR enabling renovate updates for .pre-commit is ready, but this PR should be merged first, then an upcoming PR fixing up existing pre-commit violations.