### PR TITLE
grass.benchmark: Compute speedup and enable plotting speedup/efficiency

### DIFF
--- a/python/grass/benchmark/app.py
+++ b/python/grass/benchmark/app.py
@@ -69,6 +69,7 @@ def plot_nprocs_cli(args):
         results.results,
         filename=args.output,
         title=args.title,
+        metric=args.metric,
     )
 
 
@@ -161,9 +162,17 @@ def add_results_subcommand(parent_subparsers):
 
 def add_plot_io_arguments(parser):
     """Add input and output arguments to *parser*."""
-    parser.add_argument("input", help="file with results (JSON)", metavar="input_file")
     parser.add_argument(
-        "output", help="output file (e.g., PNG)", nargs="?", metavar="output_file"
+        "input", help="file with results (e.g. results.json)", metavar="input_file"
+    )
+    parser.add_argument(
+        "output",
+        help=(
+            "output file with extension (e.g., figure.png)."
+            " If not provided, the plot will be opened in a new window."
+        ),
+        nargs="?",
+        metavar="output_file",
     )
 
 
@@ -173,6 +182,16 @@ def add_plot_title_argument(parser):
         "--title",
         help="Title for the plot",
         metavar="text",
+    )
+
+
+def add_plot_metric_argument(parser):
+    """Add metric argument to *parser*."""
+    parser.add_argument(
+        "--metric",
+        help="Metric for the plot (default: time)",
+        default="time",
+        choices=["time", "speedup", "efficiency"],
     )
 
 
@@ -198,6 +217,7 @@ def add_plot_subcommand(parent_subparsers):
     )
     add_plot_io_arguments(nprocs)
     add_plot_title_argument(nprocs)
+    add_plot_metric_argument(nprocs)
     nprocs.set_defaults(handler=plot_nprocs_cli)
 
 
@@ -206,6 +226,7 @@ def define_arguments():
     parser = argparse.ArgumentParser(
         description="Process results from module benchmarks.",
         prog=get_executable_name(),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     subparsers = add_subparsers(parser, dest="command")
 

--- a/python/grass/benchmark/app.py
+++ b/python/grass/benchmark/app.py
@@ -66,7 +66,7 @@ def plot_nprocs_cli(args):
     """Translate CLI parser result to API calls."""
     results = load_results_from_file(args.input)
     nprocs_plot(
-        results.results,
+        results["results"],
         filename=args.output,
         title=args.title,
     )
@@ -76,7 +76,7 @@ def plot_cells_cli(args):
     """Translate CLI parser result to API calls."""
     results = load_results_from_file(args.input)
     num_cells_plot(
-        results.results,
+        results["results"],
         filename=args.output,
         title=args.title,
         show_resolution=args.resolutions,

--- a/python/grass/benchmark/app.py
+++ b/python/grass/benchmark/app.py
@@ -66,7 +66,7 @@ def plot_nprocs_cli(args):
     """Translate CLI parser result to API calls."""
     results = load_results_from_file(args.input)
     nprocs_plot(
-        results["results"],
+        results.results,
         filename=args.output,
         title=args.title,
     )
@@ -76,7 +76,7 @@ def plot_cells_cli(args):
     """Translate CLI parser result to API calls."""
     results = load_results_from_file(args.input)
     num_cells_plot(
-        results["results"],
+        results.results,
         filename=args.output,
         title=args.title,
         show_resolution=args.resolutions,

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -37,7 +37,7 @@ def get_pyplot(to_file):
     return plt
 
 
-def nprocs_plot(results, filename=None, title=None):
+def nprocs_plot(results, filename=None, title=None, metric="time"):
     """Plot results from a multiple nprocs (thread) benchmarks.
 
     *results* is a list of individual results from separate benchmarks.
@@ -54,6 +54,7 @@ def nprocs_plot(results, filename=None, title=None):
     Each result can come with a different list of nprocs, i.e., benchmarks
     which used different values for nprocs can be combined in one plot.
     """
+    ylabel = ""
     plt = get_pyplot(to_file=bool(filename))
     axes = plt.gca()
 
@@ -61,11 +62,20 @@ def nprocs_plot(results, filename=None, title=None):
     for result in results:
         x = result.nprocs
         x_ticks.update(x)
-        plt.plot(x, result.times, label=result.label)
-        if hasattr(result, "all_times"):
+        if metric == "time":
             mins = [min(i) for i in result.all_times]
             maxes = [max(i) for i in result.all_times]
+            plt.plot(x, result.times, label=result.label)
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
+            ylabel = "Time [s]"
+        elif metric in ["speedup", "efficiency"]:
+            ylabel = metric.title()
+            plt.plot(x, result.__dict__[metric], label=result.label)
+        else:
+            raise ValueError(
+                f"Invalid metric '{metric}' in result, it should be:\
+                'time', 'speedup' or 'efficiency'"
+            )
     plt.legend()
     # If there is not many x values, show ticks for each, but use default
     # ticks when there is a lot of x values.
@@ -78,11 +88,13 @@ def nprocs_plot(results, filename=None, title=None):
 
         axes.xaxis.set_major_locator(MaxNLocator(integer=True))
     plt.xlabel("Number of processing elements (cores, threads, processes)")
-    plt.ylabel("Time [s]")
+    plt.ylabel(ylabel)
     if title:
         plt.title(title)
-    else:
+    elif metric == "times":
         plt.title("Execution time by processing elements")
+    elif metric in ["speedup", "efficiency"]:
+        plt.title(f"{metric.title()} by processing elements")
     if filename:
         plt.savefig(filename)
     else:

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -60,17 +60,17 @@ def nprocs_plot(results, filename=None, title=None, metric="time"):
 
     x_ticks = set()  # gather x values
     for result in results:
-        x = result["nprocs"]
+        x = result.nprocs
         x_ticks.update(x)
         if metric == "time":
-            mins = [min(i) for i in result["all_times"]]
-            maxes = [max(i) for i in result["all_times"]]
-            plt.plot(x, result["times"], label=result["label"])
+            mins = [min(i) for i in result.all_times]
+            maxes = [max(i) for i in result.all_times]
+            plt.plot(x, result.times, label=result.label)
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
             ylabel = "Time [s]"
         elif metric in ["speedup", "efficiency"]:
             ylabel = metric.title()
-            plt.plot(x, result[metric], label=result["label"])
+            plt.plot(x, getattr(result, metric), label=result.label)
         else:
             raise ValueError(
                 f"Invalid metric '{metric}' in result, it should be:\
@@ -122,14 +122,14 @@ def num_cells_plot(results, filename=None, title=None, show_resolution=False):
     x_ticks = set()
     for result in results:
         if show_resolution:
-            x = result["resolutions"]
+            x = result.resolutions
         else:
-            x = result["cells"]
+            x = result.cells
         x_ticks.update(x)
-        plt.plot(x, result["times"], label=result["label"])
+        plt.plot(x, result.times, label=result.label)
         if hasattr(result, "all_times"):
-            mins = [min(i) for i in result["all_times"]]
-            maxes = [max(i) for i in result["all_times"]]
+            mins = [min(i) for i in result.all_times]
+            maxes = [max(i) for i in result.all_times]
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
 
     plt.legend()

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -122,14 +122,14 @@ def num_cells_plot(results, filename=None, title=None, show_resolution=False):
     x_ticks = set()
     for result in results:
         if show_resolution:
-            x = result.resolutions
+            x = result["resolutions"]
         else:
-            x = result.cells
+            x = result["cells"]
         x_ticks.update(x)
-        plt.plot(x, result.times, label=result.label)
+        plt.plot(x, result["times"], label=result["label"])
         if hasattr(result, "all_times"):
-            mins = [min(i) for i in result.all_times]
-            maxes = [max(i) for i in result.all_times]
+            mins = [min(i) for i in result["all_times"]]
+            maxes = [max(i) for i in result["all_times"]]
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
 
     plt.legend()

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -56,7 +56,7 @@ def nprocs_plot(results, filename=None, title=None, metric="time"):
     """
     ylabel = ""
     plt = get_pyplot(to_file=bool(filename))
-    axes = plt.gca()
+    _, axes = plt.subplots()
 
     x_ticks = set()  # gather x values
     for result in results:

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -48,6 +48,9 @@ def nprocs_plot(results, filename=None, title=None, metric="time"):
     from the *nprocs* list.
     The *label* attribute identifies the benchmark in the legend.
 
+    *metric* can be "time", "speedup", or "efficiency".
+    This function plots a corresponding figure based on the chosen metric.
+
     Optionally, result can have an *all_times* attribute which is a list
     of lists. One sublist is all times recorded for each value of nprocs.
 

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -60,17 +60,17 @@ def nprocs_plot(results, filename=None, title=None, metric="time"):
 
     x_ticks = set()  # gather x values
     for result in results:
-        x = result.nprocs
+        x = result["nprocs"]
         x_ticks.update(x)
         if metric == "time":
-            mins = [min(i) for i in result.all_times]
-            maxes = [max(i) for i in result.all_times]
-            plt.plot(x, result.times, label=result.label)
+            mins = [min(i) for i in result["all_times"]]
+            maxes = [max(i) for i in result["all_times"]]
+            plt.plot(x, result["times"], label=result["label"])
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
             ylabel = "Time [s]"
         elif metric in ["speedup", "efficiency"]:
             ylabel = metric.title()
-            plt.plot(x, result.__dict__[metric], label=result.label)
+            plt.plot(x, result[metric], label=result["label"])
         else:
             raise ValueError(
                 f"Invalid metric '{metric}' in result, it should be:\

--- a/python/grass/benchmark/results.py
+++ b/python/grass/benchmark/results.py
@@ -59,7 +59,7 @@ def load_results(data):
     default dictionary object. Use attribute access to access by key
     (not dict-like syntax).
     """
-    return json.loads(data, object_hook=lambda d: dict(**d))
+    return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
 
 
 def load_results_from_file(filename):
@@ -84,18 +84,18 @@ def join_results(results, prefixes=None, select=None, prefixes_as_labels=False):
         prefixes = [None] * len(results)
     joined = []
     for result_list, prefix in zip(results, prefixes):
-        if "results" in result_list:
+        if hasattr(result_list, "results"):
             # This is the actual list in the full results structure.
-            result_list = result_list["results"]
+            result_list = result_list.results
         for result in result_list:
             if select and not select(result):
                 continue
             result = copy.deepcopy(result)
             if prefix:
                 if prefixes_as_labels:
-                    result["label"] = prefix
+                    result.label = prefix
                 else:
-                    result["label"] = f"{prefix}: {result.label}"
+                    result.label = f"{prefix}: {result.label}"
             joined.append(result)
     return joined
 

--- a/python/grass/benchmark/results.py
+++ b/python/grass/benchmark/results.py
@@ -59,7 +59,7 @@ def load_results(data):
     default dictionary object. Use attribute access to access by key
     (not dict-like syntax).
     """
-    return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
+    return json.loads(data, object_hook=lambda d: dict(**d))
 
 
 def load_results_from_file(filename):
@@ -84,18 +84,18 @@ def join_results(results, prefixes=None, select=None, prefixes_as_labels=False):
         prefixes = [None] * len(results)
     joined = []
     for result_list, prefix in zip(results, prefixes):
-        if hasattr(result_list, "results"):
+        if "results" in result_list:
             # This is the actual list in the full results structure.
-            result_list = result_list.results
+            result_list = result_list["results"]
         for result in result_list:
             if select and not select(result):
                 continue
             result = copy.deepcopy(result)
             if prefix:
                 if prefixes_as_labels:
-                    result.label = prefix
+                    result["label"] = prefix
                 else:
-                    result.label = f"{prefix}: {result.label}"
+                    result["label"] = f"{prefix}: {result.label}"
             joined.append(result)
     return joined
 

--- a/python/grass/benchmark/runners.py
+++ b/python/grass/benchmark/runners.py
@@ -105,6 +105,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
     serial_avg = None
     avg_times = []
     all_times = []
+    speedup = []
     efficiency = []
     nprocs_list = list(range(1, max_nprocs + 1))
     nprocs_list_shuffled = sorted(nprocs_list * repeat)
@@ -129,6 +130,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
         if avg < min_avg:
             min_avg = avg
             min_time = nprocs
+        speedup.append(avg / serial_avg)
         efficiency.append(serial_avg / (nprocs * avg))
 
     print("\u2500" * term_size.columns)
@@ -139,6 +141,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
     return SimpleNamespace(
         all_times=all_times,
         times=avg_times,
+        speedup=speedup,
         efficiency=efficiency,
         nprocs=nprocs_list,
         label=label,

--- a/python/grass/benchmark/runners.py
+++ b/python/grass/benchmark/runners.py
@@ -128,7 +128,7 @@ def benchmark_nprocs(module, label, max_nprocs, repeat=5, shuffle=True):
         if avg < min_avg:
             min_avg = avg
             min_time = nprocs
-        result.speedup.append(avg / serial_avg)
+        result.speedup.append(serial_avg / avg)
         result.efficiency.append(serial_avg / (nprocs * avg))
 
     print("\u2500" * term_size.columns)

--- a/python/grass/benchmark/runners.py
+++ b/python/grass/benchmark/runners.py
@@ -52,7 +52,7 @@ def benchmark_single(module, label, repeat=5):
         module.run()
         print(f"{module.time}s")
         time_sum += module.time
-        result["label"].append(module.time)
+        result["all_times"].append(module.time)
 
     result["time"] = time_sum / repeat
     if result["time"] < min_avg:
@@ -167,7 +167,7 @@ def benchmark_resolutions(module, resolutions, label, repeat=5, nprocs=None):
     for resolution in resolutions:
         gs.run_command("g.region", res=resolution)
         region = gs.region()
-        result["label"].append(region["cells"])
+        result["cells"].append(region["cells"])
         print("\u2500" * term_size.columns)
         print(f"Benchmark with {resolution} resolution...\n")
         time_sum = 0

--- a/python/grass/benchmark/testsuite/test_benchmark.py
+++ b/python/grass/benchmark/testsuite/test_benchmark.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 
 from grass.benchmark import (
     benchmark_resolutions,
+    benchmark_nprocs,
     benchmark_single,
     join_results,
     load_results,
@@ -78,6 +79,30 @@ class TestBenchmarksRun(TestCase):
         for result in results:
             self.assertTrue(hasattr(result, "all_times"))
             self.assertTrue(hasattr(result, "time"))
+            self.assertTrue(hasattr(result, "label"))
+            self.assertEqual(len(result.all_times), repeat)
+        self.assertEqual(results[0].label, label)
+
+    def test_nprocs(self):
+        """Test that benchmark function runs for nprocs"""
+        label = "Standard output"
+        repeat = 4
+        benchmarks = [
+            dict(
+                module=Module("r.univar", map="elevation", stdout_=DEVNULL, run_=False),
+                label=label,
+                max_nprocs=4,
+            )
+        ]
+        results = []
+        for benchmark in benchmarks:
+            results.append(benchmark_nprocs(**benchmark, repeat=repeat, shuffle=True))
+        self.assertEqual(len(results), len(benchmarks))
+        for result in results:
+            self.assertTrue(hasattr(result, "times"))
+            self.assertTrue(hasattr(result, "all_times"))
+            self.assertTrue(hasattr(result, "speedup"))
+            self.assertTrue(hasattr(result, "efficiency"))
             self.assertTrue(hasattr(result, "label"))
             self.assertEqual(len(result.all_times), repeat)
         self.assertEqual(results[0].label, label)

--- a/python/grass/benchmark/testsuite/test_benchmark.py
+++ b/python/grass/benchmark/testsuite/test_benchmark.py
@@ -14,7 +14,6 @@
 
 from pathlib import Path
 from subprocess import DEVNULL
-from types import SimpleNamespace
 
 from grass.benchmark import (
     benchmark_resolutions,
@@ -76,11 +75,11 @@ class TestBenchmarksRun(TestCase):
             results.append(benchmark_single(**benchmark, repeat=repeat))
         self.assertEqual(len(results), len(benchmarks))
         for result in results:
-            self.assertTrue(hasattr(result, "all_times"))
-            self.assertTrue(hasattr(result, "time"))
-            self.assertTrue(hasattr(result, "label"))
-            self.assertEqual(len(result.all_times), repeat)
-        self.assertEqual(results[0].label, label)
+            self.assertTrue("all_times" in result)
+            self.assertTrue("time" in result)
+            self.assertTrue("label" in result)
+            self.assertEqual(len(result["all_times"]), repeat)
+        self.assertEqual(results[0]["label"], label)
 
 
 class TestBenchmarkResults(TestCase):
@@ -104,39 +103,39 @@ class TestBenchmarkResults(TestCase):
         ]
         results = load_results(save_results(results))
         plot_file = "test_res_plot.png"
-        num_cells_plot(results.results, filename=plot_file)
+        num_cells_plot(results["results"], filename=plot_file)
         self.assertTrue(Path(plot_file).is_file())
 
     def test_data_file_roundtrip(self):
         """Test functions can save and load to a file"""
-        original = [SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1")]
+        original = [dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1")]
         filename = "test_res_file.json"
 
         save_results_to_file(original, filename)
         self.assertTrue(Path(filename).is_file())
 
-        loaded = load_results_from_file(filename).results
+        loaded = load_results_from_file(filename)["results"]
         self.assertEqual(original, loaded)
 
     def test_join_results_list(self):
         """Test that we can join lists"""
         list_1 = [
-            SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
-            SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
+            dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
+            dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
         ]
-        list_2 = [SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
+        list_2 = [dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
         new_results = join_results([list_1, list_2])
         self.assertEqual(len(new_results), 3)
 
     def test_join_results_structure(self):
         """Test that we can join a full results structure"""
-        list_1 = SimpleNamespace(
+        list_1 = dict(
             results=[
-                SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
-                SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
+                dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
+                dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
             ]
         )
-        list_2 = [SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
+        list_2 = [dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
         new_results = join_results([list_1, list_2])
         self.assertEqual(len(new_results), 3)
 

--- a/python/grass/benchmark/testsuite/test_benchmark.py
+++ b/python/grass/benchmark/testsuite/test_benchmark.py
@@ -14,6 +14,7 @@
 
 from pathlib import Path
 from subprocess import DEVNULL
+from types import SimpleNamespace
 
 from grass.benchmark import (
     benchmark_resolutions,
@@ -75,11 +76,11 @@ class TestBenchmarksRun(TestCase):
             results.append(benchmark_single(**benchmark, repeat=repeat))
         self.assertEqual(len(results), len(benchmarks))
         for result in results:
-            self.assertTrue("all_times" in result)
-            self.assertTrue("time" in result)
-            self.assertTrue("label" in result)
-            self.assertEqual(len(result["all_times"]), repeat)
-        self.assertEqual(results[0]["label"], label)
+            self.assertTrue(hasattr(result, "all_times"))
+            self.assertTrue(hasattr(result, "time"))
+            self.assertTrue(hasattr(result, "label"))
+            self.assertEqual(len(result.all_times), repeat)
+        self.assertEqual(results[0].label, label)
 
 
 class TestBenchmarkResults(TestCase):
@@ -103,39 +104,39 @@ class TestBenchmarkResults(TestCase):
         ]
         results = load_results(save_results(results))
         plot_file = "test_res_plot.png"
-        num_cells_plot(results["results"], filename=plot_file)
+        num_cells_plot(results.results, filename=plot_file)
         self.assertTrue(Path(plot_file).is_file())
 
     def test_data_file_roundtrip(self):
         """Test functions can save and load to a file"""
-        original = [dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1")]
+        original = [SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1")]
         filename = "test_res_file.json"
 
         save_results_to_file(original, filename)
         self.assertTrue(Path(filename).is_file())
 
-        loaded = load_results_from_file(filename)["results"]
+        loaded = load_results_from_file(filename).results
         self.assertEqual(original, loaded)
 
     def test_join_results_list(self):
         """Test that we can join lists"""
         list_1 = [
-            dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
-            dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
+            SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
+            SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
         ]
-        list_2 = [dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
+        list_2 = [SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
         new_results = join_results([list_1, list_2])
         self.assertEqual(len(new_results), 3)
 
     def test_join_results_structure(self):
         """Test that we can join a full results structure"""
-        list_1 = dict(
+        list_1 = SimpleNamespace(
             results=[
-                dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
-                dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
+                SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 1"),
+                SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 2"),
             ]
         )
-        list_2 = [dict(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
+        list_2 = [SimpleNamespace(nprocs=[1, 2, 3], times=[3, 2, 1], label="Test 3")]
         new_results = join_results([list_1, list_2])
         self.assertEqual(len(new_results), 3)
 


### PR DESCRIPTION
Based on issue #2118, add an argument to `nprocs_plot` function in `plots.py`, so it can plot speedup and efficiency for the parallelization results. It's tested on my fork repository (https://github.com/cyliang368/grass/pull/8#).