### PR TITLE
packaging: Update Vagrantfile to Ubuntu 24.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   vm_ram = ENV['VAGRANT_VM_RAM'] || 1024
   vm_cpu = ENV['VAGRANT_VM_CPU'] || 1
 
-  config.vm.box = "bionic64"
+  config.vm.box = "noble64"
 
   config.vm.hostname = "grass-gis-vagrant"
-  config.vm.box_url = "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64-vagrant.box"
+  config.vm.box = "alvistack/ubuntu-24.04"
   config.vm.define "grass-gis-vagrant" do |host|
 
     config.vm.network :forwarded_port, guest: 80, host: 8080
@@ -36,11 +36,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # host.vm.synced_folder grassdata_dir, "/home/vagrant/grassdata"
 
     ppaRepos = [
-      "ppa:ubuntugis/ubuntugis-unstable"
+      # TODO: enable PPA & PDAL support when available
+      # "ppa:ubuntugis/ubuntugis-unstable"
     ]
 
     packageList = [
-      "autoconf2.13",
+      "autoconf2.69",
       "autotools-dev",
       "make",
       "g++",
@@ -77,7 +78,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "liblapack-dev",
       "unixodbc-dev",
       "zlib1g-dev",
-      "liblas-c-dev"
+      # "libpdal-dev"
     ]
 
     unless File.exists?(".no_apt_cache")
@@ -88,7 +89,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/grass-gis-vagrant/*/id").empty?
       pkg_cmd = "sed -i 's#deb http://archive.ubuntu.com/ubuntu#deb mirror://mirrors.ubuntu.com/mirrors.txt#' /etc/apt/sources.list; "
-      pkg_cmd << "apt-get update -qq; apt-get install -q -y python-software-properties; "
+      pkg_cmd << "apt-get update -qq; apt-get install -q -y python3-software-properties; "
 
       if ppaRepos.length > 0
 	ppaRepos.each { |repo| pkg_cmd << "add-apt-repository -y " << repo << " ; " }

--- a/utils/vagrant/compile.sh
+++ b/utils/vagrant/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ### inspired by https://github.com/OSGeo/gdal/blob/master/gdal/scripts/vagrant/gdal.sh
 
@@ -21,7 +21,6 @@ if [ ! -f "include/Make/Platform.make" ] ; then
         --bindir=/usr/bin \
         --srcdir=/vagrant \
         --prefix=/usr/lib \
-        --enable-socket \
         --enable-shared \
         --with-postgres \
         --with-mysql \
@@ -30,7 +29,6 @@ if [ ! -f "include/Make/Platform.make" ] ; then
         --with-gdal \
         --with-geos \
         --with-freetype \
-        --with-motif \
         --with-readline \
         --with-nls \
         --with-odbc \
@@ -43,9 +41,10 @@ if [ ! -f "include/Make/Platform.make" ] ; then
         --with-postgres-includes=`pg_config --includedir` \
         --with-mysql-includes=`mysql_config --include | sed -e 's/-I//'` \
         --with-proj-share=/usr/share/proj \
-        --with-python \
         --with-cairo \
-        --with-liblas
+        --with-pthread \
+        --with-bzlib \
+        --without-pdal
 fi
 
 make -j $NUMTHREADS


### PR DESCRIPTION
This PR updates Vagrantfile to use Ubuntu 24.04 LTS.

## Notes

- unofficial Ubuntu image is used (https://app.vagrantup.com/alvistack/boxes/ubuntu-24.04 which is one of the most popular on [Vagrant Cloud](https://app.vagrantup.com/boxes/search?utf8=%E2%9C%93&sort=downloads&provider=&q=ubuntu+24.04) and has X Windows system activated) Reason: Canonical no longer publish Vagrant image ([source](https://documentation.ubuntu.com/public-images/en/latest/public-images-explanation/vagrant/))
- PDAL support not included since UbuntuGIS doesn't provide any package for Ubuntu 24.04 yet ([link](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable/+packages?field.name_filter=pdal&field.status_filter=published&field.series_filter=))


## How to test

```sh
vagrant up
vagrant ssh -c grass
```