### PR TITLE
checks: Disable Bandit B603 check for untrusted input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ timeout = 300
 
 [tool.bandit]
 exclude_dirs = ["./testsuite", "*/tests/*", "*/testsuite/*", "utils/test_generate_last_commit_file.py"]
-skips = ["B324","B110", "B101", "B112", "B311", "B404"]
+skips = ["B324","B110", "B101", "B112", "B311", "B404", "B603"]


### PR DESCRIPTION
The message 'check for execution of untrusted input' is triggered by any use of subprocess regardless of the actual input, so even fixed input triggers it. Bandit issue https://github.com/PyCQA/bandit/issues/333 discusses that this is a common false positive triggered by any usage.

The pattern is common enough in our code to ignore this to avoid clutter and warning fatigue. We already ignore B404 mentioned in the issue above.
