### PR TITLE
CI: Enable pre-commit updates by Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,5 +16,8 @@
 
         // when a dependency is really out of date, this will prevent to skip directly to the latest version.
         ":separateMultipleMajorReleases",
+
+        // Renovate's pre-commit support is still opt-in
+        ":enablePreCommit",
     ]
 }


### PR DESCRIPTION
Renovate supports updating hooks in pre-commit, but it is still opt-in. This PR opts in for these updates.

The prerequisite work for this PR has been merged, that is that pre-commit doesn’t fail when run on all code-base (#3834) and that when the pre-commit config changes, pre-commit is ran in CI on all files to know if the changes would work on a local computer (#3833).


Once merge, PRs updating pre-commit hooks will start to be filed, and CI will allow us to check that they are compatible