### PR TITLE
CI: Remove build tests for C99, C++11, C++14

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -21,12 +21,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - c: gnu99
-            cpp: c++11
-          - c: gnu11
-            cpp: c++11
-          - c: gnu11
-            cpp: c++14
           - c: gnu17
             cpp: c++17
       fail-fast: false


### PR DESCRIPTION
Remove tests for old C and C++ standards, aligning with the spirit of _RFC 7: Language Standards Support_.

Using (GNU) C17 and C++17, aligning with GDAL RFC 98 which introduces C++ >= 17 for v3.9.
