### PR TITLE
lib/gis: lib/display, fixing slash to HOST_DIRSEP

### DIFF
--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -92,6 +92,7 @@ int D_open_driver(void)
     if (!p && (m || c)) {
         char *cmd;
         char progname[GPATH_MAX];
+        char sep[2] = {HOST_DIRSEP, '\0'};
 
         cmd = G_recreate_command();
 
@@ -108,9 +109,9 @@ int D_open_driver(void)
             char element[GPATH_MAX];
 
             G_temp_element(element);
-            strcat(element, "/");
+            strcat(element, sep);
             strcat(element, "MONITORS");
-            strcat(element, "/");
+            strcat(element, sep);
             strcat(element, m);
             G_file_name(progname, element, "render.py", G_mapset());
         }

--- a/lib/gis/tempfile.c
+++ b/lib/gis/tempfile.c
@@ -159,11 +159,12 @@ void G_temp_element(char *element)
 void G__temp_element(char *element, int tmp)
 {
     const char *machine;
+    char sep[2] = {HOST_DIRSEP, '\0'};
 
     strcpy(element, ".tmp");
     machine = G__machine_name();
     if (machine != NULL && *machine != 0) {
-        strcat(element, "/");
+        strcat(element, sep);
         strcat(element, machine);
     }
 
@@ -185,11 +186,12 @@ void G__temp_element(char *element, int tmp)
 void G__temp_element_basedir(char *element, const char *basedir)
 {
     const char *machine;
+    char sep[2] = {HOST_DIRSEP, '\0'};
 
     strcpy(element, ".tmp");
     machine = G__machine_name();
     if (machine != NULL && *machine != 0) {
-        strcat(element, "/");
+        strcat(element, sep);
         strcat(element, machine);
     }
 


### PR DESCRIPTION
Changes hardcoded slash (`/`) in path to HOST_DIRSEP for portability.

Fixes #3296