### PR TITLE
lib/cdhc: Cdhc_alnfac, fix bound condition

### DIFF
--- a/lib/cdhc/as177.c
+++ b/lib/cdhc/as177.c
@@ -82,18 +82,20 @@ void init(double work[])
  */
 static double Cdhc_alnfac(int j)
 {
-    static const double r[7] = {0.0,           1.0,           0.69314718056,
+    static const double r[7] = {0.0,           0.0,           0.69314718056,
                                 1.79175946923, 3.17805383035, 4.78749174278,
                                 6.57925121101};
     double w, z;
 
-    if (j >= 0 && j < 7)
+    if (j < 0)
+        return 1.0;
+    if (j < 7)
         return r[j];
 
     w = (double)j + 1;
     z = 1.0 / (w * w);
 
-    return (w - 0.5) * log(w) - w + 0.918938522305 +
+    return (w - 0.5) * log(w) - w + 0.918938533205 +
            (((4.0 - 3.0 * z) * z - 14.0) * z + 420.0) / (5040.0 * w);
 }
 

--- a/lib/cdhc/as177.c
+++ b/lib/cdhc/as177.c
@@ -82,14 +82,12 @@ void init(double work[])
  */
 static double Cdhc_alnfac(int j)
 {
-    static double r[7] = {0.0,           0.0,           0.69314718056,
-                          1.79175946923, 3.17805383035, 4.78749174278,
-                          6.57925121101};
+    static const double r[7] = {0.0,           1.0,           0.69314718056,
+                                1.79175946923, 3.17805383035, 4.78749174278,
+                                6.57925121101};
     double w, z;
 
-    if (j == 1)
-        return (double)1.0;
-    else if (j <= 7)
+    if (j >= 0 && j < 7)
         return r[j];
 
     w = (double)j + 1;


### PR DESCRIPTION
The array r has a maximum index of 6.
Additionally, since j is an int, it can have a negative value. This commit limits the risk of errors when accessing r. Moreover, since r is only used within this function, we remove the j == 1 condition and integrate it directly into the r array.