### PR TITLE
lib/gis: user_config.c: Fix CWE 398

### DIFF
--- a/lib/gis/user_config.c
+++ b/lib/gis/user_config.c
@@ -156,7 +156,9 @@ static int _elem_count_split(char *elems)
 
     /* Some basic assertions */
     assert(elems != NULL);
-    assert((len = strlen(elems)) > 0);
+
+    len = strlen(elems);
+    assert(len > 0);
     assert(len < PTRDIFF_MAX);
     assert(*elems != '/');
 


### PR DESCRIPTION
> Variable 'len' is modified inside assert statement. Assert statements are removed from release builds so the code inside assert statement is not executed. If the code is needed also in release builds, this is a bug.