### PR TITLE
CI(Titles): Validate PR titles in CI

### DIFF
--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -1,0 +1,24 @@
+---
+name: Validate Titles
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      # The following types are default for pull_request_target
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  validate-titles:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base repository (doesn't include the PR changes)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Call PR title validation function
+        run: python utils/generate_release_notes.py check "${PR_TITLE}"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Checkout base repository (doesn't include the PR changes)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Call PR title validation function
-        run: python utils/generate_release_notes.py check "${PR_TITLE}"
+        run: python utils/generate_release_notes.py check "${PR_TITLE}" "" ""
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Uses the utils/generate_release_notes.py "check" argument introduced in #3824.
Runs on pull_request_target (so safer to checkout the python script, as the code isn't from the external pull request), and in addition to the 3 default activity types, it runs on the `edited` activity type. This also means that it runs when the body of the PR is edited, but for now, it only takes 12 seconds to run.


Possible improvements possible include:
* Avoid using checkout and use GitHub API to fetch 2 files (utils/generate_release_notes.py and utils/release.yml)
* Filter out when the activity type is `edited` AND that `${{ github.event.changes.title.from }}` is present (I didn't find obviously what field of any of the contexts available to use for knowing if the activity type is `edited`).