### PR TITLE
d.linegraph: Fix null pointer issue in qsort call

### DIFF
--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -126,7 +126,9 @@ static char *icon_files(void)
 
     closedir(dir);
 
+    if (list != NULL) {
     qsort(list, count, sizeof(char *), cmp);
+}
 
     if (len > 0) {
         ret = G_malloc((len + 1) * sizeof(char)); /* \0 */

--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -128,7 +128,7 @@ static char *icon_files(void)
 
     if (list != NULL) {
         qsort(list, count, sizeof(char *), cmp);
-}
+    }
 
     if (len > 0) {
         ret = G_malloc((len + 1) * sizeof(char)); /* \0 */

--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -127,7 +127,7 @@ static char *icon_files(void)
     closedir(dir);
 
     if (list != NULL) {
-    qsort(list, count, sizeof(char *), cmp);
+        qsort(list, count, sizeof(char *), cmp);
 }
 
     if (len > 0) {


### PR DESCRIPTION
This pull request addresses warning identified by Clang in the `display/d.linegraph/main.c` file.

### Changes Made
1. **Null Pointer Check in `qsort`:**
   - **Issue:** Null pointer passed to 1st parameter expecting 'nonnull'.
   - **Fix:** Added a null pointer check before calling `qsort`.

### Issue Fixed
- Clang warnings:
  - `main.c:129:5: warning: Null pointer passed to 1st parameter expecting 'nonnull' [core.NonNullParamChecker]`
