### PR TITLE
CI(pytest): Run tests marked need_solo_run separately

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -73,11 +73,17 @@ jobs:
       - name: Test executing of the grass command
         run: .github/workflows/test_simple.sh
 
-      - name: Run pytest
+      - name: Run pytest with multiple workers in parallel
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 --numprocesses auto -ra .
+          pytest --verbose --color=yes --durations=0 --durations-min=0.5 --numprocesses auto -ra . -m 'not needs_solo_run'
+
+      - name: Run pytest with a single worker (for tests marked with needs_solo_run)
+        run: |
+          export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
+          export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
+          pytest --verbose --color=yes --durations=0 --durations-min=0.5 -ra . -m 'needs_solo_run'
 
       - name: Print installed versions
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ addopts = """
     --ignore='raster/r.category/test_rcategory_doctest.txt'
 """
 timeout = 300
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "needs_solo_run: marks tests that must be run without any other tests running in parallel",
+]
 
 
 [tool.bandit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ addopts = """
     --doctest-glob='*doctest*.txt'
     --ignore='raster/r.category/test_rcategory_doctest.txt'
 """
-timeout = 300
+timeout = 30
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "needs_solo_run: marks tests that must be run without any other tests running in parallel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ addopts = """
     --doctest-glob='*doctest*.txt'
     --ignore='raster/r.category/test_rcategory_doctest.txt'
 """
-timeout = 30
+timeout = 300
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "needs_solo_run: marks tests that must be run without any other tests running in parallel",

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -23,6 +23,7 @@ def run_in_subprocess(function):
     process.join()
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize("processes", list(range(1, max_processes() + 1)) + [None])
 def test_processes(tmp_path, processes):
     """Check that running with multiple processes works"""
@@ -232,6 +233,7 @@ def test_tiling(tmp_path, width, height, processes):
         assert info["min"] > 0
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize(
     "processes, backend",
     [


### PR DESCRIPTION
One probable explanation of some flaky pytest failures is that a small number of tests use more resources since they expect they would be the only module running. Or, for example, testing with multiple number of processes, while already multiple pytest runners are executing tests.

This ended up stalling the other tests, and we regularly encountered failures to different tests files.

The solution here is identifying which tests have this behaviour, and should be run separately from the tests run in parallel, with a single runner. Inspired by pytest’s docs on markers, the `needs_solo_run` marker name was chosen and applied to two tests (10 items). 
The slow marker from pytest’s docs is kept as I intend to mark some tests that are way slower than expected with it.

~~With these two steps running with parallel (pytest-xdist) and without, we end up with a somewhat constant time execution, no timeouts, but having to do the test collection phase twice (currently about 10 more seconds). It also allows to reduce the timeout to 30 seconds without any problem~~, as in any case, NO TESTS should take near 30 seconds to setup and execute, especially if they are unit tests. 