### PR TITLE
grass.jupyter: Add LayerControl to InteractiveMap by default

### DIFF
--- a/doc/notebooks/jupyter_example.ipynb
+++ b/doc/notebooks/jupyter_example.ipynb
@@ -30,7 +30,6 @@
    "outputs": [],
    "source": [
     "# Import Python standard library and IPython packages we need.\n",
-    "import os\n",
     "import subprocess\n",
     "import sys\n",
     "\n",

--- a/doc/notebooks/jupyter_tutorial.ipynb
+++ b/doc/notebooks/jupyter_tutorial.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "# Import Python standard library and IPython packages we need.\n",
     "import subprocess\n",
     "import sys\n",
     "\n",
@@ -231,8 +231,7 @@
    "source": [
     "# Add raster, vector and layer control to map\n",
     "raleigh_map.add_raster(\"elevation\")\n",
-    "raleigh_map.add_vector(\"roadsmajor\")\n",
-    "raleigh_map.add_layer_control(position=\"bottomright\")"
+    "raleigh_map.add_vector(\"roadsmajor\")"
    ]
   },
   {
@@ -241,6 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Display Interactive Map\n",
     "raleigh_map.show()"
    ]
   },

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -189,7 +189,6 @@ class InteractiveMap:
     >>> m = InteractiveMap()
     >>> m.add_vector("streams")
     >>> m.add_raster("elevation")
-    >>> m.add_layer_control()
     >>> m.show()
     """
 

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -364,7 +364,7 @@ class InteractiveMap:
             fig.add_child(self.map)
 
             return fig
-        
+
         # ipyleaflet
         self.map.add(self.layer_control_object)
         return self.map

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -336,9 +336,11 @@ class InteractiveMap:
         Raster(name, title=title, renderer=self._renderer, **kwargs).add_to(self.map)
 
     def add_layer_control(self, **kwargs):
-        """Add layer control to display"
-
-        Accepts keyword arguments to be passed to layer control object"""
+        """Add layer control to display.
+        
+        A Layer Control is added by default. Call this function to customize
+        layer control object. Accepts keyword arguments to be passed to leaflet
+        layer control object"""
 
         if self._folium:
             self.layer_control_object = self._folium.LayerControl(**kwargs)

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -336,7 +336,7 @@ class InteractiveMap:
 
     def add_layer_control(self, **kwargs):
         """Add layer control to display.
-        
+
         A Layer Control is added by default. Call this function to customize
         layer control object. Accepts keyword arguments to be passed to leaflet
         layer control object"""

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -300,7 +300,6 @@ class InteractiveMap:
                 API_key=API_key,  # pylint: disable=invalid-name
             )
         # Set LayerControl default
-        self.layer_control = False
         self.layer_control_object = None
 
         self._renderer = ReprojectionRenderer(
@@ -341,7 +340,6 @@ class InteractiveMap:
 
         Accepts keyword arguments to be passed to layer control object"""
 
-        self.layer_control = True
         if self._folium:
             self.layer_control_object = self._folium.LayerControl(**kwargs)
         else:
@@ -355,16 +353,20 @@ class InteractiveMap:
         added after calling show()."""
 
         self.map.fit_bounds(self._renderer.get_bbox())
+
+        if not self.layer_control_object:
+            self.add_layer_control()
+
+        # folium
         if self._folium:
-            if self.layer_control:
-                self.map.add_child(self.layer_control_object)
+            self.map.add_child(self.layer_control_object)
             fig = self._folium.Figure(width=self.width, height=self.height)
             fig.add_child(self.map)
 
             return fig
+        
         # ipyleaflet
-        if self.layer_control:
-            self.map.add(self.layer_control_object)
+        self.map.add(self.layer_control_object)
         return self.map
 
     def save(self, filename):


### PR DESCRIPTION
Previously, users needed to add a layer control to an `InteractiveMap` with `add_layer_control()`.

This PR changes this so that `add_layer_control()` is called when the users calls `InteractiveMap.show()` by default if the user has not already called it.