### PR TITLE
contributing: Add monthly financial supporters to release notes

### DIFF
--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -9,12 +9,14 @@ import argparse
 import csv
 import itertools
 import json
+import random
 import re
 import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
 
+import requests
 import yaml
 
 PRETTY_TEMPLATE = (
@@ -128,6 +130,20 @@ def binder_badge(tag):
     return f"[![Binder]({binder_image_url})]({binder_url})"
 
 
+def print_support(file=None):
+    url = "https://opencollective.com/grass/tiers/supporter/all.json"
+    response = requests.get(url=url)
+    data = response.json()
+    if data:
+        print_section_heading_3("Monthly financial supporters", file=file)
+        random.shuffle(data)
+        supporters = []
+        for member in data:
+            supporters.append(f"""[{member['name']}]({member['profile']})""")
+        print(", ".join(supporters))
+        print("")
+
+
 def adjust_after(lines):
     """Adjust new contributor lines in the last part of the generated notes"""
     bot_file = Path("utils") / "known_bot_names.txt"
@@ -171,6 +187,7 @@ def print_notes(
         print(before)
     print_section_heading_2("Highlights", file=file)
     print("* _Put handcrafted list of items here._\n")
+    print_support(file=file)
     print_section_heading_2("What's Changed", file=file)
     changes_by_category = split_to_categories(changes, categories=categories)
     print_by_category(changes_by_category, categories=categories, file=file)


### PR DESCRIPTION
The generated release notes now contain members of supportes tier on Open Collective. We want to highlight financial contributions in the release notes. Monthly supporters seem like a fitting category in context of release. Current (draft) release notes are already updated.

The list is randomized when generated. Images are not included because that would require generating content for the missing images and making them circular (more work and circular did not work for me).

They are included under a heading at the end of highlights section, so not at the end, but not at the very beginning either.
