### PR TITLE
r.stats: add json output

### DIFF
--- a/raster/r.stats/Makefile
+++ b/raster/r.stats/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.stats
 
-LIBES = $(RASTERLIB) $(GISLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.stats/cell_stats.c
+++ b/raster/r.stats/cell_stats.c
@@ -1,9 +1,11 @@
 #include <stdlib.h>
+#include <grass/parson.h>
 #include <grass/glocale.h>
 #include "global.h"
 
 int cell_stats(int fd[], int with_percents, int with_counts, int with_areas,
-               int do_sort, int with_labels, char *fmt)
+               int do_sort, int with_labels, char *fmt, char **names,
+               enum OutputFormat format, JSON_Array *root_array)
 {
     CELL **cell;
     int i;
@@ -65,7 +67,7 @@ int cell_stats(int fd[], int with_percents, int with_counts, int with_areas,
 
     sort_cell_stats(do_sort);
     print_cell_stats(fmt, with_percents, with_counts, with_areas, with_labels,
-                     fs);
+                     fs, names, format, root_array);
 
     return 0;
 }

--- a/raster/r.stats/global.h
+++ b/raster/r.stats/global.h
@@ -1,9 +1,12 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
+#include <grass/parson.h>
 
 #define SORT_DEFAULT 0
 #define SORT_ASC     1
 #define SORT_DESC    2
+
+enum OutputFormat { PLAIN, JSON };
 
 extern char *no_data_str;
 extern int nfiles;
@@ -19,10 +22,11 @@ extern char *fs;
 extern struct Categories *labels;
 
 /* cell_stats.c */
-int cell_stats(int[], int, int, int, int, int, char *);
+int cell_stats(int[], int, int, int, int, int, char *, char **,
+               enum OutputFormat, JSON_Array *);
 
 /* raw_stats.c */
-int raw_stats(int[], int, int, int);
+int raw_stats(int[], int, int, int, char **, enum OutputFormat, JSON_Array *);
 
 /* stats.c */
 int initialize_cell_stats(int);
@@ -33,4 +37,5 @@ void reset_null_vals(CELL *, int);
 int update_cell_stats(CELL **, int, double);
 int sort_cell_stats(int);
 int print_node_count(void);
-int print_cell_stats(char *, int, int, int, int, char *);
+int print_cell_stats(char *, int, int, int, int, char *, char **,
+                     enum OutputFormat, JSON_Array *);

--- a/raster/r.stats/main.c
+++ b/raster/r.stats/main.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <grass/parson.h>
 #include <grass/glocale.h>
 
 #include "global.h"
@@ -55,6 +56,10 @@ int main(int argc, char *argv[])
     int with_areas;
     int with_labels;
     int do_sort;
+
+    enum OutputFormat format;
+    JSON_Array *root_array;
+    JSON_Value *root_value;
 
     /* printf format */
     char fmt[20];
@@ -95,6 +100,7 @@ int main(int argc, char *argv[])
                                   explicit fp ranges in cats or when the map
                                   is int, nsteps is ignored */
         struct Option *sort;   /* sort by cell counts */
+        struct Option *format;
     } option;
 
     G_gisinit(argv[0]);
@@ -144,6 +150,9 @@ int main(int argc, char *argv[])
                _("Sort by cell counts in ascending order"),
                _("Sort by cell counts in descending order"));
     option.sort->guisection = _("Formatting");
+
+    option.format = G_define_standard_option(G_OPT_F_FORMAT);
+    option.format->guisection = _("Print");
 
     /* Define the different flags */
 
@@ -233,6 +242,16 @@ int main(int argc, char *argv[])
                   option.nsteps->key, option.nsteps->key);
         nsteps = 255;
     }
+
+    if (strcmp(option.format->answer, "json") == 0) {
+        format = JSON;
+        root_value = json_value_init_array();
+        root_array = json_array(root_value);
+    }
+    else {
+        format = PLAIN;
+    }
+
     cat_ranges = flag.C->answer;
 
     averaged = flag.A->answer;
@@ -375,11 +394,25 @@ int main(int argc, char *argv[])
     else
         sprintf(fmt, "%%.%dlf", dp);
 
+    char **names_copy = option.cell->answers;
+
     if (raw_data)
-        raw_stats(fd, with_coordinates, with_xy, with_labels);
+        raw_stats(fd, with_coordinates, with_xy, with_labels, names_copy,
+                  format, root_array);
     else
         cell_stats(fd, with_percents, with_counts, with_areas, do_sort,
-                   with_labels, fmt);
+                   with_labels, fmt, names_copy, format, root_array);
+
+    if (format == JSON) {
+        char *serialized_string = NULL;
+        serialized_string = json_serialize_to_string_pretty(root_value);
+        if (serialized_string == NULL) {
+            G_fatal_error(_("Failed to initialize pretty JSON string."));
+        }
+        puts(serialized_string);
+        json_free_serialized_string(serialized_string);
+        json_value_free(root_value);
+    }
 
     exit(EXIT_SUCCESS);
 }

--- a/raster/r.stats/raw_stats.c
+++ b/raster/r.stats/raw_stats.c
@@ -1,10 +1,12 @@
 #include <stdlib.h>
+#include <grass/parson.h>
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
 #include "global.h"
 
-int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels)
+int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
+              char **names, enum OutputFormat format, JSON_Array *array)
 {
     CELL null_cell;
     void **rast, **rastp;
@@ -14,6 +16,9 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels)
     struct Cell_head window;
     char nbuf[100], ebuf[100];
     RASTER_MAP_TYPE *map_type;
+    JSON_Array *categories;
+    JSON_Object *object, *category;
+    JSON_Value *categories_value, *object_value, *category_value;
 
     /* allocate i/o buffers for each raster map */
     rast = (void **)G_calloc(nfiles, sizeof(void *));
@@ -46,11 +51,20 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels)
             rastp[i] = rast[i];
         }
 
-        if (with_coordinates)
-            G_format_northing(Rast_row_to_northing(row + .5, &window), nbuf,
+        double northing;
+        if (with_coordinates || format == JSON) {
+            northing = Rast_row_to_northing(row + .5, &window);
+            G_format_northing(northing, nbuf,
                               G_projection() == PROJECTION_LL ? -1 : 0);
+        }
 
         for (col = 0; col < ncols; col++) {
+            if (format == JSON) {
+                object_value = json_value_init_object();
+                object = json_object(object_value);
+                categories_value = json_value_init_array();
+                categories = json_array(categories_value);
+            }
             if (no_nulls || no_nulls_all) {
                 nulls_found = 0;
                 for (i = 0; i < nfiles; i++) {
@@ -70,53 +84,132 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels)
                     continue;
                 }
             }
-            if (with_coordinates) {
-                G_format_easting(Rast_col_to_easting(col + .5, &window), ebuf,
-                                 G_projection() == PROJECTION_LL ? -1 : 0);
-                fprintf(stdout, "%s%s%s%s", ebuf, fs, nbuf, fs);
+            switch (format) {
+            case JSON:
+                json_object_set_number(object, "easting",
+                                       Rast_col_to_easting(col + .5, &window));
+                json_object_set_number(object, "northing", northing);
+                json_object_set_number(object, "col", col + 1);
+                json_object_set_number(object, "row", row + 1);
+                break;
+            case PLAIN:
+                if (with_coordinates) {
+                    G_format_easting(Rast_col_to_easting(col + .5, &window),
+                                     ebuf,
+                                     G_projection() == PROJECTION_LL ? -1 : 0);
+                    fprintf(stdout, "%s%s%s%s", ebuf, fs, nbuf, fs);
+                }
+                if (with_xy)
+                    fprintf(stdout, "%d%s%d%s", col + 1, fs, row + 1, fs);
+                break;
             }
-            if (with_xy)
-                fprintf(stdout, "%d%s%d%s", col + 1, fs, row + 1, fs);
 
             for (i = 0; i < nfiles; i++) {
+                if (format == JSON) {
+                    category_value = json_value_init_object();
+                    category = json_object(category_value);
+                }
+
                 if (Rast_is_null_value(rastp[i], map_type[i])) {
-                    fprintf(stdout, "%s%s", i ? fs : "", no_data_str);
-                    if (with_labels)
-                        fprintf(stdout, "%s%s", fs,
-                                Rast_get_c_cat(&null_cell, &labels[i]));
+                    switch (format) {
+                    case JSON:
+                        json_object_set_null(category, "value");
+                        json_object_set_string(
+                            category, "label",
+                            Rast_get_c_cat(&null_cell, &labels[i]));
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        fprintf(stdout, "%s%s", i ? fs : "", no_data_str);
+                        if (with_labels)
+                            fprintf(stdout, "%s%s", fs,
+                                    Rast_get_c_cat(&null_cell, &labels[i]));
+                        break;
+                    }
                 }
                 else if (map_type[i] == CELL_TYPE) {
-                    fprintf(stdout, "%s%ld", i ? fs : "",
-                            (long)*((CELL *)rastp[i]));
-                    if (with_labels && !is_fp[i])
-                        fprintf(stdout, "%s%s", fs,
+                    switch (format) {
+                    case JSON:
+                        json_object_set_number(category, "value",
+                                               (long)*((CELL *)rastp[i]));
+                        json_object_set_string(
+                            category, "label",
+                            Rast_get_c_cat((CELL *)rastp[i], &labels[i]));
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        fprintf(stdout, "%s%ld", i ? fs : "",
+                                (long)*((CELL *)rastp[i]));
+                        if (with_labels && !is_fp[i])
+                            fprintf(
+                                stdout, "%s%s", fs,
                                 Rast_get_c_cat((CELL *)rastp[i], &labels[i]));
+                        break;
+                    }
                 }
                 else if (map_type[i] == FCELL_TYPE) {
-                    sprintf(str1, "%.8g", *((FCELL *)rastp[i]));
-                    G_trim_decimal(str1);
-                    G_strip(str1);
-                    fprintf(stdout, "%s%s", i ? fs : "", str1);
-                    if (with_labels)
-                        fprintf(stdout, "%s%s", fs,
+                    switch (format) {
+                    case JSON:
+                        json_object_set_number(category, "value",
+                                               *((FCELL *)rastp[i]));
+                        json_object_set_string(
+                            category, "label",
+                            Rast_get_f_cat((FCELL *)rastp[i], &labels[i]));
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        sprintf(str1, "%.8g", *((FCELL *)rastp[i]));
+                        G_trim_decimal(str1);
+                        G_strip(str1);
+                        fprintf(stdout, "%s%s", i ? fs : "", str1);
+                        if (with_labels)
+                            fprintf(
+                                stdout, "%s%s", fs,
                                 Rast_get_f_cat((FCELL *)rastp[i], &labels[i]));
+                        break;
+                    }
                 }
                 else if (map_type[i] == DCELL_TYPE) {
-                    sprintf(str1, "%.16g", *((DCELL *)rastp[i]));
-                    G_trim_decimal(str1);
-                    G_strip(str1);
-                    fprintf(stdout, "%s%s", i ? fs : "", str1);
-                    if (with_labels)
-                        fprintf(stdout, "%s%s", fs,
+                    switch (format) {
+                    case JSON:
+                        json_object_set_number(category, "value",
+                                               *((DCELL *)rastp[i]));
+                        json_object_set_string(
+                            category, "label",
+                            Rast_get_d_cat((DCELL *)rastp[i], &labels[i]));
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        sprintf(str1, "%.16g", *((DCELL *)rastp[i]));
+                        G_trim_decimal(str1);
+                        G_strip(str1);
+                        fprintf(stdout, "%s%s", i ? fs : "", str1);
+                        if (with_labels)
+                            fprintf(
+                                stdout, "%s%s", fs,
                                 Rast_get_d_cat((DCELL *)rastp[i], &labels[i]));
+                        break;
+                    }
                 }
                 else
                     G_fatal_error(_("Invalid map type"));
 
+                if (format == JSON) {
+                    json_array_append_value(categories, category_value);
+                }
+
                 rastp[i] =
                     G_incr_void_ptr(rastp[i], Rast_cell_size(map_type[i]));
             }
-            fprintf(stdout, "\n");
+            switch (format) {
+            case JSON:
+                json_object_set_value(object, "labels", categories_value);
+                json_array_append_value(array, object_value);
+                break;
+            case PLAIN:
+                fprintf(stdout, "\n");
+                break;
+            }
         }
     }
 

--- a/raster/r.stats/stats.c
+++ b/raster/r.stats/stats.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include "global.h"
 
+#include <grass/parson.h>
+
 /* hash definitions (these should be prime numbers) ************* */
 #define HASHSIZE 7307
 #define HASHMOD  89
@@ -253,7 +255,8 @@ int print_node_count(void)
 }
 
 int print_cell_stats(char *fmt, int with_percents, int with_counts,
-                     int with_areas, int with_labels, char *fs)
+                     int with_areas, int with_labels, char *fs, char **names,
+                     enum OutputFormat format, JSON_Array *array)
 {
     int i, n, nulls_found;
     struct Node *node;
@@ -261,26 +264,43 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
     DCELL dLow, dHigh;
     char str1[50], str2[50];
 
+    JSON_Object *object, *category;
+    JSON_Array *categories;
+    JSON_Value *object_value, *category_value, *categories_value;
+
     if (no_nulls)
         total_count -= sorted_list[node_count - 1]->count;
 
     Rast_set_c_null_value(&null_cell, 1);
     if (node_count <= 0) {
-        fprintf(stdout, "0");
-        for (i = 1; i < nfiles; i++)
-            fprintf(stdout, "%s%s", fs, no_data_str);
-        if (with_areas)
-            fprintf(stdout, "%s0.0", fs);
-        if (with_counts)
-            fprintf(stdout, "%s0", fs);
-        if (with_percents)
-            fprintf(stdout, "%s0.00%%", fs);
-        if (with_labels)
-            fprintf(stdout, "%s%s", fs, Rast_get_c_cat(&null_cell, &labels[i]));
-        fprintf(stdout, "\n");
+        switch (format) {
+        case JSON:
+            break;
+        case PLAIN:
+            fprintf(stdout, "0");
+            for (i = 1; i < nfiles; i++)
+                fprintf(stdout, "%s%s", fs, no_data_str);
+            if (with_areas)
+                fprintf(stdout, "%s0.0", fs);
+            if (with_counts)
+                fprintf(stdout, "%s0", fs);
+            if (with_percents)
+                fprintf(stdout, "%s0.00%%", fs);
+            if (with_labels)
+                fprintf(stdout, "%s%s", fs,
+                        Rast_get_c_cat(&null_cell, &labels[i]));
+            fprintf(stdout, "\n");
+        }
     }
     else {
         for (n = 0; n < node_count; n++) {
+            if (format == JSON) {
+                object_value = json_value_init_object();
+                object = json_object(object_value);
+                categories_value = json_value_init_array();
+                categories = json_array(categories_value);
+            }
+
             node = sorted_list[n];
 
             if (no_nulls || no_nulls_all) {
@@ -301,19 +321,47 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
             }
 
             for (i = 0; i < nfiles; i++) {
+                if (format == JSON) {
+                    category_value = json_value_init_object();
+                    category = json_object(category_value);
+                }
                 if (node->values[i] == NULL_CELL) {
-                    fprintf(stdout, "%s%s", i ? fs : "", no_data_str);
-                    if (with_labels && !(raw_output && is_fp[i]))
-                        fprintf(stdout, "%s%s", fs,
-                                Rast_get_c_cat(&null_cell, &labels[i]));
+                    switch (format) {
+                    case JSON:
+                        json_object_set_null(category, "value");
+                        json_object_set_string(
+                            category, "label",
+                            Rast_get_c_cat(&null_cell, &labels[i]));
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        fprintf(stdout, "%s%s", i ? fs : "", no_data_str);
+                        if (with_labels && !(raw_output && is_fp[i]))
+                            fprintf(stdout, "%s%s", fs,
+                                    Rast_get_c_cat(&null_cell, &labels[i]));
+                        break;
+                    }
                 }
                 else if (raw_output || !is_fp[i] || as_int) {
-                    fprintf(stdout, "%s%ld", i ? fs : "",
-                            (long)node->values[i]);
-                    if (with_labels && !is_fp[i])
-                        fprintf(stdout, "%s%s", fs,
-                                Rast_get_c_cat((CELL *)&(node->values[i]),
-                                               &labels[i]));
+                    switch (format) {
+                    case JSON:
+                        json_object_set_number(category, "value",
+                                               (long)node->values[i]);
+                        json_object_set_string(
+                            category, "label",
+                            Rast_get_c_cat((CELL *)&(node->values[i]),
+                                           &labels[i]));
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        fprintf(stdout, "%s%ld", i ? fs : "",
+                                (long)node->values[i]);
+                        if (with_labels && !is_fp[i])
+                            fprintf(stdout, "%s%s", fs,
+                                    Rast_get_c_cat((CELL *)&(node->values[i]),
+                                                   &labels[i]));
+                        break;
+                    }
                 }
                 else { /* find out which floating point range to print */
 
@@ -331,42 +379,119 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                     }
                     if (averaged) {
                         /* print averaged values */
-                        sprintf(str1, "%10f", (dLow + dHigh) / 2.0);
-                        G_trim_decimal(str1);
-                        G_strip(str1);
-                        fprintf(stdout, "%s%s", i ? fs : "", str1);
+                        double average = (dLow + dHigh) / 2.0;
+                        switch (format) {
+                        case JSON:
+                            json_object_set_number(category, "average",
+                                                   average);
+                            break;
+                        case PLAIN:
+                            sprintf(str1, "%10f", average);
+                            G_trim_decimal(str1);
+                            G_strip(str1);
+                            fprintf(stdout, "%s%s", i ? fs : "", str1);
+                            break;
+                        }
                     }
                     else {
-                        /* print intervals */
-                        sprintf(str1, "%10f", dLow);
-                        sprintf(str2, "%10f", dHigh);
-                        G_trim_decimal(str1);
-                        G_trim_decimal(str2);
-                        G_strip(str1);
-                        G_strip(str2);
-                        fprintf(stdout, "%s%s-%s", i ? fs : "", str1, str2);
+                        switch (format) {
+                        case JSON:
+                            json_object_set_number(category, "low", dLow);
+                            json_object_set_number(category, "high", dHigh);
+                            break;
+                        case PLAIN:
+                            /* print intervals */
+                            sprintf(str1, "%10f", dLow);
+                            sprintf(str2, "%10f", dHigh);
+                            G_trim_decimal(str1);
+                            G_trim_decimal(str2);
+                            G_strip(str1);
+                            G_strip(str2);
+                            fprintf(stdout, "%s%s-%s", i ? fs : "", str1, str2);
+                            break;
+                        }
                     }
-                    if (with_labels) {
-                        if (cat_ranges)
-                            fprintf(stdout, "%s%s", fs,
-                                    labels[i].labels[node->values[i]]);
-                        else
-                            fprintf(stdout, "%sfrom %s to %s", fs,
-                                    Rast_get_d_cat(&dLow, &labels[i]),
-                                    Rast_get_d_cat(&dHigh, &labels[i]));
+                    switch (format) {
+                    case JSON:
+                        if (cat_ranges) {
+                            json_object_set_string(
+                                category, "label",
+                                labels[i].labels[node->values[i]]);
+                        }
+                        else {
+                            json_object_set_string(
+                                category, "label_low",
+                                Rast_get_d_cat(&dLow, &labels[i]));
+                            json_object_set_string(
+                                category, "label_high",
+                                Rast_get_d_cat(&dHigh, &labels[i]));
+                        }
+                        json_object_set_string(category, "name", names[i]);
+                        break;
+                    case PLAIN:
+                        if (with_labels) {
+                            if (cat_ranges)
+                                fprintf(stdout, "%s%s", fs,
+                                        labels[i].labels[node->values[i]]);
+                            else
+                                fprintf(stdout, "%sfrom %s to %s", fs,
+                                        Rast_get_d_cat(&dLow, &labels[i]),
+                                        Rast_get_d_cat(&dHigh, &labels[i]));
+                        }
+                        break;
                     }
                 }
+
+                if (format == JSON) {
+                    json_array_append_value(categories, category_value);
+                }
             }
+
+            if (format == JSON) {
+                json_object_set_value(object, "labels", categories_value);
+            }
+
             if (with_areas) {
-                fprintf(stdout, "%s", fs);
-                fprintf(stdout, fmt, node->area);
+                switch (format) {
+                case JSON:
+                    json_object_set_number(object, "area", node->area);
+                    break;
+                case PLAIN:
+                    fprintf(stdout, "%s", fs);
+                    fprintf(stdout, fmt, node->area);
+                    break;
+                }
             }
-            if (with_counts)
-                fprintf(stdout, "%s%ld", fs, (long)node->count);
-            if (with_percents)
-                fprintf(stdout, "%s%.2f%%", fs,
-                        (double)100 * node->count / total_count);
-            fprintf(stdout, "\n");
+            if (with_counts) {
+                switch (format) {
+                case JSON:
+                    json_object_set_number(object, "count", node->count);
+                    break;
+                case PLAIN:
+                    fprintf(stdout, "%s%ld", fs, (long)node->count);
+                    break;
+                }
+            }
+            if (with_percents) {
+                double percent = (double)100 * node->count / total_count;
+                switch (format) {
+                case JSON:
+                    json_object_set_number(object, "percent", percent);
+                    break;
+                case PLAIN:
+                    fprintf(stdout, "%s%.2f%%", fs, percent);
+                    break;
+                }
+            }
+
+            switch (format) {
+            case JSON:
+                json_array_append_value(array, object_value);
+                break;
+            case PLAIN:
+                fprintf(stdout, "\n");
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Using parson, add JSON output support to r.stats module.

For cell stats, the output looks like:

```json
[
    {
        "labels": [
            {
                "value": 1,
                "label": "CARY",
                "name": "towns"
            },
            {
                "value": 55,
                "label": "",
                "name": "urban"
            }
        ],
        "area": 23475900,
        "count": 234759,
        "percent": 11.651235678463038
    },
    {
        "labels": [
            {
                "value": 2,
                "label": "GARNER",
                "name": "towns"
            },
            {
                "value": 55,
                "label": "",
                "name": "urban"
            }
        ],
        "area": 14142700,
        "count": 141427,
        "percent": 7.0191102718021128
    },
    {
        "labels": [
            {
                "value": 3,
                "label": "APEX",
                "name": "towns"
            },
            {
                "value": 55,
                "label": "",
                "name": "urban"
            }
        ],
        "area": 1519700,
        "count": 15197,
        "percent": 0.75423659414805311
    }
]
```

For raw stats, the output looks like:

```json
[
    {
        "easting": 639315,
        "northing": 228495,
        "col": 932,
        "row": 1,
        "labels": [
            {
                "value": 6,
                "label": "RALEIGH-WEST",
                "name": "towns"
            },
            {
                "value": 55,
                "label": "",
                "name": "urban"
            }
        ]
    },
    {
        "easting": 639325,
        "northing": 228495,
        "col": 933,
        "row": 1,
        "labels": [
            {
                "value": 6,
                "label": "RALEIGH-WEST",
                "name": "towns"
            },
            {
                "value": 55,
                "label": "",
                "name": "urban"
            }
        ]
    }
]
```

The `labels` array has the numerical value, categorical name, and the name of the inputs associated with the stat. I am unsure if these fields can be named better.

Once the JSON format is decided, I will add tests and update the documentation as well.