### PR TITLE
contributing: Improve message for failing PR title check

### DIFF
--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -376,12 +376,26 @@ def main():
             if re.match(category["regexp"], args.branch):
                 has_match = True
                 break
+        for item in config["notes"]["exclude"]["regexp"]:
+            if re.match(item, args.branch):
+                has_match = True
+                break
         if has_match:
             sys.exit(0)
         else:
+            expressions = "\n".join(
+                [category["regexp"] for category in config["notes"]["categories"]]
+            )
+            suggestions = "\n".join(
+                [category["example"] for category in config["notes"]["categories"]]
+            )
             sys.exit(
                 f"Title '{args.branch}' does not fit into one of "
-                f"the categories specified in {config_file}"
+                f"the categories specified in {config_file}. "
+                "Try to make it fit one of these regular expressions:\n"
+                f"{expressions}\n"
+                "Here are some examples:\n"
+                f"{suggestions}"
             )
     try:
         create_release_notes(args)

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -3,42 +3,55 @@ notes:
   categories:
     - title: Modules
       regexp: '((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools|temporal): '
+      example: 'r.slope.aspect:'
 
     - title: Graphical User Interface
       regexp: '(wxGUI.*|gui|GUI): '
+      example: 'wxGUI:'
 
     - title: Python
       regexp: '(grass\.[^ ]*|libpython.*|pythonlib.*|ctypesgen|ctypes|[Pp]ython|[Bb]inder): '
+      example: 'grass.script:'
 
     - title: Documentation and Messages
       regexp: '(docs?|man|manual|manual pages|[Ss]phinx|mkhtml|messages?): '
+      example: 'doc:'
 
     - title: Libraries and General Functionality
       regexp: '(grass_|lib|TGIS|tgis|raster|vector)[^ ]*: '
+      example: 'grass_btree: or lib/btree:'
 
     - title: Startup, Initialization, and Environment
       regexp: '(init|startup): '
+      example: 'startup:'
 
     - title: Translations, Internationalization, and Localization
       regexp: '(i18n|i18N|L10n|L10N|t9n|translations?): |Translations update from '
+      example: 'i18n:'
 
     - title: Windows
       regexp: '(winGRASS|win|[Ww]indows): '
+      example: 'win:'
 
     - title: Packaging, Configuration, Portability, and Compilation
       regexp: '(packaging|pkg|rpm|deb|pkg-config|configure|config|[Mm]ake|build): '
+      example: 'build:'
 
     - title: Docker
       regexp: '[Dd]ocker(/[^ ]+)?(\(\w[\w.-]*\))?: '
+      example: 'Docker:'
 
     - title: Singularity
       regexp: '[Ss]ingularity(\(\w[\w.-]*\))?: '
+      example: 'Singularity:'
 
     - title: Continuous Integration, Infrastructure, Tests and Code Quality
       regexp: '(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest)(\(\w[\w.-]*\))?: '
+      example: 'CI:'
 
     - title: Contributing and Management
       regexp: '(contributing|CONTRIBUTING.md|contributors|contributors.csv): '
+      example: 'contributing:'
 
   exclude:
     regexp:


### PR DESCRIPTION
The message now includes the expressions (except the excluded ones typically used only by maintainers) and examples (newly added).