### PR TITLE
CI: Cancel in progress jobs for other workflows

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
   workflow_dispatch:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref_protected != true }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 permissions: {}
 jobs:
   formatting-check:

--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -13,6 +13,11 @@ on:
       - .github/**
       - utils/**
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   OUT_DIR: ${{ github.workspace }}/../grass_outdir
   GRASS: grass-${{ github.ref_name }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,6 +13,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   validate-titles:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This week during the code sprint, I observed that some workflows or jobs weren't cancelled when another push/force push to a PR was made. Most of them didn't have a long runtime, and some were tricky as they continued to be queued after a force push.

Also fixes a small issue where clang-format jobs were cancelled on main (supposed to be a protected branch) when multiple jobs of this typed were queued. Suppose three merges to main made extremely close together, and the first set of jobs start normally. The first one, currently executing, continued, but the second was cancelled, and the third was made "pending", waiting for the first to finish. This PR finally makes use of the same known pattern.