### PR TITLE
r.in.pdal: use 1 based return numbers in LAS info output

### DIFF
--- a/raster/r.in.pdal/info.cpp
+++ b/raster/r.in.pdal/info.cpp
@@ -116,7 +116,7 @@ void print_lasinfo(struct StringList *infiles)
         std::cout << "Point offset: " << h.pointOffset() << "\n";
         std::cout << "Point count: " << h.pointCount() << "\n";
         for (size_t i = 0; i < pdal::LasHeader::RETURN_COUNT; ++i)
-            std::cout << "Point count by return[" << i << "]: "
+            std::cout << "Point count by return[" << i + 1 << "]: "
                       << const_cast<pdal::LasHeader &>(h).pointCountByReturn(i)
                       << "\n";
         std::cout << "Scales X/Y/Z: " << h.scaleX() << "/" << h.scaleY() << "/"


### PR DESCRIPTION
According to LAS specification, the first return number is 1. Fixes #3827