### PR TITLE
lib: Fix out-of-bounds array access in i.atcorr/computations.cpp

### DIFF
--- a/imagery/i.atcorr/computations.cpp
+++ b/imagery/i.atcorr/computations.cpp
@@ -111,7 +111,7 @@ double trunca()
             break;
         kk = i - 1;
     }
-
+    if (kk < 0) kk = 0;
     double aa =
         (double)((log10(sixs_trunc.pha[kk]) - log10(sixs_trunc.pha[k])) /
                  (acos(rmu[kk]) - acos(rmu[k])));


### PR DESCRIPTION
This pull request fixes several instances of out-of-bounds array access in the `computations.cpp` file within the `i.atcorr` module. Specifically, it addresses issues where negative indices were being used to access arrays, which could lead to undefined behavior and potential crashes.

### Changes Made

- Added a condition to ensure `kk` is not negative before using it as an array index.
  ```cpp
  if (kk < 0) kk = 0;

### Issues Resolved
1. Error : Array sixs_trunc.pha[83] accessed at index -1, which is out of bounds.
Location : imagery/i.atcorr/computations.cpp:116:39
Details : (double)((log10(sixs_trunc.pha[kk]) - log10(sixs_trunc.pha[k])) /

2. Error : Assuming condition is false
Location : imagery/i.atcorr/computations.cpp:110:20
Details : if (rmu[i] > 0.94)

3. Error : Assignment 'kk=i-1', assigned value is -1
Location : imagery/i.atcorr/computations.cpp:112:16
Details : kk = i - 1;

4. Error : Negative array index
Location : imagery/i.atcorr/computations.cpp:116:39
Details : (double)((log10(sixs_trunc.pha[kk]) - log10(sixs_trunc.pha[k])) /

5. Error : Array rmu[83] accessed at index -1, which is out of bounds.
Location : imagery/i.atcorr/computations.cpp:117:27
Details : (acos(rmu[kk]) - acos(rmu[k])));

6. Error : Assuming condition is false
Location : imagery/i.atcorr/computations.cpp:110:20
Details : if (rmu[i] > 0.94)

7. Error : Assignment 'kk=i-1', assigned value is -1
Location : imagery/i.atcorr/computations.cpp:112:16
Details : kk = i - 1;

8. Error : Negative array index
Location : imagery/i.atcorr/computations.cpp:117:27
Details : (acos(rmu[kk]) - acos(rmu[k])));

9. Error : Array sixs_trunc.pha[83] accessed at index -1, which is out of bounds.
Location : imagery/i.atcorr/computations.cpp:118:46
Details : double x1 = (double)(log10(sixs_trunc.pha[kk]));

10. Error : Assuming condition is false
Location : imagery/i.atcorr/computations.cpp:110:20
Details : if (rmu[i] > 0.94)

11. Error : Assignment 'kk=i-1', assigned value is -1
Location : imagery/i.atcorr/computations.cpp:112:16
Details : kk = i - 1;

12. Error : Negative array index
Location : imagery/i.atcorr/computations.cpp:118:46
Details : double x1 = (double)(log10(sixs_trunc.pha[kk]));

13. Error : Array rmu[83] accessed at index -1, which is out of bounds.
Location : imagery/i.atcorr/computations.cpp:119:33
Details : double x2 = (double)acos(rmu[kk]);

14. Error : Assuming condition is false
Location : imagery/i.atcorr/computations.cpp:110:20
Details : if (rmu[i] > 0.94)

15. Error : Assignment 'kk=i-1', assigned value is -1
Location : imagery/i.atcorr/computations.cpp:112:16
Details : kk = i - 1;

16. Error : Negative array index
Location : imagery/i.atcorr/computations.cpp:119:33
Details : double x2 = (double)acos(rmu[kk]);
