### PR TITLE
CI(super-linter): Specify linter rules path to pick up configuration files

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -77,13 +77,17 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 --numprocesses auto -ra . -m 'not needs_solo_run'
+          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
+            --numprocesses auto -ra . \
+            -m 'not needs_solo_run'
 
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 -ra . -m 'needs_solo_run'
+          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
+            -ra . \
+            -m 'needs_solo_run'
 
       - name: Print installed versions
         if: always()

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -37,7 +37,7 @@ jobs:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # By default, super-linter expect all linters to have their config
-          # files inside .github/linters. 
+          # files inside .github/linters.
           # Setting it to the root of the repo for easier configuration here.
           LINTER_RULES_PATH: .
           # Listed but commented out linters would be nice to have.

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,7 +23,7 @@ jobs:
       packages: read
       # To report GitHub Actions status checks
       statuses: write
-      checks: read
+      checks: write
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,3 +52,4 @@ jobs:
           VALIDATE_POWERSHELL: true
           # VALIDATE_XML: true
           VALIDATE_YAML: true
+          YAML_CONFIG_FILE: .yamllint

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,6 +23,7 @@ jobs:
       packages: read
       # To report GitHub Actions status checks
       statuses: write
+      checks: read
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -36,6 +36,10 @@ jobs:
           DEFAULT_BRANCH: main
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # By default, super-linter expect all linters to have their config
+          # files inside .github/linters. 
+          # Setting it to the root of the repo for easier configuration here.
+          LINTER_RULES_PATH: .
           # Listed but commented out linters would be nice to have.
           # (see https://github.com/github/super-linter#environment-variables)
           #

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -56,4 +56,5 @@ jobs:
           VALIDATE_POWERSHELL: true
           # VALIDATE_XML: true
           VALIDATE_YAML: true
+          MARKDOWN_CONFIG_FILE: .markdownlint.yml
           YAML_CONFIG_FILE: .yamllint

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,7 +23,6 @@ jobs:
       packages: read
       # To report GitHub Actions status checks
       statuses: write
-      checks: write
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache: ccache
 # safelist
 branches:
   only:
-  - main
-  - releasebranch*
+    - main
+    - releasebranch*
 
 jobs:
   include:


### PR DESCRIPTION
yamllint in pre-commit fails while yamllint from super-linter doesn't. Adds the config file to the super-linter config, as surprisingly super-linter defaults to .yaml-lint.yml, which wasn't a default known config file name in yamllint in all versions of the docs I looked at, going back to v1.0.0 too.