### PR TITLE
d.linegraph: Fix dead store warning in main.c

### DIFF
--- a/display/d.linegraph/main.c
+++ b/display/d.linegraph/main.c
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
         in[i].value = 0.0;
         in[i].num_pnts = 0;
 
-        while ((err = fscanf(in[i].fp, "%f", &in[i].value)) != EOF) {
+        while (fscanf(in[i].fp, "%f", &in[i].value) != EOF) {
             if (scale_y_values)
                 in[i].value *= y_scale;
             in[i].num_pnts++;


### PR DESCRIPTION
This pull request addresses a dead store warning in the `d.linegraph` module's `main.c` file.

 **Fixed Issue**:
- **Warning:** Although the value stored to 'err' is used in the enclosing expression, the value is never actually read from 'err'.

 **Changes Made**:
- Replaced the assignment and usage of **err** in the following block:
 
  while ((err = fscanf(in[i].fp, "%f", &in[i].value)) != EOF) {
      
  }

**with** 
while (fscanf(in[i].fp, "%f", &in[i].value) != EOF) {
    
}