### PR TITLE
d.legend.vect: Fix dead store warnings in draw.c

### DIFF
--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -86,7 +86,7 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
         if (strstr(buf, sub_delim) == NULL) {
             /* Get the maximum symbol size */
             tokens = G_tokenize(buf, sep);
-            symb_name = G_store(tokens[1]);
+            //symb_name = G_store(tokens[1]);
             size = atof(tokens[2]);
             type_str = G_store(tokens[7]);
             G_free_tokens(tokens);
@@ -137,7 +137,7 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
         }
         if (strstr(buf, sub_delim) != NULL) {
             /* Group subtitle */
-            label = G_malloc(GNAME_MAX);
+            //label = G_malloc(GNAME_MAX);
             part = strtok(buf, sep);
             label = G_store(part);
 

--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -86,7 +86,6 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
         if (strstr(buf, sub_delim) == NULL) {
             /* Get the maximum symbol size */
             tokens = G_tokenize(buf, sep);
-            // symb_name = G_store(tokens[1]);
             size = atof(tokens[2]);
             type_str = G_store(tokens[7]);
             G_free_tokens(tokens);
@@ -137,7 +136,6 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
         }
         if (strstr(buf, sub_delim) != NULL) {
             /* Group subtitle */
-            // label = G_malloc(GNAME_MAX);
             part = strtok(buf, sep);
             label = G_store(part);
 

--- a/display/d.legend.vect/draw.c
+++ b/display/d.legend.vect/draw.c
@@ -86,7 +86,7 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
         if (strstr(buf, sub_delim) == NULL) {
             /* Get the maximum symbol size */
             tokens = G_tokenize(buf, sep);
-            //symb_name = G_store(tokens[1]);
+            // symb_name = G_store(tokens[1]);
             size = atof(tokens[2]);
             type_str = G_store(tokens[7]);
             G_free_tokens(tokens);
@@ -137,7 +137,7 @@ void draw(char *file_name, double LL, double LT, char *title, int cols,
         }
         if (strstr(buf, sub_delim) != NULL) {
             /* Group subtitle */
-            //label = G_malloc(GNAME_MAX);
+            // label = G_malloc(GNAME_MAX);
             part = strtok(buf, sep);
             label = G_store(part);
 


### PR DESCRIPTION
This pull request addresses dead store warnings in the **d.legend.vect** module's **draw.c** file.

**Fixed Issues**:
- **Warning:** Value stored to 'symb_name' is never read.
- **Warning:** Value stored to 'label' is never read.

**Changes Made**:
- Commented out the redundant assignment to **symb_name**:
  // symb_name = G_store(tokens[1]);

- Commented out the redundant assignment to **label**:
 // label = G_malloc(GNAME_MAX); 