### PR TITLE
Checks: fix flake8 E741 in gui/wxpython directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -71,8 +71,7 @@ per-file-ignores =
     gui/wxpython/gui_core/widgets.py: F841, E722, E266
     gui/wxpython/image2target/*: F841, E722, E265
     gui/wxpython/image2target/g.gui.image2target.py: E501, E265, F841
-    gui/wxpython/iscatt/*: F841, E722, E741, F405, F403
-    gui/wxpython/lmgr/giface.py: E741
+    gui/wxpython/iscatt/*: F841, E722, F405, F403
     gui/wxpython/lmgr/frame.py: F841, E722
     # layertree still includes some formatting issues (it is ignored by Black)
     gui/wxpython/lmgr/layertree.py: E722, E266, W504, E225
@@ -82,16 +81,15 @@ per-file-ignores =
     gui/wxpython/photo2image/*: F841, E722, E265
     gui/wxpython/photo2image/g.gui.photo2image.py: E501, F841
     gui/wxpython/psmap/*: F841, E266, E722, F405, F403
-    gui/wxpython/vdigit/*: F841, E722, E741, F405, F403
+    gui/wxpython/vdigit/*: F841, E722, F405, F403
     gui/wxpython/vnet/*: F841
     gui/wxpython/wxgui.py: F841
     gui/wxpython/animation/g.gui.animation.py: E501
     gui/wxpython/animation/mapwindow.py: F841
     gui/wxpython/animation/provider.py: F841
-    gui/wxpython/tplot/frame.py: F841, E722, E741
+    gui/wxpython/tplot/frame.py: F841, E722
     gui/wxpython/tplot/g.gui.tplot.py: E501
     gui/wxpython/rdigit/g.gui.rdigit.py: F841
-    gui/wxpython/iclass/dialogs.py: E741
     gui/wxpython/iclass/digit.py: F405, F403
     gui/wxpython/iclass/frame.py: F405, F403
     gui/wxpython/iclass/g.gui.iclass.py: E501
@@ -109,14 +107,12 @@ per-file-ignores =
     gui/wxpython/mapwin/buffered.py: E722
     gui/wxpython/mapwin/graphics.py: E722
     gui/wxpython/startup/locdownload.py: E722, E402
-    gui/wxpython/timeline/g.gui.timeline.py: E501, E741
-    gui/wxpython/timeline/frame.py: E741
+    gui/wxpython/timeline/g.gui.timeline.py: E501
     gui/wxpython/tools/build_modules_xml.py: E722
     gui/wxpython/web_services/cap_interface.py: E501
-    gui/wxpython/web_services/widgets.py: F841, E741, E402
-    gui/wxpython/rlisetup/frame.py: E741
+    gui/wxpython/web_services/widgets.py: F841, E402
     gui/wxpython/rlisetup/sampling_frame.py: F841
-    gui/wxpython/rlisetup/wizard.py: E722, E741
+    gui/wxpython/rlisetup/wizard.py: E722
     # Generated file
     gui/wxpython/menustrings.py: E501
     # F821 undefined name 'cmp'

--- a/gui/wxpython/iclass/dialogs.py
+++ b/gui/wxpython/iclass/dialogs.py
@@ -573,10 +573,10 @@ class CategoryListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.TextEdi
         text_c = wx.Colour(*ContrastColor(back_c))
 
         # if it is in scope of the method, gui falls, using self solved it
-        self.l = wx.ItemAttr()
-        self.l.SetBackgroundColour(back_c)
-        self.l.SetTextColour(text_c)
-        return self.l
+        self.item_attr = wx.ItemAttr()
+        self.item_attr.SetBackgroundColour(back_c)
+        self.item_attr.SetTextColour(text_c)
+        return self.item_attr
 
 
 def ContrastColor(color):

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -543,10 +543,10 @@ class CategoryListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin):
             text_c = wx.SystemSettings.GetColour(wx.SYS_COLOUR_INACTIVECAPTIONTEXT)
 
         # if it is in scope of the method, gui falls, using self solved it
-        self.l = wx.ItemAttr()
-        self.l.SetBackgroundColour(back_c)
-        self.l.SetTextColour(text_c)
-        return self.l
+        self.item_attr = wx.ItemAttr()
+        self.item_attr.SetBackgroundColour(back_c)
+        self.item_attr.SetTextColour(text_c)
+        return self.item_attr
 
     def OnCategoryRightUp(self, event):
         """Show context menu on right click"""

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -105,10 +105,10 @@ class LayerList:
         :param opacity: layer opacity level
         :param cmd: command (given as a list)
         """
-        l = self._tree.AddLayer(
+        new_layer_lst = self._tree.AddLayer(
             ltype=ltype, lname=name, lchecked=checked, lopacity=opacity, lcmd=cmd
         )
-        return Layer(l, self._tree.GetPyData(l))
+        return Layer(new_layer_lst, self._tree.GetPyData(new_layer_lst))
 
     def DeleteLayer(self, layer):
         """Remove layer from layer list"""

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -66,7 +66,7 @@ class LayerList:
 
     def __getitem__(self, index):
         """Select a layer from the LayerList using the index."""
-        return [l for l in self][index]
+        return [layer for layer in self][index]
 
     def __repr__(self):
         """Return a representation of the object."""

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -217,9 +217,9 @@ class RLiSetupFrame(wx.Frame):
         listfiles = []
         # return all the configuration files in self.rlipath, check if there are
         # link or directory and doesn't add them
-        for l in os.listdir(self.rlipath):
-            if os.path.isfile(os.path.join(self.rlipath, l)):
-                listfiles.append(l)
+        for rli_conf in os.listdir(self.rlipath):
+            if os.path.isfile(os.path.join(self.rlipath, rli_conf)):
+                listfiles.append(rli_conf)
         return sorted(listfiles)
 
     def OnClose(self, event):

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -1888,13 +1888,13 @@ class VectorAreasPage(TitledPage):
             opacity=1.0,
             render=True,
         )
-        for l in self.map_.GetListOfLayers():
-            if l.name == self.outname:
+        for layer in self.map_.GetListOfLayers():
+            if layer.name == self.outname:
                 self.mapPanel.mapWindow.ZoomToMap(
-                    layers=[l], render=True, ignoreNulls=True
+                    layers=[layer], render=True, ignoreNulls=True
                 )
-            elif l.name != self.rast:
-                self.map_.DeleteLayer(l)
+            elif layer.name != self.rast:
+                self.map_.DeleteLayer(layer)
         self.areaText.SetLabel("Is this area (cat={n}) ok?".format(n=cat))
 
     def OnEnterPage(self, event):

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -503,7 +503,10 @@ class TimelineFrame(wx.Frame):
             )
             mapsets = tgis.get_tgis_c_library_interface().available_mapsets()
             allDatasets = [
-                i for i in sorted(allDatasets, key=lambda l: mapsets.index(l[1]))
+                i
+                for i in sorted(
+                    allDatasets, key=lambda dataset_info: mapsets.index(dataset_info[1])
+                )
             ]
 
         for dataset in datasets:

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -1159,7 +1159,10 @@ class TplotFrame(wx.Frame):
             )
             mapsets = tgis.get_tgis_c_library_interface().available_mapsets()
             allDatasets = [
-                i for i in sorted(allDatasets, key=lambda l: mapsets.index(l[1]))
+                i
+                for i in sorted(
+                    allDatasets, key=lambda dataset_info: mapsets.index(dataset_info[1])
+                )
             ]
 
         for dataset in datasets:

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -1182,8 +1182,8 @@ class DisplayDriver:
             catsDict[layer].append(cats.cat[i])
 
         catsStr = ""
-        for l, c in catsDict.items():
-            catsStr = "%d: (%s)" % (l, ",".join(map(str, c)))
+        for layer_num, c in catsDict.items():
+            catsStr = "%d: (%s)" % (layer_num, ",".join(map(str, c)))
 
         return catsStr
 

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -453,20 +453,20 @@ class WSPanel(wx.Panel):
     def _updateLayerOrderList(self, selected=None):
         """Update order in list."""
 
-        def getlayercaption(l):
-            if l["title"]:
-                cap = l["title"]
+        def getlayercaption(layer):
+            if layer["title"]:
+                cap = layer["title"]
             else:
-                cap = l["name"]
+                cap = layer["name"]
 
-            if l["style"]:
-                if l["style"]["title"]:
-                    cap += " / " + l["style"]["title"]
+            if layer["style"]:
+                if layer["style"]["title"]:
+                    cap += " / " + layer["style"]["title"]
                 else:
-                    cap += " / " + l["style"]["name"]
+                    cap += " / " + layer["style"]["name"]
             return cap
 
-        layer_capts = [getlayercaption(l) for l in self.sel_layers]
+        layer_capts = [getlayercaption(sel_layer) for sel_layer in self.sel_layers]
         self.l_odrder_list.Set(layer_capts)
         if self.l_odrder_list.IsEmpty():
             self.enableButtons(False)

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -634,7 +634,7 @@ class WSPanel(wx.Panel):
 
         # WMS standard - first layer in params is most bottom...
         # therefore layers order need to be reversed
-        l_st_list = [l for l in reversed(l_st_list)]
+        l_st_list = [layer for layer in reversed(l_st_list)]
         self.list.SelectLayers(l_st_list)
 
         params = {}

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -744,9 +744,9 @@ class WSPanel(wx.Panel):
                 if sel_l not in curr_sel_ls:
                     self.sel_layers.remove(sel_l)
 
-            for l in curr_sel_ls:
-                if l not in self.sel_layers:
-                    self.sel_layers.append(l)
+            for curr in curr_sel_ls:
+                if curr not in self.sel_layers:
+                    self.sel_layers.append(curr)
 
             self._updateLayerOrderList()
         else:
@@ -759,8 +759,8 @@ class WSPanel(wx.Panel):
 
         intersect_proj = []
         first = True
-        for l in curr_sel_ls:
-            layer_projs = l["cap_intf_l"].GetLayerData("srs")
+        for curr in curr_sel_ls:
+            layer_projs = curr["cap_intf_l"].GetLayerData("srs")
             if first:
                 projs_list = layer_projs
                 first = False


### PR DESCRIPTION
The E741 "ambiguous variable name 'l'" is fixed in the gui/wxpython directory. Many of the fixes involved renaming "l" in iterables.

One thing I would like to point out is that [01eb8dd](https://github.com/OSGeo/grass/commit/01eb8dd10b34e4457f27d6c12dc8b253f133a988) returns its self value. Personally, I don't see a problem with changing the name, but I thought it would be best to consult with a developer who is familiar with GRASS GUIs.