### PR TITLE
d.histogram: Fix dead store warnings in bar.c

### DIFF
--- a/display/d.histogram/bar.c
+++ b/display/d.histogram/bar.c
@@ -147,7 +147,7 @@ int bar(struct stat_list *dist_stats, /* list of distribution statistics */
     for (i = dist_stats->mincat; i <= dist_stats->maxcat; i++) {
         if (!ptr)
             break;
-        draw = NO;
+        
         /* figure bar color and height
          *
          * the cat number determines the color, the corresponding stat,

--- a/display/d.histogram/bar.c
+++ b/display/d.histogram/bar.c
@@ -147,7 +147,6 @@ int bar(struct stat_list *dist_stats, /* list of distribution statistics */
     for (i = dist_stats->mincat; i <= dist_stats->maxcat; i++) {
         if (!ptr)
             break;
-        
         /* figure bar color and height
          *
          * the cat number determines the color, the corresponding stat,


### PR DESCRIPTION
This pull request addresses dead store warnings in the d.histogram module's bar.c file

**Issue**
This pull request addresses a warning in bar.c related to the variable draw being assigned a value that is never read.

**Changes Made**
Removed the redundant assignment draw = NO at line 150.