### PR TITLE
Checks: fix flake8 E741 remainder

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -39,7 +39,7 @@ per-file-ignores =
     doc/python/vector_example_ctypes.py: F403, F405
     doc/python/m.distance.py: F403, F405, E501
     doc/gui/wxpython/example/dialogs.py: F401
-    locale/grass_po_stats.py: E122, E128, E231, E401, E722, E741
+    locale/grass_po_stats.py: E122, E128, E231, E401, E722
     gui/scripts/d.wms.py: E501
     gui/wxpython/core/gcmd.py: E402
     gui/wxpython/core/gthread.py: F841
@@ -130,7 +130,6 @@ per-file-ignores =
     python/grass/pygrass/vector/__init__.py: E402
     python/grass/pygrass/modules/interface/*.py: F401
     python/grass/pygrass/modules/grid/*.py: F401
-    python/grass/pygrass/raster/rowio.py: E741
     python/grass/pygrass/raster/category.py: E721
     python/grass/pygrass/rpc/__init__.py: F401, F403
     python/grass/pygrass/utils.py: E402
@@ -140,13 +139,11 @@ per-file-ignores =
     python/grass/temporal/datetime_math.py: F841, E722
     python/grass/temporal/open_stds.py: F841
     python/grass/temporal/spatial_topology_dataset_connector.py: E722
-    python/grass/temporal/temporal_algebra.py: E741, F841, E722
+    python/grass/temporal/temporal_algebra.py: F841, E722
     python/grass/temporal/temporal_granularity.py: F841, E722
-    python/grass/temporal/temporal_raster_algebra.py: E741
     python/grass/temporal/temporal_raster_base_algebra.py: F841, E722
-    python/grass/temporal/temporal_raster3d_algebra.py: E741
     python/grass/temporal/temporal_topology_dataset_connector.py: E722
-    python/grass/temporal/temporal_vector_algebra.py: E741, F841
+    python/grass/temporal/temporal_vector_algebra.py: F841
     python/grass/temporal/univar_statistics.py: E231
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
@@ -165,7 +162,7 @@ per-file-ignores =
     # E402 module level import not at top of file
     scripts/d.polar/d.polar.py: F841
     scripts/r.in.wms/wms_gdal_drv.py: F841, E722
-    scripts/r.in.wms/wms_cap_parsers.py: F841, E741
+    scripts/r.in.wms/wms_cap_parsers.py: F841
     scripts/r.in.wms/wms_drv.py: E402, E722
     scripts/r.in.wms/srs.py: E722
     scripts/r.semantic.label/r.semantic.label.py: F841, E501
@@ -174,8 +171,7 @@ per-file-ignores =
     scripts/g.extension/g.extension.py: F841, E722, E501
     scripts/v.unpack/v.unpack.py: F841, E722, E501
     scripts/v.import/v.import.py: F841, E722, E501
-    scripts/db.univar/db.univar.py: E741, E501
-    scripts/d.rast.leg/d.rast.leg.py: E741
+    scripts/db.univar/db.univar.py: E501
     scripts/d.frame/d.frame.py: E722
     scripts/i.pansharpen/i.pansharpen.py: E722, E501
     scripts/r.in.srtm/r.in.srtm.py: E722

--- a/locale/grass_po_stats.py
+++ b/locale/grass_po_stats.py
@@ -72,9 +72,9 @@ def read_msgfmt_statistics(msg, lgood, lfuzzy, lbad):
 
 def langDefinition(fil):
     f = codecs.open(fil, encoding="utf-8", errors="replace", mode="r")
-    for l in f.readlines():
-        if '"Language-Team:' in l:
-            lang = l.split(" ")[1:-1]
+    for line in f.readlines():
+        if '"Language-Team:' in line:
+            lang = line.split(" ")[1:-1]
             break
     f.close()
     if len(lang) == 2:
@@ -136,7 +136,7 @@ def writejson(stats, outfile):
     # load dictionary into json format
     fjson = json.dumps(stats, sort_keys=True, indent=4)
     # write a string with pretty style
-    outjson = os.linesep.join([l.rstrip() for l in fjson.splitlines()])
+    outjson = os.linesep.join([line.rstrip() for line in fjson.splitlines()])
     # write out file
     fout = open(outfile, "w")
     fout.write(outjson)

--- a/python/grass/pygrass/raster/rowio.py
+++ b/python/grass/pygrass/raster/rowio.py
@@ -18,17 +18,17 @@ CMPFUNC = ctypes.CFUNCTYPE(
 )
 
 
-def getmaprow_CELL(fd, buf, row, l):
+def getmaprow_CELL(fd, buf, row):
     librast.Rast_get_c_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.CELL)), row)
     return 1
 
 
-def getmaprow_FCELL(fd, buf, row, l):
+def getmaprow_FCELL(fd, buf, row):
     librast.Rast_get_f_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.FCELL)), row)
     return 1
 
 
-def getmaprow_DCELL(fd, buf, row, l):
+def getmaprow_DCELL(fd, buf, row):
     librast.Rast_get_d_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.DCELL)), row)
     return 1
 

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -868,7 +868,7 @@ class TemporalAlgebraParser:
 
         :return: True if successful, False otherwise
         """
-        l = lexer
+        lx = lexer
         # Split the expression to ignore the left part
         expressions = expression.split("=")[1:]
         expression = " ".join(expressions)
@@ -884,17 +884,17 @@ class TemporalAlgebraParser:
             return False
 
         # detect all STDS
-        if l is None:
-            l = TemporalAlgebraLexer()
-        l.build()
-        l.lexer.input(expression)
+        if lx is None:
+            lx = TemporalAlgebraLexer()
+        lx.build()
+        lx.lexer.input(expression)
 
         name_list = []
         tokens = []
 
         count = 0
         while True:
-            tok = l.lexer.token()
+            tok = lx.lexer.token()
             if not tok:
                 break
 

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -53,12 +53,12 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
 
     def parse(self, expression, basename=None, overwrite=False):
         # Check for space time dataset type definitions from temporal algebra
-        l = TemporalRasterAlgebraLexer()
-        l.build()
-        l.lexer.input(expression)
+        lx = TemporalRasterAlgebraLexer()
+        lx.build()
+        lx.lexer.input(expression)
 
         while True:
-            tok = l.lexer.token()
+            tok = lx.lexer.token()
             if not tok:
                 break
 

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -99,12 +99,12 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
 
     def parse(self, expression, basename=None, overwrite=False):
         # Check for space time dataset type definitions from temporal algebra
-        l = TemporalRasterAlgebraLexer()
-        l.build()
-        l.lexer.input(expression)
+        lx = TemporalRasterAlgebraLexer()
+        lx.build()
+        lx.lexer.input(expression)
 
         while True:
-            tok = l.lexer.token()
+            tok = lx.lexer.token()
             if not tok:
                 break
 

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -152,12 +152,12 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
 
     def parse(self, expression, basename=None, overwrite=False):
         # Check for space time dataset type definitions from temporal algebra
-        l = TemporalVectorAlgebraLexer()
-        l.build()
-        l.lexer.input(expression)
+        lx = TemporalVectorAlgebraLexer()
+        lx.build()
+        lx.lexer.input(expression)
 
         while True:
-            tok = l.lexer.token()
+            tok = lx.lexer.token()
             if not tok:
                 break
 

--- a/scripts/d.rast.leg/d.rast.leg.py
+++ b/scripts/d.rast.leg/d.rast.leg.py
@@ -66,7 +66,7 @@ import os
 import grass.script as grass
 
 
-def make_frame(f, b, t, l, r):
+def make_frame(f, b, t, l, r):  # noqa: E741
     (fl, fr, ft, fb) = f
 
     t /= 100.0

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -313,23 +313,23 @@ def main():
         pval[i] = 0
 
     inf = open(tmp + ".sort")
-    l = 1
+    ln = 1
     for line in inf:
         line = line.rstrip("\r\n")
         if len(line) == 0:
             continue
-        if l == q25pos:
+        if ln == q25pos:
             q25 = float(line)
-        if l == q50apos:
+        if ln == q50apos:
             q50a = float(line)
-        if l == q50bpos:
+        if ln == q50bpos:
             q50b = float(line)
-        if l == q75pos:
+        if ln == q75pos:
             q75 = float(line)
         for i in range(len(ppos)):
-            if l == ppos[i]:
+            if ln == ppos[i]:
                 pval[i] = float(line)
-        l += 1
+        ln += 1
 
     q50 = (q50a + q50b) / 2
 

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -313,23 +313,23 @@ def main():
         pval[i] = 0
 
     inf = open(tmp + ".sort")
-    ln = 1
+    line_number = 1
     for line in inf:
         line = line.rstrip("\r\n")
         if len(line) == 0:
             continue
-        if ln == q25pos:
+        if line_number == q25pos:
             q25 = float(line)
-        if ln == q50apos:
+        if line_number == q50apos:
             q50a = float(line)
-        if ln == q50bpos:
+        if line_number == q50bpos:
             q50b = float(line)
-        if ln == q75pos:
+        if line_number == q75pos:
             q75 = float(line)
         for i in range(len(ppos)):
-            if ln == ppos[i]:
+            if line_number == ppos[i]:
                 pval[i] = float(line)
-        ln += 1
+        line_number += 1
 
     q50 = (q50a + q50b) / 2
 

--- a/scripts/r.in.wms/wms_cap_parsers.py
+++ b/scripts/r.in.wms/wms_cap_parsers.py
@@ -140,9 +140,9 @@ class WMSCapabilitiesTree(BaseCapabilitiesTree):
 
         layers = parent_layer.findall(self.xml_ns.Ns("Layer"))
 
-        for l in layers:
-            self._initLayer(l, parent_layer)
-            self._checkLayerTree(l, False)
+        for layer in layers:
+            self._initLayer(layer, parent_layer)
+            self._checkLayerTree(layer, False)
 
     def _initLayer(self, layer, parent_layer):
         """Inherit elements from parent layer
@@ -340,10 +340,10 @@ class WMTSCapabilitiesTree(BaseCapabilitiesTree):
         self._findall(contents, "TileMatrixSet", self.xml_ns.NsWmts)
 
         layers = self._findall(contents, "Layer", self.xml_ns.NsWmts)
-        for l in layers:
-            if not self._checkLayer(l):
+        for layer in layers:
+            if not self._checkLayer(layer):
                 grass.debug("Removed invalid <Layer> element.", 4)
-                contents.remove(l)
+                contents.remove(layer)
 
         # are there any <Layer> elements after the check
         self._findall(contents, "Layer", self.xml_ns.NsWmts)
@@ -580,12 +580,12 @@ class OnEarthCapabilitiesTree(BaseCapabilitiesTree):
             layers = parent_layer.findall("TiledGroup")
             layers += parent_layer.findall("TiledGroups")
 
-        for l in layers:
-            if not self._checkLayer(l):
-                grass.debug(("Removed invalid <%s> element." % l.tag), 4)
-                parent_layer.remove(l)
-            if l.tag == "TiledGroups":
-                self._checkLayerTree(l, False)
+        for layer in layers:
+            if not self._checkLayer(layer):
+                grass.debug(("Removed invalid <%s> element." % layer.tag), 4)
+                parent_layer.remove(layer)
+            if layer.tag == "TiledGroups":
+                self._checkLayerTree(layer, False)
 
     def _find(self, etreeElement, tag):
         """!Find child element.


### PR DESCRIPTION
Reminder of E741 fixes for the "locale", "python", and "scripts" directories. The majority of fixes involved renaming variable names in iterables. The "noqa: E741" was added to "scripts/d.rast.leg/d.rast.leg.py" since it didn't make sense to change just the "l".