### PR TITLE
CI: regularly update nix lock file

### DIFF
--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -7,6 +7,11 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'package.nix'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -1,0 +1,44 @@
+---
+name: Update Nix dependencies
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  update-nix:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-request: write
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v12
+
+      - name: Update nix lock file
+        run: nix flake update
+
+      - name: Generate branch name
+        id: branch
+        run: echo branch="weekly-nix-dependencies-update-$(date "+%Y.%V")" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: |
+            flake.lock
+          title: "nix: weekly nix dependencies update (${{ steps.branch.outputs.branch }})"
+          body: Weekly update of nix flake.lock file.
+          branch: "${{ steps.branch.outputs.branch }}"
+          commit-message: "nix: weekly nix dependencies update"
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          delete-branch: true

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,6 @@
               echo " 2.  export LD_LIBRARY_PATH=\$(app/bin/grass --config path)/lib:\$LD_LIBRARY_PATH"
               echo " 3.  pytest"
               echo
-              echo "Note: run 'nix flake update' from time to time to update dependencies."
-              echo
               echo "Run 'dev-help' to see this message again."
             }
 


### PR DESCRIPTION
Add CI job to regularly update flake.lock file. This will keep GRASS package and development environment dependencies up-to-date.

I think, this is the last piece of Nix puzzle :).
