### PR TITLE
pytest: Mark tests using space_time_raster_dataset as needs_solo_run

### DIFF
--- a/python/grass/jupyter/tests/seriesmap_test.py
+++ b/python/grass/jupyter/tests/seriesmap_test.py
@@ -16,6 +16,7 @@ except ImportError:
 import grass.jupyter as gj
 
 
+@pytest.mark.needs_solo_run
 def test_default_init(space_time_raster_dataset):
     """Check that TimeSeriesMap init runs with default parameters"""
     img = gj.SeriesMap()
@@ -23,6 +24,7 @@ def test_default_init(space_time_raster_dataset):
     assert img._labels == space_time_raster_dataset.raster_names
 
 
+@pytest.mark.needs_solo_run
 def test_render_layers(space_time_raster_dataset):
     """Check that layers are rendered"""
     # create instance of TimeSeriesMap
@@ -41,6 +43,7 @@ def test_render_layers(space_time_raster_dataset):
         assert Path(filename).is_file()
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.skipif(IPython is None, reason="IPython package not available")
 @pytest.mark.skipif(ipywidgets is None, reason="ipywidgets package not available")
 def test_save(space_time_raster_dataset, tmp_path):

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -24,6 +24,7 @@ def test_fill_none_values():
     assert fill_names == ["r1", "r1", "r3"]
 
 
+@pytest.mark.needs_solo_run
 def test_collect_layers(space_time_raster_dataset):
     """Check that collect layers returns list of layers and dates"""
     names, dates = collect_layers(
@@ -40,6 +41,7 @@ def test_collect_layers(space_time_raster_dataset):
     assert len(names) == len(dates)
 
 
+@pytest.mark.needs_solo_run
 def test_default_init(space_time_raster_dataset):
     """Check that TimeSeriesMap init runs with default parameters"""
     img = gj.TimeSeriesMap()
@@ -47,6 +49,7 @@ def test_default_init(space_time_raster_dataset):
     assert img.baseseries == space_time_raster_dataset.name
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize("fill_gaps", [False, True])
 def test_render_layers(space_time_raster_dataset, fill_gaps):
     """Check that layers are rendered"""
@@ -67,6 +70,7 @@ def test_render_layers(space_time_raster_dataset, fill_gaps):
         assert Path(filename).is_file()
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.skipif(IPython is None, reason="IPython package not available")
 @pytest.mark.skipif(ipywidgets is None, reason="ipywidgets package not available")
 def test_save(space_time_raster_dataset, tmp_path):

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -15,6 +15,7 @@ except ImportError:
 import grass.script as gs
 
 
+@pytest.mark.needs_solo_run
 def test_defaults(space_time_raster_dataset):
     """Check that the module runs with default parameters"""
     gs.run_command(
@@ -24,6 +25,7 @@ def test_defaults(space_time_raster_dataset):
     )
 
 
+@pytest.mark.needs_solo_run
 def test_line(space_time_raster_dataset):
     """Line format can be parsed and contains full names by default"""
     names = (
@@ -39,6 +41,7 @@ def test_line(space_time_raster_dataset):
     assert names == space_time_raster_dataset.full_raster_names
 
 
+@pytest.mark.needs_solo_run
 def test_json(space_time_raster_dataset):
     """Check JSON can be parsed and contains the right values"""
     result = json.loads(
@@ -58,6 +61,7 @@ def test_json(space_time_raster_dataset):
     assert names == space_time_raster_dataset.raster_names
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.skipif(yaml is None, reason="PyYAML package not available")
 def test_yaml(space_time_raster_dataset):
     """Check JSON can be parsed and contains the right values"""
@@ -81,6 +85,7 @@ def test_yaml(space_time_raster_dataset):
     assert times == space_time_raster_dataset.start_times
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize(
     "separator,delimiter", [(None, ","), (",", ","), (";", ";"), ("tab", "\t")]
 )
@@ -110,6 +115,7 @@ def test_csv(space_time_raster_dataset, separator, delimiter):
         assert len(row) == len(columns)
 
 
+@pytest.mark.needs_solo_run
 def test_columns_list(space_time_raster_dataset):
     """Check CSV can be parsed with different separators"""
     # All relevant columns from the interface.
@@ -151,6 +157,7 @@ def test_columns_list(space_time_raster_dataset):
         assert len(row) == len(columns)
 
 
+@pytest.mark.needs_solo_run
 def test_columns_delta_gran(space_time_raster_dataset):
     """Check CSV can be parsed with different separators"""
     # All relevant columns from the interface.
@@ -179,6 +186,7 @@ def test_columns_delta_gran(space_time_raster_dataset):
         assert len(row) == len(columns)
 
 
+@pytest.mark.needs_solo_run
 def test_json_empty_result(space_time_raster_dataset):
     """Check JSON is generated for no returned values"""
     result = json.loads(
@@ -195,6 +203,7 @@ def test_json_empty_result(space_time_raster_dataset):
     assert len(result["data"]) == 0
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize("output_format", ["plain", "line"])
 def test_plain_empty_result(space_time_raster_dataset, output_format):
     """Check module fails with non-zero return code for empty result"""
@@ -209,6 +218,7 @@ def test_plain_empty_result(space_time_raster_dataset, output_format):
     assert return_code != 0
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize("output_format", ["csv", "plain"])
 def test_no_header_accepted(space_time_raster_dataset, output_format):
     """Check that the no column names flag is accepted"""
@@ -220,6 +230,7 @@ def test_no_header_accepted(space_time_raster_dataset, output_format):
     )
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize("output_format", ["json", "yaml"])
 def test_no_header_rejected(space_time_raster_dataset, output_format):
     """Check that the no column names flag is rejected
@@ -238,6 +249,7 @@ def test_no_header_rejected(space_time_raster_dataset, output_format):
     assert return_code != 0
 
 
+@pytest.mark.needs_solo_run
 @pytest.mark.parametrize("method", ["delta", "deltagaps", "gran"])
 def test_other_methods_json(space_time_raster_dataset, method):
     """Test methods other than list"""
@@ -259,6 +271,7 @@ def test_other_methods_json(space_time_raster_dataset, method):
     assert names == space_time_raster_dataset.raster_names
 
 
+@pytest.mark.needs_solo_run
 def test_gran_json(space_time_raster_dataset):
     """Test granularity method"""
     result = json.loads(


### PR DESCRIPTION
The test fixture `space_time_raster_dataset` used in some pytest tests, including in some of the Jupyter tests, is unexpectedly slow at the setup stage when running in pytest with multiple workers. There might be a deadlock problem, or might just use many processes or threads by itself. 

Since it causes some intermittent timeouts, this PR adds the marker to run them separately, without other tests in parallel. The setup stage is still slow, but I highly expect after my couple tries that it will prevent some more timeouts that were still present after https://github.com/OSGeo/grass/pull/3879.

On the positive side, there's (hopefully) less flaky tests to retry, that can cause delays when there is a lot of activity. On the negative side, since these tests are slow AND that the setup phase of that fixture is also slow, the overall time taken for the tests increases compared to the sum of parallel+serial test steps durations. So that means that there was some speedup of running them in parallel that we are temporarily letting go. It is still better than no parallel workers as before. And either way, some of deadlock issues, if they are caused by the multiprocessing using the fork startup method, will need to be fixed in order to run any of these tests on macOS and Windows. It's a work in progress (not this PR, this PR is ready)