### PR TITLE
style: Manual fixes for single-line-implicit-string-concatenation violations (ISC001)

### DIFF
--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1690,7 +1690,7 @@ class GMFrame(wx.Frame):
 
         if not haveIClass:
             GError(
-                _('Unable to launch "Supervised Classification Tool".\n\n' "Reason: %s")
+                _('Unable to launch "Supervised Classification Tool".\n\nReason: %s')
                 % errMsg
             )
             return

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -1840,7 +1840,7 @@ class GMFrame(wx.Frame):
 
         if not haveIClass:
             GError(
-                _('Unable to launch "Supervised Classification Tool".\n\n' "Reason: %s")
+                _('Unable to launch "Supervised Classification Tool".\n\nReason: %s')
                 % errMsg
             )
             return

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -132,7 +132,7 @@ keywordsfile.write("<dl>")
 sortedKeys = sorted(keywords.keys(), key=lambda s: s.lower())
 
 for key in sortedKeys:
-    keyword_line = '<dt><b><a name="%s" class="urlblack">%s</a></b></dt>' "<dd>" % (
+    keyword_line = '<dt><b><a name="%s" class="urlblack">%s</a></b></dt><dd>' % (
         key,
         key,
     )

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -277,7 +277,7 @@ def get_html_test_authors_table(directory, tests_authors):
     # TODO: don't do this for the top level directories?
     tests_authors = set(tests_authors)
     no_svn_text = (
-        '<span style="font-size: 60%">' "Test file authors were not obtained." "</span>"
+        '<span style="font-size: 60%">Test file authors were not obtained.</span>'
     )
     if not tests_authors or (len(tests_authors) == 1 and list(tests_authors)[0] == ""):
         return "<h3>Code and test authors</h3>" + no_svn_text
@@ -522,9 +522,9 @@ def returncode_to_html_sentence(returncode):
 
 def returncode_to_success_html_par(returncode):
     if returncode:
-        return '<p> <span style="color: red">&#x274c;</span>' " Test failed</p>"
+        return '<p> <span style="color: red">&#x274c;</span> Test failed</p>'
     else:
-        return '<p> <span style="color: green">&#x2713;</span>' " Test succeeded</p>"
+        return '<p> <span style="color: green">&#x2713;</span> Test succeeded</p>'
 
 
 def success_to_html_text(total, successes):
@@ -587,7 +587,7 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
             url = get_source_url(
                 path=svn_info["relative-url"], revision=svn_info["revision"]
             )
-            svn_text = ("SVN revision" ' <a href="{url}">' "{rev}</a>").format(
+            svn_text = ('SVN revision <a href="{url}">{rev}</a>').format(
                 url=url, rev=svn_info["revision"]
             )
         self.main_index.write(

--- a/python/libgrass_interface_generator/ctypesgen/expressions.py
+++ b/python/libgrass_interface_generator/ctypesgen/expressions.py
@@ -135,7 +135,7 @@ class UnaryExpressionNode(ExpressionNode):
         if self.op:
             return self.op(self.child.evaluate(context))
         else:
-            raise ValueError('The C operator "%s" can\'t be evaluated right ' "now" % self.name)
+            raise ValueError('The C operator "%s" can\'t be evaluated right now' % self.name)
 
     def py_string(self, can_be_ctype):
         return self.format % self.child.py_string(self.child_can_be_ctype and can_be_ctype)
@@ -182,7 +182,7 @@ class BinaryExpressionNode(ExpressionNode):
         if self.op:
             return self.op(self.left.evaluate(context), self.right.evaluate(context))
         else:
-            raise ValueError('The C operator "%s" can\'t be evaluated right ' "now" % self.name)
+            raise ValueError('The C operator "%s" can\'t be evaluated right now' % self.name)
 
     def py_string(self, can_be_ctype):
         return self.format % (

--- a/temporal/t.rast.algebra/testsuite/test_raster_algebra_arithmetic.py
+++ b/temporal/t.rast.algebra/testsuite/test_raster_algebra_arithmetic.py
@@ -296,7 +296,7 @@ class TestTRastAlgebra(TestCase):
 
         self.assertModule(
             "t.rast.algebra",
-            expression="R = if({equal}, start_date(A)" ' >= "2001-01-02", A + A)',
+            expression='R = if({equal}, start_date(A) >= "2001-01-02", A + A)',
             basename="r",
         )
 


### PR DESCRIPTION
Applies the remaining fixes that weren't picked up by `ruff check --select "ISC001" --fix` in order to limit the review scope of https://github.com/OSGeo/grass/pull/3943