### PR TITLE
style: Fixes unnecessary-collection-call (C408) for empty collections

### DIFF
--- a/gui/wxpython/animation/frame.py
+++ b/gui/wxpython/animation/frame.py
@@ -118,7 +118,7 @@ class AnimationFrame(wx.Frame):
         self._addPanes()
         self._mgr.Update()
 
-        self.dialogs = dict()
+        self.dialogs = {}
         self.dialogs["speed"] = None
         self.dialogs["preferences"] = None
 

--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -121,7 +121,7 @@ class BitmapProvider:
     def _getUniqueCmds(self):
         """Returns list of unique commands.
         Takes into account the region assigned."""
-        unique = list()
+        unique = []
         for cmdList, region in zip(self._cmdsForComposition, self._regions):
             for cmd in cmdList:
                 if region:

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -118,7 +118,7 @@ class Layer:
         self.name = name
 
         if self.type == "command":
-            self.cmd = list()
+            self.cmd = []
             for c in cmd:
                 self.cmd.append(cmdlist_to_tuple(c))
         else:
@@ -670,9 +670,9 @@ class RenderMapMgr(wx.EvtHandler):
         """
         stopTime = time.time()
 
-        maps = list()
-        masks = list()
-        opacities = list()
+        maps = []
+        masks = []
+        opacities = []
 
         # TODO: g.pnmcomp is now called every time
         # even when only overlays are rendered
@@ -824,16 +824,16 @@ class Map:
         """
         Debug.msg(1, "Map.__init__(): gisrc=%s" % gisrc)
         # region/extent settings
-        self.wind = dict()  # WIND settings (wind file)
-        self.region = dict()  # region settings (g.region)
+        self.wind = {}  # WIND settings (wind file)
+        self.region = {}  # region settings (g.region)
         self.width = 640  # map width
         self.height = 480  # map height
 
         # list of layers
-        self.layers = list()  # stack of available GRASS layer
+        self.layers = []  # stack of available GRASS layer
 
-        self.overlays = list()  # stack of available overlays
-        self.ovlookup = dict()  # lookup dictionary for overlay items and overlays
+        self.overlays = []  # stack of available overlays
+        self.ovlookup = {}  # lookup dictionary for overlay items and overlays
 
         # path to external gisrc
         self.gisrc = gisrc
@@ -866,7 +866,7 @@ class Map:
 
     def _projInfo(self):
         """Return region projection and map units information"""
-        projinfo = dict()
+        projinfo = {}
         if not grass.find_program("g.proj", "--help"):
             sys.exit(
                 _("GRASS tool '%s' not found. Unable to start map " "display window.")

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -1065,8 +1065,8 @@ class Settings:
                 else:
                     return settings[group][key]
             else:
-                if isinstance(subkey, type(tuple())) or isinstance(
-                    subkey, type(list())
+                if isinstance(subkey, type(())) or isinstance(
+                    subkey, type([])
                 ):
                     return settings[group][key][subkey[0]][subkey[1]]
                 else:
@@ -1104,8 +1104,8 @@ class Settings:
                 else:
                     settings[group][key] = value
             else:
-                if isinstance(subkey, type(tuple())) or isinstance(
-                    subkey, type(list())
+                if isinstance(subkey, type(())) or isinstance(
+                    subkey, type([])
                 ):
                     settings[group][key][subkey[0]][subkey[1]] = value
                 else:
@@ -1201,7 +1201,7 @@ UserSettings = Settings()
 
 
 def GetDisplayVectSettings():
-    settings = list()
+    settings = []
     if not UserSettings.Get(
         group="vectorLayer", key="featureColor", subkey=["transparent", "enabled"]
     ):

--- a/gui/wxpython/core/units.py
+++ b/gui/wxpython/core/units.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
 class BaseUnits:
     def __init__(self):
-        self._units = dict()
+        self._units = {}
         self._units["length"] = {
             0: {"key": "mu", "label": _("map units")},
             1: {"key": "me", "label": _("meters")},
@@ -53,7 +53,7 @@ class BaseUnits:
 
         :return: list of units labels
         """
-        result = list()
+        result = []
         try:
             keys = sorted(self._units[type].keys())
             for idx in keys:

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -109,7 +109,7 @@ def GetLayerNameFromCmd(dcmd, fullyQualified=False, param=None, layerType=None):
     elif "d.graph" in dcmd[0]:
         mapname = "graph"
     else:
-        params = list()
+        params = []
         for idx in range(len(dcmd)):
             try:
                 p, v = dcmd[idx].split("=", 1)
@@ -186,7 +186,7 @@ def GetLayerNameFromCmd(dcmd, fullyQualified=False, param=None, layerType=None):
             if i in mapsets and mapsets[i]:
                 dcmd[i] += "@" + mapsets[i]
 
-        maps = list()
+        maps = []
         ogr = False
         for i, p, v in params:
             if v.lower().rfind("@ogr") > -1:
@@ -321,7 +321,7 @@ def ListSortLower(list):
 
 def GetVectorNumberOfLayers(vector):
     """Get list of all vector layers"""
-    layers = list()
+    layers = []
     if not vector:
         return layers
 
@@ -514,7 +514,7 @@ def ReadEpsgCodes():
 
     :return: dictionary of EPSG code
     """
-    epsgCodeDict = dict()
+    epsgCodeDict = {}
 
     ret = RunCommand("g.proj", read=True, list_codes="EPSG")
 
@@ -570,7 +570,7 @@ def GetListOfLocations(dbase):
 
     :return: list of locations (sorted)
     """
-    listOfLocations = list()
+    listOfLocations = []
 
     try:
         for location in glob.glob(os.path.join(dbase, "*")):
@@ -598,7 +598,7 @@ def GetListOfMapsets(dbase, location, selectable=False):
 
     :return: list of mapsets - sorted (PERMANENT first)
     """
-    listOfMapsets = list()
+    listOfMapsets = []
 
     if selectable:
         ret = RunCommand(
@@ -625,7 +625,7 @@ def GetColorTables():
     """Get list of color tables"""
     ret = RunCommand("r.colors", read=True, flags="l")
     if not ret:
-        return list()
+        return []
 
     return ret.splitlines()
 
@@ -835,8 +835,8 @@ def StoreEnvVariable(key, value=None, envFile=None):
             )
 
     # read env file
-    environ = dict()
-    lineSkipped = list()
+    environ = {}
+    lineSkipped = []
     if os.path.exists(envFile):
         try:
             fd = open(envFile)

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -282,7 +282,7 @@ class ProcessWorkspaceFile:
 
         :param layer: tree node
         """
-        cmd = list()
+        cmd = []
 
         #
         # layer attributes (task) - 2D settings
@@ -344,7 +344,7 @@ class ProcessWorkspaceFile:
         Process overlay item
         :param overlay: tree node
         """
-        cmd = list()
+        cmd = []
 
         cmd.append(node_overlay.get("name", "unknown"))
 
@@ -374,12 +374,12 @@ class ProcessWorkspaceFile:
         :param node_vdigit: vdigit node
         """
         # init nviz layer properties
-        vdigit = dict()
+        vdigit = {}
         for node in node_vdigit.findall("geometryAttribute"):
             if "geomAttr" not in vdigit:
-                vdigit["geomAttr"] = dict()
+                vdigit["geomAttr"] = {}
             type = node.get("type")
-            vdigit["geomAttr"][type] = dict()
+            vdigit["geomAttr"][type] = {}
             vdigit["geomAttr"][type]["column"] = node.get("column")  # required
             # default map units
             vdigit["geomAttr"][type]["units"] = node.get("units", "mu")
@@ -736,7 +736,7 @@ class ProcessWorkspaceFile:
                     else:
                         value = None
             if dc:
-                dc[tag] = dict()
+                dc[tag] = {}
                 dc[tag]["value"] = value
             else:
                 return value

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -503,13 +503,13 @@ class DataCatalogTree(TreeView):
         except NotImplementedError:
             nprocs = 1
 
-        results = dict()
+        results = {}
         errors = []
         location_nodes = []
         all_location_nodes = []
         nlocations = len(locations)
         for location in locations:
-            results[location] = dict()
+            results[location] = {}
             varloc = self._model.AppendNode(
                 parent=grassdb_node, data=dict(type="location", name=location)
             )

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -1537,7 +1537,7 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         if dlg.ShowModal() == wx.ID_OK:
             values = dlg.GetValues()  # string
-            updateList = list()
+            updateList = []
             try:
                 for i in range(len(values)):
                     if i == keyId:  # skip key column

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -745,7 +745,7 @@ class ModifyTableRecord(wx.Dialog):
 
         If columns is given (list), return only values of given columns.
         """
-        valueList = list()
+        valueList = []
         for labelId, ctypeId, valueId in self.widgets:
             column = self.FindWindowById(labelId).GetLabel()
             if columns is None or column in columns:

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -124,9 +124,9 @@ class VectorDBInfo(VectorDBInfoBase):
             return None
 
         # process attributes
-        ret = dict()
+        ret = {}
         for key in ["Category", "Layer", "Table", "Id"]:
-            ret[key] = list()
+            ret[key] = []
 
         for record in data:
             if "Table" not in record:

--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -110,7 +110,7 @@ class ModelCanvas(ogl.ShapeCanvas):
 
     def GetShapesSelected(self):
         """Get list of selected shapes"""
-        selected = list()
+        selected = []
         diagram = self.GetDiagram()
         for shape in diagram.GetShapeList():
             if shape.Selected():
@@ -219,7 +219,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
                 shape.SetLabel(dlg.GetCondition())
                 model = self.frame.GetModel()
                 ids = dlg.GetItems()
-                alist = list()
+                alist = []
                 for aId in ids["unchecked"]:
                     action = model.GetItem(aId, objType=ModelAction)
                     if action:
@@ -244,7 +244,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
                 model = self.frame.GetModel()
                 ids = dlg.GetItems()
                 for b in ids.keys():
-                    alist = list()
+                    alist = []
                     for aId in ids[b]["unchecked"]:
                         action = model.GetItem(aId, objType=ModelAction)
                         action.UnSetBlock(shape)
@@ -295,7 +295,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
     def OnRightClick(self, x, y, keys=0, attachment=0):
         """Right click -> pop-up menu"""
         if not hasattr(self, "popupID"):
-            self.popupID = dict()
+            self.popupID = {}
             for key in (
                 "remove",
                 "enable",
@@ -445,7 +445,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
             shape.Select(False, dc)
         else:
             shapeList = canvas.GetDiagram().GetShapeList()
-            toUnselect = list()
+            toUnselect = []
 
             if not append:
                 for s in shapeList:

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -287,7 +287,7 @@ class ModelSearchDialog(wx.Dialog):
     def _getCmd(self):
         line = self.cmd_prompt.GetCurLine()[0].strip()
         if len(line) == 0:
-            cmd = list()
+            cmd = []
         else:
             cmd = utils.split(str(line))
         return cmd
@@ -801,7 +801,7 @@ class VariableListCtrl(ModelListCtrl):
 
     def Populate(self, data):
         """Populate the list"""
-        self.itemDataMap = dict()
+        self.itemDataMap = {}
         i = 0
         for name, values in data.items():
             self.itemDataMap[i] = [
@@ -875,7 +875,7 @@ class VariableListCtrl(ModelListCtrl):
             return
 
         self.DeleteAllItems()
-        self.itemDataMap = dict()
+        self.itemDataMap = {}
 
         self.parent.UpdateModelVariables()
 
@@ -926,7 +926,7 @@ class ItemListCtrl(ModelListCtrl):
         self.disablePopup = disablePopup
 
         ModelListCtrl.__init__(self, parent, columns, frame, **kwargs)
-        self.itemIdMap = list()
+        self.itemIdMap = []
 
         self.SetColumnWidth(0, 100)
         self.SetColumnWidth(1, 75)
@@ -939,8 +939,8 @@ class ItemListCtrl(ModelListCtrl):
 
     def Populate(self, data):
         """Populate the list"""
-        self.itemDataMap = dict()
-        self.itemIdMap = list()
+        self.itemDataMap = {}
+        self.itemIdMap = []
 
         if self.shape:
             items = self.frame.GetModel().GetItems(objType=ModelAction)
@@ -956,11 +956,11 @@ class ItemListCtrl(ModelListCtrl):
             else:
                 shapeItems = map(lambda x: x.GetId(), self.shape.GetItems(items))
         else:
-            shapeItems = list()
+            shapeItems = []
 
         i = 0
         if len(self.columns) == 2:  # ItemCheckList
-            checked = list()
+            checked = []
         for action in data:
             if isinstance(action, ModelData) or action == self.shape:
                 continue
@@ -1065,7 +1065,7 @@ class ItemListCtrl(ModelListCtrl):
             return
 
         if not hasattr(self, "popupId"):
-            self.popupID = dict()
+            self.popupID = {}
             self.popupID["remove"] = NewId()
             self.popupID["reload"] = NewId()
             self.Bind(wx.EVT_MENU, self.OnRemove, id=self.popupID["remove"])
@@ -1103,8 +1103,8 @@ class ItemListCtrl(ModelListCtrl):
 
         model = self.frame.GetModel()
         modelActions = model.GetItems(objType=ModelAction)
-        idxList = dict()
-        itemsToSelect = list()
+        idxList = {}
+        itemsToSelect = []
         for i in items:
             if up:
                 idx = i - 1
@@ -1154,7 +1154,7 @@ class ItemCheckListCtrl(ItemListCtrl, CheckListCtrlMixin):
 
     def GetItems(self):
         """Get list of selected actions"""
-        ids = {"checked": list(), "unchecked": list()}
+        ids = {"checked": [], "unchecked": []}
 
         # action ids start at 1
         for i in range(self.GetItemCount()):

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -73,7 +73,7 @@ class Model:
         giface,
         canvas=None,
     ):
-        self.items = list()  # list of ordered items (action/loop/condition)
+        self.items = []  # list of ordered items (action/loop/condition)
 
         # model properties
         self.properties = {
@@ -82,8 +82,8 @@ class Model:
             "author": getpass.getuser(),
         }
         # model variables
-        self.variables = dict()
-        self.variablesParams = dict()
+        self.variables = {}
+        self.variablesParams = {}
 
         self.canvas = canvas
         self._giface = giface
@@ -100,7 +100,7 @@ class Model:
         if not objType:
             return self.items
 
-        result = list()
+        result = []
         for item in self.items:
             if isinstance(item, objType):
                 result.append(item)
@@ -134,7 +134,7 @@ class Model:
         return len(self.GetItems())
 
     def ReorderItems(self, idxList):
-        items = list()
+        items = []
         for oldIdx, newIdx in idxList.items():
             item = self.items.pop(oldIdx)
             items.append(item)
@@ -210,7 +210,7 @@ class Model:
 
     def Reset(self):
         """Reset model"""
-        self.items = list()
+        self.items = []
 
     def RemoveItem(self, item, reference=None):
         """Remove item from model
@@ -220,8 +220,8 @@ class Model:
 
         :return: list of related items to remove/update
         """
-        relList = list()
-        upList = list()
+        relList = []
+        upList = []
         doRemove = True
 
         if isinstance(item, ModelAction):
@@ -269,7 +269,7 @@ class Model:
         """Get list of maps of selected type
 
         :param prompt: to filter maps"""
-        maps = list()
+        maps = []
         for data in self.GetData():
             if prompt == data.GetPrompt():
                 mapName = data.GetValue()
@@ -281,7 +281,7 @@ class Model:
 
     def GetData(self):
         """Get list of data items"""
-        result = list()
+        result = []
         dataItems = self.GetItems(objType=ModelData)
 
         for action in self.GetItems(objType=ModelAction):
@@ -439,7 +439,7 @@ class Model:
         for condition in gxmXml.conditions:
             conditionItem = self.GetItem(condition["id"])
             for b in condition["items"].keys():
-                alist = list()
+                alist = []
                 for aId in condition["items"][b]:
                     action = self.GetItem(aId)
                     alist.append(action)
@@ -485,7 +485,7 @@ class Model:
     def Validate(self):
         """Validate model, return None if model is valid otherwise
         error string"""
-        errList = list()
+        errList = []
 
         variables = self.GetVariables().keys()
         pattern = re.compile(r"(.*)(%.+\s?)(.*)")
@@ -532,9 +532,9 @@ class Model:
 
         :return: list of undefined variables
         """
-        errList = list()
+        errList = []
 
-        self.fileInput = dict()
+        self.fileInput = {}
 
         # collect ascii inputs
         for p in item.GetParams()["params"]:
@@ -685,7 +685,7 @@ class Model:
                 GError(parent=parent, message="\n".join(err))
                 return
 
-            err = list()
+            err = []
             for key, item in params.items():
                 for p in item["params"]:
                     if p.get("value", "") == "":
@@ -740,7 +740,7 @@ class Model:
                 )
                 pattern = re.compile("%" + condVar)
                 # for vars()[condVar] in eval(condText): ?
-                vlist = list()
+                vlist = []
                 if condText[0] == "`" and condText[-1] == "`":
                     # run command
                     cmd, dcmd = gtask.cmdlist_to_tuple(condText[1:-1].split(" "))
@@ -789,9 +789,9 @@ class Model:
 
     def GetIntermediateData(self):
         """Get info about intermediate data"""
-        rast = list()
-        rast3d = list()
-        vect = list()
+        rast = []
+        rast3d = []
+        vect = []
         for data in self.GetData():
             if not data.IsIntermediate():
                 continue
@@ -831,11 +831,11 @@ class Model:
 
     def Parameterize(self):
         """Return parameterized options"""
-        result = dict()
+        result = {}
         idx = 0
         if self.variables:
-            params = list()
-            result["variables"] = {"flags": list(), "params": params, "idx": idx}
+            params = []
+            result["variables"] = {"flags": [], "params": params, "idx": idx}
             for name, values in self.variables.items():
                 gtype = values.get("type", "string")
                 if gtype in ("raster", "vector", "mapset", "file", "region", "dir"):
@@ -864,9 +864,9 @@ class Model:
                         "label": "",
                         "guisection": "",
                         "key_desc": "",
-                        "values": list(),
+                        "values": [],
                         "parameterized": False,
-                        "values_desc": list(),
+                        "values_desc": [],
                         "prompt": prompt,
                         "element": element,
                         "type": ptype,
@@ -886,13 +886,13 @@ class Model:
                 if f.get("parameterized", False):
                     if name not in result:
                         increment = True
-                        result[name] = {"flags": list(), "params": list(), "idx": idx}
+                        result[name] = {"flags": [], "params": [], "idx": idx}
                     result[name]["flags"].append(f)
             for p in params["params"]:
                 if p.get("parameterized", False):
                     if name not in result:
                         increment = True
-                        result[name] = {"flags": list(), "params": list(), "idx": idx}
+                        result[name] = {"flags": [], "params": [], "idx": idx}
                     result[name]["params"].append(p)
             if increment:
                 idx += 1
@@ -906,10 +906,10 @@ class ModelObject:
     def __init__(self, id=-1, label=""):
         self.id = id  # internal id, should be not changed
         self.label = ""
-        self.rels = list()  # list of ModelRelations
+        self.rels = []  # list of ModelRelations
 
         self.isEnabled = True
-        self.inBlock = list()  # list of related loops/conditions
+        self.inBlock = []  # list of related loops/conditions
 
     def __del__(self):
         pass
@@ -947,7 +947,7 @@ class ModelObject:
         if fdir is None:
             return self.rels
 
-        result = list()
+        result = []
         for rel in self.rels:
             if fdir == "from":
                 if rel.GetFrom() == self:
@@ -1001,7 +1001,7 @@ class ModelObject:
 
         :return: list of ids
         """
-        ret = list()
+        ret = []
         for mo in self.inBlock:
             ret.append(mo.GetId())
 
@@ -1049,7 +1049,7 @@ class ModelAction(ModelObject, ogl.DividedShape):
 
         self.propWin = None
 
-        self.data = list()  # list of connected data items
+        self.data = []  # list of connected data items
 
         self.isValid = False
         self.isParameterized = False
@@ -1428,7 +1428,7 @@ class ModelData(ModelObject):
 
     def GetLog(self, string=True):
         """Get logging info"""
-        name = list()
+        name = []
         for rel in self.GetRelations():
             name.append(rel.GetLabel())
         if name:
@@ -1438,7 +1438,7 @@ class ModelData(ModelObject):
 
     def GetLabel(self):
         """Get list of names"""
-        name = list()
+        name = []
         for rel in self.GetRelations():
             name.append(rel.GetLabel())
 
@@ -1765,7 +1765,7 @@ class ModelItem(ModelObject):
 
     def Clear(self):
         """Clear object, remove rels"""
-        self.rels = list()
+        self.rels = []
 
 
 class ModelLoop(ModelItem, ogl.RectangleShape):
@@ -1774,7 +1774,7 @@ class ModelLoop(ModelItem, ogl.RectangleShape):
     ):
         """Defines a loop"""
         ModelItem.__init__(self, parent, x, y, id, width, height, label, items)
-        self.itemIds = list()  # unordered
+        self.itemIds = []  # unordered
 
         if not width:
             width = UserSettings.Get(
@@ -1824,7 +1824,7 @@ class ModelLoop(ModelItem, ogl.RectangleShape):
 
     def GetItems(self, items):
         """Get sorted items by id"""
-        result = list()
+        result = []
         for item in items:
             if item.GetId() in self.itemIds:
                 result.append(item)
@@ -2009,13 +2009,13 @@ class ProcessModelFile:
             raise GException(_("Details: unsupported tag name '{0}'.").format(tagName))
 
         # list of actions, data
-        self.properties = dict()
-        self.variables = dict()
-        self.actions = list()
-        self.data = list()
-        self.loops = list()
-        self.conditions = list()
-        self.comments = list()
+        self.properties = {}
+        self.variables = {}
+        self.actions = []
+        self.data = []
+        self.loops = []
+        self.conditions = []
+        self.comments = []
 
         self._processWindow()
         self._processProperties()
@@ -2170,14 +2170,14 @@ class ProcessModelFile:
 
             display = False if data.find("display") is None else True
 
-            rels = list()
+            rels = []
             for rel in data.findall("relation"):
                 defrel = {
                     "id": int(rel.get("id", -1)),
                     "dir": rel.get("dir", "to"),
                     "name": rel.get("name", ""),
                 }
-                points = list()
+                points = []
                 for point in rel.findall("point"):
                     x = self._filterValue(self._getNodeText(point, "x"))
                     y = self._filterValue(self._getNodeText(point, "y"))
@@ -2203,8 +2203,8 @@ class ProcessModelFile:
         :return: grassTask instance
         :return: None on error
         """
-        cmd = list()
-        parameterized = list()
+        cmd = []
+        parameterized = []
 
         name = node.get("name", None)
         if not name:
@@ -2249,7 +2249,7 @@ class ProcessModelFile:
         for node in self.root.findall("loop"):
             pos, size = self._getDim(node)
             text = self._filterValue(self._getNodeText(node, "condition")).strip()
-            aid = list()
+            aid = []
             for anode in node.findall("item"):
                 try:
                     aid.append(int(anode.text))
@@ -2271,7 +2271,7 @@ class ProcessModelFile:
         for node in self.root.findall("if-else"):
             pos, size = self._getDim(node)
             text = self._filterValue(self._getNodeText(node, "condition")).strip()
-            aid = {"if": list(), "else": list()}
+            aid = {"if": [], "else": []}
             for b in aid.keys():
                 bnode = node.find(b)
                 if bnode is None:
@@ -2328,7 +2328,7 @@ class WriteModelFile:
         self._variables()
         self._items()
 
-        dataList = list()
+        dataList = []
         for action in model.GetItems(objType=ModelAction):
             for rel in action.GetRelations():
                 dataItem = rel.GetData()
@@ -3694,7 +3694,7 @@ class ModelParamDialog(wx.Dialog):
         self._model = model
         self._giface = giface
         self.params = params
-        self.tasks = list()  # list of tasks/pages
+        self.tasks = []  # list of tasks/pages
 
         wx.Dialog.__init__(
             self, parent=parent, id=id, title=title, style=style, **kwargs
@@ -3791,7 +3791,7 @@ class ModelParamDialog(wx.Dialog):
 
     def GetErrors(self):
         """Check for errors, get list of messages"""
-        errList = list()
+        errList = []
         for task in self.tasks:
             errList += task.get_cmd_error()
 

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -1479,7 +1479,7 @@ class VariablePanel(wx.Panel):
 
     def UpdateModelVariables(self):
         """Update model variables"""
-        variables = dict()
+        variables = {}
         for values in self.list.GetData().values():
             name = values[0]
             variables[name] = {"type": str(values[1])}

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1139,7 +1139,7 @@ class GroupDialog(wx.Dialog):
         """Group was selected, check if changes were applied"""
         self._checkChange()
         group, s = self.GetSelectedGroup()
-        maps = list()
+        maps = []
         groups = self.GetExistGroups()
         if group in groups:
             maps = self.GetGroupLayers(group)
@@ -1179,7 +1179,7 @@ class GroupDialog(wx.Dialog):
         subgroup = self.subGroupSelect.GetValue().strip()
         group = self.currentGroup
 
-        gmaps = list()
+        gmaps = []
         groups = self.GetExistGroups()
 
         self.subgmaps = {}
@@ -1353,7 +1353,7 @@ class GroupDialog(wx.Dialog):
 
     def GetGroupLayers(self, group, subgroup=None):
         """Get layers in group"""
-        kwargs = dict()
+        kwargs = {}
         kwargs["group"] = group
         if subgroup:
             kwargs["subgroup"] = subgroup
@@ -1883,8 +1883,8 @@ class SetOpacityDialog(wx.Dialog):
 
 def GetImageHandlers(image):
     """Get list of supported image handlers"""
-    lext = list()
-    ltype = list()
+    lext = []
+    ltype = []
     try:
         for h in image.GetHandlers():
             lext.append(h.GetExtension())

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -197,7 +197,7 @@ class UpdateThread(Thread):
             map = None
 
         # avoid running db.describe several times
-        cparams = dict()
+        cparams = {}
         cparams[map] = {
             "dbInfo": None,
             "layers": None,
@@ -1216,7 +1216,7 @@ class CmdPanel(wx.Panel):
                         isEnabled[defval] = "yes"
                         # for multi checkboxes, this is an array of all wx IDs
                         # for each individual checkbox
-                        p["wxId"] = list()
+                        p["wxId"] = []
                     idx = 0
                     for val in valuelist:
                         try:
@@ -2303,7 +2303,7 @@ class CmdPanel(wx.Panel):
                         p["wxId"] = [self.win1.GetId()]
 
                         def OnCheckItem(index=None, flag=None, event=None):
-                            layers = list()
+                            layers = []
                             geometry = None
                             for layer, match, listId in self.win1.GetLayers():
                                 if "|" in layer:
@@ -2404,7 +2404,7 @@ class CmdPanel(wx.Panel):
                     pOpt = self.task.get_param(opt, element="name", raiseError=False)
                     if pOpt and id:
                         if "wxId-bind" not in p:
-                            p["wxId-bind"] = list()
+                            p["wxId-bind"] = []
                         p["wxId-bind"] += pOpt["wxId"]
                 continue
             if p.get("gisprompt", False) is False:
@@ -2574,7 +2574,7 @@ class CmdPanel(wx.Panel):
     def OnFileLoad(self, event):
         """Load file to interactive input"""
         me = event.GetId()
-        win = dict()
+        win = {}
         for p in self.task.params:
             if "wxId" in p and me in p["wxId"]:
                 win["file"] = self.FindWindowById(p["wxId"][0])
@@ -3091,7 +3091,7 @@ class GUI:
         self.checkError = checkError
 
         self.grass_task = None
-        self.cmd = list()
+        self.cmd = []
 
         global _blackList
         if self.parent:
@@ -3137,7 +3137,7 @@ class GUI:
             if "flags" in dcmd_params:
                 self.grass_task.flags = dcmd_params["flags"]
 
-        err = list()
+        err = []
         # update parameters if needed && validate command
         if len(cmd) > 1:
             i = 0

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -387,8 +387,8 @@ class AboutWindow(wx.Frame):
             contribfile = os.path.join(os.getenv("GISBASE"), "contributors.csv")
         if os.path.exists(contribfile):
             contribFile = codecs.open(contribfile, encoding="utf-8", mode="r")
-            contribs = list()
-            errLines = list()
+            contribs = []
+            errLines = []
             for line in contribFile.readlines()[1:]:
                 line = line.rstrip("\n")
                 try:
@@ -472,8 +472,8 @@ class AboutWindow(wx.Frame):
         translatorsfile = os.path.join(os.getenv("GISBASE"), "translators.csv")
         if os.path.exists(translatorsfile):
             translatorsFile = codecs.open(translatorsfile, encoding="utf-8", mode="r")
-            translators = dict()
-            errLines = list()
+            translators = {}
+            errLines = []
             for line in translatorsFile.readlines()[1:]:
                 line = line.rstrip("\n")
                 try:
@@ -483,7 +483,7 @@ class AboutWindow(wx.Frame):
                     continue
                 for language in languages.split(" "):
                     if language not in translators:
-                        translators[language] = list()
+                        translators[language] = []
                     translators[language].append((name, email))
             translatorsFile.close()
 
@@ -747,7 +747,7 @@ class HelpWindow(HtmlWindow):
         HtmlWindow.__init__(self, parent=parent, **kwargs)
 
         self.loaded = False
-        self.history = list()
+        self.history = []
         self.historyIdx = 0
         self.fspath = os.path.join(os.getenv("GISBASE"), "docs", "html")
 

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -441,7 +441,7 @@ class TreeCtrlComboPopup(ListCtrlComboPopup):
         self.mapsets = None
         self.onPopup = None
         self.fullyQualified = True
-        self.extraItems = dict()
+        self.extraItems = {}
 
         self.SetFilter(None)
         self.tgis_error = False
@@ -977,7 +977,7 @@ class LayerSelect(wx.ComboBox):
         :param str vector: vector map name (native or connected via v.external)
         :param str dsn: OGR data source name
         """
-        layers = list()
+        layers = []
 
         if vector:
             layers = GetVectorNumberOfLayers(vector)
@@ -1407,14 +1407,14 @@ class FormatSelect(wx.Choice):
         else:
             ftype = "gdal"
 
-        formats = list()
+        formats = []
         for f in GetFormats()[ftype][srcType].items():
             formats += f
         self.SetItems(formats)
 
     def GetExtension(self, name):
         """Get file extension by format name"""
-        formatToExt = dict()
+        formatToExt = {}
         formatToExt.update(rasterFormatExtension)
         formatToExt.update(vectorFormatExtension)
 
@@ -1462,7 +1462,7 @@ class GdalSelect(wx.Panel):
             self.inputBox.SetLabel(" %s " % _("Source input"))
 
         # source type
-        sources = list()
+        sources = []
         self.sourceMap = {"file": -1, "dir": -1, "db": -1, "pro": -1, "native": -1}
         idx = 0
         if dest:
@@ -1724,7 +1724,7 @@ class GdalSelect(wx.Panel):
                 if k == "dbname":
                     dsn = v
                     break
-            optList = list()
+            optList = []
             for k, v in data.items():
                 if k in ("format", "conninfo", "topology"):
                     continue
@@ -1964,7 +1964,7 @@ class GdalSelect(wx.Panel):
 
     def _getExtension(self, name):
         """Get file extension by format name"""
-        formatToExt = dict()
+        formatToExt = {}
         formatToExt.update(rasterFormatExtension)
         formatToExt.update(vectorFormatExtension)
 
@@ -2204,7 +2204,7 @@ class GdalSelect(wx.Panel):
                     p = grass.Popen([self._psql, "-ltA"], stdout=grass.PIPE)
                     ret = p.communicate()[0]
                     if ret:
-                        dbNames = list()
+                        dbNames = []
                         for line in ret.splitlines():
                             sline = line.split("|")
                             if len(sline) < 2:
@@ -2309,8 +2309,8 @@ class GdalSelect(wx.Panel):
         if not dsn:
             return
 
-        data = list()
-        listData = list()
+        data = []
+        listData = []
         layerId = 1
 
         if self.ogr:
@@ -2727,7 +2727,7 @@ class ProjSelect(wx.ComboBox):
                 project=location,
                 mapset=mapset,
             )
-        listMaps = list()
+        listMaps = []
         if ret:
             for line in ret.splitlines():
                 listMaps.append(line.strip())

--- a/gui/wxpython/gui_core/menu.py
+++ b/gui/wxpython/gui_core/menu.py
@@ -50,7 +50,7 @@ class MenuBase:
         """
         self.parent = parent
         self.model = model
-        self.menucmd = dict()
+        self.menucmd = {}
         self.bmpsize = (16, 16)
         self.class_handler = class_handler if class_handler is not None else parent
 

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -1818,7 +1818,7 @@ class PreferencesDialog(PreferencesBaseDialog):
         epsgCode = wx.ComboBox(
             parent=panel, id=wx.ID_ANY, name="GetValue", size=(150, -1)
         )
-        self.epsgCodeDict = dict()
+        self.epsgCodeDict = {}
         epsgCode.SetValue(
             str(self.settings.Get(group="projection", key="statusbar", subkey="epsg"))
         )
@@ -2044,7 +2044,7 @@ class PreferencesDialog(PreferencesBaseDialog):
                 caption=_("Error"),
                 style=wx.OK | wx.ICON_ERROR | wx.CENTRE,
             )
-            self.epsgCodeDict = dict()
+            self.epsgCodeDict = {}
             epsgCombo.SetItems([])
             epsgCombo.SetValue("")
             self.FindWindowById(self.winId["projection:statusbar:proj4"]).SetValue("")

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -58,14 +58,14 @@ class GPrompt:
         self.mapsetList = utils.ListOfMapsets()
 
         # auto complete items
-        self.autoCompList = list()
+        self.autoCompList = []
         self.autoCompFilter = None
 
         # command description (gtask.grassTask)
         self.cmdDesc = None
 
         # list of traced commands
-        self.commands = list()
+        self.commands = []
 
         # reload map lists when needed
         if giface:
@@ -74,7 +74,7 @@ class GPrompt:
 
     def _getListOfMaps(self):
         """Get list of maps"""
-        result = dict()
+        result = {}
         result["raster"] = grass.list_strings("raster")
         result["vector"] = grass.list_strings("vector")
 
@@ -423,7 +423,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
         """
         textLeft = self.GetTextLeft()
 
-        parts = list()
+        parts = []
         if ignoredDelimiter is None:
             ignoredDelimiter = ""
 
@@ -512,7 +512,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
         pos = self.GetCurrentPos()
         # complete command after pressing '.'
         if event.GetKeyCode() == 46:
-            self.autoCompList = list()
+            self.autoCompList = []
             entry = self.GetTextLeft()
             self.InsertText(pos, ".")
             self.CharRight()
@@ -539,7 +539,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             or event.GetKeyCode() == wx.WXK_NUMPAD_SUBTRACT
             or event.GetKeyCode() == wx.WXK_SUBTRACT
         ):
-            self.autoCompList = list()
+            self.autoCompList = []
             entry = self.GetTextLeft()
             self.InsertText(pos, "-")
             self.CharRight()
@@ -557,7 +557,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
 
         # complete map or values after parameter
         elif event.GetKeyCode() == 61:
-            self.autoCompList = list()
+            self.autoCompList = []
             self.InsertText(pos, "=")
             self.CharRight()
             self.toComplete = self.EntityToComplete()
@@ -574,7 +574,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
 
         # complete mapset ('@')
         elif event.GetKeyCode() == 64:
-            self.autoCompList = list()
+            self.autoCompList = []
             self.InsertText(pos, "@")
             self.CharRight()
             self.toComplete = self.EntityToComplete()
@@ -585,7 +585,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
 
         # complete after pressing CTRL + Space
         elif event.GetKeyCode() == wx.WXK_SPACE and event.ControlDown():
-            self.autoCompList = list()
+            self.autoCompList = []
             self.toComplete = self.EntityToComplete()
 
             # complete command
@@ -615,7 +615,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             # r.colors | ...-w, -q, -l, color, map, rast, rules
             # r.colors color=grey | ...-w, -q, -l, color, map, rast, rules
             elif self.toComplete["entity"] == "params+flags" and self.cmdDesc:
-                self.autoCompList = list()
+                self.autoCompList = []
 
                 for param in self.cmdDesc.get_options()["params"]:
                     self.autoCompList.append(param["name"])
@@ -631,13 +631,13 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             # r.buffer input=| ...list of raster maps
             # r.buffer units=| ... feet, kilometers, ...
             elif self.toComplete["entity"] == "raster map":
-                self.autoCompList = list()
+                self.autoCompList = []
                 self.autoCompList = self.mapList["raster"]
             elif self.toComplete["entity"] == "vector map":
-                self.autoCompList = list()
+                self.autoCompList = []
                 self.autoCompList = self.mapList["vector"]
             elif self.toComplete["entity"] == "param values":
-                self.autoCompList = list()
+                self.autoCompList = []
                 param = self.GetWordLeft(
                     withDelimiter=False, ignoredDelimiter="="
                 ).strip(" =")

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -245,7 +245,7 @@ class ToolbarController:
 
     def _getToolbarData(self, data):
         """Define tool"""
-        retData = list()
+        retData = []
         for args in data:
             retData.append(self._defineTool(*args))
         return retData

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -247,7 +247,7 @@ class VectorSelectBase:
                 + "@"
                 + self.selectedFeatures[0]["Mapset"]
             )
-            tmp = list()
+            tmp = []
             for i in self.selectedFeatures:
                 tmp.append(i["Category"])
 
@@ -405,7 +405,7 @@ class VectorSelectHighlighter:
         self.giface = giface
         self.layerCat = {}
         self.data = {}
-        self.data["Category"] = list()
+        self.data["Category"] = []
         self.data["Map"] = None
         self.data["Layer"] = None
 
@@ -419,7 +419,7 @@ class VectorSelectHighlighter:
         self.data["Category"] = cats
 
     def Clear(self):
-        self.data["Category"] = list()
+        self.data["Category"] = []
         self.data["Map"] = None
         self.data["Layer"] = None
         self.mapdisp.RemoveQueryLayer()

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1567,7 +1567,7 @@ class ManageSettingsWidget(wx.Panel):
         :return: empty dict on error
         """
 
-        data = dict()
+        data = {}
         if not os.path.exists(self.settingsFile):
             return data
 
@@ -1602,7 +1602,7 @@ class ManageSettingsWidget(wx.Panel):
         :return: parsed dict
         :return: empty dict on error
         """
-        data = dict()
+        data = {}
 
         for line in fd_lines[1:]:
             try:
@@ -1657,7 +1657,7 @@ class ManageSettingsWidget(wx.Panel):
         :return: parsed dict
         :return: empty dict on error
         """
-        data = dict()
+        data = {}
 
         for line in fd_lines:
             try:

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -179,7 +179,7 @@ class IClassMapPanel(DoubleMapPanel):
         self.exportVector = None
 
         # dialogs
-        self.dialogs = dict()
+        self.dialogs = {}
         self.dialogs["classManager"] = None
         self.dialogs["scatt_plot"] = None
         # just to make digitizer happy

--- a/gui/wxpython/icons/grass_icons.py
+++ b/gui/wxpython/icons/grass_icons.py
@@ -12,7 +12,7 @@ from core import globalvar
 
 iconPath = os.path.join(globalvar.ICONDIR, "grass")
 
-iconSet = dict()
+iconSet = {}
 
 for icon in os.listdir(iconPath):
     name, ext = os.path.splitext(icon)

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -898,7 +898,7 @@ class GRASSStartup(wx.Frame):
         """Update list of mapsets"""
         self.FormerMapsetSelection = wx.NOT_FOUND  # for non-selectable item
 
-        self.listOfMapsetsSelectable = list()
+        self.listOfMapsetsSelectable = []
         self.listOfMapsets = GetListOfMapsets(self.gisdbase, location)
 
         self.lbmapsets.Clear()

--- a/gui/wxpython/iscatt/dialogs.py
+++ b/gui/wxpython/iscatt/dialogs.py
@@ -428,7 +428,7 @@ class SettingsDialog(wx.Dialog):
         gridSizer = wx.GridBagSizer(vgap=1, hgap=1)
 
         row = 0
-        setts = dict()
+        setts = {}
         setts.update(self.colorsSetts)
         setts.update(self.sizeSetts)
 

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -150,10 +150,10 @@ class GMFrame(wx.Frame):
         self._auimgr = wx.aui.AuiManager(self)
 
         # list of open dialogs
-        self.dialogs = dict()
+        self.dialogs = {}
         self.dialogs["preferences"] = None
         self.dialogs["nvizPreferences"] = None
-        self.dialogs["atm"] = list()
+        self.dialogs["atm"] = []
 
         # create widgets
         self._createMenuBar()
@@ -1090,7 +1090,7 @@ class GMFrame(wx.Frame):
             else:
                 return None
         else:  # -> return list of all mapdisplays
-            mlist = list()
+            mlist = []
             for idx in range(0, self.notebookLayers.GetPageCount()):
                 mlist.append(self.notebookLayers.GetPage(idx).maptree.GetMapDisplay())
 

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -405,7 +405,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         Debug.msg(4, "LayerTree.OnContextMenu: layertype=%s" % ltype)
 
         if not hasattr(self, "popupID"):
-            self.popupID = dict()
+            self.popupID = {}
             for key in (
                 "remove",
                 "rename",

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -213,7 +213,7 @@ class WorkspaceManager:
         # start map displays first (list of layers can be empty)
         #
         displayId = 0
-        mapdisplay = list()
+        mapdisplay = []
         for display in gxwXml.displays:
             mapdisp = self.lmgr.NewDisplay(name=display["name"], show=False)
             mapdisplay.append(mapdisp)

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -835,7 +835,7 @@ class ProjParamsPage(TitledPage):
         self.panel = None
         self.prjParamSizer = None
 
-        self.pparam = dict()
+        self.pparam = {}
 
         self.p4projparams = ""
         self.projdesc = ""
@@ -954,7 +954,7 @@ class ProjParamsPage(TitledPage):
             self.paramSBox.SetLabel(
                 _(" Enter parameters for %s projection ") % self.projdesc
             )
-            self.pparam = dict()
+            self.pparam = {}
             row = 0
             for paramgrp in self.parent.projections[self.parent.projpage.proj][1]:
                 # get parameters
@@ -1757,10 +1757,10 @@ class EPSGPage(TitledPage):
                 message=_("Unable to read EPGS codes: {0}").format(e),
                 showTraceback=False,
             )
-            self.epsglist.Populate(list(), update=True)
+            self.epsglist.Populate([], update=True)
             return
 
-        data = list()
+        data = []
         for code, val in self.epsgCodeDict.items():
             if code is not None:
                 data.append((code, val[0], val[1]))
@@ -2033,10 +2033,10 @@ class IAUPage(TitledPage):
                 message=_("Unable to read IAU codes: {0}").format(e),
                 showTraceback=False,
             )
-            self.epsglist.Populate(list(), update=True)
+            self.epsglist.Populate([], update=True)
             return
 
-        data = list()
+        data = []
         for code, val in self.epsgCodeDict.items():
             if code is not None:
                 data.append((code, val[0], val[1]))

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -167,10 +167,10 @@ class GMFrame(wx.Frame):
         self._auimgr = SingleWindowAuiManager(self)
 
         # list of open dialogs
-        self.dialogs = dict()
+        self.dialogs = {}
         self.dialogs["preferences"] = None
         self.dialogs["nvizPreferences"] = None
-        self.dialogs["atm"] = list()
+        self.dialogs["atm"] = []
 
         # set pane sizes according to the full screen size of the primary monitor
         self.PANE_BEST_SIZE = tuple(t // 5 for t in self.size)
@@ -1241,7 +1241,7 @@ class GMFrame(wx.Frame):
             else:
                 return None
         else:  # -> return list of all mapdisplays
-            mlist = list()
+            mlist = []
             for idx in range(0, self.notebookLayers.GetPageCount()):
                 mlist.append(self.notebookLayers.GetPage(idx).maptree.GetMapDisplay())
 

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1146,7 +1146,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
             self._highlighter_layer.SetMap(
                 vectQuery[0]["Map"] + "@" + vectQuery[0]["Mapset"]
             )
-            tmp = list()
+            tmp = []
             for i in vectQuery:
                 tmp.append(i["Category"])
 

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -78,7 +78,7 @@ class DMonMap(Map):
         self._giface = giface
 
         # environment settings
-        self.env = dict()
+        self.env = {}
 
         self.cmdfile = cmdfile
 
@@ -169,7 +169,7 @@ class DMonMap(Map):
             # next number in rendering order
             next_layer = 0
             mapFile = None
-            render_env = dict()
+            render_env = {}
             for line in lines:
                 if line.startswith("#"):
                     if "GRASS_RENDER_FILE" in line:
@@ -254,7 +254,7 @@ class DMonMap(Map):
                 )
                 if render_env:
                     mapLayer.GetRenderMgr().UpdateRenderEnv(render_env)
-                    render_env = dict()
+                    render_env = {}
 
                 newLayer = self._addLayer(mapLayer)
 

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -75,7 +75,7 @@ class SbManager:
         self.mapFrame = mapframe
         self.statusbar = statusbar
 
-        self.statusbarItems = dict()
+        self.statusbarItems = {}
 
         self._postInitialized = False
         self._modeIndexSet = False

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -1902,7 +1902,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         """
         Debug.msg(4, "BufferedWindow.ZoomBack(): hist)=%s" % self.zoomhistory)
 
-        zoom = list()
+        zoom = []
 
         if len(self.zoomhistory) > 1:
             self.zoomhistory.pop()
@@ -1984,7 +1984,7 @@ class BufferedMapWindow(MapWindowBase, Window):
 
     def ResetZoomHistory(self):
         """Reset zoom history"""
-        self.zoomhistory = list()
+        self.zoomhistory = []
 
     def ZoomToMap(self, layers=None, ignoreNulls=False, render=True):
         """Set display extents to match selected raster

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -722,7 +722,7 @@ class ColorTable(wx.Frame):
             self.rulesPanel.ruleslines[count]["value"] = value
             self.rulesPanel.ruleslines[count]["color"] = color
             self.rulesPanel.mainPanel.FindWindowById(count + 1000).SetValue(value)
-            rgb = list()
+            rgb = []
             for c in color.split(":"):
                 rgb.append(int(c))
             self.rulesPanel.mainPanel.FindWindowById(count + 2000).SetColour(rgb)

--- a/gui/wxpython/modules/extensions.py
+++ b/gui/wxpython/modules/extensions.py
@@ -47,7 +47,7 @@ class InstallExtensionWindow(wx.Frame):
     ):
         self.parent = parent
         self._giface = giface
-        self.options = dict()  # list of options
+        self.options = {}  # list of options
 
         wx.Frame.__init__(self, parent=parent, id=id, title=title, **kwargs)
         self.SetIcon(
@@ -190,7 +190,7 @@ class InstallExtensionWindow(wx.Frame):
 
         name = item[0].data["command"]
 
-        flags = list()
+        flags = []
         for key in self.options.keys():
             if self.options[key].IsChecked():
                 if len(key) == 1:
@@ -240,7 +240,7 @@ class InstallExtensionWindow(wx.Frame):
 
     def OnContextMenu(self, node):
         if not hasattr(self, "popupID"):
-            self.popupID = dict()
+            self.popupID = {}
             for key in ("install", "help"):
                 self.popupID[key] = NewId()
 
@@ -301,7 +301,7 @@ class ExtensionTreeModelBuilder:
     """Tree model of available extensions."""
 
     def __init__(self):
-        self.mainNodes = dict()
+        self.mainNodes = {}
         self.model = TreeModel(ModuleNode)
         for prefix in (
             "display",
@@ -557,7 +557,7 @@ class CheckListExtension(GListCtrl):
 
     def GetExtensions(self):
         """Get extensions to be un-installed"""
-        extList = list()
+        extList = []
         for i in range(self.GetItemCount()):
             if self.IsItemChecked(i):
                 name = self.GetItemText(i)

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -53,8 +53,8 @@ class ImportDialog(wx.Dialog):
         self.parent = parent  # GMFrame
         self._giface = giface  # used to add layers
         self.importType = itype
-        self.options = dict()  # list of options
-        self.options_par = dict()
+        self.options = {}  # list of options
+        self.options_par = {}
 
         self.commandId = -1  # id of running command
 
@@ -902,7 +902,7 @@ class DxfImportDialog(ImportDialog):
         if not path:
             return
 
-        data = list()
+        data = []
         ret = RunCommand(
             "v.in.dxf", quiet=True, parent=self, read=True, flags="l", input=path
         )

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -176,7 +176,7 @@ class MapCalcFrame(wx.Frame):
         self.btn_copy = Button(parent=self.panel, id=wx.ID_ANY, label=_("Copy"))
         self.btn_copy.SetToolTip(_("Copy the current command string to the clipboard"))
 
-        self.btn = dict()
+        self.btn = {}
         self.btn["pow"] = Button(parent=self.panel, id=wx.ID_ANY, label="^")
         self.btn["pow"].SetToolTip(_("exponent"))
         self.btn["div"] = Button(parent=self.panel, id=wx.ID_ANY, label="/")

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -134,15 +134,15 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         self.mouse = {"use": "pointer"}
 
         # list of loaded map layers (layer tree items)
-        self.layers = list()
+        self.layers = []
         # list of constant surfaces
-        self.constants = list()
+        self.constants = []
         # id of base surface (when vector is loaded and no surface exist)
         self.baseId = -1
         # list of cutting planes
-        self.cplanes = list()
+        self.cplanes = []
         # list of query points
-        self.qpoints = list()
+        self.qpoints = []
         # list of past views
         self.viewhistory = []
         self.saveHistory = False
@@ -1013,7 +1013,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
 
     def ResetViewHistory(self):
         """Reset view history"""
-        self.viewhistory = list()
+        self.viewhistory = []
 
     def GoTo(self, e, n):
         """Focus on given point"""
@@ -1454,8 +1454,8 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
     def SetVectorSurface(self, data):
         """Set reference surfaces of vector"""
         data["mode"]["surface"] = {}
-        data["mode"]["surface"]["value"] = list()
-        data["mode"]["surface"]["show"] = list()
+        data["mode"]["surface"]["value"] = []
+        data["mode"]["surface"]["show"] = []
         for name in self.GetLayerNames("raster"):
             data["mode"]["surface"]["value"].append(name)
             data["mode"]["surface"]["show"].append(True)
@@ -1635,7 +1635,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             name = self.constants[-1]["constant"]["object"]["name"] + 1
         except IndexError:
             name = 1
-        data = dict()
+        data = {}
         self.constants.append(data)
         data = self.SetMapObjProperties(item=index, id=-1, nvizType="constant")
         self.AddConstant(data, name)

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -2008,7 +2008,7 @@ class NvizToolWindow(GNotebook):
 
     def GselectOnPopup(self, ltype, exclude=False):
         """Update gselect.Select() items"""
-        maps = list()
+        maps = []
         for layer in self.mapWindow.Map.GetListOfLayers(ltype=ltype, active=True):
             maps.append(layer.GetName())
         return maps, exclude
@@ -3243,7 +3243,7 @@ class NvizToolWindow(GNotebook):
         floatSlider=False,
     ):
         """Add control (Slider + TextCtrl)"""
-        data[name] = dict()
+        data[name] = {}
         if sliderHor:
             style = wx.SL_HORIZONTAL | wx.SL_AUTOTICKS | wx.SL_BOTTOM
             sizeW = (size, -1)
@@ -4146,8 +4146,8 @@ class NvizToolWindow(GNotebook):
             mode["type"] = "surface"
             mode["surface"] = {}
             checklist = self.FindWindowById(self.win["vector"]["lines"]["surface"])
-            value = list()
-            checked = list()
+            value = []
+            checked = []
             for surface in range(checklist.GetCount()):
                 value.append(checklist.GetString(surface))
                 checked.append(checklist.IsChecked(surface))

--- a/gui/wxpython/nviz/workspace.py
+++ b/gui/wxpython/nviz/workspace.py
@@ -30,7 +30,7 @@ class NvizSettings:
 
     def SetConstantDefaultProp(self):
         """Set default constant data properties"""
-        data = dict()
+        data = {}
         for key, value in UserSettings.Get(group="nviz", key="constant").items():
             data[key] = value
         color = (
@@ -47,7 +47,7 @@ class NvizSettings:
     def SetSurfaceDefaultProp(self, data=None):
         """Set default surface data properties"""
         if not data:
-            data = dict()
+            data = {}
         for sec in ("attribute", "draw", "mask", "position"):
             data[sec] = {}
 
@@ -105,11 +105,11 @@ class NvizSettings:
 
     def SetVolumeDefaultProp(self):
         """Set default volume data properties"""
-        data = dict()
+        data = {}
         for sec in ("attribute", "draw", "position"):
-            data[sec] = dict()
+            data[sec] = {}
             for sec in ("isosurface", "slice"):
-                data[sec] = list()
+                data[sec] = []
 
         #
         # draw
@@ -172,7 +172,7 @@ class NvizSettings:
 
     def SetIsosurfaceDefaultProp(self):
         """Set default isosurface properties"""
-        data = dict()
+        data = {}
         for attr in ("shine", "topo", "transp", "color", "inout"):
             data[attr] = {}
             data[attr]["update"] = None
@@ -187,7 +187,7 @@ class NvizSettings:
 
     def SetSliceDefaultProp(self):
         """Set default slice properties"""
-        data = dict()
+        data = {}
         data["position"] = copy.deepcopy(
             UserSettings.Get(group="nviz", key="volume", subkey="slice_position")
         )
@@ -201,7 +201,7 @@ class NvizSettings:
     def SetVectorDefaultProp(self, longDim, data=None):
         """Set default vector data properties"""
         if not data:
-            data = dict()
+            data = {}
         for sec in ("lines", "points"):
             data[sec] = {}
 

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -263,7 +263,7 @@ class PsmapDialog(Dialog):
         self.Bind(wx.EVT_CLOSE, self.OnClose)
 
     def AddUnits(self, parent, dialogDict):
-        parent.units = dict()
+        parent.units = {}
         parent.units["unitsLabel"] = StaticText(parent, id=wx.ID_ANY, label=_("Units:"))
         choices = self.unitConv.getPageUnitsNames()
         parent.units["unitsCtrl"] = Choice(parent, id=wx.ID_ANY, choices=choices)
@@ -273,7 +273,7 @@ class PsmapDialog(Dialog):
 
     def AddPosition(self, parent, dialogDict):
         if not hasattr(parent, "position"):
-            parent.position = dict()
+            parent.position = {}
         parent.position["comment"] = StaticText(
             parent,
             id=wx.ID_ANY,
@@ -307,7 +307,7 @@ class PsmapDialog(Dialog):
 
     def AddExtendedPosition(self, panel, gridBagSizer, dialogDict):
         """Add widgets for setting position relative to paper and to map"""
-        panel.position = dict()
+        panel.position = {}
         positionLabel = StaticText(panel, id=wx.ID_ANY, label=_("Position is given:"))
         panel.position["toPaper"] = RadioButton(
             panel, id=wx.ID_ANY, label=_("relative to paper"), style=wx.RB_GROUP
@@ -435,7 +435,7 @@ class PsmapDialog(Dialog):
         gridBagSizer.Add(sizerM, pos=(2, 1), flag=wx.ALIGN_LEFT | wx.EXPAND, border=0)
 
     def AddFont(self, parent, dialogDict, color=True):
-        parent.font = dict()
+        parent.font = {}
         # parent.font["fontLabel"] = wx.StaticText(
         #     parent, id=wx.ID_ANY, label=_("Choose font:")
         # )
@@ -758,7 +758,7 @@ class PageSetupDialog(PsmapDialog):
         currPaper = self.paperTable[self.getCtrl("Format").GetSelection()]
         currUnit = self.unitConv.findUnit(self.getCtrl("Units").GetStringSelection())
         currOrientIdx = self.getCtrl("Orientation").GetSelection()
-        newSize = dict()
+        newSize = {}
         for item in self.cat[3:]:
             newSize[item] = self.unitConv.convert(
                 float(currPaper[item]), fromUnit="inch", toUnit=currUnit
@@ -782,7 +782,7 @@ class PageSetupDialog(PsmapDialog):
         return self.hBoxDict[item].GetItem(1).GetWindow()
 
     def _toList(self, paperStr):
-        sizeList = list()
+        sizeList = []
         for line in paperStr.strip().split("\n"):
             d = dict(zip([self.cat[1]] + self.cat[3:], line.split()))
             sizeList.append(d)

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -146,7 +146,7 @@ class PsMapFrame(wx.Frame):
             parent=self, objectsToDraw=self.objectId, env=self.env
         )
         # open dialogs
-        self.openDialogs = dict()
+        self.openDialogs = {}
 
         self.pageId = NewId()
         # current page of GNotebook

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -59,7 +59,7 @@ class Instruction:
         self.parent = parent
         self.objectsToDraw = objectsToDraw
         # here are kept objects like mapinfo, rasterlegend, etc.
-        self.instruction = list()
+        self.instruction = []
         self.env = env
 
     def __str__(self):
@@ -545,7 +545,7 @@ class InstructionObject:
         self.env = env
 
         # default values
-        self.defaultInstruction = dict()
+        self.defaultInstruction = {}
         # current values
         self.instruction = self.defaultInstruction
         # converting units
@@ -863,7 +863,7 @@ class PageSetup(InstructionObject):
         return True
 
     def _toDict(self, paperStr):
-        sizeDict = dict()
+        sizeDict = {}
         #     cats = self.subInstr[ 'Width', 'Height', 'Left', 'Right', 'Top', 'Bottom']
         for line in paperStr.strip().split("\n"):
             d = dict(zip(self.cats, line.split()[1:]))

--- a/gui/wxpython/tools/update_menudata.py
+++ b/gui/wxpython/tools/update_menudata.py
@@ -34,7 +34,7 @@ from core.globalvar import grassCmd
 
 def parseModules():
     """Parse modules' interface"""
-    modules = dict()
+    modules = {}
 
     # list of modules to be ignored
     ignore = ["g.mapsets_picker.py", "v.type_wrapper.py", "g.parser", "vcolors"]
@@ -66,12 +66,12 @@ def updateData(data, modules):
     # list of modules to be ignored
     ignore = ["v.type_wrapper.py", "vcolors"]
 
-    menu_modules = list()
+    menu_modules = []
     for node in data.tree.iter():
         if node.tag != "menuitem":
             continue
 
-        item = dict()
+        item = {}
         for child in node:
             item[child.tag] = child.text
 
@@ -149,7 +149,7 @@ def main(argv=None):
     grass.info("Step 1: running make...")
     grass.call(["make"], stderr=nuldev)
     grass.info("Step 2: parsing modules...")
-    modules = dict()
+    modules = {}
     modules = parseModules()
     grass.info("Step 3: reading menu data...")
     data = LayerManagerMenuData()

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -460,11 +460,11 @@ class VDigitWindow(BufferedMapWindow):
         """Left mouse button pressed - vector digitizer move
         feature/vertex, edit linear feature
         """
-        self.moveInfo = dict()
+        self.moveInfo = {}
         # geographic coordinates of initial position (left-down)
         self.moveInfo["begin"] = None
         # list of ids to modify
-        self.moveInfo["id"] = list()
+        self.moveInfo["id"] = []
 
         # set pen
         if self.toolbar.GetAction() in ["moveVertex", "editLine"]:

--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -999,7 +999,7 @@ class VDigitSettingsDialog(wx.Dialog):
             column = self.FindWindowById(val["column"]).GetValue()
             unitsIdx = self.FindWindowById(val["units"]).GetSelection()
             if item and not tree.GetLayerInfo(item, key="vdigit"):
-                tree.SetLayerInfo(item, key="vdigit", value={"geomAttr": dict()})
+                tree.SetLayerInfo(item, key="vdigit", value={"geomAttr": {}})
 
             if checked:  # enable
                 if key == "area":

--- a/gui/wxpython/vdigit/wxdigit.py
+++ b/gui/wxpython/vdigit/wxdigit.py
@@ -177,13 +177,13 @@ class IVDigit:
         # self.SetCategory()
 
         # layer / max category
-        self.cats = dict()
+        self.cats = {}
 
-        self._settings = dict()
+        self._settings = {}
         self.UpdateSettings()  # -> self._settings
 
         # undo/redo
-        self.changesets = list()
+        self.changesets = []
         self.changesetCurrent = -1  # first changeset to apply
 
         if self.poMapInfo:
@@ -391,7 +391,7 @@ class IVDigit:
             del self.changesets[self.changesetCurrent + 1 : changesetLast + 1]
             self.toolbar.EnableRedo(False)
 
-        data = list()
+        data = []
         for i in range(Vect_get_num_updated_lines(self.poMapInfo) - 1, -1, -1):
             line = Vect_get_updated_line(self.poMapInfo, i)
             offset = Vect_get_updated_line_offset(self.poMapInfo, i)
@@ -536,7 +536,7 @@ class IVDigit:
 
         # collect categories for deleting if requested
         deleteRec = UserSettings.Get(group="vdigit", key="delRecord", subkey="enabled")
-        catDict = dict()
+        catDict = {}
 
         old_bboxs = []
         old_areas_cats = []
@@ -562,7 +562,7 @@ class IVDigit:
         nlines = Vedit_delete_lines(self.poMapInfo, poList)
 
         Vect_destroy_list(poList)
-        self._display.selected["ids"] = list()
+        self._display.selected["ids"] = []
 
         if nlines > 0:
             if deleteRec:
@@ -1449,7 +1449,7 @@ class IVDigit:
         ftype = GV_POINTS | GV_LINES  # TODO: 3D
         layer = 1  # TODO
 
-        ids = list()
+        ids = []
         poList = Vect_new_list()
         coList = poList.contents
         if UserSettings.Get(group="vdigit", key="query", subkey="box"):
@@ -1838,7 +1838,7 @@ class IVDigit:
         :return: tuple (number of added features, list of fids)
         :return: number of features -1 on error
         """
-        fids = list()
+        fids = []
         if not self._checkMap():
             return (-1, None)
 
@@ -2063,7 +2063,7 @@ class IVDigit:
 
         :return: list of layer/cats
         """
-        ret = dict()
+        ret = {}
         if not self._checkMap():
             return ret
 
@@ -2085,7 +2085,7 @@ class IVDigit:
         for i in range(cats.n_cats):
             field = cats.field[i]
             if field not in ret:
-                ret[field] = list()
+                ret[field] = []
             ret[field].append(cats.cat[i])
 
         return ret

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -128,9 +128,9 @@ class DisplayDriver:
         # selected objects
         self.selected = {
             "field": -1,  # field number
-            "cats": list(),  # list of cats
-            "ids": list(),  # list of ids
-            "idsDupl": list(),  # list of duplicated features
+            "cats": [],  # list of cats
+            "ids": [],  # list of ids
+            "idsDupl": [],  # list of duplicated features
         }
 
         # digitizer settings
@@ -350,7 +350,7 @@ class DisplayDriver:
                     ),
                 )
             else:
-                points = list()
+                points = []
                 for i in range(robj.npoints):
                     p = robj.point[i]
                     points.append(wx.Point(p.x, p.y))
@@ -536,7 +536,7 @@ class DisplayDriver:
         # reset list of selected features by cat
         # list of ids - see IsSelected()
         self.selected["field"] = -1
-        self.selected["cats"] = list()
+        self.selected["cats"] = []
 
     def _getSelectType(self):
         """Get type(s) to be selected
@@ -596,7 +596,7 @@ class DisplayDriver:
             self._drawSelected = True
 
             # select by ids
-            self.selected["cats"] = list()
+            self.selected["cats"] = []
 
         poList = Vect_new_list()
         x1, y1 = bbox[0]
@@ -689,7 +689,7 @@ class DisplayDriver:
         if thisMapInfo:
             self._drawSelected = True
             # select by ids
-            self.selected["cats"] = list()
+            self.selected["cats"] = []
 
         poFound = Vect_new_list()
 
@@ -788,7 +788,7 @@ class DisplayDriver:
         if grassId:
             return self.selected["ids"]
 
-        dc_ids = list()
+        dc_ids = []
 
         if not self._drawSegments:
             dc_ids.append(1)
@@ -816,7 +816,7 @@ class DisplayDriver:
         self.selected["field"] = layer
         if layer > 0:
             self.selected["cats"] = ids
-            self.selected["ids"] = list()
+            self.selected["ids"] = []
             # cidx is not up-to-date
             # Vect_cidx_find_all(self.poMapInfo,
             # layer, GV_POINTS | GV_LINES, lid, ilist)
@@ -853,7 +853,7 @@ class DisplayDriver:
         :return: 0 no line found
         :return: -1 on error
         """
-        returnId = list()
+        returnId = []
         # only one object can be selected
         if len(self.selected["ids"]) != 1 or not self._drawSegments:
             return returnId
@@ -1059,7 +1059,7 @@ class DisplayDriver:
 
         :param alpha: color value for alpha channel
         """
-        color = dict()
+        color = {}
         for key in self.settings.keys():
             if key == "lineWidth":
                 self.settings[key] = int(
@@ -1137,11 +1137,11 @@ class DisplayDriver:
         if not self.poMapInfo:
             return
 
-        ids = dict()
+        ids = {}
         APoints = Vect_new_line_struct()
         BPoints = Vect_new_line_struct()
 
-        self.selected["idsDupl"] = list()
+        self.selected["idsDupl"] = []
 
         for i in range(len(self.selected["ids"])):
             line1 = self.selected["ids"][i]
@@ -1158,7 +1158,7 @@ class DisplayDriver:
 
                 if Vect_line_check_duplicate(APoints, BPoints, WITHOUT_Z):
                     if i not in ids:
-                        ids[i] = list()
+                        ids[i] = []
                         ids[i].append((line1, self._getCatString(line1)))
                         self.selected["idsDupl"].append(line1)
 
@@ -1174,11 +1174,11 @@ class DisplayDriver:
         Vect_read_line(self.poMapInfo, None, self.poCats, line)
 
         cats = self.poCats.contents
-        catsDict = dict()
+        catsDict = {}
         for i in range(cats.n_cats):
             layer = cats.field[i]
             if layer not in catsDict:
-                catsDict[layer] = list()
+                catsDict[layer] = []
             catsDict[layer].append(cats.cat[i])
 
         catsStr = ""

--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -271,13 +271,13 @@ class ScatterRasterDialog(wx.Dialog):
 
     def GetRasterPairs(self):
         """Get raster pairs"""
-        pairsList = list()
-        pair = list()
+        pairsList = []
+        pair = []
         for r in self.rasterList:
             pair.append(r)
             if len(pair) == 2:
                 pairsList.append(tuple(pair))
-                pair = list()
+                pair = []
 
         return list(pairsList)
 

--- a/python/grass/grassdb/checks.py
+++ b/python/grass/grassdb/checks.py
@@ -617,7 +617,7 @@ def get_list_of_locations(dbase):
 
     :return: list of locations (sorted)
     """
-    locations = list()
+    locations = []
     for location in glob.glob(os.path.join(dbase, "*")):
         if os.path.join(location, "PERMANENT") in glob.glob(
             os.path.join(location, "*")

--- a/python/grass/grassdb/history.py
+++ b/python/grass/grassdb/history.py
@@ -80,7 +80,7 @@ def _read_from_plain_text(history_path):
     with 'command' and 'command_info' keys
     'command_info' is always empty since plain text history file
     stores only executed commands."""
-    content_list = list()
+    content_list = []
     try:
         with open(
             history_path, encoding="utf-8", mode="r", errors="replace"
@@ -103,7 +103,7 @@ def _read_from_JSON(history_path):
     :return content_list: list of dictionaries
     with 'command' and 'command_info' keys
     """
-    content_list = list()
+    content_list = []
     try:
         with open(
             history_path, encoding="utf-8", mode="r", errors="replace"

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -93,7 +93,7 @@ class Category(list):
         return cats
 
     def __dict__(self):
-        diz = dict()
+        diz = {}
         for cat in self.__iter__():
             label, min_cat, max_cat = cat
             diz[(min_cat, max_cat)] = label

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -150,7 +150,7 @@ class Filters:
 
     def get_sql(self):
         """Return the SQL query"""
-        sql_list = list()
+        sql_list = []
         if self._select is None:
             self.select()
         sql_list.append(self._select)

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -155,8 +155,8 @@ def get_commands(*, env=None):
 
         gisbase = get_install_path()
 
-    cmd = list()
-    scripts = {".py": list()} if sys.platform == "win32" else {}
+    cmd = []
+    scripts = {".py": []} if sys.platform == "win32" else {}
 
     def scan(gisbase, directory):
         dir_path = os.path.join(gisbase, directory)
@@ -1459,7 +1459,7 @@ def list_strings(type, pattern=None, mapset=None, exclude=None, flag="", env=Non
     if type == "cell":
         verbose(_('Element type should be "raster" and not "%s"') % type)
 
-    result = list()
+    result = []
     for line in read_command(
         "g.list",
         quiet=True,
@@ -1807,7 +1807,7 @@ def create_project(
         shutil.rmtree(os.path.join(mapset_path.directory, mapset_path.location))
 
     stdin = None
-    kwargs = dict()
+    kwargs = {}
     if datum:
         kwargs["datum"] = datum
     if datum_trans:

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -224,7 +224,7 @@ def raster_what(map, coord, env=None, localized=False):
     else:
         map_list = map
 
-    coord_list = list()
+    coord_list = []
     if isinstance(coord, tuple):
         coord_list.append("%f,%f" % (coord[0], coord[1]))
     else:
@@ -244,7 +244,7 @@ def raster_what(map, coord, env=None, localized=False):
         quiet=True,
         env=env,
     )
-    data = list()
+    data = []
     if not ret:
         return data
 

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -48,11 +48,11 @@ class grassTask:
     def __init__(self, path=None, blackList=None):
         self.path = path
         self.name = _("unknown")
-        self.params = list()
+        self.params = []
         self.description = ""
         self.label = ""
-        self.flags = list()
-        self.keywords = list()
+        self.flags = []
+        self.keywords = []
         self.errorMsg = ""
         self.firstParam = None
         if blackList:
@@ -177,7 +177,7 @@ class grassTask:
 
         :return: list of errors
         """
-        errorList = list()
+        errorList = []
         # determine if suppress_required flag is given
         for f in self.flags:
             if f["value"] and f["suppress_required"]:
@@ -585,8 +585,8 @@ def command_info(cmd):
     cmdinfo["params"] = params = task.get_options()["params"]
 
     usage = task.get_name()
-    flags_short = list()
-    flags_long = list()
+    flags_short = []
+    flags_long = []
     for f in flags:
         fname = f.get("name", "unknown")
         if len(fname) > 1:

--- a/python/grass/script/testsuite/test_utils.py
+++ b/python/grass/script/testsuite/test_utils.py
@@ -7,7 +7,7 @@ from grass.script import utils
 
 
 class EnvironChange(TestCase):
-    env = dict()
+    env = {}
     NOT_FOUND = "Not found!"
 
     def setUp(self):

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -130,9 +130,9 @@ def vector_columns(map, layer=None, getDict=True, env=None, **kwargs):
         "v.info", flags="c", map=map, layer=layer, quiet=True, env=env, **kwargs
     )
     if getDict:
-        result = dict()
+        result = {}
     else:
-        result = list()
+        result = []
     i = 0
     for line in s.splitlines():
         ctype, cname = line.split("|")
@@ -397,7 +397,7 @@ def vector_what(
     else:
         layer_list = ["-1"] * len(map_list)
 
-    coord_list = list()
+    coord_list = []
     if isinstance(coord, tuple):
         coord_list.append("%f,%f" % (coord[0], coord[1]))
     else:
@@ -425,7 +425,7 @@ def vector_what(
     except CalledModuleError as e:
         raise ScriptError(e.msg)
 
-    data = list()
+    data = []
     if not ret:
         return data
 

--- a/python/grass/semantic_label/reader.py
+++ b/python/grass/semantic_label/reader.py
@@ -32,7 +32,7 @@ class SemanticLabelReader:
 
     def _read_config(self):
         """Read configuration"""
-        self.config = dict()
+        self.config = {}
         for json_file in self._json_files:
             try:
                 with open(json_file) as fd:

--- a/scripts/g.extension.all/g.extension.all.py
+++ b/scripts/g.extension.all/g.extension.all.py
@@ -75,7 +75,7 @@ def get_extensions():
     fo.close()
 
     libgis_rev = gscript.version()["libgis_revision"]
-    ret = list()
+    ret = []
     for tnode in tree.findall("task"):
         gnode = tnode.find("libgis")
         if gnode is not None and gnode.get("revision", "") != libgis_rev:

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -691,7 +691,7 @@ def get_installed_toolboxes(force=False):
         os.remove(xml_file)
         write_xml_toolboxes(xml_file)
         return []
-    ret = list()
+    ret = []
     for tnode in tree.findall("toolbox"):
         ret.append(tnode.get("code"))
     return ret
@@ -718,7 +718,7 @@ def get_installed_modules(force=False):
         os.remove(xml_file)
         write_xml_modules(xml_file)
         return []
-    ret = list()
+    ret = []
     for tnode in tree.findall("task"):
         if flags["g"]:
             desc, keyw = get_optional_params(tnode)
@@ -767,13 +767,13 @@ def list_available_extensions(url):
 
 def get_available_toolboxes(url):
     """Return toolboxes available in the repository"""
-    tdict = dict()
+    tdict = {}
     url = url + "toolboxes.xml"
     try:
         tree = etree_fromurl(url)
         for tnode in tree.findall("toolbox"):
-            mlist = list()
-            clist = list()
+            mlist = []
+            clist = []
             tdict[tnode.get("code")] = {
                 "name": tnode.get("name"),
                 "correlate": clist,
@@ -798,7 +798,7 @@ def get_toolbox_extensions(url, name):
     :param name: toolbox name
     """
     # dictionary of extensions
-    edict = dict()
+    edict = {}
 
     url = url + "toolboxes.xml"
 
@@ -809,11 +809,11 @@ def get_toolbox_extensions(url, name):
                 for enode in tnode.findall("task"):
                     # extension name
                     ename = enode.get("name")
-                    edict[ename] = dict()
+                    edict[ename] = {}
                     # list of modules installed by this extension
-                    edict[ename]["mlist"] = list()
+                    edict[ename]["mlist"] = []
                     # list of files installed by this extension
-                    edict[ename]["flist"] = list()
+                    edict[ename]["flist"] = []
                 break
     except (HTTPError, OSError):
         gs.fatal(_("Unable to fetch addons metadata file"))
@@ -982,7 +982,7 @@ def get_wxgui_extensions(url):
 
     :param url: a directory URL (filename will be attached)
     """
-    mlist = list()
+    mlist = []
     gs.debug(
         "Fetching list of wxGUI extensions from "
         "GRASS-Addons SVN repository (be patient)..."
@@ -1175,12 +1175,12 @@ def install_extension(source=None, url=None, xmlurl=None, branch=None):
         gs.message(_("Installing toolbox <%s>...") % options["extension"])
         edict = get_toolbox_extensions(xmlurl, options["extension"])
     else:
-        edict = dict()
-        edict[options["extension"]] = dict()
+        edict = {}
+        edict[options["extension"]] = {}
         # list of modules installed by this extension
-        edict[options["extension"]]["mlist"] = list()
+        edict[options["extension"]]["mlist"] = []
         # list of files installed by this extension
-        edict[options["extension"]]["flist"] = list()
+        edict[options["extension"]]["flist"] = []
     if not edict:
         gs.warning(_("Nothing to install"))
         return
@@ -1188,7 +1188,7 @@ def install_extension(source=None, url=None, xmlurl=None, branch=None):
     ret = 0
     tmp_dir = None
 
-    new_modules = list()
+    new_modules = []
     for extension in edict:
         ret1 = 0
         new_modules_ext = None
@@ -1253,15 +1253,15 @@ def get_toolboxes_metadata(url):
         and dictionary with dest, keyw, files keys as value, the second item
         is list of 'binary' files (installation files)
     """
-    data = dict()
+    data = {}
     try:
         tree = etree_fromurl(url)
         for tnode in tree.findall("toolbox"):
-            clist = list()
+            clist = []
             for cnode in tnode.findall("correlate"):
                 clist.append(cnode.get("code"))
 
-            mlist = list()
+            mlist = []
             for mnode in tnode.findall("task"):
                 mlist.append(mnode.get("name"))
 
@@ -1355,7 +1355,7 @@ def get_addons_metadata(url, mlist):
         name = mnode.get("name")
         if name not in mlist:
             continue
-        file_list = list()
+        file_list = []
         bnode = mnode.find("binary")
         windows = sys.platform == "win32"
         if bnode is not None:
@@ -1637,7 +1637,7 @@ def install_extension_win(name):
     )
 
     # collect module names and file names
-    module_list = list()
+    module_list = []
     module_name_pattern = re.compile(
         r"^([d,g,i,m,p,r,s,t,v]|^db|^ps|^r3|^wx)\..*[\.py,\.exe]$"
     )
@@ -1661,7 +1661,7 @@ def install_extension_win(name):
         replace_shebang_win(filename)
 
     # collect old files
-    old_file_list = list()
+    old_file_list = []
     for r, d, f in os.walk(options["prefix"]):
         for filename in f:
             fullname = os.path.join(r, filename)
@@ -1673,7 +1673,7 @@ def install_extension_win(name):
     )
 
     # collect new files
-    file_list = list()
+    file_list = []
     for r, d, f in os.walk(options["prefix"]):
         for filename in f:
             fullname = os.path.join(r, filename)
@@ -1996,7 +1996,7 @@ def install_extension_std_platforms(name, source, url, branch):
         "Module name not found." " Check module Makefile syntax (PGM variable)."
     )
     # collect module names
-    module_list = list()
+    module_list = []
     for r, d, f in os.walk(srcdir):
         for filename in f:
             if filename == "Makefile":
@@ -2089,7 +2089,7 @@ def install_extension_std_platforms(name, source, url, branch):
         return 0, None, None, None
 
     # collect old files
-    old_file_list = list()
+    old_file_list = []
     for r, d, f in os.walk(options["prefix"]):
         for filename in f:
             fullname = os.path.join(r, filename)
@@ -2099,7 +2099,7 @@ def install_extension_std_platforms(name, source, url, branch):
     ret = gs.call(install_cmd, stdout=outdev)
 
     # collect new files
-    file_list = list()
+    file_list = []
     for r, d, f in os.walk(options["prefix"]):
         for filename in f:
             fullname = os.path.join(r, filename)
@@ -2115,15 +2115,15 @@ def remove_extension(force=False):
     if flags["t"]:
         edict = get_toolbox_extensions(options["prefix"], options["extension"])
     else:
-        edict = dict()
-        edict[options["extension"]] = dict()
+        edict = {}
+        edict[options["extension"]] = {}
         # list of modules installed by this extension
-        edict[options["extension"]]["mlist"] = list()
+        edict[options["extension"]]["mlist"] = []
         # list of files installed by this extension
-        edict[options["extension"]]["flist"] = list()
+        edict[options["extension"]]["flist"] = []
 
     # collect modules and files installed by these extensions
-    mlist = list()
+    mlist = []
     xml_file = os.path.join(options["prefix"], "extensions.xml")
     if os.path.exists(xml_file):
         # read XML file
@@ -2230,8 +2230,8 @@ def remove_extension_files(edict, force=False):
     # try to read XML metadata file first
     xml_file = os.path.join(options["prefix"], "extensions.xml")
 
-    einstalled = list()
-    eremoved = list()
+    einstalled = []
+    eremoved = []
 
     if os.path.exists(xml_file):
         tree = etree_fromfile(xml_file)
@@ -2245,7 +2245,7 @@ def remove_extension_files(edict, force=False):
     for name in edict:
         removed = True
         if len(edict[name]["flist"]) > 0:
-            err = list()
+            err = []
             for fpath in edict[name]["flist"]:
                 gs.verbose(fpath)
                 if force:

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -108,8 +108,8 @@ import subprocess
 import grass.script as grass
 from grass.exceptions import CalledModuleError
 
-tmp_rmaps = list()
-tmp_vmaps = list()
+tmp_rmaps = []
+tmp_vmaps = []
 usermask = None
 mapset = None
 
@@ -151,7 +151,7 @@ def main():
     unique = str(os.getpid())  # Shouldn't we use temp name?
     prefix = "r_fillnulls_%s_" % unique
     failed_list = (
-        list()
+        []
     )  # a list of failed holes. Caused by issues with v.surf.rst. Connected with #1813
 
     # check if input file exists
@@ -292,7 +292,7 @@ def main():
             file=cats_file_name,
             quiet=quiet,
         )
-        cat_list = list()
+        cat_list = []
         cats_file = open(cats_file_name)
         for line in cats_file:
             cat_list.append(line.rstrip("\n"))

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -39,7 +39,7 @@ def make_gradient(path):
     fh.close()
 
     lines = text.splitlines()
-    records = list()
+    records = []
     for line in lines:
         if line.startswith("#"):
             # skip comments


### PR DESCRIPTION
Only applies fixes to empty collections by  `ruff check --select "C408" --unsafe-fixes --fix --config "lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true"` in order to limit the review scope.

Part of preparing the repo for Pylint 3.x for https://github.com/OSGeo/grass/issues/3921


Uses the fixes provided for ruff rule [unnecessary-collection-call (C408)](https://docs.astral.sh/ruff/rules/unnecessary-collection-call/) to fix part of Pylint's [use-dict-literal / R1735 rule](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-dict-literal.html). I say "Part of", as for this PR I limited it to only the empty initializers.

Using literals instead of function calls is faster, as it doesn't require to load from global scope (to make sure "list" or "dict" wasn't changed to something else). Also, for the same reason it is better to import the functions to put them in scope (from xyz import thatfunc") instead of just using "import xyz" and then calling "xyz.thatfunc()" (it is slower to go fetch in xyz in global scope and then fetching thatfunc in that scope than importing it once, especially in loops).

Here, it says 3x faster (using `[]` instead of `list()` saves 1 opcode, and the `[]` avoids the `LOAD_NAME` opcode.  https://ealexbarros.medium.com/why-is-faster-than-list-in-python-5bef48b530fc

Here, where it is analyzed for Python 3.12 in 2024, it goes in the same direction https://madebyme.today/blog/python-dict-vs-curly-brackets/, plus explains that `{}` uses a pre-allocated dict and adds the values if needed.