### PR TITLE
docker: Downgrade PDAL to 2.7.1 in ubuntu_wxgui

### DIFF
--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # define versions to be used (PDAL is not available on Ubuntu/Debian, so we compile it here)
 # https://github.com/PDAL/PDAL/releases
 # renovate: datasource=github-tags depName=PDAL/PDAL
-ARG PDAL_VERSION=2.7.2
+ARG PDAL_VERSION=2.7.1
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
When building the image, only PROJ 8.2.1 is available, and PDAL 2.7.2 checks for PROJ 9.0+

This is a temporary fix to continue having working Docker builds. Renovate will open a PR to update PDAL again afterwards. But a more substantial fix is needed.