### PR TITLE
style: Fixes manual-from-import (PLR0402)

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -39,7 +39,7 @@ import mimetypes
 import time
 
 import xml.etree.ElementTree as etree
-import xml.sax.saxutils as saxutils
+from xml.sax import saxutils
 
 import wx
 from abc import ABC, abstractmethod

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -50,7 +50,7 @@ import ctypes
 import wx
 
 from core import globalvar
-import wx.lib.buttons as buttons
+from wx.lib import buttons
 import wx.lib.filebrowsebutton as filebrowse
 
 

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -36,7 +36,7 @@ except ImportError:
     havePwd = False
 
 import wx
-import wx.lib.agw.aui as aui
+from wx.lib.agw import aui
 import wx.lib.colourselect as csel
 import wx.lib.mixins.listctrl as listmix
 import wx.lib.scrolledpanel as SP

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -20,7 +20,7 @@ import platform
 import os
 
 import wx
-import wx.lib.agw.aui as aui
+from wx.lib.agw import aui
 
 from core import globalvar
 from core.debug import Debug

--- a/gui/wxpython/iclass/plots.py
+++ b/gui/wxpython/iclass/plots.py
@@ -17,7 +17,7 @@ for details.
 
 import wx
 
-import wx.lib.plot as plot
+from wx.lib import plot
 import wx.lib.scrolledpanel as scrolled
 from core.gcmd import GError
 

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -39,7 +39,7 @@ from iclass.dialogs import ContrastColor
 try:
     from agw import aui
 except ImportError:
-    import wx.lib.agw.aui as aui
+    from wx.lib.agw import aui
 
 
 class IClassIScattPanel(wx.Panel, ManageBusyCursorMixin):

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -30,7 +30,7 @@ from core import globalvar
 try:
     from agw import aui
 except ImportError:
-    import wx.lib.agw.aui as aui
+    from wx.lib.agw import aui
 
 import wx
 

--- a/gui/wxpython/main_window/notebook.py
+++ b/gui/wxpython/main_window/notebook.py
@@ -19,7 +19,7 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-import wx.lib.agw.aui as aui
+from wx.lib.agw import aui
 
 from core import globalvar
 from gui_core.wrap import SimpleTabArt

--- a/gui/wxpython/mapwin/analysis.py
+++ b/gui/wxpython/mapwin/analysis.py
@@ -20,7 +20,7 @@ import os
 import math
 import wx
 
-import core.units as units
+from core import units
 from core.gcmd import RunCommand
 from core.giface import Notification
 

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -48,7 +48,7 @@ from core.gcmd import RunCommand, GException, GError
 from core.debug import Debug
 from core.settings import UserSettings
 from mapwin.base import MapWindowBase
-import core.utils as utils
+from core import utils
 from mapwin.graphics import GraphicsSet
 from core.gthread import gThread
 

--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -20,7 +20,7 @@ import os
 import wx
 from random import randint
 
-import wx.lib.plot as plot
+from wx.lib import plot
 from core.globalvar import ICONDIR
 from core.settings import UserSettings
 from wxplot.dialogs import TextDialog, OptDialog

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -20,7 +20,7 @@ import sys
 import wx
 
 import grass.script as grass
-import wx.lib.plot as plot
+from wx.lib import plot
 from gui_core.wrap import StockCursor
 from gui_core.toolbars import BaseToolbar, BaseIcons
 from wxplot.base import BasePlotFrame, PlotIcons

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -22,7 +22,7 @@ import numpy
 
 import wx
 
-import wx.lib.plot as plot
+from wx.lib import plot
 import grass.script as grass
 from wxplot.base import BasePlotFrame, PlotIcons
 from gui_core.toolbars import BaseToolbar, BaseIcons

--- a/gui/wxpython/wxplot/scatter.py
+++ b/gui/wxpython/wxplot/scatter.py
@@ -20,7 +20,7 @@ import sys
 import wx
 
 import grass.script as grass
-import wx.lib.plot as plot
+from wx.lib import plot
 from wxplot.base import BasePlotFrame, PlotIcons
 from gui_core.toolbars import BaseToolbar, BaseIcons
 from gui_core.wrap import StockCursor

--- a/python/grass/experimental/tests/conftest.py
+++ b/python/grass/experimental/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 import grass.script as gs
-import grass.experimental as experimental
+from grass import experimental
 
 
 @pytest.fixture

--- a/python/grass/experimental/tests/grass_script_mapset_session_test.py
+++ b/python/grass/experimental/tests/grass_script_mapset_session_test.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 import grass.script as gs
-import grass.experimental as experimental
+from grass import experimental
 
 
 def test_simple_create(xy_session):

--- a/python/grass/experimental/tests/grass_script_tmp_mapset_session_test.py
+++ b/python/grass/experimental/tests/grass_script_tmp_mapset_session_test.py
@@ -3,7 +3,7 @@
 import os
 
 import grass.script as gs
-import grass.experimental as experimental
+from grass import experimental
 
 
 def test_with_context_manager(xy_session):

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -11,7 +11,7 @@ for details.
 
 import os
 import datetime
-import xml.sax.saxutils as saxutils
+from xml.sax import saxutils
 import xml.etree.ElementTree as et
 import subprocess
 import collections

--- a/python/grass/imaging/operations.py
+++ b/python/grass/imaging/operations.py
@@ -59,7 +59,7 @@ try:
     from PIL import Image
 
     try:
-        import PIL.ImageOps as ImageOps
+        from PIL import ImageOps
     except ImportError:
         ImageOps = None
 except ImportError:

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -14,7 +14,7 @@ from .core import get_tgis_message_interface
 import copy
 
 try:
-    import dateutil.parser as parser
+    from dateutil import parser
 
     has_dateutil = True
 except:

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -22,9 +22,9 @@ from datetime import datetime
 from .core import init_dbif
 from .abstract_dataset import AbstractDatasetComparisonKeyStartTime
 from .datetime_math import time_delta_to_relative_time_seconds
-import grass.lib.vector as vector
-import grass.lib.rtree as rtree
-import grass.lib.gis as gis
+from grass.lib import vector
+from grass.lib import rtree
+from grass.lib import gis
 
 ###############################################################################
 

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -440,8 +440,8 @@ for details.
 """
 
 try:
-    import ply.lex as lex
-    import ply.yacc as yacc
+    from ply import lex
+    from ply import yacc
 except:
     pass
 

--- a/python/grass/temporal/temporal_operator.py
+++ b/python/grass/temporal/temporal_operator.py
@@ -141,8 +141,8 @@ for details.
 """  # noqa: E501
 
 try:
-    import ply.lex as lex
-    import ply.yacc as yacc
+    from ply import lex
+    from ply import yacc
 except ImportError:
     pass
 

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -12,7 +12,7 @@ for details.
 """
 
 try:
-    import ply.yacc as yacc
+    from ply import yacc
 except ImportError:
     pass
 

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -53,7 +53,7 @@ for details.
 """
 
 try:
-    import ply.yacc as yacc
+    from ply import yacc
 except ImportError:
     pass
 

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -43,7 +43,7 @@ for details.
 """
 
 try:
-    import ply.yacc as yacc
+    from ply import yacc
 except ImportError:
     pass
 

--- a/python/grass/temporal/unit_tests.py
+++ b/python/grass/temporal/unit_tests.py
@@ -11,7 +11,7 @@ for details.
 
 import copy
 from datetime import datetime
-import grass.script.core as core
+from grass.script import core
 from .abstract_dataset import (
     AbstractDatasetComparisonKeyStartTime,
     AbstractDatasetComparisonKeyEndTime,
@@ -26,9 +26,9 @@ from .temporal_granularity import (
     compute_absolute_time_granularity,
 )
 
-import grass.lib.vector as vector
-import grass.lib.rtree as rtree
-import grass.lib.gis as gis
+from grass.lib import vector
+from grass.lib import rtree
+from grass.lib import gis
 from ctypes import byref
 
 # Uncomment this to detect the error

--- a/temporal/t.rast.algebra/t.rast.algebra.py
+++ b/temporal/t.rast.algebra/t.rast.algebra.py
@@ -103,8 +103,8 @@ def main():
     # Check for PLY istallation
     try:
         # Intentionally unused imports
-        import ply.lex as lex  # noqa: F401
-        import ply.yacc as yacc  # noqa: F401
+        from ply import lex  # noqa: F401
+        from ply import yacc  # noqa: F401
     except ImportError:
         grass.script.fatal(
             _(

--- a/temporal/t.rast3d.algebra/t.rast3d.algebra.py
+++ b/temporal/t.rast3d.algebra/t.rast3d.algebra.py
@@ -89,8 +89,8 @@ def main():
     # Check for PLY istallation
     try:
         # Intentionally unused imports
-        import ply.lex as lex  # noqa: F401
-        import ply.yacc as yacc  # noqa: F401
+        from ply import lex  # noqa: F401
+        from ply import yacc  # noqa: F401
     except ImportError:
         grass.script.fatal(
             _(

--- a/temporal/t.select/t.select.py
+++ b/temporal/t.select/t.select.py
@@ -70,8 +70,8 @@ def main():
     # Check for PLY istallation
     try:
         # Intentionally unused imports
-        import ply.lex as lex  # noqa: F401
-        import ply.yacc as yacc  # noqa: F401
+        from ply import lex  # noqa: F401
+        from ply import yacc  # noqa: F401
     except ImportError:
         grass.fatal(
             _(

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -68,8 +68,8 @@ def main():
     # Check for PLY istallation
     try:
         # Intentionally unused imports
-        import ply.lex as lex  # noqa: F401
-        import ply.yacc as yacc  # noqa: F401
+        from ply import lex  # noqa: F401
+        from ply import yacc  # noqa: F401
     except ImportError:
         grass.script.fatal(
             _(

--- a/temporal/t.vect.what.strds/t.vect.what.strds.py
+++ b/temporal/t.vect.what.strds/t.vect.what.strds.py
@@ -66,7 +66,7 @@
 
 import os
 import grass.script as grass
-import grass.script.raster as raster
+from grass.script import raster
 from grass.exceptions import CalledModuleError
 
 ############################################################################


### PR DESCRIPTION
Concerns Pylint rule "consider-using-from-import / R0402"

Using `ruff check --output-format=concise --select PLR0402 --fix`.

Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [manual-from-import (PLR0402)](https://docs.astral.sh/ruff/rules/manual-from-import/) to fix part of Pylint's [consider-using-from-import / R0402](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-from-import.html).