### PR TITLE
style: Fixes if-stmt-min-max (PLR1730)

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -238,8 +238,7 @@ class Popen(subprocess.Popen):
             try:
                 x = msvcrt.get_osfhandle(conn.fileno())
                 (read, nAvail, nMessage) = PeekNamedPipe(x, 0)
-                if maxsize < nAvail:
-                    nAvail = maxsize
+                nAvail = min(maxsize, nAvail)
                 if nAvail > 0:
                     (errCode, read) = ReadFile(x, nAvail, None)
             except ValueError:
@@ -301,8 +300,7 @@ message = "Other end disconnected!"
 
 
 def recv_some(p, t=0.1, e=1, tr=5, stderr=0):
-    if tr < 1:
-        tr = 1
+    tr = max(tr, 1)
     x = time.time() + t
     y = []
     r = ""

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -357,10 +357,8 @@ class VirtualAttributeList(
         i = 0
         for col in columns:
             width = self.columns[col]["length"] * 6  # FIXME
-            if width < 60:
-                width = 60
-            if width > 300:
-                width = 300
+            width = max(width, 60)
+            width = min(width, 300)
             self.SetColumnWidth(col=i, width=width)
             i += 1
 

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -2236,14 +2236,10 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             e, n = errlist[i].split()
             fe = float(e)
             fn = float(n)
-            if fe < newreg["w"]:
-                newreg["w"] = fe
-            if fe > newreg["e"]:
-                newreg["e"] = fe
-            if fn < newreg["s"]:
-                newreg["s"] = fn
-            if fn > newreg["n"]:
-                newreg["n"] = fn
+            newreg["w"] = min(fe, newreg["w"])
+            newreg["e"] = max(fe, newreg["e"])
+            newreg["s"] = min(fn, newreg["s"])
+            newreg["n"] = max(fn, newreg["n"])
 
         return newreg
 
@@ -2292,10 +2288,8 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
         # LL locations
         if self.Map.projinfo["proj"] == "ll":
-            if newreg["n"] > 90.0:
-                newreg["n"] = 90.0
-            if newreg["s"] < -90.0:
-                newreg["s"] = -90.0
+            newreg["n"] = min(newreg["n"], 90.0)
+            newreg["s"] = max(newreg["s"], -90.0)
 
         ce = newreg["w"] + (newreg["e"] - newreg["w"]) / 2
         cn = newreg["s"] + (newreg["n"] - newreg["s"]) / 2

--- a/gui/wxpython/gcp/statusbar.py
+++ b/gui/wxpython/gcp/statusbar.py
@@ -97,8 +97,7 @@ class SbGoToGCP(SbItem):
         and sets the spin limits accordingly."""
         self.statusbar.SetStatusText("")
         maximum = self.mapFrame.GetListCtrl().GetItemCount()
-        if maximum < 1:
-            maximum = 1
+        maximum = max(maximum, 1)
         self.widget.SetRange(0, maximum)
         self.Show()
 

--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -103,8 +103,7 @@ class ModelCanvas(ogl.ShapeCanvas):
         ymax = 20
         for item in self.GetDiagram().GetShapeList():
             y = item.GetY() + item.GetBoundingBoxMin()[1]
-            if y > ymax:
-                ymax = y
+            ymax = max(y, ymax)
 
         return (self.GetSize()[0] // 2, ymax + yoffset)
 

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -989,14 +989,10 @@ class ModelerPanel(wx.Panel, MainPageBase):
             xmax = x + w / 2
             ymin = y - h / 2
             ymax = y + h / 2
-            if xmin < xminImg:
-                xminImg = xmin
-            if xmax > xmaxImg:
-                xmaxImg = xmax
-            if ymin < yminImg:
-                yminImg = ymin
-            if ymax > ymaxImg:
-                ymaxImg = ymax
+            xminImg = min(xmin, xminImg)
+            xmaxImg = max(xmax, xmaxImg)
+            yminImg = min(ymin, yminImg)
+            ymaxImg = max(ymax, ymaxImg)
         size = wx.Size(int(xmaxImg - xminImg) + 50, int(ymaxImg - yminImg) + 50)
         bitmap = EmptyBitmap(width=size.width, height=size.height)
 

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -480,10 +480,8 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
                 self.cmdindex = self.cmdindex - 1
             if event.GetKeyCode() == wx.WXK_DOWN:
                 self.cmdindex = self.cmdindex + 1
-            if self.cmdindex < 0:
-                self.cmdindex = 0
-            if self.cmdindex > len(self.cmdbuffer) - 1:
-                self.cmdindex = len(self.cmdbuffer) - 1
+            self.cmdindex = max(self.cmdindex, 0)
+            self.cmdindex = min(self.cmdindex, len(self.cmdbuffer) - 1)
 
             try:
                 # without strip causes problem on windows

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -2174,14 +2174,10 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             e, n = errlist[i].split()
             fe = float(e)
             fn = float(n)
-            if fe < newreg["w"]:
-                newreg["w"] = fe
-            if fe > newreg["e"]:
-                newreg["e"] = fe
-            if fn < newreg["s"]:
-                newreg["s"] = fn
-            if fn > newreg["n"]:
-                newreg["n"] = fn
+            newreg["w"] = min(fe, newreg["w"])
+            newreg["e"] = max(fe, newreg["e"])
+            newreg["s"] = min(fn, newreg["s"])
+            newreg["n"] = max(fn, newreg["n"])
 
         return newreg
 
@@ -2230,10 +2226,8 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
         # LL locations
         if self.Map.projinfo["proj"] == "ll":
-            if newreg["n"] > 90.0:
-                newreg["n"] = 90.0
-            if newreg["s"] < -90.0:
-                newreg["s"] = -90.0
+            newreg["n"] = min(newreg["n"], 90.0)
+            newreg["s"] = max(newreg["s"], -90.0)
 
         ce = newreg["w"] + (newreg["e"] - newreg["w"]) / 2
         cn = newreg["s"] + (newreg["n"] - newreg["s"]) / 2

--- a/gui/wxpython/image2target/ii2t_statusbar.py
+++ b/gui/wxpython/image2target/ii2t_statusbar.py
@@ -97,8 +97,7 @@ class SbGoToGCP(SbItem):
         and sets the spin limits accordingly."""
         self.statusbar.SetStatusText("")
         maximum = self.mapFrame.GetListCtrl().GetItemCount()
-        if maximum < 1:
-            maximum = 1
+        maximum = max(maximum, 1)
         self.widget.SetRange(0, maximum)
         self.Show()
 

--- a/gui/wxpython/location_wizard/dialogs.py
+++ b/gui/wxpython/location_wizard/dialogs.py
@@ -703,11 +703,9 @@ class SelectTransformDialog(wx.Dialog):
             width = max(width, w)
 
         height = height + 5
-        if height > 400:
-            height = 400
+        height = min(height, 400)
         width = width + 5
-        if width > 400:
-            width = 400
+        width = min(width, 400)
 
         #
         # VListBox for displaying and selecting transformations

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -728,10 +728,8 @@ class ColorTable(wx.Frame):
             self.rulesPanel.mainPanel.FindWindowById(count + 2000).SetColour(rgb)
             # range
             try:
-                if float(value) < minim:
-                    minim = float(value)
-                if float(value) > maxim:
-                    maxim = float(value)
+                minim = min(float(value), minim)
+                maxim = max(float(value), maxim)
             except ValueError:  # nv, default
                 pass
             count += 1
@@ -1619,10 +1617,8 @@ class VectorColorTable(ColorTable):
             else:
                 col1, col2 = record.split(sep)
 
-            if float(col1) < minim:
-                minim = float(col1)
-            if float(col1) > maxim:
-                maxim = float(col1)
+            minim = min(float(col1), minim)
+            maxim = max(float(col1), maxim)
 
             # color rules list should only have unique values of col1, not all
             # records

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -2790,8 +2790,7 @@ class NvizToolWindow(GNotebook):
         frameCount = anim.GetFrameCount()
         if index >= frameCount:
             index = frameCount - 1
-        if index < 0:
-            index = 0
+        index = max(index, 0)
 
         if sliderWidget:
             slider = self.FindWindowById(self.win["anim"]["frameIndex"]["slider"])

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1455,14 +1455,10 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             e, n = errlist[i].split()
             fe = float(e)
             fn = float(n)
-            if fe < newreg["w"]:
-                newreg["w"] = fe
-            if fe > newreg["e"]:
-                newreg["e"] = fe
-            if fn < newreg["s"]:
-                newreg["s"] = fn
-            if fn > newreg["n"]:
-                newreg["n"] = fn
+            newreg["w"] = min(fe, newreg["w"])
+            newreg["e"] = max(fe, newreg["e"])
+            newreg["s"] = min(fn, newreg["s"])
+            newreg["n"] = max(fn, newreg["n"])
 
         return newreg
 
@@ -1511,10 +1507,8 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
         # LL locations
         if self.Map.projinfo["proj"] == "ll":
-            if newreg["n"] > 90.0:
-                newreg["n"] = 90.0
-            if newreg["s"] < -90.0:
-                newreg["s"] = -90.0
+            newreg["n"] = min(newreg["n"], 90.0)
+            newreg["s"] = max(newreg["s"], -90.0)
 
         ce = newreg["w"] + (newreg["e"] - newreg["w"]) / 2
         cn = newreg["s"] + (newreg["n"] - newreg["s"]) / 2

--- a/gui/wxpython/photo2image/ip2i_statusbar.py
+++ b/gui/wxpython/photo2image/ip2i_statusbar.py
@@ -97,8 +97,7 @@ class SbGoToGCP(SbItem):
         and sets the spin limits accordingly."""
         self.statusbar.SetStatusText("")
         maximum = self.mapFrame.GetListCtrl().GetItemCount()
-        if maximum < 1:
-            maximum = 1
+        maximum = max(maximum, 1)
         self.widget.SetRange(0, maximum)
         self.Show()
 

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -1743,8 +1743,7 @@ class VnetStatusbar(wx.StatusBar):
             if item["key"] == statusTextItem["key"]:
                 self.statusItems.remove(item)
         self.statusItems.append(statusTextItem)
-        if self.maxPriority < statusTextItem["priority"]:
-            self.maxPriority = statusTextItem["priority"]
+        self.maxPriority = max(self.maxPriority, statusTextItem["priority"])
         self._updateStatus()
 
     def _updateStatus(self):
@@ -1770,8 +1769,7 @@ class VnetStatusbar(wx.StatusBar):
         if update:
             for item in self.statusItems:
                 self.maxPriority = 0
-                if self.maxPriority < item["priority"]:
-                    self.maxPriority = item["priority"]
+                self.maxPriority = max(self.maxPriority, item["priority"])
             self._updateStatus()
 
 

--- a/python/grass/benchmark/runners.py
+++ b/python/grass/benchmark/runners.py
@@ -55,8 +55,7 @@ def benchmark_single(module, label, repeat=5):
         measured_times.append(module.time)
 
     avg = time_sum / repeat
-    if avg < min_avg:
-        min_avg = avg
+    min_avg = min(avg, min_avg)
     print(f"\nResult - {avg}s")
 
     print("\u2500" * term_size.columns)

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -341,8 +341,7 @@ def twitsToBits(arr):
     maxlen = 1
     for i in arr:
         tmp = len(signedIntToBits(i * 20))
-        if tmp > maxlen:
-            maxlen = tmp
+        maxlen = max(tmp, maxlen)
 
     # build array
     bits = intToBits(maxlen, 5)

--- a/python/grass/jupyter/region.py
+++ b/python/grass/jupyter/region.py
@@ -114,14 +114,10 @@ class RegionManagerForInteractiveMap:
         west = float(bbox["ll_w"])
         north = float(bbox["ll_n"])
         east = float(bbox["ll_e"])
-        if self._bbox[0][0] > south:
-            self._bbox[0][0] = south
-        if self._bbox[0][1] > west:
-            self._bbox[0][1] = west
-        if self._bbox[1][0] < north:
-            self._bbox[1][0] = north
-        if self._bbox[1][1] < east:
-            self._bbox[1][1] = east
+        self._bbox[0][0] = min(self._bbox[0][0], south)
+        self._bbox[0][1] = min(self._bbox[0][1], west)
+        self._bbox[1][0] = max(self._bbox[1][0], north)
+        self._bbox[1][1] = max(self._bbox[1][1], east)
 
 
 class RegionManagerFor2D:

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -948,55 +948,43 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
         if gran in ["seconds", "second"]:
             has_seconds = True
-            if min_gran > 0:
-                min_gran = 0
-            if max_gran < 0:
-                max_gran = 0
+            min_gran = min(min_gran, 0)
+            max_gran = max(max_gran, 0)
 
             seconds.append(int(num))
 
         if gran in ["minutes", "minute"]:
             has_minutes = True
-            if min_gran > 1:
-                min_gran = 1
-            if max_gran < 1:
-                max_gran = 1
+            min_gran = min(min_gran, 1)
+            max_gran = max(max_gran, 1)
 
             minutes.append(int(num))
 
         if gran in ["hours", "hour"]:
             has_hours = True
-            if min_gran > 2:
-                min_gran = 2
-            if max_gran < 2:
-                max_gran = 2
+            min_gran = min(min_gran, 2)
+            max_gran = max(max_gran, 2)
 
             hours.append(int(num))
 
         if gran in ["days", "day"]:
             has_days = True
-            if min_gran > 3:
-                min_gran = 3
-            if max_gran < 3:
-                max_gran = 3
+            min_gran = min(min_gran, 3)
+            max_gran = max(max_gran, 3)
 
             days.append(int(num))
 
         if gran in ["months", "month"]:
             has_months = True
-            if min_gran > 4:
-                min_gran = 4
-            if max_gran < 4:
-                max_gran = 4
+            min_gran = min(min_gran, 4)
+            max_gran = max(max_gran, 4)
 
             months.append(int(num))
 
         if gran in ["years", "year"]:
             has_years = True
-            if min_gran > 5:
-                min_gran = 5
-            if max_gran < 5:
-                max_gran = 5
+            min_gran = min(min_gran, 5)
+            max_gran = max(max_gran, 5)
 
             years.append(int(num))
 

--- a/scripts/d.correlate/d.correlate.py
+++ b/scripts/d.correlate/d.correlate.py
@@ -83,14 +83,10 @@ def main():
                         minx = maxx = x
                         miny = maxy = y
                         first = False
-                    if minx > x:
-                        minx = x
-                    if maxx < x:
-                        maxx = x
-                    if miny > y:
-                        miny = y
-                    if maxy < y:
-                        maxy = y
+                    minx = min(minx, x)
+                    maxx = max(maxx, x)
+                    miny = min(miny, y)
+                    maxy = max(maxy, y)
                 ifile.close()
 
                 kx = 100.0 / (maxx - minx + 1)

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -483,10 +483,8 @@ def wxGUI():
             for k, f in wind_keys.values():
                 self.total[k] = (f)(reg[k])
 
-            if self.cols > self.total["cols"]:
-                self.cols = self.total["cols"]
-            if self.rows > self.total["rows"]:
-                self.rows = self.total["rows"]
+            self.cols = min(self.cols, self.total["cols"])
+            self.rows = min(self.rows, self.total["rows"])
 
             tempbase = grass.tempfile()
             grass.try_remove(tempbase)
@@ -627,14 +625,10 @@ def wxGUI():
             del wait
 
         def force_window(self):
-            if self.origin_x < 0:
-                self.origin_x = 0
-            if self.origin_x > self.total["cols"] - self.cols:
-                self.origin_x = self.total["cols"] - self.cols
-            if self.origin_y < 0:
-                self.origin_y = 0
-            if self.origin_y > self.total["rows"] - self.rows:
-                self.origin_y = self.total["rows"] - self.rows
+            self.origin_x = max(self.origin_x, 0)
+            self.origin_x = min(self.origin_x, self.total["cols"] - self.cols)
+            self.origin_y = max(self.origin_y, 0)
+            self.origin_y = min(self.origin_y, self.total["rows"] - self.rows)
 
         def update_status(self, row, col):
             self.status["row"] = row

--- a/scripts/d.rast.leg/d.rast.leg.py
+++ b/scripts/d.rast.leg/d.rast.leg.py
@@ -126,10 +126,8 @@ def main():
     ncats = len(cats.strip().split("\n"))
 
     # Only need to adjust legend size if number of categories is between 1 and 10
-    if ncats < 2:
-        ncats = 2
-    if ncats > 10:
-        ncats = 10
+    ncats = max(ncats, 2)
+    ncats = min(ncats, 10)
 
     VSpacing = 100 - (ncats * 10) + 10
 

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -137,14 +137,10 @@ def pointsToBbox(points):
         if not min_y:
             min_y = max_y = point[1]
 
-        if min_x > point[0]:
-            min_x = point[0]
-        if max_x < point[0]:
-            max_x = point[0]
-        if min_y > point[1]:
-            min_y = point[1]
-        if max_y < point[1]:
-            max_y = point[1]
+        min_x = min(min_x, point[0])
+        max_x = max(max_x, point[0])
+        min_y = min(min_y, point[1])
+        max_y = max(max_y, point[1])
 
     bbox["n"] = max_y
     bbox["s"] = min_y

--- a/temporal/t.rast.what/t.rast.what.py
+++ b/temporal/t.rast.what/t.rast.what.py
@@ -248,8 +248,7 @@ def main(options, flags):
     else:
         gscript.error(_("Please specify points or coordinates"))
 
-    if len(maps) < nprocs:
-        nprocs = len(maps)
+    nprocs = min(len(maps), nprocs)
 
     # The module queue for parallel execution
     process_queue = pymod.ParallelModuleQueue(int(nprocs))


### PR DESCRIPTION
Concerns Pylint rules ["consider-using-min-builtin / R1730"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-min-builtin.html) and ["consider-using-max-builtin / R1731"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-max-builtin.html)

Using `ruff check --output-format=concise --select PLR1730 --preview --fix`.

Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [if-stmt-min-max (PLR1730)](https://docs.astral.sh/ruff/rules/if-stmt-min-max/) to fix part of Pylint's ["consider-using-min-builtin / R1730"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-min-builtin.html) and ["consider-using-max-builtin / R1731"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-max-builtin.html).

It also happens to reduce the number of branches and number of lines, where multiple places still exceeds some (already raised) limits, so its a good thing.