### PR TITLE
style: Fixes sys-exit-alias (PLR1722)

### DIFF
--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -94,7 +94,7 @@ for html_file in htmlfiles:
         except:
             pass
         if not key:
-            exit("Empty keyword from file %s line: %s" % (fname, lines[index_keys]))
+            sys.exit("Empty keyword from file %s line: %s" % (fname, lines[index_keys]))
         if key not in keywords.keys():
             keywords[key] = []
             keywords[key].append(fname)

--- a/python/grass/temporal/extract.py
+++ b/python/grass/temporal/extract.py
@@ -9,6 +9,7 @@ for details.
 :authors: Soeren Gebbert
 """
 
+import sys
 from .core import (
     get_tgis_message_interface,
     get_current_mapset,
@@ -320,7 +321,7 @@ def run_mapcalc2d(expr):
             "r.mapcalc", expression=expr, overwrite=gscript.overwrite(), quiet=True
         )
     except CalledModuleError:
-        exit(1)
+        sys.exit(1)
 
 
 def run_mapcalc3d(expr):
@@ -330,7 +331,7 @@ def run_mapcalc3d(expr):
             "r3.mapcalc", expression=expr, overwrite=gscript.overwrite(), quiet=True
         )
     except CalledModuleError:
-        exit(1)
+        sys.exit(1)
 
 
 def run_vector_extraction(input, output, layer, type, where):
@@ -347,4 +348,4 @@ def run_vector_extraction(input, output, layer, type, where):
             quiet=True,
         )
     except CalledModuleError:
-        exit(1)
+        sys.exit(1)

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -9,6 +9,7 @@ for details.
 :authors: Soeren Gebbert
 """
 
+import sys
 import copy
 from datetime import datetime
 from multiprocessing import Process
@@ -412,7 +413,7 @@ def _run_mapcalc2d(expr):
             "r.mapcalc", expression=expr, overwrite=gscript.overwrite(), quiet=True
         )
     except CalledModuleError:
-        exit(1)
+        sys.exit(1)
 
 
 ###############################################################################
@@ -425,7 +426,7 @@ def _run_mapcalc3d(expr):
             "r3.mapcalc", expression=expr, overwrite=gscript.overwrite(), quiet=True
         )
     except CalledModuleError:
-        exit(1)
+        sys.exit(1)
 
 
 ###############################################################################

--- a/raster/r.topidx/arc_to_gridatb.py
+++ b/raster/r.topidx/arc_to_gridatb.py
@@ -16,18 +16,18 @@ def match(pattern, string):
 
 if len(sys.argv) != 3 or re.match("^-*help", sys.argv[1]):
     print("Usage: arc.to.gridatb.py arc_file gridatb_file")
-    exit()
+    sys.exit()
 
 infname = sys.argv[1]
 outfname = sys.argv[2]
 
 if not os.path.isfile(infname):
     print(f"{infname}: File not found")
-    exit()
+    sys.exit()
 
 if os.path.isfile(outfname):
     print(f"{outfname}: File already exists")
-    exit()
+    sys.exit()
 
 inf = open(infname)
 
@@ -54,14 +54,14 @@ for inline in inf:
     else:
         print(f"{infname}: Invalid input file format")
         inf.close()
-        exit()
+        sys.exit()
     if head == 0x3F:
         break
 
 if head != 0x3F:
     print(f"{infname}: Invalid input file format")
     inf.close()
-    exit()
+    sys.exit()
 
 outf = open(outfname, "w")
 outf.write(

--- a/raster/r.topidx/gridatb_to_arc.py
+++ b/raster/r.topidx/gridatb_to_arc.py
@@ -10,7 +10,7 @@ if (
     or re.match("^-*help", sys.argv[1])
 ):
     print("Usage: gridatb.to.arc.py gridatb_file arc_file [xllcorner yllcorner]")
-    exit()
+    sys.exit()
 
 xllcorner = 0
 yllcorner = 0
@@ -23,11 +23,11 @@ outfname = sys.argv[2]
 
 if not os.path.isfile(infname):
     print(f"{infname}: File not found")
-    exit()
+    sys.exit()
 
 if os.path.isfile(outfname):
     print(f"{outfname}: File already exists")
-    exit()
+    sys.exit()
 
 inf = open(infname)
 
@@ -37,7 +37,7 @@ m = re.match("^[ \t]*([0-9.]+)[ \t]+([0-9.]+)[ \t]+([0-9.]+)[ \t]*$", inline)
 if not m:
     print(f"{infname}: Invalid input file format")
     inf.close()
-    exit()
+    sys.exit()
 
 ncols = m.group(1)
 nrows = m.group(2)


### PR DESCRIPTION
Using  `ruff check --select "PLR1722" --unsafe-fixes --output-format=concise --fix`.


Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [sys-exit-alias (PLR1722)](https://docs.astral.sh/ruff/rules/sys-exit-alias/) to fix part of Pylint's [consider-using-sys-exit / R1722](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-sys-exit.html).