### PR TITLE
style(gui): Fixes literal-membership (PLR6201)

### DIFF
--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -460,7 +460,7 @@ class AnimationController(wx.EvtHandler):
         for anim in animationData:
             for layer in anim.layerList:
                 if layer.active and hasattr(layer, "maps"):
-                    if layer.mapType in ("strds", "stvds", "str3ds"):
+                    if layer.mapType in {"strds", "stvds", "str3ds"}:
                         stds += 1
                     else:
                         maps += 1
@@ -672,5 +672,5 @@ class AnimationController(wx.EvtHandler):
             del self.busy
             GError(parent=self.frame, message=str(e))
             return
-        if exportInfo["method"] in ("sequence", "gif", "swf"):
+        if exportInfo["method"] in {"sequence", "gif", "swf"}:
             del self.busy

--- a/gui/wxpython/animation/data.py
+++ b/gui/wxpython/animation/data.py
@@ -85,7 +85,7 @@ class AnimationData:
         timeseriesList = []
         for layer in layerList:
             if layer.active and hasattr(layer, "maps"):
-                if layer.mapType in ("strds", "stvds", "str3ds"):
+                if layer.mapType in {"strds", "stvds", "str3ds"}:
                     timeseriesList.append((layer.name, layer.mapType))
                     self._firstStdsNameType = layer.name, layer.mapType
                 else:
@@ -298,7 +298,7 @@ class AnimLayer(Layer):
                 raise ValueError(
                     "To set layer name, the type of layer must be specified."
                 )
-            if self._mapType in ("strds", "stvds", "str3ds"):
+            if self._mapType in {"strds", "stvds", "str3ds"}:
                 try:
                     name = validateTimeseriesName(name, self._mapType)
                     self._maps = getRegisteredMaps(name, self._mapType)

--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -1399,7 +1399,7 @@ class ExportDialog(wx.Dialog):
             self._hideAll()
             return
         cdata = self.listbox.GetClientData(index)
-        self.hidevbox.Show(self.fontBox, (cdata["name"] in ("time", "text")))
+        self.hidevbox.Show(self.fontBox, (cdata["name"] in {"time", "text"}))
         self.hidevbox.Show(self.imageBox, (cdata["name"] == "image"))
         self.hidevbox.Show(self.textBox, (cdata["name"] == "text"))
         self.hidevbox.Show(self.posBox, True)
@@ -1409,7 +1409,7 @@ class ExportDialog(wx.Dialog):
         self.spinY.SetValue(cdata["pos"][1])
         if cdata["name"] == "image":
             self.browse.SetValue(cdata["file"])
-        elif cdata["name"] in ("time", "text"):
+        elif cdata["name"] in {"time", "text"}:
             self.sampleLabel.SetFont(cdata["font"])
             if cdata["name"] == "text":
                 self.textCtrl.SetValue(cdata["text"])
@@ -1750,7 +1750,7 @@ class AddTemporalLayerDialog(wx.Dialog):
         if typeName:
             self.tchoice.SetStringSelection(self._types[typeName])
             self.tselect.SetType(typeName)
-            if typeName in ("strds", "stvds", "str3ds"):
+            if typeName in {"strds", "stvds", "str3ds"}:
                 self.tselect.SetType(typeName, multiple=False)
                 self.addManyMapsButton.Disable()
             else:
@@ -1760,7 +1760,7 @@ class AddTemporalLayerDialog(wx.Dialog):
             self.tselect.SetValue("")
         else:
             typeName = self.tchoice.GetClientData(self.tchoice.GetSelection())
-            if typeName in ("strds", "stvds", "str3ds"):
+            if typeName in {"strds", "stvds", "str3ds"}:
                 self.tselect.SetType(typeName, multiple=False)
                 self.addManyMapsButton.Disable()
             else:
@@ -1773,14 +1773,14 @@ class AddTemporalLayerDialog(wx.Dialog):
 
     def _createDefaultCommand(self):
         cmd = []
-        if self._mapType in ("raster", "strds"):
+        if self._mapType in {"raster", "strds"}:
             cmd.append("d.rast")
-        elif self._mapType in ("vector", "stvds"):
+        elif self._mapType in {"vector", "stvds"}:
             cmd.append("d.vect")
-        elif self._mapType in ("raster_3d", "str3ds"):
+        elif self._mapType in {"raster_3d", "str3ds"}:
             cmd.append("d.rast3d")
         if self._name:
-            if self._mapType in ("raster", "vector", "raster_3d"):
+            if self._mapType in {"raster", "vector", "raster_3d"}:
                 cmd.append("map={name}".format(name=self._name.split(",")[0]))
             else:
                 try:

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -222,7 +222,7 @@ class Popen(subprocess.Popen):
             except ValueError:
                 return self._close("stdin")
             except (pywintypes.error, Exception) as why:
-                if why.winerror in (109, errno.ESHUTDOWN):
+                if why.winerror in {109, errno.ESHUTDOWN}:
                     return self._close("stdin")
                 raise
 
@@ -245,7 +245,7 @@ class Popen(subprocess.Popen):
             except ValueError:
                 return self._close(which)
             except (pywintypes.error, Exception) as why:
-                if why.winerror in (109, errno.ESHUTDOWN):
+                if why.winerror in {109, errno.ESHUTDOWN}:
                     return self._close(which)
                 raise
 

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -661,7 +661,7 @@ class GConsole(wx.EvtHandler):
                 return
 
             skipInterface = True
-            if os.path.splitext(command[0])[1] in (".py", ".sh"):
+            if os.path.splitext(command[0])[1] in {".py", ".sh"}:
                 try:
                     with open(command[0], "r") as sfile:
                         for line in sfile.readlines():
@@ -805,14 +805,14 @@ class GConsole(wx.EvtHandler):
         name = task.get_name()
         for p in task.get_options()["params"]:
             prompt = p.get("prompt", "")
-            if prompt in ("raster", "vector", "raster_3d") and p.get("value", None):
-                if p.get("age", "old") == "new" or name in (
+            if prompt in {"raster", "vector", "raster_3d"} and p.get("value", None):
+                if p.get("age", "old") == "new" or name in {
                     "r.colors",
                     "r3.colors",
                     "v.colors",
                     "v.proj",
                     "r.proj",
-                ):
+                }:
                     # if multiple maps (e.g. r.series.interp), we need add each
                     if p.get("multiple", False):
                         lnames = p.get("value").split(",")

--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -167,7 +167,7 @@ GM_WINDOW_MIN_SIZE = (525, 400)
 # use UBUNTU_MENUPROXY=0 to disable global menu on ubuntu but in the same time
 # to get smaller lmgr
 # [1] https://wiki.ubuntu.com/DesktopExperienceTeam/ApplicationMenu#Troubleshooting
-if sys.platform in ("win32", "darwin") or os.environ.get("UBUNTU_MENUPROXY"):
+if sys.platform in {"win32", "darwin"} or os.environ.get("UBUNTU_MENUPROXY"):
     GM_WINDOW_SIZE = (GM_WINDOW_MIN_SIZE[0], 600)
 else:
     GM_WINDOW_SIZE = (625, 600)
@@ -213,12 +213,12 @@ def UpdateGRASSAddOnCommands(eList=None):
             os.environ["PATH"] = path + os.pathsep + os.environ["PATH"]
 
         for fname in os.listdir(path):
-            if fname in ["docs", "modules.xml"]:
+            if fname in {"docs", "modules.xml"}:
                 continue
             if grassScripts:  # win32
                 name, ext = os.path.splitext(fname)
                 if name not in grassCmd:
-                    if ext not in [BIN_EXT, SCT_EXT]:
+                    if ext not in {BIN_EXT, SCT_EXT}:
                         continue
                     if name not in grassCmd:
                         grassCmd.add(name)

--- a/gui/wxpython/core/menutree.py
+++ b/gui/wxpython/core/menutree.py
@@ -242,9 +242,9 @@ if __name__ == "__main__":
     menu = "manager"
 
     for arg in sys.argv:
-        if arg in ("strings", "tree", "commands", "dump"):
+        if arg in {"strings", "tree", "commands", "dump"}:
             action = arg
-        elif arg in ("manager", "module_tree", "modeler", "psmap"):
+        elif arg in {"manager", "module_tree", "modeler", "psmap"}:
             menu = arg
 
     # FIXME: cross-dependencies

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -368,7 +368,7 @@ class MapLayer(Layer):
     def __init__(self, *args, **kwargs):
         """Represents map layer in the map canvas"""
         Layer.__init__(self, *args, **kwargs)
-        if self.type in ("vector", "thememap"):
+        if self.type in {"vector", "thememap"}:
             self._legrow = get_tempfile_name(suffix=".legrow", create=True)
         else:
             self._legrow = ""
@@ -439,7 +439,7 @@ class RenderLayerMgr(wx.EvtHandler):
         env_cmd = env.copy()
         env_cmd.update(self._render_env)
         env_cmd["GRASS_RENDER_FILE"] = self.layer.mapfile
-        if self.layer.GetType() in ("vector", "thememap"):
+        if self.layer.GetType() in {"vector", "thememap"}:
             if not self.layer._legrow:
                 self.layer._legrow = grass.tempfile(create=True)
             if os.path.isfile(self.layer._legrow):
@@ -721,7 +721,7 @@ class RenderMapMgr(wx.EvtHandler):
         new_legend = []
         with open(self.Map.legfile, "w") as outfile:
             for layer in reversed(self.layers):
-                if layer.GetType() not in ("vector", "thememap"):
+                if layer.GetType() not in {"vector", "thememap"}:
                     continue
 
                 if os.path.isfile(layer._legrow) and not layer.hidden:
@@ -883,7 +883,7 @@ class Map:
         for line in ret.splitlines():
             if ":" in line:
                 key, val = map(lambda x: x.strip(), line.split(":", 1))
-                if key in ["units"]:
+                if key in {"units"}:
                     val = val.lower()
                 projinfo[key] = val
             elif "XY location (unprojected)" in line:
@@ -1452,7 +1452,7 @@ class Map:
                 for f in glob.glob(basefile):
                     os.remove(f)
 
-            if layer.GetType() in ("vector", "thememap"):
+            if layer.GetType() in {"vector", "thememap"}:
                 if os.path.isfile(layer._legrow):
                     os.remove(layer._legrow)
 

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -73,7 +73,7 @@ def settings_JSON_decode_hook(obj):
         return tuple(int(hexcode[i : i + 2], 16) for i in range(0, len(hexcode), 2))
 
     for k, v in obj.items():
-        if isinstance(v, str) and v.startswith("#") and len(v) in [7, 9]:
+        if isinstance(v, str) and v.startswith("#") and len(v) in {7, 9}:
             obj[k] = colorhex2tuple(v)
     return obj
 

--- a/gui/wxpython/core/treemodel.py
+++ b/gui/wxpython/core/treemodel.py
@@ -310,7 +310,7 @@ class ModuleNode(DictNode):
             keys = key
 
         for key in keys:
-            if key not in ("command", "keywords", "description"):
+            if key not in {"command", "keywords", "description"}:
                 return False
             try:
                 text = self.data[key]

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -121,7 +121,7 @@ def GetLayerNameFromCmd(dcmd, fullyQualified=False, param=None, layerType=None):
                 break
 
             # this does not use types, just some (incomplete subset of?) names
-            if p in (
+            if p in {
                 "map",
                 "input",
                 "layer",
@@ -133,7 +133,7 @@ def GetLayerNameFromCmd(dcmd, fullyQualified=False, param=None, layerType=None):
                 "intensity",
                 "shade",
                 "labels",
-            ):
+            }:
                 params.append((idx, p, v))
 
         if len(params) < 1:
@@ -161,9 +161,9 @@ def GetLayerNameFromCmd(dcmd, fullyQualified=False, param=None, layerType=None):
             mapname = v
             mapset = ""
             if fullyQualified and "@" not in mapname:
-                if layerType in ("raster", "vector", "raster_3d", "rgb", "his"):
+                if layerType in {"raster", "vector", "raster_3d", "rgb", "his"}:
                     try:
-                        if layerType in ("raster", "rgb", "his"):
+                        if layerType in {"raster", "rgb", "his"}:
                             findType = "cell"
                         elif layerType == "raster_3d":
                             findType = "grid3"
@@ -477,11 +477,11 @@ def __ll_parts(value, reverse=False, precision=3):
                 except ValueError:
                     raise ValueError
 
-        if hs not in ("N", "S", "E", "W"):
+        if hs not in {"N", "S", "E", "W"}:
             raise ValueError
 
         coef = 1.0
-        if hs in ("S", "W"):
+        if hs in {"S", "W"}:
             coef = -1.0
 
         fm = int(m) / 60.0
@@ -552,7 +552,7 @@ def ReprojectCoordinates(coord, projOut, projIn=None, flags=""):
             proj = projOut.split(" ")[0].split("=")[1]
         except IndexError:
             proj = ""
-        if proj in ("ll", "latlong", "longlat") and "d" not in flags:
+        if proj in {"ll", "latlong", "longlat"} and "d" not in flags:
             return (proj, (e, n))
         else:
             try:
@@ -666,9 +666,9 @@ def _parseFormats(output, writableOnly=False):
         if writableOnly and not patt.search(key):
             continue
 
-        if name in ("Memory", "Virtual Raster", "In Memory Raster"):
+        if name in {"Memory", "Virtual Raster", "In Memory Raster"}:
             continue
-        if name in (
+        if name in {
             "PostgreSQL",
             "PostgreSQL/PostGIS",
             "SQLite",
@@ -681,16 +681,16 @@ def _parseFormats(output, writableOnly=False):
             "CouchDB",
             "MSSQLSpatial",
             "FileGDB",
-        ):
+        }:
             formats["database"][key.split(" ")[0]] = name
-        elif name in (
+        elif name in {
             "GeoJSON",
             "OGC Web Coverage Service",
             "OGC Web Map Service",
             "WFS",
             "GeoRSS",
             "HTTP Fetching Wrapper",
-        ):
+        }:
             formats["protocol"][key.split(" ")[0]] = name
         else:
             formats["file"][key.split(" ")[0]] = name

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -1102,7 +1102,7 @@ class WriteWorkspaceFile:
                             self.file.write(
                                 '%s<flag name="%s" />\n' % (" " * self.indent, f)
                             )
-                    elif val in (True, False):
+                    elif val in {True, False}:
                         self.file.write(
                             '%s<flag name="%s" />\n' % (" " * self.indent, key)
                         )
@@ -1369,7 +1369,7 @@ class WriteWorkspaceFile:
                         self.indent += 4
                         self.file.write("%s<%s>\n" % (" " * self.indent, name))
                         for att in slice_[name].keys():
-                            if att in ("map", "update"):
+                            if att in {"map", "update"}:
                                 continue
                             val = slice_[name][att]
                             self.indent += 4
@@ -1382,7 +1382,7 @@ class WriteWorkspaceFile:
                         self.file.write("%s</%s>\n" % (" " * self.indent, name))
                         self.indent -= 4
                     self.file.write("%s</%s>\n" % (" " * self.indent, attrb))
-            if attrb not in ("attribute", "isosurface", "slice"):
+            if attrb not in {"attribute", "isosurface", "slice"}:
                 # end tag
                 self.file.write("%s</%s>\n" % (" " * self.indent, attrb))
 
@@ -1417,7 +1417,7 @@ class WriteWorkspaceFile:
                 )
             self.indent += 4
             for name in data[attrb].keys():
-                if name in ("object", "marker"):
+                if name in {"object", "marker"}:
                     continue
                 if name == "mode":
                     self.file.write(
@@ -1871,7 +1871,7 @@ class ProcessGrcFile:
 
         elif (
             element
-            in (
+            in {
                 "display_shape",
                 "display_cat",
                 "display_topo",
@@ -1883,7 +1883,7 @@ class ProcessGrcFile:
                 "type_centroid",
                 "type_area",
                 "type_face",
-            )
+            }
             and self.inVector
         ):
             if int(self._get_value(line)) == 1:
@@ -1895,7 +1895,7 @@ class ProcessGrcFile:
                 else:
                     self.layers[-1]["cmd"][paramId] += ",%s" % type
 
-        elif element in ("color", "fcolor", "lcolor") and self.inVector:
+        elif element in {"color", "fcolor", "lcolor"} and self.inVector:
             value = self._get_value(line)
             if value != "":
                 self.layers[-1]["cmd"].append(
@@ -1912,7 +1912,7 @@ class ProcessGrcFile:
 
         elif (
             element
-            in (
+            in {
                 "icon",
                 "size",
                 "layer",
@@ -1922,7 +1922,7 @@ class ProcessGrcFile:
                 "where",
                 "minreg",
                 "maxreg",
-            )
+            }
             and self.inVector
         ):
             value = self._get_value(line)
@@ -1985,7 +1985,7 @@ class ProcessGrcFile:
                     "textcolor=%s" % self._color_name_to_rgb(value)
                 )
 
-        elif element in ("gridsize", "gridorigin"):
+        elif element in {"gridsize", "gridorigin"}:
             value = self._get_value(line)
             if value != "":
                 self.layers[-1]["cmd"].append("%s=%s" % (element[4:], value))

--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -215,10 +215,10 @@ class RenderWMSMgr(wx.EvtHandler):
             if len(r) < 2:
                 continue
             try:
-                if r[0] in ["e-w resol3", "n-s resol3", "rows3", "cols3", "depths"]:
+                if r[0] in {"e-w resol3", "n-s resol3", "rows3", "cols3", "depths"}:
                     # ignore 3D region values (causing problems in latlong locations)
                     continue
-                if r[0] in ["cols", "rows", "zone", "proj"]:
+                if r[0] in {"cols", "rows", "zone", "proj"}:
                     region[r[0]] = int(r[1])
                 else:
                     region[r[0]] = float(r[1])

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -98,7 +98,7 @@ class DataCatalog(wx.Panel):
             # get reason why last used mapset is not usable
             last_mapset_path = gisenv()["LAST_MAPSET_PATH"]
             self.reason_id = get_reason_id_mapset_not_usable(last_mapset_path)
-            if self.reason_id in ("non-existent", "invalid", "different-owner"):
+            if self.reason_id in {"non-existent", "invalid", "different-owner"}:
                 # show non-standard situation info
                 wx.CallLater(delay, self.showFallbackSessionInfo)
             elif self.reason_id == "locked":

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -786,7 +786,7 @@ class DataCatalogTree(TreeView):
         mixed = []
         for item in selected:
             type = item.data["type"]
-            if type in ("raster", "raster_3d", "vector"):
+            if type in {"raster", "raster_3d", "vector"}:
                 self.selected_layer.append(item)
                 self.selected_mapset.append(item.parent)
                 self.selected_location.append(item.parent.parent)
@@ -901,7 +901,7 @@ class DataCatalogTree(TreeView):
         if node.data["type"] == "mapset" and not node.children:
             self._reloadMapsetNode(node)
             self.RefreshNode(node, recursive=True)
-        if node.data["type"] in ("mapset", "location", "grassdb"):
+        if node.data["type"] in {"mapset", "location", "grassdb"}:
             # expand/collapse location/mapset...
             if self.IsNodeExpanded(node):
                 self.CollapseNode(node, recursive=False)
@@ -967,12 +967,12 @@ class DataCatalogTree(TreeView):
         Used to highlight current db/loc/mapset."""
         node = self._model.GetNodeByIndex(index)
         font = self.GetFont()
-        if node.data["type"] in ("grassdb", "location", "mapset"):
-            if node in (
+        if node.data["type"] in {"grassdb", "location", "mapset"}:
+            if node in {
                 self.current_grassdb_node,
                 self.current_location_node,
                 self.current_mapset_node,
-            ):
+            }:
                 font.SetWeight(wx.FONTWEIGHT_BOLD)
             else:
                 font.SetWeight(wx.FONTWEIGHT_NORMAL)
@@ -1156,7 +1156,7 @@ class DataCatalogTree(TreeView):
                 self.selected_location[0].data["name"],
             ):
                 event.Veto()
-        elif node.data["type"] in ("raster", "raster_3d", "vector"):
+        elif node.data["type"] in {"raster", "raster_3d", "vector"}:
             currentGrassDb, currentLocation, currentMapset = self._isCurrent(gisenv())
             if not currentMapset:
                 event.Veto()
@@ -1170,7 +1170,7 @@ class DataCatalogTree(TreeView):
         Debug.msg(1, "End label edit {name}".format(name=old_name))
         new_name = event.GetLabel()
 
-        if node.data["type"] in ("raster", "raster_3d", "vector"):
+        if node.data["type"] in {"raster", "raster_3d", "vector"}:
             self.Rename(old_name, new_name)
 
         elif node.data["type"] == "mapset":
@@ -1810,7 +1810,7 @@ class DataCatalogTree(TreeView):
                 node = self.GetDbNode(grassdb=grassdb)
                 if node:
                     self.RemoveGrassDB(node)
-        elif element in ("raster", "vector", "raster_3d"):
+        elif element in {"raster", "vector", "raster_3d"}:
             # when watchdog is used, it watches current mapset,
             # so we don't process any signals here,
             # instead the watchdog handler takes care of refreshing tree

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -382,7 +382,7 @@ class SQLBuilder(wx.Frame):
         i = 0
         items = []
         for item in data:  # sorted(set(map(lambda x: desc['ctype'](x[0]), data))):
-            if desc["type"] not in ("character", "text"):
+            if desc["type"] not in {"character", "text"}:
                 items.append(str(item[0]))
             else:
                 items.append("'{}'".format(GetUnicodeValue(item[0])))
@@ -605,7 +605,7 @@ class SQLBuilderSelect(SQLBuilder):
                 curspos = self.text_sql.GetLastPosition() + len(newsqlstr)
                 newsqlstr = sqlstr + newsqlstr
 
-        elif element in ["value", "mark"]:
+        elif element in {"value", "mark"}:
             addstr = " " + value + " "
             newsqlstr = sqlstr[:curspos] + addstr + sqlstr[curspos:]
             curspos += len(addstr)
@@ -820,7 +820,7 @@ class SQLBuilderUpdate(SQLBuilder):
         curspos = self.text_sql.GetInsertionPoint()
         newsqlstr = ""
 
-        if element in ["value", "mark", "func"] or (
+        if element in {"value", "mark", "func"} or (
             element == "column" and self.mode.GetSelection() == 2
         ):
             addstr = " " + value + " "
@@ -925,7 +925,7 @@ class SQLBuilderWhere(SQLBuilder):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in [3, 4]:
+    if len(sys.argv) not in {3, 4}:
         print(__doc__, file=sys.stderr)
         sys.exit()
 

--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -198,7 +198,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
             )
 
         elif isinstance(shape, ModelData):
-            if shape.GetPrompt() in (
+            if shape.GetPrompt() in {
                 "raster",
                 "vector",
                 "raster_3d",
@@ -206,7 +206,7 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
                 "strds",
                 "stvds",
                 "str3ds",
-            ):
+            }:
                 dlg = ModelDataDialog(parent=self.frame, shape=shape)
                 shape.SetPropDialog(dlg)
                 dlg.CentreOnParent()

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -838,7 +838,7 @@ class Model:
             result["variables"] = {"flags": list(), "params": params, "idx": idx}
             for name, values in self.variables.items():
                 gtype = values.get("type", "string")
-                if gtype in ("raster", "vector", "mapset", "file", "region", "dir"):
+                if gtype in {"raster", "vector", "mapset", "file", "region", "dir"}:
                     gisprompt = True
                     prompt = gtype
                     if gtype == "raster":
@@ -1487,15 +1487,15 @@ class ModelData(ModelObject):
 
     def _getBrush(self):
         """Get brush"""
-        if self.prompt in ("raster", "strds"):
+        if self.prompt in {"raster", "strds"}:
             color = UserSettings.Get(
                 group="modeler", key="data", subkey=("color", "raster")
             )
-        elif self.prompt in ("raster_3d", "str3ds"):
+        elif self.prompt in {"raster_3d", "str3ds"}:
             color = UserSettings.Get(
                 group="modeler", key="data", subkey=("color", "raster3d")
             )
-        elif self.prompt in ("vector", "stvds"):
+        elif self.prompt in {"vector", "stvds"}:
             color = UserSettings.Get(
                 group="modeler", key="data", subkey=("color", "vector")
             )
@@ -1926,7 +1926,7 @@ class ModelCondition(ModelItem, ogl.PolygonShape):
         :param items: list of items
         :param branch: 'if' / 'else'
         """
-        if branch in ["if", "else"]:
+        if branch in {"if", "else"}:
             self.itemIds[branch] = items
 
 
@@ -3289,7 +3289,7 @@ if __name__ == "__main__":
 
     def _getParamValue(self, param):
         if param["value"] and "output" not in param["name"]:
-            if param["type"] in ["float", "integer"]:
+            if param["type"] in {"float", "integer"}:
                 value = param["value"]
             else:
                 value = '"{}"'.format(param["value"])

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -455,7 +455,7 @@ class ModelerPanel(wx.Panel, MainPageBase):
             y = layer.GetY()
 
             for p in params["params"]:
-                if p.get("prompt", "") not in (
+                if p.get("prompt", "") not in {
                     "raster",
                     "vector",
                     "raster_3d",
@@ -464,7 +464,7 @@ class ModelerPanel(wx.Panel, MainPageBase):
                     "strds",
                     "stvds",
                     "str3ds",
-                ):
+                }:
                     continue
 
                 # add new data item if defined or required
@@ -1848,7 +1848,7 @@ class PythonPanel(wx.Panel):
         if self.body.script_type == "Python":
             self.btnRun.Enable()
             self.btnRun.SetToolTip(_("Run script"))
-        elif self.body.script_type in ("PyWPS", "actinia"):
+        elif self.body.script_type in {"PyWPS", "actinia"}:
             self.btnRun.Disable()
             self.btnRun.SetToolTip(
                 _("Run script - enabled only for basic Python scripts")

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -170,7 +170,7 @@ class UpdateThread(Thread):
                 prompt = p.get("element", "")
                 if prompt == "vector":
                     name = p.get("name", "")
-                    if name in ("map", "input"):
+                    if name in {"map", "input"}:
                         self.eventId = p["wxId"][0]
             if self.eventId is None:
                 return
@@ -254,7 +254,7 @@ class UpdateThread(Thread):
 
             map = layer = None
             driver = db = None
-            if name in ("LayerSelect", "ColumnSelect", "SqlWhereSelect"):
+            if name in {"LayerSelect", "ColumnSelect", "SqlWhereSelect"}:
                 if p.get("element", "") == "vector":  # -> vector
                     # get map name
                     map = p.get("value", "")
@@ -265,7 +265,7 @@ class UpdateThread(Thread):
                         if not p:
                             continue
 
-                        if p.get("element", "") in ["layer", "layer_all"]:
+                        if p.get("element", "") in {"layer", "layer_all"}:
                             layer = p.get("value", "")
                             if layer != "":
                                 layer = p.get("value", "")
@@ -273,7 +273,7 @@ class UpdateThread(Thread):
                                 layer = p.get("default", "")
                             break
 
-                elif p.get("element", "") in ["layer", "layer_all"]:  # -> layer
+                elif p.get("element", "") in {"layer", "layer_all"}:  # -> layer
                     # get layer
                     layer = p.get("value", "")
                     if layer != "":
@@ -665,11 +665,11 @@ class TaskFrame(wx.Frame):
         if self._giface and self._giface.GetLayerTree():
             addLayer = False
             for p in self.task.params:
-                if p.get("age", "old") == "new" and p.get("prompt", "") in (
+                if p.get("age", "old") == "new" and p.get("prompt", "") in {
                     "raster",
                     "vector",
                     "raster_3d",
-                ):
+                }:
                     addLayer = True
 
             if addLayer:
@@ -917,21 +917,21 @@ class TaskFrame(wx.Frame):
         if (
             self.get_dcmd
             and self.parent
-            and self.parent.GetName() in ("LayerTree", "MapWindow")
+            and self.parent.GetName() in {"LayerTree", "MapWindow"}
         ):
             Debug.msg(1, "TaskFrame.OnCancel(): known parent")
             # display decorations and
             # pressing OK or cancel after setting layer properties
             if (
                 self.task.name
-                in [
+                in {
                     "d.barscale",
                     "d.legend",
                     "d.northarrow",
                     "d.histogram",
                     "d.text",
                     "d.legend.vect",
-                ]
+                }
                 or len(self.parent.GetLayerInfo(self.layer, key="cmd")) >= 1
             ):
                 # TODO: do this through policy
@@ -1109,7 +1109,7 @@ class CmdPanel(wx.Panel):
                 parChk.Bind(wx.EVT_CHECKBOX, self.OnSetValue)
                 which_sizer.Add(parChk, proportion=0, flag=wx.LEFT, border=20)
 
-            if f["name"] in ("verbose", "quiet"):
+            if f["name"] in {"verbose", "quiet"}:
                 chk.Bind(wx.EVT_CHECKBOX, self.OnVerbosity)
                 vq = UserSettings.Get(group="cmd", key="verbosity", subkey="selection")
                 if f["name"] == vq:
@@ -1301,7 +1301,7 @@ class CmdPanel(wx.Panel):
                         title_txt.SetLabel(title + ":")
                         value = self._getValue(p)
 
-                        if p["name"] in ("icon", "icon_area", "icon_line"):  # symbols
+                        if p["name"] in {"icon", "icon_area", "icon_line"}:  # symbols
                             bitmap = wx.Bitmap(
                                 os.path.join(globalvar.SYMBDIR, value) + ".png"
                             )
@@ -1363,7 +1363,7 @@ class CmdPanel(wx.Panel):
 
             # text entry
             if (
-                p.get("type", "string") in ("string", "integer", "float")
+                p.get("type", "string") in {"string", "integer", "float"}
                 and len(p.get("values", [])) == 0
                 and p.get("gisprompt", False) is False
                 and p.get("prompt", "") != "color"
@@ -1446,7 +1446,7 @@ class CmdPanel(wx.Panel):
             if p.get("gisprompt", False):
                 title_txt.SetLabel(title + ":")
                 # GIS element entry
-                if p.get("prompt", "") not in (
+                if p.get("prompt", "") not in {
                     "color",
                     "cat",
                     "cats",
@@ -1471,7 +1471,7 @@ class CmdPanel(wx.Panel):
                     "datasource",
                     "datasource_layer",
                     "sql_query",
-                ):
+                }:
                     multiple = p.get("multiple", False)
                     if p.get("age", "") == "new":
                         mapsets = [
@@ -1480,7 +1480,7 @@ class CmdPanel(wx.Panel):
                     else:
                         mapsets = None
                     if (
-                        self.task.name in ("r.proj", "v.proj")
+                        self.task.name in {"r.proj", "v.proj"}
                         and p.get("name", "") == "input"
                     ):
                         selection = gselect.ProjSelect(
@@ -1494,7 +1494,7 @@ class CmdPanel(wx.Panel):
                     else:
                         elem = p.get("element", None)
                         # hack for t.* modules
-                        if elem in ("stds", "map"):
+                        if elem in {"stds", "map"}:
                             orig_elem = elem
                             type_param = self.task.get_param(
                                 "type", element="name", raiseError=False
@@ -1655,7 +1655,7 @@ class CmdPanel(wx.Panel):
                             border=5,
                         )
                     else:
-                        if prompt in ("stds", "strds", "stvds", "str3ds"):
+                        if prompt in {"stds", "strds", "stvds", "str3ds"}:
                             showButton = True
                             try:
                                 # if matplotlib is there
@@ -1800,7 +1800,7 @@ class CmdPanel(wx.Panel):
                     )
 
                 # layer, dbdriver, dbname, dbcolumn, dbtable entry
-                elif prompt in (
+                elif prompt in {
                     "dbdriver",
                     "dbname",
                     "dbtable",
@@ -1809,7 +1809,7 @@ class CmdPanel(wx.Panel):
                     "location",
                     "mapset",
                     "dbase",
-                ):
+                }:
                     if p.get("multiple", "no") == "yes":
                         win = TextCtrl(
                             parent=which_panel,
@@ -2195,7 +2195,7 @@ class CmdPanel(wx.Panel):
                         border=5,
                     )
 
-                elif prompt in ("cat", "cats"):
+                elif prompt in {"cat", "cats"}:
                     # interactive selection of vector categories if layer
                     # manager is accessible
                     if self._giface:
@@ -2224,7 +2224,7 @@ class CmdPanel(wx.Panel):
                         border=5,
                     )
 
-                elif prompt in ("colortable", "barscale", "northarrow"):
+                elif prompt in {"colortable", "barscale", "northarrow"}:
                     if prompt == "colortable":
                         cb = ColorTablesComboBox(
                             parent=which_panel,
@@ -2411,9 +2411,9 @@ class CmdPanel(wx.Panel):
                 continue
 
             prompt = p.get("prompt", "")
-            if prompt in ("raster", "vector"):
+            if prompt in {"raster", "vector"}:
                 name = p.get("name", "")
-                if name in ("map", "input"):
+                if name in {"map", "input"}:
                     pMap = p
             elif prompt == "layer":
                 pLayer.append(p)
@@ -3231,14 +3231,14 @@ class GUI:
             self.grass_task = gtask.processTask(tree).get_task()
 
             for p in self.grass_task.params:
-                if p.get("name", "") in ("input", "map"):
+                if p.get("name", "") in {"input", "map"}:
                     age = p.get("age", "")
                     prompt = p.get("prompt", "")
                     element = p.get("element", "")
                     if (
                         age == "old"
-                        and element in ("cell", "grid3", "vector")
-                        and prompt in ("raster", "raster_3d", "vector")
+                        and element in {"cell", "grid3", "vector"}
+                        and prompt in {"raster", "raster_3d", "vector"}
                     ):
                         return p.get("name", None)
         return None

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -392,7 +392,7 @@ class GConsoleWindow(wx.SplitterWindow):
 
         self.cmdOutput.AddStyledMessage(message, type)
 
-        if event.type in ("warning", "error"):
+        if event.type in {"warning", "error"}:
             self.contentChanged.emit(notification=Notification.MAKE_VISIBLE)
         else:
             self.contentChanged.emit(notification=Notification.HIGHLIGHT)

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -525,7 +525,7 @@ class TreeCtrlComboPopup(ListCtrlComboPopup):
             else:
                 renamed_elements.append(elementdict[elem])
 
-        if element in ("stds", "strds", "str3ds", "stvds"):
+        if element in {"stds", "strds", "str3ds", "stvds"}:
             if not self.tgis_error:
                 import grass.temporal as tgis
 
@@ -603,7 +603,7 @@ class TreeCtrlComboPopup(ListCtrlComboPopup):
                 collapse = True
 
                 if sel == 0:  # collapse all except PERMANENT and current
-                    if mapset in ("PERMANENT", curr_mapset):
+                    if mapset in {"PERMANENT", curr_mapset}:
                         collapse = False
                 elif sel == 1:  # collapse all except PERMANENT
                     if mapset == "PERMANENT":
@@ -776,7 +776,7 @@ class TreeCtrlComboPopup(ListCtrlComboPopup):
         ListCtrlComboPopup.SetData(self, **kargs)
         if "type" in kargs:
             self.type = kargs["type"]
-            if self.type in ("stds", "strds", "str3ds", "stvds"):
+            if self.type in {"stds", "strds", "str3ds", "stvds"}:
                 # Initiate the temporal framework. Catch database error
                 # and set the error flag for the stds listing.
                 try:
@@ -1541,7 +1541,7 @@ class GdalSelect(wx.Panel):
             }
 
         for name, ext in sorted(extList.items()):
-            if name in ("ESRI Shapefile", "GeoTIFF"):
+            if name in {"ESRI Shapefile", "GeoTIFF"}:
                 continue
             fileMask += "%(name)s (*.%(low)s;*.%(up)s)|*.%(low)s;*.%(up)s|" % {
                 "name": name,
@@ -1726,7 +1726,7 @@ class GdalSelect(wx.Panel):
                     break
             optList = list()
             for k, v in data.items():
-                if k in ("format", "conninfo", "topology"):
+                if k in {"format", "conninfo", "topology"}:
                     continue
                 optList.append("%s=%s" % (k, v))
             options = ",".join(optList)
@@ -2097,11 +2097,11 @@ class GdalSelect(wx.Panel):
     def GetDsn(self):
         """Get datasource name"""
         if self._sourceType == "db":
-            if self.dbWidgets["format"].GetStringSelection() in (
+            if self.dbWidgets["format"].GetStringSelection() in {
                 "PostgreSQL",
                 "PostgreSQL/PostGIS",
                 "PostGIS Raster driver",
-            ):
+            }:
                 ret = RunCommand("db.login", read=True, quiet=True, flags="p")
                 message = _(
                     "PostgreSQL/PostGIS login was not set."
@@ -2157,7 +2157,7 @@ class GdalSelect(wx.Panel):
                 dsn = "/vsizip/" + dsn
             elif ext == ".gzip":
                 dsn = "/vsigzip/" + dsn
-            elif ext in (".tar", ".tar.gz", ".tgz"):
+            elif ext in {".tar", ".tar.gz", ".tgz"}:
                 dsn = "/vsitar/" + dsn
 
         return dsn
@@ -2165,22 +2165,22 @@ class GdalSelect(wx.Panel):
     def SetDatabase(self, db):
         """Update database panel."""
         sizer = self.dbPanel.GetSizer()
-        showBrowse = db in ("SQLite", "SQLite / Spatialite", "Rasterlite")
+        showBrowse = db in {"SQLite", "SQLite / Spatialite", "Rasterlite"}
         showDirbrowse = db in ("FileGDB")
-        showChoice = db in (
+        showChoice = db in {
             "PostgreSQL",
             "PostgreSQL/PostGIS",
             "PostGIS WKT Raster driver",
             "PostGIS Raster driver",
-        )
+        }
         enableFeatType = (
             self.dest
             and self.ogr
             and db
-            in (
+            in {
                 "PostgreSQL",
                 "PostgreSQL/PostGIS",
-            )
+            }
         )
         showText = not (showBrowse or showChoice or showDirbrowse)
 

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -1137,10 +1137,10 @@ class PreferencesDialog(PreferencesBaseDialog):
         #
 
         # see initialization of nviz GLWindow
-        if globalvar.CheckWxVersion(version=[2, 8, 11]) and sys.platform not in (
+        if globalvar.CheckWxVersion(version=[2, 8, 11]) and sys.platform not in {
             "win32",
             "darwin",
-        ):
+        }:
             box = StaticBox(
                 parent=panel,
                 id=wx.ID_ANY,

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -538,7 +538,7 @@ class SymbolButton(BitmapTextButton):
         elif usage == "pause":
             self.DrawPause(dc, size)
 
-        if sys.platform not in ("win32", "darwin"):
+        if sys.platform not in {"win32", "darwin"}:
             buffer.SetMaskColour(maskColor)
         self.SetBitmapLabel(buffer)
         dc.SelectObject(wx.NullBitmap)

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -63,7 +63,7 @@ def get_translated_value(key, value):
         return _("{} sec".format(value))
     elif key == "status":
         return _(value.capitalize())
-    elif key in ("mask2d", "mask3d"):
+    elif key in {"mask2d", "mask3d"}:
         return _(str(value))
 
 

--- a/gui/wxpython/iscatt/controllers.py
+++ b/gui/wxpython/iscatt/controllers.py
@@ -421,7 +421,7 @@ class ScattsManager:
             if not scatt["scatt"]:
                 continue
             scatt["scatt"].SetSelectionPolygonMode(activate)
-            if not activate and self.plot_mode not in ["zoom", "pan", "zoom_extend"]:
+            if not activate and self.plot_mode not in {"zoom", "pan", "zoom_extend"}:
                 self.SetPlotsMode(None)
 
         self.render_mgr.RunningProcessDone()
@@ -740,9 +740,9 @@ class CategoriesManager:
         update_cat_rast = []
 
         for k, v in attrs_dict.items():
-            if not render and k in ["color", "opacity", "show", "nstd"]:
+            if not render and k in {"color", "opacity", "show", "nstd"}:
                 render = True
-            if k in ["color", "name"]:
+            if k in {"color", "name"}:
                 update_cat_rast.append(k)
 
             self.cats[cat_id][k] = v

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -195,7 +195,7 @@ def _regionToCellHead(region):
     }
 
     for k, v in region.items():
-        if k in ["rows", "cols", "cells", "zone"]:  # zone added in r65224
+        if k in {"rows", "cols", "cells", "zone"}:  # zone added in r65224
             v = int(v)
         else:
             v = float(v)

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -809,7 +809,7 @@ def _parseRegion(region_str):
 
     for param in region_str:
         k, v = param.split("=")
-        if k in ["rows", "cols", "cells"]:
+        if k in {"rows", "cols", "cells"}:
             v = int(v)
         else:
             v = float(v)
@@ -837,7 +837,7 @@ def GetRasterInfo(rast):
             if v != "CELL":
                 return None
             pass
-        elif k in ["rows", "cols", "cells", "min", "max"]:
+        elif k in {"rows", "cols", "cells", "min", "max"}:
             v = int(v)
         else:
             v = float(v)

--- a/gui/wxpython/iscatt/toolbars.py
+++ b/gui/wxpython/iscatt/toolbars.py
@@ -150,7 +150,7 @@ class MainToolbar(BaseToolbar):
         if event.IsChecked():
             for i_tool_data in self.controller.data:
                 i_tool_name = get_tool_name(i_tool_data[0])
-                if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
+                if not i_tool_name or i_tool_name in {"cats_mgr", "sel_pol_mode"}:
                     continue
                 if i_tool_name == tool_name:
                     continue
@@ -175,7 +175,7 @@ class MainToolbar(BaseToolbar):
     def UnsetMode(self):
         for i_tool_data in self.controller.data:
             i_tool_name = get_tool_name(i_tool_data[0])
-            if not i_tool_name or i_tool_name in ["cats_mgr", "sel_pol_mode"]:
+            if not i_tool_name or i_tool_name in {"cats_mgr", "sel_pol_mode"}:
                 continue
             i_tool_id = vars(self)[i_tool_name]
             self.ToggleTool(i_tool_id, False)
@@ -309,7 +309,7 @@ class EditingToolbar(BaseToolbar):
         self.scatt_mgr.modeSet.connect(self.ModeSet)
 
     def ModeSet(self, mode):
-        if mode in ["zoom", "pan", "zoom_extend", None]:
+        if mode in {"zoom", "pan", "zoom_extend", None}:
             self.UnsetMode()
 
     def UnsetMode(self):

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -1128,7 +1128,7 @@ class GMFrame(wx.Frame):
 
         # check list of dummy commands for GUI modules that do not have GRASS
         # bin modules or scripts.
-        if cmd in ["vcolors", "r.mapcalc", "r3.mapcalc"]:
+        if cmd in {"vcolors", "r.mapcalc", "r3.mapcalc"}:
             return cmdlist
 
         try:
@@ -1420,7 +1420,7 @@ class GMFrame(wx.Frame):
         # use chdir or dialog
         if cmd and len(cmd) == 2:
             write_beginning(parameter=cmd[1])
-            if cmd[1] in ["-h", "--h", "--help", "help"]:
+            if cmd[1] in {"-h", "--h", "--help", "help"}:
                 write_help()
                 write_end()
                 return
@@ -1985,7 +1985,7 @@ class GMFrame(wx.Frame):
     def AddOrUpdateMap(self, mapName, ltype):
         """Add map layer or update"""
         # start new map display if no display is available
-        if ltype not in ["raster", "raster_3d", "vector"]:
+        if ltype not in {"raster", "raster_3d", "vector"}:
             GError(parent=self, message=_("Unsupported map layer type <%s>.") % ltype)
             return
 

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -490,7 +490,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                 same = False
                 break
 
-        if ltype not in ("group", "command"):
+        if ltype not in {"group", "command"}:
             if numSelected == 1:
                 self.popupMenu.AppendSeparator()
                 if not (ltype == "raster_3d" or self.mapdisplay.IsPaneShown("3d")):
@@ -517,17 +517,17 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                     wx.EVT_MENU, self.OnPopupProperties, id=self.popupID["properties"]
                 )
 
-                if ltype in (
+                if ltype in {
                     "raster",
                     "vector",
                     "raster_3d",
-                ) and self.mapdisplay.IsPaneShown("3d"):
+                } and self.mapdisplay.IsPaneShown("3d"):
                     self.popupMenu.Append(self.popupID["nviz"], _("3D view properties"))
                     self.Bind(
                         wx.EVT_MENU, self.OnNvizProperties, id=self.popupID["nviz"]
                     )
 
-            if same and ltype in ("raster", "vector", "rgb", "raster_3d"):
+            if same and ltype in {"raster", "vector", "rgb", "raster_3d"}:
                 self.popupMenu.AppendSeparator()
                 item = wx.MenuItem(
                     self.popupMenu,
@@ -1370,9 +1370,9 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         gisenv = grass.gisenv()
         if not (gisenv["GISDBASE"] == grassdb and gisenv["LOCATION_NAME"] == location):
             return
-        if action not in ("delete", "rename"):
+        if action not in {"delete", "rename"}:
             return
-        if element in ("raster", "vector", "raster_3d"):
+        if element in {"raster", "vector", "raster_3d"}:
             name = map + "@" + mapset if "@" not in map else map
             items = self.FindItemByData(key="name", value=name)
             if items:
@@ -1706,7 +1706,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             self.SetLayerInfo(layer, key="cmd", value=module.GetCmd())
         elif self.GetLayerInfo(layer, key="type") != "command":
             cmd = [ltype2command[ltype]]
-            if ltype in ("raster", "rgb"):
+            if ltype in {"raster", "rgb"}:
                 if UserSettings.Get(
                     group="rasterLayer", key="opaque", subkey="enabled"
                 ):
@@ -1956,7 +1956,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             group="display", key="autoZooming", subkey="enabled"
         ):
             mapLayer = self.GetLayerInfo(layer, key="maplayer")
-            if mapLayer.GetType() in ("raster", "vector"):
+            if mapLayer.GetType() in {"raster", "vector"}:
                 self.mapdisplay.MapWindow.ZoomToMap(
                     layers=[
                         mapLayer,
@@ -2183,7 +2183,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
                 )
             ):
                 mapLayer = self.GetLayerInfo(layer, key="maplayer")
-                if mapLayer.GetType() in ("raster", "vector"):
+                if mapLayer.GetType() in {"raster", "vector"}:
                     self.mapdisplay.MapWindow.ZoomToMap(
                         layers=[
                             mapLayer,
@@ -2426,7 +2426,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
     def _createCommandCtrl(self):
         """Creates text control for command layer"""
         height = 25
-        if sys.platform in ("win32", "darwin"):
+        if sys.platform in {"win32", "darwin"}:
             height = 40
         ctrl = TextCtrl(
             self,

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -149,7 +149,7 @@ class WorkspaceManager:
                 style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
             )
             dlg.CenterOnParent()
-            if dlg.ShowModal() in [wx.ID_NO, wx.ID_CANCEL]:
+            if dlg.ShowModal() in {wx.ID_NO, wx.ID_CANCEL}:
                 return False
         else:
             # TODO: copy from ChangeLocation function

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2298,7 +2298,7 @@ class SummaryPage(TitledPage):
         global coordsys
 
         # print coordsys,proj4string
-        if coordsys in ("proj", "epsg", "iau", "wkt", "file"):
+        if coordsys in {"proj", "epsg", "iau", "wkt", "file"}:
             extra_opts = {}
             extra_opts["project"] = "project"
             extra_opts["getErrorMsg"] = True

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -1279,7 +1279,7 @@ class GMFrame(wx.Frame):
 
         # check list of dummy commands for GUI modules that do not have GRASS
         # bin modules or scripts.
-        if cmd in ["vcolors", "r.mapcalc", "r3.mapcalc"]:
+        if cmd in {"vcolors", "r.mapcalc", "r3.mapcalc"}:
             return cmdlist
 
         try:
@@ -1571,7 +1571,7 @@ class GMFrame(wx.Frame):
         # use chdir or dialog
         if cmd and len(cmd) == 2:
             write_beginning(parameter=cmd[1])
-            if cmd[1] in ["-h", "--h", "--help", "help"]:
+            if cmd[1] in {"-h", "--h", "--help", "help"}:
                 write_help()
                 write_end()
                 return
@@ -2133,7 +2133,7 @@ class GMFrame(wx.Frame):
     def AddOrUpdateMap(self, mapName, ltype):
         """Add map layer or update"""
         # start new map display if no display is available
-        if ltype not in ["raster", "raster_3d", "vector"]:
+        if ltype not in {"raster", "raster_3d", "vector"}:
             GError(parent=self, message=_("Unsupported map layer type <%s>.") % ltype)
             return
 

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1014,10 +1014,10 @@ class MapPanel(SingleMapPanel, MainPageBase):
                 ltype = layer.maplayer.GetType()
                 if ltype == "raster":
                     rast.append(name)
-                elif ltype in ("rgb", "his"):
+                elif ltype in {"rgb", "his"}:
                     for iname in name.split("\n"):
                         rast.append(iname)
-                elif ltype in ("vector", "thememap", "themechart"):
+                elif ltype in {"vector", "thememap", "themechart"}:
                     vect.append(name)
             if vect:
                 # check for vector maps open to be edited

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -196,7 +196,7 @@ class DMonMap(Map):
 
                 args = {}
 
-                if ltype in ("barscale", "rastleg", "northarrow", "text", "vectleg"):
+                if ltype in {"barscale", "rastleg", "northarrow", "text", "vectleg"}:
                     # TODO: this is still not optimal
                     # it is there to prevent adding the same overlay multiple times
                     if cmd in self.oldOverlays:

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -549,7 +549,7 @@ class SbGoTo(SbItem):
                 projIn = settings
                 projOut = RunCommand("g.proj", flags="jf", read=True)
                 proj = projIn.split(" ")[0].split("=")[1]
-                if proj in ("ll", "latlong", "longlat"):
+                if proj in {"ll", "latlong", "longlat"}:
                     e, n = utils.DMS2Deg(e, n)
                     proj, coord1 = utils.ReprojectCoordinates(
                         coord=(e, n), projIn=projIn, projOut=projOut, flags="d"
@@ -629,7 +629,7 @@ class SbGoTo(SbItem):
                     flags="d",
                 )
                 if coord:
-                    if proj in ("ll", "latlong", "longlat") and format == "DMS":
+                    if proj in {"ll", "latlong", "longlat"} and format == "DMS":
                         return "%s" % utils.Deg2DMS(
                             coord[0], coord[1], precision=precision
                         )
@@ -807,7 +807,7 @@ class SbCoordinates(SbTextItem):
                 )
                 if coord:
                     e, n = coord
-                    if proj in ("ll", "latlong", "longlat") and format == "DMS":
+                    if proj in {"ll", "latlong", "longlat"} and format == "DMS":
                         return utils.Deg2DMS(e, n, precision=precision)
                     else:
                         return "%.*f; %.*f" % (precision, e, precision, n)
@@ -897,7 +897,7 @@ class SbRegionExtent(SbTextItem):
                     coord=(region["ewres"], region["nsres"]), projOut=projOut, flags="d"
                 )
                 if coord1 and coord2:
-                    if proj in ("ll", "latlong", "longlat") and format == "DMS":
+                    if proj in {"ll", "latlong", "longlat"} and format == "DMS":
                         w, s = utils.Deg2DMS(
                             coord1[0], coord1[1], string=False, precision=precision
                         )

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -417,7 +417,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         # polyline is a series of connected lines defined as sequence of points
         # lines are individual, not connected lines which must be drawn as 1
         # object (e.g. cross)
-        elif pdctype in ("polyline", "lines"):
+        elif pdctype in {"polyline", "lines"}:
             if pen:
                 pdc.SetBrush(wx.Brush(wx.CYAN, wx.TRANSPARENT))
                 pdc.SetPen(pen)
@@ -1526,7 +1526,7 @@ class BufferedMapWindow(MapWindowBase, Window):
             self.mouse["end"] = event.GetPosition()
             if event.LeftIsDown() and not (
                 digitToolbar
-                and digitToolbar.GetAction() in ("moveLine",)
+                and digitToolbar.GetAction() in {"moveLine",}
                 and len(self.digit.GetDisplay().GetSelected()) > 0
             ):
                 self.MouseDraw(pdc=self.pdcTmp)
@@ -1574,7 +1574,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         self.mouse["end"] = event.GetPosition()
         coordinates = self.Pixel2Cell(self.mouse["end"])
 
-        if self.mouse["use"] in ["zoom", "pan"]:
+        if self.mouse["use"] in {"zoom", "pan"}:
             # set region in zoom or pan
             begin = self.mouse["begin"]
             end = self.mouse["end"]

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -1526,7 +1526,7 @@ class BufferedMapWindow(MapWindowBase, Window):
             self.mouse["end"] = event.GetPosition()
             if event.LeftIsDown() and not (
                 digitToolbar
-                and digitToolbar.GetAction() in {"moveLine",}
+                and digitToolbar.GetAction() in {"moveLine"}
                 and len(self.digit.GetDisplay().GetSelected()) > 0
             ):
                 self.MouseDraw(pdc=self.pdcTmp)

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -787,7 +787,7 @@ class ColorTable(wx.Frame):
                 continue
 
             if (
-                rule["value"] not in ("nv", "default")
+                rule["value"] not in {"nv", "default"}
                 and rule["value"][-1] != "%"
                 and not self._IsNumber(rule["value"])
             ):

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -631,10 +631,10 @@ class OgrImportDialog(ImportDialog):
         if (
             self.dsnInput.GetType() == "db"
             and self.dsnInput.GetFormat()
-            in (
+            in {
                 "PostgreSQL",
                 "PostgreSQL/PostGIS",
-            )
+            }
             and "GRASS_VECTOR_OGR" not in os.environ
         ):
             self.popOGR = True

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -85,10 +85,10 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         # for wxGTK we need to set WX_GL_DEPTH_SIZE to draw vectors correctly
         # but we don't know the right value
         # in wxpython 2.9, there is IsDisplaySupported
-        if CheckWxVersion(version=[2, 8, 11]) and sys.platform not in (
+        if CheckWxVersion(version=[2, 8, 11]) and sys.platform not in {
             "win32",
             "darwin",
-        ):
+        }:
             depthBuffer = int(
                 UserSettings.Get(group="display", key="nvizDepthBuffer", subkey="value")
             )
@@ -217,10 +217,10 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
 
         self.Bind(wx.EVT_CLOSE, self.OnClose)
 
-        if CheckWxVersion(version=[2, 8, 11]) and sys.platform not in (
+        if CheckWxVersion(version=[2, 8, 11]) and sys.platform not in {
             "win32",
             "darwin",
-        ):
+        }:
             wx.CallLater(3000, self._warningDepthBuffer)
 
         # cplanes cannot be initialized now
@@ -478,7 +478,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         Updates self.imagelist"""
         # update images (legend and text)
         for oid, overlay in self.overlays.items():
-            if not overlay.IsShown() or overlay.name in ("barscale", "northarrow"):
+            if not overlay.IsShown() or overlay.name in {"barscale", "northarrow"}:
                 continue
             if oid not in [t.GetId() for t in self.imagelist]:  # new
                 self.CreateTexture(overlay=overlay)
@@ -557,7 +557,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             self.render["quick"] = False
             self.Refresh(False)
 
-        elif key in (wx.WXK_UP, wx.WXK_DOWN, wx.WXK_LEFT, wx.WXK_RIGHT):
+        elif key in {wx.WXK_UP, wx.WXK_DOWN, wx.WXK_LEFT, wx.WXK_RIGHT}:
             if not self.fly["mouseControl"]:
                 if not self.timerFly.IsRunning():
                     sx, sy = self.GetClientSize()
@@ -575,9 +575,9 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 elif key == wx.WXK_DOWN:
                     self.ChangeFlySpeed(increase=False)
 
-        elif key in (wx.WXK_HOME, wx.WXK_PAGEUP) and self.timerFly.IsRunning():
+        elif key in {wx.WXK_HOME, wx.WXK_PAGEUP} and self.timerFly.IsRunning():
             self.ChangeFlySpeed(increase=True)
-        elif key in (wx.WXK_END, wx.WXK_PAGEDOWN) and self.timerFly.IsRunning():
+        elif key in {wx.WXK_END, wx.WXK_PAGEDOWN} and self.timerFly.IsRunning():
             self.ChangeFlySpeed(increase=False)
 
         event.Skip()
@@ -806,7 +806,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             # and moreover we are in left up
             self.mapQueried.emit(x=self.mouse["end"][0], y=self.mouse["end"][1])
 
-        elif self.mouse["use"] in ("arrow", "scalebar"):
+        elif self.mouse["use"] in {"arrow", "scalebar"}:
             self.lmgr.nviz.FindWindowById(
                 self.lmgr.nviz.win["decoration"][self.mouse["use"]]["place"]
             ).SetValue(False)
@@ -1343,7 +1343,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 item = self.tree.GetNextItem(item)
                 continue
 
-            if not item.IsChecked() or type not in ("raster", "vector", "raster_3d"):
+            if not item.IsChecked() or type not in {"raster", "vector", "raster_3d"}:
                 item = self.tree.GetNextItem(item)
                 continue
 
@@ -1544,7 +1544,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                         continue
                     if isinstance(data[sec][sec1], dict):
                         for sec2 in data[sec][sec1].keys():
-                            if sec2 not in ("all", "init", "id"):
+                            if sec2 not in {"all", "init", "id"}:
                                 data[sec][sec1][sec2]["update"] = None
                     elif isinstance(data[sec][sec1], list):
                         for i in range(len(data[sec][sec1])):
@@ -1555,7 +1555,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
 
         # set id
         if id > 0:
-            if mapType in ("raster", "raster_3d"):
+            if mapType in {"raster", "raster_3d"}:
                 data[nvizType]["object"] = {"id": id, "init": False}
             elif mapType == "vector":
                 data["vector"][nvizType]["object"] = {"id": id, "init": False}
@@ -1585,7 +1585,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         """
         layer = self.tree.GetLayerInfo(item, key="maplayer")
 
-        if layer.type not in ("raster", "raster_3d"):
+        if layer.type not in {"raster", "raster_3d"}:
             return
 
         if layer.type == "raster":
@@ -1600,7 +1600,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             id = -1
 
         if id < 0:
-            if layer.type in ("raster", "raster_3d"):
+            if layer.type in {"raster", "raster_3d"}:
                 self.log.WriteError("%s <%s> %s" % (errorMsg, layer.name, _("failed")))
             else:
                 self.log.WriteError(_("Unsupported layer type '%s'") % layer.type)
@@ -1714,7 +1714,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         """
         layer = self.tree.GetLayerInfo(item, key="maplayer")
 
-        if layer.type not in ("raster", "raster_3d"):
+        if layer.type not in {"raster", "raster_3d"}:
             return
 
         data = self.tree.GetLayerInfo(item, key="nviz")

--- a/gui/wxpython/nviz/preferences.py
+++ b/gui/wxpython/nviz/preferences.py
@@ -704,7 +704,7 @@ class NvizPreferencesDialog(PreferencesBaseDialog):
                 group, key, subkey, subkey1 = gks.split(":")
                 value = self.settings.Get(group, key, [subkey, subkey1])
             if subkey == "position":
-                if subkey1 in ("x", "y"):
+                if subkey1 in {"x", "y"}:
                     value = float(value) * 100
             win = self.FindWindowById(self.winId[gks])
             if win.GetName() == "GetSelection":
@@ -731,7 +731,7 @@ class NvizPreferencesDialog(PreferencesBaseDialog):
                 value = win.GetValue()
 
             if subkey == "position":
-                if subkey1 in ("x", "y"):
+                if subkey1 in {"x", "y"}:
                     value = float(value) / 100
             if subkey1:
                 self.settings.Set(group, value, key, [subkey, subkey1])

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -263,7 +263,7 @@ class NvizToolWindow(GNotebook):
                     foldpanel.GetFoldPanel(panelIdx).GetParent().GetGrandParent()
                 )
                 width = self.GetSize()[0]
-                if sys.platform in ("darwin", "win32"):
+                if sys.platform in {"darwin", "win32"}:
                     width -= 60  # 60px right margin to show scrollbar
                 scrolledPanel.SetVirtualSize(width=width, height=length[2])
                 scrolledPanel.Layout()
@@ -1086,7 +1086,7 @@ class NvizToolWindow(GNotebook):
                 parent=panel, id=wx.ID_ANY, size=(100, -1), choices=[_("map")]
             )
 
-            if code not in ("color", "shine"):
+            if code not in {"color", "shine"}:
                 use.Insert(item=_("unset"), pos=0)
                 self.win["surface"][code]["required"] = False
             else:
@@ -2926,7 +2926,7 @@ class NvizToolWindow(GNotebook):
         for attr, value in data["constant"].items():
             if attr == "color":
                 value = self._getColorFromString(value)
-            if attr in ("color", "value", "resolution", "transp"):
+            if attr in {"color", "value", "resolution", "transp"}:
                 if attr == "transp":
                     self.FindWindowById(self.win["constant"][attr]).SetValue(
                         self._getPercent(value)
@@ -3036,7 +3036,7 @@ class NvizToolWindow(GNotebook):
             else:
                 use = None
             # check for required properties
-            if code not in ("topo", "color", "shine"):
+            if code not in {"topo", "color", "shine"}:
                 use.Insert(item=_("unset"), pos=0)
                 self.win["volume"][code]["required"] = False
             else:
@@ -3091,7 +3091,7 @@ class NvizToolWindow(GNotebook):
                 value = SpinCtrl(parent=panel, id=wx.ID_ANY, size=size, initial=0)
                 if code == "topo":
                     value.SetRange(minVal=-1e9, maxVal=1e9)
-                elif code in ("shine", "transp"):
+                elif code in {"shine", "transp"}:
                     value.SetRange(minVal=0, maxVal=100)
 
                 value.Bind(wx.EVT_SPINCTRL, self.OnVolumeIsosurfMap)
@@ -3483,7 +3483,7 @@ class NvizToolWindow(GNotebook):
         else:
             self.PostViewEvent(zExag=False)
 
-        if winName in ("persp", "twist"):
+        if winName in {"persp", "twist"}:
             convert = int
         else:
             convert = float
@@ -3687,7 +3687,7 @@ class NvizToolWindow(GNotebook):
     def EnablePage(self, name, enabled=True):
         """Enable/disable all widgets on page"""
         for key, item in self.win[name].items():
-            if key in ("map", "surface", "new", "planes"):
+            if key in {"map", "surface", "new", "planes"}:
                 continue
             if isinstance(item, dict):
                 for skey, sitem in self.win[name][key].items():
@@ -3706,7 +3706,7 @@ class NvizToolWindow(GNotebook):
 
     def SetMapObjUseMap(self, nvizType, attrb, map=None):
         """Update dialog widgets when attribute type changed"""
-        if attrb in ("topo", "color", "shine"):
+        if attrb in {"topo", "color", "shine"}:
             incSel = -1  # decrement selection (no 'unset')
         else:
             incSel = 0
@@ -3998,10 +3998,10 @@ class NvizToolWindow(GNotebook):
         self.AdjustSliderRange(slider=slider, value=value)
 
         for win in self.win["surface"]["position"].values():
-            if win in (
+            if win in {
                 self.win["surface"]["position"]["axis"],
                 self.win["surface"]["position"]["reset"],
-            ):
+            }:
                 continue
             else:
                 self.FindWindowById(win).SetValue(value)
@@ -4831,10 +4831,10 @@ class NvizToolWindow(GNotebook):
         self.AdjustSliderRange(slider=slider, value=value)
 
         for win in self.win["volume"]["position"].values():
-            if win in (
+            if win in {
                 self.win["volume"]["position"]["axis"],
                 self.win["volume"]["position"]["reset"],
-            ):
+            }:
                 continue
             else:
                 self.FindWindowById(win).SetValue(value)
@@ -5251,7 +5251,7 @@ class NvizToolWindow(GNotebook):
 
                 self.FindWindowById(self.win["view"]["persp"][control]).SetValue(pval)
 
-        elif pageId in ("surface", "vector", "volume"):
+        elif pageId in {"surface", "vector", "volume"}:
             name = self.FindWindowById(self.win[pageId]["map"]).GetValue()
             data = self.GetLayerData(pageId)
             if data:
@@ -5830,7 +5830,7 @@ class NvizToolWindow(GNotebook):
         """Get named page"""
         if name == "view":
             self.SetSelection(0)
-        elif name in ("surface", "vector", "volume"):
+        elif name in {"surface", "vector", "volume"}:
             self.SetSelection(1)
         else:
             self.SetSelection(2)

--- a/gui/wxpython/nviz/workspace.py
+++ b/gui/wxpython/nviz/workspace.py
@@ -79,7 +79,7 @@ class NvizSettings:
 
             if control == "wire-color":
                 value = str(value[0]) + ":" + str(value[1]) + ":" + str(value[2])
-            elif control in ("mode", "style", "shading"):
+            elif control in {"mode", "style", "shading"}:
                 if "mode" not in data["draw"]:
                     data["draw"]["mode"] = {}
                 continue

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -1267,7 +1267,7 @@ class MapFramePanel(Panel):
             self.scaleType = scaleType
             self.select.SetValue("")
 
-        if scaleType in (0, 1):  # automatic - region from raster map, saved region
+        if scaleType in {0, 1}:  # automatic - region from raster map, saved region
             if scaleType == 0:
                 # set map selection
                 self.rasterTypeRadio.Show()
@@ -2208,7 +2208,7 @@ class VPropertiesDialog(Dialog):
         self.ColorsPanel = selectPanel[self.type][0](notebook)
 
         self.OnOutline(None)
-        if self.type in ("points", "areas"):
+        if self.type in {"points", "areas"}:
             self.OnFill(None)
         self.OnColor(None)
 
@@ -2252,7 +2252,7 @@ class VPropertiesDialog(Dialog):
 
         # data type
         self.checkType1 = self.checkType2 = None
-        if self.type in ("lines", "points"):
+        if self.type in {"lines", "points"}:
             box = StaticBox(
                 parent=panel, id=wx.ID_ANY, label=" %s " % _("Feature type")
             )
@@ -3108,7 +3108,7 @@ class VPropertiesDialog(Dialog):
         self.choiceColumns.SetItems(cols)
 
         self.choiceColumns.SetSelection(0)
-        if self.type in ("points", "lines"):
+        if self.type in {"points", "lines"}:
             self.colorColChoice.SetItems(cols)
             self.colorColChoice.SetSelection(0)
 
@@ -3205,7 +3205,7 @@ class VPropertiesDialog(Dialog):
 
     def update(self):
         # feature type
-        if self.type in ("lines", "points"):
+        if self.type in {"lines", "points"}:
             featureType = None
             if self.checkType1.GetValue():
                 featureType = self.checkType1.GetName()
@@ -3235,7 +3235,7 @@ class VPropertiesDialog(Dialog):
             self.vPropertiesDict["masked"] = "n"
 
         # colors
-        if self.type in ("points", "areas"):
+        if self.type in {"points", "areas"}:
             if self.outlineCheck.GetValue():
                 self.vPropertiesDict["color"] = convertRGB(self.colorPicker.GetColour())
                 self.vPropertiesDict["width"] = self.widthSpin.GetValue()
@@ -4011,7 +4011,7 @@ class LegendDialog(PsmapDialog):
 
         if type == "CELL":
             self.discrete.SetValue(True)
-        elif type in ("FCELL", "DCELL"):
+        elif type in {"FCELL", "DCELL"}:
             self.continuous.SetValue(True)
         if event is None:
             if self.rLegendDict["discrete"] == "y":

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -1128,7 +1128,7 @@ class PsMapFrame(wx.Frame):
         for id in ids:
             itype = self.instruction[id].type
 
-            if itype in ("scalebar", "mapinfo", "image"):
+            if itype in {"scalebar", "mapinfo", "image"}:
                 drawRectangle = self.canvas.CanvasPaperCoordinates(
                     rect=self.instruction[id]["rect"], canvasToPaper=False
                 )
@@ -1157,7 +1157,7 @@ class PsMapFrame(wx.Frame):
                 )
                 self.canvas.RedrawSelectBox(id)
 
-            if itype in ("point", "line", "rectangle"):
+            if itype in {"point", "line", "rectangle"}:
                 drawRectangle = self.canvas.CanvasPaperCoordinates(
                     rect=self.instruction[id]["rect"], canvasToPaper=False
                 )
@@ -1243,7 +1243,7 @@ class PsMapFrame(wx.Frame):
                 )
                 self.canvas.RedrawSelectBox(id)
 
-            if itype in ("map", "vector", "raster", "labels"):
+            if itype in {"map", "vector", "raster", "labels"}:
                 if itype == "raster":  # set resolution
                     try:
                         info = grass.raster_info(self.instruction[id]["raster"])
@@ -1539,7 +1539,7 @@ class PsMapBufferedWindow(wx.Window):
             items = self.instruction.FindInstructionByType(itemType, list=True)
             for item in items:
                 instr = self.instruction[item.id]
-                if itemType in ("line", "rectangle"):
+                if itemType in {"line", "rectangle"}:
                     if itemType == "line":
                         e1, n1 = PaperMapCoordinates(
                             mapInstr=self.instruction[mapId],
@@ -1611,14 +1611,14 @@ class PsMapBufferedWindow(wx.Window):
 
     def MouseActions(self, event):
         """Mouse motion and button click notifier"""
-        disable = self.preview and self.mouse["use"] in (
+        disable = self.preview and self.mouse["use"] in {
             "pointer",
             "resize",
             "addMap",
             "addPoint",
             "addLine",
             "addRectangle",
-        )
+        }
         # zoom with mouse wheel
         if event.GetWheelRotation() != 0:
             self.OnMouseWheel(event)
@@ -1681,7 +1681,7 @@ class PsMapBufferedWindow(wx.Window):
         if self.preview:
             return
 
-        if self.mouse["use"] in ("pointer", "resize"):
+        if self.mouse["use"] in {"pointer", "resize"}:
             pos = event.GetPosition()
             foundResize = self.pdcTmp.FindObjects(pos[0], pos[1])
             if (
@@ -1724,7 +1724,7 @@ class PsMapBufferedWindow(wx.Window):
                 if self.instruction[self.dragId].type == "map":
                     self.constraint = False
                     self.mapBounds = self.pdcObj.GetIdBounds(self.dragId)
-                    if self.instruction[self.dragId]["scaleType"] in (0, 1, 2):
+                    if self.instruction[self.dragId]["scaleType"] in {0, 1, 2}:
                         self.constraint = True
                         self.mapBounds = self.pdcObj.GetIdBounds(self.dragId)
 
@@ -1734,7 +1734,7 @@ class PsMapBufferedWindow(wx.Window):
             elif found:
                 self.dragId = found[0]
                 self.RedrawSelectBox(self.dragId)
-                if self.instruction[self.dragId].type not in ("map", "rectangle"):
+                if self.instruction[self.dragId].type not in {"map", "rectangle"}:
                     self.pdcTmp.RemoveId(self.idResizeBoxTmp)
                     self.Refresh()
                 if self.instruction[self.dragId].type != "line":
@@ -1756,7 +1756,7 @@ class PsMapBufferedWindow(wx.Window):
         Recalculate zooming/resizing/moving and redraw.
         """
         # zoom in, zoom out
-        if self.mouse["use"] in ("zoomin", "zoomout"):
+        if self.mouse["use"] in {"zoomin", "zoomout"}:
             zoomR = self.pdcTmp.GetIdBounds(self.idZoomBoxTmp)
             self.pdcTmp.RemoveId(self.idZoomBoxTmp)
             self.Refresh()
@@ -1802,7 +1802,7 @@ class PsMapBufferedWindow(wx.Window):
                 )
                 self.instruction[mapId]["rect"] = newRectPaper
 
-                if self.instruction[mapId]["scaleType"] in (0, 1, 2):
+                if self.instruction[mapId]["scaleType"] in {0, 1, 2}:
                     if self.instruction[mapId]["scaleType"] == 0:
                         scale, foo, rect = AutoAdjust(
                             self,
@@ -1871,13 +1871,13 @@ class PsMapBufferedWindow(wx.Window):
             self.mouse["use"] = "pointer"
 
         # recalculate the position of objects after dragging
-        if self.mouse["use"] in ("pointer", "resize") and self.dragId != -1:
+        if self.mouse["use"] in {"pointer", "resize"} and self.dragId != -1:
             if self.mouse["begin"] != event.GetPosition():  # for double click
                 self.RecalculatePosition(ids=[self.dragId])
                 if self.instruction[self.dragId].type in self.openDialogs:
                     self.openDialogs[self.instruction[self.dragId].type].updateDialog()
 
-        elif self.mouse["use"] in ("addPoint", "addLine", "addRectangle"):
+        elif self.mouse["use"] in {"addPoint", "addLine", "addRectangle"}:
             endCoordinates = self.CanvasPaperCoordinates(
                 rect=Rect(event.GetX(), event.GetY(), 0, 0), canvasToPaper=True
             )[:2]
@@ -1887,7 +1887,7 @@ class PsMapBufferedWindow(wx.Window):
 
             if self.mouse["use"] == "addPoint":
                 self.parent.AddPoint(coordinates=endCoordinates)
-            elif self.mouse["use"] in ("addLine", "addRectangle"):
+            elif self.mouse["use"] in {"addLine", "addRectangle"}:
                 # not too small lines/rectangles
                 if sqrt(diffX * diffX + diffY * diffY) < 5:
                     self.pdcTmp.RemoveId(self.idZoomBoxTmp)
@@ -1951,13 +1951,13 @@ class PsMapBufferedWindow(wx.Window):
 
         elif event.LeftIsDown():
             # draw box when zooming, creating map
-            if self.mouse["use"] in (
+            if self.mouse["use"] in {
                 "zoomin",
                 "zoomout",
                 "addMap",
                 "addLine",
                 "addRectangle",
-            ):
+            }:
                 self.mouse["end"] = event.GetPosition()
                 r = Rect(
                     self.mouse["begin"][0],
@@ -1967,7 +1967,7 @@ class PsMapBufferedWindow(wx.Window):
                 )
                 r = self.modifyRectangle(r)
 
-                if self.mouse["use"] in ("addLine", "addRectangle"):
+                if self.mouse["use"] in {"addLine", "addRectangle"}:
                     if self.mouse["use"] == "addLine":
                         pdcType = "line"
                         lineCoords = (self.mouse["begin"], self.mouse["end"])
@@ -2125,26 +2125,26 @@ class PsMapBufferedWindow(wx.Window):
     def RecalculatePosition(self, ids):
         for id in ids:
             itype = self.instruction[id].type
-            if itype in ("map", "rectangle"):
+            if itype in {"map", "rectangle"}:
                 self.instruction[id]["rect"] = self.CanvasPaperCoordinates(
                     rect=self.pdcObj.GetIdBounds(id), canvasToPaper=True
                 )
                 self.RecalculateEN()
 
-            elif itype in (
+            elif itype in {
                 "mapinfo",
                 "rasterLegend",
                 "vectorLegend",
                 "image",
                 "northArrow",
-            ):
+            }:
                 self.instruction[id]["rect"] = self.CanvasPaperCoordinates(
                     rect=self.pdcObj.GetIdBounds(id), canvasToPaper=True
                 )
                 self.instruction[id]["where"] = self.CanvasPaperCoordinates(
                     rect=self.pdcObj.GetIdBounds(id), canvasToPaper=True
                 )[:2]
-                if itype in ("image", "northArrow"):
+                if itype in {"image", "northArrow"}:
                     self.RecalculateEN()
 
             elif itype == "point":
@@ -2322,14 +2322,14 @@ class PsMapBufferedWindow(wx.Window):
                         bb=oRect,
                     )
 
-                elif type in ("point", "line", "rectangle"):
+                elif type in {"point", "line", "rectangle"}:
                     instr = self.instruction[id]
                     color = self.instruction[id]["color"]
                     width = fcolor = coords = None
 
-                    if type in ("point", "rectangle"):
+                    if type in {"point", "rectangle"}:
                         fcolor = self.instruction[id]["fcolor"]
-                    if type in ("line", "rectangle"):
+                    if type in {"line", "rectangle"}:
                         width = self.instruction[id]["width"]
                     if type in ("line"):
                         point1, point2 = instr["where"][0], instr["where"][1]
@@ -2418,7 +2418,7 @@ class PsMapBufferedWindow(wx.Window):
             else:  # draw only rectangle with label
                 pdctype = "rectText"
 
-        if pdctype in ("rect", "rectText"):
+        if pdctype in {"rect", "rectText"}:
             pdc.DrawRectangle(*bb)
 
         if pdctype == "rectText":
@@ -2635,7 +2635,7 @@ class PsMapBufferedWindow(wx.Window):
             )
 
             # draw small marks signalizing resizing
-            if self.instruction[id].type in ("map", "rectangle"):
+            if self.instruction[id].type in {"map", "rectangle"}:
                 controlP = self.pdcObj.GetIdBounds(id).GetBottomRight()
                 rect = Rect(
                     controlP[0],

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -118,14 +118,14 @@ class Instruction:
         else:
             self.instruction.append(instruction)
         # add to drawable objects
-        if instruction.type not in (
+        if instruction.type not in {
             "page",
             "raster",
             "vector",
             "vProperties",
             "initMap",
             "labels",
-        ):
+        }:
             if instruction.type == "map":
                 self.objectsToDraw.insert(0, instruction.id)
             else:
@@ -201,9 +201,9 @@ class Instruction:
                     kwargs = {}
                     if instruction == "scalebar":
                         kwargs["scale"] = map["scale"]
-                    elif instruction in ("text", "eps", "point", "line", "rectangle"):
+                    elif instruction in {"text", "eps", "point", "line", "rectangle"}:
                         kwargs["mapInstruction"] = map
-                    elif instruction in ("vpoints", "vlines", "vareas"):
+                    elif instruction in {"vpoints", "vlines", "vareas"}:
                         kwargs["id"] = NewId()
                         kwargs["vectorMapNumber"] = vectorMapNumber
                         vectorMapNumber += 1
@@ -222,11 +222,11 @@ class Instruction:
                 buffer.append(line)
 
             elif line.startswith("border"):
-                if line.split()[1].lower() in ("n", "no", "none"):
+                if line.split()[1].lower() in {"n", "no", "none"}:
                     ok = self.SendToRead("border", [line])
                     if not ok:
                         return False
-                elif line.split()[1].lower() in ("y", "yes"):
+                elif line.split()[1].lower() in {"y", "yes"}:
                     instruction = "border"
                     isBuffer = True
                     buffer.append(line)
@@ -284,11 +284,11 @@ class Instruction:
                 buffer.append(line)
 
             elif line.startswith("colortable"):
-                if len(line.split()) == 2 and line.split()[1].lower() in (
+                if len(line.split()) == 2 and line.split()[1].lower() in {
                     "n",
                     "no",
                     "none",
-                ):
+                }:
                     break
                 instruction = "colortable"
                 isBuffer = True
@@ -451,7 +451,7 @@ class Instruction:
             instr = self.FindInstructionByType(i)
             if (
                 i
-                in (
+                in {
                     "text",
                     "vProperties",
                     "image",
@@ -459,7 +459,7 @@ class Instruction:
                     "point",
                     "line",
                     "rectangle",
-                )
+                }
                 or not instr
             ):
                 id = NewId()  # !vProperties expect subtype
@@ -470,7 +470,7 @@ class Instruction:
                         subType=instruction[1:],
                         env=self.env,
                     )
-                elif i in ("image", "northArrow"):
+                elif i in {"image", "northArrow"}:
                     commentFound = False
                     for line in text:
                         if line.find("# north arrow") >= 0:
@@ -642,7 +642,7 @@ class MapFrame(InstructionObject):
             region = self.instruction["region"]
             comment = "# g.region region=%s\n" % region
         # current region, fixed scale
-        elif self.instruction["scaleType"] in (2, 3):
+        elif self.instruction["scaleType"] in {2, 3}:
             comment = string.Template(
                 "# g.region n=$n s=$s e=$e w=$w rows=$rows cols=$cols \n"
             ).substitute(**region)
@@ -693,10 +693,10 @@ class MapFrame(InstructionObject):
                 if line.startswith("end"):
                     break
                 try:
-                    if line.split()[1].lower() in ("n", "no", "none"):
+                    if line.split()[1].lower() in {"n", "no", "none"}:
                         instr["border"] = "n"
                         break
-                    elif line.split()[1].lower() in ("y", "yes"):
+                    elif line.split()[1].lower() in {"y", "yes"}:
                         instr["border"] = "y"
                     elif line.startswith("width"):
                         instr["width"] = line.split()[1]
@@ -1050,7 +1050,7 @@ class Text(InstructionObject):
                 elif sub == "yoffset":
                     instr["yoffset"] = int(line.split(None, 1)[1])
                 elif sub == "opaque":
-                    if line.split(None, 1)[1].lower() in ("n", "none"):
+                    if line.split(None, 1)[1].lower() in {"n", "none"}:
                         instr["background"] = "none"
 
             except (IndexError, ValueError):
@@ -1550,14 +1550,14 @@ class Scalebar(InstructionObject):
                 elif line.startswith("length"):
                     instr["length"] = float(line.split()[1])
                 elif line.startswith("units"):
-                    if line.split()[1] in [
+                    if line.split()[1] in {
                         "auto",
                         "meters",
                         "kilometers",
                         "feet",
                         "miles",
                         "nautmiles",
-                    ]:
+                    }:
                         instr["unitsLength"] = line.split()[1]
                 elif line.startswith("height"):
                     instr["height"] = float(line.split()[1])
@@ -1568,9 +1568,9 @@ class Scalebar(InstructionObject):
                 elif line.startswith("segment"):
                     instr["segment"] = int(line.split()[1])
                 elif line.startswith("background"):
-                    if line.split()[1].strip().lower() in ("y", "yes"):
+                    if line.split()[1].strip().lower() in {"y", "yes"}:
                         instr["background"] = "y"
-                    elif line.split()[1].strip().lower() in ("n", "no", "none"):
+                    elif line.split()[1].strip().lower() in {"n", "no", "none"}:
                         instr["background"] = "n"
             except (IndexError, ValueError):
                 GError(_("Failed to read instruction %s") % instruction)
@@ -1701,19 +1701,19 @@ class RasterLegend(InstructionObject):
                     instr["min"] = float(line.split()[1])
                     instr["max"] = float(line.split()[2])
                 elif line.startswith("nodata"):
-                    if line.split()[1].strip().lower() in ("y", "yes"):
+                    if line.split()[1].strip().lower() in {"y", "yes"}:
                         instr["nodata"] = "y"
-                    elif line.split()[1].strip().lower() in ("n", "no", "none"):
+                    elif line.split()[1].strip().lower() in {"n", "no", "none"}:
                         instr["nodata"] = "n"
                 elif line.startswith("tickbar"):
-                    if line.split()[1].strip().lower() in ("y", "yes"):
+                    if line.split()[1].strip().lower() in {"y", "yes"}:
                         instr["tickbar"] = "y"
-                    elif line.split()[1].strip().lower() in ("n", "no", "none"):
+                    elif line.split()[1].strip().lower() in {"n", "no", "none"}:
                         instr["tickbar"] = "n"
                 elif line.startswith("discrete"):
-                    if line.split()[1].strip().lower() in ("y", "yes"):
+                    if line.split()[1].strip().lower() in {"y", "yes"}:
                         instr["discrete"] = "y"
-                    elif line.split()[1].strip().lower() in ("n", "no", "none"):
+                    elif line.split()[1].strip().lower() in {"n", "no", "none"}:
                         instr["discrete"] = "n"
 
             except (IndexError, ValueError):
@@ -1754,7 +1754,7 @@ class RasterLegend(InstructionObject):
                 cols = 1
 
             rinfo = grass.raster_info(raster)
-            if rinfo["datatype"] in ("DCELL", "FCELL"):
+            if rinfo["datatype"] in {"DCELL", "FCELL"}:
                 minim, maxim = rinfo["min"], rinfo["max"]
                 rows = ceil(maxim / cols)
             else:
@@ -2068,7 +2068,7 @@ class VProperties(InstructionObject):
         dic = self.instruction
         vInstruction = string.Template("v$subType $name\n").substitute(dic)
         # data selection
-        if self.subType in ("points", "lines"):
+        if self.subType in {"points", "lines"}:
             vInstruction += string.Template("    type $type\n").substitute(dic)
         if dic["connection"]:
             vInstruction += string.Template("    layer $layer\n").substitute(dic)
@@ -2079,7 +2079,7 @@ class VProperties(InstructionObject):
         vInstruction += string.Template("    masked $masked\n").substitute(dic)
         # colors
         vInstruction += string.Template("    color $color\n").substitute(dic)
-        if self.subType in ("points", "areas"):
+        if self.subType in {"points", "areas"}:
             if dic["color"] != "none":
                 vInstruction += string.Template("    width $width\n").substitute(dic)
             if dic["rgbcolumn"]:
@@ -2235,7 +2235,7 @@ class VProperties(InstructionObject):
             elif line.startswith("layer"):
                 instr["layer"] = line.split()[1]
             elif line.startswith("masked"):
-                if line.split()[1].lower() in ("y", "yes"):
+                if line.split()[1].lower() in {"y", "yes"}:
                     instr["masked"] = "y"
                 else:
                     instr["masked"] = "n"

--- a/gui/wxpython/rlisetup/sampling_frame.py
+++ b/gui/wxpython/rlisetup/sampling_frame.py
@@ -116,12 +116,12 @@ class RLiSetupMapPanel(wx.Panel):
             self._registeredGraphics = self.mapWindow.RegisterGraphicsToDraw(
                 graphicsType="line"
             )
-        elif self.samplingtype in [SamplingType.MUNITSR, SamplingType.MMVWINR]:
+        elif self.samplingtype in {SamplingType.MUNITSR, SamplingType.MMVWINR}:
             self.sampleFrameChanged = Signal("RLiSetupMapPanel.sampleFrameChanged")
             self._registeredGraphics = self.mapWindow.RegisterGraphicsToDraw(
                 graphicsType="rectangle"
             )
-        elif self.samplingtype in [SamplingType.MUNITSC, SamplingType.MMVWINC]:
+        elif self.samplingtype in {SamplingType.MUNITSC, SamplingType.MMVWINC}:
             self.afterCircleDrawn = Signal("RLiSetupMapPanel.afterCircleDrawn")
             self._registeredGraphics = self.mapWindow.RegisterGraphicsToDraw(
                 graphicsType="line"
@@ -404,7 +404,7 @@ class RLiSetupMapPanel(wx.Panel):
         item.SetPropertyVal("hide", False)
         self.mapWindow.ClearLines()
         self._registeredGraphics.Draw()
-        if self.samplingtype in [SamplingType.MUNITSR, SamplingType.MMVWINR]:
+        if self.samplingtype in {SamplingType.MUNITSR, SamplingType.MMVWINR}:
             dlg = wx.MessageDialog(
                 self,
                 "Is this area ok?",
@@ -475,9 +475,9 @@ class RLiSetupToolbar(BaseToolbar):
 
         if self.parent.samplingtype == SamplingType.REGIONS:
             self._default = self.digitizeregion
-        elif self.parent.samplingtype in [SamplingType.MUNITSR, SamplingType.MMVWINR]:
+        elif self.parent.samplingtype in {SamplingType.MUNITSR, SamplingType.MMVWINR}:
             self._default = self.digitizeunit
-        elif self.parent.samplingtype in [SamplingType.MUNITSC, SamplingType.MMVWINC]:
+        elif self.parent.samplingtype in {SamplingType.MUNITSC, SamplingType.MMVWINC}:
             self._default = self.digitizeunitc
         elif self.parent.samplingtype == SamplingType.VECT:
             self._default = None
@@ -502,14 +502,14 @@ class RLiSetupToolbar(BaseToolbar):
                 self.parent.OnDigitizeRegion,
                 wx.ITEM_CHECK,
             )
-        elif self.parent.samplingtype in [SamplingType.MUNITSR, SamplingType.MMVWINR]:
+        elif self.parent.samplingtype in {SamplingType.MUNITSR, SamplingType.MMVWINR}:
             drawTool = (
                 ("digitizeunit", icons["digitizeunit"].label),
                 icons["digitizeunit"],
                 self.parent.OnDraw,
                 wx.ITEM_CHECK,
             )
-        elif self.parent.samplingtype in [SamplingType.MUNITSC, SamplingType.MMVWINC]:
+        elif self.parent.samplingtype in {SamplingType.MUNITSC, SamplingType.MMVWINC}:
             drawTool = (
                 ("digitizeunitc", icons["digitizeunitc"].label),
                 icons["digitizeunitc"],

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -391,10 +391,10 @@ class RLIWizard:
 
         # MUNITSC = samplingtype=units, regionbox=mouse, shape=cirlce
         # MUNITSR = samplingtype=units, regionbox=mouse, shape=rectangle
-        elif self.samplingareapage.samplingtype in [
+        elif self.samplingareapage.samplingtype in {
             SamplingType.MUNITSR,
             SamplingType.MUNITSC,
-        ]:
+        }:
             # get the raster region into rastregion
             grass.use_temp_region()
             grass.run_command("g.region", raster=self.startpage.rast)
@@ -1646,19 +1646,19 @@ class UnitsMousePage(TitledPage):
             wx.FindWindowById(wx.ID_FORWARD).Enable(True)
         else:
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
-        if self.parent.samplingareapage.samplingtype in [
+        if self.parent.samplingareapage.samplingtype in {
             SamplingType.MVWIN,
             SamplingType.MMVWINR,
             SamplingType.MMVWINC,
-        ]:
+        }:
             self.title.SetLabel(_("Draw moving windows region"))
             self.sizer.Hide(self.regionNumPanel)
             wx.FindWindowById(wx.ID_FORWARD).Enable(True)
-        elif self.parent.samplingareapage.samplingtype in [
+        elif self.parent.samplingareapage.samplingtype in {
             SamplingType.UNITS,
             SamplingType.MUNITSR,
             SamplingType.MUNITSC,
-        ]:
+        }:
             self.title.SetLabel(_("Draw sampling region"))
             self.sizer.Show(self.regionNumPanel)
         if self.typeBox.GetSelection() == 2:
@@ -1668,22 +1668,22 @@ class UnitsMousePage(TitledPage):
     def OnType(self, event):
         chosen = self.typeBox.GetSelection()
         if chosen == 0:
-            if self.parent.samplingareapage.samplingtype in [
+            if self.parent.samplingareapage.samplingtype in {
                 SamplingType.MVWIN,
                 SamplingType.MMVWINR,
                 SamplingType.MMVWINC,
-            ]:
+            }:
                 self.parent.samplingareapage.samplingtype = SamplingType.MMVWINR
                 wx.FindWindowById(wx.ID_FORWARD).Enable(True)
             else:
                 self.parent.samplingareapage.samplingtype = SamplingType.MUNITSR
             self.drawtype = "rectangle"
         else:
-            if self.parent.samplingareapage.samplingtype in [
+            if self.parent.samplingareapage.samplingtype in {
                 SamplingType.MVWIN,
                 SamplingType.MMVWINR,
                 SamplingType.MMVWINC,
-            ]:
+            }:
                 self.parent.samplingareapage.samplingtype = SamplingType.MMVWINC
                 wx.FindWindowById(wx.ID_FORWARD).Enable(True)
             else:
@@ -1739,11 +1739,11 @@ class DrawSampleUnitsPage(TitledPage):
     def OnEnterPage(self, event):
         """Function during entering"""
 
-        if self.parent.samplingareapage.samplingtype in [
+        if self.parent.samplingareapage.samplingtype in {
             SamplingType.MVWIN,
             SamplingType.MMVWINC,
             SamplingType.MMVWINR,
-        ]:
+        }:
             self.numregions = 1
         else:
             self.numregions = int(self.parent.drawunits.numregions)

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -302,7 +302,7 @@ class LocationDownloadPanel(wx.Panel):
     def OnDownload(self, event):
         """Handle user-initiated action of download"""
         button_label = self.parent.download_button.GetLabel()
-        if button_label in (_("Download"), _("Do&wnload")):
+        if button_label in {_("Download"), _("Do&wnload")}:
             self._change_download_btn_label(
                 label=self._abort_btn_label,
                 tooltip=self._abort_btn_tooltip,

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -840,13 +840,13 @@ class TplotFrame(wx.Frame):
             xdata = []
             ydata = []
             for keys, values in self.timeDataR[name].items():
-                if keys in [
+                if keys in {
                     "temporalType",
                     "granularity",
                     "validTopology",
                     "unit",
                     "temporalDataType",
-                ]:
+                }:
                     continue
                 xdata.append(self.convert(values["start_datetime"]))
                 ydata.append(values["value"])
@@ -896,13 +896,13 @@ class TplotFrame(wx.Frame):
             ydata = []
             xcsv = []
             for keys, values in self.timeDataV[name_cat[0]][name_cat[1]].items():
-                if keys in [
+                if keys in {
                     "temporalType",
                     "granularity",
                     "validTopology",
                     "unit",
                     "temporalDataType",
-                ]:
+                }:
                     continue
                 xdata.append(self.convert(values["start_datetime"]))
                 if values["value"] == "":
@@ -956,13 +956,13 @@ class TplotFrame(wx.Frame):
             ydata = []
             xcsv = []
             for keys, values in self.timeDataV[name].items():
-                if keys in [
+                if keys in {
                     "temporalType",
                     "granularity",
                     "validTopology",
                     "unit",
                     "temporalDataType",
-                ]:
+                }:
                     continue
                 xdata.append(self.convert(values["start_datetime"]))
                 ydata.append(values["value"])

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -102,7 +102,7 @@ class VDigitWindow(BufferedMapWindow):
         )
         if (
             self.toolbar.GetAction() != "addLine"
-            or self.toolbar.GetAction("type") not in ("line", "boundary")
+            or self.toolbar.GetAction("type") not in {"line", "boundary"}
             or len(self.polycoords) == 0
         ):
             # we cannot provide info, so find out if it is something new
@@ -293,7 +293,7 @@ class VDigitWindow(BufferedMapWindow):
         except:
             return
 
-        if self.toolbar.GetAction("type") in ["point", "centroid"]:
+        if self.toolbar.GetAction("type") in {"point", "centroid"}:
             # add new point / centroiud
             east, north = self.Pixel2Cell(self.mouse["begin"])
             nfeat, fids = self.digit.AddFeature(
@@ -342,7 +342,7 @@ class VDigitWindow(BufferedMapWindow):
                     addRecordDlg.ShowModal()
                 addRecordDlg.Destroy()
 
-        elif self.toolbar.GetAction("type") in ["line", "boundary", "area"]:
+        elif self.toolbar.GetAction("type") in {"line", "boundary", "area"}:
             # add new point to the line
             self.polycoords.append(self.Pixel2Cell(event.GetPosition()))
             self.DrawLines(pdc=self.pdcTmp)
@@ -467,7 +467,7 @@ class VDigitWindow(BufferedMapWindow):
         self.moveInfo["id"] = list()
 
         # set pen
-        if self.toolbar.GetAction() in ["moveVertex", "editLine"]:
+        if self.toolbar.GetAction() in {"moveVertex", "editLine"}:
             pcolor = UserSettings.Get(
                 group="vdigit", key="symbol", subkey=["highlight", "color"]
             )
@@ -612,7 +612,7 @@ class VDigitWindow(BufferedMapWindow):
         action = self.toolbar.GetAction()
         if (
             action == "addLine"
-            and self.toolbar.GetAction("type") in ["line", "boundary", "area"]
+            and self.toolbar.GetAction("type") in {"line", "boundary", "area"}
         ) or action == "editLine":
             # add line or boundary -> remove last point from the line
             try:
@@ -635,7 +635,7 @@ class VDigitWindow(BufferedMapWindow):
 
             self.UpdateMap(render=False, renderVector=False)
 
-        elif action in [
+        elif action in {
             "deleteLine",
             "deleteArea",
             "moveLine",
@@ -652,11 +652,11 @@ class VDigitWindow(BufferedMapWindow):
             "queryLine",
             "breakLine",
             "typeConv",
-        ]:
+        }:
             # various tools -> unselected selected features
             self.digit.GetDisplay().SetSelected([])
 
-            if action in ["moveLine", "moveVertex", "editLine"] and hasattr(
+            if action in {"moveLine", "moveVertex", "editLine"} and hasattr(
                 self, "moveInfo"
             ):
                 del self.moveInfo
@@ -708,7 +708,7 @@ class VDigitWindow(BufferedMapWindow):
             event.Skip()
             return
 
-        if action not in ("moveVertex", "addVertex", "removeVertex", "editLine"):
+        if action not in {"moveVertex", "addVertex", "removeVertex", "editLine"}:
             # set pen
             self.pen = wx.Pen(
                 colour=UserSettings.Get(
@@ -725,7 +725,7 @@ class VDigitWindow(BufferedMapWindow):
                 style=wx.SOLID,
             )
 
-        if action in ("addVertex", "removeVertex", "splitLines"):
+        if action in {"addVertex", "removeVertex", "splitLines"}:
             # unselect
             self.digit.GetDisplay().SetSelected([])
 
@@ -735,7 +735,7 @@ class VDigitWindow(BufferedMapWindow):
         elif action == "editLine" and hasattr(self, "moveInfo"):
             self.OnLeftDownEditLine(event)
 
-        elif action in ("moveLine", "moveVertex", "editLine") and not hasattr(
+        elif action in {"moveLine", "moveVertex", "editLine"} and not hasattr(
             self, "moveInfo"
         ):
             self.OnLeftDownMoveLine(event)
@@ -743,7 +743,7 @@ class VDigitWindow(BufferedMapWindow):
         elif action in ("displayAttrs" "displayCats"):
             self.OnLeftDownDisplayCA(event)
 
-        elif action in ("copyCats", "copyAttrs"):
+        elif action in {"copyCats", "copyAttrs"}:
             self.OnLeftDownCopyCA(event)
 
         elif action == "copyLine":
@@ -762,7 +762,7 @@ class VDigitWindow(BufferedMapWindow):
         nselected = 0
         action = self.toolbar.GetAction()
         # -> delete line || move line || move vertex
-        if action in ("moveVertex", "editLine"):
+        if action in {"moveVertex", "editLine"}:
             if len(self.digit.GetDisplay().GetSelected()) == 0:
                 nselected = int(
                     self.digit.GetDisplay().SelectLineByPoint(pos1)["line"] != -1
@@ -799,7 +799,7 @@ class VDigitWindow(BufferedMapWindow):
 
                     self.UpdateMap(render=False)
 
-        elif action in ("copyCats", "copyAttrs"):
+        elif action in {"copyCats", "copyAttrs"}:
             if not hasattr(self, "copyCatsIds"):
                 # 'from' -> select by point
                 nselected = int(
@@ -851,7 +851,7 @@ class VDigitWindow(BufferedMapWindow):
                         )
 
         if nselected > 0:
-            if action in ("moveLine", "moveVertex") and hasattr(self, "moveInfo"):
+            if action in {"moveLine", "moveVertex"} and hasattr(self, "moveInfo"):
                 # get pseudoDC id of objects which should be redrawn
                 if action == "moveLine":
                     # -> move line
@@ -893,7 +893,7 @@ class VDigitWindow(BufferedMapWindow):
 
         else:  # no vector object found
             if not (
-                action in ("moveLine", "moveVertex")
+                action in {"moveLine", "moveVertex"}
                 and hasattr(self, "moveInfo")
                 and len(self.moveInfo["id"]) > 0
             ):
@@ -910,7 +910,7 @@ class VDigitWindow(BufferedMapWindow):
         if not pointOnLine:
             return
 
-        if self.toolbar.GetAction() in ["splitLine", "addVertex"]:
+        if self.toolbar.GetAction() in {"splitLine", "addVertex"}:
             self.UpdateMap(render=False)  # highlight object
             self.DrawCross(
                 pdc=self.pdcTmp,
@@ -1031,7 +1031,7 @@ class VDigitWindow(BufferedMapWindow):
             self.mouse["begin"] = self.mouse["end"]
 
         action = self.toolbar.GetAction()
-        if action in (
+        if action in {
             "deleteLine",
             "deleteArea",
             "moveLine",
@@ -1046,10 +1046,10 @@ class VDigitWindow(BufferedMapWindow):
             "breakLine",
             "typeConv",
             "connectLine",
-        ):
+        }:
             self.OnLeftUpVarious(event)
 
-        elif action in ("splitLine", "addVertex", "removeVertex"):
+        elif action in {"splitLine", "addVertex", "removeVertex"}:
             self.OnLeftUpModifyLine(event)
 
         elif action == "copyLine":
@@ -1067,7 +1067,7 @@ class VDigitWindow(BufferedMapWindow):
     def _onRightDown(self, event):
         # digitization tool (confirm action)
         action = self.toolbar.GetAction()
-        if action in ("moveLine", "moveVertex") and hasattr(self, "moveInfo"):
+        if action in {"moveLine", "moveVertex"} and hasattr(self, "moveInfo"):
             pFrom = self.moveInfo["begin"]
             pTo = self.Pixel2Cell(event.GetPosition())
 
@@ -1094,11 +1094,11 @@ class VDigitWindow(BufferedMapWindow):
     def _onRightUp(self, event):
         """Right mouse button released (confirm action)"""
         action = self.toolbar.GetAction()
-        if action == "addLine" and self.toolbar.GetAction("type") in [
+        if action == "addLine" and self.toolbar.GetAction("type") in {
             "line",
             "boundary",
             "area",
-        ]:
+        }:
             # -> add new line / boundary
             try:
                 mapName = self.toolbar.GetLayer().GetName()
@@ -1197,7 +1197,7 @@ class VDigitWindow(BufferedMapWindow):
                     fid,
                 ]
             )
-        elif action in ("copyCats", "copyAttrs") and hasattr(self, "copyCatsIds"):
+        elif action in {"copyCats", "copyAttrs"} and hasattr(self, "copyCatsIds"):
             if action == "copyCats":
                 if (
                     self.digit.CopyCats(
@@ -1292,17 +1292,17 @@ class VDigitWindow(BufferedMapWindow):
         )
 
         action = self.toolbar.GetAction()
-        if action == "addLine" and self.toolbar.GetAction("type") in [
+        if action == "addLine" and self.toolbar.GetAction("type") in {
             "line",
             "boundary",
             "area",
-        ]:
+        }:
             if len(self.polycoords) > 0:
                 self.MouseDraw(
                     pdc=self.pdcTmp, begin=self.Cell2Pixel(self.polycoords[-1])
                 )
 
-        elif action in ["moveLine", "moveVertex", "editLine"] and hasattr(
+        elif action in {"moveLine", "moveVertex", "editLine"} and hasattr(
             self, "moveInfo"
         ):
             dx = self.mouse["end"][0] - self.mouse["begin"][0]
@@ -1313,7 +1313,7 @@ class VDigitWindow(BufferedMapWindow):
                 # move line
                 for id in self.moveInfo["id"]:
                     self.pdcTmp.TranslateId(id, dx, dy)
-            elif action in ["moveVertex", "editLine"]:
+            elif action in {"moveVertex", "editLine"}:
                 # move vertex ->
                 # (vertex, left vertex, left line,
                 # right vertex, right line)

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -403,10 +403,10 @@ class DisplayDriver:
         elif rtype == TYPE_DIRECTION:
             key = "direction"
 
-        if key not in ("direction", "area", "isle"):
+        if key not in {"direction", "area", "isle"}:
             self.topology[key] += 1
 
-        if key in ("area", "isle"):
+        if key in {"area", "isle"}:
             pen = wx.TRANSPARENT_PEN
             if key == "area":
                 brush = wx.Brush(self.settings[key]["color"], wx.SOLID)

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -1541,7 +1541,7 @@ class CreateTtbDialog(wx.Dialog):
 
         for dataSel in dataSelects:
             selPanels[dataSel[0]] = Panel(parent=self)
-            if dataSel[0] in ["input", "output"]:
+            if dataSel[0] in {"input", "output"}:
                 self.inputData[dataSel[0]] = dataSel[2](
                     parent=selPanels[dataSel[0]], size=(-1, -1), type="vector"
                 )
@@ -1935,18 +1935,18 @@ class TurnAnglesList(ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.TextEditM
 
     def OnGetItemText(self, item, col):
         val = self.data.GetValue(item, col)
-        if col in [1, 2]:
+        if col in {1, 2}:
             val = RadiansToDegrees(val)
         return str(val)
 
     def SetVirtualData(self, row, column, text):
         """Set data to table"""
-        if column in [1, 2, 3]:
+        if column in {1, 2, 3}:
             try:
                 text = float(text)
             except ValueError:
                 return
-        if column in [1, 2]:
+        if column in {1, 2}:
             text = DegreesToRadians(text)
 
             # Tested allowed range of values

--- a/gui/wxpython/vnet/vnet_core.py
+++ b/gui/wxpython/vnet/vnet_core.py
@@ -769,7 +769,7 @@ class VNETAnalyses:
             inParams.append(col + "=" + params[colInptF])
 
         for layer in ["arc_layer", "node_layer", "turn_layer", "turn_cat_layer"]:
-            if not flags["t"] and layer in ["turn_layer", "turn_cat_layer"]:
+            if not flags["t"] and layer in {"turn_layer", "turn_cat_layer"}:
                 continue
             # TODO
             if flags["t"] and layer == "node_layer":

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -177,7 +177,7 @@ class VNETData:
             "turn_cat_layer": _("unique categories layer"),
         }
         for layer, layerLabel in vals.items():
-            if layer in ["turn_layer", "turn_cat_layer"] and not flags["t"]:
+            if layer in {"turn_layer", "turn_cat_layer"} and not flags["t"]:
                 continue
             if layer in inv_params:
                 if params[layer]:
@@ -633,7 +633,7 @@ class VNETAnalysisParameters:
 
     def GetParam(self, param):
         invParams = []
-        if param in [
+        if param in {
             "input",
             "arc_layer",
             "node_layer",
@@ -642,7 +642,7 @@ class VNETAnalysisParameters:
             "node_column",
             "turn_layer",
             "turn_cat_layer",
-        ]:
+        }:
             invParams = self._getInvalidParams(self.params)
 
         if invParams:
@@ -698,10 +698,10 @@ class VNETAnalysisParameters:
                 invParams.append(col)
                 continue
 
-            if columnchoices[params[col]]["type"] not in [
+            if columnchoices[params[col]]["type"] not in {
                 "integer",
                 "double precision",
-            ]:
+            }:
                 invParams.append(col)
                 continue
 
@@ -1398,7 +1398,7 @@ class VNETGlobalTurnsData:
     def DataValidator(self, row, col, value):
         """Angle recalculation due to value changing"""
 
-        if col not in [1, 2]:
+        if col not in {1, 2}:
             return
 
         if col == 1:

--- a/gui/wxpython/web_services/cap_interface.py
+++ b/gui/wxpython/web_services/cap_interface.py
@@ -229,7 +229,7 @@ class WMTSLayer(LayerBase):
         title = self.xml_ns.NsOws("Title")
         name = self.xml_ns.NsOws("Identifier")
 
-        if self.layer_node is None and param in ["title", "name"]:
+        if self.layer_node is None and param in {"title", "name"}:
             return None
         elif self.layer_node is None:
             return []
@@ -373,7 +373,7 @@ class OnEarthLayer(LayerBase):
 
     def GetLayerData(self, param):
         """Get layer data"""
-        if self.layer_node is None and param in ["title", "name"]:
+        if self.layer_node is None and param in {"title", "name"}:
             return None
         elif self.layer_node is None:
             return []

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -135,10 +135,10 @@ def process_opt(opts, args):
     """Process command-line arguments"""
     workspaceFile = None
     for o, a in opts:
-        if o in ("-h", "--help"):
+        if o in {"-h", "--help"}:
             printHelp()
 
-        elif o in ("-w", "--workspace"):
+        elif o in {"-w", "--workspace"}:
             if a != "":
                 workspaceFile = str(a)
             else:

--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -212,7 +212,7 @@ class BasePlotFrame(wx.Frame):
             rdict[r] = {}  # initialize sub-dictionaries for each raster in the list
 
             rdict[r]["units"] = ""
-            if ret["units"] not in ("(none)", '"none"', "", None):
+            if ret["units"] not in {"(none)", '"none"', "", None}:
                 rdict[r]["units"] = ret["units"]
 
             rdict[r]["plegend"] = r  # use fully-qualified names
@@ -284,9 +284,9 @@ class BasePlotFrame(wx.Frame):
             rdict[rpair][0]["units"] = ""
             rdict[rpair][1]["units"] = ""
 
-            if ret0["units"] not in ("(none)", '"none"', "", None):
+            if ret0["units"] not in {"(none)", '"none"', "", None}:
                 rdict[rpair][0]["units"] = ret0["units"]
-            if ret1["units"] not in ("(none)", '"none"', "", None):
+            if ret1["units"] not in {"(none)", '"none"', "", None}:
                 rdict[rpair][1]["units"] = ret1["units"]
 
             rdict[rpair]["plegend"] = (


### PR DESCRIPTION
Concerns Pylint rule ["use-set-for-membership / R6201"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-set-for-membership.html)

Using `ruff check --output-format=concise --select PLR6201 --preview --unsafe-fixes --fix gui/`.


Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [literal-membership (PLR6201)](https://docs.astral.sh/ruff/rules/literal-membership/) to fix part of Pylint's ["use-set-for-membership / R6201"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-set-for-membership.html). 

I reverted some changes when I wasn't completely sure if the preconditions for this refactor were met, as described in the docs of the rule. One of these is that the objects must be hashable to be in a set. If there are any that you are unsure, I'll simply remove it from the PR, as it isn't exhaustive yet. It still helps to have less linter ignores comments to add afterwards (to have Pylint 3.x not fail).

The changes are limited to `gui/wxpython` to limit the review scope.
