### PR TITLE
style(temporal): Fixes literal-membership (PLR6201)

### DIFF
--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -779,7 +779,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         relations = [
             relation.upper().strip()
             for relation in relations
-            if relation not in ["start", "overlap", "contain"]
+            if relation not in {"start", "overlap", "contain"}
         ]
 
         #  print(relations)
@@ -1723,7 +1723,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         if not spatial_relation:
             spatial_relation = "overlaps"
-        elif spatial_relation not in ["overlaps", "is_contained", "contains"]:
+        elif spatial_relation not in {"overlaps", "is_contained", "contains"}:
             self.msgr.error(
                 _(
                     "Invalid spatial relation <{}> requested."

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -399,7 +399,7 @@ def _get_list_of_maps_stds(
             )
 
     # This method expects a list of objects for gap detection
-    if method in ["delta", "deltagaps", "gran"]:
+    if method in {"delta", "deltagaps", "gran"}:
         if not columns:
             if output_format == "list":
                 # Only one column is needed.
@@ -451,7 +451,7 @@ def _get_list_of_maps_stds(
 
         # End with error for the old, custom formats. Proper formats simply return
         # empty result whatever empty is for each format (e.g., empty list for JSON).
-        if not rows and (output_format in ["plain", "line"]):
+        if not rows and (output_format in {"plain", "line"}):
             dbif.close()
             gs.fatal(
                 _(

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -449,11 +449,11 @@ def register_maps_in_space_time_dataset(
     # Update affected datasets
     if datatsets_to_modify:
         for dataset in datatsets_to_modify:
-            if type in ["rast", "raster"]:
+            if type in {"rast", "raster"}:
                 ds = dataset_factory("strds", dataset)
-            elif type in ["raster_3d", "rast3d", "raster3d"]:
+            elif type in {"raster_3d", "rast3d", "raster3d"}:
                 ds = dataset_factory("str3ds", dataset)
-            elif type in ["vect", "vector"]:
+            elif type in {"vect", "vector"}:
                 ds = dataset_factory("stvds", dataset)
             ds.select(dbif)
             ds.update_from_registered_maps(dbif)
@@ -620,7 +620,7 @@ def register_map_object_list(
             map_layer.load()
             # In case of a empty map continue, do not register empty maps
             if delete_empty:
-                if type in ["raster", "raster_3d", "rast", "rast3d"]:
+                if type in {"raster", "raster_3d", "rast", "rast3d"}:
                     if (
                         map_layer.metadata.get_min() is None
                         and map_layer.metadata.get_max() is None

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -1064,7 +1064,7 @@ class TemporalAlgebraParser:
                     mapA.set_spatial_extent(overlay_ext)
                 else:
                     returncode = 0
-            elif bool_op in ["or", "xor"]:
+            elif bool_op in {"or", "xor"}:
                 overlay_ext = mapA.spatial_union(mapB)
                 if overlay_ext is not None:
                     mapA.set_spatial_extent(overlay_ext)
@@ -2162,14 +2162,14 @@ class TemporalAlgebraParser:
             # Get value for function name from dictionary.
             tfuncval = tfuncdict[tfunc]
             # Check if value has to be transferred to datetime object for comparison.
-            if tfunc in [
+            if tfunc in {
                 "START_DATE",
                 "END_DATE",
                 "START_TIME",
                 "END_TIME",
                 "START_DATETIME",
                 "END_DATETIME",
-            ]:
+            }:
                 timeobj = string_to_datetime(value.replace('"', ""))
                 value = timeobj.date()
                 boolname = self.eval_datetime_str(tfuncval, comp_op, value)

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -773,7 +773,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
 
     num, granule = common_granule.split()
 
-    if granule in ["seconds", "second"]:
+    if granule in {"seconds", "second"}:
         # If the start seconds are different between the start dates
         # set the granularity to one second
         for start_time in start_date_list:
@@ -786,7 +786,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
             else:
                 return "1 second"
 
-    if granule in ["minutes", "minute"]:
+    if granule in {"minutes", "minute"}:
         # If the start minutes are different between the start dates
         # set the granularity to one minute
         for start_time in start_date_list:
@@ -799,7 +799,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
             else:
                 return "1 minute"
 
-    if granule in ["hours", "hour"]:
+    if granule in {"hours", "hour"}:
         # If the start hours are different between the start dates
         # set the granularity to one hour
         for start_time in start_date_list:
@@ -812,7 +812,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
             else:
                 return "1 hour"
 
-    if granule in ["days", "day"]:
+    if granule in {"days", "day"}:
         # If the start days are different between the start dates
         # set the granularity to one day
         for start_time in start_date_list:
@@ -825,7 +825,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
             else:
                 return "1 day"
 
-    if granule in ["months", "month"]:
+    if granule in {"months", "month"}:
         # If the start months are different between the start dates
         # set the granularity to one month
         for start_time in start_date_list:
@@ -946,7 +946,7 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
         num, gran = entry.split()
 
-        if gran in ["seconds", "second"]:
+        if gran in {"seconds", "second"}:
             has_seconds = True
             if min_gran > 0:
                 min_gran = 0
@@ -955,7 +955,7 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
             seconds.append(int(num))
 
-        if gran in ["minutes", "minute"]:
+        if gran in {"minutes", "minute"}:
             has_minutes = True
             if min_gran > 1:
                 min_gran = 1
@@ -964,7 +964,7 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
             minutes.append(int(num))
 
-        if gran in ["hours", "hour"]:
+        if gran in {"hours", "hour"}:
             has_hours = True
             if min_gran > 2:
                 min_gran = 2
@@ -973,7 +973,7 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
             hours.append(int(num))
 
-        if gran in ["days", "day"]:
+        if gran in {"days", "day"}:
             has_days = True
             if min_gran > 3:
                 min_gran = 3
@@ -982,7 +982,7 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
             days.append(int(num))
 
-        if gran in ["months", "month"]:
+        if gran in {"months", "month"}:
             has_months = True
             if min_gran > 4:
                 min_gran = 4
@@ -991,7 +991,7 @@ def compute_common_absolute_time_granularity_simple(gran_list):
 
             months.append(int(num))
 
-        if gran in ["years", "year"]:
+        if gran in {"years", "year"}:
             has_years = True
             if min_gran > 5:
                 min_gran = 5

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -133,14 +133,14 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
                         cmdstring = "%s" % (map_new.cmd_list)
                     elif "cmd_list" not in dir(map_new) and len(t) == 5:
                         cmdstring = "%s" % (map_n.get_id())
-                    elif "cmd_list" in dir(map_new) and len(t) in (9, 11):
+                    elif "cmd_list" in dir(map_new) and len(t) in {9, 11}:
                         cmdstring = "%s[%s,%s,%s]" % (
                             map_new.cmd_list,
                             row_neighbor,
                             col_neighbor,
                             depth_neighbor,
                         )
-                    elif "cmd_list" not in dir(map_new) and len(t) in (9, 11):
+                    elif "cmd_list" not in dir(map_new) and len(t) in {9, 11}:
                         cmdstring = "%s[%s,%s,%s]" % (
                             map_n.get_id(),
                             row_neighbor,

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -177,13 +177,13 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
                         cmdstring = "%s" % (map_new.cmd_list)
                     elif "cmd_list" not in dir(map_new) and len(t) == 5:
                         cmdstring = "%s" % (map_n.get_id())
-                    elif "cmd_list" in dir(map_new) and len(t) in (7, 9):
+                    elif "cmd_list" in dir(map_new) and len(t) in {7, 9}:
                         cmdstring = "%s[%s,%s]" % (
                             map_new.cmd_list,
                             row_neigbour,
                             col_neigbour,
                         )
-                    elif "cmd_list" not in dir(map_new) and len(t) in (7, 9):
+                    elif "cmd_list" not in dir(map_new) and len(t) in {7, 9}:
                         cmdstring = "%s[%s,%s]" % (
                             map_n.get_id(),
                             row_neigbour,

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -351,7 +351,7 @@ def print_vector_dataset_univar_statistics(
             + fs
         )
         string += "min" + fs + "max" + fs + "range"
-        if type in ("point", "centroid"):
+        if type in {"point", "centroid"}:
             string += (
                 fs
                 + "mean"

--- a/temporal/t.info/t.info.py
+++ b/temporal/t.info/t.info.py
@@ -119,7 +119,7 @@ def main():
 
     dataset.select(dbif)
 
-    if history and type_ in ["strds", "stvds", "str3ds"]:
+    if history and type_ in {"strds", "stvds", "str3ds"}:
         dataset.print_history()
         return
 

--- a/temporal/t.rast.export/t.rast.export.py
+++ b/temporal/t.rast.export/t.rast.export.py
@@ -131,7 +131,7 @@ def main():
     if not os.access(directory, os.W_OK):
         grass.fatal(_("Directory {} is not writable".format(directory)))
 
-    if _type and _format in ["pack", "AAIGrid"]:
+    if _type and _format in {"pack", "AAIGrid"}:
         grass.warning(
             _("Type options is not working with pack format, " "it will be skipped")
         )

--- a/temporal/t.rast.gapfill/t.rast.gapfill.py
+++ b/temporal/t.rast.gapfill/t.rast.gapfill.py
@@ -121,7 +121,7 @@ def main():
     for _map in maps:
         if _map.get_id() is None:
             count += 1
-            if sp.get_temporal_type() == "absolute" and tsuffix in ["gran", "time"]:
+            if sp.get_temporal_type() == "absolute" and tsuffix in {"gran", "time"}:
                 _id = "{ba}@{ma}".format(ba=base, ma=mapset)
             else:
                 map_name = tgis.create_numeric_suffix(base, num + count, tsuffix)

--- a/temporal/t.rast.list/t.rast.list.py
+++ b/temporal/t.rast.list/t.rast.list.py
@@ -167,7 +167,7 @@ def main():
             # except for setting it to an empty string which does not have a precedence
             # in the current code and the behavior is unclear.
             separator = ","
-    if output_format in ["json", "yaml"] and header:
+    if output_format in {"json", "yaml"} and header:
         gs.fatal(
             message_option_value_excludes_flag(
                 option_name="format",
@@ -185,7 +185,7 @@ def main():
         # Pipe is currently not supported at all.
         separator = ","
 
-    if method in ["delta", "deltagaps", "gran"]:
+    if method in {"delta", "deltagaps", "gran"}:
         if order:
             gs.fatal(
                 message_option_value_excludes_option(


### PR DESCRIPTION
Concerns Pylint rule ["use-set-for-membership / R6201"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-set-for-membership.html)

Using `ruff check --output-format=concise --select PLR6201 --preview --unsafe-fixes --fix 'temporal/' 'python/grass/temporal'`.

Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [literal-membership (PLR6201)](https://docs.astral.sh/ruff/rules/literal-membership/) to fix part of Pylint's ["use-set-for-membership / R6201"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-set-for-membership.html). 

The changes are limited to the temporal-related folders to limit the review scope.