### PR TITLE
style: Fixes literal-membership (PLR6201) for other code

### DIFF
--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
     width, height, legfile = read_env_file(os.path.join(path, "env"))
     if mon.startswith("wx"):
         mapfile = tempfile.NamedTemporaryFile(dir=path).name
-        if cmd[0] in ("d.barscale", "d.legend", "d.northarrow", "d.legend.vect"):
+        if cmd[0] in {"d.barscale", "d.legend", "d.northarrow", "d.legend.vect"}:
             mapfile += ".png"
         else:
             mapfile += ".ppm"

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -624,7 +624,7 @@ def read_gui(gisrc, default_gui):
         grass_gui = default_gui
 
     # FIXME oldtcltk, gis.m, d.m no longer exist (remove this around 7.2)
-    if grass_gui in ["d.m", "gis.m", "oldtcltk", "tcltk"]:
+    if grass_gui in {"d.m", "gis.m", "oldtcltk", "tcltk"}:
         warning(_("GUI <%s> not supported in this version") % grass_gui)
         grass_gui = default_gui
 
@@ -648,7 +648,7 @@ def check_gui(expected_gui):
     # Check if we are running X windows by checking the DISPLAY variable
     if os.getenv("DISPLAY") or WINDOWS or MACOS:
         # Check if python is working properly
-        if expected_gui in ("wxpython", "gtext"):
+        if expected_gui in {"wxpython", "gtext"}:
             nul = open(os.devnull, "w")
             p = Popen(
                 [os.environ["GRASS_PYTHON"]],
@@ -1476,13 +1476,13 @@ def get_shell():
 
 def get_grass_env_file(sh, grass_config_dir):
     """Get name of the shell-specific GRASS environment (rc) file"""
-    if sh in ["csh", "tcsh"]:
+    if sh in {"csh", "tcsh"}:
         grass_env_file = os.path.join(grass_config_dir, "cshrc")
-    elif sh in ["bash", "msh", "cygwin", "sh"]:
+    elif sh in {"bash", "msh", "cygwin", "sh"}:
         grass_env_file = os.path.join(grass_config_dir, "bashrc")
     elif sh == "zsh":
         grass_env_file = os.path.join(grass_config_dir, "zshrc")
-    elif sh in ["cmd", "powershell"]:
+    elif sh in {"cmd", "powershell"}:
         grass_env_file = os.path.join(grass_config_dir, "env.bat")
     else:
         grass_env_file = os.path.join(grass_config_dir, "bashrc")
@@ -1959,7 +1959,7 @@ def print_params(params):
     for arg in params:
         if arg == "path":
             sys.stdout.write("%s\n" % GISBASE)
-        elif arg in ["python_path", "python-path"]:
+        elif arg in {"python_path", "python-path"}:
             sys.stdout.write("%s\n" % gpath("etc", "python"))
         elif arg == "arch":
             val = grep("ARCH", linesplat)
@@ -2272,7 +2272,7 @@ def main():
 
     # A shell is activated when using TTY.
     # Explicit --[g]text in command line, forces a shell to be activated.
-    force_shell = grass_gui in ["text", "gtext"]
+    force_shell = grass_gui in {"text", "gtext"}
     use_shell = io_is_interactive() or force_shell
     if not use_shell:
         # If no shell is used, always use actual GUI as GUI, even when "text" is set as
@@ -2518,16 +2518,16 @@ def main():
                     _("Launching <%s> GUI in the background, please wait...")
                     % grass_gui
                 )
-            if sh in ["csh", "tcsh"]:
+            if sh in {"csh", "tcsh"}:
                 shell_process = csh_startup(mapset_settings.full_mapset, grass_env_file)
-            elif sh in ["zsh"]:
+            elif sh in {"zsh"}:
                 shell_process = sh_like_startup(
                     mapset_settings.full_mapset,
                     mapset_settings.location,
                     grass_env_file,
                     "zsh",
                 )
-            elif sh in ["bash", "msh", "cygwin"]:
+            elif sh in {"bash", "msh", "cygwin"}:
                 shell_process = sh_like_startup(
                     mapset_settings.full_mapset,
                     mapset_settings.location,

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -145,7 +145,7 @@ def generate_page_for_category(
     )
     output.write(header_graphical_index_tmpl)
 
-    if module_family.lower() not in ["general", "postscript"]:
+    if module_family.lower() not in {"general", "postscript"}:
         if module_family == "raster3d":
             # covert keyword to nice form
             module_family = "3D raster"

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -24,7 +24,7 @@ filename = modclass + ".txt"
 f = open(filename + ".tmp", "wb")
 
 write_rest_header(f, "GRASS GIS %s Reference Manual: %s" % (grass_version, modclass))
-if modclass.lower() not in ["general", "miscellaneous", "postscript"]:
+if modclass.lower() not in {"general", "miscellaneous", "postscript"}:
     f.write(
         modclass_intro_tmpl.substitute(
             modclass=modclass, modclass_lower=modclass.lower()

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -436,9 +436,9 @@ def html_files(cls=None, ignore_gui=True):
     for cmd in sorted(os.listdir(html_dir)):
         if (
             cmd.endswith(".html")
-            and (cls in [None, "*"] or cmd.startswith(cls + "."))
+            and (cls in {None, "*"} or cmd.startswith(cls + "."))
             and (cls != "*" or len(cmd.split(".")) >= 3)
-            and cmd not in ["full_index.html", "index.html"]
+            and cmd not in {"full_index.html", "index.html"}
             and cmd not in exclude_mods
             and (ignore_gui and not cmd.startswith("wxGUI.") or not ignore_gui)
         ):

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -314,9 +314,9 @@ def rest_files(cls=None):
     for cmd in sorted(os.listdir(rest_dir)):
         if (
             cmd.endswith(".txt")
-            and (cls in [None, "*"] or cmd.startswith(cls + "."))
+            and (cls in {None, "*"} or cmd.startswith(cls + "."))
             and (cls != "*" or len(cmd.split(".")) >= 3)
-            and cmd not in ["full_index.txt", "index.txt"]
+            and cmd not in {"full_index.txt", "index.txt"}
             and cmd not in exclude_mods
             and not cmd.startswith("wxGUI.")
         ):

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
 
     options = OptTable(parse_options(cfile.readlines(), startswith=args.startswith))
     outform = args.format
-    if outform in ["csv", "html"]:
+    if outform in {"csv", "html"}:
         print(getattr(options, outform)(), file=args.output)
         args.output.close()
     else:

--- a/python/grass/benchmark/plots.py
+++ b/python/grass/benchmark/plots.py
@@ -71,7 +71,7 @@ def nprocs_plot(results, filename=None, title=None, metric="time"):
             plt.plot(x, result.times, label=result.label)
             plt.fill_between(x, mins, maxes, color="gray", alpha=0.3)
             ylabel = "Time [s]"
-        elif metric in ["speedup", "efficiency"]:
+        elif metric in {"speedup", "efficiency"}:
             ylabel = metric.title()
             plt.plot(x, getattr(result, metric), label=result.label)
         else:
@@ -96,7 +96,7 @@ def nprocs_plot(results, filename=None, title=None, metric="time"):
         plt.title(title)
     elif metric == "times":
         plt.title("Execution time by processing elements")
-    elif metric in ["speedup", "efficiency"]:
+    elif metric in {"speedup", "efficiency"}:
         plt.title(f"{metric.title()} by processing elements")
     if filename:
         plt.savefig(filename)

--- a/python/grass/jupyter/map3d.py
+++ b/python/grass/jupyter/map3d.py
@@ -132,7 +132,7 @@ class Map3D:
                     "because pyvirtualdisplay cannot be imported"
                 ).format(screen_backend)
             )
-        elif screen_backend in ["simple", "pyvirtualdisplay"]:
+        elif screen_backend in {"simple", "pyvirtualdisplay"}:
             self._screen_backend = screen_backend
         else:
             raise ValueError(

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -479,7 +479,7 @@ class GridModule:
         # if overlap > 0, r.patch won't work properly
         if not patch_backend:
             self.patch_backend = "RasterRow"
-        elif patch_backend not in ("r.patch", "RasterRow"):
+        elif patch_backend not in {"r.patch", "RasterRow"}:
             raise RuntimeError(
                 _("Parameter patch_backend must be 'r.patch' or 'RasterRow'")
             )
@@ -625,7 +625,7 @@ class GridModule:
         """Add the mapset information to the input maps"""
         for inmap in self.module.inputs:
             inm = self.module.inputs[inmap]
-            if inm.type in ("raster", "vector") and inm.value:
+            if inm.type in {"raster", "vector"} and inm.value:
                 if "@" not in inm.value:
                     mset = get_mapset_raster(inm.value)
                     inm.value = inm.value + "@%s" % mset

--- a/python/grass/pygrass/modules/interface/flag.py
+++ b/python/grass/pygrass/modules/interface/flag.py
@@ -27,7 +27,7 @@ class Flag:
         diz = read.element2dict(xflag) if xflag is not None else diz
         self.name = diz["name"]
         self.special = (
-            True if self.name in ("verbose", "overwrite", "quiet", "run") else False
+            True if self.name in {"verbose", "overwrite", "quiet", "run"} else False
         )
         self.description = diz.get("description", None)
         self.default = diz.get("default", None)

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -563,7 +563,7 @@ class Module:
         tree = fromstring(self.xml)
 
         for e in tree:
-            if e.tag not in ("parameter", "flag"):
+            if e.tag not in {"parameter", "flag"}:
                 self.__setattr__(e.tag, GETFROMTAG[e.tag](e))
 
         #

--- a/python/grass/pygrass/raster/__init__.py
+++ b/python/grass/pygrass/raster/__init__.py
@@ -313,7 +313,7 @@ class RasterSegment(RasterAbstractBase):
         return self._mode
 
     def _set_mode(self, mode):
-        if mode and mode.lower() not in ("r", "w", "rw"):
+        if mode and mode.lower() not in {"r", "w", "rw"}:
             str_err = _("Mode type: {0} not supported ('r', 'w','rw')")
             raise ValueError(str_err.format(mode))
         self._mode = mode

--- a/python/grass/pygrass/raster/abstract.py
+++ b/python/grass/pygrass/raster/abstract.py
@@ -323,7 +323,7 @@ class RasterAbstractBase:
 
     def _set_mtype(self, mtype):
         """Private method to change the Raster type"""
-        if mtype.upper() not in ("CELL", "FCELL", "DCELL"):
+        if mtype.upper() not in {"CELL", "FCELL", "DCELL"}:
             str_err = "Raster type: {0} not supported ('CELL','FCELL','DCELL')"
             raise ValueError(_(str_err).format(mtype))
         self._mtype = mtype
@@ -335,7 +335,7 @@ class RasterAbstractBase:
         return self._mode
 
     def _set_mode(self, mode):
-        if mode.upper() not in ("R", "W"):
+        if mode.upper() not in {"R", "W"}:
             str_err = _("Mode type: {0} not supported ('r', 'w')")
             raise ValueError(str_err.format(mode))
         self._mode = mode
@@ -346,7 +346,7 @@ class RasterAbstractBase:
         return self._overwrite
 
     def _set_overwrite(self, overwrite):
-        if overwrite not in (True, False):
+        if overwrite not in {True, False}:
             str_err = _("Overwrite type: {0} not supported (True/False)")
             raise ValueError(str_err.format(overwrite))
         self._overwrite = overwrite

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -66,7 +66,7 @@ class Category(list):
         return self._mtype
 
     def _set_mtype(self, mtype):
-        if mtype.upper() not in ("CELL", "FCELL", "DCELL"):
+        if mtype.upper() not in {"CELL", "FCELL", "DCELL"}:
             raise ValueError(_("Raster type: {0} not supported".format(mtype)))
         self._mtype = mtype
         self._gtype = RTYPE[self.mtype]["grass type"]

--- a/python/grass/pygrass/vector/abstract.py
+++ b/python/grass/pygrass/vector/abstract.py
@@ -368,11 +368,11 @@ class Info:
         # update the overwrite attribute
         self.overwrite = overwrite if overwrite is not None else self.overwrite
         # check if the mode is valid
-        if self.mode not in ("r", "rw", "w"):
+        if self.mode not in {"r", "rw", "w"}:
             raise ValueError("Mode not supported. Use one of: 'r', 'rw', 'w'.")
 
         # check if the map exist
-        if self.exist() and self.mode in ("r", "rw"):
+        if self.exist() and self.mode in {"r", "rw"}:
             # open in READ mode
             if self.mode == "r":
                 openvect = libvect.Vect_open_old2(
@@ -392,7 +392,7 @@ class Info:
             openvect = libvect.Vect_open_new(self.c_mapinfo, self.name, with_z)
             self.dblinks = DBlinks(self.c_mapinfo)
 
-        if self.mode in ("w", "rw") and tab_cols:
+        if self.mode in {"w", "rw"} and tab_cols:
             # create a link
             link = Link(
                 layer,

--- a/python/grass/script/array.py
+++ b/python/grass/script/array.py
@@ -155,7 +155,7 @@ class array(numpy.memmap):
             else:
                 raise ValueError(_("Invalid kind <%s>") % kind)
 
-            if size not in [1, 2, 4, 8]:
+            if size not in {1, 2, 4, 8}:
                 raise ValueError(_("Invalid size <%d>") % size)
 
             gcore.run_command(
@@ -202,7 +202,7 @@ class array(numpy.memmap):
                 raise ValueError(_("Invalid FP size <%d>") % size)
             size = None
         elif kind in "biu":
-            if size not in [1, 2, 4]:
+            if size not in {1, 2, 4}:
                 raise ValueError(_("Invalid integer size <%d>") % size)
             flags = None
         else:
@@ -267,7 +267,7 @@ class array3d(numpy.memmap):
             else:
                 raise ValueError(_("Invalid kind <%s>") % kind)
 
-            if size not in [1, 2, 4, 8]:
+            if size not in {1, 2, 4, 8}:
                 raise ValueError(_("Invalid size <%d>") % size)
 
             gcore.run_command(
@@ -310,7 +310,7 @@ class array3d(numpy.memmap):
             if size != 4 and size != 8:
                 raise ValueError(_("Invalid FP size <%d>") % size)
         elif kind in "biu":
-            if size not in [1, 2, 4, 8]:
+            if size not in {1, 2, 4, 8}:
                 raise ValueError(_("Invalid integer size <%d>") % size)
             flags = "i"
         else:

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -884,7 +884,7 @@ def _parse_opts(lines):
             flags[var[5:]] = bool(int(val))
         elif var.startswith("opt_"):
             options[var[4:]] = val
-        elif var in ["GRASS_OVERWRITE", "GRASS_VERBOSE"]:
+        elif var in {"GRASS_OVERWRITE", "GRASS_VERBOSE"}:
             os.environ[var] = val
         else:
             raise SyntaxError(
@@ -1288,13 +1288,13 @@ def region_env(region3d=False, flags=None, env=None, **kwargs):
         grass_region = ""
         for line in fd.readlines():
             key, value = map(lambda x: x.strip(), line.split(":", 1))
-            if kwargs and key not in ("proj", "zone"):
+            if kwargs and key not in {"proj", "zone"}:
                 continue
             if (
                 not kwargs
                 and not region3d
                 and key
-                in (
+                in {
                     "top",
                     "bottom",
                     "cols3",
@@ -1303,7 +1303,7 @@ def region_env(region3d=False, flags=None, env=None, **kwargs):
                     "e-w resol3",
                     "n-s resol3",
                     "t-b resol",
-                )
+                }
             ):
                 continue
 

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -66,7 +66,7 @@ def db_describe(table, env=None, **args):
         if key.startswith("Column "):
             n = int(key.split(" ")[1])
             cols.insert(n, f[1:])
-        elif key in ["ncols", "nrows"]:
+        elif key in {"ncols", "nrows"}:
             result[key] = int(f[1])
         else:
             result[key] = f[1:]
@@ -238,7 +238,7 @@ def db_begin_transaction(driver):
 
     :return: SQL command as string
     """
-    if driver in ("sqlite", "pg"):
+    if driver in {"sqlite", "pg"}:
         return "BEGIN"
     if driver == "mysql":
         return "START TRANSACTION"
@@ -250,6 +250,6 @@ def db_commit_transaction(driver):
 
     :return: SQL command as string
     """
-    if driver in ("sqlite", "pg", "mysql"):
+    if driver in {"sqlite", "pg", "mysql"}:
         return "COMMIT"
     return ""

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -88,7 +88,7 @@ class grassTask:
         """Get task name"""
         if sys.platform == "win32":
             name, ext = os.path.splitext(self.name)
-            if ext in (".py", ".sh"):
+            if ext in {".py", ".sh"}:
                 return name
             else:
                 return self.name
@@ -641,7 +641,7 @@ def cmdtuple_to_list(cmd):
             cmdList.append("--" + flag)
 
     for k, v in cmd[1].items():
-        if k in ("flags", "help", "verbose", "quiet", "overwrite"):
+        if k in {"flags", "help", "verbose", "quiet", "overwrite"}:
             continue
         if " " in v:
             v = '"%s"' % v
@@ -667,7 +667,7 @@ def cmdlist_to_tuple(cmd):
             dcmd[str(key)] = value.replace('"', "")
         elif item[:2] == "--":  # long flags
             flag = item[2:]
-            if flag in ("help", "verbose", "quiet", "overwrite"):
+            if flag in {"help", "verbose", "quiet", "overwrite"}:
                 dcmd[str(flag)] = True
         elif len(item) == 2 and item[0] == "-":  # -> flags
             if "flags" not in dcmd:

--- a/python/grass/script/testsuite/data/script_using_temporary_region.py
+++ b/python/grass/script/testsuite/data/script_using_temporary_region.py
@@ -48,7 +48,7 @@ def main():
         remaining = None
         nesting = 0
         map_name = None
-    elif len(sys.argv) not in [3, 4]:
+    elif len(sys.argv) not in {3, 4}:
         gs.fatal(
             "Usage: <script name> <size[,size,...]> <nesting level> [<map name>]\n"
             "  <script name>      The name of this file ({name})\n"

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -41,7 +41,7 @@ def float_or_dms(s):
 
     :return: float value
     """
-    if s[-1] in ["E", "W", "N", "S"]:
+    if s[-1] in {"E", "W", "N", "S"}:
         s = s[:-1]
     return sum(float(x) / 60**n for (n, x) in enumerate(s.split(":")))
 

--- a/raster/r.neighbors/testsuite/test_r_neighbors.py
+++ b/raster/r.neighbors/testsuite/test_r_neighbors.py
@@ -708,7 +708,7 @@ class TestNeighbors(TestCase):
             rinfo = raster_info(rmap)
             self.assertTrue(
                 rinfo["datatype"] == "CELL"
-                if rinfo["datatype"] in ["diversity", "range", "mode"]
+                if rinfo["datatype"] in {"diversity", "range", "mode"}
                 else "DCELL"
             )
 

--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -480,7 +480,7 @@ def main():
     freq = {}
     for line in rawf:
         line = line.rstrip("\r\n")
-        if line in ["*", undef]:
+        if line in {"*", undef}:
             continue
         nvals += 1
         x = float(line)

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -90,7 +90,7 @@ except ImportError:
     if __name__ == "__main__":
         if len(sys.argv) == 2:
             arg = sys.argv[1]
-            if arg[0:2] == "--" or arg in ["help", "-help"]:
+            if arg[0:2] == "--" or arg in {"help", "-help"}:
                 grass.parser()
     # Either we didn't call g.parser, or it returned
     # At this point, there's nothing to be done except re-raise the exception

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -134,7 +134,7 @@ def main():
     for cname, ctype, cwidth in desc_table["cols"]:
         if cname == column:
             found = True
-            if ctype not in ("INTEGER", "DOUBLE PRECISION"):
+            if ctype not in {"INTEGER", "DOUBLE PRECISION"}:
                 gscript.fatal(_("Column <%s> is not numeric") % cname)
     if not found:
         gscript.fatal(_("Column <%s> not found in table <%s>") % (column, table))
@@ -170,7 +170,7 @@ def main():
     # check if result is empty
     tmpf = open(tmp)
     if tmpf.read(1) == "":
-        if output_format in ["plain", "shell"]:
+        if output_format in {"plain", "shell"}:
             gscript.fatal(_("Table <%s> contains no data.") % table)
         tmpf.close()
 
@@ -200,7 +200,7 @@ def main():
     tmpf.close()
 
     if N <= 0:
-        if output_format in ["plain", "shell"]:
+        if output_format in {"plain", "shell"}:
             gscript.fatal(_("No non-null values found"))
         else:
             # We produce valid JSON with a value for n even when the query returned

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1004,7 +1004,7 @@ def get_wxgui_extensions(url):
         if not sline:
             continue
         name = sline.group(2).rstrip("/")
-        if name not in ("..", "Makefile"):
+        if name not in {"..", "Makefile"}:
             mlist.append(name)
 
     return mlist
@@ -1886,7 +1886,7 @@ def download_source_code(
                              URL path
     """
     gs.verbose(_("Type of source identified as '{source}'.").format(source=source))
-    if source in ("official", "official_fork"):
+    if source in {"official", "official_fork"}:
         gs.message(
             _("Fetching <{name}> from <{url}> (be patient)...").format(
                 name=name, url=url
@@ -1902,7 +1902,7 @@ def download_source_code(
             )
         )
         download_source_code_svn(url, name, outdev, directory)
-    elif source in ["remote_zip"]:
+    elif source in {"remote_zip"}:
         gs.message(
             _("Fetching <{name}> from " "<{url}> (be patient)...").format(
                 name=name, url=url
@@ -2514,7 +2514,7 @@ def resolve_xmlurl_prefix(url, source=None):
     'https://grass.osgeo.org/addons/'
     """
     gs.debug("resolve_xmlurl_prefix(url={0}, source={1})".format(url, source))
-    if source in ("official", "official_fork"):
+    if source in {"official", "official_fork"}:
         # use pregenerated modules XML file
         # Define branch to fetch from (latest or current version)
         version_branch = get_version_branch(VERSION[0])

--- a/scripts/g.manual/g.manual.py
+++ b/scripts/g.manual/g.manual.py
@@ -59,7 +59,7 @@ from grass.script import core as grass
 def start_browser(entry):
     if (
         browser
-        and browser not in ("xdg-open", "start")
+        and browser not in {"xdg-open", "start"}
         and not grass.find_program(browser)
     ):
         grass.fatal(_("Browser '%s' not found") % browser)
@@ -89,7 +89,7 @@ def start_browser(entry):
 
         url_path = "file://" + path
 
-    if browser and browser not in ("xdg-open", "start"):
+    if browser and browser not in {"xdg-open", "start"}:
         webbrowser.register(browser_name, None)
 
     grass.verbose(

--- a/scripts/i.image.mosaic/i.image.mosaic.py
+++ b/scripts/i.image.mosaic/i.image.mosaic.py
@@ -42,7 +42,7 @@ def copy_colors(fh, map, offset):
     for line in p.stdout:
         f = gscript.decode(line).rstrip("\r\n").split(" ")
         if offset:
-            if f[0] in ["nv", "default"]:
+            if f[0] in {"nv", "default"}:
                 continue
             f[0] = str(float(f[0]) + offset)
         fh.write(gscript.encode(" ".join(f) + "\n"))

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -289,7 +289,7 @@ def main():
     for line in s.splitlines():
         f = line.split("|")
         for i, v in enumerate(f):
-            if v in ["", "*"]:
+            if v in {"", "*"}:
                 f[i] = 0
             else:
                 f[i] = float(v)

--- a/scripts/r.in.aster/r.in.aster.py
+++ b/scripts/r.in.aster/r.in.aster.py
@@ -158,7 +158,7 @@ def main():
         bandlist = band.split(",")
 
     # initialize datasets for L1A, L1B, L1T
-    if proctype in ["L1A", "L1B", "L1T"]:
+    if proctype in {"L1A", "L1B", "L1T"}:
         for band in bandlist:
             if band in allbands:
                 dataset = bands[proctype][band]

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -173,7 +173,7 @@ def main():
 
     # use these from now on:
     infile = input
-    while infile[-4:].lower() in [".hgt", ".zip", ".raw"]:
+    while infile[-4:].lower() in {".hgt", ".zip", ".raw"}:
         infile = infile[:-4]
     (fdir, tile) = os.path.split(infile)
 

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -192,7 +192,7 @@ class WMSBase:
             if (
                 i_param in options
                 and options[i_param]
-                and i_param not in ["srs", "wms_version", "format"]
+                and i_param not in {"srs", "wms_version", "format"}
             ):  # params with default value
                 not_relevant_params.append("<" + i_param + ">")
 
@@ -790,7 +790,7 @@ class WMSDriversInfo:
 def GetSRSParamVal(srs):
     """!Decides whether to use CRS or EPSG prefix according to srs number."""
 
-    if srs in [84, 83, 27]:
+    if srs in {84, 83, 27}:
         return "OGC:CRS{}".format(srs)
     else:
         return "EPSG:{}".format(srs)

--- a/scripts/r.in.wms/wms_drv.py
+++ b/scripts/r.in.wms/wms_drv.py
@@ -585,7 +585,7 @@ class WMSRequestMgr(BaseRequestMgr):
         projection is geographic, the bbox x and y are in most cases flipped.
         """
         # CRS:84 and CRS:83 are exception (CRS:83 and CRS:27 need to be tested)
-        if srs_param in [84, 83] or version != "1.3.0":
+        if srs_param in {84, 83} or version != "1.3.0":
             return bbox
         elif Srs(GetSRSParamVal(srs_param)).axisorder == "yx":
             return self._flipBbox(bbox)
@@ -815,7 +815,7 @@ class WMTSRequestMgr(BaseRequestMgr):
 
                     mat_num_bbox[i[0]] = int(i_tag.text)
 
-                    if i[0] in ("max_row", "max_col"):
+                    if i[0] in {"max_row", "max_col"}:
                         mat_num_bbox[i[0]] = mat_num_bbox[i[0]] - 1
 
                 break
@@ -840,7 +840,7 @@ class WMTSRequestMgr(BaseRequestMgr):
         )  # NOTE not used params['srs'], it is just number, encoding needed
         # TODO needs to be tested, tried only on
         # http://www.landesvermessung.sachsen.de/geoserver/gwc/service/wmts?:
-        if s.getcode() == "EPSG:4326" and s.encoding in ("uri", "urn"):
+        if s.getcode() == "EPSG:4326" and s.encoding in {"uri", "urn"}:
             grass.warning("switch")
             (tl_corner["minx"], tl_corner["maxy"]) = (
                 tl_corner["maxy"],

--- a/scripts/r.reclass.area/r.reclass.area.py
+++ b/scripts/r.reclass.area/r.reclass.area.py
@@ -142,7 +142,7 @@ def reclass(inf, outf, lim, clump, diag, les):
     TMPRAST.append(recfile)
 
     sflags = "aln"
-    if grass.raster_info(infile)["datatype"] in ("FCELL", "DCELL"):
+    if grass.raster_info(infile)["datatype"] in {"FCELL", "DCELL"}:
         sflags += "i"
     p1 = grass.pipe_command("r.stats", flags=sflags, input=(clumpfile, infile), sep=";")
     p2 = grass.feed_command("r.reclass", input=clumpfile, output=recfile, rules="-")

--- a/scripts/v.db.renamecolumn/v.db.renamecolumn.py
+++ b/scripts/v.db.renamecolumn/v.db.renamecolumn.py
@@ -104,7 +104,7 @@ def main():
         grass.fatal(_("Column <%s> not found in table <%s>") % (oldcol, table))
 
     # some tricks
-    if driver in ["sqlite", "dbf"]:
+    if driver in {"sqlite", "dbf"}:
         if oldcoltype.upper() == "CHARACTER":
             colspec = f"{newcol} varchar({oldcollength})"
         else:

--- a/scripts/v.db.update/v.db.update.py
+++ b/scripts/v.db.update/v.db.update.py
@@ -111,7 +111,7 @@ def main():
         if not value:
             grass.fatal(_("Either <value> or <qcolumn> must be given"))
         # we insert a value
-        if coltype.upper() not in ["INTEGER", "DOUBLE PRECISION"]:
+        if coltype.upper() not in {"INTEGER", "DOUBLE PRECISION"}:
             value = "'%s'" % value
 
     cmd = "UPDATE %s SET %s=%s" % (table, column, value)

--- a/scripts/v.dissolve/tests/conftest.py
+++ b/scripts/v.dissolve/tests/conftest.py
@@ -34,7 +34,7 @@ def value_update_by_category(map_name, layer, column_name, cats, values, env):
     driver = db_info["driver"]
     cat_column = "cat"
     column_type = gs.vector_columns(map_name, layer, env=env)[column_name]
-    column_quote = bool(column_type["type"] in ("CHARACTER", "TEXT"))
+    column_quote = bool(column_type["type"] in {"CHARACTER", "TEXT"})
     sql = updates_as_transaction(
         table=table,
         cat_column=cat_column,

--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -169,14 +169,14 @@ def quote_from_type(column_type):
     information is assumed to be associated with numbers which don't need quoting.
     """
     # Needs a general solution, e.g., https://github.com/OSGeo/grass/pull/1110
-    if not column_type or column_type.upper() in [
+    if not column_type or column_type.upper() in {
         "INT",
         "INTEGER",
         "SMALLINT",
         "REAL",
         "DOUBLE",
         "DOUBLE PRECISION",
-    ]:
+    }:
         return ""
     return "'"
 
@@ -614,9 +614,9 @@ def main():
         except KeyError:
             gs.fatal(_("Column <%s> not found") % column)
 
-        if coltype["type"] not in ("INTEGER", "SMALLINT", "CHARACTER", "TEXT"):
+        if coltype["type"] not in {"INTEGER", "SMALLINT", "CHARACTER", "TEXT"}:
             gs.fatal(_("Key column must be of type integer or string"))
-        column_is_str = coltype["type"] in ("CHARACTER", "TEXT")
+        column_is_str = coltype["type"] in {"CHARACTER", "TEXT"}
         if columns_to_aggregate and not column_is_str:
             gs.fatal(
                 _(

--- a/scripts/v.in.e00/v.in.e00.py
+++ b/scripts/v.in.e00/v.in.e00.py
@@ -71,7 +71,7 @@ def main():
         )
 
     # check that the user didn't use all three, which gets past the parser.
-    if type not in ["point", "line", "area"]:
+    if type not in {"point", "line", "area"}:
         gcore.fatal(_('Must specify one of "point", "line", or "area".'))
 
     e00name = basename(filename, "e00")

--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -162,7 +162,7 @@ def main():
         records2 = []
         for line in p.stdout:
             fields = decode(line).rstrip("\r\n").split("|")
-            if fields[0] in ["cat", "-1", "0"]:
+            if fields[0] in {"cat", "-1", "0"}:
                 continue
             records2.append([int(fields[0])] + fields[1:])
         p.wait()
@@ -206,7 +206,7 @@ def main():
         records3 = []
         for line in p.stdout:
             fields = decode(line).rstrip("\r\n").split("|")
-            if fields[0] in ["cat", "-1", "0"]:
+            if fields[0] in {"cat", "-1", "0"}:
                 continue
             records3.append([int(fields[0])] + fields[1:])
         p.wait()

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -158,7 +158,7 @@ class Formatter:
                 self.warning("invalid item in table row: %s" % str(item))
                 continue
             (tag, attrs, body) = item
-            if tag not in ["td", "th"]:
+            if tag not in {"td", "th"}:
                 self.warning("invalid tag in table row: %s" % tag)
                 continue
             if col > 0:
@@ -174,7 +174,7 @@ class Formatter:
         for item in content:
             if is_tuple(item):
                 (tag, attrs, body) = item
-                if tag in ["thead", "tbody", "tfoot"]:
+                if tag in {"thead", "tbody", "tfoot"}:
                     self.pp_tbody(body)
                 elif tag == "tr":
                     self.pp_tr(body)
@@ -188,7 +188,7 @@ class Formatter:
                 pass
             elif is_tuple(item):
                 (tag, attrs, body) = item
-                if tag in ["thead", "tbody", "tfoot"]:
+                if tag in {"thead", "tbody", "tfoot"}:
                     n = self.count_cols(body)
                 elif tag == "tr":
                     n = len(clean(body))
@@ -241,7 +241,7 @@ class Formatter:
         s = s.replace('"', "\\(dq")
         s = s.replace("`", "\\(ga")
         s = s.replace("-", "\\-")
-        if self.at_bol and s[0] in [".", "'"]:
+        if self.at_bol and s[0] in {".", "'"}:
             s = "\\&" + s
         self.show(s)
 

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -76,7 +76,7 @@ def make_gradient(path):
                 minval += abs(minval / 100)
             maxval = float(records[-1][0])
             maxval = min(maxval, 2500000)
-        if os.path.basename(path) in ("ndvi", "ndwi", "ndwi2"):
+        if os.path.basename(path) in {"ndvi", "ndwi", "ndwi2"}:
             minval = -1.0
             maxval = 1.0
         if os.path.basename(path) == "ndvi_MODIS":
@@ -86,7 +86,7 @@ def make_gradient(path):
             maxval = 1000.0
         if os.path.basename(path) == "precipitation":
             maxval = 2000.0
-        if os.path.basename(path) in ("terrain", "srtm", "srtm_plus"):
+        if os.path.basename(path) in {"terrain", "srtm", "srtm_plus"}:
             minval = -500.0
             maxval = 3000.0
         grad = tmp_grad_abs


### PR DESCRIPTION
Concerns Pylint rule ["use-set-for-membership / R6201"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-set-for-membership.html)

Using `ruff check --output-format=concise --select PLR6201 --preview --unsafe-fixes --fix`, but reverting some changes where it wasn't clear if it was safe.


Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [literal-membership (PLR6201)](https://docs.astral.sh/ruff/rules/literal-membership/) to fix part of Pylint's ["use-set-for-membership / R6201"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/use-set-for-membership.html).

I reverted some changes when I wasn't completely sure if the preconditions for this refactor were met, as described in the docs of the rule. One of these is that the objects must be hashable to be in a set. If there are any that you are unsure, I'll simply remove it from the PR, as it isn't exhaustive yet. It still helps to have less linter ignores comments to add afterwards (to have Pylint 3.x not fail).

The changes excludes the files already submitted in different PRs to limit the review scope.