### PR TITLE
style: Fixes useless-return (PLR1711)

### DIFF
--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -259,7 +259,6 @@ class RLIWizard:
             self.CIR_RL += 1
         if not self.CIR_CL % 2:
             self.CIR_CL += 1
-        return
 
     def _circle(self, radius, mask):
         """Create a circle mask"""
@@ -1132,11 +1131,9 @@ class SamplingAreasPage(TitledPage):
 
     def OnRegionDraw(self, event):
         self.RegionDraw(event.GetInt())
-        return
 
     def OnOverwrite(self, event):
         self.overwriteTemp = self.overwriteCheck.GetValue()
-        return
 
     def OnVectYes(self, event):
         """The user choose to select the vector areas, this function set the

--- a/imagery/i.atcorr/create_iwave.py
+++ b/imagery/i.atcorr/create_iwave.py
@@ -170,8 +170,6 @@ def plot_filter(values):
     plot(response[:, 0], response[:, 1], "ro")
     plot(arange(limits[0], limits[1], 2.5), filter_f)
 
-    return
-
 
 def pretty_print(filter_f):
     """
@@ -327,8 +325,6 @@ def write_cpp(bands, values, sensor, folder):
             outfile.write("        break;\n")
         outfile.write("    }\n}\n")
 
-    return
-
 
 def main():
     """control function"""
@@ -390,8 +386,6 @@ def main():
         " iwave.h, geomcond.h, geomcond.cpp, and to i.atcorr.html"
     )
     print
-
-    return
 
 
 if __name__ == "__main__":

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -755,8 +755,6 @@ def print_temporal_topology_relationships(maps1, maps2=None, dbif=None):
     if connection_state_changed:
         dbif.close()
 
-    return
-
 
 ###############################################################################
 
@@ -789,8 +787,6 @@ def print_spatio_temporal_topology_relationships(
 
     if connection_state_changed:
         dbif.close()
-
-    return
 
 
 ###############################################################################

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1454,8 +1454,6 @@ def install_extension_xml(edict):
             )
     write_xml_extensions(xml_file, tree)
 
-    return None
-
 
 def get_multi_addon_addons_which_install_only_html_man_page():
     """Get multi-addon addons which install only manual html page

--- a/scripts/r.in.aster/r.in.aster.py
+++ b/scripts/r.in.aster/r.in.aster.py
@@ -175,8 +175,6 @@ def main():
     grass.try_remove(tempfile)
     grass.message(_("Done."))
 
-    return
-
 
 def import_aster(proj, srcfile, tempfile, output, band):
     # run gdalwarp with selected options (must be in $PATH)


### PR DESCRIPTION
Concerns Pylint rule ["useless-return / R1711"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/useless-return.html)

Using `ruff check --output-format=concise --select PLR1711 --fix`.

Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [useless-return (PLR1711)](https://docs.astral.sh/ruff/rules/useless-return/) to fix Pylint's ["useless-return / R1711"](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/useless-return.html).

This one is quite easy to review