### PR TITLE
style: Fixes some unnecessary-lambda (PLW0108)

### DIFF
--- a/gui/wxpython/animation/frame.py
+++ b/gui/wxpython/animation/frame.py
@@ -353,7 +353,7 @@ class AnimationFrame(wx.Frame):
         if not self.dialogs["preferences"]:
             dlg = PreferencesDialog(parent=self, giface=self._giface)
             self.dialogs["preferences"] = dlg
-            dlg.formatChanged.connect(lambda: self.controller.UpdateAnimations())
+            dlg.formatChanged.connect(self.controller.UpdateAnimations)
             dlg.CenterOnParent()
 
         self.dialogs["preferences"].Show()

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -206,9 +206,7 @@ class ModelSearchDialog(wx.Dialog):
             parent=self, giface=giface, menuModel=menuModel.GetModel()
         )
         self.cmd_prompt.promptRunCmd.connect(self.OnCommand)
-        self.cmd_prompt.commandSelected.connect(
-            lambda command: self.label.SetValue(command)
-        )
+        self.cmd_prompt.commandSelected.connect(self.label.SetValue)
         self.search = SearchModuleWidget(
             parent=self.panel, model=menuModel.GetModel(), showTip=True
         )

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -156,9 +156,7 @@ class ModelerPanel(wx.Panel, MainPageBase):
         self.goutput = GConsoleWindow(
             parent=self, giface=giface, gconsole=self._gconsole
         )
-        self.goutput.showNotification.connect(
-            lambda message: self.SetStatusText(message)
-        )
+        self.goutput.showNotification.connect(self.SetStatusText)
 
         # here events are binded twice
         self._gconsole.Bind(

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -568,9 +568,7 @@ class TaskFrame(wx.Frame):
             self._gconsole.mapCreated.connect(self.OnMapCreated)
         self.goutput = self.notebookpanel.goutput
         if self.goutput:
-            self.goutput.showNotification.connect(
-                lambda message: self.SetStatusText(message)
-            )
+            self.goutput.showNotification.connect(self.SetStatusText)
 
         self.notebookpanel.OnUpdateValues = self.updateValuesHook
         guisizer.Add(self.notebookpanel, proportion=1, flag=wx.EXPAND)

--- a/gui/wxpython/gui_core/menu.py
+++ b/gui/wxpython/gui_core/menu.py
@@ -227,7 +227,7 @@ class SearchModuleWindow(wx.Panel):
         self._btnAdvancedSearch.Bind(wx.EVT_BUTTON, lambda evt: self.AdvancedSearch())
 
         self._tree.selectionChanged.connect(self.OnItemSelected)
-        self._tree.itemActivated.connect(lambda node: self.Run(node))
+        self._tree.itemActivated.connect(self.Run)
 
         self._layout()
 

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -167,11 +167,9 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
         self._loadHistory()
         if giface:
             giface.currentMapsetChanged.connect(self._loadHistory)
-            giface.entryToHistoryAdded.connect(
-                lambda entry: self._addEntryToCmdHistoryBuffer(entry)
-            )
+            giface.entryToHistoryAdded.connect(self._addEntryToCmdHistoryBuffer)
             giface.entryFromHistoryRemoved.connect(
-                lambda index: self._removeEntryFromCmdHistoryBuffer(index)
+                self._removeEntryFromCmdHistoryBuffer
             )
         #
         # bindings
@@ -433,7 +431,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             else:
                 delimiter = char
             parts.append(delimiter + textLeft.rpartition(char)[2])
-        return min(parts, key=lambda x: len(x))
+        return min(parts, key=len)
 
     def ShowList(self):
         """Show sorted auto-completion list if it is not empty"""

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -1335,7 +1335,7 @@ class SearchModuleWidget(wx.Panel):
             nodes.update(self._model.SearchNodes(key=key, value=value))
 
         nodes = list(nodes)
-        nodes.sort(key=lambda node: self._model.GetIndexOfNode(node))
+        nodes.sort(key=self._model.GetIndexOfNode)
         self._results = nodes
         self._resultIndex = -1
         commands = sorted(

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -137,12 +137,8 @@ class HistoryBrowserTree(CTreeView):
         self.runIgnoredCmdPattern = Signal("HistoryBrowserTree.runIgnoredCmdPattern")
 
         self._giface.currentMapsetChanged.connect(self.UpdateHistoryModelFromScratch)
-        self._giface.entryToHistoryAdded.connect(
-            lambda entry: self.InsertCommand(entry)
-        )
-        self._giface.entryInHistoryUpdated.connect(
-            lambda entry: self.UpdateCommand(entry)
-        )
+        self._giface.entryToHistoryAdded.connect(self.InsertCommand)
+        self._giface.entryInHistoryUpdated.connect(self.UpdateCommand)
 
         self.SetToolTip(_("Double-click to open the tool"))
         self.selectionChanged.connect(self.OnItemSelected)

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -139,9 +139,7 @@ class IClassMapPanel(DoubleMapPanel):
         # TODO: for vdigit: it does nothing here because areas do not produce
         # this info
         self.firstMapWindow.digitizingInfo.connect(
-            lambda text: self.statusbarManager.statusbarItems[
-                "coordinates"
-            ].SetAdditionalInfo(text)
+            self.statusbarManager.statusbarItems["coordinates"].SetAdditionalInfo
         )
         self.firstMapWindow.digitizingInfoUnavailable.connect(
             lambda: self.statusbarManager.statusbarItems[

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -389,9 +389,7 @@ class GMFrame(wx.Frame):
     def _createDataCatalog(self, parent):
         """Initialize Data Catalog widget"""
         self.datacatalog = DataCatalog(parent=parent, giface=self._giface)
-        self.datacatalog.showNotification.connect(
-            lambda message: self.SetStatusText(message)
-        )
+        self.datacatalog.showNotification.connect(self.SetStatusText)
 
     def _createDisplay(self, parent):
         """Initialize Display widget"""
@@ -412,9 +410,7 @@ class GMFrame(wx.Frame):
                 giface=self._giface,
                 model=self._moduleTreeBuilder.GetModel(),
             )
-            self.search.showNotification.connect(
-                lambda message: self.SetStatusText(message)
-            )
+            self.search.showNotification.connect(self.SetStatusText)
         else:
             self.search = None
 
@@ -434,9 +430,7 @@ class GMFrame(wx.Frame):
             menuModel=self._moduleTreeBuilder.GetModel(),
             gcstyle=GC_PROMPT,
         )
-        self.goutput.showNotification.connect(
-            lambda message: self.SetStatusText(message)
-        )
+        self.goutput.showNotification.connect(self.SetStatusText)
 
         self._gconsole.mapCreated.connect(self.OnMapCreated)
         self._gconsole.Bind(
@@ -449,9 +443,7 @@ class GMFrame(wx.Frame):
         """Initialize history browser widget"""
         if not UserSettings.Get(group="manager", key="hideTabs", subkey="history"):
             self.history = HistoryBrowser(parent=parent, giface=self._giface)
-            self.history.showNotification.connect(
-                lambda message: self.SetStatusText(message)
-            )
+            self.history.showNotification.connect(self.SetStatusText)
             self.history.runIgnoredCmdPattern.connect(
                 lambda cmd: self.RunSpecialCmd(command=cmd),
             )
@@ -637,9 +629,7 @@ class GMFrame(wx.Frame):
 
         # add 'console' widget to main notebook page and add connect switch page signal
         self.notebook.AddPage(page=self.goutput, text=_("Console"), name="output")
-        self.goutput.contentChanged.connect(
-            lambda notification: self._switchPage(notification)
-        )
+        self.goutput.contentChanged.connect(self._switchPage)
 
         # add 'history module' widget to main notebook page
         if self.history:

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -1248,7 +1248,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             lambda value: self.ChangeGroupLayerOpacity(layer=child, value=value)
         )
         # Apply button
-        dlg.applyOpacity.connect(lambda: self._recalculateLayerButtonPosition())
+        dlg.applyOpacity.connect(self._recalculateLayerButtonPosition)
         dlg.CentreOnParent()
 
         if dlg.ShowModal() == wx.ID_OK:
@@ -1288,7 +1288,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
             )
         )
         # Apply button
-        dlg.applyOpacity.connect(lambda: self._recalculateLayerButtonPosition())
+        dlg.applyOpacity.connect(self._recalculateLayerButtonPosition)
         dlg.CentreOnParent()
 
         if dlg.ShowModal() == wx.ID_OK:

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -331,9 +331,7 @@ class GMFrame(wx.Frame):
     def _createDataCatalog(self, parent):
         """Initialize Data Catalog widget"""
         self.datacatalog = DataCatalog(parent=parent, giface=self._giface)
-        self.datacatalog.showNotification.connect(
-            lambda message: self.SetStatusText(message)
-        )
+        self.datacatalog.showNotification.connect(self.SetStatusText)
 
     def _createDisplay(self, parent):
         """Initialize Display widget"""
@@ -355,9 +353,7 @@ class GMFrame(wx.Frame):
                 giface=self._giface,
                 model=self._moduleTreeBuilder.GetModel(),
             )
-            self.search.showNotification.connect(
-                lambda message: self.SetStatusText(message)
-            )
+            self.search.showNotification.connect(self.SetStatusText)
         else:
             self.search = None
 
@@ -377,12 +373,8 @@ class GMFrame(wx.Frame):
             menuModel=self._moduleTreeBuilder.GetModel(),
             gcstyle=GC_PROMPT,
         )
-        self.goutput.showNotification.connect(
-            lambda message: self.SetStatusText(message)
-        )
-        self.goutput.contentChanged.connect(
-            lambda notification: self._focusPage(notification)
-        )
+        self.goutput.showNotification.connect(self.SetStatusText)
+        self.goutput.contentChanged.connect(self._focusPage)
 
         self._gconsole.mapCreated.connect(self.OnMapCreated)
         self._gconsole.Bind(
@@ -395,9 +387,7 @@ class GMFrame(wx.Frame):
         """Initialize history browser widget"""
         if not UserSettings.Get(group="manager", key="hideTabs", subkey="history"):
             self.history = HistoryBrowser(parent=parent, giface=self._giface)
-            self.history.showNotification.connect(
-                lambda message: self.SetStatusText(message)
-            )
+            self.history.showNotification.connect(self.SetStatusText)
             self.history.runIgnoredCmdPattern.connect(
                 lambda cmd: self.RunSpecialCmd(command=cmd),
             )

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -324,9 +324,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
             )
             self._setUpMapWindow(self.MapWindowVDigit)
             self.MapWindowVDigit.digitizingInfo.connect(
-                lambda text: self.statusbarManager.statusbarItems[
-                    "coordinates"
-                ].SetAdditionalInfo(text)
+                self.statusbarManager.statusbarItems["coordinates"].SetAdditionalInfo
             )
             self.MapWindowVDigit.digitizingInfoUnavailable.connect(
                 lambda: self.statusbarManager.statusbarItems[
@@ -366,9 +364,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
             def openATM(selection):
                 self._layerManager.OnShowAttributeTable(None, selection=selection)
 
-            self.toolbars["vdigit"].openATM.connect(
-                lambda selection: openATM(selection)
-            )
+            self.toolbars["vdigit"].openATM.connect(openATM)
             self.Map.layerAdded.connect(self._updateVDigitLayers)
         self.MapWindowVDigit.SetToolbar(self.toolbars["vdigit"])
 
@@ -1247,9 +1243,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
         self.measureController = controller(self._giface, mapWindow=self.GetMapWindow())
         # assure that the mode is ended and lines are cleared whenever other
         # tool is selected
-        self._toolSwitcher.toggleToolChanged.connect(
-            lambda: self.measureController.Stop()
-        )
+        self._toolSwitcher.toggleToolChanged.connect(self.measureController.Stop)
         self.measureController.Start()
 
     def OnProfile(self, event):

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -579,8 +579,8 @@ class MapApp(wx.App):
             ),
         )
 
-        self.Map.saveToFile.connect(lambda cmd: self.mapDisplay.DOutFile(cmd))
-        self.Map.dToRast.connect(lambda cmd: self.mapDisplay.DToRast(cmd))
+        self.Map.saveToFile.connect(self.mapDisplay.DOutFile)
+        self.Map.dToRast.connect(self.mapDisplay.DToRast)
         self.Map.query.connect(
             lambda ltype, maps: self.mapDisplay.SetQueryLayersAndActivate(
                 ltype=ltype, maps=maps

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -85,8 +85,8 @@ class SwipeMapPanel(DoubleMapPanel):
         self.secondMapWindow.mapQueried.connect(self.Query)
 
         # bind tracking cursosr to mirror it
-        self.firstMapWindow.Bind(wx.EVT_MOTION, lambda evt: self.TrackCursor(evt))
-        self.secondMapWindow.Bind(wx.EVT_MOTION, lambda evt: self.TrackCursor(evt))
+        self.firstMapWindow.Bind(wx.EVT_MOTION, self.TrackCursor)
+        self.secondMapWindow.Bind(wx.EVT_MOTION, self.TrackCursor)
 
         self.MapWindow = self.firstMapWindow  # current by default
         self.firstMapWindow.zoomhistory = self.secondMapWindow.zoomhistory
@@ -785,9 +785,7 @@ class SwipeMapPanel(DoubleMapPanel):
         else:
             self._queryDialog = QueryDialog(parent=self, data=result)
             self._queryDialog.Bind(wx.EVT_CLOSE, self._oncloseQueryDialog)
-            self._queryDialog.redirectOutput.connect(
-                lambda output: self._giface.WriteLog(output)
-            )
+            self._queryDialog.redirectOutput.connect(self._giface.WriteLog)
             self._queryDialog.Show()
 
     def _oncloseQueryDialog(self, event):

--- a/gui/wxpython/rdigit/g.gui.rdigit.py
+++ b/gui/wxpython/rdigit/g.gui.rdigit.py
@@ -139,7 +139,7 @@ def main():
                 rdigit.OnMapSelection()
             # use Close instead of QuitRDigit for standalone tool
             self.rdigit.quitDigitizer.disconnect(self.QuitRDigit)
-            self.rdigit.quitDigitizer.connect(lambda: self.Close())
+            self.rdigit.quitDigitizer.connect(self.Close)
 
             # add Map Display panel to Map Display frame
             sizer = wx.BoxSizer(wx.VERTICAL)

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -104,7 +104,7 @@ def main():
             self.toolbars["vdigit"].StartEditing(mapLayer)
             # use Close instead of QuitVDigit for standalone tool
             self.toolbars["vdigit"].quitDigitizer.disconnect(self.QuitVDigit)
-            self.toolbars["vdigit"].quitDigitizer.connect(lambda: self.Close())
+            self.toolbars["vdigit"].quitDigitizer.connect(self.Close)
 
             # add Map Display panel to Map Display frame
             sizer = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
Concerns Pylint rule ["unnecessary-lambda / W0108"](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/unnecessary-lambda.html)

Using `ruff check --output-format=concise --select PLW0108 --preview --fix --unsafe-fixes`.

Didn't apply to cases where it wasn't clear if it was safe.

Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [unnecessary-lambda (PLW0108)](https://docs.astral.sh/ruff/rules/unnecessary-lambda/#unnecessary-lambda-plw0108) to fix part of Pylint's ["unnecessary-lambda / W0108"](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/unnecessary-lambda.html).