### PR TITLE
style: Fixes useless-exception-statement (PLW0133)

### DIFF
--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -108,7 +108,7 @@ def split_mapset_path(mapset_path):
     """Split mapset path to three parts - grassdb, location, mapset"""
     mapset_path = Path(mapset_path)
     if len(mapset_path.parts) < 3:
-        ValueError(
+        raise ValueError(
             _("Mapset path '{}' needs at least three components").format(mapset_path)
         )
     mapset = mapset_path.name

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -51,7 +51,7 @@ class TestModuleDownloadFromDifferentSources(TestCase):
         if self.install_prefix.exists():
             files = list(path.name for path in self.install_prefix.iterdir())
             if files:
-                RuntimeError(
+                raise RuntimeError(
                     f"Install prefix path '{self.install_prefix}' \
                     contains files {','.join(files)}"
                 )

--- a/scripts/g.extension/testsuite/test_addons_modules.py
+++ b/scripts/g.extension/testsuite/test_addons_modules.py
@@ -80,7 +80,7 @@ class TestModulesFromDifferentSources(TestCase):
         if os.path.exists(self.install_prefix):
             files = os.listdir(self.install_prefix)
             if files:
-                RuntimeError(
+                raise RuntimeError(
                     "Install prefix path '{}' contains files {}".format(
                         self.install_prefix, files
                     )


### PR DESCRIPTION
Concerns Pylint rule ["pointless-exception-statement / W0133"](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/pointless-exception-statement.html)

Using `ruff check --output-format=concise --select PLW0133 --unsafe-fixes --fix`.

Part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Uses the fixes provided for ruff rule [useless-exception-statement (PLW0133)](https://docs.astral.sh/ruff/rules/useless-exception-statement/) to fix Pylint's ["pointless-exception-statement / W0133"](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/pointless-exception-statement.html).


This one is extremely easy to review. The three exceptions were simply not raised, which doesn't make sense, nor do what was intended.