### PR TITLE
i.landsat.acca: Fix uninitialized variable issue in main.c

### DIFF
--- a/imagery/i.landsat.acca/main.c
+++ b/imagery/i.landsat.acca/main.c
@@ -176,6 +176,7 @@ int main(int argc, char *argv[])
     in_name = band_prefix->answer;
 
     for (i = BAND2; i <= BAND6; i++) {
+        band[i].name[0] = '\0';
         sprintf(band[i].name, "%s%d%c", in_name, i + 2,
                 (i == BAND6 && !sat5->answer ? '1' : '\0'));
         band[i].fd = check_raster(band[i].name);


### PR DESCRIPTION
 **Fix uninitialized variable issue in i.landsat.acca**

This pull request addresses an issue in **imagery/i.landsat.acca/main.c** where the variable **band[i].name** was uninitialized before being used. The fix involves initializing the first character of band[i].name to '\0' to ensure it is a valid string before passing it to sprintf.

**Changes:**
- Initialize band[i].name before using sprintf to avoid undefined behavior.
