### PR TITLE
style(python): Sort and group imports in python/grass

### DIFF
--- a/python/grass/__init__.py
+++ b/python/grass/__init__.py
@@ -19,7 +19,6 @@ so that the function ``_`` appears in the global namespace (as an additional bui
 import builtins as _builtins
 import os
 
-
 # Setup translations
 #
 # The translations in the GRASS GIS Python package grass, GRASS Python modules

--- a/python/grass/app/data.py
+++ b/python/grass/app/data.py
@@ -12,13 +12,13 @@ for details.
 This is not a stable part of the API. Use at your own risk.
 """
 
-import os
-import tempfile
 import getpass
+import os
 import sys
+import tempfile
 from shutil import copytree, ignore_patterns
-import grass.grassdb.config as cfg
 
+import grass.grassdb.config as cfg
 from grass.grassdb.checks import is_location_valid
 
 

--- a/python/grass/benchmark/testsuite/test_benchmark.py
+++ b/python/grass/benchmark/testsuite/test_benchmark.py
@@ -17,8 +17,8 @@ from subprocess import DEVNULL
 from types import SimpleNamespace
 
 from grass.benchmark import (
-    benchmark_resolutions,
     benchmark_nprocs,
+    benchmark_resolutions,
     benchmark_single,
     join_results,
     load_results,

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -10,10 +10,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-from datetime import date
 import string
+import sys
+from datetime import date
 from shutil import copy
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/python/grass/exceptions/testsuite/test_ScriptError.py
+++ b/python/grass/exceptions/testsuite/test_ScriptError.py
@@ -1,6 +1,6 @@
+from grass.exceptions import ScriptError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.exceptions import ScriptError
 
 
 class TestTextAssertions(TestCase):

--- a/python/grass/experimental/create.py
+++ b/python/grass/experimental/create.py
@@ -4,15 +4,12 @@ import pathlib
 import tempfile
 
 from grass.grassdb.checks import (
-    mapset_exists,
-    is_mapset_valid,
     get_mapset_invalid_reason,
+    is_mapset_valid,
+    mapset_exists,
 )
-from grass.grassdb.create import (
-    create_mapset,
-    _directory_to_mapset,
-)
-from grass.grassdb.manage import delete_mapset, resolve_mapset_path, MapsetPath
+from grass.grassdb.create import _directory_to_mapset, create_mapset
+from grass.grassdb.manage import MapsetPath, delete_mapset, resolve_mapset_path
 
 
 def require_create_ensure_mapset(

--- a/python/grass/experimental/mapset.py
+++ b/python/grass/experimental/mapset.py
@@ -1,13 +1,13 @@
 "Session or subsession for mapsets (subprojects)"
 
-import shutil
 import os
+import shutil
 from pathlib import Path
 
 import grass.script as gs
 from grass.experimental.create import (
-    require_create_ensure_mapset,
     create_temporary_mapset,
+    require_create_ensure_mapset,
 )
 
 

--- a/python/grass/experimental/tests/conftest.py
+++ b/python/grass/experimental/tests/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for grass.script"""
 
-import uuid
 import os
+import uuid
 
 import pytest
 

--- a/python/grass/grassdb/create.py
+++ b/python/grass/grassdb/create.py
@@ -9,11 +9,11 @@ for details.
 .. sectionauthor:: Vaclav Petras <wenzeslaus gmail com>
 """
 
+import getpass
 import os
 import shutil
-import getpass
 
-from grass.grassdb.manage import resolve_mapset_path, MapsetPath
+from grass.grassdb.manage import MapsetPath, resolve_mapset_path
 
 
 def _directory_to_mapset(path: MapsetPath):

--- a/python/grass/grassdb/history.py
+++ b/python/grass/grassdb/history.py
@@ -11,10 +11,10 @@ for details.
 
 import json
 import shutil
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
-from datetime import datetime
 import grass.script as gs
 
 

--- a/python/grass/grassdb/manage.py
+++ b/python/grass/grassdb/manage.py
@@ -14,7 +14,6 @@ import shutil
 import sys
 from pathlib import Path
 
-
 import grass.grassdb.config
 
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -9,31 +9,30 @@ for details.
 :authors: Vaclav Petras
 """
 
+import hashlib
 import os
 import shutil
 import subprocess
-import hashlib
-import uuid
 import unittest
+import uuid
+from io import StringIO
 
-from grass.pygrass.modules import Module
 from grass.exceptions import CalledModuleError
-from grass.script import text_to_string, encode, decode
+from grass.pygrass.modules import Module
+from grass.script import decode, encode, text_to_string
 
-from .gmodules import call_module, SimpleModule
 from .checkers import (
     check_text_ellipsis,
-    text_to_keyvalue,
-    keyvalue_equals,
     diff_keyvalue,
     file_md5,
-    text_file_md5,
     files_equal_md5,
+    keyvalue_equals,
+    text_file_md5,
+    text_to_keyvalue,
 )
-from .utils import safe_repr
+from .gmodules import SimpleModule, call_module
 from .gutils import is_map_in_mapset
-
-from io import StringIO
+from .utils import safe_repr
 
 
 class TestCase(unittest.TestCase):

--- a/python/grass/gunittest/checkers.py
+++ b/python/grass/gunittest/checkers.py
@@ -9,11 +9,11 @@ for details.
 :authors: Vaclav Petras, Soeren Gebbert
 """
 
-import os
-import sys
-import re
 import doctest
 import hashlib
+import os
+import re
+import sys
 
 from grass.script.utils import encode
 

--- a/python/grass/gunittest/gmodules.py
+++ b/python/grass/gunittest/gmodules.py
@@ -10,10 +10,11 @@ for details.
 """
 
 import subprocess
-from grass.script.core import start_command
-from grass.script.utils import encode, decode
+
 from grass.exceptions import CalledModuleError
 from grass.pygrass.modules import Module
+from grass.script.core import start_command
+from grass.script.utils import decode, encode
 
 from .utils import do_doctest_gettext_workaround
 

--- a/python/grass/gunittest/gutils.py
+++ b/python/grass/gunittest/gutils.py
@@ -9,11 +9,11 @@ for details.
 :authors: Vaclav Petras
 """
 
-from grass.script.core import start_command, PIPE
+from grass.script.core import PIPE, start_command
 from grass.script.utils import decode
 
-from .gmodules import call_module
 from .checkers import text_to_keyvalue
+from .gmodules import call_module
 
 
 def get_current_mapset():

--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -15,23 +15,22 @@ import shutil
 import subprocess
 import sys
 
-from .checkers import text_to_keyvalue
+import grass.script as gs
+from grass.script.utils import _get_encoding, decode
 
+from .checkers import text_to_keyvalue
 from .loader import GrassTestLoader, discover_modules
 from .reporters import (
+    GrassTestFilesHtmlReporter,
+    GrassTestFilesKeyValueReporter,
     GrassTestFilesMultiReporter,
     GrassTestFilesTextReporter,
-    GrassTestFilesHtmlReporter,
-    TestsuiteDirReporter,
-    GrassTestFilesKeyValueReporter,
-    get_svn_path_authors,
     NoopFileAnonymizer,
+    TestsuiteDirReporter,
+    get_svn_path_authors,
     keyvalue_to_text,
 )
-from .utils import silent_rmtree, ensure_dir
-
-import grass.script as gs
-from grass.script.utils import decode, _get_encoding
+from .utils import ensure_dir, silent_rmtree
 
 maketrans = str.maketrans
 

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -9,11 +9,11 @@ for details.
 :authors: Vaclav Petras
 """
 
-import os
-import fnmatch
-import unittest
 import collections
+import fnmatch
+import os
 import re
+import unittest
 
 
 def fnmatch_exclude_with_base(files, base, exclude):

--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -9,21 +9,20 @@ for details.
 :authors: Vaclav Petras
 """
 
-import os
-import sys
 import argparse
 import configparser
+import os
+import sys
 from pathlib import Path
-
 from unittest.main import TestProgram
 
 import grass.script.core as gs
 
-from .loader import GrassTestLoader
-from .runner import GrassTestRunner, MultiTestResult, TextTestResult, KeyValueTestResult
 from .invoker import GrassTestFilesInvoker
-from .utils import silent_rmtree
+from .loader import GrassTestLoader
 from .reporters import FileAnonymizer
+from .runner import GrassTestRunner, KeyValueTestResult, MultiTestResult, TextTestResult
+from .utils import silent_rmtree
 
 
 class GrassTestProgram(TestProgram):

--- a/python/grass/gunittest/multireport.py
+++ b/python/grass/gunittest/multireport.py
@@ -9,20 +9,20 @@ for details.
 :authors: Vaclav Petras
 """
 
-import sys
-import os
 import argparse
-import itertools
 import datetime
+import itertools
 import operator
+import os
+import sys
 from collections import defaultdict, namedtuple
-
-from grass.gunittest.checkers import text_to_keyvalue
-from grass.gunittest.utils import ensure_dir
-from grass.gunittest.reporters import success_to_html_percent
 
 # TODO: we should be able to work without matplotlib
 import matplotlib
+
+from grass.gunittest.checkers import text_to_keyvalue
+from grass.gunittest.reporters import success_to_html_percent
+from grass.gunittest.utils import ensure_dir
 
 matplotlib.use("Agg")
 # This counts as code already, so silence "import not at top of file".

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -9,11 +9,11 @@ for details.
 :authors: Vaclav Petras
 """
 
-import sys
-import os
 import argparse
-import subprocess
 import locale
+import os
+import subprocess
+import sys
 
 
 def _get_encoding():

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -9,20 +9,18 @@ for details.
 :authors: Vaclav Petras
 """
 
-import os
-import datetime
-from xml.sax import saxutils
-import xml.etree.ElementTree as et
-import subprocess
 import collections
+import datetime
+import os
 import re
+import subprocess
+import xml.etree.ElementTree as et
 from collections.abc import Iterable
-
-from .utils import ensure_dir
-from .checkers import text_to_keyvalue
-
-
 from io import StringIO
+from xml.sax import saxutils
+
+from .checkers import text_to_keyvalue
+from .utils import ensure_dir
 
 
 # TODO: change text_to_keyvalue to same sep as here

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -14,7 +14,6 @@ a template. It is not expected that something will left.
 
 import sys
 import time
-
 import unittest
 
 __unittest = True

--- a/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_osexit_one.py
+++ b/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_osexit_one.py
@@ -1,4 +1,5 @@
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_osexit_zero.py
+++ b/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_osexit_zero.py
@@ -1,4 +1,5 @@
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_segfaut.py
+++ b/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_segfaut.py
@@ -1,4 +1,5 @@
 import ctypes
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_sysexit_one.py
+++ b/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_sysexit_one.py
@@ -1,4 +1,5 @@
 import sys
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_sysexit_zero.py
+++ b/python/grass/gunittest/testsuite/data/samplecode/submodule_errors/subsubmodule_exiting/testsuite/test_sysexit_zero.py
@@ -1,4 +1,5 @@
 import sys
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/python/grass/gunittest/testsuite/test_assertions.py
+++ b/python/grass/gunittest/testsuite/test_assertions.py
@@ -5,11 +5,10 @@ Tests assertion methods.
 import os
 
 import grass.script.core as gcore
-from grass.pygrass.modules import Module
-
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
+from grass.pygrass.modules import Module
 
 
 class TestTextAssertions(TestCase):

--- a/python/grass/gunittest/testsuite/test_assertions_vect.py
+++ b/python/grass/gunittest/testsuite/test_assertions_vect.py
@@ -6,7 +6,6 @@ from grass.exceptions import CalledModuleError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 V_UNIVAR_SCHOOLS_WIDTH_SUBSET = """n=144
 nmissing=0
 nnull=23

--- a/python/grass/gunittest/testsuite/test_checkers.py
+++ b/python/grass/gunittest/testsuite/test_checkers.py
@@ -11,19 +11,18 @@ for details.
 @author Vaclav Petras
 """
 
-from grass.script.utils import parse_key_val, try_remove
-
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.checkers import (
-    values_equal,
-    text_to_keyvalue,
+    file_md5,
     keyvalue_equals,
     proj_info_equals,
     proj_units_equals,
-    file_md5,
     text_file_md5,
+    text_to_keyvalue,
+    values_equal,
 )
+from grass.gunittest.main import test
+from grass.script.utils import parse_key_val, try_remove
 
 
 class TestValuesEqual(TestCase):

--- a/python/grass/gunittest/testsuite/test_gmodules.py
+++ b/python/grass/gunittest/testsuite/test_gmodules.py
@@ -1,8 +1,8 @@
 import subprocess
 
 from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import CalledModuleError, call_module
 from grass.gunittest.main import test
-from grass.gunittest.gmodules import call_module, CalledModuleError
 
 G_REGION_OUTPUT = """...
 n=...

--- a/python/grass/gunittest/testsuite/test_gunitest_doctests.py
+++ b/python/grass/gunittest/testsuite/test_gunitest_doctests.py
@@ -5,12 +5,10 @@ Tests checkers
 import doctest
 
 import grass.gunittest.case
+import grass.gunittest.checkers
+import grass.gunittest.gmodules
 import grass.gunittest.main
 import grass.gunittest.utils
-
-import grass.gunittest.gmodules
-import grass.gunittest.checkers
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/gunittest/testsuite/test_module_assertions.py
+++ b/python/grass/gunittest/testsuite/test_module_assertions.py
@@ -1,12 +1,10 @@
 import copy
 import subprocess
 
-from grass.pygrass.modules import Module
-from grass.gunittest.gmodules import SimpleModule
-
 from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import CalledModuleError, SimpleModule
 from grass.gunittest.main import test
-from grass.gunittest.gmodules import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 class TestModuleAssertions(TestCase):

--- a/python/grass/imaging/__init__.py
+++ b/python/grass/imaging/__init__.py
@@ -1,4 +1,4 @@
-from grass.imaging.images2gif import readGif, writeGif
-from grass.imaging.images2swf import readSwf, writeSwf
 from grass.imaging.images2avi import readAvi, writeAvi
+from grass.imaging.images2gif import readGif, writeGif
 from grass.imaging.images2ims import readIms, writeIms
+from grass.imaging.images2swf import readSwf, writeSwf

--- a/python/grass/imaging/images2avi.py
+++ b/python/grass/imaging/images2avi.py
@@ -39,12 +39,12 @@ http://linux.die.net/man/1/ffmpeg
 """
 
 import os
-import time
-import subprocess
 import shutil
+import subprocess
+import time
 
-from grass.imaging import images2ims
 import grass.script as gscript
+from grass.imaging import images2ims
 
 
 def _cleanDir(tempDir):

--- a/python/grass/imaging/images2gif.py
+++ b/python/grass/imaging/images2gif.py
@@ -75,7 +75,7 @@ try:
         PIL.__version__  # test if user has Pillow or PIL
     except AttributeError:
         pillow = False
-    from PIL.GifImagePlugin import getheader, getdata
+    from PIL.GifImagePlugin import getdata, getheader
 except ImportError:
     PIL = None
 

--- a/python/grass/jupyter/__init__.py
+++ b/python/grass/jupyter/__init__.py
@@ -109,6 +109,6 @@ mentored by Vaclav Petras, Stephan Blumentrath, and Helena Mitasova.
 from .interactivemap import InteractiveMap, Raster, Vector
 from .map import Map
 from .map3d import Map3D
+from .seriesmap import SeriesMap
 from .setup import init
 from .timeseriesmap import TimeSeriesMap
-from .seriesmap import SeriesMap

--- a/python/grass/jupyter/baseseriesmap.py
+++ b/python/grass/jupyter/baseseriesmap.py
@@ -1,9 +1,9 @@
 """Base class for SeriesMap and TimeSeriesMap"""
 
 import os
+import shutil
 import tempfile
 import weakref
-import shutil
 
 import grass.script as gs
 

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -15,6 +15,7 @@
 
 import base64
 import json
+
 from .reprojection_renderer import ReprojectionRenderer
 
 

--- a/python/grass/jupyter/region.py
+++ b/python/grass/jupyter/region.py
@@ -16,10 +16,10 @@ import grass.script as gs
 from grass.exceptions import CalledModuleError
 
 from .utils import (
-    get_map_name_from_d_command,
     estimate_resolution,
-    set_target_region,
+    get_map_name_from_d_command,
     get_rendering_size,
+    set_target_region,
 )
 
 

--- a/python/grass/jupyter/reprojection_renderer.py
+++ b/python/grass/jupyter/reprojection_renderer.py
@@ -18,15 +18,17 @@ import os
 import tempfile
 import weakref
 from pathlib import Path
+
 import grass.script as gs
+
 from .map import Map
+from .region import RegionManagerForInteractiveMap
 from .utils import (
     get_location_proj_string,
     get_region,
     reproject_region,
     setup_location,
 )
-from .region import RegionManagerForInteractiveMap
 
 
 class ReprojectionRenderer:

--- a/python/grass/jupyter/seriesmap.py
+++ b/python/grass/jupyter/seriesmap.py
@@ -17,10 +17,10 @@ import shutil
 
 from grass.grassdb.data import map_exists
 
+from .baseseriesmap import BaseSeriesMap
 from .map import Map
 from .region import RegionManagerForSeries
 from .utils import save_gif
-from .baseseriesmap import BaseSeriesMap
 
 
 class SeriesMap(BaseSeriesMap):

--- a/python/grass/jupyter/tests/grass_jupyter_session_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_session_test.py
@@ -1,7 +1,7 @@
 """Test session functions in grass.jupyter"""
 
-import subprocess
 import os
+import subprocess
 import sys
 
 

--- a/python/grass/jupyter/tests/reprojection_renderer_test.py
+++ b/python/grass/jupyter/tests/reprojection_renderer_test.py
@@ -1,7 +1,9 @@
 """Test ReprojectionRenderer functions"""
 
 from pathlib import Path
+
 from pytest import approx
+
 from grass.jupyter.reprojection_renderer import ReprojectionRenderer
 
 

--- a/python/grass/jupyter/tests/seriesmap_test.py
+++ b/python/grass/jupyter/tests/seriesmap_test.py
@@ -1,6 +1,7 @@
 """Test SeriesMap functions"""
 
 from pathlib import Path
+
 import pytest
 
 try:

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -1,6 +1,7 @@
 """Test TimeSeriesMap functions"""
 
 from pathlib import Path
+
 import pytest
 
 try:

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -17,10 +17,10 @@ import shutil
 
 import grass.script as gs
 
+from .baseseriesmap import BaseSeriesMap
 from .map import Map
 from .region import RegionManagerForTimeSeries
 from .utils import save_gif
-from .baseseriesmap import BaseSeriesMap
 
 
 def fill_none_values(names):

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -11,6 +11,7 @@
 
 """Utility functions warpping existing processes in a suitable way"""
 from pathlib import Path
+
 import grass.script as gs
 
 

--- a/python/grass/pydispatch/dispatcher.py
+++ b/python/grass/pydispatch/dispatcher.py
@@ -27,7 +27,8 @@ Internal attributes:
 """
 
 import weakref
-from grass.pydispatch import saferef, robustapply, errors
+
+from grass.pydispatch import errors, robustapply, saferef
 
 __author__ = "Patrick K. O'Brien <pobrien@orbtech.com>"
 __cvsid__ = "Id: dispatcher.py,v 1.1 2010/03/30 15:45:55 mcfletch Exp"

--- a/python/grass/pydispatch/robust.py
+++ b/python/grass/pydispatch/robust.py
@@ -1,6 +1,6 @@
 """Module implementing error-catching version of send (sendRobust)"""
 
-from grass.pydispatch.dispatcher import Any, Anonymous, liveReceivers, getAllReceivers
+from grass.pydispatch.dispatcher import Anonymous, Any, getAllReceivers, liveReceivers
 from grass.pydispatch.robustapply import robustApply
 
 

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -1,8 +1,8 @@
 """Refactored "safe reference" from dispatcher.py"""
 
-import weakref
-import traceback
 import sys
+import traceback
+import weakref
 
 im_func = "__func__"
 im_self = "__self__"

--- a/python/grass/pygrass/errors.py
+++ b/python/grass/pygrass/errors.py
@@ -1,9 +1,8 @@
 from functools import wraps
 
-from grass.exceptions import GrassError
-
-from grass.pygrass.messages import get_msgr
 import grass.lib.gis as libgis
+from grass.exceptions import GrassError
+from grass.pygrass.messages import get_msgr
 
 
 def must_be_open(method):

--- a/python/grass/pygrass/gis/__init__.py
+++ b/python/grass/pygrass/gis/__init__.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 
-from os import listdir
-from os.path import join, isdir
-import shutil
 import ctypes as ct
 import fnmatch
-
+import shutil
+from os import listdir
+from os.path import isdir, join
 
 import grass.lib.gis as libgis
 from grass.pygrass.errors import GrassError
-from grass.script.utils import encode, decode
 from grass.pygrass.utils import getenv
+from grass.script.utils import decode, encode
 
 test_vector_name = "Gis_test_vector"
 test_raster_name = "Gis_test_raster"
@@ -493,6 +492,7 @@ class VisibleMapset:
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
     from grass.script.core import run_command
 

--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -5,10 +5,10 @@ Created on Fri May 25 12:57:10 2012
 """
 
 import ctypes
+
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster
 import grass.script as grass
-
 from grass.pygrass.errors import GrassError
 from grass.pygrass.shell.conversion import dict2html
 from grass.pygrass.utils import get_mapset_raster
@@ -665,6 +665,7 @@ class Region:
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
     from grass.script.core import run_command
 

--- a/python/grass/pygrass/gis/testsuite/test_gis.py
+++ b/python/grass/pygrass/gis/testsuite/test_gis.py
@@ -4,7 +4,6 @@
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.gis.region import Region
 
 

--- a/python/grass/pygrass/gis/testsuite/test_pygrass_gis_doctests.py
+++ b/python/grass/pygrass/gis/testsuite/test_pygrass_gis_doctests.py
@@ -7,10 +7,8 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 from grass.pygrass import gis
 from grass.pygrass.gis import region
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/messages/__init__.py
+++ b/python/grass/pygrass/messages/__init__.py
@@ -15,10 +15,9 @@ for details.
 """
 
 import sys
-from multiprocessing import Process, Lock, Pipe
+from multiprocessing import Lock, Pipe, Process
 
 import grass.lib.gis as libgis
-
 from grass.exceptions import FatalError
 
 

--- a/python/grass/pygrass/messages/testsuite/test_pygrass_messages_doctests.py
+++ b/python/grass/pygrass/messages/testsuite/test_pygrass_messages_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.pygrass.messages as gmessages
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/modules/__init__.py
+++ b/python/grass/pygrass/modules/__init__.py
@@ -1,2 +1,2 @@
-from grass.pygrass.modules.interface import Module, MultiModule, ParallelModuleQueue
 from grass.pygrass.modules import shortcuts
+from grass.pygrass.modules.interface import Module, MultiModule, ParallelModuleQueue

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -1,24 +1,22 @@
 import contextlib
-import os
-import sys
 import multiprocessing as mltp
-import subprocess as sub
+import os
 import shutil as sht
+import subprocess as sub
+import sys
 from math import ceil
 
-from grass.script.setup import write_gisrc
-from grass.script import append_node_pid, legalize_vector_name
-
-from grass.pygrass.gis import Mapset, Location
+from grass.pygrass.gis import Location, Mapset
 from grass.pygrass.gis.region import Region
 from grass.pygrass.modules import Module
-from grass.pygrass.utils import get_mapset_raster, findmaps
-
-from grass.pygrass.modules.grid.split import (
-    split_region_tiles,
-    split_region_in_overlapping_tiles,
-)
 from grass.pygrass.modules.grid.patch import rpatch_map, rpatch_map_r_patch_backend
+from grass.pygrass.modules.grid.split import (
+    split_region_in_overlapping_tiles,
+    split_region_tiles,
+)
+from grass.pygrass.utils import findmaps, get_mapset_raster
+from grass.script import append_node_pid, legalize_vector_name
+from grass.script.setup import write_gisrc
 
 
 def select(parms, ptype):

--- a/python/grass/pygrass/modules/grid/patch.py
+++ b/python/grass/pygrass/modules/grid/patch.py
@@ -5,9 +5,9 @@ Created on Tue Apr  2 18:57:42 2013
 """
 
 from grass.pygrass.gis.region import Region
+from grass.pygrass.modules import Module
 from grass.pygrass.raster import RasterRow
 from grass.pygrass.utils import coor2pixel
-from grass.pygrass.modules import Module
 
 
 def get_start_end_index(bbox_list):

--- a/python/grass/pygrass/modules/grid/testsuite/test_pygrass_modules_grid_doctests.py
+++ b/python/grass/pygrass/modules/grid/testsuite/test_pygrass_modules_grid_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.pygrass.modules as gmodules
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/modules/interface/__init__.py
+++ b/python/grass/pygrass/modules/interface/__init__.py
@@ -4,12 +4,7 @@ Created on Tue Apr  2 18:40:39 2013
 @author: pietro
 """
 
-from grass.pygrass.modules.interface import flag
-from grass.pygrass.modules.interface import parameter
-from grass.pygrass.modules.interface import module
-from grass.pygrass.modules.interface import typedict
-from grass.pygrass.modules.interface import read
-
+from grass.pygrass.modules.interface import flag, module, parameter, read, typedict
 from grass.pygrass.modules.interface.module import (
     Module,
     MultiModule,

--- a/python/grass/pygrass/modules/interface/flag.py
+++ b/python/grass/pygrass/modules/interface/flag.py
@@ -1,5 +1,5 @@
-from grass.pygrass.modules.interface.docstring import docstring_property
 from grass.pygrass.modules.interface import read
+from grass.pygrass.modules.interface.docstring import docstring_property
 
 
 class Flag:

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -1,18 +1,18 @@
-from multiprocessing import cpu_count, Process, Queue
 import time
+from itertools import zip_longest
+from multiprocessing import Process, Queue, cpu_count
 from xml.etree.ElementTree import fromstring
 
 from grass.exceptions import CalledModuleError, GrassError, ParameterError
-from grass.script.core import Popen, PIPE, use_temp_region, del_temp_region
-from grass.script.utils import encode, decode
-from .docstring import docstring_property
-from .parameter import Parameter
-from .flag import Flag
-from .typedict import TypeDict
-from .read import GETFROMTAG, DOC
-from .env import G_debug
+from grass.script.core import PIPE, Popen, del_temp_region, use_temp_region
+from grass.script.utils import decode, encode
 
-from itertools import zip_longest
+from .docstring import docstring_property
+from .env import G_debug
+from .flag import Flag
+from .parameter import Parameter
+from .read import DOC, GETFROMTAG
+from .typedict import TypeDict
 
 
 def _get_bash(self, *args, **kargs):

--- a/python/grass/pygrass/modules/interface/parameter.py
+++ b/python/grass/pygrass/modules/interface/parameter.py
@@ -7,7 +7,7 @@ Created on Tue Apr  2 18:31:47 2013
 import re
 
 from grass.pygrass.modules.interface.docstring import docstring_property
-from grass.pygrass.modules.interface.read import GETTYPE, element2dict, DOC
+from grass.pygrass.modules.interface.read import DOC, GETTYPE, element2dict
 
 
 def _check_value(param, value):

--- a/python/grass/pygrass/modules/interface/testsuite/test_flag.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_flag.py
@@ -6,7 +6,6 @@ Created on Tue Jun 24 09:43:53 2014
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.modules.interface.flag import Flag
 
 

--- a/python/grass/pygrass/modules/interface/testsuite/test_modules.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_modules.py
@@ -7,13 +7,11 @@ Created on Tue Jun 24 09:43:53 2014
 from fnmatch import fnmatch
 from io import BytesIO
 
+from grass.exceptions import ParameterError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import get_commands
-from grass.exceptions import ParameterError
 from grass.pygrass.modules.interface import Module
-
+from grass.script.core import get_commands
 
 SKIP = [
     "g.parser",

--- a/python/grass/pygrass/modules/interface/testsuite/test_parameter.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_parameter.py
@@ -6,7 +6,6 @@ Created on Fri Jul  4 16:32:54 2014
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.modules.interface.parameter import Parameter, _check_value
 
 GETTYPE = {

--- a/python/grass/pygrass/modules/interface/testsuite/test_pygrass_modules_interface_doctests.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_pygrass_modules_interface_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.pygrass.modules as gmodules
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/modules/testsuite/test_import_isolation.py
+++ b/python/grass/pygrass/modules/testsuite/test_import_isolation.py
@@ -10,8 +10,8 @@ Copyright: (C) 2015 pietro
 Created on  Wed Jul 15 11:34:32 2015
 """
 
-import sys
 import fnmatch
+import sys
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
@@ -36,8 +36,8 @@ class TestImportIsolation(TestCase):
             isolate, check(*self.patterns), msg="Test isolation before any import."
         )
         # same import done in __init__ file
-        from grass.pygrass.modules.interface import Module, ParallelModuleQueue
         from grass.pygrass.modules import shortcuts
+        from grass.pygrass.modules.interface import Module, ParallelModuleQueue
 
         self.assertEqual(
             isolate, check(*self.patterns), msg="Test isolation after import Module."

--- a/python/grass/pygrass/modules/testsuite/test_pygrass_modules_doctests.py
+++ b/python/grass/pygrass/modules/testsuite/test_pygrass_modules_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
-from grass.pygrass.modules import shortcuts, grid, interface
-
+from grass.pygrass.modules import grid, interface, shortcuts
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/raster/__init__.py
+++ b/python/grass/pygrass/raster/__init__.py
@@ -1,29 +1,30 @@
 import ctypes
+
 import numpy as np
 
 #
 # import GRASS modules
 #
-from grass.script import fatal
-from grass.exceptions import OpenError
-
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster
 import grass.lib.rowio as librowio
+from grass.exceptions import OpenError
+from grass.script import fatal
 
 libgis.G_gisinit("")
 
 # import pygrass modules
+from grass.pygrass import utils
 from grass.pygrass.errors import must_be_open
 from grass.pygrass.gis.region import Region
-from grass.pygrass import utils
 
 # import raster classes
 from grass.pygrass.raster.abstract import RasterAbstractBase
-from grass.pygrass.raster.raster_type import TYPE as RTYPE, RTYPE_STR
 from grass.pygrass.raster.buffer import Buffer
-from grass.pygrass.raster.segment import Segment
+from grass.pygrass.raster.raster_type import RTYPE_STR
+from grass.pygrass.raster.raster_type import TYPE as RTYPE
 from grass.pygrass.raster.rowio import RowIO
+from grass.pygrass.raster.segment import Segment
 
 WARN_OVERWRITE = "Raster map <{0}> already exists and will be overwritten"
 
@@ -717,6 +718,7 @@ def numpy2raster(array, mtype, rastname, overwrite=False):
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass.modules import Module
 
     Module("g.region", n=40, s=0, e=40, w=0, res=10)

--- a/python/grass/pygrass/raster/abstract.py
+++ b/python/grass/pygrass/raster/abstract.py
@@ -6,28 +6,18 @@ Created on Fri Aug 17 16:05:25 2012
 
 import ctypes
 
-#
-# import GRASS modules
-#
-from grass.script import fatal, gisenv
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster
-
-#
-# import pygrass modules
-#
 from grass.pygrass import utils
+from grass.pygrass.errors import must_be_in_current_mapset, must_be_open
 from grass.pygrass.gis.region import Region
-from grass.pygrass.errors import must_be_open, must_be_in_current_mapset
-from grass.pygrass.shell.conversion import dict2html
-from grass.pygrass.shell.show import raw_figure
-
-#
-# import raster classes
-#
-from grass.pygrass.raster.raster_type import TYPE as RTYPE, RTYPE_STR
 from grass.pygrass.raster.category import Category
 from grass.pygrass.raster.history import History
+from grass.pygrass.raster.raster_type import RTYPE_STR
+from grass.pygrass.raster.raster_type import TYPE as RTYPE
+from grass.pygrass.shell.conversion import dict2html
+from grass.pygrass.shell.show import raw_figure
+from grass.script import fatal, gisenv
 
 test_raster_name = "abstract_test_map"
 
@@ -623,6 +613,7 @@ class RasterAbstractBase:
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass.modules import Module
 
     Module("g.region", n=40, s=0, e=40, w=0, res=10)

--- a/python/grass/pygrass/raster/buffer.py
+++ b/python/grass/pygrass/raster/buffer.py
@@ -1,7 +1,8 @@
-from grass.pygrass.raster.raster_type import TYPE as RTYPE
 import ctypes
+
 import numpy as np
 
+from grass.pygrass.raster.raster_type import TYPE as RTYPE
 
 _CELL = ("int", "intp", "int8", "int16", "int32", "int64")
 CELL = tuple([getattr(np, attr) for attr in _CELL if hasattr(np, attr)])

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -9,10 +9,9 @@ from operator import itemgetter
 
 import grass.lib.raster as libraster
 from grass.exceptions import ImplementationError
-
 from grass.pygrass.errors import GrassError
-from grass.pygrass.utils import decode
 from grass.pygrass.raster.raster_type import TYPE as RTYPE
+from grass.pygrass.utils import decode
 
 
 class Category(list):

--- a/python/grass/pygrass/raster/history.py
+++ b/python/grass/pygrass/raster/history.py
@@ -5,10 +5,11 @@ Created on Thu Jun 28 17:44:45 2012
 """
 
 import ctypes
-import grass.lib.raster as libraster
 import datetime
-from grass.script.utils import encode
+
+import grass.lib.raster as libraster
 from grass.pygrass.utils import decode
+from grass.script.utils import encode
 
 
 class History:

--- a/python/grass/pygrass/raster/raster_type.py
+++ b/python/grass/pygrass/raster/raster_type.py
@@ -4,9 +4,11 @@ Created on Wed Jun 13 19:42:22 2012
 @author: pietro
 """
 
-import grass.lib.raster as libraster
 import ctypes
+
 import numpy as np
+
+import grass.lib.raster as libraster
 
 # Private dictionary to convert RASTER_TYPE into type string.
 RTYPE_STR = {

--- a/python/grass/pygrass/raster/rowio.py
+++ b/python/grass/pygrass/raster/rowio.py
@@ -6,12 +6,10 @@ Created on Mon Jun 18 13:22:38 2012
 
 import ctypes
 
-import grass.lib.rowio as librowio
 import grass.lib.raster as librast
-
+import grass.lib.rowio as librowio
 from grass.pygrass.errors import GrassError
 from grass.pygrass.raster.raster_type import TYPE as RTYPE
-
 
 CMPFUNC = ctypes.CFUNCTYPE(
     ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_int, ctypes.c_int

--- a/python/grass/pygrass/raster/segment.py
+++ b/python/grass/pygrass/raster/segment.py
@@ -5,6 +5,7 @@ Created on Mon Jun 11 18:02:27 2012
 """
 
 import ctypes
+
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster
 import grass.lib.segment as libseg

--- a/python/grass/pygrass/raster/testsuite/test_category.py
+++ b/python/grass/pygrass/raster/testsuite/test_category.py
@@ -6,7 +6,6 @@ Created on Mon Sep 15 17:09:40 2014
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.raster import RasterRow
 from grass.pygrass.raster.category import Category
 from grass.script.core import tempfile

--- a/python/grass/pygrass/raster/testsuite/test_history.py
+++ b/python/grass/pygrass/raster/testsuite/test_history.py
@@ -6,7 +6,6 @@ Created on Mon Sep 15 17:09:40 2014
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.raster import RasterRow
 from grass.pygrass.raster.history import History
 from grass.script.utils import decode

--- a/python/grass/pygrass/raster/testsuite/test_numpy.py
+++ b/python/grass/pygrass/raster/testsuite/test_numpy.py
@@ -4,10 +4,11 @@ Created on Thu Jul 30 18:27:22 2015
 @author: lucadelu
 """
 
+from numpy.random import random
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from numpy.random import random
-from grass.pygrass.raster import raster2numpy, numpy2raster, RasterRow
+from grass.pygrass.raster import RasterRow, numpy2raster, raster2numpy
 
 
 def check_raster(name):

--- a/python/grass/pygrass/raster/testsuite/test_pygrass_raster.py
+++ b/python/grass/pygrass/raster/testsuite/test_pygrass_raster.py
@@ -1,7 +1,6 @@
 from grass.exceptions import OpenError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.raster import RasterRow
 
 

--- a/python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
+++ b/python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.pygrass.raster as pgrass
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/raster/testsuite/test_raster_img.py
+++ b/python/grass/pygrass/raster/testsuite/test_raster_img.py
@@ -1,11 +1,11 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.pygrass.raster import raster2numpy_img
 from grass.pygrass.gis.region import Region
+from grass.pygrass.raster import raster2numpy_img
 from grass.script.core import tempfile
 
 has_PyQt4 = False

--- a/python/grass/pygrass/raster/testsuite/test_raster_region.py
+++ b/python/grass/pygrass/raster/testsuite/test_raster_region.py
@@ -1,9 +1,7 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.pygrass.raster import RasterRow
-from grass.pygrass.raster import raster2numpy
 from grass.pygrass.gis.region import Region
+from grass.pygrass.raster import RasterRow, raster2numpy
 
 
 class RasterRowRegionTestCase(TestCase):

--- a/python/grass/pygrass/rpc/__init__.py
+++ b/python/grass/pygrass/rpc/__init__.py
@@ -10,21 +10,22 @@ for details.
 :authors: Soeren Gebbert
 """
 
-import time
-import threading
+import logging
 import sys
-from multiprocessing import Process, Lock, Pipe
+import threading
+import time
 from ctypes import CFUNCTYPE, c_void_p
+from multiprocessing import Lock, Pipe, Process
 
+import grass.lib.gis as libgis
 from grass.exceptions import FatalError
+from grass.pygrass import utils
+from grass.pygrass.gis.region import Region
+from grass.pygrass.raster import RasterRow, raster2numpy_img
 from grass.pygrass.vector import VectorTopo
 from grass.pygrass.vector.basic import Bbox
-from grass.pygrass.raster import RasterRow, raster2numpy_img
-import grass.lib.gis as libgis
+
 from .base import RPCServerBase
-from grass.pygrass.gis.region import Region
-from grass.pygrass import utils
-import logging
 
 ###############################################################################
 ###############################################################################
@@ -464,6 +465,7 @@ class DataProvider(RPCServerBase):
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass.modules import Module
 
     Module("g.region", n=40, s=0, e=40, w=0, res=10)

--- a/python/grass/pygrass/rpc/base.py
+++ b/python/grass/pygrass/rpc/base.py
@@ -10,12 +10,13 @@ for details.
 :authors: Soeren Gebbert
 """
 
-from grass.exceptions import FatalError
-import time
-import threading
-import sys
-from multiprocessing import Process, Lock, Pipe
 import logging
+import sys
+import threading
+import time
+from multiprocessing import Lock, Pipe, Process
+
+from grass.exceptions import FatalError
 
 ###############################################################################
 

--- a/python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py
+++ b/python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.pygrass.rpc as pygrpc
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/shell/testsuite/test_pygrass_shell_doctests.py
+++ b/python/grass/pygrass/shell/testsuite/test_pygrass_shell_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 from grass.pygrass.shell import conversion, show
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/tests/benchmark.py
+++ b/python/grass/pygrass/tests/benchmark.py
@@ -4,24 +4,25 @@ Created on Sat Jun 16 20:24:56 2012
 @author: soeren
 """
 
-import optparse
-
-# import numpy as np
-import time
 import collections
 import copy
 import cProfile
-import sys
+import optparse
 import os
+import sys
+import time
+
+# import numpy as np
 from jinja2 import Template
 
 sys.path.append(os.getcwd())
 sys.path.append("%s/.." % (os.getcwd()))
 
+import ctypes
+
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster
 import grass.script as core
-import ctypes
 
 
 def test__RasterSegment_value_access__if():

--- a/python/grass/pygrass/tests/set_mapset.py
+++ b/python/grass/pygrass/tests/set_mapset.py
@@ -5,9 +5,9 @@ Created on Thu Aug 23 11:07:38 2012
 
 """
 
+import optparse
 import os
 import subprocess
-import optparse
 
 from grass.script import core as grasscore
 

--- a/python/grass/pygrass/testsuite/test_pygrass_doctests.py
+++ b/python/grass/pygrass/testsuite/test_pygrass_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.pygrass.utils as gutils
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -1,5 +1,5 @@
-import itertools
 import fnmatch
+import itertools
 import os
 from sqlite3 import OperationalError
 
@@ -9,11 +9,9 @@ libgis.G_gisinit("")
 
 import grass.lib.raster as libraster
 from grass.lib.ctypes_preamble import String
+from grass.pygrass.errors import GrassError
 from grass.script import core as grasscore
 from grass.script import utils as grassutils
-
-from grass.pygrass.errors import GrassError
-
 
 test_vector_name = "Utils_test_vector"
 test_raster_name = "Utils_test_raster"
@@ -467,7 +465,7 @@ def create_test_vector_map(map_name="test_vector"):
     """
 
     from grass.pygrass.vector import VectorTopo
-    from grass.pygrass.vector.geometry import Point, Line, Centroid, Boundary
+    from grass.pygrass.vector.geometry import Boundary, Centroid, Line, Point
 
     cols = [
         ("cat", "INTEGER PRIMARY KEY"),
@@ -595,6 +593,7 @@ def create_test_stream_network_map(map_name="streams"):
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
     from grass.script.core import run_command
 

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -1,22 +1,22 @@
-from os.path import join, exists
+from os.path import exists, join
+
 import grass.lib.gis as libgis
 
 libgis.G_gisinit("")
 
-import grass.lib.vector as libvect
 import ctypes
+
+import grass.lib.vector as libvect
+from grass.pygrass.errors import GrassError, must_be_open
+from grass.pygrass.gis import Location
+from grass.pygrass.vector.abstract import Info
+from grass.pygrass.vector.basic import Bbox, Cats, Ilist
+from grass.pygrass.vector.geometry import GEOOBJ as _GEOOBJ
+from grass.pygrass.vector.geometry import Area as _Area
+from grass.pygrass.vector.geometry import read_line, read_next_line
 
 # import pygrass modules
 from grass.pygrass.vector.vector_type import VTYPE
-from grass.pygrass.errors import GrassError, must_be_open
-from grass.pygrass.gis import Location
-
-from grass.pygrass.vector.geometry import GEOOBJ as _GEOOBJ
-from grass.pygrass.vector.geometry import read_line, read_next_line
-from grass.pygrass.vector.geometry import Area as _Area
-from grass.pygrass.vector.abstract import Info
-from grass.pygrass.vector.basic import Bbox, Cats, Ilist
-
 
 _NUMOF = {
     "areas": libvect.Vect_get_num_areas,
@@ -969,6 +969,7 @@ class VectorTopo(Vector):
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
 
     utils.create_test_vector_map(test_vector_name)

--- a/python/grass/pygrass/vector/abstract.py
+++ b/python/grass/pygrass/vector/abstract.py
@@ -6,14 +6,14 @@ Created on Fri Aug 17 17:24:03 2012
 
 import ctypes
 import datetime
-import grass.lib.vector as libvect
-from grass.pygrass.vector.vector_type import MAPTYPE
 
+import grass.lib.vector as libvect
+from grass.exceptions import GrassError, OpenError
 from grass.pygrass import utils
 from grass.pygrass.errors import must_be_open
+from grass.pygrass.vector.find import BboxFinder, PointFinder, PolygonFinder
 from grass.pygrass.vector.table import DBlinks, Link
-from grass.pygrass.vector.find import PointFinder, BboxFinder, PolygonFinder
-from grass.exceptions import GrassError, OpenError
+from grass.pygrass.vector.vector_type import MAPTYPE
 
 test_vector_name = "abstract_doctest_map"
 

--- a/python/grass/pygrass/vector/basic.py
+++ b/python/grass/pygrass/vector/basic.py
@@ -5,9 +5,9 @@ Created on Tue Jul 31 13:06:20 2012
 """
 
 import ctypes
-import grass.lib.vector as libvect
 from collections.abc import Iterable
 
+import grass.lib.vector as libvect
 from grass.pygrass.shell.conversion import dict2html
 
 

--- a/python/grass/pygrass/vector/find.py
+++ b/python/grass/pygrass/vector/find.py
@@ -5,11 +5,9 @@ Created on Tue Mar 19 11:09:30 2013
 """
 
 import grass.lib.vector as libvect
-
 from grass.pygrass.errors import must_be_open
-
-from grass.pygrass.vector.basic import Ilist, BoxList
-from grass.pygrass.vector.geometry import read_line, Isle, Area, Node
+from grass.pygrass.vector.basic import BoxList, Ilist
+from grass.pygrass.vector.geometry import Area, Isle, Node, read_line
 
 # For test purposes
 test_vector_name = "find_doctest_map"
@@ -677,6 +675,7 @@ class PolygonFinder(AbstractFinder):
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
 
     utils.create_test_vector_map(test_vector_name)

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -12,12 +12,10 @@ import numpy as np
 
 import grass.lib.gis as libgis
 import grass.lib.vector as libvect
-
-from grass.pygrass.utils import decode
 from grass.pygrass.errors import GrassError, mapinfo_must_be_set
-
-from grass.pygrass.vector.basic import Ilist, Bbox, Cats
+from grass.pygrass.utils import decode
 from grass.pygrass.vector import sql
+from grass.pygrass.vector.basic import Bbox, Cats, Ilist
 
 # For test purposes
 test_vector_name = "geometry_doctest_map"
@@ -1966,6 +1964,7 @@ def read_line(
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
 
     utils.create_test_vector_map(test_vector_name)

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -7,20 +7,18 @@ Created on Wed Aug  8 15:29:21 2012
 import ctypes
 import os
 from collections import OrderedDict
-
-import numpy as np
 from sqlite3 import OperationalError
 
+import numpy as np
+
 import grass.lib.vector as libvect
-from grass.pygrass.gis import Mapset
 from grass.exceptions import DBError
-from grass.pygrass.utils import table_exist, decode
-from grass.script.db import db_table_in_vector
-from grass.script.core import warning
-
-from grass.pygrass.vector import sql
 from grass.lib.ctypes_preamble import ReturnString
-
+from grass.pygrass.gis import Mapset
+from grass.pygrass.utils import decode, table_exist
+from grass.pygrass.vector import sql
+from grass.script.core import warning
+from grass.script.db import db_table_in_vector
 
 # For test purposes
 test_vector_name = "table_doctest_map"
@@ -1290,6 +1288,7 @@ class Table:
 
 if __name__ == "__main__":
     import doctest
+
     from grass.pygrass import utils
 
     utils.create_test_vector_map(test_vector_name)

--- a/python/grass/pygrass/vector/testsuite/test_filters.py
+++ b/python/grass/pygrass/vector/testsuite/test_filters.py
@@ -6,7 +6,6 @@ Created on Thu Jul  2 07:25:34 2015
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.vector.table import Filters
 
 

--- a/python/grass/pygrass/vector/testsuite/test_geometry.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry.py
@@ -6,18 +6,16 @@ Created on Thu Jun 19 14:13:53 2014
 
 import sys
 import unittest
+
 import numpy as np
 
+import grass.lib.vector as libvect
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.lib.vector as libvect
-from grass.script.core import run_command
-
 from grass.pygrass.vector import Vector, VectorTopo
-from grass.pygrass.vector.geometry import Point, Line, Node
-from grass.pygrass.vector.geometry import Area, Boundary, Centroid
 from grass.pygrass.vector.basic import Bbox
+from grass.pygrass.vector.geometry import Area, Boundary, Centroid, Line, Node, Point
+from grass.script.core import run_command
 
 
 class PointTestCase(TestCase):

--- a/python/grass/pygrass/vector/testsuite/test_geometry_attrs.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry_attrs.py
@@ -6,15 +6,14 @@ Created on Thu Jun 19 14:13:53 2014
 
 import sys
 import unittest
+
 import numpy as np
 
+import grass.lib.vector as libvect
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.lib.vector as libvect
-from grass.script.core import run_command
-
 from grass.pygrass.vector import VectorTopo
+from grass.script.core import run_command
 
 
 class GeometryAttrsTestCase(TestCase):

--- a/python/grass/pygrass/vector/testsuite/test_pygrass_vector_doctests.py
+++ b/python/grass/pygrass/vector/testsuite/test_pygrass_vector_doctests.py
@@ -7,10 +7,8 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
-import grass.pygrass.vector as gvector
 import grass.pygrass.utils as gutils
-
+import grass.pygrass.vector as gvector
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/pygrass/vector/testsuite/test_table.py
+++ b/python/grass/pygrass/vector/testsuite/test_table.py
@@ -7,15 +7,14 @@ Created on Wed Jun 25 11:08:22 2014
 import os
 import sqlite3
 import tempfile as tmp
-from string import ascii_letters, digits
 from random import choice
+from string import ascii_letters, digits
+
 import numpy as np
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.pygrass.vector.table import Table, get_path
-
 
 # dictionary that generate random data
 COL2VALS = {

--- a/python/grass/pygrass/vector/testsuite/test_vector.py
+++ b/python/grass/pygrass/vector/testsuite/test_vector.py
@@ -6,9 +6,8 @@ Created on Wed Jun 18 17:21:42 2014
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import run_command
 from grass.pygrass.vector import VectorTopo
+from grass.script.core import run_command
 
 
 class VectorTopoTestCase(TestCase):

--- a/python/grass/pygrass/vector/testsuite/test_vector3d.py
+++ b/python/grass/pygrass/vector/testsuite/test_vector3d.py
@@ -8,13 +8,11 @@ import numpy as np
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import run_command
-
-from grass.pygrass.vector import VectorTopo
-from grass.pygrass.vector.geometry import Point
 from grass.pygrass.gis.region import Region
 from grass.pygrass.utils import get_mapset_vector
+from grass.pygrass.vector import VectorTopo
+from grass.pygrass.vector.geometry import Point
+from grass.script.core import run_command
 
 
 def generate_coordinates(number, bbox=None, with_z=False):

--- a/python/grass/pygrass/vector/vector_type.py
+++ b/python/grass/pygrass/vector/vector_type.py
@@ -6,7 +6,6 @@ Created on Wed Jul 18 10:49:26 2012
 
 import grass.lib.vector as libvect
 
-
 MAPTYPE = {
     libvect.GV_FORMAT_NATIVE: "native",
     libvect.GV_FORMAT_OGR: "OGR",

--- a/python/grass/script/__init__.py
+++ b/python/grass/script/__init__.py
@@ -1,10 +1,10 @@
 """Python interface to launch GRASS GIS modules in scripts
 """
 
+from . import setup
 from .core import *
 from .db import *
 from .raster import *
 from .raster3d import *
-from .vector import *
 from .utils import *
-from . import setup
+from .vector import *

--- a/python/grass/script/array.py
+++ b/python/grass/script/array.py
@@ -111,10 +111,10 @@ for details.
 
 import numpy
 
-from .utils import try_remove
-from . import core as gcore
 from grass.exceptions import CalledModuleError
 
+from . import core as gcore
+from .utils import try_remove
 
 ###############################################################################
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -18,24 +18,25 @@ for details.
 .. sectionauthor:: Michael Barton <michael.barton asu.edu>
 """
 
-import os
-import sys
 import atexit
-import subprocess
-import shutil
 import codecs
-import string
-import random
-import shlex
-import json
 import csv
 import io
-from tempfile import NamedTemporaryFile
+import json
+import os
+import random
+import shlex
+import shutil
+import string
+import subprocess
+import sys
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
-from .utils import KeyValue, parse_key_val, basename, encode, decode, try_remove
-from grass.exceptions import ScriptError, CalledModuleError
+from grass.exceptions import CalledModuleError, ScriptError
 from grass.grassdb.manage import resolve_mapset_path
+
+from .utils import KeyValue, basename, decode, encode, parse_key_val, try_remove
 
 
 # subprocess wrapper that uses shell on Windows

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -20,16 +20,18 @@ for details.
 """
 
 import os
+
+from grass.exceptions import CalledModuleError
+
 from .core import (
-    run_command,
-    parse_command,
-    read_command,
-    tempfile,
     fatal,
     list_strings,
+    parse_command,
+    read_command,
+    run_command,
+    tempfile,
 )
 from .utils import try_remove
-from grass.exceptions import CalledModuleError
 
 
 def db_describe(table, env=None, **args):

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -22,18 +22,19 @@ import os
 import string
 import time
 
-from .core import (
-    gisenv,
-    find_file,
-    tempfile,
-    run_command,
-    read_command,
-    write_command,
-    feed_command,
-    warning,
-    fatal,
-)
 from grass.exceptions import CalledModuleError
+
+from .core import (
+    fatal,
+    feed_command,
+    find_file,
+    gisenv,
+    read_command,
+    run_command,
+    tempfile,
+    warning,
+    write_command,
+)
 from .utils import encode, float_or_dms, parse_key_val, try_remove
 
 

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -20,12 +20,13 @@ for details.
 """
 
 import os
-import time
 import string
+import time
 
-from .core import read_command, write_command, fatal
-from .utils import float_or_dms, parse_key_val
 from grass.exceptions import CalledModuleError
+
+from .core import fatal, read_command, write_command
+from .utils import float_or_dms, parse_key_val
 
 
 def raster3d_info(map, env=None):

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -80,13 +80,13 @@ for details.
 # is known, this would allow moving things from there, here
 # then this could even do locking
 
-from pathlib import Path
 import datetime
 import os
 import shutil
 import subprocess
 import sys
 import tempfile as tmpfile
+from pathlib import Path
 
 WINDOWS = sys.platform.startswith("win")
 MACOS = sys.platform.startswith("darwin")

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -25,8 +25,9 @@ import xml.etree.ElementTree as etree
 from xml.parsers import expat
 
 from grass.exceptions import ScriptError
+
+from .core import PIPE, Popen, get_real_command
 from .utils import decode, split
-from .core import Popen, PIPE, get_real_command
 
 ETREE_EXCEPTIONS = (etree.ParseError, expat.ExpatError)
 

--- a/python/grass/script/testsuite/data/script_using_temporary_region.py
+++ b/python/grass/script/testsuite/data/script_using_temporary_region.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-import subprocess
-import sys
 import os
 import platform
+import subprocess
+import sys
 
 import grass.script as gs
 

--- a/python/grass/script/testsuite/test_core_make_val.py
+++ b/python/grass/script/testsuite/test_core_make_val.py
@@ -1,6 +1,5 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.script.core import _make_val
 
 

--- a/python/grass/script/testsuite/test_names.py
+++ b/python/grass/script/testsuite/test_names.py
@@ -1,12 +1,10 @@
 import os
 import platform
 
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.script as gs
-from grass.script import legal_name
-from grass.script import utils
+from grass.script import legal_name, utils
 
 
 class TestUnique(TestCase):

--- a/python/grass/script/testsuite/test_script_doctests.py
+++ b/python/grass/script/testsuite/test_script_doctests.py
@@ -7,9 +7,7 @@ import doctest
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
 import grass.script.array as garray
-
 
 # doctest does not allow changing the base classes of test case, skip test case
 # and test suite, so we need to create a new type which inherits from our class

--- a/python/grass/script/testsuite/test_script_raster.py
+++ b/python/grass/script/testsuite/test_script_raster.py
@@ -4,10 +4,9 @@ Created on Thu Feb 18 09:42:23 2016
 @author: lucadelu
 """
 
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.script as gs
 
 
 class TestRaster(TestCase):

--- a/python/grass/script/testsuite/test_start_command_functions.py
+++ b/python/grass/script/testsuite/test_start_command_functions.py
@@ -4,9 +4,14 @@ Tests of start_command function family (location independent)
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import start_command, PIPE, run_command, write_command
-from grass.script.core import read_command, find_program
+from grass.script.core import (
+    PIPE,
+    find_program,
+    read_command,
+    run_command,
+    start_command,
+    write_command,
+)
 from grass.script.utils import encode
 
 

--- a/python/grass/script/testsuite/test_start_command_functions_nc.py
+++ b/python/grass/script/testsuite/test_start_command_functions_nc.py
@@ -2,8 +2,7 @@
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import parse_command, start_command, PIPE
+from grass.script.core import PIPE, parse_command, start_command
 from grass.script.utils import parse_key_val
 
 LOCATION = "nc"

--- a/python/grass/script/testsuite/test_utils.py
+++ b/python/grass/script/testsuite/test_utils.py
@@ -2,7 +2,6 @@ import os
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.script import utils
 
 

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -17,16 +17,16 @@ for details.
 .. sectionauthor:: Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
-import shutil
 import locale
-import shlex
-import re
-import time
+import os
 import platform
-import uuid
 import random
+import re
+import shlex
+import shutil
 import string
+import time
+import uuid
 
 
 def float_or_dms(s):
@@ -363,8 +363,8 @@ def naturally_sort(items, key=None):
 
 def get_lib_path(modname, libname=None):
     """Return the path of the libname contained in the module."""
-    from os.path import isdir, join, sep
     from os import getenv
+    from os.path import isdir, join, sep
 
     if isdir(join(getenv("GISBASE"), "etc", modname)):
         path = join(os.getenv("GISBASE"), "etc", modname)

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -19,16 +19,10 @@ for details.
 
 import os
 
-from .utils import parse_key_val
-from .core import (
-    run_command,
-    read_command,
-    error,
-    fatal,
-    debug,
-)
-
 from grass.exceptions import CalledModuleError, ScriptError
+
+from .core import debug, error, fatal, read_command, run_command
+from .utils import parse_key_val
 
 
 def vector_db(map, env=None, **kwargs):

--- a/python/grass/semantic_label/reader.py
+++ b/python/grass/semantic_label/reader.py
@@ -1,8 +1,8 @@
-import os
-import sys
-import json
 import glob
+import json
+import os
 import re
+import sys
 from collections import OrderedDict
 
 import grass.script as gs


### PR DESCRIPTION
Uses a combination of `ruff check --output-format=concise --select I --fix 'python/grass'`, `isort --profile=black python/grass` and `black .`
