### PR TITLE
style: Sort and group imports on modules

### DIFF
--- a/general/g.list/testsuite/test_g_list.py
+++ b/general/g.list/testsuite/test_g_list.py
@@ -1,8 +1,8 @@
 """g.list tests"""
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class GMlistWrongParamertersTest(TestCase):

--- a/general/g.mapsets/tests/conftest.py
+++ b/general/g.mapsets/tests/conftest.py
@@ -7,8 +7,9 @@ Fixture for ReprojectionRenderer test with simple GRASS location, raster, vector
 
 from types import SimpleNamespace
 
-import grass.script as gs
 import pytest
+
+import grass.script as gs
 
 TEST_MAPSETS = ["PERMANENT", "test1", "test2", "test3"]
 ACCESSIBLE_MAPSETS = ["test3", "PERMANENT"]

--- a/general/g.mapsets/tests/g_mapsets_list_format_test.py
+++ b/general/g.mapsets/tests/g_mapsets_list_format_test.py
@@ -14,7 +14,9 @@
 """Test parsing and structure of CSV and JSON outputs from g.mapsets"""
 
 import json
+
 import pytest
+
 import grass.script as gs
 from grass.script import utils as gutils
 

--- a/general/g.parser/test.py
+++ b/general/g.parser/test.py
@@ -25,8 +25,8 @@
 # % required: no
 # %end
 
-import sys
 import atexit
+import sys
 
 import grass.script as gs
 

--- a/general/g.proj/testsuite/test_g_proj.py
+++ b/general/g.proj/testsuite/test_g_proj.py
@@ -9,8 +9,8 @@ for details.
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class GProjWKTTestCase(TestCase):

--- a/general/g.region/testsuite/test_g_region.py
+++ b/general/g.region/testsuite/test_g_region.py
@@ -3,9 +3,9 @@
 @author Anna Petrasova
 """
 
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import call_module
-import grass.script as gs
 
 
 class TestRegion(TestCase):

--- a/general/g.remove/testsuite/test_g_remove.py
+++ b/general/g.remove/testsuite/test_g_remove.py
@@ -1,12 +1,11 @@
 """Test of g.remove module"""
 
 # TODO: rmapcalc probably fatals, replace or add raise on error?
-from grass.script.raster import mapcalc as rmapcalc
-
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gutils import get_current_mapset
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.gutils import get_current_mapset
+from grass.gunittest.main import test
+from grass.script.raster import mapcalc as rmapcalc
 
 # when used user1 must be replaced by current mapset
 REMOVE_RASTERS = """raster/test_map_0@user1

--- a/general/g.rename/testsuite/test_overwrite.py
+++ b/general/g.rename/testsuite/test_overwrite.py
@@ -9,10 +9,10 @@ for details.
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
+from grass.gunittest.checkers import diff_keyvalue, keyvalue_equals, text_to_keyvalue
 from grass.gunittest.gmodules import SimpleModule
 from grass.gunittest.gutils import is_map_in_mapset
-from grass.gunittest.checkers import text_to_keyvalue, keyvalue_equals, diff_keyvalue
+from grass.gunittest.main import test
 
 
 class RasterRenameTestCase(TestCase):

--- a/imagery/i.atcorr/create_iwave.py
+++ b/imagery/i.atcorr/create_iwave.py
@@ -28,6 +28,7 @@ Bug fix (9/12/2010) by Daniel:
 """
 import os
 import sys
+
 import numpy as np
 from scipy import interpolate
 

--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -9,30 +9,28 @@ Licence:   This program is free software under the GNU General Public
            for details.
 """
 
-import os
-import stat
 import ctypes
+import os
 import shutil
-
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-from grass.script.core import tempname
+import stat
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.lib.gis import G_mapset_path
-from grass.lib.raster import Rast_write_semantic_label
 from grass.lib.imagery import (
-    Signature,
-    Ref,
-    I_init_group_ref,
     I_add_file_to_group_ref,
+    I_fopen_signature_file_old,
+    I_init_group_ref,
     I_put_group_ref,
     I_put_subgroup_ref,
-    I_fopen_signature_file_old,
     I_read_signatures,
+    Ref,
+    Signature,
 )
+from grass.lib.raster import Rast_write_semantic_label
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class SuccessTest(TestCase):

--- a/imagery/i.maxlik/testsuite/test_i_maxlik.py
+++ b/imagery/i.maxlik/testsuite/test_i_maxlik.py
@@ -12,28 +12,25 @@ Licence:   This program is free software under the GNU General Public
 import ctypes
 import shutil
 
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-from grass.pygrass import raster
-from grass.script.core import tempname
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.lib.gis import G_mapset_path
-from grass.lib.raster import Rast_write_semantic_label
 from grass.lib.imagery import (
-    Signature,
-    Ref,
+    I_add_file_to_group_ref,
+    I_fopen_signature_file_new,
+    I_init_group_ref,
     I_init_signatures,
     I_new_signature,
-    I_fopen_signature_file_new,
-    I_write_signatures,
-    I_init_group_ref,
-    I_add_file_to_group_ref,
     I_put_group_ref,
     I_put_subgroup_ref,
+    I_write_signatures,
+    Ref,
+    Signature,
 )
+from grass.lib.raster import Rast_write_semantic_label
+from grass.pygrass import raster, utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class SuccessTest(TestCase):

--- a/imagery/i.signatures/testsuite/test_i_signatures.py
+++ b/imagery/i.signatures/testsuite/test_i_signatures.py
@@ -9,21 +9,17 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
+import json
 import os
 import shutil
-import json
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
-from grass.script.core import tempname
+from grass.gunittest.main import test
+from grass.lib.gis import G_mapset_path
 from grass.pygrass import utils
 from grass.pygrass.gis import Mapset
-
-from grass.lib.gis import (
-    G_mapset_path,
-)
+from grass.script.core import tempname
 
 
 class PrintSignaturesTestCase(TestCase):

--- a/imagery/i.svm.predict/testsuite/test_i_svm_predict.py
+++ b/imagery/i.svm.predict/testsuite/test_i_svm_predict.py
@@ -9,18 +9,15 @@ Licence:   This program is free software under the GNU General Public
            for details.
 """
 
-import unittest
 import shutil
+import unittest
 
-from grass.script import core as grass
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
+from grass.lib.imagery import I_SIGFILE_TYPE_LIBSVM, I_signatures_remove
 from grass.pygrass.gis import Mapset
-from grass.lib.imagery import (
-    I_SIGFILE_TYPE_LIBSVM,
-    I_signatures_remove,
-)
+from grass.script import core as grass
 
 
 class IOValidationTest(TestCase):

--- a/imagery/i.svm.train/testsuite/test_i_svm_train.py
+++ b/imagery/i.svm.train/testsuite/test_i_svm_train.py
@@ -9,28 +9,23 @@ Licence:   This program is free software under the GNU General Public
            for details.
 """
 
-import os
-import unittest
 import ctypes
+import os
 import shutil
+import unittest
 
-from grass.script import core as grass
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-from grass.pygrass.gis import Mapset
-from grass.pygrass import utils
-
-from grass.lib.gis import (
-    GPATH_MAX,
-    GNAME_MAX,
-    G_file_name_misc,
-)
+from grass.gunittest.main import test
+from grass.lib.gis import GNAME_MAX, GPATH_MAX, G_file_name_misc
 from grass.lib.imagery import (
     I_SIGFILE_TYPE_LIBSVM,
     I_get_signatures_dir,
     I_signatures_remove,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script import core as grass
 
 
 class IOValidationTest(TestCase):

--- a/raster/r.basins.fill/testsuite/testrbf.py
+++ b/raster/r.basins.fill/testsuite/testrbf.py
@@ -10,6 +10,7 @@ Licence:    This program is free software under the GNU General Public
 """
 
 import unittest
+
 from grass.gunittest.case import TestCase
 
 

--- a/raster/r.contour/testsuite/test_r_contour.py
+++ b/raster/r.contour/testsuite/test_r_contour.py
@@ -9,8 +9,9 @@ Licence:    This program is free software under the GNU General Public
             for details.
 """
 
-from grass.gunittest.case import TestCase
 import os
+
+from grass.gunittest.case import TestCase
 
 
 class TestRasterWhat(TestCase):

--- a/raster/r.horizon/testsuite/test_r_horizon.py
+++ b/raster/r.horizon/testsuite/test_r_horizon.py
@@ -15,10 +15,9 @@ COPYRIGHT: (C) 2015-2024 Anna Petrasova
 import json
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script import raster_what
-
 
 ref1 = """azimuth,horizon_height
 180.000000,0.023101

--- a/raster/r.in.pdal/testsuite/test_r_in_pdal_binning.py
+++ b/raster/r.in.pdal/testsuite/test_r_in_pdal_binning.py
@@ -11,13 +11,13 @@ Licence:   This program is free software under the GNU General Public
 
 import os
 import pathlib
-import unittest
 import shutil
+import unittest
 from tempfile import TemporaryDirectory
 
-from grass.script import core as grass
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+from grass.script import core as grass
 
 
 class BinningTest(TestCase):

--- a/raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
+++ b/raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
@@ -15,9 +15,9 @@ import shutil
 import unittest
 from tempfile import TemporaryDirectory
 
-from grass.script import core as grass
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+from grass.script import core as grass
 
 
 class SelectionTest(TestCase):

--- a/raster/r.in.poly/testsuite/test_rinpoly.py
+++ b/raster/r.in.poly/testsuite/test_rinpoly.py
@@ -1,9 +1,9 @@
 import os
 import tempfile
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script.core import read_command
-
 
 input1 = b"""
 A

--- a/raster/r.kappa/testsuite/test_r_kappa.py
+++ b/raster/r.kappa/testsuite/test_r_kappa.py
@@ -9,18 +9,16 @@ Licence:   This program is free software under the GNU General Public
            for details.
 """
 
+import json
 import os
 import pathlib
-import json
-
 from tempfile import NamedTemporaryFile
 
-from grass.script import read_command
-from grass.script import decode
-from grass.script.core import tempname
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.checkers import keyvalue_equals
+from grass.gunittest.main import test
+from grass.script import decode, read_command
+from grass.script.core import tempname
 
 
 class MatrixCorrectnessTest(TestCase):

--- a/raster/r.mapcalc/testsuite/test_nmedian_bug_3296.py
+++ b/raster/r.mapcalc/testsuite/test_nmedian_bug_3296.py
@@ -21,7 +21,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 OUTPUT = """\
 north: 3
 south: 0

--- a/raster/r.mapcalc/testsuite/test_r3_mapcalc.py
+++ b/raster/r.mapcalc/testsuite/test_r3_mapcalc.py
@@ -1,7 +1,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 # TODO: add more expressions
 # TODO: add tests with prepared data
 

--- a/raster/r.mapcalc/testsuite/test_r_mapcalc.py
+++ b/raster/r.mapcalc/testsuite/test_r_mapcalc.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 cell_seed_500 = """\
 north: 20

--- a/raster/r.mapcalc/testsuite/test_row_above_below_bug.py
+++ b/raster/r.mapcalc/testsuite/test_row_above_below_bug.py
@@ -21,7 +21,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 INPUT = """\
 north: 10
 south: 8

--- a/raster/r.mfilter/benchmark/benchmark_r_mfilter_nprocs.py
+++ b/raster/r.mfilter/benchmark/benchmark_r_mfilter_nprocs.py
@@ -3,12 +3,12 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
-from grass.script import tempfile
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
+from grass.script import tempfile
 
 
 def main():

--- a/raster/r.mfilter/testsuite/test_r_mfilter.py
+++ b/raster/r.mfilter/testsuite/test_r_mfilter.py
@@ -1,4 +1,5 @@
 from tempfile import NamedTemporaryFile
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/raster/r.neighbors/benchmark/benchmark_r_neighbors_memory.py
+++ b/raster/r.neighbors/benchmark/benchmark_r_neighbors_memory.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.neighbors/benchmark/benchmark_r_neighbors_nprocs.py
+++ b/raster/r.neighbors/benchmark/benchmark_r_neighbors_nprocs.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.neighbors/benchmark/benchmark_r_neighbors_size.py
+++ b/raster/r.neighbors/benchmark/benchmark_r_neighbors_size.py
@@ -3,11 +3,11 @@
 @author Anna Petrasova
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.neighbors/testsuite/test_r_neighbors.py
+++ b/raster/r.neighbors/testsuite/test_r_neighbors.py
@@ -1,7 +1,7 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.script.raster import raster_info
 from grass.script import tempfile
+from grass.script.raster import raster_info
 
 
 class TestNeighbors(TestCase):

--- a/raster/r.object.geometry/testsuite/r_object_geometry_test.py
+++ b/raster/r.object.geometry/testsuite/r_object_geometry_test.py
@@ -5,6 +5,7 @@ Purpose:   This script is to demonstrate a unit test for r.object.geometry
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/raster/r.patch/benchmark/benchmark_r_patch.py
+++ b/raster/r.patch/benchmark/benchmark_r_patch.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.patch/benchmark/benchmark_r_patch_memory.py
+++ b/raster/r.patch/benchmark/benchmark_r_patch_memory.py
@@ -4,11 +4,11 @@
 @author Anna Petrasova
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.patch/testsuite/test_rpatch_artificial.py
+++ b/raster/r.patch/testsuite/test_rpatch_artificial.py
@@ -13,9 +13,8 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import call_module
-
+from grass.gunittest.main import test
 
 cell_1 = """\
 north: 20

--- a/raster/r.profile/testsuite/test_profile_ncspm.py
+++ b/raster/r.profile/testsuite/test_profile_ncspm.py
@@ -1,7 +1,7 @@
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
 import grass.script.core as gcore
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 # not used yet
 LOCATION = "nc_spm"

--- a/raster/r.random/testsuite/testrandom.py
+++ b/raster/r.random/testsuite/testrandom.py
@@ -10,8 +10,8 @@ Licence:    This program is free software under the GNU General Public
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class Testrr(TestCase):

--- a/raster/r.reclass/testsuite/test_r_reclass.py
+++ b/raster/r.reclass/testsuite/test_r_reclass.py
@@ -10,8 +10,8 @@ Licence:    This program is free software under the GNU General Public
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 rules1 = """
 1 2 3   = 1    good quality

--- a/raster/r.recode/testsuite/test_rrecode_ncspm.py
+++ b/raster/r.recode/testsuite/test_rrecode_ncspm.py
@@ -1,8 +1,7 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script.core import read_command
-
 
 rules1 = """
 55:65:1

--- a/raster/r.report/testsuite/test_r_report.py
+++ b/raster/r.report/testsuite/test_r_report.py
@@ -10,6 +10,7 @@ Licence:    This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 
 

--- a/raster/r.resamp.filter/benchmark/benchmark_r_resamp_filter.py
+++ b/raster/r.resamp.filter/benchmark/benchmark_r_resamp_filter.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.resamp.interp/benchmark/benchmark_r_resamp_interp.py
+++ b/raster/r.resamp.interp/benchmark/benchmark_r_resamp_interp.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.series/benchmark/benchmark_r_series.py
+++ b/raster/r.series/benchmark/benchmark_r_series.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.series/benchmark/benchmark_r_series_memory.py
+++ b/raster/r.series/benchmark/benchmark_r_series_memory.py
@@ -4,11 +4,11 @@
 @author Anna Petrasova
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.series/testsuite/test_r_series.py
+++ b/raster/r.series/testsuite/test_r_series.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import call_module
+from grass.gunittest.main import test
 
 
 class TestRSeries(TestCase):

--- a/raster/r.slope.aspect/benchmark/benchmark_r_slope_aspect.py
+++ b/raster/r.slope.aspect/benchmark/benchmark_r_slope_aspect.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.slope.aspect/benchmark/benchmark_r_slope_aspect_memory.py
+++ b/raster/r.slope.aspect/benchmark/benchmark_r_slope_aspect_memory.py
@@ -4,11 +4,11 @@
 @author Anna Petrasova
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.slope.aspect/testsuite/test_r_slope_aspect.py
+++ b/raster/r.slope.aspect/testsuite/test_r_slope_aspect.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import call_module
+from grass.gunittest.main import test
 
 SMALL_MAP = """\
 north:   15

--- a/raster/r.stats.quantile/testsuite/test_r_stats_quantile.py
+++ b/raster/r.stats.quantile/testsuite/test_r_stats_quantile.py
@@ -1,7 +1,6 @@
 from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule, call_module
 from grass.gunittest.main import test
-from grass.gunittest.gmodules import call_module
-from grass.gunittest.gmodules import SimpleModule
 
 reference_str = """\
 27511:0:33.333333:134.717331

--- a/raster/r.sun/testsuite/test_rsun.py
+++ b/raster/r.sun/testsuite/test_rsun.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestRSunMode1Metadata(TestCase):

--- a/raster/r.support/testsuite/test_r_support.py
+++ b/raster/r.support/testsuite/test_r_support.py
@@ -14,13 +14,11 @@ import string
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass.gis import Mapset
-from grass.pygrass import utils
-
 from grass.lib.gis import G_remove_misc
 from grass.lib.raster import Rast_read_semantic_label
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class RSupportSemanticLabelHandlingTestCase(TestCase):

--- a/raster/r.surf.gauss/testsuite/test_r_surf_gauss.py
+++ b/raster/r.surf.gauss/testsuite/test_r_surf_gauss.py
@@ -15,6 +15,7 @@ for details.
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/raster/r.surf.random/testsuite/test_min_max.py
+++ b/raster/r.surf.random/testsuite/test_min_max.py
@@ -15,7 +15,6 @@ for details.
 """
 
 import grass.script as gs
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/raster/r.terraflow/testsuite/test_r_terraflow.py
+++ b/raster/r.terraflow/testsuite/test_r_terraflow.py
@@ -4,6 +4,7 @@
 
 import os
 import tempfile
+
 from grass.gunittest.case import TestCase
 
 

--- a/raster/r.texture/benchmark/benchmark_rtexture.py
+++ b/raster/r.texture/benchmark/benchmark_rtexture.py
@@ -4,11 +4,11 @@
         Chung-Yuan Liang
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.texture/benchmark/benchmark_rtexture_window.py
+++ b/raster/r.texture/benchmark/benchmark_rtexture_window.py
@@ -4,11 +4,11 @@
         Chung-Yuan Liang
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.texture/testsuite/test_rtexture.py
+++ b/raster/r.texture/testsuite/test_rtexture.py
@@ -10,8 +10,9 @@ Licence:    This program is free software under the GNU General Public
             for details.
 """
 
-from grass.gunittest.case import TestCase
 import sys
+
+from grass.gunittest.case import TestCase
 
 IS_MAC = sys.platform.startswith("darwin")
 

--- a/raster/r.texture/testsuite/test_rtexture_parallel.py
+++ b/raster/r.texture/testsuite/test_rtexture_parallel.py
@@ -10,8 +10,9 @@ Licence:    This program is free software under the GNU General Public
             for details.
 """
 
-from grass.gunittest.case import TestCase
 import sys
+
+from grass.gunittest.case import TestCase
 
 IS_MAC = sys.platform.startswith("darwin")
 THREADS = 4

--- a/raster/r.topidx/arc_to_gridatb.py
+++ b/raster/r.topidx/arc_to_gridatb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-import sys
-import re
 import os
+import re
+import sys
 
 
 def match(pattern, string):

--- a/raster/r.topidx/gridatb_to_arc.py
+++ b/raster/r.topidx/gridatb_to_arc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-import sys
-import re
 import os
+import re
+import sys
 
 if (
     len(sys.argv) == 1

--- a/raster/r.univar/benchmark/benchmark_r_univar.py
+++ b/raster/r.univar/benchmark/benchmark_r_univar.py
@@ -3,11 +3,11 @@
 @author Aaron Saw Min Sern
 """
 
-from grass.exceptions import CalledModuleError
-from grass.pygrass.modules import Module
 from subprocess import DEVNULL
 
 import grass.benchmark as bm
+from grass.exceptions import CalledModuleError
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/raster/r.viewshed/testsuite/test_r_viewshed.py
+++ b/raster/r.viewshed/testsuite/test_r_viewshed.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import call_module
+from grass.gunittest.main import test
 
 
 class TestViewshed(TestCase):

--- a/raster/r.what/testsuite/test_r_what.py
+++ b/raster/r.what/testsuite/test_r_what.py
@@ -9,10 +9,11 @@ Licence:    This program is free software under the GNU General Public
             for details.
 """
 
+import json
+import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
-import os
-import json
 
 
 class TestRasterWhat(TestCase):

--- a/raster/r.what/testsuite/testrw.py
+++ b/raster/r.what/testsuite/testrw.py
@@ -10,8 +10,8 @@ Licence:    This program is free software under the GNU General Public
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class Testrr(TestCase):

--- a/raster3d/r3.flow/testsuite/r3flow_test.py
+++ b/raster3d/r3.flow/testsuite/r3flow_test.py
@@ -5,6 +5,7 @@ Test of r3.flow
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/raster3d/r3.gradient/testsuite/r3gradient_test.py
+++ b/raster3d/r3.gradient/testsuite/r3gradient_test.py
@@ -7,7 +7,6 @@ Test of r3.gradient
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 r3univar_test_grad_x = """
 n=600
 null_cells=0

--- a/vector/v.db.select/testsuite/test_v_db_select.py
+++ b/vector/v.db.select/testsuite/test_v_db_select.py
@@ -10,9 +10,10 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 out_group = """CZab
 CZam

--- a/vector/v.db.select/testsuite/test_v_db_select_json_csv.py
+++ b/vector/v.db.select/testsuite/test_v_db_select_json_csv.py
@@ -13,13 +13,12 @@
 
 """Test parsing and structure of CSV and JSON outputs from v.db.select"""
 
-import json
 import csv
-import itertools
 import io
+import itertools
+import json
 
 import grass.script as gs
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/vector/v.distance/testsuite/test_areas_points.py
+++ b/vector/v.distance/testsuite/test_areas_points.py
@@ -13,8 +13,8 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import call_module
+from grass.gunittest.main import test
 
 areas = """\
 VERTI:

--- a/vector/v.extract/testsuite/test_v_extract.py
+++ b/vector/v.extract/testsuite/test_v_extract.py
@@ -10,6 +10,7 @@ Licence:    This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 from grass.script.core import read_command

--- a/vector/v.fill.holes/tests/conftest.py
+++ b/vector/v.fill.holes/tests/conftest.py
@@ -1,7 +1,6 @@
 """Fixture for v.fill.holes test"""
 
 import os
-
 from types import SimpleNamespace
 
 import pytest

--- a/vector/v.in.ascii/testsuite/test_csv.py
+++ b/vector/v.in.ascii/testsuite/test_csv.py
@@ -4,10 +4,10 @@
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script.core import read_command
-
 
 INPUT_NOQUOTES = """Id,POINT_X,POINT_Y,Category,ED field estimate
 100,437343.6704,4061363.41525,High Erosion,Low Deposition

--- a/vector/v.in.lidar/testsuite/decimation_test.py
+++ b/vector/v.in.lidar/testsuite/decimation_test.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/vector/v.in.lidar/testsuite/mask_test.py
+++ b/vector/v.in.lidar/testsuite/mask_test.py
@@ -78,6 +78,7 @@ C  1 1
 
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py
+++ b/vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/vector/v.in.lidar/testsuite/test_v_in_lidar_filter.py
+++ b/vector/v.in.lidar/testsuite/test_v_in_lidar_filter.py
@@ -10,9 +10,9 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 
 POINTS = """\
 17.46938776,18.67346939,143,1,1,2

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
@@ -11,9 +11,10 @@ Licence:   This program is free software under the GNU General Public
 
 import os
 import shutil
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-import unittest
 
 
 class BasicTest(TestCase):

--- a/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
+++ b/vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
@@ -11,9 +11,10 @@ Licence:   This program is free software under the GNU General Public
 
 import os
 import shutil
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-import unittest
 
 POINTS = """\
 17.46938776,18.67346939,143,1,1,2

--- a/vector/v.info/testsuite/test_vinfo.py
+++ b/vector/v.info/testsuite/test_vinfo.py
@@ -1,9 +1,8 @@
 import json
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVInfo(TestCase):

--- a/vector/v.out.lidar/testsuite/test_v_out_lidar.py
+++ b/vector/v.out.lidar/testsuite/test_v_out_lidar.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import os
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/vector/v.profile/testsuite/test_v_profile.py
+++ b/vector/v.profile/testsuite/test_v_profile.py
@@ -15,8 +15,8 @@ TODO:       Convert to synthetic dataset. It would allow to shorten output sampl
 import os
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 output_full = """Number|Distance|cat|feature_id|featurenam|class|st_alpha|st_num|county|county_num|primlat_dm|primlon_dm|primlatdec|primlondec|srclat_dms|srclon_dms|srclatdec|srclondec|elev_m|map_name
 1|19537.97|572|986138|"Greshams Lake"|"Reservoir"|"NC"|37|"Wake"|183|"078:34:31W"|"35:52:43N"|35.878484|-78.57528|""|""|""|""|77|"Wake Forest"

--- a/vector/v.surf.rst/benchmark/benchmark_v_surf_rst.py
+++ b/vector/v.surf.rst/benchmark/benchmark_v_surf_rst.py
@@ -4,10 +4,11 @@
         Chung-Yuan Liang
 """
 
-from grass.pygrass.modules import Module
-import grass.benchmark as bm
-from subprocess import DEVNULL
 import math
+from subprocess import DEVNULL
+
+import grass.benchmark as bm
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/vector/v.surf.rst/benchmark/benchmark_v_surf_rst_cv.py
+++ b/vector/v.surf.rst/benchmark/benchmark_v_surf_rst_cv.py
@@ -4,10 +4,11 @@
         Chung-Yuan Liang
 """
 
-from grass.pygrass.modules import Module
-import grass.benchmark as bm
-from subprocess import DEVNULL
 import math
+from subprocess import DEVNULL
+
+import grass.benchmark as bm
+from grass.pygrass.modules import Module
 
 
 def main():

--- a/vector/v.surf.rst/testsuite/test_vsurfrst.py
+++ b/vector/v.surf.rst/testsuite/test_vsurfrst.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVsurfrst(TestCase):

--- a/vector/v.univar/testsuite/v_univar_test.py
+++ b/vector/v.univar/testsuite/v_univar_test.py
@@ -10,8 +10,8 @@ Licence:    This program is free software under the GNU General Public
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestProfiling(TestCase):

--- a/vector/v.vect.stats/testsuite/test_vect_stats.py
+++ b/vector/v.vect.stats/testsuite/test_vect_stats.py
@@ -10,8 +10,8 @@ Licence:    This program is free software under the GNU General Public
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class Testrr(TestCase):

--- a/vector/v.what/testsuite/test_vwhat_layers.py
+++ b/vector/v.what/testsuite/test_vwhat_layers.py
@@ -1,6 +1,6 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 out1 = """East: 634243
 North: 226193

--- a/vector/v.what/testsuite/test_vwhat_ncspm.py
+++ b/vector/v.what/testsuite/test_vwhat_ncspm.py
@@ -1,9 +1,8 @@
 # Author: Anna Petrasova
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 
 # v.what map=schools,roadsmajor,elev_points,geology layer=-1,-1,-1,-1 coordinates=636661,226489 distance=1000
 out1 = """East: 636661


### PR DESCRIPTION
Uses a combination of `ruff check --output-format=concise --select I --fix vector raster raster3d imagery general misc`, `isort --profile=black vector raster raster3d imagery general misc` and `black .`

Continues on the same PRs as https://github.com/OSGeo/grass/pull/3961 and https://github.com/OSGeo/grass/pull/3959