### PR TITLE
style(scripts): Sort and group imports

### DIFF
--- a/scripts/d.correlate/d.correlate.py
+++ b/scripts/d.correlate/d.correlate.py
@@ -26,11 +26,12 @@
 # %option G_OPT_R_MAPS
 # %end
 
-import sys
 import os
-from grass.script.utils import try_remove
-from grass.script import core as gcore
+import sys
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as gcore
+from grass.script.utils import try_remove
 
 
 def main():

--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -42,14 +42,15 @@
 # % description: Plot using Xgraph
 # %end
 
-import os
-import string
-import math
 import atexit
 import glob
+import math
+import os
 import shutil
-from grass.script.utils import try_remove, basename
+import string
+
 from grass.script import core as gcore
+from grass.script.utils import basename, try_remove
 
 
 def raster_map_required(name):

--- a/scripts/d.polar/testsuite/test_d_polar.py
+++ b/scripts/d.polar/testsuite/test_d_polar.py
@@ -4,11 +4,11 @@ Created on Fri 20 Nov 2020
 @author: Markus Neteler
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestDPolar(TestCase):

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -74,11 +74,11 @@
 # % answer: 100
 # %end
 
-import sys
-import math
 import atexit
-import grass.script as grass
+import math
+import sys
 
+import grass.script as grass
 from grass.script.setup import set_gui_path
 
 set_gui_path()

--- a/scripts/d.rast.leg/d.rast.leg.py
+++ b/scripts/d.rast.leg/d.rast.leg.py
@@ -61,8 +61,9 @@
 # % required: no
 # %end
 
-import sys
 import os
+import sys
+
 import grass.script as grass
 
 

--- a/scripts/d.shade/d.shade.py
+++ b/scripts/d.shade/d.shade.py
@@ -40,8 +40,8 @@
 # %end
 
 
-from grass.script import core as gcore
 from grass.exceptions import CalledModuleError
+from grass.script import core as gcore
 
 
 def main():

--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -42,11 +42,11 @@
 # % options: dbf,odbc,ogr,sqlite,pg
 # %end
 
-import sys
 import string
+import sys
 
-from grass.exceptions import CalledModuleError
 import grass.script as gscript
+from grass.exceptions import CalledModuleError
 
 
 def main():

--- a/scripts/db.dropcolumn/testsuite/test_db_dropcolumn.py
+++ b/scripts/db.dropcolumn/testsuite/test_db_dropcolumn.py
@@ -5,9 +5,8 @@ Created on Sun Jun 07 19:08:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/db.droptable/db.droptable.py
+++ b/scripts/db.droptable/db.droptable.py
@@ -43,6 +43,7 @@
 # %end
 
 import sys
+
 import grass.script as grass
 from grass.script.utils import encode
 

--- a/scripts/db.droptable/testsuite/test_db_droptable.py
+++ b/scripts/db.droptable/testsuite/test_db_droptable.py
@@ -5,9 +5,8 @@ Created on Sun Jun 07 19:38:12 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/db.in.ogr/db.in.ogr.py
+++ b/scripts/db.in.ogr/db.in.ogr.py
@@ -73,9 +73,10 @@
 # %end
 
 import os
+
 import grass.script as grass
-from grass.script.utils import decode
 from grass.exceptions import CalledModuleError
+from grass.script.utils import decode
 
 
 def main():

--- a/scripts/db.in.ogr/testsuite/test_db_in_ogr.py
+++ b/scripts/db.in.ogr/testsuite/test_db_in_ogr.py
@@ -4,14 +4,13 @@ Created on Sun Jun 07 20:14:04 2018
 @author: Sanjeet Bhatti
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
+import os
 
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
-
-import os
 
 
 class TestDbInOgr(TestCase):

--- a/scripts/db.out.ogr/db.out.ogr.py
+++ b/scripts/db.out.ogr/db.out.ogr.py
@@ -57,9 +57,9 @@
 
 import os
 
-from grass.script.utils import try_remove, basename
-from grass.script import core as gcore
 from grass.exceptions import CalledModuleError
+from grass.script import core as gcore
+from grass.script.utils import basename, try_remove
 
 
 def main():

--- a/scripts/db.test/db.test.py
+++ b/scripts/db.test/db.test.py
@@ -26,12 +26,12 @@
 # % options: test1
 # %end
 
-import sys
 import os
+import sys
 
+from grass.exceptions import CalledModuleError
 from grass.script import core as gcore
 from grass.script import db as grassdb
-from grass.exceptions import CalledModuleError
 
 
 def main():

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -63,10 +63,10 @@
 # % description: Print stats in shell script style
 # %end
 
-import sys
 import atexit
 import json
 import math
+import sys
 
 import grass.script as gscript
 

--- a/scripts/db.univar/testsuite/test_db_univar.py
+++ b/scripts/db.univar/testsuite/test_db_univar.py
@@ -6,8 +6,8 @@ Created on Sun Jun 07 21:01:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestDbUnivar(TestCase):

--- a/scripts/g.extension.all/g.extension.all.py
+++ b/scripts/g.extension.all/g.extension.all.py
@@ -40,9 +40,7 @@ import http
 import os
 import re
 import sys
-
 import xml.etree.ElementTree as etree
-
 from urllib import request as urlrequest
 from urllib.error import HTTPError, URLError
 

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -143,17 +143,17 @@
 
 # TODO: solve addon-extension(-module) confusion
 
-import fileinput
-import os
-import codecs
-import sys
-import re
 import atexit
-import shutil
-import zipfile
-import tempfile
+import codecs
+import fileinput
 import json
+import os
+import re
+import shutil
+import sys
+import tempfile
 import xml.etree.ElementTree as etree
+import zipfile
 
 if sys.version_info.major == 3 and sys.version_info.minor < 8:
     from distutils.dir_util import copy_tree

--- a/scripts/g.extension/testsuite/test_addons_download.py
+++ b/scripts/g.extension/testsuite/test_addons_download.py
@@ -15,7 +15,6 @@ COPYRIGHT: (C) 2022 Stefan Blumentrath and by the GRASS Development Team
 import re
 import sys
 import unittest
-
 from pathlib import Path
 from urllib import request as urlrequest
 

--- a/scripts/g.extension/testsuite/test_addons_modules.py
+++ b/scripts/g.extension/testsuite/test_addons_modules.py
@@ -12,14 +12,13 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
            for details.
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-from grass.gunittest.utils import silent_rmtree
-from grass.script.utils import decode
-
 import os
 
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
+from grass.gunittest.utils import silent_rmtree
+from grass.script.utils import decode
 
 MODULES_OUTPUT = """\
 d.frame

--- a/scripts/g.extension/testsuite/test_addons_toolboxes.py
+++ b/scripts/g.extension/testsuite/test_addons_toolboxes.py
@@ -12,11 +12,11 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
            for details.
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 FULL_TOOLBOXES_OUTPUT = """\
 Hydrology (HY)

--- a/scripts/g.manual/g.manual.py
+++ b/scripts/g.manual/g.manual.py
@@ -46,14 +46,13 @@
 # % required : yes
 # %end
 
-import sys
 import os
+import sys
+import webbrowser
 from urllib.request import urlopen
 
-import webbrowser
-
-from grass.script.utils import basename
 from grass.script import core as grass
+from grass.script.utils import basename
 
 
 def start_browser(entry):

--- a/scripts/g.search.modules/g.search.modules.py
+++ b/scripts/g.search.modules/g.search.modules.py
@@ -65,11 +65,10 @@
 
 import os
 import sys
-
-from grass.script import core as grass
-from grass.exceptions import CalledModuleError
-
 import xml.etree.ElementTree as etree
+
+from grass.exceptions import CalledModuleError
+from grass.script import core as grass
 
 COLORIZE = False
 

--- a/scripts/g.search.modules/testsuite/test_g_search_modules.py
+++ b/scripts/g.search.modules/testsuite/test_g_search_modules.py
@@ -12,12 +12,12 @@ COPYRIGHT: (C) 2015 Jachym Cepicky, and by the GRASS Development Team
            for details.
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-from grass.script.utils import decode
-
 import unittest
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
+from grass.script.utils import decode
 
 try:
     has_termcolor = True

--- a/scripts/i.band.library/testsuite/test_i_band_library.py
+++ b/scripts/i.band.library/testsuite/test_i_band_library.py
@@ -1,8 +1,8 @@
 import os
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import call_module
+from grass.gunittest.main import test
 
 
 class TestBandsSystemDefined(TestCase):

--- a/scripts/i.colors.enhance/i.colors.enhance.py
+++ b/scripts/i.colors.enhance/i.colors.enhance.py
@@ -67,8 +67,8 @@
 # % description: Process bands serially (default: run in parallel)
 # %end
 
-import sys
 import multiprocessing as mp
+import sys
 
 import grass.script as gscript
 

--- a/scripts/i.in.spotvgt/i.in.spotvgt.py
+++ b/scripts/i.in.spotvgt/i.in.spotvgt.py
@@ -47,12 +47,12 @@
 # % required : no
 # %end
 
-import os
 import atexit
+import os
 import string
+
 import grass.script as gscript
 from grass.exceptions import CalledModuleError
-
 
 vrt = """<VRTDataset rasterXSize="$XSIZE" rasterYSize="$YSIZE">
  <SRS>GEOGCS[&quot;wgs84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;wgs84&quot;,6378137,298.257223563],TOWGS84[0.000,0.000,0.000]],PRIMEM[&quot;Greenwich&quot;,0],UNIT[&quot;degree&quot;,0.0174532925199433]]</SRS>

--- a/scripts/i.oif/i.oif.py
+++ b/scripts/i.oif/i.oif.py
@@ -40,10 +40,11 @@
 # % description: Process bands serially (default: run in parallel)
 # % End
 
-import sys
 import os
-from grass.script.utils import parse_key_val
+import sys
+
 from grass.script import core as grass
+from grass.script.utils import parse_key_val
 
 
 def oifcalc(sdev, corr, k1, k2, k3):

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -78,10 +78,11 @@
 # % description: output to text file
 # %end
 
-import os
 import atexit
-from grass.script.utils import try_rmdir
+import os
+
 from grass.script import core as gcore
+from grass.script.utils import try_rmdir
 
 
 def cleanup():

--- a/scripts/i.tasscap/i.tasscap.py
+++ b/scripts/i.tasscap/i.tasscap.py
@@ -84,7 +84,6 @@
 
 import grass.script as grass
 
-
 # weights for 6 Landsat bands: TM4, TM5, TM7, OLI
 # MODIS: Red, NIR1, Blue, Green, NIR2, SWIR1, SWIR2
 # Sentinel-2: B1 ... B12, B8A

--- a/scripts/m.proj/m.proj.py
+++ b/scripts/m.proj/m.proj.py
@@ -98,11 +98,12 @@ COPYRIGHT: (c) 2006-2019 Hamish Bowman, and the GRASS Development Team
 # % exclusive: -i, -o
 # %end
 
-import sys
 import os
+import sys
 import threading
-from grass.script.utils import separator, parse_key_val, encode, decode
+
 from grass.script import core as gcore
+from grass.script.utils import decode, encode, parse_key_val, separator
 
 
 class TrThread(threading.Thread):

--- a/scripts/r.blend/r.blend.py
+++ b/scripts/r.blend/r.blend.py
@@ -45,6 +45,7 @@
 
 import os
 import string
+
 import grass.script as gscript
 
 

--- a/scripts/r.blend/testsuite/test_r_blend.py
+++ b/scripts/r.blend/testsuite/test_r_blend.py
@@ -5,8 +5,8 @@ Created on Sun Jun 07 21:42:39 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script.core import run_command
 
 

--- a/scripts/r.blend/testsuite/test_r_blend_quoting.py
+++ b/scripts/r.blend/testsuite/test_r_blend_quoting.py
@@ -5,11 +5,12 @@ Created on Mon 17 Feb 2020 02:27:26 PM UTC
 """
 
 import os
+
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-from grass.script.core import run_command
+from grass.gunittest.main import test
 from grass.gunittest.utils import silent_rmtree
+from grass.script.core import run_command
 
 
 class TestRBlend(TestCase):

--- a/scripts/r.buffer.lowmem/r.buffer.lowmem.py
+++ b/scripts/r.buffer.lowmem/r.buffer.lowmem.py
@@ -41,11 +41,11 @@
 # % answer: meters
 # %end
 
-import os
 import atexit
+import os
+
 import grass.script as grass
 from grass.script.utils import encode
-
 
 scales = {
     "meters": 1.0,

--- a/scripts/r.colors.stddev/r.colors.stddev.py
+++ b/scripts/r.colors.stddev/r.colors.stddev.py
@@ -30,8 +30,8 @@
 # % description: Force center at zero
 # %end
 
-import os
 import atexit
+import os
 
 import grass.script as gscript
 from grass.script.utils import decode

--- a/scripts/r.drain/r.drain.py
+++ b/scripts/r.drain/r.drain.py
@@ -108,8 +108,8 @@
 # % required: start_coordinates, start_points
 # %end
 
-import sys
 import atexit
+import sys
 
 import grass.script as gs
 

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -101,8 +101,8 @@
 # %end
 
 
-import os
 import atexit
+import os
 import subprocess
 
 import grass.script as grass

--- a/scripts/r.fillnulls/testsuite/test_r_fillnulls.py
+++ b/scripts/r.fillnulls/testsuite/test_r_fillnulls.py
@@ -7,8 +7,8 @@ Created on Sun Jun 07 21:57:07 2018
 import os
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script.core import run_command
 
 

--- a/scripts/r.grow/r.grow.py
+++ b/scripts/r.grow/r.grow.py
@@ -60,9 +60,9 @@
 # % description: Value to write for "grown" cells
 # %end
 
-import os
 import atexit
 import math
+import os
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/scripts/r.grow/testsuite/test_r_grow.py
+++ b/scripts/r.grow/testsuite/test_r_grow.py
@@ -5,8 +5,8 @@ Created on Sun Jun 07 22:09:41 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script.core import run_command
 
 

--- a/scripts/r.grow/testsuite/test_r_grow_quoting.py
+++ b/scripts/r.grow/testsuite/test_r_grow_quoting.py
@@ -5,11 +5,12 @@ Created on Mon 17 Feb 2020 02:27:26 PM UTC
 """
 
 import os
+
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-from grass.script.core import run_command
+from grass.gunittest.main import test
 from grass.gunittest.utils import silent_rmtree
+from grass.script.core import run_command
 
 
 class TestRGrow(TestCase):

--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -113,14 +113,13 @@
 # % required: output,-e
 # %end
 
-import sys
-import os
 import atexit
 import math
+import os
+import sys
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError
-
 
 # initialize global vars
 TMPLOC = None

--- a/scripts/r.import/testsuite/test_r_import.py
+++ b/scripts/r.import/testsuite/test_r_import.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
+import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.script as gs
 
 
 class TestRImportRegion(TestCase):

--- a/scripts/r.in.aster/r.in.aster.py
+++ b/scripts/r.in.aster/r.in.aster.py
@@ -52,6 +52,7 @@
 # %end
 
 import os
+
 import grass.script as grass
 
 bands = {

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -71,12 +71,12 @@
 # %end
 
 
+import atexit
 import os
 import shutil
-import atexit
-import grass.script as grass
 import zipfile as zfile
 
+import grass.script as grass
 
 tmpl1sec = """BYTEORDER M
 LAYOUT BIL

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -19,9 +19,8 @@ import base64
 import os
 from http.client import HTTPException
 from math import ceil
-from urllib.request import Request, urlopen
 from urllib.error import HTTPError
-
+from urllib.request import Request, urlopen
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/scripts/r.in.wms/wms_cap_parsers.py
+++ b/scripts/r.in.wms/wms_cap_parsers.py
@@ -18,10 +18,9 @@ This program is free software under the GNU General Public License
 """
 
 import pathlib
-
+import xml.etree.ElementTree as etree
 from xml.etree.ElementTree import ParseError
 
-import xml.etree.ElementTree as etree
 import grass.script as grass
 
 

--- a/scripts/r.in.wms/wms_drv.py
+++ b/scripts/r.in.wms/wms_drv.py
@@ -18,9 +18,9 @@ This program is free software under the GNU General Public License
 """
 
 import socket
-import grass.script as grass
-
 from time import sleep
+
+import grass.script as grass
 
 try:
     from osgeo import gdal
@@ -36,17 +36,14 @@ import numpy as Numeric
 
 Numeric.arrayrange = Numeric.arange
 
-from math import pi, floor
-
-from urllib.error import HTTPError
 from http.client import HTTPException
-
+from math import floor, pi
+from urllib.error import HTTPError
 from xml.etree.ElementTree import ParseError
 
-from wms_base import GetEpsg, GetSRSParamVal, WMSBase
-
-from wms_cap_parsers import WMTSCapabilitiesTree, OnEarthCapabilitiesTree
 from srs import Srs
+from wms_base import GetEpsg, GetSRSParamVal, WMSBase
+from wms_cap_parsers import OnEarthCapabilitiesTree, WMTSCapabilitiesTree
 
 
 class WMSDrv(WMSBase):

--- a/scripts/r.in.wms/wms_gdal_drv.py
+++ b/scripts/r.in.wms/wms_gdal_drv.py
@@ -27,7 +27,7 @@ except:
 
 import xml.etree.ElementTree as etree
 
-from wms_base import WMSBase, GetSRSParamVal
+from wms_base import GetSRSParamVal, WMSBase
 
 
 class NullDevice:

--- a/scripts/r.mapcalc.simple/r.mapcalc.simple.py
+++ b/scripts/r.mapcalc.simple/r.mapcalc.simple.py
@@ -90,8 +90,8 @@ for details.
 # % description: Case sensitive variable names
 # %end
 
-import sys
 import re
+import sys
 
 import grass.script as gs
 

--- a/scripts/r.mask/r.mask.py
+++ b/scripts/r.mask/r.mask.py
@@ -68,13 +68,13 @@
 # % guisection: Remove
 # %end
 
+import atexit
 import os
 import sys
-import atexit
 
 import grass.script as grass
-from grass.script.utils import encode
 from grass.exceptions import CalledModuleError
+from grass.script.utils import encode
 
 
 def cleanup():

--- a/scripts/r.mask/testsuite/test_r_mask.py
+++ b/scripts/r.mask/testsuite/test_r_mask.py
@@ -5,8 +5,8 @@ Created on Sun Jun 07 22:19:41 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestRMask(TestCase):

--- a/scripts/r.out.xyz/r.out.xyz.py
+++ b/scripts/r.out.xyz/r.out.xyz.py
@@ -39,8 +39,9 @@
 # %end
 
 import sys
-from grass.script import core as grass
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as grass
 
 
 def main():

--- a/scripts/r.out.xyz/testsuite/test_r_out_xyz.py
+++ b/scripts/r.out.xyz/testsuite/test_r_out_xyz.py
@@ -4,11 +4,11 @@ Created on Sun Jun 08 10:11:18 2018
 @author: Sanjeet Bhatti
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestROutXyz(TestCase):

--- a/scripts/r.pack/r.pack.py
+++ b/scripts/r.pack/r.pack.py
@@ -31,14 +31,14 @@
 # % description: Switch the compression off
 # %end
 
-import os
-import sys
-import shutil
 import atexit
+import os
+import shutil
+import sys
 import tarfile
 
-from grass.script.utils import try_rmdir, try_remove
 from grass.script import core as grass
+from grass.script.utils import try_remove, try_rmdir
 
 
 def cleanup():

--- a/scripts/r.pack/testsuite/test_r_pack.py
+++ b/scripts/r.pack/testsuite/test_r_pack.py
@@ -4,11 +4,11 @@ Created on Sun Jun 08 10:15:22 2018
 @author: Sanjeet Bhatti
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestRPack(TestCase):

--- a/scripts/r.plane/r.plane.py
+++ b/scripts/r.plane/r.plane.py
@@ -65,6 +65,7 @@
 
 import math
 import string
+
 import grass.script as gscript
 
 

--- a/scripts/r.plane/testsuite/test_r_plane.py
+++ b/scripts/r.plane/testsuite/test_r_plane.py
@@ -5,8 +5,8 @@ Created on Sun Jun 08 12:12:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestRPlane(TestCase):

--- a/scripts/r.reclass.area/r.reclass.area.py
+++ b/scripts/r.reclass.area/r.reclass.area.py
@@ -72,9 +72,10 @@
 # % description: Clumps including diagonal neighbors
 # %end
 
-import sys
-import os
 import atexit
+import os
+import sys
+
 import grass.script as grass
 from grass.script.utils import decode, encode
 

--- a/scripts/r.rgb/testsuite/test_r_rgb.py
+++ b/scripts/r.rgb/testsuite/test_r_rgb.py
@@ -5,8 +5,8 @@ Created on Sun Jun 08 13:20:31 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestRRGB(TestCase):

--- a/scripts/r.semantic.label/testsuite/test_r_semantic_label.py
+++ b/scripts/r.semantic.label/testsuite/test_r_semantic_label.py
@@ -1,10 +1,9 @@
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
-from grass.script.core import tempname
+from grass.gunittest.main import test
 from grass.pygrass.gis import Mapset
 from grass.pygrass.raster import RasterRow
+from grass.script.core import tempname
 
 
 class TestSemanticLabelsSystemDefined(TestCase):

--- a/scripts/r.shade/r.shade.py
+++ b/scripts/r.shade/r.shade.py
@@ -63,9 +63,10 @@
 
 
 import os
+
+from grass.exceptions import CalledModuleError
 from grass.script import core as gcore
 from grass.script import raster as grast
-from grass.exceptions import CalledModuleError
 
 
 def remove(maps):

--- a/scripts/r.shade/testsuite/test_r_shade.py
+++ b/scripts/r.shade/testsuite/test_r_shade.py
@@ -5,8 +5,8 @@ Created on Sun Jun 08 13:44:07 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestRShade(TestCase):

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -107,14 +107,13 @@
 # A reprojector [0] is name of source projection, [1] is name of destination
 # A projection - [0] is proj.4 text, [1] is scale
 
+import math
 import sys
 import tempfile
-import math
 
-from grass.script.utils import separator
-from grass.script import core as gcore
-from grass.script.utils import decode
 from grass.exceptions import CalledModuleError
+from grass.script import core as gcore
+from grass.script.utils import decode, separator
 
 
 def bboxToPoints(bbox):

--- a/scripts/r.tileset/testsuite/test_r_tileset.py
+++ b/scripts/r.tileset/testsuite/test_r_tileset.py
@@ -4,13 +4,12 @@ Created on Sun Jun 08 19:42:32 2018
 @author: Sanjeet Bhatti
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
-from grass.script.utils import decode
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
+from grass.script.utils import decode
 
 output = """\
 -78.77462049|35.6875073|-78.60830318|35.74855834|1506|678

--- a/scripts/r.unpack/r.unpack.py
+++ b/scripts/r.unpack/r.unpack.py
@@ -40,14 +40,14 @@
 # % guisection: Print
 # %end
 
-import os
-import sys
-import shutil
-import tarfile
 import atexit
+import os
+import shutil
+import sys
+import tarfile
 
-from grass.script.utils import diff_files, try_rmdir
 from grass.script import core as grass
+from grass.script.utils import diff_files, try_rmdir
 
 
 def cleanup():

--- a/scripts/r3.in.xyz/r3.in.xyz.py
+++ b/scripts/r3.in.xyz/r3.in.xyz.py
@@ -168,11 +168,12 @@
 # %End
 
 
-import sys
-import os
 import atexit
-from grass.script import core as grass
+import os
+import sys
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as grass
 
 
 def cleanup():

--- a/scripts/v.build.all/v.build.all.py
+++ b/scripts/v.build.all/v.build.all.py
@@ -19,8 +19,9 @@
 # %end
 
 import sys
-from grass.script import core as grass
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as grass
 
 
 def main():

--- a/scripts/v.centroids/testsuite/test_v_centroids.py
+++ b/scripts/v.centroids/testsuite/test_v_centroids.py
@@ -5,8 +5,8 @@ Created on Thrs Jun 09 11:26:12 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVCentroids(TestCase):

--- a/scripts/v.centroids/v.centroids.py
+++ b/scripts/v.centroids/v.centroids.py
@@ -50,6 +50,7 @@
 # %end
 
 import sys
+
 import grass.script as gscript
 
 

--- a/scripts/v.clip/v.clip.py
+++ b/scripts/v.clip/v.clip.py
@@ -52,13 +52,13 @@
 # % requires_all: -r, input, output
 # %end
 
+import atexit
 import os
 import sys
-import atexit
 
-from grass.script import parser
 import grass.script as grass
 from grass.exceptions import CalledModuleError
+from grass.script import parser
 
 TMP = []
 

--- a/scripts/v.db.addcolumn/testsuite/test_v_db_addcolumn.py
+++ b/scripts/v.db.addcolumn/testsuite/test_v_db_addcolumn.py
@@ -5,9 +5,8 @@ Created on Sun Jun 09 11:28:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/v.db.addcolumn/v.db.addcolumn.py
+++ b/scripts/v.db.addcolumn/v.db.addcolumn.py
@@ -44,8 +44,8 @@ import atexit
 import os
 import re
 
-from grass.exceptions import CalledModuleError
 import grass.script as grass
+from grass.exceptions import CalledModuleError
 
 rm_files = []
 

--- a/scripts/v.db.addtable/testsuite/test_v_db_addtable.py
+++ b/scripts/v.db.addtable/testsuite/test_v_db_addtable.py
@@ -5,9 +5,8 @@ Created on Sun Jun 09 12:01:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/v.db.addtable/v.db.addtable.py
+++ b/scripts/v.db.addtable/v.db.addtable.py
@@ -53,11 +53,12 @@
 # % guisection: Definition
 # %end
 
-import sys
 import os
+import sys
+
 import grass.script as grass
-from grass.script.utils import decode
 from grass.exceptions import CalledModuleError
+from grass.script.utils import decode
 
 
 def main():

--- a/scripts/v.db.dropcolumn/testsuite/test_v_db_dropcolumn.py
+++ b/scripts/v.db.dropcolumn/testsuite/test_v_db_dropcolumn.py
@@ -5,9 +5,8 @@ Created on Sun Jun 09 01:12:22 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/v.db.dropcolumn/v.db.dropcolumn.py
+++ b/scripts/v.db.dropcolumn/v.db.dropcolumn.py
@@ -38,6 +38,7 @@
 # %end
 
 import string
+
 import grass.script as grass
 from grass.exceptions import CalledModuleError
 

--- a/scripts/v.db.droprow/testsuite/test_v_db_droprow.py
+++ b/scripts/v.db.droprow/testsuite/test_v_db_droprow.py
@@ -5,9 +5,8 @@ Created on Sun Jun 09 01:52:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 
 

--- a/scripts/v.db.droprow/v.db.droprow.py
+++ b/scripts/v.db.droprow/v.db.droprow.py
@@ -36,6 +36,7 @@
 # %end
 
 import sys
+
 import grass.script as grass
 from grass.exceptions import CalledModuleError
 

--- a/scripts/v.db.droptable/testsuite/test_v_db_droptable.py
+++ b/scripts/v.db.droptable/testsuite/test_v_db_droptable.py
@@ -5,9 +5,8 @@ Created on Sun Jun 09 09:18:39 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/v.db.droptable/v.db.droptable.py
+++ b/scripts/v.db.droptable/v.db.droptable.py
@@ -34,8 +34,9 @@
 # % required : no
 # %end
 
-import sys
 import os
+import sys
+
 import grass.script as gscript
 from grass.exceptions import CalledModuleError
 

--- a/scripts/v.db.join/testsuite/test_v_db_join.py
+++ b/scripts/v.db.join/testsuite/test_v_db_join.py
@@ -13,8 +13,8 @@ COPYRIGHT: (C) 2024 Stefan Blumentrath, and by the GRASS Development Team
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVDbJoin(TestCase):

--- a/scripts/v.db.join/v.db.join.py
+++ b/scripts/v.db.join/v.db.join.py
@@ -65,7 +65,6 @@
 
 import atexit
 import sys
-
 from pathlib import Path
 
 import grass.script as gs

--- a/scripts/v.db.reconnect.all/v.db.reconnect.all.py
+++ b/scripts/v.db.reconnect.all/v.db.reconnect.all.py
@@ -49,9 +49,9 @@
 # % label: Name for target database schema
 # %end
 
-import sys
 import os
 import string
+import sys
 
 import grass.script as gscript
 from grass.exceptions import CalledModuleError

--- a/scripts/v.db.renamecolumn/testsuite/test_v_db_renamecolumn.py
+++ b/scripts/v.db.renamecolumn/testsuite/test_v_db_renamecolumn.py
@@ -5,9 +5,8 @@ Created on Sun Jun 07 19:08:34 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/v.db.univar/tests/conftest.py
+++ b/scripts/v.db.univar/tests/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for v.db.univar tests"""
 
 import os
-
 from types import SimpleNamespace
 
 import pytest

--- a/scripts/v.db.univar/testsuite/test_v_db_univar.py
+++ b/scripts/v.db.univar/testsuite/test_v_db_univar.py
@@ -6,8 +6,8 @@ Created on Sun Jun 08 19:08:07 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVDbUnivar(TestCase):

--- a/scripts/v.db.univar/v.db.univar.py
+++ b/scripts/v.db.univar/v.db.univar.py
@@ -59,8 +59,9 @@
 # % description: Print stats in shell script style
 # %end
 
-import sys
 import os
+import sys
+
 import grass.script as gscript
 from grass.exceptions import CalledModuleError
 

--- a/scripts/v.db.update/testsuite/test_v_db_update.py
+++ b/scripts/v.db.update/testsuite/test_v_db_update.py
@@ -5,9 +5,8 @@ Created on Sun Jun 08 22:14:26 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 
 

--- a/scripts/v.db.update/v.db.update.py
+++ b/scripts/v.db.update/v.db.update.py
@@ -52,8 +52,9 @@
 # % required: no
 # %end
 
-import sys
 import os
+import sys
+
 import grass.script as grass
 
 

--- a/scripts/v.dissolve/tests/conftest.py
+++ b/scripts/v.dissolve/tests/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for v.dissolve tests"""
 
 import os
-
 from types import SimpleNamespace
 
 import pytest

--- a/scripts/v.dissolve/testsuite/test_v_dissolve.py
+++ b/scripts/v.dissolve/testsuite/test_v_dissolve.py
@@ -5,9 +5,8 @@ Created on Sun Jun 08 23:58:10 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 
 

--- a/scripts/v.dissolve/v.dissolve.py
+++ b/scripts/v.dissolve/v.dissolve.py
@@ -83,7 +83,6 @@ from collections import defaultdict
 import grass.script as gs
 from grass.exceptions import CalledModuleError
 
-
 # Methods supported by v.db.univar by default.
 UNIVAR_METHODS = [
     "n",

--- a/scripts/v.import/testsuite/test_v_import.py
+++ b/scripts/v.import/testsuite/test_v_import.py
@@ -3,7 +3,6 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
-
 # Input data notes
 
 # Created in:

--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -97,11 +97,11 @@
 # % description: Assume that the dataset has the same coordinate reference system (CRS) as the current project
 # %end
 
-import sys
-import os
 import atexit
-import xml.etree.ElementTree as ET  # only needed for GDAL version < 2.4.1
+import os
 import re  # only needed for GDAL version < 2.4.1
+import sys
+import xml.etree.ElementTree as ET  # only needed for GDAL version < 2.4.1
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError

--- a/scripts/v.in.e00/v.in.e00.py
+++ b/scripts/v.in.e00/v.in.e00.py
@@ -38,13 +38,14 @@
 # %option G_OPT_V_OUTPUT
 # %end
 
+import glob
 import os
 import shutil
-import glob
-from grass.script.utils import try_rmdir, try_remove, basename
-from grass.script import vector as gvect
-from grass.script import core as gcore
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as gcore
+from grass.script import vector as gvect
+from grass.script.utils import basename, try_remove, try_rmdir
 
 
 def main():

--- a/scripts/v.in.lines/v.in.lines.py
+++ b/scripts/v.in.lines/v.in.lines.py
@@ -34,11 +34,12 @@
 # %option G_OPT_F_SEP
 # %end
 
-import sys
-import os
 import atexit
-from grass.script.utils import separator, try_remove
+import os
+import sys
+
 from grass.script import core as grass
+from grass.script.utils import separator, try_remove
 
 
 def cleanup():

--- a/scripts/v.in.mapgen/v.in.mapgen.py
+++ b/scripts/v.in.mapgen/v.in.mapgen.py
@@ -44,15 +44,16 @@
 # % required: no
 # %end
 
-import sys
-import os
 import atexit
-import string
-import time
+import os
 import shutil
-from grass.script.utils import try_remove
-from grass.script import core as grass
+import string
+import sys
+import time
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as grass
+from grass.script.utils import try_remove
 
 
 def cleanup():

--- a/scripts/v.in.wfs/v.in.wfs.py
+++ b/scripts/v.in.wfs/v.in.wfs.py
@@ -107,14 +107,17 @@
 
 import os
 import sys
-from grass.script.utils import try_remove
-from grass.script import core as grass
+from urllib.error import HTTPError, URLError
+from urllib.request import (
+    HTTPBasicAuthHandler,
+    HTTPPasswordMgrWithDefaultRealm,
+    build_opener,
+    install_opener,
+    urlopen,
+)
 
-from urllib.request import urlopen
-from urllib.request import build_opener, install_opener
-from urllib.request import HTTPPasswordMgrWithDefaultRealm
-from urllib.request import HTTPBasicAuthHandler
-from urllib.error import URLError, HTTPError
+from grass.script import core as grass
+from grass.script.utils import try_remove
 
 
 def main():

--- a/scripts/v.pack/testsuite/test_v_pack.py
+++ b/scripts/v.pack/testsuite/test_v_pack.py
@@ -4,11 +4,11 @@ Created on Sun Jun 08 23:19:09 2018
 @author: Sanjeet Bhatti
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVPack(TestCase):

--- a/scripts/v.pack/v.pack.py
+++ b/scripts/v.pack/v.pack.py
@@ -33,14 +33,14 @@
 # % description: Switch the compression off
 # %end
 
+import atexit
 import os
 import sys
 import tarfile
-import atexit
 
-from grass.script.utils import try_rmdir, try_remove
 from grass.script import core as grass
 from grass.script import vector as vector
+from grass.script.utils import try_remove, try_rmdir
 
 
 def cleanup():

--- a/scripts/v.rast.stats/testsuite/test_v_rast_stats.py
+++ b/scripts/v.rast.stats/testsuite/test_v_rast_stats.py
@@ -6,9 +6,7 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 from grass.pygrass.vector import VectorTopo
-from grass.pygrass.vector.geometry import Line
-from grass.pygrass.vector.geometry import Boundary
-from grass.pygrass.vector.geometry import Centroid
+from grass.pygrass.vector.geometry import Boundary, Centroid, Line
 
 
 class TestRastStats(TestCase):

--- a/scripts/v.rast.stats/v.rast.stats.py
+++ b/scripts/v.rast.stats/v.rast.stats.py
@@ -73,12 +73,13 @@
 # % required : no
 # %end
 
-import sys
-import os
 import atexit
+import os
+import sys
+
 import grass.script as grass
-from grass.script.utils import decode
 from grass.exceptions import CalledModuleError
+from grass.script.utils import decode
 
 
 def cleanup():

--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -53,10 +53,11 @@
 # % description: Report for geometries with no database records
 # %end
 
-import sys
 import os
+import sys
+
 import grass.script as grass
-from grass.script.utils import separator, decode
+from grass.script.utils import decode, separator
 
 
 def uniq(items):

--- a/scripts/v.to.lines/testsuite/test_v_to_lines.py
+++ b/scripts/v.to.lines/testsuite/test_v_to_lines.py
@@ -5,8 +5,8 @@ Created on Sun Jun 09 12:28:03 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVDToLines(TestCase):

--- a/scripts/v.to.lines/v.to.lines.py
+++ b/scripts/v.to.lines/v.to.lines.py
@@ -40,10 +40,11 @@
 # % guisection: Area
 # %end
 
-import grass.script as grass
-from grass.script.utils import decode
-from grass.exceptions import CalledModuleError
 import os
+
+import grass.script as grass
+from grass.exceptions import CalledModuleError
+from grass.script.utils import decode
 
 
 def main():

--- a/scripts/v.unpack/testsuite/test_v_unpack.py
+++ b/scripts/v.unpack/testsuite/test_v_unpack.py
@@ -4,11 +4,11 @@ Created on Sun Jun 08 12:50:45 2018
 @author: Sanjeet Bhatti
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
-
 import os
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 
 
 class TestVUnpack(TestCase):

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -42,16 +42,16 @@
 # % guisection: Print
 # %end
 
-import os
-import sys
-import shutil
-import tarfile
 import atexit
+import os
+import shutil
+import sys
+import tarfile
 
-from grass.script.utils import diff_files, try_rmdir
+from grass.exceptions import CalledModuleError
 from grass.script import core as grass
 from grass.script import db as grassdb
-from grass.exceptions import CalledModuleError
+from grass.script.utils import diff_files, try_rmdir
 
 
 def cleanup():

--- a/scripts/v.what.strds/testsuite/test_what_strds.py
+++ b/scripts/v.what.strds/testsuite/test_what_strds.py
@@ -9,10 +9,10 @@ for details.
 @author Luca Delucchi
 """
 
-from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
-from grass.gunittest.gmodules import SimpleModule
 import grass.script as gscript
+from grass.gunittest.case import TestCase
+from grass.gunittest.gmodules import SimpleModule
+from grass.gunittest.main import test
 from grass.script.utils import decode
 
 

--- a/scripts/v.what.strds/v.what.strds.py
+++ b/scripts/v.what.strds/v.what.strds.py
@@ -95,8 +95,8 @@ class Sample:
 def main():
     # lazy imports
     import grass.temporal as tgis
-    from grass.pygrass.utils import copy as gcopy
     from grass.pygrass.messages import Messenger
+    from grass.pygrass.utils import copy as gcopy
     from grass.pygrass.vector import Vector
 
     # Get the options

--- a/scripts/v.what.vect/testsuite/test_v_what_vect.py
+++ b/scripts/v.what.vect/testsuite/test_v_what_vect.py
@@ -5,9 +5,8 @@ Created on Sun Jun 09 11:42:54 2018
 """
 
 from grass.gunittest.case import TestCase
-from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
-
+from grass.gunittest.main import test
 from grass.script.core import run_command
 from grass.script.utils import decode
 

--- a/scripts/v.what.vect/v.what.vect.py
+++ b/scripts/v.what.vect/v.what.vect.py
@@ -58,8 +58,9 @@
 # %end
 
 import sys
-from grass.script import core as grass
+
 from grass.exceptions import CalledModuleError
+from grass.script import core as grass
 
 
 def main():

--- a/scripts/wxpyimgview/wxpyimgview.py
+++ b/scripts/wxpyimgview/wxpyimgview.py
@@ -38,6 +38,7 @@
 # %end
 
 import os
+
 import grass.script as grass
 
 if __name__ == "__main__":

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -40,8 +40,8 @@ import signal
 import struct
 import sys
 import time
-import numpy
 
+import numpy
 import wx
 
 import grass.script as grass


### PR DESCRIPTION
Uses a combination of `ruff check --output-format=concise --select I --fix scripts`, `isort --profile=black scripts` and `black .`

Continues on the same PRs as https://github.com/OSGeo/grass/pull/3961, https://github.com/OSGeo/grass/pull/3959, and https://github.com/OSGeo/grass/pull/3962