### PR TITLE
style(gui): Sort and group imports for simple changes only

### DIFF
--- a/gui/scripts/d.wms.py
+++ b/gui/scripts/d.wms.py
@@ -156,8 +156,8 @@
 # %end
 
 import os
-import sys
 import shutil
+import sys
 
 from grass.script import core as grass
 

--- a/gui/wxpython/animation/anim.py
+++ b/gui/wxpython/animation/anim.py
@@ -15,6 +15,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
+
 from .utils import Orientation, ReplayMode
 
 

--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -15,25 +15,26 @@ This program is free software under the GNU General Public License
 """
 
 import os
+
 import wx
 
-from core.gcmd import GException, GError, GMessage
+from core.gcmd import GError, GException, GMessage
 from grass.imaging import writeAvi, writeGif, writeIms, writeSwf
 from core.gthread import gThread
 from core.settings import UserSettings
 from gui_core.wrap import EmptyImage, ImageFromBitmap
 
 from animation.temporal_manager import TemporalManager
-from animation.dialogs import InputDialog, EditDialog, ExportDialog
+from animation.dialogs import EditDialog, ExportDialog, InputDialog
 from animation.utils import (
-    TemporalMode,
-    TemporalType,
+    HashCmds,
     Orientation,
     RenderText,
+    TemporalMode,
+    TemporalType,
     WxImageToPil,
-    sampleCmdMatrixAndCreateNames,
     layerListToCmdsMatrix,
-    HashCmds,
+    sampleCmdMatrixAndCreateNames,
 )
 from animation.data import AnimationData
 

--- a/gui/wxpython/animation/data.py
+++ b/gui/wxpython/animation/data.py
@@ -16,8 +16,8 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
 import copy
+import os
 
 from grass.script.utils import parse_key_val
 from grass.script import core as gcore
@@ -25,13 +25,13 @@ from grass.script import core as gcore
 from core.gcmd import GException
 from animation.nviztask import NvizTask
 from animation.utils import (
-    validateMapNames,
-    getRegisteredMaps,
     checkSeriesCompatibility,
-    validateTimeseriesName,
+    getRegisteredMaps,
     interpolate,
+    validateMapNames,
+    validateTimeseriesName,
 )
-from core.layerlist import LayerList, Layer
+from core.layerlist import Layer, LayerList
 
 
 class AnimationData:

--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -20,10 +20,11 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
-import wx
 import copy
 import datetime
+import os
+
+import wx
 import wx.lib.filebrowsebutton as filebrowse
 import wx.lib.scrolledpanel as SP
 import wx.lib.colourselect as csel
@@ -33,9 +34,9 @@ try:
 except ImportError:
     from wx import HyperlinkCtrl
 
-from core.gcmd import GMessage, GError, GException
+from core.gcmd import GError, GException, GMessage
 from core import globalvar
-from gui_core.dialogs import MapLayersDialog, GetImageHandlers
+from gui_core.dialogs import GetImageHandlers, MapLayersDialog
 from gui_core.preferences import PreferencesBaseDialog
 from gui_core.forms import GUI
 from core.settings import UserSettings
@@ -57,17 +58,17 @@ from gui_core.wrap import (
 
 from animation.utils import (
     TemporalMode,
-    getRegisteredMaps,
-    getNameAndLayer,
     getCpuCount,
+    getNameAndLayer,
+    getRegisteredMaps,
 )
 from animation.data import AnimationData, AnimLayer
-from animation.toolbars import AnimSimpleLmgrToolbar, SIMPLE_LMGR_STDS
+from animation.toolbars import SIMPLE_LMGR_STDS, AnimSimpleLmgrToolbar
 from gui_core.simplelmgr import (
-    SimpleLayerManager,
     SIMPLE_LMGR_RASTER,
-    SIMPLE_LMGR_VECTOR,
     SIMPLE_LMGR_TB_TOP,
+    SIMPLE_LMGR_VECTOR,
+    SimpleLayerManager,
 )
 
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/animation/frame.py
+++ b/gui/wxpython/animation/frame.py
@@ -19,6 +19,7 @@ This program is free software under the GNU General Public License
 """
 
 import os
+
 import wx
 import wx.aui
 
@@ -27,15 +28,15 @@ import grass.temporal as tgis
 from grass.exceptions import FatalError
 from core import globalvar
 from gui_core.widgets import IntegerValidator
-from gui_core.wrap import StaticText, TextCtrl, Slider
-from core.gcmd import RunCommand, GWarning
+from gui_core.wrap import Slider, StaticText, TextCtrl
+from core.gcmd import GWarning, RunCommand
 
 from animation.mapwindow import AnimationWindow
-from animation.provider import BitmapProvider, BitmapPool, MapFilesPool, CleanUp
+from animation.provider import BitmapPool, BitmapProvider, CleanUp, MapFilesPool
 from animation.controller import AnimationController
 from animation.anim import Animation
-from animation.toolbars import MainToolbar, AnimationToolbar, MiscToolbar
-from animation.dialogs import SpeedDialog, PreferencesDialog
+from animation.toolbars import AnimationToolbar, MainToolbar, MiscToolbar
+from animation.dialogs import PreferencesDialog, SpeedDialog
 from animation.utils import Orientation, ReplayMode, TemporalType
 
 

--- a/gui/wxpython/animation/g.gui.animation.py
+++ b/gui/wxpython/animation/g.gui.animation.py
@@ -69,7 +69,7 @@ def main():
 
     from core.giface import StandaloneGrassInterface
     from core.layerlist import LayerList
-    from animation.frame import AnimationFrame, MAX_COUNT
+    from animation.frame import MAX_COUNT, AnimationFrame
     from animation.data import AnimLayer
 
     rast = options["raster"]

--- a/gui/wxpython/animation/mapwindow.py
+++ b/gui/wxpython/animation/mapwindow.py
@@ -18,6 +18,7 @@ This program is free software under the GNU General Public License
 import wx
 from core.debug import Debug
 from gui_core.wrap import BitmapFromImage, EmptyBitmap, ImageFromBitmap, PseudoDC, Rect
+
 from .utils import ComputeScaledRect
 
 

--- a/gui/wxpython/animation/nviztask.py
+++ b/gui/wxpython/animation/nviztask.py
@@ -17,7 +17,7 @@ This program is free software under the GNU General Public License
 import xml.etree.ElementTree as etree
 
 from core.workspace import ProcessWorkspaceFile
-from core.gcmd import RunCommand, GException
+from core.gcmd import GException, RunCommand
 from core.utils import GetLayerNameFromCmd
 from grass.script import task as gtask
 from core.settings import UserSettings

--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -22,17 +22,17 @@ This program is free software under the GNU General Public License
 
 import os
 import sys
-import wx
 import tempfile
 from multiprocessing import Process, Queue
 
-from core.gcmd import GException, DecodeString
+import wx
+from core.gcmd import DecodeString, GException
 from core.settings import UserSettings
 from core.debug import Debug
 from core.utils import autoCropImageFromFile
 
-from animation.utils import HashCmd, HashCmds, GetFileFromCmd, GetFileFromCmds
-from gui_core.wrap import EmptyBitmap, BitmapFromImage
+from animation.utils import GetFileFromCmd, GetFileFromCmds, HashCmd, HashCmds
+from gui_core.wrap import BitmapFromImage, EmptyBitmap
 
 import grass.script.core as gcore
 from grass.script.task import cmdlist_to_tuple
@@ -869,9 +869,10 @@ def read2_command(*args, **kwargs):
 def test():
     import shutil
 
-    from core.layerlist import LayerList, Layer
+    from core.layerlist import Layer, LayerList
     from animation.data import AnimLayer
     from animation.utils import layerListToCmdsMatrix
+
     import grass.temporal as tgis
 
     tgis.init()

--- a/gui/wxpython/animation/temporal_manager.py
+++ b/gui/wxpython/animation/temporal_manager.py
@@ -23,7 +23,7 @@ import grass.script as grass
 import grass.temporal as tgis
 from core.gcmd import GException
 from core.settings import UserSettings
-from animation.utils import validateTimeseriesName, TemporalType
+from animation.utils import TemporalType, validateTimeseriesName
 
 
 class DataMode:

--- a/gui/wxpython/animation/toolbars.py
+++ b/gui/wxpython/animation/toolbars.py
@@ -19,7 +19,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 from gui_core.simplelmgr import SimpleLmgrToolbar
 from animation.anim import ReplayMode

--- a/gui/wxpython/animation/utils.py
+++ b/gui/wxpython/animation/utils.py
@@ -18,10 +18,11 @@ This program is free software under the GNU General Public License
 @author Anna Perasova <kratochanna gmail.com>
 """
 
-import os
-import wx
 import hashlib
+import os
 from multiprocessing import cpu_count
+
+import wx
 
 try:
     from PIL import Image

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -25,25 +25,27 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
+import errno
+import locale
 import os
+import signal
+import subprocess
 import sys
 import time
-import errno
-import signal
 import traceback
-import locale
-import subprocess
 from threading import Thread
+
 import wx
 
 is_mswindows = sys.platform == "win32"
 if is_mswindows:
+    import msvcrt
+
     from win32file import ReadFile, WriteFile
     from win32pipe import PeekNamedPipe
-    import msvcrt
 else:
-    import select
     import fcntl
+    import select
 
 from core.debug import Debug
 from core.globalvar import SCT_EXT

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -21,16 +21,14 @@ This program is free software under the GNU General Public License
 @author Wolf Bergenheim <wolf bergenheim.net> (#962)
 """
 
-import os
-import sys
-import re
-import time
-import threading
-
-import queue as Queue
-
 import codecs
 import locale
+import os
+import queue as Queue
+import re
+import sys
+import threading
+import time
 
 import wx
 from wx.lib.newevent import NewEvent

--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -19,7 +19,6 @@ import os
 import sys
 
 import grass.script as grass
-
 from grass.pydispatch.signal import Signal
 
 # to disable Abstract class not referenced
@@ -250,7 +249,7 @@ class StandaloneGrassInterface(GrassInterface):
         )
 
         # workaround, standalone grass interface should be moved to sep. file
-        from core.gconsole import GConsole, EVT_CMD_OUTPUT, EVT_CMD_PROGRESS
+        from core.gconsole import EVT_CMD_OUTPUT, EVT_CMD_PROGRESS, GConsole
 
         self._gconsole = GConsole()
         self._gconsole.Bind(EVT_CMD_PROGRESS, self._onCmdProgress)

--- a/gui/wxpython/core/gthread.py
+++ b/gui/wxpython/core/gthread.py
@@ -14,16 +14,13 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (mentor: Martin Landa)
 """
 
+import queue as Queue
+import sys
 import threading
 import time
 
 import wx
 from wx.lib.newevent import NewEvent
-
-import sys
-
-import queue as Queue
-
 from core.gconsole import EVT_CMD_DONE, wxCmdDone
 
 wxThdTerminate, EVT_THD_TERMINATE = NewEvent()

--- a/gui/wxpython/core/menutree.py
+++ b/gui/wxpython/core/menutree.py
@@ -33,14 +33,14 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
+import copy
 import os
 import sys
-import copy
 import xml.etree.ElementTree as etree
 
 import wx
 
-from core.treemodel import TreeModel, ModuleNode
+from core.treemodel import ModuleNode, TreeModel
 from core.settings import UserSettings
 from core.toolboxes import expandAddons as expAddons
 from core.toolboxes import getMessages as getToolboxMessages

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -21,24 +21,24 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import os
-import sys
+import copy
 import glob
 import math
-import copy
+import os
+import sys
 import tempfile
 import time
 
 import wx
 
 from grass.script import core as grass
-from grass.script.utils import try_remove, text_to_string
+from grass.script.utils import text_to_string, try_remove
 from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
 from grass.pydispatch.signal import Signal
 
 from core import utils
 from core.ws import RenderWMSMgr
-from core.gcmd import GException, GError, RunCommand
+from core.gcmd import GError, GException, RunCommand
 from core.debug import Debug
 from core.settings import UserSettings
 from core.gthread import gThread

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -19,15 +19,15 @@ This program is free software under the GNU General Public License
 @author Luca Delucchi <lucadeluge gmail.com> (language choice)
 """
 
+import collections.abc
+import copy
+import json
 import os
 import sys
-import copy
-import wx
-import json
-import collections.abc
 
+import wx
 from core import globalvar
-from core.gcmd import GException, GError
+from core.gcmd import GError, GException
 from core.utils import GetSettingsPath, PathJoin, rgb2str
 
 

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -12,17 +12,17 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
-import sys
 import copy
+import os
 import shutil
+import sys
 import xml.etree.ElementTree as etree
 from xml.parsers import expat
 
 import grass.script.task as gtask
 import grass.script.core as gcore
-from grass.script.utils import try_remove, decode
-from grass.exceptions import ScriptError, CalledModuleError
+from grass.script.utils import decode, try_remove
+from grass.exceptions import CalledModuleError, ScriptError
 
 ETREE_EXCEPTIONS = (etree.ParseError, expat.ExpatError)
 

--- a/gui/wxpython/core/units.py
+++ b/gui/wxpython/core/units.py
@@ -209,6 +209,7 @@ def doc_test():
     :return: a number of failed tests
     """
     import doctest
+
     from core.utils import do_doctest_gettext_workaround
 
     do_doctest_gettext_workaround()

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -12,14 +12,14 @@ This program is free software under the GNU General Public License
 @author Jachym Cepicky
 """
 
-import os
-import sys
-import platform
 import glob
-import shlex
-import re
 import inspect
 import operator
+import os
+import platform
+import re
+import shlex
+import sys
 
 from grass.script import core as grass
 from grass.script import task as gtask

--- a/gui/wxpython/core/watchdog.py
+++ b/gui/wxpython/core/watchdog.py
@@ -23,10 +23,7 @@ import time
 watchdog_used = True
 try:
     from watchdog.observers import Observer
-    from watchdog.events import (
-        PatternMatchingEventHandler,
-        FileSystemEventHandler,
-    )
+    from watchdog.events import FileSystemEventHandler, PatternMatchingEventHandler
 except ImportError:
     watchdog_used = False
     PatternMatchingEventHandler = object

--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -17,8 +17,8 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (mentor: Martin Landa)
 """
 
-import sys
 import copy
+import sys
 import time
 
 import wx

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -16,12 +16,12 @@ for details.
 @author Linda Kladivova l.kladivova@seznam.cz
 """
 
-import wx
 import os
 
+import wx
 from core.debug import Debug
 from datacatalog.tree import DataCatalogTree
-from datacatalog.toolbars import DataCatalogToolbar, DataCatalogSearch
+from datacatalog.toolbars import DataCatalogSearch, DataCatalogToolbar
 from gui_core.infobar import InfoBar
 from datacatalog.infomanager import DataCatalogInfoManager
 from gui_core.wrap import Menu

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -18,8 +18,8 @@ for details.
 """
 
 import os
-import wx
 
+import wx
 from core.globalvar import ICONDIR
 from datacatalog.catalog import DataCatalog
 from gui_core.wrap import Button

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -19,48 +19,48 @@ for details.
 @author Linda Kladivova (l.kladivova@seznam.cz)
 """
 
+import copy
 import os
 import re
-import copy
 from multiprocessing import Process, Queue, cpu_count
 
 import wx
 
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import GError, GMessage, RunCommand
 from core.utils import GetListOfLocations
 from core.debug import Debug
 from core.gthread import gThread
 from core.watchdog import (
-    EVT_UPDATE_MAPSET,
     EVT_CURRENT_MAPSET_CHANGED,
+    EVT_UPDATE_MAPSET,
     MapsetWatchdog,
     watchdog_used,
 )
 from gui_core.dialogs import TextEntryDialog
 from core.giface import StandaloneGrassInterface
-from core.treemodel import TreeModel, DictFilterNode
+from core.treemodel import DictFilterNode, TreeModel
 from gui_core.treeview import TreeView
 from gui_core.wrap import Menu
 from datacatalog.dialogs import CatalogReprojectionDialog
 from icons.icon import MetaIcon
 from core.settings import UserSettings
 from startup.guiutils import (
-    create_mapset_interactively,
-    create_location_interactively,
-    rename_mapset_interactively,
-    rename_location_interactively,
-    delete_mapsets_interactively,
-    delete_locations_interactively,
-    download_location_interactively,
-    delete_grassdb_interactively,
     can_switch_mapset_interactive,
-    switch_mapset_interactively,
+    create_location_interactively,
+    create_mapset_interactively,
+    delete_grassdb_interactively,
+    delete_locations_interactively,
+    delete_mapsets_interactively,
+    download_location_interactively,
+    get_location_name_invalid_reason,
+    get_mapset_name_invalid_reason,
     get_reason_mapset_not_removable,
     get_reasons_location_not_removable,
-    get_mapset_name_invalid_reason,
-    get_location_name_invalid_reason,
+    rename_location_interactively,
+    rename_mapset_interactively,
+    switch_mapset_interactively,
 )
-from grass.grassdb.manage import rename_mapset, rename_location
+from grass.grassdb.manage import rename_location, rename_mapset
 
 from grass.pydispatch.signal import Signal
 
@@ -69,9 +69,9 @@ from grass.script import gisenv
 from grass.grassdb.data import map_exists
 from grass.grassdb.checks import (
     get_mapset_owner,
-    is_mapset_locked,
     is_different_mapset_owner,
     is_first_time_user,
+    is_mapset_locked,
 )
 from grass.exceptions import CalledModuleError
 

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -30,12 +30,12 @@ This program is free software under the GNU General Public License
         (GSoC 2012, mentor: Martin Landa)
 """
 
-import os
-import locale
-import tempfile
 import copy
-import math
 import functools
+import locale
+import math
+import os
+import tempfile
 
 from core import globalvar
 import wx
@@ -48,19 +48,20 @@ if globalvar.wxPythonPhoenix:
         import wx.lib.agw.flatnotebook as FN
 else:
     import wx.lib.flatnotebook as FN
+
 import wx.lib.scrolledpanel as scrolled
 
 import grass.script as grass
 from grass.script.utils import decode
 
 from dbmgr.sqlbuilder import SQLBuilderSelect, SQLBuilderUpdate
-from core.gcmd import RunCommand, GException, GError, GMessage, GWarning
-from core.utils import ListOfCatsToRange
+from core.gcmd import GError, GException, GMessage, GWarning, RunCommand
+from core.utils import ListOfCatsToRange, cmp
 from gui_core.dialogs import CreateNewVector
 from gui_core.widgets import GNotebook
-from dbmgr.vinfo import VectorDBInfo, GetUnicodeValue, CreateDbInfoDesc, GetDbEncoding
+from dbmgr.vinfo import CreateDbInfoDesc, GetDbEncoding, GetUnicodeValue, VectorDBInfo
 from core.debug import Debug
-from dbmgr.dialogs import ModifyTableRecord, AddColumnDialog
+from dbmgr.dialogs import AddColumnDialog, ModifyTableRecord
 from core.settings import UserSettings
 from gui_core.wrap import (
     Button,
@@ -74,7 +75,6 @@ from gui_core.wrap import (
     StaticText,
     TextCtrl,
 )
-from core.utils import cmp
 
 
 class Log:

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -21,11 +21,11 @@ This program is free software under the GNU General Public License
 import wx
 import wx.lib.scrolledpanel as scrolled
 
-from core.gcmd import RunCommand, GError
+from core.gcmd import GError, RunCommand
 from core.debug import Debug
-from dbmgr.vinfo import VectorDBInfo, GetUnicodeValue, GetDbEncoding
-from gui_core.widgets import IntegerValidator, FloatValidator
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
+from dbmgr.vinfo import GetDbEncoding, GetUnicodeValue, VectorDBInfo
+from gui_core.widgets import FloatValidator, IntegerValidator
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 
 class DisplayAttributesDialog(wx.Dialog):

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -33,16 +33,16 @@ import wx
 
 from grass.pydispatch.signal import Signal
 
-from core.gcmd import RunCommand, GError, GMessage
-from dbmgr.vinfo import CreateDbInfoDesc, VectorDBInfo, GetUnicodeValue
+from core.gcmd import GError, GMessage, RunCommand
+from dbmgr.vinfo import CreateDbInfoDesc, GetUnicodeValue, VectorDBInfo
 from gui_core.wrap import (
     ApplyButton,
     Button,
     ClearButton,
     CloseButton,
-    TextCtrl,
-    StaticText,
     StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 import grass.script as grass

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -20,7 +20,7 @@ import wx
 
 from gui_core.gselect import VectorDBInfo as VectorDBInfoBase
 from gui_core.wrap import StaticText
-from core.gcmd import RunCommand, GError
+from core.gcmd import GError, RunCommand
 from core.settings import UserSettings
 import grass.script as grass
 

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -10,10 +10,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-from datetime import date
 import string
+import sys
+from datetime import date
 from shutil import copy
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -28,8 +28,8 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 
 import wx
@@ -48,24 +48,24 @@ import grass.script as grass
 
 from core import utils
 from core.render import Map
-from gui_core.gselect import Select, LocationSelect, MapsetSelect
+from gui_core.gselect import LocationSelect, MapsetSelect, Select
 from gui_core.dialogs import GroupDialog
 from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from core.settings import UserSettings
 from gcp.mapdisplay import MapPanel
 from core.giface import Notification
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    CheckListBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
+    CheckListBox,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage

--- a/gui/wxpython/gcp/toolbars.py
+++ b/gui/wxpython/gcp/toolbars.py
@@ -16,8 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -20,23 +20,24 @@ import wx
 from wx.lib import ogl
 
 from gui_core.dialogs import TextEntryDialog as CustomTextEntryDialog
-from gui_core.wrap import TextEntryDialog as wxTextEntryDialog, NewId, Menu
+from gui_core.wrap import Menu, NewId
+from gui_core.wrap import TextEntryDialog as wxTextEntryDialog
 from gui_core.forms import GUI
-from core.gcmd import GException, GError
+from core.gcmd import GError, GException
 
 from gmodeler.model import (
-    ModelRelation,
     ModelAction,
+    ModelComment,
+    ModelCondition,
     ModelData,
     ModelLoop,
-    ModelCondition,
-    ModelComment,
+    ModelRelation,
 )
 from gmodeler.dialogs import (
-    ModelRelationDialog,
+    ModelConditionDialog,
     ModelDataDialog,
     ModelLoopDialog,
-    ModelConditionDialog,
+    ModelRelationDialog,
 )
 from gmodeler.giface import GraphicalModelerGrassInterface
 

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -28,25 +28,24 @@ import os
 import wx
 import wx.lib.mixins.listctrl as listmix
 
-from core import globalvar
-from core import utils
+from core import globalvar, utils
 from gui_core.widgets import SearchModuleWidget, SimpleValidator
 from core.gcmd import GError
-from gui_core.dialogs import SimpleDialog, MapLayersDialogForModeler
+from gui_core.dialogs import MapLayersDialogForModeler, SimpleDialog
 from gui_core.prompt import GPromptSTC
-from gui_core.gselect import Select, ElementSelect
+from gui_core.gselect import ElementSelect, Select
 from lmgr.menudata import LayerManagerMenuData
 from gui_core.wrap import (
     Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
-    NewId,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    NewId,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-from gmodeler.model import ModelData, ModelAction, ModelCondition
+from gmodeler.model import ModelAction, ModelCondition, ModelData
 
 
 class ModelDataDialog(SimpleDialog):

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -31,29 +31,26 @@ This program is free software under the GNU General Public License
 @actinia, PyWPS, Python parameterization Ondrej Pesek <pesej.ondrek gmail.com>
 """
 
-import os
-import getpass
 import copy
-import re
+import getpass
 import mimetypes
+import os
+import re
 import time
-
 import xml.etree.ElementTree as etree
+from abc import ABC, abstractmethod
 from xml.sax import saxutils
 
 import wx
-from abc import ABC, abstractmethod
 from wx.lib import ogl
-
-from core import globalvar
-from core import utils
+from core import globalvar, utils
 from core.gcmd import (
-    GMessage,
-    GException,
     GError,
-    RunCommand,
-    GWarning,
     GetDefaultEncoding,
+    GException,
+    GMessage,
+    GWarning,
+    RunCommand,
 )
 from core.settings import UserSettings
 from core.giface import StandaloneGrassInterface

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -18,12 +18,12 @@ This program is free software under the GNU General Public License
 @author Python exports Ondrej Pesek <pesej.ondrek gmail.com>
 """
 
+import math
 import os
-import time
+import random
 import stat
 import tempfile
-import random
-import math
+import time
 
 import wx
 
@@ -39,9 +39,9 @@ else:
     import wx.lib.flatnotebook as FN
 from wx.lib.newevent import NewEvent
 
-from core.gconsole import GConsole, EVT_CMD_RUN, EVT_CMD_DONE, EVT_CMD_PREPARE
+from core.gconsole import EVT_CMD_DONE, EVT_CMD_PREPARE, EVT_CMD_RUN, GConsole
 from core.debug import Debug
-from core.gcmd import GMessage, GException, GWarning, GError
+from core.gcmd import GError, GException, GMessage, GWarning
 from core.settings import UserSettings
 from core.giface import Notification
 
@@ -56,33 +56,33 @@ from gui_core.wrap import (
     Button,
     EmptyBitmap,
     ImageFromBitmap,
+    IsDark,
     StaticBox,
     StaticText,
     StockCursor,
     TextCtrl,
-    IsDark,
 )
 from main_window.page import MainPageBase
 from gmodeler.giface import GraphicalModelerGrassInterface
 from gmodeler.model import (
     Model,
     ModelAction,
-    ModelRelation,
-    ModelLoop,
-    ModelCondition,
     ModelComment,
-    WriteModelFile,
+    ModelCondition,
     ModelDataSeries,
     ModelDataSingle,
+    ModelLoop,
+    ModelRelation,
     WriteActiniaFile,
+    WriteModelFile,
     WritePythonFile,
     WritePyWPSFile,
 )
 from gmodeler.dialogs import (
+    ItemListCtrl,
     ModelDataDialog,
     ModelSearchDialog,
     VariableListCtrl,
-    ItemListCtrl,
 )
 from gmodeler.canvas import ModelCanvas, ModelEvtHandler
 from gmodeler.toolbars import ModelerToolbar

--- a/gui/wxpython/gmodeler/preferences.py
+++ b/gui/wxpython/gmodeler/preferences.py
@@ -21,7 +21,7 @@ import wx.lib.colourselect as csel
 from core import globalvar
 from gui_core.preferences import PreferencesBaseDialog
 from core.settings import UserSettings
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 
 class PreferencesDialog(PreferencesBaseDialog):

--- a/gui/wxpython/gmodeler/toolbars.py
+++ b/gui/wxpython/gmodeler/toolbars.py
@@ -17,9 +17,7 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
-
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -39,15 +39,15 @@ from grass.script.utils import naturally_sorted, try_remove
 from grass.pydispatch.signal import Signal
 
 from core import globalvar
-from core.gcmd import GError, RunCommand, GMessage
+from core.gcmd import GError, GMessage, RunCommand
 from gui_core.gselect import (
     LocationSelect,
     MapsetSelect,
-    Select,
     OgrTypeSelect,
+    Select,
     SubGroupSelect,
 )
-from gui_core.widgets import SingleSymbolPanel, SimpleValidator, MapValidator
+from gui_core.widgets import MapValidator, SimpleValidator, SingleSymbolPanel
 from core.settings import UserSettings
 from core.debug import Debug
 from core.utils import is_shell_running
@@ -56,6 +56,7 @@ from gui_core.wrap import (
     CheckListBox,
     EmptyBitmap,
     HyperlinkCtrl,
+    ListBox,
     Menu,
     NewId,
     Slider,
@@ -63,7 +64,6 @@ from gui_core.wrap import (
     StaticBox,
     StaticText,
     TextCtrl,
-    ListBox,
 )
 
 

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -46,24 +46,20 @@ COPYING coming with GRASS for details.
 @author Stepan Turek <stepan.turek seznam.cz> (CoordinatesSelect)
 """
 
-import sys
-import textwrap
-import os
+import codecs
 import copy
 import locale
+import os
 import queue as Queue
-
-import codecs
-
+import sys
+import textwrap
+import xml.etree.ElementTree as etree
 from threading import Thread
 
 import wx
-
 import wx.lib.colourselect as csel
 import wx.lib.filebrowsebutton as filebrowse
 from wx.lib.newevent import NewEvent
-
-import xml.etree.ElementTree as etree
 
 # needed when started from command line and for testing
 if __name__ == "__main__":
@@ -83,37 +79,35 @@ from grass.script import core as grass
 from grass.script import task as gtask
 
 from core import globalvar
-from gui_core.widgets import (
-    StaticWrapText,
-    ScrolledPanel,
-    ColorTablesComboBox,
-    BarscalesComboBox,
-    NArrowsComboBox,
-)
 from gui_core.ghelp import HelpPanel
 from gui_core import gselect
 from core import gcmd
 from core import utils
 from core.settings import UserSettings
 from gui_core.widgets import (
+    BarscalesComboBox,
+    ColorTablesComboBox,
     FloatValidator,
     FormListbook,
     FormNotebook,
+    LayersList,
+    NArrowsComboBox,
     PlacementValidator,
+    ScrolledPanel,
+    StaticWrapText,
 )
 from core.giface import Notification, StandaloneGrassInterface
-from gui_core.widgets import LayersList
 from gui_core.wrap import (
+    BitmapButton,
     BitmapFromImage,
     Button,
-    CloseButton,
-    StaticText,
-    StaticBox,
-    SpinCtrl,
     CheckBox,
-    BitmapButton,
-    TextCtrl,
+    CloseButton,
     NewId,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 from core.debug import Debug
 
@@ -2513,7 +2507,7 @@ class CmdPanel(wx.Panel):
         # are we running from command line?
         # add 'command output' tab regardless standalone dialog
         if self.parent.GetName() == "MainFrame" and self.parent.get_dcmd is None:
-            from core.gconsole import GConsole, EVT_CMD_RUN, EVT_CMD_DONE
+            from core.gconsole import EVT_CMD_DONE, EVT_CMD_RUN, GConsole
             from gui_core.goutput import GConsoleWindow
 
             self._gconsole = GConsole(guiparent=self.notebook, giface=self._giface)

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -17,12 +17,13 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import os
 import codecs
+import os
 import platform
 import re
-import textwrap
 import sys
+import textwrap
+
 import wx
 from wx.html import HtmlWindow
 
@@ -31,11 +32,9 @@ try:
 except ImportError:
     from wx.lib.hyperlink import HyperLinkCtrl
 try:
-    from wx.adv import AboutDialogInfo
-    from wx.adv import AboutBox
+    from wx.adv import AboutBox, AboutDialogInfo
 except ImportError:
-    from wx import AboutDialogInfo
-    from wx import AboutBox
+    from wx import AboutBox, AboutDialogInfo
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError
@@ -47,7 +46,7 @@ if __name__ == "__main__":
     set_gui_path()
 
 from core import globalvar
-from core.gcmd import GError, DecodeString
+from core.gcmd import DecodeString, GError
 from core.settings import UserSettings
 from gui_core.widgets import FormNotebook, ScrolledPanel
 from gui_core.wrap import Button, StaticText, TextCtrl

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -34,11 +34,11 @@ if __name__ == "__main__":
 
 from core.gcmd import GError
 from core.gconsole import (
-    GConsole,
+    EVT_CMD_DONE,
     EVT_CMD_OUTPUT,
     EVT_CMD_PROGRESS,
     EVT_CMD_RUN,
-    EVT_CMD_DONE,
+    GConsole,
     Notification,
 )
 from core.globalvar import CheckWxVersion, wxPythonPhoenix

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -42,10 +42,10 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (VectorCategorySelect)
 """
 
+import ctypes
+import glob
 import os
 import sys
-import glob
-import ctypes
 
 import wx
 
@@ -58,30 +58,32 @@ import grass.script as grass
 from grass.script import task as gtask
 from grass.exceptions import CalledModuleError
 
-from gui_core.widgets import ManageSettingsWidget, CoordinatesValidator
+from gui_core.widgets import CoordinatesValidator, ManageSettingsWidget
 
-from core.gcmd import RunCommand, GError, GMessage, GWarning, GException
+from core.gcmd import GError, GException, GMessage, GWarning, RunCommand
 from core.utils import (
+    GetFormats,
     GetListOfLocations,
     GetListOfMapsets,
-    GetFormats,
+    GetSettingsPath,
+    GetValidLayerName,
+    GetVectorNumberOfLayers,
+    ListSortLower,
     rasterFormatExtension,
     vectorFormatExtension,
 )
-from core.utils import GetSettingsPath, GetValidLayerName, ListSortLower
-from core.utils import GetVectorNumberOfLayers
 from core.settings import UserSettings
 from core.debug import Debug
 from gui_core.vselect import VectorSelectBase
 from gui_core.wrap import (
-    TreeCtrl,
     Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Panel,
-    ComboPopup,
     ComboCtrl,
+    ComboPopup,
+    Panel,
+    StaticBox,
+    StaticText,
+    TextCtrl,
+    TreeCtrl,
 )
 
 from grass.pydispatch.signal import Signal
@@ -3152,11 +3154,11 @@ class SignatureSelect(wx.ComboBox):
             return
         try:
             from grass.lib.imagery import (
+                I_SIGFILE_TYPE_LIBSVM,
                 I_SIGFILE_TYPE_SIG,
                 I_SIGFILE_TYPE_SIGSET,
-                I_SIGFILE_TYPE_LIBSVM,
-                I_signatures_list_by_type,
                 I_free_signatures_list,
+                I_signatures_list_by_type,
             )
         except ImportError as e:
             sys.stderr.write(

--- a/gui/wxpython/gui_core/infobar.py
+++ b/gui/wxpython/gui_core/infobar.py
@@ -17,6 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import sys
+
 import wx
 import wx.aui
 

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -23,7 +23,6 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
 from core.debug import Debug
 from gui_core.toolbars import ToolSwitcher
 from gui_core.wrap import NewId

--- a/gui/wxpython/gui_core/menu.py
+++ b/gui/wxpython/gui_core/menu.py
@@ -23,16 +23,16 @@ This program is free software under the GNU General Public License
 @author Tomas Zigo <tomas.zigo slovanet.sk> RecentFilesMenu
 """
 
-import re
 import os
-import wx
+import re
 
-from core import globalvar
-from core import utils
+import wx
+from core import globalvar, utils
 from core.gcmd import EncodeString
 from gui_core.treeview import CTreeView
-from gui_core.wrap import Button, SearchCtrl
+from gui_core.wrap import Button
 from gui_core.wrap import Menu as MenuWidget
+from gui_core.wrap import SearchCtrl
 from icons.icon import MetaIcon
 
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -47,21 +47,21 @@ from grass.exceptions import OpenError
 
 from core import globalvar
 from core.gcmd import GError
-from core.utils import ListOfMapsets, GetColorTables, ReadEpsgCodes
+from core.utils import GetColorTables, ListOfMapsets, ReadEpsgCodes
 from core.settings import UserSettings
 from core.globalvar import CheckWxVersion
-from gui_core.dialogs import SymbolDialog, DefaultFontDialog
-from gui_core.widgets import IntegerValidator, ColorTablesComboBox
+from gui_core.dialogs import DefaultFontDialog, SymbolDialog
+from gui_core.widgets import ColorTablesComboBox, IntegerValidator
 from core.debug import Debug
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
     BitmapButton,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    ListCtrl,
+    Button,
     CheckListCtrlMixin,
+    ListCtrl,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -31,9 +31,8 @@ from grass.grassdb import history
 
 from grass.pydispatch.signal import Signal
 
-from core import globalvar
-from core import utils
-from core.gcmd import EncodeString, DecodeString, GError
+from core import globalvar, utils
+from core.gcmd import DecodeString, EncodeString, GError
 
 
 class GPrompt:

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -10,12 +10,11 @@ for details.
 :authors: Martin Landa
 """
 
-import sys
 import os
 import stat
-
-from io import StringIO
+import sys
 import time
+from io import StringIO
 
 import wx
 
@@ -32,8 +31,8 @@ from core.gcmd import GError
 from gui_core.pystc import PyStc, SetDarkMode
 from core import globalvar
 from core.menutree import MenuTreeModelBuilder
-from gui_core.menu import RecentFilesMenu, Menu
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.menu import Menu, RecentFilesMenu
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import IsDark
 from icons.icon import MetaIcon
 from core.debug import Debug

--- a/gui/wxpython/gui_core/query.py
+++ b/gui/wxpython/gui_core/query.py
@@ -17,8 +17,8 @@ This program is free software under the GNU General Public License
 import wx
 
 from gui_core.treeview import TreeListView
-from gui_core.wrap import Button, StaticText, Menu, NewId
-from core.treemodel import TreeModel, DictNode
+from gui_core.wrap import Button, Menu, NewId, StaticText
+from core.treemodel import DictNode, TreeModel
 
 from grass.pydispatch.signal import Signal
 
@@ -272,8 +272,8 @@ def PrepareQueryResults(coordinates, result):
 
 def test():
     app = wx.App()
-    from grass.script import vector as gvect
     from grass.script import raster as grast
+    from grass.script import vector as gvect
 
     testdata1 = grast.raster_what(
         map=("elevation_shade@PERMANENT", "landclass96"),

--- a/gui/wxpython/gui_core/simplelmgr.py
+++ b/gui/wxpython/gui_core/simplelmgr.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
 
     set_gui_path()
 
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 from gui_core.forms import GUI
 from gui_core.dialogs import SetOpacityDialog

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -16,8 +16,9 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import platform
 import os
+import platform
+from collections import defaultdict
 
 import wx
 from wx.lib.agw import aui
@@ -25,9 +26,8 @@ from wx.lib.agw import aui
 from core import globalvar
 from core.debug import Debug
 from icons.icon import MetaIcon
-from collections import defaultdict
 from core.globalvar import IMGDIR
-from gui_core.wrap import ToolBar, Menu, BitmapButton, NewId
+from gui_core.wrap import BitmapButton, Menu, NewId, ToolBar
 
 from grass.pydispatch.signal import Signal
 

--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -15,7 +15,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from wx.lib.mixins.treemixin import VirtualTree, ExpansionState
+from wx.lib.mixins.treemixin import ExpansionState, VirtualTree
 from core.globalvar import hasAgw, wxPythonPhoenix
 
 try:
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     set_gui_path()
 
-from core.treemodel import TreeModel, DictNode
+from core.treemodel import DictNode, TreeModel
 from gui_core.wrap import CustomTreeCtrl
 
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -19,14 +19,12 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (mentor: Martin Landa)
 """
 
-import string
 import random
+import string
 
 import wx
 import wx.lib.mixins.listctrl as listmix
-
-from core.gcmd import GMessage, GError, GWarning
-from core.gcmd import RunCommand
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from gui_core.wrap import Button, ListCtrl
 
 import grass.script as grass

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -51,9 +51,9 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
-import string
 import re
+import string
+import sys
 from bisect import bisect
 from datetime import datetime
 from core.globalvar import wxPythonPhoenix
@@ -89,21 +89,21 @@ from grass.script import core as grass
 from grass.pydispatch.signal import Signal
 
 from core import globalvar
-from core.gcmd import GMessage, GError
+from core.gcmd import GError, GMessage
 from core.debug import Debug
 from gui_core.wrap import (
     Button,
-    SearchCtrl,
-    Slider,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Menu,
-    Rect,
+    CheckListCtrlMixin,
     EmptyBitmap,
     ListCtrl,
+    Menu,
     NewId,
-    CheckListCtrlMixin,
+    Rect,
+    SearchCtrl,
+    Slider,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 

--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -21,8 +21,7 @@ import wx.lib.agw.floatspin as fs
 import wx.lib.colourselect as csel
 import wx.lib.filebrowsebutton as filebrowse
 import wx.lib.scrolledpanel as scrolled
-from wx.lib import expando
-from wx.lib import buttons
+from wx.lib import buttons, expando
 from wx.lib.agw.aui import tabart
 
 try:

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -23,7 +23,7 @@ from datetime import datetime
 import wx
 import wx.lib.scrolledpanel as SP
 
-from gui_core.wrap import SearchCtrl, StaticText, StaticBox, Button
+from gui_core.wrap import Button, SearchCtrl, StaticBox, StaticText
 from history.tree import HistoryBrowserTree
 from icons.icon import MetaIcon
 

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -17,22 +17,18 @@ for details.
 @author Tomas Zigo
 """
 
-import re
 import copy
 import datetime
+import re
 
 import wx
 
 from core import globalvar
 
 from core.gcmd import GError, GException
-from core.utils import (
-    parse_mapcalc_cmd,
-    replace_module_cmd_special_flags,
-    split,
-)
+from core.utils import parse_mapcalc_cmd, replace_module_cmd_special_flags, split
 from gui_core.forms import GUI
-from core.treemodel import TreeModel, DictFilterNode
+from core.treemodel import DictFilterNode, TreeModel
 from gui_core.treeview import CTreeView
 from gui_core.wrap import Menu
 

--- a/gui/wxpython/iclass/dialogs.py
+++ b/gui/wxpython/iclass/dialogs.py
@@ -21,6 +21,7 @@ for details.
 """
 
 import os
+
 import wx
 
 import wx.lib.mixins.listctrl as listmix
@@ -28,19 +29,19 @@ import wx.lib.scrolledpanel as scrolled
 
 from core import globalvar
 from core.settings import UserSettings
-from core.gcmd import GError, RunCommand, GMessage
-from gui_core.dialogs import SimpleDialog, GroupDialog
+from core.gcmd import GError, GMessage, RunCommand
+from gui_core.dialogs import GroupDialog, SimpleDialog
 from gui_core import gselect
 from gui_core.widgets import SimpleValidator
 from gui_core.wrap import (
-    CheckBox,
     Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
+    CheckBox,
+    ListCtrl,
     Menu,
     NewId,
-    ListCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 import grass.script as grass

--- a/gui/wxpython/iclass/digit.py
+++ b/gui/wxpython/iclass/digit.py
@@ -20,11 +20,11 @@ import wx
 
 from vdigit.mapwindow import VDigitWindow
 from vdigit.wxdigit import IVDigit
-from vdigit.wxdisplay import DisplayDriver, TYPE_AREA
+from vdigit.wxdisplay import TYPE_AREA, DisplayDriver
 from core.gcmd import GWarning
 
 try:
-    from grass.lib.gis import G_verbose, G_set_verbose
+    from grass.lib.gis import G_set_verbose, G_verbose
     from grass.lib.vector import *
     from grass.lib.vedit import *
 except ImportError:

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -18,13 +18,12 @@ for details.
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
-import os
 import copy
+import os
 import tempfile
+from ctypes import *
 
 import wx
-
-from ctypes import *
 
 try:
     from grass.lib.imagery import *
@@ -45,25 +44,25 @@ from vdigit.toolbars import VDigitToolbar
 from gui_core.mapdisp import DoubleMapPanel, FrameMixin
 from core import globalvar
 from core.render import Map
-from core.gcmd import RunCommand, GMessage, GError
+from core.gcmd import GError, GMessage, RunCommand
 from gui_core.dialogs import SetOpacityDialog
 from gui_core.wrap import Menu
 from dbmgr.vinfo import VectorDBInfo
 
-from iclass.digit import IClassVDigitWindow, IClassVDigit
+from iclass.digit import IClassVDigit, IClassVDigitWindow
 from iclass.toolbars import (
+    IClassMapManagerToolbar,
     IClassMapToolbar,
     IClassMiscToolbar,
     IClassToolbar,
-    IClassMapManagerToolbar,
 )
 from iclass.statistics import StatisticsData
 from iclass.dialogs import (
     IClassCategoryManagerDialog,
-    IClassGroupDialog,
-    IClassSignatureFileDialog,
     IClassExportAreasDialog,
+    IClassGroupDialog,
     IClassMapDialog,
+    IClassSignatureFileDialog,
 )
 from iclass.plots import PlotPanel
 

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -50,6 +50,7 @@
 # %end
 
 import os
+
 import grass.script as gscript
 
 

--- a/gui/wxpython/iclass/toolbars.py
+++ b/gui/wxpython/iclass/toolbars.py
@@ -20,9 +20,9 @@ for details.
 
 import wx
 
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
-from iclass.dialogs import IClassMapDialog, ContrastColor
+from iclass.dialogs import ContrastColor, IClassMapDialog
 from gui_core.forms import GUI
 from gui_core.wrap import StaticText
 

--- a/gui/wxpython/icons/icon.py
+++ b/gui/wxpython/icons/icon.py
@@ -15,17 +15,16 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
+import copy
 import os
 import sys
-import copy
 
 import wx
-
 from core.settings import UserSettings
 
 # default icon set
-from .grass_icons import iconSet as g_iconSet
 from .grass_icons import iconPath as g_iconPath
+from .grass_icons import iconSet as g_iconSet
 
 iconSetDefault = g_iconSet
 iconPathDefault = g_iconPath

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -20,12 +20,12 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com> (various updates)
 """
 
-import os
-import sys
-import shutil
 import copy
-import platform
 import getpass
+import os
+import platform
+import shutil
+import sys
 
 from core import globalvar
 import wx
@@ -33,18 +33,18 @@ import wx.lib.mixins.listctrl as listmix
 
 from grass.script import core as grass
 
-from core.gcmd import GMessage, GError, DecodeString, RunCommand
+from core.gcmd import DecodeString, GError, GMessage, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
 from location_wizard.dialogs import RegionDef
 from gui_core.dialogs import TextEntryDialog
 from gui_core.widgets import GenericValidator, StaticWrapText
 from gui_core.wrap import (
+    BitmapFromImage,
     Button,
     ListCtrl,
-    StaticText,
     StaticBox,
+    StaticText,
     TextCtrl,
-    BitmapFromImage,
 )
 
 

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -34,8 +34,8 @@ This program is free software under the GNU General Public License
 
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 
 import wx
@@ -54,26 +54,25 @@ import grass.script as grass
 
 from core import utils
 from core.render import Map
-from gui_core.gselect import Select, LocationSelect, MapsetSelect
+from gui_core.gselect import LocationSelect, MapsetSelect, Select
 from gui_core.dialogs import GroupDialog
 from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from core.settings import UserSettings
 from gcp.mapdisplay import MapPanel
 from core.giface import Notification
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    CheckListBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
+    CheckListBox,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 
 #
@@ -1528,6 +1527,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 )
                 # Get the elevation height from the map given by i.ortho.elev
                 from subprocess import PIPE
+
                 from grass.pygrass.modules import Module
 
                 rwhat = Module(

--- a/gui/wxpython/image2target/ii2t_toolbars.py
+++ b/gui/wxpython/image2target/ii2t_toolbars.py
@@ -16,8 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/iscatt/controllers.py
+++ b/gui/wxpython/iscatt/controllers.py
@@ -24,18 +24,18 @@ from copy import deepcopy
 import wx
 
 
-from core.gcmd import GError, GMessage, RunCommand, GWarning
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from core.settings import UserSettings
 from core.gthread import gThread
 from iscatt.iscatt_core import (
+    MAX_NCELLS,
+    MAX_SCATT_SIZE,
+    WARN_NCELLS,
+    WARN_SCATT_SIZE,
     Core,
-    idBandsToidScatt,
     GetRasterInfo,
     GetRegion,
-    MAX_SCATT_SIZE,
-    WARN_SCATT_SIZE,
-    MAX_NCELLS,
-    WARN_NCELLS,
+    idBandsToidScatt,
 )
 from iscatt.dialogs import AddScattPlotDialog, ExportCategoryRaster
 from iclass.dialogs import IClassGroupDialog

--- a/gui/wxpython/iscatt/dialogs.py
+++ b/gui/wxpython/iscatt/dialogs.py
@@ -28,7 +28,7 @@ from core import globalvar
 from core.gcmd import GMessage
 from core.settings import UserSettings
 from gui_core.dialogs import SimpleDialog
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 
 class AddScattPlotDialog(wx.Dialog):

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -28,9 +28,9 @@ from core import globalvar
 from core.gcmd import GError, GMessage
 
 from gui_core.dialogs import SetOpacityDialog
-from gui_core.wrap import StaticBox, Menu, ListCtrl
+from gui_core.wrap import ListCtrl, Menu, StaticBox
 from iscatt.controllers import ScattsManager
-from iscatt.toolbars import MainToolbar, EditingToolbar, CategoryToolbar
+from iscatt.toolbars import CategoryToolbar, EditingToolbar, MainToolbar
 from iscatt.iscatt_core import idScattToidBands
 from iscatt.dialogs import ManageBusyCursorMixin, RenameClassDialog
 from iscatt.plots import ScatterPlotWidget

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -26,13 +26,13 @@ import numpy as np
 # from matplotlib.path import Path
 # from scipy.signal import convolve2d
 
-from math import sqrt, ceil, floor
+from math import ceil, floor, sqrt
 
 from core.gcmd import GException, RunCommand
 
 import grass.script as grass
 
-from iscatt.core_c import CreateCatRast, ComputeScatts, UpdateCatRast, Rasterize
+from iscatt.core_c import ComputeScatts, CreateCatRast, Rasterize, UpdateCatRast
 
 MAX_SCATT_SIZE = 4100 * 4100
 WARN_SCATT_SIZE = 2000 * 2000

--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -22,7 +22,7 @@ from math import ceil
 from multiprocessing import Process, Queue
 
 from copy import deepcopy
-from iscatt.core_c import MergeArrays, ApplyColormap
+from iscatt.core_c import ApplyColormap, MergeArrays
 from iscatt.dialogs import ManageBusyCursorMixin
 from iscatt.utils import dist_point_to_segment
 from core.settings import UserSettings
@@ -36,7 +36,7 @@ try:
     from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
     from matplotlib.lines import Line2D
     from matplotlib.artist import Artist
-    from matplotlib.patches import Polygon, Ellipse
+    from matplotlib.patches import Ellipse, Polygon
     import matplotlib.image as mi
     import matplotlib.colors as mcolors
 except ImportError as e:

--- a/gui/wxpython/iscatt/toolbars.py
+++ b/gui/wxpython/iscatt/toolbars.py
@@ -15,9 +15,8 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from icons.icon import MetaIcon
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from core.gcmd import RunCommand
 from iscatt.dialogs import SettingsDialog
 

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -18,11 +18,11 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (menu customization)
 """
 
-import sys
 import os
-import stat
 import platform
 import re
+import stat
+import sys
 
 from core import globalvar
 import wx
@@ -39,34 +39,35 @@ if os.path.join(globalvar.ETCDIR, "python") not in sys.path:
 from grass.script import core as grass
 from grass.script.utils import decode
 
-from core.gcmd import RunCommand, GError, GMessage
-from core.settings import UserSettings, GetDisplayVectSettings
-from core.utils import SetAddOnPath, GetLayerNameFromCmd, command2ltype, get_shell_pid
-from core.watchdog import (
-    EVT_UPDATE_MAPSET,
-    EVT_CURRENT_MAPSET_CHANGED,
-    MapsetWatchdog,
-)
+from core.gcmd import GError, GMessage, RunCommand
+from core.settings import GetDisplayVectSettings, UserSettings
+from core.utils import GetLayerNameFromCmd, SetAddOnPath, command2ltype, get_shell_pid
+from core.watchdog import EVT_CURRENT_MAPSET_CHANGED, EVT_UPDATE_MAPSET, MapsetWatchdog
 from gui_core.preferences import MapsetAccess, PreferencesDialog
 from lmgr.layertree import LayerTree, LMIcons
 from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
-from gui_core.widgets import GNotebook, FormNotebook
-from core.gconsole import GConsole, EVT_IGNORED_CMD_RUN
+from gui_core.widgets import FormNotebook, GNotebook
+from core.gconsole import EVT_IGNORED_CMD_RUN, GConsole
 from core.giface import Notification
-from gui_core.goutput import GConsoleWindow, GC_PROMPT
+from gui_core.goutput import GC_PROMPT, GConsoleWindow
 from gui_core.dialogs import (
-    LocationDialog,
-    MapsetDialog,
     CreateNewVector,
     GroupDialog,
+    LocationDialog,
     MapLayersDialog,
+    MapsetDialog,
     QuitDialog,
 )
 from gui_core.menu import SearchModuleWindow
 from gui_core.menu import Menu as GMenu
 from core.debug import Debug
-from lmgr.toolbars import LMWorkspaceToolbar, LMToolsToolbar
-from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
+from lmgr.toolbars import (
+    DisplayPanelToolbar,
+    LMMiscToolbar,
+    LMNvizToolbar,
+    LMToolsToolbar,
+    LMWorkspaceToolbar,
+)
 from lmgr.statusbar import SbMain
 from lmgr.workspace import WorkspaceManager
 from lmgr.pyshell import PyShellWindow
@@ -78,9 +79,9 @@ from gui_core.forms import GUI
 from gui_core.wrap import Menu, TextEntryDialog
 from startup.guiutils import (
     can_switch_mapset_interactive,
-    switch_mapset_interactively,
-    create_mapset_interactively,
     create_location_interactively,
+    create_mapset_interactively,
+    switch_mapset_interactively,
 )
 from grass.grassdb.checks import is_first_time_user
 from grass.grassdb.history import Status
@@ -1684,7 +1685,7 @@ class GMFrame(wx.Frame):
             This documentation is actually documentation of some
             component related to gui_core/menu.py file.
         """
-        from iclass.frame import IClassMapDisplay, haveIClass, errMsg
+        from iclass.frame import IClassMapDisplay, errMsg, haveIClass
 
         if not haveIClass:
             GError(

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -17,6 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import sys
+
 import wx
 
 try:
@@ -34,17 +35,17 @@ from grass.script import vector as gvector
 from grass.script import utils as gutils
 
 from core import globalvar
-from gui_core.dialogs import SqlQueryFrame, SetOpacityDialog, TextEntryDialog
+from gui_core.dialogs import SetOpacityDialog, SqlQueryFrame, TextEntryDialog
 from gui_core.forms import GUI
 from core.render import Map
 from core.utils import GetLayerNameFromCmd, ltype2command
 from core.debug import Debug
-from core.settings import UserSettings, GetDisplayVectSettings
+from core.settings import GetDisplayVectSettings, UserSettings
 from vdigit.main import haveVDigit
-from core.gcmd import GWarning, GError, RunCommand
+from core.gcmd import GError, GWarning, RunCommand
 from icons.icon import MetaIcon
 from gui_core.widgets import MapValidator
-from gui_core.wrap import Menu, GenBitmapButton, TextCtrl, NewId
+from gui_core.wrap import GenBitmapButton, Menu, NewId, TextCtrl
 from lmgr.giface import LayerManagerGrassInterfaceForMapDisplay
 
 

--- a/gui/wxpython/lmgr/pyshell.py
+++ b/gui/wxpython/lmgr/pyshell.py
@@ -19,8 +19,8 @@ This program is free software under the GNU General Public License
 """
 
 import io
-from contextlib import redirect_stdout
 import sys
+from contextlib import redirect_stdout
 
 import wx
 from wx.py.shell import Shell as PyShell

--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -24,7 +24,7 @@ This program is free software under the GNU General Public License
 """
 
 from core.gcmd import RunCommand
-from gui_core.toolbars import BaseToolbar, AuiToolbar, BaseIcons
+from gui_core.toolbars import AuiToolbar, BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -15,14 +15,12 @@ for details.
 
 import os
 import tempfile
-
 import xml.etree.ElementTree as etree
 
 import wx
 import wx.aui
-
 from core.settings import UserSettings
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import GError, GMessage, RunCommand
 from core.workspace import ProcessWorkspaceFile, WriteWorkspaceFile
 from core.debug import Debug
 from gui_core.menu import RecentFilesMenu

--- a/gui/wxpython/location_wizard/base.py
+++ b/gui/wxpython/location_wizard/base.py
@@ -17,7 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from gui_core.wrap import StaticText, TextCtrl, Button, CheckBox
+from gui_core.wrap import Button, CheckBox, StaticText, TextCtrl
 
 
 class BaseClass(wx.Object):

--- a/gui/wxpython/location_wizard/dialogs.py
+++ b/gui/wxpython/location_wizard/dialogs.py
@@ -22,11 +22,10 @@ import os
 
 import wx
 import wx.lib.scrolledpanel as scrolled
-
 from core import globalvar
 from core.gcmd import RunCommand
 from location_wizard.base import BaseClass
-from gui_core.wrap import Button, StaticText, StaticBox, TextCtrl
+from gui_core.wrap import Button, StaticBox, StaticText, TextCtrl
 
 
 class RegionDef(BaseClass, wx.Dialog):
@@ -757,6 +756,7 @@ class SelectTransformDialog(wx.Dialog):
 
 def testRegionDef():
     import wx.lib.inspection
+
     import grass.script as gscript
 
     app = wx.App()

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -34,9 +34,9 @@ This program is free software under the GNU General Public License
 @author Hamish Bowman (planetary ellipsoids)
 """
 
-import os
-import locale
 import functools
+import locale
+import os
 
 import wx
 import wx.lib.mixins.listctrl as listmix
@@ -44,29 +44,27 @@ from core import globalvar
 
 if globalvar.wxPythonPhoenix:
     from wx import adv as wiz
-    from wx.adv import Wizard
-    from wx.adv import WizardPageSimple
+    from wx.adv import Wizard, WizardPageSimple
 else:
     from wx import wizard as wiz
-    from wx.wizard import Wizard
-    from wx.wizard import WizardPageSimple
+    from wx.wizard import Wizard, WizardPageSimple
 import wx.lib.scrolledpanel as scrolled
 
 from core import utils
 from core.utils import cmp
-from core.gcmd import RunCommand, GError, GWarning
+from core.gcmd import GError, GWarning, RunCommand
 from gui_core.widgets import GenericMultiValidator
 from gui_core.wrap import (
-    SpinCtrl,
-    SearchCtrl,
-    StaticText,
-    TextCtrl,
     Button,
     CheckBox,
-    StaticBox,
-    NewId,
-    ListCtrl,
     HyperlinkCtrl,
+    ListCtrl,
+    NewId,
+    SearchCtrl,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 from location_wizard.dialogs import SelectTransformDialog
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -19,11 +19,11 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (menu customization)
 """
 
-import sys
 import os
-import stat
 import platform
 import re
+import stat
+import sys
 
 from core import globalvar
 
@@ -45,34 +45,36 @@ if os.path.join(globalvar.ETCDIR, "python") not in sys.path:
 from grass.script import core as grass
 from grass.script.utils import decode
 
-from core.gcmd import RunCommand, GError, GMessage
-from core.settings import UserSettings, GetDisplayVectSettings
-from core.utils import SetAddOnPath, GetLayerNameFromCmd, command2ltype, get_shell_pid
-from core.watchdog import (
-    EVT_UPDATE_MAPSET,
-    EVT_CURRENT_MAPSET_CHANGED,
-    MapsetWatchdog,
-)
+from core.gcmd import GError, GMessage, RunCommand
+from core.settings import GetDisplayVectSettings, UserSettings
+from core.utils import GetLayerNameFromCmd, SetAddOnPath, command2ltype, get_shell_pid
+from core.watchdog import EVT_CURRENT_MAPSET_CHANGED, EVT_UPDATE_MAPSET, MapsetWatchdog
 from gui_core.preferences import MapsetAccess, PreferencesDialog
 from lmgr.layertree import LayerTree, LMIcons
 from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
 from main_window.notebook import MainNotebook
 from gui_core.widgets import GNotebook
-from core.gconsole import GConsole, EVT_IGNORED_CMD_RUN
+from core.gconsole import EVT_IGNORED_CMD_RUN, GConsole
 from core.giface import Notification
-from gui_core.goutput import GConsoleWindow, GC_PROMPT
+from gui_core.goutput import GC_PROMPT, GConsoleWindow
 from gui_core.dialogs import (
-    LocationDialog,
-    MapsetDialog,
     CreateNewVector,
     GroupDialog,
+    LocationDialog,
     MapLayersDialog,
+    MapsetDialog,
     QuitDialog,
 )
-from gui_core.menu import SearchModuleWindow, Menu as GMenu
+from gui_core.menu import Menu as GMenu
+from gui_core.menu import SearchModuleWindow
 from core.debug import Debug
-from lmgr.toolbars import LMWorkspaceToolbar, LMToolsToolbar
-from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
+from lmgr.toolbars import (
+    DisplayPanelToolbar,
+    LMMiscToolbar,
+    LMNvizToolbar,
+    LMToolsToolbar,
+    LMWorkspaceToolbar,
+)
 from lmgr.statusbar import SbMain
 from lmgr.workspace import WorkspaceManager
 from lmgr.pyshell import PyShellWindow
@@ -81,13 +83,14 @@ from mapdisp.frame import MapPanel
 from datacatalog.catalog import DataCatalog
 from history.browser import HistoryBrowser
 from gui_core.forms import GUI
-from gui_core.wrap import Menu, TextEntryDialog, SimpleTabArt
+from gui_core.wrap import Menu, SimpleTabArt, TextEntryDialog
 from startup.guiutils import (
     can_switch_mapset_interactive,
-    switch_mapset_interactively,
-    create_mapset_interactively,
     create_location_interactively,
+    create_mapset_interactively,
+    switch_mapset_interactively,
 )
+
 from grass.grassdb.checks import is_first_time_user
 from grass.grassdb.history import Status
 
@@ -889,8 +892,8 @@ class GMFrame(wx.Frame):
 
     def OnGModeler(self, event=None, cmd=None):
         """Launch Graphical Modeler. See OnIClass documentation"""
-        from gmodeler.panels import ModelerPanel
         from gmodeler.menudata import ModelerMenuData
+        from gmodeler.panels import ModelerPanel
 
         gmodeler_panel = ModelerPanel(
             parent=self, giface=self._giface, statusbar=self.statusbar, dockable=True
@@ -1834,7 +1837,7 @@ class GMFrame(wx.Frame):
             This documentation is actually documentation of some
             component related to gui_core/menu.py file.
         """
-        from iclass.frame import IClassMapDisplay, haveIClass, errMsg
+        from iclass.frame import IClassMapDisplay, errMsg, haveIClass
 
         if not haveIClass:
             GError(

--- a/gui/wxpython/main_window/page.py
+++ b/gui/wxpython/main_window/page.py
@@ -16,7 +16,9 @@ This program is free software under the GNU General Public License
 """
 
 from grass.pydispatch.signal import Signal
-from gui_core.menu import MenuItem as GMenuItem, Menu as GMenu
+
+from gui_core.menu import Menu as GMenu
+from gui_core.menu import MenuItem as GMenuItem
 
 
 class MainPageBase:

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -22,8 +22,8 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (handlers support)
 """
 
-import os
 import copy
+import os
 
 from core import globalvar
 import wx
@@ -32,24 +32,24 @@ import wx.aui
 from mapdisp.toolbars import MapToolbar, NvizIcons
 from mapdisp.gprint import PrintOptions
 from core.gcmd import GError, GMessage, RunCommand
-from core.utils import ListOfCatsToRange, GetLayerNameFromCmd
+from core.utils import GetLayerNameFromCmd, ListOfCatsToRange
 from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from core.debug import Debug
 from core.settings import UserSettings
-from gui_core.mapdisp import SingleMapPanel, FrameMixin
-from gui_core.query import QueryDialog, PrepareQueryResults
+from gui_core.mapdisp import FrameMixin, SingleMapPanel
+from gui_core.query import PrepareQueryResults, QueryDialog
 from mapwin.buffered import BufferedMapWindow
 from mapwin.decorations import (
-    LegendController,
-    BarscaleController,
     ArrowController,
+    BarscaleController,
     DtextController,
+    LegendController,
     LegendVectController,
 )
 from mapwin.analysis import (
-    ProfileController,
-    MeasureDistanceController,
     MeasureAreaController,
+    MeasureDistanceController,
+    ProfileController,
 )
 from gui_core.forms import GUI
 from core.giface import Notification
@@ -296,7 +296,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
 
     def _addToolbarVDigit(self):
         """Add vector digitizer toolbar"""
-        from vdigit.main import haveVDigit, VDigit
+        from vdigit.main import VDigit, haveVDigit
         from vdigit.toolbars import VDigitToolbar
 
         if not haveVDigit:
@@ -401,7 +401,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
 
     def AddNviz(self):
         """Add 3D view mode window"""
-        from nviz.main import haveNviz, GLWindow, errorMsg
+        from nviz.main import GLWindow, errorMsg, haveNviz
 
         # check for GLCanvas and OpenGL
         if not haveNviz:
@@ -1606,7 +1606,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
     def AddRDigit(self):
         """Adds raster digitizer: creates toolbar and digitizer controller,
         binds events and signals."""
-        from rdigit.controller import RDigitController, EVT_UPDATE_PROGRESS
+        from rdigit.controller import EVT_UPDATE_PROGRESS, RDigitController
         from rdigit.toolbars import RDigitToolbar
 
         self.rdigit = RDigitController(self._giface, mapWindow=self.GetMapWindow())

--- a/gui/wxpython/mapdisp/gprint.py
+++ b/gui/wxpython/mapdisp/gprint.py
@@ -17,7 +17,6 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.gcmd import GMessage
 
 

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -27,15 +27,15 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (MapPanelBase)
 """  # noqa: E501
 
+import fileinput
 import os
+import shutil
 import sys
 import time
-import shutil
-import fileinput
 
 from grass.script.utils import try_remove
 from grass.script import core as grass
-from grass.script.task import cmdtuple_to_list, cmdlist_to_tuple
+from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
 from grass.pydispatch.signal import Signal
 
 from grass.script.setup import set_gui_path

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -27,12 +27,12 @@ This program is free software under the GNU General Public License
 """
 
 import copy
-import wx
 
+import wx
 from core import utils
 from core.gcmd import RunCommand
 from core.settings import UserSettings
-from gui_core.wrap import TextCtrl, Menu, NewId
+from gui_core.wrap import Menu, NewId, TextCtrl
 
 from grass.pydispatch.signal import Signal
 

--- a/gui/wxpython/mapdisp/test_mapdisp.py
+++ b/gui/wxpython/mapdisp/test_mapdisp.py
@@ -51,10 +51,10 @@ Module to run test map window (BufferedWidnow) and map display (MapFrame).
 
 import os
 import sys
+
 import wx
 
 import grass.script as grass
-
 from grass.script.setup import set_gui_path
 
 set_gui_path()

--- a/gui/wxpython/mapdisp/toolbars.py
+++ b/gui/wxpython/mapdisp/toolbars.py
@@ -18,7 +18,7 @@ This program is free software under the GNU General Public License
 
 import wx
 
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from nviz.main import haveNviz
 from vdigit.main import haveVDigit
 from icons.icon import MetaIcon

--- a/gui/wxpython/mapswipe/dialogs.py
+++ b/gui/wxpython/mapswipe/dialogs.py
@@ -26,14 +26,14 @@ from gui_core.preferences import PreferencesBaseDialog
 from core.gcmd import GMessage
 from core.layerlist import LayerList
 from core.settings import UserSettings
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText
 from gui_core.simplelmgr import (
-    SimpleLayerManager,
     SIMPLE_LMGR_RASTER,
-    SIMPLE_LMGR_VECTOR,
     SIMPLE_LMGR_RGB,
     SIMPLE_LMGR_TB_LEFT,
     SIMPLE_LMGR_TB_RIGHT,
+    SIMPLE_LMGR_VECTOR,
+    SimpleLayerManager,
 )
 
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -30,11 +30,11 @@ from core.debug import Debug
 from core.gcmd import GError, GMessage
 from core.layerlist import LayerListToRendererConverter
 from core import globalvar
-from gui_core.query import QueryDialog, PrepareQueryResults
+from gui_core.query import PrepareQueryResults, QueryDialog
 
-from mapswipe.toolbars import SwipeMapToolbar, SwipeMainToolbar, SwipeMiscToolbar
+from mapswipe.toolbars import SwipeMainToolbar, SwipeMapToolbar, SwipeMiscToolbar
 from mapswipe.mapwindow import SwipeBufferedWindow
-from mapswipe.dialogs import SwipeMapDialog, PreferencesDialog
+from mapswipe.dialogs import PreferencesDialog, SwipeMapDialog
 
 
 class SwipeMapPanel(DoubleMapPanel):

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.py
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.py
@@ -45,6 +45,7 @@
 # %end
 
 import os
+
 import grass.script as gscript
 
 

--- a/gui/wxpython/mapswipe/mapwindow.py
+++ b/gui/wxpython/mapswipe/mapwindow.py
@@ -18,12 +18,10 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.debug import Debug
 from core.settings import UserSettings
 from mapwin.buffered import BufferedMapWindow
-from gui_core.wrap import Rect, NewId
-
+from gui_core.wrap import NewId, Rect
 
 EVT_MY_MOUSE_EVENTS = wx.NewEventType()
 EVT_MY_MOTION = wx.NewEventType()

--- a/gui/wxpython/mapswipe/toolbars.py
+++ b/gui/wxpython/mapswipe/toolbars.py
@@ -17,11 +17,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import Menu
 from icons.icon import MetaIcon
-
 
 swipeIcons = {
     "tools": MetaIcon(img="tools", label=_("Tools")),

--- a/gui/wxpython/mapwin/analysis.py
+++ b/gui/wxpython/mapwin/analysis.py
@@ -16,10 +16,10 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
 import math
-import wx
+import os
 
+import wx
 from core import units
 from core.gcmd import RunCommand
 from core.giface import Notification

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -21,10 +21,10 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (refactoring)
 """
 
-import os
-import time
 import math
+import os
 import sys
+import time
 
 import wx
 
@@ -35,16 +35,16 @@ import grass.script as grass
 
 from gui_core.dialogs import SavedRegion
 from gui_core.wrap import (
-    DragImage,
-    PseudoDC,
-    EmptyBitmap,
     BitmapFromImage,
-    Window,
+    DragImage,
+    EmptyBitmap,
     Menu,
-    Rect,
     NewId,
+    PseudoDC,
+    Rect,
+    Window,
 )
-from core.gcmd import RunCommand, GException, GError
+from core.gcmd import GError, GException, RunCommand
 from core.debug import Debug
 from core.settings import UserSettings
 from mapwin.base import MapWindowBase

--- a/gui/wxpython/mapwin/graphics.py
+++ b/gui/wxpython/mapwin/graphics.py
@@ -18,7 +18,6 @@ This program is free software under the GNU General Public License
 from copy import copy
 
 import wx
-
 from gui_core.wrap import NewId
 
 

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -22,9 +22,9 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (split to base and derived classes)
 """
 
+import copy
 import os
 import shutil
-import copy
 import tempfile
 
 import wx
@@ -35,24 +35,23 @@ import wx.lib.filebrowsebutton as filebrowse
 import grass.script as grass
 from grass.script.task import cmdlist_to_tuple
 
-from core import globalvar
-from core import utils
-from core.gcmd import GMessage, RunCommand, GError
-from gui_core.gselect import Select, LayerSelect, ColumnSelect, VectorDBInfo
+from core import globalvar, utils
+from core.gcmd import GError, GMessage, RunCommand
+from gui_core.gselect import ColumnSelect, LayerSelect, Select, VectorDBInfo
 from core.render import Map
 from gui_core.forms import GUI
 from core.debug import Debug as Debug
 from gui_core.widgets import ColorTablesComboBox
 from gui_core.wrap import (
-    SpinCtrl,
-    PseudoDC,
-    TextCtrl,
+    BitmapFromImage,
     Button,
     CancelButton,
-    StaticText,
-    StaticBox,
     EmptyBitmap,
-    BitmapFromImage,
+    PseudoDC,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 

--- a/gui/wxpython/modules/extensions.py
+++ b/gui/wxpython/modules/extensions.py
@@ -26,14 +26,14 @@ import wx
 from grass.script import task as gtask
 
 from core import globalvar
-from core.gcmd import GError, RunCommand, GException, GMessage
+from core.gcmd import GError, GException, GMessage, RunCommand
 from core.utils import SetAddOnPath
 from core.gthread import gThread
-from core.menutree import TreeModel, ModuleNode
+from core.menutree import ModuleNode, TreeModel
 from gui_core.widgets import GListCtrl
 from gui_core.treeview import CTreeView
 from core.toolboxes import toolboxesOutdated
-from gui_core.wrap import Button, StaticBox, Menu, NewId, SearchCtrl
+from gui_core.wrap import Button, Menu, NewId, SearchCtrl, StaticBox
 
 
 class InstallExtensionWindow(wx.Frame):

--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -32,8 +32,8 @@ from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.preferences import DefaultFontDialog
 from core.debug import Debug
 from core.gcmd import GError
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from gui_core.wrap import PseudoDC, Menu, EmptyBitmap, NewId, BitmapFromImage
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.wrap import BitmapFromImage, EmptyBitmap, Menu, NewId, PseudoDC
 
 
 class BufferedWindow(wx.Window):

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -33,9 +33,9 @@ from core.gcmd import GError, GMessage, GWarning, RunCommand
 from gui_core.forms import CmdPanel
 from gui_core.gselect import GdalSelect
 from gui_core.widgets import GListCtrl, GNotebook, LayersList, LayersListValidator
-from gui_core.wrap import Button, CloseButton, StaticText, StaticBox
+from gui_core.wrap import Button, CloseButton, StaticBox, StaticText
 from core.utils import GetValidLayerName
-from core.settings import UserSettings, GetDisplayVectSettings
+from core.settings import GetDisplayVectSettings, UserSettings
 
 
 class ImportDialog(wx.Dialog):

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -31,9 +31,9 @@ from gui_core.wrap import (
     Button,
     ClearButton,
     CloseButton,
-    TextCtrl,
-    StaticText,
     StaticBox,
+    StaticText,
+    TextCtrl,
 )
 from core.settings import UserSettings
 

--- a/gui/wxpython/nviz/animation.py
+++ b/gui/wxpython/nviz/animation.py
@@ -14,8 +14,8 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
-import os
 import copy
+import os
 
 import wx
 

--- a/gui/wxpython/nviz/main.py
+++ b/gui/wxpython/nviz/main.py
@@ -21,9 +21,7 @@ errorMsg = ""
 
 try:
     from wx import glcanvas  # noqa: F401
-    from nviz import mapwindow
-    from nviz import tools
-    from nviz import workspace
+    from nviz import mapwindow, tools, workspace
     from nviz import wxnviz  # noqa: F401
 
     haveNviz = True

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -18,23 +18,22 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (Google SoC 2011)
 """
 
+import copy
+import math
 import os
 import sys
 import time
-import copy
-import math
-
 from threading import Thread
 
 import wx
 from wx.lib.newevent import NewEvent
 from wx import glcanvas
-from wx.glcanvas import WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE
+from wx.glcanvas import WX_GL_DEPTH_SIZE, WX_GL_DOUBLEBUFFER, WX_GL_RGBA
 
 import grass.script as grass
 from grass.pydispatch.signal import Signal
 
-from core.gcmd import GMessage, GException, GError
+from core.gcmd import GError, GException, GMessage
 from core.debug import Debug
 from mapwin.base import MapWindowBase
 from core.settings import UserSettings

--- a/gui/wxpython/nviz/preferences.py
+++ b/gui/wxpython/nviz/preferences.py
@@ -16,16 +16,15 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <KratochAnna seznam.cz> (Google SoC 2011)
 """
 
-import os
 import copy
+import os
 
 import wx
 import wx.lib.colourselect as csel
-
 from core import globalvar
 from core.settings import UserSettings
 from gui_core.preferences import PreferencesBaseDialog
-from gui_core.wrap import SpinCtrl, CheckBox, StaticText, StaticBox
+from gui_core.wrap import CheckBox, SpinCtrl, StaticBox, StaticText
 
 
 class NvizPreferencesDialog(PreferencesBaseDialog):

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -19,9 +19,9 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (Google SoC 2011)
 """
 
+import copy
 import os
 import sys
-import copy
 
 import wx
 import wx.lib.colourselect as csel
@@ -46,37 +46,36 @@ except ImportError:
 import grass.script as grass
 
 from core import globalvar
-from gui_core.gselect import VectorDBInfo
+from gui_core.gselect import Select, VectorDBInfo
 from core.gcmd import GMessage, RunCommand
 from modules.colorrules import ThematicVectorTable
 from core.settings import UserSettings
 from gui_core.widgets import (
-    ScrolledPanel,
-    NumTextCtrl,
     FloatSlider,
-    SymbolButton,
     GNotebook,
+    NumTextCtrl,
+    ScrolledPanel,
+    SymbolButton,
 )
-from gui_core.gselect import Select
 from gui_core.wrap import (
-    Window,
-    SpinCtrl,
-    PseudoDC,
-    ToggleButton,
     Button,
-    TextCtrl,
-    Slider,
-    StaticText,
-    StaticBox,
     CheckListBox,
     ColourSelect,
+    PseudoDC,
+    Slider,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
+    ToggleButton,
+    Window,
 )
 from core.debug import Debug
 from nviz.mapwindow import (
+    wxUpdateCPlane,
+    wxUpdateLight,
     wxUpdateProperties,
     wxUpdateView,
-    wxUpdateLight,
-    wxUpdateCPlane,
 )
 from .wxnviz import DM_FLAT, DM_GOURAUD, MAX_ISOSURFS
 

--- a/gui/wxpython/nviz/wxnviz.py
+++ b/gui/wxpython/nviz/wxnviz.py
@@ -22,9 +22,9 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <KratochAnna seznam.cz> (Google SoC 2011)
 """
 
-import sys
 import locale
 import struct
+import sys
 from math import sqrt
 
 try:
@@ -61,6 +61,7 @@ from core.utils import autoCropImageFromFile
 from core.gcmd import DecodeString
 from core.globalvar import wxPythonPhoenix
 from gui_core.wrap import Rect
+
 import grass.script as grass
 
 log = None

--- a/gui/wxpython/photo2image/g.gui.photo2image.py
+++ b/gui/wxpython/photo2image/g.gui.photo2image.py
@@ -71,6 +71,7 @@ Module to run GCP management tool as stadalone application.
 @author Vaclav Petras  <wenzeslaus gmail.com> (standalone module)
 """
 import os
+
 import grass.script as gscript
 
 
@@ -79,6 +80,7 @@ def main():
     options, flags = gscript.parser()
 
     import wx
+
     from grass.script.setup import set_gui_path
 
     set_gui_path()

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -27,8 +27,8 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 
 import wx
@@ -37,23 +37,23 @@ import wx.lib.colourselect as csel
 
 import grass.script as grass
 
-from core import utils, globalvar
+from core import globalvar, utils
 from core.render import Map
 from gui_core.gselect import Select
 from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from core.settings import UserSettings
 from photo2image.ip2i_mapdisplay import MapPanel
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 #

--- a/gui/wxpython/photo2image/ip2i_toolbars.py
+++ b/gui/wxpython/photo2image/ip2i_toolbars.py
@@ -16,8 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -54,7 +54,7 @@ import grass.script as grass
 from core.utils import PilImageToWxImage
 from dbmgr.vinfo import VectorDBInfo
 from gui_core.gselect import Select
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import GError, GMessage, RunCommand
 from gui_core.dialogs import SymbolDialog
 from gui_core.wrap import (
     BitmapButton,
@@ -62,12 +62,14 @@ from gui_core.wrap import (
     BitmapFromImage,
     Button,
     CheckBox,
+    CheckListCtrlMixin,
     Choice,
     ClientDC,
     ColourPickerCtrl,
     Dialog,
     DirBrowseButton,
     EmptyBitmap,
+    EmptyImage,
     ExpandoTextCtrl,
     FileBrowseButton,
     FloatSpin,
@@ -84,8 +86,6 @@ from gui_core.wrap import (
     StaticText,
     TextCtrl,
     TextEntryDialog,
-    EmptyImage,
-    CheckListCtrlMixin,
 )
 from psmap.utils import *
 from psmap.instructions import *

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -16,10 +16,9 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
-
 import queue as Queue
-from math import sin, cos, pi, sqrt
+import sys
+from math import cos, pi, sin, sqrt
 
 import wx
 
@@ -32,16 +31,16 @@ import grass.script as grass
 
 from core import globalvar
 from gui_core.menu import Menu
-from core.gconsole import CmdThread, EVT_CMD_DONE
+from core.gconsole import EVT_CMD_DONE, CmdThread
 from psmap.toolbars import PsMapToolbar
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import GError, GMessage, RunCommand
 from core.settings import UserSettings
 from core.utils import PilImageToWxImage
 from gui_core.forms import GUI
 from gui_core.widgets import GNotebook
 from gui_core.dialogs import HyperlinkDialog
 from gui_core.ghelp import ShowAboutDialog
-from gui_core.wrap import ClientDC, PseudoDC, Rect, StockCursor, EmptyBitmap
+from gui_core.wrap import ClientDC, EmptyBitmap, PseudoDC, Rect, StockCursor
 from psmap.menudata import PsMapMenuData
 from gui_core.toolbars import ToolSwitcher
 

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -35,7 +35,7 @@ This program is free software under the GNU General Public License
 import os
 import string
 from math import ceil
-from time import strftime, localtime
+from time import localtime, strftime
 
 import wx
 import grass.script as grass

--- a/gui/wxpython/psmap/toolbars.py
+++ b/gui/wxpython/psmap/toolbars.py
@@ -17,8 +17,7 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -16,8 +16,9 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
+from math import ceil, cos, floor, pi, sin
+
 import wx
-from math import ceil, floor, sin, cos, pi
 
 try:
     from PIL import Image as PILImage  # noqa
@@ -27,7 +28,7 @@ except ImportError:
     havePILImage = False
 
 import grass.script as grass
-from core.gcmd import RunCommand, GError
+from core.gcmd import GError, RunCommand
 
 
 class Rect2D(wx.Rect2D):

--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -16,8 +16,9 @@ for details.
 
 import os
 import tempfile
-import wx
 import uuid
+
+import wx
 from wx.lib.newevent import NewEvent
 
 from grass.script import core as gcore

--- a/gui/wxpython/rdigit/toolbars.py
+++ b/gui/wxpython/rdigit/toolbars.py
@@ -16,13 +16,11 @@ for details.
 
 import wx
 
-from gui_core.toolbars import BaseToolbar
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 from gui_core.widgets import FloatValidator
 import wx.lib.colourselect as csel
-from gui_core.wrap import TextCtrl, StaticText, ColourSelect
-from gui_core.toolbars import BaseIcons
-
+from gui_core.wrap import ColourSelect, StaticText, TextCtrl
 
 rdigitIcons = {
     "area": MetaIcon(img="polygon-create", label=_("Digitize area")),

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -4,15 +4,15 @@ Created on Mon Nov 26 11:57:54 2012
 @author: lucadelu
 """
 
-import wx
+import codecs
+import locale
 import os
 
-from core import globalvar, gcmd
+import wx
+from core import gcmd, globalvar
 from grass.script.utils import try_remove
 from rlisetup.functions import retRLiPath
 from rlisetup.wizard import RLIWizard
-import locale
-import codecs
 from gui_core.wrap import Button, StaticBox, TextCtrl
 
 

--- a/gui/wxpython/rlisetup/sampling_frame.py
+++ b/gui/wxpython/rlisetup/sampling_frame.py
@@ -24,7 +24,7 @@ import wx.aui
 
 # start new import
 import tempfile
-from core.gcmd import RunCommand
+from core.gcmd import GMessage, RunCommand
 import grass.script.core as grass
 from core import gcmd
 
@@ -32,9 +32,8 @@ from core.giface import StandaloneGrassInterface
 from mapwin.base import MapWindowProperties
 from mapwin.buffered import BufferedMapWindow
 from core.render import Map
-from gui_core.toolbars import BaseToolbar, BaseIcons, ToolSwitcher
+from gui_core.toolbars import BaseIcons, BaseToolbar, ToolSwitcher
 from icons.icon import MetaIcon
-from core.gcmd import GMessage
 from grass.pydispatch.signal import Signal
 from grass.pydispatch.errors import DispatcherKeyError
 

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -15,31 +15,32 @@ This is for code which depend on something from GUI (wx or wxGUI).
 """
 
 import os
+
 import wx
 
 from grass.grassdb.checks import (
-    is_mapset_locked,
-    get_mapset_lock_info,
-    is_mapset_name_valid,
-    is_location_name_valid,
-    get_mapset_name_invalid_reason,
     get_location_name_invalid_reason,
+    get_mapset_lock_info,
+    get_mapset_name_invalid_reason,
     get_reason_mapset_not_removable,
-    get_reasons_mapsets_not_removable,
+    get_reasons_grassdb_not_removable,
     get_reasons_location_not_removable,
     get_reasons_locations_not_removable,
-    get_reasons_grassdb_not_removable,
+    get_reasons_mapsets_not_removable,
     is_fallback_session,
+    is_location_name_valid,
+    is_mapset_locked,
+    is_mapset_name_valid,
 )
 import grass.grassdb.config as cfg
 
 from grass.grassdb.create import create_mapset, get_default_mapset_name
 from grass.grassdb.manage import (
-    delete_mapset,
-    delete_location,
     delete_grassdb,
-    rename_mapset,
+    delete_location,
+    delete_mapset,
     rename_location,
+    rename_mapset,
 )
 from grass.script.core import create_environment
 from grass.script.utils import try_remove

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -17,16 +17,16 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
 import shutil
+import sys
 import textwrap
 import time
 
 import wx
 from wx.lib.newevent import NewEvent
 
-from grass.script.utils import try_rmdir, legalize_vector_name
-from grass.utils.download import download_and_extract, name_from_url, DownloadError
+from grass.script.utils import legalize_vector_name, try_rmdir
+from grass.utils.download import DownloadError, download_and_extract, name_from_url
 from grass.grassdb.checks import is_location_valid
 from grass.script.setup import set_gui_path
 
@@ -35,7 +35,6 @@ set_gui_path()
 from core.debug import Debug
 from core.gthread import gThread
 from gui_core.wrap import Button, StaticText
-
 
 # TODO: labels (and descriptions) translatable?
 LOCATIONS = [

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -16,12 +16,12 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
-from math import ceil
-from itertools import cycle
-import numpy as np
-
-import wx
 from functools import reduce
+from itertools import cycle
+from math import ceil
+
+import numpy as np
+import wx
 
 try:
     import matplotlib
@@ -31,8 +31,8 @@ try:
     matplotlib.use("WXAgg")
     from matplotlib import gridspec
     from matplotlib.figure import Figure
+    from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
     from matplotlib.backends.backend_wxagg import (
-        FigureCanvasWxAgg as FigCanvas,
         NavigationToolbar2WxAgg as NavigationToolbar,
     )
     import matplotlib.dates as mdates

--- a/gui/wxpython/tools/update_menudata.py
+++ b/gui/wxpython/tools/update_menudata.py
@@ -22,7 +22,6 @@ Usage: python support/update_menudata.py [-d]
 import os
 import sys
 import tempfile
-
 import xml.etree.ElementTree as etree
 
 from grass.script import core as grass

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -19,14 +19,14 @@ This program is free software under the GNU General Public License
 @author start stvds support Matej Krejci
 """
 import os
+from functools import reduce
 from itertools import cycle
-import numpy as np
 
+import numpy as np
 import wx
 from grass.pygrass.modules import Module
 
 import grass.script as grass
-from functools import reduce
 
 try:
     import matplotlib
@@ -35,8 +35,8 @@ try:
     # backend.
     matplotlib.use("WXAgg")
     from matplotlib.figure import Figure
+    from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
     from matplotlib.backends.backend_wxagg import (
-        FigureCanvasWxAgg as FigCanvas,
         NavigationToolbar2WxAgg as NavigationToolbar,
     )
     import matplotlib.dates as mdates
@@ -50,7 +50,7 @@ except ImportError as e:
 
 
 import grass.temporal as tgis
-from core.gcmd import GMessage, GError, GException, RunCommand
+from core.gcmd import GError, GException, GMessage, RunCommand
 from gui_core.widgets import CoordinatesValidator
 from gui_core import gselect
 from core import globalvar
@@ -67,7 +67,7 @@ except ImportError:
 import wx.lib.filebrowsebutton as filebrowse
 
 from gui_core.widgets import GNotebook
-from gui_core.wrap import CheckBox, TextCtrl, Button, StaticText
+from gui_core.wrap import Button, CheckBox, StaticText, TextCtrl
 
 ALPHA = 0.5
 COLORS = ["b", "g", "r", "c", "m", "y", "k"]

--- a/gui/wxpython/vdigit/dialogs.py
+++ b/gui/wxpython/vdigit/dialogs.py
@@ -23,17 +23,17 @@ import copy
 import wx
 import wx.lib.mixins.listctrl as listmix
 
-from core.gcmd import RunCommand, GError
+from core.gcmd import GError, RunCommand
 from core.debug import Debug
 from gui_core.wrap import (
-    SpinCtrl,
     Button,
-    StaticText,
-    StaticBox,
-    Menu,
-    ListCtrl,
-    NewId,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    NewId,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
 )
 
 

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -35,6 +35,7 @@
 # %end
 
 import os
+
 import grass.script as grass
 
 
@@ -57,7 +58,7 @@ def main():
     from gui_core.mapdisp import FrameMixin
     from mapdisp.main import DMonGrassInterface
     from core.settings import UserSettings
-    from vdigit.main import haveVDigit, errorMsg
+    from vdigit.main import errorMsg, haveVDigit
     from grass.exceptions import CalledModuleError
 
     # define classes which needs imports as local

--- a/gui/wxpython/vdigit/main.py
+++ b/gui/wxpython/vdigit/main.py
@@ -15,7 +15,7 @@ This program is free software under the GNU General Public License
 """
 
 try:
-    from vdigit.wxdigit import IVDigit, GV_LINES, CFUNCTYPE  # noqa: F401
+    from vdigit.wxdigit import CFUNCTYPE, GV_LINES, IVDigit  # noqa: F401
 
     haveVDigit = True
     errorMsg = ""

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -20,7 +20,7 @@ import tempfile
 from grass.pydispatch.signal import Signal
 
 from dbmgr.dialogs import DisplayAttributesDialog
-from core.gcmd import RunCommand, GMessage, GError
+from core.gcmd import GError, GMessage, RunCommand
 from core.debug import Debug
 from mapwin.buffered import BufferedMapWindow
 from core.settings import UserSettings
@@ -29,11 +29,11 @@ from core.units import ConvertValue as UnitsConvertValue
 from core.globalvar import QUERYLAYER
 from vdigit.dialogs import (
     VDigitCategoryDialog,
-    VDigitZBulkDialog,
     VDigitDuplicatesDialog,
+    VDigitZBulkDialog,
 )
 from gui_core import gselect
-from gui_core.wrap import PseudoDC, NewId
+from gui_core.wrap import NewId, PseudoDC
 
 
 class VDigitWindow(BufferedMapWindow):

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -20,9 +20,9 @@ import wx
 from grass import script as grass
 from grass.pydispatch.signal import Signal
 
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.dialogs import CreateNewVector, VectorDialog
-from gui_core.wrap import PseudoDC, Menu
+from gui_core.wrap import Menu, PseudoDC
 from vdigit.preferences import VDigitSettingsDialog
 from core.debug import Debug
 from core.settings import UserSettings

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -18,11 +18,10 @@ This program is free software under the GNU General Public License
 """
 
 import locale
-
 import os
 import sys
-import wx
 
+import wx
 from core.debug import Debug
 from core.settings import UserSettings
 from core.gcmd import DecodeString

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -24,30 +24,30 @@ This program is free software under the GNU General Public License
 @author Eliska Kyzlikova <eliska.kyzlikova gmail.com> (turn costs support)
 """
 
-import os
 import math
+import os
 
 from grass.script import core as grass
 
 import wx
 import wx.aui
 
+
 try:
     import wx.lib.agw.flatnotebook as FN
 except ImportError:
     import wx.lib.flatnotebook as FN
+
 import wx.lib.colourselect as csel
 import wx.lib.mixins.listctrl as listmix
-
 from core import globalvar
-from core.gcmd import RunCommand, GMessage
+from core.gcmd import GMessage, RunCommand
 from core.settings import UserSettings
-
 from dbmgr.base import DbMgrBase
 
 from gui_core.widgets import GNotebook
 from gui_core.goutput import GConsoleWindow
-from gui_core.gselect import Select, LayerSelect, ColumnSelect
+from gui_core.gselect import ColumnSelect, LayerSelect, Select
 from gui_core.wrap import (
     BitmapButton,
     BitmapFromImage,
@@ -64,13 +64,13 @@ from gui_core.wrap import (
 )
 
 from vnet.widgets import PointsList
-from vnet.toolbars import MainToolbar, PointListToolbar, AnalysisToolbar
+from vnet.toolbars import AnalysisToolbar, MainToolbar, PointListToolbar
 from vnet.vnet_core import VNETManager
 from vnet.vnet_utils import (
     DegreesToRadians,
-    RadiansToDegrees,
     GetNearestNodeCat,
     ParseMapStr,
+    RadiansToDegrees,
 )
 
 # Main TODOs

--- a/gui/wxpython/vnet/toolbars.py
+++ b/gui/wxpython/vnet/toolbars.py
@@ -20,7 +20,7 @@ This program is free software under the GNU General Public License
 import wx
 
 from icons.icon import MetaIcon
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import ComboBox
 from core.gcmd import RunCommand
 

--- a/gui/wxpython/vnet/vnet_core.py
+++ b/gui/wxpython/vnet/vnet_core.py
@@ -26,13 +26,13 @@ from grass.script.task import cmdlist_to_tuple
 
 import wx
 
-from core.gcmd import RunCommand, GMessage
-from core.gconsole import CmdThread, EVT_CMD_DONE, GConsole
+from core.gcmd import GMessage, RunCommand
+from core.gconsole import EVT_CMD_DONE, CmdThread, GConsole
 
 from gui_core.gselect import VectorDBInfo
 
-from vnet.vnet_data import VNETData, VNETTmpVectMaps, VectMap, History
-from vnet.vnet_utils import ParseMapStr, haveCtypes, GetNearestNodeCat
+from vnet.vnet_data import History, VectMap, VNETData, VNETTmpVectMaps
+from vnet.vnet_utils import GetNearestNodeCat, ParseMapStr, haveCtypes
 
 from grass.pydispatch.signal import Signal
 

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -23,8 +23,8 @@ This program is free software under the GNU General Public License
 @author Eliska Kyzlikova <eliska.kyzlikova gmail.com> (turn costs support)
 """
 
-import os
 import math
+import os
 from copy import deepcopy
 
 from grass.script.utils import try_remove
@@ -33,17 +33,14 @@ from grass.script.task import cmdlist_to_tuple
 
 import wx
 
-
 from core import utils
-from core.gcmd import RunCommand, GMessage
+from core.gcmd import GMessage, RunCommand
 from core.settings import UserSettings
 
-from vnet.vnet_utils import ParseMapStr, SnapToNode
+from vnet.vnet_utils import DegreesToRadians, ParseMapStr, SnapToNode
 
 from gui_core.gselect import VectorDBInfo
 from grass.pydispatch.signal import Signal
-
-from vnet.vnet_utils import DegreesToRadians
 
 
 class VNETData:

--- a/gui/wxpython/vnet/vnet_utils.py
+++ b/gui/wxpython/vnet/vnet_utils.py
@@ -19,12 +19,13 @@ This program is free software under the GNU General Public License
 """
 
 import math
+
 from grass.script import core as grass
 from grass.script.utils import encode
 
 try:
     import grass.lib.vector as vectlib
-    from ctypes import pointer, byref, c_char_p, c_int, c_double, POINTER
+    from ctypes import POINTER, byref, c_char_p, c_double, c_int, pointer
 
     haveCtypes = True
 except ImportError:

--- a/gui/wxpython/vnet/widgets.py
+++ b/gui/wxpython/vnet/widgets.py
@@ -31,13 +31,13 @@ from gui_core.widgets import FloatValidator, IntegerValidator
 from gui_core.wrap import (
     BitmapFromImage,
     Button,
+    CheckListCtrlMixin,
     ComboBox,
     ListCtrl,
     Panel,
     StaticBox,
     StaticText,
     TextCtrl,
-    CheckListCtrlMixin,
 )
 
 

--- a/gui/wxpython/web_services/cap_interface.py
+++ b/gui/wxpython/web_services/cap_interface.py
@@ -31,9 +31,9 @@ if WMSLibPath not in sys.path:
 
 # Import only after the path has been set up.
 from wms_cap_parsers import (  # noqa: E402
+    OnEarthCapabilitiesTree,
     WMSCapabilitiesTree,
     WMTSCapabilitiesTree,
-    OnEarthCapabilitiesTree,
 )
 
 

--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -18,26 +18,24 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz>
 """
 
-import wx
-
 import os
 import shutil
-
 from copy import deepcopy
 
+import wx
 import grass.script as grass
 from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
 
 from core import globalvar
 from core.debug import Debug
-from core.gcmd import GMessage, GWarning, GError
+from core.gcmd import GError, GMessage, GWarning
 from core.utils import GetSettingsPath
-from core.gconsole import CmdThread, GStderr, EVT_CMD_DONE, EVT_CMD_OUTPUT
+from core.gconsole import EVT_CMD_DONE, EVT_CMD_OUTPUT, CmdThread, GStderr
 
 from gui_core.gselect import Select
-from gui_core.wrap import Button, StaticText, StaticBox, TextCtrl, RadioButton
+from gui_core.wrap import Button, RadioButton, StaticBox, StaticText, TextCtrl
 
-from web_services.widgets import WSPanel, WSManageSettingsWidget
+from web_services.widgets import WSManageSettingsWidget, WSPanel
 
 
 class WSDialogBase(wx.Dialog):

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -16,11 +16,10 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz>
 """
 
-import re
 import os
-import sys
+import re
 import shutil
-
+import sys
 from copy import deepcopy
 from core import globalvar
 
@@ -39,16 +38,15 @@ import wx.lib.colourselect as csel
 
 from core.debug import Debug
 from core.gcmd import GMessage
-from core.gconsole import CmdThread, GStderr, EVT_CMD_DONE, EVT_CMD_OUTPUT
+from core.gconsole import EVT_CMD_DONE, EVT_CMD_OUTPUT, CmdThread, GStderr
 
 from web_services.cap_interface import (
+    OnEarthCapabilities,
     WMSCapabilities,
     WMTSCapabilities,
-    OnEarthCapabilities,
 )
 
-from gui_core.widgets import GNotebook
-from gui_core.widgets import ManageSettingsWidget
+from gui_core.widgets import GNotebook, ManageSettingsWidget
 from gui_core.wrap import (
     Button,
     ScrolledPanel,

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -17,14 +17,14 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (menu customization)
 """
 
+import getopt
 import os
 import sys
-import getopt
 
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
 from grass.exceptions import Usage
-from grass.script.core import set_raise_on_error, warning, error
+from grass.script.core import error, set_raise_on_error, warning
 
 from core import globalvar
 from core.utils import registerPid, unregisterPid

--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -16,14 +16,13 @@ This program is free software under the GNU General Public License
 """
 
 import os
-
-import wx
 from random import randint
 
+import wx
 from wx.lib import plot
 from core.globalvar import ICONDIR
 from core.settings import UserSettings
-from wxplot.dialogs import TextDialog, OptDialog
+from wxplot.dialogs import OptDialog, TextDialog
 from core.render import Map
 from icons.icon import MetaIcon
 from gui_core.toolbars import BaseIcons

--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -22,17 +22,16 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-
 from core import globalvar
 from core.settings import UserSettings
 from core.globalvar import ICONDIR
 from gui_core.gselect import Select
 from gui_core.wrap import (
-    ColourSelect,
-    ComboBox,
     Button,
     CheckBox,
     Choice,
+    ColourSelect,
+    ComboBox,
     ScrolledPanel,
     SpinCtrl,
     StaticBox,

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -22,10 +22,10 @@ import wx
 import grass.script as grass
 from wx.lib import plot
 from gui_core.wrap import StockCursor
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from wxplot.base import BasePlotFrame, PlotIcons
 from wxplot.dialogs import HistRasterDialog, PlotStatsFrame
-from core.gcmd import RunCommand, GException, GError
+from core.gcmd import GError, GException, RunCommand
 
 
 class HistogramPlotFrame(BasePlotFrame):

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -15,20 +15,19 @@ This program is free software under the GNU General Public License
 @author Michael Barton, Arizona State University
 """
 
+import math
 import os
 import sys
-import math
+
 import numpy
-
 import wx
-
 from wx.lib import plot
 import grass.script as grass
 from wxplot.base import BasePlotFrame, PlotIcons
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import StockCursor
-from wxplot.dialogs import ProfileRasterDialog, PlotStatsFrame
-from core.gcmd import RunCommand, GWarning, GError, GMessage
+from wxplot.dialogs import PlotStatsFrame, ProfileRasterDialog
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 
 try:
     import grass.lib.gis as gislib

--- a/gui/wxpython/wxplot/scatter.py
+++ b/gui/wxpython/wxplot/scatter.py
@@ -22,10 +22,10 @@ import wx
 import grass.script as grass
 from wx.lib import plot
 from wxplot.base import BasePlotFrame, PlotIcons
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import StockCursor
-from wxplot.dialogs import ScatterRasterDialog, PlotStatsFrame
-from core.gcmd import RunCommand, GException, GError, GMessage
+from wxplot.dialogs import PlotStatsFrame, ScatterRasterDialog
+from core.gcmd import GError, GException, GMessage, RunCommand
 
 
 class ScatterFrame(BasePlotFrame):


### PR DESCRIPTION
This is a first part for the changes in this folder, as the changes were too long and complex to do in one pass. This only kept the low risk changes, that don't require thinking much.

Uses a combination of `ruff check --output-format=concise --select I --fix gui`, `isort --profile=black gui` and `black .`

The complete changes that I want to make are here: https://github.com/echoix/grass/tree/group-sort-imports-gui-all
I need to wait for this one to be merged, so I can rebase the remaining changes. The next ones will require a more specialized review.

Continues on the same PRs as https://github.com/OSGeo/grass/pull/3961, https://github.com/OSGeo/grass/pull/3959, https://github.com/OSGeo/grass/pull/3962, and https://github.com/OSGeo/grass/pull/3963