### PR TITLE
style: Sort and group imports in remaining files

### DIFF
--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
+import glob
 import os
 import sys
-import glob
 import tempfile
 from pathlib import Path
 
+from grass.exceptions import CalledModuleError
 from grass.script import core as grass
 from grass.script import task as gtask
-from grass.exceptions import CalledModuleError
 
 non_rendering_modules = (
     "d.colorlist",

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -47,7 +47,6 @@
 import sys
 
 import grass.script as gs
-
 from grass.lib.gis import *
 
 

--- a/docker/testdata/test_grass_python.py
+++ b/docker/testdata/test_grass_python.py
@@ -1,5 +1,6 @@
 # Import GRASS Python bindings
 import os
+
 import grass.script as gs
 
 # hint: do not use ~ as an alias for HOME

--- a/lib/gis/tests/lib_gis_env_test.py
+++ b/lib/gis/tests/lib_gis_env_test.py
@@ -31,8 +31,8 @@ def test_reading_respects_change_of_session(tmp_path):
         """Switches through a list of locations"""
         # Just to be sure we don't influence other tests.
         # pylint: disable=import-outside-toplevel
-        import grass.pygrass.utils as pygrass_utils
         import grass.lib.gis as libgis
+        import grass.pygrass.utils as pygrass_utils
 
         names = []
         for location_name in ["test1", "test2", "abc"]:

--- a/lib/gis/testsuite/gis_lib_env_test.py
+++ b/lib/gis/testsuite/gis_lib_env_test.py
@@ -3,8 +3,8 @@
 @author Soeren Gebbert
 """
 
-from grass.gunittest.case import TestCase
 import grass.lib.gis as libgis
+from grass.gunittest.case import TestCase
 
 
 class GisLibraryTestEnv(TestCase):

--- a/lib/gis/testsuite/gis_lib_str_color.py
+++ b/lib/gis/testsuite/gis_lib_str_color.py
@@ -5,10 +5,9 @@
 
 from ctypes import byref, c_int
 
+import grass.lib.gis as libgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.lib.gis as libgis
 
 
 class StringToColorTestCase(TestCase):

--- a/lib/gis/testsuite/gis_lib_tokenize.py
+++ b/lib/gis/testsuite/gis_lib_tokenize.py
@@ -3,10 +3,9 @@
 @author Vaclav Petras
 """
 
+import grass.lib.gis as libgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.lib.gis as libgis
 
 # TODO: add tests for content (now testing only number of items)
 

--- a/lib/gis/testsuite/test_parser_json.py
+++ b/lib/gis/testsuite/test_parser_json.py
@@ -8,10 +8,11 @@ for details.
 @author Soeren Gebbert
 """
 
+import json
 import subprocess
+
 from grass.gunittest.case import TestCase
 from grass.script import decode
-import json
 
 
 class TestParserJson(TestCase):

--- a/lib/imagery/testsuite/test_imagery_find.py
+++ b/lib/imagery/testsuite/test_imagery_find.py
@@ -14,19 +14,17 @@ import shutil
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-
 from grass.lib.gis import G_mapset_path
 from grass.lib.imagery import (
+    I_SIGFILE_TYPE_LIBSVM,
     I_SIGFILE_TYPE_SIG,
     I_SIGFILE_TYPE_SIGSET,
-    I_SIGFILE_TYPE_LIBSVM,
     I_find_signature,
     I_find_signature2,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class FindSignatureTestCase(TestCase):

--- a/lib/imagery/testsuite/test_imagery_sigfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigfile.py
@@ -9,35 +9,33 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-import os
-import stat
 import ctypes
+import os
 import shutil
+import stat
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-
 from grass.lib.gis import G_mapset_path
-from grass.lib.raster import Rast_write_semantic_label
 from grass.lib.imagery import (
-    Signature,
-    Ref,
-    I_init_signatures,
-    I_new_signature,
+    I_add_file_to_group_ref,
     I_fopen_signature_file_new,
-    I_write_signatures,
     I_fopen_signature_file_old,
-    I_read_signatures,
-    I_sort_signatures_by_semantic_label,
+    I_free_group_ref,
     I_free_signatures,
     I_init_group_ref,
-    I_add_file_to_group_ref,
-    I_free_group_ref,
+    I_init_signatures,
+    I_new_signature,
+    I_read_signatures,
+    I_sort_signatures_by_semantic_label,
+    I_write_signatures,
+    Ref,
+    Signature,
 )
+from grass.lib.raster import Rast_write_semantic_label
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class SignatureFileTestCase(TestCase):

--- a/lib/imagery/testsuite/test_imagery_signature_management.py
+++ b/lib/imagery/testsuite/test_imagery_signature_management.py
@@ -9,38 +9,36 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
+import ctypes
 import os
 import shutil
-import ctypes
 
+import grass.script as grass
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-import grass.script as grass
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset, make_mapset
-
 from grass.lib.gis import (
-    G_mapset_path,
-    G_make_mapset,
-    G_reset_mapsets,
     GNAME_MAX,
     HOST_DIRSEP,
+    G_make_mapset,
+    G_mapset_path,
+    G_reset_mapsets,
 )
 from grass.lib.imagery import (
+    I_SIGFILE_TYPE_LIBSVM,
     I_SIGFILE_TYPE_SIG,
     I_SIGFILE_TYPE_SIGSET,
-    I_SIGFILE_TYPE_LIBSVM,
     I_find_signature,
-    I_signatures_remove,
-    I_signatures_copy,
-    I_signatures_rename,
-    I_signatures_list_by_type,
     I_free_signatures_list,
     I_get_signatures_dir,
     I_make_signatures_dir,
+    I_signatures_copy,
+    I_signatures_list_by_type,
+    I_signatures_remove,
+    I_signatures_rename,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset, make_mapset
+from grass.script.core import tempname
 
 
 class GetSignaturesDirTestCase(TestCase):

--- a/lib/imagery/testsuite/test_imagery_sigsetfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigsetfile.py
@@ -9,36 +9,34 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-import os
-import stat
 import ctypes
+import os
 import shutil
+import stat
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass import utils
-from grass.pygrass.gis import Mapset
-
 from grass.lib.gis import G_mapset_path
-from grass.lib.raster import Rast_write_semantic_label
 from grass.lib.imagery import (
-    SigSet,
+    I_add_file_to_group_ref,
+    I_fopen_sigset_file_new,
+    I_fopen_sigset_file_old,
+    I_free_group_ref,
+    I_init_group_ref,
     I_InitSigSet,
     I_NewClassSig,
     I_NewSubSig,
-    I_WriteSigSet,
     I_ReadSigSet,
     I_SortSigSetBySemanticLabel,
-    I_fopen_sigset_file_new,
-    I_fopen_sigset_file_old,
+    I_WriteSigSet,
     Ref,
-    I_init_group_ref,
-    I_add_file_to_group_ref,
-    I_free_group_ref,
     ReturnString,
+    SigSet,
 )
+from grass.lib.raster import Rast_write_semantic_label
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class SigSetFileTestCase(TestCase):

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -37,25 +37,24 @@ is not safe, i.e. it has side effects (this should be changed in the future).
 # (this makes it more stable since we have to set up paths first)
 # pylint: disable=too-many-lines
 
-import sys
-import os
-import errno
+import argparse
 import atexit
 import datetime
+import errno
 import gettext
+import json
+import locale
+import os
+import platform
+import re
 import shutil
 import signal
 import string
 import subprocess
-import re
-import platform
+import sys
 import tempfile
-import locale
-import uuid
 import unicodedata
-import argparse
-import json
-
+import uuid
 
 # mechanism meant for debugging this script (only)
 # private global to store if we are debugging
@@ -794,11 +793,11 @@ def set_mapset(
     tmp_location requires tmpdir (which is used as gisdbase)
     """
     from grass.grassdb.checks import (
-        is_mapset_valid,
-        is_location_valid,
-        get_mapset_invalid_reason,
         get_location_invalid_reason,
         get_location_invalid_suggestion,
+        get_mapset_invalid_reason,
+        is_location_valid,
+        is_mapset_valid,
         mapset_exists,
     )
 
@@ -2311,10 +2310,10 @@ def main():
 
     from grass.app.runtime import (
         ensure_home,
-        set_paths,
+        set_browser,
         set_defaults,
         set_display_defaults,
-        set_browser,
+        set_paths,
     )
 
     ensure_home()

--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -14,11 +14,10 @@ License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 """
 
-import unittest
 import os
 import shutil
 import subprocess
-
+import unittest
 
 # Note that unlike rest of GRASS GIS, here we are using unittest package
 # directly. The grass.gunittest machinery for mapsets is not needed here.

--- a/lib/raster/testsuite/rast_parse_color_rule.py
+++ b/lib/raster/testsuite/rast_parse_color_rule.py
@@ -10,11 +10,10 @@ Read the file COPYING that comes with GRASS
 for details
 """
 
-from ctypes import byref, c_int, c_double
+from ctypes import byref, c_double, c_int
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
 from grass.lib.raster import Rast_parse_color_rule, Rast_parse_color_rule_error
 
 

--- a/lib/raster/testsuite/test_raster_metadata.py
+++ b/lib/raster/testsuite/test_raster_metadata.py
@@ -14,18 +14,16 @@ import string
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-from grass.script.core import tempname
-from grass.pygrass.gis import Mapset
-from grass.pygrass import utils
-
 from grass.lib.gis import G_remove_misc
 from grass.lib.raster import (
+    Rast_get_semantic_label_or_name,
     Rast_legal_semantic_label,
     Rast_read_semantic_label,
-    Rast_get_semantic_label_or_name,
     Rast_write_semantic_label,
 )
+from grass.pygrass import utils
+from grass.pygrass.gis import Mapset
+from grass.script.core import tempname
 
 
 class RastLegalBandIdTestCase(TestCase):

--- a/lib/vector/Vlib/testsuite/test_vlib_box.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_box.py
@@ -13,8 +13,8 @@ COPYRIGHT: (C) 2015 Vaclav Petras, and by the GRASS Development Team
 """
 
 import ctypes
-import grass.lib.vector as libvect
 
+import grass.lib.vector as libvect
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/lib/vector/Vlib/testsuite/test_vlib_intersect.py
+++ b/lib/vector/Vlib/testsuite/test_vlib_intersect.py
@@ -13,7 +13,6 @@ COPYRIGHT: (C) 2022 Maris Nartiss, and by the GRASS Development Team
 """
 
 import grass.lib.vector as libvect
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -6,8 +6,8 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_html import *
 

--- a/man/build_check_rest.py
+++ b/man/build_check_rest.py
@@ -6,8 +6,8 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_rest import *
 

--- a/man/build_class.py
+++ b/man/build_class.py
@@ -6,11 +6,10 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_html import *
-
 
 no_intro_page_classes = ["display", "general", "miscellaneous", "postscript"]
 

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -13,24 +13,22 @@
 #
 #############################################################################
 
-import sys
-import os
 import fnmatch
+import os
+import sys
 
-# from build_html import *
 from build_html import (
-    default_year,
-    header1_tmpl,
-    grass_version,
-    modclass_intro_tmpl,
-    to_title,
-    html_files,
     check_for_desc_override,
+    default_year,
     get_desc,
-    write_html_footer,
+    grass_version,
+    header1_tmpl,
+    html_files,
+    modclass_intro_tmpl,
     replace_file,
+    to_title,
+    write_html_footer,
 )
-
 
 header_graphical_index_tmpl = """\
 <link rel="stylesheet" href="grassdocs.css" type="text/css">

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -6,8 +6,8 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_rest import *
 

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -6,8 +6,8 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_html import *
 

--- a/man/build_graphical_index.py
+++ b/man/build_graphical_index.py
@@ -16,8 +16,7 @@
 import os
 import sys
 
-from build_html import write_html_footer, grass_version, header1_tmpl
-
+from build_html import grass_version, header1_tmpl, write_html_footer
 
 output_name = "graphical_index.html"
 

--- a/man/build_index.py
+++ b/man/build_index.py
@@ -6,8 +6,8 @@
 #   Markus Neteler
 #   Glynn Clements
 
-import sys
 import os
+import sys
 
 from build_html import *
 

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -18,9 +18,10 @@ python man/build_keywords.py <dir_path_to_core_modules_html_man_files>
 @author Tomas Zigo <tomas.zigo slovanet.sk> - inject addons modules keywords
 """
 
+import glob
 import os
 import sys
-import glob
+
 from build_html import *
 
 blacklist = [

--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -13,13 +13,12 @@
 #
 #############################################################################
 
-import os
-import sys
 import fnmatch
+import os
 import re
+import sys
 
-from build_html import write_html_footer, grass_version, header1_tmpl
-
+from build_html import grass_version, header1_tmpl, write_html_footer
 
 output_name = "manual_gallery.html"
 

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -3,9 +3,10 @@
 # generates topics.html and topic_*.html
 # (c) 2012 by the GRASS Development Team, Markus Neteler, Luca Delucchi
 
+import glob
 import os
 import sys
-import glob
+
 from build_html import *
 
 path = sys.argv[1]

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -7,15 +7,9 @@ Created on Fri Jun 26 19:10:58 2015
 import argparse
 import os
 import sys
-
 from urllib.request import urlopen
 
-from build_html import (
-    header1_tmpl,
-    grass_version,
-    headerpso_tmpl,
-    write_html_footer,
-)
+from build_html import grass_version, header1_tmpl, headerpso_tmpl, write_html_footer
 
 
 def parse_options(lines, startswith="Opt"):

--- a/python/libgrass_interface_generator/run.py
+++ b/python/libgrass_interface_generator/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import sys
 import os
+import sys
 
 THIS_DIR = os.path.dirname(__file__)
 # ensure that we can load the ctypesgen library

--- a/utils/create_python_init_file.py
+++ b/utils/create_python_init_file.py
@@ -15,9 +15,9 @@ This program is free software under the GNU General Public License
 """
 
 
+import glob
 import os
 import sys
-import glob
 
 
 def main(path):

--- a/utils/g.html2man/g.html2man.py
+++ b/utils/g.html2man/g.html2man.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-import sys
 import re
-from ghtml import HTMLParser
-from ggroff import Formatter
-
+import sys
 from io import StringIO
+
+from ggroff import Formatter
+from ghtml import HTMLParser
 
 entities = {"nbsp": " ", "bull": "*"}
 

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -1,6 +1,6 @@
-import sys
 import os
 import re
+import sys
 
 __all__ = ["Formatter"]
 

--- a/utils/generate_last_commit_file.py
+++ b/utils/generate_last_commit_file.py
@@ -24,10 +24,9 @@ python utils/generate_last_commit_file.py .
 
 import json
 import os
-import subprocess
 import shutil
+import subprocess
 import sys
-
 
 # Strict ISO 8601 format
 COMMIT_DATE_FORMAT = "%aI"

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -4,9 +4,9 @@
 # Distributed under the terms of the GNU General Public License v2 or later
 
 import re
-from textwrap import TextWrapper
-import sys
 import subprocess
+import sys
+from textwrap import TextWrapper
 
 rev_range = ""
 

--- a/utils/md_isvalid.py
+++ b/utils/md_isvalid.py
@@ -5,10 +5,10 @@
 #   (on Debian/Ubuntu - apt install markdownlint)
 #   (using Ruby installer - gem install mdl)
 
-import os
-import sys
 import argparse
+import os
 import subprocess
+import sys
 
 import grass.script as gs
 

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -17,21 +17,19 @@
 #############################################################################
 
 import http
-import sys
-import os
-import string
-import re
-from datetime import datetime
-import locale
 import json
+import locale
+import os
 import pathlib
+import re
+import string
 import subprocess
-
+import sys
+import urllib.parse as urlparse
+from datetime import datetime
 from html.parser import HTMLParser
-
 from urllib import request as urlrequest
 from urllib.error import HTTPError, URLError
-import urllib.parse as urlparse
 
 try:
     import grass.script as gs

--- a/utils/mkrest.py
+++ b/utils/mkrest.py
@@ -14,10 +14,10 @@
 #
 #############################################################################
 
-import sys
-import string
 import re
+import string
 import subprocess
+import sys
 from datetime import datetime
 
 pgm = sys.argv[1]

--- a/utils/ppmrotate.py
+++ b/utils/ppmrotate.py
@@ -13,10 +13,11 @@
 #       for details.
 #
 
-import sys
-import os
-import atexit
 import array
+import atexit
+import os
+import sys
+
 import grass.script as grass
 
 tmp_img = None

--- a/utils/test_generate_last_commit_file.py
+++ b/utils/test_generate_last_commit_file.py
@@ -17,8 +17,8 @@ pytest utils/test_generate_last_commit_file.py
 @author Tomas Zigo <tomas.zigo slovanet.sk>
 """
 
-import os
 import json
+import os
 import subprocess
 
 import pytest

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -13,10 +13,10 @@
 #       for details.
 #
 
-import os
 import atexit
-import grass.script as grass
+import os
 
+import grass.script as grass
 
 tmp_grad_abs = None
 tmp_grad_rel = None

--- a/utils/update_version.py
+++ b/utils/update_version.py
@@ -2,11 +2,10 @@
 
 """Update VERSION file to release and development versions"""
 
-import sys
-import datetime
-from types import SimpleNamespace
-
 import argparse
+import datetime
+import sys
+from types import SimpleNamespace
 
 
 def read_version_file():


### PR DESCRIPTION
Uses a combination of `ruff check --output-format=concise --select I --fix .`, `isort --profile=black .` and `black .`

Excludes changes in ctypesgen code.

Continues on the same PRs as https://github.com/OSGeo/grass/pull/3961, https://github.com/OSGeo/grass/pull/3959, https://github.com/OSGeo/grass/pull/3962, https://github.com/OSGeo/grass/pull/3963, and https://github.com/OSGeo/grass/pull/3964