### PR TITLE
raster: Fix uninitialized variable 'flowpq' in raster/r.terraflow/sweep.cpp

### DIFF
--- a/raster/r.terraflow/sweep.cpp
+++ b/raster/r.terraflow/sweep.cpp
@@ -118,7 +118,7 @@ FLOW_DATASTR *initializePQ()
     if (stats)
         stats->comment("sweep:initialize flow data structure", opt->verbose);
 
-    FLOW_DATASTR *flowpq;
+    FLOW_DATASTR *flowpq = nullptr;
 #ifdef IM_PQUEUE
     if (stats)
         stats->comment("FLOW_DATASTRUCTURE: in-memory pqueue");


### PR DESCRIPTION
**Fix uninitialized variable 'flowpq' in raster/r.terraflow/sweep.cpp**

This pull request addresses an issue in `r.terraflow` where the variable `flowpq` was used without being initialized.

**Changes:**
- Initialize `flowpq` to `nullptr` in the `initializePQ` function to ensure it is properly initialized before use.

This fix resolves the cppcheck warning related to the uninitialized variable.
