### PR TITLE
style: fix missing whitespace between operators

### DIFF
--- a/raster/r.texture/benchmark/benchmark_rtexture.py
+++ b/raster/r.texture/benchmark/benchmark_rtexture.py
@@ -17,7 +17,7 @@ def main():
     metrics = ["time", "speedup", "efficiency"]
 
     for mapsize in mapsizes:
-        benchmark(int(mapsize**0.5), f"r.texture_{int(mapsize/1e6)}M", results)
+        benchmark(int(mapsize**0.5), f"r.texture_{int(mapsize / 1e6)}M", results)
 
     for metric in metrics:
         bm.nprocs_plot(


### PR DESCRIPTION
In between the last time I applied the missing pre-commit violations and the time it was merged, some new violations were introduced in here:
https://github.com/OSGeo/grass/commit/a24714ec1fcca3699d1b1d810c48ed5dac9f0bee#diff-fdcb5f33abc00bc15a934808d3d868490e61db92909e6747a2a635faf2c4df02R20
 as the PR changed python files, but the CI wasn't run containing the changes on main that updated the flake8 version or exclusions.

Anyways, here's a missing fix for this:
```python
gitpod /workspace/grass $ flake8 --count --statistics --show-source --jobs=$(nproc) .
./raster/r.texture/benchmark/benchmark_rtexture.py:20:62: E226 missing whitespace around arithmetic operator
        benchmark(int(mapsize**0.5), f"r.texture_{int(mapsize/1e6)}M", results)
                                                             ^
1     E226 missing whitespace around arithmetic operator
1
``` 