### PR TITLE
checks: Configure isort and enable isort in CI

### DIFF
--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -47,6 +47,7 @@ jobs:
           INPUT_TOOL_NAMES: >-
             black
             clang-format
+            isort
       - name: Post Black suggestions
         if: ${{ steps.tools.outputs.black == 'true' }}
         run: |
@@ -78,6 +79,24 @@ jobs:
               -reporter="github-pr-review" < "${TMPFILE}"
         env:
           INPUT_TOOL_NAME: clang-format
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get
+      - name: Post isort suggestions
+        if: ${{ steps.tools.outputs.isort == 'true' }}
+        run: |
+          TMPFILE="diff-${INPUT_TOOL_NAME}.patch"
+          GITHUB_ACTIONS="" reviewdog \
+              -name="${INPUT_TOOL_NAME:-reviewdog-suggester}" \
+              -f=diff \
+              -f.diff.strip=1 \
+              -filter-mode=nofilter \
+              -guess \
+              -reporter="github-pr-review" < "${TMPFILE}"
+        env:
+          INPUT_TOOL_NAME: isort
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
           CI_REPO_OWNER: ${{ github.event.workflow_run.repository.owner.login }}

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -31,6 +31,8 @@ jobs:
       BLACK_VERSION: "24.4.2"
       # renovate: datasource=pypi depName=flake8
       FLAKE8_VERSION: "7.1.0"
+      # renovate: datasource=pypi depName=isort
+      ISORT_VERSION: "5.13.2"
       # renovate: datasource=pypi depName=pylint
       PYLINT_VERSION: "2.12.2"
       # renovate: datasource=pypi depName=bandit
@@ -48,6 +50,7 @@ jobs:
           echo Minimal Python version: ${{ env.MIN_PYTHON_VERSION }}
           echo Black: ${{ env.BLACK_VERSION }}
           echo Flake8: ${{ env.FLAKE8_VERSION }}
+          echo isort: ${{ env.ISORT_VERSION }}
           echo Pylint: ${{ env.PYLINT_VERSION }}
           echo Bandit: ${{ env.BANDIT_VERSION }}
 
@@ -133,6 +136,17 @@ jobs:
       - name: Add the bin directory to PATH
         run: |
           echo "$HOME/install/bin" >> $GITHUB_PATH
+
+      - name: Run isort
+        run: pipx run isort==${{ env.ISORT_VERSION }} .
+      - name: Create and uploads code suggestions to apply for isort
+        # Will fail fast here if there are changes required
+        id: diff-isort
+        uses: ./.github/actions/create-upload-suggestions
+        with:
+          tool-name: isort
+          # To keep repo's file structure in formatted changes artifact
+          extra-upload-changes: pyproject.toml
 
       - name: Run Pylint on grass package
         run: |

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -54,7 +54,9 @@ jobs:
           VALIDATE_JSON: true
           VALIDATE_MARKDOWN: true
           VALIDATE_POWERSHELL: true
+          VALIDATE_PYTHON_ISORT: true
           # VALIDATE_XML: true
           VALIDATE_YAML: true
+          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           MARKDOWN_CONFIG_FILE: .markdownlint.yml
           YAML_CONFIG_FILE: .yamllint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,13 @@ repos:
     rev: v0.41.0
     hooks:
       - id: markdownlint-fix
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        # Since pre-commit sends a list of files,
+        # filter files will make isort respect file exclusions in configuration
+        args: ["--filter-files"]
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,11 @@ markers = [
 [tool.bandit]
 exclude_dirs = ["./testsuite", "*/tests/*", "*/testsuite/*", "utils/test_generate_last_commit_file.py"]
 skips = ["B324","B110", "B101", "B112", "B311", "B404", "B603"]
+
+
+[tool.isort]
+# *GRASS modified*
+# *GRASS TODO: keep un sync with MIN_PYTHON_VERSION supported*
+py_version = 39
+profile = "black"
+skip_glob = ["python/libgrass_interface_generator/*"]


### PR DESCRIPTION
This PRs configures isort in pyproject.toml

It also enables checking in pre-commit and in CI, with suggestions.

To not fail uselessly, these PRs (that fix import sorting) must be merged:

- [x] https://github.com/OSGeo/grass/pull/3959
- [ ] https://github.com/OSGeo/grass/pull/3962
- [ ] https://github.com/OSGeo/grass/pull/3963
- [ ] https://github.com/OSGeo/grass/pull/3964
- [ ] https://github.com/OSGeo/grass/pull/3965
- [ ] The follow-up PR after https://github.com/OSGeo/grass/pull/3965 for the real fixes in gui/wxpython folder

That way, the fixes in the above PRs will stay fixed in future.