### PR TITLE
style(gui): [DRAFT] Sort and group imports for gui/wxpython

### DIFF
--- a/doc/gui/wxpython/example/dialogs.py
+++ b/doc/gui/wxpython/example/dialogs.py
@@ -20,11 +20,11 @@ import wx
 # So we need to import it before any of the GUI code.
 # NOTE: in this particular case, we don't really need the grass library;
 # NOTE: we import it just for the side effects of gettext.install()
-import grass
+import grass  # isort: split
 
 from core import globalvar
-from gui_core.dialogs import SimpleDialog
 from gui_core import gselect
+from gui_core.dialogs import SimpleDialog
 
 
 class ExampleMapDialog(SimpleDialog):

--- a/doc/gui/wxpython/example/frame.py
+++ b/doc/gui/wxpython/example/frame.py
@@ -18,6 +18,7 @@ for details.
 
 import os
 import sys
+
 import wx
 
 # this enables to run application standalone (> python example/frame.py )
@@ -26,19 +27,18 @@ if __name__ == "__main__":
 
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
-from grass.script import core as gcore
+from grass.script import core as gcore  # isort: split
 
-from gui_core.mapdisp import SingleMapPanel, FrameMixin
-from mapwin.buffered import BufferedMapWindow
-from mapwin.base import MapWindowProperties
-from mapdisp import statusbar as sb
-from core.render import Map
-from core.debug import Debug
-from core.gcmd import RunCommand, GError
 from core import globalvar
-
-from example.toolbars import ExampleMapToolbar, ExampleMiscToolbar, ExampleMainToolbar
+from core.debug import Debug
+from core.gcmd import GError, RunCommand
+from core.render import Map
 from example.dialogs import ExampleMapDialog
+from example.toolbars import ExampleMainToolbar, ExampleMapToolbar, ExampleMiscToolbar
+from gui_core.mapdisp import FrameMixin, SingleMapPanel
+from mapdisp import statusbar as sb
+from mapwin.base import MapWindowProperties
+from mapwin.buffered import BufferedMapWindow
 
 # It is possible to call grass library functions (in C) directly via ctypes
 # however this is less stable. Example is available in trunk/doc/python/, ctypes

--- a/doc/gui/wxpython/example/g.gui.example.py
+++ b/doc/gui/wxpython/example/g.gui.example.py
@@ -32,10 +32,9 @@
 import os
 import sys
 
-
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
-import grass.script.core as gcore
+import grass.script.core as gcore  # isort: split
 
 if __name__ == "__main__":
     wxbase = os.path.join(os.getenv("GISBASE"), "etc", "gui", "wxpython")
@@ -52,8 +51,8 @@ def main():
 
     set_gui_path()
 
-    from core.globalvar import CheckWxVersion, MAP_WINDOW_SIZE
     from core.giface import StandaloneGrassInterface
+    from core.globalvar import MAP_WINDOW_SIZE, CheckWxVersion
     from core.settings import UserSettings
     from example.frame import ExampleMapDisplay
 

--- a/doc/gui/wxpython/example/toolbars.py
+++ b/doc/gui/wxpython/example/toolbars.py
@@ -17,8 +17,7 @@ for details.
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 
 
 class ExampleMapToolbar(BaseToolbar):

--- a/gui/scripts/d.wms.py
+++ b/gui/scripts/d.wms.py
@@ -156,8 +156,8 @@
 # %end
 
 import os
-import sys
 import shutil
+import sys
 
 from grass.script import core as grass
 

--- a/gui/wxpython/animation/anim.py
+++ b/gui/wxpython/animation/anim.py
@@ -15,6 +15,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
+
 from .utils import Orientation, ReplayMode
 
 

--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -15,27 +15,27 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import wx
 
-from core.gcmd import GException, GError, GMessage
-from grass.imaging import writeAvi, writeGif, writeIms, writeSwf
+import wx
+from animation.data import AnimationData
+from animation.dialogs import EditDialog, ExportDialog, InputDialog
+from animation.temporal_manager import TemporalManager
+from animation.utils import (
+    HashCmds,
+    Orientation,
+    RenderText,
+    TemporalMode,
+    TemporalType,
+    WxImageToPil,
+    layerListToCmdsMatrix,
+    sampleCmdMatrixAndCreateNames,
+)
+from core.gcmd import GError, GException, GMessage
 from core.gthread import gThread
 from core.settings import UserSettings
 from gui_core.wrap import EmptyImage, ImageFromBitmap
 
-from animation.temporal_manager import TemporalManager
-from animation.dialogs import InputDialog, EditDialog, ExportDialog
-from animation.utils import (
-    TemporalMode,
-    TemporalType,
-    Orientation,
-    RenderText,
-    WxImageToPil,
-    sampleCmdMatrixAndCreateNames,
-    layerListToCmdsMatrix,
-    HashCmds,
-)
-from animation.data import AnimationData
+from grass.imaging import writeAvi, writeGif, writeIms, writeSwf
 
 
 class AnimationController(wx.EvtHandler):

--- a/gui/wxpython/animation/data.py
+++ b/gui/wxpython/animation/data.py
@@ -16,22 +16,22 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
 import copy
+import os
 
-from grass.script.utils import parse_key_val
-from grass.script import core as gcore
-
-from core.gcmd import GException
 from animation.nviztask import NvizTask
 from animation.utils import (
-    validateMapNames,
-    getRegisteredMaps,
     checkSeriesCompatibility,
-    validateTimeseriesName,
+    getRegisteredMaps,
     interpolate,
+    validateMapNames,
+    validateTimeseriesName,
 )
-from core.layerlist import LayerList, Layer
+from core.gcmd import GException
+from core.layerlist import Layer, LayerList
+
+from grass.script import core as gcore
+from grass.script.utils import parse_key_val
 
 
 class AnimationData:

--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -20,26 +20,41 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
-import wx
 import copy
 import datetime
+import os
+
+import wx
+import wx.lib.colourselect as csel
 import wx.lib.filebrowsebutton as filebrowse
 import wx.lib.scrolledpanel as SP
-import wx.lib.colourselect as csel
 
 try:
     from wx.adv import HyperlinkCtrl
 except ImportError:
     from wx import HyperlinkCtrl
 
-from core.gcmd import GMessage, GError, GException
+from animation.data import AnimationData, AnimLayer
+from animation.toolbars import SIMPLE_LMGR_STDS, AnimSimpleLmgrToolbar
+from animation.utils import (
+    TemporalMode,
+    getCpuCount,
+    getNameAndLayer,
+    getRegisteredMaps,
+)
 from core import globalvar
-from gui_core.dialogs import MapLayersDialog, GetImageHandlers
-from gui_core.preferences import PreferencesBaseDialog
-from gui_core.forms import GUI
+from core.gcmd import GError, GException, GMessage
 from core.settings import UserSettings
+from gui_core.dialogs import GetImageHandlers, MapLayersDialog
+from gui_core.forms import GUI
 from gui_core.gselect import Select
+from gui_core.preferences import PreferencesBaseDialog
+from gui_core.simplelmgr import (
+    SIMPLE_LMGR_RASTER,
+    SIMPLE_LMGR_TB_TOP,
+    SIMPLE_LMGR_VECTOR,
+    SimpleLayerManager,
+)
 from gui_core.widgets import FloatValidator
 from gui_core.wrap import (
     BitmapButton,
@@ -55,23 +70,8 @@ from gui_core.wrap import (
     TextCtrl,
 )
 
-from animation.utils import (
-    TemporalMode,
-    getRegisteredMaps,
-    getNameAndLayer,
-    getCpuCount,
-)
-from animation.data import AnimationData, AnimLayer
-from animation.toolbars import AnimSimpleLmgrToolbar, SIMPLE_LMGR_STDS
-from gui_core.simplelmgr import (
-    SimpleLayerManager,
-    SIMPLE_LMGR_RASTER,
-    SIMPLE_LMGR_VECTOR,
-    SIMPLE_LMGR_TB_TOP,
-)
-
-from grass.pydispatch.signal import Signal
 import grass.script.core as gcore
+from grass.pydispatch.signal import Signal
 
 
 class SpeedDialog(wx.Dialog):

--- a/gui/wxpython/animation/frame.py
+++ b/gui/wxpython/animation/frame.py
@@ -19,25 +19,24 @@ This program is free software under the GNU General Public License
 """
 
 import os
+
 import wx
 import wx.aui
+from animation.anim import Animation
+from animation.controller import AnimationController
+from animation.dialogs import PreferencesDialog, SpeedDialog
+from animation.mapwindow import AnimationWindow
+from animation.provider import BitmapPool, BitmapProvider, CleanUp, MapFilesPool
+from animation.toolbars import AnimationToolbar, MainToolbar, MiscToolbar
+from animation.utils import Orientation, ReplayMode, TemporalType
+from core import globalvar
+from core.gcmd import GWarning, RunCommand
+from gui_core.widgets import IntegerValidator
+from gui_core.wrap import Slider, StaticText, TextCtrl
 
 import grass.script as gcore
 import grass.temporal as tgis
 from grass.exceptions import FatalError
-from core import globalvar
-from gui_core.widgets import IntegerValidator
-from gui_core.wrap import StaticText, TextCtrl, Slider
-from core.gcmd import RunCommand, GWarning
-
-from animation.mapwindow import AnimationWindow
-from animation.provider import BitmapProvider, BitmapPool, MapFilesPool, CleanUp
-from animation.controller import AnimationController
-from animation.anim import Animation
-from animation.toolbars import MainToolbar, AnimationToolbar, MiscToolbar
-from animation.dialogs import SpeedDialog, PreferencesDialog
-from animation.utils import Orientation, ReplayMode, TemporalType
-
 
 MAX_COUNT = 4
 TMP_DIR = None

--- a/gui/wxpython/animation/g.gui.animation.py
+++ b/gui/wxpython/animation/g.gui.animation.py
@@ -60,17 +60,17 @@ def main():
 
     # import wx only after running parser
     # to avoid issues when only interface is needed
-    import grass.temporal as tgis
     import wx
 
+    import grass.temporal as tgis
     from grass.script.setup import set_gui_path
 
     set_gui_path()
 
+    from animation.data import AnimLayer
+    from animation.frame import MAX_COUNT, AnimationFrame
     from core.giface import StandaloneGrassInterface
     from core.layerlist import LayerList
-    from animation.frame import AnimationFrame, MAX_COUNT
-    from animation.data import AnimLayer
 
     rast = options["raster"]
     vect = options["vector"]

--- a/gui/wxpython/animation/mapwindow.py
+++ b/gui/wxpython/animation/mapwindow.py
@@ -18,6 +18,7 @@ This program is free software under the GNU General Public License
 import wx
 from core.debug import Debug
 from gui_core.wrap import BitmapFromImage, EmptyBitmap, ImageFromBitmap, PseudoDC, Rect
+
 from .utils import ComputeScaledRect
 
 

--- a/gui/wxpython/animation/nviztask.py
+++ b/gui/wxpython/animation/nviztask.py
@@ -16,11 +16,12 @@ This program is free software under the GNU General Public License
 
 import xml.etree.ElementTree as etree
 
-from core.workspace import ProcessWorkspaceFile
-from core.gcmd import RunCommand, GException
-from core.utils import GetLayerNameFromCmd
-from grass.script import task as gtask
+from core.gcmd import GException, RunCommand
 from core.settings import UserSettings
+from core.utils import GetLayerNameFromCmd
+from core.workspace import ProcessWorkspaceFile
+
+from grass.script import task as gtask
 
 
 class NvizTask:

--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -22,21 +22,20 @@ This program is free software under the GNU General Public License
 
 import os
 import sys
-import wx
 import tempfile
 from multiprocessing import Process, Queue
 
-from core.gcmd import GException, DecodeString
-from core.settings import UserSettings
+import wx
+from animation.utils import GetFileFromCmd, GetFileFromCmds, HashCmd, HashCmds
 from core.debug import Debug
+from core.gcmd import DecodeString, GException
+from core.settings import UserSettings
 from core.utils import autoCropImageFromFile
-
-from animation.utils import HashCmd, HashCmds, GetFileFromCmd, GetFileFromCmds
-from gui_core.wrap import EmptyBitmap, BitmapFromImage
+from gui_core.wrap import BitmapFromImage, EmptyBitmap
 
 import grass.script.core as gcore
-from grass.script.task import cmdlist_to_tuple
 from grass.pydispatch.signal import Signal
+from grass.script.task import cmdlist_to_tuple
 
 
 class BitmapProvider:
@@ -869,9 +868,10 @@ def read2_command(*args, **kwargs):
 def test():
     import shutil
 
-    from core.layerlist import LayerList, Layer
     from animation.data import AnimLayer
     from animation.utils import layerListToCmdsMatrix
+    from core.layerlist import Layer, LayerList
+
     import grass.temporal as tgis
 
     tgis.init()

--- a/gui/wxpython/animation/temporal_manager.py
+++ b/gui/wxpython/animation/temporal_manager.py
@@ -19,11 +19,12 @@ This program is free software under the GNU General Public License
 
 import datetime
 
-import grass.script as grass
-import grass.temporal as tgis
+from animation.utils import TemporalType, validateTimeseriesName
 from core.gcmd import GException
 from core.settings import UserSettings
-from animation.utils import validateTimeseriesName, TemporalType
+
+import grass.script as grass
+import grass.temporal as tgis
 
 
 class DataMode:

--- a/gui/wxpython/animation/toolbars.py
+++ b/gui/wxpython/animation/toolbars.py
@@ -19,10 +19,10 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from icons.icon import MetaIcon
-from gui_core.simplelmgr import SimpleLmgrToolbar
 from animation.anim import ReplayMode
+from gui_core.simplelmgr import SimpleLmgrToolbar
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from icons.icon import MetaIcon
 
 ganimIcons = {
     "speed": MetaIcon(img="move", label=_("Change animation speed")),

--- a/gui/wxpython/animation/utils.py
+++ b/gui/wxpython/animation/utils.py
@@ -18,10 +18,11 @@ This program is free software under the GNU General Public License
 @author Anna Perasova <kratochanna gmail.com>
 """
 
-import os
-import wx
 import hashlib
+import os
 from multiprocessing import cpu_count
+
+import wx
 
 try:
     from PIL import Image
@@ -30,12 +31,12 @@ try:
 except ImportError:
     hasPIL = False
 
-import grass.temporal as tgis
-import grass.script as grass
-from grass.script.utils import encode
+from core.gcmd import GException
 from gui_core.wrap import EmptyBitmap
 
-from core.gcmd import GException
+import grass.script as grass
+import grass.temporal as tgis
+from grass.script.utils import encode
 
 
 class TemporalMode:

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -25,25 +25,27 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
+import errno
+import locale
 import os
+import signal
+import subprocess
 import sys
 import time
-import errno
-import signal
 import traceback
-import locale
-import subprocess
 from threading import Thread
+
 import wx
 
 is_mswindows = sys.platform == "win32"
 if is_mswindows:
+    import msvcrt
+
     from win32file import ReadFile, WriteFile
     from win32pipe import PeekNamedPipe
-    import msvcrt
 else:
-    import select
     import fcntl
+    import select
 
 from core.debug import Debug
 from core.globalvar import SCT_EXT

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -21,35 +21,30 @@ This program is free software under the GNU General Public License
 @author Wolf Bergenheim <wolf bergenheim.net> (#962)
 """
 
-import os
-import sys
-import re
-import time
-import threading
-
-import queue as Queue
-
 import codecs
 import locale
+import os
+import queue as Queue
+import re
+import sys
+import threading
+import time
 
 import wx
+from core import globalvar
+from core.debug import Debug
+from core.gcmd import CommandThread, GError, GException
+from core.giface import Notification
+from core.settings import UserSettings
+from gui_core.forms import GUI
+from gui_core.widgets import FormNotebook
 from wx.lib.newevent import NewEvent
 
 import grass.script as grass
-from grass.script import task as gtask
-
-from grass.pydispatch.signal import Signal
-
 from grass.grassdb import history
 from grass.grassdb.history import Status
-
-from core import globalvar
-from core.gcmd import CommandThread, GError, GException
-from gui_core.forms import GUI
-from core.debug import Debug
-from core.settings import UserSettings
-from core.giface import Notification
-from gui_core.widgets import FormNotebook
+from grass.pydispatch.signal import Signal
+from grass.script import task as gtask
 
 wxCmdOutput, EVT_CMD_OUTPUT = NewEvent()
 wxCmdProgress, EVT_CMD_PROGRESS = NewEvent()

--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -19,7 +19,6 @@ import os
 import sys
 
 import grass.script as grass
-
 from grass.pydispatch.signal import Signal
 
 # to disable Abstract class not referenced
@@ -250,7 +249,7 @@ class StandaloneGrassInterface(GrassInterface):
         )
 
         # workaround, standalone grass interface should be moved to sep. file
-        from core.gconsole import GConsole, EVT_CMD_OUTPUT, EVT_CMD_PROGRESS
+        from core.gconsole import EVT_CMD_OUTPUT, EVT_CMD_PROGRESS, GConsole
 
         self._gconsole = GConsole()
         self._gconsole.Bind(EVT_CMD_PROGRESS, self._onCmdProgress)

--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -11,16 +11,16 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
+import locale
 import os
 import sys
-import locale
 
 if not os.getenv("GISBASE"):
     sys.exit("GRASS is not running. Exiting...")
 
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
-from grass.script.core import get_commands
+from grass.script.core import get_commands  # isort: split
 
 from core.debug import Debug
 

--- a/gui/wxpython/core/gthread.py
+++ b/gui/wxpython/core/gthread.py
@@ -14,17 +14,14 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (mentor: Martin Landa)
 """
 
+import queue as Queue
+import sys
 import threading
 import time
 
 import wx
-from wx.lib.newevent import NewEvent
-
-import sys
-
-import queue as Queue
-
 from core.gconsole import EVT_CMD_DONE, wxCmdDone
+from wx.lib.newevent import NewEvent
 
 wxThdTerminate, EVT_THD_TERMINATE = NewEvent()
 

--- a/gui/wxpython/core/menutree.py
+++ b/gui/wxpython/core/menutree.py
@@ -33,19 +33,18 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
+import copy
 import os
 import sys
-import copy
 import xml.etree.ElementTree as etree
 
 import wx
-
-from core.treemodel import TreeModel, ModuleNode
+from core.gcmd import GError
 from core.settings import UserSettings
+from core.toolboxes import clearMessages as clearToolboxMessages
 from core.toolboxes import expandAddons as expAddons
 from core.toolboxes import getMessages as getToolboxMessages
-from core.toolboxes import clearMessages as clearToolboxMessages
-from core.gcmd import GError
+from core.treemodel import ModuleNode, TreeModel
 
 if not os.getenv("GISBASE"):
     sys.exit("GRASS is not running. Exiting...")
@@ -249,16 +248,16 @@ if __name__ == "__main__":
 
     # FIXME: cross-dependencies
     if menu == "manager":
-        from lmgr.menudata import LayerManagerMenuData
         from core.globalvar import WXGUIDIR
+        from lmgr.menudata import LayerManagerMenuData
 
         filename = os.path.join(WXGUIDIR, "xml", "menudata.xml")
         menudata = LayerManagerMenuData(filename)
     # FIXME: since module descriptions are used again we have now the third
     # copy of the same string (one is in modules)
     elif menu == "module_tree":
-        from lmgr.menudata import LayerManagerModuleTree
         from core.globalvar import WXGUIDIR
+        from lmgr.menudata import LayerManagerModuleTree
 
         filename = os.path.join(WXGUIDIR, "xml", "module_tree_menudata.xml")
         menudata = LayerManagerModuleTree(filename)

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -21,27 +21,26 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import os
-import sys
+import copy
 import glob
 import math
-import copy
+import os
+import sys
 import tempfile
 import time
 
 import wx
-
-from grass.script import core as grass
-from grass.script.utils import try_remove, text_to_string
-from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
-from grass.pydispatch.signal import Signal
-
 from core import utils
-from core.ws import RenderWMSMgr
-from core.gcmd import GException, GError, RunCommand
 from core.debug import Debug
-from core.settings import UserSettings
+from core.gcmd import GError, GException, RunCommand
 from core.gthread import gThread
+from core.settings import UserSettings
+from core.ws import RenderWMSMgr
+
+from grass.pydispatch.signal import Signal
+from grass.script import core as grass
+from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
+from grass.script.utils import text_to_string, try_remove
 
 
 def get_tempfile_name(suffix, create=False):

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -19,15 +19,15 @@ This program is free software under the GNU General Public License
 @author Luca Delucchi <lucadeluge gmail.com> (language choice)
 """
 
+import collections.abc
+import copy
+import json
 import os
 import sys
-import copy
-import wx
-import json
-import collections.abc
 
+import wx
 from core import globalvar
-from core.gcmd import GException, GError
+from core.gcmd import GError, GException
 from core.utils import GetSettingsPath, PathJoin, rgb2str
 
 

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -12,17 +12,17 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
-import sys
 import copy
+import os
 import shutil
+import sys
 import xml.etree.ElementTree as etree
 from xml.parsers import expat
 
-import grass.script.task as gtask
 import grass.script.core as gcore
-from grass.script.utils import try_remove, decode
-from grass.exceptions import ScriptError, CalledModuleError
+import grass.script.task as gtask
+from grass.exceptions import CalledModuleError, ScriptError
+from grass.script.utils import decode, try_remove
 
 ETREE_EXCEPTIONS = (etree.ParseError, expat.ExpatError)
 

--- a/gui/wxpython/core/units.py
+++ b/gui/wxpython/core/units.py
@@ -209,6 +209,7 @@ def doc_test():
     :return: a number of failed tests
     """
     import doctest
+
     from core.utils import do_doctest_gettext_workaround
 
     do_doctest_gettext_workaround()

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -12,21 +12,21 @@ This program is free software under the GNU General Public License
 @author Jachym Cepicky
 """
 
-import os
-import sys
-import platform
 import glob
-import shlex
-import re
 import inspect
 import operator
+import os
+import platform
+import re
+import shlex
+import sys
+
+from core.debug import Debug
+from core.gcmd import RunCommand
+from core.globalvar import ETCDIR, wxPythonPhoenix
 
 from grass.script import core as grass
 from grass.script import task as gtask
-
-from core.gcmd import RunCommand
-from core.debug import Debug
-from core.globalvar import ETCDIR, wxPythonPhoenix
 
 
 def cmp(a, b):

--- a/gui/wxpython/core/watchdog.py
+++ b/gui/wxpython/core/watchdog.py
@@ -22,11 +22,8 @@ import time
 
 watchdog_used = True
 try:
+    from watchdog.events import FileSystemEventHandler, PatternMatchingEventHandler
     from watchdog.observers import Observer
-    from watchdog.events import (
-        PatternMatchingEventHandler,
-        FileSystemEventHandler,
-    )
 except ImportError:
     watchdog_used = False
     PatternMatchingEventHandler = object

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -20,10 +20,9 @@ import os
 from io import StringIO
 
 import wx
-
-from core.utils import normalize_whitespace
-from core.settings import UserSettings
 from core.gcmd import EncodeString, GetDefaultEncoding
+from core.settings import UserSettings
+from core.utils import normalize_whitespace
 from nviz.main import NvizSettings
 
 from grass.script import core as gcore

--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -17,18 +17,17 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (mentor: Martin Landa)
 """
 
-import sys
 import copy
+import sys
 import time
 
 import wx
-
-from grass.script.utils import try_remove
-from grass.script import core as grass
-from grass.exceptions import CalledModuleError
-
 from core.debug import Debug
 from core.gthread import gThread
+
+from grass.exceptions import CalledModuleError
+from grass.script import core as grass
+from grass.script.utils import try_remove
 
 try:
     haveGdal = True

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -16,28 +16,27 @@ for details.
 @author Linda Kladivova l.kladivova@seznam.cz
 """
 
-import wx
 import os
 
+import wx
 from core.debug import Debug
-from datacatalog.tree import DataCatalogTree
-from datacatalog.toolbars import DataCatalogToolbar, DataCatalogSearch
-from gui_core.infobar import InfoBar
-from datacatalog.infomanager import DataCatalogInfoManager
-from gui_core.wrap import Menu
-from gui_core.forms import GUI
 from core.settings import UserSettings
+from datacatalog.infomanager import DataCatalogInfoManager
+from datacatalog.toolbars import DataCatalogSearch, DataCatalogToolbar
+from datacatalog.tree import DataCatalogTree
+from gui_core.forms import GUI
+from gui_core.infobar import InfoBar
+from gui_core.wrap import Menu
 
-from grass.pydispatch.signal import Signal
-from grass.script.utils import clock
-from grass.script import gisenv
-
-from grass.grassdb.manage import split_mapset_path
 from grass.grassdb.checks import (
     get_reason_id_mapset_not_usable,
     is_fallback_session,
     is_first_time_user,
 )
+from grass.grassdb.manage import split_mapset_path
+from grass.pydispatch.signal import Signal
+from grass.script import gisenv
+from grass.script.utils import clock
 
 
 class DataCatalog(wx.Panel):

--- a/gui/wxpython/datacatalog/dialogs.py
+++ b/gui/wxpython/datacatalog/dialogs.py
@@ -15,9 +15,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from gui_core.widgets import FloatValidator, IntegerValidator
-from core.giface import Notification
 from core.gcmd import RunCommand
+from core.giface import Notification
+from gui_core.widgets import FloatValidator, IntegerValidator
 from gui_core.wrap import Button, StaticText, TextCtrl
 
 from grass.script import parse_key_val, region_env

--- a/gui/wxpython/datacatalog/frame.py
+++ b/gui/wxpython/datacatalog/frame.py
@@ -18,8 +18,8 @@ for details.
 """
 
 import os
-import wx
 
+import wx
 from core.globalvar import ICONDIR
 from datacatalog.catalog import DataCatalog
 from gui_core.wrap import Button

--- a/gui/wxpython/datacatalog/infomanager.py
+++ b/gui/wxpython/datacatalog/infomanager.py
@@ -19,8 +19,8 @@ This program is free software under the GNU General Public License
 
 import wx
 
-from grass.script import gisenv
 from grass.grassdb.checks import get_mapset_owner
+from grass.script import gisenv
 
 
 class DataCatalogInfoManager:

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -19,61 +19,59 @@ for details.
 @author Linda Kladivova (l.kladivova@seznam.cz)
 """
 
+import copy
 import os
 import re
-import copy
 from multiprocessing import Process, Queue, cpu_count
 
 import wx
-
-from core.gcmd import RunCommand, GError, GMessage
-from core.utils import GetListOfLocations
 from core.debug import Debug
+from core.gcmd import GError, GMessage, RunCommand
+from core.giface import StandaloneGrassInterface
 from core.gthread import gThread
+from core.settings import UserSettings
+from core.treemodel import DictFilterNode, TreeModel
+from core.utils import GetListOfLocations
 from core.watchdog import (
-    EVT_UPDATE_MAPSET,
     EVT_CURRENT_MAPSET_CHANGED,
+    EVT_UPDATE_MAPSET,
     MapsetWatchdog,
     watchdog_used,
 )
+from datacatalog.dialogs import CatalogReprojectionDialog
 from gui_core.dialogs import TextEntryDialog
-from core.giface import StandaloneGrassInterface
-from core.treemodel import TreeModel, DictFilterNode
 from gui_core.treeview import TreeView
 from gui_core.wrap import Menu
-from datacatalog.dialogs import CatalogReprojectionDialog
 from icons.icon import MetaIcon
-from core.settings import UserSettings
 from startup.guiutils import (
-    create_mapset_interactively,
-    create_location_interactively,
-    rename_mapset_interactively,
-    rename_location_interactively,
-    delete_mapsets_interactively,
-    delete_locations_interactively,
-    download_location_interactively,
-    delete_grassdb_interactively,
     can_switch_mapset_interactive,
-    switch_mapset_interactively,
+    create_location_interactively,
+    create_mapset_interactively,
+    delete_grassdb_interactively,
+    delete_locations_interactively,
+    delete_mapsets_interactively,
+    download_location_interactively,
+    get_location_name_invalid_reason,
+    get_mapset_name_invalid_reason,
     get_reason_mapset_not_removable,
     get_reasons_location_not_removable,
-    get_mapset_name_invalid_reason,
-    get_location_name_invalid_reason,
+    rename_location_interactively,
+    rename_mapset_interactively,
+    switch_mapset_interactively,
 )
-from grass.grassdb.manage import rename_mapset, rename_location
-
-from grass.pydispatch.signal import Signal
 
 import grass.script as gscript
-from grass.script import gisenv
-from grass.grassdb.data import map_exists
+from grass.exceptions import CalledModuleError
 from grass.grassdb.checks import (
     get_mapset_owner,
-    is_mapset_locked,
     is_different_mapset_owner,
     is_first_time_user,
+    is_mapset_locked,
 )
-from grass.exceptions import CalledModuleError
+from grass.grassdb.data import map_exists
+from grass.grassdb.manage import rename_location, rename_mapset
+from grass.pydispatch.signal import Signal
+from grass.script import gisenv
 
 
 def getLocationTree(gisdbase, location, queue, mapsets=None, lazy=False):

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -30,16 +30,16 @@ This program is free software under the GNU General Public License
         (GSoC 2012, mentor: Martin Landa)
 """
 
-import os
-import locale
-import tempfile
 import copy
-import math
 import functools
+import locale
+import math
+import os
+import tempfile
 
-from core import globalvar
 import wx
 import wx.lib.mixins.listctrl as listmix
+from core import globalvar
 
 if globalvar.wxPythonPhoenix:
     try:
@@ -48,20 +48,17 @@ if globalvar.wxPythonPhoenix:
         import wx.lib.agw.flatnotebook as FN
 else:
     import wx.lib.flatnotebook as FN
+
 import wx.lib.scrolledpanel as scrolled
-
-import grass.script as grass
-from grass.script.utils import decode
-
+from core.debug import Debug
+from core.gcmd import GError, GException, GMessage, GWarning, RunCommand
+from core.settings import UserSettings
+from core.utils import ListOfCatsToRange, cmp
+from dbmgr.dialogs import AddColumnDialog, ModifyTableRecord
 from dbmgr.sqlbuilder import SQLBuilderSelect, SQLBuilderUpdate
-from core.gcmd import RunCommand, GException, GError, GMessage, GWarning
-from core.utils import ListOfCatsToRange
+from dbmgr.vinfo import CreateDbInfoDesc, GetDbEncoding, GetUnicodeValue, VectorDBInfo
 from gui_core.dialogs import CreateNewVector
 from gui_core.widgets import GNotebook
-from dbmgr.vinfo import VectorDBInfo, GetUnicodeValue, CreateDbInfoDesc, GetDbEncoding
-from core.debug import Debug
-from dbmgr.dialogs import ModifyTableRecord, AddColumnDialog
-from core.settings import UserSettings
 from gui_core.wrap import (
     Button,
     CheckBox,
@@ -74,7 +71,9 @@ from gui_core.wrap import (
     StaticText,
     TextCtrl,
 )
-from core.utils import cmp
+
+import grass.script as grass
+from grass.script.utils import decode
 
 
 class Log:

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -20,12 +20,11 @@ This program is free software under the GNU General Public License
 
 import wx
 import wx.lib.scrolledpanel as scrolled
-
-from core.gcmd import RunCommand, GError
 from core.debug import Debug
-from dbmgr.vinfo import VectorDBInfo, GetUnicodeValue, GetDbEncoding
-from gui_core.widgets import IntegerValidator, FloatValidator
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
+from core.gcmd import GError, RunCommand
+from dbmgr.vinfo import GetDbEncoding, GetUnicodeValue, VectorDBInfo
+from gui_core.widgets import FloatValidator, IntegerValidator
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 
 class DisplayAttributesDialog(wx.Dialog):

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -28,24 +28,22 @@ This program is free software under the GNU General Public License
 import os
 import sys
 
-from core import globalvar
 import wx
-
-from grass.pydispatch.signal import Signal
-
-from core.gcmd import RunCommand, GError, GMessage
-from dbmgr.vinfo import CreateDbInfoDesc, VectorDBInfo, GetUnicodeValue
+from core import globalvar
+from core.gcmd import GError, GMessage, RunCommand
+from dbmgr.vinfo import CreateDbInfoDesc, GetUnicodeValue, VectorDBInfo
 from gui_core.wrap import (
     ApplyButton,
     Button,
     ClearButton,
     CloseButton,
-    TextCtrl,
-    StaticText,
     StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 import grass.script as grass
+from grass.pydispatch.signal import Signal
 
 
 class SQLBuilder(wx.Frame):

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -17,11 +17,11 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-
+from core.gcmd import GError, RunCommand
+from core.settings import UserSettings
 from gui_core.gselect import VectorDBInfo as VectorDBInfoBase
 from gui_core.wrap import StaticText
-from core.gcmd import RunCommand, GError
-from core.settings import UserSettings
+
 import grass.script as grass
 
 

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -10,10 +10,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-from datetime import date
 import string
+import sys
+from datetime import date
 from shutil import copy
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/gui/wxpython/gcp/g.gui.gcp.py
+++ b/gui/wxpython/gcp/g.gui.gcp.py
@@ -53,8 +53,8 @@ def main():
 
     set_gui_path()
 
-    from core.settings import UserSettings
     from core.giface import StandaloneGrassInterface
+    from core.settings import UserSettings
     from gcp.manager import GCPWizard
 
     driver = UserSettings.Get(group="display", key="driver", subkey="type")

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -28,47 +28,44 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 
 import wx
-from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 import wx.lib.colourselect as csel
-
 from core import globalvar
+from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 
 if globalvar.wxPythonPhoenix:
     from wx import adv as wiz
 else:
     from wx import wizard as wiz
 
-import grass.script as grass
-
-
 from core import utils
+from core.gcmd import GError, GMessage, GWarning, RunCommand
+from core.giface import Notification
 from core.render import Map
-from gui_core.gselect import Select, LocationSelect, MapsetSelect
-from gui_core.dialogs import GroupDialog
-from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from gcp.mapdisplay import MapPanel
-from core.giface import Notification
+from gui_core.dialogs import GroupDialog
+from gui_core.gselect import LocationSelect, MapsetSelect, Select
+from gui_core.mapdisp import FrameMixin
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    CheckListBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
+    CheckListBox,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
+
+import grass.script as grass
 
 #
 # global variables

--- a/gui/wxpython/gcp/mapdisplay.py
+++ b/gui/wxpython/gcp/mapdisplay.py
@@ -18,21 +18,19 @@ This program is free software under the GNU General Public License
 import os
 import platform
 
-from core import globalvar
+import gcp.statusbar as sbgcp
+import mapdisp.statusbar as sb
 import wx
 import wx.aui
-
-from mapdisp.toolbars import MapToolbar
-from gcp.toolbars import GCPDisplayToolbar, GCPManToolbar
-from mapdisp.gprint import PrintOptions
+from core import globalvar
 from core.gcmd import GMessage
+from gcp.toolbars import GCPDisplayToolbar, GCPManToolbar
 from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.mapdisp import SingleMapPanel
 from gui_core.wrap import Menu
+from mapdisp.gprint import PrintOptions
+from mapdisp.toolbars import MapToolbar
 from mapwin.buffered import BufferedMapWindow
-
-import mapdisp.statusbar as sb
-import gcp.statusbar as sbgcp
 
 # for standalone app
 cmdfilename = None

--- a/gui/wxpython/gcp/statusbar.py
+++ b/gui/wxpython/gcp/statusbar.py
@@ -17,10 +17,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.gcmd import GMessage
-from mapdisp.statusbar import SbItem, SbTextItem
 from gui_core.wrap import SpinCtrl
+from mapdisp.statusbar import SbItem, SbTextItem
 
 
 class SbGoToGCP(SbItem):

--- a/gui/wxpython/gcp/toolbars.py
+++ b/gui/wxpython/gcp/toolbars.py
@@ -16,8 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -17,28 +17,27 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from wx.lib import ogl
-
-from gui_core.dialogs import TextEntryDialog as CustomTextEntryDialog
-from gui_core.wrap import TextEntryDialog as wxTextEntryDialog, NewId, Menu
-from gui_core.forms import GUI
-from core.gcmd import GException, GError
-
-from gmodeler.model import (
-    ModelRelation,
-    ModelAction,
-    ModelData,
-    ModelLoop,
-    ModelCondition,
-    ModelComment,
-)
+from core.gcmd import GError, GException
 from gmodeler.dialogs import (
-    ModelRelationDialog,
+    ModelConditionDialog,
     ModelDataDialog,
     ModelLoopDialog,
-    ModelConditionDialog,
+    ModelRelationDialog,
 )
 from gmodeler.giface import GraphicalModelerGrassInterface
+from gmodeler.model import (
+    ModelAction,
+    ModelComment,
+    ModelCondition,
+    ModelData,
+    ModelLoop,
+    ModelRelation,
+)
+from gui_core.dialogs import TextEntryDialog as CustomTextEntryDialog
+from gui_core.forms import GUI
+from gui_core.wrap import Menu, NewId
+from gui_core.wrap import TextEntryDialog as wxTextEntryDialog
+from wx.lib import ogl
 
 
 class ModelCanvas(ogl.ShapeCanvas):

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -27,26 +27,24 @@ import os
 
 import wx
 import wx.lib.mixins.listctrl as listmix
-
-from core import globalvar
-from core import utils
-from gui_core.widgets import SearchModuleWidget, SimpleValidator
+from core import globalvar, utils
 from core.gcmd import GError
-from gui_core.dialogs import SimpleDialog, MapLayersDialogForModeler
+from gmodeler.model import ModelAction, ModelCondition, ModelData
+from gui_core.dialogs import MapLayersDialogForModeler, SimpleDialog
+from gui_core.gselect import ElementSelect, Select
 from gui_core.prompt import GPromptSTC
-from gui_core.gselect import Select, ElementSelect
-from lmgr.menudata import LayerManagerMenuData
+from gui_core.widgets import SearchModuleWidget, SimpleValidator
 from gui_core.wrap import (
     Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
-    NewId,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    NewId,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-from gmodeler.model import ModelData, ModelAction, ModelCondition
+from lmgr.menudata import LayerManagerMenuData
 
 
 class ModelDataDialog(SimpleDialog):

--- a/gui/wxpython/gmodeler/frame.py
+++ b/gui/wxpython/gmodeler/frame.py
@@ -18,12 +18,10 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-
 from core import globalvar
-from gui_core.menu import Menu as Menubar
-
 from gmodeler.menudata import ModelerMenuData
 from gmodeler.panels import ModelerPanel
+from gui_core.menu import Menu as Menubar
 
 
 class ModelerFrame(wx.Frame):

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -31,36 +31,33 @@ This program is free software under the GNU General Public License
 @actinia, PyWPS, Python parameterization Ondrej Pesek <pesej.ondrek gmail.com>
 """
 
-import os
-import getpass
 import copy
-import re
+import getpass
 import mimetypes
+import os
+import re
 import time
-
 import xml.etree.ElementTree as etree
+from abc import ABC, abstractmethod
 from xml.sax import saxutils
 
 import wx
-from abc import ABC, abstractmethod
-from wx.lib import ogl
-
-from core import globalvar
-from core import utils
+from core import globalvar, utils
 from core.gcmd import (
-    GMessage,
-    GException,
     GError,
-    RunCommand,
-    GWarning,
     GetDefaultEncoding,
+    GException,
+    GMessage,
+    GWarning,
+    RunCommand,
 )
-from core.settings import UserSettings
 from core.giface import StandaloneGrassInterface
+from core.settings import UserSettings
+from gmodeler.giface import GraphicalModelerGrassInterface
 from gui_core.forms import GUI, CmdPanel
 from gui_core.widgets import GNotebook
 from gui_core.wrap import Button, IsDark
-from gmodeler.giface import GraphicalModelerGrassInterface
+from wx.lib import ogl
 
 from grass.script import task as gtask
 

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -18,17 +18,16 @@ This program is free software under the GNU General Public License
 @author Python exports Ondrej Pesek <pesej.ondrek gmail.com>
 """
 
+import math
 import os
-import time
+import random
 import stat
 import tempfile
-import random
-import math
+import time
 
 import wx
-
-from wx.lib import ogl
 from core import globalvar
+from wx.lib import ogl
 
 if globalvar.wxPythonPhoenix:
     try:
@@ -37,59 +36,58 @@ if globalvar.wxPythonPhoenix:
         import wx.lib.agw.flatnotebook as FN
 else:
     import wx.lib.flatnotebook as FN
-from wx.lib.newevent import NewEvent
 
-from core.gconsole import GConsole, EVT_CMD_RUN, EVT_CMD_DONE, EVT_CMD_PREPARE
 from core.debug import Debug
-from core.gcmd import GMessage, GException, GWarning, GError
-from core.settings import UserSettings
+from core.gcmd import GError, GException, GMessage, GWarning
+from core.gconsole import EVT_CMD_DONE, EVT_CMD_PREPARE, EVT_CMD_RUN, GConsole
 from core.giface import Notification
-
-from gui_core.widgets import GNotebook
-from gui_core.goutput import GConsoleWindow
-from gui_core.dialogs import GetImageHandlers
-from gui_core.dialogs import TextEntryDialog as CustomTextEntryDialog
-from gui_core.ghelp import ShowAboutDialog
-from gui_core.forms import GUI
-from gui_core.pystc import PyStc, SetDarkMode
-from gui_core.wrap import (
-    Button,
-    EmptyBitmap,
-    ImageFromBitmap,
-    StaticBox,
-    StaticText,
-    StockCursor,
-    TextCtrl,
-    IsDark,
+from core.settings import UserSettings
+from gmodeler.canvas import ModelCanvas, ModelEvtHandler
+from gmodeler.dialogs import (
+    ItemListCtrl,
+    ModelDataDialog,
+    ModelSearchDialog,
+    VariableListCtrl,
 )
-from main_window.page import MainPageBase
 from gmodeler.giface import GraphicalModelerGrassInterface
 from gmodeler.model import (
     Model,
     ModelAction,
-    ModelRelation,
-    ModelLoop,
-    ModelCondition,
     ModelComment,
-    WriteModelFile,
+    ModelCondition,
     ModelDataSeries,
     ModelDataSingle,
+    ModelLoop,
+    ModelRelation,
     WriteActiniaFile,
+    WriteModelFile,
     WritePythonFile,
     WritePyWPSFile,
 )
-from gmodeler.dialogs import (
-    ModelDataDialog,
-    ModelSearchDialog,
-    VariableListCtrl,
-    ItemListCtrl,
-)
-from gmodeler.canvas import ModelCanvas, ModelEvtHandler
-from gmodeler.toolbars import ModelerToolbar
 from gmodeler.preferences import PreferencesDialog, PropertiesDialog
+from gmodeler.toolbars import ModelerToolbar
+from gui_core.dialogs import GetImageHandlers
+from gui_core.dialogs import TextEntryDialog as CustomTextEntryDialog
+from gui_core.forms import GUI
+from gui_core.ghelp import ShowAboutDialog
+from gui_core.goutput import GConsoleWindow
+from gui_core.pystc import PyStc, SetDarkMode
+from gui_core.widgets import GNotebook
+from gui_core.wrap import (
+    Button,
+    EmptyBitmap,
+    ImageFromBitmap,
+    IsDark,
+    StaticBox,
+    StaticText,
+    StockCursor,
+    TextCtrl,
+)
+from main_window.page import MainPageBase
+from wx.lib.newevent import NewEvent
 
-from grass.script.utils import try_remove
 from grass.script import core as grass
+from grass.script.utils import try_remove
 
 wxModelDone, EVT_MODEL_DONE = NewEvent()
 

--- a/gui/wxpython/gmodeler/preferences.py
+++ b/gui/wxpython/gmodeler/preferences.py
@@ -17,11 +17,10 @@ This program is free software under the GNU General Public License
 
 import wx
 import wx.lib.colourselect as csel
-
 from core import globalvar
-from gui_core.preferences import PreferencesBaseDialog
 from core.settings import UserSettings
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
+from gui_core.preferences import PreferencesBaseDialog
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText, TextCtrl
 
 
 class PreferencesDialog(PreferencesBaseDialog):

--- a/gui/wxpython/gmodeler/toolbars.py
+++ b/gui/wxpython/gmodeler/toolbars.py
@@ -17,9 +17,7 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
-
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -32,30 +32,25 @@ import os
 import re
 
 import wx
-
-from grass.script import core as grass
-from grass.script.utils import naturally_sorted, try_remove
-
-from grass.pydispatch.signal import Signal
-
 from core import globalvar
-from core.gcmd import GError, RunCommand, GMessage
+from core.debug import Debug
+from core.gcmd import GError, GMessage, RunCommand
+from core.settings import UserSettings
+from core.utils import is_shell_running
 from gui_core.gselect import (
     LocationSelect,
     MapsetSelect,
-    Select,
     OgrTypeSelect,
+    Select,
     SubGroupSelect,
 )
-from gui_core.widgets import SingleSymbolPanel, SimpleValidator, MapValidator
-from core.settings import UserSettings
-from core.debug import Debug
-from core.utils import is_shell_running
+from gui_core.widgets import MapValidator, SimpleValidator, SingleSymbolPanel
 from gui_core.wrap import (
     Button,
     CheckListBox,
     EmptyBitmap,
     HyperlinkCtrl,
+    ListBox,
     Menu,
     NewId,
     Slider,
@@ -63,8 +58,11 @@ from gui_core.wrap import (
     StaticBox,
     StaticText,
     TextCtrl,
-    ListBox,
 )
+
+from grass.pydispatch.signal import Signal
+from grass.script import core as grass
+from grass.script.utils import naturally_sorted, try_remove
 
 
 class SimpleDialog(wx.Dialog):

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -46,24 +46,20 @@ COPYING coming with GRASS for details.
 @author Stepan Turek <stepan.turek seznam.cz> (CoordinatesSelect)
 """
 
-import sys
-import textwrap
-import os
+import codecs
 import copy
 import locale
+import os
 import queue as Queue
-
-import codecs
-
+import sys
+import textwrap
+import xml.etree.ElementTree as etree
 from threading import Thread
 
 import wx
-
 import wx.lib.colourselect as csel
 import wx.lib.filebrowsebutton as filebrowse
 from wx.lib.newevent import NewEvent
-
-import xml.etree.ElementTree as etree
 
 # needed when started from command line and for testing
 if __name__ == "__main__":
@@ -77,45 +73,40 @@ if __name__ == "__main__":
 
     set_gui_path()
 
-from grass.pydispatch.signal import Signal
-
-from grass.script import core as grass
-from grass.script import task as gtask
-
-from core import globalvar
-from gui_core.widgets import (
-    StaticWrapText,
-    ScrolledPanel,
-    ColorTablesComboBox,
-    BarscalesComboBox,
-    NArrowsComboBox,
-)
-from gui_core.ghelp import HelpPanel
-from gui_core import gselect
-from core import gcmd
-from core import utils
+from core import gcmd, globalvar, utils
+from core.debug import Debug
+from core.giface import Notification, StandaloneGrassInterface
 from core.settings import UserSettings
+from gui_core import gselect
+from gui_core.ghelp import HelpPanel
 from gui_core.widgets import (
+    BarscalesComboBox,
+    ColorTablesComboBox,
     FloatValidator,
     FormListbook,
     FormNotebook,
+    LayersList,
+    NArrowsComboBox,
     PlacementValidator,
+    ScrolledPanel,
+    StaticWrapText,
 )
-from core.giface import Notification, StandaloneGrassInterface
-from gui_core.widgets import LayersList
 from gui_core.wrap import (
+    BitmapButton,
     BitmapFromImage,
     Button,
-    CloseButton,
-    StaticText,
-    StaticBox,
-    SpinCtrl,
     CheckBox,
-    BitmapButton,
-    TextCtrl,
+    CloseButton,
     NewId,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-from core.debug import Debug
+
+from grass.pydispatch.signal import Signal
+from grass.script import core as grass
+from grass.script import task as gtask
 
 wxUpdateDialog, EVT_DIALOG_UPDATE = NewEvent()
 
@@ -2513,7 +2504,7 @@ class CmdPanel(wx.Panel):
         # are we running from command line?
         # add 'command output' tab regardless standalone dialog
         if self.parent.GetName() == "MainFrame" and self.parent.get_dcmd is None:
-            from core.gconsole import GConsole, EVT_CMD_RUN, EVT_CMD_DONE
+            from core.gconsole import EVT_CMD_DONE, EVT_CMD_RUN, GConsole
             from gui_core.goutput import GConsoleWindow
 
             self._gconsole = GConsole(guiparent=self.notebook, giface=self._giface)

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -17,12 +17,13 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import os
 import codecs
+import os
 import platform
 import re
-import textwrap
 import sys
+import textwrap
+
 import wx
 from wx.html import HtmlWindow
 
@@ -31,11 +32,9 @@ try:
 except ImportError:
     from wx.lib.hyperlink import HyperLinkCtrl
 try:
-    from wx.adv import AboutDialogInfo
-    from wx.adv import AboutBox
+    from wx.adv import AboutBox, AboutDialogInfo
 except ImportError:
-    from wx import AboutDialogInfo
-    from wx import AboutBox
+    from wx import AboutBox, AboutDialogInfo
 
 import grass.script as grass
 from grass.exceptions import CalledModuleError
@@ -47,11 +46,11 @@ if __name__ == "__main__":
     set_gui_path()
 
 from core import globalvar
-from core.gcmd import GError, DecodeString
+from core.debug import Debug
+from core.gcmd import DecodeString, GError
 from core.settings import UserSettings
 from gui_core.widgets import FormNotebook, ScrolledPanel
 from gui_core.wrap import Button, StaticText, TextCtrl
-from core.debug import Debug
 
 
 class AboutWindow(wx.Frame):

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -34,18 +34,17 @@ if __name__ == "__main__":
 
 from core.gcmd import GError
 from core.gconsole import (
-    GConsole,
+    EVT_CMD_DONE,
     EVT_CMD_OUTPUT,
     EVT_CMD_PROGRESS,
     EVT_CMD_RUN,
-    EVT_CMD_DONE,
+    GConsole,
     Notification,
 )
 from core.globalvar import CheckWxVersion, wxPythonPhoenix
+from core.settings import UserSettings
 from gui_core.prompt import GPromptSTC
 from gui_core.wrap import Button, ClearButton, StaticText
-from core.settings import UserSettings
-
 
 GC_EMPTY = 0
 GC_PROMPT = 1

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -42,49 +42,46 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (VectorCategorySelect)
 """
 
+import ctypes
+import glob
 import os
 import sys
-import glob
-import ctypes
 
 import wx
-
-from core import globalvar
-from wx.lib import buttons
 import wx.lib.filebrowsebutton as filebrowse
-
-
-import grass.script as grass
-from grass.script import task as gtask
-from grass.exceptions import CalledModuleError
-
-from gui_core.widgets import ManageSettingsWidget, CoordinatesValidator
-
-from core.gcmd import RunCommand, GError, GMessage, GWarning, GException
+from core import globalvar
+from core.debug import Debug
+from core.gcmd import GError, GException, GMessage, GWarning, RunCommand
+from core.settings import UserSettings
 from core.utils import (
+    GetFormats,
     GetListOfLocations,
     GetListOfMapsets,
-    GetFormats,
+    GetSettingsPath,
+    GetValidLayerName,
+    GetVectorNumberOfLayers,
+    ListSortLower,
     rasterFormatExtension,
     vectorFormatExtension,
 )
-from core.utils import GetSettingsPath, GetValidLayerName, ListSortLower
-from core.utils import GetVectorNumberOfLayers
-from core.settings import UserSettings
-from core.debug import Debug
 from gui_core.vselect import VectorSelectBase
+from gui_core.widgets import CoordinatesValidator, ManageSettingsWidget
 from gui_core.wrap import (
-    TreeCtrl,
     Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Panel,
-    ComboPopup,
     ComboCtrl,
+    ComboPopup,
+    Panel,
+    StaticBox,
+    StaticText,
+    TextCtrl,
+    TreeCtrl,
 )
+from wx.lib import buttons
 
+import grass.script as grass
+from grass.exceptions import CalledModuleError
 from grass.pydispatch.signal import Signal
+from grass.script import task as gtask
 
 
 class Select(ComboCtrl):
@@ -3152,11 +3149,11 @@ class SignatureSelect(wx.ComboBox):
             return
         try:
             from grass.lib.imagery import (
+                I_SIGFILE_TYPE_LIBSVM,
                 I_SIGFILE_TYPE_SIG,
                 I_SIGFILE_TYPE_SIGSET,
-                I_SIGFILE_TYPE_LIBSVM,
-                I_signatures_list_by_type,
                 I_free_signatures_list,
+                I_signatures_list_by_type,
             )
         except ImportError as e:
             sys.stderr.write(

--- a/gui/wxpython/gui_core/infobar.py
+++ b/gui/wxpython/gui_core/infobar.py
@@ -17,6 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import sys
+
 import wx
 import wx.aui
 

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -23,7 +23,6 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
 from core.debug import Debug
 from gui_core.toolbars import ToolSwitcher
 from gui_core.wrap import NewId

--- a/gui/wxpython/gui_core/menu.py
+++ b/gui/wxpython/gui_core/menu.py
@@ -23,16 +23,16 @@ This program is free software under the GNU General Public License
 @author Tomas Zigo <tomas.zigo slovanet.sk> RecentFilesMenu
 """
 
-import re
 import os
-import wx
+import re
 
-from core import globalvar
-from core import utils
+import wx
+from core import globalvar, utils
 from core.gcmd import EncodeString
 from gui_core.treeview import CTreeView
-from gui_core.wrap import Button, SearchCtrl
+from gui_core.wrap import Button
 from gui_core.wrap import Menu as MenuWidget
+from gui_core.wrap import SearchCtrl
 from icons.icon import MetaIcon
 
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -36,33 +36,32 @@ except ImportError:
     havePwd = False
 
 import wx
-from wx.lib.agw import aui
 import wx.lib.colourselect as csel
 import wx.lib.mixins.listctrl as listmix
 import wx.lib.scrolledpanel as SP
+from core import globalvar
+from core.debug import Debug
+from core.gcmd import GError
+from core.globalvar import CheckWxVersion
+from core.settings import UserSettings
+from core.utils import GetColorTables, ListOfMapsets, ReadEpsgCodes
+from gui_core.dialogs import DefaultFontDialog, SymbolDialog
+from gui_core.widgets import ColorTablesComboBox, IntegerValidator
+from gui_core.wrap import (
+    BitmapButton,
+    Button,
+    CheckListCtrlMixin,
+    ListCtrl,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
+)
+from wx.lib.agw import aui
 
-from grass.pydispatch.signal import Signal
 import grass.script as grass
 from grass.exceptions import OpenError
-
-from core import globalvar
-from core.gcmd import GError
-from core.utils import ListOfMapsets, GetColorTables, ReadEpsgCodes
-from core.settings import UserSettings
-from core.globalvar import CheckWxVersion
-from gui_core.dialogs import SymbolDialog, DefaultFontDialog
-from gui_core.widgets import IntegerValidator, ColorTablesComboBox
-from core.debug import Debug
-from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    BitmapButton,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    ListCtrl,
-    CheckListCtrlMixin,
-)
+from grass.pydispatch.signal import Signal
 
 
 class PreferencesBaseDialog(wx.Dialog):

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -23,17 +23,13 @@ import sys
 
 import wx
 import wx.stc
-
-from grass.script import core as grass
-from grass.script import task as gtask
+from core import globalvar, utils
+from core.gcmd import DecodeString, EncodeString, GError
 
 from grass.grassdb import history
-
 from grass.pydispatch.signal import Signal
-
-from core import globalvar
-from core import utils
-from core.gcmd import EncodeString, DecodeString, GError
+from grass.script import core as grass
+from grass.script import task as gtask
 
 
 class GPrompt:

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -10,12 +10,11 @@ for details.
 :authors: Martin Landa
 """
 
-import sys
 import os
 import stat
-
-from io import StringIO
+import sys
 import time
+from io import StringIO
 
 import wx
 
@@ -28,15 +27,15 @@ if __name__ == "__main__":
 
     set_gui_path()
 
-from core.gcmd import GError
-from gui_core.pystc import PyStc, SetDarkMode
 from core import globalvar
+from core.debug import Debug
+from core.gcmd import GError
 from core.menutree import MenuTreeModelBuilder
-from gui_core.menu import RecentFilesMenu, Menu
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.menu import Menu, RecentFilesMenu
+from gui_core.pystc import PyStc, SetDarkMode
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import IsDark
 from icons.icon import MetaIcon
-from core.debug import Debug
 
 # TODO: add validation: call/import pep8 (error message if not available)
 # TODO: run with parameters (alternatively, just use console or GUI)

--- a/gui/wxpython/gui_core/query.py
+++ b/gui/wxpython/gui_core/query.py
@@ -15,10 +15,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
+from core.treemodel import DictNode, TreeModel
 from gui_core.treeview import TreeListView
-from gui_core.wrap import Button, StaticText, Menu, NewId
-from core.treemodel import TreeModel, DictNode
+from gui_core.wrap import Button, Menu, NewId, StaticText
 
 from grass.pydispatch.signal import Signal
 
@@ -272,8 +271,8 @@ def PrepareQueryResults(coordinates, result):
 
 def test():
     app = wx.App()
-    from grass.script import vector as gvect
     from grass.script import raster as grast
+    from grass.script import vector as gvect
 
     testdata1 = grast.raster_what(
         map=("elevation_shade@PERMANENT", "landclass96"),

--- a/gui/wxpython/gui_core/simplelmgr.py
+++ b/gui/wxpython/gui_core/simplelmgr.py
@@ -26,14 +26,14 @@ if __name__ == "__main__":
 
     set_gui_path()
 
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from icons.icon import MetaIcon
-from gui_core.forms import GUI
-from gui_core.dialogs import SetOpacityDialog
-from gui_core.wrap import CheckListBox, Menu, NewId
-from core.utils import GetLayerNameFromCmd
 from core.gcmd import GError
 from core.layerlist import LayerList
+from core.utils import GetLayerNameFromCmd
+from gui_core.dialogs import SetOpacityDialog
+from gui_core.forms import GUI
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.wrap import CheckListBox, Menu, NewId
+from icons.icon import MetaIcon
 
 SIMPLE_LMGR_RASTER = 1
 SIMPLE_LMGR_VECTOR = 2

--- a/gui/wxpython/gui_core/toolbars.py
+++ b/gui/wxpython/gui_core/toolbars.py
@@ -16,21 +16,19 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import platform
 import os
+import platform
+from collections import defaultdict
 
 import wx
-from wx.lib.agw import aui
-
 from core import globalvar
 from core.debug import Debug
-from icons.icon import MetaIcon
-from collections import defaultdict
 from core.globalvar import IMGDIR
-from gui_core.wrap import ToolBar, Menu, BitmapButton, NewId
+from gui_core.wrap import BitmapButton, Menu, NewId, ToolBar
+from icons.icon import MetaIcon
+from wx.lib.agw import aui
 
 from grass.pydispatch.signal import Signal
-
 
 BaseIcons = {
     "display": MetaIcon(

--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -15,8 +15,8 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from wx.lib.mixins.treemixin import VirtualTree, ExpansionState
 from core.globalvar import hasAgw, wxPythonPhoenix
+from wx.lib.mixins.treemixin import ExpansionState, VirtualTree
 
 try:
     import wx.lib.agw.customtreectrl as CT
@@ -36,7 +36,7 @@ if __name__ == "__main__":
 
     set_gui_path()
 
-from core.treemodel import TreeModel, DictNode
+from core.treemodel import DictNode, TreeModel
 from gui_core.wrap import CustomTreeCtrl
 
 from grass.pydispatch.signal import Signal

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -19,14 +19,12 @@ This program is free software under the GNU General Public License
 @author Matej Krejci <matejkrejci gmail.com> (mentor: Martin Landa)
 """
 
-import string
 import random
+import string
 
 import wx
 import wx.lib.mixins.listctrl as listmix
-
-from core.gcmd import GMessage, GError, GWarning
-from core.gcmd import RunCommand
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from gui_core.wrap import Button, ListCtrl
 
 import grass.script as grass

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -51,16 +51,16 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
-import string
 import re
+import string
+import sys
 from bisect import bisect
 from datetime import datetime
-from core.globalvar import wxPythonPhoenix
 
 import wx
 import wx.lib.mixins.listctrl as listmix
 import wx.lib.scrolledpanel as SP
+from core.globalvar import wxPythonPhoenix
 from wx.lib.stattext import GenStaticText
 from wx.lib.wordwrap import wordwrap
 
@@ -84,27 +84,26 @@ if wxPythonPhoenix:
 else:
     from wx import PyValidator as Validator
 
-from grass.script import core as grass
-
-from grass.pydispatch.signal import Signal
-
 from core import globalvar
-from core.gcmd import GMessage, GError
 from core.debug import Debug
+from core.gcmd import GError, GMessage
 from gui_core.wrap import (
     Button,
-    SearchCtrl,
-    Slider,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Menu,
-    Rect,
+    CheckListCtrlMixin,
     EmptyBitmap,
     ListCtrl,
+    Menu,
     NewId,
-    CheckListCtrlMixin,
+    Rect,
+    SearchCtrl,
+    Slider,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
+
+from grass.pydispatch.signal import Signal
+from grass.script import core as grass
 
 
 class NotebookController:

--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -16,13 +16,13 @@ This program is free software under the GNU General Public License
 """
 
 import sys
+
 import wx
 import wx.lib.agw.floatspin as fs
 import wx.lib.colourselect as csel
 import wx.lib.filebrowsebutton as filebrowse
 import wx.lib.scrolledpanel as scrolled
-from wx.lib import expando
-from wx.lib import buttons
+from wx.lib import buttons, expando
 from wx.lib.agw.aui import tabart
 
 try:
@@ -34,21 +34,25 @@ from core.globalvar import CheckWxVersion, gtk3, wxPythonPhoenix
 
 if wxPythonPhoenix:
     import wx.adv
-    from wx.adv import OwnerDrawnComboBox as OwnerDrawnComboBox_
-    from wx.adv import ODCB_PAINTING_CONTROL, ODCB_PAINTING_SELECTED
+    from wx.adv import (
+        HL_ALIGN_LEFT,
+        HL_CONTEXTMENU,
+        ODCB_PAINTING_CONTROL,
+        ODCB_PAINTING_SELECTED,
+    )
     from wx.adv import BitmapComboBox as BitmapComboBox_
     from wx.adv import HyperlinkCtrl as HyperlinkCtrl_
-    from wx.adv import HL_ALIGN_LEFT, HL_CONTEXTMENU
+    from wx.adv import OwnerDrawnComboBox as OwnerDrawnComboBox_
 
     ComboPopup = wx.ComboPopup
     wxComboCtrl = wx.ComboCtrl
 else:
     import wx.combo
-    from wx.combo import OwnerDrawnComboBox as OwnerDrawnComboBox_
+    from wx import HL_ALIGN_LEFT, HL_CONTEXTMENU
+    from wx import HyperlinkCtrl as HyperlinkCtrl_
     from wx.combo import ODCB_PAINTING_CONTROL, ODCB_PAINTING_SELECTED
     from wx.combo import BitmapComboBox as BitmapComboBox_
-    from wx import HyperlinkCtrl as HyperlinkCtrl_
-    from wx import HL_ALIGN_LEFT, HL_CONTEXTMENU
+    from wx.combo import OwnerDrawnComboBox as OwnerDrawnComboBox_
 
     ComboPopup = wx.combo.ComboPopup
     wxComboCtrl = wx.combo.ComboCtrl

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -22,19 +22,14 @@ from datetime import datetime
 
 import wx
 import wx.lib.scrolledpanel as SP
-
-from gui_core.wrap import SearchCtrl, StaticText, StaticBox, Button
+from core.gcmd import GError
+from gui_core.wrap import Button, SearchCtrl, StaticBox, StaticText
 from history.tree import HistoryBrowserTree
 from icons.icon import MetaIcon
 
 import grass.script as gs
-
 from grass.grassdb import history
-
 from grass.pydispatch.signal import Signal
-
-from core.gcmd import GError
-
 
 TRANSLATION_KEYS = {
     "timestamp": _("Timestamp:"),

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -17,32 +17,23 @@ for details.
 @author Tomas Zigo
 """
 
-import re
 import copy
 import datetime
+import re
 
 import wx
-
 from core import globalvar
-
 from core.gcmd import GError, GException
-from core.utils import (
-    parse_mapcalc_cmd,
-    replace_module_cmd_special_flags,
-    split,
-)
+from core.treemodel import DictFilterNode, TreeModel
+from core.utils import parse_mapcalc_cmd, replace_module_cmd_special_flags, split
 from gui_core.forms import GUI
-from core.treemodel import TreeModel, DictFilterNode
 from gui_core.treeview import CTreeView
 from gui_core.wrap import Menu
-
 from icons.icon import MetaIcon
-
-from grass.pydispatch.signal import Signal
 
 from grass.grassdb import history
 from grass.grassdb.history import Status
-
+from grass.pydispatch.signal import Signal
 
 # global variables for node types
 TIME_PERIOD = "time_period"

--- a/gui/wxpython/iclass/dialogs.py
+++ b/gui/wxpython/iclass/dialogs.py
@@ -21,26 +21,25 @@ for details.
 """
 
 import os
-import wx
 
+import wx
 import wx.lib.mixins.listctrl as listmix
 import wx.lib.scrolledpanel as scrolled
-
 from core import globalvar
+from core.gcmd import GError, GMessage, RunCommand
 from core.settings import UserSettings
-from core.gcmd import GError, RunCommand, GMessage
-from gui_core.dialogs import SimpleDialog, GroupDialog
 from gui_core import gselect
+from gui_core.dialogs import GroupDialog, SimpleDialog
 from gui_core.widgets import SimpleValidator
 from gui_core.wrap import (
-    CheckBox,
     Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
+    CheckBox,
+    ListCtrl,
     Menu,
     NewId,
-    ListCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 
 import grass.script as grass

--- a/gui/wxpython/iclass/digit.py
+++ b/gui/wxpython/iclass/digit.py
@@ -17,14 +17,13 @@ for details.
 """
 
 import wx
-
+from core.gcmd import GWarning
 from vdigit.mapwindow import VDigitWindow
 from vdigit.wxdigit import IVDigit
-from vdigit.wxdisplay import DisplayDriver, TYPE_AREA
-from core.gcmd import GWarning
+from vdigit.wxdisplay import TYPE_AREA, DisplayDriver
 
 try:
-    from grass.lib.gis import G_verbose, G_set_verbose
+    from grass.lib.gis import G_set_verbose, G_verbose
     from grass.lib.vector import *
     from grass.lib.vedit import *
 except ImportError:

--- a/gui/wxpython/iclass/frame.py
+++ b/gui/wxpython/iclass/frame.py
@@ -18,13 +18,12 @@ for details.
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
-import os
 import copy
+import os
 import tempfile
+from ctypes import *
 
 import wx
-
-from ctypes import *
 
 try:
     from grass.lib.imagery import *
@@ -36,37 +35,35 @@ except ImportError as e:
     haveIClass = False
     errMsg = _("Loading imagery lib failed.\n%s") % e
 
-import grass.script as grass
-
+from core import globalvar
+from core.gcmd import GError, GMessage, RunCommand
+from core.render import Map
+from dbmgr.vinfo import VectorDBInfo
+from gui_core.dialogs import SetOpacityDialog
+from gui_core.mapdisp import DoubleMapPanel, FrameMixin
+from gui_core.wrap import Menu
+from iclass.dialogs import (
+    IClassCategoryManagerDialog,
+    IClassExportAreasDialog,
+    IClassGroupDialog,
+    IClassMapDialog,
+    IClassSignatureFileDialog,
+)
+from iclass.digit import IClassVDigit, IClassVDigitWindow
+from iclass.plots import PlotPanel
+from iclass.statistics import StatisticsData
+from iclass.toolbars import (
+    IClassMapManagerToolbar,
+    IClassMapToolbar,
+    IClassMiscToolbar,
+    IClassToolbar,
+)
 from mapdisp import statusbar as sb
 from mapdisp.main import StandaloneMapDisplayGrassInterface
 from mapwin.buffered import BufferedMapWindow
 from vdigit.toolbars import VDigitToolbar
-from gui_core.mapdisp import DoubleMapPanel, FrameMixin
-from core import globalvar
-from core.render import Map
-from core.gcmd import RunCommand, GMessage, GError
-from gui_core.dialogs import SetOpacityDialog
-from gui_core.wrap import Menu
-from dbmgr.vinfo import VectorDBInfo
 
-from iclass.digit import IClassVDigitWindow, IClassVDigit
-from iclass.toolbars import (
-    IClassMapToolbar,
-    IClassMiscToolbar,
-    IClassToolbar,
-    IClassMapManagerToolbar,
-)
-from iclass.statistics import StatisticsData
-from iclass.dialogs import (
-    IClassCategoryManagerDialog,
-    IClassGroupDialog,
-    IClassSignatureFileDialog,
-    IClassExportAreasDialog,
-    IClassMapDialog,
-)
-from iclass.plots import PlotPanel
-
+import grass.script as grass
 from grass.pydispatch.signal import Signal
 
 

--- a/gui/wxpython/iclass/g.gui.iclass.py
+++ b/gui/wxpython/iclass/g.gui.iclass.py
@@ -50,6 +50,7 @@
 # %end
 
 import os
+
 import grass.script as gscript
 
 
@@ -63,8 +64,8 @@ def main():
 
     set_gui_path()
 
-    from core.settings import UserSettings
     from core import globalvar
+    from core.settings import UserSettings
     from iclass.frame import IClassMapDisplay
 
     group_name = subgroup_name = map_name = trainingmap_name = None

--- a/gui/wxpython/iclass/plots.py
+++ b/gui/wxpython/iclass/plots.py
@@ -16,10 +16,9 @@ for details.
 """
 
 import wx
-
-from wx.lib import plot
 import wx.lib.scrolledpanel as scrolled
 from core.gcmd import GError
+from wx.lib import plot
 
 
 class PlotPanel(scrolled.ScrolledPanel):

--- a/gui/wxpython/iclass/toolbars.py
+++ b/gui/wxpython/iclass/toolbars.py
@@ -19,12 +19,11 @@ for details.
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from icons.icon import MetaIcon
-from iclass.dialogs import IClassMapDialog, ContrastColor
 from gui_core.forms import GUI
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import StaticText
+from iclass.dialogs import ContrastColor, IClassMapDialog
+from icons.icon import MetaIcon
 
 import grass.script as grass
 

--- a/gui/wxpython/icons/icon.py
+++ b/gui/wxpython/icons/icon.py
@@ -15,17 +15,16 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
+import copy
 import os
 import sys
-import copy
 
 import wx
-
 from core.settings import UserSettings
 
 # default icon set
-from .grass_icons import iconSet as g_iconSet
 from .grass_icons import iconPath as g_iconPath
+from .grass_icons import iconSet as g_iconSet
 
 iconSetDefault = g_iconSet
 iconPathDefault = g_iconPath

--- a/gui/wxpython/image2target/g.gui.image2target.py
+++ b/gui/wxpython/image2target/g.gui.image2target.py
@@ -119,8 +119,8 @@ def main():
 
     set_gui_path()
 
-    from core.settings import UserSettings
     from core.giface import StandaloneGrassInterface
+    from core.settings import UserSettings
     from image2target.ii2t_manager import GCPWizard
 
     driver = UserSettings.Get(group="display", key="driver", subkey="type")

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -20,32 +20,31 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com> (various updates)
 """
 
-import os
-import sys
-import shutil
 import copy
-import platform
 import getpass
+import os
+import platform
+import shutil
+import sys
 
-from core import globalvar
 import wx
 import wx.lib.mixins.listctrl as listmix
-
-from grass.script import core as grass
-
-from core.gcmd import GMessage, GError, DecodeString, RunCommand
+from core import globalvar
+from core.gcmd import DecodeString, GError, GMessage, RunCommand
 from core.utils import GetListOfLocations, GetListOfMapsets
-from location_wizard.dialogs import RegionDef
 from gui_core.dialogs import TextEntryDialog
 from gui_core.widgets import GenericValidator, StaticWrapText
 from gui_core.wrap import (
+    BitmapFromImage,
     Button,
     ListCtrl,
-    StaticText,
     StaticBox,
+    StaticText,
     TextCtrl,
-    BitmapFromImage,
 )
+from location_wizard.dialogs import RegionDef
+
+from grass.script import core as grass
 
 
 class GRASSStartup(wx.Frame):

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -34,47 +34,44 @@ This program is free software under the GNU General Public License
 
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 
 import wx
-from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 import wx.lib.colourselect as csel
-
 from core import globalvar
+from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 
 if globalvar.wxPythonPhoenix:
     from wx import adv as wiz
 else:
     from wx import wizard as wiz
 
-import grass.script as grass
-
-
 from core import utils
+from core.gcmd import GError, GMessage, GWarning, RunCommand
+from core.giface import Notification
 from core.render import Map
-from gui_core.gselect import Select, LocationSelect, MapsetSelect
-from gui_core.dialogs import GroupDialog
-from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from gcp.mapdisplay import MapPanel
-from core.giface import Notification
+from gui_core.dialogs import GroupDialog
+from gui_core.gselect import LocationSelect, MapsetSelect, Select
+from gui_core.mapdisp import FrameMixin
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    CheckListBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
+    CheckListBox,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
+
+import grass.script as grass
 
 #
 # global variables
@@ -1528,6 +1525,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 )
                 # Get the elevation height from the map given by i.ortho.elev
                 from subprocess import PIPE
+
                 from grass.pygrass.modules import Module
 
                 rwhat = Module(

--- a/gui/wxpython/image2target/ii2t_mapdisplay.py
+++ b/gui/wxpython/image2target/ii2t_mapdisplay.py
@@ -18,21 +18,19 @@ This program is free software under the GNU General Public License
 import os
 import platform
 
-from core import globalvar
+import gcp.statusbar as sbgcp
+import mapdisp.statusbar as sb
 import wx
 import wx.aui
-
-from mapdisp.toolbars import MapToolbar
-from gcp.toolbars import GCPDisplayToolbar, GCPManToolbar
-from mapdisp.gprint import PrintOptions
+from core import globalvar
 from core.gcmd import GMessage
+from gcp.toolbars import GCPDisplayToolbar, GCPManToolbar
 from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.mapdisp import SingleMapPanel
 from gui_core.wrap import Menu
+from mapdisp.gprint import PrintOptions
+from mapdisp.toolbars import MapToolbar
 from mapwin.buffered import BufferedMapWindow
-
-import mapdisp.statusbar as sb
-import gcp.statusbar as sbgcp
 
 # for standalone app
 cmdfilename = None

--- a/gui/wxpython/image2target/ii2t_statusbar.py
+++ b/gui/wxpython/image2target/ii2t_statusbar.py
@@ -17,10 +17,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.gcmd import GMessage
-from mapdisp.statusbar import SbItem, SbTextItem
 from gui_core.wrap import SpinCtrl
+from mapdisp.statusbar import SbItem, SbTextItem
 
 
 class SbGoToGCP(SbItem):

--- a/gui/wxpython/image2target/ii2t_toolbars.py
+++ b/gui/wxpython/image2target/ii2t_toolbars.py
@@ -16,8 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/iscatt/controllers.py
+++ b/gui/wxpython/iscatt/controllers.py
@@ -21,27 +21,25 @@ This program is free software under the GNU General Public License
 """
 
 from copy import deepcopy
+
 import wx
-
-
-from core.gcmd import GError, GMessage, RunCommand, GWarning
-from core.settings import UserSettings
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from core.gthread import gThread
+from core.settings import UserSettings
+from iclass.dialogs import IClassGroupDialog
+from iscatt.dialogs import AddScattPlotDialog, ExportCategoryRaster
 from iscatt.iscatt_core import (
+    MAX_NCELLS,
+    MAX_SCATT_SIZE,
+    WARN_NCELLS,
+    WARN_SCATT_SIZE,
     Core,
-    idBandsToidScatt,
     GetRasterInfo,
     GetRegion,
-    MAX_SCATT_SIZE,
-    WARN_SCATT_SIZE,
-    MAX_NCELLS,
-    WARN_NCELLS,
+    idBandsToidScatt,
 )
-from iscatt.dialogs import AddScattPlotDialog, ExportCategoryRaster
-from iclass.dialogs import IClassGroupDialog
 
 import grass.script as grass
-
 from grass.pydispatch.signal import Signal
 
 

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -12,18 +12,19 @@ This program is free software under the GNU General Public License
 """
 
 import sys
-import numpy as np
+from ctypes import *
 from multiprocessing import Process, Queue
 
-from ctypes import *
+import numpy as np
 
 try:
-    from grass.lib.imagery import *
     from grass.lib.gis import G_get_window
+    from grass.lib.imagery import *
 except ImportError as e:
     sys.stderr.write(_("Loading ctypes libs failed"))
 
 from core.gcmd import GException
+
 from grass.script import encode
 
 

--- a/gui/wxpython/iscatt/dialogs.py
+++ b/gui/wxpython/iscatt/dialogs.py
@@ -19,16 +19,15 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from gui_core.gselect import Select
 import wx.lib.colourselect as csel
-
-import grass.script as grass
-
 from core import globalvar
 from core.gcmd import GMessage
 from core.settings import UserSettings
 from gui_core.dialogs import SimpleDialog
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox, TextCtrl
+from gui_core.gselect import Select
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText, TextCtrl
+
+import grass.script as grass
 
 
 class AddScattPlotDialog(wx.Dialog):

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -21,20 +21,18 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-import wx.lib.scrolledpanel as scrolled
 import wx.lib.mixins.listctrl as listmix
-
+import wx.lib.scrolledpanel as scrolled
 from core import globalvar
 from core.gcmd import GError, GMessage
-
 from gui_core.dialogs import SetOpacityDialog
-from gui_core.wrap import StaticBox, Menu, ListCtrl
-from iscatt.controllers import ScattsManager
-from iscatt.toolbars import MainToolbar, EditingToolbar, CategoryToolbar
-from iscatt.iscatt_core import idScattToidBands
-from iscatt.dialogs import ManageBusyCursorMixin, RenameClassDialog
-from iscatt.plots import ScatterPlotWidget
+from gui_core.wrap import ListCtrl, Menu, StaticBox
 from iclass.dialogs import ContrastColor
+from iscatt.controllers import ScattsManager
+from iscatt.dialogs import ManageBusyCursorMixin, RenameClassDialog
+from iscatt.iscatt_core import idScattToidBands
+from iscatt.plots import ScatterPlotWidget
+from iscatt.toolbars import CategoryToolbar, EditingToolbar, MainToolbar
 
 try:
     from agw import aui

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -20,19 +20,16 @@ This program is free software under the GNU General Public License
 
 import os
 
-import numpy as np
-
 # used iclass perimeters algorithm instead of convolve2d
 # from matplotlib.path import Path
 # from scipy.signal import convolve2d
+from math import ceil, floor, sqrt
 
-from math import sqrt, ceil, floor
-
+import numpy as np
 from core.gcmd import GException, RunCommand
+from iscatt.core_c import ComputeScatts, CreateCatRast, Rasterize, UpdateCatRast
 
 import grass.script as grass
-
-from iscatt.core_c import CreateCatRast, ComputeScatts, UpdateCatRast, Rasterize
 
 MAX_SCATT_SIZE = 4100 * 4100
 WARN_SCATT_SIZE = 2000 * 2000

--- a/gui/wxpython/iscatt/plots.py
+++ b/gui/wxpython/iscatt/plots.py
@@ -16,29 +16,29 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (mentor: Martin Landa)
 """
 
-import wx
-import numpy as np
+from copy import deepcopy
 from math import ceil
 from multiprocessing import Process, Queue
 
-from copy import deepcopy
-from iscatt.core_c import MergeArrays, ApplyColormap
-from iscatt.dialogs import ManageBusyCursorMixin
-from iscatt.utils import dist_point_to_segment
+import numpy as np
+import wx
 from core.settings import UserSettings
 from gui_core.wrap import Menu, NewId
+from iscatt.core_c import ApplyColormap, MergeArrays
+from iscatt.dialogs import ManageBusyCursorMixin
+from iscatt.utils import dist_point_to_segment
 
 try:
     import matplotlib
 
     matplotlib.use("WXAgg")
-    from matplotlib.figure import Figure
-    from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
-    from matplotlib.lines import Line2D
-    from matplotlib.artist import Artist
-    from matplotlib.patches import Polygon, Ellipse
-    import matplotlib.image as mi
     import matplotlib.colors as mcolors
+    import matplotlib.image as mi
+    from matplotlib.artist import Artist
+    from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
+    from matplotlib.figure import Figure
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Ellipse, Polygon
 except ImportError as e:
     raise ImportError(
         _(

--- a/gui/wxpython/iscatt/toolbars.py
+++ b/gui/wxpython/iscatt/toolbars.py
@@ -15,10 +15,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from icons.icon import MetaIcon
-from gui_core.toolbars import BaseToolbar, BaseIcons
 from core.gcmd import RunCommand
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from icons.icon import MetaIcon
 from iscatt.dialogs import SettingsDialog
 
 

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -18,15 +18,15 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (menu customization)
 """
 
-import sys
 import os
-import stat
 import platform
 import re
+import stat
+import sys
 
-from core import globalvar
 import wx
 import wx.aui
+from core import globalvar
 
 try:
     import wx.lib.agw.flatnotebook as FN
@@ -36,54 +36,55 @@ except ImportError:
 if os.path.join(globalvar.ETCDIR, "python") not in sys.path:
     sys.path.append(os.path.join(globalvar.ETCDIR, "python"))
 
-from grass.script import core as grass
-from grass.script.utils import decode
-
-from core.gcmd import RunCommand, GError, GMessage
-from core.settings import UserSettings, GetDisplayVectSettings
-from core.utils import SetAddOnPath, GetLayerNameFromCmd, command2ltype, get_shell_pid
-from core.watchdog import (
-    EVT_UPDATE_MAPSET,
-    EVT_CURRENT_MAPSET_CHANGED,
-    MapsetWatchdog,
-)
-from gui_core.preferences import MapsetAccess, PreferencesDialog
-from lmgr.layertree import LayerTree, LMIcons
-from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
-from gui_core.widgets import GNotebook, FormNotebook
-from core.gconsole import GConsole, EVT_IGNORED_CMD_RUN
+from core.debug import Debug
+from core.gcmd import GError, GMessage, RunCommand
+from core.gconsole import EVT_IGNORED_CMD_RUN, GConsole
 from core.giface import Notification
-from gui_core.goutput import GConsoleWindow, GC_PROMPT
+from core.settings import GetDisplayVectSettings, UserSettings
+from core.utils import GetLayerNameFromCmd, SetAddOnPath, command2ltype, get_shell_pid
+from core.watchdog import EVT_CURRENT_MAPSET_CHANGED, EVT_UPDATE_MAPSET, MapsetWatchdog
+from datacatalog.catalog import DataCatalog
 from gui_core.dialogs import (
-    LocationDialog,
-    MapsetDialog,
     CreateNewVector,
     GroupDialog,
+    LocationDialog,
     MapLayersDialog,
+    MapsetDialog,
     QuitDialog,
 )
-from gui_core.menu import SearchModuleWindow
-from gui_core.menu import Menu as GMenu
-from core.debug import Debug
-from lmgr.toolbars import LMWorkspaceToolbar, LMToolsToolbar
-from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
-from lmgr.statusbar import SbMain
-from lmgr.workspace import WorkspaceManager
-from lmgr.pyshell import PyShellWindow
-from lmgr.giface import LayerManagerGrassInterface
-from mapdisp.frame import MapDisplay
-from datacatalog.catalog import DataCatalog
-from history.browser import HistoryBrowser
 from gui_core.forms import GUI
+from gui_core.goutput import GC_PROMPT, GConsoleWindow
+from gui_core.menu import Menu as GMenu
+from gui_core.menu import SearchModuleWindow
+from gui_core.preferences import MapsetAccess, PreferencesDialog
+from gui_core.widgets import FormNotebook, GNotebook
 from gui_core.wrap import Menu, TextEntryDialog
+from history.browser import HistoryBrowser
+from lmgr.giface import LayerManagerGrassInterface
+from lmgr.layertree import LayerTree, LMIcons
+from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
+from lmgr.pyshell import PyShellWindow
+from lmgr.statusbar import SbMain
+from lmgr.toolbars import (
+    DisplayPanelToolbar,
+    LMMiscToolbar,
+    LMNvizToolbar,
+    LMToolsToolbar,
+    LMWorkspaceToolbar,
+)
+from lmgr.workspace import WorkspaceManager
+from mapdisp.frame import MapDisplay
 from startup.guiutils import (
     can_switch_mapset_interactive,
-    switch_mapset_interactively,
-    create_mapset_interactively,
     create_location_interactively,
+    create_mapset_interactively,
+    switch_mapset_interactively,
 )
+
 from grass.grassdb.checks import is_first_time_user
 from grass.grassdb.history import Status
+from grass.script import core as grass
+from grass.script.utils import decode
 
 
 class GMFrame(wx.Frame):
@@ -1684,7 +1685,7 @@ class GMFrame(wx.Frame):
             This documentation is actually documentation of some
             component related to gui_core/menu.py file.
         """
-        from iclass.frame import IClassMapDisplay, haveIClass, errMsg
+        from iclass.frame import IClassMapDisplay, errMsg, haveIClass
 
         if not haveIClass:
             GError(
@@ -1718,8 +1719,8 @@ class GMFrame(wx.Frame):
                 if tree.GetLayerInfo(layer, key="type") == "raster":
                     rasters.append(tree.GetLayerInfo(layer, key="maplayer").GetName())
             if len(rasters) >= 2:
-                from core.layerlist import LayerList
                 from animation.data import AnimLayer
+                from core.layerlist import LayerList
 
                 layerList = LayerList()
                 layer = AnimLayer()

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -15,9 +15,10 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com>
 """
 
-from grass.pydispatch.signal import Signal
 from core.giface import Notification
 from core.utils import GetLayerNameFromCmd
+
+from grass.pydispatch.signal import Signal
 
 
 class Layer:

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -17,6 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import sys
+
 import wx
 
 try:
@@ -29,24 +30,23 @@ try:
 except ImportError:
     from wx.lib.mixins import treemixin
 
-from grass.script import core as grass
-from grass.script import vector as gvector
-from grass.script import utils as gutils
-
 from core import globalvar
-from gui_core.dialogs import SqlQueryFrame, SetOpacityDialog, TextEntryDialog
-from gui_core.forms import GUI
-from core.render import Map
-from core.utils import GetLayerNameFromCmd, ltype2command
 from core.debug import Debug
-from core.settings import UserSettings, GetDisplayVectSettings
-from vdigit.main import haveVDigit
-from core.gcmd import GWarning, GError, RunCommand
-from icons.icon import MetaIcon
+from core.gcmd import GError, GWarning, RunCommand
+from core.render import Map
+from core.settings import GetDisplayVectSettings, UserSettings
+from core.utils import GetLayerNameFromCmd, ltype2command
+from gui_core.dialogs import SetOpacityDialog, SqlQueryFrame, TextEntryDialog
+from gui_core.forms import GUI
 from gui_core.widgets import MapValidator
-from gui_core.wrap import Menu, GenBitmapButton, TextCtrl, NewId
+from gui_core.wrap import GenBitmapButton, Menu, NewId, TextCtrl
+from icons.icon import MetaIcon
 from lmgr.giface import LayerManagerGrassInterfaceForMapDisplay
+from vdigit.main import haveVDigit
 
+from grass.script import core as grass
+from grass.script import utils as gutils
+from grass.script import vector as gvector
 
 TREE_ITEM_HEIGHT = 25
 

--- a/gui/wxpython/lmgr/menudata.py
+++ b/gui/wxpython/lmgr/menudata.py
@@ -17,10 +17,10 @@ This program is free software under the GNU General Public License
 
 import os
 
+from core.gcmd import GError
+from core.globalvar import WXGUIDIR
 from core.menutree import MenuTreeModelBuilder
 from core.toolboxes import getMenudataFile
-from core.globalvar import WXGUIDIR
-from core.gcmd import GError
 
 
 class LayerManagerMenuData(MenuTreeModelBuilder):

--- a/gui/wxpython/lmgr/pyshell.py
+++ b/gui/wxpython/lmgr/pyshell.py
@@ -19,18 +19,17 @@ This program is free software under the GNU General Public License
 """
 
 import io
-from contextlib import redirect_stdout
 import sys
+from contextlib import redirect_stdout
 
 import wx
+from core.globalvar import CheckWxVersion
+from gui_core.pystc import SetDarkMode
+from gui_core.wrap import Button, ClearButton, IsDark
 from wx.py.shell import Shell as PyShell
 from wx.py.version import VERSION
 
 import grass.script as grass
-
-from gui_core.wrap import Button, ClearButton, IsDark
-from gui_core.pystc import SetDarkMode
-from core.globalvar import CheckWxVersion
 
 
 class PyShellWindow(wx.Panel):

--- a/gui/wxpython/lmgr/statusbar.py
+++ b/gui/wxpython/lmgr/statusbar.py
@@ -18,12 +18,11 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-import grass.script as gs
-
 from core.gcmd import RunCommand
 from core.watchdog import watchdog_used
 from gui_core.wrap import Button
+
+import grass.script as gs
 
 
 class SbMain:

--- a/gui/wxpython/lmgr/toolbars.py
+++ b/gui/wxpython/lmgr/toolbars.py
@@ -24,7 +24,7 @@ This program is free software under the GNU General Public License
 """
 
 from core.gcmd import RunCommand
-from gui_core.toolbars import BaseToolbar, AuiToolbar, BaseIcons
+from gui_core.toolbars import AuiToolbar, BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -15,16 +15,14 @@ for details.
 
 import os
 import tempfile
-
 import xml.etree.ElementTree as etree
 
 import wx
 import wx.aui
-
-from core.settings import UserSettings
-from core.gcmd import RunCommand, GError, GMessage
-from core.workspace import ProcessWorkspaceFile, WriteWorkspaceFile
 from core.debug import Debug
+from core.gcmd import GError, GMessage, RunCommand
+from core.settings import UserSettings
+from core.workspace import ProcessWorkspaceFile, WriteWorkspaceFile
 from gui_core.menu import RecentFilesMenu
 
 

--- a/gui/wxpython/location_wizard/base.py
+++ b/gui/wxpython/location_wizard/base.py
@@ -17,7 +17,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-from gui_core.wrap import StaticText, TextCtrl, Button, CheckBox
+from gui_core.wrap import Button, CheckBox, StaticText, TextCtrl
 
 
 class BaseClass(wx.Object):

--- a/gui/wxpython/location_wizard/dialogs.py
+++ b/gui/wxpython/location_wizard/dialogs.py
@@ -22,11 +22,10 @@ import os
 
 import wx
 import wx.lib.scrolledpanel as scrolled
-
 from core import globalvar
 from core.gcmd import RunCommand
+from gui_core.wrap import Button, StaticBox, StaticText, TextCtrl
 from location_wizard.base import BaseClass
-from gui_core.wrap import Button, StaticText, StaticBox, TextCtrl
 
 
 class RegionDef(BaseClass, wx.Dialog):
@@ -757,6 +756,7 @@ class SelectTransformDialog(wx.Dialog):
 
 def testRegionDef():
     import wx.lib.inspection
+
     import grass.script as gscript
 
     app = wx.App()

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -34,9 +34,9 @@ This program is free software under the GNU General Public License
 @author Hamish Bowman (planetary ellipsoids)
 """
 
-import os
-import locale
 import functools
+import locale
+import os
 
 import wx
 import wx.lib.mixins.listctrl as listmix
@@ -44,36 +44,34 @@ from core import globalvar
 
 if globalvar.wxPythonPhoenix:
     from wx import adv as wiz
-    from wx.adv import Wizard
-    from wx.adv import WizardPageSimple
+    from wx.adv import Wizard, WizardPageSimple
 else:
     from wx import wizard as wiz
-    from wx.wizard import Wizard
-    from wx.wizard import WizardPageSimple
-import wx.lib.scrolledpanel as scrolled
+    from wx.wizard import Wizard, WizardPageSimple
 
+import wx.lib.scrolledpanel as scrolled
 from core import utils
+from core.gcmd import GError, GWarning, RunCommand
 from core.utils import cmp
-from core.gcmd import RunCommand, GError, GWarning
 from gui_core.widgets import GenericMultiValidator
 from gui_core.wrap import (
-    SpinCtrl,
-    SearchCtrl,
-    StaticText,
-    TextCtrl,
     Button,
     CheckBox,
-    StaticBox,
-    NewId,
-    ListCtrl,
     HyperlinkCtrl,
+    ListCtrl,
+    NewId,
+    SearchCtrl,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 from location_wizard.dialogs import SelectTransformDialog
 
-from grass.grassdb.checks import location_exists
-from grass.script import decode
-from grass.script import core as grass
 from grass.exceptions import OpenError
+from grass.grassdb.checks import location_exists
+from grass.script import core as grass
+from grass.script import decode
 
 global coordsys
 global north

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -19,11 +19,11 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (menu customization)
 """
 
-import sys
 import os
-import stat
 import platform
 import re
+import stat
+import sys
 
 from core import globalvar
 
@@ -42,54 +42,56 @@ except ImportError:
 if os.path.join(globalvar.ETCDIR, "python") not in sys.path:
     sys.path.append(os.path.join(globalvar.ETCDIR, "python"))
 
-from grass.script import core as grass
-from grass.script.utils import decode
-
-from core.gcmd import RunCommand, GError, GMessage
-from core.settings import UserSettings, GetDisplayVectSettings
-from core.utils import SetAddOnPath, GetLayerNameFromCmd, command2ltype, get_shell_pid
-from core.watchdog import (
-    EVT_UPDATE_MAPSET,
-    EVT_CURRENT_MAPSET_CHANGED,
-    MapsetWatchdog,
-)
-from gui_core.preferences import MapsetAccess, PreferencesDialog
-from lmgr.layertree import LayerTree, LMIcons
-from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
-from main_window.notebook import MainNotebook
-from gui_core.widgets import GNotebook
-from core.gconsole import GConsole, EVT_IGNORED_CMD_RUN
+from core.debug import Debug
+from core.gcmd import GError, GMessage, RunCommand
+from core.gconsole import EVT_IGNORED_CMD_RUN, GConsole
 from core.giface import Notification
-from gui_core.goutput import GConsoleWindow, GC_PROMPT
+from core.settings import GetDisplayVectSettings, UserSettings
+from core.utils import GetLayerNameFromCmd, SetAddOnPath, command2ltype, get_shell_pid
+from core.watchdog import EVT_CURRENT_MAPSET_CHANGED, EVT_UPDATE_MAPSET, MapsetWatchdog
+from datacatalog.catalog import DataCatalog
 from gui_core.dialogs import (
-    LocationDialog,
-    MapsetDialog,
     CreateNewVector,
     GroupDialog,
+    LocationDialog,
     MapLayersDialog,
+    MapsetDialog,
     QuitDialog,
 )
-from gui_core.menu import SearchModuleWindow, Menu as GMenu
-from core.debug import Debug
-from lmgr.toolbars import LMWorkspaceToolbar, LMToolsToolbar
-from lmgr.toolbars import LMMiscToolbar, LMNvizToolbar, DisplayPanelToolbar
-from lmgr.statusbar import SbMain
-from lmgr.workspace import WorkspaceManager
-from lmgr.pyshell import PyShellWindow
-from lmgr.giface import LayerManagerGrassInterface
-from mapdisp.frame import MapPanel
-from datacatalog.catalog import DataCatalog
-from history.browser import HistoryBrowser
 from gui_core.forms import GUI
-from gui_core.wrap import Menu, TextEntryDialog, SimpleTabArt
+from gui_core.goutput import GC_PROMPT, GConsoleWindow
+from gui_core.menu import Menu as GMenu
+from gui_core.menu import SearchModuleWindow
+from gui_core.preferences import MapsetAccess, PreferencesDialog
+from gui_core.widgets import GNotebook
+from gui_core.wrap import Menu, SimpleTabArt, TextEntryDialog
+from history.browser import HistoryBrowser
+from lmgr.giface import LayerManagerGrassInterface
+from lmgr.layertree import LayerTree, LMIcons
+from lmgr.menudata import LayerManagerMenuData, LayerManagerModuleTree
+from lmgr.pyshell import PyShellWindow
+from lmgr.statusbar import SbMain
+from lmgr.toolbars import (
+    DisplayPanelToolbar,
+    LMMiscToolbar,
+    LMNvizToolbar,
+    LMToolsToolbar,
+    LMWorkspaceToolbar,
+)
+from lmgr.workspace import WorkspaceManager
+from main_window.notebook import MainNotebook
+from mapdisp.frame import MapPanel
 from startup.guiutils import (
     can_switch_mapset_interactive,
-    switch_mapset_interactively,
-    create_mapset_interactively,
     create_location_interactively,
+    create_mapset_interactively,
+    switch_mapset_interactively,
 )
+
 from grass.grassdb.checks import is_first_time_user
 from grass.grassdb.history import Status
+from grass.script import core as grass
+from grass.script.utils import decode
 
 
 class SingleWindowAuiManager(aui.AuiManager):
@@ -889,8 +891,8 @@ class GMFrame(wx.Frame):
 
     def OnGModeler(self, event=None, cmd=None):
         """Launch Graphical Modeler. See OnIClass documentation"""
-        from gmodeler.panels import ModelerPanel
         from gmodeler.menudata import ModelerMenuData
+        from gmodeler.panels import ModelerPanel
 
         gmodeler_panel = ModelerPanel(
             parent=self, giface=self._giface, statusbar=self.statusbar, dockable=True
@@ -1834,7 +1836,7 @@ class GMFrame(wx.Frame):
             This documentation is actually documentation of some
             component related to gui_core/menu.py file.
         """
-        from iclass.frame import IClassMapDisplay, haveIClass, errMsg
+        from iclass.frame import IClassMapDisplay, errMsg, haveIClass
 
         if not haveIClass:
             GError(
@@ -1868,8 +1870,8 @@ class GMFrame(wx.Frame):
                 if tree.GetLayerInfo(layer, key="type") == "raster":
                     rasters.append(tree.GetLayerInfo(layer, key="maplayer").GetName())
             if len(rasters) >= 2:
-                from core.layerlist import LayerList
                 from animation.data import AnimLayer
+                from core.layerlist import LayerList
 
                 layerList = LayerList()
                 layer = AnimLayer()

--- a/gui/wxpython/main_window/notebook.py
+++ b/gui/wxpython/main_window/notebook.py
@@ -19,11 +19,10 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-from wx.lib.agw import aui
-
 from core import globalvar
 from gui_core.wrap import SimpleTabArt
 from mapdisp.frame import MapPanel
+from wx.lib.agw import aui
 
 
 class MainPageFrame(wx.Frame):

--- a/gui/wxpython/main_window/page.py
+++ b/gui/wxpython/main_window/page.py
@@ -15,8 +15,10 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
+from gui_core.menu import Menu as GMenu
+from gui_core.menu import MenuItem as GMenuItem
+
 from grass.pydispatch.signal import Signal
-from gui_core.menu import MenuItem as GMenuItem, Menu as GMenu
 
 
 class MainPageBase:

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -22,44 +22,42 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (handlers support)
 """
 
-import os
 import copy
+import os
 
-from core import globalvar
 import wx
 import wx.aui
-
-from mapdisp.toolbars import MapToolbar, NvizIcons
-from mapdisp.gprint import PrintOptions
-from core.gcmd import GError, GMessage, RunCommand
-from core.utils import ListOfCatsToRange, GetLayerNameFromCmd
-from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
+from core import globalvar
 from core.debug import Debug
-from core.settings import UserSettings
-from gui_core.mapdisp import SingleMapPanel, FrameMixin
-from gui_core.query import QueryDialog, PrepareQueryResults
-from mapwin.buffered import BufferedMapWindow
-from mapwin.decorations import (
-    LegendController,
-    BarscaleController,
-    ArrowController,
-    DtextController,
-    LegendVectController,
-)
-from mapwin.analysis import (
-    ProfileController,
-    MeasureDistanceController,
-    MeasureAreaController,
-)
-from gui_core.forms import GUI
+from core.gcmd import GError, GMessage, RunCommand
 from core.giface import Notification
+from core.settings import UserSettings
+from core.utils import GetLayerNameFromCmd, ListOfCatsToRange
+from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
+from gui_core.forms import GUI
+from gui_core.mapdisp import FrameMixin, SingleMapPanel
+from gui_core.query import PrepareQueryResults, QueryDialog
 from gui_core.vselect import VectorSelectBase, VectorSelectHighlighter
 from gui_core.wrap import Menu
-from mapdisp import statusbar as sb
 from main_window.page import MainPageBase
+from mapdisp import statusbar as sb
+from mapdisp.gprint import PrintOptions
+from mapdisp.toolbars import MapToolbar, NvizIcons
+from mapwin.analysis import (
+    MeasureAreaController,
+    MeasureDistanceController,
+    ProfileController,
+)
+from mapwin.buffered import BufferedMapWindow
+from mapwin.decorations import (
+    ArrowController,
+    BarscaleController,
+    DtextController,
+    LegendController,
+    LegendVectController,
+)
 
 import grass.script as grass
-
 from grass.pydispatch.signal import Signal
 
 
@@ -296,7 +294,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
 
     def _addToolbarVDigit(self):
         """Add vector digitizer toolbar"""
-        from vdigit.main import haveVDigit, VDigit
+        from vdigit.main import VDigit, haveVDigit
         from vdigit.toolbars import VDigitToolbar
 
         if not haveVDigit:
@@ -401,7 +399,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
 
     def AddNviz(self):
         """Add 3D view mode window"""
-        from nviz.main import haveNviz, GLWindow, errorMsg
+        from nviz.main import GLWindow, errorMsg, haveNviz
 
         # check for GLCanvas and OpenGL
         if not haveNviz:
@@ -1606,7 +1604,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
     def AddRDigit(self):
         """Adds raster digitizer: creates toolbar and digitizer controller,
         binds events and signals."""
-        from rdigit.controller import RDigitController, EVT_UPDATE_PROGRESS
+        from rdigit.controller import EVT_UPDATE_PROGRESS, RDigitController
         from rdigit.toolbars import RDigitToolbar
 
         self.rdigit = RDigitController(self._giface, mapWindow=self.GetMapWindow())

--- a/gui/wxpython/mapdisp/gprint.py
+++ b/gui/wxpython/mapdisp/gprint.py
@@ -17,7 +17,6 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.gcmd import GMessage
 
 

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -27,33 +27,31 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (MapPanelBase)
 """  # noqa: E501
 
+import fileinput
 import os
+import shutil
 import sys
 import time
-import shutil
-import fileinput
 
-from grass.script.utils import try_remove
-from grass.script import core as grass
-from grass.script.task import cmdtuple_to_list, cmdlist_to_tuple
 from grass.pydispatch.signal import Signal
-
+from grass.script import core as grass
 from grass.script.setup import set_gui_path
+from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
+from grass.script.utils import try_remove
 
 set_gui_path()
 
 # GUI imports require path to GUI code to be set.
-from core import globalvar  # noqa: E402
 import wx  # noqa: E402
-
+from core import globalvar  # noqa: E402
 from core import utils  # noqa: E402
-from core.giface import StandaloneGrassInterface  # noqa: E402
-from core.gcmd import RunCommand  # noqa: E402
-from core.render import Map, MapLayer, RenderMapMgr  # noqa: E402
-from mapdisp.frame import MapPanel  # noqa: E402
-from gui_core.mapdisp import FrameMixin  # noqa: E402
 from core.debug import Debug  # noqa: E402
+from core.gcmd import RunCommand  # noqa: E402
+from core.giface import StandaloneGrassInterface  # noqa: E402
+from core.render import Map, MapLayer, RenderMapMgr  # noqa: E402
 from core.settings import UserSettings  # noqa: E402
+from gui_core.mapdisp import FrameMixin  # noqa: E402
+from mapdisp.frame import MapPanel  # noqa: E402
 
 # for standalone app
 monFile = {

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -27,12 +27,12 @@ This program is free software under the GNU General Public License
 """
 
 import copy
-import wx
 
+import wx
 from core import utils
 from core.gcmd import RunCommand
 from core.settings import UserSettings
-from gui_core.wrap import TextCtrl, Menu, NewId
+from gui_core.wrap import Menu, NewId, TextCtrl
 
 from grass.pydispatch.signal import Signal
 

--- a/gui/wxpython/mapdisp/test_mapdisp.py
+++ b/gui/wxpython/mapdisp/test_mapdisp.py
@@ -51,23 +51,23 @@ Module to run test map window (BufferedWidnow) and map display (MapFrame).
 
 import os
 import sys
+
 import wx
 
 import grass.script as grass
-
 from grass.script.setup import set_gui_path
 
 set_gui_path()
 
 # GUI imports require path to GUI code to be set.
-from core.settings import UserSettings  # noqa: E402
 from core.giface import StandaloneGrassInterface  # noqa: E402
+from core.render import Map  # noqa: E402
+from core.settings import UserSettings  # noqa: E402
+from gui_core.wrap import StaticText  # noqa: E402
+from mapdisp.main import LayerList  # noqa: E402
 from mapwin.base import MapWindowProperties  # noqa: E402
 from mapwin.buffered import BufferedMapWindow  # noqa: E402
-from core.render import Map  # noqa: E402
 from rlisetup.sampling_frame import RLiSetupMapPanel  # noqa: E402
-from mapdisp.main import LayerList  # noqa: E402
-from gui_core.wrap import StaticText  # noqa: E402
 
 
 class MapdispGrassInterface(StandaloneGrassInterface):

--- a/gui/wxpython/mapdisp/toolbars.py
+++ b/gui/wxpython/mapdisp/toolbars.py
@@ -17,11 +17,10 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from icons.icon import MetaIcon
 from nviz.main import haveNviz
 from vdigit.main import haveVDigit
-from icons.icon import MetaIcon
 
 MapIcons = {
     "query": MetaIcon(

--- a/gui/wxpython/mapswipe/dialogs.py
+++ b/gui/wxpython/mapswipe/dialogs.py
@@ -15,26 +15,26 @@ This program is free software under the GNU General Public License
 """
 
 import copy
-import wx
-import wx.lib.scrolledpanel as SP
-import wx.lib.colourselect as csel
 
+import wx
+import wx.lib.colourselect as csel
+import wx.lib.scrolledpanel as SP
 from core import globalvar
-from gui_core import gselect
-from gui_core.widgets import SimpleValidator
-from gui_core.preferences import PreferencesBaseDialog
 from core.gcmd import GMessage
 from core.layerlist import LayerList
 from core.settings import UserSettings
-from gui_core.wrap import SpinCtrl, Button, StaticText, StaticBox
+from gui_core import gselect
+from gui_core.preferences import PreferencesBaseDialog
 from gui_core.simplelmgr import (
-    SimpleLayerManager,
     SIMPLE_LMGR_RASTER,
-    SIMPLE_LMGR_VECTOR,
     SIMPLE_LMGR_RGB,
     SIMPLE_LMGR_TB_LEFT,
     SIMPLE_LMGR_TB_RIGHT,
+    SIMPLE_LMGR_VECTOR,
+    SimpleLayerManager,
 )
+from gui_core.widgets import SimpleValidator
+from gui_core.wrap import Button, SpinCtrl, StaticBox, StaticText
 
 from grass.pydispatch.signal import Signal
 

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -17,24 +17,23 @@ This program is free software under the GNU General Public License
 """
 
 import os
+
 import wx
-
-import grass.script as grass
-
-from gui_core.mapdisp import DoubleMapPanel, FrameMixin
-from gui_core.dialogs import GetImageHandlers
-from gui_core.wrap import Slider
-from core.render import Map
-from mapdisp import statusbar as sb
+from core import globalvar
 from core.debug import Debug
 from core.gcmd import GError, GMessage
 from core.layerlist import LayerListToRendererConverter
-from core import globalvar
-from gui_core.query import QueryDialog, PrepareQueryResults
-
-from mapswipe.toolbars import SwipeMapToolbar, SwipeMainToolbar, SwipeMiscToolbar
+from core.render import Map
+from gui_core.dialogs import GetImageHandlers
+from gui_core.mapdisp import DoubleMapPanel, FrameMixin
+from gui_core.query import PrepareQueryResults, QueryDialog
+from gui_core.wrap import Slider
+from mapdisp import statusbar as sb
+from mapswipe.dialogs import PreferencesDialog, SwipeMapDialog
 from mapswipe.mapwindow import SwipeBufferedWindow
-from mapswipe.dialogs import SwipeMapDialog, PreferencesDialog
+from mapswipe.toolbars import SwipeMainToolbar, SwipeMapToolbar, SwipeMiscToolbar
+
+import grass.script as grass
 
 
 class SwipeMapPanel(DoubleMapPanel):

--- a/gui/wxpython/mapswipe/g.gui.mapswipe.py
+++ b/gui/wxpython/mapswipe/g.gui.mapswipe.py
@@ -45,6 +45,7 @@
 # %end
 
 import os
+
 import grass.script as gscript
 
 
@@ -57,9 +58,9 @@ def main():
 
     set_gui_path()
 
-    from core.settings import UserSettings
-    from core.giface import StandaloneGrassInterface
     from core import globalvar
+    from core.giface import StandaloneGrassInterface
+    from core.settings import UserSettings
     from mapswipe.frame import SwipeMapDisplay
 
     driver = UserSettings.Get(group="display", key="driver", subkey="type")

--- a/gui/wxpython/mapswipe/mapwindow.py
+++ b/gui/wxpython/mapswipe/mapwindow.py
@@ -18,12 +18,10 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.debug import Debug
 from core.settings import UserSettings
+from gui_core.wrap import NewId, Rect
 from mapwin.buffered import BufferedMapWindow
-from gui_core.wrap import Rect, NewId
-
 
 EVT_MY_MOUSE_EVENTS = wx.NewEventType()
 EVT_MY_MOTION = wx.NewEventType()

--- a/gui/wxpython/mapswipe/toolbars.py
+++ b/gui/wxpython/mapswipe/toolbars.py
@@ -17,11 +17,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import Menu
 from icons.icon import MetaIcon
-
 
 swipeIcons = {
     "tools": MetaIcon(img="tools", label=_("Tools")),

--- a/gui/wxpython/mapwin/analysis.py
+++ b/gui/wxpython/mapwin/analysis.py
@@ -16,10 +16,10 @@ This program is free software under the GNU General Public License
 @author Anna Petrasova <kratochanna gmail.com>
 """
 
-import os
 import math
-import wx
+import os
 
+import wx
 from core import units
 from core.gcmd import RunCommand
 from core.giface import Notification

--- a/gui/wxpython/mapwin/base.py
+++ b/gui/wxpython/mapwin/base.py
@@ -20,13 +20,12 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from core.settings import UserSettings
 from core.gcmd import GError
+from core.settings import UserSettings
 from gui_core.wrap import StockCursor
 
-from grass.script import core as grass
 from grass.pydispatch.signal import Signal
+from grass.script import core as grass
 
 
 class MapWindowProperties:

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -21,36 +21,34 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (refactoring)
 """
 
-import os
-import time
 import math
+import os
 import sys
+import time
 
 import wx
-
-from grass.pydispatch.signal import Signal
-
+from core import utils
+from core.debug import Debug
+from core.gcmd import GError, GException, RunCommand
 from core.globalvar import wxPythonPhoenix
-import grass.script as grass
-
+from core.gthread import gThread
+from core.settings import UserSettings
 from gui_core.dialogs import SavedRegion
 from gui_core.wrap import (
-    DragImage,
-    PseudoDC,
-    EmptyBitmap,
     BitmapFromImage,
-    Window,
+    DragImage,
+    EmptyBitmap,
     Menu,
-    Rect,
     NewId,
+    PseudoDC,
+    Rect,
+    Window,
 )
-from core.gcmd import RunCommand, GException, GError
-from core.debug import Debug
-from core.settings import UserSettings
 from mapwin.base import MapWindowBase
-from core import utils
 from mapwin.graphics import GraphicsSet
-from core.gthread import gThread
+
+import grass.script as grass
+from grass.pydispatch.signal import Signal
 
 try:
     import grass.lib.gis as gislib

--- a/gui/wxpython/mapwin/graphics.py
+++ b/gui/wxpython/mapwin/graphics.py
@@ -18,7 +18,6 @@ This program is free software under the GNU General Public License
 from copy import copy
 
 import wx
-
 from gui_core.wrap import NewId
 
 

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -22,38 +22,36 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (split to base and derived classes)
 """
 
+import copy
 import os
 import shutil
-import copy
 import tempfile
 
 import wx
 import wx.lib.colourselect as csel
-import wx.lib.scrolledpanel as scrolled
 import wx.lib.filebrowsebutton as filebrowse
+import wx.lib.scrolledpanel as scrolled
+from core import globalvar, utils
+from core.debug import Debug as Debug
+from core.gcmd import GError, GMessage, RunCommand
+from core.render import Map
+from gui_core.forms import GUI
+from gui_core.gselect import ColumnSelect, LayerSelect, Select, VectorDBInfo
+from gui_core.widgets import ColorTablesComboBox
+from gui_core.wrap import (
+    BitmapFromImage,
+    Button,
+    CancelButton,
+    EmptyBitmap,
+    PseudoDC,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
+)
 
 import grass.script as grass
 from grass.script.task import cmdlist_to_tuple
-
-from core import globalvar
-from core import utils
-from core.gcmd import GMessage, RunCommand, GError
-from gui_core.gselect import Select, LayerSelect, ColumnSelect, VectorDBInfo
-from core.render import Map
-from gui_core.forms import GUI
-from core.debug import Debug as Debug
-from gui_core.widgets import ColorTablesComboBox
-from gui_core.wrap import (
-    SpinCtrl,
-    PseudoDC,
-    TextCtrl,
-    Button,
-    CancelButton,
-    StaticText,
-    StaticBox,
-    EmptyBitmap,
-    BitmapFromImage,
-)
 
 
 class RulesPanel:

--- a/gui/wxpython/modules/extensions.py
+++ b/gui/wxpython/modules/extensions.py
@@ -22,18 +22,17 @@ import os
 import sys
 
 import wx
+from core import globalvar
+from core.gcmd import GError, GException, GMessage, RunCommand
+from core.gthread import gThread
+from core.menutree import ModuleNode, TreeModel
+from core.toolboxes import toolboxesOutdated
+from core.utils import SetAddOnPath
+from gui_core.treeview import CTreeView
+from gui_core.widgets import GListCtrl
+from gui_core.wrap import Button, Menu, NewId, SearchCtrl, StaticBox
 
 from grass.script import task as gtask
-
-from core import globalvar
-from core.gcmd import GError, RunCommand, GException, GMessage
-from core.utils import SetAddOnPath
-from core.gthread import gThread
-from core.menutree import TreeModel, ModuleNode
-from gui_core.widgets import GListCtrl
-from gui_core.treeview import CTreeView
-from core.toolboxes import toolboxesOutdated
-from gui_core.wrap import Button, StaticBox, Menu, NewId, SearchCtrl
 
 
 class InstallExtensionWindow(wx.Frame):

--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -21,19 +21,18 @@ import os
 import sys
 
 import wx
-
 from core import globalvar
-from core.render import Map
-from core.settings import UserSettings
-from gui_core.forms import GUI
-from mapdisp.gprint import PrintOptions
-from core.utils import GetLayerNameFromCmd
-from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
-from gui_core.preferences import DefaultFontDialog
 from core.debug import Debug
 from core.gcmd import GError
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from gui_core.wrap import PseudoDC, Menu, EmptyBitmap, NewId, BitmapFromImage
+from core.render import Map
+from core.settings import UserSettings
+from core.utils import GetLayerNameFromCmd
+from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
+from gui_core.forms import GUI
+from gui_core.preferences import DefaultFontDialog
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.wrap import BitmapFromImage, EmptyBitmap, Menu, NewId, PseudoDC
+from mapdisp.gprint import PrintOptions
 
 
 class BufferedWindow(wx.Window):

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -23,19 +23,18 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-from core import globalvar
 import wx.lib.filebrowsebutton as filebrowse
-
-from grass.script import core as grass
-from grass.script import task as gtask
-
+from core import globalvar
 from core.gcmd import GError, GMessage, GWarning, RunCommand
+from core.settings import GetDisplayVectSettings, UserSettings
+from core.utils import GetValidLayerName
 from gui_core.forms import CmdPanel
 from gui_core.gselect import GdalSelect
 from gui_core.widgets import GListCtrl, GNotebook, LayersList, LayersListValidator
-from gui_core.wrap import Button, CloseButton, StaticText, StaticBox
-from core.utils import GetValidLayerName
-from core.settings import UserSettings, GetDisplayVectSettings
+from gui_core.wrap import Button, CloseButton, StaticBox, StaticText
+
+from grass.script import core as grass
+from grass.script import task as gtask
 
 
 class ImportDialog(wx.Dialog):

--- a/gui/wxpython/modules/mcalc_builder.py
+++ b/gui/wxpython/modules/mcalc_builder.py
@@ -20,22 +20,22 @@ import os
 import re
 
 import wx
-import grass.script as grass
-
 from core import globalvar
 from core.gcmd import GError, RunCommand
 from core.giface import StandaloneGrassInterface
+from core.settings import UserSettings
 from gui_core.gselect import Select
 from gui_core.widgets import IntegerValidator
 from gui_core.wrap import (
     Button,
     ClearButton,
     CloseButton,
-    TextCtrl,
-    StaticText,
     StaticBox,
+    StaticText,
+    TextCtrl,
 )
-from core.settings import UserSettings
+
+import grass.script as grass
 
 
 class MapCalcFrame(wx.Frame):

--- a/gui/wxpython/nviz/animation.py
+++ b/gui/wxpython/nviz/animation.py
@@ -14,8 +14,8 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
-import os
 import copy
+import os
 
 import wx
 

--- a/gui/wxpython/nviz/main.py
+++ b/gui/wxpython/nviz/main.py
@@ -20,11 +20,9 @@ This program is free software under the GNU General Public License
 errorMsg = ""
 
 try:
-    from wx import glcanvas  # noqa: F401
-    from nviz import mapwindow
-    from nviz import tools
-    from nviz import workspace
     from nviz import wxnviz  # noqa: F401
+    from nviz import mapwindow, tools, workspace
+    from wx import glcanvas  # noqa: F401
 
     haveNviz = True
 except (ImportError, NameError) as err:

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -18,32 +18,30 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (Google SoC 2011)
 """
 
+import copy
+import math
 import os
 import sys
 import time
-import copy
-import math
-
 from threading import Thread
 
 import wx
-from wx.lib.newevent import NewEvent
+from core.debug import Debug
+from core.gcmd import GError, GException, GMessage
+from core.giface import Notification
+from core.globalvar import CheckWxVersion
+from core.settings import UserSettings
+from core.utils import str2rgb
+from mapwin.base import MapWindowBase
+from nviz import wxnviz
+from nviz.animation import Animation
+from nviz.workspace import NvizSettings
 from wx import glcanvas
-from wx.glcanvas import WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE
+from wx.glcanvas import WX_GL_DEPTH_SIZE, WX_GL_DOUBLEBUFFER, WX_GL_RGBA
+from wx.lib.newevent import NewEvent
 
 import grass.script as grass
 from grass.pydispatch.signal import Signal
-
-from core.gcmd import GMessage, GException, GError
-from core.debug import Debug
-from mapwin.base import MapWindowBase
-from core.settings import UserSettings
-from nviz.workspace import NvizSettings
-from nviz.animation import Animation
-from nviz import wxnviz
-from core.globalvar import CheckWxVersion
-from core.utils import str2rgb
-from core.giface import Notification
 
 wxUpdateProperties, EVT_UPDATE_PROP = NewEvent()
 wxUpdateView, EVT_UPDATE_VIEW = NewEvent()

--- a/gui/wxpython/nviz/preferences.py
+++ b/gui/wxpython/nviz/preferences.py
@@ -16,16 +16,15 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <KratochAnna seznam.cz> (Google SoC 2011)
 """
 
-import os
 import copy
+import os
 
 import wx
 import wx.lib.colourselect as csel
-
 from core import globalvar
 from core.settings import UserSettings
 from gui_core.preferences import PreferencesBaseDialog
-from gui_core.wrap import SpinCtrl, CheckBox, StaticText, StaticBox
+from gui_core.wrap import CheckBox, SpinCtrl, StaticBox, StaticText
 
 
 class NvizPreferencesDialog(PreferencesBaseDialog):

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -19,14 +19,14 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (Google SoC 2011)
 """
 
+import copy
 import os
 import sys
-import copy
 
 import wx
 import wx.lib.colourselect as csel
-import wx.lib.scrolledpanel as SP
 import wx.lib.filebrowsebutton as filebrowse
+import wx.lib.scrolledpanel as SP
 
 try:
     import wx.lib.agw.flatnotebook as FN
@@ -43,41 +43,41 @@ try:
     import wx.lib.agw.floatspin as fs
 except ImportError:
     fs = None
-import grass.script as grass
-
 from core import globalvar
-from gui_core.gselect import VectorDBInfo
+from core.debug import Debug
 from core.gcmd import GMessage, RunCommand
-from modules.colorrules import ThematicVectorTable
 from core.settings import UserSettings
+from gui_core.gselect import Select, VectorDBInfo
 from gui_core.widgets import (
-    ScrolledPanel,
-    NumTextCtrl,
     FloatSlider,
-    SymbolButton,
     GNotebook,
+    NumTextCtrl,
+    ScrolledPanel,
+    SymbolButton,
 )
-from gui_core.gselect import Select
 from gui_core.wrap import (
-    Window,
-    SpinCtrl,
-    PseudoDC,
-    ToggleButton,
     Button,
-    TextCtrl,
-    Slider,
-    StaticText,
-    StaticBox,
     CheckListBox,
     ColourSelect,
+    PseudoDC,
+    Slider,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
+    ToggleButton,
+    Window,
 )
-from core.debug import Debug
+from modules.colorrules import ThematicVectorTable
 from nviz.mapwindow import (
+    wxUpdateCPlane,
+    wxUpdateLight,
     wxUpdateProperties,
     wxUpdateView,
-    wxUpdateLight,
-    wxUpdateCPlane,
 )
+
+import grass.script as grass
+
 from .wxnviz import DM_FLAT, DM_GOURAUD, MAX_ISOSURFS
 
 

--- a/gui/wxpython/nviz/wxnviz.py
+++ b/gui/wxpython/nviz/wxnviz.py
@@ -22,9 +22,9 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <KratochAnna seznam.cz> (Google SoC 2011)
 """
 
-import sys
 import locale
 import struct
+import sys
 from math import sqrt
 
 try:
@@ -48,19 +48,20 @@ except KeyError as e:
 
 try:
     from grass.lib.gis import *
+    from grass.lib.nviz import *
+    from grass.lib.ogsf import *
+    from grass.lib.raster import *
     from grass.lib.raster3d import *
     from grass.lib.vector import *
-    from grass.lib.ogsf import *
-    from grass.lib.nviz import *
-    from grass.lib.raster import *
 except (ImportError, OSError, TypeError) as e:
     print("wxnviz.py: {}".format(e), file=sys.stderr)
 
 from core.debug import Debug
-from core.utils import autoCropImageFromFile
 from core.gcmd import DecodeString
 from core.globalvar import wxPythonPhoenix
+from core.utils import autoCropImageFromFile
 from gui_core.wrap import Rect
+
 import grass.script as grass
 
 log = None

--- a/gui/wxpython/photo2image/g.gui.photo2image.py
+++ b/gui/wxpython/photo2image/g.gui.photo2image.py
@@ -71,6 +71,7 @@ Module to run GCP management tool as stadalone application.
 @author Vaclav Petras  <wenzeslaus gmail.com> (standalone module)
 """
 import os
+
 import grass.script as gscript
 
 
@@ -79,12 +80,13 @@ def main():
     options, flags = gscript.parser()
 
     import wx
+
     from grass.script.setup import set_gui_path
 
     set_gui_path()
 
-    from core.settings import UserSettings
     from core.giface import StandaloneGrassInterface
+    from core.settings import UserSettings
     from photo2image.ip2i_manager import GCPWizard
 
     driver = UserSettings.Get(group="display", key="driver", subkey="type")

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -27,34 +27,33 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 
 import wx
-from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 import wx.lib.colourselect as csel
-
-import grass.script as grass
-
-from core import utils, globalvar
+from core import globalvar, utils
+from core.gcmd import GError, GMessage, GWarning, RunCommand
 from core.render import Map
+from core.settings import UserSettings
 from gui_core.gselect import Select
 from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
-from core.settings import UserSettings
-from photo2image.ip2i_mapdisplay import MapPanel
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
+from photo2image.ip2i_mapdisplay import MapPanel
+from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
+
+import grass.script as grass
 
 #
 # global variables

--- a/gui/wxpython/photo2image/ip2i_mapdisplay.py
+++ b/gui/wxpython/photo2image/ip2i_mapdisplay.py
@@ -13,21 +13,19 @@ This program is free software under the GNU General Public License
 import os
 import platform
 
-from core import globalvar
+import gcp.statusbar as sbgcp
+import mapdisp.statusbar as sb
 import wx
 import wx.aui
-
-from mapdisp.toolbars import MapToolbar
-from gcp.toolbars import GCPDisplayToolbar, GCPManToolbar
-from mapdisp.gprint import PrintOptions
+from core import globalvar
 from core.gcmd import GMessage
+from gcp.toolbars import GCPDisplayToolbar, GCPManToolbar
 from gui_core.dialogs import GetImageHandlers, ImageSizeDialog
 from gui_core.mapdisp import SingleMapPanel
 from gui_core.wrap import Menu
+from mapdisp.gprint import PrintOptions
+from mapdisp.toolbars import MapToolbar
 from mapwin.buffered import BufferedMapWindow
-
-import mapdisp.statusbar as sb
-import gcp.statusbar as sbgcp
 
 # for standalone app
 cmdfilename = None

--- a/gui/wxpython/photo2image/ip2i_statusbar.py
+++ b/gui/wxpython/photo2image/ip2i_statusbar.py
@@ -17,10 +17,9 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
 from core.gcmd import GMessage
-from mapdisp.statusbar import SbItem, SbTextItem
 from gui_core.wrap import SpinCtrl
+from mapdisp.statusbar import SbItem, SbTextItem
 
 
 class SbGoToGCP(SbItem):

--- a/gui/wxpython/photo2image/ip2i_toolbars.py
+++ b/gui/wxpython/photo2image/ip2i_toolbars.py
@@ -16,8 +16,7 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -40,34 +40,33 @@ from copy import deepcopy
 
 import wx
 import wx.lib.agw.floatspin as fs
-from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin
-
 from core import globalvar
+from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin
 
 if globalvar.wxPythonPhoenix:
     from wx import Validator
 else:
     from wx import PyValidator as Validator
 
-import grass.script as grass
-
+from core.gcmd import GError, GMessage, RunCommand
 from core.utils import PilImageToWxImage
 from dbmgr.vinfo import VectorDBInfo
-from gui_core.gselect import Select
-from core.gcmd import RunCommand, GError, GMessage
 from gui_core.dialogs import SymbolDialog
+from gui_core.gselect import Select
 from gui_core.wrap import (
     BitmapButton,
     BitmapComboBox,
     BitmapFromImage,
     Button,
     CheckBox,
+    CheckListCtrlMixin,
     Choice,
     ClientDC,
     ColourPickerCtrl,
     Dialog,
     DirBrowseButton,
     EmptyBitmap,
+    EmptyImage,
     ExpandoTextCtrl,
     FileBrowseButton,
     FloatSpin,
@@ -84,11 +83,11 @@ from gui_core.wrap import (
     StaticText,
     TextCtrl,
     TextEntryDialog,
-    EmptyImage,
-    CheckListCtrlMixin,
 )
-from psmap.utils import *
 from psmap.instructions import *
+from psmap.utils import *
+
+import grass.script as grass
 
 # grass.set_raise_on_error(True)
 

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -16,10 +16,9 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
-
 import queue as Queue
-from math import sin, cos, pi, sqrt
+import sys
+from math import cos, pi, sin, sqrt
 
 import wx
 
@@ -28,26 +27,25 @@ try:
 except ImportError:
     import wx.lib.flatnotebook as FN
 
-import grass.script as grass
-
 from core import globalvar
-from gui_core.menu import Menu
-from core.gconsole import CmdThread, EVT_CMD_DONE
-from psmap.toolbars import PsMapToolbar
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import GError, GMessage, RunCommand
+from core.gconsole import EVT_CMD_DONE, CmdThread
 from core.settings import UserSettings
 from core.utils import PilImageToWxImage
-from gui_core.forms import GUI
-from gui_core.widgets import GNotebook
 from gui_core.dialogs import HyperlinkDialog
+from gui_core.forms import GUI
 from gui_core.ghelp import ShowAboutDialog
-from gui_core.wrap import ClientDC, PseudoDC, Rect, StockCursor, EmptyBitmap
-from psmap.menudata import PsMapMenuData
+from gui_core.menu import Menu
 from gui_core.toolbars import ToolSwitcher
-
+from gui_core.widgets import GNotebook
+from gui_core.wrap import ClientDC, EmptyBitmap, PseudoDC, Rect, StockCursor
 from psmap.dialogs import *
 from psmap.instructions import *
+from psmap.menudata import PsMapMenuData
+from psmap.toolbars import PsMapToolbar
 from psmap.utils import *
+
+import grass.script as grass
 
 
 class PsMapFrame(wx.Frame):

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -35,17 +35,17 @@ This program is free software under the GNU General Public License
 import os
 import string
 from math import ceil
-from time import strftime, localtime
+from time import localtime, strftime
 
 import wx
-import grass.script as grass
-from grass.script.task import cmdlist_to_tuple
-
 from core.gcmd import GError, GMessage, GWarning
 from core.utils import GetCmdString
 from dbmgr.vinfo import VectorDBInfo
 from gui_core.wrap import NewId as wxNewId
 from psmap.utils import *
+
+import grass.script as grass
+from grass.script.task import cmdlist_to_tuple
 
 
 def NewId():

--- a/gui/wxpython/psmap/toolbars.py
+++ b/gui/wxpython/psmap/toolbars.py
@@ -17,8 +17,7 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from icons.icon import MetaIcon
 
 

--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -16,8 +16,9 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
+from math import ceil, cos, floor, pi, sin
+
 import wx
-from math import ceil, floor, sin, cos, pi
 
 try:
     from PIL import Image as PILImage  # noqa
@@ -26,8 +27,9 @@ try:
 except ImportError:
     havePILImage = False
 
+from core.gcmd import GError, RunCommand
+
 import grass.script as grass
-from core.gcmd import RunCommand, GError
 
 
 class Rect2D(wx.Rect2D):

--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -16,19 +16,19 @@ for details.
 
 import os
 import tempfile
-import wx
 import uuid
+
+import wx
+from core.gcmd import GError, GMessage
+from core.gthread import gThread
+from core.settings import UserSettings
+from rdigit.dialogs import NewRasterDialog
 from wx.lib.newevent import NewEvent
 
-from grass.script import core as gcore
-from grass.script import raster as grast
 from grass.exceptions import CalledModuleError, ScriptError
 from grass.pydispatch.signal import Signal
-
-from core.gcmd import GError, GMessage
-from core.settings import UserSettings
-from core.gthread import gThread
-from rdigit.dialogs import NewRasterDialog
+from grass.script import core as gcore
+from grass.script import raster as grast
 
 updateProgress, EVT_UPDATE_PROGRESS = NewEvent()
 

--- a/gui/wxpython/rdigit/dialogs.py
+++ b/gui/wxpython/rdigit/dialogs.py
@@ -15,10 +15,9 @@ for details.
 """
 
 import wx
-
+from core.gcmd import GWarning
 from gui_core.gselect import Select
 from gui_core.wrap import Button, StaticText
-from core.gcmd import GWarning
 
 import grass.script.core as gcore
 import grass.script.raster as grast

--- a/gui/wxpython/rdigit/g.gui.rdigit.py
+++ b/gui/wxpython/rdigit/g.gui.rdigit.py
@@ -72,12 +72,12 @@ def main():
 
     set_gui_path()
 
-    from core.render import Map
     from core.globalvar import ICONDIR
-    from mapdisp.frame import MapPanel
-    from gui_core.mapdisp import FrameMixin
-    from mapdisp.main import DMonGrassInterface
+    from core.render import Map
     from core.settings import UserSettings
+    from gui_core.mapdisp import FrameMixin
+    from mapdisp.frame import MapPanel
+    from mapdisp.main import DMonGrassInterface
 
     # define classes which needs imports as local
     # for longer definitions, a separate file would be a better option

--- a/gui/wxpython/rdigit/toolbars.py
+++ b/gui/wxpython/rdigit/toolbars.py
@@ -15,14 +15,11 @@ for details.
 """
 
 import wx
-
-from gui_core.toolbars import BaseToolbar
-from icons.icon import MetaIcon
-from gui_core.widgets import FloatValidator
 import wx.lib.colourselect as csel
-from gui_core.wrap import TextCtrl, StaticText, ColourSelect
-from gui_core.toolbars import BaseIcons
-
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.widgets import FloatValidator
+from gui_core.wrap import ColourSelect, StaticText, TextCtrl
+from icons.icon import MetaIcon
 
 rdigitIcons = {
     "area": MetaIcon(img="polygon-create", label=_("Digitize area")),

--- a/gui/wxpython/rlisetup/frame.py
+++ b/gui/wxpython/rlisetup/frame.py
@@ -4,16 +4,17 @@ Created on Mon Nov 26 11:57:54 2012
 @author: lucadelu
 """
 
-import wx
+import codecs
+import locale
 import os
 
-from core import globalvar, gcmd
-from grass.script.utils import try_remove
+import wx
+from core import gcmd, globalvar
+from gui_core.wrap import Button, StaticBox, TextCtrl
 from rlisetup.functions import retRLiPath
 from rlisetup.wizard import RLIWizard
-import locale
-import codecs
-from gui_core.wrap import Button, StaticBox, TextCtrl
+
+from grass.script.utils import try_remove
 
 
 class ViewFrame(wx.Frame):

--- a/gui/wxpython/rlisetup/functions.py
+++ b/gui/wxpython/rlisetup/functions.py
@@ -4,11 +4,13 @@ Created on Mon Nov 26 11:48:03 2012
 @author: lucadelu
 """
 
-import wx
 import os
 import sys
-from grass.script import core as grass
+
+import wx
 from core.gcmd import GError
+
+from grass.script import core as grass
 
 
 class SamplingType:

--- a/gui/wxpython/rlisetup/sampling_frame.py
+++ b/gui/wxpython/rlisetup/sampling_frame.py
@@ -18,25 +18,23 @@ This program is free software under the GNU General Public License
 
 import os
 
-import wx
-import wx.aui
-
-
 # start new import
 import tempfile
-from core.gcmd import RunCommand
-import grass.script.core as grass
-from core import gcmd
 
+import wx
+import wx.aui
+from core import gcmd
+from core.gcmd import GMessage, RunCommand
 from core.giface import StandaloneGrassInterface
+from core.render import Map
+from gui_core.toolbars import BaseIcons, BaseToolbar, ToolSwitcher
+from icons.icon import MetaIcon
 from mapwin.base import MapWindowProperties
 from mapwin.buffered import BufferedMapWindow
-from core.render import Map
-from gui_core.toolbars import BaseToolbar, BaseIcons, ToolSwitcher
-from icons.icon import MetaIcon
-from core.gcmd import GMessage
-from grass.pydispatch.signal import Signal
+
+import grass.script.core as grass
 from grass.pydispatch.errors import DispatcherKeyError
+from grass.pydispatch.signal import Signal
 
 from .functions import SamplingType, checkMapExists
 

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -31,17 +31,19 @@ if wxPythonPhoenix:
 else:
     from wx import wizard as wiz
     from wx.wizard import Wizard
-import wx.lib.scrolledpanel as scrolled
 
+import wx.lib.scrolledpanel as scrolled
+from core.gcmd import GError, GMessage, RunCommand
 from gui_core import gselect
 from gui_core.wrap import Button, StaticText, TextCtrl
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 from rlisetup.functions import checkValue, retRLiPath
 from rlisetup.sampling_frame import RLiSetupMapPanel
+
+from grass.exceptions import CalledModuleError
 from grass.script import core as grass
 from grass.script import raster as grast
 from grass.script import vector as gvect
-from grass.exceptions import CalledModuleError
 
 from .functions import (
     SamplingType,
@@ -50,7 +52,6 @@ from .functions import (
     obtainCategories,
     sampleAreaVector,
 )
-from core.gcmd import GError, GMessage, RunCommand
 
 
 class RLIWizard:

--- a/gui/wxpython/startup/guiutils.py
+++ b/gui/wxpython/startup/guiutils.py
@@ -15,40 +15,39 @@ This is for code which depend on something from GUI (wx or wxGUI).
 """
 
 import os
+
 import wx
-
-from grass.grassdb.checks import (
-    is_mapset_locked,
-    get_mapset_lock_info,
-    is_mapset_name_valid,
-    is_location_name_valid,
-    get_mapset_name_invalid_reason,
-    get_location_name_invalid_reason,
-    get_reason_mapset_not_removable,
-    get_reasons_mapsets_not_removable,
-    get_reasons_location_not_removable,
-    get_reasons_locations_not_removable,
-    get_reasons_grassdb_not_removable,
-    is_fallback_session,
-)
-import grass.grassdb.config as cfg
-
-from grass.grassdb.create import create_mapset, get_default_mapset_name
-from grass.grassdb.manage import (
-    delete_mapset,
-    delete_location,
-    delete_grassdb,
-    rename_mapset,
-    rename_location,
-)
-from grass.script.core import create_environment
-from grass.script.utils import try_remove
-from grass.script import gisenv
-
 from core.gcmd import GError, GMessage, RunCommand
 from gui_core.dialogs import TextEntryDialog
-from location_wizard.dialogs import RegionDef
 from gui_core.widgets import GenericValidator
+from location_wizard.dialogs import RegionDef
+
+import grass.grassdb.config as cfg
+from grass.grassdb.checks import (
+    get_location_name_invalid_reason,
+    get_mapset_lock_info,
+    get_mapset_name_invalid_reason,
+    get_reason_mapset_not_removable,
+    get_reasons_grassdb_not_removable,
+    get_reasons_location_not_removable,
+    get_reasons_locations_not_removable,
+    get_reasons_mapsets_not_removable,
+    is_fallback_session,
+    is_location_name_valid,
+    is_mapset_locked,
+    is_mapset_name_valid,
+)
+from grass.grassdb.create import create_mapset, get_default_mapset_name
+from grass.grassdb.manage import (
+    delete_grassdb,
+    delete_location,
+    delete_mapset,
+    rename_location,
+    rename_mapset,
+)
+from grass.script import gisenv
+from grass.script.core import create_environment
+from grass.script.utils import try_remove
 
 
 class MapsetDialog(TextEntryDialog):

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -17,25 +17,24 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
 import shutil
+import sys
 import textwrap
 import time
 
 import wx
 from wx.lib.newevent import NewEvent
 
-from grass.script.utils import try_rmdir, legalize_vector_name
-from grass.utils.download import download_and_extract, name_from_url, DownloadError
 from grass.grassdb.checks import is_location_valid
 from grass.script.setup import set_gui_path
+from grass.script.utils import legalize_vector_name, try_rmdir
+from grass.utils.download import DownloadError, download_and_extract, name_from_url
 
 set_gui_path()
 
 from core.debug import Debug
 from core.gthread import gThread
 from gui_core.wrap import Button, StaticText
-
 
 # TODO: labels (and descriptions) translatable?
 LOCATIONS = [

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -16,12 +16,12 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
-from math import ceil
-from itertools import cycle
-import numpy as np
-
-import wx
 from functools import reduce
+from itertools import cycle
+from math import ceil
+
+import numpy as np
+import wx
 
 try:
     import matplotlib
@@ -29,13 +29,13 @@ try:
     # The recommended way to use wx with mpl is with the WXAgg
     # backend.
     matplotlib.use("WXAgg")
+    import matplotlib.dates as mdates
     from matplotlib import gridspec
-    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
     from matplotlib.backends.backend_wxagg import (
-        FigureCanvasWxAgg as FigCanvas,
         NavigationToolbar2WxAgg as NavigationToolbar,
     )
-    import matplotlib.dates as mdates
+    from matplotlib.figure import Figure
 except ImportError as e:
     raise ImportError(
         _(
@@ -45,13 +45,13 @@ except ImportError as e:
         ).format(e)
     )
 
-import grass.script as grass
-
-import grass.temporal as tgis
+from core import globalvar
 from core.gcmd import GError, GException, RunCommand
 from gui_core import gselect
 from gui_core.wrap import Button, StaticText
-from core import globalvar
+
+import grass.script as grass
+import grass.temporal as tgis
 
 ALPHA = 1
 COLORS = ["b", "g", "r", "c", "m", "y", "k"]

--- a/gui/wxpython/tools/update_menudata.py
+++ b/gui/wxpython/tools/update_menudata.py
@@ -22,14 +22,13 @@ Usage: python support/update_menudata.py [-d]
 import os
 import sys
 import tempfile
-
 import xml.etree.ElementTree as etree
+
+from core.globalvar import grassCmd
+from lmgr.menudata import LayerManagerMenuData
 
 from grass.script import core as grass
 from grass.script import task as gtask
-
-from lmgr.menudata import LayerManagerMenuData
-from core.globalvar import grassCmd
 
 
 def parseModules():

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -19,14 +19,14 @@ This program is free software under the GNU General Public License
 @author start stvds support Matej Krejci
 """
 import os
+from functools import reduce
 from itertools import cycle
-import numpy as np
 
+import numpy as np
 import wx
-from grass.pygrass.modules import Module
 
 import grass.script as grass
-from functools import reduce
+from grass.pygrass.modules import Module
 
 try:
     import matplotlib
@@ -34,12 +34,12 @@ try:
     # The recommended way to use wx with mpl is with the WXAgg
     # backend.
     matplotlib.use("WXAgg")
-    from matplotlib.figure import Figure
+    import matplotlib.dates as mdates
+    from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigCanvas
     from matplotlib.backends.backend_wxagg import (
-        FigureCanvasWxAgg as FigCanvas,
         NavigationToolbar2WxAgg as NavigationToolbar,
     )
-    import matplotlib.dates as mdates
+    from matplotlib.figure import Figure
 except ImportError as e:
     raise ImportError(
         _(
@@ -49,25 +49,27 @@ except ImportError as e:
     )
 
 
-import grass.temporal as tgis
-from core.gcmd import GMessage, GError, GException, RunCommand
-from gui_core.widgets import CoordinatesValidator
-from gui_core import gselect
-from core import globalvar
-from grass.pygrass.vector.geometry import Point
-from grass.pygrass.raster import RasterRow
-from grass.pygrass.gis.region import Region
 from collections import OrderedDict
 from subprocess import PIPE
+
+from core import globalvar
+from core.gcmd import GError, GException, GMessage, RunCommand
+from gui_core import gselect
+from gui_core.widgets import CoordinatesValidator
+
+import grass.temporal as tgis
+from grass.pygrass.gis.region import Region
+from grass.pygrass.raster import RasterRow
+from grass.pygrass.vector.geometry import Point
 
 try:
     import wx.lib.agw.flatnotebook as FN
 except ImportError:
     import wx.lib.flatnotebook as FN
-import wx.lib.filebrowsebutton as filebrowse
 
+import wx.lib.filebrowsebutton as filebrowse
 from gui_core.widgets import GNotebook
-from gui_core.wrap import CheckBox, TextCtrl, Button, StaticText
+from gui_core.wrap import Button, CheckBox, StaticText, TextCtrl
 
 ALPHA = 0.5
 COLORS = ["b", "g", "r", "c", "m", "y", "k"]

--- a/gui/wxpython/vdigit/dialogs.py
+++ b/gui/wxpython/vdigit/dialogs.py
@@ -22,18 +22,17 @@ import copy
 
 import wx
 import wx.lib.mixins.listctrl as listmix
-
-from core.gcmd import RunCommand, GError
 from core.debug import Debug
+from core.gcmd import GError, RunCommand
 from gui_core.wrap import (
-    SpinCtrl,
     Button,
-    StaticText,
-    StaticBox,
-    Menu,
-    ListCtrl,
-    NewId,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    NewId,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
 )
 
 

--- a/gui/wxpython/vdigit/g.gui.vdigit.py
+++ b/gui/wxpython/vdigit/g.gui.vdigit.py
@@ -35,6 +35,7 @@
 # %end
 
 import os
+
 import grass.script as grass
 
 
@@ -51,13 +52,14 @@ def main():
 
     set_gui_path()
 
-    from core.render import Map
     from core.globalvar import ICONDIR
-    from mapdisp.frame import MapPanel
-    from gui_core.mapdisp import FrameMixin
-    from mapdisp.main import DMonGrassInterface
+    from core.render import Map
     from core.settings import UserSettings
-    from vdigit.main import haveVDigit, errorMsg
+    from gui_core.mapdisp import FrameMixin
+    from mapdisp.frame import MapPanel
+    from mapdisp.main import DMonGrassInterface
+    from vdigit.main import errorMsg, haveVDigit
+
     from grass.exceptions import CalledModuleError
 
     # define classes which needs imports as local

--- a/gui/wxpython/vdigit/main.py
+++ b/gui/wxpython/vdigit/main.py
@@ -15,7 +15,7 @@ This program is free software under the GNU General Public License
 """
 
 try:
-    from vdigit.wxdigit import IVDigit, GV_LINES, CFUNCTYPE  # noqa: F401
+    from vdigit.wxdigit import CFUNCTYPE, GV_LINES, IVDigit  # noqa: F401
 
     haveVDigit = True
     errorMsg = ""

--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -14,26 +14,26 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import wx
 import tempfile
 
-from grass.pydispatch.signal import Signal
-
-from dbmgr.dialogs import DisplayAttributesDialog
-from core.gcmd import RunCommand, GMessage, GError
+import wx
 from core.debug import Debug
-from mapwin.buffered import BufferedMapWindow
-from core.settings import UserSettings
-from core.utils import ListOfCatsToRange
-from core.units import ConvertValue as UnitsConvertValue
+from core.gcmd import GError, GMessage, RunCommand
 from core.globalvar import QUERYLAYER
+from core.settings import UserSettings
+from core.units import ConvertValue as UnitsConvertValue
+from core.utils import ListOfCatsToRange
+from dbmgr.dialogs import DisplayAttributesDialog
+from gui_core import gselect
+from gui_core.wrap import NewId, PseudoDC
+from mapwin.buffered import BufferedMapWindow
 from vdigit.dialogs import (
     VDigitCategoryDialog,
-    VDigitZBulkDialog,
     VDigitDuplicatesDialog,
+    VDigitZBulkDialog,
 )
-from gui_core import gselect
-from gui_core.wrap import PseudoDC, NewId
+
+from grass.pydispatch.signal import Signal
 
 
 class VDigitWindow(BufferedMapWindow):

--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -18,10 +18,9 @@ import textwrap
 
 import wx
 import wx.lib.colourselect as csel
-
-from gui_core.gselect import ColumnSelect
-from core.units import Units
 from core.settings import UserSettings
+from core.units import Units
+from gui_core.gselect import ColumnSelect
 from gui_core.wrap import Button, CheckBox, FloatSpin, SpinCtrl, StaticBox, StaticText
 
 

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -16,19 +16,18 @@ This program is free software under the GNU General Public License
 """
 
 import wx
+from core.debug import Debug
+from core.gcmd import GError, RunCommand
+from core.giface import Notification
+from core.settings import UserSettings
+from gui_core.dialogs import CreateNewVector, VectorDialog
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.wrap import Menu, PseudoDC
+from icons.icon import MetaIcon
+from vdigit.preferences import VDigitSettingsDialog
 
 from grass import script as grass
 from grass.pydispatch.signal import Signal
-
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from gui_core.dialogs import CreateNewVector, VectorDialog
-from gui_core.wrap import PseudoDC, Menu
-from vdigit.preferences import VDigitSettingsDialog
-from core.debug import Debug
-from core.settings import UserSettings
-from core.gcmd import GError, RunCommand
-from icons.icon import MetaIcon
-from core.giface import Notification
 
 
 class VDigitToolbar(BaseToolbar):

--- a/gui/wxpython/vdigit/wxdigit.py
+++ b/gui/wxpython/vdigit/wxdigit.py
@@ -26,20 +26,19 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
-import grass.script.core as grass
-
-from grass.pydispatch.signal import Signal
-
-from core.gcmd import GError
 from core.debug import Debug
+from core.gcmd import GError
 from core.settings import UserSettings
 from vdigit.wxdisplay import DisplayDriver, GetLastError
 
+import grass.script.core as grass
+from grass.pydispatch.signal import Signal
+
 try:
+    from grass.lib.dbmi import *
     from grass.lib.gis import *
     from grass.lib.vector import *
     from grass.lib.vedit import *
-    from grass.lib.dbmi import *
 except (ImportError, OSError, TypeError) as e:
     print("wxdigit.py: {}".format(e), file=sys.stderr)
 

--- a/gui/wxpython/vdigit/wxdisplay.py
+++ b/gui/wxpython/vdigit/wxdisplay.py
@@ -18,14 +18,13 @@ This program is free software under the GNU General Public License
 """
 
 import locale
-
 import os
 import sys
-import wx
 
+import wx
 from core.debug import Debug
-from core.settings import UserSettings
 from core.gcmd import DecodeString
+from core.settings import UserSettings
 from gui_core.wrap import Rect
 
 try:

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -24,30 +24,28 @@ This program is free software under the GNU General Public License
 @author Eliska Kyzlikova <eliska.kyzlikova gmail.com> (turn costs support)
 """
 
-import os
 import math
-
-from grass.script import core as grass
+import os
 
 import wx
 import wx.aui
+
+from grass.script import core as grass
 
 try:
     import wx.lib.agw.flatnotebook as FN
 except ImportError:
     import wx.lib.flatnotebook as FN
+
 import wx.lib.colourselect as csel
 import wx.lib.mixins.listctrl as listmix
-
 from core import globalvar
-from core.gcmd import RunCommand, GMessage
+from core.gcmd import GMessage, RunCommand
 from core.settings import UserSettings
-
 from dbmgr.base import DbMgrBase
-
-from gui_core.widgets import GNotebook
 from gui_core.goutput import GConsoleWindow
-from gui_core.gselect import Select, LayerSelect, ColumnSelect
+from gui_core.gselect import ColumnSelect, LayerSelect, Select
+from gui_core.widgets import GNotebook
 from gui_core.wrap import (
     BitmapButton,
     BitmapFromImage,
@@ -62,16 +60,15 @@ from gui_core.wrap import (
     StaticText,
     TextCtrl,
 )
-
-from vnet.widgets import PointsList
-from vnet.toolbars import MainToolbar, PointListToolbar, AnalysisToolbar
+from vnet.toolbars import AnalysisToolbar, MainToolbar, PointListToolbar
 from vnet.vnet_core import VNETManager
 from vnet.vnet_utils import (
     DegreesToRadians,
-    RadiansToDegrees,
     GetNearestNodeCat,
     ParseMapStr,
+    RadiansToDegrees,
 )
+from vnet.widgets import PointsList
 
 # Main TODOs
 # - when layer tree of is changed, tmp result map is removed from render list

--- a/gui/wxpython/vnet/toolbars.py
+++ b/gui/wxpython/vnet/toolbars.py
@@ -18,11 +18,10 @@ This program is free software under the GNU General Public License
 """
 
 import wx
-
-from icons.icon import MetaIcon
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from gui_core.wrap import ComboBox
 from core.gcmd import RunCommand
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.wrap import ComboBox
+from icons.icon import MetaIcon
 
 
 class PointListToolbar(BaseToolbar):

--- a/gui/wxpython/vnet/vnet_core.py
+++ b/gui/wxpython/vnet/vnet_core.py
@@ -20,21 +20,18 @@ This program is free software under the GNU General Public License
 """
 
 import math
-from grass.script.utils import try_remove
-from grass.script import core as grass
-from grass.script.task import cmdlist_to_tuple
 
 import wx
-
-from core.gcmd import RunCommand, GMessage
-from core.gconsole import CmdThread, EVT_CMD_DONE, GConsole
-
+from core.gcmd import GMessage, RunCommand
+from core.gconsole import EVT_CMD_DONE, CmdThread, GConsole
 from gui_core.gselect import VectorDBInfo
-
-from vnet.vnet_data import VNETData, VNETTmpVectMaps, VectMap, History
-from vnet.vnet_utils import ParseMapStr, haveCtypes, GetNearestNodeCat
+from vnet.vnet_data import History, VectMap, VNETData, VNETTmpVectMaps
+from vnet.vnet_utils import GetNearestNodeCat, ParseMapStr, haveCtypes
 
 from grass.pydispatch.signal import Signal
+from grass.script import core as grass
+from grass.script.task import cmdlist_to_tuple
+from grass.script.utils import try_remove
 
 
 class VNETManager:

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -23,27 +23,21 @@ This program is free software under the GNU General Public License
 @author Eliska Kyzlikova <eliska.kyzlikova gmail.com> (turn costs support)
 """
 
-import os
 import math
+import os
 from copy import deepcopy
 
-from grass.script.utils import try_remove
+import wx
+from core import utils
+from core.gcmd import GMessage, RunCommand
+from core.settings import UserSettings
+from gui_core.gselect import VectorDBInfo
+from vnet.vnet_utils import DegreesToRadians, ParseMapStr, SnapToNode
+
+from grass.pydispatch.signal import Signal
 from grass.script import core as grass
 from grass.script.task import cmdlist_to_tuple
-
-import wx
-
-
-from core import utils
-from core.gcmd import RunCommand, GMessage
-from core.settings import UserSettings
-
-from vnet.vnet_utils import ParseMapStr, SnapToNode
-
-from gui_core.gselect import VectorDBInfo
-from grass.pydispatch.signal import Signal
-
-from vnet.vnet_utils import DegreesToRadians
+from grass.script.utils import try_remove
 
 
 class VNETData:

--- a/gui/wxpython/vnet/vnet_utils.py
+++ b/gui/wxpython/vnet/vnet_utils.py
@@ -19,12 +19,14 @@ This program is free software under the GNU General Public License
 """
 
 import math
+
 from grass.script import core as grass
 from grass.script.utils import encode
 
 try:
+    from ctypes import POINTER, byref, c_char_p, c_double, c_int, pointer
+
     import grass.lib.vector as vectlib
-    from ctypes import pointer, byref, c_char_p, c_int, c_double, POINTER
 
     haveCtypes = True
 except ImportError:

--- a/gui/wxpython/vnet/widgets.py
+++ b/gui/wxpython/vnet/widgets.py
@@ -23,22 +23,21 @@ import os
 from copy import copy, deepcopy
 
 import wx
-from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
-
 from core import globalvar
 from core.gcmd import GError
 from gui_core.widgets import FloatValidator, IntegerValidator
 from gui_core.wrap import (
     BitmapFromImage,
     Button,
+    CheckListCtrlMixin,
     ComboBox,
     ListCtrl,
     Panel,
     StaticBox,
     StaticText,
     TextCtrl,
-    CheckListCtrlMixin,
 )
+from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 
 
 class PointsList(

--- a/gui/wxpython/web_services/cap_interface.py
+++ b/gui/wxpython/web_services/cap_interface.py
@@ -31,9 +31,9 @@ if WMSLibPath not in sys.path:
 
 # Import only after the path has been set up.
 from wms_cap_parsers import (  # noqa: E402
+    OnEarthCapabilitiesTree,
     WMSCapabilitiesTree,
     WMTSCapabilitiesTree,
-    OnEarthCapabilitiesTree,
 )
 
 

--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -18,26 +18,22 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz>
 """
 
-import wx
-
 import os
 import shutil
-
 from copy import deepcopy
+
+import wx
+from core import globalvar
+from core.debug import Debug
+from core.gcmd import GError, GMessage, GWarning
+from core.gconsole import EVT_CMD_DONE, EVT_CMD_OUTPUT, CmdThread, GStderr
+from core.utils import GetSettingsPath
+from gui_core.gselect import Select
+from gui_core.wrap import Button, RadioButton, StaticBox, StaticText, TextCtrl
+from web_services.widgets import WSManageSettingsWidget, WSPanel
 
 import grass.script as grass
 from grass.script.task import cmdlist_to_tuple, cmdtuple_to_list
-
-from core import globalvar
-from core.debug import Debug
-from core.gcmd import GMessage, GWarning, GError
-from core.utils import GetSettingsPath
-from core.gconsole import CmdThread, GStderr, EVT_CMD_DONE, EVT_CMD_OUTPUT
-
-from gui_core.gselect import Select
-from gui_core.wrap import Button, StaticText, StaticBox, TextCtrl, RadioButton
-
-from web_services.widgets import WSPanel, WSManageSettingsWidget
 
 
 class WSDialogBase(wx.Dialog):

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -16,17 +16,15 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz>
 """
 
-import re
 import os
-import sys
+import re
 import shutil
-
+import sys
 from copy import deepcopy
-from core import globalvar
-
 from xml.etree.ElementTree import ParseError
 
 import wx
+from core import globalvar
 
 if globalvar.wxPythonPhoenix:
     try:
@@ -35,20 +33,12 @@ if globalvar.wxPythonPhoenix:
         import wx.lib.agw.flatnotebook as FN
 else:
     import wx.lib.flatnotebook as FN
-import wx.lib.colourselect as csel
 
+import wx.lib.colourselect as csel
 from core.debug import Debug
 from core.gcmd import GMessage
-from core.gconsole import CmdThread, GStderr, EVT_CMD_DONE, EVT_CMD_OUTPUT
-
-from web_services.cap_interface import (
-    WMSCapabilities,
-    WMTSCapabilities,
-    OnEarthCapabilities,
-)
-
-from gui_core.widgets import GNotebook
-from gui_core.widgets import ManageSettingsWidget
+from core.gconsole import EVT_CMD_DONE, EVT_CMD_OUTPUT, CmdThread, GStderr
+from gui_core.widgets import GNotebook, ManageSettingsWidget
 from gui_core.wrap import (
     Button,
     ScrolledPanel,
@@ -58,6 +48,11 @@ from gui_core.wrap import (
     TextCtrl,
     TreeCtrl,
 )
+from web_services.cap_interface import (
+    OnEarthCapabilities,
+    WMSCapabilities,
+    WMTSCapabilities,
+)
 
 import grass.script as grass
 
@@ -65,8 +60,8 @@ rinwms_path = os.path.join(os.getenv("GISBASE"), "etc", "r.in.wms")
 if rinwms_path not in sys.path:
     sys.path.append(rinwms_path)
 
-from wms_base import WMSDriversInfo
 from srs import Srs
+from wms_base import WMSDriversInfo
 
 from grass.pydispatch.signal import Signal
 

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -17,18 +17,17 @@ This program is free software under the GNU General Public License
 @author Vaclav Petras <wenzeslaus gmail.com> (menu customization)
 """
 
+import getopt
 import os
 import sys
-import getopt
 
+# isort: split
 # i18n is taken care of in the grass library code.
 # So we need to import it before any of the GUI code.
 from grass.exceptions import Usage
-from grass.script.core import set_raise_on_error, warning, error
+from grass.script.core import error, set_raise_on_error, warning
 
-from core import globalvar
-from core.utils import registerPid, unregisterPid
-from core.settings import UserSettings
+# isort: split
 
 import wx
 
@@ -37,6 +36,9 @@ import wx
 # during start up, remove when not needed
 import wx.adv
 import wx.html
+from core import globalvar
+from core.settings import UserSettings
+from core.utils import registerPid, unregisterPid
 
 try:
     import wx.lib.agw.advancedsplash as SC

--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -16,18 +16,17 @@ This program is free software under the GNU General Public License
 """
 
 import os
-
-import wx
 from random import randint
 
-from wx.lib import plot
+import wx
 from core.globalvar import ICONDIR
-from core.settings import UserSettings
-from wxplot.dialogs import TextDialog, OptDialog
 from core.render import Map
-from icons.icon import MetaIcon
+from core.settings import UserSettings
 from gui_core.toolbars import BaseIcons
 from gui_core.wrap import Menu
+from icons.icon import MetaIcon
+from wx.lib import plot
+from wxplot.dialogs import OptDialog, TextDialog
 
 import grass.script as grass
 

--- a/gui/wxpython/wxplot/dialogs.py
+++ b/gui/wxpython/wxplot/dialogs.py
@@ -22,17 +22,16 @@ This program is free software under the GNU General Public License
 import os
 
 import wx
-
 from core import globalvar
-from core.settings import UserSettings
 from core.globalvar import ICONDIR
+from core.settings import UserSettings
 from gui_core.gselect import Select
 from gui_core.wrap import (
-    ColourSelect,
-    ComboBox,
     Button,
     CheckBox,
     Choice,
+    ColourSelect,
+    ComboBox,
     ScrolledPanel,
     SpinCtrl,
     StaticBox,

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -18,14 +18,14 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
-import grass.script as grass
-from wx.lib import plot
+from core.gcmd import GError, GException, RunCommand
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import StockCursor
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from wx.lib import plot
 from wxplot.base import BasePlotFrame, PlotIcons
 from wxplot.dialogs import HistRasterDialog, PlotStatsFrame
-from core.gcmd import RunCommand, GException, GError
+
+import grass.script as grass
 
 
 class HistogramPlotFrame(BasePlotFrame):

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -15,20 +15,20 @@ This program is free software under the GNU General Public License
 @author Michael Barton, Arizona State University
 """
 
+import math
 import os
 import sys
-import math
+
 import numpy
-
 import wx
-
-from wx.lib import plot
-import grass.script as grass
-from wxplot.base import BasePlotFrame, PlotIcons
-from gui_core.toolbars import BaseToolbar, BaseIcons
+from core.gcmd import GError, GMessage, GWarning, RunCommand
+from gui_core.toolbars import BaseIcons, BaseToolbar
 from gui_core.wrap import StockCursor
-from wxplot.dialogs import ProfileRasterDialog, PlotStatsFrame
-from core.gcmd import RunCommand, GWarning, GError, GMessage
+from wx.lib import plot
+from wxplot.base import BasePlotFrame, PlotIcons
+from wxplot.dialogs import PlotStatsFrame, ProfileRasterDialog
+
+import grass.script as grass
 
 try:
     import grass.lib.gis as gislib

--- a/gui/wxpython/wxplot/scatter.py
+++ b/gui/wxpython/wxplot/scatter.py
@@ -18,14 +18,14 @@ This program is free software under the GNU General Public License
 import sys
 
 import wx
-
-import grass.script as grass
+from core.gcmd import GError, GException, GMessage, RunCommand
+from gui_core.toolbars import BaseIcons, BaseToolbar
+from gui_core.wrap import StockCursor
 from wx.lib import plot
 from wxplot.base import BasePlotFrame, PlotIcons
-from gui_core.toolbars import BaseToolbar, BaseIcons
-from gui_core.wrap import StockCursor
-from wxplot.dialogs import ScatterRasterDialog, PlotStatsFrame
-from core.gcmd import RunCommand, GException, GError, GMessage
+from wxplot.dialogs import PlotStatsFrame, ScatterRasterDialog
+
+import grass.script as grass
 
 
 class ScatterFrame(BasePlotFrame):


### PR DESCRIPTION
_**NOTE:** This is the follow-up PR for https://github.com/OSGeo/grass/pull/3964. Once https://github.com/OSGeo/grass/pull/3964 is merged, we need to rebase this PR, as it is too big to review properly._


Uses a combination of `ruff check --output-format=concise --select I --fix gui`, `isort --profile=black gui` and `black .`

Some files had an `# isort: split` comment added either inline or above/below to have isort not swap imports past this barrier when a comment explaining that an import has to be made first.
See https://pycqa.github.io/isort/docs/configuration/action_comments.html#isort-split
This instruction hasn't been added when a comment indicating that requirement wasn't present.


### **Once ready to review**
 Once ready to review, a special attention must be made to know if there are other places not indicated by a comment where import of another package (like grass) is required before others due to side effects. In an ideal world, there shouldn't be any side effects, and a file must import what it needs and not rely on the order, nor other files.