### PR TITLE
i.segment: Fix uninitialized struct member 'ngbr_rc.next' in mean_shift.c

### DIFF
--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -457,6 +457,7 @@ static int find_best_neighbour(struct globals *globals, int row, int col,
     visited = pavl_create(cmp_rc, NULL);
     ngbr_rc.row = row;
     ngbr_rc.col = col;
+    ngbr_rc.next = NULL;
     pngbr_rc = G_malloc(sizeof(struct rc));
     *pngbr_rc = ngbr_rc;
     pavl_insert(visited, pngbr_rc);


### PR DESCRIPTION
This pull request fixes an issue in `mean_shift.c` where the struct member `ngbr_rc.next` was used without being initialized. The change initializes `ngbr_rc.next` to `NULL` to ensure it is properly set before use.

**Changes Made:**
- Initialize `ngbr_rc.next` to `NULL` 

This fix resolves the cppcheck warning related to the uninitialized variable.
