### PR TITLE
i.segment: Fix uninitialized struct member error in region_growing.c

### DIFF
--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -192,7 +192,8 @@ int region_growing(struct globals *globals)
     int pathflag; /* =1 if we didn't find mutually best neighbors, continue with
                      Rk */
     int candidates_only;
-    struct ngbr_stats Ri = {0}, Rk = {0}, Rk_bestn = {0}, /* Rk's best neighbor */
+    struct ngbr_stats Ri = {0}, Rk = {0},
+                      Rk_bestn = {0}, /* Rk's best neighbor */
         *next;
     int Ri_nn, Rk_nn; /* number of neighbors for Ri/Rk */
     struct NB_TREE *Ri_ngbrs, *Rk_ngbrs;

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -192,7 +192,7 @@ int region_growing(struct globals *globals)
     int pathflag; /* =1 if we didn't find mutually best neighbors, continue with
                      Rk */
     int candidates_only;
-    struct ngbr_stats Ri = {0}, Rk, Rk_bestn, /* Rk's best neighbor */
+    struct ngbr_stats Ri = {0}, Rk = {0}, Rk_bestn = {0}, /* Rk's best neighbor */
         *next;
     int Ri_nn, Rk_nn; /* number of neighbors for Ri/Rk */
     struct NB_TREE *Ri_ngbrs, *Rk_ngbrs;

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -192,7 +192,7 @@ int region_growing(struct globals *globals)
     int pathflag; /* =1 if we didn't find mutually best neighbors, continue with
                      Rk */
     int candidates_only;
-    struct ngbr_stats Ri, Rk, Rk_bestn, /* Rk's best neighbor */
+    struct ngbr_stats Ri = {0}, Rk, Rk_bestn, /* Rk's best neighbor */
         *next;
     int Ri_nn, Rk_nn; /* number of neighbors for Ri/Rk */
     struct NB_TREE *Ri_ngbrs, *Rk_ngbrs;


### PR DESCRIPTION
This pull request fixes an issue in region_growing.c where the struct member Ri was used without being initialized. The change initializes Ri to {0} to ensure all members are properly set before use.

**Changes Made:**

- Initialize Ri to {0}.

This fix resolves the cppcheck warning related to the uninitialized variable.