### PR TITLE
lib: Fix uninitialized variable 'encoding' in parser_interface.c

### DIFF
--- a/lib/gis/parser_interface.c
+++ b/lib/gis/parser_interface.c
@@ -107,7 +107,7 @@ void G__usage_xml(void)
     char *type;
     char *s, *top;
     int i;
-    const char *encoding;
+    const char *encoding = NULL;
     int new_prompt = 0;
 
     new_prompt = G__uses_new_gisprompt();


### PR DESCRIPTION
This pull request fixes an issue in `parser_interface.c` where the variable encoding was used without being initialized. The change initializes encoding to NULL to ensure it is properly set before use.

**Changes Made:**

- Initialize encoding to NULL