### PR TITLE
CI(ruff): Fine tune posting Ruff suggestions

### DIFF
--- a/.github/workflows/post-pr-reviews.yml
+++ b/.github/workflows/post-pr-reviews.yml
@@ -85,7 +85,7 @@ jobs:
           CI_REPO_NAME: ${{ github.event.workflow_run.repository.name }}
           # CI_PULL_REQUEST: "" # Populated from reviewdog's "-guess" flag since hard to get
       - name: Post Ruff suggestions
-        if: ${{ steps.tools.outputs.black == 'true' }}
+        if: ${{ steps.tools.outputs.ruff == 'true' }}
         run: |
           TMPFILE="diff-${INPUT_TOOL_NAME}.patch"
           GITHUB_ACTIONS="" reviewdog \

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff
+        if: always()
         uses: ./.github/actions/create-upload-suggestions
         with:
           tool-name: ruff

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -71,7 +71,8 @@ jobs:
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff
-        if: always()
+        # To run after ruff step exits with failure when rules don't have fixes available
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/create-upload-suggestions
         with:
           tool-name: ruff

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Ruff
         run: pip install ruff==${{ env.RUFF_VERSION }}
       - name: Run Ruff
-        run: ruff check --output-format=github . --preview --fix
+        run: ruff check --output-format=github . --preview --fix --unsafe-fixes
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff


### PR DESCRIPTION
I overlooked the situation where some ruff errors can and cannot be fixed in the same pass. The exit code won’t be 0 if not all files were fixed. This prevented to reach the step where the diff was stored as an artifact to upload suggestions, to post.

So instead of setting the ruff step with `continue-on-errors: true`, which would have shown the step as gray (passing), even when rules without fixes are failing, I set the condition to `if: ${{ !cancelled() }}` as mentioned in the docs for always() https://docs.github.com/en/actions/learn-github-actions/expressions#always

I also spotted a copy-paste typo in the post-pr-reviews workflow, that I had already fixed on another branch but forgot to apply on the one that ended up being a PR.

Finally, I reconsidered my initial position on only applying the safe fixes. Since it is not directly committing, only posting _suggestions_, it makes sense to show _suggestions_ on what will still remain an error, but without the suggested fixes. Unlike Black, we might need to think a bit about the fixes anyways, when available. Following that thought, I don’t think it’s appropriate in pre-commit to make unsafe fixes on behalf of the user, without any review.

