### PR TITLE
d.labels: Reduce scope of minreg and maxreg variables in main.c

### DIFF
--- a/display/d.labels/main.c
+++ b/display/d.labels/main.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     struct Cell_head window;
     char *label_name;
     const char *mapset;
-    double minreg, maxreg, reg, dx, dy;
+    double reg, dx, dy;
     FILE *infile;
     struct Option *opt1;
     struct Option *maxreg_opt, *minreg_opt;
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     dy = window.north - window.south;
     reg = sqrt(dx * dx + dy * dy);
     if (minreg_opt->answer) {
-        minreg = atof(minreg_opt->answer);
+        double minreg = atof(minreg_opt->answer);
         if (reg < minreg) {
             G_warning(
                 _("Region size is lower than minreg, nothing displayed."));
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
         }
     }
     if (maxreg_opt->answer) {
-        maxreg = atof(maxreg_opt->answer);
+        double maxreg = atof(maxreg_opt->answer);
         if (reg > maxreg) {
             G_warning(
                 _("Region size is greater than maxreg, nothing displayed."));


### PR DESCRIPTION
**Description**

This pull request reduces the scope of the `minreg` and `maxreg` variables in the `d.labels/main.c` file.

**Changes Made**

- Moved the declaration of `minreg` and `maxreg` inside their respective `if` blocks to reduce their scope.

This change addresses the following cppcheck warnings:
- display/d.labels/main.c:31:12: style: The scope of the variable 'minreg' can be reduced. [variableScope]
- display/d.labels/main.c:31:20: style: The scope of the variable 'maxreg' can be reduced. [variableScope]
