### PR TITLE
lib: Reduce the scope of the variable 'len' in list_subgp.c

### DIFF
--- a/lib/imagery/list_subgp.c
+++ b/lib/imagery/list_subgp.c
@@ -83,7 +83,7 @@ int I_list_subgroup(const char *group, const char *subgroup,
 {
     char buf[80];
     int i;
-    int len, tot_len;
+    int tot_len;
     int max;
 
     if (ref->nfiles <= 0) {
@@ -93,6 +93,7 @@ int I_list_subgroup(const char *group, const char *subgroup,
     }
     max = 0;
     for (i = 0; i < ref->nfiles; i++) {
+        int len;
         I__list_group_name_fit(buf, ref->file[i].name, ref->file[i].mapset);
         len = strlen(buf) + 4;
         if (len > max)


### PR DESCRIPTION
**Overview:**
This pull request reduces the scope of the variable 'len' in the `list_subgp.c` file. The variable 'len' is now declared inside the loops where it is used.

**Issue:**
cppcheck identified the following issue:
list_subgp.c:86:9: The scope of the variable 'len' can be reduced. [variableScope]
    int len, tot_len;
           ^
**Solution:**
The `len` variable has been moved inside the for loop where it is used. This change reduces its scope.
