### PR TITLE
lib: Reduce scope of 'len' variable in list_gp.c

### DIFF
--- a/lib/imagery/list_gp.c
+++ b/lib/imagery/list_gp.c
@@ -27,7 +27,7 @@ int I_list_group(const char *group, const struct Ref *ref, FILE *fd)
 {
     char buf[80];
     int i;
-    int len, tot_len;
+    int tot_len;
     int max;
 
     if (ref->nfiles <= 0) {
@@ -36,6 +36,7 @@ int I_list_group(const char *group, const struct Ref *ref, FILE *fd)
     }
     max = 0;
     for (i = 0; i < ref->nfiles; i++) {
+        int len;
         I__list_group_name_fit(buf, ref->file[i].name, ref->file[i].mapset);
         len = strlen(buf) + 4;
         if (len > max)


### PR DESCRIPTION
**Overview:**
This pull request reduces the scope of the variable 'len' in the `list_gp.c` file. The variable 'len' is now declared inside the loops where it is used.

**Issue:**
cppcheck identified the following issue:
list_gp.c:30:9: :The scope of the variable 'len' can be reduced. [variableScope]
    int len, tot_len;
           ^
**Solution:**
The `len` variable has been moved inside the for loop where it is used. This change reduces its scope.
