### PR TITLE
lib: Fix uninitialized variable issue in shapiroe.c

### DIFF
--- a/lib/cdhc/shapiroe.c
+++ b/lib/cdhc/shapiroe.c
@@ -6,6 +6,7 @@ double *Cdhc_shapiro_wilk_exp(double *x, int n)
     static double y[2];
     double mean, b, s1, xs, sum1 = 0.0, sum2 = 0.0;
     int i;
+    xs = x[0];
 
     for (i = 0; i < n; ++i)
         if (i == 0 || xs > x[i])


### PR DESCRIPTION
This pull request addresses the uninitialized variable issue in shapiroe.c identified by cppcheck. 

**Issues**
shapiroe.c:22:17: error: Uninitialized variable: xs [uninitvar]
    b = (mean - xs) * sqrt((double)n / (n - 1.0));
                ^
shapiroe.c:11:19: note: Assuming condition is false
    for (i = 0; i < n; ++i)
                  ^
shapiroe.c:22:17: note: Uninitialized variable: xs
    b = (mean - xs) * sqrt((double)n / (n - 1.0));
    
**Changes Made**
Initialized xs to the first element of the array x to ensure it is properly set before being used in subsequent calculations.


