### PR TITLE
lib: Fixed uninitialized variable warning in dmax.c by initializing dp, dp_max, dm, and dm_max to 0.0

### DIFF
--- a/lib/cdhc/dmax.c
+++ b/lib/cdhc/dmax.c
@@ -7,7 +7,7 @@ double *Cdhc_dmax(double *x, int n)
 {
     static double y[2];
     double *xcopy, sqrt2, mean = 0.0, sdx = 0.0, fx;
-    double dp, dp_max, dm, dm_max;
+    double dp = 0.0, dp_max = 0.0, dm = 0.0, dm_max = 0.0;
     int i;
 
     if ((xcopy = (double *)malloc(n * sizeof(double))) == NULL) {


### PR DESCRIPTION
This pull request addresses the following warning identified by clang.

**Issue:**
dmax.c:48:10: warning: Assigned value is garbage or undefined [core.uninitialized.Assign]
y[0] = dp_max;

**Changes made:**

The issue was fixed by initializing the variables `dp`, `dp_max`, `dm`, and `dm_max` to `0.0`. This ensures that the variables have a defined value before they are used in the calculation. The updated part of the code is:

double dp = 0.0, dp_max = 0.0, dm = 0.0, dm_max = 0.0;

To maintain consistency across the code, variables other than dp_max are also initialized.
