### PR TITLE
style: Fix pylint try-except-raise (W0706)

### DIFF
--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -572,17 +572,14 @@ def GetListOfLocations(dbase):
     """
     listOfLocations = []
 
-    try:
-        for location in glob.glob(os.path.join(dbase, "*")):
-            try:
-                if os.path.join(location, "PERMANENT") in glob.glob(
-                    os.path.join(location, "*")
-                ):
-                    listOfLocations.append(os.path.basename(location))
-            except:
-                pass
-    except (UnicodeEncodeError, UnicodeDecodeError) as e:
-        raise e
+    for location in glob.glob(os.path.join(dbase, "*")):
+        try:
+            if os.path.join(location, "PERMANENT") in glob.glob(
+                os.path.join(location, "*")
+            ):
+                listOfLocations.append(os.path.basename(location))
+        except:
+            pass
 
     ListSortLower(listOfLocations)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,6 @@ ignore = [
     "TRY201",  # verbose-raise
     "TRY300",  # try-consider-else
     "TRY301",  # raise-within-try
-    "TRY302",  # useless-try-except
     "UP015",   # redundant-open-modes
     "UP018",   # native-literals
     "UP022",   # replace-stdout-stderr

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -828,8 +828,6 @@ def writeSwf(filename, images, duration=0.1, repeat=True):
     fp = open(filename, "wb")
     try:
         buildFile(fp, taglist, nframes=nframes, framesize=wh, fps=fps)
-    except Exception:
-        raise
     finally:
         fp.close()
 

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -80,8 +80,6 @@ def _read_map_full_info(lock, conn, data):
             info = _read_raster_full_info(name, mapset)
         elif maptype == RPCDefs.TYPE_VECTOR:
             info = _read_vector_full_info(name, mapset)
-    except:
-        raise
     finally:
         conn.send(info)
 
@@ -295,8 +293,6 @@ def _get_database_name(lock, conn, data):
             dbstring = dbstring.replace(encode("$GISDBASE"), libgis.G_gisdbase())
             dbstring = dbstring.replace(encode("$LOCATION_NAME"), libgis.G_location())
             dbstring = dbstring.replace(encode("$MAPSET"), mapset)
-    except:
-        raise
     finally:
         conn.send(decode(dbstring))
 
@@ -353,8 +349,6 @@ def _available_mapsets(lock, conn, data):
         mapset_list.reverse()
         mapset_list.append(current_mapset)
         mapset_list.reverse()
-    except:
-        raise
     finally:
         conn.send(mapset_list)
 
@@ -387,8 +381,6 @@ def _has_timestamp(lock, conn, data):
         elif maptype == RPCDefs.TYPE_RASTER3D:
             if libgis.G_has_raster3d_timestamp(name, mapset) == 1:
                 check = True
-    except:
-        raise
     finally:
         conn.send(check)
 
@@ -437,8 +429,6 @@ def _read_timestamp(lock, conn, data):
             check = libgis.G_read_raster3d_timestamp(name, mapset, byref(ts))
 
         dates = _convert_timestamp_from_grass(ts)
-    except:
-        raise
     finally:
         conn.send((check, dates))
 
@@ -481,8 +471,6 @@ def _write_timestamp(lock, conn, data):
             check = libgis.G_write_vector_timestamp(name, layer, byref(ts))
         elif maptype == RPCDefs.TYPE_RASTER3D:
             check = libgis.G_write_raster3d_timestamp(name, byref(ts))
-    except:
-        raise
     finally:
         conn.send(check)
 
@@ -518,8 +506,6 @@ def _remove_timestamp(lock, conn, data):
             check = libgis.G_remove_vector_timestamp(name, layer, mapset)
         elif maptype == RPCDefs.TYPE_RASTER3D:
             check = libgis.G_remove_raster3d_timestamp(name, mapset)
-    except:
-        raise
     finally:
         conn.send(check)
 
@@ -558,8 +544,6 @@ def _read_semantic_label(lock, conn, data):
                 "Unable to read semantic label. Unsupported map type %s" % maptype
             )
             return -1
-    except:
-        raise
     finally:
         conn.send(semantic_label)
 
@@ -595,8 +579,6 @@ def _write_semantic_label(lock, conn, data):
                 "Unable to write semantic label. Unsupported map type %s" % maptype
             )
             return -2
-    except:
-        raise
     finally:
         conn.send(True)
 
@@ -629,8 +611,6 @@ def _remove_semantic_label(lock, conn, data):
                 "Unable to remove semantic label. Unsupported map type %s" % maptype
             )
             return -2
-    except:
-        raise
     finally:
         conn.send(check)
 
@@ -663,8 +643,6 @@ def _map_exists(lock, conn, data):
 
         if mapset:
             check = True
-    except:
-        raise
     finally:
         conn.send(check)
 
@@ -691,8 +669,6 @@ def _read_map_info(lock, conn, data):
             kvp = _read_vector_info(name, mapset)
         elif maptype == RPCDefs.TYPE_RASTER3D:
             kvp = _read_raster3d_info(name, mapset)
-    except:
-        raise
     finally:
         conn.send(kvp)
 
@@ -1001,8 +977,6 @@ def _read_map_history(lock, conn, data):
             kvp = _read_vector_history(name, mapset)
         elif maptype == RPCDefs.TYPE_RASTER3D:
             kvp = _read_raster3d_history(name, mapset)
-    except:
-        raise
     finally:
         conn.send(kvp)
 

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -323,10 +323,7 @@ def modify_datetime(
         if residual_months == 0:
             residual_months = 1
 
-        try:
-            dt1 = dt1.replace(year=year + years_to_add, month=residual_months)
-        except:
-            raise
+        dt1 = dt1.replace(year=year + years_to_add, month=residual_months)
 
         tdelta_months = dt1 - mydate
     elif months < 0:
@@ -350,10 +347,7 @@ def modify_datetime(
         if residual_months <= 0:
             residual_months += 12
 
-        try:
-            dt1 = dt1.replace(year=year - years_to_remove, month=residual_months)
-        except:
-            raise
+        dt1 = dt1.replace(year=year - years_to_remove, month=residual_months)
 
         tdelta_months = dt1 - mydate
 


### PR DESCRIPTION
Do not catch exception only to raise it again


In one file (gui/wxpython/core/utils.py), there was a backport done in 2010 in https://trac.osgeo.org/grass/changeset/41398/ that was supposed to adapt https://trac.osgeo.org/grass/changeset/41396, but with part of the function extracted, having the try in GetListOfLocations is useless, as it is not really used, and will need to get caught elsewhere.

This is part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921