### PR TITLE
style: Fix python logging-related pylint and ruff warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,8 +177,6 @@ ignore = [
     "FURB154", # repeated-global
     "FURB171", # single-item-membership-test
     "FURB192", # sorted-min-max
-    "G002",    # logging-percent-format
-    "G003",    # logging-string-concat
     "I001",    # unsorted-imports
     "ISC003",  # explicit-string-concatenation
     "PERF102", # incorrect-dict-iterator

--- a/python/grass/pygrass/rpc/base.py
+++ b/python/grass/pygrass/rpc/base.py
@@ -154,7 +154,7 @@ class RPCServerBase:
 
         if self.stopped is not True:
             logging.warning(
-                "Needed to restart the libgis server, caller: %s" % (caller)
+                "Needed to restart the libgis server, caller: {caller}", caller=caller
             )
 
         self.threadLock.release()

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -472,7 +472,9 @@ def _write_timestamp(lock, conn, data):
         check = libgis.G_scan_timestamp(byref(ts), timestring)
 
         if check != 1:
-            logging.error("Unable to convert the timestamp: " + timestring)
+            logging.error(
+                "Unable to convert the timestamp: {timestring}", timestring=timestring
+            )
             return -2
 
         if maptype == RPCDefs.TYPE_RASTER:
@@ -555,7 +557,8 @@ def _read_semantic_label(lock, conn, data):
                 semantic_label = decode(ret)
         else:
             logging.error(
-                "Unable to read semantic label. Unsupported map type %s" % maptype
+                "Unable to read semantic label. Unsupported map type {maptype}",
+                maptype=maptype,
             )
             return -1
     except:
@@ -592,7 +595,8 @@ def _write_semantic_label(lock, conn, data):
             libraster.Rast_write_semantic_label(name, semantic_label)
         else:
             logging.error(
-                "Unable to write semantic label. Unsupported map type %s" % maptype
+                "Unable to write semantic label. Unsupported map type {maptype}",
+                maptype=maptype,
             )
             return -2
     except:
@@ -626,7 +630,8 @@ def _remove_semantic_label(lock, conn, data):
             check = libgis.G_remove_misc("cell_misc", "semantic_label", name)
         else:
             logging.error(
-                "Unable to remove semantic label. Unsupported map type %s" % maptype
+                "Unable to remove semantic label. Unsupported map type {maptype}",
+                maptype=maptype,
             )
             return -2
     except:


### PR DESCRIPTION
This is part of the effort to introduce Pylint 3.x for https://github.com/OSGeo/grass/issues/3921

Pylint error: https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/logging-not-lazy.html
Ruff rules category: https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
A stack-overflow answer showing the use of the "new" logging format (configured as "new" in my branch for my upcoming pylint 3.x config PR): https://stackoverflow.com/a/59027338

The goal of the python logging module https://docs.python.org/3/howto/logging.html#logging-variable-data is to not create a string already formatted, but let the logging format it. In other ecosystems (at least, I don't know for python), there is a concept called structured logging. A good logging usage would have only the templates coded in, and the values passed aside, and then the log output can be machine parsable. So the changes were made by tending to what I use in other languages, like C# (dotnet).