### PR TITLE
style: Fix replace-stdout-stderr (UP022)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,7 +320,6 @@ ignore = [
     "TRY302",  # useless-try-except
     "UP015",   # redundant-open-modes
     "UP018",   # native-literals
-    "UP022",   # replace-stdout-stderr
     "UP030",   # format-literals
     "UP031",   # printf-string-formatting
     "UP032",   # f-string

--- a/python/grass/gunittest/invoker.py
+++ b/python/grass/gunittest/invoker.py
@@ -196,8 +196,7 @@ class GrassTestFilesInvoker:
                 args,
                 cwd=cwd,
                 env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 timeout=timeout,
                 check=False,
             )

--- a/utils/generate_last_commit_file.py
+++ b/utils/generate_last_commit_file.py
@@ -65,8 +65,7 @@ def get_last_commit(src_dir):
                 f"--format=%H,{COMMIT_DATE_FORMAT}",
                 rel_path,
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
         )  # --format=%H,COMMIT_DATE_FORMAT commit hash,author date
         if process_result.returncode == 0:
             try:

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -380,8 +380,7 @@ def has_src_code_git(src_dir, is_addon):
                 f"--format=%H,{COMMIT_DATE_FORMAT}",
                 src_dir,
             ],
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
+            capture_output=True,
         )  # --format=%H,COMMIT_DATE_FORMAT commit hash,author date
         os.chdir(actual_dir)
         return process_result if process_result.returncode == 0 else None

--- a/utils/test_generate_last_commit_file.py
+++ b/utils/test_generate_last_commit_file.py
@@ -83,8 +83,7 @@ def test_compare_json_file_data(read_json_file, core_module_path):
             f"--format=%H,{COMMIT_DATE_FORMAT}",
             core_module_path,
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=True,
     )  # --format=%H,COMMIT_DATE_FORMAT commit hash,author date
     commit, date = process_result.stdout.decode().strip().split(",")


### PR DESCRIPTION
Using `ruff check --output-format=concise --preview --select UP022 --unsafe-fixes --fix`

Ruff rule [replace-stdout-stderr (UP022)](https://docs.astral.sh/ruff/rules/replace-stdout-stderr/):

> Why is this bad?[#](https://docs.astral.sh/ruff/rules/replace-stdout-stderr/#why-is-this-bad)
> As of Python 3.7, `subprocess.run` has a `capture_output` keyword argument that can be set to `True` to capture `stdout` and `stderr` outputs. This is equivalent to setting `stdout` and `stderr` to `subprocess.PIPE`, but is more explicit and readable.