### PR TITLE
ps.map: Fix uninitialized variable issues in r_colortable.c

### DIFF
--- a/ps/ps.map/r_colortable.c
+++ b/ps/ps.map/r_colortable.c
@@ -37,7 +37,7 @@ int read_colortable(void)
     int fontsize, cols, nodata, tickbar, discrete;
     double w, h, x, y, lw;
     int range_override;
-    double min, max, tmpD;
+    double min = 0.0, max = 0.0, tmpD = 0.0;
     int r, g, b, ret;
     PSCOLOR color;
 


### PR DESCRIPTION
This pull request addresses the following warnings identified by cppcheck in `r_colortable.c`:

**Issues:**
r_colortable.c:194:14: error: Uninitialized variable: min [uninitvar]
    ct.min = min;
            
r_colortable.c:195:14: error: Uninitialized variable: max [uninitvar]
    ct.max = max;

**Changes Made:**
The variables min, max, and tmpD are now initialized to 0.0 to ensure they have defined values before use. This resolves the warnings about uninitialized variables.