### PR TITLE
raster: Fix uninitialized variable issue in o_var.c

### DIFF
--- a/raster/r.statistics/o_var.c
+++ b/raster/r.statistics/o_var.c
@@ -17,7 +17,7 @@ int o_var(const char *basemap, const char *covermap, const char *outputmap,
 {
     struct Popen stats_child, reclass_child;
     FILE *stats, *reclass;
-    int first, i, count;
+    int first, i, count = 0;
     size_t mem;
     long basecat, covercat, catb, catc;
     double value, vari, x;


### PR DESCRIPTION
This pull request addresses the following warning identified by cppcheck.

**Issue:**
o_var.c:70:16: error: Uninitialized variable: count [uninitvar]
    m_var(tab, count, &vari);

**Changes made:**
The issue was fixed by initializing the variable `count` to `0` at the beginning of the `o_var` function. This ensures that the variable has a defined value before it is used in the calculation.

