### PR TITLE
raster3d: Fix uninitialized variable issue in main.c

### DIFF
--- a/raster3d/r3.info/main.c
+++ b/raster3d/r3.info/main.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 {
     const char *mapset;
     char *line = NULL;
-    char tmp1[TMP_LENGTH], tmp2[TMP_LENGTH], tmp3[TMP_LENGTH];
+    char tmp1[TMP_LENGTH] = "", tmp2[TMP_LENGTH] = "", tmp3[TMP_LENGTH] = "";
     char timebuff[256];
     int i;
     FILE *out;


### PR DESCRIPTION
This pull request addresses the following warning identified by cppcheck.

**Issue:**
main.c:203:47: error: Uninitialized variable: tmp1 [uninitvar]
                   "raster_3d", cats_ok ? tmp1 : "??") > 0)

**Changes made:**
The issue was fixed by initializing the variables `tmp1`, `tmp2`, and `tmp3` as empty strings. This ensures that the variables have defined values before they are used in the calculation.