### PR TITLE
style: Fix incorrect-dict-iterator (PERF102)

### DIFF
--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -454,7 +454,7 @@ class SQLBuilder(wx.Frame):
         elif self.btn_arithmeticpanel and self.btn_arithmeticpanel.IsShown():
             btns = self.btn_arithmetic
 
-        for key, value in btns.items():
+        for value in btns.values():
             if event.GetId() == value[1]:
                 mark = value[0]
                 break

--- a/gui/wxpython/iscatt/controllers.py
+++ b/gui/wxpython/iscatt/controllers.py
@@ -109,7 +109,7 @@ class ScattsManager:
         self.core.CleanUp()
 
     def CleanUpDone(self):
-        for scatt_id, scatt in self.plots.items():
+        for scatt in self.plots.values():
             if scatt["scatt"]:
                 scatt["scatt"].CleanUp()
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -905,7 +905,7 @@ class ProjParamsPage(TitledPage):
         """Go to next page"""
         if event.GetDirection():
             self.p4projparams = ""
-            for id, param in self.pparam.items():
+            for param in self.pparam.values():
                 if param["type"] == "bool":
                     if param["value"] is False:
                         continue

--- a/gui/wxpython/mapwin/base.py
+++ b/gui/wxpython/mapwin/base.py
@@ -304,7 +304,7 @@ class MapWindowBase:
         Before each handler is unregistered it is called with string
         value "unregistered" of event parameter.
         """
-        for containerEv, handlers in self.handlersContainer.items():
+        for handlers in self.handlersContainer.values():
             for handler in handlers:
                 try:
                     handler("unregistered")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,6 @@ ignore = [
     "FURB192", # sorted-min-max
     "I001",    # unsorted-imports
     "ISC003",  # explicit-string-concatenation
-    "PERF102", # incorrect-dict-iterator
     "PERF203", # try-except-in-loop
     "PERF401", # manual-list-comprehension
     "PERF402", # manual-list-copy

--- a/python/grass/jupyter/seriesmap.py
+++ b/python/grass/jupyter/seriesmap.py
@@ -198,7 +198,7 @@ class SeriesMap(BaseSeriesMap):
             self.render()
 
         tmp_files = []
-        for _, file in self._base_filename_dict.items():
+        for file in self._base_filename_dict.values():
             tmp_files.append(file)
 
         save_gif(

--- a/python/grass/jupyter/tests/seriesmap_test.py
+++ b/python/grass/jupyter/tests/seriesmap_test.py
@@ -39,7 +39,7 @@ def test_render_layers(space_time_raster_dataset):
     # check files exist
     # We need to check values which are only in protected attributes
     # pylint: disable=protected-access
-    for unused_layer, filename in img._base_filename_dict.items():
+    for filename in img._base_filename_dict.values():
         assert Path(filename).is_file()
 
 

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -66,7 +66,7 @@ def test_render_layers(space_time_raster_dataset, fill_gaps):
     # check files exist
     # We need to check values which are only in protected attributes
     # pylint: disable=protected-access
-    for unused_date, filename in img._base_filename_dict.items():
+    for filename in img._base_filename_dict.values():
         assert Path(filename).is_file()
 
 

--- a/python/grass/pygrass/tests/benchmark.py
+++ b/python/grass/pygrass/tests/benchmark.py
@@ -334,7 +334,7 @@ def print_test(testdict):
         print(execmode)
         for oper, operdict in operation.items():
             print("    ", oper)
-            for key, value in operdict.items():
+            for key in operdict.keys():
                 print("        ", key)
 
 

--- a/python/grass/script/testsuite/test_utils.py
+++ b/python/grass/script/testsuite/test_utils.py
@@ -18,7 +18,7 @@ class EnvironChange(TestCase):
             os.environ[k] = v
 
     def tearDown(self):
-        for k, v in self.env.items():
+        for k in self.env.keys():
             oval = self.original_env[k]
             if oval == self.NOT_FOUND:
                 os.environ.pop(k)

--- a/scripts/v.pack/v.pack.py
+++ b/scripts/v.pack/v.pack.py
@@ -106,7 +106,7 @@ def main():
     else:
         # for each layer connection save a table in sqlite database
         sqlitedb = os.path.join(basedir, "db.sqlite")
-        for i, dbconn in db_vect.items():
+        for dbconn in db_vect.values():
             grass.run_command(
                 "db.copy",
                 from_driver=dbconn["driver"],


### PR DESCRIPTION
When iterating over a dictionary with dict.items() but discarding either the values or the keys, dict.values() or dict.keys() should be used instead

Ruff rule: https://docs.astral.sh/ruff/rules/incorrect-dict-iterator/