### PR TITLE
style: Fix loop-variable-overrides-iterator (B020)

### DIFF
--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -342,8 +342,8 @@ def _indent(elem, level=0):
             elem.text = i + "  "
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
-        for elem in elem:
-            _indent(elem, level + 1)
+        for _elem in elem:
+            _indent(_elem, level + 1)
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ ignore = [
     "B008",    # function-call-in-default-argument
     "B009",    # get-attr-with-constant
     "B015",    # useless-comparison
-    "B020",    # loop-variable-overrides-iterator
     "B023",    # function-uses-loop-variable
     "B026",    # star-arg-unpacking-after-keyword-arg
     "B028",    # no-explicit-stacklevel

--- a/scripts/r.in.wms/wms_cap_parsers.py
+++ b/scripts/r.in.wms/wms_cap_parsers.py
@@ -234,17 +234,17 @@ class WMSCapabilitiesTree(BaseCapabilitiesTree):
                 continue
 
             is_there = False
-            for elem in elem:
+            for _elem in elem:
                 cmp_text = None
                 if cmp_type == "attribute":
-                    if add_arg in elem.attrib:
-                        cmp_text = elem.attrib[add_arg]
+                    if add_arg in _elem.attrib:
+                        cmp_text = _elem.attrib[add_arg]
 
                 elif cmp_type == "element_content":
-                    cmp_text = elem.text
+                    cmp_text = _elem.text
 
                 elif cmp_type == "child_element_content":
-                    cmp = elem.find(self.xml_ns.Ns(add_arg))
+                    cmp = _elem.find(self.xml_ns.Ns(add_arg))
                     if cmp is not None:
                         cmp_text = cmp.text
 


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/loop-variable-overrides-iterator/

Some loops used `for elem in elem`, so I replaced by `for _elem in elem`.