### PR TITLE
CI: automatic update of nix lock file

### DIFF
--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -7,6 +7,12 @@ on:
   push:
     tags:
       - '*'
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'package.nix'
+      - '.github/workflows/test-nix.yml'
   workflow_dispatch:
 
 concurrency:

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,5 +19,13 @@
 
         // Renovate's pre-commit support is still opt-in
         ":enablePreCommit",
-    ]
+
+        // weekly update of lock files (flake.lock)
+        ":maintainLockFilesWeekly",
+    ],
+
+    // enable Nix lock file update (flake.lock)
+    "nix": {
+        "enabled": true
+    }
 }


### PR DESCRIPTION
Regularly update a Nix lock file to get fresh packages from nixpkgs.

Usage of Renovate discussed in https://github.com/OSGeo/grass/pull/3933 .