### PR TITLE
nix: pin python version to 3.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1720571246,
+        "narHash": "sha256-nkUXwunTck+hNMt2wZuYRN+jf2ySRjKTzI0fo5TDH78=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "16e401f01842c5bb2499e78c1fe227f939c0c474",
         "type": "github"
       },
       "original": {
@@ -35,14 +35,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,37 +21,42 @@
 
         packages.grass = pkgs.callPackage ./package.nix { };
 
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [ self'.packages.grass ];
+        devShells.default =
+          let
+            pyPackages = pkgs.python311Packages;
 
-          # additional packages
-          buildInputs = with pkgs.python3Packages; [
-            pytest
-          ];
+          in
+          pkgs.mkShell {
+            inputsFrom = [ self'.packages.grass ];
 
-          shellHook = ''
-            function dev-help {
-              echo -e "\nWelcome to a GRASS development environment !"
-              echo "Build GRASS using following commands:"
-              echo
-              echo " 1.  ./configure --prefix=\$(pwd)/app"
-              echo " 2.  make -j$(nproc)"
-              echo " 3.  make install"
-              echo
-              echo "Run tests:"
-              echo
-              echo " 1.  export PYTHONPATH=\$(app/bin/grass --config python_path):\$PYTHONPATH"
-              echo " 2.  export LD_LIBRARY_PATH=\$(app/bin/grass --config path)/lib:\$LD_LIBRARY_PATH"
-              echo " 3.  pytest"
-              echo
-              echo "Note: run 'nix flake update' from time to time to update dependencies."
-              echo
-              echo "Run 'dev-help' to see this message again."
-            }
+            # additional packages
+            buildInputs =  with pyPackages; [
+                pytest
+              ];
 
-            dev-help
-          '';
-        };
+            shellHook = ''
+              function dev-help {
+                echo -e "\nWelcome to a GRASS development environment !"
+                echo "Build GRASS using following commands:"
+                echo
+                echo " 1.  ./configure --prefix=\$(pwd)/app"
+                echo " 2.  make -j$(nproc)"
+                echo " 3.  make install"
+                echo
+                echo "Run tests:"
+                echo
+                echo " 1.  export PYTHONPATH=\$(app/bin/grass --config python_path):\$PYTHONPATH"
+                echo " 2.  export LD_LIBRARY_PATH=\$(app/bin/grass --config path)/lib:\$LD_LIBRARY_PATH"
+                echo " 3.  pytest"
+                echo
+                echo "Note: run 'nix flake update' from time to time to update dependencies."
+                echo
+                echo "Run 'dev-help' to see this message again."
+              }
+
+              dev-help
+            '';
+          };
       };
 
       flake = { };

--- a/package.nix
+++ b/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     geos # for `geos-config`
     netcdf # for `nc-config`
     pkg-config
-  ] ++ (with pyPackages; [ python-dateutil numpy wxPython_4_2 ]);
+  ] ++ (with pyPackages; [ python-dateutil numpy wxpython ]);
 
   buildInputs = [
     blas

--- a/package.nix
+++ b/package.nix
@@ -26,15 +26,19 @@
 , pkg-config
 , postgresql
 , proj
-, python3Packages
+, python311Packages
 , readline
 , sqlite
 , wxGTK32
 , zlib
 , zstd
-
 }:
 
+
+let
+  pyPackages = python311Packages;
+
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "grass";
   version = "dev";
@@ -61,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     geos # for `geos-config`
     netcdf # for `nc-config`
     pkg-config
-  ] ++ (with python3Packages; [ python-dateutil numpy wxPython_4_2 ]);
+  ] ++ (with pyPackages; [ python-dateutil numpy wxPython_4_2 ]);
 
   buildInputs = [
     blas
@@ -137,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     wrapProgram $out/bin/grass \
     --set PYTHONPATH $PYTHONPATH \
-    --set GRASS_PYTHON ${python3Packages.python.interpreter} \
+    --set GRASS_PYTHON ${pyPackages.python.interpreter} \
     --suffix LD_LIBRARY_PATH ':' '${gdal}/lib'
     ln -s $out/grass*/lib $out/lib
     ln -s $out/grass*/include $out/include


### PR DESCRIPTION
Nixpkgs is moving to Python 3.12 as a default version. It looks like wxPython doesn't support Python 3.12 yet.

This PR will pin Python version used for GRASS to version 3.11.
We are applying the same fix for [upstream Nixpkgs GRASS package](https://github.com/NixOS/nixpkgs/pull/325731).

This PR also contains updated flake.lock file to the latest version of nixpkgs (using `nix flake update` command).
