### PR TITLE
i.atcorr: Fix uninitialized variable

### DIFF
--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -208,6 +208,7 @@ private:
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
         rbitem.vis = (int)(vis + 0.5);
+
         return rbitem;
     }
 

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -205,7 +205,6 @@ private:
     struct RBitem set_alt_vis(double alt, double vis)
     {
         struct RBitem rbitem = {};
-        
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
         rbitem.vis = (int)(vis + 0.5);

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -208,7 +208,6 @@ private:
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
         rbitem.vis = (int)(vis + 0.5);
-      
         return rbitem;
     }
 

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -208,7 +208,6 @@ private:
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
         rbitem.vis = (int)(vis + 0.5);
-        
         return rbitem;
     }
 

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -204,7 +204,7 @@ class TICache {
 private:
     struct RBitem set_alt_vis(double alt, double vis)
     {
-        struct RBitem rbitem = {0};
+        struct RBitem rbitem = {0, 0, {0, 0.0, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
 
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -204,12 +204,12 @@ class TICache {
 private:
     struct RBitem set_alt_vis(double alt, double vis)
     {
-        struct RBitem rbitem = {0, 0, {0, 0.0, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
+        struct RBitem rbitem = {
 
         /* alt and vis must be in meters */
-        rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
-        rbitem.vis = (int)(vis + 0.5);
-
+        .alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5)),
+        .vis = (int)(vis + 0.5)
+        };
         return rbitem;
     }
 

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -204,7 +204,7 @@ class TICache {
 private:
     struct RBitem set_alt_vis(double alt, double vis)
     {
-        struct RBitem rbitem;
+        struct RBitem rbitem = {0};
 
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -204,11 +204,12 @@ class TICache {
 private:
     struct RBitem set_alt_vis(double alt, double vis)
     {
-        struct RBitem rbitem = {
+        struct RBitem rbitem = {};
+        
         /* alt and vis must be in meters */
-        .alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5)),
-        .vis = (int)(vis + 0.5)
-        };
+        rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
+        rbitem.vis = (int)(vis + 0.5);
+        
         return rbitem;
     }
 

--- a/imagery/i.atcorr/main.cpp
+++ b/imagery/i.atcorr/main.cpp
@@ -208,6 +208,7 @@ private:
         /* alt and vis must be in meters */
         rbitem.alt = (alt < 0 ? (int)(alt - 0.5) : (int)(alt + 0.5));
         rbitem.vis = (int)(vis + 0.5);
+      
         return rbitem;
     }
 


### PR DESCRIPTION
**This pull request addresses uninitialized variable issue for all cpp files in imagery**

**Issue:**
i.atcorr/main.cpp:213:16: error: Uninitialized variable: rbitem.ti [uninitvar]
return rbitem;

**Changes Made:**
Initialized the RBitem struct to zero to ensure all members, including nested structures, are properly initialized.