### PR TITLE
i.segment: Fix uninitialized variable issue

### DIFF
--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -1541,7 +1541,7 @@ static int calculate_reg_stats(int row, int col, struct reg_stats *rs,
         /* rs->id must be set */
         struct pavl_table *rc_check_tree; /* cells already checked */
         int n, rid;
-        struct rc ngbr_rc = {0}, *pngbr_rc = NULL, next ={0};
+        struct rc ngbr_rc = {0}, *pngbr_rc = NULL, next = {0};
         struct rclist rilist;
         int neighbors[8][2];
         int no_check;

--- a/imagery/i.segment/region_growing.c
+++ b/imagery/i.segment/region_growing.c
@@ -696,7 +696,7 @@ static int find_best_neighbor(struct ngbr_stats *Ri, struct reg_stats *Ri_rs,
                               int clear_cand, struct globals *globals)
 {
     int n, n_ngbrs, no_check, cmp;
-    struct rc ngbr_rc, next, *pngbr_rc;
+    struct rc ngbr_rc = {0}, next = {0}, *pngbr_rc = NULL;
     struct rclist rilist;
     double tempsim;
     int neighbors[8][2];
@@ -893,7 +893,7 @@ double calculate_shape(struct reg_stats *rsi, struct reg_stats *rsk,
     double smooth, compact;
     int pl, pbbox, count;
     double bboxdiag;
-    int pl1, pl2, count1, count2;
+    int pl1 = 0, pl2 = 0, count1 = 0, count2 = 0;
     int e1, n1, s1, w1, e2, n2, s2, w2, ns_extent, ew_extent;
 
     pl = pl1 + pl2 - nshared;
@@ -989,7 +989,7 @@ static int search_neighbors(struct ngbr_stats *Ri, struct reg_stats *Ri_rs,
 int update_band_vals(int row, int col, struct reg_stats *rs,
                      struct globals *globals)
 {
-    struct rc next, ngbr_rc;
+    struct rc next = {0}, ngbr_rc = {0};
     int neighbors[8][2];
     int rid, count, n;
 
@@ -1498,7 +1498,7 @@ static int calculate_reg_stats(int row, int col, struct reg_stats *rs,
         ret = 1;
     else if (globals->min_reg_size == 3) {
         int n, rid;
-        struct rc ngbr_rc;
+        struct rc ngbr_rc = {0};
         int neighbors[8][2];
 
         globals->find_neighbors(row, col, neighbors);
@@ -1541,7 +1541,7 @@ static int calculate_reg_stats(int row, int col, struct reg_stats *rs,
         /* rs->id must be set */
         struct pavl_table *rc_check_tree; /* cells already checked */
         int n, rid;
-        struct rc ngbr_rc, *pngbr_rc, next;
+        struct rc ngbr_rc = {0}, *pngbr_rc = NULL, next ={0};
         struct rclist rilist;
         int neighbors[8][2];
         int no_check;


### PR DESCRIPTION
This pull request address all the uninitialized variables for c files in imagery folder.

Issues:

region_growing.c:725:17: Uninitialized struct member: ngbr_rc.next [uninitStructMember]
    *pngbr_rc = ngbr_rc;
          
region_growing.c:1077:21: Uninitialized struct member: ngbr_rc.next [uninitStructMember]
        *pngbr_rc = ngbr_rc;
                 
region_growing.c:1555:21: Uninitialized struct member: ngbr_rc.next [uninitStructMember]
        *pngbr_rc = ngbr_rc;
                    
region_growing.c:1555:21: Uninitialized variable: ngbr_rc.next [uninitvar]
        *pngbr_rc = ngbr_rc;
                    
region_growing.c:899:10: Uninitialized variable: pl1 [uninitvar]
    pl = pl1 + pl2 - nshared;
         
region_growing.c:899:16: Uninitialized variable: pl2 [uninitvar]
    pl = pl1 + pl2 - nshared;
               
region_growing.c:916:13: Uninitialized variable: count1 [uninitvar]
    count = count1 + count2;
            
region_growing.c:916:22: Uninitialized variable: count2 [uninitvar]
    count = count1 + count2;
                     
                     
