### PR TITLE
style: Fix too-many-newlines-at-end-of-file (W391)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,6 @@ ignore = [
     "UP032",   # f-string
     "UP034",   # extraneous-parentheses
     "UP036",   # outdated-version-block
-    "W391",    # too-many-newlines-at-end-of-file
     "W605",    # invalid-escape-sequence
     "YTT204",  # sys-version-info-minor-cmp-int
 ]

--- a/raster/r.stats.zonal/graphics_for_description.ipynb
+++ b/raster/r.stats.zonal/graphics_for_description.ipynb
@@ -77,13 +77,6 @@
     "!optipng -o7 {filename}\n",
     "Image(filename)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/too-many-newlines-at-end-of-file/

Only one file changed, a single python notebook had an empty cell at the end of the document, so removed that cell.