### PR TITLE
style: Fix if-expr-min-max (FURB136)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ ignore = [
     "FURB118", # reimplemented-operator
     "FURB129", # readlines-in-for
     "FURB131", # delete-full-slice
-    "FURB136", # if-expr-min-max
     "FURB140", # reimplemented-starmap
     "FURB142", # for-loop-set-mutations
     "FURB148", # unnecessary-enumerate

--- a/python/grass/pygrass/modules/grid/split.py
+++ b/python/grass/pygrass/modules/grid/split.py
@@ -29,10 +29,10 @@ def get_bbox(reg, row, col, width, height, overlap):
     east = reg.west + ((col + 1) * width + overlap) * reg.ewres
     west = reg.west + (col * width - overlap) * reg.ewres
     return Bbox(
-        north=north if north <= reg.north else reg.north,
-        south=south if south >= reg.south else reg.south,
-        east=east if east <= reg.east else reg.east,
-        west=west if west >= reg.west else reg.west,
+        north=min(north, reg.north),
+        south=max(south, reg.south),
+        east=min(east, reg.east),
+        west=max(west, reg.west),
     )
 
 


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/if-expr-min-max/
Only one file affected, when returning a bounding box.