### PR TITLE
style: Fix unnecessary-comprehension-in-call (C419)

### DIFF
--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -2092,10 +2092,8 @@ class DataCatalogTree(TreeView):
 
         if not isinstance(self._giface, StandaloneGrassInterface):
             if all(
-                [
-                    each.data["name"] == genv["LOCATION_NAME"]
-                    for each in self.selected_location
-                ]
+                each.data["name"] == genv["LOCATION_NAME"]
+                for each in self.selected_location
             ):
                 if len(self.selected_layer) > 1:
                     item = wx.MenuItem(menu, wx.ID_ANY, _("&Display layers"))

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1947,7 +1947,7 @@ def print_params(params):
 
     # check if we are dealing with parameters which require dev files
     dev_params = ["arch", "compiler", "build", "date"]
-    if any([param in dev_params for param in params]):
+    if any(param in dev_params for param in params):
         plat = gpath("include", "Make", "Platform.make")
         if not os.path.exists(plat):
             fatal(_("Please install the GRASS GIS development package"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ ignore = [
     "C414",    # unnecessary-double-cast-or-process
     "C416",    # unnecessary-comprehension
     "C417",    # unnecessary-map
-    "C419",    # unnecessary-comprehension-in-call
     "COM812",  # missing-trailing-comma
     "COM818",  # trailing-comma-on-bare-tuple
     "D1",

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -2249,7 +2249,7 @@ class TemporalAlgebraParser:
             # Use method eval_global_var to evaluate expression.
             resultlist = self.eval_global_var(tvarexpr, thenlist)
         # Check if a given list is a list of maps.
-        elif all([issubclass(type(ele), AbstractMapDataset) for ele in tvarexpr]):
+        elif all(issubclass(type(ele), AbstractMapDataset) for ele in tvarexpr):
             # Use method eval_map_list to evaluate map_list in comparison to thenlist.
             resultlist = self.eval_map_list(tvarexpr, thenlist, topolist)
         elif len(tvarexpr) % 2 != 0:
@@ -2259,12 +2259,12 @@ class TemporalAlgebraParser:
                 expr = tvarexpr[iter]
                 operator = tvarexpr[iter + 1]
                 relexpr = tvarexpr[iter + 2]
-                if all([issubclass(type(ele), list) for ele in [expr, relexpr]]):
+                if all(issubclass(type(ele), list) for ele in [expr, relexpr]):
                     resultlist = self.build_spatio_temporal_topology_list(expr, relexpr)
             # Loop through the list, search for map lists or global variables.
             for expr in tvarexpr:
                 if isinstance(expr, list):
-                    if all([issubclass(type(ele), AbstractMapDataset) for ele in expr]):
+                    if all(issubclass(type(ele), AbstractMapDataset) for ele in expr):
                         # Use method eval_map_list to evaluate map_list
                         resultlist = self.eval_map_list(expr, thenlist, topolist)
                     else:
@@ -2274,7 +2274,7 @@ class TemporalAlgebraParser:
                 elif isinstance(expr, GlobalTemporalVar):
                     # Use according functions for different global variable types.
                     if expr.get_type() == "operator":
-                        if all(["condition_value" in dir(map_i) for map_i in thenlist]):
+                        if all("condition_value" in dir(map_i) for map_i in thenlist):
                             # Add operator string to the condition list.
                             [
                                 map_i.condition_value.extend(expr.get_type_value())

--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -510,7 +510,7 @@ def main():
     occurrences = sorted([(math.radians(x), freq[x]) for x in freq])
 
     # find the maximum value
-    maxradius = max([f for a, f in occurrences])
+    maxradius = max(f for a, f in occurrences)
 
     # now do cos() sin()
     sine_cosine = [(math.cos(a) * f, math.sin(a) * f) for a, f in occurrences]


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/unnecessary-comprehension-in-call/
The explanations are well written in that page. For example, they show this:


> ### Why is this bad?[#](https://docs.astral.sh/ruff/rules/unnecessary-comprehension-in-call/#why-is-this-bad)
> Many builtin functions (this rule currently covers `any`, `all`, `min`, `max`, and `sum`) take any iterable, including a generator. Constructing a temporary list via list comprehension is unnecessary and wastes memory for large iterables.
> 
> `any` and `all` can also short-circuit iteration, saving a lot of time. The unnecessary comprehension forces a full iteration of the input iterable, giving up the benefits of short-circuiting. For example, compare the performance of `all` with a list comprehension against that of a generator in a case where an early short-circuit is possible (almost 40x faster):
> 
> 
> ```
> In [1]: %timeit all([i for i in range(1000)])
> 8.14 µs ± 25.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
> 
> In [2]: %timeit all(i for i in range(1000))
> 212 ns ± 0.892 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
> ```
> This performance improvement is due to short-circuiting. If the entire iterable has to be traversed, the comprehension version may even be a bit faster: list allocation overhead is not necessarily greater than generator overhead.
> 
> Applying this rule simplifies the code and will usually save memory, but in the absence of short-circuiting it may not improve performance. (It may even slightly regress performance, though the difference will usually be small.)