### PR TITLE
style: Fix readlines-in-for (FURB129)

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -664,7 +664,7 @@ class GConsole(wx.EvtHandler):
             if os.path.splitext(command[0])[1] in {".py", ".sh"}:
                 try:
                     with open(command[0], "r") as sfile:
-                        for line in sfile.readlines():
+                        for line in sfile:
                             if len(line) < 3:
                                 continue
                             if line.startswith(("#%", "# %")):

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -908,7 +908,7 @@ class Map:
                 % {"file": filename, "ret": e}
             )
 
-        for line in windfile.readlines():
+        for line in windfile:
             line = line.strip()
             try:
                 key, value = line.split(":", 1)

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -951,7 +951,7 @@ class Settings:
 
         try:
             line = ""
-            for line in fd.readlines():
+            for line in fd:
                 line = line.rstrip("%s" % os.linesep)
                 group, key = line.split(self.sep)[0:2]
                 kv = line.split(self.sep)[2:]

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -840,7 +840,7 @@ def StoreEnvVariable(key, value=None, envFile=None):
         except OSError as e:
             sys.stderr.write(_("Unable to open file '%s'\n") % envFile)
             return
-        for line in fd.readlines():
+        for line in fd:
             line = line.rstrip(os.linesep)
             try:
                 k, v = (x.strip() for x in line.split(" ", 1)[1].split("=", 1))

--- a/gui/wxpython/core/watchdog.py
+++ b/gui/wxpython/core/watchdog.py
@@ -68,7 +68,7 @@ class CurrentMapsetWatch(FileSystemEventHandler):
             time.sleep(0.1)
             with open(event.src_path, "r") as f:
                 gisrc = {}
-                for line in f.readlines():
+                for line in f:
                     key, val = line.split(":")
                     gisrc[key.strip()] = val.strip()
                 new = os.path.join(

--- a/gui/wxpython/core/workspace.py
+++ b/gui/wxpython/core/workspace.py
@@ -1757,7 +1757,7 @@ class ProcessGrcFile:
             return []
 
         line_id = 1
-        for line in file.readlines():
+        for line in file:
             self.process_line(line.rstrip("\n"), line_id)
             line_id += 1
 

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -122,7 +122,7 @@ class GCPWizard:
         self.gisrc_dict = {}
         try:
             f = open(self.target_gisrc, "r")
-            for line in f.readlines():
+            for line in f:
                 line = line.replace("\n", "").strip()
                 if len(line) < 1:
                     continue
@@ -978,7 +978,7 @@ class DispMapPage(TitledPage):
 
             try:
                 with open(vgrpfile) as f:
-                    for vect in f.readlines():
+                    for vect in f:
                         vect = vect.strip("\n")
                         if len(vect) < 1:
                             continue
@@ -1616,7 +1616,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             f = open(self.file["points"], "r")
             GCPcnt = 0
 
-            for line in f.readlines():
+            for line in f:
                 if line[0] == "#" or line == "":
                     continue
                 line = line.replace("\n", "").strip()
@@ -1868,7 +1868,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             f = open(self.file["vgrp"])
             vectlist = []
             try:
-                for vect in f.readlines():
+                for vect in f:
                     vect = vect.strip("\n")
                     if len(vect) < 1:
                         continue
@@ -2736,7 +2736,7 @@ class VectGroup(wx.Dialog):
             f = open(self.vgrpfile)
             try:
                 checked = []
-                for line in f.readlines():
+                for line in f:
                     line = line.replace("\n", "")
                     if len(line) < 1:
                         continue

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -809,7 +809,7 @@ class HelpWindow(HtmlWindow):
         try:
             contents = []
             skip = False
-            for line in open(htmlFile, "rb").readlines():
+            for line in open(htmlFile, "rb"):
                 if "DESCRIPTION" in line:
                     skip = False
                 if not skip:

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -542,7 +542,7 @@ class GRASSStartup(wx.Frame):
         if gisrc and os.path.isfile(gisrc):
             try:
                 rc = open(gisrc, "r")
-                for line in rc.readlines():
+                for line in rc:
                     try:
                         key, val = line.split(":", 1)
                     except ValueError as e:

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -162,7 +162,7 @@ class GCPWizard:
         self.gisrc_dict = {}
         try:
             f = open(self.target_gisrc, "r")
-            for line in f.readlines():
+            for line in f:
                 line = line.replace("\n", "").strip()
                 if len(line) < 1:
                     continue
@@ -974,7 +974,7 @@ class DispMapPage(TitledPage):
 
             f = open(vgrpfile)
             try:
-                for vect in f.readlines():
+                for vect in f:
                     vect = vect.strip("\n")
                     if len(vect) < 1:
                         continue
@@ -1640,7 +1640,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             f = open(self.file["control_points"], "r")
             GCPcnt = 0
 
-            for line in f.readlines():
+            for line in f:
                 if line[0] == "#" or line == "":
                     continue
                 line = line.replace("\n", "").strip()
@@ -1821,7 +1821,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             f = open(self.file["vgrp"])
             vectlist = []
             try:
-                for vect in f.readlines():
+                for vect in f:
                     vect = vect.strip("\n")
                     if len(vect) < 1:
                         continue
@@ -2682,7 +2682,7 @@ class VectGroup(wx.Dialog):
             f = open(self.vgrpfile)
             try:
                 checked = []
-                for line in f.readlines():
+                for line in f:
                     line = line.replace("\n", "")
                     if len(line) < 1:
                         continue

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -2563,7 +2563,7 @@ class LocationWizard(wx.Object):
         f = open(os.path.join(globalvar.ETCDIR, "proj", "parms.table"), "r")
         self.projections = {}
         self.projdesc = {}
-        for line in f.readlines():
+        for line in f:
             line = line.strip()
             try:
                 proj, projdesc, params = line.split(":")
@@ -2586,7 +2586,7 @@ class LocationWizard(wx.Object):
         f = open(os.path.join(globalvar.ETCDIR, "proj", "datum.table"), "r")
         self.datums = {}
         paramslist = []
-        for line in f.readlines():
+        for line in f:
             line = line.expandtabs(1)
             line = line.strip()
             if line == "" or line[0] == "#":
@@ -2603,7 +2603,7 @@ class LocationWizard(wx.Object):
         # read Earth-based ellipsiod definitions
         f = open(os.path.join(globalvar.ETCDIR, "proj", "ellipse.table"), "r")
         self.ellipsoids = {}
-        for line in f.readlines():
+        for line in f:
             line = line.expandtabs(1)
             line = line.strip()
             if line == "" or line[0] == "#":
@@ -2621,7 +2621,7 @@ class LocationWizard(wx.Object):
             os.path.join(globalvar.ETCDIR, "proj", "ellipse.table.solar.system"), "r"
         )
         self.planetary_ellipsoids = {}
-        for line in f.readlines():
+        for line in f:
             line = line.expandtabs(1)
             line = line.strip()
             if line == "" or line[0] == "#":
@@ -2637,7 +2637,7 @@ class LocationWizard(wx.Object):
         # read projection parameter description and parsing table
         f = open(os.path.join(globalvar.ETCDIR, "proj", "desc.table"), "r")
         self.paramdesc = {}
-        for line in f.readlines():
+        for line in f:
             line = line.strip()
             try:
                 pparam, datatype, proj4term, desc = line.split(":")

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -123,7 +123,7 @@ class GCPWizard:
         self.gisrc_dict = {}
         try:
             f = open(self.target_gisrc, "r")
-            for line in f.readlines():
+            for line in f:
                 line = line.replace("\n", "").strip()
                 if len(line) < 1:
                     continue
@@ -963,7 +963,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             f = open(self.file["points"], "r")
             GCPcnt = 0
 
-            for line in f.readlines():
+            for line in f:
                 if line[0] == "#" or line == "":
                     continue
                 line = line.replace("\n", "").strip()

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -1072,7 +1072,7 @@ class VectMap:
         )
         try:
             head = open(headPath, "r")
-            for line in head.readlines():
+            for line in head:
                 i = line.find(
                     "MAP DATE:",
                 )
@@ -1299,7 +1299,7 @@ class History:
 
         newHistStep = False
         isSearchedHistStep = False
-        for line in hist.readlines():
+        for line in hist:
             if not line.strip() and isSearchedHistStep:
                 break
             elif not line.strip():

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -1990,7 +1990,7 @@ def print_params(params):
             date_str = "#define GRASS_HEADERS_DATE "
             gdate = gpath("include", "grass", "version.h")
             with open(gdate) as filegdate:
-                for line in filegdate.readlines():
+                for line in filegdate:
                     if line.startswith(date_str):
                         sys.stdout.write(
                             "{}\n".format(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ ignore = [
     "FURB101", # read-whole-file
     "FURB103", # write-whole-file.
     "FURB118", # reimplemented-operator
-    "FURB129", # readlines-in-for
     "FURB131", # delete-full-slice
     "FURB140", # reimplemented-starmap
     "FURB142", # for-loop-set-mutations

--- a/python/grass/grassdb/history.py
+++ b/python/grass/grassdb/history.py
@@ -86,8 +86,7 @@ def _read_from_plain_text(history_path):
             history_path, encoding="utf-8", mode="r", errors="replace"
         ) as file_history:
             content_list = [
-                {"command": line.strip(), "command_info": None}
-                for line in file_history.readlines()
+                {"command": line.strip(), "command_info": None} for line in file_history
             ]
     except OSError as e:
         raise OSError(

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -299,7 +299,7 @@ class Category(list):
         """
         self.reset()
         with open(filename, "r") as f:
-            for row in f.readlines():
+            for row in f:
                 cat = row.strip().split(sep)
                 if len(cat) == 2:
                     label, min_cat = cat

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1284,7 +1284,7 @@ def region_env(region3d=False, flags=None, env=None, **kwargs):
     )
     with open(windfile, "r") as fd:
         grass_region = ""
-        for line in fd.readlines():
+        for line in fd:
             key, value = (x.strip() for x in line.split(":", 1))
             if kwargs and key not in {"proj", "zone"}:
                 continue

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -191,7 +191,7 @@ def db_select(sql=None, filename=None, table=None, env=None, **args):
         fatal(_("Fetching data failed"))
 
     ofile = open(fname)
-    result = [tuple(x.rstrip(os.linesep).split(args["sep"])) for x in ofile.readlines()]
+    result = [tuple(x.rstrip(os.linesep).split(args["sep"])) for x in ofile]
     ofile.close()
     try_remove(fname)
 

--- a/scripts/d.frame/d.frame.py
+++ b/scripts/d.frame/d.frame.py
@@ -96,7 +96,7 @@ def read_monitor_file(monitor, ftype="env"):
         fatal(_("Unable to get monitor info. %s"), e)
 
     lines = []
-    for line in fd.readlines():
+    for line in fd:
         lines.append(line)
 
     fd.close()

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -2000,7 +2000,7 @@ def install_extension_std_platforms(name, source, url, branch):
             if filename == "Makefile":
                 # get the module name: PGM = <module name>
                 with open(os.path.join(r, "Makefile")) as fp:
-                    for line in fp.readlines():
+                    for line in fp:
                         if re.match(r"PGM.*.=|PGM=", line):
                             try:
                                 modulename = line.split("=")[1].strip()

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -211,7 +211,7 @@ def draw_linegraph(what):
             )
         )
     with open(gcore.parse_command("d.mon", flags="g", quiet=True)["env"]) as f:
-        for line in f.readlines():
+        for line in f:
             if "GRASS_RENDER_FILE=" in line:
                 gcore.info(
                     _(

--- a/scripts/r.pack/r.pack.py
+++ b/scripts/r.pack/r.pack.py
@@ -94,7 +94,7 @@ def main():
             vrt = os.path.join(map_file["file"], "vrt")
             if os.path.exists(vrt):
                 with open(vrt, "r") as f:
-                    for r in f.readlines():
+                    for r in f:
                         map, mapset = r.split("@")
                         map_basedir = os.path.sep.join(
                             os.path.normpath(


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/readlines-in-for/
"It is more convenient and performant to iterate over the file object directly"

In python docs for [io.IOBase.readlines](https://docs.python.org/3/library/io.html#io.IOBase.readlines) 
"Note that it’s already possible to iterate on file objects using `for line in file: ...` without calling file.readlines()."