### PR TITLE
style: Fix sorted-min-max (FURB192)

### DIFF
--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -128,7 +128,7 @@ def get_module_image(module, images):
             return image
         if basename == module:
             return image
-    return sorted(candidates, key=len)[0]
+    return min(candidates, key=len)
 
 
 def generate_page_for_category(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ ignore = [
     "FURB152", # math-constant
     "FURB154", # repeated-global
     "FURB171", # single-item-membership-test
-    "FURB192", # sorted-min-max
     "I001",    # unsorted-imports
     "ISC003",  # explicit-string-concatenation
     "PERF203", # try-except-in-loop


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/sorted-min-max/

One instance changed. It is calling the element at index 0 of a sorted() call.

The check will now be enabled after this, since all instances are fixed and should stay fixed