### PR TITLE
d.labels: Fix buffer overflow issues in do_labels.c

### DIFF
--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -465,7 +465,6 @@ int scan_ref(char *buf)
         if (buf[i] >= 'A' && buf[i] <= 'Z')
             buf[i] += 'a' - 'A';
     xref = yref = CENT;
-
     switch (sscanf(buf, word_fmt, word1, word2)) {
     case 2:
         if (!(xmatch(word2) || ymatch(word2)))

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -84,7 +84,7 @@ int do_labels(FILE *infile, int do_rotation)
         else if (!strncmp(text, "yof", 3))
             sscanf(text, "%*s %d", &yoffset);
         else if (!strncmp(text, "col", 3)) {
-            sscanf(text, "%*s %s", buff);
+            sscanf(text, "%*s %127s", buff);
             set_RGBA_from_str(&color, buff);
         }
         else if (!strncmp(text, "siz", 3))
@@ -94,15 +94,15 @@ int do_labels(FILE *infile, int do_rotation)
         else if (!strncmp(text, "wid", 3))
             sscanf(text, "%*s %lf", &width);
         else if (!strncmp(text, "bac", 3)) {
-            sscanf(text, "%*s %s", buff);
+            sscanf(text, "%*s %127s", buff);
             set_RGBA_from_str(&background, buff);
         }
         else if (!strncmp(text, "bor", 3)) {
-            sscanf(text, "%*s %s", buff);
+            sscanf(text, "%*s %127s", buff);
             set_RGBA_from_str(&border, buff);
         }
         else if (!strncmp(text, "opa", 3)) {
-            sscanf(text, "%*s %s", buff);
+            sscanf(text, "%*s %127s", buff);
             if (!strncmp(buff, "YES", 3))
                 opaque = YES;
             else
@@ -115,7 +115,7 @@ int do_labels(FILE *infile, int do_rotation)
             }
         }
         else if (!strncmp(text, "fon", 3)) {
-            if (sscanf(text, "%*s %s", font) != 1 || !strcmp(font, "standard"))
+            if (sscanf(text, "%*s %255s", font) != 1 || !strcmp(font, "standard"))
                 strcpy(font, std_font);
         }
         else if (!strncmp(text, "rot", 3)) {
@@ -123,7 +123,7 @@ int do_labels(FILE *infile, int do_rotation)
                 sscanf(text, "%*s %lf", &rotation);
         }
         else if (!strncmp(text, "hco", 3)) {
-            sscanf(text, "%*s %s", buff);
+            sscanf(text, "%*s %127s", buff);
             set_RGBA_from_str(&highlight_color, buff);
         }
         else if (!strncmp(text, "hwi", 3))
@@ -452,7 +452,7 @@ int scan_ref(char *buf)
         if (buf[i] >= 'A' && buf[i] <= 'Z')
             buf[i] += 'a' - 'A';
     xref = yref = CENT;
-    switch (sscanf(buf, "%s%s", word1, word2)) {
+    switch (sscanf(buf, "%49s%49s", word1, word2)) {
     case 2:
         if (!(xmatch(word2) || ymatch(word2)))
             return 0;

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -79,7 +79,8 @@ int do_labels(FILE *infile, int do_rotation)
 
     snprintf(buff_fmt, sizeof(buff_fmt), "%%*s %%%ds", BUFFSIZE - 1);
     snprintf(font_fmt, sizeof(font_fmt), "%%*s %%%ds", FONTSIZE - 1);
-    snprintf(word_fmt, sizeof(word_fmt), "%%%ds %%%ds", WORDSIZE - 1, WORDSIZE - 1);
+    snprintf(word_fmt, sizeof(word_fmt), "%%%ds %%%ds", WORDSIZE - 1,
+             WORDSIZE - 1);
 
     initialize_options();
 

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -129,7 +129,6 @@ int do_labels(FILE *infile, int do_rotation)
         }
         else if (!strncmp(text, "fon", 3)) {
             if (sscanf(text, font_fmt, font) != 1 || !strcmp(font, "standard"))
-
                 strcpy(font, std_font);
         }
         else if (!strncmp(text, "rot", 3)) {

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -20,6 +20,10 @@
 #define YES   1
 #define NO    0
 
+#define BUFFSIZE 128
+#define FONTSIZE 256
+#define WORDSIZE 50
+
 static double east;
 static double north;
 static int xoffset;
@@ -68,6 +72,13 @@ int initialize_options(void)
 int do_labels(FILE *infile, int do_rotation)
 {
     char buff[128];
+    char buff_fmt[10];
+    char font_fmt[10];
+    char word_fmt[10];
+
+    snprintf(buff_fmt, sizeof(buff_fmt), "%%%ds", BUFFSIZE - 1);
+    snprintf(font_fmt, sizeof(font_fmt), "%%%ds", FONTSIZE - 1);
+    snprintf(word_fmt, sizeof(word_fmt), "%%%ds%%%ds", WORDSIZE - 1, WORDSIZE - 1);
 
     initialize_options();
 
@@ -84,7 +95,7 @@ int do_labels(FILE *infile, int do_rotation)
         else if (!strncmp(text, "yof", 3))
             sscanf(text, "%*s %d", &yoffset);
         else if (!strncmp(text, "col", 3)) {
-            sscanf(text, "%*s %127s", buff);
+            sscanf(text, buff_fmt, buff);
             set_RGBA_from_str(&color, buff);
         }
         else if (!strncmp(text, "siz", 3))
@@ -94,15 +105,15 @@ int do_labels(FILE *infile, int do_rotation)
         else if (!strncmp(text, "wid", 3))
             sscanf(text, "%*s %lf", &width);
         else if (!strncmp(text, "bac", 3)) {
-            sscanf(text, "%*s %127s", buff);
+            sscanf(text, buff_fmt, buff);
             set_RGBA_from_str(&background, buff);
         }
         else if (!strncmp(text, "bor", 3)) {
-            sscanf(text, "%*s %127s", buff);
+            sscanf(text, buff_fmt, buff);
             set_RGBA_from_str(&border, buff);
         }
         else if (!strncmp(text, "opa", 3)) {
-            sscanf(text, "%*s %127s", buff);
+            sscanf(text, buff_fmt, buff);
             if (!strncmp(buff, "YES", 3))
                 opaque = YES;
             else
@@ -115,7 +126,7 @@ int do_labels(FILE *infile, int do_rotation)
             }
         }
         else if (!strncmp(text, "fon", 3)) {
-            if (sscanf(text, "%*s %255s", font) != 1 || !strcmp(font, "standard"))
+            if (sscanf(text, font_fmt, font) != 1 || !strcmp(font, "standard"))
                 strcpy(font, std_font);
         }
         else if (!strncmp(text, "rot", 3)) {
@@ -123,7 +134,7 @@ int do_labels(FILE *infile, int do_rotation)
                 sscanf(text, "%*s %lf", &rotation);
         }
         else if (!strncmp(text, "hco", 3)) {
-            sscanf(text, "%*s %127s", buff);
+            sscanf(text, buff_fmt, buff);
             set_RGBA_from_str(&highlight_color, buff);
         }
         else if (!strncmp(text, "hwi", 3))
@@ -452,7 +463,10 @@ int scan_ref(char *buf)
         if (buf[i] >= 'A' && buf[i] <= 'Z')
             buf[i] += 'a' - 'A';
     xref = yref = CENT;
-    switch (sscanf(buf, "%49s%49s", word1, word2)) {
+    char word_fmt[10];
+    snprintf(word_fmt, sizeof(word_fmt), "%%%ds%%%ds", WORDSIZE - 1, WORDSIZE - 1);
+
+    switch (sscanf(buf, word_fmt, word1, word2)) {
     case 2:
         if (!(xmatch(word2) || ymatch(word2)))
             return 0;
@@ -461,10 +475,11 @@ int scan_ref(char *buf)
         if (xmatch(word1) || ymatch(word1))
             return 1;
         FALLTHROUGH;
+    case EOF:
+        FALLTHROUGH;
     default:
         return 0;
-    case EOF:
-        return 0;
+
     }
 }
 

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -463,6 +463,8 @@ int scan_ref(char *buf)
         FALLTHROUGH;
     default:
         return 0;
+    case EOF:
+        return 0;
     }
 }
 

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -37,8 +37,12 @@ static int highlight_width;
 static int opaque;
 static double width, rotation;
 static char text[MTEXT];
-static char font[256];
+static char font[FONTSIZE];
 static const char *std_font;
+
+static char buff_fmt[10];
+static char font_fmt[10];
+static char word_fmt[10];
 
 static int ymatch(char *);
 static int xmatch(char *);
@@ -71,15 +75,11 @@ int initialize_options(void)
 
 int do_labels(FILE *infile, int do_rotation)
 {
-    char buff[128];
-    char buff_fmt[10];
-    char font_fmt[10];
-    char word_fmt[10];
+    char buff[BUFFSIZE];
 
-    snprintf(buff_fmt, sizeof(buff_fmt), "%%%ds", BUFFSIZE - 1);
-    snprintf(font_fmt, sizeof(font_fmt), "%%%ds", FONTSIZE - 1);
-    snprintf(word_fmt, sizeof(word_fmt), "%%%ds%%%ds", WORDSIZE - 1,
-             WORDSIZE - 1);
+    snprintf(buff_fmt, sizeof(buff_fmt), "%%*s %%%ds", BUFFSIZE - 1);
+    snprintf(font_fmt, sizeof(font_fmt), "%%*s %%%ds", FONTSIZE - 1);
+    snprintf(word_fmt, sizeof(word_fmt), "%%%ds %%%ds", WORDSIZE - 1, WORDSIZE - 1);
 
     initialize_options();
 
@@ -465,9 +465,6 @@ int scan_ref(char *buf)
         if (buf[i] >= 'A' && buf[i] <= 'Z')
             buf[i] += 'a' - 'A';
     xref = yref = CENT;
-    char word_fmt[10];
-    snprintf(word_fmt, sizeof(word_fmt), "%%%ds%%%ds", WORDSIZE - 1,
-             WORDSIZE - 1);
 
     switch (sscanf(buf, word_fmt, word1, word2)) {
     case 2:
@@ -479,7 +476,6 @@ int scan_ref(char *buf)
             return 1;
         FALLTHROUGH;
     case EOF:
-        FALLTHROUGH;
     default:
         return 0;
     }

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -40,9 +40,9 @@ static char text[MTEXT];
 static char font[FONTSIZE];
 static const char *std_font;
 
-static char buff_fmt[10];
-static char font_fmt[10];
-static char word_fmt[10];
+static char buff_fmt[WORDSIZE];
+static char font_fmt[WORDSIZE];
+static char word_fmt[WORDSIZE];
 
 static int ymatch(char *);
 static int xmatch(char *);

--- a/display/d.labels/do_labels.c
+++ b/display/d.labels/do_labels.c
@@ -7,18 +7,18 @@
 #include <grass/glocale.h>
 #include "local_proto.h"
 
-#define NL    012
-#define TAB   011
-#define BACK  0134
-#define MTEXT 1024
+#define NL       012
+#define TAB      011
+#define BACK     0134
+#define MTEXT    1024
 
-#define TOP   0
-#define CENT  1
-#define BOT   2
-#define LEFT  0
-#define RITE  2
-#define YES   1
-#define NO    0
+#define TOP      0
+#define CENT     1
+#define BOT      2
+#define LEFT     0
+#define RITE     2
+#define YES      1
+#define NO       0
 
 #define BUFFSIZE 128
 #define FONTSIZE 256


### PR DESCRIPTION
This pull request addresses multiple warnings identified by cppcheck related to potential buffer overflow issues.

**Issues:**
1. do_labels.c:87:13: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
            sscanf(text, "%*s %s", buff);
2. do_labels.c:97:13: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
            sscanf(text, "%*s %s", buff);
3. do_labels.c:101:13: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
            sscanf(text, "%*s %s", buff);
4. do_labels.c:105:13: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
            sscanf(text, "%*s %s", buff);
5. do_labels.c:118:17: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
            if (sscanf(text, "%*s %s", font) != 1 || !strcmp(font, "standard"))
6. do_labels.c:126:13: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
            sscanf(text, "%*s %s", buff);
7. do_labels.c:455:13: warning: sscanf() without field width limits can crash with huge input data. [invalidscanf]
    switch (sscanf(buf, "%s%s", word1, word2)) 

**Changes Made:**
 Added field width specifiers to the sscanf calls to prevent buffer overflows.

The field width is one less than the buffer size.
buff[128] -> %127s
font[256] -> %255s
word1[50], word2[50] -> %49s

