### PR TITLE
style: Fix math-constant (FURB152)

### DIFF
--- a/display/d.text/test.py
+++ b/display/d.text/test.py
@@ -56,8 +56,8 @@ for i in range(36):
     rotate(i * 10)
     color(colors[i % len(colors)])
     xy(
-        (80 + 10 * math.cos(i * 10 / 180 * 3.141593)),
-        (50 + 10 * 640 / 480 * math.sin(i * 10 / 180 * 3.141593)),
+        (80 + 10 * math.cos(i * 10 / 180 * math.pi)),
+        (50 + 10 * 640 / 480 * math.sin(i * 10 / 180 * math.pi)),
     )
     text(fonts[int(i % len(fonts))])
 

--- a/lib/imagery/testsuite/test_imagery_sigsetfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigsetfile.py
@@ -39,7 +39,6 @@ from grass.lib.imagery import (
     I_free_group_ref,
     ReturnString,
 )
-import math
 
 
 class SigSetFileTestCase(TestCase):
@@ -79,7 +78,7 @@ class SigSetFileTestCase(TestCase):
         So.ClassSig[0].classnum = 2
         So.ClassSig[0].title = ReturnString("1st class")
         So.ClassSig[0].type = 1
-        So.ClassSig[0].SubSig[0].pi = math.pi
+        So.ClassSig[0].SubSig[0].pi = 3.14
         So.ClassSig[0].SubSig[0].means[0] = 42.42
         So.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -109,7 +108,7 @@ class SigSetFileTestCase(TestCase):
         self.assertEqual(Sn.ClassSig[0].classnum, 2)
         self.assertEqual(utils.decode(Sn.ClassSig[0].title), "1st class")
         self.assertEqual(Sn.ClassSig[0].type, 1)
-        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, math.pi)
+        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, 3.14)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].means[0], 42.42)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].R[0][0], 69.69)
 
@@ -134,7 +133,7 @@ class SigSetFileTestCase(TestCase):
         So.ClassSig[0].classnum = 2
         So.ClassSig[0].title = ReturnString("1st class")
         So.ClassSig[0].type = 1
-        So.ClassSig[0].SubSig[0].pi = math.pi
+        So.ClassSig[0].SubSig[0].pi = 3.14
         So.ClassSig[0].SubSig[0].means[0] = 42.42
         So.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -174,7 +173,7 @@ class SigSetFileTestCase(TestCase):
         So.ClassSig[0].classnum = 2
         So.ClassSig[0].title = ReturnString("1st class")
         So.ClassSig[0].type = 1
-        So.ClassSig[0].SubSig[0].pi = math.pi
+        So.ClassSig[0].SubSig[0].pi = 3.14
         So.ClassSig[0].SubSig[0].means[0] = 42.42
         So.ClassSig[0].SubSig[0].means[1] = 24.24
         So.ClassSig[0].SubSig[0].R[0][0] = 69.69
@@ -211,7 +210,7 @@ class SigSetFileTestCase(TestCase):
         self.assertEqual(Sn.ClassSig[0].classnum, 2)
         self.assertEqual(utils.decode(Sn.ClassSig[0].title), "1st class")
         self.assertEqual(Sn.ClassSig[0].type, 1)
-        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, math.pi)
+        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, 3.14)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].means[0], 42.42)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].means[1], 24.24)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].R[0][0], 69.69)
@@ -268,7 +267,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = math.pi
+        S.ClassSig[0].SubSig[0].pi = 3.14
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -313,7 +312,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = math.pi
+        S.ClassSig[0].SubSig[0].pi = 3.14
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -359,7 +358,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = math.pi
+        S.ClassSig[0].SubSig[0].pi = 3.14
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -408,7 +407,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = math.pi
+        S.ClassSig[0].SubSig[0].pi = 3.14
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -419,7 +418,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
             ctypes.cast(S.semantic_labels[0], ctypes.c_char_p).value
         )
         self.assertEqual(semantic_label, "The_Doors")
-        self.assertEqual(S.ClassSig[0].SubSig[0].pi, math.pi)
+        self.assertEqual(S.ClassSig[0].SubSig[0].pi, 3.14)
         self.assertEqual(S.ClassSig[0].SubSig[0].means[0], 42.42)
         self.assertEqual(S.ClassSig[0].SubSig[0].R[0][0], 69.69)
 
@@ -456,7 +455,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = math.pi
+        S.ClassSig[0].SubSig[0].pi = 3.14
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].means[1] = 24.24
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
@@ -469,7 +468,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         self.assertFalse(bool(ret))
         # Semantic labels and sig items should be swapped
         # Static items
-        self.assertEqual(S.ClassSig[0].SubSig[0].pi, math.pi)
+        self.assertEqual(S.ClassSig[0].SubSig[0].pi, 3.14)
         # Reordered items
         semantic_label1 = utils.decode(
             ctypes.cast(S.semantic_labels[0], ctypes.c_char_p).value
@@ -519,7 +518,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = math.pi
+        S.ClassSig[0].SubSig[0].pi = 3.14
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].means[1] = 24.24
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
@@ -532,7 +531,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         self.assertFalse(bool(ret))
         # Semantic labels and sig items should not be swapped
         # Static items
-        self.assertEqual(S.ClassSig[0].SubSig[0].pi, math.pi)
+        self.assertEqual(S.ClassSig[0].SubSig[0].pi, 3.14)
         # Reordered items
         semantic_label1 = utils.decode(
             ctypes.cast(S.semantic_labels[0], ctypes.c_char_p).value

--- a/lib/imagery/testsuite/test_imagery_sigsetfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigsetfile.py
@@ -39,6 +39,7 @@ from grass.lib.imagery import (
     I_free_group_ref,
     ReturnString,
 )
+import math
 
 
 class SigSetFileTestCase(TestCase):
@@ -78,7 +79,7 @@ class SigSetFileTestCase(TestCase):
         So.ClassSig[0].classnum = 2
         So.ClassSig[0].title = ReturnString("1st class")
         So.ClassSig[0].type = 1
-        So.ClassSig[0].SubSig[0].pi = 3.14
+        So.ClassSig[0].SubSig[0].pi = math.pi
         So.ClassSig[0].SubSig[0].means[0] = 42.42
         So.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -108,7 +109,7 @@ class SigSetFileTestCase(TestCase):
         self.assertEqual(Sn.ClassSig[0].classnum, 2)
         self.assertEqual(utils.decode(Sn.ClassSig[0].title), "1st class")
         self.assertEqual(Sn.ClassSig[0].type, 1)
-        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, 3.14)
+        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, math.pi)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].means[0], 42.42)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].R[0][0], 69.69)
 
@@ -133,7 +134,7 @@ class SigSetFileTestCase(TestCase):
         So.ClassSig[0].classnum = 2
         So.ClassSig[0].title = ReturnString("1st class")
         So.ClassSig[0].type = 1
-        So.ClassSig[0].SubSig[0].pi = 3.14
+        So.ClassSig[0].SubSig[0].pi = math.pi
         So.ClassSig[0].SubSig[0].means[0] = 42.42
         So.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -173,7 +174,7 @@ class SigSetFileTestCase(TestCase):
         So.ClassSig[0].classnum = 2
         So.ClassSig[0].title = ReturnString("1st class")
         So.ClassSig[0].type = 1
-        So.ClassSig[0].SubSig[0].pi = 3.14
+        So.ClassSig[0].SubSig[0].pi = math.pi
         So.ClassSig[0].SubSig[0].means[0] = 42.42
         So.ClassSig[0].SubSig[0].means[1] = 24.24
         So.ClassSig[0].SubSig[0].R[0][0] = 69.69
@@ -210,7 +211,7 @@ class SigSetFileTestCase(TestCase):
         self.assertEqual(Sn.ClassSig[0].classnum, 2)
         self.assertEqual(utils.decode(Sn.ClassSig[0].title), "1st class")
         self.assertEqual(Sn.ClassSig[0].type, 1)
-        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, 3.14)
+        self.assertEqual(Sn.ClassSig[0].SubSig[0].pi, math.pi)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].means[0], 42.42)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].means[1], 24.24)
         self.assertEqual(Sn.ClassSig[0].SubSig[0].R[0][0], 69.69)
@@ -267,7 +268,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = 3.14
+        S.ClassSig[0].SubSig[0].pi = math.pi
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -312,7 +313,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = 3.14
+        S.ClassSig[0].SubSig[0].pi = math.pi
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -358,7 +359,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = 3.14
+        S.ClassSig[0].SubSig[0].pi = math.pi
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -407,7 +408,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = 3.14
+        S.ClassSig[0].SubSig[0].pi = math.pi
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
 
@@ -418,7 +419,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
             ctypes.cast(S.semantic_labels[0], ctypes.c_char_p).value
         )
         self.assertEqual(semantic_label, "The_Doors")
-        self.assertEqual(S.ClassSig[0].SubSig[0].pi, 3.14)
+        self.assertEqual(S.ClassSig[0].SubSig[0].pi, math.pi)
         self.assertEqual(S.ClassSig[0].SubSig[0].means[0], 42.42)
         self.assertEqual(S.ClassSig[0].SubSig[0].R[0][0], 69.69)
 
@@ -455,7 +456,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = 3.14
+        S.ClassSig[0].SubSig[0].pi = math.pi
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].means[1] = 24.24
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
@@ -468,7 +469,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         self.assertFalse(bool(ret))
         # Semantic labels and sig items should be swapped
         # Static items
-        self.assertEqual(S.ClassSig[0].SubSig[0].pi, 3.14)
+        self.assertEqual(S.ClassSig[0].SubSig[0].pi, math.pi)
         # Reordered items
         semantic_label1 = utils.decode(
             ctypes.cast(S.semantic_labels[0], ctypes.c_char_p).value
@@ -518,7 +519,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         S.ClassSig[0].classnum = 2
         S.ClassSig[0].title = ReturnString("1st class")
         S.ClassSig[0].type = 1
-        S.ClassSig[0].SubSig[0].pi = 3.14
+        S.ClassSig[0].SubSig[0].pi = math.pi
         S.ClassSig[0].SubSig[0].means[0] = 42.42
         S.ClassSig[0].SubSig[0].means[1] = 24.24
         S.ClassSig[0].SubSig[0].R[0][0] = 69.69
@@ -531,7 +532,7 @@ class SortSigSetBySemanticLabelTest(TestCase):
         self.assertFalse(bool(ret))
         # Semantic labels and sig items should not be swapped
         # Static items
-        self.assertEqual(S.ClassSig[0].SubSig[0].pi, 3.14)
+        self.assertEqual(S.ClassSig[0].SubSig[0].pi, math.pi)
         # Reordered items
         semantic_label1 = utils.decode(
             ctypes.cast(S.semantic_labels[0], ctypes.c_char_p).value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,6 +353,7 @@ ignore = [
 "gui/wxpython/web_services/widgets.py" = ["INT003"]
 "gui/wxpython/wxgui.py" = ["INT002"]
 "gui/wxpython/wxplot/profile.py" = ["NPY001"]
+"lib/imagery/testsuite/test_imagery_sigsetfile.py" = ["FURB152"]
 "lib/init/grass.py" = ["INT003"]
 "python/grass/__init__.py" = ["PYI056"]
 "python/grass/exp*/tests/grass_script_mapset_session_test.py" = ["SIM117"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ ignore = [
     "FBT002",  # boolean-default-value-positional-argument
     "FBT003",  # boolean-positional-value-in-call
     "FURB118", # reimplemented-operator
-    "FURB152", # math-constant
     "I001",    # unsorted-imports
     "ISC003",  # explicit-string-concatenation
     "PERF203", # try-except-in-loop


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/math-constant/

The rule finds hard-coded constants like pi, tau, e, and replaces it with the constants from `math`.


Two files are affected. One seems unused (a test.py that isn't run as tests), and a test file in imagery. Since the complete test file seemed to use two decimal points, I reverted and added a per-file-ignore. I made it in a separate commit so it would be possible to see what it looks like with the change.