### PR TITLE
CI: Configure Renovate update groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,7 @@
 
         // weekly update of lock files (flake.lock)
         ":maintainLockFilesWeekly",
+        "group:githubArtifactActions",
     ],
 
     // enable Nix lock file update (flake.lock)
@@ -30,15 +31,6 @@
     },
 
     "packageRules": [
-        {
-            // Adapted from https://docs.renovatebot.com/presets-group/#groupgithubartifactactions
-            "groupName": "GitHub Artifact Actions",
-            "matchManagers": ["github-actions"],
-            "matchPackageNames": [
-                "actions/download-artifact",
-                "actions/upload-artifact",
-            ],
-        },
         {
             "groupName": "ruff",
             "matchPackageNames": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,38 @@
 
     // enable Nix lock file update (flake.lock)
     "nix": {
-        "enabled": true
-    }
+        "enabled": true,
+    },
+
+    "packageRules": [
+        {
+            // Adapted from https://docs.renovatebot.com/presets-group/#groupgithubartifactactions
+            "groupName": "GitHub Artifact Actions",
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": [
+                "actions/download-artifact",
+                "actions/upload-artifact",
+            ],
+        },
+        {
+            "groupName": "ruff",
+            "matchPackageNames": [
+                "astral-sh/ruff",
+                "astral-sh/ruff-pre-commit",
+                "ruff",
+            ],
+        },
+        {
+            "groupName": "flake8",
+            "matchPackageNames": ["pycqa/flake8", "flake8"],
+        },
+        {
+            "groupName": "black",
+            "matchPackageNames": [
+                "psf/black-pre-commit-mirror",
+                "psf/black",
+                "black",
+            ],
+        },
+    ],
 }


### PR DESCRIPTION
Configures update groups so simultaneous updates of pre-commit and the tool in CI are updated together. (Especially when the pre-commit mirror repo isn't the same repo as the tool).
Worked in my repo, it autoclosed a duplicated ruff and ruff-pre-commit PR https://github.com/echoix/grass/pull/152 and created this instead: https://github.com/echoix/grass/pull/159