### PR TITLE
g.findfile: copy into fixed size buffer issue

### DIFF
--- a/general/g.findfile/main.c
+++ b/general/g.findfile/main.c
@@ -104,8 +104,11 @@ int main(int argc, char *argv[])
             strcpy(name, file_opt->answer);
         G_free_tokens(map_mapset);
     }
-    else
-        strcpy(name, file_opt->answer);
+    else {
+    strncpy(name, file_opt->answer, sizeof(name) - 1);
+    name[sizeof(name) - 1] = '\0';  // Ensure null-termination
+    }
+        
 
     mapset = G_find_file2(elem_opt->answer, name, search_mapset);
     if (mapset) {


### PR DESCRIPTION
This pull request resolves a buffer overflow issue detected by Coverity Scan **(CID 1208235)** in the g.findfile module. The problem arises when the file_opt->answer string is copied into a fixed-size buffer without validating its length, potentially causing the buffer to be overrun if the source string is excessively long.

**Changes Made:**
Replaced the use of strcpy with strncpy to copy file_opt->answer into the name buffer.
Ensured that the name buffer is null-terminated by explicitly setting the last character to '\0'.

