### PR TITLE
i.smap: fix sizeof not portable issue

### DIFF
--- a/imagery/i.smap/multialloc.c
+++ b/imagery/i.smap/multialloc.c
@@ -37,7 +37,7 @@ char *multialloc(size_t s, /* individual array element size */
     for (i = 0; i < d - 1; i++, q++) { /* for each of the dimensions
                                         * but the last */
         max *= (*q);
-        r[0] = (char *)G_malloc(max * sizeof(char **));
+        r[0] = (char *)G_malloc(max * sizeof(char *));
         r = (char **)r[0]; /* step through to beginning of next
                             * dimension array */
     }


### PR DESCRIPTION
**Issue:** Sizeof not portable issue identified by coverity scan

This pull request resolves a sizeof mismatch issue identified by Coverity Scan (CID 1208214) in the memory allocation logic of the multialloc function.

**Changes Made:**
Replaced the use of sizeof(char **) with sizeof(char *) to ensure correct and portable memory allocation.