### PR TITLE
abstract_space_time_dataset: use keyword arguments in calls to get_registered_maps

### DIFF
--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1556,7 +1556,12 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         # use all columns
         rows = self.get_registered_maps(
-            None, where, order, dbif, spatial_extent, spatial_relation
+            columns=None,
+            where=where,
+            order=order,
+            dbif=dbif,
+            spatial_extent=spatial_extent,
+            spatial_relation=spatial_relation,
         )
 
         if rows:
@@ -2376,7 +2381,9 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             self.msgr.debug(
                 1, _("Drop map register table: %s") % (self.get_map_register())
             )
-            rows = self.get_registered_maps("id", None, None, dbif)
+            rows = self.get_registered_maps(
+                columns="id", where=None, order=None, dbif=dbif
+            )
             # Unregister each registered map in the table
             if rows is not None:
                 for row in rows:


### PR DESCRIPTION
Calling ` get_registered_maps_as_objects` may fail, depending on the arguments provided. This PR backports a fix in how the underlying ` get_registered_maps` method is called.

See also: #3798