### PR TITLE
pytest: Collect all uncovered Python files in code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,64 @@
+[run]
+; branch = True
+; dynamic_context = test_function
+concurrency = multiprocessing,thread
+parallel = True
+data_file = ${INITIAL_PWD-.}/.coverage
+omit =
+    ${INITIAL_PWD-.}/testreport
+    ${INITIAL_PWD-.}/.github/*
+    ${INITIAL_PWD-.}/bin.*/*
+    ${INITIAL_PWD-.}/dist.*/*
+    **/OBJ.*/*
+source = 
+    .
+    ${INITIAL_PWD-.}/
+    ${INITIAL_GISBASE-/usr/local/grass??}/
+
+[paths]
+root =
+    ./
+    ${INITIAL_GISBASE-/usr/local/grass??}/
+    /home/*/install/grass??/
+python =
+    ./python/
+    ${INITIAL_GISBASE-/usr/local/grass??}/etc/python/
+    /home/*/install/grass??/etc/python/
+special_d_mon =
+    ./display/d.mon/
+    ${INITIAL_GISBASE-/usr/local/grass??}/etc/d.mon/
+    /home/*/install/grass??/etc/d.mon/
+special_r_in_wms =
+    ./scripts/r.in.wms/
+    ${INITIAL_GISBASE-/usr/local/grass??}/etc/r.in.wms/
+    /home/*/install/grass??/etc/r.in.wms/
+
+
+[report]
+; Since our file structure isn't an importable package, not all files are found
+; This allows to find python files even if there is missing __init__.py files, but is slow
+include_namespace_packages = True
+skip_covered = False
+; Regexes for lines to exclude from consideration
+exclude_also =
+    ; Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    ; Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    ; Don't complain if non-runnable code isn't run:
+    ; if 0:
+    ; if __name__ == .__main__.:
+
+    ; Don't complain about abstract methods, they aren't run:
+    @(abc\.)?abstractmethod
+
+ignore_errors = True
+precision = 2
+
+[html]
+directory = coverage_html_report
+show_contexts = true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -93,9 +93,17 @@ jobs:
           INITIAL_PWD="${PWD}" pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
             --cov \
             --cov-context=test \
-            --cov-report=html \
             -ra . \
             -m 'needs_solo_run'
+      - name: Fix non-standard installed script paths in coverage data
+        run: |
+          export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
+          export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
+          export INITIAL_GISBASE="$(grass --config path)"
+          export INITIAL_PWD="${PWD}"
+          python utils/coverage_mapper.py
+          coverage combine
+          coverage html
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -89,8 +89,11 @@ jobs:
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
+          export INITIAL_GISBASE="$(grass --config path)"
+          INITIAL_PWD="${PWD}" pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
             --cov \
+            --cov-context=test \
+            --cov-report=html \
             -ra . \
             -m 'needs_solo_run'
 
@@ -101,6 +104,13 @@ jobs:
           flags: pytest-python-${{ matrix.python-version }}
           name: pytest-python-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Make python-only code coverage test report available
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: python-codecoverage-report-${{ matrix.os }}-${{ matrix.python-version }}
+          path: coverage_html_report
+          retention-days: 1
 
   pytest-success:
     name: pytest Result

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ lib/*/latex/
 *.gcno
 *.gcda
 .coverage
+.coverage.*
+coverage.xml

--- a/utils/coverage_mapper.py
+++ b/utils/coverage_mapper.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def get_grass_config_path():
+    grass_config_path = None
+    try:
+        grass_config_path = subprocess.run(
+            ["grass", "--config", "path"], capture_output=True, text=True, check=True
+        ).stdout.rstrip()
+    except OSError:
+        grass_config_path = None
+    return grass_config_path
+
+
+INITIAL_GISBASE = os.getenv("INITIAL_GISBASE", get_grass_config_path())
+INITIAL_PWD = os.getenv("INITIAL_PWD", str(Path.cwd().absolute()))
+
+
+def map_scripts_paths(old_path):
+    if INITIAL_GISBASE is None or INITIAL_PWD is None:
+        return old_path
+    p = Path(old_path)
+    temporal_base = Path(INITIAL_GISBASE) / "scripts" / "t.*"
+    base = Path(INITIAL_GISBASE) / "scripts" / "*"
+    if p.match(str(temporal_base)):
+        return str(Path(INITIAL_PWD) / "temporal" / (p.name) / (p.name)) + ".py"
+    if p.match(str(base)):
+        return str(Path(INITIAL_PWD) / "scripts" / (p.name) / (p.name)) + ".py"
+
+    return old_path
+
+
+if __name__ == "__main__":
+    from coverage import CoverageData
+
+    a = CoverageData(".coverage")
+    b = CoverageData(".coverage.fixed_scripts")
+    b.update(a, map_path=map_scripts_paths)
+    b.write()


### PR DESCRIPTION
This PR makes sure all Python files are collected in the code coverage report, even if uncovered.

Because of our special layout, the coverage tool can't map back to files in the repo easily, so special configuration was needed.
In order to collect for files that can't be imported, `include_namespace_packages = True` must be used. It adds about 1 min on report creation.
Also, handling the case of the installed scripts not having the same file name as the code in the repo was really hard to solve, and unsolvable only by configuration. I had to resort to using their API that edits the SQLite database with a custom function that maps paths to a path in the repo.

I also made sure to upload HTML report artifacts, as the python coverage tool can save what test function touched what line, and is quite useful to debug even further. It isn't presented in the codecov interface yet. The pytest-cov plugin goes even further, and sets the context to “setup”, “run”, or “teardown” for each test. the https://pytest-cov.readthedocs.io/en/latest/contexts.html

I didn't keep the branch coverage yet, to make sure the coverage isn't flaky now.


The config file is adapted from what I had worked on in January/February, and is probably already ready for its usage in the gunittest-based python code coverage. I want this PR to be merged for a couple commits before introducing a new change.

I was motived to rework on this now, as there are multiple weird regressions on Windows tests that I saw yesterday (including C-code library error codes that are kind of weird), so I think having code coverage on Windows set up is becoming more urgent. But I need this and another step to be done and merged first.

I also didn't enable code coverage for pytest with multiple workers, to be sure this is not flaky before introducing coverage to another set of files.
