### PR TITLE
i.aster.toar: Fix buffer overflow check issue

### DIFF
--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -165,21 +165,21 @@ int main(int argc, char *argv[])
     /*Prepare the output file names */
 
     /********************/
-    sprintf(result0, "%s%s", result, ".1");
-    sprintf(result1, "%s%s", result, ".2");
-    sprintf(result2, "%s%s", result, ".3N");
-    sprintf(result3, "%s%s", result, ".3B");
-    sprintf(result4, "%s%s", result, ".4");
-    sprintf(result5, "%s%s", result, ".5");
-    sprintf(result6, "%s%s", result, ".6");
-    sprintf(result7, "%s%s", result, ".7");
-    sprintf(result8, "%s%s", result, ".8");
-    sprintf(result9, "%s%s", result, ".9");
-    sprintf(result10, "%s%s", result, ".10");
-    sprintf(result11, "%s%s", result, ".11");
-    sprintf(result12, "%s%s", result, ".12");
-    sprintf(result13, "%s%s", result, ".13");
-    sprintf(result14, "%s%s", result, ".14");
+    snprintf(result0, sizeof(result0), "%s%s", result, ".1");
+    snprintf(result1, sizeof(result1), "%s%s", result, ".2");
+    snprintf(result2, sizeof(result2), "%s%s", result, ".3N");
+    snprintf(result3, sizeof(result3), "%s%s", result, ".3B");
+    snprintf(result4, sizeof(result4), "%s%s", result, ".4");
+    snprintf(result5, sizeof(result5), "%s%s", result, ".5");
+    snprintf(result6, sizeof(result6), "%s%s", result, ".6");
+    snprintf(result7, sizeof(result7), "%s%s", result, ".7");
+    snprintf(result8, sizeof(result8), "%s%s", result, ".8");
+    snprintf(result9, sizeof(result9), "%s%s", result, ".9");
+    snprintf(result10, sizeof(result10), "%s%s", result, ".10");
+    snprintf(result11, sizeof(result11), "%s%s", result, ".11");
+    snprintf(result12, sizeof(result12), "%s%s", result, ".12");
+    snprintf(result13, sizeof(result13), "%s%s", result, ".13");
+    snprintf(result14, sizeof(result14), "%s%s", result, ".14");
 
     /********************/
     /*Prepare radiance boundaries */


### PR DESCRIPTION
fix: Replace sprintf with snprintf to prevent buffer overflow

- Replaced all occurrences of `sprintf` with `snprintf` to ensure buffer sizes are not exceeded.
- This fixes issues reported by flawfinder related to potential buffer overflows.

Issue:
./main.c:168:  [4] (buffer) sprintf:
  Does not check for buffer overflows (CWE-120). Use sprintf_s, snprintf, or
  vsnprintf.
