### PR TITLE
r.path: Fix buffer overflow check issue

### DIFF
--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -219,13 +219,17 @@ int main(int argc, char **argv)
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    strcpy(dir_name, opt.dir->answer);
+    strncpy(dir_name, opt.dir->answer, sizeof(dir_name) - 1);
+    dir_name[sizeof(dir_name) - 1] = '\0';
     *map_name = '\0';
     *out_name = '\0';
     if (opt.rast->answer) {
-        strcpy(out_name, opt.rast->answer);
-        if (opt.val->answer)
-            strcpy(map_name, opt.val->answer);
+        strncpy(out_name, opt.rast->answer, sizeof(out_name) - 1);
+        out_name[sizeof(out_name) - 1] = '\0';
+        if (opt.val->answer) {
+            strncpy(map_name, opt.val->answer, sizeof(map_name) - 1);
+            map_name[sizeof(map_name) - 1] = '\0';
+        }
     }
 
     pvout = NULL;

--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -139,6 +139,7 @@ int main(int argc, char **argv)
     struct line_cats *Cats;
     struct Map_info vout, *pvout;
     char *desc = NULL;
+    size_t len;
 
     G_gisinit(argv[0]);
 
@@ -219,19 +220,23 @@ int main(int argc, char **argv)
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    if (G_strlcpy(dir_name, opt.dir->answer, sizeof(dir_name)) >= sizeof(dir_name)) {
-        G_fatal_error(_("Buffer overflow while copying dir_name"));
+    len = G_strlcpy(dir_name, opt.dir->answer, sizeof(dir_name));
+    if (len >= sizeof(dir_name)) {
+        G_fatal_error(_("Name <%s> is too long"), opt.dir->answer);
     }
     *map_name = '\0';
     *out_name = '\0';
     if (opt.rast->answer) {
-        if (G_strlcpy(out_name, opt.rast->answer, sizeof(out_name)) >= sizeof(out_name)) {
-            G_fatal_error(_("Buffer overflow while copying out_name"));
+        len = G_strlcpy(out_name, opt.rast->answer, sizeof(out_name));
+        if (len >= sizeof(out_name)) {
+            G_fatal_error(_("Name <%s> is too long"), opt.rast->answer);
         }
-        if (opt.val->answer) {
-            if (G_strlcpy(map_name, opt.val->answer, sizeof(map_name)) >= sizeof(map_name)) {
-                G_fatal_error(_("Buffer overflow while copying map_name"));
-            }
+    }
+
+    if (opt.rast->answer && opt.val->answer) {
+        len = G_strlcpy(map_name, opt.val->answer, sizeof(map_name));
+        if (len >= sizeof(map_name)) {
+            G_fatal_error(_("Name <%s> is too long"), opt.val->answer);
         }
     }
 

--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -219,13 +219,20 @@ int main(int argc, char **argv)
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    G_strlcpy(dir_name, opt.dir->answer, sizeof(dir_name));
+    if (G_strlcpy(dir_name, opt.dir->answer, sizeof(dir_name)) >= sizeof(dir_name)) {
+        G_fatal_error(_("Buffer overflow while copying dir_name"));
+    }
     *map_name = '\0';
     *out_name = '\0';
     if (opt.rast->answer) {
-        G_strlcpy(out_name, opt.rast->answer, sizeof(out_name));
-        if (opt.val->answer)
-            G_strlcpy(map_name, opt.val->answer, sizeof(map_name));
+        if (G_strlcpy(out_name, opt.rast->answer, sizeof(out_name)) >= sizeof(out_name)) {
+            G_fatal_error(_("Buffer overflow while copying out_name"));
+        }
+        if (opt.val->answer) {
+            if (G_strlcpy(map_name, opt.val->answer, sizeof(map_name)) >= sizeof(map_name)) {
+                G_fatal_error(_("Buffer overflow while copying map_name"));
+            }
+        }
     }
 
     pvout = NULL;

--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -232,7 +232,6 @@ int main(int argc, char **argv)
             G_fatal_error(_("Name <%s> is too long"), opt.rast->answer);
         }
     }
-
     if (opt.rast->answer && opt.val->answer) {
         len = G_strlcpy(map_name, opt.val->answer, sizeof(map_name));
         if (len >= sizeof(map_name)) {

--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -219,17 +219,13 @@ int main(int argc, char **argv)
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    strncpy(dir_name, opt.dir->answer, sizeof(dir_name) - 1);
-    dir_name[sizeof(dir_name) - 1] = '\0';
+    G_strlcpy(dir_name, opt.dir->answer, sizeof(dir_name));
     *map_name = '\0';
     *out_name = '\0';
     if (opt.rast->answer) {
-        strncpy(out_name, opt.rast->answer, sizeof(out_name) - 1);
-        out_name[sizeof(out_name) - 1] = '\0';
-        if (opt.val->answer) {
-            strncpy(map_name, opt.val->answer, sizeof(map_name) - 1);
-            map_name[sizeof(map_name) - 1] = '\0';
-        }
+        G_strlcpy(out_name, opt.rast->answer, sizeof(out_name));
+        if (opt.val->answer)
+            G_strlcpy(map_name, opt.val->answer, sizeof(map_name));
     }
 
     pvout = NULL;


### PR DESCRIPTION
This pull request addresses several potential buffer overflow issues in the r.path module by replacing instances of strcpy with strncpy.
The issue is identified by both Coverity scan (CID :1415799) and by flawfinder

 