### PR TITLE
r.out.mpeg: Fix potential buffer overflow issue

### DIFF
--- a/raster/r.out.mpeg/main.c
+++ b/raster/r.out.mpeg/main.c
@@ -144,7 +144,8 @@ int main(int argc, char **argv)
     parse_command(viewopts, vfiles, &numviews, &frames);
 
     /* output file */
-    strcpy(outfile, out->answer);
+    strncpy(outfile, out->answer, sizeof(outfile) - 1);
+    outfile[sizeof(outfile) - 1] = '\0';
 
     r_out = 0;
     if (conv->answer)

--- a/raster/r.out.mpeg/main.c
+++ b/raster/r.out.mpeg/main.c
@@ -95,6 +95,7 @@ int main(int argc, char **argv)
     struct Flag *conv;
     int i;
     int *sdimp, longdim, r_out;
+    size_t len;
 
     G_gisinit(argv[0]);
 
@@ -144,8 +145,10 @@ int main(int argc, char **argv)
     parse_command(viewopts, vfiles, &numviews, &frames);
 
     /* output file */
-    strncpy(outfile, out->answer, sizeof(outfile) - 1);
-    outfile[sizeof(outfile) - 1] = '\0';
+    len = G_strlcpy(outfile, out->answer, sizeof(outfile));
+    if (len >= sizeof(outfile)) {
+        G_fatal_error(_("Name <%s> is too long"), out->answer);
+    }
 
     r_out = 0;
     if (conv->answer)

--- a/raster/r.out.mpeg/write.c
+++ b/raster/r.out.mpeg/write.c
@@ -197,12 +197,16 @@ void write_params(char *mpfilename, char *yfiles[], char *outfile, int frames,
     FILE *fp;
     char dir[1000], *enddir;
     int i, dirlen = 0;
+    size_t len;
 
     if (NULL == (fp = fopen(mpfilename, "w")))
         G_fatal_error(_("Unable to create temporary files."));
 
     if (!fly) {
-        strcpy(dir, yfiles[0]);
+        len = G_strlcpy(dir, yfiles[0], sizeof(dir));
+        if (len >= sizeof(dir)) {
+            G_fatal_error(_("Directory <%s> too long"), yfiles[0]);
+        }
         enddir = strrchr(dir, '/');
 
         if (enddir) {


### PR DESCRIPTION
This pull request addresses a potential buffer overflow issue in the r.out.mpeg module by replacing the strcpy function with strncpy.

The issue is identified by both coverity scan (CID:1415777) and by flawfinder.
