### PR TITLE
tests: Add .gitignore to gunittest testreport folder if not present

### DIFF
--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -19,7 +19,7 @@ import collections
 import re
 from collections.abc import Iterable
 
-from .utils import ensure_dir
+from .utils import add_gitignore_to_dir, ensure_dir
 from .checkers import text_to_keyvalue
 
 
@@ -330,9 +330,10 @@ class GrassTestFilesMultiReporter:
 
     def start(self, results_dir):
         # TODO: no directory cleaning (self.clean_before)? now cleaned by caller
-        # TODO: perhaps only those whoe need it should do it (even multiple times)
+        # TODO: perhaps only those who need it should do it (even multiple times)
         # and there is also the delete problem
         ensure_dir(os.path.abspath(results_dir))
+        add_gitignore_to_dir(os.path.abspath(results_dir))
         for reporter in self.reporters:
             try:
                 reporter.start(results_dir)

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -11,6 +11,7 @@ for details.
 
 import errno
 import os
+from pathlib import Path
 import shutil
 import sys
 
@@ -19,6 +20,12 @@ def ensure_dir(directory):
     """Create all directories in the given path if needed."""
     if not os.path.exists(directory):
         os.makedirs(directory)
+
+
+def add_gitignore_to_dir(directory):
+    gitignore_path = Path(directory) / ".gitignore"
+    if not Path(gitignore_path).exists():
+        Path(gitignore_path).write_text("*")
 
 
 def silent_rmtree(filename):


### PR DESCRIPTION
This is similar to what `coverage html` does when creating an html report. It adds a .gitignore file with a single star, that ignores all the files in that directory, preventing to show up as added files with git. It’s useful for contributors, preventing to accidentally commit the test report folders.

I limited calling that new function to a single place, the one that is normally used in CI (and me locally). The potential places that this new function be called is right after every time ensure_dir() is called (about 4, but only this one had the effect I expected).

I extracted this from my work to add coverage on gunittest (Ubuntu), that works locally but just now on CI (after 50 back-and-forths).
