### PR TITLE
i.ortho.photo: Fix uninitialized variable and potential buffer overflow

### DIFF
--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
     char *desc_ortho_opt;
     char *moduletorun;
     const char *grname;
-    char tosystem[99];
+    char tosystem[99] = "";
 
     /* initialize grass */
     G_gisinit(argv[0]);

--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -84,8 +84,7 @@ int main(int argc, char **argv)
     /* group validity check */
 
     /*----------------------*/
-    strncpy(group.name, group_opt->answer, BUFFER_SIZE);
-    group.name[BUFFER_SIZE - 1] = '\0';
+    G_strlcpy(group.name, group_opt->answer, BUFFER_SIZE);
     /* strip off mapset if it's there: I_() fns only work with current mapset */
     if ((p = strchr(group.name, '@')))
         *p = 0;
@@ -98,30 +97,26 @@ int main(int argc, char **argv)
     moduletorun = ortho_opt->answer;
     /* run the program chosen */
     if (strcmp(moduletorun, "g.gui.photo2image") == 0) {
-        strncpy(tosystem, "g.gui.photo2image", BUFFER_SIZE - 1);
-        tosystem[BUFFER_SIZE - 1] = '\0';
+        G_strlcpy(tosystem, "g.gui.photo2image", BUFFER_SIZE);
         return system((const char *)tosystem);
     }
     else if (strcmp(moduletorun, "g.gui.image2target") == 0) {
-        strncpy(tosystem, "g.gui.image2target", BUFFER_SIZE - 1);
-        tosystem[BUFFER_SIZE - 1] = '\0';
+        G_strlcpy(tosystem, "g.gui.image2target", BUFFER_SIZE);
         return system((const char *)tosystem);
     }
     else {
         if (strcmp(moduletorun, "i.group") == 0)
-            strncpy(tosystem, "i.group --ui group=", BUFFER_SIZE - 1);
+            G_strlcpy(tosystem, "i.group --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.target") == 0)
-            strncpy(tosystem, "i.ortho.target --ui group=", BUFFER_SIZE - 1);
+            G_strlcpy(tosystem, "i.ortho.target --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.elev") == 0)
-            strncpy(tosystem, "i.ortho.elev --ui group=", BUFFER_SIZE - 1);
+            G_strlcpy(tosystem, "i.ortho.elev --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.camera") == 0)
-            strncpy(tosystem, "i.ortho.camera --ui group=", BUFFER_SIZE - 1);
+            G_strlcpy(tosystem, "i.ortho.camera --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.init") == 0)
-            strncpy(tosystem, "i.ortho.init --ui group=", BUFFER_SIZE - 1);
+            G_strlcpy(tosystem, "i.ortho.init --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.rectify") == 0)
-            strncpy(tosystem, "i.ortho.rectify --ui group=", BUFFER_SIZE - 1);
-
-        tosystem[BUFFER_SIZE - 1] = '\0';
+            G_strlcpy(tosystem, "i.ortho.rectify --ui group=", BUFFER_SIZE);
         strcat(tosystem, grname);
         return system((const char *)tosystem);
     }

--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -36,6 +36,7 @@ int main(int argc, char **argv)
     char *moduletorun;
     const char *grname;
     char tosystem[BUFFER_SIZE] = "";
+    size_t len;
 
     /* initialize grass */
     G_gisinit(argv[0]);
@@ -84,7 +85,10 @@ int main(int argc, char **argv)
     /* group validity check */
 
     /*----------------------*/
-    G_strlcpy(group.name, group_opt->answer, BUFFER_SIZE);
+    len = G_strlcpy(group.name, group_opt->answer, BUFFER_SIZE);
+    if (len >= BUFFER_SIZE) {
+        G_fatal_error(_("Name <%s> is too long"), group_opt->answer);
+    }
     /* strip off mapset if it's there: I_() fns only work with current mapset */
     if ((p = strchr(group.name, '@')))
         *p = 0;
@@ -97,26 +101,26 @@ int main(int argc, char **argv)
     moduletorun = ortho_opt->answer;
     /* run the program chosen */
     if (strcmp(moduletorun, "g.gui.photo2image") == 0) {
-        G_strlcpy(tosystem, "g.gui.photo2image", BUFFER_SIZE);
+        (void)G_strlcpy(tosystem, "g.gui.photo2image", BUFFER_SIZE);
         return system((const char *)tosystem);
     }
     else if (strcmp(moduletorun, "g.gui.image2target") == 0) {
-        G_strlcpy(tosystem, "g.gui.image2target", BUFFER_SIZE);
+        (void)G_strlcpy(tosystem, "g.gui.image2target", BUFFER_SIZE);
         return system((const char *)tosystem);
     }
     else {
         if (strcmp(moduletorun, "i.group") == 0)
-            G_strlcpy(tosystem, "i.group --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.group --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.target") == 0)
-            G_strlcpy(tosystem, "i.ortho.target --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.target --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.elev") == 0)
-            G_strlcpy(tosystem, "i.ortho.elev --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.elev --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.camera") == 0)
-            G_strlcpy(tosystem, "i.ortho.camera --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.camera --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.init") == 0)
-            G_strlcpy(tosystem, "i.ortho.init --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.init --ui group=", BUFFER_SIZE);
         if (strcmp(moduletorun, "i.ortho.rectify") == 0)
-            G_strlcpy(tosystem, "i.ortho.rectify --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.rectify --ui group=", BUFFER_SIZE);
         strcat(tosystem, grname);
         return system((const char *)tosystem);
     }

--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -24,6 +24,8 @@
 #include <grass/spawn.h>
 #include "orthophoto.h"
 
+#define BUFFER_SIZE 99
+
 int main(int argc, char **argv)
 {
     char *p;
@@ -33,7 +35,7 @@ int main(int argc, char **argv)
     char *desc_ortho_opt;
     char *moduletorun;
     const char *grname;
-    char tosystem[99] = "";
+    char tosystem[BUFFER_SIZE] = "";
 
     /* initialize grass */
     G_gisinit(argv[0]);
@@ -82,8 +84,8 @@ int main(int argc, char **argv)
     /* group validity check */
 
     /*----------------------*/
-    strncpy(group.name, group_opt->answer, 99);
-    group.name[99] = '\0';
+    strncpy(group.name, group_opt->answer, BUFFER_SIZE);
+    group.name[BUFFER_SIZE - 1] = '\0';
     /* strip off mapset if it's there: I_() fns only work with current mapset */
     if ((p = strchr(group.name, '@')))
         *p = 0;
@@ -96,26 +98,30 @@ int main(int argc, char **argv)
     moduletorun = ortho_opt->answer;
     /* run the program chosen */
     if (strcmp(moduletorun, "g.gui.photo2image") == 0) {
-        strcpy(tosystem, "g.gui.photo2image");
+        strncpy(tosystem, "g.gui.photo2image", BUFFER_SIZE - 1);
+        tosystem[BUFFER_SIZE - 1] = '\0';
         return system((const char *)tosystem);
     }
     else if (strcmp(moduletorun, "g.gui.image2target") == 0) {
-        strcpy(tosystem, "g.gui.image2target");
+        strncpy(tosystem, "g.gui.image2target", BUFFER_SIZE - 1);
+        tosystem[BUFFER_SIZE - 1] = '\0';
         return system((const char *)tosystem);
     }
     else {
         if (strcmp(moduletorun, "i.group") == 0)
-            strcpy(tosystem, "i.group --ui group=");
+            strncpy(tosystem, "i.group --ui group=", BUFFER_SIZE - 1);
         if (strcmp(moduletorun, "i.ortho.target") == 0)
-            strcpy(tosystem, "i.ortho.target --ui group=");
+            strncpy(tosystem, "i.ortho.target --ui group=", BUFFER_SIZE - 1);
         if (strcmp(moduletorun, "i.ortho.elev") == 0)
-            strcpy(tosystem, "i.ortho.elev --ui group=");
+            strncpy(tosystem, "i.ortho.elev --ui group=", BUFFER_SIZE - 1);
         if (strcmp(moduletorun, "i.ortho.camera") == 0)
-            strcpy(tosystem, "i.ortho.camera --ui group=");
+            strncpy(tosystem, "i.ortho.camera --ui group=", BUFFER_SIZE - 1);
         if (strcmp(moduletorun, "i.ortho.init") == 0)
-            strcpy(tosystem, "i.ortho.init --ui group=");
+            strncpy(tosystem, "i.ortho.init --ui group=", BUFFER_SIZE - 1);
         if (strcmp(moduletorun, "i.ortho.rectify") == 0)
-            strcpy(tosystem, "i.ortho.rectify --ui group=");
+            strncpy(tosystem, "i.ortho.rectify --ui group=", BUFFER_SIZE - 1);
+
+        tosystem[BUFFER_SIZE - 1] = '\0';
         strcat(tosystem, grname);
         return system((const char *)tosystem);
     }

--- a/imagery/i.ortho.photo/i.ortho.photo/menu.c
+++ b/imagery/i.ortho.photo/i.ortho.photo/menu.c
@@ -24,7 +24,7 @@
 #include <grass/spawn.h>
 #include "orthophoto.h"
 
-#define BUFFER_SIZE 99
+#define BUF_SIZE 99
 
 int main(int argc, char **argv)
 {
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
     char *desc_ortho_opt;
     char *moduletorun;
     const char *grname;
-    char tosystem[BUFFER_SIZE] = "";
+    char tosystem[BUF_SIZE] = "";
     size_t len;
 
     /* initialize grass */
@@ -85,8 +85,8 @@ int main(int argc, char **argv)
     /* group validity check */
 
     /*----------------------*/
-    len = G_strlcpy(group.name, group_opt->answer, BUFFER_SIZE);
-    if (len >= BUFFER_SIZE) {
+    len = G_strlcpy(group.name, group_opt->answer, BUF_SIZE);
+    if (len >= BUF_SIZE) {
         G_fatal_error(_("Name <%s> is too long"), group_opt->answer);
     }
     /* strip off mapset if it's there: I_() fns only work with current mapset */
@@ -101,26 +101,26 @@ int main(int argc, char **argv)
     moduletorun = ortho_opt->answer;
     /* run the program chosen */
     if (strcmp(moduletorun, "g.gui.photo2image") == 0) {
-        (void)G_strlcpy(tosystem, "g.gui.photo2image", BUFFER_SIZE);
+        (void)G_strlcpy(tosystem, "g.gui.photo2image", BUF_SIZE);
         return system((const char *)tosystem);
     }
     else if (strcmp(moduletorun, "g.gui.image2target") == 0) {
-        (void)G_strlcpy(tosystem, "g.gui.image2target", BUFFER_SIZE);
+        (void)G_strlcpy(tosystem, "g.gui.image2target", BUF_SIZE);
         return system((const char *)tosystem);
     }
     else {
         if (strcmp(moduletorun, "i.group") == 0)
-            (void)G_strlcpy(tosystem, "i.group --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.group --ui group=", BUF_SIZE);
         if (strcmp(moduletorun, "i.ortho.target") == 0)
-            (void)G_strlcpy(tosystem, "i.ortho.target --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.target --ui group=", BUF_SIZE);
         if (strcmp(moduletorun, "i.ortho.elev") == 0)
-            (void)G_strlcpy(tosystem, "i.ortho.elev --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.elev --ui group=", BUF_SIZE);
         if (strcmp(moduletorun, "i.ortho.camera") == 0)
-            (void)G_strlcpy(tosystem, "i.ortho.camera --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.camera --ui group=", BUF_SIZE);
         if (strcmp(moduletorun, "i.ortho.init") == 0)
-            (void)G_strlcpy(tosystem, "i.ortho.init --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.init --ui group=", BUF_SIZE);
         if (strcmp(moduletorun, "i.ortho.rectify") == 0)
-            (void)G_strlcpy(tosystem, "i.ortho.rectify --ui group=", BUFFER_SIZE);
+            (void)G_strlcpy(tosystem, "i.ortho.rectify --ui group=", BUF_SIZE);
         strcat(tosystem, grname);
         return system((const char *)tosystem);
     }


### PR DESCRIPTION
This issue was identified by coverity scan (CID: 1415632).
Initially cppcheck was used on imagery folder and all uninitialized variables were resolved but this issue was missed by cppcheck.

**Changes Made:**
Initialized the tosystem array with an empty string (char tosystem[99] = "";). 