### PR TITLE
r.out.mpeg: Fix buffer overflow issues by replacing sprintf with snprintf 

### DIFF
--- a/raster/r.out.mpeg/main.c
+++ b/raster/r.out.mpeg/main.c
@@ -395,9 +395,9 @@ static void mlist(const char *element, const char *wildarg, const char *outfile)
         if (strcmp(mapset, ".") == 0)
             mapset = G_mapset();
 
-        sprintf(type_arg, "type=%s", element);
-        sprintf(pattern_arg, "pattern=%s", wildarg);
-        sprintf(mapset_arg, "mapset=%s", mapset);
+        snprintf(type_arg, sizeof(type_arg), "type=%s", element);
+        snprintf(pattern_arg, sizeof(pattern_arg), "pattern=%s", wildarg);
+        snprintf(mapset_arg, sizeof(mapset_arg), "mapset=%s", mapset);
 
         G_spawn_ex("g.list", "g.list", type_arg, pattern_arg, mapset_arg,
                    SF_REDIRECT_FILE, SF_STDOUT, SF_MODE_APPEND, outfile, NULL);


### PR DESCRIPTION
This pull request addresses buffer overflow issues identified by flawfinder in the `main.c` file of the `r.out.mpeg` module. Specifically, the `sprintf` function calls have been replaced with the safer `snprintf` function.

Issues:
main.c:399:  [4] (buffer) sprintf:
  Does not check for buffer overflows (CWE-120).
main.c:400:  [4] (buffer) sprintf:
  Does not check for buffer overflows (CWE-120).
main.c:401:  [4] (buffer) sprintf:
  Does not check for buffer overflows (CWE-120).

Changes:
Replaced `sprintf` with `snprintf` at lines 399, 400, and 401 to prevent potential buffer overflows.