### PR TITLE
lib/gis: Add portable G_strlcpy function

### DIFF
--- a/configure
+++ b/configure
@@ -766,6 +766,7 @@ ICONVLIB
 DLLIB
 MATHLIB
 HAVE_ASPRINTF
+HAVE_STRLCPY
 DBMIEXTRALIB
 USE_X11
 XTLIB
@@ -8311,6 +8312,12 @@ then :
 
 fi
 
+ac_fn_c_check_func "$LINENO" "strlcpy" "ac_cv_func_strlcpy"
+if test "x$ac_cv_func_strlcpy" = xyes
+then :
+  printf "%s\n" "#define HAVE_STRLCPY 1" >>confdefs.h
+
+fi
 
 
 # Test if mathlib needs -lm flag or is included with libc

--- a/configure.ac
+++ b/configure.ac
@@ -596,7 +596,7 @@ AC_CHECK_FUNCS(asprintf)
 AC_SUBST(HAVE_ASPRINTF)
 
 # Test if strlcpy exists
-# This is a function part of *BSD libc (optionnaly available on Linux via libbsd)
+# This is a function part of *BSD libc (optionally available on Linux via libbsd)
 AC_CHECK_FUNCS(strlcpy)
 AC_SUBST(HAVE_STRLCPY)
 

--- a/configure.ac
+++ b/configure.ac
@@ -595,6 +595,11 @@ AC_SUBST(DBMIEXTRALIB)
 AC_CHECK_FUNCS(asprintf)
 AC_SUBST(HAVE_ASPRINTF)
 
+# Test if strlcpy exists
+# This is a function part of *BSD libc (optionnaly available on Linux via libbsd)
+AC_CHECK_FUNCS(strlcpy)
+AC_SUBST(HAVE_STRLCPY)
+
 # Test if mathlib needs -lm flag or is included with libc
 AC_CHECK_FUNC(atan, MATHLIB=, [
 AC_CHECK_LIB(m, atan, MATHLIB=-lm, [

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -14,6 +14,9 @@
 /* Define to 1 if you have the `asprintf' function. */
 #undef HAVE_ASPRINTF
 
+/* Define to 1 if you have the `strlcpy' function. */
+#undef HAVE_STRLCPY
+
 /* Define to 1 if you have the <bzlib.h> header file. */
 #undef HAVE_BZLIB_H
 

--- a/include/grass/defs/gis.h
+++ b/include/grass/defs/gis.h
@@ -152,6 +152,10 @@ int G_vfaprintf(FILE *, const char *, va_list);
 int G_vsaprintf(char *, const char *, va_list);
 int G_vsnaprintf(char *, size_t, const char *, va_list);
 
+/* strlcpy.c */
+size_t G_strlcpy(char *__restrict dst, const char *__restrict src,
+                 size_t dsize);
+
 /* basename.c */
 char *G_basename(char *, const char *);
 size_t G_get_num_decimals(const char *);

--- a/include/grass/defs/gis.h
+++ b/include/grass/defs/gis.h
@@ -153,8 +153,7 @@ int G_vsaprintf(char *, const char *, va_list);
 int G_vsnaprintf(char *, size_t, const char *, va_list);
 
 /* strlcpy.c */
-size_t G_strlcpy(char *__restrict dst, const char *__restrict src,
-                 size_t dsize);
+size_t G_strlcpy(char *, const char *, size_t);
 
 /* basename.c */
 char *G_basename(char *, const char *);

--- a/lib/gis/strlcpy.c
+++ b/lib/gis/strlcpy.c
@@ -1,0 +1,55 @@
+/*!
+ * \file lib/gis/strlcpy.c
+ *
+ * \brief GIS Library - GRASS implementation of strlcpy().
+ *
+ * Loïc Bartoletti - 2024-07-25
+ *
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+#include <stddef.h>
+size_t G_strlcpy(char *__restrict dst, const char *__restrict src, size_t dsize)
+{
+#ifdef HAVE_STRLCPY
+    return strlcpy(dst, src, dsize);
+#else
+    const char *osrc = src;
+    size_t nleft = dsize;
+
+    /* Copy as many bytes as will fit. */
+    if (nleft != 0) {
+        while (--nleft != 0) {
+            if ((*dst++ = *src++) == '\0')
+                break;
+        }
+    }
+
+    /* Not enough room in dst, add NUL and traverse rest of src. */
+    if (nleft == 0) {
+        if (dsize != 0)
+            *dst = '\0'; /* NUL-terminate dst */
+        while (*src++)
+            ;
+    }
+
+    return (src - osrc - 1); /* count does not include NUL */
+#endif
+}

--- a/lib/gis/strlcpy.c
+++ b/lib/gis/strlcpy.c
@@ -31,7 +31,7 @@
  *
  * \param[out] dst Pointer to the destination buffer.
  * \param[in] src Pointer to the source string. Must be a NUL-terminated C
- * string.
+ *                string.
  * \param[in] dsize The size of the destination buffer.
  *
  * \return The total length of the string src (not including the terminating

--- a/lib/gis/strlcpy.c
+++ b/lib/gis/strlcpy.c
@@ -20,13 +20,34 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-/*
- * Copy string src to buffer dst of size dsize.  At most dsize-1
- * chars will be copied.  Always NUL terminates (unless dsize == 0).
- * Returns strlen(src); if retval >= dsize, truncation occurred.
- */
 #include <stddef.h>
-size_t G_strlcpy(char *__restrict dst, const char *__restrict src, size_t dsize)
+
+/**
+ * \brief Safe string copy function.
+ *
+ * Copy string src to buffer dst of size dsize. At most dsize-1
+ * characters will be copied. Always NUL terminates (unless dsize == 0).
+ * This function is a safer alternative to strncpy.
+ *
+ * \param[out] dst Pointer to the destination buffer.
+ * \param[in] src Pointer to the source string. Must be a NUL-terminated C
+ * string.
+ * \param[in] dsize The size of the destination buffer.
+ *
+ * \return The total length of the string src (not including the terminating
+ *         NUL character). If the return value is >= dsize, truncation occurred.
+ *
+ * \note If truncation occurred, the return value is the length of the string
+ *       that would have been created if enough space had been available.
+ *
+ * \warning This function does not pad the destination buffer with NUL bytes
+ *          if the source string is shorter than dsize-1 bytes, unlike strncpy.
+ *
+ * \warning The src string must be a valid NUL-terminated C string. Passing an
+ *          unterminated string may result in buffer overrun.
+ */
+
+size_t G_strlcpy(char *restrict dst, const char *restrict src, size_t dsize)
 {
 #ifdef HAVE_STRLCPY
     return strlcpy(dst, src, dsize);


### PR DESCRIPTION
From commit message:

> This commit introduces a new G_strlcpy function in lib/gis, inspired by
> G_asprintf. G_strlcpy provides a safer alternative to strcpy and strncpy,
> with consistent behavior across different systems.
> 
> Key points:
> - Implements strlcpy functionality, available natively on BSD systems
> - Portable implementation for non-BSD systems (excluding Linux with libbsd)
> - Based on FreeBSD's implementation:
>   https://github.com/freebsd/freebsd-src/blob/98dd639c94f716858ae29958f484729b1d2fd387/sys/libkern/strlcpy.c#L28
> - Designed to replace unsafe uses of strcpy and strncpy throughout the project
> 
> The function is implemented to use the native strlcpy where available,
> falling back to our portable version on systems without it. This ensures
> optimal performance on BSD systems while maintaining compatibility across
> different platforms.
> 
> By providing G_strlcpy, we aim to improve the overall safety and
> consistency of string operations in our codebase.

Marked as draft for now, since only tested on FreeBSD, which have strlcpy of course :wink: 

Supersed #4087 for the "test"