### PR TITLE
CI(ruff): Show ruff annotations even for fixes

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -70,7 +70,7 @@ jobs:
         run: ruff check --output-format=github . --preview --unsafe-fixes
         continue-on-error: true
       - name: Run Ruff (apply fixes for suggestions)
-        run: ruff check --output-format=github . --preview --fix --unsafe-fixes
+        run: ruff check . --preview --fix --unsafe-fixes
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -66,7 +66,10 @@ jobs:
 
       - name: Install Ruff
         run: pip install ruff==${{ env.RUFF_VERSION }}
-      - name: Run Ruff
+      - name: Run Ruff (output annotations on fixable errors)
+        run: ruff check --output-format=github . --preview --unsafe-fixes
+        continue-on-error: true
+      - name: Run Ruff (apply fixes for suggestions)
         run: ruff check --output-format=github . --preview --fix --unsafe-fixes
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required


### PR DESCRIPTION
Following @ldesousa’s message for #3903 https://matrix.to/#/!BOjyJgENYOLyXbRKxO%3Agitter.im/%24WJLQLw0paLT9URnQRpv7LutALr-5tJeGuGRt0uu-jns,
this PR runs ruff two times:
1. Without fixing anything, but the GitHub output format so a certain number of annotations will be added to the files (somewhere between 10 or 20, GitHub’s UI limits them). Continue on error is set to true, so the next step (that can fail) will be executed.
2. Applying the fixes, but removing the GitHub output format, using the default output format, so there shouldn’t be duplicate annotations for unfixable issues (unless ruff outputs GitHub annotations by itself when running in GitHub Actions).

Since running ruff takes negligible time, running two times isn’t problematic. 

This would allow to show a bit more explications on what the errors that ruff fails on, are available right away in the job summaries (and on the changed files view), and the normal code suggestions will appear once the callback job reaches its turn in the queue

