### PR TITLE
grass.pygrass: remove unused arg in ctypes.CFUNCTYPE

### DIFF
--- a/python/grass/pygrass/raster/rowio.py
+++ b/python/grass/pygrass/raster/rowio.py
@@ -18,17 +18,17 @@ CMPFUNC = ctypes.CFUNCTYPE(
 )
 
 
-def getmaprow_CELL(fd, buf, row):
+def getmaprow_CELL(fd, buf, row, l_what):
     librast.Rast_get_c_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.CELL)), row)
     return 1
 
 
-def getmaprow_FCELL(fd, buf, row):
+def getmaprow_FCELL(fd, buf, row, l_what):
     librast.Rast_get_f_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.FCELL)), row)
     return 1
 
 
-def getmaprow_DCELL(fd, buf, row):
+def getmaprow_DCELL(fd, buf, row, l_what):
     librast.Rast_get_d_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.DCELL)), row)
     return 1
 

--- a/python/grass/pygrass/raster/rowio.py
+++ b/python/grass/pygrass/raster/rowio.py
@@ -13,22 +13,20 @@ from grass.pygrass.errors import GrassError
 from grass.pygrass.raster.raster_type import TYPE as RTYPE
 
 
-CMPFUNC = ctypes.CFUNCTYPE(
-    ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_int, ctypes.c_int
-)
+CMPFUNC = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_int)
 
 
-def getmaprow_CELL(fd, buf, row, l_what):
+def getmaprow_CELL(fd, buf, row):
     librast.Rast_get_c_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.CELL)), row)
     return 1
 
 
-def getmaprow_FCELL(fd, buf, row, l_what):
+def getmaprow_FCELL(fd, buf, row):
     librast.Rast_get_f_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.FCELL)), row)
     return 1
 
 
-def getmaprow_DCELL(fd, buf, row, l_what):
+def getmaprow_DCELL(fd, buf, row):
     librast.Rast_get_d_row(fd, ctypes.cast(buf, ctypes.POINTER(librast.DCELL)), row)
     return 1
 


### PR DESCRIPTION
Please see the comment [here](https://github.com/OSGeo/grass/pull/3928#discussion_r1685058517).

Initially, the PR was about fixing "ambiguous variable name 'l', but in this case 'l's were also unused so deletion was the initial fix. However, it appears Windows has a "ctypes" issue.

I would like to revert them as they were, but rename "l"s to avoid the E741 (Checks for the use of the characters 'l', 'O', or 'I' as variable names) issue. Since I couldn't figure out what "l" parameters are so I renamed it "l_what" for now. Let me know if you find appropriate variable name. Here is [pygrass.raster package documentation](https://grass.osgeo.org/grass83/manuals/libpython/pygrass.raster.html#module-pygrass.raster.rowio).

However, the flake8 problem in F841 (unused-variable) will be addressed next, and noqa:F841 will be applied to them when I work on F841 problem.

I propose raising a separate issue if this needs to be investigated further since I don't have experience with C and "ctypes".

What do you think?