### PR TITLE
lib/vector: fix always true if-condition in Vect_point_buffer2()

### DIFF
--- a/lib/vector/Vlib/buffer2.c
+++ b/lib/vector/Vlib/buffer2.c
@@ -1135,6 +1135,8 @@ void Vect_area_buffer2(struct Map_info *Map, int area, double da, double db,
    \param round make corners round
    \param tol maximum distance between theoretical arc and output segments
    \param[out] oPoints output polygon outer border (ccw order)
+
+   \note Currently only handles buffers with rounded corners (round = 1)
  */
 void Vect_point_buffer2(double px, double py, double da, double db,
                         double dalpha, int round, double tol,
@@ -1144,13 +1146,13 @@ void Vect_point_buffer2(double px, double py, double da, double db,
     double angular_tol, angular_step, phi1;
     int j, nsegments;
 
-    G_debug(2, "Vect_point_buffer()");
+    G_debug(2, "%s()", __func__);
 
     *oPoints = Vect_new_line_struct();
 
     dalpha *= PI / 180; /* convert dalpha from degrees to radians */
 
-    if (round || (!round)) {
+    if (round) {
         angular_tol = angular_tolerance(tol, da, db);
 
         nsegments = (int)(2 * PI / angular_tol) + 1;


### PR DESCRIPTION
The true if-statement only handles buffers with rounded corners. E.g. using `v.buffer` without `-s` on points. GEOS handles buffers with corners.


Building with Clang 18 a compiler warning is issued:

```
buffer2.c:1153:15: error: '||' of a value and its negation always evaluates to true [-Werror,-Wtautological-negation-compare]
 1153 |     if (round || (!round)) {
      |         ~~~~~~^~~~~~~~~~~
```

which in combination with `-Werror` causes build failure.

(Part of preparation for upgrading dependencies for the macOS CI runner).