### PR TITLE
docker: define GISBASE for Alpine

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -202,6 +202,9 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
 COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
+# Set GISBASE
+ENV GISBASE /usr/local/grass
+
 # run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/
 COPY docker/testdata/test_grass_python.py docker/testdata/test_grass_session.py docker/alpine/grass_tests.sh /scripts/


### PR DESCRIPTION
This PR fixes issue raised by https://github.com/OSGeo/grass/pull/3899#issuecomment-2266134209

```py
File "/usr/local/bin/grass", line 2551, in <module>
    main()
File "/usr/local/bin/grass", line 2222, in main
    find_grass_python_package()
File "/usr/local/bin/grass", line 2207, in find_grass_python_package
   raise RuntimeError(
RuntimeError: The grass Python package is missing. Is the installation of GRASS GIS complete?
```

Python package is not found because GISBASE is defined to `/usr/local/grass85` but this path doesn't exists.