### PR TITLE
style: Fix unnecessary-placeholder (PIE790)

### DIFF
--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -49,8 +49,6 @@ class Layer:
         layer as used in lmgr.
     """
 
-    pass
-
 
 class LayerList:
     def GetSelectedLayers(self, checkedOnly=True):

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2962,7 +2962,6 @@ class DbMgrLayersPage(wx.Panel):
 
     def OnLayerRightUp(self, event):
         """Layer description area, context menu"""
-        pass
 
 
 class TableListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin):

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -189,7 +189,6 @@ class DisplayAttributesDialog(wx.Dialog):
 
     def OnSQLStatement(self, event):
         """Update SQL statement"""
-        pass
 
     def IsFound(self):
         """Check for status

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1243,7 +1243,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         """Disable GCP manager mode"""
         # leaving the method here but was used only to delete gcpmanagement
         # from layer manager which is now not needed
-        pass
 
     def CreateGCPList(self):
         """Create GCP List Control"""
@@ -2377,7 +2376,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 self.resize = False
             elif self.resize:
                 event.RequestMore()
-        pass
 
 
 class GCPDisplay(FrameMixin, GCPPanel):

--- a/gui/wxpython/gmodeler/dialogs.py
+++ b/gui/wxpython/gmodeler/dialogs.py
@@ -544,7 +544,6 @@ class ModelItemDialog(wx.Dialog):
 
     def _layout(self):
         """Do layout (virtual method)"""
-        pass
 
     def GetCondition(self):
         """Get loop condition"""
@@ -777,7 +776,6 @@ class ModelListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.TextEditMi
 
     def OnEndEdit(self, event):
         """Finish editing of item"""
-        pass
 
     def GetListCtrl(self):
         """Used by ColumnSorterMixin"""

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -1390,7 +1390,6 @@ class ModelData(ModelObject):
         :param width, height: dimension of the shape
         :param x, y: position of the shape
         """
-        pass
 
     def IsIntermediate(self):
         """Checks if data item is intermediate"""

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -1471,13 +1471,11 @@ class MapLayersDialogBase(wx.Dialog):
         """Method used only by MapLayersDialogForModeler,
         for other subclasses does nothing.
         """
-        pass
 
     def _addApplyButton(self):
         """Method used only by MapLayersDialog,
         for other subclasses does nothing.
         """
-        pass
 
     def _fullyQualifiedNames(self):
         """Adds CheckBox which determines is fully qualified names are retuned."""

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2852,7 +2852,6 @@ class CmdPanel(wx.Panel):
         needed. It's a hook, actually.  Beware of what is 'self' in
         the method def, though. It will be called with no arguments.
         """
-        pass
 
     def OnCheckBoxMulti(self, event):
         """Fill the values as a ','-separated string according to

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -348,7 +348,6 @@ class GNotebook(FN.FlatNotebook):
 
     def SetPageImage(self, page, index):
         """Does nothing because we don't want images for this style"""
-        pass
 
     def __getattr__(self, name):
         return getattr(self.controller, name)

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -1228,7 +1228,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         """Disable GCP manager mode"""
         # leaving the method here but was used only to delete gcpmanagement
         # from layer manager which is now not needed
-        pass
 
     def CreateGCPList(self):
         """Create GCP List Control"""
@@ -2316,7 +2315,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 self.resize = False
             elif self.resize:
                 event.RequestMore()
-        pass
 
 
 class GCPDisplay(FrameMixin, GCPPanel):

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -832,7 +832,6 @@ def GetRasterInfo(rast):
         if k == "datatype":
             if v != "CELL":
                 return None
-            pass
         elif k in {"rows", "cols", "cells", "min", "max"}:
             v = int(v)
         else:

--- a/gui/wxpython/mapdisp/properties.py
+++ b/gui/wxpython/mapdisp/properties.py
@@ -44,7 +44,6 @@ class PropertyItem:
 
     def mapWindowPropertyChanged(self):
         """Returns signal from MapWindowProperties."""
-        pass
 
     def _setValue(self, value):
         self.widget.SetValue(value)

--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -659,7 +659,6 @@ class SwipeMapPanel(DoubleMapPanel):
 
         So far not implemented.
         """
-        pass
 
     def SetViewMode(self, mode):
         """Sets view mode.

--- a/gui/wxpython/mapswipe/toolbars.py
+++ b/gui/wxpython/mapswipe/toolbars.py
@@ -123,7 +123,6 @@ class SwipeMapToolbar(BaseToolbar):
         """Set currently selected map.
         Unused, needed because of DoubleMapPanel API.
         """
-        pass
 
 
 class SwipeMainToolbar(BaseToolbar):

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -274,7 +274,6 @@ class ImportDialog(wx.Dialog):
 
     def OnRun(self, event):
         """Import/Link data (each layes as separate vector map)"""
-        pass
 
     def OnCheckOverwrite(self, event):
         """Check/uncheck overwrite checkbox widget"""
@@ -344,11 +343,9 @@ class ImportDialog(wx.Dialog):
         .. todo::
             not yet implemented
         """
-        pass
 
     def OnCmdDone(self, event):
         """Do what has to be done after importing"""
-        pass
 
     def _getLayersToReprojetion(self, projMatch_idx, grassName_idx):
         """If there are layers with different projection from loation projection,

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -2751,8 +2751,6 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
 
     def DisactivateWin(self):
         """Use when the class instance is hidden in MapFrame."""
-        pass
 
     def ActivateWin(self):
         """Used when the class instance is activated in MapFrame."""
-        pass

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -596,7 +596,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         """Disable GCP manager mode"""
         # leaving the method here but was used only to delete gcpmanagement
         # from layer manager which is now not needed
-        pass
 
     def CreateGCPList(self):
         """Create GCP List Control"""
@@ -1602,7 +1601,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 self.resize = False
             elif self.resize:
                 event.RequestMore()
-        pass
 
 
 class GCPDisplay(FrameMixin, GCPPanel):

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -2103,7 +2103,6 @@ class RasterDialog(PsmapDialog):
 
     def updateDialog(self):
         """Update information (not used)"""
-        pass
 
 
 # if "map" in self.parent.openDialogs:
@@ -2149,7 +2148,6 @@ class MainVectorDialog(PsmapDialog):
 
     def updateDialog(self):
         """Update information (not used)"""
-        pass
 
 
 class VPropertiesDialog(Dialog):
@@ -6729,7 +6727,6 @@ class RectangleDialog(PsmapDialog):
 
     def updateDialog(self):
         """Update text coordinates, after moving"""
-        pass
 
 
 class LabelsDialog(PsmapDialog):

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -573,7 +573,6 @@ class InstructionObject:
 
     def Read(self, instruction, text, **kwargs):
         """Read instruction and save them"""
-        pass
 
     def PercentToReal(self, e, n):
         """Converts text coordinates from percent of region to map coordinates"""

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -1780,7 +1780,6 @@ class DrawSampleUnitsPage(TitledPage):
 
     def OnExitPage(self, event=None):
         """Function during exiting"""
-        pass
 
         # if event.GetDirection():
         #    self.SetNext(self.parent.samplingareapage)

--- a/gui/wxpython/vdigit/dialogs.py
+++ b/gui/wxpython/vdigit/dialogs.py
@@ -774,4 +774,3 @@ class CheckListFeature(ListCtrl, listmix.ListCtrlAutoWidthMixin, CheckListCtrlMi
 
     def OnCheckItem(self, index, flag):
         """Mapset checked/unchecked"""
-        pass

--- a/gui/wxpython/vdigit/preferences.py
+++ b/gui/wxpython/vdigit/preferences.py
@@ -797,8 +797,6 @@ class VDigitSettingsDialog(wx.Dialog):
 
     def OnChangeAddRecord(self, event):
         """Checkbox 'Add new record' status changed"""
-        pass
-        # self.category.SetValue(self.digit.SetCategory())
 
     def OnChangeSnappingValue(self, event):
         """Change snapping value - update static text"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,6 @@ ignore = [
     "PERF401", # manual-list-comprehension
     "PERF402", # manual-list-copy
     "PERF403", # manual-dict-comprehension
-    "PIE790",  # unnecessary-placeholder
     "PIE794",  # duplicate-class-field-definition
     "PIE808",  # unnecessary-range-start
     "PIE810",  # multiple-starts-ends-with

--- a/python/grass/pygrass/raster/history.py
+++ b/python/grass/pygrass/raster/history.py
@@ -57,7 +57,6 @@ class History:
 
     def __del__(self):
         """Rast_free_history"""
-        pass
 
     def __eq__(self, hist):
         for attr in self.attrs:

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -79,7 +79,6 @@ def read_WKT(string):
 
 def read_WKB(buff):
     """Read the binary buffer and return a geometry object"""
-    pass
 
 
 def intersects(lineA, lineB, with_z=False):
@@ -940,7 +939,6 @@ class Line(Geo):
         """
         # TODO: add this method.
         # libvect.Vect_get_line_cat(self.c_mapinfo, self.id, self.field)
-        pass
 
     def pop(self, indx):
         """Return the point in the index position and remove from the Line.
@@ -1807,7 +1805,6 @@ class Area(Geo):
 
         ..warning: Not implemented
         """
-        pass
 
     @mapinfo_must_be_set
     def contains_point(self, point, bbox=None):

--- a/python/grass/pygrass/vector/testsuite/test_geometry.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry.py
@@ -98,7 +98,6 @@ class PointTestCase(TestCase):
     def test_buffer(self):
         """Test buffer method"""
         # TODO: verify if the buffer depends from the mapset's projection
-        pass
 
 
 class LineTestCase(TestCase):

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -1240,7 +1240,6 @@ class AbstractMapDataset(AbstractDataset):
         Currently only implemented in RasterDataset. Otherwise
         silently pass.
         """
-        pass
 
     def set_semantic_label(self, semantic_label):
         """Set semantic label identifier

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_spatial_topology.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_spatial_topology.py
@@ -91,7 +91,6 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
 
     def tearDown(self):
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
-        pass
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/unnecessary-placeholder/

Even a docstring is enough to not need a placeholder, as it is a statement.

39 instances fixed.