### PR TITLE
style: Fix self-assigning-variable (PLW0127)

### DIFF
--- a/gui/wxpython/animation/temporal_manager.py
+++ b/gui/wxpython/animation/temporal_manager.py
@@ -288,25 +288,23 @@ class TemporalManager:
                     followsPoint = True
                     lastTimeseries = series
                     end = None
-                else:
-                    # interval data
-                    if series:
-                        # map exists, stop point mode
-                        listOfMaps.append(series)
-                        afterPoint = False
-                    elif afterPoint:
-                        # check point mode
-                        if followsPoint:
-                            # skip this one, already there
-                            followsPoint = False
-                            continue
-                        else:
-                            # append the last one (of point time)
-                            listOfMaps.append(lastTimeseries)
-                            end = None
+                elif series:
+                    # map exists, stop point mode
+                    listOfMaps.append(series)
+                    afterPoint = False
+                elif afterPoint:
+                    # check point mode
+                    if followsPoint:
+                        # skip this one, already there
+                        followsPoint = False
+                        continue
                     else:
-                        # append series which is None
-                        listOfMaps.append(series)
+                        # append the last one (of point time)
+                        listOfMaps.append(lastTimeseries)
+                        end = None
+                else:
+                    # append series which is None
+                    listOfMaps.append(series)
                 timeLabels.append((start, end, unit))
 
         return timeLabels, listOfMaps

--- a/gui/wxpython/animation/temporal_manager.py
+++ b/gui/wxpython/animation/temporal_manager.py
@@ -289,7 +289,6 @@ class TemporalManager:
                     lastTimeseries = series
                     end = None
                 else:
-                    end = end
                     # interval data
                     if series:
                         # map exists, stop point mode

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -2230,7 +2230,7 @@ class PsMapBufferedWindow(wx.Window):
                 zoomFactor = 1
             # when zooming to full extent, in some cases, there was zoom
             # 1.01..., which causes problem
-            if not (abs(zoomFactor - 1) > 0.01):
+            if abs(zoomFactor - 1) <= 0.01:
                 zoomFactor = 1.0
 
             if self.mouse["use"] == "zoomout":

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -2230,9 +2230,7 @@ class PsMapBufferedWindow(wx.Window):
                 zoomFactor = 1
             # when zooming to full extent, in some cases, there was zoom
             # 1.01..., which causes problem
-            if abs(zoomFactor - 1) > 0.01:
-                zoomFactor = zoomFactor
-            else:
+            if not (abs(zoomFactor - 1) > 0.01):
                 zoomFactor = 1.0
 
             if self.mouse["use"] == "zoomout":

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -1736,17 +1736,13 @@ class RasterLegend(InstructionObject):
     def EstimateHeight(self, raster, discrete, fontsize, cols=None, height=None):
         """Estimate height to draw raster legend"""
         if discrete == "n":
-            if height:
-                height = height
-            else:
+            if not height:
                 height = self.unitConv.convert(
                     value=fontsize * 10, fromUnit="point", toUnit="inch"
                 )
 
         if discrete == "y":
-            if cols:
-                cols = cols
-            else:
+            if not cols:
                 cols = 1
 
             rinfo = gs.raster_info(raster)
@@ -1775,9 +1771,7 @@ class RasterLegend(InstructionObject):
         if discrete == "n":
             rinfo = gs.raster_info(raster)
             minim, maxim = rinfo["min"], rinfo["max"]
-            if width:
-                width = width
-            else:
+            if not width:
                 width = self.unitConv.convert(
                     value=fontsize * 2, fromUnit="point", toUnit="inch"
                 )
@@ -1788,14 +1782,10 @@ class RasterLegend(InstructionObject):
             width += textPart
 
         elif discrete == "y":
-            if cols:
-                cols = cols
-            else:
+            if not cols:
                 cols = 1
 
-            if width:
-                width = width
-            else:
+            if not width:
                 paperWidth = (
                     paperInstr["Width"] - paperInstr["Right"] - paperInstr["Left"]
                 )
@@ -1875,14 +1865,10 @@ class VectorLegend(InstructionObject):
 
     def EstimateSize(self, vectorInstr, fontsize, width=None, cols=None):
         """Estimate size to draw vector legend"""
-        if width:
-            width = width
-        else:
+        if not width:
             width = fontsize / 24.0
 
-        if cols:
-            cols = cols
-        else:
+        if not cols:
             cols = 1
 
         vectors = vectorInstr["list"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ ignore = [
     "PLR6104", # non-augmented-assignment
     "PLR6201", # literal-membership
     "PLR6301", # no-self-use
-    "PLW0127", # self-assigning-variable
     "PLW0406", # import-self
     "PLW0602", # global-variable-not-assigned
     "PLW0603", # global-statement

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -479,7 +479,6 @@ def get_available_temporal_mapsets():
     tgis_mapsets = {}
 
     for mapset in mapsets:
-        mapset = mapset
         driver = c_library_interface.get_driver_name(mapset)
         database = c_library_interface.get_database_name(mapset)
 

--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -238,7 +238,7 @@ def main():
                 )
             )
         if indicator.find("@") >= 0:
-            indicator = indicator
+            indicator_id = indicator
         else:
             indicator_id = indicator + "@" + mapset
 

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -244,9 +244,6 @@ def main():
 
     # The lower threshold space time raster dataset
     if lower:
-        # TODO: Check if range is defined elsewhere than this file.
-        # Otherwise, the code is unreachable as range is a class, built into Python,
-        # used in for loops notably. See t.rast.accdetect for usage of range_
         if not range:
             dbif.close()
             gs.fatal(

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -244,6 +244,9 @@ def main():
 
     # The lower threshold space time raster dataset
     if lower:
+        # TODO: Check if range is defined elsewhere than this file.
+        # Otherwise, the code is unreachable as range is a class, built into Python,
+        # used in for loops notably. See t.rast.accdetect for usage of range_
         if not range:
             dbif.close()
             gs.fatal(

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -280,7 +280,7 @@ def main():
             )
 
         if upper.find("@") >= 0:
-            upper = upper
+            upper_id = upper
         else:
             upper_id = upper + "@" + mapset
 


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/self-assigning-variable/

12 instance fixed, no auto fixes were available.
I think I found a bug that was apparent from the syntax highlighting and context. I added a note, but could be removed from this PR after some input.

In some files from temporal, I think by context that the self-assigned variable was meant to be the map id as in the "else" branch. Otherwise, the variable with `_id` wouldn't be available at all if the name contained "@" when doing for example `upper_strds = tgis.SpaceTimeRasterDataset(upper_id)`.