### PR TITLE
style: Fix parenthesize-chained-operators (RUF021)

### DIFF
--- a/display/d.text/test.py
+++ b/display/d.text/test.py
@@ -52,7 +52,7 @@ def text(in_text):
 
 for i in range(36):
     font(fonts[int(i % len(fonts))])
-    size((36 - i if (i >= 9 and i <= 18 or i > 27) else i) % 9)
+    size((36 - i if ((i >= 9 and i <= 18) or i > 27) else i) % 9)
     rotate(i * 10)
     color(colors[i % len(colors)])
     xy(

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -2472,7 +2472,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                     cmd += mode[3]
                 if "wire" in mode[4]:
                     cmd += mode[4]
-                if "coarse" in mode[0] or "both" in mode[0] and "wire" in mode[3]:
+                if "coarse" in mode[0] or ("both" in mode[0] and "wire" in mode[3]):
                     cmd += mode[5]
             #
             # attributes

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -2716,11 +2716,8 @@ class PsMapBufferedWindow(wx.Window):
     def OnSize(self, event):
         """Init image size to match window size"""
         # not zoom all when notebook page is changed
-        if (
-            self.preview
-            and self.parent.currentPage == 1
-            or not self.preview
-            and self.parent.currentPage == 0
+        if (self.preview and self.parent.currentPage == 1) or (
+            not self.preview and self.parent.currentPage == 0
         ):
             self.ZoomAll()
         self.OnIdle(None)

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -474,11 +474,8 @@ class Instruction:
                     for line in text:
                         if line.find("# north arrow") >= 0:
                             commentFound = True
-                    if (
-                        i == "image"
-                        and commentFound
-                        or i == "northArrow"
-                        and not commentFound
+                    if (i == "image" and commentFound) or (
+                        i == "northArrow" and not commentFound
                     ):
                         continue
                     newInstr = myInstrDict[i](id, settings=self, env=self.env)

--- a/gui/wxpython/vdigit/toolbars.py
+++ b/gui/wxpython/vdigit/toolbars.py
@@ -565,9 +565,9 @@ class VDigitToolbar(BaseToolbar):
         menuItems = []
         if not self.tools or "addArea" in self.tools:
             menuItems.append((self.icons["addArea"], self.OnAddArea))
-        if not self.fType and not self.tools or "addBoundary" in self.tools:
+        if (not self.fType and not self.tools) or "addBoundary" in self.tools:
             menuItems.append((self.icons["addBoundary"], self.OnAddBoundary))
-        if not self.fType and not self.tools or "addCentroid" in self.tools:
+        if (not self.fType and not self.tools) or "addCentroid" in self.tools:
             menuItems.append((self.icons["addCentroid"], self.OnAddCentroid))
 
         self._onMenu(menuItems)

--- a/gui/wxpython/web_services/widgets.py
+++ b/gui/wxpython/web_services/widgets.py
@@ -1096,11 +1096,8 @@ class LayersList(TreeCtrl):
                 return bool(
                     it_l_name == l_name
                     and (
-                        not it_st
-                        and not st_name
-                        or it_st
-                        and it_st["name"] == st_name
-                        and it_type == "style"
+                        (not it_st and not st_name)
+                        or (it_st and it_st["name"] == st_name and it_type == "style")
                     )
                 )
 

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -440,7 +440,7 @@ def html_files(cls=None, ignore_gui=True):
             and (cls != "*" or len(cmd.split(".")) >= 3)
             and cmd not in {"full_index.html", "index.html"}
             and cmd not in exclude_mods
-            and (ignore_gui and not cmd.startswith("wxGUI.") or not ignore_gui)
+            and ((ignore_gui and not cmd.startswith("wxGUI.")) or not ignore_gui)
         ):
             yield cmd
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,6 @@ ignore = [
     "RUF013",  # unnecessary-iterable-allocation-for-first-element
     "RUF015",  # unnecessary-iterable-allocation-for-first-element
     "RUF019",  # unnecessary-key-check
-    "RUF021",  # parenthesize-chained-operators
     "RUF027",  # missing-f-string-syntax
     "RUF100",  # unused-noqa
     "S101",    #assert

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -164,7 +164,7 @@ class TextTestResult(TestResult):
         self.printErrors()
         self.stream.writeln(self.separator2)
         run = self.testsRun
-        self.stream.write("Ran %d test%s" % (run, run != 1 and "s" or ""))
+        self.stream.write("Ran %d test%s" % (run, (run != 1 and "s") or ""))
         if self.time_taken:
             self.stream.write(" in %.3fs" % (self.time_taken))
         self.stream.writeln()

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -42,7 +42,7 @@ def select(parms, ptype):
     """
     for k in parms:
         par = parms[k]
-        if par.type == ptype or par.typedesc == ptype and par.value:
+        if par.type == ptype or (par.typedesc == ptype and par.value):
             if par.multiple:
                 yield from par.value
             else:

--- a/scripts/r.in.wms/srs.py
+++ b/scripts/r.in.wms/srs.py
@@ -105,7 +105,7 @@ class Srs:
         """
 
         return "urn:%s:def:crs:%s:%s:%s" % (
-            (self.naming_authority and self.naming_authority or "ogc"),
+            ((self.naming_authority and self.naming_authority) or "ogc"),
             (self.authority or ""),
             (self.version or ""),
             (self.code or ""),


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/parenthesize-chained-operators/

14 instances fixed

Some changes are continuations of #4055, like for web_services/widgets.py:
https://github.com/OSGeo/grass/pull/4055/files#diff-609b60828c5ebf25e54baf62e63b945705831a5849bc5d3e5e8e5ba302e11d62