### PR TITLE
lib/vector: Replaced strcpy with G_strlcpy

### DIFF
--- a/lib/vector/diglib/frmt.c
+++ b/lib/vector/diglib/frmt.c
@@ -50,7 +50,8 @@ int dig_read_frmt_ascii(FILE *dascii, struct Format_info *finfo)
 
         len = G_strlcpy(buf1, buff, sizeof(buf1));
         if (len >= sizeof(buf1)) {
-            G_fatal_error(_("Name <%s> is too long"), buff);
+            G_warning(_("Line <%s> is too long"), buff);
+            return -1;
         }
         buf1[ptr - buff] = '\0';
 
@@ -105,7 +106,8 @@ int dig_read_frmt_ascii(FILE *dascii, struct Format_info *finfo)
 
         len = G_strlcpy(buf1, buff, sizeof(buf1));
         if (len >= sizeof(buf1)) {
-            G_fatal_error(_("Name <%s> is too long"), buff);
+            G_warning(_("Line <%s> is too long"), buff);
+            return -1;
         }
         buf1[ptr - buff] = '\0';
 

--- a/lib/vector/diglib/frmt.c
+++ b/lib/vector/diglib/frmt.c
@@ -19,6 +19,7 @@
 
 #include <grass/vector.h>
 #include <grass/glocale.h>
+#include <grass/gis.h>
 
 /*!
    \brief Read external vector format file
@@ -34,6 +35,7 @@ int dig_read_frmt_ascii(FILE *dascii, struct Format_info *finfo)
     char buff[2001], buf1[2001];
     char *ptr;
     int frmt = -1;
+    size_t len;
 
     G_debug(3, "dig_read_frmt_ascii()");
 
@@ -46,7 +48,10 @@ int dig_read_frmt_ascii(FILE *dascii, struct Format_info *finfo)
             return -1;
         }
 
-        strcpy(buf1, buff);
+        len = G_strlcpy(buf1, buff, sizeof(buf1));
+        if (len >= sizeof(buf1)) {
+            G_fatal_error(_("Name <%s> is too long"), buff);
+        }
         buf1[ptr - buff] = '\0';
 
         ptr++; /* Search for the start of text */
@@ -98,7 +103,10 @@ int dig_read_frmt_ascii(FILE *dascii, struct Format_info *finfo)
             continue;
         }
 
-        strcpy(buf1, buff);
+        len = G_strlcpy(buf1, buff, sizeof(buf1));
+        if (len >= sizeof(buf1)) {
+            G_fatal_error(_("Name <%s> is too long"), buff);
+        }
         buf1[ptr - buff] = '\0';
 
         ptr++; /* Search for the start of text */


### PR DESCRIPTION
This pull request addresses the potential buffer overflow issues by replacing all instances of strcpy with G_strlcpy.
