### PR TITLE
r.in.xyz: Fix Uninitialized variable in main.c file

### DIFF
--- a/raster/r.in.xyz/main.c
+++ b/raster/r.in.xyz/main.c
@@ -1213,7 +1213,14 @@ int scan_bounds(FILE *fp, int xcol, int ycol, int zcol, int vcol, char *fs,
     unsigned long line;
     int first, max_col;
     char buff[BUFFSIZE];
-    double min_x, max_x, min_y, max_y, min_z, max_z, min_v, max_v;
+    double min_x = 0.0;
+    double max_x = 0.0;
+    double min_y = 0.0;
+    double max_y = 0.0;
+    double min_z = 0.0;
+    double max_z = 0.0;
+    double min_v = 0.0;
+    double max_v = 0.0;
     char **tokens;
     int ntokens; /* number of tokens */
     double x, y, z, v;

--- a/raster/r.in.xyz/main.c
+++ b/raster/r.in.xyz/main.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     double zrange_min, zrange_max, vrange_min, vrange_max, d_tmp;
     char *fs; /* field delim */
     off_t filesize;
-    int linesize;
+    int linesize = 0;
     unsigned long estimated_lines, line;
     int from_stdin;
     int can_seek;


### PR DESCRIPTION
This pull request addresses the uninitialized variable issue identified by Coverity Scan (CID: 1547103). This issue was not detected by cppcheck but was flagged by Coverity Scan.

The variable linesize is used in a division operation. The fix ensures that if linesize is less than 6, it is assigned a value of 6, thus avoiding any potential division by zero errors.