### PR TITLE
i.segment: Move unused variable value into a code comment

### DIFF
--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -179,8 +179,9 @@ int mean_shift(struct globals *globals)
 
     hspec = globals->hr;
     if (hspec < 0 || hspec >= 1) {
-        // hspec = sqrt(avgdiffavg / 10.0);
-        // hspec = avgdiffavg;
+        // Other ideas how to compute this are:
+        // sqrt(avgdiffavg / 10.0)
+        // avgdiffavg (as is)
         hspec = mindiffzeroavg;
 
         if (do_progressive)

--- a/imagery/i.segment/mean_shift.c
+++ b/imagery/i.segment/mean_shift.c
@@ -179,8 +179,8 @@ int mean_shift(struct globals *globals)
 
     hspec = globals->hr;
     if (hspec < 0 || hspec >= 1) {
-        hspec = sqrt(avgdiffavg / 10.0);
-        hspec = avgdiffavg;
+        // hspec = sqrt(avgdiffavg / 10.0);
+        // hspec = avgdiffavg;
         hspec = mindiffzeroavg;
 
         if (do_progressive)


### PR DESCRIPTION
This pull request addresses the issue identified by coverity scan (CID : 1415633).
The variable hspec is getting overwritten and only last assigned value is being updated.
To resolve this, the redundant assignments have been commented out rather than removing completely.