### PR TITLE
t.rast.accumulate: Remove check of non-existing `range` option

### DIFF
--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -244,14 +244,6 @@ def main():
 
     # The lower threshold space time raster dataset
     if lower:
-        if not range:
-            dbif.close()
-            gs.fatal(
-                _(
-                    "You need to set the range to compute the occurrence"
-                    " space time raster dataset"
-                )
-            )
 
         if lower.find("@") >= 0:
             lower_id = lower


### PR DESCRIPTION
Seems like a copy-paste artifact from another module like t.rast.accdetect

See https://github.com/OSGeo/grass/pull/4137#discussion_r1707325256 and the thread