### PR TITLE
g.download.location: Print target path in error message

### DIFF
--- a/scripts/g.download.location/g.download.location.html
+++ b/scripts/g.download.location/g.download.location.html
@@ -13,18 +13,18 @@ Other projects or any other files are ignored.
 
 <h2>EXAMPLES</h2>
 
-<h3>Download the full GRASS GIS sample database</h3>
+<h3>Download the full GRASS GIS sample project within a running session</h3>
 
-Download and unpack the GRASS GIS sample database into the user's
+Download and unpack the full North Carolina sample project into the user's
 HOME directory:
 
 <div class="code"><pre>
 g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
 </pre></div>
 
-<h3>Download the full GRASS GIS sample database in a temporary session</h3>
+<h3>Download the full GRASS GIS sample project in a temporary session</h3>
 
-In a temporary session, download and unpack the GRASS GIS sample database
+In a temporary session, download and unpack the full North Carolina sample project
 into the user's HOME directory:
 
 <div class="code"><pre>

--- a/scripts/g.download.location/g.download.location.html
+++ b/scripts/g.download.location/g.download.location.html
@@ -11,6 +11,27 @@ will recognize that and use the project automatically.
 The first directory which is a project is used.
 Other projects or any other files are ignored.
 
+<h2>EXAMPLES</h2>
+
+<h3>Download the full GRASS GIS sample database</h3>
+
+Download and unpack the GRASS GIS sample database into the user's
+HOME directory:
+
+<div class="code"><pre>
+g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
+</pre></div>
+
+<h3>Download the full GRASS GIS sample database in a temporary session</h3>
+
+In a temporary session, download and unpack the GRASS GIS sample database
+into the user's HOME directory:
+
+<div class="code"><pre>
+grass --tmp-location XY --exec g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
+</pre></div>
+
+
 <h2>SEE ALSO</h2>
 
 <em>

--- a/scripts/g.download.location/g.download.location.py
+++ b/scripts/g.download.location/g.download.location.py
@@ -102,8 +102,8 @@ def main(options, unused_flags):
 
     if destination.exists():
         gs.fatal(
-            _("Location named <{}> already exists in <{}>, download canceled").format(
-                name, destination
+            _("Location named <{name}> already exists in <{directory}>, download canceled").format(
+                name=name, directory=database
             )
         )
 

--- a/scripts/g.download.location/g.download.location.py
+++ b/scripts/g.download.location/g.download.location.py
@@ -102,9 +102,9 @@ def main(options, unused_flags):
 
     if destination.exists():
         gs.fatal(
-            _("Location named <{name}> already exists in <{directory}>, download canceled").format(
-                name=name, directory=database
-            )
+            _(
+                "Location named <{name}> already exists in <{directory}>, download canceled"
+            ).format(name=name, directory=database)
         )
 
     gs.message(_("Downloading and extracting..."))

--- a/scripts/g.download.location/g.download.location.py
+++ b/scripts/g.download.location/g.download.location.py
@@ -102,7 +102,9 @@ def main(options, unused_flags):
 
     if destination.exists():
         gs.fatal(
-            _("Location named <{}> already exists, download canceled").format(name)
+            _("Location named <{}> already exists in <{}>, download canceled").format(
+                name, destination
+            )
         )
 
     gs.message(_("Downloading and extracting..."))


### PR DESCRIPTION
To be less obscure in case the target location directory already exists:

```
ERROR: Location named <nc_spm_full_v2alpha2> already exists, download
       canceled
```

this PR improves the error message to include the path:

```
g.download.location url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=$HOME
ERROR: Location named <nc_spm_full_v2alpha2> already exists in
       </home/mneteler/nc_spm_full_v2alpha2>, download canceled
```

This is esp. relevant for scripted usage when the command isn't invoked directly by the user.

In addition, section  of **EXAMPLES** added.