### PR TITLE
style: Fix unnecessary-dunder-call (PLC2801)

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1272,7 +1272,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         # initialize column sorter
         self.itemDataMap = self.mapcoordlist
         ncols = self.list.GetColumnCount()
-        ColumnSorterMixin.__init__(self, ncols)
+        ColumnSorterMixin(self, ncols)
         # init to ascending sort on first click
         self._colSortFlag = [1] * ncols
 

--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -85,10 +85,10 @@ class ModelCanvas(ogl.ShapeCanvas):
             remList, upList = self.parent.GetModel().RemoveItem(shape)
             shape.Select(False)
             diagram.RemoveShape(shape)
-            shape.__del__()
+            shape.__del__()  # noqa: PLC2801, C2801
             for item in remList:
                 diagram.RemoveShape(item)
-                item.__del__()
+                item.__del__()  # noqa: PLC2801, C2801
 
             for item in upList:
                 item.Update()

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -1577,7 +1577,7 @@ class ModelDataSingle(ModelData, ogl.EllipseShape):
         :param width, height: dimension of the shape
         :param x, y: position of the shape
         """
-        ogl.EllipseShape.__init__(self, width, height)
+        ogl.EllipseShape(self, width, height)
         if self.parent.GetCanvas():
             self.SetCanvas(self.parent.GetCanvas())
 
@@ -1592,7 +1592,7 @@ class ModelDataSeries(ModelData, ogl.CompositeShape):
         :param width, height: dimension of the shape
         :param x, y: position of the shape
         """
-        ogl.CompositeShape.__init__(self)
+        ogl.CompositeShape(self)
         if self.parent.GetCanvas():
             self.SetCanvas(self.parent.GetCanvas())
 

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -542,7 +542,7 @@ class ModelerPanel(wx.Panel, MainPageBase):
                         remList, upList = self.model.RemoveItem(data, layer)
                         for item in remList:
                             self.canvas.diagram.RemoveShape(item)
-                            item.__del__()
+                            item.__del__()  # noqa: PLC2801, C2801
 
                         for item in upList:
                             item.Update()

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -1257,7 +1257,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         # initialize column sorter
         self.itemDataMap = self.mapcoordlist
         ncols = self.list.GetColumnCount()
-        ColumnSorterMixin.__init__(self, ncols)
+        ColumnSorterMixin(self, ncols)
         # init to ascending sort on first click
         self._colSortFlag = [1] * ncols
 

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -370,7 +370,7 @@ class LayerList:
         return result
 
     def next(self):
-        return self.__next__()
+        return next(self)
 
     def GetSelectedLayers(self, checkedOnly=True):
         # hidden and selected vs checked and selected

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -625,7 +625,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         # initialize column sorter
         self.itemDataMap = self.mapcoordlist
         ncols = self.list.GetColumnCount()
-        ColumnSorterMixin.__init__(self, ncols)
+        ColumnSorterMixin(self, ncols)
         # init to ascending sort on first click
         self._colSortFlag = [1] * ncols
 

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -140,7 +140,10 @@ class TplotFrame(wx.Frame):
         if self._giface.GetMapDisplay():
             self.coorval.OnClose()
             self.cats.OnClose()
-        self.__del__()
+
+        # __del__() and del keyword seem to have differences,
+        # how can self.Destroy(), called after del, work otherwise
+        self.__del__()  # noqa: PLC2801, C2801
         self.Destroy()
 
     def _layout(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ ignore = [
     "PLC0415", # import-outside-top-level
     "PLC1901", # compare-to-empty-string
     "PLC2701", # import-private-name
-    "PLC2801", # unnecessary-dunder-call
     "PLE0704", # misplaced-bare-raise
     "PLR0124", # comparison-with-itself
     "PLR0202", # no-classmethod-decorator

--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -76,7 +76,7 @@ def safe_repr(obj, short=False):
     try:
         result = repr(obj)
     except Exception:
-        result = object.__repr__(obj)
+        result = object.__repr__(obj)  # noqa: PLC2801
     if not short or len(result) < _MAX_LENGTH:
         return result
     return result[:_MAX_LENGTH] + " [truncated]..."

--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -370,7 +370,7 @@ class Region:
 
     def items(self):
         """Return a list of tuple with key and value."""
-        return [(k, self.__getattribute__(k)) for k in self.keys()]
+        return [(k, getattr(self, k)) for k in self.keys()]
 
     # ----------METHODS----------
     def zoom(self, raster_name):

--- a/python/grass/pygrass/modules/interface/typedict.py
+++ b/python/grass/pygrass/modules/interface/typedict.py
@@ -64,6 +64,6 @@ class TypeDict(OrderedDict):
     def used(self):
         key_dict = {}
         for key in self:
-            if self.__getattr__(key):
-                key_dict[key] = self.__getattr__(key)
+            if getattr(self, key):
+                key_dict[key] = getattr(self, key)
         return key_dict

--- a/python/grass/pygrass/raster/abstract.py
+++ b/python/grass/pygrass/raster/abstract.py
@@ -247,10 +247,10 @@ class Info:
         ]
 
     def items(self):
-        return [(k, self.__getattribute__(k)) for k in self.keys()]
+        return [(k, getattr(self, k)) for k in self.keys()]
 
     def __iter__(self):
-        return ((k, self.__getattribute__(k)) for k in self.keys())
+        return ((k, getattr(self, k)) for k in self.keys())
 
     def _repr_html_(self):
         return dict2html(dict(self.items()), keys=self.keys(), border="1", kdec="b")

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -196,13 +196,13 @@ class Category(list):
         libraster.Rast_free_cats(ctypes.byref(self.c_cats))
 
     def get_cat(self, index):
-        return self.__getitem__(index)
+        return self[index]
 
     def set_cat(self, index, value):
         if index is None:
             self.append(value)
         elif index < (len(self)):
-            self.__setitem__(index, value)
+            self[index] = value
         else:
             raise TypeError("Index outside range.")
 

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -201,7 +201,7 @@ class Category(list):
     def set_cat(self, index, value):
         if index is None:
             self.append(value)
-        elif index < self.__len__():
+        elif index < (len(self)):
             self.__setitem__(index, value)
         else:
             raise TypeError("Index outside range.")
@@ -221,7 +221,7 @@ class Category(list):
         # reset only the C struct
         libraster.Rast_init_cats("", ctypes.byref(self.c_cats))
         # write to the c struct
-        for cat in self.__iter__():
+        for cat in iter(self):
             label, min_cat, max_cat = cat
             if max_cat is None:
                 max_cat = min_cat
@@ -273,7 +273,7 @@ class Category(list):
         self._read_cats()
 
     def ncats(self):
-        return self.__len__()
+        return len(self)
 
     def set_cats_fmt(self, fmt, m1, a1, m2, a2):
         """Not implemented yet.
@@ -327,7 +327,7 @@ class Category(list):
         :param str sep: the separator used to divide values and category
         """
         cats = []
-        for cat in self.__iter__():
+        for cat in iter(self):
             if cat[-1] is None:
                 cat = cat[:-1]
             cats.append(sep.join([str(i) for i in cat]))

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -108,7 +108,7 @@ class Vector(Info):
 
     @must_be_open
     def next(self):
-        return self.__next__()
+        return next(self)
 
     @must_be_open
     def rewind(self):

--- a/python/grass/pygrass/vector/basic.py
+++ b/python/grass/pygrass/vector/basic.py
@@ -215,7 +215,7 @@ class BoxList:
         3
 
         """
-        indx = self.__len__()
+        indx = len(self)
         libvect.Vect_boxlist_append(self.c_boxlist, indx, box.c_bbox)
 
     #    def extend(self, boxlist):

--- a/python/grass/pygrass/vector/basic.py
+++ b/python/grass/pygrass/vector/basic.py
@@ -137,7 +137,7 @@ class Bbox:
         )
 
     def items(self):
-        return [(k, self.__getattribute__(k)) for k in self.keys()]
+        return [(k, getattr(self, k)) for k in self.keys()]
 
     def nsewtb(self, tb=True):
         """Return a list of values from bounding box

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1028,7 +1028,7 @@ class Line(Geo):
 
         ..
         """
-        for indx, point in enumerate(self.__iter__()):
+        for indx, point in enumerate(iter(self)):
             if pnt == point:
                 libvect.Vect_line_delete_point(self.c_points, indx)
                 return
@@ -1086,7 +1086,7 @@ class Line(Geo):
 
         ..
         """
-        return [pnt.coords() for pnt in self.__iter__()]
+        return [pnt.coords() for pnt in iter(self)]
 
     def to_array(self):
         """Return an array of coordinates. ::
@@ -1112,10 +1112,7 @@ class Line(Geo):
         ..
         """
         return "LINESTRING(%s)" % ", ".join(
-            [
-                " ".join(["%f" % coord for coord in pnt.coords()])
-                for pnt in self.__iter__()
-            ]
+            [" ".join(["%f" % coord for coord in pnt.coords()]) for pnt in iter(self)]
         )
 
     def from_wkt(self, wkt):
@@ -1592,7 +1589,7 @@ class Isles:
         """Return the id of isles"""
         return [
             libvect.Vect_get_area_isle(self.c_mapinfo, self.area_id, i)
-            for i in range(self.__len__())
+            for i in range(len(self))
         ]
 
     @mapinfo_must_be_set

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -958,7 +958,7 @@ class Line(Geo):
             indx += self.c_points.contents.n_points
         if indx >= self.c_points.contents.n_points:
             raise IndexError("Index out of range")
-        pnt = self.__getitem__(indx)
+        pnt = self[indx]
         libvect.Vect_line_delete_point(self.c_points, indx)
         return pnt
 

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -297,7 +297,7 @@ class Columns:
             [
                 "?",
             ]
-            * self.__len__()
+            * (len(self))
         )
         kv = ",".join(["%s=?" % k for k in self.odict.keys() if k != self.key])
         where = "%s=?" % self.key

--- a/python/grass/pygrass/vector/testsuite/test_geometry_attrs.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry_attrs.py
@@ -60,11 +60,11 @@ class GeometryAttrsTestCase(TestCase):
         newvalue = 100.0
         newpairs = ("setitem_point_2", 1000.0)
 
-        self.attrs.__setitem__("name", newname)
+        self.attrs.__setitem__("name", newname)  # noqa: PLC2801
         self.assertEqual(self.attrs["name"], newname)
-        self.attrs.__setitem__("value", newvalue)
+        self.attrs.__setitem__("value", newvalue)  # noqa: PLC2801
         self.assertEqual(self.attrs["value"], newvalue)
-        self.attrs.__setitem__(("name", "value"), newpairs)
+        self.attrs.__setitem__(("name", "value"), newpairs)  # noqa: PLC2801
         self.assertEqual(self.attrs["name", "value"], newpairs)
 
 


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/unnecessary-dunder-call/
Pylint rule: https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/unnecessary-dunder-call.html

Solves some issues reported by Pylint 3.2.6 through unnecessary-dunder-call / C2801.

I left out the cases where it touched `__del__()` as the Python docs explain a difference, and even with static analysis the meaning of the code was worse with a change.
I also left out the cases where it changed the test cases, so that they can fail as before if the current changes are wrong (it wouldn't be wise to change the code + the tests at the same time).