### PR TITLE
style: Fix Pylint bad-chained-comparison / W3601

### DIFF
--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -806,7 +806,7 @@ def check_datetime_string(time_string, use_dateutil=True):
     if "bc" in time_string:
         return _("Dates Before Christ (BC) are not supported")
 
-    # BC is not supported
+    # Time zones are not supported
     if "+" in time_string:
         return _("Time zones are not supported")
 

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -803,7 +803,7 @@ def check_datetime_string(time_string, use_dateutil=True):
         return time_object
 
     # BC is not supported
-    if "bc" in time_string > 0:
+    if "bc" in time_string:
         return _("Dates Before Christ (BC) are not supported")
 
     # BC is not supported


### PR DESCRIPTION
Pylint rule: https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/bad-chained-comparison.html

It seems that from this commit, https://github.com/OSGeo/grass/commit/e2188758f6cc424d887b397faff247cc396aa6ea, it is simply a typo, forgetting to remove  `> 0` after the find().

There's also a copy pasted comment below that should be adapted