### PR TITLE
style: use overwrite and not 'o' flag in Python scripts

### DIFF
--- a/scripts/v.db.reconnect.all/v.db.reconnect.all.py
+++ b/scripts/v.db.reconnect.all/v.db.reconnect.all.py
@@ -298,7 +298,7 @@ def main():
                 try:
                     gs.run_command(
                         "v.db.connect",
-                        flags="o",
+                        overwrite=True,
                         quiet=True,
                         map=vect,
                         layer=layer,

--- a/scripts/v.unpack/v.unpack.py
+++ b/scripts/v.unpack/v.unpack.py
@@ -280,7 +280,7 @@ def main():
             try:
                 grass.run_command(
                     "v.db.connect",
-                    flags="o",
+                    overwrite=True,
                     quiet=True,
                     driver=dbconn["driver"],
                     database=todb,

--- a/vector/v.fill.holes/tests/conftest.py
+++ b/vector/v.fill.holes/tests/conftest.py
@@ -216,7 +216,7 @@ def import_data(path, areas_name, areas_with_space_in_between, env):
         "v.db.connect",
         map=areas_with_space_in_between,
         table=areas_with_space_in_between,
-        flags="o",
+        overwrite=True,
         env=env,
     )
 


### PR DESCRIPTION
(replaces #4175)

Fixes message

```bash
WARNING: Please update the usage of <v.db.connect>: flag <o> has been
         renamed to <--overwrite>
```