### PR TITLE
CI: also remove /opt/homebrew from macOS runner

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,12 +28,19 @@ jobs:
       - name: Uninstalling Homebrew
         run: |
           echo "Moving directories..."
-          sudo mkdir /opt/off
-          /usr/bin/sudo /usr/bin/find /usr/local /opt/homebrew -mindepth 1 -maxdepth 1 \
-            -type d -print -exec /bin/mv {} /opt/off/ \;
+          sudo mkdir /opt/local-off /opt/homebrew-off
+          test ! -d /usr/local || /usr/bin/sudo /usr/bin/find /usr/local \
+            -mindepth 1 -maxdepth 1 -type d -print -exec /bin/mv {} \
+            /opt/local-off/ \;
+          test ! -d /opt/homebrew || /usr/bin/sudo /usr/bin/find /opt/homebrew \
+            -mindepth 1 -maxdepth 1 -type d -print -exec /bin/mv {} \
+            /opt/homebrew-off/ \;
           echo "Removing files..."
-          /usr/bin/sudo /usr/bin/find /usr/local /opt/homebrew -mindepth 1 -maxdepth 1 \
-            -type f -print -delete
+          test ! -d /usr/local || /usr/bin/sudo /usr/bin/find /usr/local \
+            -mindepth 1 -maxdepth 1 -type f -print -delete
+          test ! -d /opt/homebrew || /usr/bin/sudo /usr/bin/find /opt/homebrew \
+            -mindepth 1 -maxdepth 1 -type f -print -delete
+          # Rehash to forget about the deleted files
           hash -r
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Setup Mamba


### PR DESCRIPTION
Also remove homebrew from `/opt/homebrew`, which is the default location for homebrew on apple arm machines (which currently is the case for our CI runner).