### PR TITLE
lib: deprecate G_snprintf() and replace with C99 snprintf()

### DIFF
--- a/imagery/i.topo.corr/main.c
+++ b/imagery/i.topo.corr/main.c
@@ -184,8 +184,8 @@ int main(int argc, char *argv[])
             }
             /* ----- */
             dem.fd = Rast_open_old(base->answer, "");
-            G_snprintf(out.name, GNAME_MAX - 1, "%s.%s", output->answer,
-                       input->answers[i]);
+            snprintf(out.name, GNAME_MAX - 1, "%s.%s", output->answer,
+                     input->answers[i]);
             out.fd = Rast_open_new(out.name, DCELL_TYPE);
             out.rast = Rast_allocate_buf(out.type);
             band.rast = Rast_allocate_buf(band.type);

--- a/lib/gis/color_rules.c
+++ b/lib/gis/color_rules.c
@@ -8,6 +8,7 @@
    (C) 2001-2011 by the GRASS Development Team
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -267,7 +268,7 @@ struct colorinfo *get_colorinfo(int *nrules)
     char **cnames;
 
     /* load color rules */
-    G_snprintf(path, GPATH_MAX, "%s/etc/colors", G_gisbase());
+    snprintf(path, GPATH_MAX, "%s/etc/colors", G_gisbase());
 
     *nrules = 0;
     cnames = G_ls2(path, nrules);
@@ -283,8 +284,8 @@ struct colorinfo *get_colorinfo(int *nrules)
         colorinfo[i].desc = NULL;
 
         /* open color rule file */
-        G_snprintf(path, GPATH_MAX, "%s/etc/colors/%s", G_gisbase(),
-                   colorinfo[i].name);
+        snprintf(path, GPATH_MAX, "%s/etc/colors/%s", G_gisbase(),
+                 colorinfo[i].name);
         fp = fopen(path, "r");
         if (!fp)
             G_fatal_error(_("Unable to open color rule"));
@@ -338,7 +339,7 @@ struct colorinfo *get_colorinfo(int *nrules)
         if (cisperc)
             colorinfo[i].type = G_store(_("range: map values"));
         else {
-            G_snprintf(buf, sizeof(buf) - 1, _("range: %g to %g"), rmin, rmax);
+            snprintf(buf, sizeof(buf) - 1, _("range: %g to %g"), rmin, rmax);
             colorinfo[i].type = G_store(buf);
         }
     }
@@ -360,7 +361,7 @@ struct colorinfo *get_colorinfo(int *nrules)
     qsort(colorinfo, *nrules, sizeof(struct colorinfo), cmp_clrname);
 
     /* load color descriptions */
-    G_snprintf(path, GPATH_MAX, "%s/etc/colors.desc", G_gisbase());
+    snprintf(path, GPATH_MAX, "%s/etc/colors.desc", G_gisbase());
     fp = fopen(path, "r");
     if (!fp)
         G_fatal_error(_("Unable to open color descriptions"));

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -1812,7 +1812,7 @@ const char *get_renamed_option(const char *key)
         /* read renamed options from file (renamed_options) */
         char path[GPATH_MAX];
 
-        G_snprintf(path, GPATH_MAX, "%s/etc/renamed_options", G_gisbase());
+        snprintf(path, GPATH_MAX, "%s/etc/renamed_options", G_gisbase());
         st->renamed_options = G_read_key_value_file(path);
     }
 

--- a/lib/gis/parser_wps.c
+++ b/lib/gis/parser_wps.c
@@ -869,10 +869,10 @@ static void wps_print_literal_input_output(
             strcmp(datatype, "float") == 0) {
             str = strtok((char *)choices[0], "-");
             if (str != NULL) {
-                G_snprintf(range[0], 24, "%s", str);
+                snprintf(range[0], 24, "%s", str);
                 str = strtok(NULL, "-");
                 if (str != NULL) {
-                    G_snprintf(range[1], 24, "%s", str);
+                    snprintf(range[1], 24, "%s", str);
                     type = TYPE_RANGE;
                 }
             }

--- a/lib/gis/snprintf.c
+++ b/lib/gis/snprintf.c
@@ -19,11 +19,9 @@
  * \date 2006-2008
  */
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdarg.h>
-#include <unistd.h>
-#include <assert.h>
+#include <stdio.h>
+
 #include <grass/gis.h>
 
 /**
@@ -32,6 +30,8 @@
  * <b>Note:</b> The use of <i>snprintf()</i>/<i>G_snprintf()</i> is
  * discouraged in favour of calculating how long the string will be and
  * allocating enough memory!
+ *
+ * \deprecated Use C99 standard function snprintf() instead.
  *
  * \param[in] str input string
  * \param[in] size length of string
@@ -47,10 +47,6 @@ int G_snprintf(char *str, size_t size, const char *fmt, ...)
     va_start(ap, fmt);
     count = vsnprintf(str, size, fmt, ap);
     va_end(ap);
-
-    /* Windows' vsnprintf() doesn't always NUL-terminate the buffer */
-    if (count >= 0 && (unsigned int)count == size)
-        str[--count] = '\0';
 
     return count;
 }

--- a/lib/gis/timestamp.c
+++ b/lib/gis/timestamp.c
@@ -76,8 +76,10 @@
  * \author Soeren Gebbert, vector timestamp implementation update
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+
 #include <grass/gis.h>
 #include <grass/vect/dig_defines.h>
 #include <grass/glocale.h>

--- a/lib/gis/timestamp.c
+++ b/lib/gis/timestamp.c
@@ -425,11 +425,11 @@ int G_has_vector_timestamp(const char *name, const char *layer,
     char ele[GNAME_MAX];
 
     if (layer != NULL)
-        G_snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
+        snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
     else
-        G_snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
+        snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
 
-    G_snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
+    snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
     G_file_name(path, dir, ele, mapset);
 
     G_debug(1, "Check for timestamp <%s>", path);
@@ -466,11 +466,11 @@ int G_read_vector_timestamp(const char *name, const char *layer,
         return 0;
 
     if (layer != NULL)
-        G_snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
+        snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
     else
-        G_snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
+        snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
 
-    G_snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
+    snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
 
     G_debug(1, "Read timestamp <%s/%s>", dir, ele);
 
@@ -511,11 +511,11 @@ int G_write_vector_timestamp(const char *name, const char *layer,
     char ele[GNAME_MAX];
 
     if (layer != NULL)
-        G_snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
+        snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
     else
-        G_snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
+        snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
 
-    G_snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
+    snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
 
     G_debug(1, "Write timestamp <%s/%s>", dir, ele);
 
@@ -554,11 +554,11 @@ int G_remove_vector_timestamp(const char *name, const char *layer)
     char ele[GNAME_MAX];
 
     if (layer)
-        G_snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
+        snprintf(ele, GNAME_MAX, "%s_%s", GV_TIMESTAMP_ELEMENT, layer);
     else
-        G_snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
+        snprintf(ele, GNAME_MAX, "%s_1", GV_TIMESTAMP_ELEMENT);
 
-    G_snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
+    snprintf(dir, GPATH_MAX, "%s/%s", GV_DIRECTORY, name);
     return G_remove(dir, ele);
 }
 

--- a/lib/imagery/loc_info.c
+++ b/lib/imagery/loc_info.c
@@ -1,4 +1,5 @@
 #include <grass/imagery.h>
+#include <stdio.h>
 #include <string.h>
 #include <grass/gis.h>
 
@@ -10,13 +11,13 @@ char *I_location_info(const char *middle)
     char *buf;
     int len, buf_len;
 
-    G_snprintf(left, 80, "LOCATION: %s", G_location());
-    G_snprintf(right, 80, "MAPSET: %s", G_mapset());
+    snprintf(left, 80, "LOCATION: %s", G_location());
+    snprintf(right, 80, "MAPSET: %s", G_mapset());
     len = 79 - strlen(left) - strlen(middle) - strlen(right);
     buf_len = len + strlen(left) + strlen(middle) + strlen(right);
     buf = (char *)G_calloc(buf_len, sizeof(char));
-    G_snprintf(buf, buf_len, "%s%*s%s%*s%s", left, len / 2, "", middle, len / 2,
-               "", right);
+    snprintf(buf, buf_len, "%s%*s%s%*s%s", left, len / 2, "", middle, len / 2,
+             "", right);
 
     return buf;
 }

--- a/lib/init/clean_temp.c
+++ b/lib/init/clean_temp.c
@@ -1,5 +1,6 @@
 #include <grass/config.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <signal.h>
 #include <unistd.h>
 #include <time.h>
@@ -57,8 +58,8 @@ void clean_dir(const char *pathname, uid_t uid, pid_t pid, time_t now,
             (G_strcasecmp(cur_entry->d_name, "..") == 0))
             continue; /* Skip dir and parent dir entries */
 
-        if ((pathlen = G_snprintf(buf, BUF_MAX, "%s/%s", pathname,
-                                  cur_entry->d_name)) >= BUF_MAX)
+        if ((pathlen = snprintf(buf, BUF_MAX, "%s/%s", pathname,
+                                cur_entry->d_name)) >= BUF_MAX)
             G_fatal_error("clean_temp: exceeded maximum pathname length %d, "
                           "got %d, shouldn't happen",
                           BUF_MAX, pathlen);

--- a/lib/temporal/lib/default_name.c
+++ b/lib/temporal/lib/default_name.c
@@ -13,6 +13,7 @@
    Joel Jones (CERL/UIUC) and Radim Blazek
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <grass/gis.h>
@@ -40,8 +41,8 @@ char *tgis_get_default_database_name(void)
 {
     char default_connection[2048];
 
-    G_snprintf(default_connection, 2048, "$GISDBASE/$LOCATION_NAME/$MAPSET/%s",
-               TGISDB_DEFAULT_SQLITE_PATH);
+    snprintf(default_connection, 2048, "$GISDBASE/$LOCATION_NAME/$MAPSET/%s",
+             TGISDB_DEFAULT_SQLITE_PATH);
 
     return G_store(default_connection);
 }
@@ -57,7 +58,7 @@ int tgis_set_default_connection(void)
     char db_name[2048];
     char *tmp = tgis_get_default_database_name();
 
-    G_snprintf(db_name, 2048, "%s", tmp);
+    snprintf(db_name, 2048, "%s", tmp);
     G_free(tmp);
 
     if (strcmp(TGISDB_DEFAULT_DRIVER, "sqlite") == 0) {

--- a/raster/r.colors/edit_colors.c
+++ b/raster/r.colors/edit_colors.c
@@ -17,6 +17,7 @@
  *
  ***************************************************************************/
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -470,7 +471,7 @@ int edit_colors(int argc, char **argv, int type, const char *maptype,
             /* check if this style is a percentage style */
             /* don't bother with native dirsep as not needed for backwards
              * compatibility */
-            G_snprintf(path, GPATH_MAX, "%s/etc/colors/%s", G_gisbase(), style);
+            snprintf(path, GPATH_MAX, "%s/etc/colors/%s", G_gisbase(), style);
             rule_is_percent = check_percent_rule(path);
             do_scale = 1;
         }
@@ -490,7 +491,7 @@ int edit_colors(int argc, char **argv, int type, const char *maptype,
 
             /* don't bother with native dirsep as not needed for backwards
              * compatibility */
-            G_snprintf(path, GPATH_MAX, "%s/etc/colors/%s", G_gisbase(), rules);
+            snprintf(path, GPATH_MAX, "%s/etc/colors/%s", G_gisbase(), rules);
 
             if (!Rast_load_fp_colors(&colors, path, min, max))
                 G_fatal_error(_("Unable to load rules file <%s>"), rules);

--- a/raster/r.external/main.c
+++ b/raster/r.external/main.c
@@ -16,6 +16,7 @@
  *
  *****************************************************************************/
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <math.h>
@@ -189,7 +190,7 @@ int main(int argc, char *argv[])
         if (!cwd)
             G_fatal_error(_("Unable to get current working directory"));
 
-        G_snprintf(path, GPATH_MAX, "%s%c%s", cwd, HOST_DIRSEP, input);
+        snprintf(path, GPATH_MAX, "%s%c%s", cwd, HOST_DIRSEP, input);
         input = G_store(path);
         CPLFree(cwd);
     }

--- a/raster/r.geomorphon/main.c
+++ b/raster/r.geomorphon/main.c
@@ -528,9 +528,9 @@ int main(int argc, char **argv)
                         prof_int("format_version_major", 0);
                         prof_int("format_version_minor", 9);
                         prof_utc("timestamp", time(NULL));
-                        G_snprintf(buf, sizeof(buf),
-                                   "r.geomorphon GRASS GIS %s [%s]",
-                                   GRASS_VERSION_STRING, GRASS_HEADERS_VERSION);
+                        snprintf(buf, sizeof(buf),
+                                 "r.geomorphon GRASS GIS %s [%s]",
+                                 GRASS_VERSION_STRING, GRASS_HEADERS_VERSION);
                         prof_str("generator", buf);
 
                         oneoff_done =

--- a/raster/r.geomorphon/profile.c
+++ b/raster/r.geomorphon/profile.c
@@ -56,7 +56,7 @@ static void prof_int_internal(const toktype type, const char *key,
         return;
     }
     token[size].type = type;
-    G_snprintf(token[size].key, MAX_STR_LEN, "%s", key);
+    snprintf(token[size].key, MAX_STR_LEN, "%s", key);
     token[size].int_val = val;
     size++;
 }
@@ -79,7 +79,7 @@ static void prof_dbl_internal(const toktype type, const char *key,
         return;
     }
     token[size].type = type;
-    G_snprintf(token[size].key, MAX_STR_LEN, "%s", key);
+    snprintf(token[size].key, MAX_STR_LEN, "%s", key);
     token[size].dbl_val = val;
     size++;
 }
@@ -101,8 +101,8 @@ void prof_str(const char *key, const char *val)
         return;
     }
     token[size].type = T_STR;
-    G_snprintf(token[size].key, MAX_STR_LEN, "%s", key);
-    G_snprintf(token[size].str_val, MAX_STR_LEN, "%s", val);
+    snprintf(token[size].key, MAX_STR_LEN, "%s", key);
+    snprintf(token[size].str_val, MAX_STR_LEN, "%s", val);
     size++;
 }
 
@@ -121,7 +121,7 @@ void prof_sso(const char *key)
         return;
     }
     token[size].type = T_SSO;
-    G_snprintf(token[size].key, MAX_STR_LEN, "%s", key);
+    snprintf(token[size].key, MAX_STR_LEN, "%s", key);
     size++;
 }
 
@@ -213,7 +213,7 @@ static const char *quote_val(const toktype t, const char *v)
 
     if (t != T_STR)
         return v;
-    G_snprintf(buf, sizeof(buf), "\"%s\"", v);
+    snprintf(buf, sizeof(buf), "\"%s\"", v);
     return buf;
 }
 
@@ -225,19 +225,19 @@ static const char *format_token_common(const struct token *t)
     case T_BLN:
         return t->int_val ? "true" : "false";
     case T_INT:
-        G_snprintf(buf, sizeof(buf), "%d", t->int_val);
+        snprintf(buf, sizeof(buf), "%d", t->int_val);
         return buf;
     case T_DBL:
         if (isnan(t->dbl_val))
             return "null";
-        G_snprintf(buf, sizeof(buf), "%.8f", t->dbl_val);
+        snprintf(buf, sizeof(buf), "%.8f", t->dbl_val);
         return buf;
     case T_STR:
         return t->str_val;
     case T_MTR:
         if (isnan(t->dbl_val))
             return "null";
-        G_snprintf(buf, sizeof(buf), "%.2f", t->dbl_val);
+        snprintf(buf, sizeof(buf), "%.2f", t->dbl_val);
         return buf;
     default:
         return NULL;
@@ -330,7 +330,7 @@ static unsigned stack_push(const char *s)
         overflow = 1;
         return 0;
     }
-    G_snprintf(stack[stack_size], MAX_STR_LEN, "%s", s);
+    snprintf(stack[stack_size], MAX_STR_LEN, "%s", s);
     stack_size++;
     return 1;
 }

--- a/raster/r.in.gdal/main.c
+++ b/raster/r.in.gdal/main.c
@@ -788,11 +788,11 @@ int main(int argc, char *argv[])
 
             /* Generate the suffix */
             if (num_digits > 0) {
-                G_snprintf(suffix, num_digits + 1, "%0*d", num_digits,
-                           nBand + offset);
+                snprintf(suffix, num_digits + 1, "%0*d", num_digits,
+                         nBand + offset);
             }
             else {
-                G_snprintf(suffix, 65, "%d", nBand + offset);
+                snprintf(suffix, 65, "%d", nBand + offset);
             }
 
             G_debug(3, "Import raster band %d", nBand);
@@ -1954,7 +1954,7 @@ static int dump_rat(GDALRasterBandH hBand, char *outrat, int nBand)
 
     field_type = G_malloc(ncols * sizeof(GDALRATFieldType));
 
-    G_snprintf(fname, GNAME_MAX, "%s_%d.csv", outrat, nBand);
+    snprintf(fname, GNAME_MAX, "%s_%d.csv", outrat, nBand);
     if (!(fp = fopen(fname, "w"))) {
         int err = errno;
 

--- a/raster/r.in.pdal/main.cpp
+++ b/raster/r.in.pdal/main.cpp
@@ -17,6 +17,8 @@
  *
  *****************************************************************************/
 
+#include <cstdio>
+
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -892,9 +894,10 @@ int main(int argc, char *argv[])
     char file_list[4096];
 
     if (file_list_opt->answer)
-        G_snprintf(file_list, sizeof(file_list), "%s", file_list_opt->answer);
+        std::snprintf(file_list, sizeof(file_list), "%s",
+                      file_list_opt->answer);
     else
-        G_snprintf(file_list, sizeof(file_list), "%s", input_opt->answer);
+        std::snprintf(file_list, sizeof(file_list), "%s", input_opt->answer);
 
     Rast_set_history(&history, HIST_DATSRC_1, file_list);
     Rast_write_history(outmap, &history);

--- a/raster/r.reclass/reclass.c
+++ b/raster/r.reclass/reclass.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <grass/gis.h>
@@ -238,8 +239,7 @@ int reclass(const char *old_name, const char *old_mapset, const char *new_name,
         G_fatal_error(_("Cannot create reclass file of <%s>"), new_name);
 
     if (!title) {
-        G_snprintf(buf, sizeof(buf), "Reclass of %s in %s", new.name,
-                   new.mapset);
+        snprintf(buf, sizeof(buf), "Reclass of %s in %s", new.name, new.mapset);
         title = buf;
     }
 

--- a/raster/r.sim/simlib/output.c
+++ b/raster/r.sim/simlib/output.c
@@ -42,8 +42,7 @@ void output_walker_as_vector(int tt_minutes, int ndigit,
         /* In case of time series we extent the output name with the time value
          */
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s_%.*d", outwalk, ndigit,
-                       tt_minutes);
+            snprintf(buf, sizeof(buf), "%s_%.*d", outwalk, ndigit, tt_minutes);
             outwalk_time = G_store(buf);
             if (Vect_open_new(&Out, outwalk_time, WITH_Z) < 0)
                 G_fatal_error(_("Unable to create vector map <%s>"),
@@ -146,7 +145,7 @@ int output_data(int tt, double ft UNUSED)
     if (depth) {
         depth_cell = Rast_allocate_f_buf();
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s.%.*d", depth, ndigit, tt_minutes);
+            snprintf(buf, sizeof(buf), "%s.%.*d", depth, ndigit, tt_minutes);
             depth0 = G_store(buf);
             depth_fd = Rast_open_fp_new(depth0);
         }
@@ -157,7 +156,7 @@ int output_data(int tt, double ft UNUSED)
     if (disch) {
         disch_cell = Rast_allocate_f_buf();
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s.%.*d", disch, ndigit, tt_minutes);
+            snprintf(buf, sizeof(buf), "%s.%.*d", disch, ndigit, tt_minutes);
             disch0 = G_store(buf);
             disch_fd = Rast_open_fp_new(disch0);
         }
@@ -168,7 +167,7 @@ int output_data(int tt, double ft UNUSED)
     if (err) {
         err_cell = Rast_allocate_f_buf();
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s.%.*d", err, ndigit, tt_minutes);
+            snprintf(buf, sizeof(buf), "%s.%.*d", err, ndigit, tt_minutes);
             err0 = G_store(buf);
             err_fd = Rast_open_fp_new(err0);
         }
@@ -179,7 +178,7 @@ int output_data(int tt, double ft UNUSED)
     if (conc) {
         conc_cell = Rast_allocate_f_buf();
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s.%.*d", conc, ndigit, tt_minutes);
+            snprintf(buf, sizeof(buf), "%s.%.*d", conc, ndigit, tt_minutes);
             conc0 = G_store(buf);
             conc_fd = Rast_open_fp_new(conc0);
         }
@@ -190,7 +189,7 @@ int output_data(int tt, double ft UNUSED)
     if (flux) {
         flux_cell = Rast_allocate_f_buf();
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s.%.*d", flux, ndigit, tt_minutes);
+            snprintf(buf, sizeof(buf), "%s.%.*d", flux, ndigit, tt_minutes);
             flux0 = G_store(buf);
             flux_fd = Rast_open_fp_new(flux0);
         }
@@ -201,7 +200,7 @@ int output_data(int tt, double ft UNUSED)
     if (erdep) {
         erdep_cell = Rast_allocate_f_buf();
         if (ts == 1) {
-            G_snprintf(buf, sizeof(buf), "%s.%.*d", erdep, ndigit, tt_minutes);
+            snprintf(buf, sizeof(buf), "%s.%.*d", erdep, ndigit, tt_minutes);
             erdep0 = G_store(buf);
             erdep_fd = Rast_open_fp_new(erdep0);
         }

--- a/raster3d/r3.in.ascii/main.c
+++ b/raster3d/r3.in.ascii/main.c
@@ -142,7 +142,7 @@ void readHeaderString(FILE *fp, char *valueString, double *value)
     char line_buff[1024];
 
     /* to avoid buffer overflows we use G_snprintf */
-    G_snprintf(format, 100, "%s %%lf", valueString);
+    snprintf(format, 100, "%s %%lf", valueString);
     G_getl2(line_buff, 1024, fp);
     if (sscanf(line_buff, format, value) != 1) {
         /* this would be ideal to merge if Rast3d_close could be solved */

--- a/raster3d/r3.out.ascii/main.c
+++ b/raster3d/r3.out.ascii/main.c
@@ -137,7 +137,7 @@ void writeHeaderString(FILE *fp, char *valueString, double value)
 {
     static char format[100];
 
-    G_snprintf(format, 100, "%s %%lf\n", valueString);
+    snprintf(format, 100, "%s %%lf\n", valueString);
     if (fprintf(fp, format, value) < 0)
         fatalError("writeHeaderString: header value invalid");
 }
@@ -147,7 +147,7 @@ void writeHeaderString2(FILE *fp, char *valueString, int value)
 {
     static char format[100];
 
-    G_snprintf(format, 100, "%s %%d\n", valueString);
+    snprintf(format, 100, "%s %%d\n", valueString);
     if (fprintf(fp, format, value) < 0)
         fatalError("writeHeaderString: header value invalid");
 }
@@ -157,7 +157,7 @@ void writeHeaderString3(FILE *fp, char *valueString, const char *value)
 {
     static char format[100];
 
-    G_snprintf(format, 100, "%s %%s\n", valueString);
+    snprintf(format, 100, "%s %%s\n", valueString);
     if (fprintf(fp, format, value) < 0)
         fatalError("writeHeaderString: header value invalid");
 }

--- a/raster3d/r3.out.bin/main.c
+++ b/raster3d/r3.out.bin/main.c
@@ -291,7 +291,7 @@ int main(int argc, char *argv[])
         outfile = parm.output->answer;
     else {
         outfile = G_malloc(strlen(name) + 4 + 1);
-        G_snprintf(outfile, sizeof(outfile), "%s.bin", name);
+        snprintf(outfile, sizeof(outfile), "%s.bin", name);
     }
 
     if (G_strcasecmp(parm.order->answer, "big") == 0)

--- a/raster3d/r3.out.bin/main.c
+++ b/raster3d/r3.out.bin/main.c
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
 
     if (snprintf(outfile, sizeof(outfile), "%s%s",
                  (parm.output->answer ? parm.output->answer : name),
-                 (parm.output->answer ? "" : ".bin")) >= sizeof(outfile)) {
+                 (parm.output->answer ? "" : ".bin")) >= (int)sizeof(outfile)) {
         G_fatal_error(_("Output map name too long."));
     }
 

--- a/raster3d/r3.out.bin/main.c
+++ b/raster3d/r3.out.bin/main.c
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
         struct Flag *row, *depth, *integer;
     } flag;
     char *name;
-    char *outfile;
+    char outfile[GNAME_MAX];
     double null_val;
     int do_stdout;
     int order = 0;
@@ -287,11 +287,10 @@ int main(int argc, char *argv[])
             _("Integer output doesn't support bytes=8 in this build"));
 #endif
 
-    if (parm.output->answer)
-        outfile = parm.output->answer;
-    else {
-        outfile = G_malloc(strlen(name) + 4 + 1);
-        snprintf(outfile, sizeof(outfile), "%s.bin", name);
+    if (snprintf(outfile, sizeof(outfile), "%s%s",
+                 (parm.output->answer ? parm.output->answer : name),
+                 (parm.output->answer ? "" : ".bin")) >= sizeof(outfile)) {
+        G_fatal_error(_("Output map name too long."));
     }
 
     if (G_strcasecmp(parm.order->answer, "big") == 0)

--- a/raster3d/r3.out.netcdf/main.c
+++ b/raster3d/r3.out.netcdf/main.c
@@ -292,8 +292,8 @@ static void write_netcdf_header(int ncid, RASTER3D_Region *region, int *varid,
             char long_name[1024];
             char time_unit[1024];
 
-            G_snprintf(long_name, 1024, "Time in %s",
-                       Rast3d_get_vertical_unit(map));
+            snprintf(long_name, 1024, "Time in %s",
+                     Rast3d_get_vertical_unit(map));
 
             if ((retval =
                      nc_def_dim(ncid, TIME_NAME, region->depths, &time_dimid)))
@@ -311,21 +311,20 @@ static void write_netcdf_header(int ncid, RASTER3D_Region *region, int *varid,
                 /* Days since datum in ISO norm */
                 if (datetime_is_absolute(&ts.dt[0])) {
                     is_absolute_time = 1;
-                    G_snprintf(time_unit, 1024,
-                               "%s since %d-%02d-%02d %02d:%02d:%02.0f",
-                               Rast3d_get_vertical_unit(map), ts.dt[0].year,
-                               ts.dt[0].month, ts.dt[0].day, ts.dt[0].hour,
-                               ts.dt[0].minute, ts.dt[0].second);
+                    snprintf(time_unit, 1024,
+                             "%s since %d-%02d-%02d %02d:%02d:%02.0f",
+                             Rast3d_get_vertical_unit(map), ts.dt[0].year,
+                             ts.dt[0].month, ts.dt[0].day, ts.dt[0].hour,
+                             ts.dt[0].minute, ts.dt[0].second);
                 }
                 else {
-                    G_snprintf(time_unit, 1024, "%s",
-                               Rast3d_get_vertical_unit(map));
+                    snprintf(time_unit, 1024, "%s",
+                             Rast3d_get_vertical_unit(map));
                 }
             }
             else {
-                G_snprintf(time_unit, 1024, "%s since %s",
-                           Rast3d_get_vertical_unit(map),
-                           "1900-01-01 00:00:00");
+                snprintf(time_unit, 1024, "%s since %s",
+                         Rast3d_get_vertical_unit(map), "1900-01-01 00:00:00");
             }
 
             if ((retval = nc_put_att_text(ncid, time_varid, UNITS,

--- a/vector/v.what.rast3/main.c
+++ b/vector/v.what.rast3/main.c
@@ -280,8 +280,7 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        G_snprintf(buf, 2048, "update %s set %s = ", Fi->table,
-                   opt.col->answer);
+        snprintf(buf, 2048, "update %s set %s = ", Fi->table, opt.col->answer);
 
         db_set_string(&stmt, buf);
 
@@ -297,23 +296,23 @@ int main(int argc, char *argv[])
                 Rast3d_is_null_value_num(&cache[point].dvalue, DCELL_TYPE);
 
         if (is_empty) {
-            G_snprintf(buf, 2048, "NULL");
+            snprintf(buf, 2048, "NULL");
         }
         else {
             if (typeIntern == FCELL_TYPE)
-                G_snprintf(buf, 2048, "%.10f", cache[point].fvalue);
+                snprintf(buf, 2048, "%.10f", cache[point].fvalue);
             if (typeIntern == DCELL_TYPE)
-                G_snprintf(buf, 2048, "%.15f", cache[point].dvalue);
+                snprintf(buf, 2048, "%.15f", cache[point].dvalue);
         }
 
         db_append_string(&stmt, buf);
 
-        G_snprintf(buf, 2048, " where %s = %d", Fi->key, cache[point].cat);
+        snprintf(buf, 2048, " where %s = %d", Fi->key, cache[point].cat);
 
         db_append_string(&stmt, buf);
         /* user provides where condition: */
         if (opt.where->answer) {
-            G_snprintf(buf, 2048, " AND %s", opt.where->answer);
+            snprintf(buf, 2048, " AND %s", opt.where->answer);
             db_append_string(&stmt, buf);
         }
         G_debug(3, "%s", db_get_string(&stmt));


### PR DESCRIPTION
Beginning with UCRT in Visual Studio 2015 and Windows 10, the behaviour of `snprintf()` (and `vsnprintf()`) is now C99 standard conformant ([source](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-140#remarks)).

Thus, the output is now always null-terminated. The justification for an internal fix for that is no longer needed.

I should add that the code base is already using snprintf() in a number of places.