### PR TITLE
lib: fix missing prototypes

### DIFF
--- a/.github/workflows/macos_install.sh
+++ b/.github/workflows/macos_install.sh
@@ -69,7 +69,7 @@ export CPPFLAGS="-isystem${CONDA_PREFIX}/include"
 
 ./configure $CONFIGURE_FLAGS
 
-EXEMPT="-Wno-error=deprecated-non-prototype -Wno-error=strict-prototypes"
+EXEMPT=""
 make -j$(sysctl -n hw.ncpu) CFLAGS="$CFLAGS -Werror $EXEMPT" \
   CXXFLAGS="$CXXFLAGS -Werror $EXEMPT"
 

--- a/include/grass/la.h
+++ b/include/grass/la.h
@@ -44,7 +44,7 @@ typedef long int __g77_longint;
 typedef unsigned long int __g77_ulongint;
 
 #include <g2c.h>
-#else  /* for gcc4+ */
+#else /* for gcc4+ */
 typedef int integer;
 typedef unsigned int uinteger;
 typedef char *address;
@@ -67,6 +67,14 @@ typedef unsigned long ulongint;
 /* IO stuff */
 typedef int ftnlen;
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
+
 /* procedure parameter types for -A */
 typedef int (*U_fp)();
 typedef shortint (*J_fp)();
@@ -79,6 +87,12 @@ typedef logical (*L_fp)();
 typedef shortlogical (*K_fp)();
 typedef void (*H_fp)();
 typedef int (*S_fp)();
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 /* E_fp is for real functions when -R is not specified */
 typedef void C_f;       /* complex function                    */

--- a/lib/db/sqlp/sqlp.l
+++ b/lib/db/sqlp/sqlp.l
@@ -273,7 +273,7 @@ void yyerror( const char *s )
  * of this func anyway so we can avoid the link dependency.
  *
  **********************************************************************/
-int yywrap()
+int yywrap(void)
 {
         return 1;
 }

--- a/raster/r.report/global.h
+++ b/raster/r.report/global.h
@@ -121,7 +121,7 @@ int print_unit(int, int, int);
 JSON_Value *make_units(int, int);
 JSON_Value *make_category(int, int, JSON_Value *);
 JSON_Value *make_categories(int, int, int);
-void print_json();
+void print_json(void);
 
 /* report.c */
 int report(void);

--- a/raster/r.report/prt_json.c
+++ b/raster/r.report/prt_json.c
@@ -129,7 +129,7 @@ JSON_Value *make_categories(int start, int end, int level)
     return array_value;
 }
 
-void print_json()
+void print_json(void)
 {
     compute_unit_format(0, nunits - 1, JSON);
 


### PR DESCRIPTION
Address `-Wstrict-prototypes` warnings and make CI macOS runner fail in new cases.