### PR TITLE
Checks: fix Flake8 F841 (local variable assigned to but never used) in python/grass/temporal

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -129,17 +129,15 @@ per-file-ignores =
     python/grass/pygrass/raster/category.py: E721
     python/grass/pygrass/rpc/__init__.py: F401, F403
     python/grass/pygrass/utils.py: E402
-    python/grass/temporal/abstract_space_time_dataset.py: F841, E722
-    python/grass/temporal/c_libraries_interface.py: F841, E722
+    python/grass/temporal/abstract_space_time_dataset.py: E722
+    python/grass/temporal/c_libraries_interface.py: E722
     python/grass/temporal/core.py: E722
-    python/grass/temporal/datetime_math.py: F841, E722
-    python/grass/temporal/open_stds.py: F841
+    python/grass/temporal/datetime_math.py: E722
     python/grass/temporal/spatial_topology_dataset_connector.py: E722
-    python/grass/temporal/temporal_algebra.py: F841, E722
-    python/grass/temporal/temporal_granularity.py: F841, E722
-    python/grass/temporal/temporal_raster_base_algebra.py: F841, E722
+    python/grass/temporal/temporal_algebra.py: E722
+    python/grass/temporal/temporal_granularity.py: E722
+    python/grass/temporal/temporal_raster_base_algebra.py: E722
     python/grass/temporal/temporal_topology_dataset_connector.py: E722
-    python/grass/temporal/temporal_vector_algebra.py: F841
     python/grass/temporal/univar_statistics.py: E231
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -2803,8 +2803,6 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         use_start_time = False
 
         # Get basic info
-        self.base.get_name()
-        self.base.get_mapset()
         sql_path = get_sql_template_path()
         stds_register_table = self.get_map_register()
 

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -2549,7 +2549,6 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         # Get basic info
         map_id = map.base.get_id()
-        map.base.get_mapset()
         map_rel_time_unit = map.get_relative_time_unit()
         map_ttype = map.get_temporal_type()
 

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -2549,7 +2549,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         # Get basic info
         map_id = map.base.get_id()
-        map_mapset = map.base.get_mapset()
+        map.base.get_mapset()
         map_rel_time_unit = map.get_relative_time_unit()
         map_ttype = map.get_temporal_type()
 
@@ -2804,8 +2804,8 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         use_start_time = False
 
         # Get basic info
-        stds_name = self.base.get_name()
-        stds_mapset = self.base.get_mapset()
+        self.base.get_name()
+        self.base.get_mapset()
         sql_path = get_sql_template_path()
         stds_register_table = self.get_map_register()
 

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -791,8 +791,8 @@ def check_datetime_string(time_string, use_dateutil=True):
         # relative time. dateutil will interpret a single number as a valid
         # time string, so we have to catch this case beforehand
         try:
-            value = int(time_string)
-            return _("Time string seems to specify relative time")
+            if int(time_string):
+                return _("Time string seems to specify relative time")
         except ValueError:
             pass
 

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -791,8 +791,8 @@ def check_datetime_string(time_string, use_dateutil=True):
         # relative time. dateutil will interpret a single number as a valid
         # time string, so we have to catch this case beforehand
         try:
-            if int(time_string):
-                return _("Time string seems to specify relative time")
+            int(time_string)
+            return _("Time string seems to specify relative time")
         except ValueError:
             pass
 

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -269,7 +269,7 @@ def open_new_map_dataset(
 
     """
 
-    mapset = get_current_mapset()
+    get_current_mapset()
 
     dbif, connection_state_changed = init_dbif(dbif)
     new_map = check_new_map_dataset(name, layer, type, overwrite, dbif)

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -269,8 +269,6 @@ def open_new_map_dataset(
 
     """
 
-    get_current_mapset()
-
     dbif, connection_state_changed = init_dbif(dbif)
     new_map = check_new_map_dataset(name, layer, type, overwrite, dbif)
 

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -2143,7 +2143,6 @@ class TemporalAlgebraParser:
 
         :return: List of maps from maplist with added conditional boolean values.
         """
-        boollist = []
         # Loop over maps of input map list.
         for map_i in maplist:
             # Get dictionary with temporal variables for the map.
@@ -2248,7 +2247,6 @@ class TemporalAlgebraParser:
             # self.msgr.fatal("Condition list is not complete. Elements missing")
             for iter in range(len(tvarexpr)):
                 expr = tvarexpr[iter]
-                operator = tvarexpr[iter + 1]
                 relexpr = tvarexpr[iter + 2]
                 if all(issubclass(type(ele), list) for ele in [expr, relexpr]):
                     resultlist = self.build_spatio_temporal_topology_list(expr, relexpr)

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -96,12 +96,12 @@ def check_granularity_string(granularity, temporal_type):
             return False
 
         try:
-            integer = int(num)
+            int(num)
         except:
             return False
     elif temporal_type == "relative":
         try:
-            integer = int(granularity)
+            int(granularity)
         except:
             return False
     else:

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -511,7 +511,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         """
 
         temporal_relations = map_i.get_temporal_relations()
-        spatial_relations = map_i.get_spatial_relations()
+        map_i.get_spatial_relations()
 
         # Build comandlist list with elements from related maps and given relation
         # operator.
@@ -933,7 +933,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                         map_i.insert(dbif)
                     # Register map in result space time dataset.
                     if self.dry_run is False:
-                        success = resultstds.register_map(map_i, dbif)
+                        resultstds.register_map(map_i, dbif)
 
                 if self.dry_run is False:
                     resultstds.update_from_registered_maps(dbif)
@@ -1040,10 +1040,10 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                         break
                     if count == 0:
                         # Set map name.
-                        name = map_new.get_id()
+                        map_new.get_id()
                     else:
                         # Generate an intermediate map
-                        name = self.generate_map_name()
+                        self.generate_map_name()
 
                     # Create r.mapcalc expression string for the operation.
                     cmdstring = self.build_command_string(
@@ -1208,10 +1208,10 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                         break
                     if count == 0:
                         # Set map name.
-                        name = map_new.get_id()
+                        map_new.get_id()
                     else:
                         # Generate an intermediate map
-                        name = self.generate_map_name()
+                        self.generate_map_name()
 
                     # Create r.mapcalc expression string for the operation.
                     cmdstring = self.build_command_string(
@@ -2038,7 +2038,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                 for obj in map_i.map_value:
                     if isinstance(obj, GlobalTemporalVar):
                         n_maps = obj.td
-                mapinput = map_i.get_id()
+                map_i.get_id()
                 # Create r.mapcalc expression string for the operation.
                 cmdstring = "(%s)" % (n_maps)
                 # Append module command.

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -511,7 +511,6 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         """
 
         temporal_relations = map_i.get_temporal_relations()
-        map_i.get_spatial_relations()
 
         # Build comandlist list with elements from related maps and given relation
         # operator.
@@ -2038,7 +2037,6 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                 for obj in map_i.map_value:
                     if isinstance(obj, GlobalTemporalVar):
                         n_maps = obj.td
-                map_i.get_id()
                 # Create r.mapcalc expression string for the operation.
                 cmdstring = "(%s)" % (n_maps)
                 # Append module command.

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -232,19 +232,6 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
             "STARTED",
             "FINISHED",
         ]
-        complementdict = {
-            "EQUAL": "EQUAL",
-            "FOLLOWS": "PRECEDES",
-            "PRECEDES": "FOLLOWS",
-            "OVERLAPS": "OVERLAPPED",
-            "OVERLAPPED": "OVERLAPS",
-            "DURING": "CONTAINS",
-            "CONTAINS": "DURING",
-            "STARTS": "STARTED",
-            "STARTED": "STARTS",
-            "FINISHES": "FINISHED",
-            "FINISHED": "FINISHES",
-        }
         resultdict = {}
         # Check if given temporal relation are valid.
         for topo in topolist:
@@ -577,7 +564,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
                         # Register map in result space time dataset.
                         if self.debug:
                             print(map_i.get_temporal_extent_as_tuple())
-                        success = resultstds.register_map(map_i, dbif=dbif)
+                        resultstds.register_map(map_i, dbif=dbif)
                     resultstds.update_from_registered_maps(dbif)
 
             # Remove intermediate maps


### PR DESCRIPTION
The following are fixes for Flake8 F841 (local variable assigned to but never used) in the python/grass/temporal directory.

In order to fix the F841 problem I deleted unused variable assignments, but I left the module declarations alone since the module itself assigns global or class variables. In this way, I was able to maintain the existing code structure while fixing the Flake8 issues. However, please check that any module declarations are unnecessary.