### PR TITLE
gui: replace python imp library with importlib for python 3.12

### DIFF
--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -585,8 +585,23 @@ class GConsole(wx.EvtHandler):
 
                 if len(command) == 1:
                     if command[0].startswith("g.gui."):
-                        import imp
                         import inspect
+                        import importlib.util
+                        import importlib.machinery
+
+                        def load_source(modname, filename):
+                            loader = importlib.machinery.SourceFileLoader(
+                                modname, filename
+                            )
+                            spec = importlib.util.spec_from_file_location(
+                                modname, filename, loader=loader
+                            )
+                            module = importlib.util.module_from_spec(spec)
+                            # Module is always executed and not cached in sys.modules.
+                            # Uncomment the following line to cache the module.
+                            # sys.modules[module.__name__] = module
+                            loader.exec_module(module)
+                            return module
 
                         pyFile = command[0]
                         if sys.platform == "win32":
@@ -601,7 +616,7 @@ class GConsole(wx.EvtHandler):
                                 parent=self._guiparent,
                                 message=_("Module <%s> not found.") % command[0],
                             )
-                        pymodule = imp.load_source(command[0].replace(".", "_"), pyPath)
+                        pymodule = load_source(command[0].replace(".", "_"), pyPath)
                         pymain = inspect.getfullargspec(pymodule.main)
                         if pymain and "giface" in pymain.args:
                             pymodule.main(self._giface)


### PR DESCRIPTION
imp library was dropped in Python 3.12, it's only used in one place in gui and I fixed it based on [Python documentation](https://docs.python.org/3/whatsnew/3.12.html#imp). I tested it.