### PR TITLE
contributing: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -16,7 +16,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing
-functionality to not work as expected)
+functionality to not work as before)
 
 ## Checklist
 <!-- See the following points, and put an `x` in all the boxes that apply. -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,31 @@
+## Description
+<!-- Describe your changes in detail -->
+
+## Motivation and context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link the issue here. -->
+
+## How has this been tested?
+<!-- Please describe how you tested your changes. -->
+
+## Screenshots (if appropriate)
+
+## Types of changes
+<!-- What types of changes does your code introduce? -->
+<!-- Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing
+functionality to not work as expected)
+
+## Checklist
+<!-- See the following points, and put an `x` in all the boxes that apply. -->
+<!-- If you're unsure about any of these, please ask. We're here to help! -->
+- [ ] PR title provides summary of the changes and starts with one of the
+[pre-defined prefixes](../../utils/release.yml)
+<!-- For example: "db.describe: add example to documentation" -->
+- [ ] My code follows the [code style](../../doc/development/style_guide.md)
+of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -23,7 +23,8 @@ functionality to not work as expected)
 <!-- If you're unsure about any of these, please ask. We're here to help! -->
 - [ ] PR title provides summary of the changes and starts with one of the
 [pre-defined prefixes](../../utils/release.yml)
-<!-- For example: "db.describe: add example to documentation" -->
+<!-- For example: "doc: Add example to db.describe documentation" -->
+<!-- or if it is a fix use "db.describe: fix JSON output format" -->
 - [ ] My code follows the [code style](../../doc/development/style_guide.md)
 of this project.
 - [ ] My change requires a change to the documentation.

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -4,3 +4,5 @@ default: true
 
 # Fix any fixable errors (depending on the markdownlint wrapper tool used)
 fix: true
+
+MD041: false # first-line-h1


### PR DESCRIPTION
Based on discussion in #4197, I used the [questions-answers](https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md) template with small modifications.

I would like to keep the second level of headings to not have too giant font, but that interferes with the markdownlint [style](https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md041.md), @echoix any opinion?