### PR TITLE
CI(python): Enable printing of all Python warnings with PYTHONWARNINGS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,8 @@ jobs:
   macos_build:
     name: macOS build
     runs-on: macos-14
+    env:
+      PYTHONWARNINGS: always
     steps:
       - name: Info
         run: |

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -18,6 +18,8 @@ jobs:
       cancel-in-progress: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHONWARNINGS: always
     strategy:
       matrix:
         os:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       FORCE_COLOR: 1 # for software including pip: https://force-color.org/
       CLICOLOR_FORCE: 1 # for other software including ninja: https://bixense.com/clicolors/
+      PYTHONWARNINGS: always
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,6 +18,8 @@ jobs:
       cancel-in-progress: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHONWARNINGS: always
     strategy:
       matrix:
         name:


### PR DESCRIPTION
Enables to print all occurrences of warnings, and shows all warnings.

Addresses the additional idea expressed in #4203 of showing other warnings.