### PR TITLE
r.out.png: fix consecutive fclose calls on same pointer

### DIFF
--- a/raster/r.out.png/main.c
+++ b/raster/r.out.png/main.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     int png_compr, /* ret, */ do_alpha;
     struct Cell_head win;
     FILEDESC cellfile = 0;
-    FILE *fp;
+    FILE *fp = NULL;
 
     /* now goes from pnmtopng.c* -A.Sh */
     /*
@@ -207,20 +207,29 @@ int main(int argc, char *argv[])
         png_create_write_struct(PNG_LIBPNG_VER_STRING, &pnmtopng_jmpbuf_struct,
                                 pnmtopng_error_handler, NULL);
     if (png_ptr == NULL) {
-        fclose(fp);
+        if (fp) {
+            fclose(fp);
+            fp = NULL;
+        }
         G_fatal_error("cannot allocate LIBPNG structure");
     }
 
     info_ptr = png_create_info_struct(png_ptr);
     if (info_ptr == NULL) {
         png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
-        fclose(fp);
+        if (fp) {
+            fclose(fp);
+            fp = NULL;
+        }
         G_fatal_error("cannot allocate LIBPNG structure");
     }
 
     if (setjmp(pnmtopng_jmpbuf_struct.jmpbuf)) {
         png_destroy_write_struct(&png_ptr, &info_ptr);
-        fclose(fp);
+        if (fp) {
+            fclose(fp);
+            fp = NULL;
+        }
         G_fatal_error("setjmp returns error condition (1)");
     }
 
@@ -360,7 +369,8 @@ int main(int argc, char *argv[])
     /* G_free (info_ptr); */
     png_destroy_write_struct(&png_ptr, &info_ptr); /* al 11/2000 */
 
-    fclose(fp);
+    if (fp)
+        fclose(fp);
 
     if (wld_flag->answer) {
         if (do_stdout)


### PR DESCRIPTION
This patch fixes two issues:

1. In one of the code paths, we are calling fclose on a file pointer which could potentially be NULL. Doing that would lead to undefined behavior. Check if a file pointer is NULL before closing it.

2. If we call fclose on same file pointer twice, in the second instance we could be closing file descriptor allocated to some other file, which typically happens to a freed descriptor.

This issue was found by using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Tool used in finding this error: cppcheck

<img width="856" alt="image" src="https://github.com/user-attachments/assets/9b5712f0-5c56-4ec3-a9f3-b808982b0b27">

Tool's output after applying the patch

<img width="599" alt="image" src="https://github.com/user-attachments/assets/dd40e4c3-fe4d-481f-a18a-ca8d2b7b3431">

3. Reproduction rate: 100%, reproducible every time.
4. Architecture: Not specific to any underlying architecture.
