### PR TITLE
r.out.png: reset file pointer to NULL after fclose

### DIFF
--- a/raster/r.out.png/main.c
+++ b/raster/r.out.png/main.c
@@ -369,8 +369,10 @@ int main(int argc, char *argv[])
     /* G_free (info_ptr); */
     png_destroy_write_struct(&png_ptr, &info_ptr); /* al 11/2000 */
 
-    if (fp)
+    if (fp) {
         fclose(fp);
+        fp = NULL;
+    }
 
     if (wld_flag->answer) {
         if (do_stdout)


### PR DESCRIPTION
This patch continues the work from 917ba58. It's a good practice to immediately reset the file pointer once we do fclose on it, as it prevents using/closing descriptor allocated to another file in the future execution paths.