### PR TITLE
grass.jupyter: Ensure width and height in InteractiveMap are integers 

### DIFF
--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -17,7 +17,6 @@ import os
 import base64
 import json
 from pathlib import Path
-import grass.script as gs
 from .reprojection_renderer import ReprojectionRenderer
 
 from .utils import (
@@ -296,8 +295,8 @@ class InteractiveMap:
             import xyzservices  # pylint: disable=import-outside-toplevel
 
         # Store height and width
-        self.width = width
-        self.height = height
+        self.width = int(width)
+        self.height = int(height)
         self._controllers = {}
 
         # Store vector and raster name
@@ -766,12 +765,7 @@ class InteractiveQueryController:
         self.raster_name = rasters
         self.vector_name = vectors
         self.query_control = None
-
-        try:
-            self.width = int(width)
-        except (ValueError, TypeError):
-            gs.warning(_("Invalid width value, using default width of 300px."))
-            self.width = 300
+        self.width = width
 
     def activate(self):
         """Activates the interactive querying."""

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -764,8 +764,8 @@ class InteractiveQueryController:
         self._ipywidgets = ipywidgets
         self.raster_name = rasters
         self.vector_name = vectors
-        self.query_control = None
         self.width = width
+        self.query_control = None
 
     def activate(self):
         """Activates the interactive querying."""

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -17,6 +17,7 @@ import os
 import base64
 import json
 from pathlib import Path
+import grass.script as gs
 from .reprojection_renderer import ReprojectionRenderer
 
 from .utils import (
@@ -745,7 +746,7 @@ class InteractiveQueryController:
         _ipywidgets: The ipywidgets module.
         raster_name: The name of the raster layer.
         vector_name: The name of the vector layer.
-        width: The width of the map.
+        width: The width of the map as an int.
         query_control: The query control.
 
     """
@@ -764,8 +765,13 @@ class InteractiveQueryController:
         self._ipywidgets = ipywidgets
         self.raster_name = rasters
         self.vector_name = vectors
-        self.width = width
         self.query_control = None
+
+        try:
+            self.width = int(width)
+        except (ValueError, TypeError):
+            gs.warning(_("Invalid width value, using default width of 300px."))
+            self.width = 300
 
     def activate(self):
         """Activates the interactive querying."""


### PR DESCRIPTION
The users input wasn't getting checked here causing the query to fail if the user defined the `width` parameter as a string.

The code below would render the map and fail when the query_vector tried to return.

 ```
m = gj.InteractiveMap(width="500", map_backend="ipyleaflet")
```
