### PR TITLE
wxGUI: Update link to the Natural Earth sample dataset

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -73,8 +73,8 @@ LOCATIONS = [
     },
     {
         "label": "Natural Earth Dataset in WGS84",
-        "url": "https://zenodo.org/record/3968936/files/natural-earth-dataset.tar.gz",
-        "size": "207 MB",
+        "url": "https://zenodo.org/records/13370131/files/natural_earth_dataset.zip",
+        "size": "121.3 MB",
         "epsg": "4326",
         "license": "ODC Public Domain Dedication and License 1.0",
         "maintainer": "Brendan Harmon (brendan.harmon@gmail.com)",


### PR DESCRIPTION
Update link to latest natural earth sample dataset, see #4172 and https://github.com/OSGeo/grass-website/issues/454
@neteler, not sure if this is the only place to change the URL, and if I have done it correctly, but to give it a start
