### PR TITLE
wxGUI: fix adding and removing from history for new mapset

### DIFF
--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -505,6 +505,7 @@ class HistoryBrowserTree(CTreeView):
                 },
             )
             self._model.SortChildren(self._model.root)
+            self.RefreshItems()
 
         # Populate today's node by executed command
         command_node = self._populateDayItem(today_node, entry)
@@ -621,9 +622,9 @@ class HistoryBrowserTree(CTreeView):
         selected_day = selected_command.parent
         if selected_day and len(selected_day.children) == 0:
             self._model.RemoveNode(selected_day)
-
-        # Reload day node
-        self._reloadNode(selected_day)
+            self._reloadNode(self._model.root)
+        else:
+            self._reloadNode(selected_day)
         self.showNotification.emit(message=_("<{}> removed").format(command))
 
     def OnItemSelected(self, node):


### PR DESCRIPTION
When running a command in a new mapset with no prior history, I was getting a traceback, and similarly when removing command from history when there was a single command. This was introduced in 02e45e93a when trying to avoid calling complete tree refresh every time.