### PR TITLE
Checks: flake8 F841 (local variable assigned to but never used) fixes in the temporal directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -174,12 +174,9 @@ per-file-ignores =
     scripts/v.what.strds/v.what.strds.py: E722, E501
     # Line too long (esp. module interface definitions)
     scripts/*/*.py: E501
-    # local variable 'column' is assigned to but never used
     temporal/t.rast.to.vect/t.rast.to.vect.py: E501
-    # local variable 'stdstype' is assigned to but never used
     temporal/t.vect.algebra/t.vect.algebra.py: E501
     # ## used (##% key: r etc)
-    # local variable 'map_list' is assigned to but never used
     temporal/t.rast.what/t.rast.what.py: E265, E266, E501
     # Line too long (esp. module interface definitions)
     temporal/*/*.py: E501

--- a/.flake8
+++ b/.flake8
@@ -177,10 +177,10 @@ per-file-ignores =
     # local variable 'column' is assigned to but never used
     temporal/t.rast.to.vect/t.rast.to.vect.py: E501
     # local variable 'stdstype' is assigned to but never used
-    temporal/t.vect.algebra/t.vect.algebra.py: F841, E501
+    temporal/t.vect.algebra/t.vect.algebra.py: E501
     # ## used (##% key: r etc)
     # local variable 'map_list' is assigned to but never used
-    temporal/t.rast.what/t.rast.what.py: E265, E266, F841, E501
+    temporal/t.rast.what/t.rast.what.py: E265, E266, E501
     # Line too long (esp. module interface definitions)
     temporal/*/*.py: E501
 

--- a/temporal/t.rast.what/t.rast.what.py
+++ b/temporal/t.rast.what/t.rast.what.py
@@ -466,7 +466,6 @@ def one_point_per_col_output(
     for count in range(len(output_files)):
         file_name = output_files[count]
         gs.verbose(_("Transforming r.what output file %s" % (file_name)))
-        map_list = output_time_list[count]
         in_file = open(file_name, "r")
         lines = in_file.readlines()
 

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -64,7 +64,6 @@ def main():
     expression = options["expression"]
     basename = options["basename"]
     spatial = flags["s"]
-    stdstype = "stvds"
 
     # Check for PLY istallation
     try:


### PR DESCRIPTION
## Description
Flake8 F841 (local variable assigned to but never used) fixes in the `temporal` directory.  Two declarations of unused functions were deleted.  

## Motivation and context
Changes require resolving a part of Flake8 warnings that are currently ignored. The issue title and number as follows.

- [Bug] Fix currently ignored Flake8 warnings [#1522](https://github.com/OSGeo/grass/issues/1522)

## How has this been tested?
I've tested them with the gunittest tool in the tool folder.

## Types of changes
Two declarations of unused functions were deleted.  

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist
I was initially instructed to use 'Checks' for the PR title, however, if any cases need to be changed, please let me know since it isn't listed in `release.yml`.
- [ ] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](../../utils/release.yml)
- [x] My code follows the [code style](../../doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.