### PR TITLE
r.viewshed: initialize struct member before using struct

### DIFF
--- a/raster/r.viewshed/viewshed.cpp
+++ b/raster/r.viewshed/viewshed.cpp
@@ -261,6 +261,7 @@ MemoryVisibilityGrid *viewshed_in_memory(char *inputfname, GridHeader *hd,
         e.elev[0] = data[0][i];
         e.elev[1] = data[1][i];
         e.elev[2] = data[2][i];
+        e.angle = -1;
 
         if (!is_nodata(visgrid->grid->hd, data[1][i]) &&
             !is_point_outside_max_dist(*vp, *hd, sn.row, sn.col,
@@ -499,6 +500,7 @@ IOVisibilityGrid *viewshed_external(char *inputfname, GridHeader *hd,
         e.elev[0] = data[0][i];
         e.elev[1] = data[1][i];
         e.elev[2] = data[2][i];
+        e.angle = -1;
         if (!is_nodata(visgrid->hd, data[1][i]) &&
             !is_point_outside_max_dist(*vp, *hd, sn.row, sn.col,
                                        viewOptions.maxDist)) {

--- a/raster/r.viewshed/viewshed.cpp
+++ b/raster/r.viewshed/viewshed.cpp
@@ -261,7 +261,7 @@ MemoryVisibilityGrid *viewshed_in_memory(char *inputfname, GridHeader *hd,
         e.elev[0] = data[0][i];
         e.elev[1] = data[1][i];
         e.elev[2] = data[2][i];
-        e.angle = -1;
+        e.angle = -1.0;
 
         if (!is_nodata(visgrid->grid->hd, data[1][i]) &&
             !is_point_outside_max_dist(*vp, *hd, sn.row, sn.col,
@@ -500,7 +500,7 @@ IOVisibilityGrid *viewshed_external(char *inputfname, GridHeader *hd,
         e.elev[0] = data[0][i];
         e.elev[1] = data[1][i];
         e.elev[2] = data[2][i];
-        e.angle = -1;
+        e.angle = -1.0;
         if (!is_nodata(visgrid->hd, data[1][i]) &&
             !is_point_outside_max_dist(*vp, *hd, sn.row, sn.col,
                                        viewOptions.maxDist)) {


### PR DESCRIPTION
This was reported by cppcheck tool. Technically, we are not using the member in the struct variable in any of the subsequent functions, but it's a good practice to initialize all the struct members whenever possible.

Initial errors from cppcheck tool:

<img width="954" alt="image" src="https://github.com/user-attachments/assets/e599c552-022e-43d5-8661-3705618f4fa5">

After applying the patch:

<img width="665" alt="image" src="https://github.com/user-attachments/assets/f748c935-43bd-4474-826e-02b36468f235">

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Architecture: Not specific to any underlying architecture.

Testing done:

Ran the complete `test_r_viewshed.py` gunittest from the testsuite and it was successful. 
