### PR TITLE
init: Use pathlib Path.read_text for readfile in the main executable

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -55,6 +55,7 @@ import uuid
 import unicodedata
 import argparse
 import json
+from pathlib import Path
 
 
 # mechanism meant for debugging this script (only)
@@ -167,10 +168,7 @@ def fatal(msg):
 
 def readfile(path):
     debug("Reading %s" % path)
-    f = open(path, "r")
-    s = f.read()
-    f.close()
-    return s
+    return Path(path).read_text()
 
 
 def writefile(path, s):


### PR DESCRIPTION
I explicitly don't want readfile and writefile to be changed in the same PR.
I don't see any coverage (pytest from here, nor gunittest from my fork (too slow to be used allways)), that runs into the init script. So the approach is to leave it for some time before changing.

The readfile function is only used inside that file, 10 references, in functions like `create_gisrc()`, `set_mapset()`, `load_env()`, `csh_startup()`, `sh_like_startup()`, `classic_parser()`.
![image](https://github.com/user-attachments/assets/00403280-b09c-4cc4-8ada-cbacada9e81a)

If it were to have an impact, we should see it easily. 

I seriously don't think there are any difference, as Pathlib's `read_text()` function is really simple to understand, so I'm including it here for reference when reviewing my similar PRs:

> ```python
>     def read_text(self, encoding=None, errors=None, newline=None):
>         """
>         Open the file in text mode, read it, and close the file.
>         """
>         # Call io.text_encoding() here to ensure any warning is raised at an
>         # appropriate stack level.
>         encoding = io.text_encoding(encoding)
>         return PathBase.read_text(self, encoding, errors, newline)
> ```
> https://github.com/python/cpython/blob/fe85a8291d9aa11c9ce9e207c39ea0a0c35f9625/Lib/pathlib/_local.py#L591-L598

calling

> ```python
>     def read_text(self, encoding=None, errors=None, newline=None):
>         """
>         Open the file in text mode, read it, and close the file.
>         """
>         with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
>             return f.read()
> 
> ```
> https://github.com/python/cpython/blob/fe85a8291d9aa11c9ce9e207c39ea0a0c35f9625/Lib/pathlib/_abc.py#L736-L741

and `write_text()` (not used here):

> ```python
>     def write_text(self, data, encoding=None, errors=None, newline=None):
>         """
>         Open the file in text mode, write to it, and close the file.
>         """
>         # Call io.text_encoding() here to ensure any warning is raised at an
>         # appropriate stack level.
>         encoding = io.text_encoding(encoding)
>         return PathBase.write_text(self, data, encoding, errors, newline)
> ```
> https://github.com/python/cpython/blob/fe85a8291d9aa11c9ce9e207c39ea0a0c35f9625/Lib/pathlib/_local.py#L600-L607

calling

> ```python
>     def write_text(self, data, encoding=None, errors=None, newline=None):
>         """
>         Open the file in text mode, write to it, and close the file.
>         """
>         if not isinstance(data, str):
>             raise TypeError('data must be str, not %s' %
>                             data.__class__.__name__)
>         with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
>             return f.write(data)
> ```
> https://github.com/python/cpython/blob/fe85a8291d9aa11c9ce9e207c39ea0a0c35f9625/Lib/pathlib/_abc.py#L752-L760