### PR TITLE
init: Use pathlib Path.write_text for writefile in the main executable

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -55,7 +55,7 @@ import uuid
 import unicodedata
 import argparse
 import json
-
+from pathlib import Path
 
 # mechanism meant for debugging this script (only)
 # private global to store if we are debugging
@@ -175,9 +175,7 @@ def readfile(path):
 
 def writefile(path, s):
     debug("Writing %s" % path)
-    f = open(path, "w")
-    f.write(s)
-    f.close()
+    Path(path).write_text(s)
 
 
 def call(cmd, **kwargs):


### PR DESCRIPTION
Paired PR of https://github.com/OSGeo/grass/pull/4234. https://github.com/OSGeo/grass/pull/4234 should be merged, then solving the upcoming merge conflict as both PRs added the pathlib import, then this PR can be considered to merge. I want to make sure that we could catch differences in new/old behaviour, that wouldn't be possible if we changed the input and output functions at the same time.

Like https://github.com/OSGeo/grass/pull/4234, this file isn't visible in my code coverage at the moment.
The `writefile()` function is used 4 times, all in the same file.
![image](https://github.com/user-attachments/assets/2d31c08c-2556-4ad3-b517-bf90fa84ba98)
