### PR TITLE
grass.temporal.stds_import: Use pathlib Path.read_text and Path.write_text for proj string

### DIFF
--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -32,6 +32,7 @@ for details.
 import os
 import os.path
 import tarfile
+from pathlib import Path
 
 import grass.script as gs
 from grass.exceptions import CalledModuleError
@@ -302,16 +303,12 @@ def import_stds(
         # from other programs than g.proj into
         # new line format so that the grass file comparison function
         # can be used to compare the projections
-        proj_name_tmp = temp_name + "_in_projection"
-        proj_file = open(proj_name, "r")
-        proj_content = proj_file.read()
+        proj_content = Path(proj_name).read_text()
         proj_content = proj_content.replace(" +", "\n+")
         proj_content = proj_content.replace("\t+", "\n+")
-        proj_file.close()
 
-        proj_file = open(proj_name_tmp, "w")
-        proj_file.write(proj_content)
-        proj_file.close()
+        proj_name_tmp = f"{temp_name}_in_projection"
+        Path(proj_name_tmp).write_text(proj_content)
 
         p = gs.start_command("g.proj", flags="j", stdout=temp_file)
         p.communicate()
@@ -336,7 +333,7 @@ def import_stds(
     old_env = gs.gisenv()
     if location:
         try:
-            proj4_string = open(proj_file_name, "r").read()
+            proj4_string = Path(proj_file_name).read_text()
             gs.create_location(
                 dbase=old_env["GISDBASE"], location=location, proj4=proj4_string
             )


### PR DESCRIPTION
Similar changes for stds_export are not in this PR by purpose. During the weekend, I had made a mistake in stds_export somewhere and didn't find it, but the mismatch in lengths of init file vs list file in stds_import, that wasn't touched yet. That's why I insist so much on separating input/output in different PRs.
<details><summary>Details on a failing test saved because stds_import and stds_export weren't changed together</summary>
<p>

![image](https://github.com/user-attachments/assets/2c039961-6a22-4db7-ba4b-d20d01b8455c)



</p>
</details> 



In the spirit of https://github.com/OSGeo/grass/pull/4224#discussion_r1731736845, this is only fixes the part where a context manager can be avoided.

See PR description of https://github.com/OSGeo/grass/pull/4234 for an illustration of the implementation of read_text() and write_text()