### PR TITLE
checks: flake8 F841 (local variable assigned to but never used) fixes in scripts directory part 1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -154,9 +154,7 @@ per-file-ignores =
     python/grass/*/*/__init__.py: F401, F403
     python/grass/*/*/*/__init__.py: F401, F403
     # E402 module level import not at top of file
-    scripts/d.polar/d.polar.py: F841
-    scripts/r.in.wms/wms_gdal_drv.py: F841, E722
-    scripts/r.in.wms/wms_cap_parsers.py: F841
+    scripts/r.in.wms/wms_gdal_drv.py: E722
     scripts/r.in.wms/wms_drv.py: E402, E722
     scripts/r.in.wms/srs.py: E722
     scripts/r.semantic.label/r.semantic.label.py: F841, E501

--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -202,7 +202,6 @@ def plot_eps(psout):
     epsscale = 0.1
     frameallowance = 1.1
     halfframe = 3000
-    center = (halfframe, halfframe)
     scale = halfframe / (outerradius * frameallowance)
 
     diagramlinewidth = halfframe / 400
@@ -210,11 +209,6 @@ def plot_eps(psout):
     axesfontsize = halfframe / 16
     diagramfontsize = halfframe / 20
     halfframe_2 = halfframe * 2
-
-    averagedirectioncolor = 1  # (blue)
-    diagramcolor = 4  # (red)
-    circlecolor = 2  # (green)
-    axescolor = 0  # (black)
 
     northjustification = 2
     eastjustification = 6
@@ -287,7 +281,6 @@ newpath
     )
     outf.write(s)
 
-    sublength = len(outercircle) - 2
     (x, y) = outercircle[1]
     outf.write("%.2f %.2f moveto\n" % (x * scale + halfframe, y * scale + halfframe))
     for x, y in outercircle[2:]:
@@ -343,7 +336,6 @@ newpath
     )
     outf.write(s)
 
-    sublength = len(sine_cosine_replic) - 2
     (x, y) = sine_cosine_replic[1]
     outf.write("%.2f %.2f moveto\n" % (x * scale + halfframe, y * scale + halfframe))
     for x, y in sine_cosine_replic[2:]:
@@ -369,7 +361,6 @@ newpath
     s = t.substitute(DIAGRAMLINEWIDTH=diagramlinewidth)
     outf.write(s)
 
-    sublength = len(vector) - 2
     (x, y) = vector[1]
     outf.write("%.2f %.2f moveto\n" % (x * scale + halfframe, y * scale + halfframe))
     for x, y in vector[2:]:

--- a/scripts/r.in.wms/wms_cap_parsers.py
+++ b/scripts/r.in.wms/wms_cap_parsers.py
@@ -131,7 +131,7 @@ class WMSCapabilitiesTree(BaseCapabilitiesTree):
         """!Check if format element is defined."""
         request = self._find(capability, "Request")
         get_map = self._find(request, "GetMap")
-        formats = self._findall(get_map, "Format")
+        self._findall(get_map, "Format")
 
     def _checkLayerTree(self, parent_layer, first=True):
         """!Recursively check layer tree and manage inheritance in the tree"""

--- a/scripts/r.in.wms/wms_gdal_drv.py
+++ b/scripts/r.in.wms/wms_gdal_drv.py
@@ -60,7 +60,6 @@ class WMSGdalDrv(WMSBase):
 
         gdal_wms = ET.Element("GDAL_WMS")
         service = ET.SubElement(gdal_wms, "Service")
-        name = ET.Element("name")
         service.set("name", "WMS")
 
         version = ET.SubElement(service, "Version")


### PR DESCRIPTION
## Description

Flake8 F841 (local variable assigned to but never used) fixes in the `scripts` directory, specifically, `d.polar` and `r.in.wms`.

## Motivation and context

Changes require resolving a part of Flake8 warnings that are currently ignored. The issue title and number as follows.

- [Bug] Fix currently ignored Flake8 warnings [#1522](https://github.com/OSGeo/grass/issues/1522)

## How has this been tested?

- **d.polar**: Tested with *test_d_polar.py* and all passed.

- **r.in.wms**: Since this tool doesn't have gunittest, I tested with GUI entered parameters following. Test was successful.
```r.in.wms url="https://tiles.maps.eox.at/wms?" layers=s2cloudless output=sentinel2 format=png```

## Types of changes

Delete unused variables and entire variable declarations.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist

- [ ]  PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](https://github.com/OSGeo/grass/blob/main/utils/release.yml)
- [x]  My code follows the [code style](https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md)
of this project.
- [ ]  My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.
- [ ]  I have added tests to cover my changes.