### PR TITLE
r3.showdspf: fix null pointer dereference when opening database file

### DIFF
--- a/raster3d/r3.showdspf/main_ogl.c
+++ b/raster3d/r3.showdspf/main_ogl.c
@@ -202,8 +202,7 @@ int main(int argc, char **argv)
             G_fatal_error(buff);
         }
         if ((Headfax.dspfinfp = G_fopen_old(buff, dsp, mapset)) == NULL) {
-            fprintf(stderr, "Unable to open <%s> for reading\n",
-                    Headfax.dspfinfp);
+            fprintf(stderr, "Unable to open <%s> for reading\n", dsp);
             exit(EXIT_FAILURE);
         }
 


### PR DESCRIPTION
In the current execution, when we face an error while trying to open a database file, as part of error log we are dereferencing a NULL file pointer (which is returend when we try to open a file and error out). Ideally we should be printing the name of the database file rather than the file pointer. This fixes the problem of null pointer dereference.

This issue was found using cppcheck tool.

Output from cppcheck tool:

<img width="808" alt="image" src="https://github.com/user-attachments/assets/d3c35834-c24d-4299-87f3-482cda6b1faf">

Output from cppcheck with the fix applied:

<img width="667" alt="image" src="https://github.com/user-attachments/assets/20c9cb7f-875b-472b-a094-9cb744cfc0e0">

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Architecture: Not specific to any underlying architecture.