### PR TITLE
r3.showdspf: fix accessing uninitialized pointer

### DIFF
--- a/raster3d/r3.showdspf/get_color_ogl.c
+++ b/raster3d/r3.showdspf/get_color_ogl.c
@@ -79,7 +79,7 @@ short color[3];
 {
     int curr;
     float cat1, cat2;
-    short *color1, *color2;
+    short *color1 = NULL, *color2 = NULL;
     float delta;
 
     /*DEBUG
@@ -123,9 +123,11 @@ short color[3];
     }
     /* for any thresholds greater than last color table entry, use last entry *
      */
-    color[0] = color2[0];
-    color[1] = color2[1];
-    color[2] = color2[2];
+    if (color2) {
+        color[0] = color2[0];
+        color[1] = color2[1];
+        color[2] = color2[2];
+    }
 }
 
 /******************************************************************************


### PR DESCRIPTION
color2 pointer is not initialized and it is assigned a value depending on a conditional.

```
    for (curr = 1; ctable[curr].color[0] >= 0; curr++) {
        cat2 = ctable[curr].data;
        color2 = ctable[curr].color;
        if (cat2 > cat) {
            delta = (cat - cat1) / (cat2 - cat1);
            color[0] = delta * color2[0] + (1 - delta) * color1[0];
            color[1] = delta * color2[1] + (1 - delta) * color1[1];
            color[2] = delta * color2[2] + (1 - delta) * color1[2];
            return;
        }
        cat1 = cat2;
        color1 = color2;
```

Potentially, in an execution path if conditional fails and we do not enter the for loop above, we would be accessing an uninitialized pointer after this loop, whose behavior is undefined. Initialize the pointer to NULL to avoid this.

This issue was found by using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Architecture: Not specific to any underlying architecture.
4. cppcheck output before the fix

<img width="893" alt="image" src="https://github.com/user-attachments/assets/1599953f-a60b-433b-a04f-099729d80d7c">

cppcheck output after the fix

<img width="739" alt="image" src="https://github.com/user-attachments/assets/40c7b640-cf76-4682-90e0-958ab33d9dae">
