### PR TITLE
v.external.out: Check for valid array before passing it to qsort

### DIFF
--- a/vector/v.external.out/list.c
+++ b/vector/v.external.out/list.c
@@ -53,7 +53,8 @@ char **format_list(int *count, size_t *len)
     }
 
     /* order formats by name */
-    qsort(list, *count, sizeof(char *), cmp);
+    if (list)
+        qsort(list, *count, sizeof(char *), cmp);
 #endif
 #if defined HAVE_POSTGRES && !defined HAVE_OGR
     list = G_realloc(list, ((*count) + 1) * sizeof(char *));


### PR DESCRIPTION
Currently, if 'HAVE_OGR' macro is defined, as part of execution, we sort all formats by name using qsort. But, array containing all formats is assigned based on a conditional and if the conditional fails, it can be NULL.

Behavior of qsort when a NULL array is provided is undefined. To avoid getting into that situation, check if the array is NULL before performing qsort on it.

This issue was found by using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Should only be valid, when 'HAVE_OGR' flag is specified as part of the compilation process.
4. Output from cppcheck prior to fix

<img width="912" alt="image" src="https://github.com/user-attachments/assets/5cef3039-9f3b-4d30-9499-ea3ae44be967">

After the fix

<img width="679" alt="image" src="https://github.com/user-attachments/assets/c2cb8e1c-df88-4d6b-9a1f-e54924458550">
