### PR TITLE
checks: Flake8 F841 fixes in the wxpython directory part 2

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -52,11 +52,10 @@ per-file-ignores =
     gui/wxpython/core/settings.py: E722
     gui/wxpython/core/watchdog.py: E402
     gui/wxpython/datacatalog/tree.py: E731, E402
-    gui/wxpython/dbmgr/base.py: E722, F841
-    gui/wxpython/dbmgr/dialogs.py: F841, E722
-    gui/wxpython/dbmgr/sqlbuilder.py: E722, F841
+    gui/wxpython/dbmgr/base.py: E722
+    gui/wxpython/dbmgr/dialogs.py: E722
+    gui/wxpython/dbmgr/sqlbuilder.py: E722
     gui/wxpython/dbmgr/manager.py: E722
-    gui/wxpython/dbmgr/vinfo.py: F841
     gui/wxpython/docs/wxgui_sphinx/conf.py: E402, W291
     gui/wxpython/gcp/g.gui.gcp.py: F841
     gui/wxpython/gcp/manager.py: F841, E722

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -228,7 +228,7 @@ class VirtualAttributeList(
 
         if sql:
             cmdParams.update({"sql": sql, "output": outFile.name, "overwrite": True})
-            ret = RunCommand("db.select", **cmdParams)
+            RunCommand("db.select", **cmdParams)
             self.sqlFilter = {"sql": sql}
         else:
             cmdParams.update(
@@ -246,7 +246,7 @@ class VirtualAttributeList(
                 # Enclose column name with SQL standard double quotes
                 cmdParams.update({"columns": ",".join([f'"{col}"' for col in columns])})
 
-            ret = RunCommand("v.db.select", **cmdParams)
+            RunCommand("v.db.select", **cmdParams)
 
         # These two should probably be passed to init more cleanly
         # setting the numbers of items = number of elements in the dictionary
@@ -296,7 +296,7 @@ class VirtualAttributeList(
                 record = (
                     decode(outFile.readline(), encoding=enc).strip().replace("\n", "")
                 )
-            except UnicodeDecodeError as e:
+            except UnicodeDecodeError:
                 record = (
                     outFile.readline()
                     .decode(encoding=enc, errors="replace")
@@ -965,7 +965,7 @@ class DbMgrNotebookBase(GNotebook):
             pass
 
         if idCol:
-            winCol = self.FindWindowById(idCol)
+            self.FindWindowById(idCol)
             table = self.dbMgrData["mapDBInfo"].layers[self.selLayer]["table"]
             self.dbMgrData["mapDBInfo"].GetColumns(table)
 
@@ -2687,7 +2687,6 @@ class DbMgrTablesPage(DbMgrNotebookBase):
         tlist = self.FindWindowById(self.layerPage[self.selLayer]["tableData"])
 
         item = tlist.GetFirstSelected()
-        countSelected = tlist.GetSelectedItemCount()
         if UserSettings.Get(group="atm", key="askOnDeleteRec", subkey="enabled"):
             # if the user select more columns to delete, all the columns name
             # will appear the the warning dialog

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -965,7 +965,6 @@ class DbMgrNotebookBase(GNotebook):
             pass
 
         if idCol:
-            self.FindWindowById(idCol)
             table = self.dbMgrData["mapDBInfo"].layers[self.selLayer]["table"]
             self.dbMgrData["mapDBInfo"].GetColumns(table)
 

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -305,7 +305,6 @@ class DisplayAttributesDialog(wx.Dialog):
             columns = self.mapDBInfo.tables[table]
             for idx in range(len(columns[key]["values"])):
                 for name in columns.keys():
-                    type = columns[name]["type"]
                     value = columns[name]["values"][idx]
                     if value is None:
                         value = ""

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -414,10 +414,6 @@ class SQLBuilder(wx.Frame):
 
         idx = selection[0]
         value = self.list_values.GetString(idx)
-        idx = self.list_columns.GetSelections()[0]
-        column = self.list_columns.GetString(idx)
-
-        self.dbInfo.GetTableDesc(self.dbInfo.GetTable(self.layer))[column]["type"]
 
         self._add(element="value", value=value)
 

--- a/gui/wxpython/dbmgr/sqlbuilder.py
+++ b/gui/wxpython/dbmgr/sqlbuilder.py
@@ -356,7 +356,6 @@ class SQLBuilder(wx.Frame):
 
     def OnUniqueValues(self, event, justsample=False):
         """Get unique values"""
-        vals = []
         try:
             idx = self.list_columns.GetSelections()[0]
             column = self.list_columns.GetString(idx)
@@ -418,9 +417,7 @@ class SQLBuilder(wx.Frame):
         idx = self.list_columns.GetSelections()[0]
         column = self.list_columns.GetString(idx)
 
-        ctype = self.dbInfo.GetTableDesc(self.dbInfo.GetTable(self.layer))[column][
-            "type"
-        ]
+        self.dbInfo.GetTableDesc(self.dbInfo.GetTable(self.layer))[column]["type"]
 
         self._add(element="value", value=value)
 

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -102,9 +102,6 @@ class VectorDBInfo(VectorDBInfoBase):
         """Get attributes by coordinates (all available layers)
 
         Return line id or None if no line is found"""
-        line = None
-        nselected = 0
-
         try:
             data = gs.vector_what(
                 map=self.map,


### PR DESCRIPTION
## Description

Flake8 F841 (local variable assigned to but never used) fixes in the `gui/wxpython/dbmgr` directory. 

## Motivation and context

Changes require resolving a part of Flake8 warnings that are currently ignored. The issue title and number as follows.

- [Bug] Fix currently ignored Flake8 warnings [#1522](https://github.com/OSGeo/grass/issues/1522)

## How has this been tested?
The GUI worked fine when I briefly tested it.

## Types of changes

Removed unused variables and lines to fix F841.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist
- [x]  PR title provides summary of the changes and starts with one of the [pre-defined prefixes](https://www.notion.so/utils/release.yml)
- [x]  My code follows the [code style](https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md) of this project.
- [ ]  My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.
- [ ]  I have added tests to cover my changes.