### PR TITLE
lib/db: Fix copy into fixed size buffer issue in SQLite driver

### DIFF
--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -30,7 +30,6 @@
  * \return DB_OK on success
  */
 
-size_t len;
 
 int db__driver_open_database(dbHandle *handle)
 {
@@ -38,6 +37,7 @@ int db__driver_open_database(dbHandle *handle)
     const char *name;
     char name3[GPATH_MAX + 14], *env_nolock;
     int i;
+    size_t len;
 
     G_debug(3, "\ndb_driver_open_database()");
 
@@ -175,6 +175,7 @@ int db__driver_create_database(dbHandle *handle)
 {
     const char *name;
     char name2[GPATH_MAX], *env_nolock;
+    size_t len;
 
     name = db_get_handle_dbname(handle);
 

--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -30,14 +30,12 @@
  * \return DB_OK on success
  */
 
-
 int db__driver_open_database(dbHandle *handle)
 {
     char name2[GPATH_MAX], *path;
     const char *name;
     char name3[GPATH_MAX + 14], *env_nolock;
     int i;
-    size_t len;
 
     G_debug(3, "\ndb_driver_open_database()");
 
@@ -81,8 +79,7 @@ int db__driver_open_database(dbHandle *handle)
         G_free_tokens(tokens);
     }
     else {
-        len = G_strlcpy(name2, name, sizeof(name2));
-        if (len >= sizeof(name2)) {
+        if (G_strlcpy(name2, name, sizeof(name2)) >= sizeof(name2)) {
             G_warning(_("Database name <%s> is too long"), name);
         }
     }
@@ -120,15 +117,13 @@ int db__driver_open_database(dbHandle *handle)
         else {
             G_warning(_("The sqlite config option '%s' is not supported"),
                       "SQLITE_CONFIG_URI");
-            len = G_strlcpy(name3, name2, sizeof(name3));
-            if (len >= sizeof(name3)) {
+            if (G_strlcpy(name3, name2, sizeof(name3)) >= sizeof(name3)) {
                 G_warning(_("Database name <%s> is too long"), name2);
             }
         }
     }
     else {
-        len = G_strlcpy(name3, name2, sizeof(name3));
-        if (len >= sizeof(name3)) {
+        if (G_strlcpy(name3, name2, sizeof(name3)) >= sizeof(name3)) {
             G_warning(_("Database name <%s> is too long"), name2);
         }
     }
@@ -175,7 +170,6 @@ int db__driver_create_database(dbHandle *handle)
 {
     const char *name;
     char name2[GPATH_MAX], *env_nolock;
-    size_t len;
 
     name = db_get_handle_dbname(handle);
 
@@ -198,15 +192,13 @@ int db__driver_create_database(dbHandle *handle)
         else {
             G_warning(_("The sqlite config option '%s' is not supported"),
                       "SQLITE_CONFIG_URI");
-            len = G_strlcpy(name2, name, sizeof(name2));
-            if (len >= sizeof(name2)) {
+            if (G_strlcpy(name2, name, sizeof(name2)) >= sizeof(name2)) {
                 G_warning(_("Database name <%s> is too long"), name);
             }
         }
     }
     else {
-        len = G_strlcpy(name2, name, sizeof(name2));
-        if (len >= sizeof(name2)) {
+        if (G_strlcpy(name2, name, sizeof(name2)) >= sizeof(name2)) {
             G_warning(_("Database name <%s> is too long"), name);
         }
     }

--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -35,6 +35,7 @@ int db__driver_open_database(dbHandle *handle)
     const char *name;
     char name3[GPATH_MAX + 14], *env_nolock;
     int i;
+    size_t len;
 
     G_debug(3, "\ndb_driver_open_database()");
 
@@ -78,7 +79,10 @@ int db__driver_open_database(dbHandle *handle)
         G_free_tokens(tokens);
     }
     else {
-        strcpy(name2, name);
+        len = G_strlcpy(name2, name, sizeof(name2));
+        if (len >= sizeof(name2)) {
+            G_warning(_("Database name <%s> is too long"), name);
+        }
     }
 
     G_debug(2, "name2 = '%s'", name2);
@@ -114,11 +118,18 @@ int db__driver_open_database(dbHandle *handle)
         else {
             G_warning(_("The sqlite config option '%s' is not supported"),
                       "SQLITE_CONFIG_URI");
-            strcpy(name3, name2);
+            len = G_strlcpy(name3, name2, sizeof(name3));
+            if (len >= sizeof(name3)) {
+                G_warning(_("Database name <%s> is too long"), name2);
+            }
         }
     }
-    else
-        strcpy(name3, name2);
+    else {
+        len = G_strlcpy(name3, name2, sizeof(name3));
+        if (len >= sizeof(name3)) {
+            G_warning(_("Database name <%s> is too long"), name2);
+        }
+    }
     if (sqlite3_open(name3, &sqlite) != SQLITE_OK) {
         db_d_append_error("%s %s\n%s", _("Unable to open database:"), name3,
                           (char *)sqlite3_errmsg(sqlite));
@@ -184,11 +195,18 @@ int db__driver_create_database(dbHandle *handle)
         else {
             G_warning(_("The sqlite config option '%s' is not supported"),
                       "SQLITE_CONFIG_URI");
-            strcpy(name2, name);
+            len = G_strlcpy(name2, name, sizeof(name2));
+            if (len >= sizeof(name2)) {
+                G_warning(_("Database name <%s> is too long"), name);
+            }
         }
     }
-    else
-        strcpy(name2, name);
+    else {
+        len = G_strlcpy(name2, name, sizeof(name2));
+        if (len >= sizeof(name2)) {
+            G_warning(_("Database name <%s> is too long"), name);
+        }
+    }
     if (sqlite3_open(name2, &sqlite) != SQLITE_OK) {
         db_d_append_error("%s %s\n%s", _("Unable to create database:"), name,
                           (char *)sqlite3_errmsg(sqlite));

--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -29,13 +29,15 @@
  * \return DB_FAILED on error
  * \return DB_OK on success
  */
+
+size_t len;
+
 int db__driver_open_database(dbHandle *handle)
 {
     char name2[GPATH_MAX], *path;
     const char *name;
     char name3[GPATH_MAX + 14], *env_nolock;
     int i;
-    size_t len;
 
     G_debug(3, "\ndb_driver_open_database()");
 

--- a/db/drivers/sqlite/db.c
+++ b/db/drivers/sqlite/db.c
@@ -80,7 +80,9 @@ int db__driver_open_database(dbHandle *handle)
     }
     else {
         if (G_strlcpy(name2, name, sizeof(name2)) >= sizeof(name2)) {
-            G_warning(_("Database name <%s> is too long"), name);
+            db_d_append_error(_("Database name <%s> is too long"), name);
+            db_d_report_error();
+            return DB_FAILED;
         }
     }
 
@@ -118,13 +120,17 @@ int db__driver_open_database(dbHandle *handle)
             G_warning(_("The sqlite config option '%s' is not supported"),
                       "SQLITE_CONFIG_URI");
             if (G_strlcpy(name3, name2, sizeof(name3)) >= sizeof(name3)) {
-                G_warning(_("Database name <%s> is too long"), name2);
+                db_d_append_error(_("Database name <%s> is too long"), name2);
+                db_d_report_error();
+                return DB_FAILED;
             }
         }
     }
     else {
         if (G_strlcpy(name3, name2, sizeof(name3)) >= sizeof(name3)) {
-            G_warning(_("Database name <%s> is too long"), name2);
+            db_d_append_error(_("Database name <%s> is too long"), name2);
+            db_d_report_error();
+            return DB_FAILED;
         }
     }
     if (sqlite3_open(name3, &sqlite) != SQLITE_OK) {
@@ -193,13 +199,17 @@ int db__driver_create_database(dbHandle *handle)
             G_warning(_("The sqlite config option '%s' is not supported"),
                       "SQLITE_CONFIG_URI");
             if (G_strlcpy(name2, name, sizeof(name2)) >= sizeof(name2)) {
-                G_warning(_("Database name <%s> is too long"), name);
+                db_d_append_error(_("Database name <%s> is too long"), name);
+                db_d_report_error();
+                return DB_FAILED;
             }
         }
     }
     else {
         if (G_strlcpy(name2, name, sizeof(name2)) >= sizeof(name2)) {
-            G_warning(_("Database name <%s> is too long"), name);
+            db_d_append_error(_("Database name <%s> is too long"), name);
+            db_d_report_error();
+            return DB_FAILED;
         }
     }
     if (sqlite3_open(name2, &sqlite) != SQLITE_OK) {


### PR DESCRIPTION
This pull request resolves a buffer overflow issue detected by Coverity Scan (CID 1501211).
strcpy is replaced with G_strlcpy