### PR TITLE
checks: Flake8 F841 fixes in the wxpython directory part 3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -58,17 +58,14 @@ per-file-ignores =
     gui/wxpython/dbmgr/manager.py: E722
     gui/wxpython/dbmgr/vinfo.py: F841
     gui/wxpython/docs/wxgui_sphinx/conf.py: E402, W291
-    gui/wxpython/gcp/g.gui.gcp.py: F841
-    gui/wxpython/gcp/manager.py: F841, E722
-    gui/wxpython/gcp/mapdisplay.py: F841
-    gui/wxpython/gui_core/*: F841, E266, E722
-    gui/wxpython/gui_core/dialogs.py: E722, F841
-    gui/wxpython/gui_core/forms.py: E722, F841
+    gui/wxpython/gcp/manager.py: E722
+    gui/wxpython/gui_core/*: E266, E722
+    gui/wxpython/gui_core/dialogs.py: E722
+    gui/wxpython/gui_core/forms.py: E722
     gui/wxpython/gui_core/ghelp.py: E722
-    gui/wxpython/gui_core/gselect.py: F841, E266, E722
-    gui/wxpython/gui_core/preferences.py: E266, F841
-    gui/wxpython/gui_core/treeview.py: F841
-    gui/wxpython/gui_core/widgets.py: F841, E722, E266
+    gui/wxpython/gui_core/gselect.py: E266, E722
+    gui/wxpython/gui_core/preferences.py: E266
+    gui/wxpython/gui_core/widgets.py: E722, E266
     gui/wxpython/image2target/*: F841, E722, E265
     gui/wxpython/image2target/g.gui.image2target.py: E501, E265, F841
     gui/wxpython/iscatt/*: F841, E722, F405, F403

--- a/gui/wxpython/gcp/g.gui.gcp.py
+++ b/gui/wxpython/gcp/g.gui.gcp.py
@@ -65,7 +65,7 @@ def main():
 
     app = wx.App()
 
-    wizard = GCPWizard(parent=None, giface=StandaloneGrassInterface())
+    GCPWizard(parent=None, giface=StandaloneGrassInterface())
 
     app.MainLoop()
 

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1826,7 +1826,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             else:
                 flags = "a"
 
-            busy = wx.BusyInfo(_("Rectifying images, please wait..."), parent=self)
+            wx.BusyInfo(_("Rectifying images, please wait..."), parent=self)
             wx.GetApp().Yield()
 
             ret, msg = RunCommand(
@@ -1886,7 +1886,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 )
                 ret = msg = ""
 
-                busy = wx.BusyInfo(
+                wx.BusyInfo(
                     _("Rectifying vector map <%s>, please wait...") % vect, parent=self
                 )
                 wx.GetApp().Yield()
@@ -2028,7 +2028,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
         elif self.gr_order == 2:
             minNumOfItems = 6
-            diff = 6 - numOfItems
             # self.SetStatusText(
             # _('Insufficient points, 6+ points needed for 2nd order'))
 
@@ -2331,7 +2330,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
     def OnZoomMenuGCP(self, event):
         """Popup Zoom menu"""
-        point = wx.GetMousePosition()
         zoommenu = Menu()
         # Add items to the menu
 
@@ -3433,7 +3431,6 @@ class GrSettingsDialog(wx.Dialog):
         srcrenderVector = False
         tgtrender = False
         tgtrenderVector = False
-        reload_target = False
         if self.new_src_map != src_map:
             # remove old layer
             layers = self.parent.grwiz.SrcMap.GetListOfLayers()
@@ -3471,7 +3468,6 @@ class GrSettingsDialog(wx.Dialog):
                 del layers[0]
                 layers = self.parent.grwiz.TgtMap.GetListOfLayers()
             # self.parent.grwiz.TgtMap.DeleteAllLayers()
-            reload_target = True
             tgt_map["raster"] = self.new_tgt_map["raster"]
             tgt_map["vector"] = self.new_tgt_map["vector"]
 

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1826,23 +1826,21 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             else:
                 flags = "a"
 
-            wx.BusyInfo(_("Rectifying images, please wait..."), parent=self)
-            wx.GetApp().Yield()
+            with wx.BusyInfo(_("Rectifying images, please wait..."), parent=self):
+                wx.GetApp().Yield()
 
-            ret, msg = RunCommand(
-                "i.rectify",
-                parent=self,
-                getErrorMsg=True,
-                quiet=True,
-                group=self.xygroup,
-                extension=self.extension,
-                order=self.gr_order,
-                method=self.gr_method,
-                flags=flags,
-                overwrite=overwrite,
-            )
-
-            del busy
+                ret, msg = RunCommand(
+                    "i.rectify",
+                    parent=self,
+                    getErrorMsg=True,
+                    quiet=True,
+                    group=self.xygroup,
+                    extension=self.extension,
+                    order=self.gr_order,
+                    method=self.gr_method,
+                    flags=flags,
+                    overwrite=overwrite,
+                )
 
             # provide feedback on failure
             if ret != 0:
@@ -1886,24 +1884,22 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 )
                 ret = msg = ""
 
-                wx.BusyInfo(
+                with wx.BusyInfo(
                     _("Rectifying vector map <%s>, please wait...") % vect, parent=self
-                )
-                wx.GetApp().Yield()
+                ):
+                    wx.GetApp().Yield()
 
-                ret, msg = RunCommand(
-                    "v.rectify",
-                    parent=self,
-                    getErrorMsg=True,
-                    quiet=True,
-                    input=vect,
-                    output=self.outname,
-                    group=self.xygroup,
-                    order=self.gr_order,
-                    overwrite=overwrite,
-                )
-
-                del busy
+                    ret, msg = RunCommand(
+                        "v.rectify",
+                        parent=self,
+                        getErrorMsg=True,
+                        quiet=True,
+                        input=vect,
+                        output=self.outname,
+                        group=self.xygroup,
+                        order=self.gr_order,
+                        overwrite=overwrite,
+                    )
 
                 # provide feedback on failure
                 if ret != 0:

--- a/gui/wxpython/gcp/mapdisplay.py
+++ b/gui/wxpython/gcp/mapdisplay.py
@@ -484,7 +484,6 @@ class MapPanel(SingleMapPanel):
         """
         Print options and output menu for map display
         """
-        point = wx.GetMousePosition()
         printmenu = Menu()
         # Add items to the menu
         setup = wx.MenuItem(printmenu, wx.ID_ANY, _("Page setup"))
@@ -528,7 +527,6 @@ class MapPanel(SingleMapPanel):
 
     def OnZoomMenu(self, event):
         """Popup Zoom menu"""
-        point = wx.GetMousePosition()
         zoommenu = Menu()
         # Add items to the menu
 

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -180,7 +180,6 @@ class LocationDialog(SimpleDialog):
             dbase = grass.gisenv()["GISDBASE"]
             self.element2.UpdateItems(dbase=dbase, location=location)
             self.element2.SetSelection(0)
-            self.element2.GetStringSelection()
 
     def GetValues(self):
         """Get location, mapset"""

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -180,7 +180,7 @@ class LocationDialog(SimpleDialog):
             dbase = grass.gisenv()["GISDBASE"]
             self.element2.UpdateItems(dbase=dbase, location=location)
             self.element2.SetSelection(0)
-            mapset = self.element2.GetStringSelection()
+            self.element2.GetStringSelection()
 
     def GetValues(self):
         """Get location, mapset"""

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -307,8 +307,6 @@ class UpdateThread(Thread):
                     pTable = self.task.get_param(
                         "dbtable", element="element", raiseError=False
                     )
-                    if pTable:
-                        table = pTable.get("value", "")
 
             if name == "LayerSelect":
                 # determine format
@@ -1546,7 +1544,6 @@ class CmdPanel(wx.Panel):
                         if value:
                             selection.SetValue(value)
 
-                        formatSelector = True
                         # A gselect.Select is a combobox with two children: a textctl
                         # and a popupwindow; we target the textctl here
                         textWin = selection.GetTextCtrl()

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -620,7 +620,7 @@ class GStc(stc.StyledTextCtrl):
                     self.linePos -= 1
                 else:
                     if c == "\r":
-                        pos = self.GetCurLine()[1]
+                        self.GetCurLine()[1]
                         # self.SetCurrentPos(pos)
                     else:
                         self.SetCurrentPos(self.linePos)

--- a/gui/wxpython/gui_core/goutput.py
+++ b/gui/wxpython/gui_core/goutput.py
@@ -619,11 +619,7 @@ class GStc(stc.StyledTextCtrl):
                 if c == "\b":
                     self.linePos -= 1
                 else:
-                    if c == "\r":
-                        self.GetCurLine()[1]
-                        # self.SetCurrentPos(pos)
-                    else:
-                        self.SetCurrentPos(self.linePos)
+                    self.SetCurrentPos(self.linePos)
                     self.ReplaceSelection(c)
                     self.linePos = self.GetCurrentPos()
                     if c != " ":

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1373,12 +1373,6 @@ class SubGroupSelect(wx.ComboBox):
         """Insert subgroups for defined group"""
         if not group:
             return
-        gisenv = gs.gisenv()
-        try:
-            name, mapset = group.split("@", 1)
-        except ValueError:
-            name = group
-            mapset = gisenv["MAPSET"]
 
         mlist = RunCommand("i.group", group=group, read=True, flags="sg").splitlines()
         try:

--- a/gui/wxpython/gui_core/menu.py
+++ b/gui/wxpython/gui_core/menu.py
@@ -144,7 +144,7 @@ class MenuBase:
         id = event.GetMenuId()
         item = self.FindItemById(id)
         if item:
-            help = item.GetHelp()
+            item.GetHelp()
 
         # but in this case just call Skip so the default is done
         event.Skip()

--- a/gui/wxpython/gui_core/menu.py
+++ b/gui/wxpython/gui_core/menu.py
@@ -68,8 +68,6 @@ class MenuBase:
 
                 self._createMenuItem(menu, label=child.label, **data)
 
-        self.parent.Bind(wx.EVT_MENU_HIGHLIGHT_ALL, self.OnMenuHighlight)
-
         return menu
 
     def _createMenuItem(
@@ -135,19 +133,6 @@ class MenuBase:
         :return: dictionary of commands
         """
         return self.menucmd
-
-    def OnMenuHighlight(self, event):
-        """
-        Default menu help handler
-        """
-        # Show how to get menu item info from this event handler
-        id = event.GetMenuId()
-        item = self.FindItemById(id)
-        if item:
-            item.GetHelp()
-
-        # but in this case just call Skip so the default is done
-        event.Skip()
 
 
 class Menu(MenuBase, wx.MenuBar):

--- a/gui/wxpython/gui_core/preferences.py
+++ b/gui/wxpython/gui_core/preferences.py
@@ -2021,8 +2021,6 @@ class PreferencesDialog(PreferencesBaseDialog):
 
     def OnLoadEpsgCodes(self, event):
         """Load EPSG codes from the file"""
-        win = self.FindWindowById(self.winId["projection:statusbar:projFile"])
-        path = win.GetValue()
         epsgCombo = self.FindWindowById(self.winId["projection:statusbar:epsg"])
         wx.BeginBusyCursor()
         try:

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -511,7 +511,6 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
         # complete command after pressing '.'
         if event.GetKeyCode() == 46:
             self.autoCompList = []
-            self.GetTextLeft()
             self.InsertText(pos, ".")
             self.CharRight()
             self.toComplete = self.EntityToComplete()

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -511,7 +511,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
         # complete command after pressing '.'
         if event.GetKeyCode() == 46:
             self.autoCompList = []
-            entry = self.GetTextLeft()
+            self.GetTextLeft()
             self.InsertText(pos, ".")
             self.CharRight()
             self.toComplete = self.EntityToComplete()
@@ -538,7 +538,7 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             or event.GetKeyCode() == wx.WXK_SUBTRACT
         ):
             self.autoCompList = []
-            entry = self.GetTextLeft()
+            self.GetTextLeft()
             self.InsertText(pos, "-")
             self.CharRight()
             self.toComplete = self.EntityToComplete()

--- a/gui/wxpython/gui_core/prompt.py
+++ b/gui/wxpython/gui_core/prompt.py
@@ -537,7 +537,6 @@ class GPromptSTC(GPrompt, wx.stc.StyledTextCtrl):
             or event.GetKeyCode() == wx.WXK_SUBTRACT
         ):
             self.autoCompList = []
-            self.GetTextLeft()
             self.InsertText(pos, "-")
             self.CharRight()
             self.toComplete = self.EntityToComplete()

--- a/gui/wxpython/gui_core/pystc.py
+++ b/gui/wxpython/gui_core/pystc.py
@@ -98,7 +98,6 @@ class PyStc(stc.StyledTextCtrl):
             9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL
         )
         face = font.GetFaceName()
-        size = font.GetPointSize()
 
         # setting the monospace here to not mess with the rest of the code
         # TODO: review the whole styling

--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -303,11 +303,17 @@ def main():
     root = tree.root
     n1 = tree.AppendNode(parent=root, data={"label": "node1"})
     n2 = tree.AppendNode(parent=root, data={"label": "node2"})
-    n3 = tree.AppendNode(parent=root, data={"label": "node3"})  # noqa: F841
+    n3 = tree.AppendNode(  # noqa: F841 # pylint: disable=W0612
+        parent=root, data={"label": "node3"}
+    )
     n11 = tree.AppendNode(parent=n1, data={"label": "node11", "xxx": "A"})
-    n12 = tree.AppendNode(parent=n1, data={"label": "node12", "xxx": "B"})  # noqa: F841
-    n21 = tree.AppendNode(parent=n2, data={"label": "node21", "xxx": "A"})  # noqa: F841
-    n111 = tree.AppendNode(  # noqa: F841
+    n12 = tree.AppendNode(  # noqa: F841 # pylint: disable=W0612
+        parent=n1, data={"label": "node12", "xxx": "B"}
+    )
+    n21 = tree.AppendNode(  # noqa: F841 # pylint: disable=W0612
+        parent=n2, data={"label": "node21", "xxx": "A"}
+    )
+    n111 = tree.AppendNode(  # noqa: F841 # pylint: disable=W0612
         parent=n11, data={"label": "node111", "xxx": "A"}
     )
 

--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -303,17 +303,13 @@ def main():
     root = tree.root
     n1 = tree.AppendNode(parent=root, data={"label": "node1"})
     n2 = tree.AppendNode(parent=root, data={"label": "node2"})
-    n3 = tree.AppendNode(parent=root, data={"label": "node3"})  # pylint: disable=W0612
+    n3 = tree.AppendNode(parent=root, data={"label": "node3"})  # noqa: F841
     n11 = tree.AppendNode(parent=n1, data={"label": "node11", "xxx": "A"})
-    n12 = tree.AppendNode(
-        parent=n1, data={"label": "node12", "xxx": "B"}
-    )  # pylint: disable=W0612
-    n21 = tree.AppendNode(
-        parent=n2, data={"label": "node21", "xxx": "A"}
-    )  # pylint: disable=W0612
-    n111 = tree.AppendNode(
+    n12 = tree.AppendNode(parent=n1, data={"label": "node12", "xxx": "B"})  # noqa: F841
+    n21 = tree.AppendNode(parent=n2, data={"label": "node21", "xxx": "A"})  # noqa: F841
+    n111 = tree.AppendNode(  # noqa: F841
         parent=n11, data={"label": "node111", "xxx": "A"}
-    )  # pylint: disable=W0612
+    )
 
     app = wx.App()
     frame = TreeFrame(model=tree)

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -170,7 +170,7 @@ class NotebookController:
             self.classObject.InsertPage(self.widget, *args, **kwargs)
         except (
             TypeError
-        ) as e:  # documentation says 'index', but certain versions of wx require 'n'
+        ):  # documentation says 'index', but certain versions of wx require 'n'
             kwargs["n"] = kwargs["index"]
             del kwargs["index"]
             self.classObject.InsertPage(self.widget, *args, **kwargs)


### PR DESCRIPTION
## Description
Flake8 F841 (local variable assigned to but never used) fixes in the `gui/wxpython/gpc` and `gui/wxpython/gui_core` directory.

## Motivation and context
Changes require resolving a part of Flake8 warnings that are currently ignored. The issue title and number as follows.

- [Bug] Fix currently ignored Flake8 warnings https://github.com/OSGeo/grass/issues/1522
## How has this been tested?
**g.gui.gpc**: Briefly tested using GUI and worked fine
**gui_core**:  N/A 

## Types of changes
- Removed unused variables and lines to fix F841.
- Replaced `# pylint: disable=W0612` with `# noqa: F841` in `gui_core/treeview.py`. Please let me know if you want to keep "# pylint". It looks a little odd, but adding `# noqa:` to the end of code doesn't work. It must be the first line with multiline, like below.

```python
    n111 = tree.AppendNode(  # noqa: F841
        parent=n11, data={"label": "node111", "xxx": "A"}
    )
```
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Checklist
- [x] PR title provides summary of the changes and starts with one of the [pre-defined prefixes](https://github.com/OSGeo/grass/blob/main/utils/release.yml)
- [x] My code follows the [code style](https://github.com/OSGeo/grass/blob/main/doc/development/style_guide.md) of this project.
 - [ ] My change requires a change to the documentation.
-  [ ] I have updated the documentation accordingly.
-  [ ] I have added tests to cover my changes.