### PR TITLE
v.in.dwg: Avoid using same variable as parameter and destination in sprintf

### DIFF
--- a/vector/v.in.dwg/main.c
+++ b/vector/v.in.dwg/main.c
@@ -66,7 +66,8 @@ int main(int argc, char *argv[])
     struct GModule *module;
     struct Option *out_opt, *in_opt;
     struct Flag *z_flag, *circle_flag, *l_flag, *int_flag;
-    char buf[2000];
+    const size_t BUFSIZE = 2000;
+    char buf[BUFSIZE];
 
     /* DWG */
     char path[2000];
@@ -135,10 +136,13 @@ int main(int argc, char *argv[])
     /* Init OpenDWG */
     sprintf(path, "%s/etc/adinit.dat", G_gisbase());
     if (!adInitAd2(path, &initerror)) {
-        sprintf(buf, _("Unable to initialize OpenDWG Toolkit, error: %d: %s."),
-                initerror, adErrorStr(initerror));
+        snprintf(buf, BUFSIZE,
+                 _("Unable to initialize OpenDWG Toolkit, error: %d: %s."),
+                 initerror, adErrorStr(initerror));
+        size_t buflen = strlen(buf);
         if (initerror == AD_UNABLE_TO_OPEN_INIT_FILE)
-            sprintf(buf, _("%s Cannot open %s"), buf, path);
+            snprintf(buf + buflen, BUFSIZE - buflen, _(" Cannot open %s"),
+                     path);
         G_fatal_error(buf);
     }
     adSetupDwgRead();


### PR DESCRIPTION
Currently, one instance of sprintf has same variable as parameter and destination in sprintf. This scneario leads to undefined behavior in C.

```
sprintf(buf, _("%s Cannot open %s"), buf, path);
```

Modify the code to:

1. Write initial error string using snprintf() onto the buffer. Using snprintf() makes sure that we stay within the buffer size and avoid overflow errors.
2. Use snprintf() again to write another error string at the end of previous error string in the same buffer. We again use snprintf() to make sure we are not overflowing the buffer with data.

This was found using cppcheck tool.

Prior to fix:

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/5b2decd6-41a2-4dea-b453-b23111e2deb9">

After fix:

<img width="872" alt="image" src="https://github.com/user-attachments/assets/e69889b1-a72a-413d-90d5-57d94cb85f17">

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Architecture: Not specific to any underlying architecture.