### PR TITLE
CI: allow core library functions through in PR titles

### DIFF
--- a/utils/release.yml
+++ b/utils/release.yml
@@ -18,7 +18,7 @@ notes:
       example: 'doc:'
 
     - title: Libraries and General Functionality
-      regexp: '(grass_|lib|TGIS|tgis|raster|vector)[^ ]*: '
+      regexp: '(grass_|lib|TGIS|tgis|raster|vector)[^ ]*: |[DGIRSV]_[^ ]*(): '
       example: 'grass_btree: or lib/btree:'
 
     - title: Startup, Initialization, and Environment


### PR DESCRIPTION
If the main idea of enforcing PR title prefixes is to keep things clear for the reviewers, by its standardized form the library function name already describes that it is a library function and which library it belongs to, so having to start with lib/libname is wasteful bloat in the constrained resource of the short PR title space and stops those chars being used for better purpose.

If the main idea is to provide a grep'able auto- release-notes aid and thus the target audience of the PR title is the end users, then the actual library function being modified is secondary and this PR may or may not be desired.

n.b. I've left off the lesser used F_(), M_(), and P_() library prefixes.