### PR TITLE
contributing: modernize 'git remote -v' output

### DIFF
--- a/doc/development/github_guide.md
+++ b/doc/development/github_guide.md
@@ -39,10 +39,10 @@ git remote -v
 1. You should see something like:
 
 ```bash
-origin  https://github.com/your_GH_account/grass.git (fetch)
-origin  https://github.com/your_GH_account/grass.git (push)
-upstream  https://github.com/OSGeo/grass (fetch)
-upstream  https://github.com/OSGeo/grass (push)
+origin  git@github.com:your_GH_account/grass.git (fetch)
+origin  git@github.com:your_GH_account/grass.git (push)
+upstream  git@github.com:OSGeo/grass (fetch)
+upstream  git@github.com:OSGeo/grass (push)
 
 ```
 


### PR DESCRIPTION
My understanding is that ssh keys are preferred and that means the output of 'git remote -v' looks different than described. GitHub prompts for passwds if you have https here, but no longer accepts them, only tokens in their place. This change mirrors what is shown on the Trac HowToGit page.