### PR TITLE
docker: fix missing libraries in ubuntu wxgui Dockerfile

### DIFF
--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -94,6 +94,7 @@ RUN apt-get update && apt-get upgrade -y && \
     python3-ply \
     python3-setuptools \
     python3-venv \
+    python3-wxgtk4.0 \
     software-properties-common \
     sqlite3 \
     subversion \

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get upgrade -y && \
     libglu1-mesa-dev \
     libgsl0-dev \
     libgtk-3-0 \
+    libgtk-3-dev \
     libjpeg-dev \
     libjsoncpp-dev \
     libnetcdf-dev \


### PR DESCRIPTION
Add `libgtk-3-dev` to address:

```
...
checking for GTK+ - version >= 3.0.0... Package gtk+-3.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gtk+-3.0.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gtk+-3.0' found
```

For the usage, also install `python3-wxgtk4.0`.