### PR TITLE
v.in.wfs : Migration to OWSLib based web service requests

### DIFF
--- a/scripts/v.in.wfs/v.in.wfs.py
+++ b/scripts/v.in.wfs/v.in.wfs.py
@@ -7,7 +7,7 @@
 #               Hamish Bowman
 #               Converted to Python by Glynn Clements
 #               German ALKIS support added by Veronica Köß
-                V1 migration to OWSLib by Karunakar Kintada
+#               V1 migration to OWSLib by Karunakar Kintada
 # PURPOSE:    WFS support
 # COPYRIGHT:    (C) 2006-2024 Markus Neteler and the GRASS Development Team
 #

--- a/scripts/v.in.wfs/v.in.wfs.py
+++ b/scripts/v.in.wfs/v.in.wfs.py
@@ -7,6 +7,7 @@
 #               Hamish Bowman
 #               Converted to Python by Glynn Clements
 #               German ALKIS support added by Veronica Köß
+                V1 migration to OWSLib by Karunakar Kintada
 # PURPOSE:    WFS support
 # COPYRIGHT:    (C) 2006-2024 Markus Neteler and the GRASS Development Team
 #


### PR DESCRIPTION
The python code of v.in.wfs uses Urllib and fetches features based on updating the wfs_url. OWSLib can be utilised for the purpose.

Modify the code to:
The code is updated to use OWSLib for web service requests in v.in.wfs and caters to the ToDo item / Enhancement in the code.

Prior code:
1. wfs_url is modified to construct WFS requests

Proposed code:
1. OWSlib functions are used to get capabilities and features
2. variables are used to adapt to the option variables.

Note:
There is a need to update on the code against options["name"] and options["layer"] for uniformity; Suggestions welcome.
Attempting my first pull request in the space, request you to comment to update where necessary.
