### PR TITLE
Fix ResourceWarning for  python/libgrass_interface_generator/ctypesgen/version.py::68

### DIFF
--- a/python/libgrass_interface_generator/ctypesgen/version.py
+++ b/python/libgrass_interface_generator/ctypesgen/version.py
@@ -23,18 +23,17 @@ def version_tuple(v):
 
 
 def read_file_version():
-    f = open(VERSION_FILE)
-    v = f.readline()
-    f.close()
+    with open(VERSION_FILE) as f:
+        v = f.readline()
     return v.strip()
 
 
 def version():
     try:
         args = {"cwd": THIS_DIR}
-        devnull = open(os.devnull, "w")
-        p = Popen(["git", "describe"], stdout=PIPE, stderr=devnull, **args)
-        out, err = p.communicate()
+        with open(os.devnull, "w") as devnull:
+            p = Popen(["git", "describe"], stdout=PIPE, stderr=devnull, **args)
+            out, err = p.communicate()
         if p.returncode:
             raise RuntimeError("no version defined?")
         git_tag = out.strip().decode()
@@ -60,9 +59,8 @@ def compatible(v0, v1):
 def write_version_file(v=None):
     if v is None:
         v = version()
-    f = open(VERSION_FILE, "w")
-    f.write(v)
-    f.close()
+    with open(VERSION_FILE, "w") as f:
+        f.write(v)
 
 
 VERSION = version()


### PR DESCRIPTION
This pull request addresses the recurring ResourceWarning about an unclosed file in the version.py script. The following changes have been made:

- Modified the version() function to use a context manager for handling the file opened for /dev/null, ensuring proper closure.
- Updated read_file_version() and write_version_file() functions to also use context managers for file operations.

These changes should resolve the ResourceWarnings in that particular case
As our CI is not fully set up on my fork of this repository yet, I will manually review the raw logs of the new CI run once it's completed to verify that the warnings have been resolved.
Also as @echoix mentioned here: https://github.com/OSGeo/grass/pull/4239#issuecomment-2314138752
workign through the errors in the result will fix most of ResourceWarnings although it also highlights simple linting cases where the warning may not exist