### PR TITLE
v.out.ogr: Check for valid array before passing to qsort

### DIFF
--- a/vector/v.out.ogr/list.c
+++ b/vector/v.out.ogr/list.c
@@ -43,7 +43,8 @@ char *OGR_list_write_drivers(void)
         len += strlen(buf) + 1; /* + ',' */
     }
 
-    qsort(list, count, sizeof(char *), cmp);
+    if (list)
+        qsort(list, count, sizeof(char *), cmp);
 
     if (len > 0) {
         ret = G_malloc((len + 1) * sizeof(char)); /* \0 */


### PR DESCRIPTION
Currently, filling list with GDAL driver names is based on a conditional and if the conditional fails, the list can be NULL.

We pass this list to qsort to sort the names, but behavior of qsort with a NULL array is undefined. To avoid getting into this situation, check if the array is NULL before performing qsort on it.

This issue was found using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Output from cppcheck prior to fix

<img width="867" alt="image" src="https://github.com/user-attachments/assets/716acf25-55a2-4551-b624-9a71d86fe086">

After the fix

<img width="620" alt="image" src="https://github.com/user-attachments/assets/6dc2a526-3c8e-46de-bf05-ac32b49ed4e6">
