### PR TITLE
v.external: Check for valid list before passing to qsort

### DIFF
--- a/vector/v.external/list.c
+++ b/vector/v.external/list.c
@@ -64,7 +64,8 @@ char **format_list(int *count, size_t *len)
     }
 
     /* order formats by name */
-    qsort(list, *count, sizeof(char *), cmp);
+    if (list)
+        qsort(list, *count, sizeof(char *), cmp);
 #endif
 #if defined HAVE_POSTGRES && !defined HAVE_OGR
     list = G_realloc(list, ((*count) + 1) * sizeof(char *));


### PR DESCRIPTION
Currently, if 'HAVE_OGR' macro is defined, as part of execution, we order all formats by name using qsort. But, list containing all formats is assigned based on a conditional and if the conditional fails, it can be NULL.

Behavior of qsort is undefined when a NULL ptr is passed as array argument. To avoid getting into that situation, check if the array is NULL before performing qsort on it.

This issue was found using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Should only be valid, when 'HAVE_OGR' flag is specified as part of the compilation process.
4. Output from cppcheck prior to fix:

<img width="878" alt="image" src="https://github.com/user-attachments/assets/8626d7c4-2248-482a-b2d9-2d691065acc7">

After the fix:

<img width="628" alt="image" src="https://github.com/user-attachments/assets/f737cbe5-8bbc-4822-b7a5-417407a1149c">
