### PR TITLE
v.generalize: Initialize all of structure contents before using it

### DIFF
--- a/vector/v.generalize/smoothing.c
+++ b/vector/v.generalize/smoothing.c
@@ -422,6 +422,7 @@ int hermite(struct line_pnts *Points, double step, double angle_thresh,
     angle_thresh *= M_PI / 180.0;
 
     head.next = NULL;
+    head.p.x = head.p.y = head.p.z = 0;
     point = last = &head;
 
     if (!is_loop) {

--- a/vector/v.generalize/smoothing.c
+++ b/vector/v.generalize/smoothing.c
@@ -422,7 +422,7 @@ int hermite(struct line_pnts *Points, double step, double angle_thresh,
     angle_thresh *= M_PI / 180.0;
 
     head.next = NULL;
-    head.p.x = head.p.y = head.p.z = 0;
+    head.p.x = head.p.y = head.p.z = 0.0;
     point = last = &head;
 
     if (!is_loop) {


### PR DESCRIPTION
Currently, in `head` which is a `POINT_LIST` structure, we are only initializing the next pointer to NULL, but data present in the point substructure is not initialized which implies that it would be filled with random data. To avoid such scenario, initialize point coordinates to zero.

This was found using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Output from cppcheck prior to fix

<img width="842" alt="image" src="https://github.com/user-attachments/assets/ccdda3ca-90cb-4bfe-92f1-049f82152931">

After the fix

<img width="571" alt="image" src="https://github.com/user-attachments/assets/4528b134-f96b-4883-965c-86595692ef20">
