### PR TITLE
v.vol.rst: Initialize structure contents before passing it around

### DIFF
--- a/vector/v.vol.rst/user2.c
+++ b/vector/v.vol.rst/user2.c
@@ -92,6 +92,7 @@ int interp_call(struct octtree *root, struct octtree *tree)
     int skip_index, segtest;
     double xx, yy, zz /*, ww */;
 
+    skip_point.x = skip_point.y = skip_point.z = skip_point.w = 0;
     if (tree == NULL)
         return -1;
     if (tree->data == NULL)

--- a/vector/v.vol.rst/user2.c
+++ b/vector/v.vol.rst/user2.c
@@ -92,7 +92,7 @@ int interp_call(struct octtree *root, struct octtree *tree)
     int skip_index, segtest;
     double xx, yy, zz /*, ww */;
 
-    skip_point.x = skip_point.y = skip_point.z = skip_point.w = 0;
+    skip_point.x = skip_point.y = skip_point.z = skip_point.w = 0.0;
     if (tree == NULL)
         return -1;
     if (tree->data == NULL)


### PR DESCRIPTION
`skip_point` structure is not initialized when declared.

1. Only when `cv` is true, `skip_point` contents are filled and the structure is used.
2. cppcheck raised the issue when `cv` is false. Technically, we don't need `skip_point` in such cases and not initializing it won't affect the execution. Nevertheless, it's a good practice to initialize structure contents at the time of declaration.

This was found using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Output from cppcheck prior to fix

<img width="845" alt="image" src="https://github.com/user-attachments/assets/e08179f5-7de6-48e7-a9ed-25f6382c21c0">

After the fix:

<img width="656" alt="image" src="https://github.com/user-attachments/assets/56c36cef-1d67-44f5-a43c-6bd87034c29e">
