### PR TITLE
Fix Flake8 errors and improve exception handling in lib/init/grass.py. Fixes ResourceWarning for python/libgrass_interface_generator/ctypesgen/version.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,6 @@ per-file-ignores =
     # F841 local variable assigned to but never used
     # E741 ambiguous variable name 'l'
     __init__.py: F401, F403
-    lib/init/grass.py: E722, F821, F841
     utils/gitlog2changelog.py: E722, E712
     man/build_check_rest.py: F403, F405
     man/build_full_index_rest.py: F403, F405

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -484,7 +484,7 @@ def create_gisrc(tmpdir, gisrcrc):
         if "UNKNOWN" in s:
             try_remove(gisrcrc)
             s = None
-    except:
+    except Exception:
         s = None
 
     # Copy the global grassrc file to the session grassrc file
@@ -1176,7 +1176,7 @@ def set_language(grass_config_dir):
                 encoding = "UTF-8"
                 normalized = locale.normalize("%s.%s" % (language, encoding))
                 locale.setlocale(locale.LC_ALL, normalized)
-            except locale.Error as e:
+            except locale.Error:
                 if language == "en":
                     # A workaround for Python Issue30755
                     # https://bugs.python.org/issue30755
@@ -1202,7 +1202,7 @@ def set_language(grass_config_dir):
                     # See bugs #3441 and #3423
                     try:
                         locale.setlocale(locale.LC_ALL, "C.UTF-8")
-                    except locale.Error as e:
+                    except locale.Error:
                         # All lost. Setting to C as much as possible.
                         # We can not call locale.normalize on C as it
                         # will transform it to en_US and we already know
@@ -1585,7 +1585,7 @@ def say_hello():
 
             revision = linerev.split(" ")[1]
             sys.stderr.write(" (" + revision + ")")
-        except:
+        except Exception:
             pass
 
 
@@ -1951,7 +1951,7 @@ def print_params(params):
             try:
                 revision = linerev.split(" ")[1]
                 sys.stdout.write("%s\n" % revision[1:])
-            except:
+            except Exception:
                 sys.stdout.write("No SVN revision defined\n")
         elif arg == "version":
             sys.stdout.write("%s\n" % GRASS_VERSION)

--- a/python/libgrass_interface_generator/ctypesgen/version.py
+++ b/python/libgrass_interface_generator/ctypesgen/version.py
@@ -23,18 +23,17 @@ def version_tuple(v):
 
 
 def read_file_version():
-    f = open(VERSION_FILE)
-    v = f.readline()
-    f.close()
+    with open(VERSION_FILE) as f:
+            v = f.readline()
     return v.strip()
 
 
 def version():
     try:
         args = {"cwd": THIS_DIR}
-        devnull = open(os.devnull, "w")
-        p = Popen(["git", "describe"], stdout=PIPE, stderr=devnull, **args)
-        out, err = p.communicate()
+        with open(os.devnull, "w") as devnull:
+            p = Popen(["git", "describe"], stdout=PIPE, stderr=devnull, **args)
+            out, err = p.communicate()
         if p.returncode:
             raise RuntimeError("no version defined?")
         git_tag = out.strip().decode()
@@ -60,9 +59,8 @@ def compatible(v0, v1):
 def write_version_file(v=None):
     if v is None:
         v = version()
-    f = open(VERSION_FILE, "w")
-    f.write(v)
-    f.close()
+    with open(VERSION_FILE, "w") as f:
+        f.write(v)
 
 
 VERSION = version()


### PR DESCRIPTION
## Description
This pull request addresses several Flake8 warnings and improves exception handling in the GRASS GIS initialization script. The changes focus on removing unused variables and replacing bare except clauses with more specific exception handling. This pull request also addresses the recurring ResourceWarning about an unclosed file in the version.py script. 

## Changes
1. Removed unused 'e' variables in exception handling for locale errors.
2. Improved exception handling when reading the VERSIONNUMBER file.
3. Modified the version() function to use a context manager for handling the file opened for /dev/null, ensuring proper closure.
4. Updated read_file_version() and write_version_file() functions to also use context managers for file operations.

Also as @echoix mentioned here: https://github.com/OSGeo/grass/pull/4239#issuecomment-2314138752
workign through the errors in the result will fix most of ResourceWarnings although it also highlights simple linting cases where the warning may not exist

## Specific Changes

### 1. Removed unused 'e' variables:
In the locale setting section, removed `as e` from two `except locale.Error` clauses where the error variable was not being used.

```python
# Before
except locale.Error as e:
    # code not using 'e'

# After
except locale.Error:
    # code remains the same