### PR TITLE
ps.map: Initialize variable before using it in conditional

### DIFF
--- a/ps/ps.map/ps_header.c
+++ b/ps/ps.map/ps_header.c
@@ -16,7 +16,7 @@ extern int rotate_plot;
 int write_PS_header(void)
 {
     struct Categories cats;
-    int cats_ok;
+    int cats_ok = 0;
 
     if (PS.do_raster)
         cats_ok = Rast_read_cats(PS.cell_name, PS.cell_mapset, &cats) >= 0;


### PR DESCRIPTION
Currently, `cats_ok` variable is only set when `do_raster` is true in post script structure. Variable can be filled with any value as it it uninitiazlied which can lead to unpredictable behavior. Set the value to 0 indicating error by default.

This was found using cppcheck tool.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Output from cppcheck prior to fix:

<img width="743" alt="image" src="https://github.com/user-attachments/assets/ce58cb25-575b-4962-96ae-7035eace1d15">

After the fix:

<img width="617" alt="image" src="https://github.com/user-attachments/assets/d4bf4807-6756-468d-8a40-c2ffb30e40b8">
