### PR TITLE
pythonlib: Fix ResourceWarning in libgrass_interface_generator/ctypesgen/version.py

### DIFF
--- a/python/libgrass_interface_generator/ctypesgen/version.py
+++ b/python/libgrass_interface_generator/ctypesgen/version.py
@@ -3,6 +3,7 @@
 from subprocess import Popen, PIPE
 import os
 from os import path
+from pathlib import Path
 
 THIS_DIR = path.dirname(__file__)
 VERSION_FILE = path.join(THIS_DIR, "VERSION")
@@ -23,17 +24,16 @@ def version_tuple(v):
 
 
 def read_file_version():
-    f = open(VERSION_FILE)
-    v = f.readline()
-    f.close()
+    with open(VERSION_FILE) as f:
+            v = f.readline()
     return v.strip()
 
 
 def version():
     try:
         args = {"cwd": THIS_DIR}
-        devnull = open(os.devnull, "w")
-        p = Popen(["git", "describe"], stdout=PIPE, stderr=devnull, **args)
+        with open(os.devnull, "w") as devnull:
+            p = Popen(["git", "describe"], stdout=PIPE, stderr=devnull, **args)
         out, err = p.communicate()
         if p.returncode:
             raise RuntimeError("no version defined?")
@@ -60,9 +60,9 @@ def compatible(v0, v1):
 def write_version_file(v=None):
     if v is None:
         v = version()
-    f = open(VERSION_FILE, "w")
-    f.write(v)
-    f.close()
+    # with open(VERSION_FILE, "w") as f:
+    #     f.write(v)
+    Path(VERSION_FILE).write_text(v)
 
 
 VERSION = version()

--- a/python/libgrass_interface_generator/ctypesgen/version.py
+++ b/python/libgrass_interface_generator/ctypesgen/version.py
@@ -9,7 +9,7 @@ THIS_DIR = path.dirname(__file__)
 VERSION_FILE = path.join(THIS_DIR, "VERSION")
 DEFAULT_PREFIX = "ctypesgen"
 
-__all__ = ["VERSION", "version_tuple", "version", "compatible"]
+__all__ = ["VERSION", "compatible", "version", "version_tuple"]
 
 
 def version_tuple(v):
@@ -48,7 +48,8 @@ def version():
 
 
 def version_number():
-    return version().partition("-")[-1]
+    v = version()
+    return v.partition("-")[-1]
 
 
 def compatible(v0, v1):

--- a/python/libgrass_interface_generator/ctypesgen/version.py
+++ b/python/libgrass_interface_generator/ctypesgen/version.py
@@ -60,8 +60,6 @@ def compatible(v0, v1):
 def write_version_file(v=None):
     if v is None:
         v = version()
-    # with open(VERSION_FILE, "w") as f:
-    #     f.write(v)
     Path(VERSION_FILE).write_text(v)
 
 


### PR DESCRIPTION
This pull request addresses the recurring `ResourceWarning` about an unclosed file in the version.py script. The following changes have been made:

- Modified the version() function to use a context manager for handling the file opened for /dev/null, ensuring proper closure.
- Updated read_file_version() and write_version_file() functions to also use context managers for file operations.
- Updated the write_version_file() method to use `Path(VERSION_FILE).write_text(v)` which fixes the FURB103 warning generated further as pointed out here: https://github.com/OSGeo/grass/pull/4285#discussion_r1749008784

These changes should resolve the ResourceWarnings in this particular case