### PR TITLE
man: Use a context manager for opening files

### DIFF
--- a/man/build_class.py
+++ b/man/build_class.py
@@ -33,41 +33,39 @@ def build_class(ext):
     os.chdir(man_dir)
 
     filename = modclass + f".{ext}"
-    f = open(filename + ".tmp", "w")
-
-    write_header(
-        f,
-        "{} modules - GRASS GIS {} Reference Manual".format(
-            modclass.capitalize(), grass_version
-        ),
-        template=ext,
-    )
-    modclass_lower = modclass.lower()
-    modclass_visible = modclass
-    if modclass_lower not in no_intro_page_classes:
-        if modclass_visible == "raster3d":
-            # convert keyword to nice form
-            modclass_visible = "3D raster"
-        f.write(
-            modclass_intro_tmpl.substitute(
-                modclass=modclass_visible, modclass_lower=modclass_lower
-            )
+    with open(filename + ".tmp", "w") as f:
+        write_header(
+            f,
+            "{} modules - GRASS GIS {} Reference Manual".format(
+                modclass.capitalize(), grass_version
+            ),
+            template=ext,
         )
-    f.write(modclass_tmpl.substitute(modclass=to_title(modclass_visible)))
+        modclass_lower = modclass.lower()
+        modclass_visible = modclass
+        if modclass_lower not in no_intro_page_classes:
+            if modclass_visible == "raster3d":
+                # convert keyword to nice form
+                modclass_visible = "3D raster"
+            f.write(
+                modclass_intro_tmpl.substitute(
+                    modclass=modclass_visible, modclass_lower=modclass_lower
+                )
+            )
+        f.write(modclass_tmpl.substitute(modclass=to_title(modclass_visible)))
 
-    # for all modules:
-    for cmd in get_files(man_dir, cls, extension=ext):
-        basename = os.path.splitext(cmd)[0]
-        desc = check_for_desc_override(basename)
-        if desc is None:
-            desc = get_desc(cmd)
-        f.write(desc2_tmpl.substitute(cmd=cmd, basename=basename, desc=desc))
-    if ext == "html":
-        f.write("</table>\n")
+        # for all modules:
+        for cmd in get_files(man_dir, cls, extension=ext):
+            basename = os.path.splitext(cmd)[0]
+            desc = check_for_desc_override(basename)
+            if desc is None:
+                desc = get_desc(cmd)
+            f.write(desc2_tmpl.substitute(cmd=cmd, basename=basename, desc=desc))
+        if ext == "html":
+            f.write("</table>\n")
 
-    write_footer(f, f"index.{ext}", year, template=ext)
+        write_footer(f, f"index.{ext}", year, template=ext)
 
-    f.close()
     replace_file(filename)
 
 

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -131,65 +131,62 @@ def generate_page_for_category(
     short_family, module_family, imgs, year, skip_no_image=False
 ):
     filename = module_family + "_graphical.html"
-
-    output = open(filename + ".tmp", "w")
-
-    output.write(
-        header1_tmpl.substitute(
-            title="GRASS GIS %s Reference Manual: Graphical index" % grass_version
-        )
-    )
-    output.write(header_graphical_index_tmpl)
-
-    if module_family.lower() not in {"general", "postscript"}:
-        if module_family == "raster3d":
-            # covert keyword to nice form
-            module_family = "3D raster"
+    with open(filename + ".tmp", "w") as output:
         output.write(
-            modclass_intro_tmpl.substitute(
-                modclass=module_family, modclass_lower=module_family.lower()
+            header1_tmpl.substitute(
+                title="GRASS GIS %s Reference Manual: Graphical index" % grass_version
             )
         )
-    if module_family == "wxGUI":
-        output.write("<h3>wxGUI components:</h3>")
-    elif module_family == "guimodules":
-        output.write("<h3>g.gui.* modules:</h3>")
-    else:
-        output.write("<h3>{0} modules:</h3>".format(to_title(module_family)))
-    output.write('<ul class="img-list">')
+        output.write(header_graphical_index_tmpl)
 
-    # for all modules:
-    for cmd in get_files(man_dir, short_family, ignore_gui=False):
-        basename = os.path.splitext(cmd)[0]
-        desc = check_for_desc_override(basename)
-        if desc is None:
-            desc = get_desc(cmd)
-        img = get_module_image(basename, imgs)
-        img_class = "linkimg"
-        if skip_no_image and not img:
-            continue
-        if not img:
-            img = "grass_logo.png"
-            img_class = "default-img"
-        if basename.startswith("wxGUI"):
-            basename = basename.replace(".", " ")
-        output.write(
-            "<li>"
-            '<a href="{html}">'
-            '<img class="{img_class}" src="{img}">'
-            '<span class="name">{name}</span> '
-            '<span class="desc">{desc}</span>'
-            "</a>"
-            "</li>".format(
-                html=cmd, img=img, name=basename, desc=desc, img_class=img_class
+        if module_family.lower() not in {"general", "postscript"}:
+            if module_family == "raster3d":
+                # covert keyword to nice form
+                module_family = "3D raster"
+            output.write(
+                modclass_intro_tmpl.substitute(
+                    modclass=module_family, modclass_lower=module_family.lower()
+                )
             )
-        )
+        if module_family == "wxGUI":
+            output.write("<h3>wxGUI components:</h3>")
+        elif module_family == "guimodules":
+            output.write("<h3>g.gui.* modules:</h3>")
+        else:
+            output.write("<h3>{0} modules:</h3>".format(to_title(module_family)))
+        output.write('<ul class="img-list">')
 
-    output.write("</ul>")
+        # for all modules:
+        for cmd in get_files(man_dir, short_family, ignore_gui=False):
+            basename = os.path.splitext(cmd)[0]
+            desc = check_for_desc_override(basename)
+            if desc is None:
+                desc = get_desc(cmd)
+            img = get_module_image(basename, imgs)
+            img_class = "linkimg"
+            if skip_no_image and not img:
+                continue
+            if not img:
+                img = "grass_logo.png"
+                img_class = "default-img"
+            if basename.startswith("wxGUI"):
+                basename = basename.replace(".", " ")
+            output.write(
+                "<li>"
+                '<a href="{html}">'
+                '<img class="{img_class}" src="{img}">'
+                '<span class="name">{name}</span> '
+                '<span class="desc">{desc}</span>'
+                "</a>"
+                "</li>".format(
+                    html=cmd, img=img, name=basename, desc=desc, img_class=img_class
+                )
+            )
 
-    write_footer(output, "index.html", year, template="html")
+        output.write("</ul>")
 
-    output.close()
+        write_footer(output, "index.html", year, template="html")
+
     replace_file(filename)
 
 

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -32,27 +32,26 @@ cls = sys.argv[1]
 modclass = sys.argv[2]
 
 filename = modclass + ".txt"
-
-f = open(filename + ".tmp", "wb")
-
-write_rest_header(f, "GRASS GIS %s Reference Manual: %s" % (grass_version, modclass))
-if modclass.lower() not in {"general", "miscellaneous", "postscript"}:
-    f.write(
-        modclass_intro_tmpl.substitute(
-            modclass=modclass, modclass_lower=modclass.lower()
-        )
+with open(filename + ".tmp", "wb") as f:
+    write_rest_header(
+        f, "GRASS GIS %s Reference Manual: %s" % (grass_version, modclass)
     )
-f.write(modclass_tmpl.substitute(modclass=modclass))
+    if modclass.lower() not in {"general", "miscellaneous", "postscript"}:
+        f.write(
+            modclass_intro_tmpl.substitute(
+                modclass=modclass, modclass_lower=modclass.lower()
+            )
+        )
+    f.write(modclass_tmpl.substitute(modclass=modclass))
 
-# for all modules:
-for cmd in rest_files(cls):
-    basename = os.path.splitext(cmd)[0]
-    desc = check_for_desc_override(basename)
-    if desc is None:
-        desc = get_desc(cmd)
-    f.write(desc2_tmpl.substitute(basename=basename, desc=desc))
+    # for all modules:
+    for cmd in rest_files(cls):
+        basename = os.path.splitext(cmd)[0]
+        desc = check_for_desc_override(basename)
+        if desc is None:
+            desc = get_desc(cmd)
+        f.write(desc2_tmpl.substitute(basename=basename, desc=desc))
 
-write_rest_footer(f, "index.txt")
+    write_rest_footer(f, "index.txt")
 
-f.close()
 replace_file(filename)

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -56,37 +56,35 @@ def build_full_index(ext):
 
     # begin full index:
     filename = f"full_index.{ext}"
-    f = open(filename + ".tmp", "w")
+    with open(filename + ".tmp", "w") as f:
+        write_header(
+            f,
+            "GRASS GIS {} Reference Manual - Full index".format(grass_version),
+            body_width="80%",
+            template=ext,
+        )
 
-    write_header(
-        f,
-        "GRASS GIS {} Reference Manual - Full index".format(grass_version),
-        body_width="80%",
-        template=ext,
-    )
+        # generate main index of all modules:
+        f.write(full_index_header)
 
-    # generate main index of all modules:
-    f.write(full_index_header)
-
-    if ext == "html":
-        f.write(toc)
-
-    # for all module groups:
-    for cls, cls_label in classes:
-        f.write(cmd2_tmpl.substitute(cmd_label=to_title(cls_label), cmd=cls))
-        # for all modules:
-        for cmd in get_files(man_dir, cls, extension=ext):
-            basename = os.path.splitext(cmd)[0]
-            desc = check_for_desc_override(basename)
-            if desc is None:
-                desc = get_desc(cmd)
-            f.write(desc1_tmpl.substitute(cmd=cmd, basename=basename, desc=desc))
         if ext == "html":
-            f.write("</table>\n")
+            f.write(toc)
 
-    write_footer(f, f"index.{ext}", year, template=ext)
+        # for all module groups:
+        for cls, cls_label in classes:
+            f.write(cmd2_tmpl.substitute(cmd_label=to_title(cls_label), cmd=cls))
+            # for all modules:
+            for cmd in get_files(man_dir, cls, extension=ext):
+                basename = os.path.splitext(cmd)[0]
+                desc = check_for_desc_override(basename)
+                if desc is None:
+                    desc = get_desc(cmd)
+                f.write(desc1_tmpl.substitute(cmd=cmd, basename=basename, desc=desc))
+            if ext == "html":
+                f.write("</table>\n")
 
-    f.close()
+        write_footer(f, f"index.{ext}", year, template=ext)
+
     replace_file(filename)
 
 

--- a/man/build_full_index_rest.py
+++ b/man/build_full_index_rest.py
@@ -34,34 +34,32 @@ classes.sort()
 
 # begin full index:
 filename = "full_index.txt"
-f = open(filename + ".tmp", "wb")
+with open(filename + ".tmp", "wb") as f:
+    write_rest_header(f, "GRASS GIS %s Reference Manual: Full index" % grass_version)
 
-write_rest_header(f, "GRASS GIS %s Reference Manual: Full index" % grass_version)
+    # generate main index of all modules:
+    f.write(full_index_header)
+    # "
 
-# generate main index of all modules:
-f.write(full_index_header)
-# "
+    # for cls in classes:
+    # f.write(cmd1_tmpl.substitute(cmd = cls))
+    # if cls != classes[-1]:
+    # f.write(" | ")
 
-# for cls in classes:
-# f.write(cmd1_tmpl.substitute(cmd = cls))
-# if cls != classes[-1]:
-# f.write(" | ")
+    f.write(sections)
 
-f.write(sections)
+    # for all module groups:
+    for cls in classes:
+        f.write(cmd2_tmpl.substitute(cmd=cls))
+        # for all modules:
+        for cmd in rest_files(cls):
+            basename = os.path.splitext(cmd)[0]
+            desc = check_for_desc_override(basename)
+            if desc is None:
+                desc = get_desc(cmd)
+            f.write(desc1_tmpl.substitute(basename=basename, desc=desc))
+        f.write("\n")
 
-# for all module groups:
-for cls in classes:
-    f.write(cmd2_tmpl.substitute(cmd=cls))
-    # for all modules:
-    for cmd in rest_files(cls):
-        basename = os.path.splitext(cmd)[0]
-        desc = check_for_desc_override(basename)
-        if desc is None:
-            desc = get_desc(cmd)
-        f.write(desc1_tmpl.substitute(basename=basename, desc=desc))
-    f.write("\n")
+    write_rest_footer(f, "index.txt")
 
-write_rest_footer(f, "index.txt")
-
-f.close()
 replace_file(filename)

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -406,25 +406,25 @@ header_graphical_index_tmpl = """\
 
 
 def get_desc(cmd):
-    f = open(cmd)
-    while True:
-        line = f.readline()
-        if not line:
-            return ""
-        if "NAME" in line:
-            break
+    with Path(cmd).open() as f:
+        while True:
+            line = f.readline()
+            if not line:
+                return ""
+            if "NAME" in line:
+                break
 
-    while True:
-        line = f.readline()
-        if not line:
-            return ""
-        if "SYNOPSIS" in line:
-            break
-        if "<em>" in line:
-            sp = line.split("-", 1)
-            if len(sp) > 1:
-                return sp[1].strip()
-            return None
+        while True:
+            line = f.readline()
+            if not line:
+                return ""
+            if "SYNOPSIS" in line:
+                break
+            if "<em>" in line:
+                sp = line.split("-", 1)
+                if len(sp) > 1:
+                    return sp[1].strip()
+                return None
 
     return ""
 

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -1,5 +1,6 @@
 import os
 import string
+from pathlib import Path
 
 # File template pieces follow
 

--- a/man/build_index_rest.py
+++ b/man/build_index_rest.py
@@ -21,11 +21,9 @@ from build_rest import (
 os.chdir(rest_dir)
 
 filename = "index.txt"
-f = open(filename + ".tmp", "w")
+with open(filename + ".tmp", "w") as f:
+    write_rest_header(f, "GRASS GIS %s Reference Manual" % grass_version, True)
+    write_rest_cmd_overview(f)
+    write_rest_footer(f, "index.txt")
 
-write_rest_header(f, "GRASS GIS %s Reference Manual" % grass_version, True)
-write_rest_cmd_overview(f)
-write_rest_footer(f, "index.txt")
-
-f.close()
 replace_file(filename)

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -133,62 +133,59 @@ def build_keywords(ext):
             if key.lower() < char_list[str(firstchar)].lower():
                 char_list[str(firstchar.lower())] = key
 
-    keywordsfile = open(os.path.join(man_dir, f"keywords.{ext}"), "w")
-    keywordsfile.write(
-        header1_tmpl.substitute(
-            title=f"GRASS GIS {grass_version} Reference Manual - Keywords index"
+    with open(os.path.join(man_dir, f"keywords.{ext}"), "w") as keywordsfile:
+        keywordsfile.write(
+            header1_tmpl.substitute(
+                title=f"GRASS GIS {grass_version} Reference Manual - Keywords index"
+            )
         )
-    )
-    keywordsfile.write(headerkeywords_tmpl)
-    if ext == "html":
-        keywordsfile.write("<dl>")
-    sortedKeys = sorted(keywords.keys(), key=lambda s: s.lower())
-
-    for key in sortedKeys:
+        keywordsfile.write(headerkeywords_tmpl)
         if ext == "html":
-            keyword_line = (
-                '<dt><b><a name="{key}" class="urlblack">{key}</a></b></dt><dd>'.format(
+            keywordsfile.write("<dl>")
+        sortedKeys = sorted(keywords.keys(), key=lambda s: s.lower())
+
+        for key in sortedKeys:
+            if ext == "html":
+                keyword_line = '<dt><b><a name="{key}" class="urlblack">{key}</a></b></dt><dd>'.format(
                     key=key
                 )
-            )
-        else:
-            keyword_line = f"### **{key}**\n"
-        for value in sorted(keywords[key]):
-            man_file_path = get_module_man_file_path(man_dir, value, addons_man_files)
-            if ext == "html":
-                keyword_line += (
-                    f' <a href="{man_file_path}">{value.replace(f".{ext}", "")}</a>,'
+            else:
+                keyword_line = f"### **{key}**\n"
+            for value in sorted(keywords[key]):
+                man_file_path = get_module_man_file_path(
+                    man_dir, value, addons_man_files
                 )
-            else:
-                keyword_line += f' [{value.rsplit(".", 1)[0]}]({man_file_path}),'
-        keyword_line = keyword_line.rstrip(",")
+                if ext == "html":
+                    keyword_line += f' <a href="{man_file_path}">{value.replace(f".{ext}", "")}</a>,'
+                else:
+                    keyword_line += f' [{value.rsplit(".", 1)[0]}]({man_file_path}),'
+            keyword_line = keyword_line.rstrip(",")
+            if ext == "html":
+                keyword_line += "</dd>"
+            keyword_line += "\n"
+            keywordsfile.write(keyword_line)
         if ext == "html":
-            keyword_line += "</dd>"
-        keyword_line += "\n"
-        keywordsfile.write(keyword_line)
-    if ext == "html":
-        keywordsfile.write("</dl>\n")
-    if ext == "html":
-        # create toc
-        toc = '<div class="toc">\n<h4 class="toc">Table of contents</h4><p class="toc">'
-        test_length = 0
-        all_keys = len(char_list.keys())
-        for k in sorted(char_list.keys()):
-            test_length += 1
-            #    toc += '<li><a href="#%s" class="toc">%s</a></li>' % (char_list[k], k)
-            if test_length % 4 == 0 and test_length != all_keys:
-                toc += '\n<a href="#%s" class="toc">%s</a>, ' % (char_list[k], k)
-            elif test_length % 4 == 0 and test_length == all_keys:
-                toc += '\n<a href="#%s" class="toc">%s</a>' % (char_list[k], k)
-            elif test_length == all_keys:
-                toc += '<a href="#%s" class="toc">%s</a>' % (char_list[k], k)
-            else:
-                toc += '<a href="#%s" class="toc">%s</a>, ' % (char_list[k], k)
-        toc += "</p></div>\n"
-        keywordsfile.write(toc)
+            keywordsfile.write("</dl>\n")
+        if ext == "html":
+            # create toc
+            toc = '<div class="toc">\n<h4 class="toc">Table of contents</h4><p class="toc">'
+            test_length = 0
+            all_keys = len(char_list.keys())
+            for k in sorted(char_list.keys()):
+                test_length += 1
+                #    toc += '<li><a href="#%s" class="toc">%s</a></li>' % (char_list[k], k)
+                if test_length % 4 == 0 and test_length != all_keys:
+                    toc += '\n<a href="#%s" class="toc">%s</a>, ' % (char_list[k], k)
+                elif test_length % 4 == 0 and test_length == all_keys:
+                    toc += '\n<a href="#%s" class="toc">%s</a>' % (char_list[k], k)
+                elif test_length == all_keys:
+                    toc += '<a href="#%s" class="toc">%s</a>' % (char_list[k], k)
+                else:
+                    toc += '<a href="#%s" class="toc">%s</a>, ' % (char_list[k], k)
+            toc += "</p></div>\n"
+            keywordsfile.write(toc)
 
-    write_footer(keywordsfile, f"index.{ext}", year, template=ext)
-    keywordsfile.close()
+        write_footer(keywordsfile, f"index.{ext}", year, template=ext)
 
 
 if __name__ == "__main__":

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -146,7 +146,7 @@ def build_keywords(ext):
 
         for key in sortedKeys:
             if ext == "html":
-                keyword_line = '<dt><b><a name="{key}" class="urlblack">{key}</a></b></dt><dd>'.format(
+                keyword_line = '<dt><b><a name="{key}" class="urlblack">{key}</a></b></dt><dd>'.format(  # noqa: E501
                     key=key
                 )
             else:
@@ -156,7 +156,7 @@ def build_keywords(ext):
                     man_dir, value, addons_man_files
                 )
                 if ext == "html":
-                    keyword_line += f' <a href="{man_file_path}">{value.replace(f".{ext}", "")}</a>,'
+                    keyword_line += f' <a href="{man_file_path}">{value.replace(f".{ext}", "")}</a>,'  # noqa: E501
                 else:
                     keyword_line += f' [{value.rsplit(".", 1)[0]}]({man_file_path}),'
             keyword_line = keyword_line.rstrip(",")
@@ -168,12 +168,12 @@ def build_keywords(ext):
             keywordsfile.write("</dl>\n")
         if ext == "html":
             # create toc
-            toc = '<div class="toc">\n<h4 class="toc">Table of contents</h4><p class="toc">'
+            toc = '<div class="toc">\n<h4 class="toc">Table of contents</h4><p class="toc">'  # noqa: E501
             test_length = 0
             all_keys = len(char_list.keys())
             for k in sorted(char_list.keys()):
                 test_length += 1
-                #    toc += '<li><a href="#%s" class="toc">%s</a></li>' % (char_list[k], k)
+                # toc += '<li><a href="#%s" class="toc">%s</a></li>' % (char_list[k], k)
                 if test_length % 4 == 0 and test_length != all_keys:
                     toc += '\n<a href="#%s" class="toc">%s</a>, ' % (char_list[k], k)
                 elif test_length % 4 == 0 and test_length == all_keys:

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -12,8 +12,8 @@ Created on Thu Aug  9 14:04:12 2012
 # (C) 2003-2024 by Luca Delucchi and the GRASS Development Team
 
 import os
-from pathlib import Path
 import string
+from pathlib import Path
 
 # TODO: better fix this in include/Make/Rest.make, see bug RT #5361
 

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -12,6 +12,7 @@ Created on Thu Aug  9 14:04:12 2012
 # (C) 2003-2024 by Luca Delucchi and the GRASS Development Team
 
 import os
+from pathlib import Path
 import string
 
 # TODO: better fix this in include/Make/Rest.make, see bug RT #5361
@@ -271,16 +272,11 @@ def check_for_desc_override(basename):
 
 
 def read_file(name):
-    f = open(name)
-    s = f.read()
-    f.close()
-    return s
+    return Path(name).read_text()
 
 
 def write_file(name, contents):
-    f = open(name, "w")
-    f.write(contents)
-    f.close()
+    Path(name).write_text(contents)
 
 
 def try_mkdir(path):

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -333,25 +333,25 @@ def write_rest_footer(f, index_url):
 
 
 def get_desc(cmd):
-    f = open(cmd)
-    while True:
-        line = f.readline()
-        if not line:
-            return ""
-        if "NAME" in line:
-            break
+    with Path(cmd).open() as f:
+        while True:
+            line = f.readline()
+            if not line:
+                return ""
+            if "NAME" in line:
+                break
 
-    while True:
-        line = f.readline()
-        if not line:
-            return ""
-        if "SYNOPSIS" in line:
-            break
-        if "*" in line:
-            sp = line.split("-", 1)
-            if len(sp) > 1:
-                return sp[1].strip()
-            return None
+        while True:
+            line = f.readline()
+            if not line:
+                return ""
+            if "SYNOPSIS" in line:
+                break
+            if "*" in line:
+                sp = line.split("-", 1)
+                if len(sp) > 1:
+                    return sp[1].strip()
+                return None
 
     return ""
 

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -78,48 +78,56 @@ def build_topics(ext):
         topicsfile.write(headertopics_tmpl)
 
         for key, values in sorted(keywords.items(), key=lambda s: s[0].lower()):
-            keyfile = open(os.path.join(man_dir, f"topic_%s.{ext}" % key), "w")
-            if ext == "html":
-                keyfile.write(
-                    header1_tmpl.substitute(
-                        title="GRASS GIS "
-                        "%s Reference Manual: Topic %s"
-                        % (grass_version, key.replace("_", " "))
+            with Path(man_dir, f"topic_%s.{ext}" % key).open("w") as keyfile:
+                if ext == "html":
+                    keyfile.write(
+                        header1_tmpl.substitute(
+                            title="GRASS GIS "
+                            "%s Reference Manual: Topic %s"
+                            % (grass_version, key.replace("_", " "))
+                        )
                     )
-                )
-            keyfile.write(headerkey_tmpl.substitute(keyword=key.replace("_", " ")))
-            num_modules = 0
-            for mod, desc in sorted(values.items()):
-                num_modules += 1
-                keyfile.write(
-                    desc1_tmpl.substitute(
-                        cmd=mod, desc=desc, basename=mod.replace(f".{ext}", "")
+                keyfile.write(headerkey_tmpl.substitute(keyword=key.replace("_", " ")))
+                num_modules = 0
+                for mod, desc in sorted(values.items()):
+                    num_modules += 1
+                    keyfile.write(
+                        desc1_tmpl.substitute(
+                            cmd=mod, desc=desc, basename=mod.replace(f".{ext}", "")
+                        )
                     )
-                )
-            if num_modules >= min_num_modules_for_topic:
-                topicsfile.writelines(
-                    [moduletopics_tmpl.substitute(key=key, name=key.replace("_", " "))]
-                )
-            if ext == "html":
-                keyfile.write("</table>\n")
-            else:
-                keyfile.write("\n")
-            # link to the keywords index
-            # TODO: the labels in keywords index are with spaces and capitals
-            # this should be probably changed to lowercase with underscores
-            if ext == "html":
-                keyfile.write(
-                    "<p><em>See also the corresponding keyword"
-                    ' <a href="keywords.html#{key}">{key}</a>'
-                    " for additional references.</em>".format(key=key.replace("_", " "))
-                )
-            else:
-                # expecting markdown
-                keyfile.write(
-                    "*See also the corresponding keyword"
-                    " [{key}](keywords.md#{key})"
-                    " for additional references.*\n".format(key=key.replace("_", " "))
-                )
+                if num_modules >= min_num_modules_for_topic:
+                    topicsfile.writelines(
+                        [
+                            moduletopics_tmpl.substitute(
+                                key=key, name=key.replace("_", " ")
+                            )
+                        ]
+                    )
+                if ext == "html":
+                    keyfile.write("</table>\n")
+                else:
+                    keyfile.write("\n")
+                # link to the keywords index
+                # TODO: the labels in keywords index are with spaces and capitals
+                # this should be probably changed to lowercase with underscores
+                if ext == "html":
+                    keyfile.write(
+                        "<p><em>See also the corresponding keyword"
+                        ' <a href="keywords.html#{key}">{key}</a>'
+                        " for additional references.</em>".format(
+                            key=key.replace("_", " ")
+                        )
+                    )
+                else:
+                    # expecting markdown
+                    keyfile.write(
+                        "*See also the corresponding keyword"
+                        " [{key}](keywords.md#{key})"
+                        " for additional references.*\n".format(
+                            key=key.replace("_", " ")
+                        )
+                    )
 
             write_footer(keyfile, f"index.{ext}", year, template=ext)
         if ext == "html":

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -129,7 +129,8 @@ def build_topics(ext):
                         )
                     )
 
-            write_footer(keyfile, f"index.{ext}", year, template=ext)
+                write_footer(keyfile, f"index.{ext}", year, template=ext)
+
         if ext == "html":
             topicsfile.write("</ul>\n")
         write_footer(topicsfile, f"index.{ext}", year, template=ext)

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -5,6 +5,7 @@
 
 import os
 import glob
+from pathlib import Path
 
 year = os.getenv("VERSION_DATE")
 
@@ -35,9 +36,9 @@ def build_topics(ext):
 
     files = glob.glob1(man_dir, f"*.{ext}")
     for fname in files:
-        fil = open(os.path.join(man_dir, fname))
-        # TODO maybe move to Python re (regex)
-        lines = fil.readlines()
+        with Path(man_dir, fname).open() as fil:
+            # TODO maybe move to Python re (regex)
+            lines = fil.readlines()
         try:
             if ext == "html":
                 index_keys = lines.index("<h2>KEYWORDS</h2>\n") + 1
@@ -68,63 +69,62 @@ def build_topics(ext):
         elif fname not in keywords[key]:
             keywords[key][fname] = desc
 
-    topicsfile = open(os.path.join(man_dir, f"topics.{ext}"), "w")
-    topicsfile.write(
-        header1_tmpl.substitute(
-            title="GRASS GIS %s Reference Manual - Topics index" % grass_version
+    with Path(man_dir, f"topics.{ext}").open("w") as topicsfile:
+        topicsfile.write(
+            header1_tmpl.substitute(
+                title="GRASS GIS %s Reference Manual - Topics index" % grass_version
+            )
         )
-    )
-    topicsfile.write(headertopics_tmpl)
+        topicsfile.write(headertopics_tmpl)
 
-    for key, values in sorted(keywords.items(), key=lambda s: s[0].lower()):
-        keyfile = open(os.path.join(man_dir, f"topic_%s.{ext}" % key), "w")
-        if ext == "html":
-            keyfile.write(
-                header1_tmpl.substitute(
-                    title="GRASS GIS "
-                    "%s Reference Manual: Topic %s"
-                    % (grass_version, key.replace("_", " "))
+        for key, values in sorted(keywords.items(), key=lambda s: s[0].lower()):
+            keyfile = open(os.path.join(man_dir, f"topic_%s.{ext}" % key), "w")
+            if ext == "html":
+                keyfile.write(
+                    header1_tmpl.substitute(
+                        title="GRASS GIS "
+                        "%s Reference Manual: Topic %s"
+                        % (grass_version, key.replace("_", " "))
+                    )
                 )
-            )
-        keyfile.write(headerkey_tmpl.substitute(keyword=key.replace("_", " ")))
-        num_modules = 0
-        for mod, desc in sorted(values.items()):
-            num_modules += 1
-            keyfile.write(
-                desc1_tmpl.substitute(
-                    cmd=mod, desc=desc, basename=mod.replace(f".{ext}", "")
+            keyfile.write(headerkey_tmpl.substitute(keyword=key.replace("_", " ")))
+            num_modules = 0
+            for mod, desc in sorted(values.items()):
+                num_modules += 1
+                keyfile.write(
+                    desc1_tmpl.substitute(
+                        cmd=mod, desc=desc, basename=mod.replace(f".{ext}", "")
+                    )
                 )
-            )
-        if num_modules >= min_num_modules_for_topic:
-            topicsfile.writelines(
-                [moduletopics_tmpl.substitute(key=key, name=key.replace("_", " "))]
-            )
-        if ext == "html":
-            keyfile.write("</table>\n")
-        else:
-            keyfile.write("\n")
-        # link to the keywords index
-        # TODO: the labels in keywords index are with spaces and capitals
-        # this should be probably changed to lowercase with underscores
-        if ext == "html":
-            keyfile.write(
-                "<p><em>See also the corresponding keyword"
-                ' <a href="keywords.html#{key}">{key}</a>'
-                " for additional references.</em>".format(key=key.replace("_", " "))
-            )
-        else:
-            # expecting markdown
-            keyfile.write(
-                "*See also the corresponding keyword"
-                " [{key}](keywords.md#{key})"
-                " for additional references.*\n".format(key=key.replace("_", " "))
-            )
+            if num_modules >= min_num_modules_for_topic:
+                topicsfile.writelines(
+                    [moduletopics_tmpl.substitute(key=key, name=key.replace("_", " "))]
+                )
+            if ext == "html":
+                keyfile.write("</table>\n")
+            else:
+                keyfile.write("\n")
+            # link to the keywords index
+            # TODO: the labels in keywords index are with spaces and capitals
+            # this should be probably changed to lowercase with underscores
+            if ext == "html":
+                keyfile.write(
+                    "<p><em>See also the corresponding keyword"
+                    ' <a href="keywords.html#{key}">{key}</a>'
+                    " for additional references.</em>".format(key=key.replace("_", " "))
+                )
+            else:
+                # expecting markdown
+                keyfile.write(
+                    "*See also the corresponding keyword"
+                    " [{key}](keywords.md#{key})"
+                    " for additional references.*\n".format(key=key.replace("_", " "))
+                )
 
-        write_footer(keyfile, f"index.{ext}", year, template=ext)
-    if ext == "html":
-        topicsfile.write("</ul>\n")
-    write_footer(topicsfile, f"index.{ext}", year, template=ext)
-    topicsfile.close()
+            write_footer(keyfile, f"index.{ext}", year, template=ext)
+        if ext == "html":
+            topicsfile.write("</ul>\n")
+        write_footer(topicsfile, f"index.{ext}", year, template=ext)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,7 @@ ignore = [
 # See https://docs.astral.sh/ruff/settings/#lint_per-file-ignores
 # "A005", # builtin-module-shadowing
 # "PLW0108", # unnecessary-lambda
+# "SIM115", # open-file-with-context-handler
 # Ignore `E402` (import violations) in all `__init__.py` files
 "**.py" = ["PYI066"]
 "*/testsuite/**.py" = ["PT009", "PT027"]
@@ -300,8 +301,6 @@ ignore = [
 "lib/imagery/testsuite/test_imagery_sigsetfile.py" = ["FURB152"]
 "lib/init/grass.py" = ["SIM115"]
 "locale/grass_po_stats.py" = ["SIM115"]
-"man/build_*.py" = ["SIM115"]
-"man/parser_standard_options.py" = ["SIM115"]
 "python/grass/__init__.py" = ["PYI056"]
 "python/grass/exp*/tests/grass_script_mapset_session_test.py" = ["SIM117"]
 "python/grass/exp*/tests/grass_script_tmp_mapset_session_test.py" = ["SIM117"]


### PR DESCRIPTION
In the same line of thought of other PRs of the moment fixing ResourceWarnings of unclosed files, this also applies the same context manager pattern when used on multiple lines + removing the f.close(), or using pathlib's Path().read_text()/ Path().write_text() when the whole file is acted upon in one step.

I am seeing these when trying to make the same script that OSGeo4W uses to package grass, (since it runs the manual creation).