### PR TITLE
CI: Fix Flake8 linter errors in man/ directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,13 +21,6 @@ per-file-ignores =
     # E741 ambiguous variable name 'l'
     __init__.py: F401, F403
     lib/init/grass.py: E722, F821, F841
-    man/build_class_rest.py: F403, F405
-    man/build_check.py: F403, F405
-    man/build_full_index.py: F403, F405
-    man/build_index.py: F403, F405
-    man/build_index_rest.py: F403, F405
-    man/build_keywords.py: F403, F405, E722
-    man/build_topics.py: F403, F405, E722
     man/build_html.py: E501
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
     doc/python/raster_example_ctypes.py: F403, F405

--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,6 @@ per-file-ignores =
     # F841 local variable assigned to but never used
     # E741 ambiguous variable name 'l'
     __init__.py: F401, F403
-    lib/init/grass.py: E722, F821, F841
     man/build_html.py: E501
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
     doc/python/raster_example_ctypes.py: F403, F405

--- a/.flake8
+++ b/.flake8
@@ -21,11 +21,6 @@ per-file-ignores =
     # E741 ambiguous variable name 'l'
     __init__.py: F401, F403
     lib/init/grass.py: E722, F821, F841
-    utils/gitlog2changelog.py: E722, E712
-    man/build_check_rest.py: F403, F405
-    man/build_full_index_rest.py: F403, F405
-    man/parser_standard_options.py: F403, F405
-    man/build_class.py: F403, F405
     man/build_class_rest.py: F403, F405
     man/build_check.py: F403, F405
     man/build_full_index.py: F403, F405

--- a/man/build_check.py
+++ b/man/build_check.py
@@ -9,7 +9,7 @@
 import sys
 import os
 
-from build_html import *
+from build_html import html_dir, message_tmpl, html_files, read_file
 
 os.chdir(html_dir)
 

--- a/man/build_check_rest.py
+++ b/man/build_check_rest.py
@@ -9,7 +9,7 @@
 import sys
 import os
 
-from build_rest import *
+from build_rest import rest_dir, message_tmpl, rest_files, read_file
 
 os.chdir(rest_dir)
 

--- a/man/build_class.py
+++ b/man/build_class.py
@@ -10,9 +10,18 @@ import sys
 import os
 
 from build_html import (
-    html_dir, write_html_header, grass_version, modclass_intro_tmpl,
-    modclass_tmpl, to_title, html_files, check_for_desc_override,
-    get_desc, desc2_tmpl, write_html_footer, replace_file
+    html_dir,
+    write_html_header,
+    grass_version,
+    modclass_intro_tmpl,
+    modclass_tmpl,
+    to_title,
+    html_files,
+    check_for_desc_override,
+    get_desc,
+    desc2_tmpl,
+    write_html_footer,
+    replace_file,
 )
 
 

--- a/man/build_class.py
+++ b/man/build_class.py
@@ -9,7 +9,11 @@
 import sys
 import os
 
-from build_html import *
+from build_html import (
+    html_dir, write_html_header, grass_version, modclass_intro_tmpl,
+    modclass_tmpl, to_title, html_files, check_for_desc_override,
+    get_desc, desc2_tmpl, write_html_footer, replace_file
+)
 
 
 no_intro_page_classes = ["display", "general", "miscellaneous", "postscript"]

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -9,7 +9,19 @@
 import sys
 import os
 
-from build_rest import *
+from build_rest import (
+    rest_dir,
+    grass_version,
+    modclass_intro_tmpl,
+    modclass_tmpl,
+    desc2_tmpl,
+    write_rest_header,
+    write_rest_footer,
+    rest_files,
+    check_for_desc_override,
+    get_desc,
+    replace_file
+)
 
 os.chdir(rest_dir)
 

--- a/man/build_class_rest.py
+++ b/man/build_class_rest.py
@@ -20,7 +20,7 @@ from build_rest import (
     rest_files,
     check_for_desc_override,
     get_desc,
-    replace_file
+    replace_file,
 )
 
 os.chdir(rest_dir)

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -9,7 +9,21 @@
 import sys
 import os
 
-from build_html import *
+from build_html import (
+    html_dir,
+    grass_version,
+    html_files,
+    write_html_header,
+    write_html_footer,
+    check_for_desc_override,
+    get_desc,
+    replace_file,
+    to_title,
+    full_index_header,
+    toc,
+    cmd2_tmpl,
+    desc1_tmpl
+)
 
 year = None
 if len(sys.argv) > 1:

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -22,7 +22,7 @@ from build_html import (
     full_index_header,
     toc,
     cmd2_tmpl,
-    desc1_tmpl
+    desc1_tmpl,
 )
 
 year = None

--- a/man/build_full_index_rest.py
+++ b/man/build_full_index_rest.py
@@ -9,9 +9,18 @@
 import os
 
 from build_rest import (
-    rest_dir, rest_files, write_rest_header, grass_version,
-    full_index_header, sections, cmd2_tmpl, check_for_desc_override,
-    get_desc, desc1_tmpl, write_rest_footer, replace_file
+    rest_dir,
+    rest_files,
+    write_rest_header,
+    grass_version,
+    full_index_header,
+    sections,
+    cmd2_tmpl,
+    check_for_desc_override,
+    get_desc,
+    desc1_tmpl,
+    write_rest_footer,
+    replace_file,
 )
 
 os.chdir(rest_dir)

--- a/man/build_full_index_rest.py
+++ b/man/build_full_index_rest.py
@@ -8,7 +8,11 @@
 
 import os
 
-from build_rest import *
+from build_rest import (
+    rest_dir, rest_files, write_rest_header, grass_version,
+    full_index_header, sections, cmd2_tmpl, check_for_desc_override,
+    get_desc, desc1_tmpl, write_rest_footer, replace_file
+)
 
 os.chdir(rest_dir)
 

--- a/man/build_index.py
+++ b/man/build_index.py
@@ -15,7 +15,7 @@ from build_html import (
     write_html_header,
     write_html_cmd_overview,
     write_html_footer,
-    replace_file
+    replace_file,
 )
 
 os.chdir(html_dir)

--- a/man/build_index.py
+++ b/man/build_index.py
@@ -9,7 +9,14 @@
 import sys
 import os
 
-from build_html import *
+from build_html import (
+    html_dir,
+    grass_version,
+    write_html_header,
+    write_html_cmd_overview,
+    write_html_footer,
+    replace_file
+)
 
 os.chdir(html_dir)
 

--- a/man/build_index_rest.py
+++ b/man/build_index_rest.py
@@ -9,7 +9,14 @@
 
 import os
 
-from build_rest import *
+from build_rest import (
+    rest_dir,
+    grass_version,
+    write_rest_header,
+    write_rest_cmd_overview,
+    write_rest_footer,
+    replace_file
+)
 
 os.chdir(rest_dir)
 

--- a/man/build_index_rest.py
+++ b/man/build_index_rest.py
@@ -15,7 +15,7 @@ from build_rest import (
     write_rest_header,
     write_rest_cmd_overview,
     write_rest_footer,
-    replace_file
+    replace_file,
 )
 
 os.chdir(rest_dir)

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -25,7 +25,7 @@ from build_html import (
     grass_version,
     header1_tmpl,
     headerkeywords_tmpl,
-    write_html_footer
+    write_html_footer,
 )
 
 

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -21,7 +21,13 @@ python man/build_keywords.py <dir_path_to_core_modules_html_man_files>
 import os
 import sys
 import glob
-from build_html import *
+from build_html import (
+    grass_version,
+    header1_tmpl,
+    headerkeywords_tmpl,
+    write_html_footer
+)
+
 
 blacklist = [
     "Display",
@@ -81,17 +87,17 @@ for html_file in htmlfiles:
     try:
         index_keys = lines.index("<h2>KEYWORDS</h2>\n") + 1
         index_desc = lines.index("<h2>NAME</h2>\n") + 1
-    except:
+    except Exception:
         continue
     try:
         keys = lines[index_keys].split(",")
-    except:
+    except Exception:
         continue
     for key in keys:
         key = key.strip()
         try:
             key = key.split(">")[1].split("<")[0]
-        except:
+        except Exception:
             pass
         if not key:
             sys.exit("Empty keyword from file %s line: %s" % (fname, lines[index_keys]))
@@ -104,10 +110,10 @@ for html_file in htmlfiles:
 for black in blacklist:
     try:
         del keywords[black]
-    except:
+    except Exception:
         try:
             del keywords[black.lower()]
-        except:
+        except Exception:
             continue
 
 for key in sorted(keywords.keys()):

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -13,7 +13,7 @@ from build_html import (
     headerkey_tmpl,
     desc1_tmpl,
     moduletopics_tmpl,
-    write_html_footer
+    write_html_footer,
 )
 
 path = sys.argv[1]

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -6,7 +6,15 @@
 import os
 import sys
 import glob
-from build_html import *
+from build_html import (
+    grass_version,
+    header1_tmpl,
+    headertopics_tmpl,
+    headerkey_tmpl,
+    desc1_tmpl,
+    moduletopics_tmpl,
+    write_html_footer
+)
 
 path = sys.argv[1]
 year = os.getenv("VERSION_DATE")
@@ -24,16 +32,16 @@ for fname in htmlfiles:
     try:
         index_keys = lines.index("<h2>KEYWORDS</h2>\n") + 1
         index_desc = lines.index("<h2>NAME</h2>\n") + 1
-    except:
+    except Exception:
         continue
     try:
         key = lines[index_keys].split(",")[1].strip().replace(" ", "_")
         key = key.split(">")[1].split("<")[0]
-    except:
+    except Exception:
         continue
     try:
         desc = lines[index_desc].split("-", 1)[1].strip()
-    except:
+    except Exception:
         desc.strip()
     if key not in keywords.keys():
         keywords[key] = {}

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -66,8 +66,8 @@ for line in fin:
             author = authorList[1]
             author = author[0 : len(author) - 1]
             authorFound = True
-        except Exception as e:
-            print(f"Could not parse authorList = '{line}'. Error: {e!s}")
+        except:
+            print("Could not parse authorList = '%s'" % (line))
 
     # Match the date line
     elif line.startswith("Date:"):
@@ -76,8 +76,8 @@ for line in fin:
             date = dateList[1]
             date = date[0 : len(date) - 1]
             dateFound = True
-        except Exception as e:
-            print(f"Could not parse dateList = '{line}'. Error: {e!s}")
+        except:
+            print("Could not parse dateList = '%s'" % (line))
     # The Fossil-IDs are ignored:
     elif line.startswith("    Fossil-ID:") or line.startswith("    [[SVN:"):
         continue

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -77,7 +77,7 @@ for line in fin:
             date = date[0 : len(date) - 1]
             dateFound = True
         except Exception as e:
-            print(f"Could not parse dateList = '{line}'. Error: {str(e)}")
+            print(f"Could not parse dateList = '{line}'. Error: {e!s}")
     # The Fossil-IDs are ignored:
     elif line.startswith("    Fossil-ID:") or line.startswith("    [[SVN:"):
         continue

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -67,7 +67,7 @@ for line in fin:
             author = author[0 : len(author) - 1]
             authorFound = True
         except Exception as e:
-            print(f"Could not parse authorList = '{line}'. Error: {str(e)}")
+            print(f"Could not parse authorList = '{line}'. Error: {e!s}")
 
     # Match the date line
     elif line.startswith("Date:"):

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -66,8 +66,8 @@ for line in fin:
             author = authorList[1]
             author = author[0 : len(author) - 1]
             authorFound = True
-        except:
-            print("Could not parse authorList = '%s'" % (line))
+        except Exception as e:
+            print(f"Could not parse authorList = '{line}'. Error: {str(e)}")
 
     # Match the date line
     elif line.startswith("Date:"):
@@ -76,8 +76,8 @@ for line in fin:
             date = dateList[1]
             date = date[0 : len(date) - 1]
             dateFound = True
-        except:
-            print("Could not parse dateList = '%s'" % (line))
+        except Exception as e:
+            print(f"Could not parse dateList = '{line}'. Error: {str(e)}")
     # The Fossil-IDs are ignored:
     elif line.startswith("    Fossil-ID:") or line.startswith("    [[SVN:"):
         continue


### PR DESCRIPTION
### Description:

This PR addresses several linter errors related to wildcard imports and improves overall code quality in multiple Python scripts within the project. The main focus was on resolving F403 and F405 errors, which are related to the use of wildcard imports and potential undefined names.

### Changes made:


   - Replaced wildcard import with specific imports from `build_html`.
   - Removed bare except clauses with Exception keyword

### Rationale for changes:

1. **Resolving linter errors**: The primary motivation was to address F403 and F405 errors. These errors indicate potential issues with undefined names due to wildcard imports.

2. Where applicable, string formatting was updated to use f-strings, which are more readable and efficient in Python 3.

These changes do not alter the functionality of the scripts. They purely focus on code quality improvements and adherence to Python best practices. 
