### PR TITLE
r.univar: fix MASK check with nprocs > 1

### DIFF
--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -192,6 +192,10 @@ int main(int argc, char *argv[])
     sscanf(param.nprocs->answer, "%d", &nprocs);
     if (nprocs < 1)
         G_fatal_error(_("<%d> is not valid number of nprocs."), nprocs);
+    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active MASK."));
+        nprocs = 1;
+    }
 #if defined(_OPENMP)
     omp_set_num_threads(nprocs);
 #else
@@ -200,10 +204,6 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
-        nprocs = 1;
-    }
     /* table field separator */
     zone_info.sep = G_option_to_separator(param.separator);
 


### PR DESCRIPTION
With MASK openmp parallelization can crash. The check for MASK was not in the right place.