### PR TITLE
i.rectify: Fix copy into fixed size buffer issue in main.c of i.rectify module

### DIFF
--- a/imagery/i.rectify/main.c
+++ b/imagery/i.rectify/main.c
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
                            nearest neighbor, bilinear, cubic */
     struct Flag *c, *a, *t;
     struct GModule *module;
-    size_t len;
 
     G_gisinit(argv[0]);
 
@@ -153,12 +152,12 @@ int main(int argc, char *argv[])
     interpolate = menu[method].method;
 
     G_strip(grp->answer);
-    len = G_strlcpy(group.name, grp->answer, sizeof(group.name));
-    if (len >= sizeof(group.name)) {
+    if (G_strlcpy(group.name, grp->answer, sizeof(group.name)) >=
+        sizeof(group.name)) {
         G_fatal_error(_("Group name <%s> is too long"), grp->answer);
     }
-    len = G_strlcpy(extension, ext->answer, sizeof(extension));
-    if (len >= sizeof(extension)) {
+    if (G_strlcpy(extension, ext->answer, sizeof(extension)) >=
+        sizeof(extension)) {
         G_fatal_error(_("Extension <%s> is too long"), ext->answer);
     }
     order = atoi(val->answer);

--- a/imagery/i.rectify/main.c
+++ b/imagery/i.rectify/main.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "global.h"
+#include <grass/gis.h>
 
 int seg_mb_img;
 
@@ -74,6 +75,7 @@ int main(int argc, char *argv[])
                            nearest neighbor, bilinear, cubic */
     struct Flag *c, *a, *t;
     struct GModule *module;
+    size_t len;
 
     G_gisinit(argv[0]);
 
@@ -151,8 +153,14 @@ int main(int argc, char *argv[])
     interpolate = menu[method].method;
 
     G_strip(grp->answer);
-    strcpy(group.name, grp->answer);
-    strcpy(extension, ext->answer);
+    len = G_strlcpy(group.name, grp->answer, sizeof(group.name));
+    if (len >= sizeof(group.name)) {
+        G_fatal_error(_("Group name <%s> is too long"), grp->answer);
+    }
+    len = G_strlcpy(extension, ext->answer, sizeof(extension));
+    if (len >= sizeof(extension)) {
+        G_fatal_error(_("Extension <%s> is too long"), ext->answer);
+    }
     order = atoi(val->answer);
 
     seg_mb = NULL;

--- a/imagery/i.rectify/main.c
+++ b/imagery/i.rectify/main.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "global.h"
+
 #include <grass/gis.h>
 
 int seg_mb_img;


### PR DESCRIPTION
This pull request resolves a buffer overflow issue detected by Coverity Scan (CID 1208277).
strcpy is replaced with G_strlcpy
The variable len is used to match the clang format check
The build was successful after the make process