### PR TITLE
lib/db: remove deprecated implementation of db_get_login() and replace it with that of db_get_login2()

### DIFF
--- a/db/drivers/mysql/db.c
+++ b/db/drivers/mysql/db.c
@@ -51,7 +51,7 @@ int db__driver_open_database(dbHandle *handle)
                 connpar.host, connpar.port, connpar.dbname, connpar.user,
                 connpar.password);
 
-        db_get_login2("mysql", name, &user, &password, &host, &port);
+        db_get_login("mysql", name, &user, &password, &host, &port);
 
         connection = mysql_init(NULL);
         res =

--- a/db/drivers/postgres/db.c
+++ b/db/drivers/postgres/db.c
@@ -54,7 +54,7 @@ int db__driver_open_database(dbHandle *handle)
         return DB_FAILED;
     }
 
-    db_get_login2("pg", name, &user, &password, &host, &port);
+    db_get_login("pg", name, &user, &password, &host, &port);
 
     pg_conn = PQsetdbLogin(host, port, pgconn.options, pgconn.tty,
                            pgconn.dbname, user, password);
@@ -241,7 +241,7 @@ int create_delete_db(dbHandle *handle, int create)
             pgconn.host, pgconn.port, pgconn.options, pgconn.tty, pgconn.dbname,
             pgconn.user, pgconn.password, pgconn.host, pgconn.port,
             pgconn.schema);
-    db_get_login2("pg", template_db, &user, &password, &host, &port);
+    db_get_login("pg", template_db, &user, &password, &host, &port);
 
     pg_conn = PQsetdbLogin(host, port, pgconn.options, pgconn.tty,
                            pgconn.dbname, user, password);

--- a/db/drivers/postgres/listdb.c
+++ b/db/drivers/postgres/listdb.c
@@ -48,7 +48,7 @@ int db__driver_list_databases(dbString *dbpath, int npaths, dbHandle **dblist,
             pgconn.dbname, pgconn.user, pgconn.password, pgconn.host,
             pgconn.port, pgconn.options, pgconn.tty);
 
-    db_get_login2("pg", NULL, &user, &passwd, &host, &port);
+    db_get_login("pg", NULL, &user, &passwd, &host, &port);
     G_debug(1, "user = %s, passwd = %s", user, passwd ? "xxx" : "");
 
     if (user || passwd) {

--- a/include/grass/defs/dbmi.h
+++ b/include/grass/defs/dbmi.h
@@ -389,7 +389,8 @@ unsigned int db_sizeof_string(const dbString *);
 int db_set_login(const char *, const char *, const char *, const char *);
 int db_set_login2(const char *, const char *, const char *, const char *,
                   const char *, const char *, int);
-int db_get_login(const char *, const char *, const char **, const char **);
+int db_get_login(const char *, const char *, const char **, const char **,
+                 const char **, const char **);
 int db_get_login2(const char *, const char *, const char **, const char **,
                   const char **, const char **);
 int db_get_login_dump(FILE *);

--- a/lib/db/dbmi_base/connect.c
+++ b/lib/db/dbmi_base/connect.c
@@ -87,11 +87,11 @@ int db_get_connection(dbConnection *connection)
     connection->group = (char *)G_getenv_nofatal2("DB_GROUP", G_VAR_MAPSET);
 
     /* try to get user/password */
-    db_get_login2(connection->driverName, connection->databaseName,
-                  (const char **)&(connection->user),
-                  (const char **)&(connection->password),
-                  (const char **)&(connection->hostName),
-                  (const char **)&(connection->port));
+    db_get_login(connection->driverName, connection->databaseName,
+                 (const char **)&(connection->user),
+                 (const char **)&(connection->password),
+                 (const char **)&(connection->hostName),
+                 (const char **)&(connection->port));
 
     return DB_OK;
 }

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -346,22 +346,20 @@ static int get_login(const char *driver, const char *database,
 
    If driver/database is not found, output arguments are set to NULL.
 
-   \deprecated Use db_set_login2() instead.
-
-   \todo: GRASS 8: to be replaced by db_set_login2().
-
    \param driver driver name
    \param database database name (can be NULL)
    \param[out] user name
    \param[out] password string
+   \param[out] host name
+   \param[out] port
 
    \return DB_OK on success
    \return DB_FAILED on failure
  */
-int db_get_login(const char *driver, const char *database, const char **user,
-                 const char **password)
+int db_get_login2(const char *driver, const char *database, const char **user,
+                  const char **password, const char **host, const char **port)
 {
-    return get_login(driver, database, user, password, NULL, NULL);
+    return db_get_login(driver, database, user, password, host, port);
 }
 
 /*!
@@ -379,8 +377,8 @@ int db_get_login(const char *driver, const char *database, const char **user,
    \return DB_OK on success
    \return DB_FAILED on failure
  */
-int db_get_login2(const char *driver, const char *database, const char **user,
-                  const char **password, const char **host, const char **port)
+int db_get_login(const char *driver, const char *database, const char **user,
+                 const char **password, const char **host, const char **port)
 {
     return get_login(driver, database, user, password, host, port);
 }

--- a/lib/vector/Vlib/open_pg.c
+++ b/lib/vector/Vlib/open_pg.c
@@ -535,11 +535,11 @@ void connect_db(struct Format_info_pg *pg_info)
 
         /* try connection settings for given database first, then try
          * any settings defined for pg driver */
-        db_get_login2("pg", dbname, &user, &passwd, &host, &port);
+        db_get_login("pg", dbname, &user, &passwd, &host, &port);
         /* any settings defined for pg driver disabled - can cause
            problems when running multiple local/remote db clusters
            if (strlen(dbname) > 0 && !user && !passwd)
-           db_get_login2("pg", NULL, &user, &passwd, &host, &port);
+           db_get_login("pg", NULL, &user, &passwd, &host, &port);
          */
         if (user || passwd || host || port) {
             char conninfo[DB_SQL_MAX];

--- a/vector/v.external/dsn.c
+++ b/vector/v.external/dsn.c
@@ -31,7 +31,7 @@ char *get_datasource_name(const char *opt_dsn, int use_ogr)
 
         /* add db.login settings (user, password, host, port) */
         if (DB_OK ==
-            db_get_login2("pg", database, &user, &passwd, &host, &port)) {
+            db_get_login("pg", database, &user, &passwd, &host, &port)) {
             if (user) {
                 if (!G_strcasestr(opt_dsn, "user=")) {
                     strcat(connect_str, " user=");

--- a/vector/v.in.ogr/dsn.c
+++ b/vector/v.in.ogr/dsn.c
@@ -38,7 +38,7 @@ char *get_datasource_name(const char *opt_dsn, int use_ogr)
 
         /* add db.login settings (user, password, host, port) */
         if (DB_OK ==
-            db_get_login2("pg", database, &user, &passwd, &host, &port)) {
+            db_get_login("pg", database, &user, &passwd, &host, &port)) {
             if (user) {
                 if (!G_strcasestr(opt_dsn, "user=")) {
                     strcat(connect_str, " user=");

--- a/vector/v.out.ogr/dsn.c
+++ b/vector/v.out.ogr/dsn.c
@@ -37,7 +37,7 @@ char *get_datasource_name(const char *opt_dsn, int use_ogr)
 
         /* add db.login settings (user, password, host, port) */
         if (DB_OK ==
-            db_get_login2("pg", database, &user, &passwd, &host, &port)) {
+            db_get_login("pg", database, &user, &passwd, &host, &port)) {
             if (user) {
                 if (!G_strcasestr(opt_dsn, "user=")) {
                     strcat(connect_str, " user=");


### PR DESCRIPTION
`db_get_login()` is deprecated in 7.8.0 release with da399c52637ee5c81228459fa374a114c8fef06c. Change its function signature and implementation to match that of the currently preferred `db_get_login2()`.

Modify `db_get_login2()` to internally call `db_get_login()` function call. In the future major version, `db_get_login2()` would be removed to have only one method to get login details for simplicity.