### PR TITLE
CI: Resolve flake8 issues in utils directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,7 +21,6 @@ per-file-ignores =
     # E741 ambiguous variable name 'l'
     __init__.py: F401, F403
     lib/init/grass.py: E722, F821, F841
-    utils/gitlog2changelog.py: E722, E712
     man/build_check_rest.py: F403, F405
     man/build_full_index_rest.py: F403, F405
     man/parser_standard_options.py: F403, F405

--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -66,8 +66,8 @@ for line in fin:
             author = authorList[1]
             author = author[0 : len(author) - 1]
             authorFound = True
-        except:
-            print("Could not parse authorList = '%s'" % (line))
+        except Exception as e:
+            print(f"Could not parse authorList = '{line}'. Error: {e!s}")
 
     # Match the date line
     elif line.startswith("Date:"):
@@ -76,8 +76,8 @@ for line in fin:
             date = dateList[1]
             date = date[0 : len(date) - 1]
             dateFound = True
-        except:
-            print("Could not parse dateList = '%s'" % (line))
+        except Exception as e:
+            print(f"Could not parse dateList = '{line}'. Error: {e!s}")
     # The Fossil-IDs are ignored:
     elif line.startswith("    Fossil-ID:") or line.startswith("    [[SVN:"):
         continue


### PR DESCRIPTION
This PR fixes the flake8 error in `utils/gitlog2changelog.py`. It addresses the E712 and E722 errors which are related to bare except clauses. I have put in Exception as blanket statement. If need be, I can also detail particular errors which might be related. I haven't yet because this might also miss out on some exceptions which are not detailed.