### PR TITLE
lib/gis: Add portable G_strlcat function

### DIFF
--- a/configure
+++ b/configure
@@ -765,8 +765,9 @@ SOCKLIB
 ICONVLIB
 DLLIB
 MATHLIB
-HAVE_ASPRINTF
 HAVE_STRLCPY
+HAVE_STRLCAT
+HAVE_ASPRINTF
 DBMIEXTRALIB
 USE_X11
 XTLIB
@@ -8312,12 +8313,26 @@ then :
 
 fi
 
+
+
+ac_fn_c_check_func "$LINENO" "strlcat" "ac_cv_func_strlcat"
+if test "x$ac_cv_func_strlcat" = xyes
+then :
+  printf "%s\n" "#define HAVE_STRLCAT 1" >>confdefs.h
+
+fi
+
+
+
+# Test if strlcpy exists
+# This is a function part of *BSD libc (optionally available on Linux via libbsd)
 ac_fn_c_check_func "$LINENO" "strlcpy" "ac_cv_func_strlcpy"
 if test "x$ac_cv_func_strlcpy" = xyes
 then :
   printf "%s\n" "#define HAVE_STRLCPY 1" >>confdefs.h
 
 fi
+
 
 
 # Test if mathlib needs -lm flag or is included with libc

--- a/configure.ac
+++ b/configure.ac
@@ -595,6 +595,9 @@ AC_SUBST(DBMIEXTRALIB)
 AC_CHECK_FUNCS(asprintf)
 AC_SUBST(HAVE_ASPRINTF)
 
+AC_CHECK_FUNCS(strlcat)
+AC_SUBST(HAVE_STRLCAT)
+
 # Test if strlcpy exists
 # This is a function part of *BSD libc (optionally available on Linux via libbsd)
 AC_CHECK_FUNCS(strlcpy)

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -14,9 +14,6 @@
 /* Define to 1 if you have the `asprintf' function. */
 #undef HAVE_ASPRINTF
 
-/* Define to 1 if you have the `strlcpy' function. */
-#undef HAVE_STRLCPY
-
 /* Define to 1 if you have the <bzlib.h> header file. */
 #undef HAVE_BZLIB_H
 
@@ -238,6 +235,12 @@
 
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
+
+/* Define to 1 if you have the `strlcat' function. */
+#undef HAVE_STRLCAT
+
+/* Define to 1 if you have the `strlcpy' function. */
+#undef HAVE_STRLCPY
 
 /* Define to 1 if you have the <svm.h> header file. */
 #undef HAVE_SVM_H

--- a/include/grass/defs/gis.h
+++ b/include/grass/defs/gis.h
@@ -152,6 +152,9 @@ int G_vfaprintf(FILE *, const char *, va_list);
 int G_vsaprintf(char *, const char *, va_list);
 int G_vsnaprintf(char *, size_t, const char *, va_list);
 
+/* strlcat.c */
+size_t G_strlcat(char *, const char *, size_t);
+
 /* strlcpy.c */
 size_t G_strlcpy(char *, const char *, size_t);
 

--- a/lib/gis/strlcat.c
+++ b/lib/gis/strlcat.c
@@ -1,0 +1,84 @@
+/*!
+ * \file lib/gis/strlcat.c
+ *
+ * \brief GIS Library - GRASS implementation of strlcat().
+ *
+ * If available, G_strlcat() calls system strlcat(), otherwise it uses
+ * implementation by Todd C. Miller of OpenBSD.
+ *
+ * Addition to GRASS GIS by Nicklas Larsson, 2024
+ *
+ * Original OpenBSD implementation notes:
+ *
+ * Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+/**
+ * \brief Size-bounded string concatenation
+ *
+ * Appends string src to the end of dst. It will append at most
+ * dstsize - strlen(dst) - 1 characters. It will then NUL-terminate, unless
+ * dstsize is 0 or the original dst string was longer than dstsize (in practice
+ * this should not happen as it means that either dstsize is incorrect or that
+ * dst is not a proper string).
+ *
+ * If the src and dst strings overlap, the behavior is undefined.
+ * This function is a safer alternative to strncat.
+ *
+ * \param[out] dst Pointer to the destination buffer. Must be a NUL-terminated
+ *                 C string.
+ * \param[in] src Pointer to the source string, which will be appended. Must
+ *                be a NUL-terminated C string.
+ * \param[in] dsize The size of the destination buffer.
+ *
+ * \return The total length of the string src, which was attempted to be
+ *         created (the initial length of dst plus the length of src, not
+ *         including the terminating NUL character). If the return value
+ *         is >= dsize, truncation occurred.
+ */
+
+size_t G_strlcat(char *restrict dst, const char *restrict src, size_t dsize)
+{
+#ifdef HAVE_STRLCAT
+    return strlcat(dst, src, dsize);
+#else
+    const char *odst = dst;
+    const char *osrc = src;
+    size_t n = dsize;
+    size_t dlen;
+
+    /* Find the end of dst and adjust bytes left but don't go past end. */
+    while (n-- != 0 && *dst != '\0')
+        dst++;
+    dlen = dst - odst;
+    n = dsize - dlen;
+
+    if (n-- == 0)
+        return (dlen + strlen(src));
+    while (*src != '\0') {
+        if (n != 0) {
+            *dst++ = *src;
+            n--;
+        }
+        src++;
+    }
+    *dst = '\0';
+
+    return (dlen + (src - osrc)); /* count does not include NUL */
+#endif
+}


### PR DESCRIPTION
Add wrapper function for [`strlcat()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/strlcat.html), using system function if available, otherwise uses implementation by Todd C. Miller originated from https://github.com/openbsd/src/blob/e291b8af02e5c2b53d7ddb1f0c9c0fd608b97d45/lib/libc/string/strlcat.c.

`G_strlcat()` is a safer alternative to `strcat()`.

(See also https://www.openbsd.org/papers/strlcpy-paper.pdf).

strlcpy and strlcat are added to [GNU C Library version 2.38](https://lists.gnu.org/archive/html/info-gnu/2023-07/msg00010.html).