### PR TITLE
lib/db: remove deprecated implementation of db_set_login() and replace it with that of db_set_login2()

### DIFF
--- a/db/db.login/main.c
+++ b/db/db.login/main.c
@@ -98,9 +98,9 @@ int main(int argc, char *argv[])
         exit(EXIT_SUCCESS);
     }
 
-    if (db_set_login2(driver->answer, database->answer, user->answer,
-                      password->answer, host->answer, port->answer,
-                      G_get_overwrite()) == DB_FAILED) {
+    if (db_set_login(driver->answer, database->answer, user->answer,
+                     password->answer, host->answer, port->answer,
+                     G_get_overwrite()) == DB_FAILED) {
         G_fatal_error(_("Unable to set user/password"));
     }
 

--- a/include/grass/defs/dbmi.h
+++ b/include/grass/defs/dbmi.h
@@ -388,6 +388,8 @@ void db_zero_string(dbString *);
 unsigned int db_sizeof_string(const dbString *);
 int db_set_login(const char *, const char *, const char *, const char *,
                  const char *, const char *, int);
+int db_set_login2(const char *, const char *, const char *, const char *,
+                  const char *, const char *, int);
 int db_get_login(const char *, const char *, const char **, const char **);
 int db_get_login2(const char *, const char *, const char **, const char **,
                   const char **, const char **);

--- a/include/grass/defs/dbmi.h
+++ b/include/grass/defs/dbmi.h
@@ -386,9 +386,8 @@ const char *db_whoami(void);
 void db_zero(void *, int);
 void db_zero_string(dbString *);
 unsigned int db_sizeof_string(const dbString *);
-int db_set_login(const char *, const char *, const char *, const char *);
-int db_set_login2(const char *, const char *, const char *, const char *,
-                  const char *, const char *, int);
+int db_set_login(const char *, const char *, const char *, const char *,
+                 const char *, const char *, int);
 int db_get_login(const char *, const char *, const char **, const char **);
 int db_get_login2(const char *, const char *, const char **, const char **,
                   const char **, const char **);

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -253,27 +253,6 @@ static int set_login(const char *driver, const char *database, const char *user,
 /*!
    \brief Set login parameters for driver/database
 
-   \deprecated Use db_set_login2() instead.
-
-   \todo: GRASS 8: to be replaced by db_set_login2().
-
-   \param driver driver name
-   \param database database name
-   \param user user name
-   \param password password string
-
-   \return DB_OK on success
-   \return DB_FAILED on failure
- */
-int db_set_login(const char *driver, const char *database, const char *user,
-                 const char *password)
-{
-    return set_login(driver, database, user, password, NULL, NULL, FALSE);
-}
-
-/*!
-   \brief Set login parameters for driver/database
-
    \param driver driver name
    \param database database name
    \param user user name
@@ -285,9 +264,9 @@ int db_set_login(const char *driver, const char *database, const char *user,
    \return DB_OK on success
    \return DB_FAILED on failure
  */
-int db_set_login2(const char *driver, const char *database, const char *user,
-                  const char *password, const char *host, const char *port,
-                  int overwrite)
+int db_set_login(const char *driver, const char *database, const char *user,
+                 const char *password, const char *host, const char *port,
+                 int overwrite)
 {
     return set_login(driver, database, user, password, host, port, overwrite);
 }

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -268,7 +268,8 @@ int db_set_login2(const char *driver, const char *database, const char *user,
                   const char *password, const char *host, const char *port,
                   int overwrite)
 {
-    return db_set_login(driver, database, user, password, host, port, overwrite);
+    return db_set_login(driver, database, user, password, host, port,
+                        overwrite);
 }
 
 /*!

--- a/lib/db/dbmi_base/login.c
+++ b/lib/db/dbmi_base/login.c
@@ -264,6 +264,27 @@ static int set_login(const char *driver, const char *database, const char *user,
    \return DB_OK on success
    \return DB_FAILED on failure
  */
+int db_set_login2(const char *driver, const char *database, const char *user,
+                  const char *password, const char *host, const char *port,
+                  int overwrite)
+{
+    return db_set_login(driver, database, user, password, host, port, overwrite);
+}
+
+/*!
+   \brief Set login parameters for driver/database
+
+   \param driver driver name
+   \param database database name
+   \param user user name
+   \param password password string
+   \param host host name
+   \param port
+   \param overwrite TRUE to overwrite existing connections
+
+   \return DB_OK on success
+   \return DB_FAILED on failure
+ */
 int db_set_login(const char *driver, const char *database, const char *user,
                  const char *password, const char *host, const char *port,
                  int overwrite)


### PR DESCRIPTION
In a similar vein to that of #4302, `db_set_login()` is deprecated in 7.8.0 release with da399c5. Change its function signature and implementation to match that of currently preferred `db_set_login2()`.

Modify `db_set_login2()` to internally call `db_set_login()` function call. In the future major version, `db_set_login()` would be removed to have only one method to set login details for simplicity.