### PR TITLE
GUI: gmodeler fix adding tool

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -941,8 +941,9 @@ class ModelObject:
 
         result = []
         for rel in self.rels:
-            if fdir == "from" and rel.GetFrom() == self:
-                result.append(rel)
+            if fdir == "from":
+                if rel.GetFrom() == self:
+                    result.append(rel)
             elif rel.GetTo() == self:
                 result.append(rel)
 

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -1577,7 +1577,7 @@ class ModelDataSingle(ModelData, ogl.EllipseShape):
         :param width, height: dimension of the shape
         :param x, y: position of the shape
         """
-        ogl.EllipseShape(self, width, height)
+        ogl.EllipseShape.__init__(self, width, height)  # noqa: PLC2801, C2801
         if self.parent.GetCanvas():
             self.SetCanvas(self.parent.GetCanvas())
 
@@ -1592,7 +1592,7 @@ class ModelDataSeries(ModelData, ogl.CompositeShape):
         :param width, height: dimension of the shape
         :param x, y: position of the shape
         """
-        ogl.CompositeShape(self)
+        ogl.CompositeShape.__init__(self)  # noqa: PLC2801, C2801
         if self.parent.GetCanvas():
             self.SetCanvas(self.parent.GetCanvas())
 


### PR DESCRIPTION
This PR fixes two regressions introduced recently.

## Steps to reproduce

1. Open graphical modeler
2. Add some tool (tested on `v.buffer`)
3. Fill required params (in the case of `v.buffer`: `input` and `output`)
4. Press OK

Adding new tool fails with:

```py
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/forms.py", line 828, in OnOK
    cmd = self.OnApply(event)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/forms.py", line 841, in OnApply
    self.get_dcmd(
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/panels.py", line 507, in GetOptData
    data = dataClass(
           ^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/model.py", line 1380, in __init__
    self._defineShape(width, height, x, y)
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/model.py", line 1580, in _defineShape
    ogl.EllipseShape(self, width, height)
TypeError: EllipseShape.__init__() takes 3 positional arguments but 4 were given
```

This regression was introduced by 2cf98da. 

After fixing this issue a new regression appears:

```py
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/forms.py", line 828, in OnOK
    cmd = self.OnApply(event)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gui_core/forms.py", line 841, in OnApply
    self.get_dcmd(
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/panels.py", line 536, in GetOptData
    data.Update()
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/model.py", line 1555, in Update
    self._setPen()
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/model.py", line 1538, in _setPen
    self.SetPen(self._getPen())
                ^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/model.py", line 1508, in _getPen
    if rel.GetTo().IsParameterized():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ModelDataSingle' object has no attribute 'IsParameterized'
```

This regression was introduced by f99780c.

This PR fixes both issues in the modeler. @echoix BTW, there are similar modifications (removed `__init__` and kept `self`) in 2cf98da related to `ColumnSorterMixin`. I didn't checked it, but possibly it's introducing similar regression.