### PR TITLE
lib/linkm: Change non-returning internal function types to void

### DIFF
--- a/lib/linkm/test/try.c
+++ b/lib/linkm/test/try.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     exit(0);
 }
 
-int add_link_rev(struct link *List, struct link *link)
+void add_link_rev(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -70,7 +70,7 @@ int add_link_rev(struct link *List, struct link *link)
     link->next = p;
 }
 
-int add_link(struct link *List, struct link *link)
+void add_link(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -81,7 +81,7 @@ int add_link(struct link *List, struct link *link)
     link->next = NULL;
 }
 
-int dumplist(struct link *List)
+void dumplist(struct link *List)
 {
     struct link *p;
 

--- a/lib/linkm/test/try2.c
+++ b/lib/linkm/test/try2.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     exit(0);
 }
 
-int add_link_rev(struct link *List, struct link *link)
+void add_link_rev(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -72,7 +72,7 @@ int add_link_rev(struct link *List, struct link *link)
     link->next = p;
 }
 
-int add_link(struct link *List, struct link *link)
+void add_link(struct link *List, struct link *link)
 {
     struct link *p;
 
@@ -83,7 +83,7 @@ int add_link(struct link *List, struct link *link)
     link->next = NULL;
 }
 
-int dumplist(struct link *List)
+void dumplist(struct link *List)
 {
     struct link *p;
 


### PR DESCRIPTION
Some of the internal functions had `int` return type, but they were not returning anything and the places where these functions are called were also not expecting anything from the function.

To, simplify such cases, change the function return type to 'void'.

This issue was found using cppcheck tool. It's a low-priority one, since it's in the tests and the functions affected are internal test functions.

Additional information:

1. Machine used: Virtual Machine running Ubuntu 22.04.4 LTS.
2. Reproduction rate: 100%, reproducible every time.
3. Output from cppcheck prior to fix

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/ca8d7be3-fb0b-43d5-9ebb-bb375be17d38">

Output from cppcheck after the fix

<img width="775" alt="image" src="https://github.com/user-attachments/assets/bb763b26-2b51-4ebb-9ebf-32917606ef71">
