### PR TITLE
wxGUI/history: fix the run of a special cmds only once

### DIFF
--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -557,14 +557,12 @@ class HistoryBrowserTree(CTreeView):
         selected_command = self.selected_command[0]
         command = selected_command.data["name"]
 
-        lst = re.split(r"\s+", command)
         if (
             globalvar.ignoredCmdPattern
             and re.compile(globalvar.ignoredCmdPattern).search(command)
             and "--help" not in command
             and "--ui" not in command
         ):
-            self.runIgnoredCmdPattern.emit(cmd=lst)
             self.runIgnoredCmdPattern.emit(cmd=split(command))
             return
         if re.compile(r"^r[3]?\.mapcalc").search(command):


### PR DESCRIPTION
After left double mouse click on the wxGUI history tab tree cmd node.

Special cmds are:

```
r"^d\..*|^r[3]?\.mapcalc$|^i.group$|^r.import$|^r.external$|^r.external.out$|"
r"^v.import$|^v.external$|^v.external.out$"
```

Fixes #4321.