### PR TITLE
grass.gunittest: Fix parsing exclusion from config file on Windows

### DIFF
--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -30,16 +30,12 @@ def fnmatch_exclude_with_base(files, base, exclude):
     # Make all dir separators slashes and drop leading current dir
     # for both patterns and (later) for files.
     for pattern in exclude:
-        pattern = pattern.replace(os.sep, "/")
-        if pattern.startswith("./"):
-            patterns.append(pattern[2:])
-        else:
-            patterns.append(pattern)
+        patterns.append(PurePath(pattern))
     for filename in files:
         test_filename: PurePath = base_path / filename
         matches = False
         for pattern in patterns:
-            if fnmatch.fnmatch(str(test_filename), pattern):
+            if fnmatch.fnmatch(str(test_filename), str(pattern)):
                 matches = True
                 break
         if not matches:

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -11,11 +11,11 @@ for details.
 
 from __future__ import annotations
 
-import os
-import fnmatch
-import unittest
 import collections
+import fnmatch
+import os
 import re
+import unittest
 from pathlib import PurePath
 from typing import TYPE_CHECKING
 

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -127,7 +127,7 @@ def discover_modules(
                 files = fnmatch_exclude_with_base(files, full, exclude)
             files = sorted(files)
             # get test/module name without .py
-            # extpecting all files to end with .py
+            # expecting all files to end with .py
             # this will not work for invoking bat files but it works fine
             # as long as we handle only Python files (and using Python
             # interpreter for invoking)

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -117,12 +117,11 @@ def discover_modules(
             dirs.remove(testsuite_dir)  # do not recurse to testsuite
             full = os.path.join(root, testsuite_dir)
 
-            all_files = os.listdir(full)
-            files = [f for f in all_files]
+            files = os.listdir(full)
             if file_pattern:
-                files = fnmatch.filter(all_files, file_pattern)
+                files = fnmatch.filter(files, file_pattern)
             if file_regexp:
-                files = [f for f in all_files if re.match(file_regexp, f)]
+                files = [f for f in files if re.match(file_regexp, f)]
             if exclude:
                 files = fnmatch_exclude_with_base(files, full, exclude)
             files = sorted(files)

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -6,7 +6,7 @@ This program is free software under the GNU General Public
 License (>=v2). Read the file COPYING that comes with GRASS GIS
 for details.
 
-:authors: Vaclav Petras
+:authors: Vaclav Petras, Edouard Choinière
 """
 
 from __future__ import annotations

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -14,7 +14,7 @@ import fnmatch
 import unittest
 import collections
 import re
-from pathlib import Path
+from pathlib import PurePath
 
 
 def fnmatch_exclude_with_base(files, base, exclude):
@@ -26,7 +26,7 @@ def fnmatch_exclude_with_base(files, base, exclude):
     """
     not_excluded = []
     patterns = []
-    base_path = Path(base)
+    base_path = PurePath(base)
     # Make all dir separators slashes and drop leading current dir
     # for both patterns and (later) for files.
     for pattern in exclude:
@@ -36,7 +36,7 @@ def fnmatch_exclude_with_base(files, base, exclude):
         else:
             patterns.append(pattern)
     for filename in files:
-        test_filename: Path = base_path / filename
+        test_filename: PurePath = base_path / filename
         matches = False
         for pattern in patterns:
             if fnmatch.fnmatch(str(test_filename), pattern):

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -117,6 +117,7 @@ def discover_modules(
             full = os.path.join(root, testsuite_dir)
 
             all_files = os.listdir(full)
+            files = [f for f in all_files]
             if file_pattern:
                 files = fnmatch.filter(all_files, file_pattern)
             if file_regexp:

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -14,6 +14,7 @@ import fnmatch
 import unittest
 import collections
 import re
+from pathlib import Path
 
 
 def fnmatch_exclude_with_base(files, base, exclude):
@@ -25,6 +26,7 @@ def fnmatch_exclude_with_base(files, base, exclude):
     """
     not_excluded = []
     patterns = []
+    base_path = Path(base)
     # Make all dir separators slashes and drop leading current dir
     # for both patterns and (later) for files.
     for pattern in exclude:
@@ -34,13 +36,10 @@ def fnmatch_exclude_with_base(files, base, exclude):
         else:
             patterns.append(pattern)
     for filename in files:
-        full_file_path = os.path.join(base, filename)
-        test_filename = full_file_path.replace(os.sep, "/")
-        if full_file_path.startswith("./"):
-            test_filename = full_file_path[2:]
+        test_filename: Path = base_path / filename
         matches = False
         for pattern in patterns:
-            if fnmatch.fnmatch(test_filename, pattern):
+            if fnmatch.fnmatch(str(test_filename), pattern):
                 matches = True
                 break
         if not matches:

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -35,7 +35,7 @@ def fnmatch_exclude_with_base(
     :param exclude: list of fnmatch glob patterns for exclusion
     """
     not_excluded = []
-    patterns = {str(PurePath(pat)) for pat in exclude}
+    patterns = {str(PurePath(item)) for item in exclude}
     base_path = PurePath(base)
     for filename in files:
         test_filename: PurePath = base_path / filename

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -17,9 +17,17 @@ import unittest
 import collections
 import re
 from pathlib import PurePath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
-def fnmatch_exclude_with_base(files, base, exclude):
+def fnmatch_exclude_with_base(
+    files: Iterable[str],
+    base: str | os.PathLike,
+    exclude: Iterable[str | os.PathLike | PurePath],
+) -> list[str]:
     """Return list of files not matching any exclusion pattern
 
     :param files: list of file names

--- a/python/grass/gunittest/loader.py
+++ b/python/grass/gunittest/loader.py
@@ -9,6 +9,8 @@ for details.
 :authors: Vaclav Petras
 """
 
+from __future__ import annotations
+
 import os
 import fnmatch
 import unittest
@@ -25,17 +27,13 @@ def fnmatch_exclude_with_base(files, base, exclude):
     :param exclude: list of fnmatch glob patterns for exclusion
     """
     not_excluded = []
-    patterns = []
+    patterns = {str(PurePath(pat)) for pat in exclude}
     base_path = PurePath(base)
-    # Make all dir separators slashes and drop leading current dir
-    # for both patterns and (later) for files.
-    for pattern in exclude:
-        patterns.append(PurePath(pattern))
     for filename in files:
         test_filename: PurePath = base_path / filename
         matches = False
         for pattern in patterns:
-            if fnmatch.fnmatch(str(test_filename), str(pattern)):
+            if fnmatch.fnmatch(str(test_filename), pattern):
                 matches = True
                 break
         if not matches:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactored the function fnmatch_exclude_with_base in grass.gunittest.loader in order to work across platforms, including Windows.

I tried multiple approaches and researched a bit, and the first really working solution was the custom `fnmatch_ex` function that pytest uses, since pathlib's `Path.match()` doesn't work properly and doesn't behave like `Path.glob()` concerning `**`s. 
https://github.com/pytest-dev/pytest/blob/9515dfa58a144f3644fd29b256113d723c9c1955/src/_pytest/pathlib.py#L414-L447
```python
def fnmatch_ex(pattern: str, path: str | os.PathLike[str]) -> bool:
    """A port of FNMatcher from py.path.common which works with PurePath() instances.

    The difference between this algorithm and PurePath.match() is that the
    latter matches "**" glob expressions for each part of the path, while
    this algorithm uses the whole path instead.

    For example:
        "tests/foo/bar/doc/test_foo.py" matches pattern "tests/**/doc/test*.py"
        with this algorithm, but not with PurePath.match().

    This algorithm was ported to keep backward-compatibility with existing
    settings which assume paths match according this logic.

    References:
    * https://bugs.python.org/issue29249
    * https://bugs.python.org/issue34731
    """
    path = PurePath(path)
    iswin32 = sys.platform.startswith("win")

    if iswin32 and sep not in pattern and posix_sep in pattern:
        # Running on Windows, the pattern has no Windows path separators,
        # and the pattern has one or more Posix path separators. Replace
        # the Posix path separators with the Windows path separator.
        pattern = pattern.replace(posix_sep, sep)

    if sep not in pattern:
        name = path.name
    else:
        name = str(path)
        if path.is_absolute() and not os.path.isabs(pattern):
            pattern = f"*{os.sep}{pattern}"
    return fnmatch.fnmatch(name, pattern)
``` 

However, after inlining more and more of that `fnmatch_ex` function, comparing how it behaves with our inputs (Windows and Linux) and what branches are taken, we don't use a mix of absolute and relative paths, and we never supported `**`, and we never only supplied a name without separator. So, since on Windows the working `fnmatch_ex` needs a pattern with backslashes `\` for the path and the pattern, and on Linux it needs forward slash on both; since pathlib's Path representation already normalizes a `./` of a relative path; and since pathlib's Path/PurePath classes works properly with `*` and `**`, especially when that variable is converted to a string at the end, I could simply replace all our logic by creating Path instances for the full name and pattern, and call the `fnmatch` with the string representations of it. I used `PurePath` instead of a concrete `Path`, as I didn't need to actually manipulate files, and the subclasses can be instantiated on any OS if further tests would need to run cross-platform.


Also included:
- the `files` list variable in `discover_modules` could not exist in all code paths, depending on the inputs. Initialized it with a list containing the same elements as `all_files`, without directly assigning `all_files` to `files`.

## Motivation and context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link the issue here. -->
Fixes #4319 

## How has this been tested?
<!-- Please describe how you tested your changes. -->
Up until my final clean rebase, I was using extra prints inside the function, to not have to wait at the end of the test run to see if the files were properly excluded.
```python
    print(f"Ed: fnmatch_exclude_with_base_pathlib, exclude: {exclude}")
    print(f"Ed: fnmatch_exclude_with_base_pathlib, patterns: {patterns}")
    print(f"Ed: fnmatch_exclude_with_base_pathlib, base: {base}")
    print(f"Ed: fnmatch_exclude_with_base_pathlib, base_path: {base_path}")
    print(f"Ed: fnmatch_exclude_with_base_pathlib, files: {files}")
    print(f"Ed: fnmatch_exclude_with_base_pathlib, not_excluded: {not_excluded}")
```

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist
<!-- See the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, please ask. We're here to help! -->
- [x] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](../../utils/release.yml)
<!-- For example: "doc: Add example to db.describe documentation" -->
<!-- or if it is a fix use "db.describe: fix JSON output format" -->
- [x] My code follows the [code style](../../doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.