### PR TITLE
CI(macOS): Use micromamba-shell for steps to load PATH changes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -65,7 +65,7 @@ jobs:
         run: echo "$HOME/install/bin" >> $GITHUB_PATH
       - name: Check installed version
         if: ${{ !cancelled() }}
-        shell: bash -l {0}
+        shell: bash -le {0}
         run: source ./.github/workflows/print_versions.sh
 
       - name: Run pytest with multiple workers in parallel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -69,7 +69,7 @@ jobs:
         run: source ./.github/workflows/print_versions.sh
 
       - name: Run pytest with multiple workers in parallel
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
         run: |
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
@@ -78,7 +78,7 @@ jobs:
             -ra . \
             -m 'not needs_solo_run'
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
         run: |
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
@@ -87,7 +87,7 @@ jobs:
             -m 'needs_solo_run'
 
       - name: Run gunittest tests
-        shell: bash -el {0}
+        shell: micromamba-shell {0}
         run: |
           grass --tmp-project XY --exec \
               g.download.project url=${{ env.SampleData }} path=$HOME

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -65,7 +65,7 @@ jobs:
         run: echo "$HOME/install/bin" >> $GITHUB_PATH
       - name: Check installed version
         if: ${{ !cancelled() }}
-        shell: bash -le {0}
+        shell: micromamba-shell {0}
         run: source ./.github/workflows/print_versions.sh
 
       - name: Run pytest with multiple workers in parallel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Create installation directory
         run: mkdir $HOME/install
       - name: Build and install
-        shell: bash -l {0}
+        shell: micromamba-shell {0}
         run: source ./.github/workflows/macos_install.sh $HOME/install
       - name: Add the bin directory to PATH
         run: echo "$HOME/install/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Fixes #4323

**This PR needs to be merged in priority to allow any other PR in the grass repo to be successful.**

After investigation, I only found that the PATH environment was missing significantly more entries with the 20240911.3 runner image. It also seems that the conda env wasn't correctly loaded. I tried multiple changes, in a PR in my fork, https://github.com/echoix/grass/pull/226/, and also investigated by connecting to the running job by ssh and examining the state myself. For example, I tried to see if a different shebang, different shell would work, if using pipefail everywhere, using `bash -leo pipefail {0}` as shell, I also checked to make sure that no useful message was swallowed in `/dev/null`, if the `-pipe` flag was swallowing errors, etc. Then, while connected by ssh, I could confirm that the grass executables were built and copied to the correct locations, and it was possible to run it by going to the folder and using `./grass` instead. Otherwise, it looks like the PATH set in the previous step wasn't applied correctly in the following steps.

I suspect that using a login shell (the -l option of bash) with the micromamba shell initialized was wiping the customizations that the GitHub runner should have been adding at each step, or the order of when the conda env activation is done vs the GitHub ones changed in between the two runner image versions. Remember that GitHub Action's runners work by having each step creating a script that is called to a shell, and all envs, paths, outputs, step summaries, etc. are all passed through a file named specifically for that step. That's why setting and env var in a step will only propagate to another step if you append to the env file whose name is stored in $GITHUB_ENV. Think of it like a .env to load in the next step. It is still unexplained.

So instead, the solution of [using the shell generated by setup-micromamba works fine](https://github.com/mamba-org/setup-micromamba?tab=readme-ov-file#custom-micromamba-shell-wrapper), as it correctly activates the conda env, and grass is now found on the PATH again. The micromamba-shell script looks like:

```bash
bash-3.2$ cd setup-micromamba/
bash-3.2$ ls -la
total 16
drwxr-xr-x   4 runner  staff  128 Sep 15 21:47 .
drwxr-xr-x  13 runner  staff  416 Sep 15 21:47 ..
-rw-r--r--   1 runner  staff   25 Sep 15 21:46 .condarc
-rwxr-xr-x   1 runner  staff  118 Sep 15 21:47 micromamba-shell
bash-3.2$ cat micromamba-shell
#!/usr/bin/env sh
chmod +x $1
/Users/runner/micromamba-bin/micromamba run -r /Users/runner/micromamba -n grass-env $1
bash-3.2$ cd ..
bash-3.2$ printenv | sort
``` 