### PR TITLE
CI(OSGeo4W): Add -pipe to CFLAGS and CXXFLAGS to reduce build time

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -66,7 +66,10 @@ jobs:
 
       - name: Compile GRASS GIS
         shell: msys2 {0}
-        run: .github/workflows/build_osgeo4w.sh
+        run: |
+          export CFLAGS="${CFLAGS} -pipe"
+          export CXXFLAGS="${CXXFLAGS} -pipe"
+          .github/workflows/build_osgeo4w.sh
 
       - name: Print installed versions
         if: always()


### PR DESCRIPTION
While investigating for #4323, I saw that the macOS builds used the `-pipe` flag on CFLAGS and CXXFLAGS.

I searched a little on this subject, and it is a quite old flag that was once popular when storage wasn't as fast as it now is and memory was limited. It essentially tells gcc or clang to use pipes instead of temporary files, so it might use a bit more memory. https://stackoverflow.com/questions/1512933/when-should-i-use-gccs-pipe-option https://wiki.gentoo.org/wiki/GCC_optimization#How_are_they_used.3F https://wiki.gentoo.org/wiki/GCC_optimization#-pipe
Knowing that on Windows, the IO is way worse than on Linux (at least for the machines available on the runners, they don't necessarily have the same specs), and that the preprocessing step is a lot slower, I thought it might be worth the try. Turns out it was really worth it.

With the current GitHub Hosted runners, the build step time is reduced by about 2 minutes, down to about 8min30 instead of about 10min30, for the couple builds I observed. 
**So something in the order of 20% faster.**
It's worth it.