### PR TITLE
grass.temporal: fix regression in printing metadata

### DIFF
--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -897,7 +897,6 @@ class VectorMetadata(SQLDatabaseInterface):
 
     def print_info(self):
         """Print information about this class in human readable style"""
-        #      0123456789012345678901234567890
         print(
             " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
         )

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -251,6 +251,26 @@ class RasterMetadataBase(SQLDatabaseInterface):
     min = property(fget=get_min, fset=set_min)
     max = property(fget=get_max, fset=set_max)
 
+    def print_info(self):
+        """Print information about this class in human readable style"""
+        self._print_info_body(shell=False)
+
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        self._print_info_body(shell=True)
+
+    def _print_info_head(self, shell=False):
+        """Print information about this class (head part).
+
+        No header printed in shell style mode.
+
+        :param bool shell: True for human readable style otherwise shell style
+        """
+        if not shell:
+            print(
+                " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
+            )
+
     def _print_info_body(self, shell=False):
         """Print information about this class (body part).
 
@@ -331,6 +351,7 @@ class RasterMetadata(RasterMetadataBase):
          | East-west resolution:....... 0.1
          | Minimum value:.............. 0.0
          | Maximum value:.............. 100.0
+         | Semantic label:............. None
         >>> meta.print_shell_info()
         datatype=CELL
         cols=100
@@ -340,6 +361,7 @@ class RasterMetadata(RasterMetadataBase):
         ewres=0.1
         min=0.0
         max=100.0
+        semantic_label=None
 
     """
 
@@ -384,17 +406,19 @@ class RasterMetadata(RasterMetadataBase):
 
     semantic_label = property(fget=get_semantic_label, fset=set_semantic_label)
 
-    def _print_info_body(self, shell=False):
-        """Print information about this class (body part).
-
-        :param bool shell: True for human readable style otherwise shell style
-        """
-        super()._print_info_body(shell)
+    def print_info(self):
+        """Print information about this class."""
+        self._print_info_head(shell=False)
+        self._print_info_body(shell=False)
         # semantic label section (raster specific only)
-        if shell:
-            print("semantic_label=" + str(self.get_semantic_label()))
-        else:
-            print(" | Semantic label:............. " + str(self.get_semantic_label()))
+        print(" | Semantic label:............. " + str(self.get_semantic_label()))
+
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        self._print_info_head(shell=True)
+        self._print_info_body(shell=True)
+        # semantic label section (raster specific only)
+        print("semantic_label=" + str(self.get_semantic_label()))
 
 
 ###############################################################################
@@ -539,18 +563,19 @@ class Raster3DMetadata(RasterMetadataBase):
     depths = property(fget=get_depths, fset=set_depths)
     tbres = property(fget=get_tbres, fset=set_tbres)
 
-    def _print_info_body(self, shell=False):
-        """Print information about this class (body part).
+    def print_info(self):
+        """Print information about this class."""
+        self._print_info_head(shell=False)
+        self._print_info_body(shell=False)
+        print(" | Number of depths:........... " + str(self.get_depths()))
+        print(" | Top-Bottom resolution:...... " + str(self.get_tbres()))
 
-        :param bool shell: True for human readable style otherwise shell style
-        """
-        super()._print_info_body(shell)
-        if shell:
-            print("depths=" + str(self.get_depths()))
-            print("tbres=" + str(self.get_tbres()))
-        else:
-            print(" | Number of depths:........... " + str(self.get_depths()))
-            print(" | Top-Bottom resolution:...... " + str(self.get_tbres()))
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        self._print_info_head(shell=True)
+        self._print_info_body(shell=True)
+        print("depths=" + str(self.get_depths()))
+        print("tbres=" + str(self.get_tbres()))
 
 
 ###############################################################################
@@ -870,53 +895,41 @@ class VectorMetadata(SQLDatabaseInterface):
     number_of_holes = property(fget=get_number_of_holes, fset=set_number_of_holes)
     number_of_volumes = property(fget=get_number_of_volumes, fset=set_number_of_volumes)
 
-    def _print_info_body(self, shell=False):
-        """Print information about this class (body part).
+    def print_info(self):
+        """Print information about this class in human readable style"""
+        #      0123456789012345678901234567890
+        print(
+            " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
+        )
+        print(" | Is map 3d .................. " + str(self.get_3d_info()))
+        print(" | Number of points ........... " + str(self.get_number_of_points()))
+        print(" | Number of lines ............ " + str(self.get_number_of_lines()))
+        print(" | Number of boundaries ....... " + str(self.get_number_of_boundaries()))
+        print(" | Number of centroids ........ " + str(self.get_number_of_centroids()))
+        print(" | Number of faces ............ " + str(self.get_number_of_faces()))
+        print(" | Number of kernels .......... " + str(self.get_number_of_kernels()))
+        print(" | Number of primitives ....... " + str(self.get_number_of_primitives()))
+        print(" | Number of nodes ............ " + str(self.get_number_of_nodes()))
+        print(" | Number of areas ............ " + str(self.get_number_of_areas()))
+        print(" | Number of islands .......... " + str(self.get_number_of_islands()))
+        print(" | Number of holes ............ " + str(self.get_number_of_holes()))
+        print(" | Number of volumes .......... " + str(self.get_number_of_volumes()))
 
-        :param bool shell: True for human readable style otherwise shell style
-        """
-        if shell:
-            print("is_3d=" + str(self.get_3d_info()))
-            print("points=" + str(self.get_number_of_points()))
-            print("lines=" + str(self.get_number_of_lines()))
-            print("boundaries=" + str(self.get_number_of_boundaries()))
-            print("centroids=" + str(self.get_number_of_centroids()))
-            print("faces=" + str(self.get_number_of_faces()))
-            print("kernels=" + str(self.get_number_of_kernels()))
-            print("primitives=" + str(self.get_number_of_primitives()))
-            print("nodes=" + str(self.get_number_of_nodes()))
-            print("areas=" + str(self.get_number_of_areas()))
-            print("islands=" + str(self.get_number_of_islands()))
-            print("holes=" + str(self.get_number_of_holes()))
-            print("volumes=" + str(self.get_number_of_volumes()))
-        else:
-            print(" | Is map 3d .................. " + str(self.get_3d_info()))
-            print(" | Number of points ........... " + str(self.get_number_of_points()))
-            print(" | Number of lines ............ " + str(self.get_number_of_lines()))
-            print(
-                " | Number of boundaries ....... "
-                + str(self.get_number_of_boundaries())
-            )
-            print(
-                " | Number of centroids ........ " + str(self.get_number_of_centroids())
-            )
-            print(" | Number of faces ............ " + str(self.get_number_of_faces()))
-            print(
-                " | Number of kernels .......... " + str(self.get_number_of_kernels())
-            )
-            print(
-                " | Number of primitives ....... "
-                + str(self.get_number_of_primitives())
-            )
-            print(" | Number of nodes ............ " + str(self.get_number_of_nodes()))
-            print(" | Number of areas ............ " + str(self.get_number_of_areas()))
-            print(
-                " | Number of islands .......... " + str(self.get_number_of_islands())
-            )
-            print(" | Number of holes ............ " + str(self.get_number_of_holes()))
-            print(
-                " | Number of volumes .......... " + str(self.get_number_of_volumes())
-            )
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        print("is_3d=" + str(self.get_3d_info()))
+        print("points=" + str(self.get_number_of_points()))
+        print("lines=" + str(self.get_number_of_lines()))
+        print("boundaries=" + str(self.get_number_of_boundaries()))
+        print("centroids=" + str(self.get_number_of_centroids()))
+        print("faces=" + str(self.get_number_of_faces()))
+        print("kernels=" + str(self.get_number_of_kernels()))
+        print("primitives=" + str(self.get_number_of_primitives()))
+        print("nodes=" + str(self.get_number_of_nodes()))
+        print("areas=" + str(self.get_number_of_areas()))
+        print("islands=" + str(self.get_number_of_islands()))
+        print("holes=" + str(self.get_number_of_holes()))
+        print("volumes=" + str(self.get_number_of_volumes()))
 
 
 ###############################################################################
@@ -1034,13 +1047,11 @@ class STDSMetadataBase(SQLDatabaseInterface):
 
     def print_info(self):
         """Print information about this class in human readable style"""
-        self._print_info_head(shell=False)
         self._print_info_body(shell=False)
         self._print_info_tail(shell=False)
 
     def print_shell_info(self):
         """Print information about this class in shell style"""
-        self._print_info_head(shell=True)
         self._print_info_body(shell=True)
         self._print_info_tail(shell=True)
 
@@ -1055,6 +1066,12 @@ class STDSMetadataBase(SQLDatabaseInterface):
             print(
                 " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
             )
+
+    def _print_info_body(self, shell=False):
+        """Print information about this class (body part).
+
+        :param bool shell: True for human readable style otherwise shell style
+        """
 
     def _print_info_tail(self, shell=False):
         """Print information about this class (tail part).
@@ -1476,6 +1493,16 @@ class STRDSMetadata(STDSRasterMetadataBase):
     number_of_semantic_labels = property(fget=get_number_of_semantic_labels)
     semantic_labels = property(fget=get_semantic_labels)
 
+    def print_info(self):
+        """Print information about this class in human readable style"""
+        self._print_info_head(shell=False)
+        super().print_info()
+
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        self._print_info_head(shell=True)
+        super().print_shell_info()
+
     def _print_info_body(self, shell=False):
         """Print information about this class (body part).
 
@@ -1562,6 +1589,8 @@ class STR3DSMetadata(STDSRasterMetadataBase):
          | Command history:
         >>> meta.print_shell_info()
         raster3d_register=None
+        tbres_min=None
+        tbres_max=None
         nsres_min=None
         nsres_max=None
         ewres_min=None
@@ -1570,8 +1599,6 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         min_max=None
         max_min=None
         max_max=None
-        tbres_min=None
-        tbres_max=None
         aggregation_type=None
         number_of_maps=None
 
@@ -1623,6 +1650,16 @@ class STR3DSMetadata(STDSRasterMetadataBase):
     raster3d_register = property(fget=get_raster3d_register, fset=set_raster3d_register)
     tbres_min = property(fget=get_tbres_min)
     tbres_max = property(fget=get_tbres_max)
+
+    def print_info(self):
+        """Print information about this class in human readable style"""
+        self._print_info_head(shell=False)
+        super().print_info()
+
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        self._print_info_head(shell=True)
+        super().print_shell_info()
 
     def _print_info_body(self, shell=False):
         """Print information about this class (body part).
@@ -1888,6 +1925,16 @@ class STVDSMetadata(STDSMetadataBase):
     number_of_islands = property(fget=get_number_of_islands)
     number_of_holes = property(fget=get_number_of_holes)
     number_of_volumes = property(fget=get_number_of_volumes)
+
+    def print_info(self):
+        """Print information about this class in human readable style"""
+        self._print_info_head(shell=False)
+        super().print_info()
+
+    def print_shell_info(self):
+        """Print information about this class in shell style"""
+        self._print_info_head(shell=True)
+        super().print_shell_info()
 
     def _print_info_body(self, shell=False):
         """Print information about this class (body part).


### PR DESCRIPTION
Fixes #4182 (t.info fails for single registered raster). I tried to work with the current design, although it might have been just easier to revert 7df1a7e, the method inheritance doesn't work very well there.

Besides the reported error, `STDSMetadataBase.print_info()` was also failing. I tested it with the currently deactivated doctests (there are issue running the doctests unrelated to this).