### PR TITLE
lib/gis: match prototype with declaration for G_strlcat and G_strlcpy

### DIFF
--- a/lib/gis/strlcat.c
+++ b/lib/gis/strlcat.c
@@ -28,6 +28,9 @@
 #include <stddef.h>
 #include <string.h>
 
+static size_t G__strlcat(char *restrict dst, const char *restrict src,
+                         size_t dsize);
+
 /**
  * \brief Size-bounded string concatenation
  *
@@ -51,12 +54,18 @@
  *         including the terminating NUL character). If the return value
  *         is >= dsize, truncation occurred.
  */
-
-size_t G_strlcat(char *restrict dst, const char *restrict src, size_t dsize)
+size_t G_strlcat(char *dst, const char *src, size_t dsize)
 {
 #ifdef HAVE_STRLCAT
     return strlcat(dst, src, dsize);
 #else
+    return G__strlcat(dst, src, dsize);
+#endif
+}
+
+static size_t G__strlcat(char *restrict dst, const char *restrict src,
+                         size_t dsize)
+{
     const char *odst = dst;
     const char *osrc = src;
     size_t n = dsize;
@@ -80,5 +89,4 @@ size_t G_strlcat(char *restrict dst, const char *restrict src, size_t dsize)
     *dst = '\0';
 
     return (dlen + (src - osrc)); /* count does not include NUL */
-#endif
 }

--- a/lib/gis/strlcpy.c
+++ b/lib/gis/strlcpy.c
@@ -22,6 +22,9 @@
 
 #include <stddef.h>
 
+static size_t G__strlcpy(char *restrict dst, const char *restrict src,
+                         size_t dsize);
+
 /**
  * \brief Safe string copy function.
  *
@@ -46,12 +49,18 @@
  * \warning The src string must be a valid NUL-terminated C string. Passing an
  *          unterminated string may result in buffer overrun.
  */
-
-size_t G_strlcpy(char *restrict dst, const char *restrict src, size_t dsize)
+size_t G_strlcpy(char *dst, const char *src, size_t dsize)
 {
 #ifdef HAVE_STRLCPY
     return strlcpy(dst, src, dsize);
 #else
+    return G__strlcpy(dst, src, dsize);
+#endif
+}
+
+static size_t G__strlcpy(char *restrict dst, const char *restrict src,
+                         size_t dsize)
+{
     const char *osrc = src;
     size_t nleft = dsize;
 
@@ -72,5 +81,4 @@ size_t G_strlcpy(char *restrict dst, const char *restrict src, size_t dsize)
     }
 
     return (src - osrc - 1); /* count does not include NUL */
-#endif
 }


### PR DESCRIPTION
Make local implementations of strlcpy() and strlcat() optimizable by using restrict type qualifier, while keeping public API for G_strlcat and G_strlcpy available to C++ code and having identical prototype and declaration.

Currently the prototypes look like:

```c
size_t G_strlcat(char *, const char *, size_t);
```
but declared as:

```c
size_t G_strlcat(char *restrict dst, const char *restrict src, size_t dsize) { ...}
```

which the compilers seem to accept, but was probably not the best choice.
