### PR TITLE
t.rast.univar: Use pathlib Path.read_text to open test outputs in t.rast.univar and t.rast3d.univar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -376,7 +376,6 @@ ignore = [
 "temporal/t.rast.algebra/testsu*/*_algebra_arithmetic.py" = ["FLY002"]
 "temporal/t.rast.colors/t.rast.colors.py" = ["SIM115"]
 "temporal/t.rast.series/t.rast.series.py" = ["SIM115"]
-"temporal/t.rast.univar/testsuite/test_t_rast_univar.py" = ["SIM115"]
 "temporal/t.rast.what/t.rast.what.py" = ["SIM115"]
 "temporal/t.register/testsu*/*_raster_different_local.py" = ["FLY002"]
 "temporal/t.register/testsu*/*_raster_mapmetadata.py" = ["FLY002"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,7 +378,6 @@ ignore = [
 "temporal/t.rast.series/t.rast.series.py" = ["SIM115"]
 "temporal/t.rast.univar/testsuite/test_t_rast_univar.py" = ["SIM115"]
 "temporal/t.rast.what/t.rast.what.py" = ["SIM115"]
-"temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py" = ["SIM115"]
 "temporal/t.register/testsu*/*_raster_different_local.py" = ["FLY002"]
 "temporal/t.register/testsu*/*_raster_mapmetadata.py" = ["FLY002"]
 "temporal/t.register/testsuite/test_t_register_raster.py" = ["FLY002"]

--- a/temporal/t.rast.univar/testsuite/test_t_rast_univar.py
+++ b/temporal/t.rast.univar/testsuite/test_t_rast_univar.py
@@ -8,6 +8,7 @@ for details.
 @author Soeren Gebbert
 """
 
+from pathlib import Path
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
@@ -243,7 +244,7 @@ a_2@testing||2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|19200
 a_3@testing||2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600
 a_4@testing||2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600
 """
-        univar_output = open("univar_output.txt", "r").read()
+        univar_output = Path("univar_output.txt").read_text()
 
         for ref, res in zip(univar_text.split("\n"), univar_output.split("\n")):
             if ref and res:
@@ -269,7 +270,7 @@ a_2@m2||2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|1920000|0|
 a_3@m2||2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600|300|300|300|300|300
 a_4@m2||2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600|400|400|400|400|400
 """
-        univar_output = open("univar_output.txt", "r").read()
+        univar_output = Path("univar_output.txt").read_text()
 
         for ref, res in zip(univar_text.split("\n"), univar_output.split("\n")):
             if ref and res:
@@ -292,7 +293,7 @@ a_4@m2||2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|
 a_3@testing||2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|2880000|0|9600|9600
 a_4@testing||2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|3840000|0|9600|9600
 """
-        univar_output = open("univar_output.txt", "r").read()
+        univar_output = Path("univar_output.txt").read_text()
 
         for ref, res in zip(univar_text.split("\n"), univar_output.split("\n")):
             if ref and res:

--- a/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
+++ b/temporal/t.rast3d.univar/testsuite/test_t_rast3d_univar.py
@@ -8,6 +8,7 @@ for details.
 @author Soeren Gebbert
 """
 
+from pathlib import Path
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
@@ -119,7 +120,7 @@ a_2@testing|2001-04-01 00:00:00|2001-07-01 00:00:00|200|200|200|200|0|0|0|960000
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|144000000|0|480000|480000
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000000|0|480000|480000
 """
-        univar_output = open("univar_output.txt", "r").read()
+        univar_output = Path("univar_output.txt").read_text()
 
         for ref, res in zip(univar_text.split("\n"), univar_output.split("\n")):
             if ref and res:
@@ -142,7 +143,7 @@ a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000
 a_3@testing|2001-07-01 00:00:00|2001-10-01 00:00:00|300|300|300|300|0|0|0|144000000|0|480000|480000
 a_4@testing|2001-10-01 00:00:00|2002-01-01 00:00:00|400|400|400|400|0|0|0|192000000|0|480000|480000
 """
-        univar_output = open("univar_output.txt", "r").read()
+        univar_output = Path("univar_output.txt").read_text()
 
         for ref, res in zip(univar_text.split("\n"), univar_output.split("\n")):
             if ref and res:


### PR DESCRIPTION
Resolves some ResourceWarnings, and also ruff SIM115.