### PR TITLE
grass.gunittest: Fix SIM115 using context managers to open files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,6 @@ ignore = [
 "python/grass/__init__.py" = ["PYI056"]
 "python/grass/exp*/tests/grass_script_mapset_session_test.py" = ["SIM117"]
 "python/grass/exp*/tests/grass_script_tmp_mapset_session_test.py" = ["SIM117"]
-"python/grass/gunittest/*.py" = ["SIM115"]
 "python/grass/gunittest/loader.py" = ["PYI024"]
 "python/grass/gunittest/multireport.py" = ["PYI024"]
 "python/grass/gunittest/testsu*/d*/s*/s*/subsub*/t*/test_segfaut.py" = ["B018"]

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1288,8 +1288,9 @@ class TestCase(unittest.TestCase):
                     "actual",
                     context=True,
                     numlines=context_lines,
+                    charset="utf-8",
                 )
-                with open(htmldiff_file_name, "w") as htmldiff_file:
+                with open(htmldiff_file_name, "w", encoding="utf-8") as htmldiff_file:
                     for line in htmldiff:
                         htmldiff_file.write(line)
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1254,18 +1254,18 @@ class TestCase(unittest.TestCase):
             os.remove(reference)
         stdmsg = "There is a difference between vectors when compared as ASCII files.\n"
 
-        output = StringIO()
         # TODO: there is a diff size constant which we can use
         # we are setting it unlimited but we can just set it large
         maxlines = 100
         i = 0
-        for line in diff:
-            if i >= maxlines:
-                break
-            output.write(line)
-            i += 1
-        stdmsg += output.getvalue()
-        output.close()
+        with StringIO() as output:
+            for line in diff:
+                if i >= maxlines:
+                    break
+                output.write(line)
+                i += 1
+            stdmsg += output.getvalue()
+
         # it seems that there is not better way of asking whether there was
         # a difference (always a iterator object is returned)
         if i > 0:

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1289,10 +1289,9 @@ class TestCase(unittest.TestCase):
                     context=True,
                     numlines=context_lines,
                 )
-                htmldiff_file = open(htmldiff_file_name, "w")
-                for line in htmldiff:
-                    htmldiff_file.write(line)
-                htmldiff_file.close()
+                with open(htmldiff_file_name, "w") as htmldiff_file:
+                    for line in htmldiff:
+                        htmldiff_file.write(line)
 
             self.fail(self._formatMessage(msg, stdmsg))
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1291,8 +1291,7 @@ class TestCase(unittest.TestCase):
                     charset="utf-8",
                 )
                 with open(htmldiff_file_name, "w", encoding="utf-8") as htmldiff_file:
-                    for line in htmldiff:
-                        htmldiff_file.write(line)
+                    htmldiff_file.write(htmldiff)
 
             self.fail(self._formatMessage(msg, stdmsg))
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -10,6 +10,7 @@ for details.
 """
 
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import hashlib
@@ -1290,8 +1291,7 @@ class TestCase(unittest.TestCase):
                     numlines=context_lines,
                     charset="utf-8",
                 )
-                with open(htmldiff_file_name, "w", encoding="utf-8") as htmldiff_file:
-                    htmldiff_file.write(htmldiff)
+                Path(htmldiff_file_name).write_text(htmldiff, encoding="utf-8")
 
             self.fail(self._formatMessage(msg, stdmsg))
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1228,8 +1228,9 @@ class TestCase(unittest.TestCase):
         """
         import difflib
 
-        fromlines = open(actual).readlines()
-        tolines = open(reference).readlines()
+        with open(actual) as f1, open(reference) as f2:
+            fromlines = f1.readlines()
+            tolines = f2.readlines()
         context_lines = 3  # number of context lines
         # TODO: filenames are set to "actual" and "reference", isn't it too general?
         # it is even more useful if map names or file names are some generated

--- a/python/grass/gunittest/multireport.py
+++ b/python/grass/gunittest/multireport.py
@@ -16,6 +16,7 @@ import itertools
 import datetime
 import operator
 from collections import defaultdict, namedtuple
+from pathlib import Path
 
 from grass.gunittest.checkers import text_to_keyvalue
 from grass.gunittest.utils import ensure_dir
@@ -472,7 +473,7 @@ def main():
                 # skipping incomplete reports
                 # use only results list for further processing
                 continue
-            summary = text_to_keyvalue(open(summary_file).read(), sep="=")
+            summary = text_to_keyvalue(Path(summary_file).read_text(), sep="=")
             if use_timestamps:
                 test_timestamp = datetime.datetime.fromtimestamp(
                     os.path.getmtime(summary_file)
@@ -516,147 +517,156 @@ def main():
         except KeyError as e:
             print("File %s does not have right values (%s)" % (report, e.message))
 
-    locations_main_page = open(os.path.join(output, "index.html"), "w")
-    locations_main_page.write(
-        "<html><body>"
-        "<h1>Test reports grouped by location type</h1>"
-        "<table>"
-        "<thead><tr>"
-        "<th>Location</th>"
-        "<th>Successful files</th><th>Successful tests</th>"
-        "</tr></thead>"
-        "<tbody>"
-    )
+    with open(os.path.join(output, "index.html"), "w") as locations_main_page:
+        locations_main_page.write(
+            "<html><body>"
+            "<h1>Test reports grouped by location type</h1>"
+            "<table>"
+            "<thead><tr>"
+            "<th>Location</th>"
+            "<th>Successful files</th><th>Successful tests</th>"
+            "</tr></thead>"
+            "<tbody>"
+        )
 
-    PlotStyle = namedtuple(
-        "PlotStyle",
-        ["linestyle", "linewidth", "success_color", "fail_color", "total_color"],
-    )
-    plot_style = PlotStyle(
-        linestyle="-", linewidth=4.0, success_color="g", fail_color="r", total_color="b"
-    )
+        PlotStyle = namedtuple(
+            "PlotStyle",
+            ["linestyle", "linewidth", "success_color", "fail_color", "total_color"],
+        )
+        plot_style = PlotStyle(
+            linestyle="-",
+            linewidth=4.0,
+            success_color="g",
+            fail_color="r",
+            total_color="b",
+        )
 
-    for location_type, results in results_in_locations.items():
-        results = sorted(results, key=operator.attrgetter("timestamp"))
-        # TODO: document: location type must be a valid dir name
-        directory = os.path.join(output, location_type)
-        ensure_dir(directory)
+        for location_type, results in results_in_locations.items():
+            results = sorted(results, key=operator.attrgetter("timestamp"))
+            # TODO: document: location type must be a valid dir name
+            directory = os.path.join(output, location_type)
+            ensure_dir(directory)
 
-        if location_type == "unknown":
-            title = "Test reports"
-        else:
-            title = "Test reports for &lt;{type}&gt; location type".format(
-                type=location_type
+            if location_type == "unknown":
+                title = "Test reports"
+            else:
+                title = "Test reports for &lt;{type}&gt; location type".format(
+                    type=location_type
+                )
+
+            x = [date2num(result.timestamp) for result in results]
+            # the following would be an alternative but it does not work with
+            # labels and automatic axis limits even after removing another date fun
+            # x = [result.svn_revision for result in results]
+            xlabels = [
+                result.timestamp.strftime("%Y-%m-%d")
+                + " (r"
+                + result.svn_revision
+                + ")"
+                for result in results
+            ]
+            step = len(x) / 10
+            xticks = x[step::step]
+            xlabels = xlabels[step::step]
+            tests_successful_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "tests_successful_plot.png"),
+                style=plot_style,
+            )
+            files_successful_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "files_successful_plot.png"),
+                style=plot_style,
+            )
+            tests_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "tests_plot.png"),
+                style=plot_style,
+            )
+            tests_percent_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "tests_percent_plot.png"),
+                style=plot_style,
+            )
+            files_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "files_plot.png"),
+                style=plot_style,
+            )
+            files_percent_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "files_percent_plot.png"),
+                style=plot_style,
+            )
+            info_plot(
+                x=x,
+                xticks=xticks,
+                xlabels=xlabels,
+                results=results,
+                filename=os.path.join(directory, "info_plot.png"),
+                style=plot_style,
             )
 
-        x = [date2num(result.timestamp) for result in results]
-        # the following would be an alternative but it does not work with
-        # labels and automatic axis limits even after removing another date fun
-        # x = [result.svn_revision for result in results]
-        xlabels = [
-            result.timestamp.strftime("%Y-%m-%d") + " (r" + result.svn_revision + ")"
-            for result in results
-        ]
-        step = len(x) / 10
-        xticks = x[step::step]
-        xlabels = xlabels[step::step]
-        tests_successful_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "tests_successful_plot.png"),
-            style=plot_style,
-        )
-        files_successful_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "files_successful_plot.png"),
-            style=plot_style,
-        )
-        tests_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "tests_plot.png"),
-            style=plot_style,
-        )
-        tests_percent_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "tests_percent_plot.png"),
-            style=plot_style,
-        )
-        files_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "files_plot.png"),
-            style=plot_style,
-        )
-        files_percent_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "files_percent_plot.png"),
-            style=plot_style,
-        )
-        info_plot(
-            x=x,
-            xticks=xticks,
-            xlabels=xlabels,
-            results=results,
-            filename=os.path.join(directory, "info_plot.png"),
-            style=plot_style,
-        )
+            main_page(
+                results=results,
+                filename="index.html",
+                images=[
+                    "tests_successful_plot.png",
+                    "files_successful_plot.png",
+                    "tests_plot.png",
+                    "files_plot.png",
+                    "tests_percent_plot.png",
+                    "files_percent_plot.png",
+                    "info_plot.png",
+                ],
+                captions=[
+                    "Success of individual tests in percents",
+                    "Success of test files in percents",
+                    "Successes, failures and number of individual tests",
+                    "Successes, failures and number of test files",
+                    "Successes and failures of individual tests in percent",
+                    "Successes and failures of test files in percents",
+                    "Additional information",
+                ],
+                directory=directory,
+                title=title,
+            )
 
-        main_page(
-            results=results,
-            filename="index.html",
-            images=[
-                "tests_successful_plot.png",
-                "files_successful_plot.png",
-                "tests_plot.png",
-                "files_plot.png",
-                "tests_percent_plot.png",
-                "files_percent_plot.png",
-                "info_plot.png",
-            ],
-            captions=[
-                "Success of individual tests in percents",
-                "Success of test files in percents",
-                "Successes, failures and number of individual tests",
-                "Successes, failures and number of test files",
-                "Successes and failures of individual tests in percent",
-                "Successes and failures of test files in percents",
-                "Additional information",
-            ],
-            directory=directory,
-            title=title,
-        )
+            files_successes = sum(result.files_successes for result in results)
+            files_total = sum(result.files_total for result in results)
+            successes = sum(result.successes for result in results)
+            total = sum(result.total for result in results)
+            per_test = success_to_html_percent(total=total, successes=successes)
+            per_file = success_to_html_percent(
+                total=files_total, successes=files_successes
+            )
+            locations_main_page.write(
+                "<tr>"
+                "<td><a href={location}/index.html>{location}</a></td>"
+                "<td>{pfiles}</td><td>{ptests}</td>"
+                "</tr>".format(location=location_type, pfiles=per_file, ptests=per_test)
+            )
+        locations_main_page.write("</tbody></table>")
+        locations_main_page.write("</body></html>")
 
-        files_successes = sum(result.files_successes for result in results)
-        files_total = sum(result.files_total for result in results)
-        successes = sum(result.successes for result in results)
-        total = sum(result.total for result in results)
-        per_test = success_to_html_percent(total=total, successes=successes)
-        per_file = success_to_html_percent(total=files_total, successes=files_successes)
-        locations_main_page.write(
-            "<tr>"
-            "<td><a href={location}/index.html>{location}</a></td>"
-            "<td>{pfiles}</td><td>{ptests}</td>"
-            "</tr>".format(location=location_type, pfiles=per_file, ptests=per_test)
-        )
-    locations_main_page.write("</tbody></table>")
-    locations_main_page.write("</body></html>")
-    locations_main_page.close()
     return 0
 
 

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -728,8 +728,7 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
         )
 
         file_index_path = os.path.join(cwd, "index.html")
-        file_index = open(file_index_path, "w")
-        file_index.write(
+        header = (
             '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>'
             "<h1>{m.name}</h1>"
             "<h2>{m.tested_dir} &ndash; {m.name}</h2>"
@@ -768,7 +767,6 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
                 dur=self.file_time,
             )
         )
-        file_index.write(summary_section)
 
         modules = test_summary.get("tested_modules", None)
         if modules:
@@ -777,12 +775,6 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
             # alternatively a link to module test summary
             if type(modules) is not list:
                 modules = [modules]
-            file_index.write(
-                "<tr><td>Tested modules</td><td>{0}</td></tr>".format(
-                    ", ".join(sorted(set(modules)))
-                )
-            )
-        file_index.write("</tbody></table>")
 
         # here we would have also links to coverage, profiling, ...
         # '<li><a href="testcodecoverage/index.html">code coverage</a></li>'
@@ -792,7 +784,6 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
             '<li><a href="stdout.html">standard output (stdout)</a></li>'
             '<li><a href="stderr.html">standard error output (stderr)</a></li>'
         )
-        file_index.write(files_section)
 
         supplementary_files = test_summary.get("supplementary_files", None)
         if supplementary_files:
@@ -804,17 +795,31 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
             # moreover something can be shared with other explicitly
             # using constructors as seems advantageous for counting
             self._file_anonymizer.anonymize(supplementary_files)
-            for f in supplementary_files:
-                file_index.write('<li><a href="{f}">{f}</a></li>'.format(f=f))
 
-        file_index.write("</ul>")
+        with open(file_index_path, "w") as file_index:
+            file_index.write(header)
+            file_index.write(summary_section)
+            if modules:
+                file_index.write(
+                    "<tr><td>Tested modules</td><td>{0}</td></tr>".format(
+                        ", ".join(sorted(set(modules)))
+                    )
+                )
+            file_index.write("</tbody></table>")
 
-        if returncode:
-            file_index.write("<h3>Standard error output (stderr)</h3>")
-            file_index.write(html_file_preview(stderr))
+            file_index.write(files_section)
 
-        file_index.write("</body></html>")
-        file_index.close()
+            if supplementary_files:
+                for f in supplementary_files:
+                    file_index.write('<li><a href="{f}">{f}</a></li>'.format(f=f))
+
+            file_index.write("</ul>")
+
+            if returncode:
+                file_index.write("<h3>Standard error output (stderr)</h3>")
+                file_index.write(html_file_preview(stderr))
+
+            file_index.write("</body></html>")
 
         if returncode:
             pass

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -1228,7 +1228,6 @@ class TestsuiteDirReporter:
         # absolute/relative paths
 
         page_name = os.path.join(root, self.main_page_name)
-        page = open(page_name, "w")
         head = "<html><body><h1>Testsuites results</h1>"
         tests_table_head = (
             "<table>"
@@ -1241,14 +1240,6 @@ class TestsuiteDirReporter:
             "<th>Failed</th><th>Percent successful</th>"
             "</tr></thead><tbody>"
         )
-        page.write(head)
-        page.write(tests_table_head)
-
-        for directory, test_files in directories.items():
-            row = self.report_for_dir(
-                root=root, directory=directory, test_files=test_files
-            )
-            page.write(row)
 
         pass_per = success_to_html_percent(total=self.total, successes=self.successes)
         file_pass_per = success_to_html_percent(
@@ -1276,5 +1267,16 @@ class TestsuiteDirReporter:
                 ptests=pass_per,
             )
         )
-        page.write(tests_table_foot)
-        page.write("</body></html>")
+
+        with open(page_name, "w") as page:
+            page.write(head)
+            page.write(tests_table_head)
+
+            for directory, test_files in directories.items():
+                row = self.report_for_dir(
+                    root=root, directory=directory, test_files=test_files
+                )
+                page.write(row)
+
+            page.write(tests_table_foot)
+            page.write("</body></html>")

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -51,12 +51,9 @@ def replace_in_file(file_path, pattern, repl):
     """
     # using tmp file to store the replaced content
     tmp_file_path = file_path + ".tmp"
-    old_file = open(file_path, "r")
-    new_file = open(tmp_file_path, "w")
-    for line in old_file:
-        new_file.write(re.sub(pattern=pattern, string=line, repl=repl))
-    new_file.close()
-    old_file.close()
+    with open(file_path, "r") as old_file, open(tmp_file_path, "w") as new_file:
+        for line in old_file:
+            new_file.write(re.sub(pattern=pattern, string=line, repl=repl))
     # remove old file since it must not exist for rename/move
     os.remove(file_path)
     # replace old file by new file

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -452,13 +452,11 @@ def percent_to_html(percent):
 def wrap_stdstream_to_html(infile, outfile, module, stream):
     before = "<html><body><h1>%s</h1><pre>" % (module.name + " " + stream)
     after = "</pre></body></html>"
-    html = open(outfile, "w")
-    html.write(before)
-    with open(infile) as text:
+    with open(outfile, "w") as html, open(infile) as text:
+        html.write(before)
         for line in text:
             html.write(color_error_line(html_escape(line)))
-    html.write(after)
-    html.close()
+        html.write(after)
 
 
 def html_file_preview(filename):

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -477,7 +477,7 @@ def html_file_preview(filename):
     elif size < 10 * max_size:
 
         def tail(filename, n):
-            return collections.deque(open(filename), n)
+            return collections.deque(open(filename), n)  # noqa: SIM115
 
         html.write("... (lines omitted)\n")
         for line in tail(filename, 50):
@@ -559,7 +559,8 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
         super().start(results_dir)
         # having all variables public although not really part of API
         main_page_name = os.path.join(results_dir, self._main_page_name)
-        self.main_index = open(main_page_name, "w")
+        # TODO: Ensure file is closed in all situations
+        self.main_index = open(main_page_name, "w")  # noqa: SIM115
 
         # TODO: this can be moved to the counter class
         self.failures = 0


### PR DESCRIPTION
Fixes all SIM115 issues in gunittest, except for two where I couldn't find a way to address with enough confidence for use in our own testing (one is not resolvable with context managers, as the opened file descriptor is assigned to the class in one function, and expected to be closed by another call at the end of the execution).


Only in two functions I had to resort to indent the most of the function since there were usages of the file descriptor throughout the function, and was used inside and outside a loop.

Otherwise, I tried to keep the amount of lines needing an indentation to a minimum, by moving down the variables needing to be within the `with` closer to that construct (in other words, placing variables assignments out the `with` further up, that ends up being understood by git as no changes except deleting the existing opening of file/writing of file, and some new code underneath with a smaller `with` context manager).


Adresses ResourceWarnings like (CI on Windows):
![image](https://github.com/user-attachments/assets/35dad715-d882-40f1-b468-535b280954ba)
![image](https://github.com/user-attachments/assets/4d247778-8efd-4324-8f2f-98710daeaf9d)
![image](https://github.com/user-attachments/assets/218305c0-4c8e-494a-a484-87d57a59526a)
![image](https://github.com/user-attachments/assets/44a9a9a1-85a7-4d04-a935-7373379331fe)

