### PR TITLE
CI(OSGeo4W): Update min-success to 86% for gunittest on Windows

### DIFF
--- a/.github/workflows/test_thorough.bat
+++ b/.github/workflows/test_thorough.bat
@@ -2,4 +2,4 @@ set grass=%1
 set python=%2
 
 call %grass% --tmp-project XY --exec g.download.project url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=%USERPROFILE%
-call %grass% --tmp-project XY --exec %python% -m grass.gunittest.main --grassdata %USERPROFILE% --location nc_spm_full_v2alpha2 --location-type nc --min-success 80
+call %grass% --tmp-project XY --exec %python% -m grass.gunittest.main --grassdata %USERPROFILE% --location nc_spm_full_v2alpha2 --location-type nc --min-success 86


### PR DESCRIPTION
Following #4324, that now has the excluded tests be properly excluded on Windows like they are on Linux, this increases the success threshold for gunittest tests on Windows to 86%. Even if we see 87%, it is 86.xx%, so not greater than or equal to 87%.
