### PR TITLE
configure: fix default variable name for blas and lapack

### DIFF
--- a/configure
+++ b/configure
@@ -5611,7 +5611,7 @@ if test ${with_blas+y}
 then :
   withval=$with_blas;
 else $as_nop
-  with-blas="no"
+  with_blas=no
 fi
 
 
@@ -5621,7 +5621,7 @@ if test ${with_lapack+y}
 then :
   withval=$with_lapack;
 else $as_nop
-  with-lapack="no"
+  with_lapack=no
 fi
 
 
@@ -13719,10 +13719,10 @@ case "$with_blas" in
   no)
     ;;
   yes)
-    USE_BLAS="$with_blas"
+    USE_BLAS=1
     ;;
   *)
-    USE_BLAS=yes
+    USE_BLAS=1
     BLAS_PKGS="$with_blas"
     ;;
 esac
@@ -13832,15 +13832,21 @@ case "$with_lapack" in
   no)
     ;;
   yes)
-    USE_LAPACK="$with_lapack"
+    USE_LAPACK=1
     ;;
   *)
-    USE_LAPACK=yes
+    USE_LAPACK=1
     LAPACK_PKG="$with_lapack"
     ;;
 esac
 
 # LAPACK is useless without BLAS
+if test -z "$USE_BLAS" && test -n "$USE_LAPACK"; then
+  USE_LAPACK=
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: LAPACK is disabled, BLAS configuration is missing" >&5
+printf "%s\n" "$as_me: WARNING: LAPACK is disabled, BLAS configuration is missing" >&2;}
+fi
+
 if test -n "$USE_BLAS" && test -n "$USE_LAPACK"; then
 
   lapack_ok=no

--- a/configure.ac
+++ b/configure.ac
@@ -323,13 +323,13 @@ AC_ARG_WITH([blas],
   [AS_HELP_STRING([--with-blas=pkg-config-package],
     [enable BLAS support with by adding name of pkg-config package name
      for CBLAS library, e.g. '--with-lapack-package=openblas',
-     default: cblas])],, [with-blas="no"])
+     default: cblas])],, [with_blas=no])
 
 AC_ARG_WITH([lapack],
   [AS_HELP_STRING([--with-lapack=pkg-config-package],
     [enable LAPACK support with by adding name of pkg-config package name
      for LAPACKE library, e.g. '--with-lapack-package=openblas',
-     default: lapacke])],, [with-lapack="no"])
+     default: lapacke])],, [with_lapack=no])
 
 AC_ARG_WITH(libpng,
 [  --with-libpng[=path/libpng-config]
@@ -1594,10 +1594,10 @@ case "$with_blas" in
   no)
     ;;
   yes)
-    USE_BLAS="$with_blas"
+    USE_BLAS=1
     ;;
   *)
-    USE_BLAS=yes
+    USE_BLAS=1
     BLAS_PKGS="$with_blas"
     ;;
 esac
@@ -1665,15 +1665,20 @@ case "$with_lapack" in
   no)
     ;;
   yes)
-    USE_LAPACK="$with_lapack"
+    USE_LAPACK=1
     ;;
   *)
-    USE_LAPACK=yes
+    USE_LAPACK=1
     LAPACK_PKG="$with_lapack"
     ;;
 esac
 
 # LAPACK is useless without BLAS
+if test -z "$USE_BLAS" && test -n "$USE_LAPACK"; then
+  USE_LAPACK=
+  AC_MSG_WARN([LAPACK is disabled, BLAS configuration is missing])
+fi
+
 if test -n "$USE_BLAS" && test -n "$USE_LAPACK"; then
 
   lapack_ok=no


### PR DESCRIPTION
Fix for bug in configuration of BLAS/LAPACK as revealed by Docker failures.

The problem was caused by a typo of the variable names `with_blas` and `with_lapack`.

In addition: improve handling of configuration with LAPACK without BLAS