### PR TITLE
style: Bump Black's target Python versions for Python 3.9 minimum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.9"
 [tool.black]
 required-version = '24'
 line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 # 'extend-exclude' excludes files or directories in addition to the defaults
 extend-exclude = '''
 (

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -470,9 +470,10 @@ def replace_shebang_win(python_file):
     cur_dir = os.path.dirname(python_file)
     tmp_name = os.path.join(cur_dir, gs.tempname(12))
 
-    with codecs.open(python_file, "r", encoding="utf8") as in_file, codecs.open(
-        tmp_name, "w", encoding="utf8"
-    ) as out_file:
+    with (
+        codecs.open(python_file, "r", encoding="utf8") as in_file,
+        codecs.open(tmp_name, "w", encoding="utf8") as out_file,
+    ):
         for line in in_file:
             new_line = line.replace(
                 "#!/usr/bin/env python\n", "#!/usr/bin/env python3\n"


### PR DESCRIPTION
As mentioned in https://github.com/OSGeo/grass/pull/4291#issuecomment-2359894484, the minimum supported Python version of the main branch is 3.9 for a while now, but we still had Black configured to restrict itself to Python 3.8 support.

This PR removes 3.8 from the list of target versions, and adds 3.13, that is going to be released in 12 days (Oct 1, 2024).


This allows Black to use language syntax not available in 3.8, like line breaks in parenthesized `with` context managers.
