### PR TITLE
tools: Flake8 - Fix undefined variable 'b' in single-band case of write_cpp function

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,7 +21,6 @@ per-file-ignores =
     # E741 ambiguous variable name 'l'
     __init__.py: F401, F403
     man/build_html.py: E501
-    imagery/i.atcorr/create_iwave.py: F632, F821, W293
     doc/python/raster_example_ctypes.py: F403, F405
     doc/python/vector_example_ctypes.py: F403, F405
     doc/python/m.distance.py: F403, F405, E501

--- a/imagery/i.atcorr/create_iwave.py
+++ b/imagery/i.atcorr/create_iwave.py
@@ -235,7 +235,7 @@ def write_cpp(bands, values, sensor, folder):
         while c < len(fi) - 1 and fi[c + 1] > rthresh:
             c += 1
         max_wavelength = np.floor(li[0] * 1000 + (2.5 * c))
-        print("   %s (%inm - %inm)" % (bands[b], min_wavelength, max_wavelength))
+        print("   %s (%inm - %inm)" % (bands[0], min_wavelength, max_wavelength))
 
     else:
         filter_f = []


### PR DESCRIPTION
This PR addresses the issue with an undefined variable (`b`) in the single-band case of the `write_cpp` function.

**Changes**:

- Replaced `bands[b]` with `bands[0]` in the single-band scenario.
  
**Testing**:

- Ran `flake8` and verified no further `F821` errors.
- `F632` and `W293` weren't found on running `flake8` checks

Works towards #1522 
