### PR TITLE
doc: Fix Flake8 issues in example files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,6 +22,7 @@ per-file-ignores =
     __init__.py: F401, F403
     man/build_html.py: E501
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
+    doc/python/m.distance.py: E501
     doc/gui/wxpython/example/dialogs.py: F401
     locale/grass_po_stats.py: E122, E128, E231, E401, E722
     gui/scripts/d.wms.py: E501

--- a/.flake8
+++ b/.flake8
@@ -22,8 +22,6 @@ per-file-ignores =
     __init__.py: F401, F403
     man/build_html.py: E501
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
-    doc/python/raster_example_ctypes.py: F403, F405
-    doc/python/vector_example_ctypes.py: F403, F405
     doc/python/m.distance.py: F403, F405, E501
     doc/gui/wxpython/example/dialogs.py: F401
     locale/grass_po_stats.py: E122, E128, E231, E401, E722

--- a/.flake8
+++ b/.flake8
@@ -22,7 +22,6 @@ per-file-ignores =
     __init__.py: F401, F403
     man/build_html.py: E501
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
-    doc/python/m.distance.py: F403, F405, E501
     doc/gui/wxpython/example/dialogs.py: F401
     locale/grass_po_stats.py: E122, E128, E231, E401, E722
     gui/scripts/d.wms.py: E501

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -25,7 +25,7 @@
 
 # %module
 # % label: Finds the distance between two or more points.
-# % description: If the projection is latitude-longitude, this distance is measured along the geodesic.
+# % description: If the projection is lat-long, distance measured along the geodesic.
 # % keyword: miscellaneous
 # % keyword: distance
 # % keyword: measure
@@ -45,10 +45,15 @@
 # %end
 
 import sys
+from ctypes import byref, c_double
 
 import grass.script as gs
-
-from grass.lib.gis import *
+from grass.lib.gis import (
+    G_gisinit, G_begin_distance_calculations, G_scan_easting, G_scan_northing,
+    G_distance, G_begin_polygon_area_calculations, G_area_of_polygon,
+    G_database_units_to_meters_factor, G_database_unit_name,
+    PROJECTION_LL
+)
 
 
 def main():

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -25,7 +25,7 @@
 
 # %module
 # % label: Finds the distance between two or more points.
-# % description: If the projection is lat-long, distance measured along the geodesic.
+# % description: If the projection is latitude-longitude, this distance is measured along the geodesic.
 # % keyword: miscellaneous
 # % keyword: distance
 # % keyword: measure

--- a/doc/python/m.distance.py
+++ b/doc/python/m.distance.py
@@ -49,10 +49,16 @@ from ctypes import byref, c_double
 
 import grass.script as gs
 from grass.lib.gis import (
-    G_gisinit, G_begin_distance_calculations, G_scan_easting, G_scan_northing,
-    G_distance, G_begin_polygon_area_calculations, G_area_of_polygon,
-    G_database_units_to_meters_factor, G_database_unit_name,
-    PROJECTION_LL
+    G_gisinit,
+    G_begin_distance_calculations,
+    G_scan_easting,
+    G_scan_northing,
+    G_distance,
+    G_begin_polygon_area_calculations,
+    G_area_of_polygon,
+    G_database_units_to_meters_factor,
+    G_database_unit_name,
+    PROJECTION_LL,
 )
 
 

--- a/doc/python/raster_example_ctypes.py
+++ b/doc/python/raster_example_ctypes.py
@@ -23,9 +23,16 @@ from ctypes import POINTER, c_int, c_float, c_double, c_void_p, cast
 
 from grass.lib.gis import G_gisinit, G_find_raster2, G_free
 from grass.lib.raster import (
-    Rast_map_type, CELL_TYPE, FCELL_TYPE, DCELL_TYPE,
-    Rast_open_old, Rast_allocate_buf, Rast_window_rows,
-    Rast_window_cols, Rast_get_row, Rast_close
+    Rast_map_type,
+    CELL_TYPE,
+    FCELL_TYPE,
+    DCELL_TYPE,
+    Rast_open_old,
+    Rast_allocate_buf,
+    Rast_window_rows,
+    Rast_window_cols,
+    Rast_get_row,
+    Rast_close,
 )
 
 # check if GRASS is running or not

--- a/doc/python/raster_example_ctypes.py
+++ b/doc/python/raster_example_ctypes.py
@@ -17,9 +17,16 @@ cols=5`
 
 import os
 import sys
+import math
 
-from grass.lib.gis import *
-from grass.lib.raster import *
+from ctypes import POINTER, c_int, c_float, c_double, c_void_p, cast
+
+from grass.lib.gis import G_gisinit, G_find_raster2, G_free
+from grass.lib.raster import (
+    Rast_map_type, CELL_TYPE, FCELL_TYPE, DCELL_TYPE,
+    Rast_open_old, Rast_allocate_buf, Rast_window_rows,
+    Rast_window_cols, Rast_get_row, Rast_close
+)
 
 # check if GRASS is running or not
 if "GISBASE" not in os.environ:

--- a/doc/python/vector_example_ctypes.py
+++ b/doc/python/vector_example_ctypes.py
@@ -7,9 +7,16 @@ interface
 
 import os
 import sys
+from ctypes import pointer, byref
 
-from grass.lib.gis import *
-from grass.lib.vector import *
+# Import specific functions and classes instead of using wildcard imports
+from grass.lib.gis import G_gisinit, G_find_vector2
+from grass.lib.vector import (
+    Map_info, Vect_set_open_level, Vect_open_old, Vect_get_full_name,
+    Vect_is_3d, Vect_get_num_dblinks, Vect_get_scale, Vect_get_map_box,
+    Vect_point_in_box, Vect_get_num_lines, Vect_get_num_primitives,
+    Vect_get_num_areas, Vect_close, bound_box, GV_POINT, GV_LINE
+)
 
 if "GISBASE" not in os.environ:
     sys.exit("You must be in GRASS GIS to run this program.")

--- a/doc/python/vector_example_ctypes.py
+++ b/doc/python/vector_example_ctypes.py
@@ -12,10 +12,22 @@ from ctypes import pointer, byref
 # Import specific functions and classes instead of using wildcard imports
 from grass.lib.gis import G_gisinit, G_find_vector2
 from grass.lib.vector import (
-    Map_info, Vect_set_open_level, Vect_open_old, Vect_get_full_name,
-    Vect_is_3d, Vect_get_num_dblinks, Vect_get_scale, Vect_get_map_box,
-    Vect_point_in_box, Vect_get_num_lines, Vect_get_num_primitives,
-    Vect_get_num_areas, Vect_close, bound_box, GV_POINT, GV_LINE
+    Map_info,
+    Vect_set_open_level,
+    Vect_open_old,
+    Vect_get_full_name,
+    Vect_is_3d,
+    Vect_get_num_dblinks,
+    Vect_get_scale,
+    Vect_get_map_box,
+    Vect_point_in_box,
+    Vect_get_num_lines,
+    Vect_get_num_primitives,
+    Vect_get_num_areas,
+    Vect_close,
+    bound_box,
+    GV_POINT,
+    GV_LINE,
 )
 
 if "GISBASE" not in os.environ:


### PR DESCRIPTION
This PR fixes the flake8 error in `doc/python`. It addresses mainly `F403`, `F405` and `E501`. These are mostly related to wild card imports and `max-line-length` errors. I haven't fixed `F401` in `dialogs.py` yet as that will require more comprehensive changes