### PR TITLE
CI: Fix PEP8 E722 Error and Confirm No Other Common flake8 Errors in locale/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,7 +24,6 @@ per-file-ignores =
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
     doc/python/m.distance.py: E501
     doc/gui/wxpython/example/dialogs.py: F401
-    locale/grass_po_stats.py: E122, E128, E231, E401, E722
     gui/scripts/d.wms.py: E501
     gui/wxpython/core/gcmd.py: E402
     gui/wxpython/core/gconsole.py: E722

--- a/locale/grass_po_stats.py
+++ b/locale/grass_po_stats.py
@@ -144,7 +144,7 @@ def writejson(stats, outfile):
     fout.close()
     try:
         os.remove("messages.mo")
-    except:
+    except OSError:
         pass
 
 


### PR DESCRIPTION
### **Description:**

This PR addresses the PEP8 style error `E722` by specifying the exception type in the `except` clause within the `writejson` function in `grass_po_stats.py`. Additionally, it confirms that no other common `flake8` errors (`E122`, `E128`, `E231`, `E401`) are present in the codebase

### **Changes Made:**

- **Specified Exception Type:**
  - Changed the bare `except:` to `except OSError:` to catch only OS-related exceptions.
  
### **Rationale:**

- **Exception Handling:**
  - Specifying `OSError` in the `except` clause is appropriate because `os.remove()` can raise various OS-related exceptions such as `FileNotFoundError` or `PermissionError`. This avoids catching unintended exceptions and adheres to PEP8 guidelines.
 