### PR TITLE
CI: Updated parser doc in scripts/d.wms.py to fix E501

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -25,7 +25,6 @@ per-file-ignores =
     doc/python/m.distance.py: E501
     doc/gui/wxpython/example/dialogs.py: F401
     locale/grass_po_stats.py: E122, E128, E231, E401, E722
-    gui/scripts/d.wms.py: E501
     gui/wxpython/core/gcmd.py: E402
     gui/wxpython/core/gconsole.py: E722
     gui/wxpython/core/toolboxes.py: E722

--- a/gui/scripts/d.wms.py
+++ b/gui/scripts/d.wms.py
@@ -75,7 +75,10 @@
 # % key: driver
 # % type:string
 # % description: Driver used to communication with server
-# % descriptions: WMS_GDAL;Download data using GDAL WMS driver;WMS_GRASS;Download data using native GRASS-WMS driver;WMTS_GRASS;Download data using native GRASS-WMTS driver;OnEarth_GRASS;Download data using native GRASS-OnEarth driver;
+# % descriptions: WMS_GDAL;Download data using GDAL WMS driver;
+# % descriptions: WMS_GRASS;Download data using native GRASS-WMS driver;
+# % descriptions: WMTS_GRASS;Download data using native GRASS-WMTS driver;
+# % descriptions: OnEarth_GRASS;Download data using native GRASS-OnEarth driver;
 # % options:WMS_GDAL, WMS_GRASS, WMTS_GRASS, OnEarth_GRASS
 # % answer:WMS_GRASS
 # % guisection: Connection
@@ -146,7 +149,8 @@
 # %option G_OPT_F_BIN_INPUT
 # % key: capfile
 # % required: no
-# % description: Capabilities file to parse (input). It is relevant for WMTS_GRASS and OnEarth_GRASS drivers
+# % description: Capabilities file to parse (input).
+# % description: It is relevant for WMTS_GRASS and OnEarth_GRASS drivers
 # %end
 
 # %flag


### PR DESCRIPTION
Fixed `flake8: E501` in `scripts/d.wms.py`. I just split description into multiple lines to comply with `max-line-length` 