### PR TITLE
tests: Re-enable passing tests from .gunittest.cfg exclusion list

### DIFF
--- a/.github/workflows/macos_gunittest.cfg
+++ b/.github/workflows/macos_gunittest.cfg
@@ -4,32 +4,18 @@
 # space. This would be ideally empty or it would include just special cases,
 # but it includes mainly tests which can (and should) be fixed.
 exclude =
-    gui/wxpython/core/testsuite/test_gcmd.py
     gui/wxpython/core/testsuite/toolboxes.sh
-    lib/init/testsuite/test_grass_tmp_mapset.py
-    python/grass/gunittest/testsuite/test_assertions_rast3d.py
-    python/grass/gunittest/testsuite/test_assertions_vect.py
-    python/grass/gunittest/testsuite/test_gmodules.py
-    python/grass/gunittest/testsuite/test_gunitest_doctests.py
     python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
     python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py
-    python/grass/script/testsuite/test_script_doctests.py
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
     python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
     raster/r.in.lidar/testsuite/test_base_resolution.sh
     raster/r.in.pdal/testsuite/test_r_in_pdal_binning.py
     raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
-    raster/r.terraflow/testsuite/test_r_terraflow.py
     raster/r.sun/testsuite/test_rsun.py
     raster3d/r3.flow/testsuite/r3flow_test.py
-    scripts/g.search.modules/testsuite/test_g_search_modules.py
-    temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
-    temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
-    temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
     temporal/t.info/testsuite/test.t.info.sh
     temporal/t.rast.aggregate/testsuite/test_aggregation_relative.py
-    temporal/t.rast.series/testsuite/test_series.py
-    vector/v.db.select/testsuite/test_v_db_select.py
     vector/v.in.lidar/testsuite/decimation_test.py
     vector/v.in.lidar/testsuite/mask_test.py
     vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py

--- a/.github/workflows/macos_gunittest.cfg
+++ b/.github/workflows/macos_gunittest.cfg
@@ -4,7 +4,9 @@
 # space. This would be ideally empty or it would include just special cases,
 # but it includes mainly tests which can (and should) be fixed.
 exclude =
+    gui/wxpython/core/testsuite/test_gcmd.py
     gui/wxpython/core/testsuite/toolboxes.sh
+    python/grass/gunittest/testsuite/test_assertions_vect.py
     python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
     python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
@@ -14,8 +16,13 @@ exclude =
     raster/r.in.pdal/testsuite/test_r_in_pdal_selection.py
     raster/r.sun/testsuite/test_rsun.py
     raster3d/r3.flow/testsuite/r3flow_test.py
+    temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
+    temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
+    temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
     temporal/t.info/testsuite/test.t.info.sh
     temporal/t.rast.aggregate/testsuite/test_aggregation_relative.py
+    temporal/t.rast.series/testsuite/test_series.py
+    vector/v.db.select/testsuite/test_v_db_select.py
     vector/v.in.lidar/testsuite/decimation_test.py
     vector/v.in.lidar/testsuite/mask_test.py
     vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -4,21 +4,14 @@
 # space. This would be ideally empty or it would include just special cases,
 # but it includes mainly tests which can (and should) be fixed.
 exclude =
-    gui/wxpython/core/testsuite/test_gcmd.py
     gui/wxpython/core/testsuite/toolboxes.sh
-    lib/init/testsuite/test_grass_tmp_mapset.py
-    python/grass/gunittest/testsuite/test_assertions_rast3d.py
     python/grass/gunittest/testsuite/test_assertions_vect.py
-    python/grass/gunittest/testsuite/test_gmodules.py
     python/grass/gunittest/testsuite/test_gunitest_doctests.py
     python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
     python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py
-    python/grass/script/testsuite/test_script_doctests.py
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
     python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
     raster/r.in.lidar/testsuite/test_base_resolution.sh
-    raster/r.in.lidar/testsuite/test_base_resolution.sh
-    scripts/g.search.modules/testsuite/test_g_search_modules.py
     temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
     temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
     temporal/t.connect/testsuite/test_distr_tgis_db_vector.py


### PR DESCRIPTION
In preparation for my PR extending the tests on Windows, I explored to see what tests were actually failing and could be enabled. Turns out some of them can be enabled on Linux too, since macOS has its own configuration file.
EDIT: I also did the same process for macOS (enable all then exclude still failing tests).

My other PR is almost ready, but I extracted these unrelated changes here.

This PR only removes some excluded test, and CI still passes.