### PR TITLE
g.proj: Fix copy into fixed size buffer issue in input.c file

### DIFF
--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -230,8 +230,12 @@ int input_proj4(char *proj4params)
         if (fgets(buff, sizeof(buff), infd) == NULL)
             G_warning(_("Failed to read PROJ.4 parameter from stdin"));
     }
-    else
-        strcpy(buff, proj4params);
+    else {
+        if (G_strlcpy(buff, proj4params, sizeof(buff)) >= sizeof(buff)) {
+            G_fatal_error(_("PROJ.4 parameter string is too long: %s"),
+                          proj4params);
+        }
+    }
 
 #if PROJ_VERSION_MAJOR >= 6
     if (!strstr(buff, "+type=crs"))


### PR DESCRIPTION
This pull request resolves a buffer overflow issue detected by Coverity Scan (CID 1501203).
strcpy is replaced with G_strlcpy.
The build was successful after the make process