### PR TITLE
Check return value

### DIFF
--- a/lib/vector/diglib/spindex.c
+++ b/lib/vector/diglib/spindex.c
@@ -48,25 +48,33 @@ int dig_spidx_init(struct Plus_head *Plus)
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Node_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         G_free(filename);
 
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Line_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         G_free(filename);
 
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Area_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         G_free(filename);
 
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Isle_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         G_free(filename);
 
         Plus->Face_spidx = NULL;
@@ -125,7 +133,9 @@ void dig_spidx_free_nodes(struct Plus_head *Plus)
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Node_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         if (!Plus->Spidx_new)
             close(Plus->Node_spidx->fd);
         G_free(filename);
@@ -158,7 +168,9 @@ void dig_spidx_free_lines(struct Plus_head *Plus)
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Line_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         if (!Plus->Spidx_new)
             close(Plus->Line_spidx->fd);
         G_free(filename);
@@ -191,7 +203,9 @@ void dig_spidx_free_areas(struct Plus_head *Plus)
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Area_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         if (!Plus->Spidx_new)
             close(Plus->Area_spidx->fd);
         G_free(filename);
@@ -224,7 +238,9 @@ void dig_spidx_free_isles(struct Plus_head *Plus)
         filename = G_tempfile();
         fd = open(filename, O_RDWR | O_CREAT | O_EXCL, 0600);
         Plus->Isle_spidx = RTreeCreateTree(fd, 0, ndims);
-        remove(filename);
+        if (remove(filename) != 0) {
+            G_fatal_error(_("Unable to remove file %s"), filename);
+        }
         if (!Plus->Spidx_new)
             close(Plus->Isle_spidx->fd);
         G_free(filename);


### PR DESCRIPTION
This pull request address "unchecked return value from library". The issue is identified by coverity scan (CID : 1207295, 1207291,1207292,1207294, 1207293).

All instances of remove(filename) are replaced with
if (remove(filename) != 0) {
            G_fatal_error(_("Unable to remove file %s"), filename);
}