### PR TITLE
grass.temporal: Remove expected failures for tests fixed by #4328

### DIFF
--- a/temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
-from grass.gunittest.utils import silent_rmtree, xfail_windows
+from grass.gunittest.utils import silent_rmtree
 
 
 class TestRasterExtraction(TestCase):
@@ -254,7 +254,6 @@ class TestRasterExtraction(TestCase):
             module=info, reference=tinfo_string, precision=2, sep="="
         )
 
-    @xfail_windows
     def test_raster_info(self):
         self.runModule("g.mapset", mapset="test3")
         tinfo_string = """id=a1@test1

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
-from grass.gunittest.utils import silent_rmtree, xfail_windows
+from grass.gunittest.utils import silent_rmtree
 
 
 class testRaster3dExtraction(TestCase):
@@ -242,7 +242,6 @@ class testRaster3dExtraction(TestCase):
             module=info, reference=tinfo_string, precision=2, sep="="
         )
 
-    @xfail_windows
     def test_raster_info(self):
         self.runModule("g.mapset", mapset="test3d3")
         tinfo_string = """id=a1@test3d1

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
-from grass.gunittest.utils import silent_rmtree, xfail_windows
+from grass.gunittest.utils import silent_rmtree
 
 
 class TestRasterExtraction(TestCase):
@@ -259,7 +259,6 @@ class TestRasterExtraction(TestCase):
             module=info, reference=tinfo_string, precision=2, sep="="
         )
 
-    @xfail_windows
     def testv_vector_info(self):
         self.runModule("g.mapset", mapset="testvect3")
         tinfo_string = """id=a1@testvect1

--- a/temporal/t.rast.series/testsuite/test_series.py
+++ b/temporal/t.rast.series/testsuite/test_series.py
@@ -67,7 +67,6 @@ class TestSnapAbsoluteSTRDS(TestCase):
         cls.runModule("g.remove", flags="f", type="raster", name="series_minimum_2")
         cls.runModule("g.remove", flags="f", type="raster", name="series_quantile")
 
-    @xfail_windows
     def test_time_stamp(self):
         self.assertModule(
             "t.rast.series",


### PR DESCRIPTION
Followup of #4328 that had outdated CI when merged, and my message was sent seconds after it was merged.

The PR fixed tests relating to t.info printing info to the shell.