### PR TITLE
CI(OSGeo4W): Run pytest tests on Windows

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -66,9 +66,11 @@ jobs:
             pdal-devel
             pdcurses
             proj-devel
+            python3-core
             python3-jupyter
             python3-matplotlib
             python3-numpy
+            python3-pip
             python3-ply
             python3-pytest
             python3-pywin32

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -66,9 +66,11 @@ jobs:
             pdal-devel
             pdcurses
             proj-devel
+            python3-jupyter
             python3-matplotlib
             python3-numpy
             python3-ply
+            python3-pytest
             python3-pywin32
             python3-wxpython
             regex-devel
@@ -97,6 +99,19 @@ jobs:
       - name: Test executing of the grass command in bash
         shell: msys2 {0}
         run: .github/workflows/test_simple.sh
+
+      - name: Install pytest plugins
+        run: python -m pip install pytest-timeout
+        shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
+      - name: Run pytest with a single worker
+        run: |
+          call %OSGEO4W_ROOT%\opt\grass\etc\env.bat
+          set PYTHONPATH=%GISBASE%\etc\python;%PYTHONPATH%
+          path %GISBASE%\lib;%GISBASE%\bin;%PATH%
+          pytest --verbose --color=yes ^
+            --durations=0 --durations-min=0.5 ^
+            -ra .
+        shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
 
       - name: Run tests
         run: .github/workflows/test_thorough.bat 'C:\OSGeo4W\opt\grass\grass85.bat' 'C:\OSGeo4W\bin\python3'

--- a/general/g.mapsets/tests/g_mapsets_list_format_test.py
+++ b/general/g.mapsets/tests/g_mapsets_list_format_test.py
@@ -14,6 +14,7 @@
 """Test parsing and structure of CSV and JSON outputs from g.mapsets"""
 
 import json
+import sys
 import pytest
 import grass.script as gs
 from grass.script import utils as gutils
@@ -30,6 +31,10 @@ def _check_parsed_list(mapsets, text, sep="|"):
     assert text == sep.join(mapsets) + "\n"
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="universal_newlines or text subprocess option not used",
+)
 @pytest.mark.parametrize("separator", SEPARATORS)
 def test_plain_list_output(simple_dataset, separator):
     """Test that the separators are properly applied with list flag"""
@@ -38,6 +43,10 @@ def test_plain_list_output(simple_dataset, separator):
     _check_parsed_list(mapsets, text, gutils.separator(separator))
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="universal_newlines or text subprocess option not used",
+)
 @pytest.mark.parametrize("separator", SEPARATORS)
 def test_plain_print_output(simple_dataset, separator):
     """Test that the separators are properly applied with print flag"""

--- a/python/grass/jupyter/tests/grass_jupyter_session_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_session_test.py
@@ -4,6 +4,8 @@ import subprocess
 import os
 import sys
 
+import pytest
+
 
 # All init tests change the global environment, but we use a separate process
 # only when it is necessary.
@@ -20,6 +22,10 @@ def run_in_subprocess(file):
     return process.stdout
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="tmp_path string in interpolated code should be escaped or use raw strings",
+)
 def test_init_finish(tmp_path):
     """Check that init function works with an explicit session finish"""
     location = "test"
@@ -42,6 +48,10 @@ session.finish()
     assert not os.path.exists(session_file), f"Session file {session_file} not deleted"
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="tmp_path string in interpolated code should be escaped or use raw strings",
+)
 def test_init_with_auto_finish(tmp_path):
     """Check that init function works with an implicit session finish"""
     location = "test"

--- a/python/grass/jupyter/tests/timeseriesmap_test.py
+++ b/python/grass/jupyter/tests/timeseriesmap_test.py
@@ -1,6 +1,7 @@
 """Test TimeSeriesMap functions"""
 
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -66,6 +67,10 @@ def test_render_layers(space_time_raster_dataset, fill_gaps):
         assert Path(filename).is_file()
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="DejaVuSans.ttf file isn't found and not installed with GRASS",
+)
 @pytest.mark.needs_solo_run
 def test_save(space_time_raster_dataset, tmp_path):
     """Test returns from animate and time_slider are correct object types"""

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -15,6 +15,9 @@
 
 import os
 import shutil
+import sys
+
+import pytest
 
 import grass.script as gs
 
@@ -313,6 +316,10 @@ class TimeSeriesMap(BaseSeriesMap):
             tasks.append((date, layer, filename))
         self._render(tasks)
 
+    @pytest.mark.xfail(
+        sys.platform == "win32",
+        reason="DejaVuSans.ttf file isn't found and not installed with GRASS",
+    )
     def save(
         self,
         filename,

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -15,9 +15,6 @@
 
 import os
 import shutil
-import sys
-
-import pytest
 
 import grass.script as gs
 
@@ -316,10 +313,6 @@ class TimeSeriesMap(BaseSeriesMap):
             tasks.append((date, layer, filename))
         self._render(tasks)
 
-    @pytest.mark.xfail(
-        sys.platform == "win32",
-        reason="DejaVuSans.ttf file isn't found and not installed with GRASS",
-    )
     def save(
         self,
         filename,


### PR DESCRIPTION
This is the next step of testing consolidation across our platforms. After that this PR is merged, we will now have pytest tests running on all our supported platforms. It will finally unleash possibilities to use pytest as a runner for our unittest (gunittest) tests.

To keep this PR concise and limited to only the enablement of pytest, I didn't fix any of the three failing test files here. I have them fixed in https://github.com/echoix/grass/pull/220 (permalink to a commit since I will probably rebase later on https://github.com/echoix/grass/commit/cb97aefb8b4b7387efc8003bf386e5c07915b3f0), where it was running directly on an installed grass-dev package from OSGeo4W instead of building each time. There are a couple differences, that's why I rebuilt the changes in this branch for this PR. The three fixes will probably need three separate discussions, so it isn't the place here to discuss them.


I also kept the pytest-xdist out of it, but also validated that it worked in one of the sessions where I connected to the runner by ssh to iterate faster and find where the files were and what env vars were present.


A particularity of both our current nonstandard osgeo4w build scripts and the official osgeo4w builds is that the bat files loading env vars wipe overwrite the path but do not include the lib folder (both), nor the bin folder (at least for our), so pytest (or any python script) cannot find the grass_gis.8.5. Note that after Python 3.8, the dll search path has changed, see https://docs.python.org/3/library/os.html#os.add_dll_directory, https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew. However, we have changes in our copy of ctypesgen for placing all entries of path as a search path (a bit overkill maybe), that aren't upstream. I didn't have the change to try out pypdfium2's maintained fork ctypesgen, as it has a newer and simpler loader, that might have solved me weeks (months) of headaches https://github.com/pypdfium2-team/ctypesgen/tree/pypdfium2.
The PYTHONPATH is also needed in order to find a module named "grass", that isn't set in these scripts (except the OSGeo4W's python-grass.bat, but we don't use it here).