### PR TITLE
grass.jupyter: Fix session tests on Windows

### DIFF
--- a/python/grass/jupyter/tests/grass_jupyter_session_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_session_test.py
@@ -4,8 +4,6 @@ import subprocess
 import os
 import sys
 
-import pytest
-
 
 # All init tests change the global environment, but we use a separate process
 # only when it is necessary.
@@ -22,10 +20,6 @@ def run_in_subprocess(file):
     return process.stdout
 
 
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="tmp_path string in interpolated code should be escaped or use raw strings",
-)
 def test_init_finish(tmp_path):
     """Check that init function works with an explicit session finish"""
     location = "test"
@@ -33,8 +27,8 @@ def test_init_finish(tmp_path):
 import os
 import grass.script as gs
 import grass.jupyter as gj
-gs.core._create_location_xy("{tmp_path}", "{location}")
-session = gj.init("{tmp_path / location}")
+gs.core._create_location_xy(r"{tmp_path}", r"{location}")
+session = gj.init(r"{tmp_path / location}")
 gs.read_command("g.region", flags="p")
 print(os.environ["GISRC"])
 session.finish()
@@ -48,10 +42,6 @@ session.finish()
     assert not os.path.exists(session_file), f"Session file {session_file} not deleted"
 
 
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="tmp_path string in interpolated code should be escaped or use raw strings",
-)
 def test_init_with_auto_finish(tmp_path):
     """Check that init function works with an implicit session finish"""
     location = "test"
@@ -59,8 +49,8 @@ def test_init_with_auto_finish(tmp_path):
 import os
 import grass.script as gs
 import grass.jupyter as gj
-gs.core._create_location_xy("{tmp_path}", "{location}")
-session = gj.init("{tmp_path / location}")
+gs.core._create_location_xy(r"{tmp_path}", r"{location}")
+session = gj.init(r"{tmp_path / location}")
 print(os.environ["GISRC"])
 """
 


### PR DESCRIPTION
The interpolated path strings aren't escaped when evaluated, so using a raw string allows C:\Users to not have an invalid \U escape sequence.