### PR TITLE
ps.map: Fix Resource leak issue in ps_vpoints.c 

### DIFF
--- a/ps/ps.map/ps_vpoints.c
+++ b/ps/ps.map/ps_vpoints.c
@@ -268,5 +268,6 @@ int PS_vpoints_plot(struct Map_info *P_map, int vec)
     } /* for (line) */
 
     fprintf(PS.fp, "\n");
+    Vect_destroy_cats_struct(Cats)
     return 0;
 }

--- a/ps/ps.map/ps_vpoints.c
+++ b/ps/ps.map/ps_vpoints.c
@@ -268,6 +268,6 @@ int PS_vpoints_plot(struct Map_info *P_map, int vec)
     } /* for (line) */
 
     fprintf(PS.fp, "\n");
-    Vect_destroy_cats_struct(Cats)
+    Vect_destroy_cats_struct(Cats);
     return 0;
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207906)

Used existing function ```Vect_destroy_cats_struct()```  to fix the memory leak issue.