### PR TITLE
docker: Add liblapacke-dev package to Ubuntu builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     libgsl27 \
     libjpeg-turbo8 \
     libjsoncpp-dev \
+    liblapacke-dev \
     libmagic1 \
     libmagic-mgc \
     libncurses5 \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -41,6 +41,7 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     libgsl27 \
     libjpeg-turbo8 \
     libjsoncpp-dev \
+    liblapacke-dev \
     libmagic1 \
     libmagic-mgc \
     libncurses5 \


### PR DESCRIPTION
The docker builds were still failing... So I took the liblapacke-dev package that was added to the apt.txt of the grass addons and added it into a list of packages in the Ubuntu build.

I just want someone to confirm I selected the correct list. I assumed it needed to be present for addons to compile with it.