### PR TITLE
docker: Sort package lists and configure options in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ WORKDIR /tmp
 ARG GUI
 
 # Todo: re-consider required dev packages for addons (~400MB in dev packages)
-ARG GRASS_RUN_PACKAGES="build-essential \
+ARG GRASS_RUN_PACKAGES="\
     bison \
+    build-essential \
     bzip2 \
     curl \
     flex \
@@ -28,8 +29,6 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     gcc \
     gdal-bin \
     geos-bin \
-    proj-bin \
-    netcdf-bin \
     git \
     language-pack-en-base \
     libcairo2 \
@@ -38,29 +37,29 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     libfftw3-dev \
     libfreetype6 \
     libgdal-dev \
+    libgeos-dev \
+    libgsl-dev \
     libgsl27 \
     libjpeg-turbo8 \
     libjsoncpp-dev \
     liblapacke-dev \
-    libmagic1 \
     libmagic-mgc \
+    libmagic1 \
     libncurses5 \
-    libopenblas-dev \
-    libopenblas-base \
-    libopenjp2-7 \
-    libomp5 \
     libomp-dev \
-    libgeos-dev \
-    libpdal-dev \
-    libproj-dev \
-    libpq-dev \
-    libgsl-dev \
+    libomp5 \
+    libopenblas-base \
+    libopenblas-dev \
+    libopenjp2-7 \
     libpdal-base13 \
+    libpdal-dev \
     libpdal-plugin-hdf \
     libpdal-plugins \
     libpdal-util13 \
     libpnglite0 \
+    libpq-dev \
     libpq5 \
+    libproj-dev \
     libpython3-all-dev \
     libreadline8 \
     libsqlite3-0 \
@@ -71,7 +70,9 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     mesa-utils \
     moreutils \
     ncurses-bin \
+    netcdf-bin \
     pdal \
+    proj-bin \
     proj-data \
     python-is-python3 \
     python3 \
@@ -87,56 +88,58 @@ ARG GRASS_RUN_PACKAGES="build-essential \
 ENV GRASS_RUN_PACKAGES=${GRASS_RUN_PACKAGES}
 
 # Define build packages
-ARG GRASS_BUILD_PACKAGES="cmake \
+ARG GRASS_BUILD_PACKAGES="\
+    cmake \
     libbz2-dev \
     libcairo2-dev \
     libfreetype6-dev \
-    zlib1g-dev \
+    libjpeg-dev \
+    libncurses5-dev \
     libnetcdf-dev \
     libopenjp2-7-dev \
-    libreadline-dev \
-    libjpeg-dev \
     libpnglite-dev \
+    libreadline-dev \
     libsqlite3-dev \
     libtiff-dev \
     libzstd-dev \
-    libncurses5-dev \
     mesa-common-dev \
     zlib1g-dev \
     "
 ENV GRASS_BUILD_PACKAGES=${GRASS_BUILD_PACKAGES}
 
-ARG GRASS_CONFIG="--with-cxx \
+ARG GRASS_CONFIG="\
   --enable-largefile \
-  --with-proj-share=/usr/share/proj \
+  --with-blas \
+  --with-bzlib \
+  --with-cairo --with-cairo-ldflags=-lfontconfig \
+  --with-cxx \
+  --with-fftw \
+  --with-freetype --with-freetype-includes=/usr/include/freetype2/ \
   --with-gdal=/usr/bin/gdal-config \
   --with-geos \
-  --with-sqlite \
-  --with-cairo --with-cairo-ldflags=-lfontconfig \
-  --with-freetype --with-freetype-includes=/usr/include/freetype2/ \
-  --with-fftw \
-  --with-postgres --with-postgres-includes=/usr/include/postgresql \
-  --with-netcdf \
-  --with-zstd \
-  --with-bzlib \
-  --with-pdal \
-  --without-mysql \
-  --with-blas \
   --with-lapack \
-  --with-readline \
+  --with-netcdf \
   --with-odbc \
   --with-openmp \
+  --with-pdal \
+  --with-postgres --with-postgres-includes=/usr/include/postgresql \
+  --with-proj-share=/usr/share/proj \
+  --with-readline \
+  --with-sqlite \
+  --with-zstd \
+  --without-mysql \
   "
 
-ARG GRASS_PYTHON_PACKAGES="pip \
-    setuptools \
+ARG GRASS_PYTHON_PACKAGES="\
+    Pillow \
+    matplotlib \
+    numpy \
+    pip \
+    ply \
+    psycopg2 \
     python-dateutil \
     python-magic \
-    numpy \
-    Pillow \
-    ply \
-    matplotlib \
-    psycopg2 \
+    setuptools \
   "
 ENV GRASS_PYTHON_PACKAGES=${GRASS_PYTHON_PACKAGES}
 
@@ -148,31 +151,33 @@ ENV GRASS_CONFIG=${GRASS_CONFIG}
 
 FROM common_start as grass_with_gui
 
-ARG GRASS_RUN_PACKAGES="${GRASS_RUN_PACKAGES} adwaita-icon-theme-full \
-  libglu1-mesa \
-  libgtk-3-0 \
-  libnotify4 \
-  libsdl2-2.0-0 \
-  libxtst6 \
-  librsvg2-common \
-  gettext \
+ARG GRASS_RUN_PACKAGES="${GRASS_RUN_PACKAGES} \
+  adwaita-icon-theme-full \
   freeglut3 \
+  gettext \
+  libglu1-mesa \
   libgstreamer-plugins-base1.0 \
+  libgtk-3-0 \
   libjpeg8 \
+  libnotify4 \
   libpng16-16 \
+  librsvg2-common \
+  libsdl2-2.0-0 \
   libsm6 \
   libtiff5 \
   libwebkit2gtk-4.0 \
+  libxtst6 \
 "
 # librsvg2-common \
 # (fix error (wxgui.py:7782): Gtk-WARNING **: 19:53:09.774:
 # Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
 # This may indicate that pixbuf loaders or the mime database could not be found.)
 
-ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} adwaita-icon-theme-full \
+ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} \
+  adwaita-icon-theme-full \
+  freeglut3-dev \
   libgl1-mesa-dev \
   libglu1-mesa-dev \
-  freeglut3-dev \
   libgstreamer-plugins-base1.0-dev \
   libgtk-3-dev \
   libjpeg-dev \
@@ -185,10 +190,11 @@ ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} adwaita-icon-theme-full \
   libxtst-dev \
 "
 
-ARG GRASS_CONFIG="${GRASS_CONFIG} --with-opengl \
-  --with-x \
+ARG GRASS_CONFIG="${GRASS_CONFIG} \
   --with-nls \
+  --with-opengl \
   --with-readline \
+  --with-x \
   "
 ARG GRASS_PYTHON_PACKAGES="${GRASS_PYTHON_PACKAGES} wxPython"
 # If you do not use any Gnome Accessibility features, to suppress warning

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -11,9 +11,9 @@ ARG PYTHON_VERSION=3
 # List of packages to be installed (proj-data omitted: 570.04 MB)
 ENV GRASS_RUN_PACKAGES="\
       attr \
-      build-base \
       bash \
       bison \
+      build-base \
       bzip2 \
       cairo \
       curl \
@@ -29,15 +29,15 @@ ENV GRASS_RUN_PACKAGES="\
       gdal-driver-JP2OpenJPEG \
       gdal-driver-LIBKML \
       gdal-driver-MSSQLSpatial \
-      gdal-driver-netCDF \
       gdal-driver-ODBC \
       gdal-driver-PG \
       gdal-driver-PNG \
       gdal-driver-WMS \
+      gdal-driver-netCDF \
       gdal-tools \
-      gettext \
       geos \
       geos-dev \
+      gettext \
       git \
       gnutls \
       jsoncpp \
@@ -52,15 +52,15 @@ ENV GRASS_RUN_PACKAGES="\
       musl \
       musl-utils \
       ncurses \
-      openjpeg \
       openblas \
-      py3-numpy \
-      py3-pillow \
-      python3 \
+      openjpeg \
       pdal \
       pdal-dev \
       postgresql15-client \
       proj-util \
+      py3-numpy \
+      py3-pillow \
+      python3 \
       sqlite \
       sqlite-libs \
       subversion \
@@ -89,23 +89,23 @@ FROM common as build
 # set configuration options, without wxGUI
 ENV GRASS_CONFIG="\
       --enable-largefile \
-      --with-cxx \
-      --with-proj-share=/usr/share/proj \
-      --with-gdal \
-      --with-pdal \
-      --with-geos \
-      --with-sqlite \
       --with-bzlib \
-      --with-zstd \
       --with-cairo --with-cairo-ldflags=-lfontconfig \
+      --with-cxx \
       --with-fftw \
-      --with-postgres --with-postgres-includes=/usr/include/postgresql \
+      --with-gdal \
+      --with-geos \
       --with-openmp \
+      --with-pdal \
+      --with-postgres --with-postgres-includes=/usr/include/postgresql \
+      --with-proj-share=/usr/share/proj \
+      --with-sqlite \
+      --with-zstd \
       --without-freetype \
-      --without-opengl \
-      --without-nls \
       --without-mysql \
+      --without-nls \
       --without-odbc \
+      --without-opengl \
       "
 
 # Set environmental variables for GRASS GIS compilation, without debug symbols
@@ -132,13 +132,13 @@ ENV GRASS_BUILD_PACKAGES="\
       libjpeg-turbo-dev \
       libpng-dev \
       libpq-dev \
-      openjpeg-dev \
       openblas-dev \
+      openjpeg-dev \
       pdal \
       pdal-dev \
       proj-dev \
-      python3-dev \
       py3-numpy-dev \
+      python3-dev \
       sqlite-dev \
       tar \
       tiff-dev \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -18,8 +18,8 @@ WORKDIR /tmp
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
-    build-essential \
     bison \
+    build-essential \
     bzip2 \
     cmake \
     curl \
@@ -40,8 +40,8 @@ RUN apt-get update && apt-get upgrade -y && \
     libgsl0-dev \
     libjpeg-dev \
     libjsoncpp-dev \
-    libnetcdf-dev \
     libncurses-dev \
+    libnetcdf-dev \
     libopenblas-dev \
     libopenjp2-7 \
     libopenjp2-7-dev \
@@ -153,24 +153,24 @@ ENV CXXFLAGS "$MYCXXFLAGS"
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
-  --with-cxx \
   --enable-largefile \
-  --with-proj-share=/usr/share/proj \
+  --with-bzlib \
+  --with-cairo --with-cairo-ldflags=-lfontconfig \
+  --with-cxx \
+  --with-fftw \
+  --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
   --with-gdal=/usr/bin/gdal-config \
   --with-geos \
-  --with-sqlite \
-  --with-cairo --with-cairo-ldflags=-lfontconfig \
-  --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
-  --with-fftw \
-  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
   --with-netcdf \
-  --with-zstd \
-  --with-bzlib \
   --with-pdal \
+  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
+  --with-proj-share=/usr/share/proj \
+  --with-sqlite \
+  --with-zstd \
   --without-mysql \
   --without-odbc \
-  --without-openmp \
   --without-opengl \
+  --without-openmp \
     && make -j $NUMTHREADS \
     && make install && ldconfig
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -19,8 +19,9 @@ WORKDIR /tmp
 ARG GUI
 
 # Todo: re-consider required dev packages for addons (~400MB in dev packages)
-ARG GRASS_RUN_PACKAGES="build-essential \
+ARG GRASS_RUN_PACKAGES="\
     bison \
+    build-essential \
     bzip2 \
     curl \
     flex \
@@ -28,8 +29,6 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     gcc \
     gdal-bin \
     geos-bin \
-    proj-bin \
-    netcdf-bin \
     git \
     language-pack-en-base \
     libcairo2 \
@@ -38,29 +37,29 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     libfftw3-dev \
     libfreetype6 \
     libgdal-dev \
+    libgeos-dev \
+    libgsl-dev \
     libgsl27 \
     libjpeg-turbo8 \
     libjsoncpp-dev \
     liblapacke-dev \
-    libmagic1 \
     libmagic-mgc \
+    libmagic1 \
     libncurses5 \
-    libopenblas-dev \
-    libopenblas-base \
-    libopenjp2-7 \
-    libomp5 \
     libomp-dev \
-    libgeos-dev \
-    libpdal-dev \
-    libproj-dev \
-    libpq-dev \
-    libgsl-dev \
+    libomp5 \
+    libopenblas-base \
+    libopenblas-dev \
+    libopenjp2-7 \
     libpdal-base13 \
+    libpdal-dev \
     libpdal-plugin-hdf \
     libpdal-plugins \
     libpdal-util13 \
     libpnglite0 \
+    libpq-dev \
     libpq5 \
+    libproj-dev \
     libpython3-all-dev \
     libreadline8 \
     libsqlite3-0 \
@@ -71,7 +70,9 @@ ARG GRASS_RUN_PACKAGES="build-essential \
     mesa-utils \
     moreutils \
     ncurses-bin \
+    netcdf-bin \
     pdal \
+    proj-bin \
     proj-data \
     python-is-python3 \
     python3 \
@@ -87,56 +88,58 @@ ARG GRASS_RUN_PACKAGES="build-essential \
 ENV GRASS_RUN_PACKAGES=${GRASS_RUN_PACKAGES}
 
 # Define build packages
-ARG GRASS_BUILD_PACKAGES="cmake \
+ARG GRASS_BUILD_PACKAGES="\
+    cmake \
     libbz2-dev \
     libcairo2-dev \
     libfreetype6-dev \
-    zlib1g-dev \
+    libjpeg-dev \
+    libncurses5-dev \
     libnetcdf-dev \
     libopenjp2-7-dev \
-    libreadline-dev \
-    libjpeg-dev \
     libpnglite-dev \
+    libreadline-dev \
     libsqlite3-dev \
     libtiff-dev \
     libzstd-dev \
-    libncurses5-dev \
     mesa-common-dev \
     zlib1g-dev \
     "
 ENV GRASS_BUILD_PACKAGES=${GRASS_BUILD_PACKAGES}
 
-ARG GRASS_CONFIG="--with-cxx \
+ARG GRASS_CONFIG="\
   --enable-largefile \
-  --with-proj-share=/usr/share/proj \
+  --with-blas \
+  --with-bzlib \
+  --with-cairo --with-cairo-ldflags=-lfontconfig \
+  --with-cxx \
+  --with-fftw \
+  --with-freetype --with-freetype-includes=/usr/include/freetype2/ \
   --with-gdal=/usr/bin/gdal-config \
   --with-geos \
-  --with-sqlite \
-  --with-cairo --with-cairo-ldflags=-lfontconfig \
-  --with-freetype --with-freetype-includes=/usr/include/freetype2/ \
-  --with-fftw \
-  --with-postgres --with-postgres-includes=/usr/include/postgresql \
-  --with-netcdf \
-  --with-zstd \
-  --with-bzlib \
-  --with-pdal \
-  --without-mysql \
-  --with-blas \
   --with-lapack \
-  --with-readline \
+  --with-netcdf \
   --with-odbc \
   --with-openmp \
+  --with-pdal \
+  --with-postgres --with-postgres-includes=/usr/include/postgresql \
+  --with-proj-share=/usr/share/proj \
+  --with-readline \
+  --with-sqlite \
+  --with-zstd \
+  --without-mysql \
   "
 
-ARG GRASS_PYTHON_PACKAGES="pip \
-    setuptools \
+ARG GRASS_PYTHON_PACKAGES="\
+    Pillow \
+    matplotlib \
+    numpy \
+    pip \
+    ply \
+    psycopg2 \
     python-dateutil \
     python-magic \
-    numpy \
-    Pillow \
-    ply \
-    matplotlib \
-    psycopg2 \
+    setuptools \
   "
 ENV GRASS_PYTHON_PACKAGES=${GRASS_PYTHON_PACKAGES}
 
@@ -148,31 +151,33 @@ ENV GRASS_CONFIG=${GRASS_CONFIG}
 
 FROM common_start as grass_with_gui
 
-ARG GRASS_RUN_PACKAGES="${GRASS_RUN_PACKAGES} adwaita-icon-theme-full \
-  libglu1-mesa \
-  libgtk-3-0 \
-  libnotify4 \
-  libsdl2-2.0-0 \
-  libxtst6 \
-  librsvg2-common \
-  gettext \
+ARG GRASS_RUN_PACKAGES="${GRASS_RUN_PACKAGES} \
+  adwaita-icon-theme-full \
   freeglut3 \
+  gettext \
+  libglu1-mesa \
   libgstreamer-plugins-base1.0 \
+  libgtk-3-0 \
   libjpeg8 \
+  libnotify4 \
   libpng16-16 \
+  librsvg2-common \
+  libsdl2-2.0-0 \
   libsm6 \
   libtiff5 \
   libwebkit2gtk-4.0 \
+  libxtst6 \
 "
 # librsvg2-common \
 # (fix error (wxgui.py:7782): Gtk-WARNING **: 19:53:09.774:
 # Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
 # This may indicate that pixbuf loaders or the mime database could not be found.)
 
-ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} adwaita-icon-theme-full \
+ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} \
+  adwaita-icon-theme-full \
+  freeglut3-dev \
   libgl1-mesa-dev \
   libglu1-mesa-dev \
-  freeglut3-dev \
   libgstreamer-plugins-base1.0-dev \
   libgtk-3-dev \
   libjpeg-dev \
@@ -185,10 +190,11 @@ ARG GRASS_BUILD_PACKAGES="${GRASS_BUILD_PACKAGES} adwaita-icon-theme-full \
   libxtst-dev \
 "
 
-ARG GRASS_CONFIG="${GRASS_CONFIG} --with-opengl \
-  --with-x \
+ARG GRASS_CONFIG="${GRASS_CONFIG} \
   --with-nls \
+  --with-opengl \
   --with-readline \
+  --with-x \
   "
 ARG GRASS_PYTHON_PACKAGES="${GRASS_PYTHON_PACKAGES} wxPython"
 # If you do not use any Gnome Accessibility features, to suppress warning

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -29,8 +29,8 @@ WORKDIR /tmp
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
     adwaita-icon-theme-full \
-    build-essential \
     bison \
+    build-essential \
     bzip2 \
     cmake \
     curl \
@@ -48,17 +48,17 @@ RUN apt-get update && apt-get upgrade -y && \
     libfftw3-bin \
     libfftw3-dev \
     libfreetype6-dev \
-    libgl1-mesa-dev \
     libgdal-dev \
     libgeos-dev \
+    libgl1-mesa-dev \
     libglu1-mesa-dev \
     libgsl0-dev \
     libgtk-3-0 \
     libgtk-3-dev \
     libjpeg-dev \
     libjsoncpp-dev \
-    libnetcdf-dev \
     libncurses5-dev \
+    libnetcdf-dev \
     libnotify4 \
     libopenblas-base \
     libopenblas-dev \
@@ -68,8 +68,8 @@ RUN apt-get update && apt-get upgrade -y && \
     libpq-dev \
     libproj-dev \
     libpython3-all-dev \
-    librsvg2-common \
     libreadline-dev \
+    librsvg2-common \
     libsdl2-2.0-0 \
     libsqlite3-dev \
     libtiff-dev \
@@ -191,26 +191,26 @@ ENV CXXFLAGS "$MYCXXFLAGS"
 ENV NUMTHREADS=4
 RUN make distclean || echo "nothing to clean"
 RUN /src/grass_build/configure \
-  --with-cxx \
   --enable-largefile \
-  --with-proj-share=/usr/share/proj \
+  --with-bzlib \
+  --with-cairo --with-cairo-ldflags=-lfontconfig \
+  --with-cxx \
+  --with-fftw \
+  --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
   --with-gdal=/usr/bin/gdal-config \
   --with-geos \
-  --with-sqlite \
-  --with-cairo --with-cairo-ldflags=-lfontconfig \
-  --with-freetype --with-freetype-includes="/usr/include/freetype2/" \
-  --with-fftw \
-  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
   --with-netcdf \
-  --with-zstd \
-  --with-bzlib \
+  --with-nls \
   --with-pdal \
+  --with-postgres --with-postgres-includes="/usr/include/postgresql" \
+  --with-proj-share=/usr/share/proj \
+  --with-readline \
+  --with-sqlite \
+  --with-x \
+  --with-zstd \
   --without-mysql \
   --without-odbc \
   --without-openmp \
-  --with-x \
-  --with-nls \
-  --with-readline \
     && make -j $NUMTHREADS \
     && make install && ldconfig
 


### PR DESCRIPTION
Package lists were unsorted, and I got tricked when adding liblapacke-dev and sorting the list thinking it was sorted (almost but not). Being unsorted makes finding a package harder. To prove this point, `zlib1g-dev` was listed twice in the same list because it was unsorted.

I simply used the sort lines feature of my IDE, VSCode, that is case-sensitive.