### PR TITLE
wxGUI/datacatalog: Replace lambda expression with named Function to fix E731

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -25,7 +25,6 @@ per-file-ignores =
     doc/python/m.distance.py: E501
     doc/gui/wxpython/example/dialogs.py: F401
     gui/scripts/d.wms.py: E501
-    gui/wxpython/datacatalog/tree.py: E731, E402
     gui/wxpython/dbmgr/base.py: E722
     gui/wxpython/dbmgr/dialogs.py: E722
     gui/wxpython/dbmgr/sqlbuilder.py: E722

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1379,7 +1379,7 @@ class DataCatalogTree(TreeView):
                     if not new_name:
                         continue
 
-                def _callback(
+                def callback(
                     gisrc2=gisrc2,
                     gisrc=gisrc,
                     cLayer=self.copy_layer[i],
@@ -1392,7 +1392,6 @@ class DataCatalogTree(TreeView):
                         env2, gisrc2, gisrc, cLayer, cMapset, cMode, sMapset, name
                     )
 
-                callback = _callback
                 dlg = CatalogReprojectionDialog(
                     self,
                     self._giface,

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -1378,15 +1378,21 @@ class DataCatalogTree(TreeView):
                     )
                     if not new_name:
                         continue
-                callback = lambda gisrc2=gisrc2, gisrc=gisrc, cLayer=self.copy_layer[
-                    i
-                ], cMapset=self.copy_mapset[
-                    i
-                ], cMode=self.copy_mode, sMapset=self.selected_mapset[
-                    0
-                ], name=new_name: self._onDoneReprojection(
-                    env2, gisrc2, gisrc, cLayer, cMapset, cMode, sMapset, name
-                )
+
+                def _callback(
+                    gisrc2=gisrc2,
+                    gisrc=gisrc,
+                    cLayer=self.copy_layer[i],
+                    cMapset=self.copy_mapset[i],
+                    cMode=self.copy_mode,
+                    sMapset=self.selected_mapset[0],
+                    name=new_name,
+                ):
+                    self._onDoneReprojection(
+                        env2, gisrc2, gisrc, cLayer, cMapset, cMode, sMapset, name
+                    )
+
+                callback = _callback
                 dlg = CatalogReprojectionDialog(
                     self,
                     self._giface,


### PR DESCRIPTION
#### Description

This PR addresses the `E731` linting issue in `tree.py` by replacing a lambda expression with a named function. The change ensures that the code adheres to PEP 8 guidelines, which recommend using a `def` statement instead of assigning a lambda expression.

#### Changes Made

- Defined a new function `_callback` to replace the lambda expression.
- Updated the code to use the `_callback` function.

#### Rationale
- Just recreated `lambda` function with a normal `def` function as specified in the `flake8`