### PR TITLE
grass.jupyter: move save() to BaseSeriesMap class to reduce redundancy

### DIFF
--- a/python/grass/jupyter/baseseriesmap.py
+++ b/python/grass/jupyter/baseseriesmap.py
@@ -25,7 +25,7 @@ import multiprocessing
 import grass.script as gs
 
 from .map import Map
-from .utils import get_number_of_cores
+from .utils import get_number_of_cores, save_gif
 
 
 class BaseSeriesMap:
@@ -210,3 +210,49 @@ class BaseSeriesMap:
             width="100%", display="inline-flex", flex_flow="row wrap"
         )
         return widgets.HBox([play, slider, out_img], layout=layout)
+
+    def save(
+        self,
+        filename,
+        duration=500,
+        label=True,
+        font=None,
+        text_size=12,
+        text_color="gray",
+    ):
+        """
+        Creates a GIF animation of rendered layers.
+
+        Text color must be in a format accepted by PIL ImageColor module. For supported
+        formats, visit:
+        https://pillow.readthedocs.io/en/stable/reference/ImageColor.html#color-names
+
+        param str filename: name of output GIF file
+        param int duration: time to display each frame; milliseconds
+        param bool label: include label on each frame
+        param str font: font file
+        param int text_size: size of label text
+        param str text_color: color to use for the text.
+        """
+
+        # Render images if they have not been already
+        if not self._layers_rendered:
+            self.render()
+
+        input_files = []
+        for index in self._indices:
+            input_files.append(self._base_filename_dict[index])
+
+        save_gif(
+            input_files,
+            filename,
+            duration=duration,
+            label=label,
+            labels=self._labels,
+            font=font,
+            text_size=text_size,
+            text_color=text_color,
+        )
+
+        # Display the GIF
+        return filename

--- a/python/grass/jupyter/seriesmap.py
+++ b/python/grass/jupyter/seriesmap.py
@@ -20,7 +20,6 @@ from grass.grassdb.data import map_exists
 
 from .map import Map
 from .region import RegionManagerForSeries
-from .utils import save_gif
 from .baseseriesmap import BaseSeriesMap
 
 
@@ -165,49 +164,3 @@ class SeriesMap(BaseSeriesMap):
             )
         tasks = [(i,) for i in range(self.baseseries)]
         self._render(tasks)
-
-    def save(
-        self,
-        filename,
-        duration=500,
-        label=True,
-        font=None,
-        text_size=12,
-        text_color="gray",
-    ):
-        """
-        Creates a GIF animation of rendered layers.
-
-        Text color must be in a format accepted by PIL ImageColor module. For supported
-        formats, visit:
-        https://pillow.readthedocs.io/en/stable/reference/ImageColor.html#color-names
-
-        param str filename: name of output GIF file
-        param int duration: time to display each frame; milliseconds
-        param bool label: include label on each frame
-        param str font: font file
-        param int text_size: size of label text
-        param str text_color: color to use for the text
-        """
-
-        # Render images if they have not been already
-        if not self._layers_rendered:
-            self.render()
-
-        tmp_files = []
-        for file in self._base_filename_dict.values():
-            tmp_files.append(file)
-
-        save_gif(
-            tmp_files,
-            filename,
-            duration=duration,
-            label=label,
-            labels=self._labels,
-            font=font,
-            text_size=text_size,
-            text_color=text_color,
-        )
-
-        # Display the GIF
-        return filename

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -20,7 +20,6 @@ import grass.script as gs
 
 from .map import Map
 from .region import RegionManagerForTimeSeries
-from .utils import save_gif
 from .baseseriesmap import BaseSeriesMap
 
 
@@ -312,49 +311,3 @@ class TimeSeriesMap(BaseSeriesMap):
                 filename = os.path.join(self._tmpdir.name, f"{layer}.png")
             tasks.append((date, layer, filename))
         self._render(tasks)
-
-    def save(
-        self,
-        filename,
-        duration=500,
-        label=True,
-        font="DejaVuSans.ttf",
-        text_size=12,
-        text_color="gray",
-    ):
-        """
-        Creates a GIF animation of rendered layers.
-
-        Text color must be in a format accepted by PIL ImageColor module. For supported
-        formats, visit:
-        https://pillow.readthedocs.io/en/stable/reference/ImageColor.html#color-names
-
-        param str filename: name of output GIF file
-        param int duration: time to display each frame; milliseconds
-        param bool label: include date/time stamp on each frame
-        param str font: font file
-        param int text_size: size of date/time text
-        param str text_color: color to use for the text.
-        """
-
-        # Render images if they have not been already
-        if not self._layers_rendered:
-            self.render()
-
-        input_files = []
-        for date in self._labels:
-            input_files.append(self._base_filename_dict[date])
-
-        save_gif(
-            input_files,
-            filename,
-            duration=duration,
-            label=label,
-            labels=self._labels,
-            font=font,
-            text_size=text_size,
-            text_color=text_color,
-        )
-
-        # Display the GIF
-        return filename


### PR DESCRIPTION
This PR replaces TimeSeriesMap.save() and SeriesMap.save() with BaseSeriesMap.save(). 

As part of this, it also fixes #4375.