### PR TITLE
wxGUI: Refactored try-except block to be more robust in dialogs.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,7 +26,6 @@ per-file-ignores =
     doc/gui/wxpython/example/dialogs.py: F401
     gui/scripts/d.wms.py: E501
     gui/wxpython/dbmgr/base.py: E722
-    gui/wxpython/dbmgr/dialogs.py: E722
     gui/wxpython/dbmgr/sqlbuilder.py: E722
     gui/wxpython/dbmgr/manager.py: E722
     gui/wxpython/docs/wxgui_sphinx/conf.py: E402, W291

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -222,10 +222,13 @@ class DisplayAttributesDialog(wx.Dialog):
                     ctype = columns[name]["ctype"]
                     value = columns[name]["values"][idx]
                     id = columns[name]["ids"][idx]
-                    try:
-                        newvalue = self.FindWindowById(id).GetValue()
-                    except:
-                        newvalue = self.FindWindowById(id).GetLabel()
+                    widget = self.FindWindowById(id)
+                    if hasattr(widget, "GetValue"):
+                        newvalue = widget.GetValue()
+                    elif hasattr(widget, "GetLabel"):
+                        newvalue = widget.GetLabel()
+                    else:
+                        raise AttributeError(f"AttributeError in {widget}")
 
                     if newvalue:
                         try:

--- a/gui/wxpython/dbmgr/dialogs.py
+++ b/gui/wxpython/dbmgr/dialogs.py
@@ -223,12 +223,10 @@ class DisplayAttributesDialog(wx.Dialog):
                     value = columns[name]["values"][idx]
                     id = columns[name]["ids"][idx]
                     widget = self.FindWindowById(id)
-                    if hasattr(widget, "GetValue"):
+                    try:
                         newvalue = widget.GetValue()
-                    elif hasattr(widget, "GetLabel"):
+                    except AttributeError:
                         newvalue = widget.GetLabel()
-                    else:
-                        raise AttributeError(f"AttributeError in {widget}")
 
                     if newvalue:
                         try:


### PR DESCRIPTION
## Description
This PR is more of a suggestion since I thought this would be a better way to handle this instead of a `try-except` block. It modifies the `GetSQLString` method in the `DisplayAttributesDialog` class to improve how it retrieves values from widgets. The changes make the code more robust and explicit in handling different widget types.

## Changes
- Replace bare `except` clause with explicit checks for `GetValue()` and `GetLabel()` methods
- Add error handling for widgets that have neither method

## Reason for Changes
The original code used a bare `except` clause to handle potential `AttributeError`s when trying to call `GetValue()` or `GetLabel()` on widgets. This approach was not robust and could potentially hide unexpected errors. The new implementation explicitly checks for the presence of these methods and raises an `AttributeError` if neither are present.