### PR TITLE
i.ortho.photo: Fix Resource Leak in find_init.c

### DIFF
--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -7,17 +7,17 @@
 
 int I_find_initial(char *group)
 {
-    char *element;
+    char element[GNAME_MAX];
     int file_exists;
 
     if (group == NULL || *group == 0)
         return 0;
 
-    element = (char *)G_malloc(GNAME_MAX * sizeof(char));
-
-    snprintf(element, GNAME_MAX, "group/%s", group);
+    if (snprintf(element, GNAME_MAX, "group/%s", group) >= GNAME_MAX) {
+        G_warning("Group name truncated");
+        return 0;
+    }
     
     file_exists = G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
-    G_free(element);
     return file_exists;
 }

--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -4,20 +4,19 @@
  * Find the a camera initial file in the current group (if it exists)
  **************************************************************/
 #include <grass/gis.h>
+#include <grass/glocale.h>
 
 int I_find_initial(char *group)
 {
-    char element[GNAME_MAX];
-    int file_exists;
+    char element[GNAME_MAX + 6];
 
     if (group == NULL || *group == 0)
         return 0;
 
     if (snprintf(element, GNAME_MAX, "group/%s", group) >= GNAME_MAX) {
-        G_warning("Group name truncated");
+        G_warning(_("Group name <%s> truncated"), group);
         return 0;
     }
 
-    file_exists = G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
-    return file_exists;
+    return G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
 }

--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -10,12 +10,13 @@ int I_find_initial(char *group)
     char *element;
     int file_exists;
 
-    element = (char *)G_malloc(80 * sizeof(char));
-
     if (group == NULL || *group == 0) {
-        G_free(element);
         return 0;
     }
+
+    element = (char *)G_malloc(80 * sizeof(char));
+
+    
     sprintf(element, "group/%s", group);
     file_exists = G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
     G_free(element);

--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -5,6 +5,8 @@
  **************************************************************/
 #include <grass/gis.h>
 
+#define ELEMENT_BUFFER_SIZE 80
+
 int I_find_initial(char *group)
 {
     char *element;
@@ -14,10 +16,9 @@ int I_find_initial(char *group)
         return 0;
     }
 
-    element = (char *)G_malloc(80 * sizeof(char));
+    element = (char *)G_malloc(ELEMENT_BUFFER_SIZE * sizeof(char));
 
-    
-    sprintf(element, "group/%s", group);
+    snprintf(element, ELEMENT_BUFFER_SIZE, "group/%s", group);
     file_exists = G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
     G_free(element);
     return file_exists;

--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -5,20 +5,17 @@
  **************************************************************/
 #include <grass/gis.h>
 
-#define ELEMENT_BUFFER_SIZE 80
-
 int I_find_initial(char *group)
 {
     char *element;
     int file_exists;
 
-    if (group == NULL || *group == 0) {
+    if (group == NULL || *group == 0)
         return 0;
-    }
 
-    element = (char *)G_malloc(ELEMENT_BUFFER_SIZE * sizeof(char));
+    element = (char *)G_malloc(GNAME_MAX * sizeof(char));
 
-    snprintf(element, ELEMENT_BUFFER_SIZE, "group/%s", group);
+    snprintf(element, GNAME_MAX, "group/%s", group);
     
     file_exists = G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
     G_free(element);

--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -14,7 +14,7 @@ int I_find_initial(char *group)
         return 0;
 
     if (snprintf(element, GNAME_MAX, "group/%s", group) >= GNAME_MAX) {
-        G_warning(_("Group name <%s> truncated"), group);
+        G_warning(_("Group name <%s> is too long"), group);
         return 0;
     }
 

--- a/imagery/i.ortho.photo/lib/find_init.c
+++ b/imagery/i.ortho.photo/lib/find_init.c
@@ -8,11 +8,16 @@
 int I_find_initial(char *group)
 {
     char *element;
+    int file_exists;
 
     element = (char *)G_malloc(80 * sizeof(char));
 
-    if (group == NULL || *group == 0)
+    if (group == NULL || *group == 0) {
+        G_free(element);
         return 0;
+    }
     sprintf(element, "group/%s", group);
-    return G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
+    file_exists = G_find_file(element, "INIT_EXP", G_mapset()) != NULL;
+    G_free(element);
+    return file_exists;
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207903).
Replaced the direct return of G_find_file with a variable (file_exists) to store the result before freeing memory.