### PR TITLE
v.vol.rst: Fix Resource Leak issue in user1.c file

### DIFF
--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -382,6 +382,7 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
         }
         G_message(_("Bitmap mask created"));
     }
+    Vect_destroy_field_info(Fi);
 
     return 1;
 }

--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -220,6 +220,7 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
             if (a < 0) {
                 G_warning(_("Can't insert %lf,%lf,%lf,%lf,%lf a=%d"), x, y, z,
                           w, sm, a);
+                Vect_destroy_field_info(Fi);
                 return -1;
             }
 
@@ -322,6 +323,7 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
         }
         else {
             fprintf(stderr, "ERROR: zero points in the given region!\n");
+            Vect_destroy_field_info(Fi);
             return -1;
         }
     }
@@ -332,6 +334,7 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
                 KMIN, KMAX);
         fprintf(stderr, "for smooth connection of segments, npmin > segmax "
                         "(see manual) \n");
+        Vect_destroy_field_info(Fi);
         return -1;
     }
 


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID: 1207918)

used ```Vect_destroy_field_info(Fi);``` to free the memory allocated by variable Fi