### PR TITLE
raster/raster3d: Initialize Cell_head structure contents before using it in r3.in.lidar, r.in.lidar, r.in.pdal, r.in.xyz

### DIFF
--- a/raster/r.in.lidar/main.c
+++ b/raster/r.in.lidar/main.c
@@ -51,8 +51,8 @@ int main(int argc, char *argv[])
     struct PointBinning point_binning;
     void *base_array;
     void *raster_row;
-    struct Cell_head region;
-    struct Cell_head input_region;
+    struct Cell_head region = {0};
+    struct Cell_head input_region = {0};
     int rows, last_rows, row0, cols; /* scan box size */
     int row;                         /* counters */
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
     int return_filter;
 
     const char *projstr;
-    struct Cell_head cellhd, loc_wind;
+    struct Cell_head cellhd = {0}, loc_wind = {0};
 
     unsigned int n_filtered;
 

--- a/raster/r.in.pdal/main.cpp
+++ b/raster/r.in.pdal/main.cpp
@@ -69,8 +69,8 @@ int main(int argc, char *argv[])
     SEGMENT base_segment;
     struct PointBinning point_binning;
     void *raster_row;
-    struct Cell_head region;
-    struct Cell_head input_region;
+    struct Cell_head region = {};
+    struct Cell_head input_region = {};
     int rows, cols; /* scan box size */
 
     char buff[BUFFSIZE];
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     bin_index_nodes.max_nodes = 0;
     bin_index_nodes.nodes = NULL;
 
-    struct Cell_head loc_wind;
+    struct Cell_head loc_wind = {};
 
     G_gisinit(argv[0]);
 

--- a/raster/r.in.xyz/main.c
+++ b/raster/r.in.xyz/main.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
     char *n_array, *min_array, *max_array, *sum_array, *sumsq_array,
         *index_array;
     void *raster_row, *ptr;
-    struct Cell_head region;
+    struct Cell_head region = {0};
     int rows, last_rows, row0, cols; /* scan box size */
     int row, col;                    /* counters */
 

--- a/raster3d/r3.in.lidar/main.c
+++ b/raster3d/r3.in.lidar/main.c
@@ -361,13 +361,12 @@ int main(int argc, char *argv[])
 
     /* for the CRS info */
     const char *projstr;
-    struct Cell_head current_region;
-    struct Cell_head file_region;
-
+    struct Cell_head current_region = {0};
+    struct Cell_head file_region = {0};
     G_get_set_window(&current_region);
 
     /* extent for all data */
-    struct Cell_head data_region;
+    struct Cell_head data_region = {0};
 
     long unsigned header_count = 0;
     int i;


### PR DESCRIPTION
If a structure is not initialized, it may contain random data. Avoid that by initializing it.

This was found using cppcheck tool.