### PR TITLE
checks: Fix E402 Flake8 in for wxGUI Sphinx doc

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,7 +29,6 @@ per-file-ignores =
     gui/wxpython/dbmgr/dialogs.py: E722
     gui/wxpython/dbmgr/sqlbuilder.py: E722
     gui/wxpython/dbmgr/manager.py: E722
-    gui/wxpython/docs/wxgui_sphinx/conf.py: E402, W291
     gui/wxpython/gcp/manager.py: E722
     gui/wxpython/gui_core/*: E266, E722
     gui/wxpython/gui_core/dialogs.py: E722

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -15,6 +15,7 @@ import os
 from datetime import date
 import string
 from shutil import copy
+from grass.script import core
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -24,8 +25,6 @@ if not os.getenv("GISBASE"):
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.environ["GISBASE"], "etc", "python", "grass"))
 )
-
-from grass.script import core
 
 footer_tmpl = string.Template(
     r"""

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -15,10 +15,6 @@ import string
 from shutil import copy
 from grass.script import core
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-
 footer_tmpl = string.Template(
     r"""
 {% block footer %}<hr class="header">

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -10,8 +10,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
 from datetime import date
 import string
 from shutil import copy
@@ -20,11 +18,6 @@ from grass.script import core
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-if not os.getenv("GISBASE"):
-    sys.exit("GISBASE not defined")
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.environ["GISBASE"], "etc", "python", "grass"))
-)
 
 footer_tmpl = string.Template(
     r"""


### PR DESCRIPTION
Fixed `E402` error in `gui/wxpython/docs/wxgui_sphinx` - moved import module to the top