### PR TITLE
lib/shapelib: sync upstream with shapelib 1.6.0 and GDAL 3.9.2

### DIFF
--- a/lib/external/shapelib/README.md
+++ b/lib/external/shapelib/README.md
@@ -18,6 +18,8 @@
 
 * dbfopen.c
    around line 1229: GDAL bug [ticket-#809](http://trac.osgeo.org/gdal/ticket/809)
+* safileio.c
+   [shapelib commit 316ff87](https://github.com/OSGeo/shapelib/commit/316ff872566ea0d91d6b62fe01bfe39931db39aa#diff-f068bc465ca1a32e1b9c214d4eb9504ef9e0f3c4cabc1aa4bab8aa41e2248cc6R153)
 
 ## Full fix
 

--- a/lib/external/shapelib/README.md
+++ b/lib/external/shapelib/README.md
@@ -19,9 +19,6 @@
 * dbfopen.c
    around line 1229: GDAL bug [ticket-#809](http://trac.osgeo.org/gdal/ticket/809)
 
-* safileio.c
-   SHP_CVSID: ISO C does not allow extra ‘;’ outside of a function
-
 ## Full fix
 
 ```diff
@@ -42,18 +39,5 @@ index 5380e3e20b..5151148d33 100644
      else
          return( FTInteger );
      }
-diff --git a/lib/external/shapelib/safileio.c b/lib/external/shapelib/safileio.c
-index 289d347eaf..7a614a5806 100644
---- a/lib/external/shapelib/safileio.c
-+++ b/lib/external/shapelib/safileio.c
-@@ -74,7 +74,7 @@
- #include <string.h>
- #include <stdio.h>
-
--SHP_CVSID("$Id: safileio.c,v 1.6 2018-06-15 19:56:32 erouault Exp $");
-+SHP_CVSID("$Id: safileio.c,v 1.6 2018-06-15 19:56:32 erouault Exp $")
-
- #ifdef SHPAPI_UTF8_HOOKS
- #   ifdef SHPAPI_WINDOWS
 
 ```

--- a/lib/external/shapelib/README.md
+++ b/lib/external/shapelib/README.md
@@ -1,12 +1,13 @@
 # Update history of SHAPELIB copy
 
-* files `shpopen.c`, `shapefil.h`, `dbfopen.c`
+* files `shpopen.c`, `shapefil.h`, `dbfopen.c`, `shapefil_private.h`
    from GDAL [ogr/ogrsf_frmts/shape/](https://github.com/OSGeo/gdal/tree/master/ogr/ogrsf_frmts/shape)
 * file `safileio.c`
    from [SHAPELIB](http://download.osgeo.org/shapelib/)
 
 ## Last update
 
+* taken from GDAL 3.9.2 and SHAPELIB 1.6.0 (Sep 2024)
 * taken from GDAL 3.5.3 and SHAPELIB 1.5.0 (Dec 2022)
 * taken from GDAL 2.1.2 and SHAPELIB 1.3.0 (Thu Nov 24 10:45:41 CET 2016)
 * taken from GDAL 1.5.1-SVN (Sun Mar 30 11:20:43 CEST 2008)

--- a/lib/external/shapelib/README.md
+++ b/lib/external/shapelib/README.md
@@ -16,30 +16,5 @@
 
 ## Summary of fixes
 
-* dbfopen.c
-   around line 1229: GDAL bug [ticket-#809](http://trac.osgeo.org/gdal/ticket/809)
 * safileio.c
    [shapelib commit 316ff87](https://github.com/OSGeo/shapelib/commit/316ff872566ea0d91d6b62fe01bfe39931db39aa#diff-f068bc465ca1a32e1b9c214d4eb9504ef9e0f3c4cabc1aa4bab8aa41e2248cc6R153)
-
-## Full fix
-
-```diff
-diff --git a/lib/external/shapelib/dbfopen.c b/lib/external/shapelib/dbfopen.c
-index 5380e3e20b..5151148d33 100644
---- a/lib/external/shapelib/dbfopen.c
-+++ b/lib/external/shapelib/dbfopen.c
-@@ -1226,9 +1226,10 @@ DBFGetFieldInfo( DBFHandle psDBF, int iField, char * pszFieldName,
-     else if( psDBF->pachFieldType[iField] == 'N'
-              || psDBF->pachFieldType[iField] == 'F' )
-     {
--    if( psDBF->panFieldDecimals[iField] > 0
--            || psDBF->panFieldSize[iField] >= 10 )
-+    if( psDBF->panFieldDecimals[iField] > 0 ) {
-+        /* || psDBF->panFieldSize[iField] >= 10 ) */ /* GDAL bug #809 */
-         return( FTDouble );
-+    }
-     else
-         return( FTInteger );
-     }
-
-```

--- a/lib/external/shapelib/dbfopen.c
+++ b/lib/external/shapelib/dbfopen.c
@@ -1205,8 +1205,8 @@ DBFFieldType SHPAPI_CALL DBFGetFieldInfo(const DBFHandle psDBF, int iField,
 
     else if (psDBF->pachFieldType[iField] == 'N' ||
              psDBF->pachFieldType[iField] == 'F') {
-        if (psDBF->panFieldDecimals[iField] > 0
-            /* || psDBF->panFieldSize[iField] >= 10 */) /* GDAL bug #809 */
+        if (psDBF->panFieldDecimals[iField] > 0 ||
+            psDBF->panFieldSize[iField] >= 10)
             return (FTDouble);
         else
             return (FTInteger);

--- a/lib/external/shapelib/dbfopen.c
+++ b/lib/external/shapelib/dbfopen.c
@@ -1,5 +1,4 @@
 /******************************************************************************
- * $Id$
  *
  * Project:  Shapelib
  * Purpose:  Implementation of .dbf access API documented in dbf_api.html.
@@ -9,32 +8,10 @@
  * Copyright (c) 1999, Frank Warmerdam
  * Copyright (c) 2012-2019, Even Rouault <even dot rouault at spatialys.com>
  *
- * This software is available under the following "MIT Style" license,
- * or at the option of the licensee under the LGPL (see COPYING).  This
- * option is discussed in more detail in shapelib.html.
- *
- * --
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************/
 
-#include "shapefil.h"
+#include "shapefil_private.h"
 
 #include <math.h>
 #include <stdbool.h>
@@ -47,7 +24,9 @@
 #include "cpl_string.h"
 #else
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_MSC_VER)
+#define STRCASECMP(a, b) (_stricmp(a, b))
+#elif defined(_WIN32)
 #define STRCASECMP(a, b) (stricmp(a, b))
 #else
 #include <strings.h>
@@ -58,7 +37,7 @@
 #if _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
-#elif defined(WIN32) || defined(_WIN32)
+#elif defined(_WIN32)
 #ifndef snprintf
 #define snprintf _snprintf
 #endif
@@ -67,8 +46,6 @@
 #define CPLsprintf  sprintf
 #define CPLsnprintf snprintf
 #endif
-
-SHP_CVSID("$Id$")
 
 #ifndef FALSE
 #define FALSE 0
@@ -91,33 +68,6 @@ CPL_INLINE static void CPL_IGNORE_RET_VAL_INT(CPL_UNUSED int unused)
 #define CPL_IGNORE_RET_VAL_INT(x) x
 #endif
 
-#ifdef __cplusplus
-#define STATIC_CAST(type, x)      static_cast<type>(x)
-#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
-#define CONST_CAST(type, x)       const_cast<type>(x)
-#define SHPLIB_NULLPTR            nullptr
-#else
-#define STATIC_CAST(type, x)      ((type)(x))
-#define REINTERPRET_CAST(type, x) ((type)(x))
-#define CONST_CAST(type, x)       ((type)(x))
-#define SHPLIB_NULLPTR            NULL
-#endif
-
-/************************************************************************/
-/*                             SfRealloc()                              */
-/*                                                                      */
-/*      A realloc cover function that will access a NULL pointer as     */
-/*      a valid input.                                                  */
-/************************************************************************/
-
-static void *SfRealloc(void *pMem, int nNewSize)
-{
-    if (pMem == SHPLIB_NULLPTR)
-        return malloc(nNewSize);
-    else
-        return realloc(pMem, nNewSize);
-}
-
 /************************************************************************/
 /*                           DBFWriteHeader()                           */
 /*                                                                      */
@@ -137,9 +87,9 @@ static void DBFWriteHeader(DBFHandle psDBF)
     psDBF->bNoHeader = FALSE;
 
     /* -------------------------------------------------------------------- */
-    /*    Initialize the file header information.                */
+    /*      Initialize the file header information.                         */
     /* -------------------------------------------------------------------- */
-    abyHeader[0] = 0x03; /* memo field? - just copying     */
+    abyHeader[0] = 0x03; /* memo field? - just copying */
 
     /* write out update date */
     abyHeader[1] = STATIC_CAST(unsigned char, psDBF->nUpdateYearSince1900);
@@ -158,7 +108,7 @@ static void DBFWriteHeader(DBFHandle psDBF)
 
     /* -------------------------------------------------------------------- */
     /*      Write the initial 32 byte file header, and all the field        */
-    /*      descriptions.                                             */
+    /*      descriptions.                                                   */
     /* -------------------------------------------------------------------- */
     psDBF->sHooks.FSeek(psDBF->fp, 0, 0);
     psDBF->sHooks.FWrite(abyHeader, XBASE_FILEHDR_SZ, 1, psDBF->fp);
@@ -344,7 +294,6 @@ void SHPAPI_CALL DBFSetLastModifiedDate(DBFHandle psDBF, int nYYSince1900,
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL DBFOpen(const char *pszFilename, const char *pszAccess)
-
 {
     SAHooks sHooks;
 
@@ -376,7 +325,7 @@ static int DBFGetLenWithoutExtension(const char *pszBasename)
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
-                                SAHooks *psHooks)
+                                const SAHooks *psHooks)
 {
     /* -------------------------------------------------------------------- */
     /*      We only allow the access strings "rb" and "r+".                  */
@@ -393,8 +342,8 @@ DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
         pszAccess = "rb+";
 
     /* -------------------------------------------------------------------- */
-    /*    Compute the base (layer) name.  If there is any extension    */
-    /*    on the passed in filename we will strip it off.            */
+    /*      Compute the base (layer) name.  If there is any extension       */
+    /*      on the passed in filename we will strip it off.                 */
     /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
@@ -402,19 +351,20 @@ DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
     memcpy(pszFullname + nLenWithoutExtension, ".dbf", 5);
 
     DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1, sizeof(DBFInfo)));
-    psDBF->fp = psHooks->FOpen(pszFullname, pszAccess);
+    psDBF->fp = psHooks->FOpen(pszFullname, pszAccess, psHooks->pvUserData);
     memcpy(&(psDBF->sHooks), psHooks, sizeof(SAHooks));
 
     if (psDBF->fp == SHPLIB_NULLPTR) {
         memcpy(pszFullname + nLenWithoutExtension, ".DBF", 5);
-        psDBF->fp = psDBF->sHooks.FOpen(pszFullname, pszAccess);
+        psDBF->fp =
+            psDBF->sHooks.FOpen(pszFullname, pszAccess, psHooks->pvUserData);
     }
 
     memcpy(pszFullname + nLenWithoutExtension, ".cpg", 5);
-    SAFile pfCPG = psHooks->FOpen(pszFullname, "r");
+    SAFile pfCPG = psHooks->FOpen(pszFullname, "r", psHooks->pvUserData);
     if (pfCPG == SHPLIB_NULLPTR) {
         memcpy(pszFullname + nLenWithoutExtension, ".CPG", 5);
-        pfCPG = psHooks->FOpen(pszFullname, "r");
+        pfCPG = psHooks->FOpen(pszFullname, "r", psHooks->pvUserData);
     }
 
     free(pszFullname);
@@ -495,7 +445,7 @@ DBFHandle SHPAPI_CALL DBFOpenLL(const char *pszFilename, const char *pszAccess,
     /* -------------------------------------------------------------------- */
     /*  Read in Field Definitions                                           */
     /* -------------------------------------------------------------------- */
-    pabyBuf = STATIC_CAST(unsigned char *, SfRealloc(pabyBuf, nHeadLen));
+    pabyBuf = STATIC_CAST(unsigned char *, realloc(pabyBuf, nHeadLen));
     psDBF->pszHeader = REINTERPRET_CAST(char *, pabyBuf);
 
     psDBF->sHooks.FSeek(psDBF->fp, XBASE_FILEHDR_SZ, 0);
@@ -583,8 +533,8 @@ void SHPAPI_CALL DBFClose(DBFHandle psDBF)
     CPL_IGNORE_RET_VAL_INT(DBFFlushRecord(psDBF));
 
     /* -------------------------------------------------------------------- */
-    /*      Update last access date, and number of records if we have    */
-    /*    write access.                                    */
+    /*      Update last access date, and number of records if we have       */
+    /*      write access.                                                   */
     /* -------------------------------------------------------------------- */
     if (psDBF->bUpdated)
         DBFUpdateHeader(psDBF);
@@ -645,11 +595,12 @@ DBFHandle SHPAPI_CALL DBFCreateEx(const char *pszFilename,
 /************************************************************************/
 
 DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
-                                  const char *pszCodePage, SAHooks *psHooks)
+                                  const char *pszCodePage,
+                                  const SAHooks *psHooks)
 {
     /* -------------------------------------------------------------------- */
-    /*    Compute the base (layer) name.  If there is any extension    */
-    /*    on the passed in filename we will strip it off.            */
+    /*      Compute the base (layer) name.  If there is any extension       */
+    /*      on the passed in filename we will strip it off.                 */
     /* -------------------------------------------------------------------- */
     const int nLenWithoutExtension = DBFGetLenWithoutExtension(pszFilename);
     char *pszFullname = STATIC_CAST(char *, malloc(nLenWithoutExtension + 5));
@@ -659,17 +610,7 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Create the file.                                                */
     /* -------------------------------------------------------------------- */
-    SAFile fp = psHooks->FOpen(pszFullname, "wb");
-    if (fp == SHPLIB_NULLPTR) {
-        free(pszFullname);
-        return SHPLIB_NULLPTR;
-    }
-
-    char chZero = '\0';
-    psHooks->FWrite(&chZero, 1, 1, fp);
-    psHooks->FClose(fp);
-
-    fp = psHooks->FOpen(pszFullname, "rb+");
+    SAFile fp = psHooks->FOpen(pszFullname, "wb+", psHooks->pvUserData);
     if (fp == SHPLIB_NULLPTR) {
         free(pszFullname);
         return SHPLIB_NULLPTR;
@@ -685,7 +626,8 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
                            // a valid one
         }
         if (ldid < 0) {
-            SAFile fpCPG = psHooks->FOpen(pszFullname, "w");
+            SAFile fpCPG =
+                psHooks->FOpen(pszFullname, "w", psHooks->pvUserData);
             psHooks->FWrite(
                 CONST_CAST(void *, STATIC_CAST(const void *, pszCodePage)),
                 strlen(pszCodePage), 1, fpCPG);
@@ -693,13 +635,13 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
         }
     }
     if (pszCodePage == SHPLIB_NULLPTR || ldid >= 0) {
-        psHooks->Remove(pszFullname);
+        psHooks->Remove(pszFullname, psHooks->pvUserData);
     }
 
     free(pszFullname);
 
     /* -------------------------------------------------------------------- */
-    /*    Create the info structure.                    */
+    /*      Create the info structure.                                      */
     /* -------------------------------------------------------------------- */
     DBFHandle psDBF = STATIC_CAST(DBFHandle, calloc(1, sizeof(DBFInfo)));
 
@@ -829,23 +771,22 @@ int SHPAPI_CALL DBFAddNativeFieldType(DBFHandle psDBF, const char *pszFieldName,
     const int nOldHeaderLength = psDBF->nHeaderLength;
 
     /* -------------------------------------------------------------------- */
-    /*      SfRealloc all the arrays larger to hold the additional field      */
+    /*      realloc all the arrays larger to hold the additional field      */
     /*      information.                                                    */
     /* -------------------------------------------------------------------- */
     psDBF->nFields++;
 
     psDBF->panFieldOffset = STATIC_CAST(
-        int *, SfRealloc(psDBF->panFieldOffset, sizeof(int) * psDBF->nFields));
+        int *, realloc(psDBF->panFieldOffset, sizeof(int) * psDBF->nFields));
 
     psDBF->panFieldSize = STATIC_CAST(
-        int *, SfRealloc(psDBF->panFieldSize, sizeof(int) * psDBF->nFields));
+        int *, realloc(psDBF->panFieldSize, sizeof(int) * psDBF->nFields));
 
-    psDBF->panFieldDecimals =
-        STATIC_CAST(int *, SfRealloc(psDBF->panFieldDecimals,
-                                     sizeof(int) * psDBF->nFields));
+    psDBF->panFieldDecimals = STATIC_CAST(
+        int *, realloc(psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields));
 
     psDBF->pachFieldType = STATIC_CAST(
-        char *, SfRealloc(psDBF->pachFieldType, sizeof(char) * psDBF->nFields));
+        char *, realloc(psDBF->pachFieldType, sizeof(char) * psDBF->nFields));
 
     /* -------------------------------------------------------------------- */
     /*      Assign the new field information fields.                        */
@@ -863,7 +804,7 @@ int SHPAPI_CALL DBFAddNativeFieldType(DBFHandle psDBF, const char *pszFieldName,
     psDBF->bUpdated = FALSE;
 
     psDBF->pszHeader = STATIC_CAST(
-        char *, SfRealloc(psDBF->pszHeader, psDBF->nFields * XBASE_FLDHDR_SZ));
+        char *, realloc(psDBF->pszHeader, psDBF->nFields * XBASE_FLDHDR_SZ));
 
     char *pszFInfo = psDBF->pszHeader + XBASE_FLDHDR_SZ * (psDBF->nFields - 1);
 
@@ -887,7 +828,7 @@ int SHPAPI_CALL DBFAddNativeFieldType(DBFHandle psDBF, const char *pszFieldName,
     /*      Make the current record buffer appropriately larger.            */
     /* -------------------------------------------------------------------- */
     psDBF->pszCurrentRecord = STATIC_CAST(
-        char *, SfRealloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
+        char *, realloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
 
     /* we're done if dealing with new .dbf */
     if (psDBF->bNoHeader)
@@ -971,13 +912,13 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
         return SHPLIB_NULLPTR;
 
     /* -------------------------------------------------------------------- */
-    /*    Have we read the record?                    */
+    /*     Have we read the record?                                         */
     /* -------------------------------------------------------------------- */
     if (!DBFLoadRecord(psDBF, hEntity))
         return SHPLIB_NULLPTR;
 
-    unsigned char *pabyRec =
-        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    const unsigned char *pabyRec =
+        REINTERPRET_CAST(const unsigned char *, psDBF->pszCurrentRecord);
 
     /* -------------------------------------------------------------------- */
     /*      Ensure we have room to extract the target field.                */
@@ -993,7 +934,7 @@ static void *DBFReadAttribute(DBFHandle psDBF, int hEntity, int iField,
     }
 
     /* -------------------------------------------------------------------- */
-    /*    Extract the requested field.                    */
+    /*      Extract the requested field.                                    */
     /* -------------------------------------------------------------------- */
     memcpy(psDBF->pszWorkField,
            REINTERPRET_CAST(const char *, pabyRec) +
@@ -1085,7 +1026,6 @@ double SHPAPI_CALL DBFReadDoubleAttribute(DBFHandle psDBF, int iRecord,
 
 const char SHPAPI_CALL1(*)
     DBFReadStringAttribute(DBFHandle psDBF, int iRecord, int iField)
-
 {
     return STATIC_CAST(const char *,
                        DBFReadAttribute(psDBF, iRecord, iField, 'C'));
@@ -1099,10 +1039,38 @@ const char SHPAPI_CALL1(*)
 
 const char SHPAPI_CALL1(*)
     DBFReadLogicalAttribute(DBFHandle psDBF, int iRecord, int iField)
-
 {
     return STATIC_CAST(const char *,
                        DBFReadAttribute(psDBF, iRecord, iField, 'L'));
+}
+
+/************************************************************************/
+/*                        DBFReadDateAttribute()                        */
+/*                                                                      */
+/*      Read a date attribute.                                          */
+/************************************************************************/
+
+SHPDate SHPAPI_CALL DBFReadDateAttribute(DBFHandle psDBF, int iRecord,
+                                         int iField)
+{
+    const char *pdateValue = STATIC_CAST(
+        const char *, DBFReadAttribute(psDBF, iRecord, iField, 'D'));
+
+    SHPDate date;
+
+    if (pdateValue == SHPLIB_NULLPTR) {
+        date.year = 0;
+        date.month = 0;
+        date.day = 0;
+    }
+    else if (3 != sscanf(pdateValue, "%4d%2d%2d", &date.year, &date.month,
+                         &date.day)) {
+        date.year = 0;
+        date.month = 0;
+        date.day = 0;
+    }
+
+    return date;
 }
 
 /************************************************************************/
@@ -1135,7 +1103,16 @@ static bool DBFIsValueNULL(char chType, const char *pszValue)
 
     case 'D':
         /* NULL date fields have value "00000000" */
-        return strncmp(pszValue, "00000000", 8) == 0;
+        /* Some DBF files have fields filled with spaces */
+        /* (trimmed by DBFReadStringAttribute) to indicate null */
+        /* values for dates (#4265). */
+        /* And others have '       0':
+         * https://lists.osgeo.org/pipermail/gdal-dev/2023-November/058010.html
+         */
+        /* And others just empty string:
+         * https://github.com/OSGeo/gdal/issues/10405 */
+        return pszValue[0] == 0 || strncmp(pszValue, "00000000", 8) == 0 ||
+               strcmp(pszValue, " ") == 0 || strcmp(pszValue, "0") == 0;
 
     case 'L':
         /* NULL boolean fields have value "?" */
@@ -1155,7 +1132,8 @@ static bool DBFIsValueNULL(char chType, const char *pszValue)
 /*      Contributed by Jim Matthews.                                    */
 /************************************************************************/
 
-int SHPAPI_CALL DBFIsAttributeNULL(DBFHandle psDBF, int iRecord, int iField)
+int SHPAPI_CALL DBFIsAttributeNULL(const DBFHandle psDBF, int iRecord,
+                                   int iField)
 {
     const char *pszValue = DBFReadStringAttribute(psDBF, iRecord, iField);
 
@@ -1171,8 +1149,7 @@ int SHPAPI_CALL DBFIsAttributeNULL(DBFHandle psDBF, int iRecord, int iField)
 /*      Return the number of fields in this table.                      */
 /************************************************************************/
 
-int SHPAPI_CALL DBFGetFieldCount(DBFHandle psDBF)
-
+int SHPAPI_CALL DBFGetFieldCount(const DBFHandle psDBF)
 {
     return (psDBF->nFields);
 }
@@ -1183,8 +1160,7 @@ int SHPAPI_CALL DBFGetFieldCount(DBFHandle psDBF)
 /*      Return the number of records in this table.                     */
 /************************************************************************/
 
-int SHPAPI_CALL DBFGetRecordCount(DBFHandle psDBF)
-
+int SHPAPI_CALL DBFGetRecordCount(const DBFHandle psDBF)
 {
     return (psDBF->nRecords);
 }
@@ -1197,10 +1173,9 @@ int SHPAPI_CALL DBFGetRecordCount(DBFHandle psDBF)
 /*      bytes long.                                                     */
 /************************************************************************/
 
-DBFFieldType SHPAPI_CALL DBFGetFieldInfo(DBFHandle psDBF, int iField,
+DBFFieldType SHPAPI_CALL DBFGetFieldInfo(const DBFHandle psDBF, int iField,
                                          char *pszFieldName, int *pnWidth,
                                          int *pnDecimals)
-
 {
     if (iField < 0 || iField >= psDBF->nFields)
         return (FTInvalid);
@@ -1230,10 +1205,9 @@ DBFFieldType SHPAPI_CALL DBFGetFieldInfo(DBFHandle psDBF, int iField,
 
     else if (psDBF->pachFieldType[iField] == 'N' ||
              psDBF->pachFieldType[iField] == 'F') {
-        if (psDBF->panFieldDecimals[iField] > 0) {
-            /* || psDBF->panFieldSize[iField] >= 10 ) */ /* GDAL bug #809 */
+        if (psDBF->panFieldDecimals[iField] > 0
+            /* || psDBF->panFieldSize[iField] >= 10 */) /* GDAL bug #809 */
             return (FTDouble);
-        }
         else
             return (FTInteger);
     }
@@ -1244,15 +1218,15 @@ DBFFieldType SHPAPI_CALL DBFGetFieldInfo(DBFHandle psDBF, int iField,
 
 /************************************************************************/
 /*                         DBFWriteAttribute()                          */
-/*                                    */
-/*    Write an attribute record to the file.                */
+/*                                                                      */
+/*      Write an attribute record to the file.                          */
 /************************************************************************/
 
 static bool DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
                               void *pValue)
 {
     /* -------------------------------------------------------------------- */
-    /*    Is this a valid record?                        */
+    /*      Is this a valid record?                                         */
     /* -------------------------------------------------------------------- */
     if (hEntity < 0 || hEntity > psDBF->nRecords)
         return false;
@@ -1333,9 +1307,13 @@ static bool DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
     case 'L':
         if (psDBF->panFieldSize[iField] >= 1 &&
             (*STATIC_CAST(char *, pValue) == 'F' ||
-             *STATIC_CAST(char *, pValue) == 'T'))
+             *STATIC_CAST(char *, pValue) == 'T')) {
             *(pabyRec + psDBF->panFieldOffset[iField]) =
                 *STATIC_CAST(char *, pValue);
+        }
+        else {
+            nRetResult = false;
+        }
         break;
 
     default: {
@@ -1370,10 +1348,10 @@ static bool DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
 /************************************************************************/
 
 int SHPAPI_CALL DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity,
-                                          int iField, void *pValue)
+                                          int iField, const void *pValue)
 {
     /* -------------------------------------------------------------------- */
-    /*    Is this a valid record?                        */
+    /*      Is this a valid record?                                         */
     /* -------------------------------------------------------------------- */
     if (hEntity < 0 || hEntity > psDBF->nRecords)
         return (FALSE);
@@ -1402,24 +1380,29 @@ int SHPAPI_CALL DBFWriteAttributeDirectly(DBFHandle psDBF, int hEntity,
     if (!DBFLoadRecord(psDBF, hEntity))
         return FALSE;
 
-    unsigned char *pabyRec =
-        REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
+    if (iField >= 0) {
+        unsigned char *pabyRec =
+            REINTERPRET_CAST(unsigned char *, psDBF->pszCurrentRecord);
 
-    /* -------------------------------------------------------------------- */
-    /*      Assign all the record fields.                                   */
-    /* -------------------------------------------------------------------- */
-    int j;
-    if (STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue))) >
-        psDBF->panFieldSize[iField])
-        j = psDBF->panFieldSize[iField];
-    else {
-        memset(pabyRec + psDBF->panFieldOffset[iField], ' ',
-               psDBF->panFieldSize[iField]);
-        j = STATIC_CAST(int, strlen(STATIC_CAST(char *, pValue)));
-    }
+        /* --------------------------------------------------------------------
+         */
+        /*      Assign all the record fields. */
+        /* --------------------------------------------------------------------
+         */
+        int j;
+        if (STATIC_CAST(int, strlen(STATIC_CAST(const char *, pValue))) >
+            psDBF->panFieldSize[iField])
+            j = psDBF->panFieldSize[iField];
+        else {
+            memset(pabyRec + psDBF->panFieldOffset[iField], ' ',
+                   psDBF->panFieldSize[iField]);
+            j = STATIC_CAST(int, strlen(STATIC_CAST(const char *, pValue)));
+        }
 
-    strncpy(REINTERPRET_CAST(char *, pabyRec + psDBF->panFieldOffset[iField]),
+        memcpy(
+            REINTERPRET_CAST(char *, pabyRec + psDBF->panFieldOffset[iField]),
             STATIC_CAST(const char *, pValue), j);
+    }
 
     psDBF->bCurrentRecordModified = TRUE;
     psDBF->bUpdated = TRUE;
@@ -1443,7 +1426,7 @@ int SHPAPI_CALL DBFWriteDoubleAttribute(DBFHandle psDBF, int iRecord,
 /************************************************************************/
 /*                      DBFWriteIntegerAttribute()                      */
 /*                                                                      */
-/*      Write a integer attribute.                                      */
+/*      Write an integer attribute.                                     */
 /************************************************************************/
 
 int SHPAPI_CALL DBFWriteIntegerAttribute(DBFHandle psDBF, int iRecord,
@@ -1463,7 +1446,6 @@ int SHPAPI_CALL DBFWriteIntegerAttribute(DBFHandle psDBF, int iRecord,
 
 int SHPAPI_CALL DBFWriteStringAttribute(DBFHandle psDBF, int iRecord,
                                         int iField, const char *pszValue)
-
 {
     return (
         DBFWriteAttribute(psDBF, iRecord, iField,
@@ -1473,11 +1455,10 @@ int SHPAPI_CALL DBFWriteStringAttribute(DBFHandle psDBF, int iRecord,
 /************************************************************************/
 /*                      DBFWriteNULLAttribute()                         */
 /*                                                                      */
-/*      Write a string attribute.                                       */
+/*      Write a NULL attribute.                                         */
 /************************************************************************/
 
 int SHPAPI_CALL DBFWriteNULLAttribute(DBFHandle psDBF, int iRecord, int iField)
-
 {
     return (DBFWriteAttribute(psDBF, iRecord, iField, SHPLIB_NULLPTR));
 }
@@ -1490,7 +1471,6 @@ int SHPAPI_CALL DBFWriteNULLAttribute(DBFHandle psDBF, int iRecord, int iField)
 
 int SHPAPI_CALL DBFWriteLogicalAttribute(DBFHandle psDBF, int iRecord,
                                          int iField, const char lValue)
-
 {
     return (
         DBFWriteAttribute(psDBF, iRecord, iField,
@@ -1498,15 +1478,40 @@ int SHPAPI_CALL DBFWriteLogicalAttribute(DBFHandle psDBF, int iRecord,
 }
 
 /************************************************************************/
-/*                         DBFWriteTuple()                              */
-/*                                    */
-/*    Write an attribute record to the file.                */
+/*                      DBFWriteDateAttribute()                         */
+/*                                                                      */
+/*      Write a date attribute.                                         */
 /************************************************************************/
 
-int SHPAPI_CALL DBFWriteTuple(DBFHandle psDBF, int hEntity, void *pRawTuple)
+int SHPAPI_CALL DBFWriteDateAttribute(DBFHandle psDBF, int iRecord, int iField,
+                                      const SHPDate *lValue)
+{
+    if (SHPLIB_NULLPTR == lValue)
+        return false;
+    /* check for supported digit range, but do not check for valid date */
+    if (lValue->year < 0 || lValue->year > 9999)
+        return false;
+    if (lValue->month < 0 || lValue->month > 99)
+        return false;
+    if (lValue->day < 0 || lValue->day > 99)
+        return false;
+    char dateValue[9]; /* "yyyyMMdd\0" */
+    snprintf(dateValue, sizeof(dateValue), "%04d%02d%02d", lValue->year,
+             lValue->month, lValue->day);
+    return (DBFWriteAttributeDirectly(psDBF, iRecord, iField, dateValue));
+}
+
+/************************************************************************/
+/*                         DBFWriteTuple()                              */
+/*                                                                      */
+/*      Write an attribute record to the file.                          */
+/************************************************************************/
+
+int SHPAPI_CALL DBFWriteTuple(DBFHandle psDBF, int hEntity,
+                              const void *pRawTuple)
 {
     /* -------------------------------------------------------------------- */
-    /*    Is this a valid record?                        */
+    /*      Is this a valid record?                                         */
     /* -------------------------------------------------------------------- */
     if (hEntity < 0 || hEntity > psDBF->nRecords)
         return (FALSE);
@@ -1554,7 +1559,6 @@ int SHPAPI_CALL DBFWriteTuple(DBFHandle psDBF, int hEntity, void *pRawTuple)
 /************************************************************************/
 
 const char SHPAPI_CALL1(*) DBFReadTuple(DBFHandle psDBF, int hEntity)
-
 {
     if (hEntity < 0 || hEntity >= psDBF->nRecords)
         return SHPLIB_NULLPTR;
@@ -1566,14 +1570,17 @@ const char SHPAPI_CALL1(*) DBFReadTuple(DBFHandle psDBF, int hEntity)
 }
 
 /************************************************************************/
-/*                          DBFCloneEmpty()                              */
+/*                          DBFCloneEmpty()                             */
 /*                                                                      */
-/*      Read one of the attribute fields of a record.                   */
+/*      Create a new .dbf file with same code page and field            */
+/*      definitions as the given handle.                                */
 /************************************************************************/
 
-DBFHandle SHPAPI_CALL DBFCloneEmpty(DBFHandle psDBF, const char *pszFilename)
+DBFHandle SHPAPI_CALL DBFCloneEmpty(const DBFHandle psDBF,
+                                    const char *pszFilename)
 {
-    DBFHandle newDBF = DBFCreateEx(pszFilename, psDBF->pszCodePage);
+    DBFHandle newDBF =
+        DBFCreateLL(pszFilename, psDBF->pszCodePage, &psDBF->sHooks);
     if (newDBF == SHPLIB_NULLPTR)
         return SHPLIB_NULLPTR;
 
@@ -1629,8 +1636,7 @@ DBFHandle SHPAPI_CALL DBFCloneEmpty(DBFHandle psDBF, const char *pszFilename)
 /*                           'M' (Memo: 10 digits .DBT block ptr)       */
 /************************************************************************/
 
-char SHPAPI_CALL DBFGetNativeFieldType(DBFHandle psDBF, int iField)
-
+char SHPAPI_CALL DBFGetNativeFieldType(const DBFHandle psDBF, int iField)
 {
     if (iField >= 0 && iField < psDBF->nFields)
         return psDBF->pachFieldType[iField];
@@ -1646,7 +1652,8 @@ char SHPAPI_CALL DBFGetNativeFieldType(DBFHandle psDBF, int iField)
 /*      Contributed by Jim Matthews.                                    */
 /************************************************************************/
 
-int SHPAPI_CALL DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName)
+int SHPAPI_CALL DBFGetFieldIndex(const DBFHandle psDBF,
+                                 const char *pszFieldName)
 {
     char name[XBASE_FLDNAME_LEN_READ + 1];
 
@@ -1665,7 +1672,7 @@ int SHPAPI_CALL DBFGetFieldIndex(DBFHandle psDBF, const char *pszFieldName)
 /*      it returns FALSE.                                               */
 /************************************************************************/
 
-int SHPAPI_CALL DBFIsRecordDeleted(DBFHandle psDBF, int iShape)
+int SHPAPI_CALL DBFIsRecordDeleted(const DBFHandle psDBF, int iShape)
 {
     /* -------------------------------------------------------------------- */
     /*      Verify selection.                                               */
@@ -1674,7 +1681,7 @@ int SHPAPI_CALL DBFIsRecordDeleted(DBFHandle psDBF, int iShape)
         return TRUE;
 
     /* -------------------------------------------------------------------- */
-    /*    Have we read the record?                    */
+    /*      Have we read the record?                                        */
     /* -------------------------------------------------------------------- */
     if (!DBFLoadRecord(psDBF, iShape))
         return FALSE;
@@ -1727,7 +1734,7 @@ int SHPAPI_CALL DBFMarkRecordDeleted(DBFHandle psDBF, int iShape,
 /*                            DBFGetCodePage                            */
 /************************************************************************/
 
-const char SHPAPI_CALL1(*) DBFGetCodePage(DBFHandle psDBF)
+const char SHPAPI_CALL1(*) DBFGetCodePage(const DBFHandle psDBF)
 {
     if (psDBF == SHPLIB_NULLPTR)
         return SHPLIB_NULLPTR;
@@ -1768,17 +1775,16 @@ int SHPAPI_CALL DBFDeleteField(DBFHandle psDBF, int iField)
     psDBF->nFields--;
 
     psDBF->panFieldOffset = STATIC_CAST(
-        int *, SfRealloc(psDBF->panFieldOffset, sizeof(int) * psDBF->nFields));
+        int *, realloc(psDBF->panFieldOffset, sizeof(int) * psDBF->nFields));
 
     psDBF->panFieldSize = STATIC_CAST(
-        int *, SfRealloc(psDBF->panFieldSize, sizeof(int) * psDBF->nFields));
+        int *, realloc(psDBF->panFieldSize, sizeof(int) * psDBF->nFields));
 
-    psDBF->panFieldDecimals =
-        STATIC_CAST(int *, SfRealloc(psDBF->panFieldDecimals,
-                                     sizeof(int) * psDBF->nFields));
+    psDBF->panFieldDecimals = STATIC_CAST(
+        int *, realloc(psDBF->panFieldDecimals, sizeof(int) * psDBF->nFields));
 
     psDBF->pachFieldType = STATIC_CAST(
-        char *, SfRealloc(psDBF->pachFieldType, sizeof(char) * psDBF->nFields));
+        char *, realloc(psDBF->pachFieldType, sizeof(char) * psDBF->nFields));
 
     /* update header information */
     psDBF->nHeaderLength -= XBASE_FLDHDR_SZ;
@@ -1790,11 +1796,11 @@ int SHPAPI_CALL DBFDeleteField(DBFHandle psDBF, int iField)
             sizeof(char) * (psDBF->nFields - iField) * XBASE_FLDHDR_SZ);
 
     psDBF->pszHeader = STATIC_CAST(
-        char *, SfRealloc(psDBF->pszHeader, psDBF->nFields * XBASE_FLDHDR_SZ));
+        char *, realloc(psDBF->pszHeader, psDBF->nFields * XBASE_FLDHDR_SZ));
 
     /* update size of current record appropriately */
     psDBF->pszCurrentRecord = STATIC_CAST(
-        char *, SfRealloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
+        char *, realloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
 
     /* we're done if we're dealing with not yet created .dbf */
     if (psDBF->bNoHeader && psDBF->nRecords == 0)
@@ -1866,7 +1872,7 @@ int SHPAPI_CALL DBFDeleteField(DBFHandle psDBF, int iField)
 /* code of DBFReorderFields.                                            */
 /************************************************************************/
 
-int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, int *panMap)
+int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, const int *panMap)
 {
     if (psDBF->nFields == 0)
         return TRUE;
@@ -1878,13 +1884,13 @@ int SHPAPI_CALL DBFReorderFields(DBFHandle psDBF, int *panMap)
     /* a simple malloc() would be enough, but calloc() helps clang static
      * analyzer */
     int *panFieldOffsetNew =
-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
     int *panFieldSizeNew =
-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
     int *panFieldDecimalsNew =
-        STATIC_CAST(int *, calloc(sizeof(int), psDBF->nFields));
+        STATIC_CAST(int *, calloc(psDBF->nFields, sizeof(int)));
     char *pachFieldTypeNew =
-        STATIC_CAST(char *, calloc(sizeof(char), psDBF->nFields));
+        STATIC_CAST(char *, calloc(psDBF->nFields, sizeof(char)));
     char *pszHeaderNew = STATIC_CAST(
         char *, malloc(sizeof(char) * XBASE_FLDHDR_SZ * psDBF->nFields));
 
@@ -2050,7 +2056,7 @@ int SHPAPI_CALL DBFAlterFieldDefn(DBFHandle psDBF, int iField,
         psDBF->nRecordLength += nWidth - nOldWidth;
 
         psDBF->pszCurrentRecord = STATIC_CAST(
-            char *, SfRealloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
+            char *, realloc(psDBF->pszCurrentRecord, psDBF->nRecordLength));
     }
 
     /* we're done if we're dealing with not yet created .dbf */
@@ -2069,7 +2075,6 @@ int SHPAPI_CALL DBFAlterFieldDefn(DBFHandle psDBF, int iField,
         char *pszOldField =
             STATIC_CAST(char *, malloc(sizeof(char) * (nOldWidth + 1)));
 
-        /* cppcheck-suppress uninitdata */
         pszOldField[nOldWidth] = 0;
 
         /* move records to their new positions */
@@ -2139,7 +2144,6 @@ int SHPAPI_CALL DBFAlterFieldDefn(DBFHandle psDBF, int iField,
         char *pszOldField =
             STATIC_CAST(char *, malloc(sizeof(char) * (nOldWidth + 1)));
 
-        /* cppcheck-suppress uninitdata */
         pszOldField[nOldWidth] = 0;
 
         /* move records to their new positions */

--- a/lib/external/shapelib/safileio.c
+++ b/lib/external/shapelib/safileio.c
@@ -129,8 +129,10 @@ static wchar_t *Utf8ToWideChar(const char *pszFilename)
 /*                           SAUtf8WFOpen                               */
 /************************************************************************/
 
-SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess)
+static SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess,
+                           void *pvUserData)
 {
+    (void)pvUserData;
     SAFile file = NULL;
     wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
     wchar_t *pwszAccess = Utf8ToWideChar(pszAccess);
@@ -142,8 +144,9 @@ SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess)
     return file;
 }
 
-int SAUtf8WRemove(const char *pszFilename)
+static int SAUtf8WRemove(const char *pszFilename, void *pvUserData)
 {
+    (void)pvUserData;
     wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
     int rc = -1;
     if (pwszFileName != NULL) {

--- a/lib/external/shapelib/safileio.c
+++ b/lib/external/shapelib/safileio.c
@@ -1,5 +1,4 @@
 /******************************************************************************
- * $Id: safileio.c,v 1.6 2018-06-15 19:56:32 erouault Exp $
  *
  * Project:  Shapelib
  * Purpose:  Default implementation of file io based on stdio.
@@ -8,74 +7,19 @@
  ******************************************************************************
  * Copyright (c) 2007, Frank Warmerdam
  *
- * This software is available under the following "MIT Style" license,
- * or at the option of the licensee under the LGPL (see COPYING).  This
- * option is discussed in more detail in shapelib.html.
- *
- * --
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
  ******************************************************************************
- *
- * $Log: safileio.c,v $
- * Revision 1.6  2018-06-15 19:56:32  erouault
- * * safileio.c: remove duplicate test. Patch by Jaroslav Fojtik.
- * Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2744
- *
- * Revision 1.5  2016-12-05 12:44:05  erouault
- * * Major overhaul of Makefile build system to use autoconf/automake.
- *
- * * Warning fixes in contrib/
- *
- * Revision 1.4  2008-01-16 20:05:14  bram
- * Add file hooks that accept UTF-8 encoded filenames on some platforms.  Use
- *SASetupUtf8Hooks tosetup the hooks and check SHPAPI_UTF8_HOOKS for its
- *availability.  Currently, this is only available on the Windows platform that
- *decodes the UTF-8 filenames to wide character strings and feeds them to
- *_wfopen and _wremove.
- *
- * Revision 1.3  2007/12/18 18:28:11  bram
- * - create hook for client specific atof (bugzilla ticket 1615)
- * - check for NULL handle before closing cpCPG file, and close after reading.
- *
- * Revision 1.2  2007/12/15 20:25:30  bram
- * dbfopen.c now reads the Code Page information from the DBF file, and exports
- * this information as a string through the DBFGetCodePage function.  This is
- * either the number from the LDID header field ("LDID/<number>") or as the
- * content of an accompanying .CPG file.  When creating a DBF file, the code can
- * be set using DBFCreateEx.
- *
- * Revision 1.1  2007/12/06 06:56:41  fwarmerdam
- * new
  *
  */
 
 #include "shapefil.h"
 
+#include <assert.h>
 #include <math.h>
 #include <limits.h>
-#include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-
-SHP_CVSID("$Id: safileio.c,v 1.6 2018-06-15 19:56:32 erouault Exp $")
 
 #ifdef SHPAPI_UTF8_HOOKS
 #ifdef SHPAPI_WINDOWS
@@ -86,102 +30,64 @@ SHP_CVSID("$Id: safileio.c,v 1.6 2018-06-15 19:56:32 erouault Exp $")
 #endif
 #endif
 
-/************************************************************************/
-/*                              SADFOpen()                              */
-/************************************************************************/
-
-SAFile SADFOpen(const char *pszFilename, const char *pszAccess)
-
+static SAFile SADFOpen(const char *pszFilename, const char *pszAccess,
+                       void *pvUserData)
 {
+    (void)pvUserData;
     return (SAFile)fopen(pszFilename, pszAccess);
 }
 
-/************************************************************************/
-/*                              SADFRead()                              */
-/************************************************************************/
-
-SAOffset SADFRead(void *p, SAOffset size, SAOffset nmemb, SAFile file)
-
+static SAOffset SADFRead(void *p, SAOffset size, SAOffset nmemb, SAFile file)
 {
     return (SAOffset)fread(p, (size_t)size, (size_t)nmemb, (FILE *)file);
 }
 
-/************************************************************************/
-/*                             SADFWrite()                              */
-/************************************************************************/
-
-SAOffset SADFWrite(void *p, SAOffset size, SAOffset nmemb, SAFile file)
-
+static SAOffset SADFWrite(const void *p, SAOffset size, SAOffset nmemb,
+                          SAFile file)
 {
     return (SAOffset)fwrite(p, (size_t)size, (size_t)nmemb, (FILE *)file);
 }
 
-/************************************************************************/
-/*                              SADFSeek()                              */
-/************************************************************************/
-
-SAOffset SADFSeek(SAFile file, SAOffset offset, int whence)
-
+static SAOffset SADFSeek(SAFile file, SAOffset offset, int whence)
 {
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+    return (SAOffset)_fseeki64((FILE *)file, (__int64)offset, whence);
+#else
     return (SAOffset)fseek((FILE *)file, (long)offset, whence);
+#endif
 }
 
-/************************************************************************/
-/*                              SADFTell()                              */
-/************************************************************************/
-
-SAOffset SADFTell(SAFile file)
-
+static SAOffset SADFTell(SAFile file)
 {
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+    return (SAOffset)_ftelli64((FILE *)file);
+#else
     return (SAOffset)ftell((FILE *)file);
+#endif
 }
 
-/************************************************************************/
-/*                             SADFFlush()                              */
-/************************************************************************/
-
-int SADFFlush(SAFile file)
-
+static int SADFFlush(SAFile file)
 {
     return fflush((FILE *)file);
 }
 
-/************************************************************************/
-/*                             SADFClose()                              */
-/************************************************************************/
-
-int SADFClose(SAFile file)
-
+static int SADFClose(SAFile file)
 {
     return fclose((FILE *)file);
 }
 
-/************************************************************************/
-/*                             SADFClose()                              */
-/************************************************************************/
-
-int SADRemove(const char *filename)
-
+static int SADRemove(const char *filename, void *pvUserData)
 {
+    (void)pvUserData;
     return remove(filename);
 }
 
-/************************************************************************/
-/*                              SADError()                              */
-/************************************************************************/
-
-void SADError(const char *message)
-
+static void SADError(const char *message)
 {
     fprintf(stderr, "%s\n", message);
 }
 
-/************************************************************************/
-/*                        SASetupDefaultHooks()                         */
-/************************************************************************/
-
 void SASetupDefaultHooks(SAHooks *psHooks)
-
 {
     psHooks->FOpen = SADFOpen;
     psHooks->FRead = SADFRead;
@@ -194,25 +100,20 @@ void SASetupDefaultHooks(SAHooks *psHooks)
 
     psHooks->Error = SADError;
     psHooks->Atof = atof;
+    psHooks->pvUserData = NULL;
 }
 
 #ifdef SHPAPI_WINDOWS
 
-/************************************************************************/
-/*                          Utf8ToWideChar                              */
-/************************************************************************/
-
-const wchar_t *Utf8ToWideChar(const char *pszFilename)
+static wchar_t *Utf8ToWideChar(const char *pszFilename)
 {
-    int nMulti, nWide;
-    wchar_t *pwszFileName;
-
-    nMulti = strlen(pszFilename) + 1;
-    nWide = MultiByteToWideChar(CP_UTF8, 0, pszFilename, nMulti, 0, 0);
+    const int nMulti = (int)strlen(pszFilename) + 1;
+    const int nWide =
+        MultiByteToWideChar(CP_UTF8, 0, pszFilename, nMulti, 0, 0);
     if (nWide == 0) {
         return NULL;
     }
-    pwszFileName = (wchar_t *)malloc(nWide * sizeof(wchar_t));
+    wchar_t *pwszFileName = (wchar_t *)malloc(nWide * sizeof(wchar_t));
     if (pwszFileName == NULL) {
         return NULL;
     }
@@ -231,48 +132,38 @@ const wchar_t *Utf8ToWideChar(const char *pszFilename)
 SAFile SAUtf8WFOpen(const char *pszFilename, const char *pszAccess)
 {
     SAFile file = NULL;
-    const wchar_t *pwszFileName, *pwszAccess;
-    pwszFileName = Utf8ToWideChar(pszFilename);
-    pwszAccess = Utf8ToWideChar(pszAccess);
+    wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
+    wchar_t *pwszAccess = Utf8ToWideChar(pszAccess);
     if (pwszFileName != NULL && pwszAccess != NULL) {
         file = (SAFile)_wfopen(pwszFileName, pwszAccess);
     }
-    free((wchar_t *)pwszFileName);
-    free((wchar_t *)pwszAccess);
+    free(pwszFileName);
+    free(pwszAccess);
     return file;
 }
 
-/************************************************************************/
-/*                             SAUtf8WRemove()                          */
-/************************************************************************/
-
 int SAUtf8WRemove(const char *pszFilename)
 {
-    const wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
+    wchar_t *pwszFileName = Utf8ToWideChar(pszFilename);
     int rc = -1;
     if (pwszFileName != NULL) {
         rc = _wremove(pwszFileName);
     }
-    free((wchar_t *)pwszFileName);
+    free(pwszFileName);
     return rc;
 }
 
 #endif
 
 #ifdef SHPAPI_UTF8_HOOKS
-
-/************************************************************************/
-/*                          SASetupUtf8Hooks()                          */
-/************************************************************************/
+#ifndef SHPAPI_WINDOWS
+#error "no implementations of UTF-8 hooks available for this platform"
+#endif
 
 void SASetupUtf8Hooks(SAHooks *psHooks)
 {
-#ifdef SHPAPI_WINDOWS
     psHooks->FOpen = SAUtf8WFOpen;
     psHooks->Remove = SAUtf8WRemove;
-#else
-#error "no implementations of UTF-8 hooks available for this platform"
-#endif
     psHooks->FRead = SADFRead;
     psHooks->FWrite = SADFWrite;
     psHooks->FSeek = SADFSeek;
@@ -283,5 +174,4 @@ void SASetupUtf8Hooks(SAHooks *psHooks)
     psHooks->Error = SADError;
     psHooks->Atof = atof;
 }
-
 #endif

--- a/lib/external/shapelib/shapefil_private.h
+++ b/lib/external/shapelib/shapefil_private.h
@@ -1,0 +1,115 @@
+#ifndef SHAPEFILE_PRIVATE_H_INCLUDED
+#define SHAPEFILE_PRIVATE_H_INCLUDED
+
+/******************************************************************************
+ *
+ * Project:  Shapelib
+ * Purpose:  Private include file for Shapelib.
+ * Author:   Frank Warmerdam, warmerdam@pobox.com
+ *
+ ******************************************************************************
+ * Copyright (c) 1999, Frank Warmerdam
+ * Copyright (c) 2012-2016, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+ ******************************************************************************
+ *
+ */
+
+#ifdef __cplusplus
+#define STATIC_CAST(type, x)      static_cast<type>(x)
+#define REINTERPRET_CAST(type, x) reinterpret_cast<type>(x)
+#define CONST_CAST(type, x)       const_cast<type>(x)
+#define SHPLIB_NULLPTR            nullptr
+#else
+#define STATIC_CAST(type, x)      ((type)(x))
+#define REINTERPRET_CAST(type, x) ((type)(x))
+#define CONST_CAST(type, x)       ((type)(x))
+#define SHPLIB_NULLPTR            NULL
+#endif
+
+#if !defined(SHP_BIG_ENDIAN)
+#if defined(CPL_MSB)
+#define SHP_BIG_ENDIAN 1
+#elif (defined(__GNUC__) && __GNUC__ >= 5) ||                         \
+    (defined(__GNUC__) && defined(__GNUC_MINOR__) && __GNUC__ == 4 && \
+     __GNUC_MINOR__ >= 6)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define SHP_BIG_ENDIAN 1
+#endif
+#elif defined(__GLIBC__)
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define SHP_BIG_ENDIAN 1
+#endif
+#elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN)
+#define SHP_BIG_ENDIAN 1
+#elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN)
+#elif defined(__sparc) || defined(__sparc__) || defined(_POWER) || \
+    defined(__powerpc__) || defined(__ppc__) || defined(__hpux) || \
+    defined(_MIPSEB) || defined(_POWER) || defined(__s390__)
+#define SHP_BIG_ENDIAN 1
+#endif
+#endif
+
+#include "shapefil.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+/************************************************************************/
+/*        Little endian <==> big endian byte swap macros.               */
+/************************************************************************/
+
+#if (defined(__GNUC__) && __GNUC__ >= 5) ||                           \
+    (defined(__GNUC__) && defined(__GNUC_MINOR__) && __GNUC__ == 4 && \
+     __GNUC_MINOR__ >= 8)
+#define _SHP_SWAP32(x) \
+    STATIC_CAST(uint32_t, __builtin_bswap32(STATIC_CAST(uint32_t, x)))
+#define _SHP_SWAP64(x) \
+    STATIC_CAST(uint64_t, __builtin_bswap64(STATIC_CAST(uint64_t, x)))
+#elif defined(_MSC_VER)
+#define _SHP_SWAP32(x) \
+    STATIC_CAST(uint32_t, _byteswap_ulong(STATIC_CAST(uint32_t, x)))
+#define _SHP_SWAP64(x) \
+    STATIC_CAST(uint64_t, _byteswap_uint64(STATIC_CAST(uint64_t, x)))
+#else
+#define _SHP_SWAP32(x)                                                \
+    STATIC_CAST(uint32_t,                                             \
+                ((STATIC_CAST(uint32_t, x) & 0x000000ffU) << 24) |    \
+                    ((STATIC_CAST(uint32_t, x) & 0x0000ff00U) << 8) | \
+                    ((STATIC_CAST(uint32_t, x) & 0x00ff0000U) >> 8) | \
+                    ((STATIC_CAST(uint32_t, x) & 0xff000000U) >> 24))
+#define _SHP_SWAP64(x)                                                      \
+    ((STATIC_CAST(uint64_t, _SHP_SWAP32(STATIC_CAST(uint32_t, x))) << 32) | \
+     (STATIC_CAST(uint64_t, _SHP_SWAP32(STATIC_CAST(                        \
+                                uint32_t, STATIC_CAST(uint64_t, x) >> 32)))))
+
+#endif
+
+/* in-place uint32_t* swap */
+#define SHP_SWAP32(p)                  \
+    *REINTERPRET_CAST(uint32_t *, p) = \
+        _SHP_SWAP32(*REINTERPRET_CAST(uint32_t *, p))
+/* in-place uint64_t* swap */
+#define SHP_SWAP64(p)                  \
+    *REINTERPRET_CAST(uint64_t *, p) = \
+        _SHP_SWAP64(*REINTERPRET_CAST(uint64_t *, p))
+/* in-place double* swap */
+#define SHP_SWAPDOUBLE(x)         \
+    do {                          \
+        uint64_t _n64;            \
+        void *_lx = x;            \
+        memcpy(&_n64, _lx, 8);    \
+        _n64 = _SHP_SWAP64(_n64); \
+        memcpy(_lx, &_n64, 8);    \
+    } while (0)
+/* copy double* swap*/
+#define SHP_SWAPDOUBLE_CPY(dst, src) \
+    do {                             \
+        uint64_t _n64;               \
+        const void *_ls = src;       \
+        void *_ld = dst;             \
+        memcpy(&_n64, _ls, 8);       \
+        _n64 = _SHP_SWAP64(_n64);    \
+        memcpy(_ld, &_n64, 8);       \
+    } while (0)
+#endif /* ndef SHAPEFILE_PRIVATE_H_INCLUDED */


### PR DESCRIPTION
Sync external library `shapelib` with upstream shapelib 1.6.0 and GDAL 3.9.2.