### PR TITLE
raster: Add library function to ask for mask presence

### DIFF
--- a/lib/raster/mask_info.c
+++ b/lib/raster/mask_info.c
@@ -70,3 +70,13 @@ int Rast__mask_info(char *name, char *mapset)
 
     return 1;
 }
+
+/**
+ * @brief Check presence of 2D raster mask
+ *
+ * @return true if mask is present, false otherwise
+ */
+bool Rast_mask_is_present()
+{
+    return G_find_raster("MASK", G_mapset()) != NULL;
+}

--- a/raster/r.mfilter/main.c
+++ b/raster/r.mfilter/main.c
@@ -132,10 +132,11 @@ int main(int argc, char **argv)
                     "threads setting."));
     nprocs = 1;
 #endif
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
-        nprocs = 1;
-    }
+    if (nprocs > 1 && Rast_mask_is_present()) != NULL)
+        {
+            G_warning(_("Parallel processing disabled due to active mask."));
+            nprocs = 1;
+        }
     out_name = opt2->answer;
     filt_name = opt3->answer;
 

--- a/raster/r.neighbors/main.c
+++ b/raster/r.neighbors/main.c
@@ -310,8 +310,8 @@ int main(int argc, char *argv[])
                     "threads setting."));
     ncb.threads = 1;
 #endif
-    if (ncb.threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (ncb.threads > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         ncb.threads = 1;
     }
     if (strcmp(parm.weighting_function->answer, "none") && flag.circle->answer)

--- a/raster/r.patch/main.c
+++ b/raster/r.patch/main.c
@@ -113,8 +113,8 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (nprocs > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         nprocs = 1;
     }
 

--- a/raster/r.resamp.filter/main.c
+++ b/raster/r.resamp.filter/main.c
@@ -494,8 +494,8 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (nprocs > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active make."));
         nprocs = 1;
     }
     if (parm.radius->answer) {

--- a/raster/r.resamp.interp/main.c
+++ b/raster/r.resamp.interp/main.c
@@ -132,8 +132,8 @@ int main(int argc, char *argv[])
                     "threads setting."));
     threads = 1;
 #endif
-    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (threads > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         threads = 1;
     }
     bufrows = atoi(memory->answer) * (((1 << 20) / sizeof(DCELL)) / dst_w.cols);

--- a/raster/r.series/main.c
+++ b/raster/r.series/main.c
@@ -227,8 +227,8 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (nprocs > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         nprocs = 1;
     }
     lo = -INFINITY;

--- a/raster/r.sim/r.sim.sediment/main.c
+++ b/raster/r.sim/r.sim.sediment/main.c
@@ -380,7 +380,7 @@ int main(int argc, char *argv[])
 #else
     threads = 1;
 #endif
-    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
+    if (threads > 1 && Rast_mask_is_present()) != NULL) {
         G_warning(_("Parallel processing disabled due to active MASK."));
         threads = 1;
     }

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -407,8 +407,8 @@ int main(int argc, char *argv[])
 #else
     threads = 1;
 #endif
-    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (threads > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         threads = 1;
     }
     G_message(_("Number of threads: %d"), threads);

--- a/raster/r.slope.aspect/main.c
+++ b/raster/r.slope.aspect/main.c
@@ -305,8 +305,8 @@ int main(int argc, char *argv[])
                     "threads setting."));
     nprocs = 1;
 #endif
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (nprocs > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         nprocs = 1;
     }
     radians_to_degrees = 180.0 / M_PI;

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -591,8 +591,8 @@ int main(int argc, char *argv[])
 #else
     threads = 1;
 #endif
-    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (threads > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         threads = 1;
     }
     G_message(_("Number of threads <%d>"), threads);

--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -192,8 +192,8 @@ int main(int argc, char *argv[])
     sscanf(param.nprocs->answer, "%d", &nprocs);
     if (nprocs < 1)
         G_fatal_error(_("<%d> is not valid number of nprocs."), nprocs);
-    if (nprocs > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (nprocs > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         nprocs = 1;
     }
 #if defined(_OPENMP)

--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -419,8 +419,8 @@ int main(int argc, char *argv[])
         G_warning(_("GRASS GIS is not compiled with OpenMP support, parallel "
                     "computation is disabled."));
 #endif
-    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
-        G_warning(_("Parallel processing disabled due to active MASK."));
+    if (threads > 1 && Rast_mask_is_present()) != NULL) {
+        G_warning(_("Parallel processing disabled due to active mask."));
         threads = 1;
     }
     if (devi) {


### PR DESCRIPTION
To avoid asking about presence of the MASK raster, add a library function which checks for presence of the raster hiding its name in the library.

This prepares way for #2392.

This also changes the message from using MASK to simply mask. I'm open to suggestion on wording of 'mask is present' versus 'mask is active' etc.
