### PR TITLE
style: Fix reimplemented-operator (FURB118)

### DIFF
--- a/gui/wxpython/animation/temporal_manager.py
+++ b/gui/wxpython/animation/temporal_manager.py
@@ -18,6 +18,7 @@ This program is free software under the GNU General Public License
 """
 
 import datetime
+from operator import itemgetter
 
 import grass.script as gs
 import grass.temporal as tgis
@@ -195,9 +196,9 @@ class TemporalManager:
         # by a temporary dataset, I don't know how it would work with point
         # data
         if self.temporalType == TemporalType.ABSOLUTE:
-            timestamps = sorted(list(labelListSet), key=lambda x: x[0])
+            timestamps = sorted(list(labelListSet), key=itemgetter(0))
         else:
-            timestamps = sorted(list(labelListSet), key=lambda x: x[0])
+            timestamps = sorted(list(labelListSet), key=itemgetter(0))
 
         newMapLists = []
         for mapList, labelList in zip(mapLists, labelLists):

--- a/gui/wxpython/gui_core/ghelp.py
+++ b/gui/wxpython/gui_core/ghelp.py
@@ -25,6 +25,7 @@ import textwrap
 import sys
 import wx
 from wx.html import HtmlWindow
+from operator import itemgetter
 
 try:
     from wx.lib.agw.hyperlink import HyperLinkCtrl
@@ -450,7 +451,7 @@ class AboutWindow(wx.Frame):
                 text = StaticText(parent=contribwin, id=wx.ID_ANY, label=item)
                 text.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.BOLD, 0, ""))
                 contribBox.Add(text)
-            for vals in sorted(contribs, key=lambda x: x[0]):
+            for vals in sorted(contribs, key=itemgetter(0)):
                 for item in vals:
                     contribBox.Add(
                         StaticText(parent=contribwin, id=wx.ID_ANY, label=item)

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -28,6 +28,8 @@ import sys
 
 import wx
 
+from operator import itemgetter
+
 from grass.pydispatch.signal import Signal
 
 from core.globalvar import wxPythonPhoenix
@@ -462,10 +464,10 @@ class BufferedMapWindow(MapWindowBase, Window):
                     brush = wx.TRANSPARENT_BRUSH
                 pdc.SetBrush(brush)
                 pdc.DrawPolygon(points=coords)
-                x = min(coords, key=lambda x: x[0])[0]
-                y = min(coords, key=lambda x: x[1])[1]
-                w = max(coords, key=lambda x: x[0])[0] - x
-                h = max(coords, key=lambda x: x[1])[1] - y
+                x = min(coords, key=itemgetter(0))[0]
+                y = min(coords, key=itemgetter(1))[1]
+                w = max(coords, key=itemgetter(0))[0] - x
+                h = max(coords, key=itemgetter(1))[1] - y
                 pdc.SetIdBounds(drawid, Rect(x, y, w, h))
 
         elif pdctype == "circle":  # draw circle

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -37,6 +37,7 @@ This program is free software under the GNU General Public License
 import os
 import string
 from copy import deepcopy
+from operator import itemgetter
 
 import wx
 import wx.lib.agw.floatspin as fs
@@ -3622,9 +3623,7 @@ class LegendDialog(PsmapDialog):
         self.vectorListCtrl.InsertColumn(0, _("Vector map"))
         self.vectorListCtrl.InsertColumn(1, _("Label"))
         if self.vectorId:
-            vectors = sorted(
-                self.instruction[self.vectorId]["list"], key=lambda x: x[3]
-            )
+            vectors = sorted(self.instruction[self.vectorId]["list"], key=itemgetter(3))
 
             for vector in vectors:
                 index = self.vectorListCtrl.InsertItem(
@@ -4455,7 +4454,7 @@ class LegendDialog(PsmapDialog):
         if self.instruction.FindInstructionByType("vector"):
             vectors = sorted(
                 self.instruction.FindInstructionByType("vector")["list"],
-                key=lambda x: x[3],
+                key=itemgetter(3),
             )
             self.vectorListCtrl.DeleteAllItems()
             for vector in vectors:

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -22,6 +22,7 @@ import numpy as np
 
 import wx
 from functools import reduce
+from operator import add
 
 try:
     import matplotlib as mpl
@@ -495,9 +496,7 @@ class TimelineFrame(wx.Frame):
         ]
         # flatten this list
         if allDatasets:
-            allDatasets = reduce(
-                lambda x, y: x + y, reduce(lambda x, y: x + y, allDatasets)
-            )
+            allDatasets = reduce(add, reduce(add, allDatasets))
             mapsets = tgis.get_tgis_c_library_interface().available_mapsets()
             allDatasets = [
                 i

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -68,6 +68,7 @@ import wx.lib.filebrowsebutton as filebrowse
 
 from gui_core.widgets import GNotebook
 from gui_core.wrap import CheckBox, TextCtrl, Button, StaticText
+from operator import add
 
 ALPHA = 0.5
 COLORS = ["b", "g", "r", "c", "m", "y", "k"]
@@ -1152,9 +1153,7 @@ class TplotFrame(wx.Frame):
         ]
         # flatten this list
         if allDatasets:
-            allDatasets = reduce(
-                lambda x, y: x + y, reduce(lambda x, y: x + y, allDatasets)
-            )
+            allDatasets = reduce(add, reduce(add, allDatasets))
             mapsets = tgis.get_tgis_c_library_interface().available_mapsets()
             allDatasets = [
                 i

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -9,6 +9,8 @@
 import sys
 import os
 
+from operator import itemgetter
+
 from build_html import (
     html_dir,
     grass_version,
@@ -50,7 +52,7 @@ for cmd in html_files("*"):
     prefix = cmd.split(".")[0]
     if prefix not in [item[0] for item in classes]:
         classes.append((prefix, class_labels.get(prefix, prefix)))
-classes.sort(key=lambda tup: tup[0])
+classes.sort(key=itemgetter(0))
 
 # begin full index:
 filename = "full_index.html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ ignore = [
     "FBT001",  # boolean-type-hint-positional-argument
     "FBT002",  # boolean-default-value-positional-argument
     "FBT003",  # boolean-positional-value-in-call
-    "FURB118", # reimplemented-operator
     "I001",    # unsorted-imports
     "ISC003",  # explicit-string-concatenation
     "PERF203", # try-except-in-loop

--- a/python/grass/imaging/images2ims.py
+++ b/python/grass/imaging/images2ims.py
@@ -31,6 +31,7 @@ Use PIL to create a series of images.
 """
 
 import os
+from operator import itemgetter
 
 try:
     import numpy as np
@@ -214,7 +215,7 @@ def readIms(filename, asNumpy=True):
             images.append((im.copy(), nr))
 
     # Sort images
-    images.sort(key=lambda x: x[1])
+    images.sort(key=itemgetter(1))
     images = [im[0] for im in images]
 
     # Convert to numpy if needed

--- a/scripts/g.search.modules/g.search.modules.py
+++ b/scripts/g.search.modules/g.search.modules.py
@@ -66,6 +66,8 @@
 import os
 import sys
 
+from operator import itemgetter
+
 from grass.script import core as grass
 from grass.exceptions import CalledModuleError
 
@@ -283,7 +285,7 @@ def _search_module(
                 }
             )
 
-    return sorted(found_modules, key=lambda k: k["name"])
+    return sorted(found_modules, key=itemgetter("name"))
 
 
 def _basic_search(pattern, name, description, module_keywords) -> bool:

--- a/scripts/v.report/v.report.py
+++ b/scripts/v.report/v.report.py
@@ -55,6 +55,8 @@
 
 import sys
 import os
+from operator import itemgetter
+
 import grass.script as gs
 from grass.script.utils import separator, decode
 
@@ -134,7 +136,7 @@ def main():
         if p.returncode != 0:
             sys.exit(1)
 
-        records1.sort(key=lambda r: r[catcol])
+        records1.sort(key=itemgetter(catcol))
 
         if len(records1) == 0:
             try:

--- a/utils/g.html2man/rest.py
+++ b/utils/g.html2man/rest.py
@@ -1,4 +1,5 @@
 import sys
+from operator import itemgetter
 
 
 def match(node, tag, attr=None, val=None):
@@ -26,8 +27,7 @@ def find(node, tag, attr=None, val=None):
     raise ValueError("child not found")
 
 
-def children(node):
-    return node[2]
+children = itemgetter(2)
 
 
 def text(node):


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/reimplemented-operator/

Replaced lambdas with `operator.itemgetter()` or `operator.add()`. These are implemented more efficiently in C and have a Python fallback. An answer on Stcak Overflow shows how sorted() and min() with a key using itemgetter can be 10-15% or 20-60% faster (on Python 3.6).

I couldn't get a definitive answer, but some articles I've read explain that these functions, like itemgetter, can be pickable (requirement for being usable in multiprocessing on Windows/macOS and for Python 3.14), while lambdas are not (as the functions are pickled by name, and lambdas are anonymous and have the same name).