### PR TITLE
style: Fix os-getcwd (PTH109) by replacing `os.getcwd()` calls with `Path.cwd()`

### DIFF
--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -24,6 +24,9 @@ import os
 import wx
 import copy
 import datetime
+
+from pathlib import Path
+
 import wx.lib.filebrowsebutton as filebrowse
 import wx.lib.scrolledpanel as SP
 import wx.lib.colourselect as csel
@@ -488,7 +491,7 @@ class InputDialog(wx.Dialog):
             labelText=_("Workspace file:"),
             dialogTitle=_("Choose workspace file to import 3D view parameters"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=0,
             fileMask="GRASS Workspace File (*.gxw)|*.gxw",
         )
@@ -1089,7 +1092,7 @@ class ExportDialog(wx.Dialog):
             labelText=_("Image file:"),
             dialogTitle=_("Choose image file"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_OPEN,
             changeCallback=self.OnSetImage,
         )
@@ -1191,7 +1194,7 @@ class ExportDialog(wx.Dialog):
             labelText=_("Directory:"),
             dialogTitle=_("Choose directory for export"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
         )
 
         dirGridSizer = wx.GridBagSizer(hgap=5, vgap=5)
@@ -1219,7 +1222,7 @@ class ExportDialog(wx.Dialog):
             labelText=_("GIF file:"),
             dialogTitle=_("Choose file to save animation"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_SAVE,
         )
         gifGridSizer = wx.GridBagSizer(hgap=5, vgap=5)
@@ -1242,7 +1245,7 @@ class ExportDialog(wx.Dialog):
             labelText=_("SWF file:"),
             dialogTitle=_("Choose file to save animation"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_SAVE,
         )
         swfGridSizer = wx.GridBagSizer(hgap=5, vgap=5)
@@ -1273,7 +1276,7 @@ class ExportDialog(wx.Dialog):
             labelText=_("AVI file:"),
             dialogTitle=_("Choose file to save animation"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_SAVE,
         )
         encodingLabel = StaticText(

--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -19,6 +19,8 @@ for details.
 import wx
 import os
 
+from pathlib import Path
+
 from core.debug import Debug
 from datacatalog.tree import DataCatalogTree
 from datacatalog.toolbars import DataCatalogToolbar, DataCatalogSearch
@@ -200,7 +202,10 @@ class DataCatalog(wx.Panel):
     def OnAddGrassDB(self, event):
         """Add grass database"""
         dlg = wx.DirDialog(
-            self, _("Choose GRASS data directory:"), os.getcwd(), wx.DD_DEFAULT_STYLE
+            self,
+            _("Choose GRASS data directory:"),
+            str(Path.cwd()),
+            wx.DD_DEFAULT_STYLE,
         )
         if dlg.ShowModal() == wx.ID_OK:
             grassdatabase = dlg.GetPath()

--- a/gui/wxpython/gmodeler/panels.py
+++ b/gui/wxpython/gmodeler/panels.py
@@ -25,6 +25,8 @@ import tempfile
 import random
 import math
 
+from pathlib import Path
+
 import wx
 
 from wx.lib import ogl
@@ -834,7 +836,7 @@ class ModelerPanel(wx.Panel, MainPageBase):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose model file"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("GRASS Model File (*.gxm)|*.gxm"),
         )
         if dlg.ShowModal() == wx.ID_OK:
@@ -892,7 +894,7 @@ class ModelerPanel(wx.Panel, MainPageBase):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose file to save current model"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("GRASS Model File (*.gxm)|*.gxm"),
             style=wx.FD_SAVE,
         )
@@ -1740,7 +1742,7 @@ class PythonPanel(wx.Panel):
             parent=self,
             message=_("Choose file to save"),
             defaultFile=os.path.basename(self.parent.GetModelFile(ext=False)),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=fn_wildcard,
             style=wx.FD_SAVE,
         )

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -58,6 +58,7 @@ import queue as Queue
 import codecs
 
 from threading import Thread
+from pathlib import Path
 
 import wx
 
@@ -2034,7 +2035,7 @@ class CmdPanel(wx.Panel):
                         dialogTitle=_("Choose %s")
                         % p.get("description", _("file")).lower(),
                         buttonText=_("Browse"),
-                        startDirectory=os.getcwd(),
+                        startDirectory=str(Path.cwd()),
                         fileMode=fmode,
                         changeCallback=self.OnSetValue,
                     )
@@ -2145,7 +2146,7 @@ class CmdPanel(wx.Panel):
                         dialogTitle=_("Choose %s")
                         % p.get("description", _("Directory")),
                         buttonText=_("Browse"),
-                        startDirectory=os.getcwd(),
+                        startDirectory=str(Path.cwd()),
                         newDirectory=True,
                         changeCallback=self.OnSetValue,
                     )
@@ -2624,7 +2625,7 @@ class CmdPanel(wx.Panel):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Save input as..."),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
         )
 

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -47,6 +47,8 @@ import sys
 import glob
 import ctypes
 
+from pathlib import Path
+
 import wx
 
 from core import globalvar
@@ -1558,7 +1560,7 @@ class GdalSelect(wx.Panel):
             labelText=_("File:"),
             dialogTitle=_("Choose file to import"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             changeCallback=self.OnUpdate,
             fileMask=fileMask,
         )
@@ -1575,7 +1577,7 @@ class GdalSelect(wx.Panel):
             labelText=_("Directory:"),
             dialogTitle=_("Choose input directory"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             changeCallback=self.OnUpdate,
         )
         browse.GetChildren()[1].SetName("GdalSelectDataSource")
@@ -1628,7 +1630,7 @@ class GdalSelect(wx.Panel):
             labelText=_("Name:"),
             dialogTitle=_("Choose file"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             changeCallback=self.OnUpdate,
         )
         browse.GetChildren()[1].SetName("GdalSelectDataSource")
@@ -1663,7 +1665,7 @@ class GdalSelect(wx.Panel):
             labelText=_("Directory:"),
             dialogTitle=_("Choose input directory"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             changeCallback=self.OnUpdate,
         )
         self.dbWidgets["dirbrowse"] = browse

--- a/gui/wxpython/gui_core/pyedit.py
+++ b/gui/wxpython/gui_core/pyedit.py
@@ -395,7 +395,7 @@ class PyEditController:
         dlg = wx.FileDialog(
             parent=self.guiparent,
             message=_("Choose file to save"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("Python script (*.py)|*.py"),
             style=wx.FD_SAVE,
         )
@@ -466,7 +466,7 @@ class PyEditController:
         dlg = wx.FileDialog(
             parent=self.guiparent,
             message=_("Open file"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("Python script (*.py)|*.py"),
             style=wx.FD_OPEN,
         )

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -27,6 +27,8 @@ import copy
 import platform
 import getpass
 
+from pathlib import Path
+
 from core import globalvar
 import wx
 import wx.lib.mixins.listctrl as listmix
@@ -315,7 +317,7 @@ class GRASSStartup(wx.Frame):
             if os.path.isdir(os.getenv("HOME")):
                 self.gisdbase = os.getenv("HOME")
             else:
-                self.gisdbase = os.getcwd()
+                self.gisdbase = str(Path.cwd())
         try:
             self.tgisdbase.SetValue(self.gisdbase)
         except UnicodeDecodeError:

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -24,6 +24,8 @@ import stat
 import platform
 import re
 
+from pathlib import Path
+
 from core import globalvar
 import wx
 import wx.aui
@@ -848,7 +850,7 @@ class GMFrame(wx.Frame):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose model to run"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("GRASS Model File (*.gxm)|*.gxm"),
         )
         if dlg.ShowModal() == wx.ID_OK:
@@ -1223,7 +1225,7 @@ class GMFrame(wx.Frame):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose script file to run"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("Python script (*.py)|*.py|Bash script (*.sh)|*.sh"),
         )
 
@@ -1377,9 +1379,7 @@ class GMFrame(wx.Frame):
                 self._giface.WriteCmdLog(" ".join(command))
 
         def write_changed():
-            self._giface.WriteLog(
-                _('Working directory changed to:\n"%s"') % os.getcwd()
-            )
+            self._giface.WriteLog(_('Working directory changed to:\n"%s"') % Path.cwd())
 
         def write_end():
             self._giface.WriteCmdLog(" ")
@@ -1433,7 +1433,7 @@ class GMFrame(wx.Frame):
             dlg = wx.DirDialog(
                 parent=self,
                 message=_("Choose a working directory"),
-                defaultPath=os.getcwd(),
+                defaultPath=str(Path.cwd()),
             )
 
             if dlg.ShowModal() == wx.ID_OK:

--- a/gui/wxpython/lmgr/workspace.py
+++ b/gui/wxpython/lmgr/workspace.py
@@ -18,6 +18,8 @@ import tempfile
 
 import xml.etree.ElementTree as ET
 
+from pathlib import Path
+
 import wx
 import wx.aui
 
@@ -103,7 +105,7 @@ class WorkspaceManager:
         dlg = wx.FileDialog(
             parent=self.lmgr,
             message=_("Choose workspace file"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("GRASS Workspace File (*.gxw)|*.gxw"),
         )
 
@@ -362,7 +364,7 @@ class WorkspaceManager:
         dlg = wx.FileDialog(
             parent=self.lmgr,
             message=_("Choose file to save current workspace"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("GRASS Workspace File (*.gxw)|*.gxw"),
             style=wx.FD_SAVE,
         )

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -38,6 +38,8 @@ import os
 import locale
 import functools
 
+from pathlib import Path
+
 import wx
 import wx.lib.mixins.listctrl as listmix
 from core import globalvar
@@ -318,7 +320,10 @@ class DatabasePage(TitledPage):
     def OnBrowse(self, event):
         """Choose GRASS data directory"""
         dlg = wx.DirDialog(
-            self, _("Choose GRASS data directory:"), os.getcwd(), wx.DD_DEFAULT_STYLE
+            self,
+            _("Choose GRASS data directory:"),
+            str(Path.cwd()),
+            wx.DD_DEFAULT_STYLE,
         )
         if dlg.ShowModal() == wx.ID_OK:
             self.grassdatabase = dlg.GetPath()
@@ -1493,7 +1498,7 @@ class GeoreferencedFilePage(TitledPage):
     def OnBrowse(self, event):
         """Choose file"""
         dlg = wx.FileDialog(
-            self, _("Select georeferenced file"), os.getcwd(), "", "*.*", wx.FD_OPEN
+            self, _("Select georeferenced file"), str(Path.cwd()), "", "*.*", wx.FD_OPEN
         )
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
@@ -1977,7 +1982,7 @@ class IAUPage(TitledPage):
         """Define path for IAU code file"""
         path = os.path.dirname(self.tfile.GetValue())
         if not path:
-            path = os.getcwd()
+            path = str(Path.cwd())
 
         dlg = wx.FileDialog(
             parent=self,

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -25,6 +25,8 @@ import stat
 import platform
 import re
 
+from pathlib import Path
+
 from core import globalvar
 
 try:
@@ -971,7 +973,7 @@ class GMFrame(wx.Frame):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose model to run"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("GRASS Model File (*.gxm)|*.gxm"),
         )
         if dlg.ShowModal() == wx.ID_OK:
@@ -1374,7 +1376,7 @@ class GMFrame(wx.Frame):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose script file to run"),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("Python script (*.py)|*.py|Bash script (*.sh)|*.sh"),
         )
 
@@ -1528,9 +1530,7 @@ class GMFrame(wx.Frame):
                 self._giface.WriteCmdLog(" ".join(command))
 
         def write_changed():
-            self._giface.WriteLog(
-                _('Working directory changed to:\n"%s"') % os.getcwd()
-            )
+            self._giface.WriteLog(_('Working directory changed to:\n"%s"') % Path.cwd())
 
         def write_end():
             self._giface.WriteCmdLog(" ")
@@ -1584,7 +1584,7 @@ class GMFrame(wx.Frame):
             dlg = wx.DirDialog(
                 parent=self,
                 message=_("Choose a working directory"),
-                defaultPath=os.getcwd(),
+                defaultPath=str(Path.cwd()),
             )
 
             if dlg.ShowModal() == wx.ID_OK:

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -27,6 +27,8 @@ import shutil
 import copy
 import tempfile
 
+from pathlib import Path
+
 import wx
 import wx.lib.colourselect as csel
 import wx.lib.scrolledpanel as scrolled
@@ -448,7 +450,7 @@ class ColorTable(wx.Frame):
             dialogTitle=_("Choose file to load color table"),
             buttonText=_("Load"),
             toolTip=_("Type filename or click to choose file and load color table"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_OPEN,
             changeCallback=self.OnLoadRulesFile,
         )
@@ -460,7 +462,7 @@ class ColorTable(wx.Frame):
             dialogTitle=_("Choose file to save color table"),
             toolTip=_("Type filename or click to choose file and save color table"),
             buttonText=_("Save"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_SAVE,
             changeCallback=self.OnSaveRulesFile,
         )

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -22,6 +22,8 @@ This program is free software under the GNU General Public License
 
 import os
 
+from pathlib import Path
+
 import wx
 from core import globalvar
 import wx.lib.filebrowsebutton as filebrowse
@@ -836,7 +838,7 @@ class DxfImportDialog(ImportDialog):
             labelText="",
             dialogTitle=_("Choose DXF file to import"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=0,
             changeCallback=self.OnSetDsn,
             fileMask="DXF File (*.dxf)|*.dxf",

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -23,6 +23,8 @@ import os
 import sys
 import copy
 
+from pathlib import Path
+
 import wx
 import wx.lib.colourselect as csel
 import wx.lib.scrolledpanel as SP
@@ -668,7 +670,7 @@ class NvizToolWindow(GNotebook):
         vSizer = wx.BoxSizer(wx.VERTICAL)
         gridSizer = wx.GridBagSizer(vgap=5, hgap=10)
 
-        pwd = os.getcwd()
+        pwd = str(Path.cwd())
         dir = filebrowse.DirBrowseButton(
             parent=panel,
             id=wx.ID_ANY,

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -37,6 +37,7 @@ This program is free software under the GNU General Public License
 import os
 import string
 from copy import deepcopy
+from pathlib import Path
 
 import wx
 import wx.lib.agw.floatspin as fs
@@ -5965,7 +5966,7 @@ class ImageDialog(PsmapDialog):
 
     def _getImageDirectory(self):
         """Default image directory"""
-        return os.getcwd()
+        return str(Path.cwd())
 
     def _addConvergence(self, panel, gridBagSizer):
         pass

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -20,6 +20,7 @@ This program is free software under the GNU General Public License
 """
 import os
 from itertools import cycle
+from pathlib import Path
 import numpy as np
 
 import wx
@@ -371,7 +372,7 @@ class TplotFrame(wx.Frame):
             labelText="",
             dialogTitle=_("CVS path"),
             buttonText=_("Browse"),
-            startDirectory=os.getcwd(),
+            startDirectory=str(Path.cwd()),
             fileMode=wx.FD_SAVE,
         )
         self.headerLabel = StaticText(

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -20,6 +20,8 @@ import sys
 import math
 import numpy as np
 
+from pathlib import Path
+
 import wx
 
 from wx.lib import plot
@@ -410,7 +412,7 @@ class ProfileFrame(BasePlotFrame):
         dlg = wx.FileDialog(
             parent=self,
             message=_("Choose prefix for file(s) where to save profile values..."),
-            defaultDir=os.getcwd(),
+            defaultDir=str(Path.cwd()),
             wildcard=_("Comma separated value (*.csv)|*.csv"),
             style=wx.FD_SAVE,
         )

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -620,7 +620,7 @@ def create_initial_gisrc(filename):
 LOCATION_NAME: <UNKNOWN>
 MAPSET: <UNKNOWN>
 """
-        % os.getcwd()
+        % Path.cwd()
     )
     writefile(filename, s)
 
@@ -789,7 +789,7 @@ def set_mapset(
         # non-empty element as the last element (which is good for both mapset
         # and location split)
         if arg == ".":
-            arg = os.getcwd()
+            arg = str(Path.cwd())
         elif not os.path.isabs(arg):
             arg = os.path.abspath(arg)
         if arg.endswith(os.path.sep):

--- a/locale/grass_po_stats.py
+++ b/locale/grass_po_stats.py
@@ -21,10 +21,12 @@ import os
 import subprocess
 import sys
 
+from pathlib import Path
+
 
 def read_po_files(inputdirpath):
     """Return a dictionary with for each language the list of *.po files"""
-    originalpath = os.getcwd()
+    originalpath = Path.cwd()
     os.chdir(inputdirpath)
     languages = {}
     for pofile in sorted(glob.glob("*.po")):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ ignore = [
     "PTH106",  # os-rmdir
     "PTH107",  # os-remove
     "PTH108",  # os-unlink
-    "PTH109",  # os-getcwd
     "PTH110",  # os-path-exists
     "PTH111",  # os-path-expanduser
     "PTH112",  # os-path-isdir

--- a/python/grass/grassdb/checks.py
+++ b/python/grass/grassdb/checks.py
@@ -159,7 +159,7 @@ def is_first_time_user():
     genv = gisenv()
     if "LAST_MAPSET_PATH" in genv.keys():
         return genv["LAST_MAPSET_PATH"] == os.path.join(
-            os.getcwd(), cfg.unknown_location, cfg.unknown_mapset
+            Path.cwd(), cfg.unknown_location, cfg.unknown_mapset
         )
     return False
 

--- a/python/grass/pygrass/tests/benchmark.py
+++ b/python/grass/pygrass/tests/benchmark.py
@@ -12,11 +12,11 @@ import collections
 import copy
 import cProfile
 import sys
-import os
 from jinja2 import Template
+from pathlib import Path
 
-sys.path.append(os.getcwd())
-sys.path.append("%s/.." % (os.getcwd()))
+sys.path.append(str(Path.cwd()))
+sys.path.append("%s/.." % (str(Path.cwd())))
 
 import grass.lib.gis as libgis
 import grass.lib.raster as libraster

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1894,7 +1894,7 @@ def _create_location_xy(database, location):
     :param database: GRASS database where to create new location
     :param location: location name
     """
-    cur_dir = os.getcwd()
+    cur_dir = Path.cwd()
     try:
         os.chdir(database)
         os.mkdir(location)

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -28,6 +28,8 @@ import uuid
 import random
 import string
 
+from pathlib import Path
+
 
 def float_or_dms(s):
     """Convert DMS to float.
@@ -383,7 +385,7 @@ def get_lib_path(modname, libname=None):
         path = join(os.getenv("GRASS_ADDON_BASE"), modname, modname)
     else:
         # used by g.extension compilation process
-        cwd = os.getcwd()
+        cwd = str(Path.cwd())
         idx = cwd.find(modname)
         if idx < 0:
             return None
@@ -463,10 +465,10 @@ def set_path(modulename, dirname=None, path="."):
     import sys
 
     # TODO: why dirname is checked first - the logic should be revised
-    pathlib = None
+    _pathlib = None
     if dirname:
-        pathlib = os.path.join(path, dirname)
-    if pathlib and os.path.exists(pathlib):
+        _pathlib = os.path.join(path, dirname)
+    if _pathlib and os.path.exists(_pathlib):
         # we are running the script from the script directory, therefore
         # we add the path to sys.path to reach the directory (dirname)
         sys.path.append(os.path.abspath(path))
@@ -477,7 +479,7 @@ def set_path(modulename, dirname=None, path="."):
             pathname = os.path.join(modulename, dirname) if dirname else modulename
             raise ImportError(
                 "Not able to find the path '%s' directory "
-                "(current dir '%s')." % (pathname, os.getcwd())
+                "(current dir '%s')." % (pathname, Path.cwd())
             )
 
         sys.path.insert(0, path)

--- a/python/grass/temporal/stds_export.py
+++ b/python/grass/temporal/stds_export.py
@@ -348,7 +348,7 @@ def export_stds(
     """
 
     # Save current working directory path
-    old_cwd = os.getcwd()
+    old_cwd = Path.cwd()
 
     # Create the temporary directory and jump into it
     new_cwd = tempfile.mkdtemp(dir=directory)

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -286,7 +286,7 @@ def import_stds(
     # We use a new list file name for map registration
     new_list_file_name = list_file_name + "_new"
     # Save current working directory path
-    old_cwd = os.getcwd()
+    old_cwd = Path.cwd()
 
     # Switch into the data directory
     os.chdir(directory)

--- a/scripts/r.pack/r.pack.py
+++ b/scripts/r.pack/r.pack.py
@@ -37,6 +37,8 @@ import shutil
 import atexit
 import tarfile
 
+from pathlib import Path
+
 from grass.script.utils import try_rmdir, try_remove
 from grass.script import core as grass
 
@@ -80,7 +82,7 @@ def main():
 
     grass.message(_("Packing <%s> to <%s>...") % (gfile["fullname"], outfile))
     basedir = os.path.sep.join(os.path.normpath(gfile["file"]).split(os.path.sep)[:-2])
-    olddir = os.getcwd()
+    olddir = Path.cwd()
 
     # copy elements
     info = grass.parse_command("r.info", flags="e", map=infile)

--- a/scripts/v.pack/v.pack.py
+++ b/scripts/v.pack/v.pack.py
@@ -38,6 +38,8 @@ import sys
 import tarfile
 import atexit
 
+from pathlib import Path
+
 from grass.script.utils import try_rmdir, try_remove
 from grass.script import core as grass
 from grass.script import vector
@@ -128,7 +130,7 @@ def main():
             tar.add(path, "PROJ_" + support)
     tar.close()
 
-    grass.message(_("Pack file <%s> created") % os.path.join(os.getcwd(), outfile))
+    grass.message(_("Pack file <%s> created") % Path(outfile).resolve())
 
 
 if __name__ == "__main__":

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -366,7 +366,7 @@ def has_src_code_git(src_dir, is_addon):
                                                  if core module or addon
                                                  source code has Git
     """
-    actual_dir = os.getcwd()
+    actual_dir = Path.cwd()
     if is_addon:
         os.chdir(src_dir)
     else:


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/os-getcwd/

When unable to confirm a Path would be accepted, I wrapped `Path.cwd()` with `str()`, so the variable would remain a string. When I had to add an import, I placed it such that it tends to what isort would do, but without changing other imports around it.