### PR TITLE
CI: Assign milestone on merged PRs

### DIFF
--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -3,8 +3,8 @@ name: Assign Milestone
 
 on:
   pull_request:
-#   pull_request_target:
-#     types: [closed]
+  pull_request_target:
+    types: [closed]
 
 jobs:
   assign-milestone:

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -25,11 +25,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
       - name: Get VERSION file
+        id: version-file
         run: |
           gh api \
             -H "Accept: application/vnd.github.raw" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/{owner}/{repo}/contents/include/VERSION" >> include/VERSION
+            "/repos/{owner}/{repo}/contents/include/VERSION" | \
+            head -n 3 | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -32,6 +32,7 @@ jobs:
         run: echo "PR does not have a milestone"
         if: ${{ !steps.current-milestone.outputs.milestone }}
       - name: Get VERSION file
+        if: ${{ !steps.current-milestone.outputs.milestone }}
         id: version-file
         run: |
           echo "version<<EOF" >> "${GITHUB_OUTPUT}"
@@ -44,10 +45,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
       - name: Show version file
+        if: ${{ !steps.current-milestone.outputs.milestone }}
         run: echo "${VERSIONFILE}"
         env:
           VERSIONFILE: ${{ steps.version-file.outputs.version }}
       - name: Get milestone title from VERSION file
+        if: ${{ !steps.current-milestone.outputs.milestone }}
         id: milestone
         run: |
           version=$(echo "$VERSIONFILE" | head -n 3 | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
@@ -55,10 +58,13 @@ jobs:
         env:
           VERSIONFILE: ${{ steps.version-file.outputs.version }}
       - name: Show milestone title
+        if: ${{ !steps.current-milestone.outputs.milestone }}
         run: echo "${MILESTONE}"
         env:
           MILESTONE: ${{ steps.milestone.outputs.title }}
-      - run: gh pr edit ${{ github.event.pull_request.html_url }} --milestone "${MILESTONE}"
+      - name: Set PR milestone
+        if: ${{ !steps.current-milestone.outputs.milestone }}
+        run: gh pr edit ${{ github.event.pull_request.html_url }} --milestone "${MILESTONE}"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -1,0 +1,14 @@
+---
+name: Assign Milestone
+
+on:
+  pull_request:
+#   pull_request_target:
+#     types: [closed]
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged || true
+    steps:
+      - run: gh pr view --json milestone

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged || true
     steps:
-      - run: gh pr view --json milestone
+      - run: gh pr view ${{ github.event.pull_request.html_url }} --json milestone
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -13,4 +13,5 @@ jobs:
     steps:
       - run: gh pr view --json milestone
         env:
-            GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -2,14 +2,13 @@
 name: Assign Milestone
 
 on:
-  pull_request:
   pull_request_target:
     types: [closed]
 
 jobs:
   assign-milestone:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged || true
+    if: github.event.pull_request.merged
     steps:
       # Retreiving the current milestoone from API instead of github context,
       # so up-to-date information is used when running after being queued or for reruns

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged || true
     steps:
+      # Retreiving the current milestoone from API instead of github context,
+      # so up-to-date information is used when running after being queued or for reruns
+      # Otherwise, the information should be available using
+      # ${{ github.event.pull_request.milestone.title }}
       - name: Get current milestone title
         id: current-milestone
         run: |

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -39,7 +39,7 @@ jobs:
           gh api \
             -H "Accept: application/vnd.github.raw" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/{owner}/{repo}/contents/include/VERSION" >> "${GITHUB_OUTPUT}"
+            "/repos/{owner}/{repo}/contents/include/VERSION?ref=${{ github.sha }}" >> "${GITHUB_OUTPUT}"
           echo "EOF" >> "${GITHUB_OUTPUT}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -15,31 +15,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-      - name: Show VERSION file
-        run: |
-          gh api \
-            -H "Accept: application/vnd.github.raw" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/{owner}/{repo}/contents/include/VERSION"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
       - name: Get VERSION file
         id: version-file
         run: |
+          echo 'version<<EOF' >> "${GITHUB_OUTPUT}"
           gh api \
             -H "Accept: application/vnd.github.raw" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/{owner}/{repo}/contents/include/VERSION" | \
-            head -n 3 | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g'
+            "/repos/{owner}/{repo}/contents/include/VERSION" >> "${GITHUB_OUTPUT}"
+          echo 'EOF' >> "${GITHUB_OUTPUT}"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+      - name: Show version file
+        run: echo "${VERSIONFILE}"
+        env:
+          VERSIONFILE: ${{ steps.version-file.outputs.version }}
       - name: Get milestone title from VERSION file
         id: version
         run: |
-          version=$(head -n 3 include/VERSION | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
+          version=$(head -n 3 $VERSIONFILE | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
           echo "version=$version" >> "${GITHUB_OUTPUT}"
-      - run: echo $VERSION
+        env:
+          VERSIONFILE: ${{ steps.version-file.outputs.version }}
+      - name: Show milestone title
+        run: echo "${VERSION}"
         env:
           VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -25,10 +25,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-      - run: echo "Has milestone gh cli"
+      - name: PR already has a milestone
+        run: echo "PR already has a milestone"
         if: ${{ steps.current-milestone.outputs.milestone }}
-      - run: echo "Does not have a milestone gh cli"
-        if: ${{ !steps.current-milestone.outputs.milestone}}
+      - name: PR does not have a milestone
+        run: echo "PR does not have a milestone"
+        if: ${{ !steps.current-milestone.outputs.milestone }}
       - name: Get VERSION file
         id: version-file
         run: |

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -32,13 +32,13 @@ jobs:
         env:
           VERSIONFILE: ${{ steps.version-file.outputs.version }}
       - name: Get milestone title from VERSION file
-        id: version
+        id: milestone
         run: |
           version=$(echo "$VERSIONFILE" | head -n 3 | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
-          echo "version=$version" >> "${GITHUB_OUTPUT}"
+          echo "title=$version" >> "${GITHUB_OUTPUT}"
         env:
           VERSIONFILE: ${{ steps.version-file.outputs.version }}
       - name: Show milestone title
-        run: echo "${VERSION}"
+        run: echo "${MILESTONE}"
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          MILESTONE: ${{ steps.milestone.outputs.title }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get milestone title from VERSION file
         id: version
         run: |
-          version=$(head -n 3 $VERSIONFILE | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
+          version=$(echo "$VERSIONFILE" | head -n 3 | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
           echo "version=$version" >> "${GITHUB_OUTPUT}"
         env:
           VERSIONFILE: ${{ steps.version-file.outputs.version }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -15,3 +15,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+      - name: Get VERSION file
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/{owner}/{repo}/contents/include/VERSION" >> include/VERSION
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+      - name: Get milestone title from VERSION file
+        id: version
+        run: |
+          version=$(head -n 3 include/VERSION | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
+          echo "version=$version" >> "${GITHUB_OUTPUT}"
+      - run: echo $VERSION
+        env:
+          VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -12,3 +12,5 @@ jobs:
     if: github.event.pull_request.merged || true
     steps:
       - run: gh pr view --json milestone
+        env:
+            GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -15,6 +15,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+      - name: Show VERSION file
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github.raw" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/{owner}/{repo}/contents/include/VERSION"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
       - name: Get VERSION file
         run: |
           gh api \

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -42,3 +42,8 @@ jobs:
         run: echo "${MILESTONE}"
         env:
           MILESTONE: ${{ steps.milestone.outputs.title }}
+      - run: gh pr edit ${{ github.event.pull_request.html_url }} --milestone "${MILESTONE}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          MILESTONE: ${{ steps.milestone.outputs.title }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ !steps.current-milestone.outputs.milestone }}
         id: milestone
         run: |
-          version=$(echo "$VERSIONFILE" | head -n 3 | xargs | sed 's/ /./g' | sed 's/\(RC\|dev\)//g')
+          version=$(echo "$VERSIONFILE" | head -n 3 | xargs | sed 's/ /./g; s/\(RC[0-9]*\|dev\)//g')
           echo "title=$version" >> "${GITHUB_OUTPUT}"
         env:
           VERSIONFILE: ${{ steps.version-file.outputs.version }}

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -11,19 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged || true
     steps:
-      - run: gh pr view ${{ github.event.pull_request.html_url }} --json milestone
+      - name: Get current milestone title
+        id: current-milestone
+        run: |
+          echo "milestone<<EOF" >> "${GITHUB_OUTPUT}"
+          gh pr view ${{ github.event.pull_request.html_url }} --json milestone \
+            --jq .milestone.title >> "${GITHUB_OUTPUT}"
+          echo 'EOF' >> "${GITHUB_OUTPUT}"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+      - run: echo "Has milestone gh cli"
+        if: ${{ steps.current-milestone.outputs.milestone }}
+      - run: echo "Does not have a milestone gh cli"
+        if: ${{ !steps.current-milestone.outputs.milestone}}
       - name: Get VERSION file
         id: version-file
         run: |
-          echo 'version<<EOF' >> "${GITHUB_OUTPUT}"
+          echo "version<<EOF" >> "${GITHUB_OUTPUT}"
           gh api \
             -H "Accept: application/vnd.github.raw" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/{owner}/{repo}/contents/include/VERSION" >> "${GITHUB_OUTPUT}"
-          echo 'EOF' >> "${GITHUB_OUTPUT}"
+          echo "EOF" >> "${GITHUB_OUTPUT}"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Addresses https://github.com/OSGeo/grass/pull/4398#issuecomment-2379676744

This PR assigns a milestone when a PR is closed if none is set, using `pull_request_target` trigger with `closed` activity type. It uses up an API call to know if the PR has a milestone set (limit is 5000 per hour when authenticated). If I used the info from the github event context, the information is populated when the job is queued, and will maybe not represent the state once it will run, and will keep the old state if a rerun is made. I tried to use the gh cli instead of their javascript action's ecosystem so steps could be reproduced locally too using the same gh cli calls.

If there are no milestones for that PR, then it uses a second API call to fetch the include/VERSION file at the ref of the merged result (so pull_request_target doesn't matter here, it is still up-to-date). It parses that file like for the coverity scan workflow, but also removes "dev" and "RC" followed by 0 or more numbers. This builds the milestone title to apply, using a third API call.

Using the VERSION file allows it to keep working on newer and older versions (working on older branches if the workflow is backported)

Known limitations:
- No attempt is made to try to prevent running on forks that merges PRs in their forks: This also allows to change the repo's name and organization in the future without having to change release branches.
- No attempt to create a milestone if it doesn't exist: this workflow will simply fail, as the gh cli will say that the milestone doesn't exist. As it might only happen once or twice during a year (assuming the milestone wasn't set on the PR already), I didn't take more time to do it. In part because running on PR merges doesn't have a lot of visibility (doesn't show on the pushed commit on main checks for example), and what dates and description should be set? That's more of a manual thing to do.