### PR TITLE
v.generalize: Fix Resource Leak issue in displacement.c

### DIFF
--- a/vector/v.generalize/displacement.c
+++ b/vector/v.generalize/displacement.c
@@ -310,6 +310,7 @@ int snakes_displacement(struct Map_info *In, struct Map_info *Out,
     matrix_free(&fy);
     matrix_free(&dx_old);
     matrix_free(&dy_old);
+    Vect_destroy_cats_struct(Cats);
 
     return 0;
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207602)
Used existing function Vect_destroy_cats_struct() to fix the memory leak issue.