### PR TITLE
v.colors: Fix resource leak issue in scan_attr.c file

### DIFF
--- a/vector/v.colors/scan_attr.c
+++ b/vector/v.colors/scan_attr.c
@@ -42,6 +42,7 @@ int scan_attr(struct Map_info *Map, int layer, const char *column_name,
                                  &cvarr);
     if (nrec < 1) {
         G_important_message(_("No data selected"));
+        Vect_destroy_field_info(fi);
         return 0;
     }
 
@@ -100,6 +101,7 @@ int scan_attr(struct Map_info *Map, int layer, const char *column_name,
     }
 
     db_close_database(driver);
+    Vect_destroy_field_info(fi);
 
     return is_fp;
 }

--- a/vector/v.colors/scan_attr.c
+++ b/vector/v.colors/scan_attr.c
@@ -43,6 +43,7 @@ int scan_attr(struct Map_info *Map, int layer, const char *column_name,
     if (nrec < 1) {
         G_important_message(_("No data selected"));
         Vect_destroy_field_info(fi);
+        db_close_database(driver);
         return 0;
     }
 


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207685)
Used existing function Vect_destroy_field_info() to fix the memory leak issue.