### PR TITLE
wxGUI: Fix F405 error by explicitly importing required modules in iscatt/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -34,7 +34,7 @@ per-file-ignores =
     gui/wxpython/gui_core/widgets.py: E722
     gui/wxpython/image2target/*: F841, E722
     gui/wxpython/image2target/g.gui.image2target.py: E501, F841
-    gui/wxpython/iscatt/*: F841, E722, F405, F403
+    gui/wxpython/iscatt/*: F841, E722
     gui/wxpython/lmgr/frame.py: F841, E722
     # layertree still includes some formatting issues (it is ignored by Black)
     gui/wxpython/lmgr/layertree.py: E722, E266, W504, E225

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -11,34 +11,34 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (mentor: Martin Landa)
 """
 
+import ctypes
 import sys
-import numpy as np
+from ctypes import POINTER, c_char_p, c_double, c_int, c_uint8, pointer
 from multiprocessing import Process, Queue
 
-import ctypes
-from ctypes import POINTER, c_uint8, c_double, c_int, c_char_p, pointer
+import numpy as np
 
 try:
-    from grass.lib.imagery import (
-        I_apply_colormap,
-        I_merge_arrays,
-        I_create_cat_rast,
-        SC_SCATT_DATA,
-        SC_SCATT_CONDITIONS,
-        I_compute_scatts,
-        I_sc_free_cats,
-        struct_Range,
-        struct_Cell_head,
-        struct_scCats,
-        I_sc_init_cats,
-        I_sc_add_cat,
-        scdScattData,
-        I_scd_init_scatt_data,
-        I_sc_insert_scatt_data,
-        I_insert_patch_to_cat_rast,
-        I_rasterize,
-    )
     from grass.lib.gis import G_get_window
+    from grass.lib.imagery import (
+        SC_SCATT_CONDITIONS,
+        SC_SCATT_DATA,
+        I_apply_colormap,
+        I_compute_scatts,
+        I_create_cat_rast,
+        I_insert_patch_to_cat_rast,
+        I_merge_arrays,
+        I_rasterize,
+        I_sc_add_cat,
+        I_sc_free_cats,
+        I_sc_init_cats,
+        I_sc_insert_scatt_data,
+        I_scd_init_scatt_data,
+        scdScattData,
+        struct_Cell_head,
+        struct_Range,
+        struct_scCats,
+    )
 except ImportError as e:
     sys.stderr.write(_("Loading ctypes libs failed"))
 

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -15,10 +15,29 @@ import sys
 import numpy as np
 from multiprocessing import Process, Queue
 
-from ctypes import *
+import ctypes
+from ctypes import POINTER, c_uint8, c_double, c_int, c_char_p, pointer
 
 try:
-    from grass.lib.imagery import *
+    from grass.lib.imagery import (
+        I_apply_colormap,
+        I_merge_arrays,
+        I_create_cat_rast,
+        SC_SCATT_DATA,
+        SC_SCATT_CONDITIONS,
+        I_compute_scatts,
+        I_sc_free_cats,
+        struct_Range,
+        struct_Cell_head,
+        struct_scCats,
+        I_sc_init_cats,
+        I_sc_add_cat,
+        scdScattData,
+        I_scd_init_scatt_data,
+        I_sc_insert_scatt_data,
+        I_insert_patch_to_cat_rast,
+        I_rasterize,
+    )
     from grass.lib.gis import G_get_window
 except ImportError as e:
     sys.stderr.write(_("Loading ctypes libs failed"))

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -257,7 +257,7 @@ def _getComputationStruct(cats, cats_rasts, cats_type, n_bands):
 
             scatt_vals = scdScattData()
 
-            c_void_p = ctypes.POINTER(ctypes.c_void_p)
+            c_void_p = POINTER(ctypes.c_void_p)
 
             if cats_type == SC_SCATT_DATA:
                 vals[:] = 0


### PR DESCRIPTION
Fixed all `F405` and `F403` by explicitly importing all the functions. I had to import `ctypes` separately as well since explicit import of `ctypes.c_void_p` wasn't working for some reason. Also updated `ctypes.POINTER` to `POINTER` since its being imported.