### PR TITLE
wxGUI: Fixed F841 is iscatt/core_c.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -27,7 +27,7 @@ per-file-ignores =
     gui/scripts/d.wms.py: E501
     gui/wxpython/image2target/*: F841, E722
     gui/wxpython/image2target/g.gui.image2target.py: E501, F841
-    gui/wxpython/iscatt/*: F841, E722
+    gui/wxpython/iscatt/*: F841
     gui/wxpython/lmgr/frame.py: F841, E722
     # layertree still includes some formatting issues (it is ignored by Black)
     gui/wxpython/lmgr/layertree.py: E722, E266, W504, E225

--- a/gui/wxpython/iscatt/core_c.py
+++ b/gui/wxpython/iscatt/core_c.py
@@ -40,7 +40,7 @@ try:
         struct_scCats,
     )
 except ImportError as e:
-    sys.stderr.write(_("Loading ctypes libs failed"))
+    sys.stderr.write(_("Loading ctypes libs failed: %s") % e)
 
 from core.gcmd import GException
 from grass.script import encode
@@ -288,7 +288,6 @@ def _updateCatRastProcess(patch_rast, region, cat_rast, output_queue):
 
 
 def _rasterize(polygon, rast, region, value, output_queue):
-    pol_size = len(polygon) * 2
     pol = np.array(polygon, dtype=float)
 
     c_uint8_p = POINTER(c_uint8)


### PR DESCRIPTION
Fixed `F841` in `iscatt/core_c.py`. Printed the error message and removed an unused variable. I'll be pushing `F841` in small PRs since they can be relatively complex to review.