### PR TITLE
wxGUI: Fixed F841 in dialogs.py, frame.py

### DIFF
--- a/gui/wxpython/iscatt/dialogs.py
+++ b/gui/wxpython/iscatt/dialogs.py
@@ -90,8 +90,6 @@ class AddScattPlotDialog(wx.Dialog):
         border = wx.BoxSizer(wx.VERTICAL)
         dialogSizer = wx.BoxSizer(wx.VERTICAL)
 
-        regionSizer = wx.BoxSizer(wx.HORIZONTAL)
-
         dialogSizer.Add(
             self._addSelectSizer(title=self.band_1_label, sel=self.band_1_ch)
         )
@@ -356,7 +354,6 @@ class SettingsDialog(wx.Dialog):
 
         self.scatt_mgr = scatt_mgr
 
-        maxValue = 1e8
         self.parent = parent
         self.settings = {}
 

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -221,8 +221,6 @@ class ScatterPlotsPanel(scrolled.ScrolledPanel):
 
         self.Bind(aui.EVT_AUI_PANE_CLOSE, self.OnPlotPaneClosed)
 
-        # self.SetBestSize(dlgSize)
-        # self.SetInitialSize(dlgSize)
         self.SetAutoLayout(1)
         # fix goutput's pane size (required for Mac OSX)
         # if self.gwindow:

--- a/gui/wxpython/iscatt/frame.py
+++ b/gui/wxpython/iscatt/frame.py
@@ -221,7 +221,6 @@ class ScatterPlotsPanel(scrolled.ScrolledPanel):
 
         self.Bind(aui.EVT_AUI_PANE_CLOSE, self.OnPlotPaneClosed)
 
-        dlgSize = (-1, 400)
         # self.SetBestSize(dlgSize)
         # self.SetInitialSize(dlgSize)
         self.SetAutoLayout(1)


### PR DESCRIPTION
Deleted 3 instances of local variable which were not used to fix `F841`. Please review if `regionSizer` is being used or not - I deleted it since it had no further use in the fucntion and did not affect any other functions, being a local variable