### PR TITLE
r.fill.dir: Fix unchecked return value in filldir.c

### DIFF
--- a/raster/r.fill.dir/filldir.c
+++ b/raster/r.fill.dir/filldir.c
@@ -145,14 +145,24 @@ void filldir(int fe, int fd, int nl, struct band3 *bnd)
     CELL *dir;
 
     /* fill single-cell depressions, except on outer rows and columns */
-    lseek(fe, 0, SEEK_SET);
+    if (lseek(fe, 0, SEEK_SET) == -1) {
+        G_warning(_("Unable to seek: %s"), strerror(errno));
+        return 0;
+    }
+        
     advance_band3(fe, bnd);
     advance_band3(fe, bnd);
     for (i = 1; i < nl - 1; i += 1) {
-        lseek(fe, (off_t)(i + 1) * bnd->sz, SEEK_SET);
+        if (lseek(fe, (off_t)(i + 1) * bnd->sz, SEEK_SET) == -1) {
+            G_warning(_("Unable to seek: %s"), strerror(errno));
+            return 0;
+        }
         advance_band3(fe, bnd);
         if (fill_row(nl, bnd->ns, bnd)) {
-            lseek(fe, (off_t)i * bnd->sz, SEEK_SET);
+            if (lseek(fe, (off_t)i * bnd->sz, SEEK_SET) == -1) {
+                G_warning(_("Unable to seek: %s"), strerror(errno));
+                return 0;
+            }
             if (write(fe, bnd->b[1], bnd->sz) < 0)
                 G_fatal_error(_("File writing error in %s() %d:%s"), __func__,
                               errno, strerror(errno));
@@ -172,8 +182,14 @@ void filldir(int fe, int fd, int nl, struct band3 *bnd)
     dir = G_calloc(bnd->ns, sizeof(CELL));
     bufsz = bnd->ns * sizeof(CELL);
 
-    lseek(fe, 0, SEEK_SET);
-    lseek(fd, 0, SEEK_SET);
+    if (lseek(fe, 0, SEEK_SET) == -1) {
+        G_warning(_("Unable to seek: %s"), strerror(errno));
+        return 0;
+    }
+    if (lseek(fd, 0, SEEK_SET) == -1) {
+        G_warning(_("Unable to seek: %s"), strerror(errno));
+        return 0;
+    }
     advance_band3(fe, bnd);
     for (i = 0; i < nl; i += 1) {
         advance_band3(fe, bnd);

--- a/raster/r.fill.dir/filldir.c
+++ b/raster/r.fill.dir/filldir.c
@@ -146,22 +146,19 @@ void filldir(int fe, int fd, int nl, struct band3 *bnd)
 
     /* fill single-cell depressions, except on outer rows and columns */
     if (lseek(fe, 0, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
-        return 0;
+        G_fatal_error(_("Unable to seek: %s"), strerror(errno));
     }
         
     advance_band3(fe, bnd);
     advance_band3(fe, bnd);
     for (i = 1; i < nl - 1; i += 1) {
         if (lseek(fe, (off_t)(i + 1) * bnd->sz, SEEK_SET) == -1) {
-            G_warning(_("Unable to seek: %s"), strerror(errno));
-            return 0;
+            G_fatal_error(_("Unable to seek: %s"), strerror(errno));
         }
         advance_band3(fe, bnd);
         if (fill_row(nl, bnd->ns, bnd)) {
             if (lseek(fe, (off_t)i * bnd->sz, SEEK_SET) == -1) {
-                G_warning(_("Unable to seek: %s"), strerror(errno));
-                return 0;
+                G_fatal_error(_("Unable to seek: %s"), strerror(errno));
             }
             if (write(fe, bnd->b[1], bnd->sz) < 0)
                 G_fatal_error(_("File writing error in %s() %d:%s"), __func__,
@@ -183,12 +180,10 @@ void filldir(int fe, int fd, int nl, struct band3 *bnd)
     bufsz = bnd->ns * sizeof(CELL);
 
     if (lseek(fe, 0, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
-        return 0;
+        G_fatal_error(_("Unable to seek: %s"), strerror(errno));
     }
     if (lseek(fd, 0, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
-        return 0;
+        G_fatal_error(_("Unable to seek: %s"), strerror(errno));
     }
     advance_band3(fe, bnd);
     for (i = 0; i < nl; i += 1) {

--- a/vector/v.transform/main.c
+++ b/vector/v.transform/main.c
@@ -188,8 +188,17 @@ int main(int argc, char *argv[])
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
-    strcpy(Current.name, vold->answer);
-    strcpy(Trans.name, vnew->answer);
+    if (G_strlcpy(Current.name, vold->answer, sizeof(Current.name)) >=
+        sizeof(Current.name)) {
+        G_fatal_error(_("Input vector map name <%s> is too long"),
+                      vold->answer);
+    }
+
+    if (G_strlcpy(Trans.name, vnew->answer, sizeof(Trans.name)) >=
+        sizeof(Trans.name)) {
+        G_fatal_error(_("Output vector map name <%s> is too long"),
+                      vnew->answer);
+    }
 
     Vect_check_input_output_name(vold->answer, vnew->answer, G_FATAL_EXIT);
 


### PR DESCRIPTION
This pull request addresses an issue identified by Coverity Scan (CID: 1207239), where the return value of the lseek function is not checked.

