### PR TITLE
style: Fix all remaining `PT` flake8-pytest-style issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,6 @@ ignore = [
     "PLW3201", # bad-dunder-method-name
     "PT001",   # pytest-fixture-incorrect-parentheses-style
     "PT004",   # pytest-missing-fixture-name-underscore
-    "PT006",   # pytest-parametrize-names-wrong-type
     "PT009",   # pytest-unittest-assertion
     "PT011",   # pytest-raises-too-broad
     "PT018",   # pytest-composite-assertion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ ignore = [
     "PT004",   # pytest-missing-fixture-name-underscore
     "PT009",   # pytest-unittest-assertion
     "PT011",   # pytest-raises-too-broad
-    "PT018",   # pytest-composite-assertion
     "PT023",   # pytest-incorrect-mark-parentheses-style
     "PTH100",  # os-path-abspath
     "PTH101",  # os-chmod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,6 @@ ignore = [
 "python/grass/gunittest/testsu*/d*/s*/s*/subsub*/t*/test_segfaut.py" = ["B018"]
 "python/grass/gunittest/testsuite/test_assertions_rast3d.py" = ["FLY002"]
 "python/grass/imaging/images2*.py" = ["SIM115"]
-"python/grass/jupyter/tests/reprojection_renderer_test.py" = ["PT013"]
 "python/grass/jupyter/testsuite/interactivemap_test.py" = ["PGH004"]
 "python/grass/jupyter/testsuite/map_test.py" = ["PGH004"]
 "python/grass/pydispatch/signal.py" = ["A005"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,11 +179,8 @@ ignore = [
     "PLW1641", # eq-without-hash
     "PLW2901", # redefined-loop-name
     "PLW3201", # bad-dunder-method-name
-    "PT001",   # pytest-fixture-incorrect-parentheses-style
-    "PT004",   # pytest-missing-fixture-name-underscore
     "PT009",   # pytest-unittest-assertion
     "PT011",   # pytest-raises-too-broad
-    "PT023",   # pytest-incorrect-mark-parentheses-style
     "PTH100",  # os-path-abspath
     "PTH101",  # os-chmod
     "PTH102",  # os-mkdir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,6 @@ ignore = [
     "PLW1641", # eq-without-hash
     "PLW2901", # redefined-loop-name
     "PLW3201", # bad-dunder-method-name
-    "PT009",   # pytest-unittest-assertion
     "PT011",   # pytest-raises-too-broad
     "PTH100",  # os-path-abspath
     "PTH101",  # os-chmod
@@ -308,6 +307,7 @@ ignore = [
 "python/grass/__init__.py" = ["PYI056"]
 "python/grass/exp*/tests/grass_script_mapset_session_test.py" = ["SIM117"]
 "python/grass/exp*/tests/grass_script_tmp_mapset_session_test.py" = ["SIM117"]
+"python/grass/gunittest/case.py" = ["PT009"]
 "python/grass/gunittest/loader.py" = ["PYI024"]
 "python/grass/gunittest/multireport.py" = ["PYI024"]
 "python/grass/gunittest/testsu*/d*/s*/s*/subsub*/t*/test_segfaut.py" = ["B018"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,6 @@ ignore = [
     "PLW1641", # eq-without-hash
     "PLW2901", # redefined-loop-name
     "PLW3201", # bad-dunder-method-name
-    "PT011",   # pytest-raises-too-broad
     "PTH100",  # os-path-abspath
     "PTH101",  # os-chmod
     "PTH102",  # os-mkdir

--- a/python/grass/experimental/tests/grass_script_mapset_session_test.py
+++ b/python/grass/experimental/tests/grass_script_mapset_session_test.py
@@ -68,7 +68,8 @@ def test_create_overwrite(xy_session):
             .strip()
             .split()
         )
-        assert len(rasters) == 1 and rasters[0] == "a"
+        assert len(rasters) == 1
+        assert rasters[0] == "a"
     with experimental.MapsetSession(
         name, create=True, overwrite=True, env=xy_session.env
     ) as session:
@@ -86,7 +87,8 @@ def test_create_overwrite(xy_session):
             .strip()
             .split()
         )
-        assert len(rasters) == 1 and rasters[0] == "a"
+        assert len(rasters) == 1
+        assert rasters[0] == "a"
     assert os.path.exists(session_file)
 
 
@@ -103,7 +105,8 @@ def test_ensure(xy_session):
             .strip()
             .split()
         )
-        assert len(rasters) == 1 and rasters[0] == "a"
+        assert len(rasters) == 1
+        assert rasters[0] == "a"
     with experimental.MapsetSession(name, ensure=True, env=xy_session.env) as session:
         session_mapset = gs.read_command("g.mapset", flags="p", env=session.env).strip()
         assert name == session_mapset
@@ -112,7 +115,8 @@ def test_ensure(xy_session):
             .strip()
             .split()
         )
-        assert len(rasters) == 1 and rasters[0] == "a"
+        assert len(rasters) == 1
+        assert rasters[0] == "a"
         gs.run_command("r.mapcalc", expression="b = 1", env=session.env)
         rasters = (
             gs.read_command("g.list", type="raster", mapset=".", env=session.env)

--- a/python/grass/jupyter/tests/reprojection_renderer_test.py
+++ b/python/grass/jupyter/tests/reprojection_renderer_test.py
@@ -1,7 +1,7 @@
 """Test ReprojectionRenderer functions"""
 
 from pathlib import Path
-from pytest import approx
+import pytest
 from grass.jupyter.reprojection_renderer import ReprojectionRenderer
 
 
@@ -21,8 +21,8 @@ def test_render_raster(simple_dataset):
     assert Path(filename).exists()
     # Test bounding box is correct
     # Raster is same extent as region so no need to test bbox for use_region=True
-    assert bbox[0] == approx([0.00072155, -85.48874388])
-    assert bbox[1] == approx([0.00000000, -85.48766880])
+    assert bbox[0] == pytest.approx([0.00072155, -85.48874388])
+    assert bbox[1] == pytest.approx([0.00000000, -85.48766880])
 
 
 # render_vector produces json

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -210,7 +210,7 @@ def test_patching_backend(tmp_path, patch_backend):
 
 @xfail_mp_spawn
 @pytest.mark.parametrize(
-    "width, height, processes",
+    ("width", "height", "processes"),
     [
         (None, None, max_processes()),
         (10, None, max_processes()),
@@ -249,7 +249,7 @@ def test_tiling(tmp_path, width, height, processes):
 @xfail_mp_spawn
 @pytest.mark.needs_solo_run
 @pytest.mark.parametrize(
-    "processes, backend",
+    ("processes", "backend"),
     [
         (1, "RasterRow"),
         (9, "RasterRow"),

--- a/python/grass/script/tests/grass_script_setup_test.py
+++ b/python/grass/script/tests/grass_script_setup_test.py
@@ -51,7 +51,7 @@ def test_init_session_finish(tmp_path):
     gs.run_command("g.region", flags="p", env=session.env)
     session_file = session.env["GISRC"]
     session.finish()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         session.finish()
     assert not session.active
     assert not os.path.exists(session_file)

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -83,7 +83,7 @@ def test_yaml(space_time_raster_dataset):
 
 @pytest.mark.needs_solo_run
 @pytest.mark.parametrize(
-    "separator,delimiter", [(None, ","), (",", ","), (";", ";"), ("tab", "\t")]
+    ("separator", "delimiter"), [(None, ","), (",", ","), (";", ";"), ("tab", "\t")]
 )
 def test_csv(space_time_raster_dataset, separator, delimiter):
     """Check CSV can be parsed with different separators"""


### PR DESCRIPTION
Only 10 issues were remaining to enable checking all available ruff rules of the `PT` category.

This PR fixes 3 types of issues, and removes unneeded exclusions, as there were no longer issues there.

The only remaining ignores per file are found in `"*/testsuite/**.py" = ["PT009", "PT027"]` and `"python/grass/gunittest/case.py" = ["PT009"]`. The first one is because we use unittest-style asserts in our gunittest tests, obviously, and the grass.gunittest.case detects our custom assertions like if they were tests (and not following pytest style assertions), which isn't desirable.

That brings us to having all rules of the `PT` category being addressed.