### PR TITLE
style: Fix unnecessary-paren-on-raise-exception (RSE102)

### DIFF
--- a/gui/wxpython/core/giface.py
+++ b/gui/wxpython/core/giface.py
@@ -60,7 +60,7 @@ class LayerList:
             However, this may be the same for some implementations
             (e.g. it d.mon has all layers checked and selected).
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetSelectedLayer(self, checkedOnly=False):
         """Returns selected layer or None when there is no selected layer.
@@ -69,7 +69,7 @@ class LayerList:
             Parameter checkedOnly is here False by default. This might
             change if we find the right way of handling unchecked layers.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def AddLayer(self, ltype, name=None, checked=None, opacity=1.0, cmd=None):
         """Adds a new layer to the layer list.
@@ -82,7 +82,7 @@ class LayerList:
         :param opacity: layer opacity level
         :param cmd: command (given as a list)
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetLayersByName(self, name):
         """Returns list of layers with a given name.
@@ -93,7 +93,7 @@ class LayerList:
             if common usage is just to check the presence of layer,
             intoroduce a new method ContainsLayerByName(name)
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetLayerByData(self, key, value):
         """Returns layer with specified.
@@ -104,7 +104,7 @@ class LayerList:
         .. warning::
             Avoid using this method, it might be removed in the future.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class GrassInterface:
@@ -118,31 +118,31 @@ class GrassInterface:
 
     def RunCmd(self, *args, **kwargs):
         """Executes a command."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def Help(self, entry):
         """Shows a manual page for a given entry."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def WriteLog(self, text, wrap=None, notification=Notification.HIGHLIGHT):
         """Writes log message."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def WriteCmdLog(self, text, pid=None, notification=Notification.MAKE_VISIBLE):
         """Writes message related to start or end of the command."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def WriteWarning(self, text):
         """Writes warning message for the user."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def WriteError(self, text):
         """Writes error message for the user."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetLog(self, err=False):
         """Returns file-like object for writing."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetLayerTree(self):
         """Returns LayerManager's tree GUI object.
@@ -150,11 +150,11 @@ class GrassInterface:
 
             Will be removed from the interface.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetLayerList(self):
         """Returns a layer management object."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetMapDisplay(self):
         """Returns current map display.
@@ -166,7 +166,7 @@ class GrassInterface:
         :return: MapFrame instance
         :return: None when no mapdisplay open
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetAllMapDisplays(self):
         """Get list of all map displays.
@@ -177,7 +177,7 @@ class GrassInterface:
 
         :return: list of MapFrame instances
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetMapWindow(self):
         """Returns current map window.
@@ -186,7 +186,7 @@ class GrassInterface:
 
             For layer related tasks use GetLayerList().
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetProgress(self):
         """Returns object which shows the progress.
@@ -195,7 +195,7 @@ class GrassInterface:
 
             Some implementations may not implement this method.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class StandaloneGrassInterface(GrassInterface):
@@ -343,9 +343,9 @@ class StandaloneGrassInterface(GrassInterface):
         return []
 
     def GetMapWindow(self):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetProgress(self):
         # TODO: implement some progress with same inface as gui one
         # (probably using g.message or similarly to Write... functions)
-        raise NotImplementedError()
+        raise NotImplementedError

--- a/gui/wxpython/core/gthread.py
+++ b/gui/wxpython/core/gthread.py
@@ -160,7 +160,7 @@ class gThread(threading.Thread, wx.EvtHandler):
             if event == "line":
                 # Send event
                 wx.PostEvent(self, self._terminate_evt)
-                raise SystemExit()
+                raise SystemExit
         return self.localtrace
 
     def OnTerminate(self, event):

--- a/gui/wxpython/core/layerlist.py
+++ b/gui/wxpython/core/layerlist.py
@@ -125,7 +125,7 @@ class LayerList:
         .. warning::
             Avoid using this method, it might be removed in the future.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetLayerIndex(self, layer):
         """Get index of layer."""

--- a/gui/wxpython/mapwin/analysis.py
+++ b/gui/wxpython/mapwin/analysis.py
@@ -93,20 +93,20 @@ class AnalysisControllerBase:
 
         :param coords: EN coordinates
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _disconnectAll(self):
         """Disconnect all mouse signals
         to stop drawing."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _connectAll(self):
         """Connect all mouse signals to draw."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _getPen(self):
         """Returns wx.Pen instance."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def Stop(self, restore=True):
         """Analysis mode is stopped.

--- a/gui/wxpython/mapwin/base.py
+++ b/gui/wxpython/mapwin/base.py
@@ -370,10 +370,10 @@ class MapWindowBase:
         return True
 
     def Pixel2Cell(self, xyCoords):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def Cell2Pixel(self, enCoords):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def OnMotion(self, event):
         """Tracks mouse motion and update statusbar
@@ -453,8 +453,8 @@ class MapWindowBase:
 
     def DisactivateWin(self):
         """Use when the class instance is hidden in MapFrame."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def ActivateWin(self):
         """Used when the class instance is activated in MapFrame."""
-        raise NotImplementedError()
+        raise NotImplementedError

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -236,15 +236,15 @@ class ImportDialog(wx.Dialog):
 
     def _getCommand(self):
         """Get command"""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _getBlackListedParameters(self):
         """Get parameters which will not be showed in Settings page"""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _getBlackListedFlags(self):
         """Get flags which will not be showed in Settings page"""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _nameValidationFailed(self, layers_list):
         """Output map name validation callback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ ignore = [
     "RET506",  # superfluous-else-raise
     "RET507",  # superfluous-else-continue
     "RET508",  # superfluous-else-break
-    "RSE102",  # unnecessary-paren-on-raise-exception
     "RUF003",  # ambiguous-unicode-character-comment
     "RUF005",  # collection-literal-concatenation
     "RUF012",  # mutable-class-default

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -392,7 +392,7 @@ class Tag:
 
     def ProcessTag(self):
         """Implement this to create the tag."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def GetTag(self):
         """Calls processTag and attaches the header."""

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1869,7 +1869,7 @@ def c_read_next_line(c_mapinfo, c_points, c_cats):
     v_id = v_id if v_id != 0 else None
     ftype = libvect.Vect_read_next_line(c_mapinfo, c_points, c_cats)
     if ftype == -2:
-        raise StopIteration()
+        raise StopIteration
     if ftype == -1:
         raise
     return ftype, v_id, c_points, c_cats


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/unnecessary-paren-on-raise-exception/

It is only possible to omit the parentheses if the exception is a class, not a function call (so it would be an exception object). In this PR, all cases were classes.