### PR TITLE
v.reclass: Fix Resource Leak issue in reclass.c

### DIFF
--- a/vector/v.reclass/reclass.c
+++ b/vector/v.reclass/reclass.c
@@ -79,6 +79,9 @@ int reclass(struct Map_info *In, struct Map_info *Out, int type, int field,
         G_warning("For %d elements requested negative category (ignored, no "
                   "category in output)",
                   negative);
+    Vect_destroy_cats_struct(Cats);
+    Vect_destroy_cats_struct(NewCats);
+    Vect_destroy_line_struct(Points);
 
     return (rclelem);
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207621, 1207624, 1207622)
Used existing function Vect_destroy_cats_struct(), Vect_destroy_line_struct() to fix the memory leak issue.