### PR TITLE
lib: Fix resource leak issue in raster.c

### DIFF
--- a/lib/lidar/raster.c
+++ b/lib/lidar/raster.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <grass/lidar.h>
+#include <grass/vector.h>
 
 /*------------------------------------------------------------------------------------------------*/
 void P_Sparse_Points(struct Map_info *Out, struct Cell_head *Elaboration,
@@ -187,6 +188,7 @@ void P_Sparse_Points(struct Map_info *Out, struct Cell_head *Elaboration,
         }
     /*IF*/}
     /*FOR*/ db_commit_transaction(driver);
+    Vect_destroy_line_struct(point);
 
     return;
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207702)
Used existing function Vect_destroy_line_struct() to fix the memory leak issue.