### PR TITLE
style: Fix superfluous-else-return (RET505)

### DIFF
--- a/gui/wxpython/animation/dialogs.py
+++ b/gui/wxpython/animation/dialogs.py
@@ -1548,37 +1548,36 @@ class ExportDialog(wx.Dialog):
         if not file_path:
             GError(parent=self, message=_("Export file is missing."))
             return False
-        else:
-            if not file_path.endswith(file_postfix):
-                filebrowsebtn.SetValue(file_path + file_postfix)
-                file_path += file_postfix
+        if not file_path.endswith(file_postfix):
+            filebrowsebtn.SetValue(file_path + file_postfix)
+            file_path += file_postfix
 
-            base_dir = os.path.dirname(file_path)
-            if not os.path.exists(base_dir):
-                GError(
-                    parent=self,
-                    message=file_path_does_not_exist_err_message.format(
-                        base_dir=base_dir,
-                    ),
-                )
-                return False
+        base_dir = os.path.dirname(file_path)
+        if not os.path.exists(base_dir):
+            GError(
+                parent=self,
+                message=file_path_does_not_exist_err_message.format(
+                    base_dir=base_dir,
+                ),
+            )
+            return False
 
-            if os.path.exists(file_path):
-                overwrite_dlg = wx.MessageDialog(
-                    self.GetParent(),
-                    message=_(
-                        "Exported animation file <{file}> exists. "
-                        "Do you want to overwrite it?"
-                    ).format(
-                        file=file_path,
-                    ),
-                    caption=_("Overwrite?"),
-                    style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
-                )
-                if overwrite_dlg.ShowModal() != wx.ID_YES:
-                    overwrite_dlg.Destroy()
-                    return False
+        if os.path.exists(file_path):
+            overwrite_dlg = wx.MessageDialog(
+                self.GetParent(),
+                message=_(
+                    "Exported animation file <{file}> exists. "
+                    "Do you want to overwrite it?"
+                ).format(
+                    file=file_path,
+                ),
+                caption=_("Overwrite?"),
+                style=wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
+            )
+            if overwrite_dlg.ShowModal() != wx.ID_YES:
                 overwrite_dlg.Destroy()
+                return False
+            overwrite_dlg.Destroy()
 
         return True
 

--- a/gui/wxpython/animation/provider.py
+++ b/gui/wxpython/animation/provider.py
@@ -328,9 +328,8 @@ class BitmapProvider:
 
         if returncode == 0:
             return BitmapFromImage(autoCropImageFromFile(filename))
-        else:
-            os.remove(filename)
-            raise GException(messages)
+        os.remove(filename)
+        raise GException(messages)
 
 
 class BitmapRenderer:

--- a/gui/wxpython/animation/utils.py
+++ b/gui/wxpython/animation/utils.py
@@ -69,8 +69,7 @@ def validateTimeseriesName(timeseries, etype="strds"):
         nameShort, mapset = timeseries.split("@", 1)
         if nameShort in trastDict[mapset]:
             return timeseries
-        else:
-            raise GException(_("Space time dataset <%s> not found.") % timeseries)
+        raise GException(_("Space time dataset <%s> not found.") % timeseries)
 
     mapsets = tgis.get_tgis_c_library_interface().available_mapsets()
     for mapset in mapsets:

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -202,11 +202,10 @@ class Popen(subprocess.Popen):
 
             handle = win32api.OpenProcess(1, 0, self.pid)
             return win32api.TerminateProcess(handle, 0) != 0
-        else:
-            try:
-                os.kill(-self.pid, signal.SIGTERM)  # kill whole group
-            except OSError:
-                pass
+        try:
+            os.kill(-self.pid, signal.SIGTERM)  # kill whole group
+        except OSError:
+            pass
 
     if sys.platform == "win32":
 
@@ -750,8 +749,7 @@ def RunCommand(
     if not read:
         if not getErrorMsg:
             return ret
-        else:
-            return ret, _formatMsg(stderr)
+        return ret, _formatMsg(stderr)
 
     if stdout:
         Debug.msg(3, "gcmd.RunCommand(): return stdout\n'%s'" % stdout)

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -589,9 +589,7 @@ class GConsole(wx.EvtHandler):
                     import importlib.machinery
 
                     def load_source(modname, filename):
-                        loader = importlib.machinery.SourceFileLoader(
-                            modname, filename
-                        )
+                        loader = importlib.machinery.SourceFileLoader(modname, filename)
                         spec = importlib.util.spec_from_file_location(
                             modname, filename, loader=loader
                         )
@@ -625,9 +623,9 @@ class GConsole(wx.EvtHandler):
                 if hasParams and not isinstance(self._guiparent, FormNotebook):
                     # also parent must be checked, see #3135 for details
                     try:
-                        GUI(
-                            parent=self._guiparent, giface=self._giface
-                        ).ParseCommand(command)
+                        GUI(parent=self._guiparent, giface=self._giface).ParseCommand(
+                            command
+                        )
                         self.UpdateHistory(status=Status.SUCCESS)
                     except GException as e:
                         print(e, file=sys.stderr)
@@ -657,8 +655,8 @@ class GConsole(wx.EvtHandler):
             )
             self.cmdOutputTimer.Start(50)
 
-                # we don't need to change computational region settings
-                # because we work on a copy
+            # we don't need to change computational region settings
+            # because we work on a copy
         else:
             # Send any other command to the shell. Send output to
             # console output window

--- a/gui/wxpython/core/gconsole.py
+++ b/gui/wxpython/core/gconsole.py
@@ -552,111 +552,110 @@ class GConsole(wx.EvtHandler):
                 wx.PostEvent(self, event)
                 return
 
-            else:
-                # other GRASS commands (r|v|g|...)
-                try:
-                    task = GUI(show=None).ParseCommand(command)
-                except GException as e:
-                    GError(parent=self._guiparent, message=str(e), showTraceback=False)
-                    return
+            # other GRASS commands (r|v|g|...)
+            try:
+                task = GUI(show=None).ParseCommand(command)
+            except GException as e:
+                GError(parent=self._guiparent, message=str(e), showTraceback=False)
+                return
 
-                hasParams = False
-                if task:
-                    options = task.get_options()
-                    hasParams = options["params"] and options["flags"]
-                    # check for <input>=-
-                    for p in options["params"]:
-                        if (
-                            p.get("prompt", "") == "input"
-                            and p.get("element", "") == "file"
-                            and p.get("age", "new") == "old"
-                            and p.get("value", "") == "-"
-                        ):
-                            GError(
-                                parent=self._guiparent,
-                                message=_(
-                                    "Unable to run command:\n%(cmd)s\n\n"
-                                    "Option <%(opt)s>: read from standard input is not "
-                                    "supported by wxGUI"
-                                )
-                                % {"cmd": " ".join(command), "opt": p.get("name", "")},
+            hasParams = False
+            if task:
+                options = task.get_options()
+                hasParams = options["params"] and options["flags"]
+                # check for <input>=-
+                for p in options["params"]:
+                    if (
+                        p.get("prompt", "") == "input"
+                        and p.get("element", "") == "file"
+                        and p.get("age", "new") == "old"
+                        and p.get("value", "") == "-"
+                    ):
+                        GError(
+                            parent=self._guiparent,
+                            message=_(
+                                "Unable to run command:\n%(cmd)s\n\n"
+                                "Option <%(opt)s>: read from standard input is not "
+                                "supported by wxGUI"
                             )
-                            return
-
-                if len(command) == 1:
-                    if command[0].startswith("g.gui."):
-                        import inspect
-                        import importlib.util
-                        import importlib.machinery
-
-                        def load_source(modname, filename):
-                            loader = importlib.machinery.SourceFileLoader(
-                                modname, filename
-                            )
-                            spec = importlib.util.spec_from_file_location(
-                                modname, filename, loader=loader
-                            )
-                            module = importlib.util.module_from_spec(spec)
-                            # Module is always executed and not cached in sys.modules.
-                            # Uncomment the following line to cache the module.
-                            # sys.modules[module.__name__] = module
-                            loader.exec_module(module)
-                            return module
-
-                        pyFile = command[0]
-                        if sys.platform == "win32":
-                            pyFile += ".py"
-                        pyPath = os.path.join(os.environ["GISBASE"], "scripts", pyFile)
-                        if not os.path.exists(pyPath):
-                            pyPath = os.path.join(
-                                os.environ["GRASS_ADDON_BASE"], "scripts", pyFile
-                            )
-                        if not os.path.exists(pyPath):
-                            GError(
-                                parent=self._guiparent,
-                                message=_("Module <%s> not found.") % command[0],
-                            )
-                        pymodule = load_source(command[0].replace(".", "_"), pyPath)
-                        pymain = inspect.getfullargspec(pymodule.main)
-                        if pymain and "giface" in pymain.args:
-                            pymodule.main(self._giface)
-                            return
-
-                    # no arguments given
-                    if hasParams and not isinstance(self._guiparent, FormNotebook):
-                        # also parent must be checked, see #3135 for details
-                        try:
-                            GUI(
-                                parent=self._guiparent, giface=self._giface
-                            ).ParseCommand(command)
-                            self.UpdateHistory(status=Status.SUCCESS)
-                        except GException as e:
-                            print(e, file=sys.stderr)
-
+                            % {"cmd": " ".join(command), "opt": p.get("name", "")},
+                        )
                         return
 
-                if env:
-                    env = env.copy()
-                else:
-                    env = os.environ.copy()
-                # activate computational region (set with g.region)
-                # for all non-display commands.
-                if compReg and "GRASS_REGION" in env:
-                    del env["GRASS_REGION"]
+            if len(command) == 1:
+                if command[0].startswith("g.gui."):
+                    import inspect
+                    import importlib.util
+                    import importlib.machinery
 
-                # process GRASS command with argument
-                self.cmdThread.RunCmd(
-                    command,
-                    stdout=self.cmdStdOut,
-                    stderr=self.cmdStdErr,
-                    onDone=onDone,
-                    onPrepare=onPrepare,
-                    userData=userData,
-                    addLayer=addLayer,
-                    env=env,
-                    notification=notification,
-                )
-                self.cmdOutputTimer.Start(50)
+                    def load_source(modname, filename):
+                        loader = importlib.machinery.SourceFileLoader(
+                            modname, filename
+                        )
+                        spec = importlib.util.spec_from_file_location(
+                            modname, filename, loader=loader
+                        )
+                        module = importlib.util.module_from_spec(spec)
+                        # Module is always executed and not cached in sys.modules.
+                        # Uncomment the following line to cache the module.
+                        # sys.modules[module.__name__] = module
+                        loader.exec_module(module)
+                        return module
+
+                    pyFile = command[0]
+                    if sys.platform == "win32":
+                        pyFile += ".py"
+                    pyPath = os.path.join(os.environ["GISBASE"], "scripts", pyFile)
+                    if not os.path.exists(pyPath):
+                        pyPath = os.path.join(
+                            os.environ["GRASS_ADDON_BASE"], "scripts", pyFile
+                        )
+                    if not os.path.exists(pyPath):
+                        GError(
+                            parent=self._guiparent,
+                            message=_("Module <%s> not found.") % command[0],
+                        )
+                    pymodule = load_source(command[0].replace(".", "_"), pyPath)
+                    pymain = inspect.getfullargspec(pymodule.main)
+                    if pymain and "giface" in pymain.args:
+                        pymodule.main(self._giface)
+                        return
+
+                # no arguments given
+                if hasParams and not isinstance(self._guiparent, FormNotebook):
+                    # also parent must be checked, see #3135 for details
+                    try:
+                        GUI(
+                            parent=self._guiparent, giface=self._giface
+                        ).ParseCommand(command)
+                        self.UpdateHistory(status=Status.SUCCESS)
+                    except GException as e:
+                        print(e, file=sys.stderr)
+
+                    return
+
+            if env:
+                env = env.copy()
+            else:
+                env = os.environ.copy()
+            # activate computational region (set with g.region)
+            # for all non-display commands.
+            if compReg and "GRASS_REGION" in env:
+                del env["GRASS_REGION"]
+
+            # process GRASS command with argument
+            self.cmdThread.RunCmd(
+                command,
+                stdout=self.cmdStdOut,
+                stderr=self.cmdStdErr,
+                onDone=onDone,
+                onPrepare=onPrepare,
+                userData=userData,
+                addLayer=addLayer,
+                env=env,
+                notification=notification,
+            )
+            self.cmdOutputTimer.Start(50)
 
                 # we don't need to change computational region settings
                 # because we work on a copy

--- a/gui/wxpython/core/gthread.py
+++ b/gui/wxpython/core/gthread.py
@@ -152,8 +152,7 @@ class gThread(threading.Thread, wx.EvtHandler):
     def globaltrace(self, frame, event, arg):
         if event == "call":
             return self.localtrace
-        else:
-            return None
+        return None
 
     def localtrace(self, frame, event, arg):
         if self.terminate:

--- a/gui/wxpython/core/menutree.py
+++ b/gui/wxpython/core/menutree.py
@@ -160,10 +160,9 @@ class MenuTreeModelBuilder:
         """
         if separators:
             return copy.deepcopy(self.model)
-        else:
-            model = copy.deepcopy(self.model)
-            removeSeparators(model)
-            return model
+        model = copy.deepcopy(self.model)
+        removeSeparators(model)
+        return model
 
     def PrintTree(self, fh):
         for child in self.model.root.children:

--- a/gui/wxpython/core/render.py
+++ b/gui/wxpython/core/render.py
@@ -229,10 +229,8 @@ class Layer:
                     scmd.append(utils.GetCmdString(c))
 
                 return ";".join(scmd)
-            else:
-                return utils.GetCmdString(self.cmd)
-        else:
-            return self.cmd
+            return utils.GetCmdString(self.cmd)
+        return self.cmd
 
     def GetType(self):
         """Get map layer type"""
@@ -462,8 +460,7 @@ class RenderLayerMgr(wx.EvtHandler):
         stdout, stderr = p.communicate()
         if p.returncode:
             return grass.decode(stderr)
-        else:
-            return None
+        return None
 
     def Abort(self):
         """Abort rendering process"""
@@ -1690,8 +1687,7 @@ class Map:
         if not list:
             if len(ovl) != 1:
                 return None
-            else:
-                return ovl[0]
+            return ovl[0]
 
         return ovl
 

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -59,8 +59,7 @@ class SettingsJSONEncoder(json.JSONEncoder):
                 return [color(e) for e in item]
             if isinstance(item, dict):
                 return {key: color(value) for key, value in item.items()}
-            else:
-                return item
+            return item
 
         return super().iterencode(color(obj))
 

--- a/gui/wxpython/core/toolboxes.py
+++ b/gui/wxpython/core/toolboxes.py
@@ -861,9 +861,8 @@ def module_test():
     if someDiff:
         print("Difference between files.")
         return 1
-    else:
-        print("OK")
-        return 0
+    print("OK")
+    return 0
 
 
 def validate_file(filename):

--- a/gui/wxpython/core/treemodel.py
+++ b/gui/wxpython/core/treemodel.py
@@ -137,8 +137,7 @@ class TreeModel:
     def _getNode(self, node, index):
         if len(index) == 1:
             return node.children[index[0]]
-        else:
-            return self._getNode(node.children[index[0]], index[1:])
+        return self._getNode(node.children[index[0]], index[1:])
 
     def RemoveNode(self, node):
         """Removes node. If node is root, removes root's children, root is kept."""
@@ -257,7 +256,7 @@ class DictFilterNode(DictNode):
 
         if method == "exact":
             return self._match_exact(**kwargs)
-        elif method == "filtering":
+        if method == "filtering":
             return self._match_filtering(**kwargs)
 
     def _match_exact(self, **kwargs):

--- a/gui/wxpython/core/utils.py
+++ b/gui/wxpython/core/utils.py
@@ -45,8 +45,7 @@ def split(s):
     try:
         if sys.platform == "win32":
             return shlex.split(s.replace("\\", r"\\"))
-        else:
-            return shlex.split(s)
+        return shlex.split(s)
     except ValueError as e:
         sys.stderr.write(_("Syntax error: %s") % e)
 
@@ -75,8 +74,7 @@ def GetTempfile(pref=None):
         path, file = os.path.split(tempfile)
         if pref:
             return os.path.join(pref, file)
-        else:
-            return tempfile
+        return tempfile
     except Exception:
         return None
 
@@ -341,8 +339,7 @@ def GetVectorNumberOfLayers(vector):
             _("Vector map <%(map)s>: %(msg)s\n") % {"map": fullname, "msg": msg}
         )
         return layers
-    else:
-        Debug.msg(1, "GetVectorNumberOfLayers(): ret %s" % ret)
+    Debug.msg(1, "GetVectorNumberOfLayers(): ret %s" % ret)
 
     for layer in out.splitlines():
         layers.append(layer)
@@ -374,8 +371,7 @@ def Deg2DMS(lon, lat, string=True, hemisphere=True, precision=3):
     except ValueError:
         if string:
             return ""
-        else:
-            return None
+        return None
 
     # fix longitude
     while flon > 180.0:
@@ -457,38 +453,38 @@ def __ll_parts(value, reverse=False, precision=3):
             s = "%.*f" % (precision, s)
 
         return str(d) + ":" + m + ":" + s
-    else:  # -> reverse
+    # -> reverse
+    try:
+        d, m, s = value.split(":")
+        hs = s[-1]
+        s = s[:-1]
+    except ValueError:
         try:
-            d, m, s = value.split(":")
-            hs = s[-1]
-            s = s[:-1]
+            d, m = value.split(":")
+            hs = m[-1]
+            m = m[:-1]
+            s = "0.0"
         except ValueError:
             try:
-                d, m = value.split(":")
-                hs = m[-1]
-                m = m[:-1]
+                d = value
+                hs = d[-1]
+                d = d[:-1]
+                m = "0"
                 s = "0.0"
             except ValueError:
-                try:
-                    d = value
-                    hs = d[-1]
-                    d = d[:-1]
-                    m = "0"
-                    s = "0.0"
-                except ValueError:
-                    raise ValueError
+                raise ValueError
 
-        if hs not in {"N", "S", "E", "W"}:
-            raise ValueError
+    if hs not in {"N", "S", "E", "W"}:
+        raise ValueError
 
-        coef = 1.0
-        if hs in {"S", "W"}:
-            coef = -1.0
+    coef = 1.0
+    if hs in {"S", "W"}:
+        coef = -1.0
 
-        fm = int(m) / 60.0
-        fs = float(s) / (60 * 60)
+    fm = int(m) / 60.0
+    fs = float(s) / (60 * 60)
 
-        return coef * (float(d) + fm + fs)
+    return coef * (float(d) + fm + fs)
 
 
 def GetCmdString(cmd):
@@ -555,11 +551,10 @@ def ReprojectCoordinates(coord, projOut, projIn=None, flags=""):
             proj = ""
         if proj in {"ll", "latlong", "longlat"} and "d" not in flags:
             return (proj, (e, n))
-        else:
-            try:
-                return (proj, (float(e), float(n)))
-            except ValueError:
-                return (None, None)
+        try:
+            return (proj, (float(e), float(n)))
+        except ValueError:
+            return (None, None)
 
     return (None, None)
 

--- a/gui/wxpython/datacatalog/tree.py
+++ b/gui/wxpython/datacatalog/tree.py
@@ -184,13 +184,13 @@ class DataCatalogNode(DictFilterNode):
             owner = data["owner"] or _("name unknown")
             if data["current"]:
                 return _("{name}  (current)").format(**data)
-            elif data["is_different_owner"] and data["lock"]:
+            if data["is_different_owner"] and data["lock"]:
                 return _("{name}  (in use, owner: {owner})").format(
                     name=data["name"], owner=owner
                 )
-            elif data["lock"]:
+            if data["lock"]:
                 return _("{name}  (in use)").format(**data)
-            elif data["is_different_owner"]:
+            if data["is_different_owner"]:
                 return _("{name}  (owner: {owner})").format(
                     name=data["name"], owner=owner
                 )
@@ -957,7 +957,7 @@ class DataCatalogTree(TreeView):
         if node.data["type"] == "mapset":
             if node.data["current"]:
                 return wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
-            elif node.data["lock"] or node.data["is_different_owner"]:
+            if node.data["lock"] or node.data["is_different_owner"]:
                 return wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         return wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
 
@@ -2052,8 +2052,7 @@ class DataCatalogTree(TreeView):
                         currentMapset = False
                         break
             return currentGrassDb, currentLocation, currentMapset
-        else:
-            return True, True, True
+        return True, True, True
 
     def _popupMenuLayer(self):
         """Create popup menu for layers"""

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -706,8 +706,7 @@ class VirtualAttributeList(
 
         if ascending:
             return cmpVal
-        else:
-            return -cmpVal
+        return -cmpVal
 
     def GetSortImages(self):
         """Used by the ColumnSorterMixin, see wx/lib/mixins/listctrl.py"""
@@ -2004,37 +2003,36 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
         if len(cats) == 0:
             GMessage(parent=self, message=_("Nothing to extract."))
             return
-        else:
-            # dialog to get file name
-            dlg = CreateNewVector(
-                parent=self,
-                title=_("Extract selected features"),
-                giface=self.giface,
-                cmd=(
-                    (
-                        "v.extract",
-                        {
-                            "input": self.dbMgrData["vectName"],
-                            "cats": ListOfCatsToRange(cats),
-                        },
-                        "output",
-                    )
-                ),
-                disableTable=True,
-            )
-            if not dlg:
-                return
-
-            name = dlg.GetName(full=True)
-
-            if not self.mapdisplay and self.mapdisplay.tree:
-                pass
-            elif name and dlg.IsChecked("add"):
-                # add layer to map layer tree
-                self.mapdisplay.tree.AddLayer(
-                    ltype="vector", lname=name, lcmd=["d.vect", "map=%s" % name]
+        # dialog to get file name
+        dlg = CreateNewVector(
+            parent=self,
+            title=_("Extract selected features"),
+            giface=self.giface,
+            cmd=(
+                (
+                    "v.extract",
+                    {
+                        "input": self.dbMgrData["vectName"],
+                        "cats": ListOfCatsToRange(cats),
+                    },
+                    "output",
                 )
-            dlg.Destroy()
+            ),
+            disableTable=True,
+        )
+        if not dlg:
+            return
+
+        name = dlg.GetName(full=True)
+
+        if not self.mapdisplay and self.mapdisplay.tree:
+            pass
+        elif name and dlg.IsChecked("add"):
+            # add layer to map layer tree
+            self.mapdisplay.tree.AddLayer(
+                ltype="vector", lname=name, lcmd=["d.vect", "map=%s" % name]
+            )
+        dlg.Destroy()
 
     def OnDeleteSelected(self, event):
         """Delete vector objects selected in attribute browse window
@@ -2606,43 +2604,41 @@ class DbMgrTablesPage(DbMgrNotebookBase):
                 message=_("Unable to rename column. No column name defined."),
             )
             return
-        else:
-            item = tlist.FindItem(start=-1, str=name)
-            if item > -1:
-                if tlist.FindItem(start=-1, str=nameTo) > -1:
-                    GError(
-                        parent=self,
-                        message=_(
-                            "Unable to rename column <%(column)s> to "
-                            "<%(columnTo)s>. Column already exists "
-                            "in the table <%(table)s>."
-                        )
-                        % {"column": name, "columnTo": nameTo, "table": table},
-                    )
-                    return
-                else:
-                    tlist.SetItemText(item, nameTo)
-
-                    self.listOfCommands.append(
-                        (
-                            "v.db.renamecolumn",
-                            {
-                                "map": self.dbMgrData["vectName"],
-                                "layer": self.selLayer,
-                                "column": "%s,%s" % (name, nameTo),
-                            },
-                        )
-                    )
-            else:
+        item = tlist.FindItem(start=-1, str=name)
+        if item > -1:
+            if tlist.FindItem(start=-1, str=nameTo) > -1:
                 GError(
                     parent=self,
                     message=_(
-                        "Unable to rename column. "
-                        "Column <%(column)s> doesn't exist in the table <%(table)s>."
+                        "Unable to rename column <%(column)s> to "
+                        "<%(columnTo)s>. Column already exists "
+                        "in the table <%(table)s>."
                     )
-                    % {"column": name, "table": table},
+                    % {"column": name, "columnTo": nameTo, "table": table},
                 )
                 return
+            tlist.SetItemText(item, nameTo)
+
+            self.listOfCommands.append(
+                (
+                    "v.db.renamecolumn",
+                    {
+                        "map": self.dbMgrData["vectName"],
+                        "layer": self.selLayer,
+                        "column": "%s,%s" % (name, nameTo),
+                    },
+                )
+            )
+        else:
+            GError(
+                parent=self,
+                message=_(
+                    "Unable to rename column. "
+                    "Column <%(column)s> doesn't exist in the table <%(table)s>."
+                )
+                % {"column": name, "table": table},
+            )
+            return
 
         # apply changes
         self.ApplyCommands(self.listOfCommands, self.listOfSQLStatements)

--- a/gui/wxpython/dbmgr/vinfo.py
+++ b/gui/wxpython/dbmgr/vinfo.py
@@ -37,8 +37,7 @@ def GetUnicodeValue(value):
     if isinstance(value, bytes):
         enc = GetDbEncoding()
         return str(value, enc, errors="replace")
-    else:
-        return str(value)
+    return str(value)
 
 
 def GetDbEncoding():

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -1233,8 +1233,7 @@ class ModelAction(ModelObject, ogl.DividedShape):
         if string:
             if cmd is None:
                 return ""
-            else:
-                return " ".join(cmd)
+            return " ".join(cmd)
 
         return cmd
 
@@ -1420,8 +1419,7 @@ class ModelData(ModelObject):
             name.append(rel.GetLabel())
         if name:
             return "/".join(name) + "=" + self.value + " (" + self.prompt + ")"
-        else:
-            return self.value + " (" + self.prompt + ")"
+        return self.value + " (" + self.prompt + ")"
 
     def GetLabel(self):
         """Get list of names"""
@@ -1672,7 +1670,7 @@ class ModelRelation(ogl.LineShape):
         """
         if isinstance(self.fromShape, ModelData):
             return self.fromShape
-        elif isinstance(self.toShape, ModelData):
+        if isinstance(self.toShape, ModelData):
             return self.toShape
 
         return None
@@ -1743,8 +1741,7 @@ class ModelItem(ModelObject):
         """Get log info"""
         if self.label:
             return _("Condition: ") + self.label
-        else:
-            return _("Condition: not defined")
+        return _("Condition: not defined")
 
     def AddRelation(self, rel):
         """Record relation"""
@@ -2024,8 +2021,7 @@ class ProcessModelFile:
         if p is not None:
             if p.text:
                 return utils.normalize_whitespace(p.text)
-            else:
-                return ""
+            return ""
 
         return default
 
@@ -3322,15 +3318,15 @@ class WritePythonFile(WriteScriptFile):
         """
         if string == "raster":
             return "G_OPT_R_MAP"
-        elif string == "vector":
+        if string == "vector":
             return "G_OPT_V_MAP"
-        elif string == "mapset":
+        if string == "mapset":
             return "G_OPT_M_MAPSET"
-        elif string == "file":
+        if string == "file":
             return "G_OPT_F_INPUT"
-        elif string == "dir":
+        if string == "dir":
             return "G_OPT_M_DIR"
-        elif string == "region":
+        if string == "region":
             return "G_OPT_M_REGION"
 
         return None

--- a/gui/wxpython/gui_core/dialogs.py
+++ b/gui/wxpython/gui_core/dialogs.py
@@ -283,8 +283,7 @@ class VectorDialog(SimpleDialog):
         if full:
             if "@" in name:
                 return name
-            else:
-                return name + "@" + grass.gisenv()["MAPSET"]
+            return name + "@" + grass.gisenv()["MAPSET"]
 
         return name.split("@", 1)[0]
 
@@ -427,7 +426,7 @@ class NewVectorDialog(VectorDialog):
         """
         if key == "add":
             return self.addbox.IsChecked()
-        elif key == "table":
+        if key == "table":
             return self.table.IsChecked()
 
         return None

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -140,8 +140,7 @@ def text_beautify(someString, width=70):
                 textwrap.wrap(utils.normalize_whitespace(someString), width)
             ).strip(".,;:")
         )
-    else:
-        return escape_ampersand(utils.normalize_whitespace(someString).strip(".,;:"))
+    return escape_ampersand(utils.normalize_whitespace(someString).strip(".,;:"))
 
 
 def escape_ampersand(text):
@@ -3206,8 +3205,7 @@ class GUI:
 
         if self.checkError:
             return self.grass_task, err
-        else:
-            return self.grass_task
+        return self.grass_task
 
     def GetCommandInputMapParamKey(self, cmd):
         """Get parameter key for input raster/vector map

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -281,8 +281,7 @@ class ListCtrlComboPopup(ComboPopup):
     def GetComboCtrl(self):
         if globalvar.wxPythonPhoenix:
             return super().GetComboCtrl()
-        else:
-            return self.GetCombo()
+        return self.GetCombo()
 
     def GetStringValue(self):
         """Get value as a string separated by commas"""
@@ -524,8 +523,7 @@ class TreeCtrlComboPopup(ListCtrlComboPopup):
             if elem not in elementdict:
                 self.AddItem(_("Not selectable element"), node=False)
                 return
-            else:
-                renamed_elements.append(elementdict[elem])
+            renamed_elements.append(elementdict[elem])
 
         if element in {"stds", "strds", "str3ds", "stvds"}:
             if not self.tgis_error:
@@ -2805,9 +2803,9 @@ class OgrTypeSelect(wx.Panel):
         sel = self.ftype.GetSelection()
         if sel == 0:
             return "point"
-        elif sel == 1:
+        if sel == 1:
             return "line"
-        elif sel == 2:
+        if sel == 2:
             return "boundary"
 
 

--- a/gui/wxpython/gui_core/mapdisp.py
+++ b/gui/wxpython/gui_core/mapdisp.py
@@ -176,8 +176,7 @@ class MapPanelBase(wx.Panel):
         """Returns property"""
         if hasattr(self.mapWindowProperties, name):
             return getattr(self.mapWindowProperties, name)
-        else:
-            return self.statusbarManager.GetProperty(name)
+        return self.statusbarManager.GetProperty(name)
 
     def HasProperty(self, name):
         """Checks whether object has property"""

--- a/gui/wxpython/gui_core/treeview.py
+++ b/gui/wxpython/gui_core/treeview.py
@@ -256,8 +256,7 @@ class TreeListView(AbstractTreeViewMixin, ExpansionState, TreeListCtrl):
         # remove & because of & needed in menu (&Files)
         if column > 0:
             return node.data.get(self._columns[column], "")
-        else:
-            return node.label.replace("&", "")
+        return node.label.replace("&", "")
 
     def OnRightClick(self, event):
         """Select item on right click.

--- a/gui/wxpython/gui_core/widgets.py
+++ b/gui/wxpython/gui_core/widgets.py
@@ -188,8 +188,7 @@ class NotebookController:
             if ret:
                 del self.notebookPages[page]
             return ret
-        else:
-            return False
+        return False
 
     def RemovePage(self, page):
         """Delete page without deleting the associated window.
@@ -203,8 +202,7 @@ class NotebookController:
             if ret:
                 del self.notebookPages[page]
             return ret
-        else:
-            return False
+        return False
 
     def SetSelectionByName(self, page):
         """Set active notebook page.
@@ -814,8 +812,7 @@ class SimpleValidator(Validator):
         if len(text) == 0:
             self.callback(ctrl)
             return False
-        else:
-            return True
+        return True
 
     def TransferToWindow(self):
         """Transfer data from validator to window.
@@ -865,8 +862,7 @@ class GenericValidator(Validator):
         if not self._condition(text):
             self._callback(ctrl)
             return False
-        else:
-            return True
+        return True
 
     def TransferToWindow(self):
         """Transfer data from validator to window."""
@@ -1183,8 +1179,7 @@ class GListCtrl(ListCtrl, listmix.ListCtrlAutoWidthMixin, CheckListCtrlMixin):
 
         if checked is not None:
             return tuple(data)
-        else:
-            return (tuple(data), tuple(checkedList))
+        return (tuple(data), tuple(checkedList))
 
     def LoadData(self, data=None, selectOne=True):
         """Load data into list"""

--- a/gui/wxpython/gui_core/wrap.py
+++ b/gui/wxpython/gui_core/wrap.py
@@ -99,36 +99,31 @@ def IsDark():
 def BitmapFromImage(image, depth=-1):
     if wxPythonPhoenix:
         return wx.Bitmap(img=image, depth=depth)
-    else:
-        return wx.BitmapFromImage(image, depth=depth)
+    return wx.BitmapFromImage(image, depth=depth)
 
 
 def ImageFromBitmap(bitmap):
     if wxPythonPhoenix:
         return bitmap.ConvertToImage()
-    else:
-        return wx.ImageFromBitmap(bitmap)
+    return wx.ImageFromBitmap(bitmap)
 
 
 def EmptyBitmap(width, height, depth=-1):
     if wxPythonPhoenix:
         return wx.Bitmap(width=width, height=height, depth=depth)
-    else:
-        return wx.EmptyBitmap(width=width, height=height, depth=depth)
+    return wx.EmptyBitmap(width=width, height=height, depth=depth)
 
 
 def EmptyImage(width, height, clear=True):
     if wxPythonPhoenix:
         return wx.Image(width=width, height=height, clear=clear)
-    else:
-        return wx.EmptyImage(width=width, height=height, clear=clear)
+    return wx.EmptyImage(width=width, height=height, clear=clear)
 
 
 def StockCursor(cursorId):
     if wxPythonPhoenix:
         return wx.Cursor(cursorId=cursorId)
-    else:
-        return wx.StockCursor(cursorId)
+    return wx.StockCursor(cursorId)
 
 
 class Window(wx.Window):
@@ -437,20 +432,18 @@ class ListCtrl(wx.ListCtrl):
             return wx.ListCtrl.InsertItem(
                 self, index=index, label=label, imageIndex=imageIndex
             )
-        else:
-            return wx.ListCtrl.InsertStringItem(
-                self, index=index, label=label, imageIndex=imageIndex
-            )
+        return wx.ListCtrl.InsertStringItem(
+            self, index=index, label=label, imageIndex=imageIndex
+        )
 
     def SetItem(self, index, column, label, imageId=-1):
         if wxPythonPhoenix:
             return wx.ListCtrl.SetItem(
                 self, index=index, column=column, label=label, imageId=imageId
             )
-        else:
-            return wx.ListCtrl.SetStringItem(
-                self, index=index, col=column, label=label, imageId=imageId
-            )
+        return wx.ListCtrl.SetStringItem(
+            self, index=index, col=column, label=label, imageId=imageId
+        )
 
     def CheckItem(self, item, check=True):
         """Uses either deprecated listmix.CheckListCtrlMixin
@@ -463,8 +456,7 @@ class ListCtrl(wx.ListCtrl):
     def IsItemChecked(self, item):
         if hasattr(self, "HasCheckBoxes"):
             return wx.ListCtrl.IsItemChecked(self, item)
-        else:
-            return super().IsChecked(item)
+        return super().IsChecked(item)
 
 
 if CheckWxVersion([4, 1, 0]):
@@ -497,16 +489,14 @@ class TreeCtrl(wx.TreeCtrl):
     def AppendItem(self, parent, text, image=-1, selImage=-1, data=None):
         if wxPythonPhoenix:
             return wx.TreeCtrl.AppendItem(self, parent, text, image, selImage, data)
-        else:
-            return wx.TreeCtrl.AppendItem(
-                self, parent, text, image, selImage, wx.TreeItemData(data)
-            )
+        return wx.TreeCtrl.AppendItem(
+            self, parent, text, image, selImage, wx.TreeItemData(data)
+        )
 
     def GetItemData(self, item):
         if wxPythonPhoenix:
             return wx.TreeCtrl.GetItemData(self, item)
-        else:
-            return wx.TreeCtrl.GetPyData(self, item)
+        return wx.TreeCtrl.GetPyData(self, item)
 
 
 class CustomTreeCtrl(CT.CustomTreeCtrl):
@@ -553,18 +543,17 @@ class ToolBar(wx.ToolBar):
                 longHelp=longHelpString,
                 clientData=clientData,
             )
-        else:
-            return wx.ToolBar.AddLabelTool(
-                self,
-                toolId,
-                label,
-                bitmap,
-                bmpDisabled,
-                kind,
-                shortHelpString,
-                longHelpString,
-                clientData,
-            )
+        return wx.ToolBar.AddLabelTool(
+            self,
+            toolId,
+            label,
+            bitmap,
+            bmpDisabled,
+            kind,
+            shortHelpString,
+            longHelpString,
+            clientData,
+        )
 
     def InsertLabelTool(
         self,
@@ -591,19 +580,18 @@ class ToolBar(wx.ToolBar):
                 longHelp=longHelpString,
                 clientData=clientData,
             )
-        else:
-            return wx.ToolBar.InsertLabelTool(
-                self,
-                pos,
-                toolId,
-                label,
-                bitmap,
-                bmpDisabled,
-                kind,
-                shortHelpString,
-                longHelpString,
-                clientData,
-            )
+        return wx.ToolBar.InsertLabelTool(
+            self,
+            pos,
+            toolId,
+            label,
+            bitmap,
+            bmpDisabled,
+            kind,
+            shortHelpString,
+            longHelpString,
+            clientData,
+        )
 
 
 class Menu(wx.Menu):
@@ -689,8 +677,7 @@ class ClientDC(wx.ClientDC):
     def GetFullMultiLineTextExtent(self, string, font=None):
         if wxPythonPhoenix:
             return super().GetFullMultiLineTextExtent(string, font)
-        else:
-            return super().GetMultiLineTextExtent(string, font)
+        return super().GetMultiLineTextExtent(string, font)
 
 
 class Rect(wx.Rect):
@@ -705,20 +692,17 @@ class Rect(wx.Rect):
     def ContainsXY(self, x, y):
         if wxPythonPhoenix:
             return wx.Rect.Contains(self, x=int(x), y=int(y))
-        else:
-            return wx.Rect.ContainsXY(self, int(x), int(y))
+        return wx.Rect.ContainsXY(self, int(x), int(y))
 
     def ContainsRect(self, rect):
         if wxPythonPhoenix:
             return wx.Rect.Contains(self, rect=rect)
-        else:
-            return wx.Rect.ContainsRect(self, rect)
+        return wx.Rect.ContainsRect(self, rect)
 
     def OffsetXY(self, dx, dy):
         if wxPythonPhoenix:
             return wx.Rect.Offset(self, int(dx), int(dy))
-        else:
-            return wx.Rect.OffsetXY(self, int(dx), int(dy))
+        return wx.Rect.OffsetXY(self, int(dx), int(dy))
 
 
 class CheckBox(wx.CheckBox):

--- a/gui/wxpython/history/browser.py
+++ b/gui/wxpython/history/browser.py
@@ -59,11 +59,11 @@ def get_translated_value(key, value):
     if key == "timestamp":
         exec_datetime = datetime.fromisoformat(value)
         return exec_datetime.strftime("%Y-%m-%d %H:%M:%S")
-    elif key == "runtime":
+    if key == "runtime":
         return _("{} sec").format(value)
-    elif key == "status":
+    if key == "status":
         return _(value.capitalize())
-    elif key in {"mask2d", "mask3d"}:
+    if key in {"mask2d", "mask3d"}:
         return _(str(value))
 
 

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -407,9 +407,7 @@ class HistoryBrowserTree(CTreeView):
                 # If no command index is specified, return the first found day node
                 return day_nodes[0]
             # Search for command nodes under the first day node
-            command_nodes = self._model.SearchNodes(
-                parent=day_nodes[0], type=COMMAND
-            )
+            command_nodes = self._model.SearchNodes(parent=day_nodes[0], type=COMMAND)
             if 0 <= command_index < len(command_nodes):
                 return command_nodes[command_index]
 

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -62,8 +62,7 @@ class HistoryBrowserNode(DictFilterNode):
     def label(self):
         if "day" in self.data.keys():
             return self.dayToLabel(self.data["day"])
-        else:
-            return self.data["name"]
+        return self.data["name"]
 
     @property
     def time_sort(self):
@@ -91,14 +90,13 @@ class HistoryBrowserNode(DictFilterNode):
 
         if day == current_date:
             return _("{base_date} (today)").format(base_date=base_date)
-        elif day == current_date - datetime.timedelta(days=1):
+        if day == current_date - datetime.timedelta(days=1):
             return _("{base_date} (yesterday)").format(base_date=base_date)
-        elif day >= (current_date - datetime.timedelta(days=current_date.weekday())):
+        if day >= (current_date - datetime.timedelta(days=current_date.weekday())):
             return _("{base_date} (this week)").format(base_date=base_date)
-        elif day.year == current_date.year:
+        if day.year == current_date.year:
             return _("{base_date}").format(base_date=base_date)
-        else:
-            return _("{base_date}, {year}").format(base_date=base_date, year=day.year)
+        return _("{base_date}, {year}").format(base_date=base_date, year=day.year)
 
 
 class HistoryTreeModel(TreeModel):
@@ -338,12 +336,11 @@ class HistoryBrowserTree(CTreeView):
         """
         if not command_node.data["timestamp"]:
             return self._model.GetIndexOfNode(command_node)[1]
-        else:
-            return history.filter(
-                json_data=self.ReadFromHistory(),
-                command=command_node.data["name"],
-                timestamp=self._timestampToISO(command_node.data["timestamp"]),
-            )
+        return history.filter(
+            json_data=self.ReadFromHistory(),
+            command=command_node.data["name"],
+            timestamp=self._timestampToISO(command_node.data["timestamp"]),
+        )
 
     def ReadFromHistory(self):
         """Read content of command history log.
@@ -409,13 +406,12 @@ class HistoryBrowserTree(CTreeView):
             if command_index is None:
                 # If no command index is specified, return the first found day node
                 return day_nodes[0]
-            else:
-                # Search for command nodes under the first day node
-                command_nodes = self._model.SearchNodes(
-                    parent=day_nodes[0], type=COMMAND
-                )
-                if 0 <= command_index < len(command_nodes):
-                    return command_nodes[command_index]
+            # Search for command nodes under the first day node
+            command_nodes = self._model.SearchNodes(
+                parent=day_nodes[0], type=COMMAND
+            )
+            if 0 <= command_index < len(command_nodes):
+                return command_nodes[command_index]
 
         return None
 
@@ -585,7 +581,7 @@ class HistoryBrowserTree(CTreeView):
         try:
             if node.data["type"] == TIME_PERIOD:
                 return self._iconTypes.index(node.data["type"])
-            elif node.data["type"] == COMMAND:
+            if node.data["type"] == COMMAND:
                 return self._iconTypes.index(node.data["status"])
         except ValueError:
             return 0

--- a/gui/wxpython/image2target/ii2t_gis_set.py
+++ b/gui/wxpython/image2target/ii2t_gis_set.py
@@ -596,8 +596,7 @@ class GRASSStartup(wx.Frame):
         """Return GRASS variable (read from GISRC)"""
         if value in self.grassrc:
             return self.grassrc[value]
-        else:
-            return None
+        return None
 
     def OnWizard(self, event):
         """Location wizard started"""
@@ -1046,8 +1045,7 @@ class GRASSStartup(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             mapset = dlg.GetValue()
             return self.CreateNewMapset(mapset=mapset)
-        else:
-            return False
+        return False
 
     def CreateNewMapset(self, mapset):
         if mapset in self.listOfMapsets:

--- a/gui/wxpython/iscatt/controllers.py
+++ b/gui/wxpython/iscatt/controllers.py
@@ -238,7 +238,7 @@ class ScattsManager:
                 )
             )
             return
-        elif ncells > WARN_NCELLS:
+        if ncells > WARN_NCELLS:
             dlg = wx.MessageDialog(
                 parent=self.guiparent,
                 message=_(
@@ -344,7 +344,7 @@ class ScattsManager:
                 ),
             )
             return False
-        elif mrange > WARN_SCATT_SIZE:
+        if mrange > WARN_SCATT_SIZE:
             dlg = wx.MessageDialog(
                 parent=self.guiparent,
                 message=_(

--- a/gui/wxpython/iscatt/iscatt_core.py
+++ b/gui/wxpython/iscatt/iscatt_core.py
@@ -323,7 +323,7 @@ class CatRastUpdater:
 
         if bbox["maxy"] <= r["s"]:
             return 0
-        elif bbox["maxy"] >= r["n"]:
+        if bbox["maxy"] >= r["n"]:
             new_r["n"] = bbox["maxy"]
         else:
             new_r["n"] = (
@@ -332,7 +332,7 @@ class CatRastUpdater:
 
         if bbox["miny"] >= r["n"]:
             return 0
-        elif bbox["miny"] <= r["s"]:
+        if bbox["miny"] <= r["s"]:
             new_r["s"] = bbox["miny"]
         else:
             new_r["s"] = (
@@ -341,7 +341,7 @@ class CatRastUpdater:
 
         if bbox["maxx"] <= r["w"]:
             return 0
-        elif bbox["maxx"] >= r["e"]:
+        if bbox["maxx"] >= r["e"]:
             new_r["e"] = bbox["maxx"]
         else:
             new_r["e"] = (
@@ -350,7 +350,7 @@ class CatRastUpdater:
 
         if bbox["minx"] >= r["e"]:
             return 0
-        elif bbox["minx"] <= r["w"]:
+        if bbox["minx"] <= r["w"]:
             new_r["w"] = bbox["minx"]
         else:
             new_r["w"] = (

--- a/gui/wxpython/lmgr/frame.py
+++ b/gui/wxpython/lmgr/frame.py
@@ -385,8 +385,7 @@ class GMFrame(wx.Frame):
         """Initialize notebook widget"""
         if sys.platform == "win32":
             return GNotebook(parent=self, style=globalvar.FNPageDStyle)
-        else:
-            return FormNotebook(parent=self, style=wx.NB_BOTTOM)
+        return FormNotebook(parent=self, style=wx.NB_BOTTOM)
 
     def _createDataCatalog(self, parent):
         """Initialize Data Catalog widget"""
@@ -1089,14 +1088,13 @@ class GMFrame(wx.Frame):
         if onlyCurrent:
             if self.currentPage:
                 return self.GetLayerTree().GetMapDisplay()
-            else:
-                return None
-        else:  # -> return list of all mapdisplays
-            mlist = []
-            for idx in range(self.notebookLayers.GetPageCount()):
-                mlist.append(self.notebookLayers.GetPage(idx).maptree.GetMapDisplay())
+            return None
+        # -> return list of all mapdisplays
+        mlist = []
+        for idx in range(self.notebookLayers.GetPageCount()):
+            mlist.append(self.notebookLayers.GetPage(idx).maptree.GetMapDisplay())
 
-            return mlist
+        return mlist
 
     def GetAllMapDisplays(self):
         """Get all (open) map displays"""

--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -86,9 +86,8 @@ class LayerList:
         item = self._tree.GetSelectedLayer(multi=False, checkedOnly=checkedOnly)
         if item is None:
             return None
-        else:
-            data = self._tree.GetPyData(item)
-            return Layer(item, data)
+        data = self._tree.GetPyData(item)
+        return Layer(item, data)
 
     def GetLayerInfo(self, layer):
         """For compatibility only, will be removed."""
@@ -147,12 +146,11 @@ class LayerList:
         items = self._tree.FindItemByData(key="name", value=name)
         if items is None:
             return []
-        else:
-            layers = []
-            for item in items:
-                layer = Layer(item, self._tree.GetPyData(item))
-                layers.append(layer)
-            return layers
+        layers = []
+        for item in items:
+            layer = Layer(item, self._tree.GetPyData(item))
+            layers.append(layer)
+        return layers
 
     def GetLayerByData(self, key, value):
         """Returns layer with specified.
@@ -168,8 +166,7 @@ class LayerList:
         item = self._tree.FindItemByData(key=key, value=value)
         if item is None:
             return None
-        else:
-            return Layer(item, self._tree.GetPyData(item))
+        return Layer(item, self._tree.GetPyData(item))
 
 
 class LayerManagerGrassInterface:
@@ -268,8 +265,7 @@ class LayerManagerGrassInterface:
     def GetMapWindow(self):
         if self.lmgr.GetMapDisplay(onlyCurrent=True):
             return self.lmgr.GetMapDisplay(onlyCurrent=True).GetMapWindow()
-        else:
-            return None
+        return None
 
     def GetProgress(self):
         return self.lmgr.goutput.GetProgressBar()

--- a/gui/wxpython/lmgr/layertree.py
+++ b/gui/wxpython/lmgr/layertree.py
@@ -2336,8 +2336,7 @@ class LayerTree(treemixin.DragAndDrop, CT.CustomTreeCtrl):
         item = self.GetFirstChild(self.root)[0]
         if key == "name":
             return self.__FindSubItemByName(item, value)
-        else:
-            return self.__FindSubItemByData(item, key, value)
+        return self.__FindSubItemByData(item, key, value)
 
     def FindItemByIndex(self, index):
         """Find item by index (starting at 0)

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -591,7 +591,7 @@ class ProjectionsPage(TitledPage):
                 self.tproj.SetValue(self.proj)
                 nextButton.Enable(False)
                 return
-            elif self.proj.lower() == "ll":
+            if self.proj.lower() == "ll":
                 self.p4proj = "+proj=longlat"
             else:
                 self.p4proj = "+proj=" + self.proj.lower()
@@ -771,8 +771,7 @@ class ItemList(ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.ColumnSorterMix
 
         if ascending:
             return cmpVal
-        else:
-            return -cmpVal
+        return -cmpVal
 
     def GetListCtrl(self):
         """Used by listmix.ColumnSorterMixin"""
@@ -804,12 +803,10 @@ class ItemList(ListCtrl, listmix.ListCtrlAutoWidthMixin, listmix.ColumnSorterMix
         if len(data) > 0:
             if firstOnly:
                 return data[0]
-            else:
-                return data
-        elif firstOnly:
+            return data
+        if firstOnly:
             return None
-        else:
-            return []
+        return []
 
 
 class ProjParamsPage(TitledPage):
@@ -1660,29 +1657,28 @@ class EPSGPage(TitledPage):
             if not self.epsgcode:
                 event.Veto()
                 return
-            else:
-                # check for datum transforms
-                ret = RunCommand(
-                    "g.proj", read=True, epsg=self.epsgcode, datum_trans="-1", flags="t"
-                )
+            # check for datum transforms
+            ret = RunCommand(
+                "g.proj", read=True, epsg=self.epsgcode, datum_trans="-1", flags="t"
+            )
 
-                if ret != "":
-                    dtrans = ""
-                    # open a dialog to select datum transform number
-                    dlg = SelectTransformDialog(self.parent.parent, transforms=ret)
+            if ret != "":
+                dtrans = ""
+                # open a dialog to select datum transform number
+                dlg = SelectTransformDialog(self.parent.parent, transforms=ret)
 
-                    if dlg.ShowModal() == wx.ID_OK:
-                        dtrans = dlg.GetTransform()
-                        if dtrans == "":
-                            dlg.Destroy()
-                            event.Veto()
-                            return "Datum transform is required."
-                    else:
+                if dlg.ShowModal() == wx.ID_OK:
+                    dtrans = dlg.GetTransform()
+                    if dtrans == "":
                         dlg.Destroy()
                         event.Veto()
                         return "Datum transform is required."
+                else:
+                    dlg.Destroy()
+                    event.Veto()
+                    return "Datum transform is required."
 
-                    self.parent.datum_trans = dtrans
+                self.parent.datum_trans = dtrans
             self.GetNext().SetPrev(self)
 
     def EnableNext(self, enable=True):
@@ -1880,55 +1876,54 @@ class IAUPage(TitledPage):
             if not self.epsgcode:
                 event.Veto()
                 return
-            else:
-                # check for datum transforms
-                ret = RunCommand(
-                    "g.proj",
-                    read=True,
-                    proj4=self.epsgparams,
-                    datum_trans="-1",
-                    flags="t",
-                )
+            # check for datum transforms
+            ret = RunCommand(
+                "g.proj",
+                read=True,
+                proj4=self.epsgparams,
+                datum_trans="-1",
+                flags="t",
+            )
 
-                if ret != "":
-                    dtrans = ""
-                    # open a dialog to select datum transform number
-                    dlg = SelectTransformDialog(self.parent.parent, transforms=ret)
+            if ret != "":
+                dtrans = ""
+                # open a dialog to select datum transform number
+                dlg = SelectTransformDialog(self.parent.parent, transforms=ret)
 
-                    if dlg.ShowModal() == wx.ID_OK:
-                        dtrans = dlg.GetTransform()
-                        if dtrans == "":
-                            dlg.Destroy()
-                            event.Veto()
-                            return "Datum transform is required."
-                    else:
+                if dlg.ShowModal() == wx.ID_OK:
+                    dtrans = dlg.GetTransform()
+                    if dtrans == "":
                         dlg.Destroy()
                         event.Veto()
                         return "Datum transform is required."
+                else:
+                    dlg.Destroy()
+                    event.Veto()
+                    return "Datum transform is required."
 
-                    self.parent.datum_trans = dtrans
-                    self.parent.epsgcode = self.epsgcode
-                    self.parent.epsgdesc = self.epsgdesc
+                self.parent.datum_trans = dtrans
+                self.parent.epsgcode = self.epsgcode
+                self.parent.epsgdesc = self.epsgdesc
 
-                # prepare +nadgrids or +towgs84 terms for Summary page. first
-                # convert them:
-                ret, projlabel, err = RunCommand(
-                    "g.proj",
-                    flags="jft",
-                    proj4=self.epsgparams,
-                    datum_trans=self.parent.datum_trans,
-                    getErrorMsg=True,
-                    read=True,
-                )
-                # splitting on space alone would break for grid files with
-                # space in pathname
-                for projterm in projlabel.split(" +"):
-                    if (
-                        projterm.find("towgs84=") != -1
-                        or projterm.find("nadgrids=") != -1
-                    ):
-                        self.custom_dtrans_string = " +%s" % projterm
-                        break
+            # prepare +nadgrids or +towgs84 terms for Summary page. first
+            # convert them:
+            ret, projlabel, err = RunCommand(
+                "g.proj",
+                flags="jft",
+                proj4=self.epsgparams,
+                datum_trans=self.parent.datum_trans,
+                getErrorMsg=True,
+                read=True,
+            )
+            # splitting on space alone would break for grid files with
+            # space in pathname
+            for projterm in projlabel.split(" +"):
+                if (
+                    projterm.find("towgs84=") != -1
+                    or projterm.find("nadgrids=") != -1
+                ):
+                    self.custom_dtrans_string = " +%s" % projterm
+                    break
 
             self.GetNext().SetPrev(self)
 

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1918,10 +1918,7 @@ class IAUPage(TitledPage):
             # splitting on space alone would break for grid files with
             # space in pathname
             for projterm in projlabel.split(" +"):
-                if (
-                    projterm.find("towgs84=") != -1
-                    or projterm.find("nadgrids=") != -1
-                ):
+                if projterm.find("towgs84=") != -1 or projterm.find("nadgrids=") != -1:
                     self.custom_dtrans_string = " +%s" % projterm
                     break
 

--- a/gui/wxpython/main_window/frame.py
+++ b/gui/wxpython/main_window/frame.py
@@ -1240,14 +1240,13 @@ class GMFrame(wx.Frame):
         if onlyCurrent:
             if self.currentPage:
                 return self.GetLayerTree().GetMapDisplay()
-            else:
-                return None
-        else:  # -> return list of all mapdisplays
-            mlist = []
-            for idx in range(self.notebookLayers.GetPageCount()):
-                mlist.append(self.notebookLayers.GetPage(idx).maptree.GetMapDisplay())
+            return None
+        # -> return list of all mapdisplays
+        mlist = []
+        for idx in range(self.notebookLayers.GetPageCount()):
+            mlist.append(self.notebookLayers.GetPage(idx).maptree.GetMapDisplay())
 
-            return mlist
+        return mlist
 
     def GetAllMapDisplays(self):
         """Get all (open) map displays"""

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1230,8 +1230,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
                 render=True,
                 **args,
             )
-        else:
-            return cmd
+        return cmd
 
     def OnMeasureDistance(self, event):
         self._onMeasure(MeasureDistanceController)

--- a/gui/wxpython/mapdisp/main.py
+++ b/gui/wxpython/mapdisp/main.py
@@ -334,14 +334,14 @@ class Layer:
     def __getattr__(self, name):
         if name == "cmd":
             return cmdtuple_to_list(self._maplayer.GetCmd())
-        elif hasattr(self._maplayer, name):
+        if hasattr(self._maplayer, name):
             return getattr(self._maplayer, name)
-        elif name == "maplayer":
+        if name == "maplayer":
             return self._maplayer
-        elif name == "type":
+        if name == "type":
             return self._maplayer.GetType()
             # elif name == 'ctrl':
-        elif name == "label":
+        if name == "label":
             return self._maplayer.GetName()
             # elif name == 'propwin':
 
@@ -386,8 +386,7 @@ class LayerList:
         layers = self.GetSelectedLayers()
         if len(layers) > 0:
             return layers[0]
-        else:
-            return None
+        return None
 
     def AddLayer(self, ltype, name=None, checked=None, opacity=1.0, cmd=None):
         """Adds a new layer to the layer list.

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -631,10 +631,8 @@ class SbGoTo(SbItem):
                         return "%s" % utils.Deg2DMS(
                             coord[0], coord[1], precision=precision
                         )
-                    else:
-                        return "%.*f; %.*f" % (precision, coord[0], precision, coord[1])
-                else:
-                    raise SbException(_("Error in projection (check the settings)"))
+                    return "%.*f; %.*f" % (precision, coord[0], precision, coord[1])
+                raise SbException(_("Error in projection (check the settings)"))
         elif self.mapFrame.GetMap().projinfo["proj"] == "ll" and format == "DMS":
             return "%s" % utils.Deg2DMS(
                 region["center_easting"],
@@ -806,10 +804,8 @@ class SbCoordinates(SbTextItem):
                     e, n = coord
                     if proj in {"ll", "latlong", "longlat"} and format == "DMS":
                         return utils.Deg2DMS(e, n, precision=precision)
-                    else:
-                        return "%.*f; %.*f" % (precision, e, precision, n)
-                else:
-                    raise SbException(_("Error in projection (check the settings)"))
+                    return "%.*f; %.*f" % (precision, e, precision, n)
+                raise SbException(_("Error in projection (check the settings)"))
         elif self.mapFrame.GetMap().projinfo["proj"] == "ll" and format == "DMS":
             return utils.Deg2DMS(e, n, precision=precision)
         else:
@@ -860,8 +856,7 @@ class SbRegionExtent(SbTextItem):
                 precision,
                 n,
             )
-        else:
-            return "%s - %s, %s - %s" % (w, e, s, n)
+        return "%s - %s, %s - %s" % (w, e, s, n)
 
     def ReprojectRegionFromMap(self, region, useDefinedProjection, precision, format):
         """Reproject region values
@@ -910,21 +905,19 @@ class SbRegionExtent(SbTextItem):
                         return self._formatRegion(
                             w=w, s=s, e=e, n=n, ewres=ewres, nsres=nsres
                         )
-                    else:
-                        w, s = coord1
-                        e, n = coord2
-                        ewres, nsres = coord3
-                        return self._formatRegion(
-                            w=w,
-                            s=s,
-                            e=e,
-                            n=n,
-                            ewres=ewres,
-                            nsres=nsres,
-                            precision=precision,
-                        )
-                else:
-                    raise SbException(_("Error in projection (check the settings)"))
+                    w, s = coord1
+                    e, n = coord2
+                    ewres, nsres = coord3
+                    return self._formatRegion(
+                        w=w,
+                        s=s,
+                        e=e,
+                        n=n,
+                        ewres=ewres,
+                        nsres=nsres,
+                        precision=precision,
+                    )
+                raise SbException(_("Error in projection (check the settings)"))
 
         elif self.mapFrame.GetMap().projinfo["proj"] == "ll" and format == "DMS":
             w, s = utils.Deg2DMS(
@@ -971,8 +964,7 @@ class SbCompRegionExtent(SbRegionExtent):
                 precision,
                 nsres,
             )
-        else:
-            return "%s - %s, %s - %s (%s, %s)" % (w, e, s, n, ewres, nsres)
+        return "%s - %s, %s - %s (%s, %s)" % (w, e, s, n, ewres, nsres)
 
     def _getRegion(self):
         """Returns computational region."""

--- a/gui/wxpython/mapswipe/dialogs.py
+++ b/gui/wxpython/mapswipe/dialogs.py
@@ -241,8 +241,7 @@ class SwipeMapDialog(wx.Dialog):
         """Get raster maps"""
         if self.IsSimpleMode():
             return (self._firstRaster.GetValue(), self._secondRaster.GetValue())
-        else:
-            return (self._firstLayerList, self._secondLayerList)
+        return (self._firstLayerList, self._secondLayerList)
 
     def IsSimpleMode(self) -> bool:
         return bool(self._switchSizer.IsShown(self._firstPanel))

--- a/gui/wxpython/mapswipe/mapwindow.py
+++ b/gui/wxpython/mapswipe/mapwindow.py
@@ -81,8 +81,7 @@ class SwipeBufferedWindow(BufferedMapWindow):
         """Overridden method which returns simulated window size."""
         if self._mode == "swipe":
             return self.specialSize
-        else:
-            return super().GetClientSize()
+        return super().GetClientSize()
 
     def SetClientSize(self, size):
         """Overridden method which sets simulated window size."""
@@ -100,8 +99,7 @@ class SwipeBufferedWindow(BufferedMapWindow):
         """Returns coordinates of rendered image"""
         if self._mode == "swipe":
             return self.specialCoords
-        else:
-            return (0, 0)
+        return (0, 0)
 
     def SetImageCoords(self, coords):
         """Sets coordinates of rendered image"""

--- a/gui/wxpython/mapwin/buffered.py
+++ b/gui/wxpython/mapwin/buffered.py
@@ -560,8 +560,7 @@ class BufferedMapWindow(MapWindowBase, Window):
             bbox[2], bbox[3] = w, h
             if relcoords:
                 return coords, bbox, relCoords
-            else:
-                return coords, bbox
+            return coords, bbox
 
         boxh = math.fabs(math.sin(math.radians(rotation)) * w) + h
         boxw = math.fabs(math.cos(math.radians(rotation)) * w) + h
@@ -580,8 +579,7 @@ class BufferedMapWindow(MapWindowBase, Window):
         bbox.Inflate(h, h)
         if relcoords:
             return coords, bbox, relCoords
-        else:
-            return coords, bbox
+        return coords, bbox
 
     def OnPaint(self, event):
         """Draw PseudoDC's to buffered paint DC

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -538,8 +538,7 @@ class GdalImportDialog(ImportDialog):
         """Get command"""
         if self.link:
             return "r.external"
-        else:
-            return "r.import"
+        return "r.import"
 
     def _getBlackListedParameters(self):
         """Get flags which will not be showed in Settings page"""
@@ -693,8 +692,7 @@ class OgrImportDialog(ImportDialog):
         """Get command"""
         if self.link:
             return "v.external"
-        else:
-            return "v.import"
+        return "v.import"
 
     def _getBlackListedParameters(self):
         """Get parametrs which will not be showed in Settings page"""

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -2358,10 +2358,10 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
             try:
                 if type == "raster":
                     return data["surface"]["object"]["id"]
-                elif type == "vector":
+                if type == "vector":
                     if vsubtyp == "vpoint":
                         return data["vector"]["points"]["object"]["id"]
-                    elif vsubtyp == "vline":
+                    if vsubtyp == "vline":
                         return data["vector"]["lines"]["object"]["id"]
                 elif type == "raster_3d":
                     return data["volume"]["object"]["id"]

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -2646,9 +2646,9 @@ class NvizToolWindow(GNotebook):
 
         if nvizType in {"surface", "fringe"}:
             return self._getLayerPropertiesByName(name, mapType="raster")
-        elif nvizType == "vector":
+        if nvizType == "vector":
             return self._getLayerPropertiesByName(name, mapType="vector")
-        elif nvizType == "volume":
+        if nvizType == "volume":
             return self._getLayerPropertiesByName(name, mapType="raster_3d")
 
         return None
@@ -2857,7 +2857,7 @@ class NvizToolWindow(GNotebook):
         if not prefix:
             GMessage(parent=self, message=_("No file prefix given."))
             return
-        elif not os.path.exists(dir):
+        if not os.path.exists(dir):
             GMessage(parent=self, message=_("Directory %s does not exist.") % dir)
             return
 
@@ -4576,7 +4576,7 @@ class NvizToolWindow(GNotebook):
         selection = event.GetSelection()
         if selection == -1:
             return
-        elif selection == 0:
+        if selection == 0:
             winUp.Enable(False)
             if not winDown.IsEnabled():
                 winDown.Enable()

--- a/gui/wxpython/nviz/wxnviz.py
+++ b/gui/wxpython/nviz/wxnviz.py
@@ -246,8 +246,7 @@ class Nviz:
             z = c_float()
             Nviz_get_focus(self.data, byref(x), byref(y), byref(z))
             return x.value, y.value, z.value
-        else:
-            return -1, -1, -1
+        return -1, -1, -1
 
     def SetFocus(self, x, y, z):
         """Set focus"""
@@ -1873,8 +1872,7 @@ class Nviz:
             Nviz_draw_cplane(self.data, -1, -1)
             x, y, z = self.GetCPlaneTranslation()
             return x, y, z
-        else:
-            return None, None, None
+        return None, None, None
 
     def SelectCPlane(self, index):
         """Select cutting plane

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -526,8 +526,7 @@ class PsmapDialog(Dialog):
         if ok:
             self.parent.DialogDataChanged(id=self.id)
             return True
-        else:
-            return False
+        return False
 
     def OnOK(self, event):
         """Apply changes, close dialog"""

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -994,8 +994,7 @@ class PsMapFrame(wx.Frame):
             Y = y - H
         if rotation == 0:
             return Rect(x, y, *textExtent)
-        else:
-            return Rect(X, Y, abs(W), abs(H)).Inflate(h, h)
+        return Rect(X, Y, abs(W), abs(H)).Inflate(h, h)
 
     def makePSFont(self, textDict):
         """creates a wx.Font object from selected postscript font. To be

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -1217,9 +1217,9 @@ class Image(InstructionObject):
                     break
             file.close()
             return float(w), float(h)
-        else:  # we can use wx.Image
-            img = wx.Image(fileName, type=wx.BITMAP_TYPE_ANY)
-            return img.GetWidth(), img.GetHeight()
+        # we can use wx.Image
+        img = wx.Image(fileName, type=wx.BITMAP_TYPE_ANY)
+        return img.GetWidth(), img.GetHeight()
 
 
 class NorthArrow(Image):

--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -162,17 +162,15 @@ def convertRGB(rgb):
                 return name
         return str(rgb.Red()) + ":" + str(rgb.Green()) + ":" + str(rgb.Blue())
     # transform a GRASS named color or an r:g:b string into a wx.Colour tuple
-    else:
-        color = (
-            int(gs.parse_color(rgb)[0] * 255),
-            int(gs.parse_color(rgb)[1] * 255),
-            int(gs.parse_color(rgb)[2] * 255),
-        )
-        color = wx.Colour(*color)
-        if color.IsOk():
-            return color
-        else:
-            return None
+    color = (
+        int(gs.parse_color(rgb)[0] * 255),
+        int(gs.parse_color(rgb)[1] * 255),
+        int(gs.parse_color(rgb)[2] * 255),
+    )
+    color = wx.Colour(*color)
+    if color.IsOk():
+        return color
+    return None
 
 
 def PaperMapCoordinates(mapInstr, x, y, paperToMap=True, env=None):
@@ -198,18 +196,16 @@ def PaperMapCoordinates(mapInstr, x, y, paperToMap=True, env=None):
 
         if projInfo()["proj"] == "ll":
             return e, n
-        else:
-            return int(e), int(n)
+        return int(e), int(n)
 
-    else:
-        diffEW = x - region["w"]
-        diffNS = region["n"] - y
-        diffX = mapWidthPaper * diffEW / mapWidthEN
-        diffY = mapHeightPaper * diffNS / mapHeightEN
-        xPaper = mapInstr["rect"].GetX() + diffX
-        yPaper = mapInstr["rect"].GetY() + diffY
+    diffEW = x - region["w"]
+    diffNS = region["n"] - y
+    diffX = mapWidthPaper * diffEW / mapWidthEN
+    diffY = mapHeightPaper * diffNS / mapHeightEN
+    xPaper = mapInstr["rect"].GetX() + diffX
+    yPaper = mapInstr["rect"].GetY() + diffY
 
-        return xPaper, yPaper
+    return xPaper, yPaper
 
 
 def AutoAdjust(self, scaleType, rect, env, map=None, mapType=None, region=None):
@@ -403,8 +399,7 @@ def getRasterType(map):
     file = gs.find_file(name=map, element="cell")
     if file.get("file"):
         return gs.raster_info(map)["datatype"]
-    else:
-        return None
+    return None
 
 
 def BBoxAfterRotation(w, h, angle):

--- a/gui/wxpython/rdigit/controller.py
+++ b/gui/wxpython/rdigit/controller.py
@@ -421,28 +421,26 @@ class RDigitController(wx.EvtHandler):
                 )
                 return False
             return True
-        else:
-            dlg = NewRasterDialog(parent=self._mapWindow)
-            dlg.CenterOnParent()
-            if dlg.ShowModal() == wx.ID_OK:
-                try:
-                    self._createNewMap(
-                        mapName=dlg.GetMapName(),
-                        backgroundMap=dlg.GetBackgroundMapName(),
-                        mapType=dlg.GetMapType(),
-                    )
-                except ScriptError:
-                    GError(
-                        parent=self._mapWindow,
-                        message=_("Failed to create new raster map."),
-                    )
-                    return False
-                finally:
-                    dlg.Destroy()
-                return True
-            else:
-                dlg.Destroy()
+        dlg = NewRasterDialog(parent=self._mapWindow)
+        dlg.CenterOnParent()
+        if dlg.ShowModal() == wx.ID_OK:
+            try:
+                self._createNewMap(
+                    mapName=dlg.GetMapName(),
+                    backgroundMap=dlg.GetBackgroundMapName(),
+                    mapType=dlg.GetMapType(),
+                )
+            except ScriptError:
+                GError(
+                    parent=self._mapWindow,
+                    message=_("Failed to create new raster map."),
+                )
                 return False
+            finally:
+                dlg.Destroy()
+            return True
+        dlg.Destroy()
+        return False
 
     def _createNewMap(self, mapName, backgroundMap, mapType):
         """Creates a new raster map based on specified background and type."""

--- a/gui/wxpython/rdigit/dialogs.py
+++ b/gui/wxpython/rdigit/dialogs.py
@@ -117,9 +117,8 @@ class NewRasterDialog(wx.Dialog):
                 if dlgOverwrite.ShowModal() != wx.ID_YES:
                     dlgOverwrite.Destroy()
                     return
-                else:
-                    dlgOverwrite.Destroy()
-                    self.EndModal(wx.ID_OK)
+                dlgOverwrite.Destroy()
+                self.EndModal(wx.ID_OK)
             else:
                 self.EndModal(wx.ID_OK)
 

--- a/gui/wxpython/rlisetup/functions.py
+++ b/gui/wxpython/rlisetup/functions.py
@@ -60,9 +60,8 @@ def retRLiPath():
     rlipath = os.path.join(grass_config_dir, "r.li")
     if os.path.exists(rlipath):
         return rlipath
-    else:
-        os.mkdir(rlipath)
-        return rlipath
+    os.mkdir(rlipath)
+    return rlipath
 
 
 def checkMapExists(name, typ="raster") -> bool:

--- a/gui/wxpython/rlisetup/sampling_frame.py
+++ b/gui/wxpython/rlisetup/sampling_frame.py
@@ -550,33 +550,32 @@ class RLiSetupToolbar(BaseToolbar):
                     ),
                 )
             )
-        else:
-            return self._getToolbarData(
+        return self._getToolbarData(
+            (
+                drawTool,
+                (None,),
                 (
-                    drawTool,
-                    (None,),
-                    (
-                        ("pan", BaseIcons["pan"].label),
-                        BaseIcons["pan"],
-                        self.parent.OnPan,
-                        wx.ITEM_CHECK,
-                    ),
-                    (
-                        ("zoomIn", BaseIcons["zoomIn"].label),
-                        BaseIcons["zoomIn"],
-                        self.parent.OnZoomIn,
-                        wx.ITEM_CHECK,
-                    ),
-                    (
-                        ("zoomOut", BaseIcons["zoomOut"].label),
-                        BaseIcons["zoomOut"],
-                        self.parent.OnZoomOut,
-                        wx.ITEM_CHECK,
-                    ),
-                    (
-                        ("zoomExtent", BaseIcons["zoomExtent"].label),
-                        BaseIcons["zoomExtent"],
-                        self.parent.OnZoomToMap,
-                    ),
-                )
+                    ("pan", BaseIcons["pan"].label),
+                    BaseIcons["pan"],
+                    self.parent.OnPan,
+                    wx.ITEM_CHECK,
+                ),
+                (
+                    ("zoomIn", BaseIcons["zoomIn"].label),
+                    BaseIcons["zoomIn"],
+                    self.parent.OnZoomIn,
+                    wx.ITEM_CHECK,
+                ),
+                (
+                    ("zoomOut", BaseIcons["zoomOut"].label),
+                    BaseIcons["zoomOut"],
+                    self.parent.OnZoomOut,
+                    wx.ITEM_CHECK,
+                ),
+                (
+                    ("zoomExtent", BaseIcons["zoomExtent"].label),
+                    BaseIcons["zoomExtent"],
+                    self.parent.OnZoomToMap,
+                ),
             )
+        )

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -720,13 +720,12 @@ class FirstPage(TitledPage):
                 % vector
             )
             return False, []
-        elif links > 0:
+        if links > 0:
             layers = []
             for i in range(1, links + 1):
                 layers.append(str(i))
             return True, layers
-        else:
-            return False, []
+        return False, []
 
     def CheckInput(self):
         """Check input fields.
@@ -1819,14 +1818,13 @@ class VectorAreasPage(TitledPage):
             self.areaOK.Enable(False)
             self.areaNO.Enable(False)
             return True
-        else:
-            self.title.SetLabel(
-                _("Select sample area {areas_count} of {area_num}").format(
-                    areas_count=self.areascount + 1, area_num=self.areanum
-                )
+        self.title.SetLabel(
+            _("Select sample area {areas_count} of {area_num}").format(
+                areas_count=self.areascount + 1, area_num=self.areanum
             )
-            wx.FindWindowById(wx.ID_FORWARD).Enable(False)
-            return False
+        )
+        wx.FindWindowById(wx.ID_FORWARD).Enable(False)
+        return False
 
     def OnYes(self, event):
         """Function to create the string for the conf file if the area

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -386,8 +386,7 @@ class LocationDownloadPanel(wx.Panel):
             )
             self.parent.download_button.SetLabel(label=_("Download"))
             return
-        else:
-            self._clearMessage()
+        self._clearMessage()
 
     def GetLocation(self):
         """Get the name of the last location downloaded by the user"""
@@ -496,9 +495,8 @@ class LocationDownloadDialog(wx.Dialog):
 
             if ret == wx.ID_NO:
                 return
-            else:
-                self.panel.thread.Terminate()
-                self.panel._change_download_btn_label()
+            self.panel.thread.Terminate()
+            self.panel._change_download_btn_label()
 
         if event:
             self.EndModal(wx.ID_CANCEL)

--- a/gui/wxpython/vdigit/wxdigit.py
+++ b/gui/wxpython/vdigit/wxdigit.py
@@ -294,10 +294,8 @@ class IVDigit:
         if threshold > 0.0:
             if UserSettings.Get(group="vdigit", key="snapToVertex", subkey="enabled"):
                 return SNAPVERTEX
-            else:
-                return SNAP
-        else:
-            return NO_SNAP
+            return SNAP
+        return NO_SNAP
 
     def _getNewFeaturesLayer(self):
         """Returns layer of new feature (from settings)"""
@@ -672,8 +670,7 @@ class IVDigit:
             # TODO centroid opttimization, can be edited also its area -> it
             # will appear two times in new_ lists
             return self._getCentroidAreaBboxCats(ln_id)
-        else:
-            return [self._getBbox(ln_id)], [self._getLineAreasCategories(ln_id)]
+        return [self._getBbox(ln_id)], [self._getLineAreasCategories(ln_id)]
 
     def _getCentroidAreaBboxCats(self, centroid):
         """Helper function
@@ -688,8 +685,7 @@ class IVDigit:
         area = Vect_get_centroid_area(self.poMapInfo, centroid)
         if area > 0:
             return self._getaAreaBboxCats(area)
-        else:
-            return None
+        return None
 
     def _getaAreaBboxCats(self, area):
         """Helper function
@@ -1946,8 +1942,7 @@ class IVDigit:
                     if newc < 0:
                         self._error.WriteLine()
                         return (len(fids), fids)
-                    else:
-                        fids.append(newc)
+                    fids.append(newc)
 
             if right > 0 and Vect_get_area_centroid(self.poMapInfo, right) == 0:
                 # if Vect_get_area_points(byref(self.poMapInfo), right, bpoints) > 0 and
@@ -1964,8 +1959,7 @@ class IVDigit:
                     if newc < 0:
                         self._error.WriteLine()
                         return len(fids, fids)
-                    else:
-                        fids.append(newc)
+                    fids.append(newc)
 
             Vect_destroy_line_struct(bpoints)
 

--- a/gui/wxpython/vnet/dialogs.py
+++ b/gui/wxpython/vnet/dialogs.py
@@ -766,7 +766,7 @@ class VNETDialog(wx.Dialog):
             for sel in ["arc_column", "arc_backward_column", "node_column"]:
                 self.inputData[sel].SetValue("")
             return
-        elif itemsLen == 1:
+        if itemsLen == 1:
             self.inputData["arc_layer"].SetSelection(0)
             self.inputData["node_layer"].SetSelection(0)
         elif itemsLen >= 1:
@@ -1648,7 +1648,7 @@ class CreateTtbDialog(wx.Dialog):
                 self._updateInputDbMgrPage(show=False)
             self.inputData["arc_layer"].SetValue("")
             return
-        elif itemsLen == 1:
+        if itemsLen == 1:
             self.inputData["arc_layer"].SetSelection(0)
         elif itemsLen >= 1:
             if "1" in items:

--- a/gui/wxpython/vnet/vnet_core.py
+++ b/gui/wxpython/vnet/vnet_core.py
@@ -144,8 +144,7 @@ class VNETManager:
         )
         if not ret:
             return -3
-        else:
-            return 1
+        return 1
 
     def RunAnDone(self, cmd, returncode, results):
         self.results["analysis"] = cmd[0]
@@ -307,19 +306,18 @@ class VNETManager:
         if event.returncode != 0:
             GMessage(parent=self.guiparent, message=_("Creation of turntable failed."))
             return
-        else:
-            params = {}
-            for c in event.cmd:
-                spl_c = c.split("=")
-                if len(spl_c) != 2:
-                    continue
+        params = {}
+        for c in event.cmd:
+            spl_c = c.split("=")
+            if len(spl_c) != 2:
+                continue
 
-                if spl_c[0] and spl_c != "input":
-                    params[spl_c[0]] = spl_c[1]
-                if spl_c[0] == "output":
-                    params["input"] = spl_c[1]
+            if spl_c[0] and spl_c != "input":
+                params[spl_c[0]] = spl_c[1]
+            if spl_c[0] == "output":
+                params["input"] = spl_c[1]
 
-            self.vnet_data.SetParams(params, {})
+        self.vnet_data.SetParams(params, {})
 
         self.ttbCreated.emit(returncode=event.returncode)
 
@@ -1147,14 +1145,10 @@ class SnappingNodes(wx.EvtHandler):
 
             return 0
         # map is already created and up to date for input data
-        else:
-            self.snapPts.AddRenderLayer()
-
-            self.giface.updateMap.emit(render=True, renderVector=True)
-
-            self.snapping.emit(evt="computing_points_done")
-
-            return 1
+        self.snapPts.AddRenderLayer()
+        self.giface.updateMap.emit(render=True, renderVector=True)
+        self.snapping.emit(evt="computing_points_done")
+        return 1
 
     def _onNodesDone(self, event):
         """Update map window, when map with nodes to snap is created"""

--- a/gui/wxpython/vnet/vnet_data.py
+++ b/gui/wxpython/vnet/vnet_data.py
@@ -78,16 +78,14 @@ class VNETData:
     def GetRelevantParams(self, analysis=None):
         if analysis:
             return self.an_props.GetRelevantParams(analysis)
-        else:
-            analysis, valid = self.an_params.GetParam("analysis")
-            return self.an_props.GetRelevantParams(analysis)
+        analysis, valid = self.an_params.GetParam("analysis")
+        return self.an_props.GetRelevantParams(analysis)
 
     def GetAnalysisProperties(self, analysis=None):
         if analysis:
             return self.an_props[analysis]
-        else:
-            analysis, valid = self.an_params.GetParam("analysis")
-            return self.an_props[analysis]
+        analysis, valid = self.an_params.GetParam("analysis")
+        return self.an_props[analysis]
 
     def GetParam(self, param):
         return self.an_params.GetParam(param)

--- a/gui/wxpython/web_services/cap_interface.py
+++ b/gui/wxpython/web_services/cap_interface.py
@@ -49,8 +49,7 @@ class CapabilitiesBase:
         """Get children layers"""
         if self.layers_by_id:
             return self.layers_by_id[0]
-        else:
-            return None
+        return None
 
 
 class LayerBase:
@@ -137,15 +136,13 @@ class WMSLayer(LayerBase):
             title_node = self.layer_node.find(title)
             if title_node is not None:
                 return title_node.text
-            else:
-                return None
+            return None
 
         if param == "name":
             name_node = self.layer_node.find(name)
             if name_node is not None:
                 return name_node.text
-            else:
-                return None
+            return None
 
         if param == "format":
             return self.cap.GetFormats()
@@ -228,22 +225,20 @@ class WMTSLayer(LayerBase):
 
         if self.layer_node is None and param in {"title", "name"}:
             return None
-        elif self.layer_node is None:
+        if self.layer_node is None:
             return []
 
         if param == "title":
             title_node = self.layer_node.find(title)
             if title_node is not None:
                 return title_node.text
-            else:
-                return None
+            return None
 
         if param == "name":
             name_node = self.layer_node.find(name)
             if name_node is not None:
                 return name_node.text
-            else:
-                return None
+            return None
 
         if param == "styles":
             styles = []
@@ -366,22 +361,20 @@ class OnEarthLayer(LayerBase):
         """Get layer data"""
         if self.layer_node is None and param in {"title", "name"}:
             return None
-        elif self.layer_node is None:
+        if self.layer_node is None:
             return []
 
         if param == "title":
             title_node = self.layer_node.find("Title")
             if title_node is not None:
                 return title_node.text
-            else:
-                return None
+            return None
 
         if param == "name":
             name_node = self.layer_node.find("Name")
             if name_node is not None:
                 return name_node.text
-            else:
-                return None
+            return None
 
         if param == "styles":
             return []

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -243,8 +243,7 @@ class HistogramPlotFrame(BasePlotFrame):
 
         if len(self.plotlist) > 0:
             return self.plotlist
-        else:
-            return None
+        return None
 
     def Update(self):
         """Update histogram after changing options"""

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -398,8 +398,7 @@ class ProfileFrame(BasePlotFrame):
 
         if len(self.plotlist) > 0:
             return self.plotlist
-        else:
-            return None
+        return None
 
     def Update(self):
         """Update profile after changing options"""

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -737,22 +737,21 @@ def cannot_create_location_reason(gisdbase, location):
             " the project <{location}>"
             " already exists."
         ).format(**locals())
-    elif os.path.isfile(path):
+    if os.path.isfile(path):
         return _(
             "Unable to create new project <{location}> because <{path}> is a file."
         ).format(**locals())
-    elif os.path.isdir(path):
+    if os.path.isdir(path):
         return _(
             "Unable to create new project <{location}> because"
             " the directory <{path}>"
             " already exists."
         ).format(**locals())
-    else:
-        return _(
-            "Unable to create new project in"
-            " the directory <{path}>"
-            " for an unknown reason."
-        ).format(**locals())
+    return _(
+        "Unable to create new project in"
+        " the directory <{path}>"
+        " for an unknown reason."
+    ).format(**locals())
 
 
 def set_mapset(
@@ -1419,7 +1418,7 @@ def run_batch_job(batch_job: list):
         if script_in_addon_path and os.path.exists(script_in_addon_path):
             batch_job[0] = script_in_addon_path
             return script_in_addon_path
-        elif os.path.exists(batch_job[0]):
+        if os.path.exists(batch_job[0]):
             return batch_job[0]
 
     try:

--- a/locale/grass_po_stats.py
+++ b/locale/grass_po_stats.py
@@ -81,10 +81,9 @@ def langDefinition(fil):
     f.close()
     if len(lang) == 2:
         return " ".join(lang)
-    elif len(lang) == 1:
+    if len(lang) == 1:
         return lang[0]
-    else:
-        return ""
+    return ""
 
 
 def get_stats(languages, directory):

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -494,8 +494,7 @@ def get_desc(cmd):
             sp = line.split("-", 1)
             if len(sp) > 1:
                 return sp[1].strip()
-            else:
-                return None
+            return None
 
     return ""
 

--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -132,8 +132,7 @@ def title_from_names(module_name, img_name):
     img_name = img_name.strip()
     if img_name:
         return "{name} ({desc})".format(name=module_name, desc=img_name)
-    else:
-        return "{name}".format(name=module_name)
+    return "{name}".format(name=module_name)
 
 
 def get_module_name(filename):

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -355,8 +355,7 @@ def get_desc(cmd):
             sp = line.split("-", 1)
             if len(sp) > 1:
                 return sp[1].strip()
-            else:
-                return None
+            return None
 
     return ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "RET501",  # unnecessary-return-none
     "RET502",  # implicit-return-value
     "RET503",  # implicit-return
-    "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "RET507",  # superfluous-else-continue
     "RET508",  # superfluous-else-break

--- a/python/grass/grassdb/checks.py
+++ b/python/grass/grassdb/checks.py
@@ -222,13 +222,13 @@ def get_reason_id_mapset_not_usable(mapset_path):
     if not os.path.exists(mapset_path):
         return "non-existent"
     # Check whether mapset is valid
-    elif not is_mapset_valid(mapset_path):
+    if not is_mapset_valid(mapset_path):
         return "invalid"
     # Check whether mapset is owned by current user
-    elif not is_current_user_mapset_owner(mapset_path):
+    if not is_current_user_mapset_owner(mapset_path):
         return "different-owner"
     # Check whether mapset is locked
-    elif is_mapset_locked(mapset_path):
+    if is_mapset_locked(mapset_path):
         return "locked"
     return None
 

--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -736,10 +736,9 @@ class TestCase(unittest.TestCase):
         # and ensure uniqueness by add UUID
         if self.readable_names:
             return "tmp_" + self.id().replace(".", "_") + "_" + name
-        else:
-            # UUID might be overkill (and expensive) but it's safe and simple
-            # alternative is to create hash from the readable name
-            return "tmp_" + str(uuid.uuid4()).replace("-", "")
+        # UUID might be overkill (and expensive) but it's safe and simple
+        # alternative is to create hash from the readable name
+        return "tmp_" + str(uuid.uuid4()).replace("-", "")
 
     def _compute_difference_raster(self, first, second, name_part):
         """Compute difference of two rasters (first - second)

--- a/python/grass/gunittest/multireport.py
+++ b/python/grass/gunittest/multireport.py
@@ -104,8 +104,7 @@ def plot_percent_successful(x, xticks, xlabels, successes, filename, style):
         sorted_values = sorted(values)
         if n % 2 == 0:
             return (sorted_values[n / 2 - 1] + sorted_values[n / 2]) / 2
-        else:
-            return sorted_values[n / 2]
+        return sorted_values[n / 2]
 
     # this is useful for debugging or some other stat
     # cmeans = []

--- a/python/grass/gunittest/multirunner.py
+++ b/python/grass/gunittest/multirunner.py
@@ -30,15 +30,13 @@ def _get_encoding():
 def decode(bytes_, encoding=None):
     if isinstance(bytes_, bytes):
         return bytes_.decode(_get_encoding())
-    else:
-        return bytes_
+    return bytes_
 
 
 def encode(string, encoding=None):
     if isinstance(string, str):
         return string.encode(_get_encoding())
-    else:
-        return string
+    return string
 
 
 def text_to_string(text):

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -110,8 +110,7 @@ def get_source_url(path, revision, line=None):
     tracurl = "http://trac.osgeo.org/grass/browser/"
     if line:
         return "{tracurl}{path}?rev={revision}#L{line}".format(**locals())
-    else:
-        return "{tracurl}{path}?rev={revision}".format(**locals())
+    return "{tracurl}{path}?rev={revision}".format(**locals())
 
 
 def html_escape(text):
@@ -150,8 +149,7 @@ def to_web_path(path):
     """
     if os.path.sep != "/":
         return path.replace(os.path.sep, "/")
-    else:
-        return path
+    return path
 
 
 def get_svn_revision():
@@ -174,8 +172,7 @@ def get_svn_revision():
             # the first one is the one of source code
             stdout = stdout.split(":")[0]
         return stdout
-    else:
-        return None
+    return None
 
 
 def get_svn_info():
@@ -436,9 +433,9 @@ class GrassTestFilesCountingReporter:
 def percent_to_html(percent):
     if percent is None:
         return '<span style="color: {color}">unknown percentage</span>'
-    elif percent > 100 or percent < 0:
+    if percent > 100 or percent < 0:
         return "? {:.2f}% ?".format(percent)
-    elif percent < 40:
+    if percent < 40:
         color = "red"
     elif percent < 70:
         color = "orange"
@@ -495,9 +492,8 @@ def returncode_to_html_text(returncode, timed_out=None):
         else:
             extra = ""
         return f'<span style="color: red">FAILED{extra}</span>'
-    else:
-        # alternatives: SUCCEEDED, passed, OK
-        return '<span style="color: green">succeeded</span>'
+    # alternatives: SUCCEEDED, passed, OK
+    return '<span style="color: green">succeeded</span>'
 
 
 # not used
@@ -507,31 +503,28 @@ def returncode_to_html_sentence(returncode):
             '<span style="color: red">&#x274c;</span>'
             " Test failed (return code %d)" % (returncode)
         )
-    else:
-        return (
-            '<span style="color: green">&#x2713;</span>'
-            " Test succeeded (return code %d)" % (returncode)
-        )
+    return (
+        '<span style="color: green">&#x2713;</span>'
+        " Test succeeded (return code %d)" % (returncode)
+    )
 
 
 def returncode_to_success_html_par(returncode):
     if returncode:
         return '<p> <span style="color: red">&#x274c;</span> Test failed</p>'
-    else:
-        return '<p> <span style="color: green">&#x2713;</span> Test succeeded</p>'
+    return '<p> <span style="color: green">&#x2713;</span> Test succeeded</p>'
 
 
 def success_to_html_text(total, successes):
     if successes < total:
         return '<span style="color: red">FAILED</span>'
-    elif successes == total:
+    if successes == total:
         # alternatives: SUCCEEDED, passed, OK
         return '<span style="color: green">succeeded</span>'
-    else:
-        return (
-            '<span style="color: red; font-size: 60%">'
-            "? more successes than total ?</span>"
-        )
+    return (
+        '<span style="color: red; font-size: 60%">'
+        "? more successes than total ?</span>"
+    )
 
 
 UNKNOWN_NUMBER_HTML = '<span style="font-size: 60%">unknown</span>'
@@ -627,8 +620,7 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
         def format_percentage(percentage):
             if percentage is not None:
                 return "{nsper:.0f}%".format(nsper=percentage)
-            else:
-                return "unknown percentage"
+            return "unknown percentage"
 
         summary_sentence = (
             "\nExecuted {nfiles} test files in {time:}."
@@ -985,8 +977,7 @@ class GrassTestFilesTextReporter(GrassTestFilesCountingReporter):
         def format_percentage(percentage):
             if percentage is not None:
                 return "{nsper:.0f}%".format(nsper=percentage)
-            else:
-                return "unknown percentage"
+            return "unknown percentage"
 
         summary_sentence = (
             "\nExecuted {nfiles} test files in {time:}."

--- a/python/grass/gunittest/runner.py
+++ b/python/grass/gunittest/runner.py
@@ -83,8 +83,7 @@ class TextTestResult(TestResult):
         doc_first_line = test.shortDescription()
         if self.descriptions and doc_first_line:
             return "\n".join((str(test), doc_first_line))
-        else:
-            return str(test)
+        return str(test)
 
     def startTest(self, test):
         super().startTest(test)

--- a/python/grass/imaging/images2avi.py
+++ b/python/grass/imaging/images2avi.py
@@ -137,11 +137,10 @@ def writeAvi(
                 + "\n"
                 + _("Could not write avi.")
             )
-        else:
-            # An error occurred, show
-            print(gs.decode(outPut))
-            print(gs.decode(S.stderr.read()))
-            raise RuntimeError(_("Could not write avi."))
+        # An error occurred, show
+        print(gs.decode(outPut))
+        print(gs.decode(S.stderr.read()))
+        raise RuntimeError(_("Could not write avi."))
     else:
         try:
             # Copy avi
@@ -151,8 +150,7 @@ def writeAvi(
             _cleanDir(tempDir)
             if bg_task:
                 return str(err)
-            else:
-                raise
+            raise
 
         # Clean up
         _cleanDir(tempDir)

--- a/python/grass/imaging/images2gif.py
+++ b/python/grass/imaging/images2gif.py
@@ -1060,9 +1060,8 @@ class NeuQuant:
         """
         if get_cKDTree():
             return self.quantize_with_scipy(image)
-        else:
-            print("Scipy not available, falling back to slower version.")
-            return self.quantize_without_scipy(image)
+        print("Scipy not available, falling back to slower version.")
+        return self.quantize_without_scipy(image)
 
     def quantize_with_scipy(self, image):
         w, h = image.size

--- a/python/grass/imaging/images2ims.py
+++ b/python/grass/imaging/images2ims.py
@@ -93,8 +93,7 @@ def checkImages(images):
 def _getFilenameParts(filename):
     if "*" in filename:
         return tuple(filename.split("*", 1))
-    else:
-        return os.path.splitext(filename)
+    return os.path.splitext(filename)
 
 
 def _getFilenameWithFormatter(filename, N):

--- a/python/grass/pydispatch/robustapply.py
+++ b/python/grass/pydispatch/robustapply.py
@@ -35,7 +35,7 @@ def function(receiver):
     if hasattr(receiver, im_func):
         # an instance-method...
         return receiver, getattr(getattr(receiver, im_func), func_code), 1
-    elif not hasattr(receiver, func_code):
+    if not hasattr(receiver, func_code):
         raise ValueError("unknown receiver type %s %s" % (receiver, type(receiver)))
     return receiver, getattr(receiver, func_code), 0
 

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -35,8 +35,7 @@ def safeRef(target, onDelete=None):
             return BoundMethodWeakref(target=target, onDelete=onDelete)
     if onDelete is not None:
         return weakref.ref(target, onDelete)
-    else:
-        return weakref.ref(target)
+    return weakref.ref(target)
 
 
 class BoundMethodWeakref:
@@ -92,11 +91,10 @@ class BoundMethodWeakref:
         if current is not None:
             current.deletionMethods.append(onDelete)
             return current
-        else:
-            base = super().__new__(cls)
-            cls._allInstances[key] = base
-            base.__init__(target, onDelete, *arguments, **named)
-            return base
+        base = super().__new__(cls)
+        cls._allInstances[key] = base
+        base.__init__(target, onDelete, *arguments, **named)
+        return base
 
     def __init__(self, target, onDelete=None):
         """Return a weak-reference-like instance for a bound method

--- a/python/grass/pygrass/errors.py
+++ b/python/grass/pygrass/errors.py
@@ -22,9 +22,7 @@ def mapinfo_must_be_set(method):
     def wrapper(self, *args, **kargs):
         if self.c_mapinfo:
             return method(self, *args, **kargs)
-        raise GrassError(
-            _("The self.c_mapinfo pointer must be correctly initiated")
-        )
+        raise GrassError(_("The self.c_mapinfo pointer must be correctly initiated"))
 
     return wrapper
 
@@ -34,8 +32,6 @@ def must_be_in_current_mapset(method):
     def wrapper(self, *args, **kargs):
         if self.mapset == libgis.G_mapset().decode():
             return method(self, *args, **kargs)
-        raise GrassError(
-            _("Map <{}> not found in current mapset").format(self.name)
-        )
+        raise GrassError(_("Map <{}> not found in current mapset").format(self.name))
 
     return wrapper

--- a/python/grass/pygrass/errors.py
+++ b/python/grass/pygrass/errors.py
@@ -11,9 +11,8 @@ def must_be_open(method):
     def wrapper(self, *args, **kargs):
         if self.is_open():
             return method(self, *args, **kargs)
-        else:
-            msgr = get_msgr()
-            msgr.warning(_("The map is close!"))
+        msgr = get_msgr()
+        msgr.warning(_("The map is close!"))
 
     return wrapper
 
@@ -23,10 +22,9 @@ def mapinfo_must_be_set(method):
     def wrapper(self, *args, **kargs):
         if self.c_mapinfo:
             return method(self, *args, **kargs)
-        else:
-            raise GrassError(
-                _("The self.c_mapinfo pointer must be correctly initiated")
-            )
+        raise GrassError(
+            _("The self.c_mapinfo pointer must be correctly initiated")
+        )
 
     return wrapper
 
@@ -36,9 +34,8 @@ def must_be_in_current_mapset(method):
     def wrapper(self, *args, **kargs):
         if self.mapset == libgis.G_mapset().decode():
             return method(self, *args, **kargs)
-        else:
-            raise GrassError(
-                _("Map <{}> not found in current mapset").format(self.name)
-            )
+        raise GrassError(
+            _("Map <{}> not found in current mapset").format(self.name)
+        )
 
     return wrapper

--- a/python/grass/pygrass/gis/__init__.py
+++ b/python/grass/pygrass/gis/__init__.py
@@ -162,8 +162,7 @@ class Gisdbase:
         """
         if location in self.locations():
             return Location(location, self.name)
-        else:
-            raise KeyError("Location: %s does not exist" % location)
+        raise KeyError("Location: %s does not exist" % location)
 
     def __iter__(self):
         for loc in self.locations():
@@ -234,8 +233,7 @@ class Location:
     def __getitem__(self, mapset):
         if mapset in self.mapsets():
             return Mapset(mapset)
-        else:
-            raise KeyError("Mapset: %s does not exist" % mapset)
+        raise KeyError("Mapset: %s does not exist" % mapset)
 
     def __iter__(self):
         lpath = self.path()

--- a/python/grass/pygrass/modules/interface/docstring.py
+++ b/python/grass/pygrass/modules/interface/docstring.py
@@ -44,8 +44,7 @@ class DocstringProperty:
     def __get__(self, obj, type=None):
         if obj is None:
             return self.class_doc
-        else:
-            return self.fget(obj)
+        return self.fget(obj)
 
     def __set__(self, obj, value):
         raise AttributeError("can't set attribute")

--- a/python/grass/pygrass/modules/interface/flag.py
+++ b/python/grass/pygrass/modules/interface/flag.py
@@ -52,10 +52,8 @@ class Flag:
         if self.value:
             if self.special:
                 return "--%s" % self.name[0]
-            else:
-                return "-%s" % self.name
-        else:
-            return ""
+            return "-%s" % self.name
+        return ""
 
     def get_python(self):
         """Return the python representation of a flag.

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -720,12 +720,11 @@ class Module:
         #     pre name par flg special
         if flags and special:
             return "%s.%s(%s, flags=%r, %s)" % (prefix, name, params, flags, special)
-        elif flags:
+        if flags:
             return "%s.%s(%s, flags=%r)" % (prefix, name, params, flags)
-        elif special:
+        if special:
             return "%s.%s(%s, %s)" % (prefix, name, params, special)
-        else:
-            return "%s.%s(%s)" % (prefix, name, params)
+        return "%s.%s(%s)" % (prefix, name, params)
 
     def __str__(self):
         """Return the command string that can be executed in a shell"""
@@ -1026,16 +1025,15 @@ g.region format=plain -p ; g.region format=plain -p'
                 module.finish_ = True
                 module.run()
             return None
+        if self.set_temp_region is True:
+            self.p = Process(
+                target=run_modules_in_temp_region, args=[self.module_list, self.q]
+            )
         else:
-            if self.set_temp_region is True:
-                self.p = Process(
-                    target=run_modules_in_temp_region, args=[self.module_list, self.q]
-                )
-            else:
-                self.p = Process(target=run_modules, args=[self.module_list, self.q])
-            self.p.start()
+            self.p = Process(target=run_modules, args=[self.module_list, self.q])
+        self.p.start()
 
-            return self.p
+        return self.p
 
     def wait(self):
         """Wait for all processes to finish. Call this method

--- a/python/grass/pygrass/raster/__init__.py
+++ b/python/grass/pygrass/raster/__init__.py
@@ -327,17 +327,16 @@ class RasterSegment(RasterAbstractBase):
         if isinstance(key, slice):
             # Get the start, stop, and step from the slice
             return [self.put_row(ii, row) for ii in range(*key.indices(len(self)))]
-        elif isinstance(key, tuple):
+        if isinstance(key, tuple):
             x, y = key
             return self.put(x, y, row)
-        elif isinstance(key, int):
+        if isinstance(key, int):
             if key < 0:  # Handle negative indices
                 key += self._rows
             if key >= self._rows:
                 raise IndexError(_("Index out of range: %r.") % key)
             return self.put_row(key, row)
-        else:
-            raise TypeError("Invalid argument type.")
+        raise TypeError("Invalid argument type.")
 
     @must_be_open
     def map2segment(self):

--- a/python/grass/pygrass/raster/abstract.py
+++ b/python/grass/pygrass/raster/abstract.py
@@ -393,10 +393,10 @@ class RasterAbstractBase:
         if isinstance(key, slice):
             # Get the start, stop, and step from the slice
             return (self.get_row(ii) for ii in range(*key.indices(len(self))))
-        elif isinstance(key, tuple):
+        if isinstance(key, tuple):
             x, y = key
             return self.get(x, y)
-        elif isinstance(key, int):
+        if isinstance(key, int):
             if not self.is_open():
                 raise IndexError("Can not operate on a closed map. Call open() first.")
             if key < 0:  # Handle negative indices
@@ -408,8 +408,7 @@ class RasterAbstractBase:
                     )
                 )
             return self.get_row(key)
-        else:
-            fatal("Invalid argument type.")
+        fatal("Invalid argument type.")
 
     def __iter__(self):
         """Return a constructor of the class"""
@@ -434,8 +433,7 @@ class RasterAbstractBase:
                 self.mapset = mapset or ""
                 return bool(mapset)
             return bool(utils.get_mapset_raster(self.name, self.mapset))
-        else:
-            return False
+        return False
 
     def is_open(self):
         """Return True if the map is open False otherwise.
@@ -485,8 +483,7 @@ class RasterAbstractBase:
 
         if mapset and mapset != gis_env["MAPSET"]:
             return "{name}@{mapset}".format(name=name, mapset=mapset)
-        else:
-            return name
+        return name
 
     def rename(self, newname):
         """Rename the map"""

--- a/python/grass/pygrass/raster/buffer.py
+++ b/python/grass/pygrass/raster/buffer.py
@@ -20,13 +20,12 @@ class Buffer(np.ndarray):
     def mtype(self):
         if self.dtype in CELL:
             return "CELL"
-        elif self.dtype in FCELL:
+        if self.dtype in FCELL:
             return "FCELL"
-        elif self.dtype in DCELL:
+        if self.dtype in DCELL:
             return DCELL
-        else:
-            err = "Raster type: %r not supported by GRASS."
-            raise TypeError(err % self.dtype)
+        err = "Raster type: %r not supported by GRASS."
+        raise TypeError(err % self.dtype)
 
     def __new__(
         cls, shape, mtype="FCELL", buffer=None, offset=0, strides=None, order=None

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -187,7 +187,7 @@ class Category(list):
         # Manage C function Errors
         if err == 1:
             return None
-        elif err == 0:
+        if err == 0:
             raise GrassError(_("Null value detected"))
         elif err == -1:
             raise GrassError(_("Error executing: Rast_set_cat"))

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -83,24 +83,23 @@ def findmaps(type, pattern=None, mapset="", location="", gisdbase=""):
             (m, mset.name, mset.location, mset.gisdbase)
             for m in mset.glist(type, pattern)
         ]
-    elif gisdbase and location:
+    if gisdbase and location:
         loc = Location(location, gisdbase)
         return find_in_location(type, pattern, loc)
-    elif gisdbase:
+    if gisdbase:
         gis = Gisdbase(gisdbase)
         return find_in_gisdbase(type, pattern, gis)
-    elif location:
+    if location:
         loc = Location(location)
         return find_in_location(type, pattern, loc)
-    elif mapset:
+    if mapset:
         mset = Mapset(mapset)
         return [
             (m, mset.name, mset.location, mset.gisdbase)
             for m in mset.glist(type, pattern)
         ]
-    else:
-        gis = Gisdbase()
-        return find_in_gisdbase(type, pattern, gis)
+    gis = Gisdbase()
+    return find_in_gisdbase(type, pattern, gis)
 
 
 def remove(oldname, maptype):
@@ -136,11 +135,10 @@ def decode(obj, encoding=None):
     """
     if isinstance(obj, String):
         return grassutils.decode(obj.data, encoding=encoding)
-    elif isinstance(obj, bytes):
+    if isinstance(obj, bytes):
         return grassutils.decode(obj)
-    else:
-        # eg None
-        return obj
+    # eg None
+    return obj
 
 
 def getenv(env):
@@ -337,9 +335,8 @@ def get_raster_for_points(poi_vector, raster, column=None, region=None):
                 result.append((poi.id, poi.x, poi.y, None))
     if not column:
         return result
-    else:
-        poi.attrs.commit()
-        return True
+    poi.attrs.commit()
+    return True
 
 
 def r_export(rast, output="", fmt="png", **kargs):
@@ -355,8 +352,7 @@ def r_export(rast, output="", fmt="png", **kargs):
             **kargs,
         )
         return output
-    else:
-        raise ValueError("Raster map does not exist.")
+    raise ValueError("Raster map does not exist.")
 
 
 def get_lib_path(modname, libname=None):

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -70,8 +70,7 @@ class Vector(Info):
     def __repr__(self):
         if self.exist():
             return "%s(%r, %r)" % (self._class_name, self.name, self.mapset)
-        else:
-            return "%s(%r)" % (self._class_name, self.name)
+        return "%s(%r)" % (self._class_name, self.name)
 
     def __iter__(self):
         """::
@@ -315,10 +314,9 @@ class VectorTopo(Vector):
                     key.step or 1,
                 )
             ]
-        elif isinstance(key, int):
+        if isinstance(key, int):
             return self.read(key)
-        else:
-            raise ValueError("Invalid argument type: %r." % key)
+        raise ValueError("Invalid argument type: %r." % key)
 
     @must_be_open
     def num_primitive_of(self, primitive):
@@ -392,11 +390,9 @@ class VectorTopo(Vector):
             if isinstance(_NUMOF[vtype], tuple):
                 fn, ptype = _NUMOF[vtype]
                 return fn(self.c_mapinfo, ptype)
-            else:
-                return _NUMOF[vtype](self.c_mapinfo)
-        else:
-            keys = "', '".join(sorted(_NUMOF.keys()))
-            raise ValueError("vtype not supported, use one of: '%s'" % keys)
+            return _NUMOF[vtype](self.c_mapinfo)
+        keys = "', '".join(sorted(_NUMOF.keys()))
+        raise ValueError("vtype not supported, use one of: '%s'" % keys)
 
     @must_be_open
     def num_primitives(self):
@@ -526,17 +522,16 @@ class VectorTopo(Vector):
                 )
                 for v_id in ilist
             )
-        else:
-            return [
-                read_line(
-                    feature_id=v_id,
-                    c_mapinfo=self.c_mapinfo,
-                    table=self.table,
-                    writeable=self.writeable,
-                    is2D=is2D,
-                )
-                for v_id in ilist
-            ]
+        return [
+            read_line(
+                feature_id=v_id,
+                c_mapinfo=self.c_mapinfo,
+                table=self.table,
+                writeable=self.writeable,
+                is2D=is2D,
+            )
+            for v_id in ilist
+        ]
 
     @must_be_open
     def read(self, feature_id):

--- a/python/grass/pygrass/vector/abstract.py
+++ b/python/grass/pygrass/vector/abstract.py
@@ -299,8 +299,7 @@ class Info:
                 self.mapset = mapset or ""
                 return bool(mapset)
             return bool(utils.get_mapset_vector(self.name, self.mapset))
-        else:
-            return False
+        return False
 
     def is_open(self):
         """Return if the Vector is open"""

--- a/python/grass/pygrass/vector/basic.py
+++ b/python/grass/pygrass/vector/basic.py
@@ -149,8 +149,7 @@ class Bbox:
         """
         if tb:
             return (self.north, self.south, self.east, self.west, self.top, self.bottom)
-        else:
-            return (self.north, self.south, self.east, self.west)
+        return (self.north, self.south, self.east, self.west)
 
 
 class BoxList:
@@ -308,14 +307,13 @@ class Ilist:
                 self.c_ilist.contents.value[indx]
                 for indx in range(*key.indices(len(self)))
             ]
-        elif isinstance(key, int):
+        if isinstance(key, int):
             if key < 0:  # Handle negative indices
                 key += self.c_ilist.contents.n_values
             if key >= self.c_ilist.contents.n_values:
                 raise IndexError("Index out of range")
             return self.c_ilist.contents.value[key]
-        else:
-            raise ValueError("Invalid argument type: %r." % key)
+        raise ValueError("Invalid argument type: %r." % key)
 
     def __setitem__(self, key, value):
         if self.contains(value):

--- a/python/grass/pygrass/vector/find.py
+++ b/python/grass/pygrass/vector/find.py
@@ -490,11 +490,10 @@ class BboxFinder(AbstractFinder):
         ):
             if bboxlist_only:
                 return found
-            else:
-                return (
-                    read_line(f_id, self.c_mapinfo, self.table, self.writeable)
-                    for f_id in found.ids
-                )
+            return (
+                read_line(f_id, self.c_mapinfo, self.table, self.writeable)
+                for f_id in found.ids
+            )
 
     @must_be_open
     def nodes(self, bbox):
@@ -592,16 +591,15 @@ class BboxFinder(AbstractFinder):
         ):
             if bboxlist_only:
                 return boxlist
-            else:
-                return (
-                    Area(
-                        v_id=a_id,
-                        c_mapinfo=self.c_mapinfo,
-                        table=self.table,
-                        writeable=self.writeable,
-                    )
-                    for a_id in boxlist.ids
+            return (
+                Area(
+                    v_id=a_id,
+                    c_mapinfo=self.c_mapinfo,
+                    table=self.table,
+                    writeable=self.writeable,
                 )
+                for a_id in boxlist.ids
+            )
 
     @must_be_open
     def islands(self, bbox, bboxlist_only=False):
@@ -652,16 +650,15 @@ class BboxFinder(AbstractFinder):
         ):
             if bboxlist_only:
                 return found
-            else:
-                return (
-                    Isle(
-                        v_id=i_id,
-                        c_mapinfo=self.c_mapinfo,
-                        table=self.table,
-                        writeable=self.writeable,
-                    )
-                    for i_id in found.ids
+            return (
+                Isle(
+                    v_id=i_id,
+                    c_mapinfo=self.c_mapinfo,
+                    table=self.table,
+                    writeable=self.writeable,
                 )
+                for i_id in found.ids
+            )
 
 
 class PolygonFinder(AbstractFinder):

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -94,8 +94,7 @@ def intersects(lineA, lineB, with_z=False):
         lineA.c_points, lineB.c_points, line.c_points, int(with_z)
     ):
         return line
-    else:
-        return []
+    return []
 
 
 # =============================================
@@ -370,8 +369,7 @@ class Geo:
     def has_topology(self):
         if self.c_mapinfo is not None:
             return self.c_mapinfo.contents.level == 2
-        else:
-            return False
+        return False
 
     @mapinfo_must_be_set
     def read(self):
@@ -539,8 +537,7 @@ class Point(Geo):
         """
         if self.is2D:
             return self.x, self.y
-        else:
-            return self.x, self.y, self.z
+        return self.x, self.y, self.z
 
     def to_wkt_p(self):
         """Return a "well know text" (WKT) geometry string Python implementation. ::
@@ -577,10 +574,9 @@ class Point(Geo):
         """
         if self.is2D or pnt.is2D:
             return libvect.Vect_points_distance(self.x, self.y, 0, pnt.x, pnt.y, 0, 0)
-        else:
-            return libvect.Vect_points_distance(
-                self.x, self.y, self.z, pnt.x, pnt.y, pnt.z, 1
-            )
+        return libvect.Vect_points_distance(
+            self.x, self.y, self.z, pnt.x, pnt.y, pnt.z, 1
+        )
 
     def buffer(
         self, dist=None, dist_x=None, dist_y=None, angle=0, round_=True, tol=0.1
@@ -675,7 +671,7 @@ class Line(Geo):
                 )
                 for indx in range(*key.indices(len(self)))
             ]
-        elif isinstance(key, int):
+        if isinstance(key, int):
             if key < 0:  # Handle negative indices
                 key += self.c_points.contents.n_points
             if key >= self.c_points.contents.n_points:
@@ -685,8 +681,7 @@ class Line(Geo):
                 self.c_points.contents.y[key],
                 None if self.is2D else self.c_points.contents.z[key],
             )
-        else:
-            raise ValueError("Invalid argument type: %r." % key)
+        raise ValueError("Invalid argument type: %r." % key)
 
     def __setitem__(self, indx, pnt):
         """Change the coordinate of point. ::
@@ -1373,8 +1368,7 @@ class Boundary(Line):
             v_id = v_id or None
             if idonly:
                 return v_id
-            else:
-                return Centroid(v_id=v_id, c_mapinfo=self.c_mapinfo)
+            return Centroid(v_id=v_id, c_mapinfo=self.c_mapinfo)
 
     def left_centroid(self, idonly=False):
         """Return left centroid
@@ -1914,8 +1908,7 @@ def c_read_line(feature_id, c_mapinfo, c_points, c_cats):
     if feature_id > 0:
         ftype = libvect.Vect_read_line(c_mapinfo, c_points, c_cats, feature_id)
         return feature_id, ftype, c_points, c_cats
-    else:
-        raise ValueError("The index must be >0, %r given." % feature_id)
+    raise ValueError("The index must be >0, %r given." % feature_id)
 
 
 def read_line(

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -65,14 +65,13 @@ def get_path(path, vect_name=None):
     """
     if "$" not in path:
         return path
-    else:
-        mapset = Mapset()
-        path = path.replace("$GISDBASE", mapset.gisdbase)
-        path = path.replace("$LOCATION_NAME", mapset.location)
-        path = path.replace("$MAPSET", mapset.name)
-        if vect_name is not None:
-            path = path.replace("$MAP", vect_name)
-        return path
+    mapset = Mapset()
+    path = path.replace("$GISDBASE", mapset.gisdbase)
+    path = path.replace("$LOCATION_NAME", mapset.location)
+    path = path.replace("$MAPSET", mapset.name)
+    if vect_name is not None:
+        path = path.replace("$MAP", vect_name)
+    return path
 
 
 class Filters:
@@ -326,8 +325,7 @@ class Columns:
             return ", ".join(
                 ["%s %s" % (key, val) for key, val in self.items() if key != remove]
             )
-        else:
-            return ", ".join(["%s %s" % (key, val) for key, val in self.items()])
+        return ", ".join(["%s %s" % (key, val) for key, val in self.items()])
 
     def types(self):
         """Return a list with the column types.
@@ -372,8 +370,7 @@ class Columns:
             nams = list(self.odict.keys())
         if unicod:
             return nams
-        else:
-            return [str(name) for name in nams]
+        return [str(name) for name in nams]
 
     def items(self):
         """Return a list of tuple with column name and column type.
@@ -847,7 +844,7 @@ class Link:
             if not os.path.exists(dbdirpath):
                 os.mkdir(dbdirpath)
             return sqlite3.connect(dbpath)
-        elif driver == "pg":
+        if driver == "pg":
             try:
                 import psycopg2
 
@@ -940,8 +937,7 @@ class DBlinks:
     def __getitem__(self, item):
         if isinstance(item, int):
             return self.by_index(item)
-        else:
-            return self.by_name(item)
+        return self.by_name(item)
 
     def __repr__(self):
         return "DBlinks(%r)" % list(self.__iter__())

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -127,8 +127,7 @@ def _make_unicode(val, enc):
 
     if enc == "default":
         return decode(val)
-    else:
-        return decode(val, encoding=enc)
+    return decode(val, encoding=enc)
 
 
 def get_commands(*, env=None):
@@ -349,7 +348,7 @@ def handle_errors(returncode, result, args, kwargs):
         return result
     if handler.lower() == "ignore":
         return result
-    elif handler.lower() == "fatal":
+    if handler.lower() == "fatal":
         module, code = get_module_and_code(args, kwargs)
         fatal(
             _(
@@ -1650,8 +1649,7 @@ def verbosity():
     vbstr = os.getenv("GRASS_VERBOSE")
     if vbstr:
         return int(vbstr)
-    else:
-        return 2
+    return 2
 
 
 # Various utilities, not specific to GRASS

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -229,8 +229,7 @@ def db_table_in_vector(table, mapset=".", env=None):
                 break
     if len(used) > 0:
         return used
-    else:
-        return None
+    return None
 
 
 def db_begin_transaction(driver):

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -88,8 +88,7 @@ def raster_info(map, env=None):
     def float_or_null(s):
         if s == "NULL":
             return None
-        else:
-            return float(s)
+        return float(s)
 
     s = read_command("r.info", flags="gre", map=map, env=env)
     kv = parse_key_val(s)

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -47,8 +47,7 @@ def raster3d_info(map, env=None):
     def float_or_null(s):
         if s == "NULL":
             return None
-        else:
-            return float(s)
+        return float(s)
 
     s = read_command("r3.info", flags="rg", map=map, env=env)
     kv = parse_key_val(s)

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -90,8 +90,7 @@ class grassTask:
             name, ext = os.path.splitext(self.name)
             if ext in {".py", ".sh"}:
                 return name
-            else:
-                return self.name
+            return self.name
 
         return self.name
 
@@ -103,10 +102,8 @@ class grassTask:
         if self.label:
             if full:
                 return self.label + " " + self.description
-            else:
-                return self.label
-        else:
-            return self.description
+            return self.label
+        return self.description
 
     def get_keywords(self):
         """Get module's keywords"""

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -69,13 +69,13 @@ def separator(sep):
     """
     if sep == "pipe":
         return "|"
-    elif sep == "comma":
+    if sep == "comma":
         return ","
-    elif sep == "space":
+    if sep == "space":
         return " "
-    elif sep in {"tab", "\\t"}:
+    if sep in {"tab", "\\t"}:
         return "\t"
-    elif sep in {"newline", "\\n"}:
+    if sep in {"newline", "\\n"}:
         return "\n"
     return sep
 

--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -76,7 +76,7 @@ class AbstractDataset(
         """
         if self.is_temporal_topology_build() and not self.is_spatial_topology_build():
             return self.get_number_of_temporal_relations()
-        elif self.is_spatial_topology_build() and not self.is_temporal_topology_build():
+        if self.is_spatial_topology_build() and not self.is_temporal_topology_build():
             self.get_number_of_spatial_relations()
         else:
             return (
@@ -511,8 +511,7 @@ class AbstractDataset(
         """
         if "temporal_type" in self.base.D:
             return self.base.get_ttype() == "absolute"
-        else:
-            return None
+        return None
 
     def is_time_relative(self):
         """Return True in case the temporal type is relative
@@ -521,8 +520,7 @@ class AbstractDataset(
         """
         if "temporal_type" in self.base.D:
             return self.base.get_ttype() == "relative"
-        else:
-            return None
+        return None
 
     def get_temporal_extent(self):
         """Return the temporal extent of the correct internal type"""

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -442,10 +442,7 @@ class AbstractMapDataset(AbstractDataset):
                 )
                 return False
             self.msgr.error(
-                _(
-                    "Start time must be of type datetime for "
-                    "%(type)s map <%(id)s>"
-                )
+                _("Start time must be of type datetime for %(type)s map <%(id)s>")
                 % {"type": self.get_type(), "id": self.get_map_id()}
             )
             return False

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -232,8 +232,7 @@ class AbstractMapDataset(AbstractDataset):
 
         if layer is not None:
             return f"{name}:{layer}@{mapset}"
-        else:
-            return f"{name}@{mapset}"
+        return f"{name}@{mapset}"
 
     @staticmethod
     def build_id(name, mapset, layer=None):
@@ -258,8 +257,7 @@ class AbstractMapDataset(AbstractDataset):
 
         if layer is not None:
             return f"{name}:{layer}@{mapset}"
-        else:
-            return f"{name}@{mapset}"
+        return f"{name}@{mapset}"
 
     def get_layer(self):
         """Return the layer of the map
@@ -443,15 +441,14 @@ class AbstractMapDataset(AbstractDataset):
                     }
                 )
                 return False
-            else:
-                self.msgr.error(
-                    _(
-                        "Start time must be of type datetime for "
-                        "%(type)s map <%(id)s>"
-                    )
-                    % {"type": self.get_type(), "id": self.get_map_id()}
+            self.msgr.error(
+                _(
+                    "Start time must be of type datetime for "
+                    "%(type)s map <%(id)s>"
                 )
-                return False
+                % {"type": self.get_type(), "id": self.get_map_id()}
+            )
+            return False
 
         if end_time and not isinstance(end_time, datetime):
             if self.get_layer():
@@ -467,12 +464,11 @@ class AbstractMapDataset(AbstractDataset):
                     }
                 )
                 return False
-            else:
-                self.msgr.error(
-                    _("End time must be of type datetime for %(type)s map <%(id)s>")
-                    % {"type": self.get_type(), "id": self.get_map_id()}
-                )
-                return False
+            self.msgr.error(
+                _("End time must be of type datetime for %(type)s map <%(id)s>")
+                % {"type": self.get_type(), "id": self.get_map_id()}
+            )
+            return False
 
         if start_time is not None and end_time is not None:
             if start_time > end_time:
@@ -490,17 +486,16 @@ class AbstractMapDataset(AbstractDataset):
                         }
                     )
                     return False
-                else:
-                    self.msgr.error(
-                        _(
-                            "End time must be greater than start "
-                            "time for %(type)s map <%(id)s>"
-                        )
-                        % {"type": self.get_type(), "id": self.get_map_id()}
+                self.msgr.error(
+                    _(
+                        "End time must be greater than start "
+                        "time for %(type)s map <%(id)s>"
                     )
-                    return False
+                    % {"type": self.get_type(), "id": self.get_map_id()}
+                )
+                return False
             # Do not create an interval in case start and end time are equal
-            elif start_time == end_time:
+            if start_time == end_time:
                 end_time = None
 
         self.base.set_ttype("absolute")
@@ -618,7 +613,7 @@ class AbstractMapDataset(AbstractDataset):
                     )
                 return False
             # Do not create an interval in case start and end time are equal
-            elif start_time == end_time:
+            if start_time == end_time:
                 end_time = None
 
         self.base.set_ttype("relative")

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1626,8 +1626,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             try:
                 if value.startswith("0"):
                     return value.lstrip("0")
-                else:
-                    return "{0:02d}".format(int(value))
+                return "{0:02d}".format(int(value))
             except ValueError:
                 return None
 

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -466,10 +466,9 @@ class SQLDatabaseInterface(DictSQLSerializer):
             return self.serialize(
                 "UPDATE", self.get_table_name(), "WHERE id = '" + str(ident) + "'"
             )
-        else:
-            return self.serialize(
-                "UPDATE", self.get_table_name(), "WHERE id = '" + str(self.ident) + "'"
-            )
+        return self.serialize(
+            "UPDATE", self.get_table_name(), "WHERE id = '" + str(self.ident) + "'"
+        )
 
     def get_update_statement_mogrified(self, dbif=None, ident=None):
         """Return the update statement as mogrified string
@@ -529,12 +528,11 @@ class SQLDatabaseInterface(DictSQLSerializer):
             return self.serialize(
                 "UPDATE ALL", self.get_table_name(), "WHERE id = '" + str(ident) + "'"
             )
-        else:
-            return self.serialize(
-                "UPDATE ALL",
-                self.get_table_name(),
-                "WHERE id = '" + str(self.ident) + "'",
-            )
+        return self.serialize(
+            "UPDATE ALL",
+            self.get_table_name(),
+            "WHERE id = '" + str(self.ident) + "'",
+        )
 
     def get_update_all_statement_mogrified(self, dbif=None, ident=None):
         """Return the update all statement as mogrified string
@@ -749,8 +747,7 @@ class DatasetBase(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_map_id(self):
         """Convenient method to get the unique map identifier
@@ -763,10 +760,8 @@ class DatasetBase(SQLDatabaseInterface):
             if self.id.find(":") >= 0:
                 # Remove the layer identifier from the id
                 return self.id.split("@")[0].split(":")[0] + "@" + self.id.split("@")[1]
-            else:
-                return self.id
-        else:
-            return None
+            return self.id
+        return None
 
     def get_layer(self):
         """Convenient method to get the layer of the map (part of primary key)
@@ -777,48 +772,42 @@ class DatasetBase(SQLDatabaseInterface):
         """
         if "layer" in self.D:
             return self.D["layer"]
-        else:
-            return None
+        return None
 
     def get_name(self):
         """Get the name of the dataset
         :return: None if not found"""
         if "name" in self.D:
             return self.D["name"]
-        else:
-            return None
+        return None
 
     def get_mapset(self):
         """Get the name of mapset of this dataset
         :return: None if not found"""
         if "mapset" in self.D:
             return self.D["mapset"]
-        else:
-            return None
+        return None
 
     def get_creator(self):
         """Get the creator of the dataset
         :return: None if not found"""
         if "creator" in self.D:
             return self.D["creator"]
-        else:
-            return None
+        return None
 
     def get_ctime(self):
         """Get the creation time of the dataset, datatype is datetime
         :return: None if not found"""
         if "creation_time" in self.D:
             return self.D["creation_time"]
-        else:
-            return None
+        return None
 
     def get_ttype(self):
         """Get the temporal type of the map
         :return: None if not found"""
         if "temporal_type" in self.D:
             return self.D["temporal_type"]
-        else:
-            return None
+        return None
 
     # Properties of this class
     id = property(fget=get_id, fset=set_id)
@@ -1027,8 +1016,7 @@ class STDSBase(DatasetBase):
         """
         if "semantic_type" in self.D:
             return self.D["semantic_type"]
-        else:
-            return None
+        return None
 
     def get_mtime(self):
         """Get the modification time of the space time dataset, datatype is
@@ -1038,8 +1026,7 @@ class STDSBase(DatasetBase):
         """
         if "modification_time" in self.D:
             return self.D["modification_time"]
-        else:
-            return None
+        return None
 
     semantic_type = property(fget=get_semantic_type, fset=set_semantic_type)
 
@@ -1201,8 +1188,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_registered_stds(self):
         """Get the comma separated list of space time datasets ids
@@ -1212,8 +1198,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
         """
         if "registered_stds" in self.D:
             return self.D["registered_stds"]
-        else:
-            return None
+        return None
 
     # Properties of this class
     id = property(fget=get_id, fset=set_id)

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -1011,13 +1011,12 @@ def _read_raster_history(name, mapset):
     if ret < 0:
         logging.warning(_("Unable to read history file"))
         return None
-    else:
-        kvp["creation_time"] = decode(
-            libraster.Rast_get_history(byref(hist), libraster.HIST_MAPID)
-        )
-        kvp["creator"] = decode(
-            libraster.Rast_get_history(byref(hist), libraster.HIST_CREATOR)
-        )
+    kvp["creation_time"] = decode(
+        libraster.Rast_get_history(byref(hist), libraster.HIST_MAPID)
+    )
+    kvp["creator"] = decode(
+        libraster.Rast_get_history(byref(hist), libraster.HIST_CREATOR)
+    )
 
     return kvp
 
@@ -1049,13 +1048,12 @@ def _read_raster3d_history(name, mapset):
     if ret < 0:
         logging.warning(_("Unable to read history file"))
         return None
-    else:
-        kvp["creation_time"] = decode(
-            libraster.Rast_get_history(byref(hist), libraster3d.HIST_MAPID)
-        )
-        kvp["creator"] = decode(
-            libraster.Rast_get_history(byref(hist), libraster3d.HIST_CREATOR)
-        )
+    kvp["creation_time"] = decode(
+        libraster.Rast_get_history(byref(hist), libraster3d.HIST_MAPID)
+    )
+    kvp["creator"] = decode(
+        libraster.Rast_get_history(byref(hist), libraster3d.HIST_CREATOR)
+    )
 
     return kvp
 
@@ -1142,43 +1140,42 @@ def _convert_timestamp_from_grass(ts):
         # ATTENTION: We ignore the time zone
         # TODO: Write time zone support
         return (pdt1, pdt2)
-    else:
-        unit = None
-        start = None
-        end = None
-        if count.value >= 1:
-            if dt1.year > 0:
-                unit = "years"
-                start = dt1.year
-            elif dt1.month > 0:
-                unit = "months"
-                start = dt1.month
-            elif dt1.day > 0:
-                unit = "days"
-                start = dt1.day
-            elif dt1.hour > 0:
-                unit = "hours"
-                start = dt1.hour
-            elif dt1.minute > 0:
-                unit = "minutes"
-                start = dt1.minute
-            elif dt1.second > 0:
-                unit = "seconds"
-                start = dt1.second
-        if count.value == 2:
-            if dt2.year > 0:
-                end = dt2.year
-            elif dt2.month > 0:
-                end = dt2.month
-            elif dt2.day > 0:
-                end = dt2.day
-            elif dt2.hour > 0:
-                end = dt2.hour
-            elif dt2.minute > 0:
-                end = dt2.minute
-            elif dt2.second > 0:
-                end = dt2.second
-        return (start, end, unit)
+    unit = None
+    start = None
+    end = None
+    if count.value >= 1:
+        if dt1.year > 0:
+            unit = "years"
+            start = dt1.year
+        elif dt1.month > 0:
+            unit = "months"
+            start = dt1.month
+        elif dt1.day > 0:
+            unit = "days"
+            start = dt1.day
+        elif dt1.hour > 0:
+            unit = "hours"
+            start = dt1.hour
+        elif dt1.minute > 0:
+            unit = "minutes"
+            start = dt1.minute
+        elif dt1.second > 0:
+            unit = "seconds"
+            start = dt1.second
+    if count.value == 2:
+        if dt2.year > 0:
+            end = dt2.year
+        elif dt2.month > 0:
+            end = dt2.month
+        elif dt2.day > 0:
+            end = dt2.day
+        elif dt2.hour > 0:
+            end = dt2.hour
+        elif dt2.minute > 0:
+            end = dt2.minute
+        elif dt2.second > 0:
+            end = dt2.second
+    return (start, end, unit)
 
 
 ###############################################################################

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -1376,7 +1376,7 @@ class DBConnection:
         if self.dbmi.__name__ == "psycopg2":
             if len(args) == 0:
                 return sql
-            elif self.connected:
+            if self.connected:
                 try:
                     return self.cursor.mogrify(sql, args)
                 except Exception as exc:
@@ -1391,57 +1391,56 @@ class DBConnection:
         elif self.dbmi.__name__ == "sqlite3":
             if len(args) == 0:
                 return sql
-            else:
-                # Unfortunately as sqlite does not support
-                # the transformation of sql strings and qmarked or
-                # named arguments we must make our hands dirty
-                # and do it by ourself. :(
-                # Doors are open for SQL injection because of the
-                # limited python sqlite3 implementation!!!
-                pos = 0
-                count = 0
-                maxcount = 100
-                statement = sql
+            # Unfortunately as sqlite does not support
+            # the transformation of sql strings and qmarked or
+            # named arguments we must make our hands dirty
+            # and do it by ourself. :(
+            # Doors are open for SQL injection because of the
+            # limited python sqlite3 implementation!!!
+            pos = 0
+            count = 0
+            maxcount = 100
+            statement = sql
 
-                while count < maxcount:
-                    pos = statement.find("?", pos + 1)
-                    if pos == -1:
-                        break
+            while count < maxcount:
+                pos = statement.find("?", pos + 1)
+                if pos == -1:
+                    break
 
-                    if args[count] is None:
-                        statement = "%sNULL%s" % (
-                            statement[0:pos],
-                            statement[pos + 1 :],
-                        )
-                    elif isinstance(args[count], int):
-                        statement = "%s%d%s" % (
-                            statement[0:pos],
-                            args[count],
-                            statement[pos + 1 :],
-                        )
-                    elif isinstance(args[count], float):
-                        statement = "%s%f%s" % (
-                            statement[0:pos],
-                            args[count],
-                            statement[pos + 1 :],
-                        )
-                    elif isinstance(args[count], datetime):
-                        statement = "%s'%s'%s" % (
-                            statement[0:pos],
-                            str(args[count]),
-                            statement[pos + 1 :],
-                        )
-                    else:
-                        # Default is a string, this works for datetime
-                        # objects too
-                        statement = "%s'%s'%s" % (
-                            statement[0:pos],
-                            str(args[count]),
-                            statement[pos + 1 :],
-                        )
-                    count += 1
+                if args[count] is None:
+                    statement = "%sNULL%s" % (
+                        statement[0:pos],
+                        statement[pos + 1 :],
+                    )
+                elif isinstance(args[count], int):
+                    statement = "%s%d%s" % (
+                        statement[0:pos],
+                        args[count],
+                        statement[pos + 1 :],
+                    )
+                elif isinstance(args[count], float):
+                    statement = "%s%f%s" % (
+                        statement[0:pos],
+                        args[count],
+                        statement[pos + 1 :],
+                    )
+                elif isinstance(args[count], datetime):
+                    statement = "%s'%s'%s" % (
+                        statement[0:pos],
+                        str(args[count]),
+                        statement[pos + 1 :],
+                    )
+                else:
+                    # Default is a string, this works for datetime
+                    # objects too
+                    statement = "%s'%s'%s" % (
+                        statement[0:pos],
+                        str(args[count]),
+                        statement[pos + 1 :],
+                    )
+                count += 1
 
-                return statement
+            return statement
 
     def check_table(self, table_name):
         """Check if a table exists in the temporal database

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -174,72 +174,63 @@ class RasterMetadataBase(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_datatype(self):
         """Get the map type
         :return: None if not found"""
         if "datatype" in self.D:
             return self.D["datatype"]
-        else:
-            return None
+        return None
 
     def get_cols(self):
         """Get number of cols
         :return: None if not found"""
         if "cols" in self.D:
             return self.D["cols"]
-        else:
-            return None
+        return None
 
     def get_rows(self):
         """Get number of rows
         :return: None if not found"""
         if "rows" in self.D:
             return self.D["rows"]
-        else:
-            return None
+        return None
 
     def get_number_of_cells(self):
         """Get number of cells
         :return: None if not found"""
         if "number_of_cells" in self.D:
             return self.D["number_of_cells"]
-        else:
-            return None
+        return None
 
     def get_nsres(self):
         """Get the north-south resolution
         :return: None if not found"""
         if "nsres" in self.D:
             return self.D["nsres"]
-        else:
-            return None
+        return None
 
     def get_ewres(self):
         """Get east-west resolution
         :return: None if not found"""
         if "ewres" in self.D:
             return self.D["ewres"]
-        else:
-            return None
+        return None
 
     def get_min(self):
         """Get the minimum cell value
         :return: None if not found"""
         if "min" in self.D:
             return self.D["min"]
-        else:
-            return None
+        return None
 
     def get_max(self):
         """Get the maximum cell value
         :return: None if not found"""
         if "max" in self.D:
             return self.D["max"]
-        else:
-            return None
+        return None
 
     # Properties
     datatype = property(fget=get_datatype, fset=set_datatype)
@@ -401,8 +392,7 @@ class RasterMetadata(RasterMetadataBase):
         :return: None if not found"""
         if "semantic_label" in self.D:
             return self.D["semantic_label"]
-        else:
-            return None
+        return None
 
     semantic_label = property(fget=get_semantic_label, fset=set_semantic_label)
 
@@ -549,16 +539,14 @@ class Raster3DMetadata(RasterMetadataBase):
         :return: None if not found"""
         if "depths" in self.D:
             return self.D["depths"]
-        else:
-            return None
+        return None
 
     def get_tbres(self):
         """Get top-bottom resolution
         :return: None if not found"""
         if "tbres" in self.D:
             return self.D["tbres"]
-        else:
-            return None
+        return None
 
     depths = property(fget=get_depths, fset=set_depths)
     tbres = property(fget=get_tbres, fset=set_tbres)
@@ -766,112 +754,98 @@ class VectorMetadata(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_3d_info(self):
         """Return True if the map is three dimensional,
         False if not and None if not info was found"""
         if "is_3d" in self.D:
             return self.D["is_3d"]
-        else:
-            return None
+        return None
 
     def get_number_of_points(self):
         """Get the number of points of the vector map
         :return: None if not found"""
         if "points" in self.D:
             return self.D["points"]
-        else:
-            return None
+        return None
 
     def get_number_of_lines(self):
         """Get the number of lines of the vector map
         :return: None if not found"""
         if "lines" in self.D:
             return self.D["lines"]
-        else:
-            return None
+        return None
 
     def get_number_of_boundaries(self):
         """Get the number of boundaries of the vector map
         :return: None if not found"""
         if "boundaries" in self.D:
             return self.D["boundaries"]
-        else:
-            return None
+        return None
 
     def get_number_of_centroids(self):
         """Get the number of centroids of the vector map
         :return: None if not found"""
         if "centroids" in self.D:
             return self.D["centroids"]
-        else:
-            return None
+        return None
 
     def get_number_of_faces(self):
         """Get the number of faces of the vector map
         :return: None if not found"""
         if "faces" in self.D:
             return self.D["faces"]
-        else:
-            return None
+        return None
 
     def get_number_of_kernels(self):
         """Get the number of kernels of the vector map
         :return: None if not found"""
         if "kernels" in self.D:
             return self.D["kernels"]
-        else:
-            return None
+        return None
 
     def get_number_of_primitives(self):
         """Get the number of primitives of the vector map
         :return: None if not found"""
         if "primitives" in self.D:
             return self.D["primitives"]
-        else:
-            return None
+        return None
 
     def get_number_of_nodes(self):
         """Get the number of nodes of the vector map
         :return: None if not found"""
         if "nodes" in self.D:
             return self.D["nodes"]
-        else:
-            return None
+        return None
 
     def get_number_of_areas(self):
         """Get the number of areas of the vector map
         :return: None if not found"""
         if "areas" in self.D:
             return self.D["areas"]
-        else:
-            return None
+        return None
 
     def get_number_of_islands(self):
         """Get the number of islands of the vector map
         :return: None if not found"""
         if "islands" in self.D:
             return self.D["islands"]
-        else:
-            return None
+        return None
 
     def get_number_of_holes(self):
         """Get the number of holes of the vector map
         :return: None if not found"""
         if "holes" in self.D:
             return self.D["holes"]
-        else:
-            return None
+        return None
 
     def get_number_of_volumes(self):
         """Get the number of volumes of the vector map
         :return: None if not found"""
         if "volumes" in self.D:
             return self.D["volumes"]
-        else:
-            return None
+        return None
 
     # Set the properties
     id = property(fget=get_id, fset=set_id)
@@ -1002,32 +976,28 @@ class STDSMetadataBase(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_title(self):
         """Get the title
         :return: None if not found"""
         if "title" in self.D:
             return self.D["title"]
-        else:
-            return None
+        return None
 
     def get_description(self):
         """Get description
         :return: None if not found"""
         if "description" in self.D:
             return self.D["description"]
-        else:
-            return None
+        return None
 
     def get_command(self):
         """Get command
         :return: None if not found"""
         if "command" in self.D:
             return self.D["command"]
-        else:
-            return None
+        return None
 
     def get_number_of_maps(self):
         """Get the number of registered maps,
@@ -1036,8 +1006,7 @@ class STDSMetadataBase(SQLDatabaseInterface):
         :return: None if not found"""
         if "number_of_maps" in self.D:
             return self.D["number_of_maps"]
-        else:
-            return None
+        return None
 
     id = property(fget=get_id, fset=set_id)
     title = property(fget=get_title, fset=set_title)
@@ -1220,8 +1189,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """
         if "aggregation_type" in self.D:
             return self.D["aggregation_type"]
-        else:
-            return None
+        return None
 
     def get_max_min(self):
         """Get the minimal maximum of all registered maps,
@@ -1230,8 +1198,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "max_min" in self.D:
             return self.D["max_min"]
-        else:
-            return None
+        return None
 
     def get_min_min(self):
         """Get the minimal minimum of all registered maps,
@@ -1240,8 +1207,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "min_min" in self.D:
             return self.D["min_min"]
-        else:
-            return None
+        return None
 
     def get_max_max(self):
         """Get the maximal maximum of all registered maps,
@@ -1250,8 +1216,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "max_max" in self.D:
             return self.D["max_max"]
-        else:
-            return None
+        return None
 
     def get_min_max(self):
         """Get the maximal minimum of all registered maps,
@@ -1260,8 +1225,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "min_max" in self.D:
             return self.D["min_max"]
-        else:
-            return None
+        return None
 
     def get_nsres_min(self):
         """Get the minimal north-south resolution of all registered maps,
@@ -1270,8 +1234,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "nsres_min" in self.D:
             return self.D["nsres_min"]
-        else:
-            return None
+        return None
 
     def get_nsres_max(self):
         """Get the maximal north-south resolution of all registered maps,
@@ -1280,8 +1243,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "nsres_max" in self.D:
             return self.D["nsres_max"]
-        else:
-            return None
+        return None
 
     def get_ewres_min(self):
         """Get the minimal east-west resolution of all registered maps,
@@ -1290,8 +1252,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "ewres_min" in self.D:
             return self.D["ewres_min"]
-        else:
-            return None
+        return None
 
     def get_ewres_max(self):
         """Get the maximal east-west resolution of all registered maps,
@@ -1300,8 +1261,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         :return: None if not found"""
         if "ewres_max" in self.D:
             return self.D["ewres_max"]
-        else:
-            return None
+        return None
 
     nsres_min = property(fget=get_nsres_min)
     nsres_max = property(fget=get_nsres_max)
@@ -1435,8 +1395,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
         :return: None if not found"""
         if "raster_register" in self.D:
             return self.D["raster_register"]
-        else:
-            return None
+        return None
 
     def get_number_of_semantic_labels(self):
         """Get the number of registered semantic labels
@@ -1444,8 +1403,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
         """
         if "number_of_semantic_labels" in self.D:
             return self.D["number_of_semantic_labels"]
-        else:
-            return None
+        return None
 
     def get_semantic_labels(self):
         """Get the distinct semantic labels of registered maps
@@ -1483,10 +1441,8 @@ class STRDSMetadata(STDSRasterMetadataBase):
 
             if count > 0:
                 return string
-            else:
-                return None
-        else:
             return None
+        return None
 
     raster_register = property(fget=get_raster_register, fset=set_raster_register)
     number_of_semantic_labels = property(fget=get_number_of_semantic_labels)
@@ -1623,8 +1579,7 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         :return: None if not found"""
         if "raster3d_register" in self.D:
             return self.D["raster3d_register"]
-        else:
-            return None
+        return None
 
     def get_tbres_min(self):
         """Get the minimal top-bottom resolution of all registered maps,
@@ -1633,8 +1588,7 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         :return: None if not found"""
         if "tbres_min" in self.D:
             return self.D["tbres_min"]
-        else:
-            return None
+        return None
 
     def get_tbres_max(self):
         """Get the maximal top-bottom resolution of all registered maps,
@@ -1643,8 +1597,7 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         :return: None if not found"""
         if "tbres_max" in self.D:
             return self.D["tbres_max"]
-        else:
-            return None
+        return None
 
     raster3d_register = property(fget=get_raster3d_register, fset=set_raster3d_register)
     tbres_min = property(fget=get_tbres_min)
@@ -1787,8 +1740,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "vector_register" in self.D:
             return self.D["vector_register"]
-        else:
-            return None
+        return None
 
     def get_number_of_points(self):
         """Get the number of points of all registered maps,
@@ -1797,8 +1749,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "points" in self.D:
             return self.D["points"]
-        else:
-            return None
+        return None
 
     def get_number_of_lines(self):
         """Get the number of lines of all registered maps,
@@ -1807,8 +1758,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "lines" in self.D:
             return self.D["lines"]
-        else:
-            return None
+        return None
 
     def get_number_of_boundaries(self):
         """Get the number of boundaries of all registered maps,
@@ -1817,8 +1767,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "boundaries" in self.D:
             return self.D["boundaries"]
-        else:
-            return None
+        return None
 
     def get_number_of_centroids(self):
         """Get the number of centroids of all registered maps,
@@ -1827,8 +1776,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "centroids" in self.D:
             return self.D["centroids"]
-        else:
-            return None
+        return None
 
     def get_number_of_faces(self):
         """Get the number of faces of all registered maps,
@@ -1837,8 +1785,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "faces" in self.D:
             return self.D["faces"]
-        else:
-            return None
+        return None
 
     def get_number_of_kernels(self):
         """Get the number of kernels of all registered maps,
@@ -1847,8 +1794,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "kernels" in self.D:
             return self.D["kernels"]
-        else:
-            return None
+        return None
 
     def get_number_of_primitives(self):
         """Get the number of primitives of all registered maps,
@@ -1857,8 +1803,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "primitives" in self.D:
             return self.D["primitives"]
-        else:
-            return None
+        return None
 
     def get_number_of_nodes(self):
         """Get the number of nodes of all registered maps,
@@ -1867,8 +1812,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "nodes" in self.D:
             return self.D["nodes"]
-        else:
-            return None
+        return None
 
     def get_number_of_areas(self):
         """Get the number of areas of all registered maps,
@@ -1877,8 +1821,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "areas" in self.D:
             return self.D["areas"]
-        else:
-            return None
+        return None
 
     def get_number_of_islands(self):
         """Get the number of islands of all registered maps,
@@ -1887,8 +1830,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "islands" in self.D:
             return self.D["islands"]
-        else:
-            return None
+        return None
 
     def get_number_of_holes(self):
         """Get the number of holes of all registered maps,
@@ -1897,8 +1839,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "holes" in self.D:
             return self.D["holes"]
-        else:
-            return None
+        return None
 
     def get_number_of_volumes(self):
         """Get the number of volumes of all registered maps,
@@ -1907,8 +1848,7 @@ class STVDSMetadata(STDSMetadataBase):
         :return: None if not found"""
         if "volumes" in self.D:
             return self.D["volumes"]
-        else:
-            return None
+        return None
 
     # Set the properties
     vector_register = property(fget=get_vector_register, fset=set_vector_register)

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -633,15 +633,13 @@ class Raster3DDataset(AbstractMapDataset):
         """Return True if the spatial extents overlap"""
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.overlapping(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.overlapping_2d(dataset.spatial_extent)
+        return self.spatial_extent.overlapping_2d(dataset.spatial_extent)
 
     def spatial_relation(self, dataset):
         """Return the two or three dimensional spatial relation"""
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.spatial_relation(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.spatial_relation_2d(dataset.spatial_extent)
+        return self.spatial_extent.spatial_relation_2d(dataset.spatial_extent)
 
     def spatial_intersection(self, dataset):
         """Return the three or two dimensional intersection as spatial_extent
@@ -652,8 +650,7 @@ class Raster3DDataset(AbstractMapDataset):
         """
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.intersect(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.intersect_2d(dataset.spatial_extent)
+        return self.spatial_extent.intersect_2d(dataset.spatial_extent)
 
     def spatial_union(self, dataset):
         """Return the three or two dimensional union as spatial_extent
@@ -664,8 +661,7 @@ class Raster3DDataset(AbstractMapDataset):
         """
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.union(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.union_2d(dataset.spatial_extent)
+        return self.spatial_extent.union_2d(dataset.spatial_extent)
 
     def spatial_disjoint_union(self, dataset):
         """Return the three or two dimensional union as spatial_extent object.
@@ -675,8 +671,7 @@ class Raster3DDataset(AbstractMapDataset):
         """
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.disjoint_union(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
+        return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
 
     def get_np_array(self):
         """Return this 3D raster map as memmap numpy style array to access the
@@ -1386,16 +1381,14 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
 
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.overlapping(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.overlapping_2d(dataset.spatial_extent)
+        return self.spatial_extent.overlapping_2d(dataset.spatial_extent)
 
     def spatial_relation(self, dataset):
         """Return the two or three dimensional spatial relation"""
 
         if self.get_type() == dataset.get_type() or dataset.get_type() == "str3ds":
             return self.spatial_extent.spatial_relation(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.spatial_relation_2d(dataset.spatial_extent)
+        return self.spatial_extent.spatial_relation_2d(dataset.spatial_extent)
 
     def spatial_intersection(self, dataset):
         """Return the three or two dimensional intersection as spatial_extent
@@ -1406,8 +1399,7 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
         """
         if self.get_type() == dataset.get_type() or dataset.get_type() == "raster3d":
             return self.spatial_extent.intersect(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.intersect_2d(dataset.spatial_extent)
+        return self.spatial_extent.intersect_2d(dataset.spatial_extent)
 
     def spatial_union(self, dataset):
         """Return the three or two dimensional union as spatial_extent
@@ -1418,8 +1410,7 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
         """
         if self.get_type() == dataset.get_type() or dataset.get_type() == "raster3d":
             return self.spatial_extent.union(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.union_2d(dataset.spatial_extent)
+        return self.spatial_extent.union_2d(dataset.spatial_extent)
 
     def spatial_disjoint_union(self, dataset):
         """Return the three or two dimensional union as spatial_extent object.
@@ -1429,8 +1420,7 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
         """
         if self.get_type() == dataset.get_type() or dataset.get_type() == "raster3d":
             return self.spatial_extent.disjoint_union(dataset.spatial_extent)
-        else:
-            return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
+        return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
 
     def reset(self, ident):
         """Reset the internal structure and set the identifier"""

--- a/python/grass/temporal/spatial_extent.py
+++ b/python/grass/temporal/spatial_extent.py
@@ -1787,8 +1787,7 @@ class SpatialExtent(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_projection(self):
         """Get the projection of the spatial extent"""
@@ -1840,48 +1839,42 @@ class SpatialExtent(SQLDatabaseInterface):
         :return: None if not found"""
         if "north" in self.D:
             return self.D["north"]
-        else:
-            return None
+        return None
 
     def get_south(self):
         """Get the southern edge of the map
         :return: None if not found"""
         if "south" in self.D:
             return self.D["south"]
-        else:
-            return None
+        return None
 
     def get_east(self):
         """Get the eastern edge of the map
         :return: None if not found"""
         if "east" in self.D:
             return self.D["east"]
-        else:
-            return None
+        return None
 
     def get_west(self):
         """Get the western edge of the map
         :return: None if not found"""
         if "west" in self.D:
             return self.D["west"]
-        else:
-            return None
+        return None
 
     def get_top(self):
         """Get the top edge of the map
         :return: None if not found"""
         if "top" in self.D:
             return self.D["top"]
-        else:
-            return None
+        return None
 
     def get_bottom(self):
         """Get the bottom edge of the map
         :return: None if not found"""
         if "bottom" in self.D:
             return self.D["bottom"]
-        else:
-            return None
+        return None
 
     id = property(fget=get_id, fset=set_id)
     north = property(fget=get_north, fset=set_north)

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -727,11 +727,11 @@ class GlobalTemporalVar:
             and self.value is not None
         ):
             return "global"
-        elif self.boolean is not None:
+        if self.boolean is not None:
             return "boolean"
-        elif self.relationop is not None and self.topology != []:
+        if self.relationop is not None and self.topology != []:
             return "operator"
-        elif self.td is not None:
+        if self.td is not None:
             return "timediff"
 
     def get_type_value(self):
@@ -2336,8 +2336,7 @@ class TemporalAlgebraParser:
                     inverselist.append(map_i)
         if inverse:
             return inverselist
-        else:
-            return resultlist
+        return resultlist
 
     def p_statement_assign(self, t):
         # The expression should always return a list of maps

--- a/python/grass/temporal/temporal_extent.py
+++ b/python/grass/temporal/temporal_extent.py
@@ -202,9 +202,9 @@ class TemporalExtent(SQLDatabaseInterface):
             return RelativeTemporalExtent(
                 start_time=start, end_time=end, unit=self.get_unit()
             )
-        elif issubclass(type(self), AbsoluteTemporalExtent):
+        if issubclass(type(self), AbsoluteTemporalExtent):
             return AbsoluteTemporalExtent(start_time=start, end_time=end)
-        elif issubclass(type(self), TemporalExtent):
+        if issubclass(type(self), TemporalExtent):
             return TemporalExtent(start_time=start, end_time=end)
 
     def disjoint_union(self, extent):
@@ -391,9 +391,9 @@ class TemporalExtent(SQLDatabaseInterface):
             return RelativeTemporalExtent(
                 start_time=start, end_time=end, unit=self.get_unit()
             )
-        elif issubclass(type(self), AbsoluteTemporalExtent):
+        if issubclass(type(self), AbsoluteTemporalExtent):
             return AbsoluteTemporalExtent(start_time=start, end_time=end)
-        elif issubclass(type(self), TemporalExtent):
+        if issubclass(type(self), TemporalExtent):
             return TemporalExtent(start_time=start, end_time=end)
 
     def union(self, extent):
@@ -986,24 +986,21 @@ class TemporalExtent(SQLDatabaseInterface):
         """
         if "id" in self.D:
             return self.D["id"]
-        else:
-            return None
+        return None
 
     def get_start_time(self):
         """Get the valid start time of the extent
         :return: None if not found"""
         if "start_time" in self.D:
             return self.D["start_time"]
-        else:
-            return None
+        return None
 
     def get_end_time(self):
         """Get the valid end time of the extent
         :return: None if not found"""
         if "end_time" in self.D:
             return self.D["end_time"]
-        else:
-            return None
+        return None
 
     # Set the properties
     id = property(fget=get_id, fset=set_id)
@@ -1153,8 +1150,7 @@ class STDSAbsoluteTime(AbsoluteTemporalExtent):
         :return: None if not found"""
         if "granularity" in self.D:
             return self.D["granularity"]
-        else:
-            return None
+        return None
 
     def get_map_time(self):
         """Get the type of the map time
@@ -1169,8 +1165,7 @@ class STDSAbsoluteTime(AbsoluteTemporalExtent):
         """
         if "map_time" in self.D:
             return self.D["map_time"]
-        else:
-            return None
+        return None
 
     # Properties
     granularity = property(fget=get_granularity, fset=set_granularity)
@@ -1277,8 +1272,7 @@ class RelativeTemporalExtent(TemporalExtent):
         :return: None if not found"""
         if "unit" in self.D:
             return self.D["unit"]
-        else:
-            return None
+        return None
 
     def temporal_relation(self, map):
         """Returns the temporal relation between temporal objects
@@ -1427,8 +1421,7 @@ class STDSRelativeTime(RelativeTemporalExtent):
         :return: None if not found"""
         if "granularity" in self.D:
             return self.D["granularity"]
-        else:
-            return None
+        return None
 
     def get_map_time(self):
         """Get the type of the map time
@@ -1443,8 +1436,7 @@ class STDSRelativeTime(RelativeTemporalExtent):
         """
         if "map_time" in self.D:
             return self.D["map_time"]
-        else:
-            return None
+        return None
 
     # Properties
     granularity = property(fget=get_granularity, fset=set_granularity)

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -146,8 +146,7 @@ def get_time_tuple_function(maps):
     # Check if input is list of MapDataset objects or SQLite rows
     if issubclass(maps[0].__class__, AbstractMapDataset):
         return _get_map_time_tuple
-    else:
-        return _get_row_time_tuple
+    return _get_row_time_tuple
 
 
 def _is_after(start, start1, end1) -> bool:
@@ -777,8 +776,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
         if int(num) > 60:
             if int(num) % 60 == 0:
                 return "60 seconds"
-            else:
-                return "1 second"
+            return "1 second"
 
     if granule in {"minutes", "minute"}:
         # If the start minutes are different between the start dates
@@ -790,8 +788,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
         if int(num) > 60:
             if int(num) % 60 == 0:
                 return "60 minutes"
-            else:
-                return "1 minute"
+            return "1 minute"
 
     if granule in {"hours", "hour"}:
         # If the start hours are different between the start dates
@@ -803,8 +800,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
         if int(num) > 24:
             if int(num) % 24 == 0:
                 return "24 hours"
-            else:
-                return "1 hour"
+            return "1 hour"
 
     if granule in {"days", "day"}:
         # If the start days are different between the start dates
@@ -816,8 +812,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
         if int(num) > 365:
             if int(num) % 365 == 0:
                 return "365 days"
-            else:
-                return "1 day"
+            return "1 day"
 
     if granule in {"months", "month"}:
         # If the start months are different between the start dates
@@ -829,8 +824,7 @@ def compute_common_absolute_time_granularity(gran_list, start_date_list=None):
         if int(num) > 12:
             if int(num) % 12 == 0:
                 return "12 months"
-            else:
-                return "1 month"
+            return "1 month"
 
     return common_granule
 
@@ -1125,20 +1119,18 @@ def gran_singular_unit(gran):
         output, unit = gran.split(" ")
         if unit in PLURAL_GRAN:
             return unit[:-1]
-        elif unit in SINGULAR_GRAN:
+        if unit in SINGULAR_GRAN:
             return unit
-        else:
-            lists = "{gr}".format(gr=SUPPORTED_GRAN).replace("[", "").replace("]", "")
-            print(
-                _(
-                    "Output granularity seems not to be valid. Please use "
-                    "one of the following values : {gr}"
-                ).format(gr=lists)
-            )
-            return False
-    else:
-        print(_("Invalid absolute granularity"))
+        lists = "{gr}".format(gr=SUPPORTED_GRAN).replace("[", "").replace("]", "")
+        print(
+            _(
+                "Output granularity seems not to be valid. Please use "
+                "one of the following values : {gr}"
+            ).format(gr=lists)
+        )
         return False
+    print(_("Invalid absolute granularity"))
+    return False
 
 
 #######################################################################
@@ -1170,16 +1162,15 @@ def gran_plural_unit(gran):
         output, unit = gran.split(" ")
         if unit in PLURAL_GRAN:
             return unit
-        elif unit in SINGULAR_GRAN:
+        if unit in SINGULAR_GRAN:
             return f"{unit}s"
-        else:
-            lists = ", ".join(SUPPORTED_GRAN)
-            print(
-                _(
-                    "Output granularity seems not to be valid. Please use "
-                    "one of the following values : {gr}"
-                ).format(gr=lists)
-            )
+        lists = ", ".join(SUPPORTED_GRAN)
+        print(
+            _(
+                "Output granularity seems not to be valid. Please use "
+                "one of the following values : {gr}"
+            ).format(gr=lists)
+        )
     else:
         print(_("Invalid absolute granularity"))
         return False
@@ -1234,8 +1225,7 @@ def gran_to_gran(from_gran, to_gran="days", shell=False):
 
         if output == 1:
             return f"{output} {tounit}"
-        else:
-            return f"{output} {tounit}s"
+        return f"{output} {tounit}s"
 
     # TODO check the leap second
     if check_granularity_string(from_gran, "absolute"):
@@ -1256,9 +1246,8 @@ def gran_to_gran(from_gran, to_gran="days", shell=False):
                 return _return(output, tounit, shell)
         print(_("Probably you need to invert 'from_gran' and 'to_gran'"))
         return False
-    else:
-        print(_("Invalid absolute granularity"))
-        return False
+    print(_("Invalid absolute granularity"))
+    return False
 
 
 ###############################################################################

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -727,7 +727,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                 # Append map to result map list.
                 resultlist.append(map_i)
             return resultlist
-        elif isinstance(conclusionlist, list):
+        if isinstance(conclusionlist, list):
             # Build result command map list between conditions and conclusions.
             if self.debug:
                 print("build_condition_cmd_list", condition_topolist)

--- a/raster/r.topidx/arc_to_gridatb.py
+++ b/raster/r.topidx/arc_to_gridatb.py
@@ -9,9 +9,8 @@ def match(pattern, string):
     if m:
         match.value = m.group(1)
         return True
-    else:
-        match.value = None
-        return False
+    match.value = None
+    return False
 
 
 if len(sys.argv) != 3 or re.match("^-*help", sys.argv[1]):

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -508,24 +508,23 @@ def get_version_branch(major_version):
     version_branch = f"grass{major_version}"
     if sys.platform == "win32":
         return version_branch
-    else:
-        branch = gs.Popen(
-            ["git", "ls-remote", "--heads", GIT_URL, f"refs/heads/{version_branch}"],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
-        branch, stderr = branch.communicate()
-        if stderr:
-            gs.fatal(
-                _(
-                    "Failed to get branch from the Git repository <{repo_path}>.\n"
-                    "{error}"
-                ).format(
-                    repo_path=GIT_URL,
-                    error=gs.decode(stderr),
-                )
+    branch = gs.Popen(
+        ["git", "ls-remote", "--heads", GIT_URL, f"refs/heads/{version_branch}"],
+        stdout=PIPE,
+        stderr=PIPE,
+    )
+    branch, stderr = branch.communicate()
+    if stderr:
+        gs.fatal(
+            _(
+                "Failed to get branch from the Git repository <{repo_path}>.\n"
+                "{error}"
+            ).format(
+                repo_path=GIT_URL,
+                error=gs.decode(stderr),
             )
-        branch = gs.decode(branch)
+        )
+    branch = gs.decode(branch)
     if version_branch not in branch:
         version_branch = "grass{}".format(int(major_version) - 1)
     return version_branch
@@ -2595,8 +2594,7 @@ def resolve_known_host_service(url, name, branch):
         )
         gs.verbose(_("Will use the following URL for download: {0}").format(url))
         return "remote_zip", url
-    else:
-        return None, None
+    return None, None
 
 
 def validate_url(url):
@@ -2720,7 +2718,7 @@ def resolve_source_code(url=None, name=None, branch=None, fork=False):
     # Handle local URLs
     if os.path.isdir(url):
         return "dir", os.path.abspath(url)
-    elif os.path.exists(url):
+    if os.path.exists(url):
         if url.endswith(".zip"):
             return "zip", os.path.abspath(url)
         for suffix in extract_tar.supported_formats:
@@ -2823,7 +2821,7 @@ def main():
         xmlurl = resolve_xmlurl_prefix(original_url, source=source)
         list_available_extensions(xmlurl)
         return 0
-    elif flags["a"]:
+    if flags["a"]:
         list_installed_extensions(toolboxes=flags["t"])
         return 0
 

--- a/scripts/g.search.modules/g.search.modules.py
+++ b/scripts/g.search.modules/g.search.modules.py
@@ -184,8 +184,7 @@ def colorize(text, attrs=None, pattern=None):
 
     if pattern:
         return text.replace(pattern, colored(pattern, attrs=attrs))
-    else:
-        return colored(text, attrs=attrs)
+    return colored(text, attrs=attrs)
 
 
 def _search_module(

--- a/scripts/i.image.mosaic/i.image.mosaic.py
+++ b/scripts/i.image.mosaic/i.image.mosaic.py
@@ -56,9 +56,8 @@ def get_limit(map):
 def make_expression(i, count):
     if i > count:
         return "null()"
-    else:
-        e = make_expression(i + 1, count)
-        return "if(isnull($image%d),%s,$image%d+$offset%d)" % (i, e, i, i)
+    e = make_expression(i + 1, count)
+    return "if(isnull($image%d),%s,$image%d+$offset%d)" % (i, e, i, i)
 
 
 def main():

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -782,8 +782,7 @@ def GetSRSParamVal(srs):
 
     if srs in {84, 83, 27}:
         return "OGC:CRS{}".format(srs)
-    else:
-        return "EPSG:{}".format(srs)
+    return "EPSG:{}".format(srs)
 
 
 def GetEpsg(srs):

--- a/scripts/r.in.wms/wms_drv.py
+++ b/scripts/r.in.wms/wms_drv.py
@@ -587,7 +587,7 @@ class WMSRequestMgr(BaseRequestMgr):
         # CRS:84 and CRS:83 are exception (CRS:83 and CRS:27 need to be tested)
         if srs_param in {84, 83} or version != "1.3.0":
             return bbox
-        elif Srs(GetSRSParamVal(srs_param)).axisorder == "yx":
+        if Srs(GetSRSParamVal(srs_param)).axisorder == "yx":
             return self._flipBbox(bbox)
 
         return bbox

--- a/temporal/t.info/t.info.py
+++ b/temporal/t.info/t.info.py
@@ -91,7 +91,7 @@ def main():
             " +----------------------------------------------------------------------------+"  # noqa: E501
         )
         return
-    elif system and not history:
+    if system and not history:
         print("dbmi_python_interface='" + str(dbif.get_dbmi().__name__) + "'")
         print("dbmi_string='" + str(tgis.get_tgis_database_string()) + "'")
         print("sql_template_path='" + str(tgis.get_sql_template_path()) + "'")

--- a/utils/g.html2man/g.html2man.py
+++ b/utils/g.html2man/g.html2man.py
@@ -17,12 +17,10 @@ def fix(content):
         tag, attrs, body = content
         if tag == "div" and ("class", "toc") in attrs:
             return None
-        else:
-            return (tag, attrs, fix(body))
-    elif isinstance(content, list):
+        return (tag, attrs, fix(body))
+    if isinstance(content, list):
         return [fixed for item in content for fixed in [fix(item)] if fixed is not None]
-    else:
-        return content
+    return content
 
 
 def main():

--- a/utils/g.html2man/ggroff.py
+++ b/utils/g.html2man/ggroff.py
@@ -253,8 +253,7 @@ class Formatter:
             for line in lines:
                 self.pp_text(line)
             return
-        else:
-            content = lines[0]
+        content = lines[0]
         if self.at_bol and not self.get("preformat"):
             content = self.strip_re.sub("", content)
         self.pp_string(content)

--- a/utils/g.html2man/ghtml.py
+++ b/utils/g.html2man/ghtml.py
@@ -225,8 +225,7 @@ class HTMLParser(base.HTMLParser):
     def top(self):
         if self.tag_stack == []:
             return None
-        else:
-            return self.tag_stack[-1][0]
+        return self.tag_stack[-1][0]
 
     def pop(self):
         self.excluded = self.excluded_stack.pop()

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -406,15 +406,14 @@ def get_last_git_commit(src_dir, addon_path, is_addon):
             commit=process_result.stdout.decode(),
             src_dir=src_dir,
         )
-    elif gs:
+    if gs:
         # Addons installation
         return get_git_commit_from_rest_api_for_addon_repo(
             addon_path=addon_path,
             src_dir=src_dir,
         )
     # During GRASS GIS compilation from source code without Git
-    else:
-        return get_git_commit_from_file(src_dir=src_dir)
+    return get_git_commit_from_file(src_dir=src_dir)
 
 
 html_page_footer_pages_path = os.getenv("HTML_PAGE_FOOTER_PAGES_PATH") or ""
@@ -849,10 +848,9 @@ def to_title(name):
     """Convert name of command class/family to form suitable for title"""
     if name == "raster3d":
         return "3D raster"
-    elif name == "postscript":
+    if name == "postscript":
         return "PostScript"
-    else:
-        return name.capitalize()
+    return name.capitalize()
 
 
 index_titles = {}


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/superfluous-else-return/

When there is an if with a return, the next `elif:` or `else:` can be flattened with one less nested level. This kind of early-return pattern is common in C#. Having simpler conditions that return, then the rest of flow continues otherwise