### PR TITLE
v.to.db: Fix resource Leak issue in update.c

### DIFF
--- a/vector/v.to.db/update.c
+++ b/vector/v.to.db/update.c
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <grass/dbmi.h>
 #include <grass/glocale.h>
+#include <grass/vector.h>
 #include "global.h"
 
 static int srch(const void *, const void *);

--- a/vector/v.to.db/update.c
+++ b/vector/v.to.db/update.c
@@ -297,6 +297,8 @@ int update(struct Map_info *Map)
 
     db_close_database_shutdown_driver(driver);
     db_free_string(&stmt);
+    Vect_destroy_field_info(Fi);
+    Vect_destroy_field_info(qFi);
 
     return 0;
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207709, 1207710)
Used existing function Vect_destroy_field_info() to fix the memory leak issue.