### PR TITLE
lib/vector/Vlib: Fix copy into buffer size issue in color_read.c

### DIFF
--- a/lib/vector/Vlib/color_read.c
+++ b/lib/vector/Vlib/color_read.c
@@ -49,7 +49,9 @@ int Vect_read_colors(const char *name, const char *mapset,
     if (colors)
         Rast_init_colors(colors);
 
-    strcpy(xname, name);
+    if (G_strlcpy(xname, name, sizeof(xname)) >= sizeof(xname)) {
+        G_fatal_error(_("Vector map name <%s> is too long"), name);
+    }
     mapset = G_find_vector(xname, mapset);
     if (!mapset)
         return -1;
@@ -58,12 +60,12 @@ int Vect_read_colors(const char *name, const char *mapset,
 
     if (strcmp(mapset, G_mapset()) == 0) {
         /* look for the regular color table */
-        sprintf(buf, "%s/%s", GV_DIRECTORY, name);
+        snprintf(buf, sizeof(buf), "%s/%s", GV_DIRECTORY, name);
         ret = Rast__read_colors(buf, GV_COLR_ELEMENT, mapset, colors);
     }
     else {
         /* look for secondary color table in current mapset */
-        sprintf(buf, "%s/%s", GV_COLR2_DIRECTORY, mapset);
+        snprintf(buf, sizeof(buf), "%s/%s", GV_COLR2_DIRECTORY, mapset);
         ret = Rast__read_colors(buf, name, G_mapset(), colors);
     }
     if (ret == -2)

--- a/lib/vector/Vlib/color_read.c
+++ b/lib/vector/Vlib/color_read.c
@@ -50,7 +50,8 @@ int Vect_read_colors(const char *name, const char *mapset,
         Rast_init_colors(colors);
 
     if (G_strlcpy(xname, name, sizeof(xname)) >= sizeof(xname)) {
-        G_fatal_error(_("Vector map name <%s> is too long"), name);
+        G_warning(_("Vector map name <%s> is too long"), name);
+        return -1;
     }
     mapset = G_find_vector(xname, mapset);
     if (!mapset)
@@ -60,12 +61,12 @@ int Vect_read_colors(const char *name, const char *mapset,
 
     if (strcmp(mapset, G_mapset()) == 0) {
         /* look for the regular color table */
-        snprintf(buf, sizeof(buf), "%s/%s", GV_DIRECTORY, name);
+        (void)snprintf(buf, sizeof(buf), "%s/%s", GV_DIRECTORY, name);
         ret = Rast__read_colors(buf, GV_COLR_ELEMENT, mapset, colors);
     }
     else {
         /* look for secondary color table in current mapset */
-        snprintf(buf, sizeof(buf), "%s/%s", GV_COLR2_DIRECTORY, mapset);
+        (void)snprintf(buf, sizeof(buf), "%s/%s", GV_COLR2_DIRECTORY, mapset);
         ret = Rast__read_colors(buf, name, G_mapset(), colors);
     }
     if (ret == -2)


### PR DESCRIPTION
This pull request resolves a buffer overflow issue detected by Coverity Scan (CID 1208238).
strcpy is replaced with G_strlcpy
sprintf is replaced with snprintf