### PR TITLE
doc: Ignore F401 in dialogs.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ per-file-ignores =
     man/build_html.py: E501
     imagery/i.atcorr/create_iwave.py: F632, F821, W293
     doc/python/m.distance.py: E501
-    doc/gui/wxpython/example/dialogs.py: F401
     gui/scripts/d.wms.py: E501
     gui/wxpython/image2target/*: F841, E722
     gui/wxpython/image2target/g.gui.image2target.py: E501, F841

--- a/doc/gui/wxpython/example/dialogs.py
+++ b/doc/gui/wxpython/example/dialogs.py
@@ -20,7 +20,7 @@ import wx
 # So we need to import it before any of the GUI code.
 # NOTE: in this particular case, we don't really need the grass library;
 # NOTE: we import it just for the side effects of gettext.install()
-import grass
+import grass  # noqa: F401
 
 from core import globalvar
 from gui_core.dialogs import SimpleDialog


### PR DESCRIPTION
`dialogs.py` has an instance of `F401` error for unused import of `grass` library. However as mentioned in the comment and post discussion with @wenzeslaus I decided it would be better to ignore this error for now in case it breaks any underlying dependencies regarding `gettext.install()`