### PR TITLE
checks: update .flake8 to reflect correct status in image2target

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -25,8 +25,7 @@ per-file-ignores =
     doc/python/m.distance.py: E501
     doc/gui/wxpython/example/dialogs.py: F401
     gui/scripts/d.wms.py: E501
-    gui/wxpython/image2target/*: F841, E722
-    gui/wxpython/image2target/g.gui.image2target.py: E501, F841
+    gui/wxpython/image2target/g.gui.image2target.py: E501
     gui/wxpython/modules/*: F841, E722
     gui/wxpython/nviz/*: F841, E266, E722, F403, F405
     gui/wxpython/photo2image/*: F841, E722, E265


### PR DESCRIPTION
The `.flake8` file had outdated details regarding flake8 errors in `image2target` folder. I updated the same after running the check on it