### PR TITLE
wxGUI: FIxed F841 in colorrules.py

### DIFF
--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -318,7 +318,9 @@ class RulesPanel:
                             int, self.ruleslines[item][self.attributeType].split(":")
                         )
                     except ValueError as e:
-                        message = _("Bad color format '%s'. Use color format '0:0:0'") % e
+                        message = (
+                            _("Bad color format '%s'. Use color format '0:0:0'") % e
+                        )
                     self.mainPanel.FindWindowById(item + 2000).SetValue((r, g, b))
                 else:
                     value = float(self.ruleslines[item][self.attributeType])

--- a/gui/wxpython/modules/colorrules.py
+++ b/gui/wxpython/modules/colorrules.py
@@ -318,7 +318,7 @@ class RulesPanel:
                             int, self.ruleslines[item][self.attributeType].split(":")
                         )
                     except ValueError as e:
-                        message = _("Bad color format. Use color format '0:0:0'")
+                        message = _("Bad color format '%s'. Use color format '0:0:0'") % e
                     self.mainPanel.FindWindowById(item + 2000).SetValue((r, g, b))
                 else:
                     value = float(self.ruleslines[item][self.attributeType])
@@ -410,7 +410,6 @@ class ColorTable(wx.Frame):
         if layer:
             mapLayer = self.layerTree.GetLayerInfo(layer, key="maplayer")
             name = mapLayer.GetName()
-            type = mapLayer.GetType()
             self.selectionInput.SetValue(name)
             self.inmap = name
 
@@ -1412,7 +1411,7 @@ class VectorColorTable(ColorTable):
             modul = "v.db.addcolumn"
         else:
             modul = "v.db.addcol"
-        ret = RunCommand(
+        RunCommand(
             modul,
             parent=self,
             map=self.inmap,
@@ -1430,7 +1429,7 @@ class VectorColorTable(ColorTable):
                 modul = "v.db.dropcolumn"
             else:
                 modul = "v.db.dropcol"
-            ret = RunCommand(
+            RunCommand(
                 modul,
                 map=self.inmap,
                 layer=self.properties["layer"],
@@ -1505,7 +1504,7 @@ class VectorColorTable(ColorTable):
                 modul = "v.db.addcolumn"
             else:
                 modul = "v.db.addcol"
-            ret = RunCommand(
+            RunCommand(
                 modul,
                 map=self.inmap,
                 layer=self.properties["layer"],


### PR DESCRIPTION
Made following modifications to fix `F841`
- Directly called `RunCommand` instead of using a variable
- Printed the error message `e`
- Removed local variable `type` which was unused