### PR TITLE
i.atcorr: fix out of bound access in trunca, os and iso

### DIFF
--- a/imagery/i.atcorr/computations.cpp
+++ b/imagery/i.atcorr/computations.cpp
@@ -444,10 +444,14 @@ void os(const double tamoy, const double trmoy, const double pizmoy,
     if (ntp == (snt - 1)) {
         /* compute position of the plane layer */
         double taup = tap + trp;
-        iplane = 0;
-        for (int i = 0; i <= ntp; i++)
+        iplane = -1;
+        for (int i = 0; i <= ntp; i++) {
             if (taup >= h[i])
                 iplane = i;
+        }
+        if (iplane == -1) {
+            G_fatal_error(_("Position of the plane layer could not be determined"));
+        }
 
         /* update the layer from the end to the position to update if necessary
          */

--- a/imagery/i.atcorr/computations.cpp
+++ b/imagery/i.atcorr/computations.cpp
@@ -102,14 +102,14 @@ double trunca()
     for (i = 0; i < 83; i++) {
         if (rmu[i] > 0.8)
             break;
-        k = i - 1;
+        k = i;
     }
 
     int kk = 0;
     for (i = 0; i < 83; i++) {
         if (rmu[i] > 0.94)
             break;
-        kk = i - 1;
+        kk = i;
     }
 
     double aa =
@@ -118,7 +118,7 @@ double trunca()
     double x1 = (double)(log10(sixs_trunc.pha[kk]));
     double x2 = (double)acos(rmu[kk]);
 
-    for (i = kk + 1; i < 83; i++) {
+    for (i = kk; i < 83; i++) {
         double a;
         if (fabs(rmu[i] - 1) <= 1e-08)
             a = x1 - aa * x2;
@@ -444,7 +444,7 @@ void os(const double tamoy, const double trmoy, const double pizmoy,
     if (ntp == (snt - 1)) {
         /* compute position of the plane layer */
         double taup = tap + trp;
-        iplane = -1;
+        iplane = 0;
         for (int i = 0; i <= ntp; i++)
             if (taup >= h[i])
                 iplane = i;
@@ -1005,7 +1005,7 @@ void iso(const double tamoy, const double trmoy, const double pizmoy,
     if (ntp == (snt - 1)) {
         /* compute position of the plane layer */
         double taup = tap + trp;
-        iplane = -1;
+        iplane = 0;
         for (int i = 0; i <= ntp; i++)
             if (taup >= h[i])
                 iplane = i;

--- a/imagery/i.atcorr/computations.cpp
+++ b/imagery/i.atcorr/computations.cpp
@@ -1009,10 +1009,14 @@ void iso(const double tamoy, const double trmoy, const double pizmoy,
     if (ntp == (snt - 1)) {
         /* compute position of the plane layer */
         double taup = tap + trp;
-        iplane = 0;
-        for (int i = 0; i <= ntp; i++)
+        iplane = -1;
+        for (int i = 0; i <= ntp; i++) {
             if (taup >= h[i])
                 iplane = i;
+        }
+        if (iplane == -1) {
+            G_fatal_error(_("Position of the plane layer could not be determined"));
+        }
 
         /* update the layer from the end to the position to update if necessary
          */

--- a/imagery/i.atcorr/computations.cpp
+++ b/imagery/i.atcorr/computations.cpp
@@ -450,7 +450,8 @@ void os(const double tamoy, const double trmoy, const double pizmoy,
                 iplane = i;
         }
         if (iplane == -1) {
-            G_fatal_error(_("Position of the plane layer could not be determined"));
+            G_fatal_error(
+                _("Position of the plane layer could not be determined"));
         }
 
         /* update the layer from the end to the position to update if necessary
@@ -1015,7 +1016,8 @@ void iso(const double tamoy, const double trmoy, const double pizmoy,
                 iplane = i;
         }
         if (iplane == -1) {
-            G_fatal_error(_("Position of the plane layer could not be determined"));
+            G_fatal_error(
+                _("Position of the plane layer could not be determined"));
         }
 
         /* update the layer from the end to the position to update if necessary


### PR DESCRIPTION
In `trunca()`, under 2 if conditionals (`if rumu[1] > 0.8 and rmu[1] > 0.94`), k and kk values are set to `-1` respectively. When these values are used to access an array, it leads to out of bound access, which is undefined behavior in c++.

Similarly in `os()` and `iso()`, if `taup < h[i]` for all values, iplane would still be `-1` and we would be accessing an array with this as an index, which is undefined behavior.

In both cases, to avoid that, set that index to zero.

This was found using cppcheck tool.