### PR TITLE
checks: Remove extra semicolons in r.terraflow

### DIFF
--- a/raster/r.terraflow/fill.cpp
+++ b/raster/r.terraflow/fill.cpp
@@ -518,7 +518,7 @@ void assignFinalDirections(AMI_STREAM<plateauStats> *statstr,
             continue;
         }
     }
-};
+}
 
 /* ********************************************************************** */
 class directionElevationMerger {

--- a/raster/r.terraflow/genericWindow.cpp
+++ b/raster/r.terraflow/genericWindow.cpp
@@ -36,4 +36,4 @@ void fillPit(ElevationWindow &win)
     if (win.get(4) < min) {
         win.set(4, min);
     }
-};
+}

--- a/raster/r.terraflow/sweep.cpp
+++ b/raster/r.terraflow/sweep.cpp
@@ -65,7 +65,7 @@ sweepOutput::sweepOutput()
 #ifdef OUTPUT_TCI
     tci = (tci_type)nodataType::ELEVATION_NODATA;
 #endif
-};
+}
 
 /* ------------------------------------------------------------ */
 /* computes output parameters of cell (i,j) given the flow value, the

--- a/raster/r.terraflow/weightWindow.cpp
+++ b/raster/r.terraflow/weightWindow.cpp
@@ -229,7 +229,7 @@ void weightWindow::compute(const dimension_type i, const dimension_type j,
         cout << form("%3.2f ", weight.get(l));
     cout << "]\n";
 #endif
-};
+}
 
 /* Find the dominant direction. Set corresponding weight to 1, and
    sets all other weights to 0. Set sumweight and sumcontour.*/


### PR DESCRIPTION
With GCC and -Werror=pedantic, the r.terraflow C++ code produces errors because extra semicolons are present after some function definitions. This removes the semincolons and I no longer get 'error: extra ;'.
