### PR TITLE
d.vect: Fix Resource Leak issue in attr.c

### DIFF
--- a/display/d.vect/attr.c
+++ b/display/d.vect/attr.c
@@ -40,7 +40,6 @@ int display_attr(struct Map_info *Map, int type, char *attrcol,
         Vect_destroy_cats_struct(Cats);
         return 1;
     }
- 
     driver = db_start_driver_open_database(fi->driver, fi->database);
     if (driver == NULL)
         G_fatal_error(_("Unable to open database <%s> by driver <%s>"),

--- a/display/d.vect/attr.c
+++ b/display/d.vect/attr.c
@@ -35,9 +35,12 @@ int display_attr(struct Map_info *Map, int type, char *attrcol,
     db_init_string(&text);
 
     fi = Vect_get_field(Map, lattr->field);
-    if (fi == NULL)
+    if (fi == NULL) {
+        Vect_destroy_line_struct(Points);
+        Vect_destroy_cats_struct(Cats);
         return 1;
-
+    }
+ 
     driver = db_start_driver_open_database(fi->driver, fi->database);
     if (driver == NULL)
         G_fatal_error(_("Unable to open database <%s> by driver <%s>"),
@@ -140,6 +143,7 @@ int display_attr(struct Map_info *Map, int type, char *attrcol,
     db_close_database_shutdown_driver(driver);
     Vect_destroy_line_struct(Points);
     Vect_destroy_cats_struct(Cats);
+    Vect_destroy_field_info(fi);
 
     return 0;
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207623, 1207625, 1207626)
Used existing function Vect_destroy_line_struct(), Vect_destroy_cats_struct(), Vect_destroy_field_info() to fix the memory leak issue.