### PR TITLE
v.colors: Fix Resource Leak issue in read_rgb.c

### DIFF
--- a/vector/v.colors/read_rgb.c
+++ b/vector/v.colors/read_rgb.c
@@ -64,4 +64,5 @@ void rgb2colr(struct Map_info *Map, int layer, const char *rgb_column,
         G_warning(_("%d invalid RGB color values skipped"), nskipped);
 
     db_close_database_shutdown_driver(driver);
+    Vect_destroy_field_info(fi);
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207628)
Used existing function Vect_destroy_field_info() to fix the memory leak issue.