### PR TITLE
v.to.db: Fix Resource Leak issue in areas.c

### DIFF
--- a/vector/v.to.db/areas.c
+++ b/vector/v.to.db/areas.c
@@ -111,5 +111,6 @@ int read_areas(struct Map_info *Map)
         G_percent(area_num, nareas, 2);
     }
 
+    Vect_destroy_cats_struct(Cats);
     return 0;
 }

--- a/vector/v.to.db/areas.c
+++ b/vector/v.to.db/areas.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <grass/glocale.h>
+#include <grass/vector.h>
 
 #include "global.h"
 


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1207638)
Used existing function Vect_destroy_cats_struct() to fix the memory leak issue.