### PR TITLE
ps.map: initialize variable contents before using them in get_ll_bounds

### DIFF
--- a/ps/ps.map/do_geogrid.c
+++ b/ps/ps.map/do_geogrid.c
@@ -300,6 +300,7 @@ void get_ll_bounds(double *w, double *e, double *s, double *n)
     double ew, ns;
     int first;
 
+    east = west = north = south = 0.0;
     e1 = PS.w.east;
     w1 = PS.w.west;
     n1 = PS.w.north;


### PR DESCRIPTION
In some situations, when some conditionals fails, we would be assigning uninitialized variables to values, which is undefined behavior. Fix that by assigning a value to the variables.

This was found using cppcheck tool.

Before the fix:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/4252be48-2b81-4d3a-b1f1-d6552b16d241">

After the fix:

<img width="613" alt="image" src="https://github.com/user-attachments/assets/9d82a302-1b1b-4839-859e-11bc44e4f361">
