### PR TITLE
r.carve: Fix resource leak issue in enforce_ds.c

### DIFF
--- a/raster/r.carve/enforce_ds.c
+++ b/raster/r.carve/enforce_ds.c
@@ -22,6 +22,7 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
+#include <grass/vector.h>
 #include "enforce.h"
 
 #ifndef MAX

--- a/raster/r.carve/enforce_ds.c
+++ b/raster/r.carve/enforce_ds.c
@@ -487,4 +487,6 @@ static void process_line_segment(const int npts, void *rbuf, Point2 *pgxypts,
         prevrow = row;
         prevcol = col;
     }
+    Vect_destroy_line_struct(points);
+    Vect_destroy_cats_struct(cats);
 }


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1208024, 1208023)
Used existing function Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix the memory leak issue.