### PR TITLE
v.kernel: Fix resource Leak issue in main.c

### DIFF
--- a/vector/v.kernel/main.c
+++ b/vector/v.kernel/main.c
@@ -769,7 +769,9 @@ double compute_all_net_distances(struct Map_info *In, struct Map_info *Net,
             G_debug(3, "  kk = %d", kk);
         }
     }
-
+    Vect_destroy_line_struct(APoints);
+    Vect_destroy_line_struct(BPoints);
+    Vect_destroy_boxlist(List);
     return (kk);
 }
 


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1208031, 1208032, 1208033)
Used existing function Vect_destroy_line_struct(), Vect_destroy_boxlist() to fix the memory leak issue.