### PR TITLE
v.net.timetable: Fix Resource Leak issue in main.c

### DIFF
--- a/vector/v.net.timetable/main.c
+++ b/vector/v.net.timetable/main.c
@@ -176,19 +176,18 @@ void write_subroute(struct segment *seg, struct line_pnts *line, int line_id)
     struct line_cats *Cats;
     struct ilist *list;
 
-    Points = Vect_new_line_struct();
     Cats = Vect_new_cats_struct();
-    list = Vect_new_list();
     r = seg->route;
 
     Vect_cat_set(Cats, 2, line_id);
 
     if (r < 0) {
         Vect_write_line(&Out, GV_LINE, line, Cats);
-        Vect_destroy_list(list);
-        Vect_destroy_line_struct(Points);
         return;
     }
+
+    Points = Vect_new_line_struct();
+    list = Vect_new_list();
 
     for (i = 0; i < nnodes; i++)
         edges[i] = 0;

--- a/vector/v.net.timetable/main.c
+++ b/vector/v.net.timetable/main.c
@@ -185,6 +185,8 @@ void write_subroute(struct segment *seg, struct line_pnts *line, int line_id)
 
     if (r < 0) {
         Vect_write_line(&Out, GV_LINE, line, Cats);
+        Vect_destroy_list(list);
+        Vect_destroy_line_struct(Points);
         return;
     }
 


### PR DESCRIPTION
This pull request addresses resource leak issue identified by coverity scan (CID : 1208053, 1208054)
Used existing function Vect_destroy_line_struct(), Vect_destroy_list() to fix the memory leak issue.