### PR TITLE
r.mask.status: fix null pointer dereference and false positive string overflow

### DIFF
--- a/lib/raster/mask_info.c
+++ b/lib/raster/mask_info.c
@@ -124,7 +124,7 @@ int Rast__mask_info(char *name, char *mapset)
     char rname[GNAME_MAX], rmapset[GMAPSET_MAX];
 
     strcpy(rname, "MASK");
-    strcpy(rmapset, G_mapset());
+    (void)G_strlcpy(rmapset, G_mapset(), GMAPSET_MAX);
 
     if (!G_find_raster(rname, rmapset))
         return -1;

--- a/raster/r.mask.status/main.c
+++ b/raster/r.mask.status/main.c
@@ -109,6 +109,8 @@ int report_status(struct Parameters *params)
         else
             json_object_set_null(root_object, "is_reclass_of");
         char *serialized_string = json_serialize_to_string_pretty(root_value);
+        if (!serialized_string)
+            G_fatal_error(_("Failed to initialize pretty JSON string."));
         puts(serialized_string);
         json_free_serialized_string(serialized_string);
         json_value_free(root_value);


### PR DESCRIPTION
Fixes two new issues reported by Coverity Scan:

- Handles case of unsuccessful creation of json string
- Silences false positive issue for string copy operation to buffer of size GMAPSET_MAX from G_mapset()