### PR TITLE
gui: Solve a recursion error in gui/wxpython/lmgr/giface.py

### DIFF
--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -54,7 +54,9 @@ class LayerList:
         self._tree = tree
 
     def __len__(self):
-        return len(list(self))
+        # The list constructor calls __len__ as an optimization if available,
+        # causing a RecursionError
+        return len([layer for layer in self])  # noqa: C416
 
     def __iter__(self):
         """Iterates over the contents of the list."""


### PR DESCRIPTION
Fixes https://github.com/OSGeo/grass/issues/4485#issuecomment-2407124541

The RecursionError is probably caused by https://github.com/OSGeo/grass/pull/4453, where one of these RecursionErrors was caught in tests, and fixed in a commit in that PR (https://github.com/OSGeo/grass/pull/4453/commits/f7874f63477585d2d936b71fbaac119740abb49c). The exact reason causing the failure wasn't known, so fixing the method `mapsets` that might have been called elsewhere was the correct thing. There wasn't the same pattern in the PR to be fixed.

However, with that comment, it is now clear that it is calling `list()` inside `__len__()` of that same object that is problematic. After reading a bit, the list constructor gets the length or the length hint (when available) as an optimization to allocate memory.
https://stackoverflow.com/questions/41474829/why-does-list-ask-about-len https://github.com/python/cpython/blob/67f6e08147bc005e460d82fcce85bf5d56009cf5/Objects/listobject.c#L1164

I've worked on creating a repro case and filed an issue to Ruff https://github.com/astral-sh/ruff/issues/13752 about that, as the explanations on why the rule was considered an unsafe fix was misleading, as it only concerned lost comments.