### PR TITLE
style: Ignore deprecated PT004 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ ignore = [
     "PLW1641", # eq-without-hash
     "PLW2901", # redefined-loop-name
     "PLW3201", # bad-dunder-method-name
+    "PT004",   # pytest-missing-fixture-name-underscore # deprecated, so doesn't appear with --preview
     "PTH100",  # os-path-abspath
     "PTH101",  # os-chmod
     "PTH102",  # os-mkdir


### PR DESCRIPTION
Ruff rule PT004 is deprecated, so doesn't run with --preview flag, but still appears without the --preview flag. Since the only error won't be fixed, ignore that rule for the time being.
This means that PR https://github.com/OSGeo/grass/pull/4452 was incomplete in a sense

See https://github.com/astral-sh/ruff/pull/12837 and https://github.com/astral-sh/ruff/issues/8796