### PR TITLE
wxGUI: Fixed F841 in modules/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,7 +24,7 @@ per-file-ignores =
     doc/python/m.distance.py: E501
     gui/scripts/d.wms.py: E501
     gui/wxpython/image2target/g.gui.image2target.py: E501
-    gui/wxpython/modules/*: F841, E722
+    gui/wxpython/modules/*: E722
     gui/wxpython/nviz/*: F841, E266, E722, F403, F405
     gui/wxpython/photo2image/*: F841, E722, E265
     gui/wxpython/photo2image/g.gui.photo2image.py: E501, F841

--- a/gui/wxpython/modules/histogram.py
+++ b/gui/wxpython/modules/histogram.py
@@ -496,7 +496,6 @@ class HistogramFrame(wx.Frame):
 
     def PrintMenu(self, event):
         """Print options and output menu"""
-        point = wx.GetMousePosition()
         printmenu = Menu()
         # Add items to the menu
         setup = wx.MenuItem(printmenu, id=wx.ID_ANY, text=_("Page setup"))

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -461,7 +461,6 @@ class GdalImportDialog(ImportDialog):
         dsn = self.dsnInput.GetDsn()
         if not dsn:
             return
-        ext = self.dsnInput.GetFormatExt()
 
         for layer, output, listId in data:
             userData = {}
@@ -612,8 +611,10 @@ class OgrImportDialog(ImportDialog):
         if data is None:
             return
 
+        _ = ""
+
         if not data:
-            GMessage(_("No layers selected. Operation canceled."), parent=self)
+            GMessage(parent=self, message=_("No layers selected. Operation canceled."))
             return
 
         if not self._validateOutputMapName():
@@ -644,13 +645,7 @@ class OgrImportDialog(ImportDialog):
             if ext and layer.rfind(ext) > -1:
                 layer = layer.replace("." + ext, "")
             if "|" in layer:
-                layer, geometry = layer.split("|", 1)
-            else:
-                geometry = None
-
-                # TODO: v.import has no geometry option
-                # if geometry:
-                #    cmd.append('geometry=%s' % geometry)
+                layer, _ = layer.split("|", 1)
 
             cmd = self.getSettingsPageCmd()
             cmd.append("input=%s" % dsn)

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -647,7 +647,7 @@ class OgrImportDialog(ImportDialog):
             if ext and layer.rfind(ext) > -1:
                 layer = layer.replace("." + ext, "")
             if "|" in layer:
-                layer, _ = layer.split("|", 1)
+                layer = layer.split("|", 1)[0]
 
             cmd = self.getSettingsPageCmd()
             cmd.append("input=%s" % dsn)

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -611,6 +611,8 @@ class OgrImportDialog(ImportDialog):
         if data is None:
             return
 
+        # Error: local variable '_' defined as a builtin referenced before assignment
+        # This error is only coming up in this file.
         _ = ""
 
         if not data:

--- a/gui/wxpython/modules/import_export.py
+++ b/gui/wxpython/modules/import_export.py
@@ -611,10 +611,6 @@ class OgrImportDialog(ImportDialog):
         if data is None:
             return
 
-        # Error: local variable '_' defined as a builtin referenced before assignment
-        # This error is only coming up in this file.
-        _ = ""
-
         if not data:
             GMessage(parent=self, message=_("No layers selected. Operation canceled."))
             return

--- a/gui/wxpython/modules/mapsets_picker.py
+++ b/gui/wxpython/modules/mapsets_picker.py
@@ -12,7 +12,7 @@ from gui_core.preferences import MapsetAccess  # noqa: E402
 
 
 def main():
-    app = wx.App()
+    wx.App()
 
     dlg = MapsetAccess(parent=None)
     dlg.CenterOnScreen()


### PR DESCRIPTION
Fixed all F841 errors in modules/
- removed `point`, `ext` and `geometry` variable which were not being used
- called the `App()` constructor directly
- One issue that popped up was while running `pre-commit` on `import_export.py`, This error constantly popped up in `ruff` checks
```
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1

gui/wxpython/modules/import_export.py:615:30: F823 Local variable `_` referenced before assignment
    |
614 |         if not data:
615 |             GMessage(message=_("No layers selected. Operation canceled."), parent=self)
    |                              ^ F823
616 |             return
    |

Found 1 error.
```

I didn't find a fix for it currently so I just referenced the `_` locally in the function