### PR TITLE
doc: Use lowercase for mask

### DIFF
--- a/imagery/i.segment/i.segment.html
+++ b/imagery/i.segment/i.segment.html
@@ -118,7 +118,7 @@ resampling.
 <h3>Boundary Constraints</h3>
 Boundary constraints limit the adjacency of pixels and segments.
 Each unique value present in the <b>bounds</b> raster are
-considered as a MASK. Thus no segments in the final segmentated map
+considered as a mask. Thus, no segments in the final segmented map
 will cross a boundary, even if their spectral data is very similar.
 
 <h3>Minimum Segment Size</h3>

--- a/imagery/i.segment/iseg.h
+++ b/imagery/i.segment/iseg.h
@@ -118,7 +118,7 @@ struct globals {
 
     /* processing flags */
     FLAG *candidate_flag,
-        *null_flag; /*TODO, need some way to remember MASK/NULL values.  Was
+        *null_flag; /*TODO, need some way to remember mask/NULL values.  Was
                        using -1, 0, 1 in int array.  Better to use 2 FLAG
                        structures, better readability? */
 

--- a/ps/ps.map/r_instructions.c
+++ b/ps/ps.map/r_instructions.c
@@ -29,7 +29,7 @@ static char *help[] = {
     "read       unix-file             eps        Encapsulated PostScript file",
     "border     [y|n]                 mapinfo    map information",
     "window     region definition     region     region definition",
-    "maskcolor  MASK color",
+    "maskcolor  mask color",
     "rectangle  east north east north",
     "scale      1:#|# inches|# panels|1 inch = # miles",
     "outline    map composition outline",

--- a/raster/r.resamp.interp/r.resamp.interp.html
+++ b/raster/r.resamp.interp/r.resamp.interp.html
@@ -28,7 +28,7 @@ r.resamp.rst</em>) resample the map to match the current region settings.
 <p>Note that for bilinear, bicubic and lanczos interpolation,
 cells of the output raster that cannot be bounded by the appropriate number
 of input cell centers are set to NULL (NULL propagation). This could occur
-due to the input cells being outside the current region, being NULL or MASKed.
+due to the input cells being outside the current region, being NULL or masked.
 
 
 <p>For longitude-latitude coordinate reference systems,

--- a/raster/r.topidx/r.topidx.html
+++ b/raster/r.topidx/r.topidx.html
@@ -10,12 +10,14 @@ map from elevation map where
   <dd>the local surface topographic slope (delta vertical) / (delta
       horizontal).</dd>
 </dl>
-<p>Input maps may have NULL values.  For example, if you have a MASK for a
-watershed (basin map from <em>r.water.outlet</em>), the following command will
-create a masked elevation map (belev):
+<p>Input maps may have NULL values. For example, if you have a raster mask set
+for a watershed (using basin map from <em>r.water.outlet</em>), the following
+command will create a masked elevation map (belev):
+
 <div class="code"><pre>
 r.mapcalc "belev = if(isnull(basin), basin, elev)"
 </pre></div>
+
 <p>
 <em>r.stats -Anc</em> prints out averaged statistics for topographic index.
 


### PR DESCRIPTION
Again, use lowercase mask and other wording instead of MASK when talking about masking, similar to #4401 and #4495.

It also adjusts the wording in r.topidx and i.segment.