### PR TITLE
r.in.gridatb: Dereference before null check

### DIFF
--- a/raster/r.in.gridatb/file_io.c
+++ b/raster/r.in.gridatb/file_io.c
@@ -12,6 +12,9 @@ void rdwr_gridatb(void)
     float idx;
 
     fp = fopen(file, "r");
+    if (!fp) {
+        G_fatal_error(_("Unable to open file: %s"), file);
+    }
 
     buf[0] = 0;
     if (fscanf(fp, "%[^\n]", buf) != 1)


### PR DESCRIPTION
The pull request addresses the issue identified by coverity scan (CID: 1208191)
fp = fopen(file, "r");
The fopen might fail in that case it will already be null.