### PR TITLE
GUI: EPSG code source: replace epsg.io with spatialreference.org

### DIFF
--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1699,7 +1699,7 @@ class EPSGPage(TitledPage):
             self.EnableNext(False)
         else:
             self.tlink.SetURL(
-                str("https://spatialreference.org/ref/epsg/?q={0}/".format(value))
+                f"https://spatialreference.org/ref/?&search={value}"
             )
             data = self.epsglist.Search(index=[0, 1, 2], pattern=value, firstOnly=False)
             if data:

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1604,7 +1604,7 @@ class EPSGPage(TitledPage):
             self, data=None, columns=[_("Code"), _("Description"), _("Parameters")]
         )
 
-        # A hyperlink to an CRS database
+        # A hyperlink to a CRS database (PROJ related)
         self.tlink = HyperlinkCtrl(
             self,
             id=wx.ID_ANY,
@@ -1698,9 +1698,7 @@ class EPSGPage(TitledPage):
             self.OnBrowseCodes(None)
             self.EnableNext(False)
         else:
-            self.tlink.SetURL(
-                f"https://spatialreference.org/ref/?&search={value}"
-            )
+            self.tlink.SetURL(f"https://spatialreference.org/ref/?&search={value}")
             data = self.epsglist.Search(index=[0, 1, 2], pattern=value, firstOnly=False)
             if data:
                 index = 0

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1604,7 +1604,7 @@ class EPSGPage(TitledPage):
             self, data=None, columns=[_("Code"), _("Description"), _("Parameters")]
         )
 
-        # spatialreference.org hyperlink
+        # A hyperlink to an CRS database
         self.tlink = HyperlinkCtrl(
             self,
             id=wx.ID_ANY,

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1604,9 +1604,12 @@ class EPSGPage(TitledPage):
             self, data=None, columns=[_("Code"), _("Description"), _("Parameters")]
         )
 
-        # epsg.io hyperlink
+        # spatialreference.org hyperlink
         self.tlink = HyperlinkCtrl(
-            self, id=wx.ID_ANY, label="epsg.io", url="https://epsg.io/"
+            self,
+            id=wx.ID_ANY,
+            label="spatialreference.org",
+            url="https://spatialreference.org/",
         )
         self.tlink.SetNormalColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
         self.tlink.SetVisitedColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
@@ -1688,14 +1691,16 @@ class EPSGPage(TitledPage):
     def OnTextChange(self, event):
         value = self.searchb.GetValue()
         if value == "":
-            self.tlink.SetURL("https://epsg.io/")
+            self.tlink.SetURL("https://spatialreference.org/")
             self.epsgcode = None
             self.epsgdesc = self.epsgparams = ""
             self.searchb.ChangeValue("")
             self.OnBrowseCodes(None)
             self.EnableNext(False)
         else:
-            self.tlink.SetURL(str("https://epsg.io/?q={0}".format(value)))
+            self.tlink.SetURL(
+                str("https://spatialreference.org/ref/epsg/?q={0}/".format(value))
+            )
             data = self.epsglist.Search(index=[0, 1, 2], pattern=value, firstOnly=False)
             if data:
                 index = 0

--- a/lib/init/helptext.html
+++ b/lib/init/helptext.html
@@ -62,7 +62,7 @@ projections.
 <h3>Creating a New project with the Project Wizard</h3>
 <p>
 If you know the CRS of your data or study area,
-you can fill <a href="https://epsg.io">EPSG code</a>
+you can fill <a href="https://spatialreference.org/">EPSG code</a>
 or description and Project Wizard finds appropriate CRS from a predefined list
 of projections.
 
@@ -97,4 +97,4 @@ See <a href="grass.html">examples</a> of running GRASS GIS from a command line.
 </em>
 
 <p>
- <a href="https://epsg.io/">List of EPSG codes</a> (Database of worldwide coordinate systems)
+ <a href="https://spatialreference.org/">List of EPSG codes</a> (Database of worldwide coordinate systems)

--- a/lib/init/helptext.html
+++ b/lib/init/helptext.html
@@ -97,4 +97,6 @@ See <a href="grass.html">examples</a> of running GRASS GIS from a command line.
 </em>
 
 <p>
- <a href="https://spatialreference.org/">List of EPSG codes</a> (Database of worldwide coordinate systems)
+ <a href="https://spatialreference.org/">List of EPSG codes</a> (Database of worldwide coordinate systems),
+ <a href="https://crs-explorer.proj.org/">CRS Explorer - PROJ codes</a>, and
+ <a href="https://epsg.org/">EPSG Geodetic Parameter Dataset</a>


### PR DESCRIPTION
As epsg.io is partially outdated (see [source](https://github.com/maptiler/epsg.io/issues/171) and related) and PROJ is our engine anyway, this PR switches the references in the GUI to https://spatialreference.org.

![image](https://github.com/user-attachments/assets/5c9ba4a6-60fc-49d4-8f29-eeb415153c64)
