### PR TITLE
docs: add intro text to imageryintro.html

### DIFF
--- a/gui/wxpython/gmodeler/g.gui.gmodeler.html
+++ b/gui/wxpython/gmodeler/g.gui.gmodeler.html
@@ -466,7 +466,7 @@ r.colors = map = %map color = ndvi
 
 <p>
 See also selected user models available from
-<a href="https://grass.osgeo.org/grass78/manuals/addons/">GRASS Addons repository</a>.
+<a href="https://grass.osgeo.org/grass8/manuals/addons/">GRASS Addons repository</a>.
 
 <p>
 See also

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -2,18 +2,19 @@
 <!-- meta page index: imagery -->
 <h3>Image processing in general</h3>
 
-GRASS GIS provides a powerful suite of tools for processing and
-analyzing geospatial raster data, including satellite imagery and
-aerial photography. Image processing in GRASS GIS supports a wide
-range of preprocessing operations, such as import, georeferencing,
+GRASS GIS provides a powerful suite of tools for the processing and
+analysis of geospatial raster data, including satellite imagery and
+aerial photography. Its image processing capabilities encompass a broad
+range of preprocessing operations, such as data import, georeferencing,
 radiometric calibration and atmospheric correction. It is particularly
-suited for handling Earth observation data, allowing users to analze
-multispectral and temporal datasets. GRASS GIS supports image classification,
-sensor fusion, point cloud statistics and more. From  to the calculation
-of vegetation indices, it enables the analysis of environmental,
-agricultural, and land cover dynamics. Numerous
+suited for handling Earth observation data, enabling the analysis of
+multispectral and temporal datasets. GRASS GIS supports advanced
+functionalities such as image classification, sensor fusion, and point
+cloud statistics. The calculation of vegetation indices further enables
+analyses of environmental, agricultural, and land cover dynamics. An
+extensive collection of
 <a href="https://grass.osgeo.org/grass8/manuals/addons/#i">addons</a>
-are available as well.
+further enhances its analytical capabilities.
 
 <b>Digital numbers and physical values (reflection/radiance-at-sensor):</b>
 <p>

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -14,7 +14,7 @@ cloud statistics. The calculation of vegetation indices further enables
 analyses of environmental, agricultural, and land cover dynamics. An
 extensive collection of
 <a href="https://grass.osgeo.org/grass8/manuals/addons/#i">addons</a>
-further enhances its analytical capabilities.
+further enhances its image processing capabilities.
 
 <b>Digital numbers and physical values (reflection/radiance-at-sensor):</b>
 <p>

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -6,7 +6,7 @@ GRASS GIS provides a powerful suite of tools for the processing and
 analysis of geospatial raster data, including satellite imagery and
 aerial photography. Its image processing capabilities encompass a broad
 range of preprocessing operations, such as data import, georeferencing,
-radiometric calibration and atmospheric correction. It is particularly
+radiometric calibration, and atmospheric correction. It is particularly
 suited for handling Earth observation data, enabling the analysis of
 multispectral and temporal datasets. GRASS GIS supports advanced
 functionalities such as image classification, sensor fusion, and point
@@ -14,7 +14,8 @@ cloud statistics. The calculation of vegetation indices further enables
 analyses of environmental, agricultural, and land cover dynamics. An
 extensive collection of
 <a href="https://grass.osgeo.org/grass8/manuals/addons/#i">addons</a>
-further enhances its image processing capabilities.
+further enhances its image processing capabilities, particularly in the
+context of Earth observation and remote sensing applications.
 
 <b>Digital numbers and physical values (reflection/radiance-at-sensor):</b>
 <p>

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -2,6 +2,19 @@
 <!-- meta page index: imagery -->
 <h3>Image processing in general</h3>
 
+GRASS GIS provides a powerful suite of tools for processing and
+analyzing geospatial raster data, including satellite imagery and
+aerial photography. Image processing in GRASS GIS supports a wide
+range of preprocessing operations, such as import, georeferencing,
+radiometric calibration and atmospheric correction. It is particularly
+suited for handling Earth observation data, allowing users to analze
+multispectral and temporal datasets. GRASS GIS supports image classification,
+sensor fusion, point cloud statistics and more. From  to the calculation
+of vegetation indices, it enables the analysis of environmental,
+agricultural, and land cover dynamics. Numerous
+<a href="https://grass.osgeo.org/grass8/manuals/addons/#i">addons</a>
+are available as well.
+
 <b>Digital numbers and physical values (reflection/radiance-at-sensor):</b>
 <p>
 Satellite imagery is commonly stored in Digital Numbers (DN) for


### PR DESCRIPTION
This PR adds an overview text to `imagery/imageryintro.html` including a link to addons to not start this intro text without context.

(aside, addons URL fix in `g.gui.gmodeler.html`)