### PR TITLE
wxGUI: Fixed F841 in mapwindow.py

### DIFF
--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -412,7 +412,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         Debug.msg(1, "GLCanvas.OnPaint()")
 
         self.render["overlays"] = True
-        dc = wx.PaintDC(self)
+        _ = wx.PaintDC(self)
         self.DoPaint()
 
     def DoPaint(self):
@@ -1438,7 +1438,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
                 GError(parent=self, message=e.value)
 
         if force and self.baseId > 0:  # unload base surface when quitting
-            ret = self._display.UnloadSurface(self.baseId)
+            self._display.UnloadSurface(self.baseId)
             self.baseId = -1
         if update:
             self.lmgr.nviz.UpdateSettings()
@@ -2134,10 +2134,10 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         #
         sliceId = 0
         for slice in data["slice"]:
-            ret = self._display.AddSlice(id, slice_id=sliceId)
+            self._display.AddSlice(id, slice_id=sliceId)
             if "update" in slice["position"]:
                 pos = slice["position"]
-                ret = self._display.SetSlicePosition(
+                self._display.SetSlicePosition(
                     id,
                     sliceId,
                     pos["x1"],

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -412,7 +412,7 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
         Debug.msg(1, "GLCanvas.OnPaint()")
 
         self.render["overlays"] = True
-        _ = wx.PaintDC(self)
+        wx.PaintDC(self)
         self.DoPaint()
 
     def DoPaint(self):


### PR DESCRIPTION
Fixed unused variables in `mapwindow.py`
- removed `dc` and `ret` and directly called the contructors