### PR TITLE
wxGUI: Fixed F405 in psmap/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -28,7 +28,7 @@ per-file-ignores =
     gui/wxpython/nviz/*: F841, E266, E722, F403, F405
     gui/wxpython/photo2image/*: F841, E722, E265
     gui/wxpython/photo2image/g.gui.photo2image.py: E501, F841
-    gui/wxpython/psmap/*: F841, E266, E722, F403
+    gui/wxpython/psmap/*: F841, E266, E722
     gui/wxpython/vdigit/*: F841, E722, F405, F403
     gui/wxpython/vnet/*: F841
     gui/wxpython/wxgui.py: F841

--- a/.flake8
+++ b/.flake8
@@ -28,7 +28,7 @@ per-file-ignores =
     gui/wxpython/nviz/*: F841, E266, E722, F403, F405
     gui/wxpython/photo2image/*: F841, E722, E265
     gui/wxpython/photo2image/g.gui.photo2image.py: E501, F841
-    gui/wxpython/psmap/*: F841, E266, E722, F405, F403
+    gui/wxpython/psmap/*: F841, E266, E722, F403
     gui/wxpython/vdigit/*: F841, E722, F405, F403
     gui/wxpython/vnet/*: F841
     gui/wxpython/wxgui.py: F841

--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -52,7 +52,7 @@ else:
 
 import grass.script as gs
 from core.gcmd import GError, GMessage, RunCommand
-from core.utils import PilImageToWxImage
+from core.utils import PilImageToWxImage, cmp
 from dbmgr.vinfo import VectorDBInfo
 from gui_core.dialogs import SymbolDialog
 from gui_core.gselect import Select
@@ -4115,26 +4115,6 @@ class LegendDialog(PsmapDialog):
             self.minText.Enable()
             self.maxText.Enable()
 
-    def Cmp(self, item1, item2):
-        """
-        Args:
-            item1 (int): ID of the first item.
-            item2 (int): ID of the second item.
-
-        Returns:
-            int: -1 if item1 < item2, 1 if item1 > item2, 0 if equal.
-        """
-        # Retrieve the data associated with each item
-        data1 = self.vectorListCtrl.GetItemData(item1)
-        data2 = self.vectorListCtrl.GetItemData(item2)
-
-        # Compare the data
-        if data1 < data2:
-            return -1
-        if data1 > data2:
-            return 1
-        return 0
-
     def OnUp(self, event):
         """Moves selected map up, changes order in vector legend"""
         if self.vectorListCtrl.GetFirstSelected() != -1:
@@ -4144,7 +4124,7 @@ class LegendDialog(PsmapDialog):
                 idx2 = self.vectorListCtrl.GetItemData(pos - 1) + 1
                 self.vectorListCtrl.SetItemData(pos, idx1)
                 self.vectorListCtrl.SetItemData(pos - 1, idx2)
-                self.vectorListCtrl.SortItems(self.Cmp)
+                self.vectorListCtrl.SortItems(cmp)
                 if pos > 0:
                     selected = pos - 1
                 else:
@@ -4161,7 +4141,7 @@ class LegendDialog(PsmapDialog):
                 idx2 = self.vectorListCtrl.GetItemData(pos + 1) - 1
                 self.vectorListCtrl.SetItemData(pos, idx1)
                 self.vectorListCtrl.SetItemData(pos + 1, idx2)
-                self.vectorListCtrl.SortItems(self.Cmp)
+                self.vectorListCtrl.SortItems(cmp)
                 if pos < self.vectorListCtrl.GetItemCount() - 1:
                     selected = pos + 1
                 else:

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -16,10 +16,9 @@ This program is free software under the GNU General Public License
 """
 
 import os
-import sys
-
 import queue as Queue
-from math import sin, cos, pi, sqrt
+import sys
+from math import cos, pi, sin, sqrt
 
 import wx
 
@@ -29,25 +28,51 @@ except ImportError:
     import wx.lib.flatnotebook as FN
 
 import grass.script as gs
-
 from core import globalvar
-from gui_core.menu import Menu
-from core.gconsole import CmdThread, EVT_CMD_DONE
-from psmap.toolbars import PsMapToolbar
-from core.gcmd import RunCommand, GError, GMessage
+from core.gcmd import GError, GMessage, RunCommand
+from core.gconsole import EVT_CMD_DONE, CmdThread
 from core.settings import UserSettings
 from core.utils import PilImageToWxImage
-from gui_core.forms import GUI
-from gui_core.widgets import GNotebook
 from gui_core.dialogs import HyperlinkDialog
+from gui_core.forms import GUI
 from gui_core.ghelp import ShowAboutDialog
-from gui_core.wrap import ClientDC, PseudoDC, Rect, StockCursor, EmptyBitmap
-from psmap.menudata import PsMapMenuData
+from gui_core.menu import Menu
 from gui_core.toolbars import ToolSwitcher
+from gui_core.widgets import GNotebook
+from gui_core.wrap import ClientDC, EmptyBitmap, PseudoDC, Rect, StockCursor
 
-from psmap.dialogs import *
-from psmap.instructions import *
-from psmap.utils import *
+from psmap.dialogs import (
+    ImageDialog,
+    LabelsDialog,
+    LegendDialog,
+    MainVectorDialog,
+    MapDialog,
+    MapinfoDialog,
+    NorthArrowDialog,
+    PageSetupDialog,
+    PointDialog,
+    RasterDialog,
+    RectangleDialog,
+    ScalebarDialog,
+    TextDialog,
+)
+from psmap.instructions import InitMap, Instruction, NewId, SetResolution, PageSetup
+from psmap.menudata import PsMapMenuData
+from psmap.toolbars import PsMapToolbar
+from psmap.utils import (
+    AutoAdjust,
+    ComputeSetRegion,
+    GetMapBounds,
+    PaperMapCoordinates,
+    PILImage,
+    Rect2D,
+    Rect2DPP,
+    Rect2DPS,
+    UnitConversion,
+    convertRGB,
+    havePILImage,
+    projInfo,
+)
 
 
 class PsMapFrame(wx.Frame):

--- a/gui/wxpython/psmap/instructions.py
+++ b/gui/wxpython/psmap/instructions.py
@@ -35,17 +35,27 @@ This program is free software under the GNU General Public License
 import os
 import string
 from math import ceil
-from time import strftime, localtime
+from time import localtime, strftime
 
-import wx
 import grass.script as gs
-from grass.script.task import cmdlist_to_tuple
-
+import wx
 from core.gcmd import GError, GMessage, GWarning
 from core.utils import GetCmdString
 from dbmgr.vinfo import VectorDBInfo
+from grass.script.task import cmdlist_to_tuple
 from gui_core.wrap import NewId as wxNewId
-from psmap.utils import *
+
+from psmap.utils import (  # Add any additional required names from psmap.utils here
+    BBoxAfterRotation,
+    GetMapBounds,
+    PaperMapCoordinates,
+    Rect2D,
+    Rect2DPP,
+    SetResolution,
+    UnitConversion,
+    getRasterType,
+    projInfo,
+)
 
 
 def NewId():


### PR DESCRIPTION
Following changes were made to fix F405 in `psmap/`
- removed `* imports`
- ran `isort` to sort all the imports
- `cmp` function was not working post doing explicit import with the error `gui/wxpython/psmap/dialogs.py:4127:47: F821 undefined name 'cmp'` - On looking more at this, I found this was removed in python3 and required an explicit comparison function. Hence I defined an explicit comparison function and referenced that instead.