### PR TITLE
wxGUI: Fixed unused variable F841

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -31,7 +31,6 @@ per-file-ignores =
     gui/wxpython/psmap/*: F841, E266, E722, F405, F403
     gui/wxpython/vdigit/*: F841, E722, F405, F403
     gui/wxpython/vnet/*: F841
-    gui/wxpython/wxgui.py: F841
     gui/wxpython/animation/g.gui.animation.py: E501
     gui/wxpython/tplot/frame.py: F841, E722
     gui/wxpython/tplot/g.gui.tplot.py: E501

--- a/gui/wxpython/wxgui.py
+++ b/gui/wxpython/wxgui.py
@@ -164,7 +164,7 @@ def main(argv=None):
     app = GMApp(workspaceFile)
 
     # suppress wxPython logs
-    q = wx.LogNull()
+    wx.LogNull()
     set_raise_on_error(True)
 
     # register GUI PID


### PR DESCRIPTION
Fixed `F841: unused variable` in `wxgui.py` by directly calling the constructor