### PR TITLE
style: Enable checking for pep8-naming (N) rules with ruff, fix N804, N805 and N813

### DIFF
--- a/gui/wxpython/mapswipe/frame.py
+++ b/gui/wxpython/mapswipe/frame.py
@@ -545,15 +545,15 @@ class SwipeMapPanel(DoubleMapPanel):
             we are pasting together 2 rendered images, so
             we need to know when both are finished."""
 
-            def __init__(self2):
+            def __init__(self2):  # noqa: N805
                 self2.called = 0
 
-            def __call__(self2):
+            def __call__(self2):  # noqa: N805
                 self2.called += 1
                 if self2.called == 2:
                     self2.process()
 
-            def process(self2):
+            def process(self2):  # noqa: N805
                 # create empty white image  - needed for line
                 im = wx.Image(width, height)
                 im.Replace(0, 0, 0, 255, 255, 255)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ ignore = [
     "N805",    # invalid-first-argument-name-for-method
     "N806",    # non-lowercase-variable-in-function
     "N812",    # lowercase-imported-as-non-lowercase
-    "N813",    # camelcase-imported-as-lowercase
     "N814",    # camelcase-imported-as-constant
     "N815",    # mixed-case-variable-in-class-scope
     "N816",    # mixed-case-variable-in-global-scope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ ignore = [
     "N801",    # invalid-class-name
     "N802",    # invalid-function-name
     "N803",    # invalid-argument-name
-    "N804",    # invalid-first-argument-name-for-class-method
     "N805",    # invalid-first-argument-name-for-method
     "N806",    # non-lowercase-variable-in-function
     "N812",    # lowercase-imported-as-non-lowercase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ select = [
     "INT",    # flake8-gettext (INT)
     "ISC",    # flake8-implicit-str-concat (ISC)
     "LOG",    # flake8-logging (LOG)
+    "N",      # pep8-naming (N)
     "NPY",    # NumPy-specific rules (NPY)
     "PERF",   # Perflint (PERF)
     "PGH",    # pygrep-hooks (PGH)
@@ -145,6 +146,19 @@ ignore = [
     "FBT003",  # boolean-positional-value-in-call
     "I001",    # unsorted-imports
     "ISC003",  # explicit-string-concatenation
+    "N801",    # invalid-class-name
+    "N802",    # invalid-function-name
+    "N803",    # invalid-argument-name
+    "N804",    # invalid-first-argument-name-for-class-method
+    "N805",    # invalid-first-argument-name-for-method
+    "N806",    # non-lowercase-variable-in-function
+    "N812",    # lowercase-imported-as-non-lowercase
+    "N813",    # camelcase-imported-as-lowercase
+    "N814",    # camelcase-imported-as-constant
+    "N815",    # mixed-case-variable-in-class-scope
+    "N816",    # mixed-case-variable-in-global-scope
+    "N818",    # error-suffix-on-exception-name
+    "N999",    # invalid-module-name
     "PERF203", # try-except-in-loop
     "PERF401", # manual-list-comprehension
     "PERF402", # manual-list-copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ ignore = [
     "N801",    # invalid-class-name
     "N802",    # invalid-function-name
     "N803",    # invalid-argument-name
-    "N805",    # invalid-first-argument-name-for-method
     "N806",    # non-lowercase-variable-in-function
     "N812",    # lowercase-imported-as-non-lowercase
     "N814",    # camelcase-imported-as-constant

--- a/python/grass/pygrass/modules/interface/testsuite/test_modules.py
+++ b/python/grass/pygrass/modules/interface/testsuite/test_modules.py
@@ -21,7 +21,7 @@ SKIP = [
 
 
 class ModulesMeta(type):
-    def __new__(mcs, name, bases, dict):
+    def __new__(cls, name, bases, dict):
         def gen_test(cmd):
             def test(self):
                 Module(cmd)
@@ -36,7 +36,7 @@ class ModulesMeta(type):
         for cmd in cmds:
             test_name = "test__%s" % cmd.replace(".", "_")
             dict[test_name] = gen_test(cmd)
-        return type.__new__(mcs, name, bases, dict)
+        return type.__new__(cls, name, bases, dict)
 
 
 class TestModules(TestCase, metaclass=ModulesMeta):

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -1,11 +1,11 @@
-from grass.script.task import grassTask as gtask
+from grass.script.task import grassTask
 
 
 def test_mapcalc_simple_e_name():
-    gt = gtask("r.mapcalc.simple")
+    gt = grassTask("r.mapcalc.simple")
     assert gt.get_param("e")["name"] == "e"
 
 
 def test_mapcalc_simple_expession_name():
-    gt = gtask("r.mapcalc.simple")
+    gt = grassTask("r.mapcalc.simple")
     assert gt.get_param("expression")["name"] == "expression"

--- a/raster/r.basins.fill/testsuite/testrbf.py
+++ b/raster/r.basins.fill/testsuite/testrbf.py
@@ -47,8 +47,8 @@ class TestRasterbasin(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
-        cls.runModule("g.remove", flags="f", type="raster", name=cls.output)
+    def tearDown(self):
+        self.runModule("g.remove", flags="f", type="raster", name=self.output)
 
     def test_no1(self):
         lakes = "lakes"

--- a/raster/r.series/testsuite/test_r_series.py
+++ b/raster/r.series/testsuite/test_r_series.py
@@ -18,13 +18,13 @@ class TestRSeries(TestCase):
         call_module("r.mapcalc", expression=f"{cls.sum_mapcalc} = {cls.elevation} * 4")
 
     @classmethod
-    def tearDownClass(self):
-        self.del_temp_region()
+    def tearDownClass(cls):
+        cls.del_temp_region()
         call_module(
             "g.remove",
             flags="f",
             type_="raster",
-            name=self.sum_mapcalc,
+            name=cls.sum_mapcalc,
         )
 
     def tearDown(self):

--- a/raster/r.terraflow/testsuite/test_r_terraflow.py
+++ b/raster/r.terraflow/testsuite/test_r_terraflow.py
@@ -23,25 +23,25 @@ class TestTerraflow(TestCase):
         """!Remove the temporary region"""
         cls.del_temp_region()
 
-    def setUp(cls):
+    def setUp(self):
         """Create input data for steady state groundwater flow computation"""
-        if not os.path.exists(cls.testdir):
-            os.mkdir(cls.testdir)
+        if not os.path.exists(self.testdir):
+            os.mkdir(self.testdir)
 
-    def test_univar_mfd(cls):
+    def test_univar_mfd(self):
         # compute a steady state groundwater flow
-        cls.assertModule(
+        self.assertModule(
             "r.terraflow",
             overwrite=True,
             verbose=True,
-            elevation=cls.elevation,
+            elevation=self.elevation,
             filled="terra_flooded",
             direction="terra_flowdir",
             swatershed="terra_sink",
             accumulation="terra_flowaccum",
             tci="terra_tci",
-            directory=cls.testdir,
-            stats=cls.teststats,
+            directory=self.testdir,
+            stats=self.teststats,
         )
 
         # Output of r.univar -g
@@ -111,16 +111,16 @@ coeff_var=47.8572213922083
 sum=8341670.75914752"""
 
         # cls.assertRasterFitsUnivar(raster="terra_flooded",  reference=terra_flooded_univar,  precision=3)
-        cls.assertRasterFitsUnivar(
+        self.assertRasterFitsUnivar(
             raster="terra_flowdir", reference=terra_flowdir_univar, precision=3
         )
-        cls.assertRasterFitsUnivar(
+        self.assertRasterFitsUnivar(
             raster="terra_sink", reference=terra_sink_univar, precision=3
         )
-        cls.assertRasterFitsUnivar(
+        self.assertRasterFitsUnivar(
             raster="terra_flowaccum", reference=terra_flowaccum_univar, precision=3
         )
-        cls.assertRasterFitsUnivar(
+        self.assertRasterFitsUnivar(
             raster="terra_tci", reference=terra_tci_univar, precision=3
         )
 

--- a/raster/r.to.vect/testsuite/test_r_to_vect.py
+++ b/raster/r.to.vect/testsuite/test_r_to_vect.py
@@ -28,8 +28,8 @@ class Testrr(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
-        cls.runModule("g.remove", type="vector", flags="f", name=cls.output)
+    def tearDown(self):
+        self.runModule("g.remove", type="vector", flags="f", name=self.output)
 
     def test_flags(self):
         """Testing flag s"""

--- a/raster/r.viewshed/testsuite/test_r_viewshed.py
+++ b/raster/r.viewshed/testsuite/test_r_viewshed.py
@@ -15,10 +15,10 @@ class TestViewshed(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
+    def tearDown(self):
         """Remove viewshed map after each test method"""
         # TODO: eventually, removing maps should be handled through testing framework functions
-        cls.runModule("g.remove", flags="f", type="raster", name=cls.viewshed)
+        self.runModule("g.remove", flags="f", type="raster", name=self.viewshed)
 
     def test_limits(self):
         """Test if results is in expected limits"""

--- a/scripts/r.import/testsuite/test_r_import.py
+++ b/scripts/r.import/testsuite/test_r_import.py
@@ -13,9 +13,9 @@ class TestRImportRegion(TestCase):
     def setUpClass(cls):
         cls.runModule("g.region", raster="elevation")
 
-    def tearDown(cls):
+    def tearDown(self):
         """Remove imported map after each test method"""
-        cls.runModule("g.remove", flags="f", type="raster", name=cls.imported)
+        self.runModule("g.remove", flags="f", type="raster", name=self.imported)
 
     def test_import_estimate(self):
         """Test e flag"""

--- a/scripts/r.reclass.area/testsuite/testrra.py
+++ b/scripts/r.reclass.area/testsuite/testrra.py
@@ -26,8 +26,8 @@ class Testrr(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
-        cls.runModule("g.remove", type="raster", flags="f", name=cls.output)
+    def tearDown(self):
+        self.runModule("g.remove", type="raster", flags="f", name=self.output)
 
     def test_flag_c(self):
         """Testing flag c"""

--- a/scripts/v.import/testsuite/test_v_import.py
+++ b/scripts/v.import/testsuite/test_v_import.py
@@ -18,9 +18,9 @@ from grass.gunittest.main import test
 class TestVImport(TestCase):
     imported = "test_v_import_imported"
 
-    def tearDown(cls):
+    def tearDown(self):
         """Remove imported map after each test method"""
-        cls.runModule("g.remove", flags="f", type="vector", name=cls.imported)
+        self.runModule("g.remove", flags="f", type="vector", name=self.imported)
 
     def test_import_same_proj_gpkg(self):
         """Import GPKG in same proj, default params"""

--- a/vector/v.extract/testsuite/test_v_extract.py
+++ b/vector/v.extract/testsuite/test_v_extract.py
@@ -54,8 +54,8 @@ class TestRasterreport(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
-        cls.runModule("g.remove", flags="f", type="vector", name=cls.output)
+    def tearDown(self):
+        self.runModule("g.remove", flags="f", type="vector", name=self.output)
 
     def test_flagd(self):
         """Testing flag d"""

--- a/vector/v.net/testsuite/test_v_net.py
+++ b/vector/v.net/testsuite/test_v_net.py
@@ -6,10 +6,10 @@ from grass.script.core import read_command
 class TestVNet(TestCase):
     network = "test_vnet"
 
-    def tearDown(cls):
+    def tearDown(self):
         """Remove viewshed map after each test method"""
         # TODO: eventually, removing maps should be handled through testing framework functions
-        cls.runModule("g.remove", flags="f", type="vector", name=cls.network)
+        self.runModule("g.remove", flags="f", type="vector", name=self.network)
 
     def test_nodes(self):
         """Test"""

--- a/vector/v.random/testsuite/test_v_random.py
+++ b/vector/v.random/testsuite/test_v_random.py
@@ -30,9 +30,9 @@ class TestVRandom(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
-        cls.runModule(
-            "g.remove", type="vector", flags="f", name=(cls.output, cls.output2)
+    def tearDown(self):
+        self.runModule(
+            "g.remove", type="vector", flags="f", name=(self.output, self.output2)
         )
 
     def test_num_points(self):

--- a/vector/v.select/testsuite/test_v_select.py
+++ b/vector/v.select/testsuite/test_v_select.py
@@ -17,8 +17,8 @@ class TestRasterReport(TestCase):
     ainput = "geology"
     output = "testvselect"
 
-    def tearDown(cls):
-        cls.runModule("g.remove", type="vector", flags="f", name=cls.output)
+    def tearDown(self):
+        self.runModule("g.remove", type="vector", flags="f", name=self.output)
 
     def test_opo(self):
         """Testing operator overlap"""

--- a/vector/v.to.3d/testsuite/test_vto3d.py
+++ b/vector/v.to.3d/testsuite/test_vto3d.py
@@ -15,10 +15,13 @@ class TestVTo3D(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def tearDown(cls):
+    def tearDown(self):
         """Remove contours map after each test method"""
-        cls.runModule(
-            "g.remove", flags="f", type="vector", name=[cls.contours2d, cls.contours3d]
+        self.runModule(
+            "g.remove",
+            flags="f",
+            type="vector",
+            name=[self.contours2d, self.contours3d],
         )
 
     def test_contours(self):


### PR DESCRIPTION
This PR initially wanted to enable and fix N804, but some similar issues could be solved at once.

So, this PR enables pep8-naming (N) rules with ruff.

Rules already respected:
- dunder-function-name (N807)
- constant-imported-as-non-constant (N811)
- camelcase-imported-as-acronym (N817)

Fixed rules:
- invalid-first-argument-name-for-class-method (N804) -> 2 instances
  - Ruff rule: https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-class-method/
  - Two files had class methods that didn't use `cls` as their first argument when they should have been
  - **Can be autofixed for further errors in the future**
- invalid-first-argument-name-for-method (N805) -> 16 instances
  - Counterpart of the previous N804, but for classes not using `self` as the first argument when they should
  - Ruff rule: https://docs.astral.sh/ruff/rules/invalid-first-argument-name-for-method/
  - Three instances in gui/wxpython/mapswipe/frame.py were ignored, as an inner class is defined using self2 and also references self from the containing class. All other instances were misusages in test files.
  - **Can be autofixed for further errors in the future**
- camelcase-imported-as-lowercase (N813) -> 1 instance
  - Ruff rule: https://docs.astral.sh/ruff/rules/camelcase-imported-as-lowercase/
  - One instance only in a pytest file -> used the non-aliased name directly, not much different