### PR TITLE
style: Fix multi-value-repeated-key-literal (F601) (Pylint W0109)

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -2285,7 +2285,6 @@ class ProcessModelFile:
                     "size": size,
                     "text": text,
                     "id": int(node.get("id", -1)),
-                    "text": text,
                 }
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ ignore = [
     "F401",    # unused-import
     "F403",    # undefined-local-with-import-star
     "F405",    # undefined-local-with-import-star-usage
-    "F601",    # multi-value-repeated-key-literal
     "F811",    # redefined-while-unused
     "F821",    # undefined-name
     "F822",    # undefined-export

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -66,7 +66,7 @@ def raster_history(map, overwrite=False, env=None):
             "Unable to write history for <%(map)s>. "
             "Raster map <%(map)s> not found in current mapset."
         )
-        % {"map": map, "map": map}
+        % {"map": map}
     )
     return False
 


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/multi-value-repeated-key-literal/
Pylint : https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/duplicate-key.html

Two instances fixed.

Just to prove that a repeated key in a dict is the same as the last one, I tested it out in a simple example, in IPython:
![image](https://github.com/user-attachments/assets/648a59c8-07f3-49b6-b32f-26708e0e62ab)

```python
gitpod /workspace/grass (main) $ ipython
Python 3.12.6 (main, Sep  9 2024, 10:33:54) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]:     aa =   {
   ...:                     "pos": "posvalue",
   ...:                     "size": "sizevalue",
   ...:                     "text": "textvalue1",
   ...:                     "id": 42,
   ...:                     "text": "textvalue2",
   ...:                 }

In [2]: aa
Out[2]: {'pos': 'posvalue', 'size': 'sizevalue', 'text': 'textvalue2', 'id': 42}

In [3]: print((
   ...:             "Unable to write history for <%(map)s>. "
   ...:             "Raster map <%(map)s> not found in current mapset."
   ...:         )
   ...:         % {"map": "mapvalue1", "map": "mapvalue2"})
Unable to write history for <mapvalue2>. Raster map <mapvalue2> not found in current mapset.

In [4]: 
``` 