### PR TITLE
style: Enable checking for E ruff rules from pycodestyle, fixing simple issues

### DIFF
--- a/gui/wxpython/psmap/dialogs.py
+++ b/gui/wxpython/psmap/dialogs.py
@@ -3619,7 +3619,7 @@ class LegendDialog(PsmapDialog):
         self.Bind(wx.EVT_CHECKBOX, self.OnIsLegend, self.isRLegend)
         self.Bind(wx.EVT_RADIOBUTTON, self.OnDiscrete, self.discrete)
         self.Bind(wx.EVT_RADIOBUTTON, self.OnDiscrete, self.continuous)
-        ##        self.Bind(wx.EVT_CHECKBOX, self.OnDefaultSize, panel.defaultSize)
+        # self.Bind(wx.EVT_CHECKBOX, self.OnDefaultSize, panel.defaultSize)
         self.Bind(wx.EVT_CHECKBOX, self.OnRange, self.range)
         self.rasterSelect.GetTextCtrl().Bind(wx.EVT_TEXT, self.OnRaster)
 

--- a/gui/wxpython/psmap/frame.py
+++ b/gui/wxpython/psmap/frame.py
@@ -780,8 +780,6 @@ class PsMapFrame(wx.Frame):
         if not self._checkMapFrameExists(type_id=id):
             return
 
-        ##        dlg = RasterDialog(self, id = id, settings = self.instruction)
-        # dlg.ShowModal()
         if "mapNotebook" in self.openDialogs:
             self.openDialogs["mapNotebook"].notebook.ChangeSelection(1)
         else:
@@ -800,8 +798,6 @@ class PsMapFrame(wx.Frame):
         if not self._checkMapFrameExists(type_id=id):
             return
 
-        ##        dlg = MainVectorDialog(self, id = id, settings = self.instruction)
-        # dlg.ShowModal()
         if "mapNotebook" in self.openDialogs:
             self.openDialogs["mapNotebook"].notebook.ChangeSelection(2)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,8 +125,6 @@ ignore = [
     "DTZ006",  # call-datetime-fromtimestamp
     "DTZ007",  # call-datetime-strptime-without-zone
     "DTZ011",  # call-date-today
-    "E265",    # no-space-after-block-comment
-    "E266",    # multiple-leading-hashes-for-block-comment
     "E402",    # module-import-not-at-top-of-file
     "E501",    # line-too-long
     "E721",    # type-comparison
@@ -367,7 +365,7 @@ ignore = [
 "temporal/t.rast.algebra/testsu*/*_algebra_arithmetic.py" = ["FLY002"]
 "temporal/t.rast.colors/t.rast.colors.py" = ["SIM115"]
 "temporal/t.rast.series/t.rast.series.py" = ["SIM115"]
-"temporal/t.rast.what/t.rast.what.py" = ["SIM115"]
+"temporal/t.rast.what/t.rast.what.py" = ["E265", "E266", "SIM115"]
 "temporal/t.register/testsu*/*_raster_different_local.py" = ["FLY002"]
 "temporal/t.register/testsu*/*_raster_mapmetadata.py" = ["FLY002"]
 "temporal/t.register/testsuite/test_t_register_raster.py" = ["FLY002"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,7 @@ select = [
     "COM",    # flake8-commas (COM)
     "D",      # pydocstyle (D)
     "DTZ",    # flake8-datetimez (DTZ)
-    "E4",     # pycodestyle (E, W)
-    "E7",     # pycodestyle (E, W)
-    "E9",     # pycodestyle (E, W)
+    "E",      # pycodestyle (E, W)
     "F",      # Pyflakes (F)
     "FA",     # flake8-future-annotations (FA)
     "FBT",    # flake8-boolean-trap (FBT)
@@ -127,8 +125,10 @@ ignore = [
     "DTZ006",  # call-datetime-fromtimestamp
     "DTZ007",  # call-datetime-strptime-without-zone
     "DTZ011",  # call-date-today
-    "E401",    # multiple-imports-on-one-line
+    "E265",    # no-space-after-block-comment
+    "E266",    # multiple-leading-hashes-for-block-comment
     "E402",    # module-import-not-at-top-of-file
+    "E501",    # line-too-long
     "E721",    # type-comparison
     "E722",    # bare-except
     "E731",    # lambda-assignment

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -103,7 +103,7 @@ def compute_univar_stats(registered_map_info, stats_module, fs, rast_region=Fals
                 for perc in stats_module.inputs.percentile:
                     perc_value = stats[
                         "percentile_"
-                        f"{str(perc).rstrip('0').rstrip('.').replace('.','_')}"
+                        f"{str(perc).rstrip('0').rstrip('.').replace('.', '_')}"
                     ]
                     string += f"{fs}{perc_value}"
         string += eol
@@ -220,7 +220,7 @@ def print_gridded_dataset_univar_statistics(
                 cols.extend(
                     [
                         "percentile_"
-                        f"{str(perc).rstrip('0').rstrip('.').replace('.','_')}"
+                        f"{str(perc).rstrip('0').rstrip('.').replace('.', '_')}"
                         for perc in percentile
                     ]
                 )

--- a/raster/r.basins.fill/testsuite/testrbf.py
+++ b/raster/r.basins.fill/testsuite/testrbf.py
@@ -5,8 +5,8 @@ Purpose:    Tests r.basins.fill and its flags/options.
 Author:     Sunveer Singh
 Copyright:  (C) 2017 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	    License (>=v2). Read the file COPYING that comes with GRASS
-	    for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 import unittest

--- a/raster/r.in.ascii/testsuite/test_r_in_ascii.py
+++ b/raster/r.in.ascii/testsuite/test_r_in_ascii.py
@@ -5,8 +5,8 @@ Purpose:    Tests r.in.ascii and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2017
 Copyright:  (C) 2017 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 from grass.gunittest.case import TestCase

--- a/raster/r.proj/testsuite/test_rproj.py
+++ b/raster/r.proj/testsuite/test_rproj.py
@@ -57,7 +57,7 @@ class TestRasterreport(TestCase):
             The expected statics of the output raster
         """
         output = method
-        ## Get the boundary and set up region for the projected map
+        # Get the boundary and set up region for the projected map
         stdout = call_module(
             "r.proj",
             project=src_project,
@@ -80,7 +80,7 @@ class TestRasterreport(TestCase):
             res=1,
         )
 
-        ## Project the map
+        # Project the map
         self.assertModule(
             "r.proj",
             project=src_project,
@@ -91,13 +91,13 @@ class TestRasterreport(TestCase):
             quiet=True,
         )
 
-        ## Validate the output
+        # Validate the output
         self.assertRasterFitsUnivar(output, reference=statics, precision=1e-7)
         self.assertRasterFitsInfo(output, reference=raster_info, precision=1e-7)
 
     def test_nearest(self):
         """Testing method nearest"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "nearest"
         statics = """n=40930
         min=55.5787925720215
@@ -109,7 +109,7 @@ class TestRasterreport(TestCase):
 
     def test_bilinear(self):
         """Testing method bilinear"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "bilinear"
         statics = """n=40845
         min=56.3932914733887
@@ -121,7 +121,7 @@ class TestRasterreport(TestCase):
 
     def test_bicubic(self):
         """Testing method bicubic"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "bicubic"
         statics = """n=40677
         min=56.2407836914062
@@ -133,7 +133,7 @@ class TestRasterreport(TestCase):
 
     def test_lanczos(self):
         """Testing method lanczos"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "lanczos"
         statics = """n=40585
         min=56.2350921630859
@@ -145,7 +145,7 @@ class TestRasterreport(TestCase):
 
     def test_bilinear_f(self):
         """Testing method bilinear_f"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "bilinear_f"
         statics = """n=40930
         min=55.5787925720215
@@ -157,7 +157,7 @@ class TestRasterreport(TestCase):
 
     def test_bicubic_f(self):
         """Testing method bicubic_f"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "bicubic_f"
         statics = """n=40930
         min=55.5787925720215
@@ -169,7 +169,7 @@ class TestRasterreport(TestCase):
 
     def test_lanczos_f(self):
         """Testing method lanczos_f"""
-        ## Set up variables and validation values
+        # Set up variables and validation values
         method = "lanczos_f"
         statics = """n=40930
         min=55.5787925720215

--- a/raster/r.reclass/testsuite/test_r_reclass.py
+++ b/raster/r.reclass/testsuite/test_r_reclass.py
@@ -5,8 +5,8 @@ Purpose:    Tests r.reclass and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2017
 Copyright:  (C) 2017 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 from grass.gunittest.case import TestCase

--- a/raster/r.tile/testsuite/testrt.py
+++ b/raster/r.tile/testsuite/testrt.py
@@ -5,8 +5,8 @@ Purpose:    Tests r.tile and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2018
 Copyright:  (C) 2018 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 from grass.gunittest.case import TestCase

--- a/raster/r.what/testsuite/testrw.py
+++ b/raster/r.what/testsuite/testrw.py
@@ -5,8 +5,8 @@ Purpose:    Tests r.what and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2018
 Copyright:  (C) 2018 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 from grass.gunittest.case import TestCase

--- a/scripts/r.reclass.area/testsuite/testrra.py
+++ b/scripts/r.reclass.area/testsuite/testrra.py
@@ -5,8 +5,8 @@ Purpose:    Tests r.reclass.area and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2018
 Copyright:  (C) 2018 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 from grass.gunittest.case import TestCase

--- a/vector/v.extract/testsuite/test_v_extract.py
+++ b/vector/v.extract/testsuite/test_v_extract.py
@@ -5,8 +5,8 @@ Purpose:    Tests v.extract and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2017
 Copyright:  (C) 2017 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 import os

--- a/vector/v.vect.stats/testsuite/test_vect_stats.py
+++ b/vector/v.vect.stats/testsuite/test_vect_stats.py
@@ -5,8 +5,8 @@ Purpose:    Tests v.vect.stats and its flags/options.
 Author:     Sunveer Singh, Google Code-in 2017
 Copyright:  (C) 2017 by Sunveer Singh and the GRASS Development Team
 Licence:    This program is free software under the GNU General Public
-	            License (>=v2). Read the file COPYING that comes with GRASS
-	            for details.
+            License (>=v2). Read the file COPYING that comes with GRASS
+            for details.
 """
 
 from grass.gunittest.case import TestCase


### PR DESCRIPTION
This PR enables checking of remaining rules in the E category. It fixes simple issues, E101, E231, E265 and E266.

- [mixed-spaces-and-tabs (E101)](https://docs.astral.sh/ruff/rules/mixed-spaces-and-tabs/): 8 file headings (in tests) copied the license text with some tab at the beginning, then continued with spaces.
- [missing-whitespace (E231)](https://docs.astral.sh/ruff/rules/missing-whitespace/): 2 similar instances in the same file didn't have the formatting of the `.replace()` arguments formatted, as it was inside an f-string.
- [no-space-after-block-comment (E265)](https://docs.astral.sh/ruff/rules/no-space-after-block-comment/): Ignored file that https://github.com/OSGeo/grass/pull/4550 is solving.
- [multiple-leading-hashes-for-block-comment (E266)](https://docs.astral.sh/ruff/rules/multiple-leading-hashes-for-block-comment/): Ignored file that https://github.com/OSGeo/grass/pull/4550 is solving, fixes the others
  - The commented out lines in the psmap file were commented out since it was introduced in the main repo from the addons repo, 13 years ago. At the time, both pair of lines had the same indentation, before PEP8 only formatted the second lines. https://github.com/OSGeo/grass/blame/a7839eac86a82a4da1b971d198f010a891b07c6b/gui/wxpython/psmap/frame.py#L595-L596