### PR TITLE
temporal: Fixed E722 in d.rast.edit/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -108,7 +108,6 @@ per-file-ignores =
     scripts/i.pansharpen/i.pansharpen.py: E722, E501
     scripts/r.in.srtm/r.in.srtm.py: E722
     scripts/r.fillnulls/r.fillnulls.py: E722
-    scripts/d.rast.edit/d.rast.edit.py: E722
     scripts/v.what.strds/v.what.strds.py: E501
     # Line too long (esp. module interface definitions)
     scripts/*/*.py: E501

--- a/scripts/d.rast.edit/d.rast.edit.py
+++ b/scripts/d.rast.edit/d.rast.edit.py
@@ -666,7 +666,7 @@ def wxGUI():
             if val not in self.colors:
                 try:
                     self.force_color(val)
-                except:
+                except ValueError:
                     self.colors[val] = "#ffffff"
 
             return self.colors[val]


### PR DESCRIPTION
Fixed `E722` by specifiying `ValueError` exception in `d.rast.edit`