### PR TITLE
r.in.srtm: Fix exception handling and add specific error types

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -106,7 +106,6 @@ per-file-ignores =
     scripts/db.univar/db.univar.py: E501
     scripts/d.frame/d.frame.py: E722
     scripts/i.pansharpen/i.pansharpen.py: E722, E501
-    scripts/r.in.srtm/r.in.srtm.py: E722
     scripts/r.fillnulls/r.fillnulls.py: E722
     scripts/d.rast.edit/d.rast.edit.py: E722
     scripts/v.what.strds/v.what.strds.py: E501

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -230,7 +230,7 @@ def main():
         try:
             zf = zfile.ZipFile(zipfile)
             zf.extractall()
-        except:
+        except (zfile.BadZipfile, zfile.LargeZipFile, PermissionError):
             gs.fatal(_("Unable to unzip file."))
 
     gs.message(_("Converting input file to BIL..."))
@@ -277,7 +277,7 @@ def main():
 
     try:
         gs.run_command("r.in.gdal", input=bilfile, out=tileout)
-    except:
+    except gs.CalledModuleError:
         gs.fatal(_("Unable to import data"))
 
     # nice color table

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -76,6 +76,7 @@ import shutil
 import atexit
 import grass.script as gs
 import zipfile as zfile
+from grass.exceptions import CalledModuleError
 
 
 tmpl1sec = """BYTEORDER M
@@ -277,7 +278,7 @@ def main():
 
     try:
         gs.run_command("r.in.gdal", input=bilfile, out=tileout)
-    except gs.CalledModuleError:
+    except CalledModuleError:
         gs.fatal(_("Unable to import data"))
 
     # nice color table


### PR DESCRIPTION
Following Exceptions added
- `zipfile.BadFIle` and `zipfile.LArgeFile` for file related errors. and `PermissionError` incase it does not have enough permission to be accessed
- In second, since `gs` module is used, I added `CalledModuleError`, I can also do a generic `Exception` here if required