### PR TITLE
wxGUI: Fixed F841 in photo2image/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -25,8 +25,8 @@ per-file-ignores =
     gui/scripts/d.wms.py: E501
     gui/wxpython/image2target/g.gui.image2target.py: E501
     gui/wxpython/nviz/*: E722
-    gui/wxpython/photo2image/*: F841, E722, E265
-    gui/wxpython/photo2image/g.gui.photo2image.py: E501, F841
+    gui/wxpython/photo2image/*: E722
+    gui/wxpython/photo2image/g.gui.photo2image.py: E501
     gui/wxpython/psmap/*: F841, E266, E722
     gui/wxpython/vdigit/*: F841, E722, F405, F403
     gui/wxpython/animation/g.gui.animation.py: E501

--- a/gui/wxpython/photo2image/g.gui.photo2image.py
+++ b/gui/wxpython/photo2image/g.gui.photo2image.py
@@ -121,7 +121,7 @@ def main():
 
     app = wx.App()
 
-    wizard = GCPWizard(
+    GCPWizard(
         parent=None,
         giface=StandaloneGrassInterface(),
         group=group,

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1107,7 +1107,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             else:
                 flags = "a"
 
-            busy = wx.BusyInfo(_("Rectifying images, please wait..."), parent=self)
+            wx.BusyInfo(_("Rectifying images, please wait..."), parent=self)
             wx.GetApp().Yield()
 
             ret, msg = RunCommand(
@@ -1130,9 +1130,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 print(self.grwiz.src_map, file=sys.stderr)
                 print(msg, file=sys.stderr)
 
-            busy = wx.BusyInfo(
-                _("Writing output image to group, please wait..."), parent=self
-            )
+            wx.BusyInfo(_("Writing output image to group, please wait..."), parent=self)
             wx.GetApp().Yield()
 
             ret1, msg1 = RunCommand(
@@ -1253,7 +1251,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
         elif self.gr_order == 2:
             minNumOfItems = 6
-            diff = 6 - numOfItems
             # self.SetStatusText(_(
             # "Insufficient points, 6+ points needed for 2nd order"))
 
@@ -1556,7 +1553,6 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
 
     def OnZoomMenuGCP(self, event):
         """Popup Zoom menu"""
-        point = wx.GetMousePosition()
         zoommenu = Menu()
         # Add items to the menu
 
@@ -2467,7 +2463,6 @@ class GrSettingsDialog(wx.Dialog):
 
         srcrender = False
         tgtrender = False
-        reload_target = False
         if self.new_src_map != src_map:
             # remove old layer
             layers = self.parent.grwiz.SrcMap.GetListOfLayers()
@@ -2499,7 +2494,6 @@ class GrSettingsDialog(wx.Dialog):
                 del layers[0]
                 layers = self.parent.grwiz.TgtMap.GetListOfLayers()
             # self.parent.grwiz.TgtMap.DeleteAllLayers()
-            reload_target = True
             tgt_map["raster"] = self.new_tgt_map["raster"]
 
             if tgt_map["raster"] != "":

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1107,22 +1107,20 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
             else:
                 flags = "a"
 
-            wx.BusyInfo(_("Rectifying images, please wait..."), parent=self)
-            wx.GetApp().Yield()
+            with wx.BusyInfo(_("Rectifying images, please wait..."), parent=self):
+                wx.GetApp().Yield()
 
-            ret, msg = RunCommand(
-                "i.rectify",
-                parent=self,
-                getErrorMsg=True,
-                quiet=True,
-                group=self.xygroup,
-                extension=self.extension,
-                order=self.gr_order,
-                method=self.gr_method,
-                flags=flags,
-            )
-
-            del busy
+                ret, msg = RunCommand(
+                    "i.rectify",
+                    parent=self,
+                    getErrorMsg=True,
+                    quiet=True,
+                    group=self.xygroup,
+                    extension=self.extension,
+                    order=self.gr_order,
+                    method=self.gr_method,
+                    flags=flags,
+                )
 
             # provide feedback on failure
             if ret != 0:
@@ -1130,19 +1128,19 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 print(self.grwiz.src_map, file=sys.stderr)
                 print(msg, file=sys.stderr)
 
-            wx.BusyInfo(_("Writing output image to group, please wait..."), parent=self)
-            wx.GetApp().Yield()
+            with wx.BusyInfo(
+                _("Writing output image to group, please wait..."), parent=self
+            ):
+                wx.GetApp().Yield()
 
-            ret1, msg1 = RunCommand(
-                "i.group",
-                parent=self,
-                getErrorMsg=True,
-                quiet=False,
-                group=self.xygroup,
-                input="".join([self.grwiz.src_map.split("@")[0], self.extension]),
-            )
-
-            del busy
+                ret1, msg1 = RunCommand(
+                    "i.group",
+                    parent=self,
+                    getErrorMsg=True,
+                    quiet=False,
+                    group=self.xygroup,
+                    input="".join([self.grwiz.src_map.split("@")[0], self.extension]),
+                )
 
             if ret1 != 0:
                 print("ip2i: Error in i.group", file=sys.stderr)

--- a/gui/wxpython/photo2image/ip2i_mapdisplay.py
+++ b/gui/wxpython/photo2image/ip2i_mapdisplay.py
@@ -466,7 +466,6 @@ class MapPanel(SingleMapPanel):
         """
         Print options and output menu for map display
         """
-        point = wx.GetMousePosition()
         printmenu = Menu()
         # Add items to the menu
         setup = wx.MenuItem(printmenu, wx.ID_ANY, _("Page setup"))
@@ -510,7 +509,6 @@ class MapPanel(SingleMapPanel):
 
     def OnZoomMenu(self, event):
         """Popup Zoom menu"""
-        point = wx.GetMousePosition()
         zoommenu = Menu()
         # Add items to the menu
 


### PR DESCRIPTION
Following changes made to fix `F841` in `photo2image/`
- Directly called contructors `GCPWizard` and `wx.BusyInfo`
- Removed `point`, `reload_target` and `diff` which were not being used