### PR TITLE
r.fillnulls: Removed bare except from r.fillnulls

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -107,7 +107,6 @@ per-file-ignores =
     scripts/d.frame/d.frame.py: E722
     scripts/i.pansharpen/i.pansharpen.py: E722, E501
     scripts/r.in.srtm/r.in.srtm.py: E722
-    scripts/r.fillnulls/r.fillnulls.py: E722
     scripts/v.what.strds/v.what.strds.py: E501
     # Line too long (esp. module interface definitions)
     scripts/*/*.py: E501

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -481,7 +481,7 @@ def main():
                     tmp_rmaps.remove(holename + "_edges")
                     tmp_rmaps.remove(holename + "_dem")
                     tmp_vmaps.remove(holename)
-                except Exception:
+                except ValueError:
                     pass
                 gs.warning(
                     _(
@@ -545,7 +545,7 @@ def main():
                 tmp_rmaps.remove(holename + "_grown")
                 tmp_rmaps.remove(holename + "_edges")
                 tmp_rmaps.remove(holename + "_dem")
-            except Exception:
+            except ValueError:
                 pass
             try:
                 gs.run_command(
@@ -569,7 +569,7 @@ def main():
                 )
             try:
                 tmp_vmaps.remove(holename)
-            except Exception:
+            except ValueError:
                 pass
             try:
                 gs.run_command(

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -273,7 +273,7 @@ def main():
                 type="area",
                 quiet=quiet,
             )
-        except:
+        except CalledModuleError:
             gs.fatal(
                 _(
                     "abandoned. Removing temporary maps, restoring "
@@ -481,7 +481,7 @@ def main():
                     tmp_rmaps.remove(holename + "_edges")
                     tmp_rmaps.remove(holename + "_dem")
                     tmp_vmaps.remove(holename)
-                except:
+                except Exception:
                     pass
                 gs.warning(
                     _(
@@ -545,7 +545,7 @@ def main():
                 tmp_rmaps.remove(holename + "_grown")
                 tmp_rmaps.remove(holename + "_edges")
                 tmp_rmaps.remove(holename + "_dem")
-            except:
+            except Exception:
                 pass
             try:
                 gs.run_command(
@@ -569,7 +569,7 @@ def main():
                 )
             try:
                 tmp_vmaps.remove(holename)
-            except:
+            except Exception:
                 pass
             try:
                 gs.run_command(


### PR DESCRIPTION
Removed bare except clauses as per this:
- `CalledModuleError` for `gs.command`
- Simple `Exception` since all others were list `remove` command