### PR TITLE
lib/iostream: Remove redundant template parameters

### DIFF
--- a/include/grass/iostream/replacementHeap.h
+++ b/include/grass/iostream/replacementHeap.h
@@ -101,10 +101,10 @@ protected:
 
 public:
     // allocate array mergeHeap and the runs in runList
-    ReplacementHeap<T, Compare>(size_t arity, queue<char *> *runList);
+    ReplacementHeap(size_t arity, queue<char *> *runList);
 
     // delete array mergeHeap
-    ~ReplacementHeap<T, Compare>();
+    ~ReplacementHeap();
 
     // is heap empty?
     int empty() const { return (size == 0); }
@@ -159,7 +159,7 @@ ReplacementHeap<T, Compare>::ReplacementHeap(size_t g_arity,
 
 /*****************************************************************/
 template <class T, class Compare>
-ReplacementHeap<T, Compare>::~ReplacementHeap<T, Compare>()
+ReplacementHeap<T, Compare>::~ReplacementHeap()
 {
 
     if (!empty()) {

--- a/include/grass/iostream/replacementHeapBlock.h
+++ b/include/grass/iostream/replacementHeapBlock.h
@@ -102,10 +102,10 @@ protected:
 
 public:
     // allocate array mergeHeap, where the streams are stored in runList
-    ReplacementHeapBlock<T, Compare>(queue<MEM_STREAM<T> *> *runList);
+    ReplacementHeapBlock(queue<MEM_STREAM<T> *> *runList);
 
     // delete array mergeHeap
-    ~ReplacementHeapBlock<T, Compare>();
+    ~ReplacementHeapBlock();
 
     // is heap empty?
     int empty() const { return (size == 0); }
@@ -161,7 +161,7 @@ ReplacementHeapBlock<T, Compare>::ReplacementHeapBlock(
 
 /*****************************************************************/
 template <class T, class Compare>
-ReplacementHeapBlock<T, Compare>::~ReplacementHeapBlock<T, Compare>()
+ReplacementHeapBlock<T, Compare>::~ReplacementHeapBlock()
 {
 
     if (!empty()) {


### PR DESCRIPTION
In C++20, repeating template parameter names with the name of the class is no longer allowed as it is redundant (https://cplusplus.github.io/CWG/issues/2237.html). The new code is valid also in C++17, but the old code is not accepted in C++20.
