### PR TITLE
lib/ogsf: Dereference after null check in gvl2.c

### DIFF
--- a/lib/ogsf/gvl2.c
+++ b/lib/ogsf/gvl2.c
@@ -316,10 +316,16 @@ void GVL_get_dims(int id, int *rows, int *cols, int *depths)
         *rows = gvl->rows;
         *cols = gvl->cols;
         *depths = gvl->depths;
-    }
 
-    G_debug(3, "GVL_get_dims() id=%d, rows=%d, cols=%d, depths=%d",
-            gvl->gvol_id, gvl->rows, gvl->cols, gvl->depths);
+        G_debug(3, "GVL_get_dims() id=%d, rows=%d, cols=%d, depths=%d",
+                gvl->gvol_id, gvl->rows, gvl->cols, gvl->depths);
+    }
+    else {
+        G_debug(2,
+                "GVL_get_dims(): Attempted to access a null volume structure "
+                "for id=%d",
+                id);
+    }
 
     return;
 }


### PR DESCRIPTION
This pull request addresses the issue identified by coverity scan (CID: 1207416)

- Added else block where gvl might be null.
- Used G_debug with level 2 which is moderate as it is already aware that it is accessing null volume structure through the message
- Thought behind using G_debug was to print some additional logs instead of just G_warning. (Open to change to normal G_warning or any other level in G_debug)