### PR TITLE
v.info: add json output for columns

### DIFF
--- a/vector/v.info/local_proto.h
+++ b/vector/v.info/local_proto.h
@@ -19,7 +19,8 @@ void parse_args(int, char **, char **, char **, int *, int *, int *,
 void format_double(double, char *);
 void print_region(struct Map_info *, enum OutputFormat, JSON_Object *);
 void print_topo(struct Map_info *, enum OutputFormat, JSON_Object *);
-void print_columns(struct Map_info *, const char *, const char *);
+void print_columns(struct Map_info *, const char *, const char *,
+                   enum OutputFormat);
 void print_info(struct Map_info *);
 void print_shell(struct Map_info *, const char *, enum OutputFormat,
                  JSON_Object *);

--- a/vector/v.info/main.c
+++ b/vector/v.info/main.c
@@ -54,11 +54,6 @@ int main(int argc, char *argv[])
     parse_args(argc, argv, &input_opt, &field_opt, &hist_flag, &col_flag,
                &shell_flag, &format);
 
-    if (format == JSON) {
-        root_value = json_value_init_object();
-        root_object = json_value_get_object(root_value);
-    }
-
     /* try to open head-only on level 2 */
     if (Vect_open_old_head2(&Map, input_opt, "", field_opt) < 2) {
         /* force level 1, open fully
@@ -90,6 +85,11 @@ int main(int argc, char *argv[])
         Vect_close(&Map);
 
         return (EXIT_SUCCESS);
+    }
+
+    if (format == JSON) {
+        root_value = json_value_init_object();
+        root_object = json_value_get_object(root_value);
     }
 
     if ((shell_flag & SHELL_BASIC) || format == JSON) {

--- a/vector/v.info/main.c
+++ b/vector/v.info/main.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
             }
         }
         else if (col_flag) {
-            print_columns(&Map, input_opt, field_opt);
+            print_columns(&Map, input_opt, field_opt, format);
         }
         Vect_close(&Map);
 

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -208,29 +208,22 @@ void print_columns(struct Map_info *Map, const char *input_opt,
     driver = db_start_driver(fi->driver);
     if (driver == NULL) {
         Vect_close(Map);
-        const char *driver_name = fi->driver;
-        Vect_destroy_field_info(fi);
-        G_fatal_error(_("Unable to open driver <%s>"), driver_name);
+        G_fatal_error(_("Unable to open driver <%s>"), fi->driver);
     }
     db_init_handle(&handle);
     db_set_handle(&handle, fi->database, NULL);
     if (db_open_database(driver, &handle) != DB_OK) {
-        const char *database_name = fi->database;
-        const char *driver_name = fi->driver;
-        Vect_destroy_field_info(fi);
         db_shutdown_driver(driver);
         Vect_close(Map);
         G_fatal_error(_("Unable to open database <%s> by driver <%s>"),
-                      database_name, driver_name);
+                      fi->database, fi->driver);
     }
     db_init_string(&table_name);
     db_set_string(&table_name, fi->table);
     if (db_describe_table(driver, &table_name, &table) != DB_OK) {
-        const char *table_name = fi->table;
-        Vect_destroy_field_info(fi);
         db_close_database_shutdown_driver(driver);
         Vect_close(Map);
-        G_fatal_error(_("Unable to describe table <%s>"), table_name);
+        G_fatal_error(_("Unable to describe table <%s>"), fi->table);
     }
 
     JSON_Value *root_value = NULL, *columns_value = NULL, *column_value = NULL;
@@ -286,7 +279,6 @@ void print_columns(struct Map_info *Map, const char *input_opt,
         serialized_string = json_serialize_to_string_pretty(root_value);
         if (serialized_string == NULL) {
             json_value_free(root_value);
-            Vect_destroy_field_info(fi);
             db_close_database_shutdown_driver(driver);
             Vect_close(Map);
             G_fatal_error(_("Failed to initialize pretty JSON string."));

--- a/vector/v.info/print.c
+++ b/vector/v.info/print.c
@@ -189,7 +189,7 @@ void print_columns(struct Map_info *Map, const char *input_opt,
     num_dblinks = Vect_get_num_dblinks(Map);
 
     if (num_dblinks <= 0) {
-        Vect_close(&Map);
+        Vect_close(Map);
         G_fatal_error(
             _("Database connection for map <%s> is not defined in DB file"),
             input_opt);
@@ -200,21 +200,21 @@ void print_columns(struct Map_info *Map, const char *input_opt,
               field_opt);
 
     if ((fi = Vect_get_field2(Map, field_opt)) == NULL) {
-        Vect_close(&Map);
+        Vect_close(Map);
         G_fatal_error(
             _("Database connection not defined for layer <%s> of <%s>"),
             field_opt, input_opt);
     }
     driver = db_start_driver(fi->driver);
     if (driver == NULL) {
-        Vect_close(&Map);
+        Vect_close(Map);
         G_fatal_error(_("Unable to open driver <%s>"), fi->driver);
     }
     db_init_handle(&handle);
     db_set_handle(&handle, fi->database, NULL);
     if (db_open_database(driver, &handle) != DB_OK) {
         db_shutdown_driver(driver);
-        Vect_close(&Map);
+        Vect_close(Map);
         G_fatal_error(_("Unable to open database <%s> by driver <%s>"),
                       fi->database, fi->driver);
     }
@@ -223,7 +223,7 @@ void print_columns(struct Map_info *Map, const char *input_opt,
     if (db_describe_table(driver, &table_name, &table) != DB_OK) {
         db_close_database(driver);
         db_shutdown_driver(driver);
-        Vect_close(&Map);
+        Vect_close(Map);
         G_fatal_error(_("Unable to describe table <%s>"), fi->table);
     }
 
@@ -277,7 +277,7 @@ void print_columns(struct Map_info *Map, const char *input_opt,
             json_value_free(root_value);
             db_close_database(driver);
             db_shutdown_driver(driver);
-            Vect_close(&Map);
+            Vect_close(Map);
             G_fatal_error(_("Failed to initialize pretty JSON string."));
         }
         puts(serialized_string);

--- a/vector/v.info/testsuite/test_vinfo.py
+++ b/vector/v.info/testsuite/test_vinfo.py
@@ -250,6 +250,27 @@ class TestVInfo(TestCase):
             result.pop(field)
         self.assertDictEqual(expected, result)
 
+    def test_json_column(self):
+        module = SimpleModule(
+            "v.info", map=self.test_vinfo_with_db_3d, format="json", flags="c"
+        )
+        self.runModule(module)
+
+        expected_json = {
+            "columns": [
+                {"is_number": True, "name": "cat", "sql_type": "INTEGER"},
+                {
+                    "is_number": True,
+                    "name": "elevation",
+                    "sql_type": "DOUBLE PRECISION",
+                },
+            ]
+        }
+
+        result = json.loads(module.outputs.stdout)
+
+        self.assertDictEqual(expected_json, result)
+
     def test_database_table(self):
         """Test the database table column and type of the two vector maps with attribute data"""
         self.assertModuleKeyValue(


### PR DESCRIPTION
Use parson to add json support to v.info for columns. The JSON output looks like as follows:
```json
{
    "columns": [
        {
            "name": "cat",
            "sql_type": "INTEGER",
            "is_number": true
        },
        {
            "name": "MAJORRDS_",
            "sql_type": "DOUBLE PRECISION",
            "is_number": true
        },
        {
            "name": "ROAD_NAME",
            "sql_type": "CHARACTER",
            "is_number": false
        },
        {
            "name": "MULTILANE",
            "sql_type": "CHARACTER",
            "is_number": false
        },
        {
            "name": "PROPYEAR",
            "sql_type": "INTEGER",
            "is_number": true
        },
        {
            "name": "OBJECTID",
            "sql_type": "INTEGER",
            "is_number": true
        },
        {
            "name": "SHAPE_LEN",
            "sql_type": "DOUBLE PRECISION",
            "is_number": true
        }
    ]
}
```
fixes: https://github.com/OSGeo/grass/issues/4218