### PR TITLE
temporal: Add precise typing overloads to dataset_factory

### DIFF
--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -68,32 +68,6 @@ def dataset_factory(type: Literal["vect", "vector"], id: str) -> VectorDataset:
     pass
 
 
-@overload
-def dataset_factory(
-    type: Literal[
-        "strds",
-        "str3ds",
-        "stvds",
-        "rast",
-        "raster",
-        "raster_3d",
-        "rast3d",
-        "raster3d",
-        "vect",
-        "vector",
-    ],
-    id: str,
-) -> (
-    SpaceTimeRasterDataset
-    | SpaceTimeRaster3DDataset
-    | SpaceTimeVectorDataset
-    | RasterDataset
-    | Raster3DDataset
-    | VectorDataset
-):
-    pass
-
-
 def dataset_factory(
     type: str, id: str
 ) -> (

--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -68,6 +68,7 @@ def dataset_factory(type: Literal["vect", "vector"], id: str) -> VectorDataset:
     pass
 
 
+@overload
 def dataset_factory(
     type: Literal[
         "strds",
@@ -82,6 +83,19 @@ def dataset_factory(
         "vector",
     ],
     id: str,
+) -> (
+    SpaceTimeRasterDataset
+    | SpaceTimeRaster3DDataset
+    | SpaceTimeVectorDataset
+    | RasterDataset
+    | Raster3DDataset
+    | VectorDataset
+):
+    pass
+
+
+def dataset_factory(
+    type: str, id: str
 ) -> (
     SpaceTimeRasterDataset
     | SpaceTimeRaster3DDataset

--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -1,21 +1,12 @@
 """
 Object factory
 
-Usage:
-
-.. code-block:: python
-
-    import grass.temporal as tgis
-
-    tgis.register_maps_in_space_time_dataset(type, name, maps)
-
-
-(C) 2012-2013 by the GRASS Development Team
+(C) 2012-2024 by the GRASS Development Team
 This program is free software under the GNU General Public
 License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 
-:authors: Soeren Gebbert
+:authors: Soeren Gebbert, Edouard Choinière
 """
 
 from __future__ import annotations

--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -59,6 +59,21 @@ def dataset_factory(type: Literal["vect", "vector"], id: str) -> VectorDataset:
     pass
 
 
+@overload
+def dataset_factory(
+    type: str, id: str
+) -> (
+    SpaceTimeRasterDataset
+    | SpaceTimeRaster3DDataset
+    | SpaceTimeVectorDataset
+    | RasterDataset
+    | Raster3DDataset
+    | VectorDataset
+    | None
+):
+    pass
+
+
 def dataset_factory(
     type: str, id: str
 ) -> (

--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -20,6 +20,8 @@ for details.
 
 from __future__ import annotations
 
+from typing import Literal, overload
+
 from .core import get_tgis_message_interface
 from .space_time_datasets import (
     Raster3DDataset,
@@ -33,8 +35,53 @@ from .space_time_datasets import (
 ###############################################################################
 
 
+@overload
+def dataset_factory(type: Literal["strds"], id: str) -> SpaceTimeRasterDataset:
+    pass
+
+
+@overload
+def dataset_factory(type: Literal["str3ds"], id: str) -> SpaceTimeRaster3DDataset:
+    pass
+
+
+@overload
+def dataset_factory(type: Literal["stvds"], id: str) -> SpaceTimeVectorDataset:
+    pass
+
+
+@overload
+def dataset_factory(type: Literal["rast", "raster"], id: str) -> RasterDataset:
+    pass
+
+
+@overload
 def dataset_factory(
-    type: str, id: str
+    type: Literal["raster_3d", "rast3d", "raster3d"],
+    id: str,
+) -> Raster3DDataset:
+    pass
+
+
+@overload
+def dataset_factory(type: Literal["vect", "vector"], id: str) -> VectorDataset:
+    pass
+
+
+def dataset_factory(
+    type: Literal[
+        "strds",
+        "str3ds",
+        "stvds",
+        "rast",
+        "raster",
+        "raster_3d",
+        "rast3d",
+        "raster3d",
+        "vect",
+        "vector",
+    ],
+    id: str,
 ) -> (
     SpaceTimeRasterDataset
     | SpaceTimeRaster3DDataset

--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -18,6 +18,8 @@ for details.
 :authors: Soeren Gebbert
 """
 
+from __future__ import annotations
+
 from .core import get_tgis_message_interface
 from .space_time_datasets import (
     Raster3DDataset,
@@ -31,7 +33,17 @@ from .space_time_datasets import (
 ###############################################################################
 
 
-def dataset_factory(type, id):
+def dataset_factory(
+    type: str, id: str
+) -> (
+    SpaceTimeRasterDataset
+    | SpaceTimeRaster3DDataset
+    | SpaceTimeVectorDataset
+    | RasterDataset
+    | Raster3DDataset
+    | VectorDataset
+    | None
+):
     """A factory functions to create space time or map datasets
 
     :param type: the dataset type: rast or raster; rast3d, raster3d or raster_3d;
@@ -39,20 +51,18 @@ def dataset_factory(type, id):
     :param id: The id of the dataset ("name@mapset")
     """
     if type == "strds":
-        sp = SpaceTimeRasterDataset(id)
-    elif type == "str3ds":
-        sp = SpaceTimeRaster3DDataset(id)
-    elif type == "stvds":
-        sp = SpaceTimeVectorDataset(id)
-    elif type in {"rast", "raster"}:
-        sp = RasterDataset(id)
-    elif type in {"raster_3d", "rast3d", "raster3d"}:
-        sp = Raster3DDataset(id)
-    elif type in {"vect", "vector"}:
-        sp = VectorDataset(id)
-    else:
-        msgr = get_tgis_message_interface()
-        msgr.error(_("Unknown dataset type: %s") % type)
-        return None
+        return SpaceTimeRasterDataset(id)
+    if type == "str3ds":
+        return SpaceTimeRaster3DDataset(id)
+    if type == "stvds":
+        return SpaceTimeVectorDataset(id)
+    if type in {"rast", "raster"}:
+        return RasterDataset(id)
+    if type in {"raster_3d", "rast3d", "raster3d"}:
+        return Raster3DDataset(id)
+    if type in {"vect", "vector"}:
+        return VectorDataset(id)
 
-    return sp
+    msgr = get_tgis_message_interface()
+    msgr.error(_("Unknown dataset type: %s") % type)
+    return None

--- a/python/grass/temporal/factory.py
+++ b/python/grass/temporal/factory.py
@@ -75,7 +75,7 @@ def dataset_factory(
 
 
 def dataset_factory(
-    type: str, id: str
+    type: str, id: str | None
 ) -> (
     SpaceTimeRasterDataset
     | SpaceTimeRaster3DDataset


### PR DESCRIPTION
This PR adds precise typing overloads to grass.temporal.factory's dataset_factory function. This enables type checkers like mypy or Pyright for example to understand the returned class from the string passed as the type argument. Combined with returning directly the dataset, this function is almost completely typed.


For example, in grass.temporal.univar_statistics, the IDE can show what overload dataset_factory is using, and the type of `sp` can be inferred to `SpaceTimeVectorDataset`
![image](https://github.com/user-attachments/assets/c281e63b-0fde-43d0-993d-ca444270fdc5)


Also, it improves the sphinx generated docs. Our current sphinx build process can understand and use the typing information, plus show the overloads too, linking to classes in our docs when appropriate. Below are before/after screenshots. Note that with trial-and-error, the non-overloaded (implementation) function signature isn't shown anymore, that's why a more generic signature was used


Before:
![image](https://github.com/user-attachments/assets/e400f01e-f96b-42bb-8919-f4927113fd31)
After:
![image](https://github.com/user-attachments/assets/263b0eec-b00e-48be-9c2a-ec7e0c1721f0)


In a previous iteration, I tried using a python typing stub file, a .pyi file, but even though the IDE experience was the same, since it wasn't installed like other python files, the sphinx doc generation didn't show the improvements like on the screenshots. I didn't try editing the makefiles to be able to copy pyi files too in the install location to see if it would have the same effect.