### PR TITLE
lib/gis: Fix resource leak issue in copy_dir.c

### DIFF
--- a/lib/gis/copy_dir.c
+++ b/lib/gis/copy_dir.c
@@ -141,8 +141,10 @@ int G_recursive_copy(const char *src, const char *dst)
         sprintf(path, "%s/%s", src, dp->d_name);
         sprintf(path2, "%s/%s", dst, dp->d_name);
 
-        if (G_recursive_copy(path, path2) != 0)
+        if (G_recursive_copy(path, path2) != 0) {
+            closedir(dirp);
             return 1;
+        }
     }
 
     closedir(dirp);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207596)

**Changes Made**
Added closedir(dirp); inside the if condition to close the directory pointer in case of errors.