### PR TITLE
r.watershed: Fix Resource Leak issue in close_maps.c

### DIFF
--- a/raster/r.watershed/seg/close_maps.c
+++ b/raster/r.watershed/seg/close_maps.c
@@ -325,6 +325,7 @@ int close_maps(void)
         }
 
         Rast_close(fd);
+        G_free(afbuf);
 
         Rast_init_colors(&colors);
         Rast_make_aspect_colors(&colors, -8, 8);

--- a/raster/r.watershed/seg/close_maps.c
+++ b/raster/r.watershed/seg/close_maps.c
@@ -326,6 +326,7 @@ int close_maps(void)
 
         Rast_close(fd);
         G_free(afbuf);
+        G_free(cbuf);
 
         Rast_init_colors(&colors);
         Rast_make_aspect_colors(&colors, -8, 8);


### PR DESCRIPTION
This pull request fixes resource leak issue identified by Coverity Scan (CID : 1207607)
**Changes Made**
- Freed afbuf in the asp_flag block: Added G_free(afbuf); after Rast_close(fd); to ensure afbuf is released after its final usage.
- in addition to afbuf; cbuf (allocated using Rast_allocate_c_buf()) is also freed to prevent memory leaks.