### PR TITLE
v.delaunay: Fix Resource Leak issue in in_out.c

### DIFF
--- a/vector/v.delaunay/in_out.c
+++ b/vector/v.delaunay/in_out.c
@@ -178,6 +178,8 @@ void output_triangles(unsigned int n, int mode3d UNUSED, int type,
             e = NEXT(e, u);
         } while (!SAME_EDGE(e, e_start));
     }
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
 }
 
 void remove_duplicates(unsigned int *size)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID: 1207851,1207849).
Used existing function Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix the memory leak issue.