### PR TITLE
lib/ogsf: Fix resource leak issue in gsd_img_tif.c

### DIFF
--- a/lib/ogsf/gsd_img_tif.c
+++ b/lib/ogsf/gsd_img_tif.c
@@ -116,6 +116,7 @@ int GS_write_tif(const char *name)
     }
 
     G_free((void *)pixbuf);
+    G_free(buf);
     (void)TIFFClose(out);
 
     return (0);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207908)
