### PR TITLE
lib/vector/Vlib: Fix resource leak issue in clean_nodes.c

### DIFF
--- a/lib/vector/Vlib/clean_nodes.c
+++ b/lib/vector/Vlib/clean_nodes.c
@@ -241,6 +241,10 @@ int Vect_clean_small_angles_at_nodes(struct Map_info *Map, int otype,
         }
     }
     G_verbose_message(_("Modifications: %d"), nmodif);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(OCats);
+    Vect_destroy_cats_struct(LCats);
+    Vect_destroy_cats_struct(SCats);
 
     return (nmodif);
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207909, 1207910, 1207911, 1207912).
Used existing function Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix the memory leak issue.