### PR TITLE
grass.script: Pass environment to message functions

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1447,7 +1447,7 @@ def list_strings(type, pattern=None, mapset=None, exclude=None, flag="", env=Non
     :return: list of elements
     """
     if type == "cell":
-        verbose(_('Element type should be "raster" and not "%s"') % type)
+        verbose(_('Element type should be "raster" and not "%s"') % type, env=env)
 
     result = []
     for line in read_command(
@@ -1520,7 +1520,9 @@ def list_grouped(
         flag += "t"
     for i in range(len(types)):
         if types[i] == "cell":
-            verbose(_('Element type should be "raster" and not "%s"') % types[i])
+            verbose(
+                _('Element type should be "raster" and not "%s"') % types[i], env=env
+            )
             types[i] = "raster"
     result = {}
     if check_search_path:
@@ -1543,7 +1545,7 @@ def list_grouped(
         try:
             name, mapset = line.split("@")
         except ValueError:
-            warning(_("Invalid element '%s'") % line)
+            warning(_("Invalid element '%s'") % line, env=env)
             continue
 
         if store_types:
@@ -1701,7 +1703,7 @@ def mapsets(search_path=False, env=None):
     flags = "p" if search_path else "l"
     mapsets = read_command("g.mapsets", flags=flags, sep="newline", quiet=True, env=env)
     if not mapsets:
-        fatal(_("Unable to list mapsets"))
+        fatal(_("Unable to list mapsets"), env=env)
 
     return mapsets.splitlines()
 

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -55,7 +55,7 @@ def db_describe(table, env=None, **args):
         args.pop("driver")
     s = read_command("db.describe", flags="c", table=table, env=env, **args)
     if not s:
-        fatal(_("Unable to describe table <%s>") % table)
+        fatal(_("Unable to describe table <%s>") % table, env=env)
 
     cols = []
     result = {}
@@ -179,7 +179,8 @@ def db_select(sql=None, filename=None, table=None, env=None, **args):
                 "Programmer error: '%(sql)s', '%(filename)s', or '%(table)s' must be \
                     provided"
             )
-            % {"sql": "sql", "filename": "filename", "table": "table"}
+            % {"sql": "sql", "filename": "filename", "table": "table"},
+            env=env,
         )
 
     if "sep" not in args:
@@ -188,7 +189,7 @@ def db_select(sql=None, filename=None, table=None, env=None, **args):
     try:
         run_command("db.select", quiet=True, flags="c", output=fname, env=env, **args)
     except CalledModuleError:
-        fatal(_("Fetching data failed"))
+        fatal(_("Fetching data failed"), env=env)
 
     ofile = open(fname)
     result = [tuple(x.rstrip(os.linesep).split(args["sep"])) for x in ofile]

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -66,7 +66,8 @@ def raster_history(map, overwrite=False, env=None):
             "Unable to write history for <%(map)s>. "
             "Raster map <%(map)s> not found in current mapset."
         )
-        % {"map": map}
+        % {"map": map},
+        env=env,
     )
     return False
 
@@ -143,7 +144,10 @@ def mapcalc(
             overwrite=overwrite,
         )
     except CalledModuleError:
-        fatal(_("An error occurred while running r.mapcalc with expression: %s") % e)
+        fatal(
+            _("An error occurred while running r.mapcalc with expression: %s") % e,
+            env=env,
+        )
 
 
 def mapcalc_start(

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -108,4 +108,7 @@ def mapcalc3d(
             overwrite=overwrite,
         )
     except CalledModuleError:
-        fatal(_("An error occurred while running r3.mapcalc with expression: %s") % e)
+        fatal(
+            _("An error occurred while running r3.mapcalc with expression: %s") % e,
+            env=env,
+        )

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -87,7 +87,7 @@ def vector_layer_db(map, layer, env=None):
     try:
         f = vector_db(map, env=env)[int(layer)]
     except KeyError:
-        fatal(_("Database connection not defined for layer %s") % layer)
+        fatal(_("Database connection not defined for layer %s") % layer, env=env)
 
     return f
 
@@ -250,7 +250,8 @@ def vector_db_select(map, layer=1, env=None, **kwargs):
     except KeyError:
         error(
             _("Missing layer %(layer)d in vector map <%(map)s>")
-            % {"layer": layer, "map": map}
+            % {"layer": layer, "map": map},
+            env=env,
         )
         return {"columns": [], "values": {}}
 
@@ -259,13 +260,13 @@ def vector_db_select(map, layer=1, env=None, **kwargs):
         if key not in kwargs["columns"].split(","):
             # add key column if missing
             include_key = False
-            debug("Adding key column to the output")
+            debug("Adding key column to the output", env=env)
             kwargs["columns"] += "," + key
 
     ret = read_command("v.db.select", map=map, layer=layer, env=env, **kwargs)
 
     if not ret:
-        error(_("vector_db_select() failed"))
+        error(_("vector_db_select() failed"), env=env)
         return {"columns": [], "values": {}}
 
     columns = []


### PR DESCRIPTION
While the message functions (fatal, warning, message, info, debug, verbose, percent) have env parameter, grass.script was not consistently passing the env parameter to these functions. This fixes all the clear cases in functions which themselves have env (but does not touch any which don't have it where the fix needs to be more complex).

These functions can now be called and produce these messages even for non-global sessions.
