### PR TITLE
r.volume: Work with any mask name

### DIFF
--- a/raster/r.volume/r.volume.html
+++ b/raster/r.volume/r.volume.html
@@ -8,7 +8,7 @@ calculating volumes and centroids of patches or clumps.
 from a <b>input</b> raster map sorted by category on a <b>clump</b>
 raster map, and optionally generates a vector points map of the
 centroids for each clump.  If a clump map is not specified, the
-current MASK is used. The MASK can be defined
+current raster mask is used. The raster mask can be defined
 by <em><a href="r.mask.html">r.mask</a></em>. The sum is multiplied by
 the area of a cell to give the volume occupied by that cell. See below
 for an example of the output table.
@@ -24,12 +24,12 @@ now, unless I get notification otherwise. - EP -->
 <h2>NOTES</h2>
 
 <p>
-If a clump map is not given and a MASK not set, the program exits with
-an error message.
+If a clump map is not given and a raster mask is not set, the program exits
+with an error message.
 
 <p>
 <em>r.volume</em> works in the current region and respects the current
-MASK.
+raster mask.
 
 <h3>CENTROIDS</h3>
 


### PR DESCRIPTION
Avoid hardcoded MASK by using the Rast_mask_status function. The rest of the logic stays the same so mask
is read just as the plain raster map is read.

Documentation is updated to use 'raster mask' instead of 'MASK'.
