### PR TITLE
r.report: Work with any mask name (also for r.kappa)

### DIFF
--- a/raster/r.kappa/mask.c
+++ b/raster/r.kappa/mask.c
@@ -13,15 +13,17 @@ char *maskinfo(void)
 {
     struct Reclass reclass;
     char *results;
-    char text[100];
+    char text[2 * GNAME_MAX + GMAPSET_MAX];
     int next;
     int first;
+    char mask_name[GNAME_MAX];
+    char mask_mapset[GMAPSET_MAX];
 
     results = NULL;
-    if (G_find_raster("MASK", G_mapset()) == NULL)
+    if (!Rast_mask_status(mask_name, mask_mapset, NULL, NULL, NULL))
         return "none";
-    if (Rast_get_reclass("MASK", G_mapset(), &reclass) <= 0) {
-        sprintf(text, "MASK in %s", G_mapset());
+    if (Rast_get_reclass(mask_name, mask_mapset, &reclass) <= 0) {
+        sprintf(text, "%s in %s", mask_name, mask_mapset);
         return append(results, text);
     }
 

--- a/raster/r.report/maskinfo.c
+++ b/raster/r.report/maskinfo.c
@@ -16,12 +16,14 @@ char *maskinfo(void)
     char text[100];
     int next;
     int first;
+    char mask_name[GNAME_MAX];
+    char mask_mapset[GMAPSET_MAX];
 
     results = NULL;
-    if (G_find_raster("MASK", G_mapset()) == NULL)
+    if (!Rast_mask_status(mask_name, mask_mapset, NULL, NULL, NULL))
         return "none";
-    if (Rast_get_reclass("MASK", G_mapset(), &reclass) <= 0) {
-        sprintf(text, "MASK in %s", G_mapset());
+    if (Rast_get_reclass(mask_name, mask_mapset, &reclass) <= 0) {
+        sprintf(text, "%s in %s", mask_name, mask_mapset);
         return append(results, text);
     }
 

--- a/raster/r.report/maskinfo.c
+++ b/raster/r.report/maskinfo.c
@@ -13,7 +13,7 @@ char *maskinfo(void)
 {
     struct Reclass reclass;
     char *results;
-    char text[100];
+    char text[2 * GNAME_MAX + GMAPSET_MAX];
     int next;
     int first;
     char mask_name[GNAME_MAX];


### PR DESCRIPTION
Use Rast_mask_status in r.report code which reports about raster mask including categories of underlying reclassified raster (if any).

This also makes the same change in the r.kappa code which uses the same mask report code as r.report.