### PR TITLE
raster: Work with any mask name (r.surf.contour, r.random.cells, r.random.surface)

### DIFF
--- a/raster/r.random.cells/init.c
+++ b/raster/r.random.cells/init.c
@@ -42,8 +42,10 @@ void Init(void)
 
     Cells = FlagCreate(Rs, Cs);
     CellCount = 0;
-    if (G_find_raster2("MASK", G_mapset())) {
-        FD = Rast_open_old("MASK", G_mapset());
+    char mask_name[GNAME_MAX];
+    char mask_mapset[GMAPSET_MAX];
+    if (Rast_mask_status(mask_name, mask_mapset, NULL, NULL, NULL)) {
+        FD = Rast_open_old(mask_name, mask_mapset);
         {
             for (row = 0; row < Rs; row++) {
                 Rast_get_c_row_nomask(FD, CellBuffer, row);

--- a/raster/r.random.surface/init.c
+++ b/raster/r.random.surface/init.c
@@ -35,12 +35,10 @@ void Init(void)
     else
         MinRes = NS;
 
-    if (NULL == G_find_file("cell", "MASK", G_mapset())) {
-        MapCount = Rs * Cs;
-        FDM = -1;
-    }
-    else {
-        FDM = Rast_open_old("MASK", G_mapset());
+    char mask_name[GNAME_MAX];
+    char mask_mapset[GMAPSET_MAX];
+    if (Rast_mask_status(mask_name, mask_mapset, NULL, NULL, NULL)) {
+        FDM = Rast_open_old(mask_name, mask_mapset);
         {
             MapCount = 0;
             CellBuffer = Rast_allocate_c_buf();
@@ -52,6 +50,10 @@ void Init(void)
                 }
             }
         }
+    }
+    else {
+        MapCount = Rs * Cs;
+        FDM = -1;
     }
 
     if (Uniform->answer)

--- a/raster/r.surf.contour/main.c
+++ b/raster/r.surf.contour/main.c
@@ -80,8 +80,10 @@ int main(int argc, char *argv[])
     alt_row = (DCELL *)G_malloc(ncols * sizeof(DCELL));
     seen = flag_create(nrows, ncols);
     mask = flag_create(nrows, ncols);
-    if (NULL != G_find_file("cell", "MASK", G_mapset())) {
-        file_fd = Rast_open_old("MASK", G_mapset());
+    char mask_name[GNAME_MAX];
+    char mask_mapset[GMAPSET_MAX];
+    if (Rast_mask_status(mask_name, mask_mapset, NULL, NULL, NULL)) {
+        file_fd = Rast_open_old(mask_name, mask_mapset);
         for (r = 0; r < nrows; r++) {
             Rast_get_d_row_nomask(file_fd, alt_row, r);
             for (c = 0; c < ncols; c++)


### PR DESCRIPTION
Use Rast_mask_status instead of hardcoded name MASK for r.surf.contour, r.random.cells, and r.random.surface. Raster mask if present, is loaded in a special way in these tools. After this change, the name of the mask is retrieved from the library (that's the important part) and the library is at the same time used to test the presence of the mask (as opposed to testing presence of raster directly, but that's just more convenient).

The code in r.random.surface switching the if and else branches to make it easier to write and more consistent with the other two.