### PR TITLE
lib/ogsf: fix possible overflow errors in gsd_wire.c

### DIFF
--- a/lib/ogsf/gsd_wire.c
+++ b/lib/ogsf/gsd_wire.c
@@ -645,7 +645,7 @@ int gsd_coarse_surf_map(geosurf *surf)
      */
     check_transp = 0;
     tratt = &(surf->att[ATT_TRANSP]);
-    ktrans = (255 << 24);
+    ktrans = (255U << 24);
     trans_src = surf->att[ATT_TRANSP].att_src;
 
     if (CONST_ATT == trans_src && surf->att[ATT_TRANSP].constant != 0.0) {
@@ -798,7 +798,7 @@ int gsd_coarse_surf_map(geosurf *surf)
                 if (check_transp) {
                     GET_MAPATT(trbuff, offset2[ii], ttr);
                     ktrans = (char)SCALE_ATT(tratt, ttr, 0, 255);
-                    ktrans = (char)(255 - ktrans) << 24;
+                    ktrans = (char)(255U - ktrans) << 24;
                 }
 
                 if (check_material) {


### PR DESCRIPTION
This is in a vein similar to https://github.com/OSGeo/grass/pull/4635.

In a code, we were doing `(255 << 24)` which causes integer overflow and positive number gets converted to negative number. We were then assigning this to an unsigned integer in multiple places, which does conversion in a different way.

For example: If we do `unsigned int x = -20`, `UINT_MAX + 1 - 20` is assigned to x.

I do not think that's what is intended when we do with `ktrans = (255 << 24)`. Fix instances of that, by using an `unsigned int literal` over `int literal`.

This issue was found using cppcheck tool.