### PR TITLE
lib/ogsf: fix possible overflow errors in gvld.c

### DIFF
--- a/lib/ogsf/gvld.c
+++ b/lib/ogsf/gvld.c
@@ -188,7 +188,7 @@ int gvld_isosurf(geovol *gvl)
 
         /* transparency */
         check_transp[i] = 0;
-        ktrans[i] = (255 << 24);
+        ktrans[i] = (255U << 24);
         if (CONST_ATT == isosurf->att[ATT_TRANSP].att_src &&
             isosurf->att[ATT_TRANSP].constant != 0.0) {
             ktrans[i] = (255 - (int)isosurf->att[ATT_TRANSP].constant) << 24;


### PR DESCRIPTION
This is similar to https://github.com/OSGeo/grass/pull/4635.

We were doing `(255 << 24)` which causes integer overflow and positive number gets converted to negative number. We were then assigning this to an unsigned integer in multiple places, which does conversion in a different way.

For example: If we do unsigned int x = -20, `UINT_MAX + 1 - 20` is assigned to x.

I do not think that's what is intended when we do
`ktrans = (255 << 24)`. Fix instances of that, by using an unsigned int literal over int literal.

This issue was found using cppcheck tool.