### PR TITLE
display/d.vect: Dereference after Null Check

### DIFF
--- a/display/d.vect/lines.c
+++ b/display/d.vect/lines.c
@@ -334,14 +334,20 @@ int draw_line(int type, int ltype, int line, const struct line_pnts *Points,
         /* use random or RGB column color if given, otherwise reset */
         /* centroids always use default color to stand out from underlying area
          */
-        if (custom_rgb && (ltype != GV_CENTROID)) {
-            primary_color->r = (unsigned char)red;
-            primary_color->g = (unsigned char)grn;
-            primary_color->b = (unsigned char)blu;
-            D_symbol2(Symb, x0, y0, primary_color, line_color);
+        if (Symb) {
+            if (custom_rgb && (ltype != GV_CENTROID)) {
+                primary_color->r = (unsigned char)red;
+                primary_color->g = (unsigned char)grn;
+                primary_color->b = (unsigned char)blu;
+                D_symbol2(Symb, x0, y0, primary_color, line_color);
+            }
+            else {
+                D_symbol(Symb, x0, y0, line_color, fill_color);
+            } 
         }
-        else
-            D_symbol(Symb, x0, y0, line_color, fill_color);
+        else {
+            G_warning(_("Symbol is NULL; unable to display points"));
+        }
 
         /* reset to defaults */
         var_size = size;


### PR DESCRIPTION
This pull request fixes issue identified by Coverity scan (CID : 1207395)
**Changes Made:**
- Added a condition to check if Symb is NULL before using it.
- If Symb is NULL, a G_warning is issued to inform the user that the symbol could not be displayed, preventing null dereference.