### PR TITLE
grass.temporal: Simple typing annotations

### DIFF
--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -29,12 +29,12 @@ class AbstractDataset(
 
     __metaclass__ = ABCMeta
 
-    def __init__(self):
+    def __init__(self) -> None:
         SpatialTopologyDatasetConnector.__init__(self)
         TemporalTopologyDatasetConnector.__init__(self)
         self.msgr = get_tgis_message_interface()
 
-    def reset_topology(self):
+    def reset_topology(self) -> None:
         """Reset any information about temporal topology"""
 
         self.reset_spatial_topology()
@@ -88,12 +88,12 @@ class AbstractDataset(
 
         return None
 
-    def set_topology_build_true(self):
+    def set_topology_build_true(self) -> None:
         """Use this method when the spatio-temporal topology was build"""
         self.set_spatial_topology_build_true()
         self.set_temporal_topology_build_true()
 
-    def set_topology_build_false(self):
+    def set_topology_build_false(self) -> None:
         """Use this method when the spatio-temporal topology was not build"""
         self.set_spatial_topology_build_false()
         self.set_temporal_topology_build_false()
@@ -110,13 +110,13 @@ class AbstractDataset(
 
         return d
 
-    def print_topology_info(self):
+    def print_topology_info(self) -> None:
         if self.is_temporal_topology_build():
             self.print_temporal_topology_info()
         if self.is_spatial_topology_build():
             self.print_spatial_topology_info()
 
-    def print_topology_shell_info(self):
+    def print_topology_shell_info(self) -> None:
         if self.is_temporal_topology_build():
             self.print_temporal_topology_shell_info()
         if self.is_spatial_topology_build():
@@ -223,7 +223,7 @@ class AbstractDataset(
     def print_self(self):
         """Print the content of the internal structure to stdout"""
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Set the identifier of the dataset"""
         self.base.set_id(ident)
         self.temporal_extent.set_id(ident)
@@ -351,7 +351,7 @@ class AbstractDataset(
         """Return the spatial extent"""
         return self.spatial_extent
 
-    def select(self, dbif=None, mapset=None):
+    def select(self, dbif=None, mapset=None) -> None:
         """Select temporal dataset entry from database and fill
         the internal structure
 
@@ -589,7 +589,7 @@ class AbstractDatasetComparisonKeyStartTime:
          sorted_map_list = sorted(map_list, key=AbstractDatasetComparisonKeyStartTime)
     """
 
-    def __init__(self, obj, *args):
+    def __init__(self, obj, *args) -> None:
         self.obj = obj
 
     def __lt__(self, other):
@@ -641,7 +641,7 @@ class AbstractDatasetComparisonKeyEndTime:
          sorted_map_list = sorted(map_list, key=AbstractDatasetComparisonKeyEndTime)
     """
 
-    def __init__(self, obj, *args):
+    def __init__(self, obj, *args) -> None:
         self.obj = obj
 
     def __lt__(self, other):

--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -392,7 +392,7 @@ class AbstractDataset(
     def delete(self):
         """Delete dataset from database if it exists"""
 
-    def insert(self, dbif=None, execute=True):
+    def insert(self, dbif=None, execute: bool = True):
         """Insert dataset into database
 
         :param dbif: The database interface to be used
@@ -434,7 +434,7 @@ class AbstractDataset(
             dbif.close()
         return statement
 
-    def update(self, dbif=None, execute=True, ident=None):
+    def update(self, dbif=None, execute: bool = True, ident=None):
         """Update the dataset entry in the database from the internal structure
         excluding None variables
 
@@ -468,7 +468,7 @@ class AbstractDataset(
             dbif.close()
         return statement
 
-    def update_all(self, dbif=None, execute=True, ident=None):
+    def update_all(self, dbif=None, execute: bool = True, ident=None):
         """Update the dataset entry in the database from the internal structure
         and include None variables.
 

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -343,7 +343,7 @@ class AbstractMapDataset(AbstractDataset):
         if self.is_topology_build():
             self.print_topology_shell_info()
 
-    def insert(self, dbif=None, execute=True):
+    def insert(self, dbif=None, execute: bool = True):
         """Insert the map content into the database from the internal
         structure
 
@@ -364,7 +364,7 @@ class AbstractMapDataset(AbstractDataset):
             self.write_timestamp_to_grass()
         return AbstractDataset.insert(self, dbif=dbif, execute=execute)
 
-    def update(self, dbif=None, execute=True):
+    def update(self, dbif=None, execute: bool = True):
         """Update the map content in the database from the internal structure
         excluding None variables
 
@@ -383,7 +383,7 @@ class AbstractMapDataset(AbstractDataset):
             self.write_timestamp_to_grass()
         return AbstractDataset.update(self, dbif, execute)
 
-    def update_all(self, dbif=None, execute=True):
+    def update_all(self, dbif=None, execute: bool = True):
         """Update the map content in the database from the internal structure
         including None variables
 
@@ -721,7 +721,7 @@ class AbstractMapDataset(AbstractDataset):
 
             self.set_absolute_time(start, end)
 
-    def temporal_buffer(self, increment, update=False, dbif=None) -> None:
+    def temporal_buffer(self, increment, update: bool = False, dbif=None) -> None:
         """Create a temporal buffer based on an increment
 
         For absolute time the increment must be a string of type "integer
@@ -870,7 +870,7 @@ class AbstractMapDataset(AbstractDataset):
         """
         self.spatial_extent.set_spatial_extent(spatial_extent)
 
-    def spatial_buffer(self, size, update=False, dbif=None) -> None:
+    def spatial_buffer(self, size, update: bool = False, dbif=None) -> None:
         """Buffer the spatial extent by a given size in all
         spatial directions.
 
@@ -902,7 +902,7 @@ class AbstractMapDataset(AbstractDataset):
         if update:
             self.spatial_extent.update(dbif)
 
-    def spatial_buffer_2d(self, size, update=False, dbif=None) -> None:
+    def spatial_buffer_2d(self, size, update: bool = False, dbif=None) -> None:
         """Buffer the spatial extent by a given size in 2d
         spatial directions.
 
@@ -972,7 +972,7 @@ class AbstractMapDataset(AbstractDataset):
 
         return True
 
-    def delete(self, dbif=None, update=True, execute=True):
+    def delete(self, dbif=None, update: bool = True, execute: bool = True):
         """Delete a map entry from database if it exists
 
          Remove dependent entries:
@@ -1034,7 +1034,7 @@ class AbstractMapDataset(AbstractDataset):
 
         return statement
 
-    def unregister(self, dbif=None, update=True, execute=True):
+    def unregister(self, dbif=None, update: bool = True, execute: bool = True):
         """Remove the map entry in each space time dataset in which this map
         is registered
 
@@ -1125,7 +1125,7 @@ class AbstractMapDataset(AbstractDataset):
 
     # this fn should not be in a class for maps,
     # but instead in a class for stds: AbstractSpaceTimeDataset ?
-    def add_stds_to_register(self, stds_id, dbif=None, execute=True):
+    def add_stds_to_register(self, stds_id, dbif=None, execute: bool = True):
         """Add a new space time dataset to the register
 
         :param stds_id: The id of the space time dataset to be registered
@@ -1174,7 +1174,7 @@ class AbstractMapDataset(AbstractDataset):
 
         return statement
 
-    def remove_stds_from_register(self, stds_id, dbif=None, execute=True):
+    def remove_stds_from_register(self, stds_id, dbif=None, execute: bool = True):
         """Remove a space time dataset from the register
 
         :param stds_id: The id of the space time dataset to removed from

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -196,7 +196,7 @@ class AbstractMapDataset(AbstractDataset):
     @staticmethod
     def build_id_from_search_path(name: str, element) -> str:
         """Convenient method to build the unique identifier while
-        checking the current seach path for the correct mapset.
+        checking the current search path for the correct mapset.
 
         Existing mapset definitions in the name string will be reused.
 
@@ -225,7 +225,7 @@ class AbstractMapDataset(AbstractDataset):
             else:
                 gs.fatal(
                     _(
-                        "Map <{map_name}> of element tpye '{element}' not found on \
+                        "Map <{map_name}> of element type '{element}' not found on \
                             search path"
                     ).format(element=element, map_name=name)
                 )

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -57,7 +57,7 @@ class AbstractMapDataset(AbstractDataset):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self):
+    def __init__(self) -> None:
         AbstractDataset.__init__(self)
         self.ciface = get_tgis_c_library_interface()
 
@@ -266,7 +266,7 @@ class AbstractMapDataset(AbstractDataset):
         """
         return self.base.get_layer()
 
-    def print_self(self):
+    def print_self(self) -> None:
         """Print the content of the internal structure to stdout"""
         self.base.print_self()
         self.temporal_extent.print_self()
@@ -274,7 +274,7 @@ class AbstractMapDataset(AbstractDataset):
         self.metadata.print_self()
         self.stds_register.print_self()
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this object in human readable style"""
 
         if self.get_type() == "raster":
@@ -322,7 +322,7 @@ class AbstractMapDataset(AbstractDataset):
             " +----------------------------------------------------------------------------+"  # noqa: E501
         )
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this object in shell style"""
         self.base.print_shell_info()
         self.temporal_extent.print_shell_info()
@@ -403,11 +403,11 @@ class AbstractMapDataset(AbstractDataset):
             self.write_timestamp_to_grass()
         return AbstractDataset.update_all(self, dbif, execute)
 
-    def set_time_to_absolute(self):
+    def set_time_to_absolute(self) -> None:
         """Set the temporal type to absolute"""
         self.base.set_ttype("absolute")
 
-    def set_time_to_relative(self):
+    def set_time_to_relative(self) -> None:
         """Set the temporal type to relative"""
         self.base.set_ttype("relative")
 
@@ -501,7 +501,7 @@ class AbstractMapDataset(AbstractDataset):
 
         return True
 
-    def update_absolute_time(self, start_time, end_time=None, dbif=None):
+    def update_absolute_time(self, start_time, end_time=None, dbif=None) -> None:
         """Update the absolute time
 
         The end time is optional and must be set to None in case of time
@@ -624,7 +624,7 @@ class AbstractMapDataset(AbstractDataset):
 
         return True
 
-    def update_relative_time(self, start_time, end_time, unit, dbif=None):
+    def update_relative_time(self, start_time, end_time, unit, dbif=None) -> None:
         """Update the relative time interval
 
         The end time is optional and must be set to None in case of time
@@ -664,7 +664,7 @@ class AbstractMapDataset(AbstractDataset):
             if get_enable_timestamp_write():
                 self.write_timestamp_to_grass()
 
-    def set_temporal_extent(self, extent):
+    def set_temporal_extent(self, extent) -> None:
         """Convenient method to set the temporal extent from a temporal extent
         object
 
@@ -721,7 +721,7 @@ class AbstractMapDataset(AbstractDataset):
 
             self.set_absolute_time(start, end)
 
-    def temporal_buffer(self, increment, update=False, dbif=None):
+    def temporal_buffer(self, increment, update=False, dbif=None) -> None:
         """Create a temporal buffer based on an increment
 
         For absolute time the increment must be a string of type "integer
@@ -827,7 +827,9 @@ class AbstractMapDataset(AbstractDataset):
             else:
                 self.set_relative_time(new_start, new_end, unit)
 
-    def set_spatial_extent_from_values(self, north, south, east, west, top=0, bottom=0):
+    def set_spatial_extent_from_values(
+        self, north, south, east, west, top=0, bottom=0
+    ) -> None:
         """Set the spatial extent of the map from values
 
          This method only modifies this object and does not commit
@@ -844,7 +846,7 @@ class AbstractMapDataset(AbstractDataset):
             north, south, east, west, top, bottom
         )
 
-    def set_spatial_extent(self, spatial_extent):
+    def set_spatial_extent(self, spatial_extent) -> None:
         """Set the spatial extent of the map
 
          This method only modifies this object and does not commit
@@ -868,7 +870,7 @@ class AbstractMapDataset(AbstractDataset):
         """
         self.spatial_extent.set_spatial_extent(spatial_extent)
 
-    def spatial_buffer(self, size, update=False, dbif=None):
+    def spatial_buffer(self, size, update=False, dbif=None) -> None:
         """Buffer the spatial extent by a given size in all
         spatial directions.
 
@@ -900,7 +902,7 @@ class AbstractMapDataset(AbstractDataset):
         if update:
             self.spatial_extent.update(dbif)
 
-    def spatial_buffer_2d(self, size, update=False, dbif=None):
+    def spatial_buffer_2d(self, size, update=False, dbif=None) -> None:
         """Buffer the spatial extent by a given size in 2d
         spatial directions.
 
@@ -1220,7 +1222,7 @@ class AbstractMapDataset(AbstractDataset):
 
         return statement
 
-    def read_semantic_label_from_grass(self):
+    def read_semantic_label_from_grass(self) -> None:
         """Read the band identifier of this map from the map metadata
         in the GRASS file system based spatial database and
         set the internal band identifier that should be insert/updated
@@ -1230,7 +1232,7 @@ class AbstractMapDataset(AbstractDataset):
         silently pass.
         """
 
-    def set_semantic_label(self, semantic_label):
+    def set_semantic_label(self, semantic_label) -> None:
         """Set semantic label identifier
 
         Currently only implemented in RasterDataset. Otherwise

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -194,7 +194,7 @@ class AbstractMapDataset(AbstractDataset):
         return name, layer, mapset
 
     @staticmethod
-    def build_id_from_search_path(name, element):
+    def build_id_from_search_path(name, element) -> str:
         """Convenient method to build the unique identifier while
         checking the current seach path for the correct mapset.
 
@@ -235,7 +235,7 @@ class AbstractMapDataset(AbstractDataset):
         return f"{name}@{mapset}"
 
     @staticmethod
-    def build_id(name, mapset, layer=None):
+    def build_id(name, mapset, layer=None) -> str:
         """Convenient method to build the unique identifier
 
         Existing layer and mapset definitions in the name
@@ -411,7 +411,7 @@ class AbstractMapDataset(AbstractDataset):
         """Set the temporal type to relative"""
         self.base.set_ttype("relative")
 
-    def set_absolute_time(self, start_time, end_time=None):
+    def set_absolute_time(self, start_time, end_time=None) -> bool:
         """Set the absolute time with start time and end time
 
          The end time is optional and must be set to None in case of time
@@ -543,7 +543,7 @@ class AbstractMapDataset(AbstractDataset):
             if get_enable_timestamp_write():
                 self.write_timestamp_to_grass()
 
-    def set_relative_time(self, start_time, end_time, unit):
+    def set_relative_time(self, start_time, end_time, unit) -> bool:
         """Set the relative time interval
 
          The end time is optional and must be set to None in case of time
@@ -932,7 +932,7 @@ class AbstractMapDataset(AbstractDataset):
         if update:
             self.spatial_extent.update(dbif)
 
-    def check_for_correct_time(self):
+    def check_for_correct_time(self) -> bool:
         """Check for correct time
 
         :return: True in case of success, False otherwise

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -167,7 +167,7 @@ class AbstractMapDataset(AbstractDataset):
         return self.base.get_map_id()
 
     @staticmethod
-    def split_name(name, layer=None, mapset=None):
+    def split_name(name: str, layer=None, mapset=None):
         """Convenient method to split a map name into three potentially
         contained parts: map name, map layer and mapset. For the layer and
         mapset, default keyword arguments can be given if not present in
@@ -194,7 +194,7 @@ class AbstractMapDataset(AbstractDataset):
         return name, layer, mapset
 
     @staticmethod
-    def build_id_from_search_path(name, element) -> str:
+    def build_id_from_search_path(name: str, element) -> str:
         """Convenient method to build the unique identifier while
         checking the current seach path for the correct mapset.
 
@@ -235,7 +235,7 @@ class AbstractMapDataset(AbstractDataset):
         return f"{name}@{mapset}"
 
     @staticmethod
-    def build_id(name, mapset, layer=None) -> str:
+    def build_id(name: str, mapset, layer=None) -> str:
         """Convenient method to build the unique identifier
 
         Existing layer and mapset definitions in the name

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -543,7 +543,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return count_temporal_topology_relationships(maps1=maps, dbif=dbif)
 
-    def check_temporal_topology(self, maps=None, dbif=None):
+    def check_temporal_topology(self, maps=None, dbif=None) -> bool:
         """Check the temporal topology of all maps of the current space time
         dataset or of an optional list of maps
 
@@ -2000,7 +2000,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return maps
 
-    def shift(self, gran, dbif=None):
+    def shift(self, gran, dbif=None) -> bool:
         """Temporally shift each registered map with the provided granularity
 
         :param gran: The granularity to be used for shifting
@@ -2469,7 +2469,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return is_registered
 
-    def register_map(self, map, dbif=None):
+    def register_map(self, map, dbif=None) -> bool:
         """Register a map in the space time dataset.
 
          This method takes care of the registration of a map

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -2558,7 +2558,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         stds_register_table = self.get_map_register()
         stds_ttype = self.get_temporal_type()
 
-        # The gathered SQL statemets are stroed here
+        # The gathered SQL statements are stored here
         statement = ""
 
         # Check temporal types

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -10,6 +10,8 @@ for details.
 :authors: Soeren Gebbert
 """
 
+from __future__ import annotations
+
 import copy
 import os
 import sys
@@ -181,7 +183,11 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         self.metadata.print_history()
 
     def set_initial_values(
-        self, temporal_type, semantic_type=None, title=None, description=None
+        self,
+        temporal_type,
+        semantic_type=None,
+        title=None,
+        description: str | None = None,
     ) -> None:
         """Set the initial values of the space time dataset
 

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -67,7 +67,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         # SpaceTimeRasterDataset related only
         self.semantic_label = None
 
-    def get_name(self, semantic_label=True):
+    def get_name(self, semantic_label: bool = True):
         """Get dataset name including semantic label filter if enabled.
 
         :param bool semantic_label: True to return dataset name
@@ -363,7 +363,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                 self.msgr.fatal(_("Unsupported temporal unit: %s") % (unit))
             self.relative_time.set_unit(unit)
 
-    def insert(self, dbif=None, execute=True):
+    def insert(self, dbif=None, execute: bool = True):
         """Insert the space time dataset content into the database from the internal
         structure
 
@@ -615,7 +615,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return True
 
-    def sample_by_dataset(self, stds, method=None, spatial=False, dbif=None):
+    def sample_by_dataset(self, stds, method=None, spatial: bool = False, dbif=None):
         """Sample this space time dataset with the temporal topology
         of a second space time dataset
 
@@ -822,7 +822,9 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return obj_list
 
-    def sample_by_dataset_sql(self, stds, method=None, spatial=False, dbif=None):
+    def sample_by_dataset_sql(
+        self, stds, method=None, spatial: bool = False, dbif=None
+    ):
         """Sample this space time dataset with the temporal topology
         of a second space time dataset using SQL queries.
 
@@ -2358,7 +2360,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         if connection_state_changed:
             dbif.close()
 
-    def delete(self, dbif=None, execute=True):
+    def delete(self, dbif=None, execute: bool = True):
         """Delete a space time dataset from the temporal database
 
         This method removes the space time dataset from the temporal
@@ -2666,7 +2668,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return True
 
-    def unregister_map(self, map, dbif=None, execute=True):
+    def unregister_map(self, map, dbif=None, execute: bool = True):
         """Unregister a map from the space time dataset.
 
         This method takes care of the un-registration of a map

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -59,7 +59,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractDataset.__init__(self)
         self.reset(ident)
         self.map_counter = 0
@@ -128,14 +128,14 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         :param name: The name of the register table
         """
 
-    def print_self(self):
+    def print_self(self) -> None:
         """Print the content of the internal structure to stdout"""
         self.base.print_self()
         self.temporal_extent.print_self()
         self.spatial_extent.print_self()
         self.metadata.print_self()
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
 
         if self.get_type() == "strds":
@@ -167,14 +167,14 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             " +----------------------------------------------------------------------------+"  # noqa: E501
         )
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self.base.print_shell_info()
         self.temporal_extent.print_shell_info()
         self.spatial_extent.print_shell_info()
         self.metadata.print_shell_info()
 
-    def print_history(self):
+    def print_history(self) -> None:
         """Print history information about this class in human readable
         shell style
         """
@@ -182,7 +182,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
     def set_initial_values(
         self, temporal_type, semantic_type=None, title=None, description=None
-    ):
+    ) -> None:
         """Set the initial values of the space time dataset
 
          In addition the command creation string is generated
@@ -213,7 +213,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         self.metadata.set_description(description)
         self.metadata.set_command(self.create_command_string())
 
-    def set_aggregation_type(self, aggregation_type):
+    def set_aggregation_type(self, aggregation_type) -> None:
         """Set the aggregation type of the space time dataset
 
         :param aggregation_type: The aggregation type of the space time
@@ -221,7 +221,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         """
         self.metadata.set_aggregation_type(aggregation_type)
 
-    def update_command_string(self, dbif=None):
+    def update_command_string(self, dbif=None) -> None:
         """Append the current command string to any existing command string
         in the metadata class and calls metadata update
 
@@ -311,7 +311,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return self.temporal_extent.get_granularity()
 
-    def set_granularity(self, granularity):
+    def set_granularity(self, granularity) -> None:
         """Set the granularity
 
         The granularity is usually computed by the space time dataset at
@@ -343,7 +343,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         self.temporal_extent.set_granularity(granularity)
 
-    def set_relative_time_unit(self, unit):
+    def set_relative_time_unit(self, unit) -> None:
         """Set the relative time unit which may be of type:
         years, months, days, hours, minutes or seconds
 
@@ -500,7 +500,9 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return gaps
 
-    def print_spatio_temporal_relationships(self, maps=None, spatial=None, dbif=None):
+    def print_spatio_temporal_relationships(
+        self, maps=None, spatial=None, dbif=None
+    ) -> None:
         """Print the spatio-temporal relationships for each map of the space
         time dataset or for each map of the optional list of maps
 
@@ -2173,7 +2175,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return maps
 
-    def snap(self, dbif=None):
+    def snap(self, dbif=None) -> None:
         """For each registered map snap the end time to the start time of
         its temporal nearest neighbor in the future
 
@@ -2231,7 +2233,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
         if connection_state_changed:
             dbif.close()
 
-    def _update_map_timestamps(self, maps, date_list, dbif):
+    def _update_map_timestamps(self, maps, date_list, dbif) -> None:
         """Update the timestamps of maps with the start and end time
         stored in the date_list.
 
@@ -2278,7 +2280,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                     ds.select(dbif)
                     ds.update_from_registered_maps(dbif)
 
-    def rename(self, ident, dbif=None):
+    def rename(self, ident, dbif=None) -> None:
         """Rename the space time dataset
 
         This method renames the space time dataset, the map register table
@@ -2749,7 +2751,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
         return statement
 
-    def update_from_registered_maps(self, dbif=None):
+    def update_from_registered_maps(self, dbif=None) -> None:
         """This methods updates the modification time, the spatial and
         temporal extent as well as type specific metadata. It should always
         been called after maps are registered or unregistered/deleted from

--- a/python/grass/temporal/aggregation.py
+++ b/python/grass/temporal/aggregation.py
@@ -115,7 +115,7 @@ def collect_map_names(sp, dbif, start, end, sampling):
 
 
 def aggregate_raster_maps(
-    inputs, base, start, end, count, method, register_null, dbif, offset=0
+    inputs, base, start, end, count, method, register_null, dbif, offset: int = 0
 ):
     """Aggregate a list of raster input maps with r.series
 
@@ -219,13 +219,13 @@ def aggregate_by_topology(
     topo_list,
     basename,
     time_suffix,
-    offset=0,
+    offset: int = 0,
     method="average",
-    nprocs=1,
+    nprocs: int = 1,
     spatial=None,
     dbif=None,
     overwrite: bool = False,
-    file_limit=1000,
+    file_limit: int = 1000,
 ):
     """Aggregate a list of raster input maps with r.series
 

--- a/python/grass/temporal/aggregation.py
+++ b/python/grass/temporal/aggregation.py
@@ -224,7 +224,7 @@ def aggregate_by_topology(
     nprocs=1,
     spatial=None,
     dbif=None,
-    overwrite=False,
+    overwrite: bool = False,
     file_limit=1000,
 ):
     """Aggregate a list of raster input maps with r.series

--- a/python/grass/temporal/aggregation.py
+++ b/python/grass/temporal/aggregation.py
@@ -115,7 +115,7 @@ def collect_map_names(sp, dbif, start, end, sampling):
 
 
 def aggregate_raster_maps(
-    inputs, base, start, end, count, method, register_null, dbif, offset: int = 0
+    inputs, base, start, end, count: int, method, register_null, dbif, offset: int = 0
 ):
     """Aggregate a list of raster input maps with r.series
 

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -38,7 +38,7 @@ from .core import (
 
 
 class DictSQLSerializer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.D = {}
         self.dbmi_paramstyle = get_tgis_dbmi_paramstyle()
 
@@ -174,7 +174,7 @@ class DictSQLSerializer:
 
         return sql, tuple(args)
 
-    def deserialize(self, row):
+    def deserialize(self, row) -> None:
         """Convert the content of the dbmi dictionary like row into the
         internal dictionary
 
@@ -184,11 +184,11 @@ class DictSQLSerializer:
         for key in row.keys():
             self.D[key] = row[key]
 
-    def clear(self):
+    def clear(self) -> None:
         """Initialize the internal storage"""
         self.D = {}
 
-    def print_self(self):
+    def print_self(self) -> None:
         """Print the content of the internal dictionary to stdout"""
         print(self.D)
 
@@ -243,7 +243,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
 
     """  # noqa: E501
 
-    def __init__(self, table=None, ident=None):
+    def __init__(self, table=None, ident=None) -> None:
         """Constructor of this class
 
         :param table: The name of the table
@@ -280,7 +280,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
             + "';\n"
         )
 
-    def delete(self, dbif=None):
+    def delete(self, dbif=None) -> None:
         """Delete the entry of this object from the temporal database
 
         :param dbif: The database interface to be used,
@@ -432,7 +432,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
         mapset = get_current_mapset()
         return dbif.mogrify_sql_statement(self.get_insert_statement(), mapset=mapset)
 
-    def insert(self, dbif=None):
+    def insert(self, dbif=None) -> None:
         """Serialize the content of this object and store it in the temporal
         database using the internal identifier
 
@@ -489,7 +489,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
             self.get_update_statement(ident), mapset=mapset
         )
 
-    def update(self, dbif=None, ident=None):
+    def update(self, dbif=None, ident=None) -> None:
         """Serialize the content of this object and update it in the temporal
         database using the internal identifier
 
@@ -547,7 +547,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
 
         return dbif.mogrify_sql_statement(self.get_update_all_statement(ident))
 
-    def update_all(self, dbif=None, ident=None):
+    def update_all(self, dbif=None, ident=None) -> None:
         """Serialize the content of this object, including None objects,
         and update it in the temporal database using the internal identifier
 
@@ -632,7 +632,7 @@ class DatasetBase(SQLDatabaseInterface):
         creator=None,
         ctime=None,
         ttype=None,
-    ):
+    ) -> None:
         """Constructor
 
         :param table: The name of the temporal database table
@@ -665,7 +665,7 @@ class DatasetBase(SQLDatabaseInterface):
         self.set_ctime(ctime)
         self.set_ttype(ttype)
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)
 
         :param ident: The unique identifier must be a combination
@@ -688,21 +688,21 @@ class DatasetBase(SQLDatabaseInterface):
                 self.set_layer(layer)
             self.set_name(name)
 
-    def set_name(self, name):
+    def set_name(self, name) -> None:
         """Set the name of the dataset
 
         :param name: The name of the dataset
         """
         self.D["name"] = name
 
-    def set_mapset(self, mapset):
+    def set_mapset(self, mapset) -> None:
         """Set the mapset of the dataset
 
         :param mapset: The name of the mapset in which this dataset is stored
         """
         self.D["mapset"] = mapset
 
-    def set_layer(self, layer):
+    def set_layer(self, layer) -> None:
         """Convenient method to set the layer of the map (part of primary key)
 
         Layer are supported for vector maps
@@ -711,14 +711,14 @@ class DatasetBase(SQLDatabaseInterface):
         """
         self.D["layer"] = layer
 
-    def set_creator(self, creator):
+    def set_creator(self, creator) -> None:
         """Set the creator of the dataset
 
         :param creator: The name of the creator
         """
         self.D["creator"] = creator
 
-    def set_ctime(self, ctime=None):
+    def set_ctime(self, ctime=None) -> None:
         """Set the creation time of the dataset,
         if nothing set the current time is used
 
@@ -729,7 +729,7 @@ class DatasetBase(SQLDatabaseInterface):
         else:
             self.D["creation_time"] = ctime
 
-    def set_ttype(self, ttype):
+    def set_ttype(self, ttype) -> None:
         """Set the temporal type of the dataset: absolute or relative,
         if nothing set absolute time will assumed
 
@@ -818,7 +818,7 @@ class DatasetBase(SQLDatabaseInterface):
     ttype = property(fget=get_ttype, fset=set_ttype)
     creator = property(fget=get_creator, fset=set_creator)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         #      0123456789012345678901234567890
         print(
@@ -833,7 +833,7 @@ class DatasetBase(SQLDatabaseInterface):
         print(" | Temporal type: ............. " + str(self.get_ttype()))
         print(" | Creation time: ............. " + str(self.get_ctime()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         print("id=" + str(self.get_id()))
         print("name=" + str(self.get_name()))
@@ -859,7 +859,7 @@ class RasterBase(DatasetBase):
         creator=None,
         creation_time=None,
         temporal_type=None,
-    ):
+    ) -> None:
         DatasetBase.__init__(
             self,
             "raster_base",
@@ -883,7 +883,7 @@ class Raster3DBase(DatasetBase):
         creator=None,
         creation_time=None,
         temporal_type=None,
-    ):
+    ) -> None:
         DatasetBase.__init__(
             self,
             "raster3d_base",
@@ -908,7 +908,7 @@ class VectorBase(DatasetBase):
         creator=None,
         creation_time=None,
         temporal_type=None,
-    ):
+    ) -> None:
         DatasetBase.__init__(
             self,
             "vector_base",
@@ -991,17 +991,17 @@ class STDSBase(DatasetBase):
         ctime=None,
         ttype=None,
         mtime=None,
-    ):
+    ) -> None:
         DatasetBase.__init__(self, table, ident, name, mapset, creator, ctime, ttype)
 
         self.set_semantic_type(semantic_type)
         self.set_mtime(mtime)
 
-    def set_semantic_type(self, semantic_type):
+    def set_semantic_type(self, semantic_type) -> None:
         """Set the semantic type of the space time dataset"""
         self.D["semantic_type"] = semantic_type
 
-    def set_mtime(self, mtime=None):
+    def set_mtime(self, mtime=None) -> None:
         """Set the modification time of the space time dataset, if nothing set
         the current time is used
         """
@@ -1030,14 +1030,14 @@ class STDSBase(DatasetBase):
 
     semantic_type = property(fget=get_semantic_type, fset=set_semantic_type)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         DatasetBase.print_info(self)
         #      0123456789012345678901234567890
         print(" | Modification time:.......... " + str(self.get_mtime()))
         print(" | Semantic type:.............. " + str(self.get_semantic_type()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         DatasetBase.print_shell_info(self)
         print("modification_time='{}'".format(str(self.get_mtime())))
@@ -1059,7 +1059,7 @@ class STRDSBase(STDSBase):
         creator=None,
         ctime=None,
         ttype=None,
-    ):
+    ) -> None:
         STDSBase.__init__(
             self,
             "strds_base",
@@ -1085,7 +1085,7 @@ class STR3DSBase(STDSBase):
         creator=None,
         ctime=None,
         ttype=None,
-    ):
+    ) -> None:
         STDSBase.__init__(
             self,
             "str3ds_base",
@@ -1111,7 +1111,7 @@ class STVDSBase(STDSBase):
         creator=None,
         ctime=None,
         ttype=None,
-    ):
+    ) -> None:
         STDSBase.__init__(
             self,
             "stvds_base",
@@ -1145,7 +1145,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
 
     """
 
-    def __init__(self, table=None, ident=None, registered_stds=None):
+    def __init__(self, table=None, ident=None, registered_stds=None) -> None:
         """Constructor
 
         :param table: The name of the temporal database table
@@ -1162,7 +1162,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
         self.set_id(ident)
         self.set_registered_stds(registered_stds)
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)
 
         :param ident: The unique identifier must be a combination
@@ -1172,7 +1172,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
         self.ident = ident
         self.D["id"] = ident
 
-    def set_registered_stds(self, registered_stds):
+    def set_registered_stds(self, registered_stds) -> None:
         """Get the comma separated list of space time datasets ids
         in which this map is registered
 
@@ -1211,7 +1211,7 @@ class AbstractSTDSRegister(SQLDatabaseInterface):
 class RasterSTDSRegister(AbstractSTDSRegister):
     """Time stamped raster map base information class"""
 
-    def __init__(self, ident=None, registered_stds=None):
+    def __init__(self, ident=None, registered_stds=None) -> None:
         AbstractSTDSRegister.__init__(
             self, "raster_stds_register", ident, registered_stds
         )
@@ -1220,7 +1220,7 @@ class RasterSTDSRegister(AbstractSTDSRegister):
 class Raster3DSTDSRegister(AbstractSTDSRegister):
     """Time stamped 3D raster map base information class"""
 
-    def __init__(self, ident=None, registered_stds=None):
+    def __init__(self, ident=None, registered_stds=None) -> None:
         AbstractSTDSRegister.__init__(
             self, "raster3d_stds_register", ident, registered_stds
         )
@@ -1229,7 +1229,7 @@ class Raster3DSTDSRegister(AbstractSTDSRegister):
 class VectorSTDSRegister(AbstractSTDSRegister):
     """Time stamped vector map base information class"""
 
-    def __init__(self, ident=None, registered_stds=None):
+    def __init__(self, ident=None, registered_stds=None) -> None:
         AbstractSTDSRegister.__init__(
             self, "vector_stds_register", ident, registered_stds
         )

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -25,6 +25,8 @@ for details.
 :author: Soeren Gebbert
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 
 from .core import (
@@ -627,7 +629,7 @@ class DatasetBase(SQLDatabaseInterface):
         self,
         table=None,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         creator=None,
         ctime=None,
@@ -854,7 +856,7 @@ class RasterBase(DatasetBase):
     def __init__(
         self,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         creator=None,
         creation_time=None,
@@ -878,7 +880,7 @@ class Raster3DBase(DatasetBase):
     def __init__(
         self,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         creator=None,
         creation_time=None,
@@ -902,7 +904,7 @@ class VectorBase(DatasetBase):
     def __init__(
         self,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         layer=None,
         creator=None,
@@ -984,7 +986,7 @@ class STDSBase(DatasetBase):
         self,
         table=None,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         semantic_type=None,
         creator=None,
@@ -1053,7 +1055,7 @@ class STRDSBase(STDSBase):
     def __init__(
         self,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         semantic_type=None,
         creator=None,
@@ -1079,7 +1081,7 @@ class STR3DSBase(STDSBase):
     def __init__(
         self,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         semantic_type=None,
         creator=None,
@@ -1105,7 +1107,7 @@ class STVDSBase(STDSBase):
     def __init__(
         self,
         ident=None,
-        name=None,
+        name: str | None = None,
         mapset=None,
         semantic_type=None,
         creator=None,

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -367,7 +367,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
             self.get_select_statement(), mapset=self.mapset
         )
 
-    def select(self, dbif=None, mapset=None):
+    def select(self, dbif=None, mapset=None) -> bool:
         """Select the content from the temporal database and store it
         in the internal dictionary structure
 

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -70,7 +70,7 @@ class RPCDefs:
 ###############################################################################
 
 
-def _read_map_full_info(lock: _LockLike, conn: Connection, data):
+def _read_map_full_info(lock: _LockLike, conn: Connection, data) -> None:
     """Read full map specific metadata from the spatial database using
     PyGRASS functions.
 
@@ -198,7 +198,7 @@ def _read_vector_full_info(name, mapset, layer=None):
     return info
 
 
-def _fatal_error(lock: _LockLike, conn: Connection, data):
+def _fatal_error(lock: _LockLike, conn: Connection, data) -> None:
     """Calls G_fatal_error()"""
     libgis.G_fatal_error("Fatal Error in C library server")
 
@@ -206,7 +206,7 @@ def _fatal_error(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _get_mapset(lock: _LockLike, conn: Connection, data):
+def _get_mapset(lock: _LockLike, conn: Connection, data) -> None:
     """Return the current mapset
 
     :param lock: A multiprocessing.Lock instance
@@ -223,7 +223,7 @@ def _get_mapset(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _get_location(lock: _LockLike, conn: Connection, data):
+def _get_location(lock: _LockLike, conn: Connection, data) -> None:
     """Return the current location
 
     :param lock: A multiprocessing.Lock instance
@@ -240,7 +240,7 @@ def _get_location(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _get_gisdbase(lock: _LockLike, conn: Connection, data):
+def _get_gisdbase(lock: _LockLike, conn: Connection, data) -> None:
     """Return the current gisdatabase
 
     :param lock: A multiprocessing.Lock instance
@@ -257,7 +257,7 @@ def _get_gisdbase(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _get_driver_name(lock: _LockLike, conn: Connection, data):
+def _get_driver_name(lock: _LockLike, conn: Connection, data) -> None:
     """Return the temporal database driver of a specific mapset
 
     :param lock: A multiprocessing.Lock instance
@@ -276,7 +276,7 @@ def _get_driver_name(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _get_database_name(lock: _LockLike, conn: Connection, data):
+def _get_database_name(lock: _LockLike, conn: Connection, data) -> None:
     """Return the temporal database name of a specific mapset
 
     :param lock: A multiprocessing.Lock instance
@@ -306,7 +306,7 @@ def _get_database_name(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _available_mapsets(lock: _LockLike, conn: Connection, data):
+def _available_mapsets(lock: _LockLike, conn: Connection, data) -> None:
     """Return all available mapsets the user can access as a list of strings
 
     :param lock: A multiprocessing.Lock instance
@@ -363,7 +363,7 @@ def _available_mapsets(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _has_timestamp(lock: _LockLike, conn: Connection, data):
+def _has_timestamp(lock: _LockLike, conn: Connection, data) -> None:
     """Check if the file based GRASS timestamp is present and send
     True or False using the provided pipe.
 
@@ -396,7 +396,7 @@ def _has_timestamp(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _read_timestamp(lock: _LockLike, conn: Connection, data):
+def _read_timestamp(lock: _LockLike, conn: Connection, data) -> None:
     """Read the file based GRASS timestamp and send
     the result using the provided pipe.
 
@@ -490,7 +490,7 @@ def _write_timestamp(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _remove_timestamp(lock: _LockLike, conn: Connection, data):
+def _remove_timestamp(lock: _LockLike, conn: Connection, data) -> None:
     """Remove the file based GRASS timestamp
     the return values of the called C-functions using the provided pipe.
 
@@ -637,7 +637,7 @@ def _remove_semantic_label(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _map_exists(lock: _LockLike, conn: Connection, data):
+def _map_exists(lock: _LockLike, conn: Connection, data) -> None:
     """Check if a map exists in the spatial database
 
     The value to be send via pipe is True in case the map exists and False
@@ -670,7 +670,7 @@ def _map_exists(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def _read_map_info(lock: _LockLike, conn: Connection, data):
+def _read_map_info(lock: _LockLike, conn: Connection, data) -> None:
     """Read map specific metadata from the spatial database using C-library
     functions
 
@@ -978,7 +978,7 @@ def _read_vector_info(name, mapset):
 ###############################################################################
 
 
-def _read_map_history(lock: _LockLike, conn: Connection, data):
+def _read_map_history(lock: _LockLike, conn: Connection, data) -> None:
     """Read map history from the spatial database using C-library functions
 
     :param lock: A multiprocessing.Lock instance
@@ -1198,7 +1198,7 @@ def _convert_timestamp_from_grass(ts):
 ###############################################################################
 
 
-def _stop(lock: _LockLike, conn: Connection, data):
+def _stop(lock: _LockLike, conn: Connection, data) -> None:
     libgis.G_debug(1, "Stop C-interface server")
     conn.close()
     lock.release()
@@ -1208,7 +1208,7 @@ def _stop(lock: _LockLike, conn: Connection, data):
 ###############################################################################
 
 
-def c_library_server(lock: _LockLike, conn: Connection):
+def c_library_server(lock: _LockLike, conn: Connection) -> None:
     """The GRASS C-libraries server function designed to be a target for
     multiprocessing.Process
 
@@ -1217,7 +1217,7 @@ def c_library_server(lock: _LockLike, conn: Connection):
                  multiprocessing.Pipe
     """
 
-    def error_handler(data):
+    def error_handler(data) -> None:
         """This function will be called in case of a fatal error in libgis"""
         # sys.stderr.write("Error handler was called\n")
         # We send an exception that will be handled in
@@ -1490,10 +1490,10 @@ class CLibrariesInterface(RPCServerBase):
 
     """  # noqa: E501
 
-    def __init__(self):
+    def __init__(self) -> None:
         RPCServerBase.__init__(self)
 
-    def start_server(self):
+    def start_server(self) -> None:
         self.client_conn, self.server_conn = Pipe(True)
         self.lock = Lock()
         self.server = Process(

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -1205,7 +1205,7 @@ class SQLDatabaseInterfaceConnection:
 
         return self.connections[mapset].execute_transaction(statement)
 
-    def _create_mapset_error_message(self, mapset):
+    def _create_mapset_error_message(self, mapset) -> str:
         return (
             "You have no permission to "
             "access mapset <%(mapset)s>, or "

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -30,6 +30,8 @@ for details.
 :author: Soeren Gebbert
 """
 
+from __future__ import annotations
+
 # import traceback
 import os
 from pathlib import Path
@@ -1114,7 +1116,7 @@ class SQLDatabaseInterfaceConnection:
 
         return self.connections[mapset].mogrify_sql_statement(content)
 
-    def check_table(self, table_name, mapset=None):
+    def check_table(self, table_name: str, mapset=None):
         """Check if a table exists in the temporal database
 
         :param table_name: The name of the table to be checked for existence
@@ -1228,7 +1230,7 @@ class DBConnection:
       - postgresql via psycopg2
     """
 
-    def __init__(self, backend=None, dbstring=None) -> None:
+    def __init__(self, backend=None, dbstring: str | None = None) -> None:
         """Constructor of a database connection
 
         param backend:The database backend sqlite or pg
@@ -1279,7 +1281,7 @@ class DBConnection:
             if self.connected:
                 self.connection.rollback()
 
-    def connect(self, dbstring=None) -> None:
+    def connect(self, dbstring: str | None = None) -> None:
         """Connect to the DBMI to execute SQL statements
 
         Supported backends are sqlite3 and postgresql
@@ -1442,7 +1444,7 @@ class DBConnection:
 
             return statement
 
-    def check_table(self, table_name):
+    def check_table(self, table_name: str):
         """Check if a table exists in the temporal database
 
         :param table_name: The name of the table to be checked for existence

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -246,7 +246,7 @@ def get_enable_timestamp_write():
 message_interface = None
 
 
-def _init_tgis_message_interface(raise_on_error=False) -> None:
+def _init_tgis_message_interface(raise_on_error: bool = False) -> None:
     """Initiate the global message interface
 
     :param raise_on_error: If True raise a FatalError exception in case of
@@ -302,7 +302,7 @@ def get_tgis_c_library_interface():
 raise_on_error = False
 
 
-def set_raise_on_error(raise_exp=True):
+def set_raise_on_error(raise_exp: bool = True):
     """Define behavior on fatal error, invoked using the tgis messenger
     interface (msgr.fatal())
 
@@ -512,7 +512,7 @@ def get_available_temporal_mapsets():
 ###############################################################################
 
 
-def init(raise_fatal_error=False, skip_db_version_check=False):
+def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
     """This function set the correct database backend from GRASS environmental
     variables and creates the grass temporal database structure for raster,
     vector and raster3d maps as well as for the space-time datasets strds,

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -59,7 +59,7 @@ from datetime import datetime
 ###############################################################################
 
 
-def profile_function(func):
+def profile_function(func) -> None:
     """Profiling function provided by the temporal framework"""
     do_profiling = os.getenv("GRASS_TGIS_PROFILE")
 
@@ -246,7 +246,7 @@ def get_enable_timestamp_write():
 message_interface = None
 
 
-def _init_tgis_message_interface(raise_on_error=False):
+def _init_tgis_message_interface(raise_on_error=False) -> None:
     """Initiate the global message interface
 
     :param raise_on_error: If True raise a FatalError exception in case of
@@ -276,7 +276,7 @@ def get_tgis_message_interface():
 c_library_interface = None
 
 
-def _init_tgis_c_library_interface():
+def _init_tgis_c_library_interface() -> None:
     """Set the global C-library interface variable that
     provides a fast and exit safe interface to the C-library libgis,
     libraster, libraster3d and libvector functions
@@ -451,7 +451,7 @@ def get_sql_template_path():
 ###############################################################################
 
 
-def stop_subprocesses():
+def stop_subprocesses() -> None:
     """Stop the messenger and C-interface subprocesses
     that are started by tgis.init()
     """
@@ -807,7 +807,7 @@ def get_database_info_string():
 ###############################################################################
 
 
-def _create_temporal_database_views(dbif):
+def _create_temporal_database_views(dbif) -> None:
     """Create all views in the temporal database (internal use only)
 
     Used by create_temporal_database() and upgrade_temporal_database().
@@ -828,7 +828,7 @@ def _create_temporal_database_views(dbif):
         dbif.execute_transaction(sql_filepath)
 
 
-def create_temporal_database(dbif):
+def create_temporal_database(dbif) -> None:
     """This function will create the temporal database
 
     It will create all tables and triggers that are needed to run
@@ -935,7 +935,7 @@ def create_temporal_database(dbif):
 ###############################################################################
 
 
-def upgrade_temporal_database(dbif):
+def upgrade_temporal_database(dbif) -> None:
     """This function will upgrade the temporal database if needed.
 
     It will update all tables and triggers that are requested by
@@ -998,7 +998,7 @@ def upgrade_temporal_database(dbif):
 ###############################################################################
 
 
-def _create_tgis_metadata_table(content, dbif=None):
+def _create_tgis_metadata_table(content, dbif=None) -> None:
     """!Create the temporal gis metadata table which stores all metadata
     information about the temporal database.
 
@@ -1025,7 +1025,7 @@ def _create_tgis_metadata_table(content, dbif=None):
 
 
 class SQLDatabaseInterfaceConnection:
-    def __init__(self):
+    def __init__(self) -> None:
         self.tgis_mapsets = get_available_temporal_mapsets()
         self.current_mapset = get_current_mapset()
         self.connections = {}
@@ -1052,7 +1052,7 @@ class SQLDatabaseInterfaceConnection:
         mapset = decode(mapset)
         return self.connections[mapset].dbmi
 
-    def rollback(self, mapset=None):
+    def rollback(self, mapset=None) -> None:
         """
         Roll back the last transaction. This must be called
         in case a new query should be performed after a db error.
@@ -1062,7 +1062,7 @@ class SQLDatabaseInterfaceConnection:
         if mapset is None:
             mapset = self.current_mapset
 
-    def connect(self):
+    def connect(self) -> None:
         """Connect to the DBMI to execute SQL statements
 
         Supported backends are sqlite3 and postgresql
@@ -1078,7 +1078,7 @@ class SQLDatabaseInterfaceConnection:
     def is_connected(self):
         return self.connected
 
-    def close(self):
+    def close(self) -> None:
         """Close the DBMI connection
 
         There may be several temporal databases in a location, hence
@@ -1228,7 +1228,7 @@ class DBConnection:
       - postgresql via psycopg2
     """
 
-    def __init__(self, backend=None, dbstring=None):
+    def __init__(self, backend=None, dbstring=None) -> None:
         """Constructor of a database connection
 
         param backend:The database backend sqlite or pg
@@ -1261,14 +1261,14 @@ class DBConnection:
             "\n  dbstring: %s" % (backend, self.dbstring),
         )
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.connected is True:
             self.close()
 
     def is_connected(self):
         return self.connected
 
-    def rollback(self):
+    def rollback(self) -> None:
         """
         Roll back the last transaction. This must be called
         in case a new query should be performed after a db error.
@@ -1279,7 +1279,7 @@ class DBConnection:
             if self.connected:
                 self.connection.rollback()
 
-    def connect(self, dbstring=None):
+    def connect(self, dbstring=None) -> None:
         """Connect to the DBMI to execute SQL statements
 
         Supported backends are sqlite3 and postgresql
@@ -1328,7 +1328,7 @@ class DBConnection:
                 )
             )
 
-    def close(self):
+    def close(self) -> None:
         """Close the DBMI connection
         TODO:
         There may be several temporal databases in a location, hence

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -9,6 +9,8 @@ for details.
 :authors: Soeren Gebbert
 """
 
+from __future__ import annotations
+
 import copy
 from datetime import datetime, timedelta
 
@@ -79,7 +81,9 @@ def time_delta_to_relative_time_seconds(delta):
 ###############################################################################
 
 
-def decrement_datetime_by_string(mydate: datetime, increment, mult=1):
+def decrement_datetime_by_string(
+    mydate: datetime, increment: str, mult=1
+) -> datetime | None:
     """Return a new datetime object decremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment
@@ -147,7 +151,9 @@ def decrement_datetime_by_string(mydate: datetime, increment, mult=1):
 ###############################################################################
 
 
-def increment_datetime_by_string(mydate: datetime, increment, mult=1):
+def increment_datetime_by_string(
+    mydate: datetime, increment: str, mult=1
+) -> datetime | None:
     """Return a new datetime object incremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment
@@ -222,7 +228,9 @@ def increment_datetime_by_string(mydate: datetime, increment, mult=1):
 ###############################################################################
 
 
-def modify_datetime_by_string(mydate: datetime, increment, mult=1, sign: int = 1):
+def modify_datetime_by_string(
+    mydate: datetime, increment: str, mult=1, sign: int = 1
+) -> datetime | None:
     """Return a new datetime object incremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment
@@ -295,7 +303,7 @@ def modify_datetime_by_string(mydate: datetime, increment, mult=1, sign: int = 1
 
 def modify_datetime(
     mydate: datetime, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0
-):
+) -> datetime:
     """Return a new datetime object incremented with the provided
     relative dates and times"""
 
@@ -831,7 +839,7 @@ def check_datetime_string(time_string: str, use_dateutil: bool = True):
 ###############################################################################
 
 
-def string_to_datetime(time_string: str):
+def string_to_datetime(time_string: str) -> datetime | None:
     """Convert a string into a datetime object
 
     In case datutil is not installed the supported ISO string formats are:

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -30,50 +30,37 @@ SECOND_AS_DAY = 1.1574074074074073e-05
 ###############################################################################
 
 
-def relative_time_to_time_delta(value):
-    """Convert the double value representing days
-    into a timedelta object.
-    """
-
+def relative_time_to_time_delta(value: float) -> timedelta:
+    """Convert the double value representing days into a timedelta object."""
     days = int(value)
     seconds = value % 1
     seconds = round(seconds * DAY_IN_SECONDS)
-
     return timedelta(days, seconds)
 
 
 ###############################################################################
 
 
-def time_delta_to_relative_time(delta):
-    """Convert the time delta into a
-    double value, representing days.
-    """
-
+def time_delta_to_relative_time(delta: timedelta) -> float:
+    """Convert the time delta into a double value, representing days."""
     return float(delta.days) + float(delta.seconds * SECOND_AS_DAY)
 
 
 ###############################################################################
 
 
-def relative_time_to_time_delta_seconds(value):
-    """Convert the double value representing seconds
-    into a timedelta object.
-    """
-
+def relative_time_to_time_delta_seconds(value: float) -> timedelta:
+    """Convert the double value representing seconds into a timedelta object."""
     days = value / 86400
     seconds = int(value % 86400)
-
     return timedelta(days, seconds)
 
 
 ###############################################################################
 
 
-def time_delta_to_relative_time_seconds(delta):
-    """Convert the time delta into a
-    double value, representing seconds.
-    """
+def time_delta_to_relative_time_seconds(delta: timedelta) -> float:
+    """Convert the time delta into a double value, representing seconds."""
 
     return float(delta.days * DAY_IN_SECONDS) + float(delta.seconds)
 
@@ -875,7 +862,7 @@ def string_to_datetime(time_string: str) -> datetime | None:
 ###############################################################################
 
 
-def datetime_to_grass_datetime_string(dt):
+def datetime_to_grass_datetime_string(dt: datetime) -> str:
     """Convert a python datetime object into a GRASS datetime string
 
     .. code-block:: python
@@ -960,7 +947,7 @@ suffix_units = {
 }
 
 
-def create_suffix_from_datetime(start_time, granularity):
+def create_suffix_from_datetime(start_time: datetime, granularity) -> str:
     """Create a datetime string based on a datetime object and a provided
     granularity that can be used as suffix for map names.
 
@@ -989,7 +976,7 @@ def create_time_suffix(mapp, end: bool = False):
     return sstring
 
 
-def create_numeric_suffix(base, count: int, zeros):
+def create_numeric_suffix(base, count: int, zeros: str) -> str:
     """Create a string based on count and number of zeros decided by zeros
 
     :param base: the basename for new map

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -222,7 +222,7 @@ def increment_datetime_by_string(mydate, increment, mult=1):
 ###############################################################################
 
 
-def modify_datetime_by_string(mydate, increment, mult=1, sign=1):
+def modify_datetime_by_string(mydate, increment, mult=1, sign: int = 1):
     """Return a new datetime object incremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -725,7 +725,7 @@ def compute_datetime_delta(start, end):
 ###############################################################################
 
 
-def check_datetime_string(time_string, use_dateutil: bool = True):
+def check_datetime_string(time_string: str, use_dateutil: bool = True):
     """Check if  a string can be converted into a datetime object and return the object
 
     In case datutil is not installed the supported ISO string formats are:
@@ -831,7 +831,7 @@ def check_datetime_string(time_string, use_dateutil: bool = True):
 ###############################################################################
 
 
-def string_to_datetime(time_string):
+def string_to_datetime(time_string: str):
     """Convert a string into a datetime object
 
     In case datutil is not installed the supported ISO string formats are:
@@ -981,7 +981,7 @@ def create_time_suffix(mapp, end: bool = False):
     return sstring
 
 
-def create_numeric_suffix(base, count, zeros):
+def create_numeric_suffix(base, count: int, zeros):
     """Create a string based on count and number of zeros decided by zeros
 
     :param base: the basename for new map

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -27,8 +27,6 @@ except:
 DAY_IN_SECONDS = 86400
 SECOND_AS_DAY = 1.1574074074074073e-05
 
-###############################################################################
-
 
 def relative_time_to_time_delta(value: float) -> timedelta:
     """Convert the double value representing days into a timedelta object."""
@@ -38,15 +36,9 @@ def relative_time_to_time_delta(value: float) -> timedelta:
     return timedelta(days, seconds)
 
 
-###############################################################################
-
-
 def time_delta_to_relative_time(delta: timedelta) -> float:
     """Convert the time delta into a double value, representing days."""
     return float(delta.days) + float(delta.seconds * SECOND_AS_DAY)
-
-
-###############################################################################
 
 
 def relative_time_to_time_delta_seconds(value: float) -> timedelta:
@@ -54,9 +46,6 @@ def relative_time_to_time_delta_seconds(value: float) -> timedelta:
     days = value / 86400
     seconds = int(value % 86400)
     return timedelta(days, seconds)
-
-
-###############################################################################
 
 
 def time_delta_to_relative_time_seconds(delta: timedelta) -> float:
@@ -135,9 +124,6 @@ def decrement_datetime_by_string(
     return modify_datetime_by_string(mydate, increment, mult, sign=-1)
 
 
-###############################################################################
-
-
 def increment_datetime_by_string(
     mydate: datetime, increment: str, mult=1
 ) -> datetime | None:
@@ -210,9 +196,6 @@ def increment_datetime_by_string(
     :return: The new datetime object or none in case of an error
     """
     return modify_datetime_by_string(mydate, increment, mult, sign=1)
-
-
-###############################################################################
 
 
 def modify_datetime_by_string(
@@ -717,9 +700,6 @@ def compute_datetime_delta(start, end):
     return comp
 
 
-###############################################################################
-
-
 def check_datetime_string(time_string: str, use_dateutil: bool = True):
     """Check if  a string can be converted into a datetime object and return the object
 
@@ -823,9 +803,6 @@ def check_datetime_string(time_string: str, use_dateutil: bool = True):
         return _("Unable to parse time string: %s") % time_string
 
 
-###############################################################################
-
-
 def string_to_datetime(time_string: str) -> datetime | None:
     """Convert a string into a datetime object
 
@@ -857,9 +834,6 @@ def string_to_datetime(time_string: str) -> datetime | None:
         return None
 
     return time_object
-
-
-###############################################################################
 
 
 def datetime_to_grass_datetime_string(dt: datetime) -> str:
@@ -931,6 +905,8 @@ def datetime_to_grass_datetime_string(dt: datetime) -> str:
 
 
 ###############################################################################
+
+
 suffix_units = {
     "years": "%Y",
     "year": "%Y",

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -725,7 +725,7 @@ def compute_datetime_delta(start, end):
 ###############################################################################
 
 
-def check_datetime_string(time_string, use_dateutil=True):
+def check_datetime_string(time_string, use_dateutil: bool = True):
     """Check if  a string can be converted into a datetime object and return the object
 
     In case datutil is not installed the supported ISO string formats are:
@@ -966,7 +966,7 @@ def create_suffix_from_datetime(start_time, granularity):
     return start_time.strftime(suffix_units[granularity.split(" ")[1]])
 
 
-def create_time_suffix(mapp, end=False):
+def create_time_suffix(mapp, end: bool = False):
     """Create a datetime string based on a map datetime object
 
     :param mapp: a temporal map dataset

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -79,7 +79,7 @@ def time_delta_to_relative_time_seconds(delta):
 ###############################################################################
 
 
-def decrement_datetime_by_string(mydate, increment, mult=1):
+def decrement_datetime_by_string(mydate: datetime, increment, mult=1):
     """Return a new datetime object decremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment
@@ -147,7 +147,7 @@ def decrement_datetime_by_string(mydate, increment, mult=1):
 ###############################################################################
 
 
-def increment_datetime_by_string(mydate, increment, mult=1):
+def increment_datetime_by_string(mydate: datetime, increment, mult=1):
     """Return a new datetime object incremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment
@@ -222,7 +222,7 @@ def increment_datetime_by_string(mydate, increment, mult=1):
 ###############################################################################
 
 
-def modify_datetime_by_string(mydate, increment, mult=1, sign: int = 1):
+def modify_datetime_by_string(mydate: datetime, increment, mult=1, sign: int = 1):
     """Return a new datetime object incremented with the provided
     relative dates specified as string.
     Additional a multiplier can be specified to multiply the increment
@@ -294,7 +294,7 @@ def modify_datetime_by_string(mydate, increment, mult=1, sign: int = 1):
 
 
 def modify_datetime(
-    mydate, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0
+    mydate: datetime, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, seconds=0
 ):
     """Return a new datetime object incremented with the provided
     relative dates and times"""
@@ -373,7 +373,7 @@ def modify_datetime(
 ###############################################################################
 
 
-def adjust_datetime_to_granularity(mydate, granularity):
+def adjust_datetime_to_granularity(mydate: datetime, granularity):
     """Modify the datetime object to fit the given granularity
 
     - Years will start at the first of January

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -703,7 +703,7 @@ def compute_datetime_delta(start, end):
 def check_datetime_string(time_string: str, use_dateutil: bool = True):
     """Check if  a string can be converted into a datetime object and return the object
 
-    In case datutil is not installed the supported ISO string formats are:
+    In case dateutil is not installed the supported ISO string formats are:
 
     - YYYY-mm-dd
     - YYYY-mm-dd HH:MM:SS

--- a/python/grass/temporal/extract.py
+++ b/python/grass/temporal/extract.py
@@ -39,9 +39,9 @@ def extract_dataset(
     expression,
     base,
     time_suffix,
-    nprocs=1,
+    nprocs: int = 1,
     register_null: bool = False,
-    layer=1,
+    layer: int = 1,
     vtype="point,line,boundary,centroid,area,face",
 ) -> None:
     """Extract a subset of a space time raster, raster3d or vector dataset

--- a/python/grass/temporal/extract.py
+++ b/python/grass/temporal/extract.py
@@ -43,7 +43,7 @@ def extract_dataset(
     register_null=False,
     layer=1,
     vtype="point,line,boundary,centroid,area,face",
-):
+) -> None:
     """Extract a subset of a space time raster, raster3d or vector dataset
 
     A mapcalc expression can be provided to process the temporal extracted
@@ -318,7 +318,7 @@ def extract_dataset(
 ###############################################################################
 
 
-def run_mapcalc2d(expr):
+def run_mapcalc2d(expr) -> None:
     """Helper function to run r.mapcalc in parallel"""
     try:
         gs.run_command(
@@ -328,7 +328,7 @@ def run_mapcalc2d(expr):
         sys.exit(1)
 
 
-def run_mapcalc3d(expr):
+def run_mapcalc3d(expr) -> None:
     """Helper function to run r3.mapcalc in parallel"""
     try:
         gs.run_command(
@@ -338,7 +338,7 @@ def run_mapcalc3d(expr):
         sys.exit(1)
 
 
-def run_vector_extraction(input, output, layer, type, where):
+def run_vector_extraction(input, output, layer, type, where) -> None:
     """Helper function to run r.mapcalc in parallel"""
     try:
         gs.run_command(

--- a/python/grass/temporal/extract.py
+++ b/python/grass/temporal/extract.py
@@ -40,7 +40,7 @@ def extract_dataset(
     base,
     time_suffix,
     nprocs=1,
-    register_null=False,
+    register_null: bool = False,
     layer=1,
     vtype="point,line,boundary,centroid,area,face",
 ) -> None:

--- a/python/grass/temporal/gui_support.py
+++ b/python/grass/temporal/gui_support.py
@@ -18,7 +18,7 @@ from .factory import dataset_factory
 ###############################################################################
 
 
-def tlist_grouped(type, group_type=False, dbif=None):
+def tlist_grouped(type, group_type: bool = False, dbif=None):
     """List of temporal elements grouped by mapsets.
 
     Returns a dictionary where the keys are mapset

--- a/python/grass/temporal/gui_support.py
+++ b/python/grass/temporal/gui_support.py
@@ -27,7 +27,7 @@ def tlist_grouped(type, group_type: bool = False, dbif=None):
 
     .. code-block:: python
 
-        >>> import grass.temporalas tgis
+        >>> import grass.temporal as tgis
         >>> tgis.tlist_grouped('strds')['PERMANENT']
         ['precipitation', 'temperature']
 

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -216,7 +216,7 @@ def _write_yaml(rows, column_names, file=sys.stdout) -> None:
         def ignore_aliases(self, data):
             return True
 
-        def increase_indent(self, flow=False, indentless=False):
+        def increase_indent(self, flow: bool = False, indentless: bool = False):
             return super().increase_indent(flow=flow, indentless=False)
 
     dict_rows = []
@@ -481,7 +481,7 @@ def list_maps_of_stds(
     where,
     separator,
     method,
-    no_header=False,
+    no_header: bool = False,
     gran=None,
     dbif=None,
     outpath=None,

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -213,7 +213,7 @@ def _write_yaml(rows, column_names, file=sys.stdout) -> None:
         when https://github.com/yaml/pyyaml/issues/234 is resolved.
         """
 
-        def ignore_aliases(self, data):
+        def ignore_aliases(self, data) -> bool:
             return True
 
         def increase_indent(self, flow: bool = False, indentless: bool = False):

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -150,7 +150,7 @@ def _open_output_file(file, encoding="utf-8", **kwargs):
             yield stream
 
 
-def _write_line(items, separator, file):
+def _write_line(items, separator, file) -> None:
     if not separator:
         separator = ","
     output = separator.join([f"{item}" for item in items])
@@ -158,8 +158,8 @@ def _write_line(items, separator, file):
         print(f"{output}", file=stream)
 
 
-def _write_plain(rows, header, separator, file):
-    def write_plain_row(items, separator, file):
+def _write_plain(rows, header, separator, file) -> None:
+    def write_plain_row(items, separator, file) -> None:
         output = separator.join([f"{item}" for item in items])
         print(f"{output}", file=file)
 
@@ -171,7 +171,7 @@ def _write_plain(rows, header, separator, file):
             write_plain_row(items=row, separator=separator, file=stream)
 
 
-def _write_json(rows, column_names, file):
+def _write_json(rows, column_names, file) -> None:
     # Lazy import output format-specific dependencies.
     # pylint: disable=import-outside-toplevel
     import datetime
@@ -197,7 +197,7 @@ def _write_json(rows, column_names, file):
         json.dump({"data": dict_rows, "metadata": meta}, stream, cls=ResultsEncoder)
 
 
-def _write_yaml(rows, column_names, file=sys.stdout):
+def _write_yaml(rows, column_names, file=sys.stdout) -> None:
     # Lazy import output format-specific dependencies.
     # pylint: disable=import-outside-toplevel
     import yaml
@@ -238,7 +238,7 @@ def _write_yaml(rows, column_names, file=sys.stdout):
         )
 
 
-def _write_csv(rows, column_names, separator, file=sys.stdout):
+def _write_csv(rows, column_names, separator, file=sys.stdout) -> None:
     # Lazy import output format-specific dependencies.
     # pylint: disable=import-outside-toplevel
     import csv
@@ -486,7 +486,7 @@ def list_maps_of_stds(
     dbif=None,
     outpath=None,
     output_format=None,
-):
+) -> None:
     """List the maps of a space time dataset using different methods
 
     :param type: The type of the maps raster, raster3d or vector

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -35,10 +35,10 @@ def dataset_mapcalculator(
     expression,
     base,
     method,
-    nprocs=1,
+    nprocs: int = 1,
     register_null: bool = False,
     spatial: bool = False,
-) -> int:
+):
     """Perform map-calculations of maps from different space time
     raster/raster3d datasets, using a specific sampling method
     to select temporal related maps.

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -487,7 +487,7 @@ def _operator_parser(expr, first, current):
 ###############################################################################
 
 
-def _parse_start_operators(expr, is_time_absolute, current):
+def _parse_start_operators(expr, is_time_absolute: bool, current):
     """
     Supported operators for absolute time:
     - start_doy() - Day of year (doy) from the start time [1 - 366]
@@ -586,7 +586,7 @@ def _parse_start_operators(expr, is_time_absolute, current):
 ###############################################################################
 
 
-def _parse_end_operators(expr, is_time_absolute, current):
+def _parse_end_operators(expr, is_time_absolute: bool, current):
     """
     Supported operators for absolute time:
     - end_doy() - Day of year (doy) from the end time [1 - 366]
@@ -706,7 +706,7 @@ def _parse_end_operators(expr, is_time_absolute, current):
 ###############################################################################
 
 
-def _parse_td_operator(expr, is_time_absolute, first, current):
+def _parse_td_operator(expr, is_time_absolute: bool, first, current):
     """Parse the time delta operator td(). This operator
     represents the size of the current sample time interval
     in days and fraction of days for absolute time,
@@ -732,7 +732,7 @@ def _parse_td_operator(expr, is_time_absolute, first, current):
 ###############################################################################
 
 
-def _parse_start_time_operator(expr, is_time_absolute, first, current):
+def _parse_start_time_operator(expr, is_time_absolute: bool, first, current):
     """Parse the start_time() operator. This operator represent
     the time difference between the start time of the sample space time
     raster dataset and the start time of the current sample interval or
@@ -755,7 +755,7 @@ def _parse_start_time_operator(expr, is_time_absolute, first, current):
 ###############################################################################
 
 
-def _parse_end_time_operator(expr, is_time_absolute, first, current):
+def _parse_end_time_operator(expr, is_time_absolute: bool, first, current):
     """Parse the end_time() operator. This operator represent
     the time difference between the start time of the sample space time
     raster dataset and the end time of the current sample interval. The time

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -36,8 +36,8 @@ def dataset_mapcalculator(
     base,
     method,
     nprocs=1,
-    register_null=False,
-    spatial=False,
+    register_null: bool = False,
+    spatial: bool = False,
 ):
     """Perform map-calculations of maps from different space time
     raster/raster3d datasets, using a specific sampling method

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -408,7 +408,7 @@ def dataset_mapcalculator(
 ###############################################################################
 
 
-def _run_mapcalc2d(expr):
+def _run_mapcalc2d(expr) -> None:
     """Helper function to run r.mapcalc in parallel"""
     try:
         gs.run_command(
@@ -421,7 +421,7 @@ def _run_mapcalc2d(expr):
 ###############################################################################
 
 
-def _run_mapcalc3d(expr):
+def _run_mapcalc3d(expr) -> None:
     """Helper function to run r3.mapcalc in parallel"""
     try:
         gs.run_command(

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -38,7 +38,7 @@ def dataset_mapcalculator(
     nprocs=1,
     register_null: bool = False,
     spatial: bool = False,
-):
+) -> int:
     """Perform map-calculations of maps from different space time
     raster/raster3d datasets, using a specific sampling method
     to select temporal related maps.

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -298,7 +298,7 @@ class RasterMetadata(RasterMetadataBase):
 
     The metadata includes the datatype, number of cols, rows and cells and
     the north-south and east west resolution of the map. Additionally the
-    minimum and maximum valuesare stored.
+    minimum and maximum values are stored.
 
     Usage:
 

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -250,7 +250,7 @@ class RasterMetadataBase(SQLDatabaseInterface):
         """Print information about this class in shell style"""
         self._print_info_body(shell=True)
 
-    def _print_info_head(self, shell=False) -> None:
+    def _print_info_head(self, shell: bool = False) -> None:
         """Print information about this class (head part).
 
         No header printed in shell style mode.
@@ -262,7 +262,7 @@ class RasterMetadataBase(SQLDatabaseInterface):
                 " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
             )
 
-    def _print_info_body(self, shell=False) -> None:
+    def _print_info_body(self, shell: bool = False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -660,7 +660,7 @@ class VectorMetadata(SQLDatabaseInterface):
     def __init__(
         self,
         ident=None,
-        is_3d=False,
+        is_3d: bool = False,
         number_of_points=None,
         number_of_lines=None,
         number_of_boundaries=None,
@@ -1023,7 +1023,7 @@ class STDSMetadataBase(SQLDatabaseInterface):
         self._print_info_body(shell=True)
         self._print_info_tail(shell=True)
 
-    def _print_info_head(self, shell=False) -> None:
+    def _print_info_head(self, shell: bool = False) -> None:
         """Print information about this class (head part).
 
         No header printed in shell style mode.
@@ -1035,13 +1035,13 @@ class STDSMetadataBase(SQLDatabaseInterface):
                 " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
             )
 
-    def _print_info_body(self, shell=False) -> None:
+    def _print_info_body(self, shell: bool = False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
         """
 
-    def _print_info_tail(self, shell=False) -> None:
+    def _print_info_tail(self, shell: bool = False) -> None:
         """Print information about this class (tail part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1273,7 +1273,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
     max_max = property(fget=get_max_max)
     aggregation_type = property(fset=set_aggregation_type, fget=get_aggregation_type)
 
-    def _print_info_body(self, shell=False) -> None:
+    def _print_info_body(self, shell: bool = False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1460,7 +1460,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
         self._print_info_head(shell=True)
         super().print_shell_info()
 
-    def _print_info_body(self, shell=False) -> None:
+    def _print_info_body(self, shell: bool = False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1615,7 +1615,7 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         self._print_info_head(shell=True)
         super().print_shell_info()
 
-    def _print_info_body(self, shell=False) -> None:
+    def _print_info_body(self, shell: bool = False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1879,7 +1879,7 @@ class STVDSMetadata(STDSMetadataBase):
         self._print_info_head(shell=True)
         super().print_shell_info()
 
-    def _print_info_body(self, shell=False) -> None:
+    def _print_info_body(self, shell: bool = False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -97,7 +97,7 @@ class RasterMetadataBase(SQLDatabaseInterface):
         ewres=None,
         min=None,
         max=None,
-    ):
+    ) -> None:
         SQLDatabaseInterface.__init__(self, table, ident)
 
         self.set_id(ident)
@@ -110,58 +110,58 @@ class RasterMetadataBase(SQLDatabaseInterface):
         self.set_min(min)
         self.set_max(max)
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)"""
         self.ident = ident
         self.D["id"] = ident
 
-    def set_datatype(self, datatype):
+    def set_datatype(self, datatype) -> None:
         """Set the datatype"""
         self.D["datatype"] = datatype
 
-    def set_cols(self, cols):
+    def set_cols(self, cols) -> None:
         """Set the number of cols"""
         if cols is not None:
             self.D["cols"] = int(cols)
         else:
             self.D["cols"] = None
 
-    def set_rows(self, rows):
+    def set_rows(self, rows) -> None:
         """Set the number of rows"""
         if rows is not None:
             self.D["rows"] = int(rows)
         else:
             self.D["rows"] = None
 
-    def set_number_of_cells(self, number_of_cells):
+    def set_number_of_cells(self, number_of_cells) -> None:
         """Set the number of cells"""
         if number_of_cells is not None:
             self.D["number_of_cells"] = int(number_of_cells)
         else:
             self.D["number_of_cells"] = None
 
-    def set_nsres(self, nsres):
+    def set_nsres(self, nsres) -> None:
         """Set the north-south resolution"""
         if nsres is not None:
             self.D["nsres"] = float(nsres)
         else:
             self.D["nsres"] = None
 
-    def set_ewres(self, ewres):
+    def set_ewres(self, ewres) -> None:
         """Set the east-west resolution"""
         if ewres is not None:
             self.D["ewres"] = float(ewres)
         else:
             self.D["ewres"] = None
 
-    def set_min(self, min):
+    def set_min(self, min) -> None:
         """Set the minimum raster value"""
         if min is not None:
             self.D["min"] = float(min)
         else:
             self.D["min"] = None
 
-    def set_max(self, max):
+    def set_max(self, max) -> None:
         """Set the maximum raster value"""
         if max is not None:
             self.D["max"] = float(max)
@@ -242,15 +242,15 @@ class RasterMetadataBase(SQLDatabaseInterface):
     min = property(fget=get_min, fset=set_min)
     max = property(fget=get_max, fset=set_max)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         self._print_info_body(shell=False)
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_body(shell=True)
 
-    def _print_info_head(self, shell=False):
+    def _print_info_head(self, shell=False) -> None:
         """Print information about this class (head part).
 
         No header printed in shell style mode.
@@ -262,7 +262,7 @@ class RasterMetadataBase(SQLDatabaseInterface):
                 " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
             )
 
-    def _print_info_body(self, shell=False):
+    def _print_info_body(self, shell=False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -368,7 +368,7 @@ class RasterMetadata(RasterMetadataBase):
         min=None,
         max=None,
         semantic_label=None,
-    ):
+    ) -> None:
         RasterMetadataBase.__init__(
             self,
             "raster_metadata",
@@ -383,7 +383,7 @@ class RasterMetadata(RasterMetadataBase):
             max,
         )
 
-    def set_semantic_label(self, semantic_label):
+    def set_semantic_label(self, semantic_label) -> None:
         """Set the semantic label identifier"""
         self.D["semantic_label"] = semantic_label
 
@@ -396,14 +396,14 @@ class RasterMetadata(RasterMetadataBase):
 
     semantic_label = property(fget=get_semantic_label, fset=set_semantic_label)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class."""
         self._print_info_head(shell=False)
         self._print_info_body(shell=False)
         # semantic label section (raster specific only)
         print(" | Semantic label:............. " + str(self.get_semantic_label()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_head(shell=True)
         self._print_info_body(shell=True)
@@ -502,7 +502,7 @@ class Raster3DMetadata(RasterMetadataBase):
         tbres=None,
         min=None,
         max=None,
-    ):
+    ) -> None:
         RasterMetadataBase.__init__(
             self,
             "raster3d_metadata",
@@ -520,14 +520,14 @@ class Raster3DMetadata(RasterMetadataBase):
         self.set_tbres(tbres)
         self.set_depths(depths)
 
-    def set_depths(self, depths):
+    def set_depths(self, depths) -> None:
         """Set the number of depths"""
         if depths is not None:
             self.D["depths"] = int(depths)
         else:
             self.D["depths"] = None
 
-    def set_tbres(self, tbres):
+    def set_tbres(self, tbres) -> None:
         """Set the top-bottom resolution"""
         if tbres is not None:
             self.D["tbres"] = float(tbres)
@@ -551,14 +551,14 @@ class Raster3DMetadata(RasterMetadataBase):
     depths = property(fget=get_depths, fset=set_depths)
     tbres = property(fget=get_tbres, fset=set_tbres)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class."""
         self._print_info_head(shell=False)
         self._print_info_body(shell=False)
         print(" | Number of depths:........... " + str(self.get_depths()))
         print(" | Top-Bottom resolution:...... " + str(self.get_tbres()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_head(shell=True)
         self._print_info_body(shell=True)
@@ -673,7 +673,7 @@ class VectorMetadata(SQLDatabaseInterface):
         number_of_islands=None,
         number_of_holes=None,
         number_of_volumes=None,
-    ):
+    ) -> None:
         SQLDatabaseInterface.__init__(self, "vector_metadata", ident)
 
         self.set_id(ident)
@@ -691,60 +691,60 @@ class VectorMetadata(SQLDatabaseInterface):
         self.set_number_of_holes(number_of_holes)
         self.set_number_of_volumes(number_of_volumes)
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)"""
         self.ident = ident
         self.D["id"] = ident
 
-    def set_3d_info(self, is_3d):
+    def set_3d_info(self, is_3d) -> None:
         """Set True if the vector map is three dimensional"""
         self.D["is_3d"] = is_3d
 
-    def set_number_of_points(self, number_of_points):
+    def set_number_of_points(self, number_of_points) -> None:
         """Set the number of points of the vector map"""
         self.D["points"] = number_of_points
 
-    def set_number_of_lines(self, number_of_lines):
+    def set_number_of_lines(self, number_of_lines) -> None:
         """Set the number of lines of the vector map"""
         self.D["lines"] = number_of_lines
 
-    def set_number_of_boundaries(self, number_of_boundaries):
+    def set_number_of_boundaries(self, number_of_boundaries) -> None:
         """Set the number of boundaries of the vector map"""
         self.D["boundaries"] = number_of_boundaries
 
-    def set_number_of_centroids(self, number_of_centroids):
+    def set_number_of_centroids(self, number_of_centroids) -> None:
         """Set the number of centroids of the vector map"""
         self.D["centroids"] = number_of_centroids
 
-    def set_number_of_faces(self, number_of_faces):
+    def set_number_of_faces(self, number_of_faces) -> None:
         """Set the number of faces of the vector map"""
         self.D["faces"] = number_of_faces
 
-    def set_number_of_kernels(self, number_of_kernels):
+    def set_number_of_kernels(self, number_of_kernels) -> None:
         """Set the number of kernels of the vector map"""
         self.D["kernels"] = number_of_kernels
 
-    def set_number_of_primitives(self, number_of_primitives):
+    def set_number_of_primitives(self, number_of_primitives) -> None:
         """Set the number of primitives of the vector map"""
         self.D["primitives"] = number_of_primitives
 
-    def set_number_of_nodes(self, number_of_nodes):
+    def set_number_of_nodes(self, number_of_nodes) -> None:
         """Set the number of nodes of the vector map"""
         self.D["nodes"] = number_of_nodes
 
-    def set_number_of_areas(self, number_of_areas):
+    def set_number_of_areas(self, number_of_areas) -> None:
         """Set the number of areas of the vector map"""
         self.D["areas"] = number_of_areas
 
-    def set_number_of_islands(self, number_of_islands):
+    def set_number_of_islands(self, number_of_islands) -> None:
         """Set the number of islands of the vector map"""
         self.D["islands"] = number_of_islands
 
-    def set_number_of_holes(self, number_of_holes):
+    def set_number_of_holes(self, number_of_holes) -> None:
         """Set the number of holes of the vector map"""
         self.D["holes"] = number_of_holes
 
-    def set_number_of_volumes(self, number_of_volumes):
+    def set_number_of_volumes(self, number_of_volumes) -> None:
         """Set the number of volumes of the vector map"""
         self.D["volumes"] = number_of_volumes
 
@@ -869,7 +869,7 @@ class VectorMetadata(SQLDatabaseInterface):
     number_of_holes = property(fget=get_number_of_holes, fset=set_number_of_holes)
     number_of_volumes = property(fget=get_number_of_volumes, fset=set_number_of_volumes)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         print(
             " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
@@ -888,7 +888,7 @@ class VectorMetadata(SQLDatabaseInterface):
         print(" | Number of holes ............ " + str(self.get_number_of_holes()))
         print(" | Number of volumes .......... " + str(self.get_number_of_volumes()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         print("is_3d=" + str(self.get_3d_info()))
         print("points=" + str(self.get_number_of_points()))
@@ -943,7 +943,7 @@ class STDSMetadataBase(SQLDatabaseInterface):
 
     def __init__(
         self, table=None, ident=None, title=None, description=None, command=None
-    ):
+    ) -> None:
         SQLDatabaseInterface.__init__(self, table, ident)
 
         self.set_id(ident)
@@ -953,20 +953,20 @@ class STDSMetadataBase(SQLDatabaseInterface):
         # No setter for this
         self.D["number_of_maps"] = None
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)"""
         self.ident = ident
         self.D["id"] = ident
 
-    def set_title(self, title):
+    def set_title(self, title) -> None:
         """Set the title"""
         self.D["title"] = title
 
-    def set_description(self, description):
+    def set_description(self, description) -> None:
         """Set the number of cols"""
         self.D["description"] = description
 
-    def set_command(self, command):
+    def set_command(self, command) -> None:
         """Set the number of cols"""
         self.D["command"] = command
 
@@ -1013,17 +1013,17 @@ class STDSMetadataBase(SQLDatabaseInterface):
     description = property(fget=get_description, fset=set_description)
     number_of_maps = property(fget=get_number_of_maps)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         self._print_info_body(shell=False)
         self._print_info_tail(shell=False)
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_body(shell=True)
         self._print_info_tail(shell=True)
 
-    def _print_info_head(self, shell=False):
+    def _print_info_head(self, shell=False) -> None:
         """Print information about this class (head part).
 
         No header printed in shell style mode.
@@ -1035,13 +1035,13 @@ class STDSMetadataBase(SQLDatabaseInterface):
                 " +-------------------- Metadata information ----------------------------------+"  # noqa: E501
             )
 
-    def _print_info_body(self, shell=False):
+    def _print_info_body(self, shell=False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
         """
 
-    def _print_info_tail(self, shell=False):
+    def _print_info_tail(self, shell=False) -> None:
         """Print information about this class (tail part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1061,7 +1061,7 @@ class STDSMetadataBase(SQLDatabaseInterface):
                 for token in command.split("\n"):
                     print(" | " + str(token))
 
-    def print_history(self):
+    def print_history(self) -> None:
         """Print history information about this class in human readable
         shell style
         """
@@ -1165,7 +1165,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         title=None,
         description=None,
         aggregation_type=None,
-    ):
+    ) -> None:
         STDSMetadataBase.__init__(self, table, ident, title, description)
 
         # Initialize the dict to select all values from the db
@@ -1179,7 +1179,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         self.D["ewres_max"] = None
         self.D["aggregation_type"] = aggregation_type
 
-    def set_aggregation_type(self, aggregation_type):
+    def set_aggregation_type(self, aggregation_type) -> None:
         """Set the aggregation type of the dataset (mean, min, max, ...)"""
         self.D["aggregation_type"] = aggregation_type
 
@@ -1273,7 +1273,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
     max_max = property(fget=get_max_max)
     aggregation_type = property(fset=set_aggregation_type, fget=get_aggregation_type)
 
-    def _print_info_body(self, shell=False):
+    def _print_info_body(self, shell=False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1376,7 +1376,9 @@ class STRDSMetadata(STDSRasterMetadataBase):
 
     """
 
-    def __init__(self, ident=None, raster_register=None, title=None, description=None):
+    def __init__(
+        self, ident=None, raster_register=None, title=None, description=None
+    ) -> None:
         STDSRasterMetadataBase.__init__(
             self, "strds_metadata", ident, title, description
         )
@@ -1386,7 +1388,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
 
         self.set_raster_register(raster_register)
 
-    def set_raster_register(self, raster_register):
+    def set_raster_register(self, raster_register) -> None:
         """Set the raster map register table name"""
         self.D["raster_register"] = raster_register
 
@@ -1448,17 +1450,17 @@ class STRDSMetadata(STDSRasterMetadataBase):
     number_of_semantic_labels = property(fget=get_number_of_semantic_labels)
     semantic_labels = property(fget=get_semantic_labels)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         self._print_info_head(shell=False)
         super().print_info()
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_head(shell=True)
         super().print_shell_info()
 
-    def _print_info_body(self, shell=False):
+    def _print_info_body(self, shell=False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1561,7 +1563,7 @@ class STR3DSMetadata(STDSRasterMetadataBase):
 
     def __init__(
         self, ident=None, raster3d_register=None, title=None, description=None
-    ):
+    ) -> None:
         STDSRasterMetadataBase.__init__(
             self, "str3ds_metadata", ident, title, description
         )
@@ -1570,7 +1572,7 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         self.D["tbres_min"] = None
         self.D["tbres_max"] = None
 
-    def set_raster3d_register(self, raster3d_register):
+    def set_raster3d_register(self, raster3d_register) -> None:
         """Set the raster map register table name"""
         self.D["raster3d_register"] = raster3d_register
 
@@ -1603,17 +1605,17 @@ class STR3DSMetadata(STDSRasterMetadataBase):
     tbres_min = property(fget=get_tbres_min)
     tbres_max = property(fget=get_tbres_max)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         self._print_info_head(shell=False)
         super().print_info()
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_head(shell=True)
         super().print_shell_info()
 
-    def _print_info_body(self, shell=False):
+    def _print_info_body(self, shell=False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style
@@ -1714,7 +1716,9 @@ class STVDSMetadata(STDSMetadataBase):
 
     """
 
-    def __init__(self, ident=None, vector_register=None, title=None, description=None):
+    def __init__(
+        self, ident=None, vector_register=None, title=None, description=None
+    ) -> None:
         STDSMetadataBase.__init__(self, "stvds_metadata", ident, title, description)
 
         self.set_vector_register(vector_register)
@@ -1731,7 +1735,7 @@ class STVDSMetadata(STDSMetadataBase):
         self.D["holes"] = None
         self.D["volumes"] = None
 
-    def set_vector_register(self, vector_register):
+    def set_vector_register(self, vector_register) -> None:
         """Set the vector map register table name"""
         self.D["vector_register"] = vector_register
 
@@ -1865,17 +1869,17 @@ class STVDSMetadata(STDSMetadataBase):
     number_of_holes = property(fget=get_number_of_holes)
     number_of_volumes = property(fget=get_number_of_volumes)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         self._print_info_head(shell=False)
         super().print_info()
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         self._print_info_head(shell=True)
         super().print_shell_info()
 
-    def _print_info_body(self, shell=False):
+    def _print_info_body(self, shell=False) -> None:
         """Print information about this class (body part).
 
         :param bool shell: True for human readable style otherwise shell style

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -88,7 +88,7 @@ def open_old_stds(name, type, dbif=None):
 ###############################################################################
 
 
-def check_new_stds(name, type, dbif=None, overwrite=False):
+def check_new_stds(name, type, dbif=None, overwrite: bool = False):
     """Check if a new space time dataset of a specific type can be created
 
     :param name: The name of the new space time dataset
@@ -153,7 +153,7 @@ def check_new_stds(name, type, dbif=None, overwrite=False):
 
 
 def open_new_stds(
-    name, type, temporaltype, title, descr, semantic, dbif=None, overwrite=False
+    name, type, temporaltype, title, descr, semantic, dbif=None, overwrite: bool = False
 ):
     """Create a new space time dataset of a specific type
 
@@ -210,7 +210,9 @@ def open_new_stds(
 ############################################################################
 
 
-def check_new_map_dataset(name, layer=None, type="raster", overwrite=False, dbif=None):
+def check_new_map_dataset(
+    name, layer=None, type="raster", overwrite: bool = False, dbif=None
+):
     """Check if a new map dataset of a specific type can be created in
      the temporal database
 
@@ -254,7 +256,12 @@ def check_new_map_dataset(name, layer=None, type="raster", overwrite=False, dbif
 
 
 def open_new_map_dataset(
-    name, layer=None, type="raster", temporal_extent=None, overwrite=False, dbif=None
+    name,
+    layer=None,
+    type="raster",
+    temporal_extent=None,
+    overwrite: bool = False,
+    dbif=None,
 ):
     """Create a new map dataset object of a specific type that can be
      registered in the temporal database

--- a/python/grass/temporal/open_stds.py
+++ b/python/grass/temporal/open_stds.py
@@ -35,7 +35,7 @@ def open_old_stds(name, type, dbif=None):
 
     :param name: The name of the space time dataset, if the name does not
                  contain the mapset (name@mapset) then the current mapset
-                 will be used to identifiy the space time dataset
+                 will be used to identify the space time dataset
     :param type: The type of the space time dataset (strd, str3ds, stvds,
                  raster, vector, raster3d)
     :param dbif: The optional database interface to be used

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -47,7 +47,7 @@ def register_maps_in_space_time_dataset(
     interval=False,
     fs="|",
     update_cmd_list=True,
-):
+) -> None:
     """Use this method to register maps in space time datasets.
 
     Additionally a start time string and an increment string can be
@@ -465,7 +465,7 @@ def register_maps_in_space_time_dataset(
 
 def assign_valid_time_to_map(
     ttype, map_object, start, end, unit, increment=None, mult=1, interval=False
-):
+) -> None:
     """Assign the valid time to a map dataset
 
     :param ttype: The temporal type which should be assigned
@@ -591,7 +591,7 @@ def assign_valid_time_to_map(
 
 def register_map_object_list(
     type, map_list, output_stds, delete_empty=False, unit=None, dbif=None
-):
+) -> None:
     """Register a list of AbstractMapDataset objects in the temporal database
     and optional in a space time dataset.
 

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -44,9 +44,9 @@ def register_maps_in_space_time_dataset(
     unit=None,
     increment=None,
     dbif=None,
-    interval=False,
+    interval: bool = False,
     fs="|",
-    update_cmd_list=True,
+    update_cmd_list: bool = True,
 ) -> None:
     """Use this method to register maps in space time datasets.
 
@@ -464,7 +464,7 @@ def register_maps_in_space_time_dataset(
 
 
 def assign_valid_time_to_map(
-    ttype, map_object, start, end, unit, increment=None, mult=1, interval=False
+    ttype, map_object, start, end, unit, increment=None, mult=1, interval: bool = False
 ) -> None:
     """Assign the valid time to a map dataset
 
@@ -590,7 +590,7 @@ def assign_valid_time_to_map(
 
 
 def register_map_object_list(
-    type, map_list, output_stds, delete_empty=False, unit=None, dbif=None
+    type, map_list, output_stds, delete_empty: bool = False, unit=None, dbif=None
 ) -> None:
     """Register a list of AbstractMapDataset objects in the temporal database
     and optional in a space time dataset.

--- a/python/grass/temporal/register.py
+++ b/python/grass/temporal/register.py
@@ -45,7 +45,7 @@ def register_maps_in_space_time_dataset(
     increment=None,
     dbif=None,
     interval: bool = False,
-    fs="|",
+    fs: str = "|",
     update_cmd_list: bool = True,
 ) -> None:
     """Use this method to register maps in space time datasets.

--- a/python/grass/temporal/sampling.py
+++ b/python/grass/temporal/sampling.py
@@ -34,8 +34,8 @@ def sample_stds_by_stds_topology(
     header,
     separator,
     method,
-    spatial=False,
-    print_only=True,
+    spatial: bool = False,
+    print_only: bool = True,
 ):
     """Sample the input space time datasets with a sample
     space time dataset, return the created map matrix and optionally

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -9,8 +9,11 @@ for details.
 :authors: Soeren Gebbert
 """
 
+from __future__ import annotations
+
 import getpass
 from datetime import datetime
+from typing import Literal
 
 import grass.script.array as garray
 
@@ -181,14 +184,14 @@ class RasterDataset(AbstractMapDataset):
         AbstractMapDataset.__init__(self)
         self.reset(ident)
 
-    def is_stds(self):
+    def is_stds(self) -> Literal[False]:
         """Return True if this class is a space time dataset
 
         :return: True if this class is a space time dataset, False otherwise
         """
         return False
 
-    def get_type(self):
+    def get_type(self) -> Literal["raster"]:
         return "raster"
 
     def get_new_instance(self, ident):
@@ -269,7 +272,7 @@ class RasterDataset(AbstractMapDataset):
         """
         return self.ciface.has_raster_timestamp(self.get_name(), self.get_mapset())
 
-    def read_timestamp_from_grass(self):
+    def read_timestamp_from_grass(self) -> bool:
         """Read the timestamp of this map from the map metadata
         in the grass file system based spatial database and
         set the internal time stamp that should be inserted/updated
@@ -300,7 +303,7 @@ class RasterDataset(AbstractMapDataset):
 
         return True
 
-    def write_timestamp_to_grass(self):
+    def write_timestamp_to_grass(self) -> bool:
         """Write the timestamp of this map into the map metadata in
         the grass file system based spatial database.
 
@@ -332,7 +335,7 @@ class RasterDataset(AbstractMapDataset):
 
         return True
 
-    def remove_timestamp_from_grass(self):
+    def remove_timestamp_from_grass(self) -> bool:
         """Remove the timestamp from the grass file system based
         spatial database
 
@@ -350,7 +353,7 @@ class RasterDataset(AbstractMapDataset):
 
         return True
 
-    def read_semantic_label_from_grass(self):
+    def read_semantic_label_from_grass(self) -> bool:
         """Read the semantic label of this map from the map metadata
         in the GRASS file system based spatial database and
         set the internal semantic label that should be inserted/updated
@@ -371,7 +374,7 @@ class RasterDataset(AbstractMapDataset):
 
         return True
 
-    def write_semantic_label_to_grass(self):
+    def write_semantic_label_to_grass(self) -> bool:
         """Write the semantic label of this map into the map metadata in
         the GRASS file system based spatial database.
 
@@ -398,7 +401,7 @@ class RasterDataset(AbstractMapDataset):
         """
         return self.ciface.raster_map_exists(self.get_name(), self.get_mapset())
 
-    def load(self):
+    def load(self) -> bool:
         """Load all info from an existing raster map into the internal structure
 
         This method checks first if the map exists, in case it exists
@@ -610,14 +613,14 @@ class Raster3DDataset(AbstractMapDataset):
         AbstractMapDataset.__init__(self)
         self.reset(ident)
 
-    def is_stds(self):
+    def is_stds(self) -> Literal[False]:
         """Return True if this class is a space time dataset
 
         :return: True if this class is a space time dataset, False otherwise
         """
         return False
 
-    def get_type(self):
+    def get_type(self) -> Literal["raster3d"]:
         return "raster3d"
 
     def get_new_instance(self, ident):
@@ -709,7 +712,7 @@ class Raster3DDataset(AbstractMapDataset):
         """
         return self.ciface.has_raster3d_timestamp(self.get_name(), self.get_mapset())
 
-    def read_timestamp_from_grass(self):
+    def read_timestamp_from_grass(self) -> bool:
         """Read the timestamp of this map from the map metadata
         in the grass file system based spatial database and
         set the internal time stamp that should be inserted/updated
@@ -740,7 +743,7 @@ class Raster3DDataset(AbstractMapDataset):
 
         return True
 
-    def write_timestamp_to_grass(self):
+    def write_timestamp_to_grass(self) -> bool:
         """Write the timestamp of this map into the map metadata
         in the grass file system based spatial database.
 
@@ -772,7 +775,7 @@ class Raster3DDataset(AbstractMapDataset):
 
         return True
 
-    def remove_timestamp_from_grass(self):
+    def remove_timestamp_from_grass(self) -> bool:
         """Remove the timestamp from the grass file system based spatial database
 
         :return: True if success, False on error
@@ -796,7 +799,7 @@ class Raster3DDataset(AbstractMapDataset):
         """
         return self.ciface.raster3d_map_exists(self.get_name(), self.get_mapset())
 
-    def load(self):
+    def load(self) -> bool:
         """Load all info from an existing 3d raster map into the internal structure
 
         This method checks first if the map exists, in case it exists
@@ -978,14 +981,14 @@ class VectorDataset(AbstractMapDataset):
         AbstractMapDataset.__init__(self)
         self.reset(ident)
 
-    def is_stds(self):
+    def is_stds(self) -> Literal[False]:
         """Return True if this class is a space time dataset
 
         :return: True if this class is a space time dataset, False otherwise
         """
         return False
 
-    def get_type(self):
+    def get_type(self) -> Literal["vector"]:
         return "vector"
 
     def get_new_instance(self, ident):
@@ -1052,7 +1055,7 @@ class VectorDataset(AbstractMapDataset):
             self.get_name(), self.get_mapset(), self.get_layer()
         )
 
-    def read_timestamp_from_grass(self):
+    def read_timestamp_from_grass(self) -> bool:
         """Read the timestamp of this map from the map metadata
         in the grass file system based spatial database and
         set the internal time stamp that should be inserted/updated
@@ -1081,7 +1084,7 @@ class VectorDataset(AbstractMapDataset):
 
         return True
 
-    def write_timestamp_to_grass(self):
+    def write_timestamp_to_grass(self) -> bool:
         """Write the timestamp of this map into the map metadata in
         the grass file system based spatial database.
 
@@ -1110,7 +1113,7 @@ class VectorDataset(AbstractMapDataset):
 
         return True
 
-    def remove_timestamp_from_grass(self):
+    def remove_timestamp_from_grass(self) -> bool:
         """Remove the timestamp from the grass file system based spatial
         database
 
@@ -1135,7 +1138,7 @@ class VectorDataset(AbstractMapDataset):
         """
         return self.ciface.vector_map_exists(self.get_name(), self.get_mapset())
 
-    def load(self):
+    def load(self) -> bool:
         """Load all info from an existing vector map into the internal structure
 
         This method checks first if the map exists, in case it exists
@@ -1240,14 +1243,14 @@ class SpaceTimeRasterDataset(AbstractSpaceTimeDataset):
         """
         self.semantic_label = semantic_label
 
-    def is_stds(self):
+    def is_stds(self) -> Literal[True]:
         """Return True if this class is a space time dataset
 
         :return: True if this class is a space time dataset, False otherwise
         """
         return True
 
-    def get_type(self):
+    def get_type(self) -> Literal["strds"]:
         return "strds"
 
     def get_new_instance(self, ident):
@@ -1349,14 +1352,14 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
     def __init__(self, ident) -> None:
         AbstractSpaceTimeDataset.__init__(self, ident)
 
-    def is_stds(self):
+    def is_stds(self) -> Literal[True]:
         """Return True if this class is a space time dataset
 
         :return: True if this class is a space time dataset, False otherwise
         """
         return True
 
-    def get_type(self):
+    def get_type(self) -> Literal["str3ds"]:
         return "str3ds"
 
     def get_new_instance(self, ident):
@@ -1470,14 +1473,14 @@ class SpaceTimeVectorDataset(AbstractSpaceTimeDataset):
     def __init__(self, ident) -> None:
         AbstractSpaceTimeDataset.__init__(self, ident)
 
-    def is_stds(self):
+    def is_stds(self) -> Literal[True]:
         """Return True if this class is a space time dataset
 
         :return: True if this class is a space time dataset, False otherwise
         """
         return True
 
-    def get_type(self):
+    def get_type(self) -> Literal["stvds"]:
         return "stvds"
 
     def get_new_instance(self, ident):

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -177,7 +177,7 @@ class RasterDataset(AbstractMapDataset):
 
     """
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractMapDataset.__init__(self)
         self.reset(ident)
 
@@ -253,7 +253,7 @@ class RasterDataset(AbstractMapDataset):
             return garray.array(self.get_map_id())
         return garray.array()
 
-    def reset(self, ident):
+    def reset(self, ident) -> None:
         """Reset the internal structure and set the identifier"""
         self.base = RasterBase(ident=ident)
         self.absolute_time = RasterAbsoluteTime(ident=ident)
@@ -462,7 +462,7 @@ class RasterDataset(AbstractMapDataset):
 
         return False
 
-    def set_semantic_label(self, semantic_label):
+    def set_semantic_label(self, semantic_label) -> None:
         """Set semantic label identifier
 
         Metadata is updated in order to propagate semantic label into
@@ -606,7 +606,7 @@ class Raster3DDataset(AbstractMapDataset):
 
     """
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractMapDataset.__init__(self)
         self.reset(ident)
 
@@ -693,7 +693,7 @@ class Raster3DDataset(AbstractMapDataset):
             return garray.array3d(self.get_map_id())
         return garray.array3d()
 
-    def reset(self, ident):
+    def reset(self, ident) -> None:
         """Reset the internal structure and set the identifier"""
         self.base = Raster3DBase(ident=ident)
         self.absolute_time = Raster3DAbsoluteTime(ident=ident)
@@ -974,7 +974,7 @@ class VectorDataset(AbstractMapDataset):
 
     """
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractMapDataset.__init__(self)
         self.reset(ident)
 
@@ -1037,7 +1037,7 @@ class VectorDataset(AbstractMapDataset):
         """
         return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
 
-    def reset(self, ident):
+    def reset(self, ident) -> None:
         """Reset the internal structure and set the identifier"""
         self.base = VectorBase(ident=ident)
         self.absolute_time = VectorAbsoluteTime(ident=ident)
@@ -1230,10 +1230,10 @@ class SpaceTimeRasterDataset(AbstractSpaceTimeDataset):
     ...
     """
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractSpaceTimeDataset.__init__(self, ident)
 
-    def set_semantic_label(self, semantic_label):
+    def set_semantic_label(self, semantic_label) -> None:
         """Set semantic label
 
         :param str semantic_label: semantic label (eg. S2_1)
@@ -1263,7 +1263,7 @@ class SpaceTimeRasterDataset(AbstractSpaceTimeDataset):
         """Return the name of the map register table"""
         return self.metadata.get_raster_register()
 
-    def set_map_register(self, name):
+    def set_map_register(self, name) -> None:
         """Set the name of the map register table"""
         self.metadata.set_raster_register(name)
 
@@ -1301,7 +1301,7 @@ class SpaceTimeRasterDataset(AbstractSpaceTimeDataset):
         """
         return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
 
-    def reset(self, ident):
+    def reset(self, ident) -> None:
         """Reset the internal structure and set the identifier"""
         self.base = STRDSBase(ident=ident)
         self.base.set_creator(str(getpass.getuser()))
@@ -1346,7 +1346,7 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
     ...
     """
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractSpaceTimeDataset.__init__(self, ident)
 
     def is_stds(self):
@@ -1372,7 +1372,7 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
         """Return the name of the map register table"""
         return self.metadata.get_raster3d_register()
 
-    def set_map_register(self, name):
+    def set_map_register(self, name) -> None:
         """Set the name of the map register table"""
         self.metadata.set_raster3d_register(name)
 
@@ -1422,7 +1422,7 @@ class SpaceTimeRaster3DDataset(AbstractSpaceTimeDataset):
             return self.spatial_extent.disjoint_union(dataset.spatial_extent)
         return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
 
-    def reset(self, ident):
+    def reset(self, ident) -> None:
         """Reset the internal structure and set the identifier"""
         self.base = STR3DSBase(ident=ident)
         self.base.set_creator(str(getpass.getuser()))
@@ -1467,7 +1467,7 @@ class SpaceTimeVectorDataset(AbstractSpaceTimeDataset):
     ...
     """
 
-    def __init__(self, ident):
+    def __init__(self, ident) -> None:
         AbstractSpaceTimeDataset.__init__(self, ident)
 
     def is_stds(self):
@@ -1493,7 +1493,7 @@ class SpaceTimeVectorDataset(AbstractSpaceTimeDataset):
         """Return the name of the map register table"""
         return self.metadata.get_vector_register()
 
-    def set_map_register(self, name):
+    def set_map_register(self, name) -> None:
         """Set the name of the map register table"""
         self.metadata.set_vector_register(name)
 
@@ -1531,7 +1531,7 @@ class SpaceTimeVectorDataset(AbstractSpaceTimeDataset):
         """
         return self.spatial_extent.disjoint_union_2d(dataset.spatial_extent)
 
-    def reset(self, ident):
+    def reset(self, ident) -> None:
         """Reset the internal structure and set the identifier"""
         self.base = STVDSBase(ident=ident)
         self.base.set_creator(str(getpass.getuser()))

--- a/python/grass/temporal/spatial_extent.py
+++ b/python/grass/temporal/spatial_extent.py
@@ -137,7 +137,7 @@ class SpatialExtent(SQLDatabaseInterface):
         top=None,
         bottom=None,
         proj="XY",
-    ):
+    ) -> None:
         SQLDatabaseInterface.__init__(self, table, ident)
         self.set_id(ident)
         self.set_spatial_extent_from_values(north, south, east, west, top, bottom)
@@ -1667,7 +1667,9 @@ class SpatialExtent(SQLDatabaseInterface):
 
         return "unknown"
 
-    def set_spatial_extent_from_values(self, north, south, east, west, top, bottom):
+    def set_spatial_extent_from_values(
+        self, north, south, east, west, top, bottom
+    ) -> None:
         """Set the three dimensional spatial extent
 
         :param north: The northern edge
@@ -1685,7 +1687,7 @@ class SpatialExtent(SQLDatabaseInterface):
         self.set_top(top)
         self.set_bottom(bottom)
 
-    def set_spatial_extent(self, spatial_extent):
+    def set_spatial_extent(self, spatial_extent) -> None:
         """Set the three dimensional spatial extent
 
         :param spatial_extent: An object of type SpatialExtent or its
@@ -1699,7 +1701,7 @@ class SpatialExtent(SQLDatabaseInterface):
         self.set_top(spatial_extent.get_top())
         self.set_bottom(spatial_extent.get_bottom())
 
-    def set_projection(self, proj):
+    def set_projection(self, proj) -> None:
         """Set the projection of the spatial extent it should be XY or LL.
         As default the projection is XY
         """
@@ -1708,7 +1710,7 @@ class SpatialExtent(SQLDatabaseInterface):
         else:
             self.D["proj"] = proj
 
-    def set_spatial_extent_from_values_2d(self, north, south, east, west):
+    def set_spatial_extent_from_values_2d(self, north, south, east, west) -> None:
         """Set the two dimensional spatial extent from values
 
         :param north: The northern edge
@@ -1722,7 +1724,7 @@ class SpatialExtent(SQLDatabaseInterface):
         self.set_east(east)
         self.set_west(west)
 
-    def set_spatial_extent_2d(self, spatial_extent):
+    def set_spatial_extent_2d(self, spatial_extent) -> None:
         """Set the three dimensional spatial extent
 
         :param spatial_extent: An object of type SpatialExtent or its
@@ -1734,47 +1736,47 @@ class SpatialExtent(SQLDatabaseInterface):
         self.set_east(spatial_extent.east)
         self.set_west(spatial_extent.west)
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)"""
         self.ident = ident
         self.D["id"] = ident
 
-    def set_north(self, north):
+    def set_north(self, north) -> None:
         """Set the northern edge of the map"""
         if north is not None:
             self.D["north"] = float(north)
         else:
             self.D["north"] = None
 
-    def set_south(self, south):
+    def set_south(self, south) -> None:
         """Set the southern edge of the map"""
         if south is not None:
             self.D["south"] = float(south)
         else:
             self.D["south"] = None
 
-    def set_west(self, west):
+    def set_west(self, west) -> None:
         """Set the western edge of the map"""
         if west is not None:
             self.D["west"] = float(west)
         else:
             self.D["west"] = None
 
-    def set_east(self, east):
+    def set_east(self, east) -> None:
         """Set the eastern edge of the map"""
         if east is not None:
             self.D["east"] = float(east)
         else:
             self.D["east"] = None
 
-    def set_top(self, top):
+    def set_top(self, top) -> None:
         """Set the top edge of the map"""
         if top is not None:
             self.D["top"] = float(top)
         else:
             self.D["top"] = None
 
-    def set_bottom(self, bottom):
+    def set_bottom(self, bottom) -> None:
         """Set the bottom edge of the map"""
         if bottom is not None:
             self.D["bottom"] = float(bottom)
@@ -1884,7 +1886,7 @@ class SpatialExtent(SQLDatabaseInterface):
     top = property(fget=get_top, fset=set_top)
     bottom = property(fget=get_bottom, fset=set_bottom)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         #      0123456789012345678901234567890
         print(
@@ -1897,7 +1899,7 @@ class SpatialExtent(SQLDatabaseInterface):
         print(" | Top:........................ " + str(self.get_top()))
         print(" | Bottom:..................... " + str(self.get_bottom()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         print("north=" + str(self.get_north()))
         print("south=" + str(self.get_south()))
@@ -1920,7 +1922,7 @@ class RasterSpatialExtent(SpatialExtent):
         west=None,
         top=None,
         bottom=None,
-    ):
+    ) -> None:
         SpatialExtent.__init__(
             self, "raster_spatial_extent", ident, north, south, east, west, top, bottom
         )
@@ -1936,7 +1938,7 @@ class Raster3DSpatialExtent(SpatialExtent):
         west=None,
         top=None,
         bottom=None,
-    ):
+    ) -> None:
         SpatialExtent.__init__(
             self,
             "raster3d_spatial_extent",
@@ -1960,7 +1962,7 @@ class VectorSpatialExtent(SpatialExtent):
         west=None,
         top=None,
         bottom=None,
-    ):
+    ) -> None:
         SpatialExtent.__init__(
             self, "vector_spatial_extent", ident, north, south, east, west, top, bottom
         )
@@ -1976,7 +1978,7 @@ class STRDSSpatialExtent(SpatialExtent):
         west=None,
         top=None,
         bottom=None,
-    ):
+    ) -> None:
         SpatialExtent.__init__(
             self, "strds_spatial_extent", ident, north, south, east, west, top, bottom
         )
@@ -1992,7 +1994,7 @@ class STR3DSSpatialExtent(SpatialExtent):
         west=None,
         top=None,
         bottom=None,
-    ):
+    ) -> None:
         SpatialExtent.__init__(
             self, "str3ds_spatial_extent", ident, north, south, east, west, top, bottom
         )
@@ -2008,7 +2010,7 @@ class STVDSSpatialExtent(SpatialExtent):
         west=None,
         top=None,
         bottom=None,
-    ):
+    ) -> None:
         SpatialExtent.__init__(
             self, "stvds_spatial_extent", ident, north, south, east, west, top, bottom
         )

--- a/python/grass/temporal/spatial_extent.py
+++ b/python/grass/temporal/spatial_extent.py
@@ -70,6 +70,8 @@ for details.
 :authors: Soeren Gebbert
 """
 
+from typing import Literal
+
 from .base import SQLDatabaseInterface
 
 
@@ -1110,7 +1112,7 @@ class SpatialExtent(SQLDatabaseInterface):
             or self.get_bottom() >= T
         )
 
-    def meet_2d(self, extent):
+    def meet_2d(self, extent) -> bool:
         """Return True if this extent (A) meets with the provided spatial
         extent (B) in two dimensions.
 
@@ -1303,7 +1305,7 @@ class SpatialExtent(SQLDatabaseInterface):
             or self.meet_2d(extent)
         )
 
-    def disjoint(self, extent):
+    def disjoint(self, extent) -> bool:
         """Return True if this extent is disjoint with the provided spatial
         extent in three dimensions.
 
@@ -1321,7 +1323,17 @@ class SpatialExtent(SQLDatabaseInterface):
             or self.meet(extent)
         )
 
-    def spatial_relation_2d(self, extent):
+    def spatial_relation_2d(self, extent) -> Literal[
+        "equivalent",
+        "contain",
+        "in",
+        "cover",
+        "covered",
+        "overlap",
+        "meet",
+        "disjoint",
+        "unknown",
+    ]:
         """Returns the two dimensional spatial relation between this
         extent and the provided spatial extent in two dimensions.
 
@@ -1358,7 +1370,17 @@ class SpatialExtent(SQLDatabaseInterface):
 
         return "unknown"
 
-    def spatial_relation(self, extent):
+    def spatial_relation(self, extent) -> Literal[
+        "equivalent",
+        "contain",
+        "in",
+        "cover",
+        "covered",
+        "overlap",
+        "meet",
+        "disjoint",
+        "unknown",
+    ]:
         """Returns the two dimensional spatial relation between this
         extent and the provided spatial extent in three dimensions.
 

--- a/python/grass/temporal/spatial_topology_dataset_connector.py
+++ b/python/grass/temporal/spatial_topology_dataset_connector.py
@@ -292,7 +292,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["COVERED"]
 
-    def _generate_map_list_string(self, map_list, line_wrap=True):
+    def _generate_map_list_string(self, map_list, line_wrap: bool = True):
         count = 0
         string = ""
         for map_ in map_list:

--- a/python/grass/temporal/spatial_topology_dataset_connector.py
+++ b/python/grass/temporal/spatial_topology_dataset_connector.py
@@ -74,10 +74,10 @@ class SpatialTopologyDatasetConnector:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reset_spatial_topology()
 
-    def reset_spatial_topology(self):
+    def reset_spatial_topology(self) -> None:
         """Reset any information about temporal topology"""
         self._spatial_topology = {}
         self._has_spatial_topology = False
@@ -147,11 +147,11 @@ class SpatialTopologyDatasetConnector:
 
         return relations
 
-    def set_spatial_topology_build_true(self):
+    def set_spatial_topology_build_true(self) -> None:
         """Same as name"""
         self._has_spatial_topology = True
 
-    def set_spatial_topology_build_false(self):
+    def set_spatial_topology_build_false(self) -> None:
         """Same as name"""
         self._has_spatial_topology = False
 
@@ -159,7 +159,7 @@ class SpatialTopologyDatasetConnector:
         """Check if the temporal topology was build"""
         return self._has_spatial_topology
 
-    def append_equivalent(self, map):
+    def append_equivalent(self, map) -> None:
         """Append a map with equivalent spatial extent as this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -178,7 +178,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["EQUIVALENT"]
 
-    def append_overlap(self, map):
+    def append_overlap(self, map) -> None:
         """Append a map that this spatial overlap with this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -197,7 +197,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["OVERLAP"]
 
-    def append_in(self, map):
+    def append_in(self, map) -> None:
         """Append a map that this is spatial in this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -216,7 +216,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["IN"]
 
-    def append_contain(self, map):
+    def append_contain(self, map) -> None:
         """Append a map that this map spatially contains
 
         :param map: This object should be of type AbstractMapDataset
@@ -235,7 +235,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["CONTAIN"]
 
-    def append_meet(self, map):
+    def append_meet(self, map) -> None:
         """Append a map that spatially meet with this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -254,7 +254,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["MEET"]
 
-    def append_cover(self, map):
+    def append_cover(self, map) -> None:
         """Append a map that spatially cover this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -273,7 +273,7 @@ class SpatialTopologyDatasetConnector:
             return None
         return self._spatial_topology["COVER"]
 
-    def append_covered(self, map):
+    def append_covered(self, map) -> None:
         """Append a map that is spatially covered by this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -316,7 +316,7 @@ class SpatialTopologyDatasetConnector:
     contain = property(fget=get_contain, fset=append_contain)
     meet = property(fget=get_meet, fset=append_meet)
 
-    def print_spatial_topology_info(self):
+    def print_spatial_topology_info(self) -> None:
         """Print information about this class in human readable style"""
 
         print(
@@ -359,7 +359,7 @@ class SpatialTopologyDatasetConnector:
                 + self._generate_map_list_string(self.meet)
             )
 
-    def print_spatial_topology_shell_info(self):
+    def print_spatial_topology_shell_info(self) -> None:
         """Print information about this class in shell style"""
 
         if self.equivalent is not None:

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -377,28 +377,28 @@ class SpatioTemporalTopologyBuilder:
 
     """  # noqa: E501
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._reset()
         # 0001-01-01 00:00:00
         self._timeref = datetime(1, 1, 1)
 
-    def _reset(self):
+    def _reset(self) -> None:
         self._store = {}
         self._first = None
         self._iteratable = False
 
-    def _set_first(self, first):
+    def _set_first(self, first) -> None:
         self._first = first
         self._insert(first)
 
-    def _detect_first(self):
+    def _detect_first(self) -> None:
         if len(self) > 0:
             prev_ = list(self._store.values())[0]
             while prev_ is not None:
                 self._first = prev_
                 prev_ = prev_.prev()
 
-    def _insert(self, t):
+    def _insert(self, t) -> None:
         self._store[t.get_id()] = t
 
     def get_first(self):
@@ -408,7 +408,7 @@ class SpatioTemporalTopologyBuilder:
         """
         return self._first
 
-    def _build_internal_iteratable(self, maps, spatial):
+    def _build_internal_iteratable(self, maps, spatial) -> None:
         """Build an iteratable temporal topology structure for all maps in
         the list and store the maps internally
 
@@ -428,7 +428,7 @@ class SpatioTemporalTopologyBuilder:
         # Detect the first map
         self._detect_first()
 
-    def _build_iteratable(self, maps, spatial):
+    def _build_iteratable(self, maps, spatial) -> None:
         """Build an iteratable temporal topology structure for
         all maps in the list
 
@@ -529,7 +529,7 @@ class SpatioTemporalTopologyBuilder:
 
         return tree
 
-    def build(self, mapsA, mapsB=None, spatial=None):
+    def build(self, mapsA, mapsB=None, spatial=None) -> None:
         """Build the spatio-temporal topology structure between
         one or two unordered lists of abstract dataset objects
 
@@ -619,7 +619,7 @@ class SpatioTemporalTopologyBuilder:
 ###############################################################################
 
 
-def set_temoral_relationship(A, B, relation):
+def set_temoral_relationship(A, B, relation) -> None:
     if relation in {"equal", "equals"}:
         if A != B:
             if not B.get_equal() or (B.get_equal() and A not in B.get_equal()):
@@ -685,7 +685,7 @@ def set_temoral_relationship(A, B, relation):
 ###############################################################################
 
 
-def set_spatial_relationship(A, B, relation):
+def set_spatial_relationship(A, B, relation) -> None:
     if relation == "equivalent":
         if A != B:
             if not B.get_equivalent() or (
@@ -731,7 +731,7 @@ def set_spatial_relationship(A, B, relation):
 ###############################################################################
 
 
-def print_temporal_topology_relationships(maps1, maps2=None, dbif=None):
+def print_temporal_topology_relationships(maps1, maps2=None, dbif=None) -> None:
     """Print the temporal relationships of the
     map lists maps1 and maps2 to stdout.
 
@@ -761,7 +761,7 @@ def print_temporal_topology_relationships(maps1, maps2=None, dbif=None):
 
 def print_spatio_temporal_topology_relationships(
     maps1, maps2=None, spatial="2D", dbif=None
-):
+) -> None:
     """Print the temporal relationships of the
     map lists maps1 and maps2 to stdout.
 

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -832,13 +832,13 @@ def count_temporal_topology_relationships(maps1, maps2=None, dbif=None):
 def create_temporal_relation_sql_where_statement(
     start,
     end,
-    use_start=True,
-    use_during=False,
-    use_overlap=False,
-    use_contain=False,
-    use_equal=False,
-    use_follows=False,
-    use_precedes=False,
+    use_start: bool = True,
+    use_during: bool = False,
+    use_overlap: bool = False,
+    use_contain: bool = False,
+    use_equal: bool = False,
+    use_follows: bool = False,
+    use_precedes: bool = False,
 ):
     """Create a SQL WHERE statement for temporal relation selection of maps in
     space time datasets

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -609,7 +609,7 @@ class SpatioTemporalTopologyBuilder:
     def __getitem__(self, index):
         return self._store[index.get_id()]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._store)
 
     def __contains__(self, _map) -> bool:

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -612,7 +612,7 @@ class SpatioTemporalTopologyBuilder:
     def __len__(self):
         return len(self._store)
 
-    def __contains__(self, _map):
+    def __contains__(self, _map) -> bool:
         return _map in self._store.values()
 
 

--- a/python/grass/temporal/stds_export.py
+++ b/python/grass/temporal/stds_export.py
@@ -53,7 +53,7 @@ exported_maps = {}
 
 def _export_raster_maps_as_gdal(
     rows, tar, list_file, new_cwd, fs, format_, type_, **kwargs
-):
+) -> None:
     kwargs = {key: value for key, value in kwargs.items() if value is not None}
     for row in rows:
         name = row["name"]
@@ -148,7 +148,7 @@ def _export_raster_maps_as_gdal(
 ############################################################################
 
 
-def _export_raster_maps(rows, tar, list_file, new_cwd, fs):
+def _export_raster_maps(rows, tar, list_file, new_cwd, fs) -> None:
     for row in rows:
         name = row["name"]
         start = row["start_time"]
@@ -173,7 +173,7 @@ def _export_raster_maps(rows, tar, list_file, new_cwd, fs):
 ############################################################################
 
 
-def _export_vector_maps_as_gml(rows, tar, list_file, new_cwd, fs):
+def _export_vector_maps_as_gml(rows, tar, list_file, new_cwd, fs) -> None:
     for row in rows:
         name = row["name"]
         start = row["start_time"]
@@ -207,7 +207,7 @@ def _export_vector_maps_as_gml(rows, tar, list_file, new_cwd, fs):
 ############################################################################
 
 
-def _export_vector_maps_as_gpkg(rows, tar, list_file, new_cwd, fs):
+def _export_vector_maps_as_gpkg(rows, tar, list_file, new_cwd, fs) -> None:
     for row in rows:
         name = row["name"]
         start = row["start_time"]
@@ -242,7 +242,7 @@ def _export_vector_maps_as_gpkg(rows, tar, list_file, new_cwd, fs):
 ############################################################################
 
 
-def _export_vector_maps(rows, tar, list_file, new_cwd, fs):
+def _export_vector_maps(rows, tar, list_file, new_cwd, fs) -> None:
     for row in rows:
         name = row["name"]
         start = row["start_time"]
@@ -276,7 +276,7 @@ def _export_vector_maps(rows, tar, list_file, new_cwd, fs):
 ############################################################################
 
 
-def _export_raster3d_maps(rows, tar, list_file, new_cwd, fs):
+def _export_raster3d_maps(rows, tar, list_file, new_cwd, fs) -> None:
     for row in rows:
         name = row["name"]
         start = row["start_time"]
@@ -310,7 +310,7 @@ def export_stds(
     type_="strds",
     datatype=None,
     **kwargs,
-):
+) -> None:
     """Export space time datasets as tar archive with optional compression
 
     This method should be used to export space time datasets

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -55,7 +55,7 @@ imported_maps = {}
 
 def _import_raster_maps_from_gdal(
     maplist, overr, exp, location, link, format_, set_current_region=False, memory=300
-):
+) -> None:
     impflags = ""
     if overr:
         impflags += "o"
@@ -113,7 +113,7 @@ def _import_raster_maps_from_gdal(
 ############################################################################
 
 
-def _import_raster_maps(maplist, set_current_region=False):
+def _import_raster_maps(maplist, set_current_region=False) -> None:
     # We need to disable the projection check because of its
     # simple implementation
     impflags = "o"
@@ -143,7 +143,7 @@ def _import_raster_maps(maplist, set_current_region=False):
 ############################################################################
 
 
-def _import_vector_maps_from_gml(maplist, overr, exp, location, link):
+def _import_vector_maps_from_gml(maplist, overr, exp, location, link) -> None:
     impflags = "o"
     if exp or location:
         impflags += "e"
@@ -169,7 +169,7 @@ def _import_vector_maps_from_gml(maplist, overr, exp, location, link):
 ############################################################################
 
 
-def _import_vector_maps(maplist):
+def _import_vector_maps(maplist) -> None:
     # We need to disable the projection check because of its
     # simple implementation
     impflags = "o"
@@ -216,7 +216,7 @@ def import_stds(
     base=None,
     set_current_region=False,
     memory=300,
-):
+) -> None:
     """Import space time datasets of type raster and vector
 
     :param input: Name of the input archive file

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -54,7 +54,14 @@ imported_maps = {}
 
 
 def _import_raster_maps_from_gdal(
-    maplist, overr, exp, location, link, format_, set_current_region=False, memory=300
+    maplist,
+    overr,
+    exp,
+    location,
+    link,
+    format_,
+    set_current_region: bool = False,
+    memory=300,
 ) -> None:
     impflags = ""
     if overr:
@@ -113,7 +120,7 @@ def _import_raster_maps_from_gdal(
 ############################################################################
 
 
-def _import_raster_maps(maplist, set_current_region=False) -> None:
+def _import_raster_maps(maplist, set_current_region: bool = False) -> None:
     # We need to disable the projection check because of its
     # simple implementation
     impflags = "o"
@@ -208,13 +215,13 @@ def import_stds(
     title=None,
     descr=None,
     location=None,
-    link=False,
-    exp=False,
-    overr=False,
-    create=False,
+    link: bool = False,
+    exp: bool = False,
+    overr: bool = False,
+    create: bool = False,
     stds_type="strds",
     base=None,
-    set_current_region=False,
+    set_current_region: bool = False,
     memory=300,
 ) -> None:
     """Import space time datasets of type raster and vector

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -753,7 +753,7 @@ class GlobalTemporalVar:
 
         return valuelist
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.tfunc) + str(self.compop) + str(self.value)
 
 
@@ -761,7 +761,7 @@ class FatalError(Exception):
     def __init__(self, msg) -> None:
         self.value = msg
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -786,7 +786,7 @@ class TemporalAlgebraParser:
 
     def __init__(
         self,
-        pid=None,
+        pid: int | None = None,
         run: bool = True,
         debug: bool = False,
         spatial: bool = False,

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -439,6 +439,10 @@ for details.
 
 """
 
+from __future__ import annotations
+
+from typing import Literal
+
 try:
     from ply import lex, yacc
 except:
@@ -720,7 +724,7 @@ class GlobalTemporalVar:
         self.topology = []
         self.td = None
 
-    def get_type(self):
+    def get_type(self) -> Literal["global", "boolean", "operator", "timediff"] | None:
         if (
             self.tfunc is not None
             and self.compop is not None
@@ -850,7 +854,9 @@ class TemporalAlgebraParser:
         if self.dbif.connected:
             self.dbif.close()
 
-    def setup_common_granularity(self, expression, stdstype="strds", lexer=None):
+    def setup_common_granularity(
+        self, expression, stdstype="strds", lexer=None
+    ) -> bool:
         """Configure the temporal algebra to use the common granularity of all
         space time datasets in the expression to generate the map lists.
 

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -783,11 +783,11 @@ class TemporalAlgebraParser:
     def __init__(
         self,
         pid=None,
-        run=True,
-        debug=False,
-        spatial=False,
-        register_null=False,
-        dry_run=False,
+        run: bool = True,
+        debug: bool = False,
+        spatial: bool = False,
+        register_null: bool = False,
+        dry_run: bool = False,
         nprocs=1,
         time_suffix=None,
     ) -> None:
@@ -958,7 +958,7 @@ class TemporalAlgebraParser:
         maptype="rast",
         mapclass=RasterDataset,
         basename=None,
-        overwrite=False,
+        overwrite: bool = False,
     ):
         """Parse the algebra expression and run the computation
 
@@ -998,7 +998,12 @@ class TemporalAlgebraParser:
         return name
 
     def generate_new_map(
-        self, base_map, bool_op="and", copy=True, rename=True, remove=False
+        self,
+        base_map,
+        bool_op="and",
+        copy: bool = True,
+        rename: bool = True,
+        remove: bool = False,
     ):
         """Generate a new map using the spatio-temporal extent of the base map
 
@@ -1030,7 +1035,9 @@ class TemporalAlgebraParser:
         map_new.uid = name
         return map_new
 
-    def overlay_map_extent(self, mapA, mapB, bool_op=None, temp_op="l", copy=False):
+    def overlay_map_extent(
+        self, mapA, mapB, bool_op=None, temp_op="l", copy: bool = False
+    ):
         """Compute the spatio-temporal extent of two topological related maps
 
         :param mapA: The first map
@@ -1213,7 +1220,9 @@ class TemporalAlgebraParser:
                 if self.dry_run is False:
                     m.run()
 
-    def check_stds(self, input, clear=False, stds_type=None, check_type=True):
+    def check_stds(
+        self, input, clear: bool = False, stds_type=None, check_type: bool = True
+    ):
         """Check if input space time dataset exist in database and return its map list.
 
         :param input: Name of space time data set as string or list of maps.
@@ -1389,9 +1398,9 @@ class TemporalAlgebraParser:
         maplistA,
         maplistB=None,
         topolist=["EQUAL"],
-        assign_val=False,
-        count_map=False,
-        compare_bool=False,
+        assign_val: bool = False,
+        count_map: bool = False,
+        compare_bool: bool = False,
         compop=None,
         aggregate=None,
     ):
@@ -1756,7 +1765,12 @@ class TemporalAlgebraParser:
         return (p.relations, p.temporal, p.function, p.aggregate)
 
     def perform_temporal_selection(
-        self, maplistA, maplistB, topolist=["EQUAL"], inverse=False, assign_val=False
+        self,
+        maplistA,
+        maplistB,
+        topolist=["EQUAL"],
+        inverse: bool = False,
+        assign_val: bool = False,
     ):
         """This function performs temporal selection operation.
 
@@ -2252,7 +2266,7 @@ class TemporalAlgebraParser:
         # Sort resulting list of maps chronological.
         return sorted(resultlist, key=AbstractDatasetComparisonKeyStartTime)
 
-    def eval_condition_list(self, maplist, inverse=False):
+    def eval_condition_list(self, maplist, inverse: bool = False):
         """This function evaluates conditional values of a map list.
         A recursive function is used to evaluate comparison statements
         from left to right in the given conditional list.

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -792,7 +792,7 @@ class TemporalAlgebraParser:
         spatial: bool = False,
         register_null: bool = False,
         dry_run: bool = False,
-        nprocs=1,
+        nprocs: int = 1,
         time_suffix=None,
     ) -> None:
         self.run = run

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -655,7 +655,7 @@ class TemporalAlgebraLexer:
     #        pass
 
     # Track line numbers.
-    def t_newline(self, t):
+    def t_newline(self, t) -> None:
         r"\n+"
         t.lineno += len(t.value)
 
@@ -685,13 +685,13 @@ class TemporalAlgebraLexer:
         )
 
     # Build the lexer
-    def build(self, **kwargs):
+    def build(self, **kwargs) -> None:
         self.lexer = lex.lex(
             module=self, optimize=False, nowarn=True, debug=0, **kwargs
         )
 
     # Just for testing
-    def test(self, data):
+    def test(self, data) -> None:
         self.name_list = {}
         print(data)
         self.lexer.input(data)
@@ -711,7 +711,7 @@ class GlobalTemporalVar:
     if-statements can be stored in this class.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.tfunc = None
         self.compop = None
         self.value = None
@@ -754,7 +754,7 @@ class GlobalTemporalVar:
 
 
 class FatalError(Exception):
-    def __init__(self, msg):
+    def __init__(self, msg) -> None:
         self.value = msg
 
     def __str__(self):
@@ -790,7 +790,7 @@ class TemporalAlgebraParser:
         dry_run=False,
         nprocs=1,
         time_suffix=None,
-    ):
+    ) -> None:
         self.run = run
         # Compute the processes and output but Do not start the processes
         self.dry_run = dry_run
@@ -846,7 +846,7 @@ class TemporalAlgebraParser:
             "MEET",
         ]
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.dbif.connected:
             self.dbif.close()
 
@@ -1174,7 +1174,7 @@ class TemporalAlgebraParser:
         resultlist = resultdict.values()
         return sorted(resultlist, key=AbstractDatasetComparisonKeyStartTime)
 
-    def remove_maps(self):
+    def remove_maps(self) -> None:
         """Removes empty or intermediate maps of different type."""
 
         map_names = {}
@@ -1191,7 +1191,7 @@ class TemporalAlgebraParser:
                 self.msgr.message(_("Removing un-needed or empty %s maps") % (key))
                 self._remove_maps(value, key)
 
-    def _remove_maps(self, namelist, map_type):
+    def _remove_maps(self, namelist, map_type) -> None:
         """Remove maps of specific type
 
         :param namelist: List of map names to be removed
@@ -2318,7 +2318,7 @@ class TemporalAlgebraParser:
             return inverselist
         return resultlist
 
-    def p_statement_assign(self, t):
+    def p_statement_assign(self, t) -> None:
         # The expression should always return a list of maps
         # This function starts all the work and is the last one that is called from the
         # parser
@@ -2551,24 +2551,24 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1], "=", t[3])
 
-    def p_stds_1(self, t):
+    def p_stds_1(self, t) -> None:
         # Definition of a space time dataset
         """
         stds : NAME
         """
         t[0] = t[1]
 
-    def p_paren_expr(self, t):
+    def p_paren_expr(self, t) -> None:
         """expr : LPAREN expr RPAREN"""
         t[0] = t[2]
 
-    def p_number(self, t):
+    def p_number(self, t) -> None:
         """number : INT
         | FLOAT
         """
         t[0] = t[1]
 
-    def p_expr_strds_function(self, t):
+    def p_expr_strds_function(self, t) -> None:
         # Explicitly specify a space time raster dataset
         # R = A : strds(B)
         """
@@ -2581,7 +2581,7 @@ class TemporalAlgebraParser:
             if self.debug:
                 print("Opening STRDS: ", t[0])
 
-    def p_expr_str3ds_function(self, t):
+    def p_expr_str3ds_function(self, t) -> None:
         # Explicitly specify a space time raster dataset
         # R = A : str3ds(B)
         """
@@ -2594,7 +2594,7 @@ class TemporalAlgebraParser:
             if self.debug:
                 print("Opening STR3DS: ", t[0])
 
-    def p_expr_stvds_function(self, t):
+    def p_expr_stvds_function(self, t) -> None:
         # Explicitly specify a space time vector dataset
         # R = A : stvds(B)
         """
@@ -2709,7 +2709,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print("merge(", t[3], ",", t[5], ")")
 
-    def p_t_hash(self, t):
+    def p_t_hash(self, t) -> None:
         """
         t_hash_var : stds HASH stds
                    | expr HASH stds
@@ -2725,7 +2725,7 @@ class TemporalAlgebraParser:
             )
             t[0] = resultlist
 
-    def p_t_hash2(self, t):
+    def p_t_hash2(self, t) -> None:
         """
         t_hash_var : stds T_HASH_OPERATOR stds
                    | stds T_HASH_OPERATOR expr
@@ -2742,13 +2742,13 @@ class TemporalAlgebraParser:
             )
             t[0] = resultlist
 
-    def p_t_hash_paren(self, t):
+    def p_t_hash_paren(self, t) -> None:
         """
         t_hash_var : LPAREN t_hash_var RPAREN
         """
         t[0] = t[2]
 
-    def p_t_td_var(self, t):
+    def p_t_td_var(self, t) -> None:
         """
         t_td_var : TD LPAREN stds RPAREN
                  | TD LPAREN expr RPAREN
@@ -2778,7 +2778,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print("td(" + str(t[3]) + ")")
 
-    def p_t_time_var(self, t):
+    def p_t_time_var(self, t) -> None:
         # Temporal variables that return a double or integer value
         """
         t_var : START_DOY
@@ -2803,7 +2803,7 @@ class TemporalAlgebraParser:
 
         t[0] = t[1]
 
-    def p_compare_op(self, t):
+    def p_compare_op(self, t) -> None:
         # Compare operators that are supported for temporal expressions
         """
         comp_op : CEQUALS
@@ -2815,7 +2815,7 @@ class TemporalAlgebraParser:
         """
         t[0] = t[1]
 
-    def p_t_var_expr_td_hash(self, t):
+    def p_t_var_expr_td_hash(self, t) -> None:
         # Examples:
         #    A # B == 2
         #    td(A) < 31
@@ -2848,7 +2848,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1], t[2], t[3])
 
-    def p_t_var_expr_number(self, t):
+    def p_t_var_expr_number(self, t) -> None:
         # Examples:
         #    start_month(A) > 2
         #    start_day(B) < 14
@@ -2877,7 +2877,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1], t[3], t[5], t[6])
 
-    def p_t_var_expr_time(self, t):
+    def p_t_var_expr_time(self, t) -> None:
         # Examples:
         #   start_time(A) == "12:30:00"
         #   start_date(B) <= "2001-01-01"
@@ -2914,7 +2914,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1], t[3], t[5], t[6])
 
-    def p_t_var_expr_comp(self, t):
+    def p_t_var_expr_comp(self, t) -> None:
         """
         t_var_expr : t_var_expr AND AND t_var_expr
                    | t_var_expr OR OR t_var_expr
@@ -2946,7 +2946,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1], t[2] + t[3], t[4])
 
-    def p_t_var_expr_comp_op(self, t):
+    def p_t_var_expr_comp_op(self, t) -> None:
         """
         t_var_expr : t_var_expr T_COMP_OPERATOR t_var_expr
         """
@@ -2976,7 +2976,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1], t[2], t[3])
 
-    def p_expr_t_select(self, t):
+    def p_expr_t_select(self, t) -> None:
         # Temporal equal selection
         # The temporal topology relation equals is implicit
         # Examples:
@@ -3003,7 +3003,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(str(t[1]), "* = ", t[1], t[2], t[3])
 
-    def p_expr_t_not_select(self, t):
+    def p_expr_t_not_select(self, t) -> None:
         # Temporal equal selection
         # The temporal topology relation equals is implicit
         # Examples:
@@ -3030,7 +3030,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1] + "* = ", t[1], t[2], t[3])
 
-    def p_expr_t_select_operator(self, t):
+    def p_expr_t_select_operator(self, t) -> None:
         # Temporal equal selection
         # The temporal topology relation equals is implicit
         # Examples:
@@ -3072,7 +3072,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(t[1] + "* = ", t[1], t[2], t[3])
 
-    def p_expr_condition_if(self, t):
+    def p_expr_condition_if(self, t) -> None:
         # Examples
         # if( start_date() < "2005-06-01", A:B)
         """
@@ -3096,7 +3096,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(str(t[5]) + "* = ", "if condition", str(t[3]), " then ", str(t[5]))
 
-    def p_expr_condition_if_relation(self, t):
+    def p_expr_condition_if_relation(self, t) -> None:
         # Examples
         # if({equal} start_date() < "2005-06-01", A:B)
         """
@@ -3129,7 +3129,7 @@ class TemporalAlgebraParser:
                 str(t[7]),
             )
 
-    def p_expr_condition_elif(self, t):
+    def p_expr_condition_elif(self, t) -> None:
         # Examples
         # if( start_date() < "2005-06-01", if(start_time() < "12:30:00", A:B), A!:B)
         """
@@ -3170,7 +3170,7 @@ class TemporalAlgebraParser:
                 str(t[7]),
             )
 
-    def p_expr_condition_elif_relation(self, t):
+    def p_expr_condition_elif_relation(self, t) -> None:
         # Examples
         # if({equal}, start_date() < "2005-06-01",
         #                               if(start_time() < "12:30:00", A:B), A!:B)
@@ -3230,7 +3230,7 @@ class TemporalAlgebraParser:
                     str(t[9]),
                 )
 
-    def p_expr_t_buff(self, t):
+    def p_expr_t_buff(self, t) -> None:
         # Examples
         # buff_t(A : B, "10 minutes")  # Select the part of A that is temporally
         #                                equal to B and create a buffer of 10 minutes
@@ -3271,7 +3271,7 @@ class TemporalAlgebraParser:
             elif len(t) == 7:
                 print(str(t[3]) + "* = buff_t(", str(t[3]), ",", str(t[5]), ")")
 
-    def p_expr_t_snap(self, t):
+    def p_expr_t_snap(self, t) -> None:
         # Examples
         # tsnap(A : B)  # Snap the maps of A temporally.
         """
@@ -3290,7 +3290,7 @@ class TemporalAlgebraParser:
         if self.debug:
             print(str(t[3]) + "* = tsnap(", str(t[3]), ")")
 
-    def p_expr_t_shift(self, t):
+    def p_expr_t_shift(self, t) -> None:
         # Examples
         # tshift(A : B, "10 minutes")  # Shift the selection from A temporally
         #                                by 10 minutes.
@@ -3329,7 +3329,7 @@ class TemporalAlgebraParser:
             elif len(t) == 7:
                 print(str(t[3]) + "* = tshift(", str(t[3]), ",", str(t[5]), ")")
 
-    def p_expr_time_const(self, t):
+    def p_expr_time_const(self, t) -> None:
         # Examples
         # start_doy(A, -1)  # Get the start DOY from the preceding map
         #                     of the time series as a numerical constant

--- a/python/grass/temporal/temporal_extent.py
+++ b/python/grass/temporal/temporal_extent.py
@@ -81,7 +81,7 @@ class TemporalExtent(SQLDatabaseInterface):
 
     """
 
-    def __init__(self, table=None, ident=None, start_time=None, end_time=None):
+    def __init__(self, table=None, ident=None, start_time=None, end_time=None) -> None:
         SQLDatabaseInterface.__init__(self, table, ident)
 
         self.set_id(ident)
@@ -967,16 +967,16 @@ class TemporalExtent(SQLDatabaseInterface):
             return "precedes"
         return None
 
-    def set_id(self, ident):
+    def set_id(self, ident) -> None:
         """Convenient method to set the unique identifier (primary key)"""
         self.ident = ident
         self.D["id"] = ident
 
-    def set_start_time(self, start_time):
+    def set_start_time(self, start_time) -> None:
         """Set the valid start time of the extent"""
         self.D["start_time"] = start_time
 
-    def set_end_time(self, end_time):
+    def set_end_time(self, end_time) -> None:
         """Set the valid end time of the extent"""
         self.D["end_time"] = end_time
 
@@ -1007,13 +1007,13 @@ class TemporalExtent(SQLDatabaseInterface):
     start_time = property(fget=get_start_time, fset=set_start_time)
     end_time = property(fget=get_end_time, fset=set_end_time)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         #      0123456789012345678901234567890
         print(" | Start time:................. " + str(self.get_start_time()))
         print(" | End time:................... " + str(self.get_end_time()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         print("start_time='{}'".format(str(self.get_start_time())))
         print("end_time='{}'".format(str(self.get_end_time())))
@@ -1028,10 +1028,10 @@ class AbsoluteTemporalExtent(TemporalExtent):
     start_time and end_time must be of type datetime
     """
 
-    def __init__(self, table=None, ident=None, start_time=None, end_time=None):
+    def __init__(self, table=None, ident=None, start_time=None, end_time=None) -> None:
         TemporalExtent.__init__(self, table, ident, start_time, end_time)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         #      0123456789012345678901234567890
         print(
@@ -1039,7 +1039,7 @@ class AbsoluteTemporalExtent(TemporalExtent):
         )
         TemporalExtent.print_info(self)
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         TemporalExtent.print_shell_info(self)
 
@@ -1048,21 +1048,21 @@ class AbsoluteTemporalExtent(TemporalExtent):
 
 
 class RasterAbsoluteTime(AbsoluteTemporalExtent):
-    def __init__(self, ident=None, start_time=None, end_time=None):
+    def __init__(self, ident=None, start_time=None, end_time=None) -> None:
         AbsoluteTemporalExtent.__init__(
             self, "raster_absolute_time", ident, start_time, end_time
         )
 
 
 class Raster3DAbsoluteTime(AbsoluteTemporalExtent):
-    def __init__(self, ident=None, start_time=None, end_time=None):
+    def __init__(self, ident=None, start_time=None, end_time=None) -> None:
         AbsoluteTemporalExtent.__init__(
             self, "raster3d_absolute_time", ident, start_time, end_time
         )
 
 
 class VectorAbsoluteTime(AbsoluteTemporalExtent):
-    def __init__(self, ident=None, start_time=None, end_time=None):
+    def __init__(self, ident=None, start_time=None, end_time=None) -> None:
         AbsoluteTemporalExtent.__init__(
             self, "vector_absolute_time", ident, start_time, end_time
         )
@@ -1122,17 +1122,17 @@ class STDSAbsoluteTime(AbsoluteTemporalExtent):
         end_time=None,
         granularity=None,
         map_time=None,
-    ):
+    ) -> None:
         AbsoluteTemporalExtent.__init__(self, table, ident, start_time, end_time)
 
         self.set_granularity(granularity)
         self.set_map_time(map_time)
 
-    def set_granularity(self, granularity):
+    def set_granularity(self, granularity) -> None:
         """Set the granularity of the space time dataset"""
         self.D["granularity"] = granularity
 
-    def set_map_time(self, map_time):
+    def set_map_time(self, map_time) -> None:
         """Set the type of the map time
 
         Registered maps may have different types of time:
@@ -1171,14 +1171,14 @@ class STDSAbsoluteTime(AbsoluteTemporalExtent):
     granularity = property(fget=get_granularity, fset=set_granularity)
     map_time = property(fget=get_map_time, fset=set_map_time)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         AbsoluteTemporalExtent.print_info(self)
         #      0123456789012345678901234567890
         print(" | Granularity:................ " + str(self.get_granularity()))
         print(" | Temporal type of maps:...... " + str(self.get_map_time()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         AbsoluteTemporalExtent.print_shell_info(self)
         print("granularity='{}'".format(str(self.get_granularity())))
@@ -1189,21 +1189,27 @@ class STDSAbsoluteTime(AbsoluteTemporalExtent):
 
 
 class STRDSAbsoluteTime(STDSAbsoluteTime):
-    def __init__(self, ident=None, start_time=None, end_time=None, granularity=None):
+    def __init__(
+        self, ident=None, start_time=None, end_time=None, granularity=None
+    ) -> None:
         STDSAbsoluteTime.__init__(
             self, "strds_absolute_time", ident, start_time, end_time, granularity
         )
 
 
 class STR3DSAbsoluteTime(STDSAbsoluteTime):
-    def __init__(self, ident=None, start_time=None, end_time=None, granularity=None):
+    def __init__(
+        self, ident=None, start_time=None, end_time=None, granularity=None
+    ) -> None:
         STDSAbsoluteTime.__init__(
             self, "str3ds_absolute_time", ident, start_time, end_time, granularity
         )
 
 
 class STVDSAbsoluteTime(STDSAbsoluteTime):
-    def __init__(self, ident=None, start_time=None, end_time=None, granularity=None):
+    def __init__(
+        self, ident=None, start_time=None, end_time=None, granularity=None
+    ) -> None:
         STDSAbsoluteTime.__init__(
             self, "stvds_absolute_time", ident, start_time, end_time, granularity
         )
@@ -1251,11 +1257,11 @@ class RelativeTemporalExtent(TemporalExtent):
 
     def __init__(
         self, table=None, ident=None, start_time=None, end_time=None, unit=None
-    ):
+    ) -> None:
         TemporalExtent.__init__(self, table, ident, start_time, end_time)
         self.set_unit(unit)
 
-    def set_unit(self, unit):
+    def set_unit(self, unit) -> None:
         """Set the unit of the relative time. Valid units are:
 
         - years
@@ -1295,7 +1301,7 @@ class RelativeTemporalExtent(TemporalExtent):
     # Properties
     unit = property(fget=get_unit, fset=set_unit)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         #      0123456789012345678901234567890
         print(
@@ -1304,7 +1310,7 @@ class RelativeTemporalExtent(TemporalExtent):
         TemporalExtent.print_info(self)
         print(" | Relative time unit:......... " + str(self.get_unit()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         TemporalExtent.print_shell_info(self)
         print("unit=" + str(self.get_unit()))
@@ -1314,21 +1320,21 @@ class RelativeTemporalExtent(TemporalExtent):
 
 
 class RasterRelativeTime(RelativeTemporalExtent):
-    def __init__(self, ident=None, start_time=None, end_time=None, unit=None):
+    def __init__(self, ident=None, start_time=None, end_time=None, unit=None) -> None:
         RelativeTemporalExtent.__init__(
             self, "raster_relative_time", ident, start_time, end_time, unit
         )
 
 
 class Raster3DRelativeTime(RelativeTemporalExtent):
-    def __init__(self, ident=None, start_time=None, end_time=None, unit=None):
+    def __init__(self, ident=None, start_time=None, end_time=None, unit=None) -> None:
         RelativeTemporalExtent.__init__(
             self, "raster3d_relative_time", ident, start_time, end_time, unit
         )
 
 
 class VectorRelativeTime(RelativeTemporalExtent):
-    def __init__(self, ident=None, start_time=None, end_time=None, unit=None):
+    def __init__(self, ident=None, start_time=None, end_time=None, unit=None) -> None:
         RelativeTemporalExtent.__init__(
             self, "vector_relative_time", ident, start_time, end_time, unit
         )
@@ -1393,17 +1399,17 @@ class STDSRelativeTime(RelativeTemporalExtent):
         unit=None,
         granularity=None,
         map_time=None,
-    ):
+    ) -> None:
         RelativeTemporalExtent.__init__(self, table, ident, start_time, end_time, unit)
 
         self.set_granularity(granularity)
         self.set_map_time(map_time)
 
-    def set_granularity(self, granularity):
+    def set_granularity(self, granularity) -> None:
         """Set the granularity of the space time dataset"""
         self.D["granularity"] = granularity
 
-    def set_map_time(self, map_time):
+    def set_map_time(self, map_time) -> None:
         """Set the type of the map time
 
         Registered maps may have different types of time:
@@ -1442,14 +1448,14 @@ class STDSRelativeTime(RelativeTemporalExtent):
     granularity = property(fget=get_granularity, fset=set_granularity)
     map_time = property(fget=get_map_time, fset=set_map_time)
 
-    def print_info(self):
+    def print_info(self) -> None:
         """Print information about this class in human readable style"""
         RelativeTemporalExtent.print_info(self)
         #      0123456789012345678901234567890
         print(" | Granularity:................ " + str(self.get_granularity()))
         print(" | Temporal type of maps:...... " + str(self.get_map_time()))
 
-    def print_shell_info(self):
+    def print_shell_info(self) -> None:
         """Print information about this class in shell style"""
         RelativeTemporalExtent.print_shell_info(self)
         print("granularity=" + str(self.get_granularity()))
@@ -1468,7 +1474,7 @@ class STRDSRelativeTime(STDSRelativeTime):
         unit=None,
         granularity=None,
         map_time=None,
-    ):
+    ) -> None:
         STDSRelativeTime.__init__(
             self,
             "strds_relative_time",
@@ -1490,7 +1496,7 @@ class STR3DSRelativeTime(STDSRelativeTime):
         unit=None,
         granularity=None,
         map_time=None,
-    ):
+    ) -> None:
         STDSRelativeTime.__init__(
             self,
             "str3ds_relative_time",
@@ -1512,7 +1518,7 @@ class STVDSRelativeTime(STDSRelativeTime):
         unit=None,
         granularity=None,
         map_time=None,
-    ):
+    ) -> None:
         STDSRelativeTime.__init__(
             self,
             "stvds_relative_time",

--- a/python/grass/temporal/temporal_extent.py
+++ b/python/grass/temporal/temporal_extent.py
@@ -861,7 +861,7 @@ class TemporalExtent(SQLDatabaseInterface):
         )
 
     def overlapped(self, extent) -> bool:
-        """Return True if this temporal extent (A) overlapps the provided
+        """Return True if this temporal extent (A) overlaps the provided
         temporal extent (B)
         ::
 

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -37,7 +37,7 @@ CONVERT_GRAN["minute"] = "60 second"
 ###############################################################################
 
 
-def check_granularity_string(granularity, temporal_type):
+def check_granularity_string(granularity, temporal_type) -> bool:
     """Check if the granularity string is valid
 
     :param granularity: The granularity string

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -1176,7 +1176,7 @@ def gran_plural_unit(gran):
 ########################################################################
 
 
-def gran_to_gran(from_gran, to_gran="days", shell=False):
+def gran_to_gran(from_gran, to_gran="days", shell: bool = False):
     """Converts the computed absolute granularity of a STDS to a smaller
     granularity based on the Gregorian calendar hierarchy that 1 year
     equals 12 months or 365.2425 days or 24 * 365.2425 hours or 86400 *

--- a/python/grass/temporal/temporal_operator.py
+++ b/python/grass/temporal/temporal_operator.py
@@ -228,7 +228,7 @@ class TemporalOperatorLexer:
     t_ignore = " \t\n"
 
     # Track line numbers.
-    def t_newline(self, t):
+    def t_newline(self, t) -> None:
         r"\n+"
         t.lineno += len(t.value)
 
@@ -268,13 +268,13 @@ class TemporalOperatorLexer:
         )
 
     # Build the lexer
-    def build(self, **kwargs):
+    def build(self, **kwargs) -> None:
         self.lexer = lex.lex(
             module=self, optimize=False, nowarn=True, debug=0, **kwargs
         )
 
     # Just for testing
-    def test(self, data):
+    def test(self, data) -> None:
         self.name_list = {}
         print(data)
         self.lexer.input(data)
@@ -291,7 +291,7 @@ class TemporalOperatorLexer:
 class TemporalOperatorParser:
     """The temporal operator class"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.lexer = TemporalOperatorLexer()
         self.lexer.build()
         self.parser = yacc.yacc(module=self, debug=0)
@@ -611,7 +611,7 @@ class TemporalOperatorParser:
 
         t[0] = t[2]
 
-    def p_relation(self, t):
+    def p_relation(self, t) -> None:
         # The list of relations. Temporal and spatial relations are supported
         """
         relation : EQUAL
@@ -634,7 +634,7 @@ class TemporalOperatorParser:
         """
         t[0] = t[1]
 
-    def p_over(self, t):
+    def p_over(self, t) -> None:
         # The the over keyword
         """
         relation : OVER
@@ -642,7 +642,7 @@ class TemporalOperatorParser:
         over_list = ["overlaps", "overlapped"]
         t[0] = over_list
 
-    def p_relationlist(self, t):
+    def p_relationlist(self, t) -> None:
         # The list of relations.
         """
         relationlist : relation OR relation
@@ -656,7 +656,7 @@ class TemporalOperatorParser:
             rel_list.append(t[3])
         t[0] = rel_list
 
-    def p_temporal_operator(self, t):
+    def p_temporal_operator(self, t) -> None:
         # The list of relations.
         """
         temporal : LEFTREF
@@ -667,7 +667,7 @@ class TemporalOperatorParser:
         """
         t[0] = t[1]
 
-    def p_select_operator(self, t):
+    def p_select_operator(self, t) -> None:
         # The list of relations.
         """
         select : T_SELECT
@@ -675,7 +675,7 @@ class TemporalOperatorParser:
         """
         t[0] = t[1]
 
-    def p_arithmetic_operator(self, t):
+    def p_arithmetic_operator(self, t) -> None:
         # The list of relations.
         """
         arithmetic : MOD
@@ -686,7 +686,7 @@ class TemporalOperatorParser:
         """
         t[0] = t[1]
 
-    def p_overlay_operator(self, t):
+    def p_overlay_operator(self, t) -> None:
         # The list of relations.
         """
         overlay : AND

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -11,6 +11,8 @@ for details.
 
 """
 
+from __future__ import annotations
+
 try:
     from ply import yacc
 except ImportError:
@@ -30,7 +32,7 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
 
     def __init__(
         self,
-        pid=None,
+        pid: int | None = None,
         run: bool = False,
         debug: bool = True,
         spatial: bool = False,

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -37,7 +37,7 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
         register_null=False,
         dry_run=False,
         nprocs=1,
-    ):
+    ) -> None:
         TemporalRasterBaseAlgebraParser.__init__(
             self,
             pid=pid,
@@ -81,14 +81,14 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
 
         return self.process_chain_dict
 
-    def p_statement_assign(self, t):
+    def p_statement_assign(self, t) -> None:
         # The expression should always return a list of maps.
         """
         statement : stds EQUALS expr
         """
         TemporalRasterBaseAlgebraParser.p_statement_assign(self, t)
 
-    def p_ts_neighbor_operation(self, t):
+    def p_ts_neighbor_operation(self, t) -> None:
         # Examples:
         # A[1,0,-1]
         # B[-2]

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -36,7 +36,7 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
         spatial: bool = False,
         register_null: bool = False,
         dry_run: bool = False,
-        nprocs=1,
+        nprocs: int = 1,
     ) -> None:
         TemporalRasterBaseAlgebraParser.__init__(
             self,

--- a/python/grass/temporal/temporal_raster3d_algebra.py
+++ b/python/grass/temporal/temporal_raster3d_algebra.py
@@ -31,11 +31,11 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
     def __init__(
         self,
         pid=None,
-        run=False,
-        debug=True,
-        spatial=False,
-        register_null=False,
-        dry_run=False,
+        run: bool = False,
+        debug: bool = True,
+        spatial: bool = False,
+        register_null: bool = False,
+        dry_run: bool = False,
         nprocs=1,
     ) -> None:
         TemporalRasterBaseAlgebraParser.__init__(
@@ -52,7 +52,7 @@ class TemporalRaster3DAlgebraParser(TemporalRasterBaseAlgebraParser):
         self.m_mapcalc = pymod.Module("r3.mapcalc")
         self.m_mremove = pymod.Module("g.remove")
 
-    def parse(self, expression, basename=None, overwrite=False):
+    def parse(self, expression, basename=None, overwrite: bool = False):
         # Check for space time dataset type definitions from temporal algebra
         lx = TemporalRasterAlgebraLexer()
         lx.build()

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -79,7 +79,7 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
         dry_run=False,
         nprocs=1,
         time_suffix=None,
-    ):
+    ) -> None:
         TemporalRasterBaseAlgebraParser.__init__(
             self,
             pid=pid,
@@ -127,14 +127,14 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
 
         return self.process_chain_dict
 
-    def p_statement_assign(self, t):
+    def p_statement_assign(self, t) -> None:
         # The expression should always return a list of maps.
         """
         statement : stds EQUALS expr
         """
         TemporalRasterBaseAlgebraParser.p_statement_assign(self, t)
 
-    def p_ts_neighbour_operation(self, t):
+    def p_ts_neighbour_operation(self, t) -> None:
         # Spatial and temporal neighbour operations via indexing
         # Examples:
         # A[1,0]

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -77,7 +77,7 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
         spatial: bool = False,
         register_null: bool = False,
         dry_run: bool = False,
-        nprocs=1,
+        nprocs: int = 1,
         time_suffix=None,
     ) -> None:
         TemporalRasterBaseAlgebraParser.__init__(

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -72,11 +72,11 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
     def __init__(
         self,
         pid=None,
-        run=False,
-        debug=True,
-        spatial=False,
-        register_null=False,
-        dry_run=False,
+        run: bool = False,
+        debug: bool = True,
+        spatial: bool = False,
+        register_null: bool = False,
+        dry_run: bool = False,
         nprocs=1,
         time_suffix=None,
     ) -> None:
@@ -98,7 +98,7 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
             self.m_mapcalc = pymod.Module("r.mapcalc")
         self.m_mremove = pymod.Module("g.remove")
 
-    def parse(self, expression, basename=None, overwrite=False):
+    def parse(self, expression, basename=None, overwrite: bool = False):
         # Check for space time dataset type definitions from temporal algebra
         lx = TemporalRasterAlgebraLexer()
         lx.build()

--- a/python/grass/temporal/temporal_raster_algebra.py
+++ b/python/grass/temporal/temporal_raster_algebra.py
@@ -52,6 +52,8 @@ for details.
 
 """
 
+from __future__ import annotations
+
 try:
     from ply import yacc
 except ImportError:
@@ -71,7 +73,7 @@ class TemporalRasterAlgebraParser(TemporalRasterBaseAlgebraParser):
 
     def __init__(
         self,
-        pid=None,
+        pid: int | None = None,
         run: bool = False,
         debug: bool = True,
         spatial: bool = False,

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -41,6 +41,8 @@ for details.
 
 """
 
+from __future__ import annotations
+
 import copy
 
 import grass.pygrass.modules as pymod
@@ -170,7 +172,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
 
     def __init__(
         self,
-        pid=None,
+        pid: int | None = None,
         run: bool = True,
         debug: bool = False,
         spatial: bool = False,

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -171,11 +171,11 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
     def __init__(
         self,
         pid=None,
-        run=True,
-        debug=False,
-        spatial=False,
-        register_null=False,
-        dry_run=False,
+        run: bool = True,
+        debug: bool = False,
+        spatial: bool = False,
+        register_null: bool = False,
+        dry_run: bool = False,
         nprocs=1,
         time_suffix=None,
     ) -> None:
@@ -203,15 +203,15 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         maplistA,
         maplistB=None,
         topolist=["EQUAL"],
-        assign_val=False,
-        count_map=False,
-        compare_bool=False,
-        compare_cmd=False,
+        assign_val: bool = False,
+        count_map: bool = False,
+        compare_bool: bool = False,
+        compare_cmd: bool = False,
         compop=None,
         aggregate=None,
-        new=False,
-        convert=False,
-        operator_cmd=False,
+        new: bool = False,
+        convert: bool = False,
+        operator_cmd: bool = False,
     ):
         """Build temporal topology for two space time data sets, copy map objects
         for given relation into map list.
@@ -420,7 +420,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         aggregate,
         temporal_topo_list=["EQUAL"],
         spatial_topo_list=[],
-        convert=False,
+        convert: bool = False,
     ):
         """Function to evaluate two map lists with boolean values by boolean
         comparison operator.
@@ -550,7 +550,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         maplist,
         topolist=["EQUAL"],
         temporal="l",
-        cmd_bool=False,
+        cmd_bool: bool = False,
         cmd_type=None,
         operator=None,
     ):
@@ -643,7 +643,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         condition_topolist=["EQUAL"],
         conclusion_topolist=["EQUAL"],
         temporal="l",
-        null=False,
+        null: bool = False,
     ):
         """This function build the r.mapcalc command strings for spatial conditionals.
         For Example: 'if(a1 == 1, b1, c2)'

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -176,7 +176,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         spatial: bool = False,
         register_null: bool = False,
         dry_run: bool = False,
-        nprocs=1,
+        nprocs: int = 1,
         time_suffix=None,
     ) -> None:
         TemporalAlgebraParser.__init__(

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -68,7 +68,7 @@ from .temporal_granularity import compute_absolute_time_granularity
 class TemporalRasterAlgebraLexer(TemporalAlgebraLexer):
     """Lexical analyzer for the GRASS GIS temporal algebra"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         TemporalAlgebraLexer.__init__(self)
 
     # Supported r.mapcalc functions.
@@ -178,7 +178,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         dry_run=False,
         nprocs=1,
         time_suffix=None,
-    ):
+    ) -> None:
         TemporalAlgebraParser.__init__(
             self,
             pid=pid,
@@ -742,7 +742,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
                 cmd_type="condition",
             )
 
-    def p_statement_assign(self, t):
+    def p_statement_assign(self, t) -> None:
         # This function executes the processing of raster/raster3d algebra
         # that was build based on the expression
         """
@@ -982,7 +982,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         if self.debug:
             print("map(" + t[3] + ")")
 
-    def p_arith1_operation(self, t):
+    def p_arith1_operation(self, t) -> None:
         # A % B
         # A / B
         # A * B
@@ -1057,7 +1057,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith1_operation_numeric1(self, t):
+    def p_arith1_operation_numeric1(self, t) -> None:
         # A % 1
         # A / 4
         # A * 5
@@ -1107,7 +1107,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith1_operation_numeric2(self, t):
+    def p_arith1_operation_numeric2(self, t) -> None:
         # 1 % A
         # 4 / A
         # 5 * A
@@ -1157,7 +1157,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith2_operation(self, t):
+    def p_arith2_operation(self, t) -> None:
         # A + B
         # A - B
         # A + td(B)
@@ -1226,7 +1226,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith2_operation_numeric1(self, t):
+    def p_arith2_operation_numeric1(self, t) -> None:
         # A + 2
         # A - 3
         # A + map(b4)
@@ -1268,7 +1268,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith2_operation_numeric2(self, t):
+    def p_arith2_operation_numeric2(self, t) -> None:
         # 2 + A
         # 3 - A
         # map(b2) + A
@@ -1310,7 +1310,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith1_operation_relation(self, t):
+    def p_arith1_operation_relation(self, t) -> None:
         # A {*, equal, l} B
         # A {*, equal, l} td(B)
         # A {*, equal, l} B {/, during, r} C
@@ -1349,7 +1349,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith2_operation_relation(self, t):
+    def p_arith2_operation_relation(self, t) -> None:
         # A {+, equal, l} B
         # A {+, equal, l} td(b)
         # A {+, equal, l} B {-, during, r} C
@@ -1388,7 +1388,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_arith_operation_numeric_string(self, t):
+    def p_arith_operation_numeric_string(self, t) -> None:
         # 1 + 1
         # 1 - 1
         # 1 * 1
@@ -1408,7 +1408,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         if self.debug:
             print(numstring)
 
-    def p_mapcalc_function(self, t):
+    def p_mapcalc_function(self, t) -> None:
         # Supported mapcalc functions.
         """
         mapcalc_arith : ABS
@@ -1429,7 +1429,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         if self.debug:
             print(t[1])
 
-    def p_mapcalc_operation1(self, t):
+    def p_mapcalc_operation1(self, t) -> None:
         # sin(A)
         # log(B)
         """
@@ -1458,7 +1458,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_mapexpr_operation(self, t):
+    def p_mapexpr_operation(self, t) -> None:
         # sin(map(a))
         """
         mapexpr : mapcalc_arith LPAREN mapexpr RPAREN
@@ -1474,7 +1474,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         if self.debug:
             print(mapstring)
 
-    def p_s_var_expr_1(self, t):
+    def p_s_var_expr_1(self, t) -> None:
         #   isnull(A)
         """
         s_var_expr : ISNULL LPAREN stds RPAREN
@@ -1502,7 +1502,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_var_expr_2(self, t):
+    def p_s_var_expr_2(self, t) -> None:
         #   isntnull(A)
         """
         s_var_expr : ISNTNULL LPAREN stds RPAREN
@@ -1530,7 +1530,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_var_expr_3(self, t):
+    def p_s_var_expr_3(self, t) -> None:
         #   A <= 2
         """
         s_var_expr : stds comp_op number
@@ -1558,7 +1558,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_var_expr_4(self, t):
+    def p_s_var_expr_4(self, t) -> None:
         #   exist(B)
         """
         s_var_expr : EXIST LPAREN stds RPAREN
@@ -1586,7 +1586,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_var_expr_comp(self, t):
+    def p_s_var_expr_comp(self, t) -> None:
         #   A <= 2 || B == 10
         #   A < 3 && A > 1
         """
@@ -1621,7 +1621,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_var_expr_comp_op(self, t):
+    def p_s_var_expr_comp_op(self, t) -> None:
         #   A <= 2 {||} B == 10
         #   A < 3 {&&, equal} A > 1
         """
@@ -1655,7 +1655,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_expr_condition_if(self, t):
+    def p_s_expr_condition_if(self, t) -> None:
         #   if(s_var_expr, B)
         #   if(A == 1, B)
         """
@@ -1681,7 +1681,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_numeric_condition_if(self, t):
+    def p_s_numeric_condition_if(self, t) -> None:
         #   if(s_var_expr, 1)
         #   if(A == 5, 10)
         """
@@ -1712,7 +1712,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_expr_condition_if_relation(self, t):
+    def p_s_expr_condition_if_relation(self, t) -> None:
         #   if({equal||during}, s_var_expr, A)
         """
         expr : IF LPAREN T_REL_OPERATOR COMMA s_var_expr  COMMA stds RPAREN
@@ -1740,7 +1740,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_expr_condition_elif(self, t):
+    def p_s_expr_condition_elif(self, t) -> None:
         #   if(s_var_expr, A, B)
         """
         expr : IF LPAREN s_var_expr  COMMA stds COMMA stds RPAREN
@@ -1773,7 +1773,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_numeric_condition_elif(self, t):
+    def p_s_numeric_condition_elif(self, t) -> None:
         #   if(s_var_expr, 1, 2)
         #   if(A == 5, 10, 0)
         """
@@ -1821,7 +1821,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_numeric_expr_condition_elif(self, t):
+    def p_s_numeric_expr_condition_elif(self, t) -> None:
         #   if(s_var_expr, 1, A)
         #   if(A == 5 && C > 5, A, null())
         """
@@ -1876,7 +1876,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_numeric_expr_condition_elif_relation(self, t):
+    def p_s_numeric_expr_condition_elif_relation(self, t) -> None:
         #   if({during},s_var_expr, 1, A)
         #   if({during}, A == 5, A, null())
         """
@@ -1934,7 +1934,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_s_expr_condition_elif_relation(self, t):
+    def p_s_expr_condition_elif_relation(self, t) -> None:
         #   if({equal||during}, s_var_expr, A, B)
         """
         expr : IF LPAREN T_REL_OPERATOR COMMA s_var_expr  COMMA stds COMMA stds RPAREN
@@ -1970,7 +1970,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             for map in resultlist:
                 print(map.cmd_list)
 
-    def p_ts_var_expr1(self, t):
+    def p_ts_var_expr1(self, t) -> None:
         # Combination of spatial and temporal conditional expressions.
         # Examples:
         #   A <= 2 || start_date <= 2013-01-01
@@ -2016,7 +2016,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
 
         t[0] = resultlist
 
-    def p_hash_operation(self, t):
+    def p_hash_operation(self, t) -> None:
         # Calculate the number of maps within an interval of another map from a
         # second space time dataset.
         # A # B

--- a/python/grass/temporal/temporal_topology_dataset_connector.py
+++ b/python/grass/temporal/temporal_topology_dataset_connector.py
@@ -475,7 +475,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["CONTAINS"]
 
-    def _generate_map_list_string(self, map_list, line_wrap=True):
+    def _generate_map_list_string(self, map_list, line_wrap: bool = True):
         count = 0
         string = ""
         for map_ in map_list:

--- a/python/grass/temporal/temporal_topology_dataset_connector.py
+++ b/python/grass/temporal/temporal_topology_dataset_connector.py
@@ -112,10 +112,10 @@ class TemporalTopologyDatasetConnector:
 
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reset_temporal_topology()
 
-    def reset_temporal_topology(self):
+    def reset_temporal_topology(self) -> None:
         """Reset any information about temporal topology"""
         self._temporal_topology = {}
         self._has_temporal_topology = False
@@ -205,11 +205,11 @@ class TemporalTopologyDatasetConnector:
 
         return relations
 
-    def set_temporal_topology_build_true(self):
+    def set_temporal_topology_build_true(self) -> None:
         """Same as name"""
         self._has_temporal_topology = True
 
-    def set_temporal_topology_build_false(self):
+    def set_temporal_topology_build_false(self) -> None:
         """Same as name"""
         self._has_temporal_topology = False
 
@@ -217,7 +217,7 @@ class TemporalTopologyDatasetConnector:
         """Check if the temporal topology was build"""
         return self._has_temporal_topology
 
-    def set_next(self, map):
+    def set_next(self, map) -> None:
         """Set the map that is temporally as closest located after this map.
 
         Temporally located means that the start time of the "next" map is
@@ -229,7 +229,7 @@ class TemporalTopologyDatasetConnector:
         """
         self._temporal_topology["NEXT"] = map
 
-    def set_prev(self, map):
+    def set_prev(self, map) -> None:
         """Set the map that is temporally as closest located before this map.
 
         Temporally located means that the start time of the "previous" map
@@ -261,7 +261,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["PREV"]
 
-    def append_equal(self, map):
+    def append_equal(self, map) -> None:
         """Append a map with equivalent temporal extent as this map
 
         :param map: This object should be of type AbstractMapDataset
@@ -281,7 +281,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["EQUAL"]
 
-    def append_starts(self, map):
+    def append_starts(self, map) -> None:
         """Append a map that this map temporally starts with
 
         :param map: This object should be of type AbstractMapDataset
@@ -300,7 +300,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["STARTS"]
 
-    def append_started(self, map):
+    def append_started(self, map) -> None:
         """Append a map that this map temporally started with
 
         :param map: This object should be of type AbstractMapDataset
@@ -319,7 +319,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["STARTED"]
 
-    def append_finishes(self, map):
+    def append_finishes(self, map) -> None:
         """Append a map that this map temporally finishes with
 
         :param map: This object should be of type AbstractMapDataset
@@ -338,7 +338,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["FINISHES"]
 
-    def append_finished(self, map):
+    def append_finished(self, map) -> None:
         """Append a map that this map temporally finished with
 
         :param map: This object should be of type AbstractMapDataset
@@ -357,7 +357,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["FINISHED"]
 
-    def append_overlaps(self, map):
+    def append_overlaps(self, map) -> None:
         """Append a map that this map temporally overlaps
 
         :param map: This object should be of type AbstractMapDataset
@@ -376,7 +376,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["OVERLAPS"]
 
-    def append_overlapped(self, map):
+    def append_overlapped(self, map) -> None:
         """Append a map that this map temporally overlapped
 
         :param map: This object should be of type AbstractMapDataset
@@ -395,7 +395,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["OVERLAPPED"]
 
-    def append_follows(self, map):
+    def append_follows(self, map) -> None:
         """Append a map that this map temporally follows
 
         :param map: This object should be of type AbstractMapDataset
@@ -414,7 +414,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["FOLLOWS"]
 
-    def append_precedes(self, map):
+    def append_precedes(self, map) -> None:
         """Append a map that this map temporally precedes
 
         :param map: This object should be of type AbstractMapDataset
@@ -433,7 +433,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["PRECEDES"]
 
-    def append_during(self, map):
+    def append_during(self, map) -> None:
         """Append a map that this map is temporally located during
         This includes temporal relationships starts and finishes
 
@@ -454,7 +454,7 @@ class TemporalTopologyDatasetConnector:
             return None
         return self._temporal_topology["DURING"]
 
-    def append_contains(self, map):
+    def append_contains(self, map) -> None:
         """Append a map that this map temporally contains
         This includes temporal relationships started and finished
 
@@ -503,7 +503,7 @@ class TemporalTopologyDatasetConnector:
     finishes = property(fget=get_finishes, fset=append_finishes)
     finished = property(fget=get_finished, fset=append_finished)
 
-    def print_temporal_topology_info(self):
+    def print_temporal_topology_info(self) -> None:
         """Print information about this class in human readable style"""
 
         print(
@@ -570,7 +570,7 @@ class TemporalTopologyDatasetConnector:
                 + self._generate_map_list_string(self.finished)
             )
 
-    def print_temporal_topology_shell_info(self):
+    def print_temporal_topology_shell_info(self) -> None:
         """Print information about this class in shell style"""
 
         if self.next() is not None:

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -42,6 +42,8 @@ for details.
 
 """
 
+from __future__ import annotations
+
 try:
     from ply import yacc
 except ImportError:
@@ -143,7 +145,11 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
     )
 
     def __init__(
-        self, pid=None, run: bool = False, debug: bool = True, spatial: bool = False
+        self,
+        pid: int | None = None,
+        run: bool = False,
+        debug: bool = True,
+        spatial: bool = False,
     ) -> None:
         TemporalAlgebraParser.__init__(self, pid, run, debug, spatial)
 
@@ -153,7 +159,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         self.m_mremove = pygrass.Module("g.remove", quiet=True, run_=False)
         self.m_buffer = pygrass.Module("v.buffer", quiet=True, run_=False)
 
-    def parse(self, expression, basename=None, overwrite: bool = False):
+    def parse(self, expression, basename: str | None = None, overwrite: bool = False):
         # Check for space time dataset type definitions from temporal algebra
         lx = TemporalVectorAlgebraLexer()
         lx.build()

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -142,7 +142,9 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         ),  # 2
     )
 
-    def __init__(self, pid=None, run=False, debug=True, spatial=False) -> None:
+    def __init__(
+        self, pid=None, run: bool = False, debug: bool = True, spatial: bool = False
+    ) -> None:
         TemporalAlgebraParser.__init__(self, pid, run, debug, spatial)
 
         self.m_overlay = pygrass.Module("v.overlay", quiet=True, run_=False)
@@ -151,7 +153,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         self.m_mremove = pygrass.Module("g.remove", quiet=True, run_=False)
         self.m_buffer = pygrass.Module("v.buffer", quiet=True, run_=False)
 
-    def parse(self, expression, basename=None, overwrite=False):
+    def parse(self, expression, basename=None, overwrite: bool = False):
         # Check for space time dataset type definitions from temporal algebra
         lx = TemporalVectorAlgebraLexer()
         lx.build()
@@ -183,15 +185,15 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         maplistA,
         maplistB=None,
         topolist=["EQUAL"],
-        assign_val=False,
-        count_map=False,
-        compare_bool=False,
-        compare_cmd=False,
+        assign_val: bool = False,
+        count_map: bool = False,
+        compare_bool: bool = False,
+        compare_cmd: bool = False,
         compop=None,
         aggregate=None,
-        new=False,
-        convert=False,
-        overlay_cmd=False,
+        new: bool = False,
+        convert: bool = False,
+        overlay_cmd: bool = False,
     ):
         """Build temporal topology for two space time data sets, copy map objects
         for given relation into map list.

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -213,9 +213,9 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         :param count_map: Boolean if the number of topological related maps
                          should be returned.
         :param compare_bool: Boolean for comparing boolean map values based on
-                          related map list and compariosn operator.
+                          related map list and comparison operator.
         :param compare_cmd: Boolean for comparing command list values based on
-                          related map list and compariosn operator.
+                          related map list and comparison operator.
         :param compop: Comparison operator, && or ||.
         :param aggregate: Aggregation operator for relation map list, & or |.
         :param new: Boolean if new temporary maps should be created.

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -66,7 +66,7 @@ from .temporal_algebra import (
 class TemporalVectorAlgebraLexer(TemporalAlgebraLexer):
     """Lexical analyzer for the GRASS GIS temporal vector algebra"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         TemporalAlgebraLexer.__init__(self)
 
     # Buffer functions from v.buffer
@@ -142,7 +142,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         ),  # 2
     )
 
-    def __init__(self, pid=None, run=False, debug=True, spatial=False):
+    def __init__(self, pid=None, run=False, debug=True, spatial=False) -> None:
         TemporalAlgebraParser.__init__(self, pid, run, debug, spatial)
 
         self.m_overlay = pygrass.Module("v.overlay", quiet=True, run_=False)
@@ -573,7 +573,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
                 dbif.close()
             t[0] = t[3]
 
-    def p_overlay_operation(self, t):
+    def p_overlay_operation(self, t) -> None:
         """
         expr : stds AND stds
              | expr AND stds
@@ -620,7 +620,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         if self.debug:
             print(str(t[1]) + t[2] + str(t[3]))
 
-    def p_overlay_operation_relation(self, t):
+    def p_overlay_operation_relation(self, t) -> None:
         """
         expr : stds T_OVERLAY_OPERATOR stds
              | expr T_OVERLAY_OPERATOR stds
@@ -651,7 +651,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         if self.debug:
             print(str(t[1]) + t[2] + str(t[3]))
 
-    def p_buffer_operation(self, t):
+    def p_buffer_operation(self, t) -> None:
         """
         expr : buff_function LPAREN stds COMMA number RPAREN
              | buff_function LPAREN expr COMMA number RPAREN
@@ -694,7 +694,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
 
             t[0] = resultlist
 
-    def p_buff_function(self, t):
+    def p_buff_function(self, t) -> None:
         """buff_function    : BUFF_POINT
         | BUFF_LINE
         | BUFF_AREA

--- a/python/grass/temporal/testsuite/test_register_function.py
+++ b/python/grass/temporal/testsuite/test_register_function.py
@@ -13,9 +13,10 @@ import datetime
 import os
 
 import grass.script as gs
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestRasterRegisterFunctions(TestCase):

--- a/python/grass/temporal/testsuite/test_register_function.py
+++ b/python/grass/temporal/testsuite/test_register_function.py
@@ -20,7 +20,7 @@ from grass.gunittest.main import test
 
 class TestRasterRegisterFunctions(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         # Use always the current mapset as temporal database
@@ -30,11 +30,11 @@ class TestRasterRegisterFunctions(TestCase):
         cls.runModule("g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=1.0, b=0.0, res=10.0)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.del_temp_region()
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Create the test maps and the space time raster datasets"""
         self.runModule(
             "r.mapcalc", overwrite=True, quiet=True, expression="register_map_1 = 1"
@@ -68,7 +68,7 @@ class TestRasterRegisterFunctions(TestCase):
             overwrite=True,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         """Remove maps from temporal database"""
         self.runModule(
             "t.unregister",
@@ -86,7 +86,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.strds_abs.delete()
         self.strds_rel.delete()
 
-    def test_absolute_time_strds_1(self):
+    def test_absolute_time_strds_1(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset
         """
@@ -116,7 +116,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 3))
 
-    def test_absolute_time_strds_2(self):
+    def test_absolute_time_strds_2(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset.
         The timestamps are set using the C-Interface beforehand,
@@ -155,7 +155,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 3))
 
-    def test_absolute_time_strds_3(self):
+    def test_absolute_time_strds_3(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset. The timestamps are set via method
         arguments and with the c-interface. The timestamps of the
@@ -188,7 +188,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 2, 1))
         self.assertEqual(end, datetime.datetime(2001, 2, 2))
 
-    def test_absolute_time_strds_4(self):
+    def test_absolute_time_strds_4(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset. The timestamps are set via method
         arguments and with the c-interface. The timestamps of the method
@@ -222,7 +222,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 2, 1))
         self.assertEqual(end, datetime.datetime(2001, 2, 2))
 
-    def test_absolute_time_1(self):
+    def test_absolute_time_1(self) -> None:
         """Test the registration of maps with absolute time
         using register_maps_in_space_time_dataset() and register_map_object_list()
         """
@@ -260,7 +260,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 3))
 
-    def test_absolute_time_2(self):
+    def test_absolute_time_2(self) -> None:
         """Test the registration of maps with absolute time
         using register_maps_in_space_time_dataset() and
         register_map_object_list() with empty map deletion
@@ -305,7 +305,7 @@ class TestRasterRegisterFunctions(TestCase):
         map_3 = tgis.VectorDataset("register_map_null@" + tgis.get_current_mapset())
         self.assertEqual(map_3.map_exists(), False)
 
-    def test_history_raster(self):
+    def test_history_raster(self) -> None:
         """Test that raster maps are registered with the history
         (creator and creation time) of the raster map itself (and from a
         different mapset (PERMANENT)
@@ -329,7 +329,7 @@ class TestRasterRegisterFunctions(TestCase):
         # Test that registered creator of the map is not the current user
         self.assertEqual(map_1.base.get_creator(), "helena")
 
-    def test_history_vector(self):
+    def test_history_vector(self) -> None:
         """Test that vector maps are registered with the history (creator
         and creation time) of the vector map itself (and from a
         different mapset (PERMANENT)
@@ -353,7 +353,7 @@ class TestRasterRegisterFunctions(TestCase):
         # Test that registered creator of the map is not the current user
         self.assertTrue(map_1.base.get_creator(), "helena")
 
-    def test_absolute_time_3(self):
+    def test_absolute_time_3(self) -> None:
         """Test the registration of maps with absolute time.
         The timestamps are set using the C-Interface beforehand,
         so that the register function needs
@@ -382,7 +382,7 @@ class TestRasterRegisterFunctions(TestCase):
         start, end = map.get_absolute_time()
         self.assertEqual(start, datetime.datetime(2001, 1, 1, 18, 30, 1))
 
-    def test_relative_time_strds_1(self):
+    def test_relative_time_strds_1(self) -> None:
         """Test the registration of maps with relative time in a
         space time raster dataset
         """
@@ -417,7 +417,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(end, 2)
         self.assertEqual(unit, "day")
 
-    def test_relative_time_strds_2(self):
+    def test_relative_time_strds_2(self) -> None:
         """Test the registration of maps with relative time in a
         space time raster dataset. The timestamps are set for the maps
         using the C-interface before registration.
@@ -460,7 +460,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(end, 2000000)
         self.assertEqual(unit, "seconds")
 
-    def test_relative_time_1(self):
+    def test_relative_time_1(self) -> None:
         """Test the registration of maps with relative time"""
         tgis.register_maps_in_space_time_dataset(
             type="raster",
@@ -486,7 +486,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(end, 2)
         self.assertEqual(unit, "day")
 
-    def test_relative_time_2(self):
+    def test_relative_time_2(self) -> None:
         """Test the registration of maps with relative time"""
         tgis.register_maps_in_space_time_dataset(
             type="raster",
@@ -512,7 +512,7 @@ class TestRasterRegisterFunctions(TestCase):
         self.assertEqual(end, 2000000)
         self.assertEqual(unit, "seconds")
 
-    def test_relative_time_3(self):
+    def test_relative_time_3(self) -> None:
         """Test the registration of maps with relative time. The
         timestamps are set beforehand using the C-interface.
         """
@@ -549,7 +549,7 @@ class TestRasterRegisterFunctions(TestCase):
 
 class TestVectorRegisterFunctions(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         # Use always the current mapset as temporal database
@@ -559,11 +559,11 @@ class TestVectorRegisterFunctions(TestCase):
         cls.runModule("g.region", n=80.0, s=0.0, e=120.0, w=0.0, t=1.0, b=0.0, res=10.0)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.del_temp_region()
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Create the test maps and the space time raster datasets"""
         self.runModule(
             "v.random",
@@ -615,7 +615,7 @@ class TestVectorRegisterFunctions(TestCase):
             overwrite=True,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         """Remove maps from temporal database"""
         self.runModule(
             "t.unregister",
@@ -640,7 +640,7 @@ class TestVectorRegisterFunctions(TestCase):
         self.stvds_abs.delete()
         self.stvds_rel.delete()
 
-    def test_absolute_time_stvds_1(self):
+    def test_absolute_time_stvds_1(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset
         """
@@ -670,7 +670,7 @@ class TestVectorRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 3))
 
-    def test_absolute_time_stvds_2(self):
+    def test_absolute_time_stvds_2(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset.
         The timestamps are set using the C-Interface beforehand,
@@ -709,7 +709,7 @@ class TestVectorRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 3))
 
-    def test_absolute_time_stvds_3(self):
+    def test_absolute_time_stvds_3(self) -> None:
         """Test the registration of maps with absolute time in a
         space time raster dataset. The timestamps are set via method
         arguments and with the C-interface. The timestamps of the method
@@ -741,7 +741,7 @@ class TestVectorRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 2, 1))
         self.assertEqual(end, datetime.datetime(2001, 2, 2))
 
-    def test_absolute_time_1(self):
+    def test_absolute_time_1(self) -> None:
         """Register vector maps in the temporal database and in addition
         in a stvds using the object method
 
@@ -781,7 +781,7 @@ class TestVectorRegisterFunctions(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 3))
 
-    def test_absolute_time_2(self):
+    def test_absolute_time_2(self) -> None:
         """Register vector maps in the temporal database and in addition
         in a stvds using the object method deleting empty maps
 
@@ -832,17 +832,17 @@ class TestVectorRegisterFunctions(TestCase):
 
 
 class TestRegisterFails(TestCase):
-    def test_error_handling_1(self):
+    def test_error_handling_1(self) -> None:
         # start option is missing
         self.assertModuleFail(
             "t.register", input="test", end="2001-01-01", maps=("a", "b")
         )
 
-    def test_error_handling_2(self):
+    def test_error_handling_2(self) -> None:
         # No input definition
         self.assertModuleFail("t.register", input="test", start="2001-01-01")
 
-    def test_error_handling_3(self):
+    def test_error_handling_3(self) -> None:
         # File and maps are mutually exclusive
         self.assertModuleFail(
             "t.register",
@@ -852,17 +852,17 @@ class TestRegisterFails(TestCase):
             file="maps.txt",
         )
 
-    def test_error_handling_4(self):
+    def test_error_handling_4(self) -> None:
         # Increment needs start
         self.assertModuleFail(
             "t.register", input="test", increment="1 day", maps=("a", "b")
         )
 
-    def test_error_handling_5(self):
+    def test_error_handling_5(self) -> None:
         # Interval needs start
         self.assertModuleFail("t.register", flags="i", input="test", maps=("a", "b"))
 
-    def test_error_handling_6(self):
+    def test_error_handling_6(self) -> None:
         # Increment and end are mutually exclusive
         self.assertModuleFail(
             "t.register",
@@ -873,7 +873,7 @@ class TestRegisterFails(TestCase):
             maps=("a", "b"),
         )
 
-    def test_error_handling_7(self):
+    def test_error_handling_7(self) -> None:
         # Interval and end are mutually exclusive
         self.assertModuleFail(
             "t.register",
@@ -887,7 +887,7 @@ class TestRegisterFails(TestCase):
 
 class TestRegisterMapsetAccess(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         os.putenv("GRASS_OVERWRITE", "1")
         tgis.init()
@@ -910,7 +910,7 @@ class TestRegisterMapsetAccess(TestCase):
 
         cls.del_temp_region()
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Create the space time raster dataset"""
         self.strds_abs = tgis.open_new_stds(
             name="register_test_abs",
@@ -958,7 +958,7 @@ class TestRegisterMapsetAccess(TestCase):
         tgis.init()
         self.assertNotEqual(self.currmapset, tgis.get_current_mapset())
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         """Remove raster maps from current mapset"""
 
         # switch to old mapset
@@ -986,7 +986,7 @@ class TestRegisterMapsetAccess(TestCase):
         )
         gs.try_rmdir(mapset_path)
 
-    def test_mapset_access_1(self):
+    def test_mapset_access_1(self) -> None:
         """Test the registration of maps from a different mapset."""
 
         self.strds_abs_2 = tgis.open_new_stds(

--- a/python/grass/temporal/testsuite/test_temporal_doctests.py
+++ b/python/grass/temporal/testsuite/test_temporal_doctests.py
@@ -8,6 +8,7 @@ import sys
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
+
 import grass.temporal
 
 doctest.DocFileCase = type(

--- a/python/grass/temporal/testsuite/unittests_temporal_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_algebra.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalAlgebra(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_algebra.py
@@ -18,7 +18,7 @@ class TestTemporalAlgebra(TestCase):
     """Class for testing temporal algebra"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -115,16 +115,16 @@ class TestTemporalAlgebra(TestCase):
             end="2001-01-04",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_select1(self):
+    def test_temporal_select1(self) -> None:
         """Testing the temporal select operator with equal relations."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -143,7 +143,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_select2(self):
+    def test_temporal_select2(self) -> None:
         """Testing the temporal select operator with equal relations."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -162,7 +162,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_select3(self):
+    def test_temporal_select3(self) -> None:
         """Testing the temporal select operator with equal relations."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -181,7 +181,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_select_operators1(self):
+    def test_temporal_select_operators1(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -203,7 +203,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_select_operators2(self):
+    def test_temporal_select_operators2(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -225,7 +225,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_select_operators3(self):
+    def test_temporal_select_operators3(self) -> None:
         """Testing the temporal select operator. Including temporal relations
         and negation operation."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
@@ -248,7 +248,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_select_operators4(self):
+    def test_temporal_select_operators4(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         temporal operators."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
@@ -276,7 +276,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), False)
         self.assertEqual(result_strds.get_granularity(), "2 days")
 
-    def test_temporal_select_operators5(self):
+    def test_temporal_select_operators5(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         temporal operators."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
@@ -304,7 +304,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "2 days")
 
-    def test_temporal_extent1(self):
+    def test_temporal_extent1(self) -> None:
         """Testing the temporal extent operators."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -326,7 +326,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), False)
         self.assertEqual(result_strds.get_granularity(), "2 days")
 
-    def test_temporal_extent2(self):
+    def test_temporal_extent2(self) -> None:
         """Testing the temporal extent operators."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -348,7 +348,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), False)
         self.assertEqual(result_strds.get_granularity(), "2 days")
 
-    def test_temporal_extent3(self):
+    def test_temporal_extent3(self) -> None:
         """Testing the temporal extent operators."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -375,7 +375,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), False)
         self.assertEqual(result_strds.get_granularity(), "2 days")
 
-    def test_temporal_hash1(self):
+    def test_temporal_hash1(self) -> None:
         """Testing the hash function in conditional statement."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -397,7 +397,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_hash_operator1(self):
+    def test_temporal_hash_operator1(self) -> None:
         """Testing the hash operator function in conditional statement."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -419,7 +419,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_temporal_hash_operator2(self):
+    def test_temporal_hash_operator2(self) -> None:
         """Testing the hash operator function in conditional statement."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -441,7 +441,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_tmap_function1(self):
+    def test_tmap_function1(self) -> None:
         """Testing the tmap function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -463,7 +463,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_tmap_function2(self):
+    def test_tmap_function2(self) -> None:
         """Testing the tmap function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -485,7 +485,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), True)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_merge_function1(self):
+    def test_merge_function1(self) -> None:
         """Testing the merge function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -504,7 +504,7 @@ class TestTemporalAlgebra(TestCase):
         self.assertEqual(result_strds.check_temporal_topology(), False)
         self.assertEqual(result_strds.get_granularity(), "1 day")
 
-    def test_merge_function2(self):
+    def test_merge_function2(self) -> None:
         """Testing the merge function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(run=True, debug=True)
         temporal_algebra_parser.parse(
@@ -531,7 +531,7 @@ class TestTemporalAlgebraDryRun(TestCase):
     """Class for testing dry runs of the temporal algebra"""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -629,12 +629,12 @@ class TestTemporalAlgebraDryRun(TestCase):
         )
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.del_temp_region()
 
-    def test_merge_function1(self):
+    def test_merge_function1(self) -> None:
         """Testing the merge function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -650,7 +650,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_merge_function2(self):
+    def test_merge_function2(self) -> None:
         """Testing the merge function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -666,7 +666,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_merge_function3(self):
+    def test_merge_function3(self) -> None:
         """Testing the merge function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -682,7 +682,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_shift1(self):
+    def test_shift1(self) -> None:
         """Testing the shift function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -698,7 +698,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_shift2(self):
+    def test_shift2(self) -> None:
         """Testing the shift function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -714,7 +714,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_buffer1(self):
+    def test_buffer1(self) -> None:
         """Testing the shift function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -730,7 +730,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_buff2(self):
+    def test_buff2(self) -> None:
         """Testing the shift function."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True
@@ -746,7 +746,7 @@ class TestTemporalAlgebraDryRun(TestCase):
         self.assertEqual(parser_content["STDS"]["name"], "R")
         self.assertEqual(parser_content["STDS"]["stdstype"], "strds")
 
-    def test_time_constant(self):
+    def test_time_constant(self) -> None:
         """Testing the time constant functions."""
         temporal_algebra_parser = tgis.TemporalAlgebraParser(
             run=True, debug=False, dry_run=True

--- a/python/grass/temporal/testsuite/unittests_temporal_algebra_grs.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_algebra_grs.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalAlgebraGranularity(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_algebra_grs.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_algebra_grs.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalAlgebraGranularity(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -131,17 +131,17 @@ class TestTemporalAlgebraGranularity(TestCase):
             end="2001-01-04",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         pass
         # self.runModule("t.remove", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         # cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.del_temp_region()
 
-    def test_common_granularity_1(self):
+    def test_common_granularity_1(self) -> None:
         """Testing the common granularity function."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = A : B"
@@ -173,7 +173,7 @@ class TestTemporalAlgebraGranularity(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 month")
 
-    def test_common_granularity_2(self):
+    def test_common_granularity_2(self) -> None:
         """Testing the common granularity function year to month samping."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = A : C"
@@ -192,7 +192,7 @@ class TestTemporalAlgebraGranularity(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 month")
 
-    def test_common_granularity_3(self):
+    def test_common_granularity_3(self) -> None:
         """Testing the common granularity function with gaps."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = A : D"
@@ -211,7 +211,7 @@ class TestTemporalAlgebraGranularity(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 month")
 
-    def test_common_granularity_4(self):
+    def test_common_granularity_4(self) -> None:
         """Testing the common granularity function year to month with gaps."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = C : D"
@@ -230,7 +230,7 @@ class TestTemporalAlgebraGranularity(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 month")
 
-    def test_common_granularity_4(self):
+    def test_common_granularity_4(self) -> None:
         """Testing the common granularity function year to month with gaps."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = C : D"
@@ -249,7 +249,7 @@ class TestTemporalAlgebraGranularity(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 month")
 
-    def test_common_granularity_5(self):
+    def test_common_granularity_5(self) -> None:
         """Testing the common granularity function year to month with gaps."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = A : C : D"
@@ -268,7 +268,7 @@ class TestTemporalAlgebraGranularity(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 month")
 
-    def test_common_granularity_6(self):
+    def test_common_granularity_6(self) -> None:
         """Testing the common granularity function year to month with gaps."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         expr = "R = if(start_month(A) > 2, A : C : D)"

--- a/python/grass/temporal/testsuite/unittests_temporal_algebra_mixed_stds.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_algebra_mixed_stds.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalAlgebraMixedDatasets(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -92,14 +92,14 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         )
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", type="str3ds", inputs="A", quiet=True)
         cls.runModule("t.remove", flags="rf", type="strds", inputs="B", quiet=True)
         cls.runModule("t.remove", flags="rf", type="stvds", inputs="C", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_select_operators1(self):
+    def test_temporal_select_operators1(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -134,7 +134,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(pc["STDS"]["name"], "R")
         self.assertEqual(pc["STDS"]["stdstype"], "str3ds")
 
-    def test_temporal_select_operators2(self):
+    def test_temporal_select_operators2(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -169,7 +169,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(pc["STDS"]["name"], "R")
         self.assertEqual(pc["STDS"]["stdstype"], "str3ds")
 
-    def test_temporal_select_operators3(self):
+    def test_temporal_select_operators3(self) -> None:
         """Testing the temporal select operator. Including temporal relations
         and negation operation."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
@@ -191,7 +191,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select_operators4(self):
+    def test_temporal_select_operators4(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         temporal operators."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
@@ -211,7 +211,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_select_operators5(self):
+    def test_temporal_select_operators5(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         temporal operators."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
@@ -231,7 +231,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_hash_operator1(self):
+    def test_temporal_hash_operator1(self) -> None:
         """Testing the hash operator function in conditional statement."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -252,7 +252,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_hash_operator2(self):
+    def test_temporal_hash_operator2(self) -> None:
         """Testing the hash operator function in conditional statement."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -273,7 +273,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_different_stds_handling1(self):
+    def test_different_stds_handling1(self) -> None:
         """Testing the handling of different stds types as output."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -294,7 +294,7 @@ class TestTemporalAlgebraMixedDatasets(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_different_stds_handling2(self):
+    def test_different_stds_handling2(self) -> None:
         """Testing the handling of different stds types as output."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True, dry_run=True)
         pc = ta.parse(

--- a/python/grass/temporal/testsuite/unittests_temporal_algebra_mixed_stds.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_algebra_mixed_stds.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalAlgebraMixedDatasets(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_conditionals.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_conditionals.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalConditionals(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_conditionals.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_conditionals.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalConditionals(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -134,16 +134,16 @@ class TestTemporalConditionals(TestCase):
             end="2001-01-04",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D,E", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_condition_1(self):
+    def test_temporal_condition_1(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -163,7 +163,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_2(self):
+    def test_temporal_condition_2(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(expression="R = if(td(A) == 1, A)", basename="r", overwrite=True)
@@ -179,7 +179,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_3(self):
+    def test_temporal_condition_3(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -199,7 +199,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_4(self):
+    def test_temporal_condition_4(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -219,7 +219,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_5(self):
+    def test_temporal_condition_5(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -237,7 +237,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_6(self):
+    def test_temporal_condition_6(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -257,7 +257,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_7(self):
+    def test_temporal_condition_7(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -277,7 +277,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_condition_8(self):
+    def test_temporal_condition_8(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -297,7 +297,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_condition_9(self):
+    def test_temporal_condition_9(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -317,7 +317,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_condition_10(self):
+    def test_temporal_condition_10(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -337,7 +337,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_condition_11(self):
+    def test_temporal_condition_11(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -357,7 +357,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_condition_12(self):
+    def test_temporal_condition_12(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -377,7 +377,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_conditional_13(self):
+    def test_temporal_conditional_13(self) -> None:
         """Testing the hash operator function in conditional statement."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -398,7 +398,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_else_1(self):
+    def test_temporal_condition_else_1(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -418,7 +418,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_else_2(self):
+    def test_temporal_condition_else_2(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -438,7 +438,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_else_3(self):
+    def test_temporal_condition_else_3(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(
@@ -458,7 +458,7 @@ class TestTemporalConditionals(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_condition_else_4(self):
+    def test_temporal_condition_else_4(self) -> None:
         """Testing the temporal select operator with equal relations."""
         ta = tgis.TemporalAlgebraParser(run=True, debug=True)
         ta.parse(

--- a/python/grass/temporal/testsuite/unittests_temporal_raster3d_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster3d_algebra.py
@@ -17,7 +17,7 @@ from grass.gunittest.main import test
 
 class TestTemporalRaster3dAlgebra(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -49,16 +49,16 @@ class TestTemporalRaster3dAlgebra(TestCase):
             interval=True,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", type="str3ds", flags="rf", inputs="D", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         # cls.runModule("t.remove", type="str3ds", flags="rf", inputs="A", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_neighbors_1(self):
+    def test_temporal_neighbors_1(self) -> None:
         """Simple temporal neighborhood computation test"""
         A = tgis.open_old_stds("A", type="str3ds")
         A.print_info()
@@ -76,7 +76,7 @@ class TestTemporalRaster3dAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
-    def test_temporal_neighbors_2(self):
+    def test_temporal_neighbors_2(self) -> None:
         """Simple temporal neighborhood computation test"""
         A = tgis.open_old_stds("A", type="str3ds")
         A.print_info()

--- a/python/grass/temporal/testsuite/unittests_temporal_raster3d_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster3d_algebra.py
@@ -10,9 +10,10 @@ for details.
 import datetime
 
 import grass.script as gs
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalRaster3dAlgebra(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalRasterAlgebra(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -116,17 +116,17 @@ class TestTemporalRasterAlgebra(TestCase):
             end="2001-01-04",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_extent1(self):
+    def test_temporal_extent1(self) -> None:
         """Testing the temporal extent operators."""
         ta = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         ta.parse(expression="R = A {:,during,r} C", basename="r", overwrite=True)
@@ -152,7 +152,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(pc["STDS"]["name"], "R")
         self.assertEqual(pc["STDS"]["stdstype"], "strds")
 
-    def test_temporal_conditional_time_dimension_bug(self):
+    def test_temporal_conditional_time_dimension_bug(self) -> None:
         """Testing the conditional time dimension bug, that uses the time
         dimension of the conditional statement instead the time dimension
         of the then/else statement."""
@@ -174,7 +174,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_simple_arith_hash_1(self):
+    def test_simple_arith_hash_1(self) -> None:
         """Simple arithmetic test including the hash operator using the granularity option
         for map name creation
 
@@ -214,7 +214,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_td_1(self):
+    def test_simple_arith_td_1(self) -> None:
         """Simple arithmetic test with time suffix option
 
         R = A + td(A)
@@ -254,7 +254,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_td_2(self):
+    def test_simple_arith_td_2(self) -> None:
         """Simple arithmetic test
 
         R = A / td(A)
@@ -280,7 +280,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_td_3(self):
+    def test_simple_arith_td_3(self) -> None:
         """Simple arithmetic test
 
         R = A {+,equal} td(A)
@@ -307,7 +307,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_td_4(self):
+    def test_simple_arith_td_4(self) -> None:
         """Simple arithmetic test
 
         R = A {/, equal} td(A)
@@ -334,7 +334,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_if_1(self):
+    def test_simple_arith_if_1(self) -> None:
         """Simple arithmetic test with if condition
 
         R = if({equal}, start_date(A) >= "2001-01-02", A + A)
@@ -362,7 +362,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_if_2(self):
+    def test_simple_arith_if_2(self) -> None:
         """Simple arithmetic test with if condition
 
         R = if({equal}, A#A == 1, A - A)
@@ -396,7 +396,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_complex_arith_if_1(self):
+    def test_complex_arith_if_1(self) -> None:
         """Complex arithmetic test with if condition
 
         R = if(start_date(A) < "2001-01-03" && A#A == 1, A{+, starts,l}C, A{+, finishes,l}C)
@@ -426,7 +426,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
-    def test_simple_arith_1(self):
+    def test_simple_arith_1(self) -> None:
         """Simple arithmetic test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -442,7 +442,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_simple_arith_2(self):
+    def test_simple_arith_2(self) -> None:
         """Simple arithmetic test that creates an empty strds"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -452,7 +452,7 @@ class TestTemporalRasterAlgebra(TestCase):
         D.select()
         self.assertEqual(D.metadata.get_number_of_maps(), 0)
 
-    def test_simple_arith_3(self):
+    def test_simple_arith_3(self) -> None:
         """Simple arithmetic test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A / A + A*A/A", basename="r", overwrite=True)
@@ -466,7 +466,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_temporal_intersection_1(self):
+    def test_temporal_intersection_1(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A {+,equal,i} B", basename="r", overwrite=True)
@@ -474,7 +474,7 @@ class TestTemporalRasterAlgebra(TestCase):
         D.select()
         self.assertEqual(D.metadata.get_number_of_maps(), 0)
 
-    def test_temporal_intersection_2(self):
+    def test_temporal_intersection_2(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A {+,during,i} B", basename="r", overwrite=True)
@@ -488,7 +488,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_temporal_intersection_3(self):
+    def test_temporal_intersection_3(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A {+,starts,i} B", basename="r", overwrite=True)
@@ -502,7 +502,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
-    def test_temporal_intersection_4(self):
+    def test_temporal_intersection_4(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -518,7 +518,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_temporal_intersection_5(self):
+    def test_temporal_intersection_5(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -534,7 +534,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_temporal_intersection_6(self):
+    def test_temporal_intersection_6(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = B {+,overlaps,u} C", basename="r", overwrite=True)
@@ -548,7 +548,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
-    def test_temporal_intersection_7(self):
+    def test_temporal_intersection_7(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = B {+,overlapped,u} C", basename="r", overwrite=True)
@@ -562,7 +562,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_temporal_intersection_8(self):
+    def test_temporal_intersection_8(self) -> None:
         """Simple temporal intersection test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -580,7 +580,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
 
-    def test_temporal_neighbors_1(self):
+    def test_temporal_neighbors_1(self) -> None:
         """Simple temporal neighborhood computation test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A[-1] + A[1]", basename="r", overwrite=True)
@@ -594,7 +594,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
-    def test_temporal_neighbors_2(self):
+    def test_temporal_neighbors_2(self) -> None:
         """Simple temporal neighborhood computation test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A[0,0,-1] + A[0,0,1]", basename="r", overwrite=True)
@@ -608,7 +608,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 1, 4))
 
-    def test_tmap_function1(self):
+    def test_tmap_function1(self) -> None:
         """Testing the tmap function."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = tmap(singletmap)", basename="r", overwrite=True)
@@ -625,7 +625,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_tmap_function2(self):
+    def test_tmap_function2(self) -> None:
         """Testing the tmap function."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = tmap(singletmap) + 1", basename="r", overwrite=True)
@@ -642,7 +642,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_map_function1(self):
+    def test_map_function1(self) -> None:
         """Testing the map function."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = map(singlemap) + A", basename="r", overwrite=True)
@@ -659,7 +659,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_map_function2(self):
+    def test_map_function2(self) -> None:
         """Testing the map function."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R =  A * map(singlemap)", basename="r", overwrite=True)
@@ -676,7 +676,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select(self):
+    def test_temporal_select(self) -> None:
         """Testing the temporal select operator."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A : A", basename="r", overwrite=True)
@@ -692,7 +692,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select(self):
+    def test_temporal_select(self) -> None:
         """Testing the temporal select operator."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A : D", basename="r", overwrite=True)
@@ -708,7 +708,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select_operators1(self):
+    def test_temporal_select_operators1(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A : D", basename="r", overwrite=True)
@@ -724,7 +724,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select_operators2(self):
+    def test_temporal_select_operators2(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A {!:,during} C", basename="r", overwrite=True)
@@ -740,7 +740,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select_operators3(self):
+    def test_temporal_select_operators3(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         different temporal operators (lr|+&)"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -757,7 +757,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_select_operators4(self):
+    def test_temporal_select_operators4(self) -> None:
         """Testing the temporal select operator. Including temporal relations and
         different temporal operators (lr|+&)"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -779,7 +779,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_hash_operator1(self):
+    def test_temporal_hash_operator1(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = if(A # D == 1, A)", basename="r", overwrite=True)
@@ -795,7 +795,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_hash_operator2(self):
+    def test_temporal_hash_operator2(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A # D", basename="r", overwrite=True)
@@ -811,7 +811,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_hash_operator3(self):
+    def test_temporal_hash_operator3(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = C {#,contains} A", basename="r", overwrite=True)
@@ -827,7 +827,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_hash_operator4(self):
+    def test_temporal_hash_operator4(self) -> None:
         """Testing the temporal hash operator in the raster algebra."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -847,7 +847,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_raster_arithmetic_relation_1(self):
+    def test_raster_arithmetic_relation_1(self) -> None:
         """Arithmetic test with temporal intersection"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = B {+,contains,l} A ", basename="r", overwrite=True)
@@ -863,7 +863,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_raster_arithmetic_relation_2(self):
+    def test_raster_arithmetic_relation_2(self) -> None:
         """Arithmetic test with temporal intersection"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = B {*,contains,l} A ", basename="r", overwrite=True)
@@ -879,7 +879,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_raster_arithmetic_relation_3(self):
+    def test_raster_arithmetic_relation_3(self) -> None:
         """Arithmetic test with temporal intersection"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = B {+,contains,l} A ", basename="r", overwrite=True)
@@ -895,7 +895,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_raster_arithmetic_relation_4(self):
+    def test_raster_arithmetic_relation_4(self) -> None:
         """Arithmetic test with temporal intersection"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = B {+,contains,r} A ", basename="r", overwrite=True)
@@ -911,7 +911,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_raster_arithmetic_relation_5(self):
+    def test_raster_arithmetic_relation_5(self) -> None:
         """Complex arithmetic test with temporal intersection"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -931,7 +931,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_capacity_1(self):
+    def test_capacity_1(self) -> None:
         """Arithmetic test with temporal intersection"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = (((((((A + A) - A) * A) / A) % A) - td(A)) - (A # A))"

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalRasterAlgebra(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
@@ -17,7 +17,7 @@ from grass.gunittest.utils import xfail_windows
 
 class TestTemporalRasterAlgebraImplicitAggregation(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -55,18 +55,18 @@ class TestTemporalRasterAlgebraImplicitAggregation(TestCase):
             type="raster", name=None, maps="singletmap", start="2001-01-01"
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A", quiet=True)
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
 
     @xfail_windows
-    def test_simple_operator(self):
+    def test_simple_operator(self) -> None:
         """Test implicit aggregation
 
         R = A + A
@@ -93,7 +93,7 @@ class TestTemporalRasterAlgebraImplicitAggregation(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_complex_operator(self):
+    def test_complex_operator(self) -> None:
         """Test implicit aggregation
 
         R = A {+,equal,l} A
@@ -120,7 +120,7 @@ class TestTemporalRasterAlgebraImplicitAggregation(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_single_map_complex_operator(self):
+    def test_single_map_complex_operator(self) -> None:
         """Test implicit aggregation
 
         R = singletmap {+,equal,l} A
@@ -152,7 +152,7 @@ class TestTemporalRasterAlgebraImplicitAggregation(TestCase):
         self.assertEqual(D.get_granularity(), None)
 
     @xfail_windows
-    def test_single_map_simple_operator(self):
+    def test_single_map_simple_operator(self) -> None:
         """Test implicit aggregation
 
         R = singletmap + A
@@ -179,7 +179,7 @@ class TestTemporalRasterAlgebraImplicitAggregation(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_single_map_complex_operator_right_ts(self):
+    def test_single_map_complex_operator_right_ts(self) -> None:
         """Test implicit aggregation
 
         TODO: Is this the correct result? Implicit aggregation and full permutation?

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py
@@ -9,10 +9,11 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.utils import xfail_windows
+
+import grass.temporal as tgis
 
 
 class TestTemporalRasterAlgebraImplicitAggregation(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_grs.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_grs.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalRasterAlgebra(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_grs.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_grs.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalRasterAlgebra(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -141,12 +141,12 @@ class TestTemporalRasterAlgebra(TestCase):
             end="2001-07-01",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         return
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         return
         """Remove the temporary region
         """
@@ -154,7 +154,7 @@ class TestTemporalRasterAlgebra(TestCase):
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
 
-    def test_1(self):
+    def test_1(self) -> None:
         """Simple arithmetik test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = if(C == 9,  A - 1)"
@@ -189,7 +189,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(pc["STDS"]["name"], "R")
         self.assertEqual(pc["STDS"]["stdstype"], "strds")
 
-    def test_2(self):
+    def test_2(self) -> None:
         """Simple arithmetik test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = A + B + C"
@@ -224,7 +224,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(pc["STDS"]["name"], "R")
         self.assertEqual(pc["STDS"]["stdstype"], "strds")
 
-    def test_3(self):
+    def test_3(self) -> None:
         """Simple arithmetik test with null map"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = A + B + C + tmap(nullmap)"
@@ -259,7 +259,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(pc["STDS"]["name"], "R")
         self.assertEqual(pc["STDS"]["stdstype"], "strds")
 
-    def test_4(self):
+    def test_4(self) -> None:
         """Simple arithmetik test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = if(D == 11,  A - 1, A + 1)"
@@ -281,7 +281,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_simple_arith_hash_1(self):
+    def test_simple_arith_hash_1(self) -> None:
         """Simple arithmetic test including the hash operator"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A + (A # A)", basename="r", overwrite=True)
@@ -295,7 +295,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-    def test_simple_arith_hash_2(self):
+    def test_simple_arith_hash_2(self) -> None:
         """Simple arithmetic test including the hash operator"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = (A + A) # A", basename="r", overwrite=True)
@@ -309,7 +309,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-    def test_simple_arith_td_1(self):
+    def test_simple_arith_td_1(self) -> None:
         """Simple arithmetic test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = A + td(A:D)"
@@ -331,7 +331,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_simple_arith_if_1(self):
+    def test_simple_arith_if_1(self) -> None:
         """Simple arithmetic test with if condition"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = 'R = if(start_date(A) >= "2001-02-01", A + A)'
@@ -351,7 +351,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 2, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-    def test_simple_arith_if_2(self):
+    def test_simple_arith_if_2(self) -> None:
         """Simple arithmetic test with if condition"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = if(A#A == 1, A - A)"
@@ -371,7 +371,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-    def test_complex_arith_if_1(self):
+    def test_complex_arith_if_1(self) -> None:
         """Complex arithmetic test with if condition"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = 'R = if(start_date(A) < "2001-03-01" && A#A == 1, A+C, A-C)'
@@ -391,7 +391,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-    def test_temporal_neighbors(self):
+    def test_temporal_neighbors(self) -> None:
         """Simple temporal neighborhood computation test"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = (A[0,0,-1] : D) + (A[0,0,1] : D)"
@@ -411,7 +411,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 2))
         self.assertEqual(end, datetime.datetime(2001, 5, 6))
 
-    def test_map(self):
+    def test_map(self) -> None:
         """Test STDS + single map without timestamp"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = A + map(singletmap)"
@@ -431,7 +431,7 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(start, datetime.datetime(2001, 1, 1))
         self.assertEqual(end, datetime.datetime(2001, 7, 1))
 
-    def test_tmap_map(self):
+    def test_tmap_map(self) -> None:
         """Test STDS + single map with and without timestamp"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         expr = "R = tmap(singletmap) + A + map(singletmap)"

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_spatial_topology.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_spatial_topology.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalRasterAlgebraSpatialTopology(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -89,17 +89,17 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
             type="raster", name=None, maps="singletmap", start="2001-01-01"
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B", quiet=True)
         cls.runModule("t.unregister", maps="singletmap", quiet=True)
         cls.del_temp_region()
 
-    def test_equal_equivalent_sum(self):
+    def test_equal_equivalent_sum(self) -> None:
         """Spatial topology distinction with equal timestamps
 
         STRDS A and B have identical time stamps, hence the differentiation
@@ -131,7 +131,7 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_equal_overlap_sum(self):
+    def test_equal_overlap_sum(self) -> None:
         """Spatial topology distinction with equal timestamps
 
         STRDS A and B have identical time stamps, hence the differentiation
@@ -161,7 +161,7 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_equal_overlap_sum_with_null(self):
+    def test_equal_overlap_sum_with_null(self) -> None:
         """Spatial topology distinction with equal timestamps
 
         STRDS A and B have identical time stamps, hence the differentiation
@@ -193,7 +193,7 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_equal_contain_sum(self):
+    def test_equal_contain_sum(self) -> None:
         """Spatial topology distinction with equal timestamps
 
         STRDS A and B have identical time stamps, hence the differentiation
@@ -220,7 +220,7 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_equal_equivalent_contain_sum(self):
+    def test_equal_equivalent_contain_sum(self) -> None:
         """Spatial topology distinction with equal timestamps
 
         STRDS A and B have identical time stamps, hence the differentiation
@@ -255,7 +255,7 @@ class TestTemporalRasterAlgebraSpatialTopology(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), None)
 
-    def test_equal_equivalent_compare(self):
+    def test_equal_equivalent_compare(self) -> None:
         """Test implicit aggregation
 
         STRDS A and B have identical time stamps, hence the differentiation

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_spatial_topology.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra_spatial_topology.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalRasterAlgebraSpatialTopology(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalRasterAlgebraConditionals(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -104,16 +104,16 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
             interval=True,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B,C,D", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_conditional_time_dimension_bug(self):
+    def test_temporal_conditional_time_dimension_bug(self) -> None:
         """Testing the conditional time dimension bug, that uses the time
         dimension of the conditional statement instead the time dimension
         of the then/else statement."""
@@ -135,7 +135,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_temporal_conditional_1(self):
+    def test_temporal_conditional_1(self) -> None:
         """Testing the conditional time dimension bug, that uses the time
         dimension of the conditional statement instead the time dimension
         of the then/else statement."""
@@ -155,7 +155,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_temporal_conditional_relation_1(self):
+    def test_temporal_conditional_relation_1(self) -> None:
         """Testing the conditional time dimension bug, that uses the time
         dimension of the conditional statement instead the time dimension
         of the then/else statement."""
@@ -177,7 +177,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), False)
         self.assertEqual(R.get_granularity(), "2 days")
 
-    def test_spatial_conditional_1(self):
+    def test_spatial_conditional_1(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -198,7 +198,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_2(self):
+    def test_spatial_conditional_2(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -219,7 +219,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_3(self):
+    def test_spatial_conditional_3(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -236,7 +236,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_4(self):
+    def test_spatial_conditional_4(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -253,7 +253,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_5(self):
+    def test_spatial_conditional_5(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -274,7 +274,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "2 days")
 
-    def test_spatial_conditional_relation_1(self):
+    def test_spatial_conditional_relation_1(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -293,7 +293,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_relation_2(self):
+    def test_spatial_conditional_relation_2(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -313,7 +313,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_numeric_relation_1(self):
+    def test_spatial_conditional_numeric_relation_1(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -331,7 +331,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_numeric_relation_2(self):
+    def test_spatial_conditional_numeric_relation_2(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -352,7 +352,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_numeric_1(self):
+    def test_spatial_conditional_numeric_1(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = if(A > 2, 0, A)", basename="r", overwrite=True)
@@ -368,7 +368,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_numeric_2(self):
+    def test_spatial_conditional_numeric_2(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = if(A > 2, A, 8)", basename="r", overwrite=True)
@@ -384,7 +384,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_numeric_3(self):
+    def test_spatial_conditional_numeric_3(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = if(A > 2, 1, 0)", basename="r", overwrite=True)
@@ -400,7 +400,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatial_conditional_numeric_4(self):
+    def test_spatial_conditional_numeric_4(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = if(A > 2, null())", basename="r", overwrite=True)
@@ -416,7 +416,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_1(self):
+    def test_spatiotemporal_conditional_1(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -436,7 +436,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_2(self):
+    def test_spatiotemporal_conditional_2(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -456,7 +456,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_relation_1(self):
+    def test_spatiotemporal_conditional_relation_1(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -476,7 +476,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_relation_2(self):
+    def test_spatiotemporal_conditional_relation_2(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -496,7 +496,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_numeric_relation_1(self):
+    def test_spatiotemporal_conditional_numeric_relation_1(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -516,7 +516,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_numeric_relation_2(self):
+    def test_spatiotemporal_conditional_numeric_relation_2(self) -> None:
         """Testing the spatial conditionals combined by AND/OR operators.
         Evaluation"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
@@ -537,7 +537,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_numeric_1(self):
+    def test_spatiotemporal_conditional_numeric_1(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -557,7 +557,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_numeric_2(self):
+    def test_spatiotemporal_conditional_numeric_2(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -577,7 +577,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_numeric_3(self):
+    def test_spatiotemporal_conditional_numeric_3(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(
@@ -597,7 +597,7 @@ class TestTemporalRasterAlgebraConditionals(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_spatiotemporal_conditional_numeric_4(self):
+    def test_spatiotemporal_conditional_numeric_4(self) -> None:
         """Testing the spatial conditionals with numeric conclusions"""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalRasterAlgebraConditionals(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalRasterAlgebraConditionalComplements(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_conditionals_complement_else.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalRasterAlgebraConditionalComplements(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -67,16 +67,16 @@ class TestTemporalRasterAlgebraConditionalComplements(TestCase):
             interval=True,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", flags="rf", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule("t.remove", flags="rf", inputs="A,B", quiet=True)
         cls.del_temp_region()
 
-    def test_temporal_conditional_complement(self):
+    def test_temporal_conditional_complement(self) -> None:
         """Test the conditional expression that evaluate if then else statements
         so that the else statement is a complement operation
 
@@ -112,7 +112,7 @@ class TestTemporalRasterAlgebraConditionalComplements(TestCase):
         self.assertEqual(R.check_temporal_topology(), True)
         self.assertEqual(R.get_granularity(), "1 day")
 
-    def test_temporal_conditional_complement_right_side_timestamps(self):
+    def test_temporal_conditional_complement_right_side_timestamps(self) -> None:
         """Test the conditional expression that evaluate if then else statements
         so that the else statement is a complement operation
 

--- a/python/grass/temporal/testsuite/unittests_temporal_vector_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_vector_algebra.py
@@ -9,9 +9,10 @@ for details.
 
 import datetime
 
-import grass.temporal as tgis
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
+
+import grass.temporal as tgis
 
 
 class TestTemporalVectorAlgebra(TestCase):

--- a/python/grass/temporal/testsuite/unittests_temporal_vector_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_vector_algebra.py
@@ -16,7 +16,7 @@ from grass.gunittest.main import test
 
 class TestTemporalVectorAlgebra(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """Initiate the temporal GIS and set the region"""
         tgis.init(True)  # Raise on error instead of exit(1)
         cls.use_temp_region()
@@ -146,18 +146,18 @@ class TestTemporalVectorAlgebra(TestCase):
             end="2001-01-04",
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.runModule("t.remove", type="stvds", inputs="R", quiet=True)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """Remove the temporary region"""
         cls.runModule(
             "t.remove", flags="rf", inputs="A,B,C,D", type="stvds", quiet=True
         )
         cls.del_temp_region()
 
-    def test_temporal_select(self):
+    def test_temporal_select(self) -> None:
         """Testing the temporal select operator."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(expression="R = A : A", basename="r", overwrite=True)
@@ -175,7 +175,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_extent1(self):
+    def test_temporal_extent1(self) -> None:
         """Testing the temporal extent operators."""
         ta = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         ta.parse(expression="R = A {:,during,r} C", basename="r", overwrite=True)
@@ -192,7 +192,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_select_operators(self):
+    def test_temporal_select_operators(self) -> None:
         """Testing the temporal select operator. Including temporal relations."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(expression="R = A {:,during} C", basename="r", overwrite=True)
@@ -210,7 +210,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_buff_operators_1(self):
+    def test_temporal_buff_operators_1(self) -> None:
         """Testing the bufferoperator."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(expression="R = buff_p(A,0.5)", basename="r", overwrite=True)
@@ -228,7 +228,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_buff_operators_2(self):
+    def test_temporal_buff_operators_2(self) -> None:
         """Testing the bufferoperator."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(expression="R = buff_a(buff_p(A,1),10)", basename="r", overwrite=True)
@@ -246,7 +246,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_overlay_operators_1(self):
+    def test_temporal_overlay_operators_1(self) -> None:
         """Testing the spatial overlay operator."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(
@@ -266,7 +266,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_overlay_operators_2(self):
+    def test_temporal_overlay_operators_2(self) -> None:
         """Testing the spatial overlay operator."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(
@@ -288,7 +288,7 @@ class TestTemporalVectorAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), False)
         self.assertEqual(D.get_granularity(), "2 days")
 
-    def test_temporal_overlay_operators_3(self):
+    def test_temporal_overlay_operators_3(self) -> None:
         """Testing the spatial overlay operator."""
         tva = tgis.TemporalVectorAlgebraParser(run=True, debug=True)
         tva.parse(

--- a/python/grass/temporal/unit_tests.py
+++ b/python/grass/temporal/unit_tests.py
@@ -36,7 +36,7 @@ core.set_raise_on_error(True)
 ###############################################################################
 
 
-def test_increment_datetime_by_string():
+def test_increment_datetime_by_string() -> None:
     # First test
     print("# Test 1")
     dt = datetime(2001, 9, 1, 0, 0, 0)
@@ -105,7 +105,7 @@ def test_increment_datetime_by_string():
 ###############################################################################
 
 
-def test_adjust_datetime_to_granularity():
+def test_adjust_datetime_to_granularity() -> None:
     # First test
     print("Test 1")
     dt = datetime(2001, 8, 8, 12, 30, 30)
@@ -223,7 +223,7 @@ def test_adjust_datetime_to_granularity():
 ###############################################################################
 
 
-def test_compute_datetime_delta():
+def test_compute_datetime_delta() -> None:
     print("Test 1")
     start = datetime(2001, 1, 1, 0, 0, 0)
     end = datetime(2001, 1, 1, 0, 0, 0)
@@ -566,7 +566,7 @@ def test_compute_datetime_delta():
         core.fatal("Compute datetime delta is wrong %s" % (delta))
 
 
-def test_compute_absolute_time_granularity():
+def test_compute_absolute_time_granularity() -> None:
     # First we test intervals
     print("Test 1")
     maps = []
@@ -886,7 +886,7 @@ def test_compute_absolute_time_granularity():
 ###############################################################################
 
 
-def test_spatial_extent_intersection():
+def test_spatial_extent_intersection() -> None:
     # Generate the extents
 
     A = SpatialExtent(north=80, south=20, east=60, west=10, bottom=-50, top=50)
@@ -970,7 +970,7 @@ def test_spatial_extent_intersection():
 ###############################################################################
 
 
-def test_spatial_relations():
+def test_spatial_relations() -> None:
     # Generate the extents
 
     A = SpatialExtent(north=80, south=20, east=60, west=10, bottom=-50, top=50)
@@ -1352,7 +1352,7 @@ def test_spatial_relations():
 ###############################################################################
 
 
-def test_temporal_topology_builder():
+def test_temporal_topology_builder() -> None:
     map_listA = []
 
     _map = RasterDataset(ident="1@a")
@@ -1465,7 +1465,7 @@ def test_temporal_topology_builder():
 ###############################################################################
 
 
-def test_map_list_sorting():
+def test_map_list_sorting() -> None:
     map_list = []
 
     _map = RasterDataset(ident="1@a")
@@ -1518,7 +1518,7 @@ def test_map_list_sorting():
 ###############################################################################
 
 
-def test_1d_rtree():
+def test_1d_rtree() -> None:
     """Testing the rtree ctypes wrapper"""
 
     tree = rtree.RTreeCreateTree(-1, 0, 1)
@@ -1548,7 +1548,7 @@ def test_1d_rtree():
 ###############################################################################
 
 
-def test_2d_rtree():
+def test_2d_rtree() -> None:
     """Testing the rtree ctypes wrapper"""
 
     tree = rtree.RTreeCreateTree(-1, 0, 2)
@@ -1580,7 +1580,7 @@ def test_2d_rtree():
 ###############################################################################
 
 
-def test_3d_rtree():
+def test_3d_rtree() -> None:
     """Testing the rtree ctypes wrapper"""
 
     tree = rtree.RTreeCreateTree(-1, 0, 3)
@@ -1622,7 +1622,7 @@ def test_3d_rtree():
 ###############################################################################
 
 
-def test_4d_rtree():
+def test_4d_rtree() -> None:
     """Testing the rtree ctypes wrapper"""
 
     tree = rtree.RTreeCreateTree(-1, 0, 4)

--- a/python/grass/temporal/unit_tests.py
+++ b/python/grass/temporal/unit_tests.py
@@ -1,5 +1,5 @@
 """
-Depricazed unittests
+Deprecated unittests
 
 (C) 2008-2011 by the GRASS Development Team
 This program is free software under the GNU General Public

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -34,7 +34,9 @@ from .open_stds import open_old_stds
 ###############################################################################
 
 
-def compute_univar_stats(registered_map_info, stats_module, fs, rast_region=False):
+def compute_univar_stats(
+    registered_map_info, stats_module, fs, rast_region: bool = False
+):
     """Compute univariate statistics for a map of a space time raster or raster3d
     dataset
 
@@ -116,9 +118,9 @@ def print_gridded_dataset_univar_statistics(
     output,
     where,
     extended,
-    no_header=False,
+    no_header: bool = False,
     fs="|",
-    rast_region=False,
+    rast_region: bool = False,
     region_relation=None,
     zones=None,
     percentile=None,
@@ -278,7 +280,16 @@ def print_gridded_dataset_univar_statistics(
 
 
 def print_vector_dataset_univar_statistics(
-    input, output, twhere, layer, type, column, where, extended, no_header=False, fs="|"
+    input,
+    output,
+    twhere,
+    layer,
+    type,
+    column,
+    where,
+    extended,
+    no_header: bool = False,
+    fs="|",
 ) -> None:
     """Print univariate statistics for a space time vector dataset
 

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -123,7 +123,7 @@ def print_gridded_dataset_univar_statistics(
     zones=None,
     percentile=None,
     nprocs=1,
-):
+) -> None:
     """Print univariate statistics for a space time raster or raster3d dataset.
     Returns None if the space time raster dataset is empty or if applied
     filters (where, region_relation) do not return any maps to process.
@@ -279,7 +279,7 @@ def print_gridded_dataset_univar_statistics(
 
 def print_vector_dataset_univar_statistics(
     input, output, twhere, layer, type, column, where, extended, no_header=False, fs="|"
-):
+) -> None:
     """Print univariate statistics for a space time vector dataset
 
     :param input: The name of the space time dataset

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -119,7 +119,7 @@ def print_gridded_dataset_univar_statistics(
     where,
     extended,
     no_header: bool = False,
-    fs="|",
+    fs: str = "|",
     rast_region: bool = False,
     region_relation=None,
     zones=None,
@@ -289,7 +289,7 @@ def print_vector_dataset_univar_statistics(
     where,
     extended,
     no_header: bool = False,
-    fs="|",
+    fs: str = "|",
 ) -> None:
     """Print univariate statistics for a space time vector dataset
 

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -124,7 +124,7 @@ def print_gridded_dataset_univar_statistics(
     region_relation=None,
     zones=None,
     percentile=None,
-    nprocs=1,
+    nprocs: int = 1,
 ) -> None:
     """Print univariate statistics for a space time raster or raster3d dataset.
     Returns None if the space time raster dataset is empty or if applied


### PR DESCRIPTION
This PR adds simple (not small, but in contrast to complex) typing annotations to the files in the temporal module.

I managed to almost get at a point where I was satisfied with some more complex annotations of the temporal module, including generics, where type checking would allow to highlight errors where the wrong type of class is used, linking the multiple types of abstract or base classes with their correct 6 variations.

Because of this, I started the work again, but using a tool https://github.com/JelleZijlstra/autotyping to do the bulk of the non-brain work, selecting only the fixes that were correct (reverting others).
The last commits are my additions that I accumulated in the last weeks throughout my work, keeping only the simple ones.

Having this PR merged before will help reviewing the further work, as only the important changes will need to be included, not hidden in all of this.