### PR TITLE
lib/gis: Fix out of scope memory access error in file_name function call

### DIFF
--- a/lib/gis/file_name.c
+++ b/lib/gis/file_name.c
@@ -161,13 +161,13 @@ char *file_name(char *path, const char *dir, const char *element,
                 const char *name, const char *mapset, const char *base)
 {
     const char *pname = name;
+    char xname[GNAME_MAX] = {'\0'};
 
     if (base && *base) {
         sprintf(path, "%s", base);
     }
     else {
-        char xname[GNAME_MAX];
-        char xmapset[GMAPSET_MAX];
+        char xmapset[GMAPSET_MAX] = {'\0'};
         char *location = G__location_path();
 
         /*


### PR DESCRIPTION
When execution takes else path, pname, a pointer, is set to point to a local variable array which has limited scope. This same pointer is accessed outside of the block containing the local variable, essentially creating a scenario where we are accessing memory outside its score, which is undefined behavior.

Move the variable array out of the loop, so that it has the same scope as pname.

This was found using cppcheck static analysis tool.