### PR TITLE
docs: i.albedo and r.li manual HTML fixes

### DIFF
--- a/imagery/i.albedo/i.albedo.html
+++ b/imagery/i.albedo/i.albedo.html
@@ -43,7 +43,7 @@ i.albedo -l input=lsat7_2000_10,lsat7_2000_20,lsat7_2000_30,lsat7_2000_40,lsat7_
 
 Maybe change input requirement of MODIS to [0.0-1.0]?
 
-<h2>References</h2>
+<h2>REFERENCES</h2>
 
 For a 2 band determination of the Aster BB Albedo see the following:
 <p>

--- a/raster/r.li/r.li.html
+++ b/raster/r.li/r.li.html
@@ -1,26 +1,3 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
-<head>
-<title>r.li - GRASS GIS manual</title>
- <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
- <link rel="stylesheet" href="grassdocs.css" type="text/css">
- <meta http-equiv="content-language" content="en-us">
- <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-<body bgcolor="white">
-<div id="container">
-
-<a href="index.html"><img src="grass_logo.png" alt="GRASS logo"></a>
-<hr class="header">
-
-<h2>NAME</h2>
-
-<em><b>r.li</b></em>  - Toolset for multiscale analysis of landscape structure
-
-<h2>KEYWORDS</h2>
-
-<a href="raster.html">raster</a>, <a href="topic_landscape_structure_analysis.html">landscape structure analysis</a>, <a href="keywords.html#diversity index">diversity index</a>, <a href="keywords.html#patch index">patch index</a>
-
 <!-- meta page description: Landscape structure analysis package overview -->
 <h2>DESCRIPTION</h2>
 


### PR DESCRIPTION
This PR removes the unneeded header of the `r.li.html` metapage.

Additionally:
- minor style fix in `i.albedo.html`