### PR TITLE
wxGUI: Fixed unused variable and bare 'except' in frame.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,8 +26,7 @@ per-file-ignores =
     gui/wxpython/photo2image/g.gui.photo2image.py: E501
     gui/wxpython/psmap/*: E501, E722
     gui/wxpython/vdigit/*: F841, E722, F405, F403
-    gui/wxpython/animation/g.gui.animation.py: E501
-    gui/wxpython/tplot/frame.py: F841, E722
+    gui/wxpython/animation/g.gui.animation.py: E5012
     gui/wxpython/tplot/g.gui.tplot.py: E501
     gui/wxpython/rdigit/g.gui.rdigit.py: F841
     gui/wxpython/iclass/digit.py: F405, F403

--- a/.flake8
+++ b/.flake8
@@ -26,7 +26,7 @@ per-file-ignores =
     gui/wxpython/photo2image/g.gui.photo2image.py: E501
     gui/wxpython/psmap/*: E501, E722
     gui/wxpython/vdigit/*: F841, E722, F405, F403
-    gui/wxpython/animation/g.gui.animation.py: E5012
+    gui/wxpython/animation/g.gui.animation.py: E501
     gui/wxpython/tplot/g.gui.tplot.py: E501
     gui/wxpython/rdigit/g.gui.rdigit.py: F841
     gui/wxpython/iclass/digit.py: F405, F403

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -212,7 +212,7 @@ class TplotFrame(wx.Frame):
             self.coorval = gselect.CoordinatesSelect(
                 parent=self.controlPanelRaster, giface=self._giface
             )
-        except:
+        except (AttributeError, TypeError):
             self.coorval = TextCtrl(
                 parent=self.controlPanelRaster,
                 id=wx.ID_ANY,
@@ -281,7 +281,7 @@ class TplotFrame(wx.Frame):
             self.cats = gselect.VectorCategorySelect(
                 parent=self.controlPanelVector, giface=self._giface
             )
-        except:
+        except (AttributeError, TypeError):
             self.cats = TextCtrl(
                 parent=self.controlPanelVector,
                 id=wx.ID_ANY,
@@ -1029,10 +1029,10 @@ class TplotFrame(wx.Frame):
 
         try:
             getcoors = self.coorval.coordsField.GetValue()
-        except:
+        except AttributeError:
             try:
                 getcoors = self.coorval.GetValue()
-            except:
+            except AttributeError:
                 getcoors = None
         if getcoors and getcoors != "":
             try:
@@ -1257,7 +1257,7 @@ class TplotFrame(wx.Frame):
                 return
             try:
                 self.coorval.coordsField.SetValue(",".join(coors))
-            except:
+            except AttributeError:
                 self.coorval.SetValue(",".join(coors))
         if self.datasetsV:
             vdatas = ",".join(f"{x[0]}@{x[1]}" for x in self.datasetsV)
@@ -1448,7 +1448,7 @@ class DataCursor:
         """Intended to be called through "mpl_connect"."""
         # Rather than trying to interpolate, just display the clicked coords
         # This will only be called if it's within "tolerance", anyway.
-        x, y = event.mouseevent.xdata, event.mouseevent.ydata
+        x = event.mouseevent.xdata
         annotation = self.annotations[event.artist.axes]
         if x is not None:
             if not self.display_all:
@@ -1460,7 +1460,7 @@ class DataCursor:
                 for a in event.artist.get_xdata():
                     try:
                         d = self.convert(a)
-                    except:
+                    except (ValueError, TypeError):
                         d = a
                     xData.append(d)
                 x = xData[np.argmin(abs(xData - x))]

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -212,7 +212,7 @@ class TplotFrame(wx.Frame):
             self.coorval = gselect.CoordinatesSelect(
                 parent=self.controlPanelRaster, giface=self._giface
             )
-        except (AttributeError, TypeError, NotImplementedError):
+        except NotImplementedError:
             self.coorval = TextCtrl(
                 parent=self.controlPanelRaster,
                 id=wx.ID_ANY,
@@ -281,7 +281,7 @@ class TplotFrame(wx.Frame):
             self.cats = gselect.VectorCategorySelect(
                 parent=self.controlPanelVector, giface=self._giface
             )
-        except (AttributeError, TypeError):
+        except NotImplementedError:
             self.cats = TextCtrl(
                 parent=self.controlPanelVector,
                 id=wx.ID_ANY,

--- a/gui/wxpython/tplot/frame.py
+++ b/gui/wxpython/tplot/frame.py
@@ -212,7 +212,7 @@ class TplotFrame(wx.Frame):
             self.coorval = gselect.CoordinatesSelect(
                 parent=self.controlPanelRaster, giface=self._giface
             )
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, NotImplementedError):
             self.coorval = TextCtrl(
                 parent=self.controlPanelRaster,
                 id=wx.ID_ANY,
@@ -1460,7 +1460,7 @@ class DataCursor:
                 for a in event.artist.get_xdata():
                     try:
                         d = self.convert(a)
-                    except (ValueError, TypeError):
+                    except (IndexError, ValueError):
                         d = a
                     xData.append(d)
                 x = xData[np.argmin(abs(xData - x))]


### PR DESCRIPTION
Following changes
- 'y' variable removed
- `AttributeError`, `TypeError` and `ValueError` added