### PR TITLE
CI: create versioned directory name of extracted tarball

### DIFF
--- a/.github/workflows/create_release_draft.yml
+++ b/.github/workflows/create_release_draft.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           cd ..
           tar -cvf ${{ env.OUT_DIR }}/${{ env.GRASS }}.tar \
-            --exclude=".gi*" --exclude=".tr*" grass
+            --exclude=".gi*" --exclude=".tr*" \
+            --transform s/grass/${{ env.GRASS }}/ grass
           cd ${{ env.OUT_DIR }}
           gzip -9k ${{ env.GRASS }}.tar
           md5sum ${{ env.GRASS }}.tar.gz > ${{ env.GRASS }}.tar.gz.md5


### PR DESCRIPTION
Extracting the tarball will with this create a containing directory named 'grass-x.y.z', where x, y, z stands for major, minor, micro/patch version.

Previously, the tarball created by CI was extracted to a directory named 'grass', which was a regression to accustomed and expected behaviour.