### PR TITLE
lib/vector/Vlib: Fix resource leak issue in remove_duplicates.c

### DIFF
--- a/lib/vector/Vlib/remove_duplicates.c
+++ b/lib/vector/Vlib/remove_duplicates.c
@@ -197,6 +197,11 @@ void Vect_remove_duplicates(struct Map_info *Map, int type,
         }
     }
     G_verbose_message(_("Removed duplicates: %d"), ndupl);
+    Vect_destroy_line_struct(APoints);
+    Vect_destroy_line_struct(BPoints);
+    Vect_destroy_cats_struct(ACats);
+    Vect_destroy_cats_struct(BCats);
+    Vect_destroy_boxlist(List);
 }
 
 /*!


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207797, 1207793, 1207795).
Used existing functions Vect_destroy_line_struct(), Vect_destroy_cats_struct(), Vect_destroy_boxlist().