### PR TITLE
r.to.vect: Fix Resource Leak issue in areas_io.c

### DIFF
--- a/raster/r.to.vect/areas_io.c
+++ b/raster/r.to.vect/areas_io.c
@@ -371,6 +371,7 @@ int write_area(
 
     if (equivs)
         G_free(equivs);
+    Vect_destroy_line_struct(points);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207812).
Existing function Vect_destroy_line_struct() is used.