### PR TITLE
temporal: Fixed bare 'except' PEP8 error

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -74,7 +74,6 @@ per-file-ignores =
     python/grass/temporal/temporal_algebra.py: E722
     python/grass/temporal/temporal_granularity.py: E722
     python/grass/temporal/temporal_raster_base_algebra.py: E722
-    python/grass/temporal/temporal_topology_dataset_connector.py: E722
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     python/grass/pygrass/tests/benchmark.py: E402, F821

--- a/python/grass/temporal/temporal_topology_dataset_connector.py
+++ b/python/grass/temporal/temporal_topology_dataset_connector.py
@@ -160,47 +160,47 @@ class TemporalTopologyDatasetConnector:
         relations = {}
         try:
             relations["equal"] = len(self._temporal_topology["EQUAL"])
-        except:
+        except KeyError:
             relations["equal"] = 0
         try:
             relations["follows"] = len(self._temporal_topology["FOLLOWS"])
-        except:
+        except KeyError:
             relations["follows"] = 0
         try:
             relations["precedes"] = len(self._temporal_topology["PRECEDES"])
-        except:
+        except KeyError:
             relations["precedes"] = 0
         try:
             relations["overlaps"] = len(self._temporal_topology["OVERLAPS"])
-        except:
+        except KeyError:
             relations["overlaps"] = 0
         try:
             relations["overlapped"] = len(self._temporal_topology["OVERLAPPED"])
-        except:
+        except KeyError:
             relations["overlapped"] = 0
         try:
             relations["during"] = len(self._temporal_topology["DURING"])
-        except:
+        except KeyError:
             relations["during"] = 0
         try:
             relations["contains"] = len(self._temporal_topology["CONTAINS"])
-        except:
+        except KeyError:
             relations["contains"] = 0
         try:
             relations["starts"] = len(self._temporal_topology["STARTS"])
-        except:
+        except KeyError:
             relations["starts"] = 0
         try:
             relations["started"] = len(self._temporal_topology["STARTED"])
-        except:
+        except KeyError:
             relations["started"] = 0
         try:
             relations["finishes"] = len(self._temporal_topology["FINISHES"])
-        except:
+        except KeyError:
             relations["finishes"] = 0
         try:
             relations["finished"] = len(self._temporal_topology["FINISHED"])
-        except:
+        except KeyError:
             relations["finished"] = 0
 
         return relations


### PR DESCRIPTION
Added `KeyError` for values no present in the dictionary