### PR TITLE
configure: build external libraries first

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -4,11 +4,11 @@ include $(MODULE_TOPDIR)/include/Make/Vars.make
 
 #order is relevant:
 SUBDIRS = \
+	external \
 	datetime \
 	gis \
 	proj \
 	raster \
-	external \
 	gmath \
 	linkm \
 	driver \


### PR DESCRIPTION
Enable use of external libraries in GRASS libraries.

As is the case with using the Parson lib in librast #4665.