### PR TITLE
r3.out.v5d: fix broken LITTLE ifdef-else macro in read_float4()

### DIFF
--- a/raster3d/r3.out.v5d/binio.c
+++ b/raster3d/r3.out.v5d/binio.c
@@ -202,13 +202,14 @@ int read_float4(int f, float *x)
     else {
         return 0;
     }
-#endif
+#else
     if (read(f, x, 4) == 4) {
         return 1;
     }
     else {
         return 0;
     }
+#endif
 }
 
 /*


### PR DESCRIPTION
Fix regression introduced by 8dced26.

Reported by Coverity Scan CID 1565401.