### PR TITLE
r.mfilter: Fix resource leak issue in getfilt.c

### DIFF
--- a/raster/r.mfilter/getfilt.c
+++ b/raster/r.mfilter/getfilt.c
@@ -158,5 +158,6 @@ FILTER *get_filter(char *name, int *nfilters, char *title)
     }
 
     *nfilters = count;
+    fclose(fd);
     return filter;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID:1207590).
Used fclose() to fix this issue.