### PR TITLE
temporal: Fix bare 'except' in temporal_raster_base_algebra

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -73,7 +73,6 @@ per-file-ignores =
     python/grass/temporal/spatial_topology_dataset_connector.py: E722
     python/grass/temporal/temporal_algebra.py: E722
     python/grass/temporal/temporal_granularity.py: E722
-    python/grass/temporal/temporal_raster_base_algebra.py: E722
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     python/grass/pygrass/tests/benchmark.py: E402, F821
@@ -88,9 +87,8 @@ per-file-ignores =
     python/grass/*/*/*/__init__.py: F403
     # E402 module level import not at top of file
     scripts/r.semantic.label/r.semantic.label.py: E501
-    scripts/db.out.ogr/db.out.ogr.py: F841
     scripts/g.extension/g.extension.py: E501
-    scripts/v.unpack/v.unpack.py: E501n
+    scripts/v.unpack/v.unpack.py: E501
     scripts/v.import/v.import.py: E501
     scripts/db.univar/db.univar.py: E501
     scripts/i.pansharpen/i.pansharpen.py: E501

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -387,7 +387,7 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
             else:
                 try:
                     map_sub = map_i.get_id()
-                except:
+                except AttributeError:
                     map_sub = map_i
             return map_sub
 


### PR DESCRIPTION
Added `AttributeError` as a possible exception on `.get_id()`. Possible `TypeError` if `map_i` can be of wrong type