### PR TITLE
lib: Replaced __cmp__ method with compensating methods for Python3 functionality

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -55,9 +55,6 @@ per-file-ignores =
     gui/wxpython/rlisetup/wizard.py: E722
     # Generated file
     gui/wxpython/menustrings.py: E501
-    # F821 undefined name 'cmp'
-    # https://github.com/OSGeo/grass/issues/1809
-    python/grass/pydispatch/saferef.py: F821
     # C wrappers call libgis.G_gisinit before importing other modules.
     # TODO: Is this really needed?
     python/grass/pygrass/vector/__init__.py: E402

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -167,8 +167,20 @@ class BoundMethodWeakref:
     def __cmp__(self, other):
         """Compare with another reference"""
         if not isinstance(other, self.__class__):
-            return cmp(self.__class__, type(other))
-        return cmp(self.key, other.key)
+            return (self.__class__.__name__ > other.__class__.__name__) - (
+                self.__class__.__name__ < other.__class__.__name__
+            )
+        return (self.key > other.key) - (self.key < other.key)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.key == other.key
+
+    def __lt__(self, other):
+        if not isinstance(other, self.__class__):
+            return self.__class__.__name__ < other.__class__.__name__
+        return self.key < other.key
 
     def __call__(self):
         """Return a strong reference to the bound method

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -182,6 +182,11 @@ class BoundMethodWeakref:
             return self.__class__.__name__ < other.__class__.__name__
         return self.key < other.key
 
+    def __gt__(self, other):
+        if not isinstance(other, self.__class__):
+            return self.__class__.__name__ > other.__class__.__name__
+        return self.key > other.key
+
     def __call__(self):
         """Return a strong reference to the bound method
 

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -164,14 +164,6 @@ class BoundMethodWeakref:
 
     __bool__ = __nonzero__
 
-    def __cmp__(self, other):
-        """Compare with another reference"""
-        if not isinstance(other, self.__class__):
-            return (self.__class__.__name__ > other.__class__.__name__) - (
-                self.__class__.__name__ < other.__class__.__name__
-            )
-        return (self.key > other.key) - (self.key < other.key)
-
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False


### PR DESCRIPTION
wrt to #1809 
This PR updates the  `__cmp__` method in `saferef.py` to be compatible with Python 3. Comparison methods `__eq__`
 and `__lt__` are implemented to maintain the same functionality without requiring changes elsewhere in the code.

**Changes:**

- Added `__eq__` method for equality comparison.
- Added `__lt__` method for less-than comparison.
- The `__cmp__` method now uses the rich comparison methods for its logic.

This shouldn't change overall behavior of `saferef` class.