### PR TITLE
r.grow: added test file for r.grow module

### DIFF
--- a/scripts/r.grow/testsuite/test_grow.py
+++ b/scripts/r.grow/testsuite/test_grow.py
@@ -1,0 +1,92 @@
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+from grass.gunittest.gmodules import SimpleModule
+
+
+class TestRGrow(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up a small region and test map."""
+        cls.output = "test_grow"
+        cls.runModule("g.region", n=10, s=0, e=10, w=0, res=1)
+
+        # Create a test map with a centered 3x3 block of 1s
+        cls.runModule(
+            "r.mapcalc",
+            expression="test_map = if(row() > 3 && row() < 7 && col() > 3 && col() < 7, 1, null())",
+            overwrite=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up test maps after all tests."""
+        cls.runModule("g.remove", type="raster", name="test_map,test_grow", flags="f")
+
+    def tearDown(self):
+        """Remove output map after each test to prevent conflicts."""
+        self.runModule("g.remove", type="raster", name=self.output, flags="f")
+
+    def test_default_growth(self):
+        """Test default growth using Euclidean metric."""
+        module = SimpleModule(
+            "r.grow", input="test_map", output=self.output, overwrite=True
+        )
+        self.assertModule(module)
+
+        self.assertRasterFitsUnivar(raster=self.output, reference="n=21")
+
+    def test_grow_with_manhattan_metric(self):
+        """Test growth with Manhattan metric and float radius of 2"""
+        module = SimpleModule(
+            "r.grow",
+            input="test_map",
+            output=self.output,
+            radius=2,
+            metric="manhattan",
+            overwrite=True,
+        )
+        self.assertModule(module)
+
+        self.assertRasterFitsUnivar(raster=self.output, reference="n=21")
+
+    def test_grow_with_maximum_metric(self):
+        """Test growth with Maximum metric."""
+        module = SimpleModule(
+            "r.grow",
+            input="test_map",
+            output=self.output,
+            metric="maximum",
+            overwrite=True,
+        )
+        self.assertModule(module)
+
+        self.assertRasterFitsUnivar(raster=self.output, reference="n=25")
+
+    def test_shrink_with_negative_radius(self):
+        """Test shrinking with a negative radius of -2 to reduce area size."""
+        module = SimpleModule(
+            "r.grow", input="test_map", radius="-2", output=self.output, overwrite=True
+        )
+        self.assertModule(module)
+
+        self.assertRasterFitsUnivar(raster=self.output, reference="n=1")
+
+    def test_old_value_replacement(self):
+        """Test replacing the original cells with -1 and new ones with 2."""
+        module = SimpleModule(
+            "r.grow",
+            input="test_map",
+            output=self.output,
+            old=-1,
+            new="2",
+            overwrite=True,
+        )
+        self.assertModule(module)
+
+        expected_values = {"n": 21, "sum": 15, "min": -1, "max": 2}
+        self.assertRasterFitsUnivar(raster=self.output, reference=expected_values)
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
This PR introduces a new set of tests for the `r.grow` module. These tests focus on specific growth and shrink behaviors, customized metrics, and handling non-standard values. Below is a summary comparing the existing tests with the new ones.

**Comparison of New and Existing Tests**

1. Existing Tests:

- Maps Used: Primarily focuses on predefined maps (`lakes`, `elevation`).
- Growth and Shrink Operations: Simple tests for basic `r.grow` usage, with specific scenarios like growing (radius=10) and shrinking (radius=-10).
- Shrink Test without NULLs: Tests shrinking for a map without NULL values and verifies the output range using `r.describe`.

2. New Tests Added:

- Small Test Map: Uses a 10x10 region `test_map` with a centered 3x3 block for verification of growth patterns.
- Growth with Different Metrics:

  - Euclidean Metric: Tests default growth behavior, expecting specific output.
  - Manhattan Metric: Tests growth using the Manhattan metric and verifies cell count with radius=2.
  - Maximum Metric: Tests growth using the Maximum metric, verifying the square-shaped pattern.
  - Negative Radius (Shrink Test): Tests shrinking behavior using a negative radius, reducing a 3x3 block down to a single cell.

- Value Replacement:

  - Old and New Values: Tests replacing original values with -1 and newly grown cells with 2, verifying expected range and sum statistics.

**Summary**

- Enhancements: The new tests provide finer control over the behavior of `r.grow` with varying metrics, radii, and custom value replacement, making it easier to detect specific issues or edge cases.
- Potential Actions: These new tests could complement the existing ones by adding a new file to the `testsuite`.