### PR TITLE
wxGUI: Removed PEP8 errors from rlisetup/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -50,8 +50,6 @@ per-file-ignores =
     gui/wxpython/tools/build_modules_xml.py: E722
     gui/wxpython/web_services/cap_interface.py: E501
     gui/wxpython/web_services/widgets.py: F841, E402
-    gui/wxpython/rlisetup/sampling_frame.py: F841
-    gui/wxpython/rlisetup/wizard.py: E722
     # Generated file
     gui/wxpython/menustrings.py: E501
     # F821 undefined name 'cmp'

--- a/gui/wxpython/rlisetup/sampling_frame.py
+++ b/gui/wxpython/rlisetup/sampling_frame.py
@@ -315,7 +315,6 @@ class RLiSetupMapPanel(wx.Panel):
     def _radiusDrawn(self, x, y):
         """When drawing finished, get region values"""
         mouse = self.mapWindow.mouse
-        item = self._registeredGraphics.GetItem(0)
         p1 = mouse["begin"]
         p2 = mouse["end"]
         dist, (north, east) = self.mapWindow.Distance(p1, p2, False)

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -687,7 +687,7 @@ class FirstPage(TitledPage):
     def OnLayer(self, event):
         try:
             self.vectorlayer = self.vectlayer.GetValue()
-        except:
+        except AttributeError:
             self.vectorlayer = None
         next = wx.FindWindowById(wx.ID_FORWARD)
         next.Enable(self.CheckInput())


### PR DESCRIPTION
Removed following errors:
- removed unused variable `item` from `sampling_frame.py`
- added `AttributeError` incase object is `None` in `wizard.py`