### PR TITLE
Create an option to write a LISFLOOD compatible header

### DIFF
--- a/raster/r.out.ascii/formspecific.c
+++ b/raster/r.out.ascii/formspecific.c
@@ -207,3 +207,25 @@ int write_GSGRID(int fd, FILE *fp, int nrows, int ncols, int out_type, int dp,
 
     return (0);
 }
+
+/* write the LISFLOOD ASCII heading */
+int writeLISFLOODheader(FILE *fp, char *nodataval)
+{
+    struct Cell_head region;
+    char buf[128];
+
+    G_get_window(&region);
+    fprintf(fp, "ncols\t\t%d\n", region.cols);
+    fprintf(fp, "nrows\t\t%d\n", region.rows);
+    G_format_easting(region.west, buf, region.proj);
+    fprintf(fp, "xllcorner\t%s\n", buf);
+    G_format_northing(region.south, buf, region.proj);
+    fprintf(fp, "yllcorner\t%s\n", buf);
+    fprintf(fp, "cellsize\t%.f\n", region.ew_res);
+
+    fprintf(fp, "NODATA_value\t%s\n", nodataval);
+
+    return 0;
+}
+
+

--- a/raster/r.out.ascii/localproto.h
+++ b/raster/r.out.ascii/localproto.h
@@ -6,3 +6,5 @@ int write_MODFLOW(int, FILE *, int, int, int, int, int);
 
 int writeGSheader(FILE *, const char *);
 int write_GSGRID(int, FILE *, int, int, int, int, char *, int);
+
+int writeLISFLOODheader(FILE *, char *);

--- a/raster/r.out.ascii/main.c
+++ b/raster/r.out.ascii/main.c
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
         struct Flag *noheader;
         struct Flag *surfer;
         struct Flag *modflow;
+        struct Flag *lisflood;
         struct Flag *int_out;
     } flag;
 
@@ -54,6 +55,9 @@ int main(int argc, char *argv[])
     G_add_keyword(_("export"));
     G_add_keyword(_("output"));
     G_add_keyword("ASCII");
+    G_add_keyword("Surfer");
+    G_add_keyword("Modflow");
+    G_add_keyword("Lisflood");
     module->description =
         _("Converts a raster map layer into a GRASS ASCII text file.");
 
@@ -97,6 +101,10 @@ int main(int argc, char *argv[])
     flag.modflow->key = 'm';
     flag.modflow->description = _("Write MODFLOW (USGS) ASCII array");
 
+    flag.lisflood = G_define_flag();
+    flag.lisflood->key = 'l';
+    flag.lisflood->description = _("Write LISFLOOD (EU) ASCII array");
+
     flag.int_out = G_define_flag();
     flag.int_out->key = 'i';
     flag.int_out->description = _("Force output of integer values");
@@ -123,7 +131,13 @@ int main(int argc, char *argv[])
         G_fatal_error(_("Both -s and -h doesn't make sense"));
 
     if (flag.surfer->answer && flag.modflow->answer)
-        G_fatal_error(_("Use -M or -s, not both"));
+        G_fatal_error(_("Use -m or -s, not both"));
+    
+    if (flag.surfer->answer && flag.lisflood->answer)
+        G_fatal_error(_("Use -l or -s, not both"));
+    
+    if (flag.lisflood->answer && flag.modflow->answer)
+        G_fatal_error(_("Use -m or -l, not both"));
 
     name = parm.map->answer;
 
@@ -167,6 +181,11 @@ int main(int argc, char *argv[])
         if (!flag.noheader->answer)
             writeMFheader(fp, dp, width, out_type);
         rc = write_MODFLOW(fd, fp, nrows, ncols, out_type, dp, width);
+    }
+    else if (flag.lisflood->answer) {
+        if (!flag.noheader->answer)
+            writeLISFLOODheader(fp, null_str);
+        rc = write_GRASS(fd, fp, nrows, ncols, out_type, dp, null_str);
     }
     else {
         if (!flag.noheader->answer)

--- a/raster/r.out.ascii/r.out.ascii.html
+++ b/raster/r.out.ascii/r.out.ascii.html
@@ -24,6 +24,24 @@ r.out.ascii -s input=inname output=outname.grd [dp=value]
 NULL data are coded to "1.70141e+038" for SURFER ASCII GRID files (ignoring
 the <em>null=</em> parameter).
 
+<p>To write a LISFLOOD .dem ASCII GRID file (with different header) use the 
+<em>-l</em> flag:
+
+<div class="code"><pre>
+r.out.ascii -l input=inname output=outname.dem
+</pre></div>
+
+NULL data output are set by the user at "-9999" in this case, see below:
+
+<div class="code"><pre>
+ncols		1514
+nrows		2747
+xllcorner	212236
+yllcorner	2910116
+cellsize	120
+NODATA_value	-9999
+</pre></div>
+
 <h2>NOTES</h2>
 
 The output from <em>r.out.ascii</em> may be placed into a file by using the


### PR DESCRIPTION
The option applied by the "-l" flag permits to write an ASCII grid file compatible with the European LISFLOOD model (https://ec-jrc.github.io/lisflood-model/1_1_introduction_LISFLOOD/)