### PR TITLE
lib/vector/Vlib: Initialize variable before using it in write_sfa module

### DIFF
--- a/lib/vector/Vlib/write_sfa.c
+++ b/lib/vector/Vlib/write_sfa.c
@@ -339,6 +339,7 @@ void V2__add_line_to_topo_sfa(struct Map_info *Map, int line,
     G_debug(3, "V2__add_line_to_topo_sfa(): line = %d npoints = %d", line,
             points->n_points);
 
+    first = TRUE;
     plus = &(Map->plus);
     Line = plus->Line[line];
     type = Line->type;


### PR DESCRIPTION
In `V2__add_line_to_topo_sfa` function which is only compiled when `HAVE_OGR` or `HAVE_POSTGRES` is defined, `first` variable is used without being initialized, which is undefined behavior.

Based on the context, initialize `first` to `TRUE`, so that we first copy and then extend a box.

This was found using cppcheck tool.