### PR TITLE
wxGUI: Fixed PEP8 errors in wxplot/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -31,9 +31,6 @@ per-file-ignores =
     gui/wxpython/iclass/frame.py: F405, F403
     gui/wxpython/iclass/g.gui.iclass.py: E501
     gui/wxpython/iclass/statistics.py: F841, F405, F403
-    gui/wxpython/wxplot/histogram.py: E722
-    gui/wxpython/wxplot/profile.py: F841, E722
-    gui/wxpython/wxplot/base.py: F841, E722
     gui/wxpython/location_wizard/dialogs.py: F841
     gui/wxpython/location_wizard/wizard.py: E722
     gui/wxpython/mapdisp/main.py: E722

--- a/gui/wxpython/wxplot/base.py
+++ b/gui/wxpython/wxplot/base.py
@@ -30,6 +30,7 @@ from gui_core.toolbars import BaseIcons
 from gui_core.wrap import Menu
 
 import grass.script as gs
+from grass.exceptions import CalledModuleError
 
 PlotIcons = {
     "draw": MetaIcon(img="show", label=_("Draw/re-draw plot")),
@@ -204,7 +205,7 @@ class BasePlotFrame(wx.Frame):
 
             try:
                 ret = gs.raster_info(r)
-            except:
+            except CalledModuleError:
                 continue
                 # if r.info cannot parse map, skip it
 
@@ -270,7 +271,7 @@ class BasePlotFrame(wx.Frame):
                 ret0 = gs.raster_info(rpair[0])
                 ret1 = gs.raster_info(rpair[1])
 
-            except:
+            except (IndexError, CalledModuleError):
                 continue
                 # if r.info cannot parse map, skip it
 
@@ -510,7 +511,6 @@ class BasePlotFrame(wx.Frame):
 
     def PlotOptionsMenu(self, event):
         """Popup menu for plot and text options"""
-        point = wx.GetMousePosition()
         popt = Menu()
         # Add items to the menu
         settext = wx.MenuItem(popt, wx.ID_ANY, _("Text settings"))
@@ -608,7 +608,6 @@ class BasePlotFrame(wx.Frame):
 
     def PrintMenu(self, event):
         """Print options and output menu"""
-        point = wx.GetMousePosition()
         printmenu = Menu()
         for title, handler in (
             (_("Page setup"), self.OnPageSetup),

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -99,7 +99,7 @@ class HistogramPlotFrame(BasePlotFrame):
         """
         try:
             self.SetCursor(StockCursor(wx.CURSOR_ARROW))
-        except:
+        except Exception:
             pass
 
         self.SetGraphStyle()

--- a/gui/wxpython/wxplot/histogram.py
+++ b/gui/wxpython/wxplot/histogram.py
@@ -97,10 +97,7 @@ class HistogramPlotFrame(BasePlotFrame):
         create a list of cell value and count/percent/area pairs. This is passed to
         plot to create a line graph of the histogram.
         """
-        try:
-            self.SetCursor(StockCursor(wx.CURSOR_ARROW))
-        except Exception:
-            pass
+        self.SetCursor(StockCursor(wx.CURSOR_ARROW))
 
         self.SetGraphStyle()
         wx.BeginBusyCursor()

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -250,7 +250,7 @@ class ProfileFrame(BasePlotFrame):
             # delete extra first segment point
             try:
                 self.seglist.pop(0)
-            except:
+            except IndexError:
                 pass
 
         #
@@ -291,7 +291,6 @@ class ProfileFrame(BasePlotFrame):
         # freezing with large, high resolution maps
         region = gs.region()
         curr_res = min(float(region["nsres"]), float(region["ewres"]))
-        transect_rec = 0
         if self.transect_length / curr_res > 500:
             transect_res = self.transect_length / 500
         else:
@@ -486,7 +485,7 @@ class ProfileFrame(BasePlotFrame):
                 statstr += "median: %f\n" % np.median(a)
                 statstr += "distance along transect: %f\n\n" % self.transect_length
                 message.append(statstr)
-            except:
+            except (ValueError, TypeError, KeyError):
                 pass
 
         stats = PlotStatsFrame(self, id=wx.ID_ANY, message=message, title=title)

--- a/gui/wxpython/wxplot/profile.py
+++ b/gui/wxpython/wxplot/profile.py
@@ -485,7 +485,7 @@ class ProfileFrame(BasePlotFrame):
                 statstr += "median: %f\n" % np.median(a)
                 statstr += "distance along transect: %f\n\n" % self.transect_length
                 message.append(statstr)
-            except (ValueError, TypeError, KeyError):
+            except (ValueError, TypeError, KeyError, IndexError):
                 pass
 
         stats = PlotStatsFrame(self, id=wx.ID_ANY, message=message, title=title)


### PR DESCRIPTION
Following PEP8 errors were fixed in `wxplot/`
- profile.py:253 - Replaced bare except with `except IndexError` when handling list.pop() failure
- profile.py:489 - Added specific exceptions `(ValueError, TypeError, KeyError)` for NumPy statistical calculations
- base.py:207 - Added `CalledModuleError` catch for GRASS raster info parsing failures
- base.py:273 - Added `(IndexError, CalledModuleError)` catch for raster pair info parsing and index access
- histogram.py - Added `Exception` as I could not find any specific exceptions which maybe applicable