### PR TITLE
lib/gis: Refactor va_list usage in debug module

### DIFF
--- a/lib/gis/debug.c
+++ b/lib/gis/debug.c
@@ -72,8 +72,6 @@ int G_debug(int level, const char *msg, ...)
     G_init_debug();
 
     if (grass_debug_level >= level) {
-        va_start(ap, msg);
-
         filen = getenv("GRASS_DEBUG_FILE");
         if (filen != NULL) {
             fd = fopen(filen, "a");
@@ -87,14 +85,14 @@ int G_debug(int level, const char *msg, ...)
         }
 
         fprintf(fd, "D%d/%d: ", level, grass_debug_level);
+        va_start(ap, msg);
         vfprintf(fd, msg, ap);
+        va_end(ap);
         fprintf(fd, "\n");
         fflush(fd);
 
         if (filen != NULL)
             fclose(fd);
-
-        va_end(ap);
     }
 
     return 1;


### PR DESCRIPTION
lib/gis: Refactor va_list usage in debug module

va_list() macro initializes va_list structure before it's usage,
and each va_list() call has to be accompanied by corresponding
va_end() macro call on the same va_list structure.

By having these macros directly before and after the va_list
structure usage, reduces the number of places we need to keep
track of whether the va_list structure was properly inintialized
or closed.

This was found using cppcheck tool.