### PR TITLE
packaging: build Windows with libopenblas

### DIFF
--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -107,7 +107,6 @@ fi
 exec 3>&1 > >(tee mswindows/osgeo4w/package.log) 2>&1
 
 DLLS="
-	/mingw64/bin/libblas.dll
 	/mingw64/bin/libbrotlicommon.dll
 	/mingw64/bin/libbrotlidec.dll
 	/mingw64/bin/libbz2-1.dll
@@ -123,7 +122,6 @@ DLLS="
 	/mingw64/bin/libharfbuzz-0.dll
 	/mingw64/bin/libiconv-2.dll
 	/mingw64/bin/libintl-8.dll
-	/mingw64/bin/liblapack.dll
 	/mingw64/bin/libpcre-1.dll
 	/mingw64/bin/libpixman-1-0.dll
 	/mingw64/bin/libpng16-16.dll
@@ -133,6 +131,7 @@ DLLS="
 	/mingw64/bin/libtre-5.dll
 	/mingw64/bin/libwinpthread-1.dll
 	/mingw64/bin/zlib1.dll
+  /mingw64/bin/libopenblas.dll
 "
 
 if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
@@ -173,7 +172,6 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 		--with-geos=$PWD/mswindows/osgeo4w/geos-config \
 		--with-includes=$OSGEO4W_ROOT_MSYS/include \
 		--with-lapack \
-		--with-lapack-includes=/mingw64/include \
 		--with-liblas=$PWD/mswindows/osgeo4w/liblas-config \
 		--with-libs="$OSGEO4W_ROOT_MSYS/lib" \
 		--with-netcdf=${OSGEO4W_ROOT_MSYS}/bin/nc-config \


### PR DESCRIPTION
Build Windows package with `libopenblas`, this addresses a missing change of d5bb442.

As tested and reported with #4485.