### PR TITLE
docs: fix broken HTML

### DIFF
--- a/raster/r.in.poly/r.in.poly.html
+++ b/raster/r.in.poly/r.in.poly.html
@@ -8,7 +8,7 @@ containing polygon, linear, and point features.
 The <b>input</b> file is an ASCII text file containing the
 polygon, linear, and point feature definitions.
 The format of this file is described in the
-<a href="#format.html"><i>INPUT FORMAT</i></a> section below.
+<a href="#format"><i>INPUT FORMAT</i></a> section below.
 
 <p>
 The number of raster <b>rows</b> to hold in memory is per default 4096.
@@ -31,8 +31,7 @@ format used by <em>v.in.ascii</em>.
 <p>
 Polygons are filled, i.e. they define an area.
 
-<A NAME="format.html"></a>
-<h3>Input Format</h3>
+<h3 id="format">Input Format</h3>
 
 The input format for the <b>input</b> file consists of
 sections describing either polygonal areas, linear features, or

--- a/raster/r.surf.idw/r.surf.idw.html
+++ b/raster/r.surf.idw/r.surf.idw.html
@@ -17,7 +17,7 @@ input data, without regard to the mask.
 
 The <b>-e</b> flag is the error analysis option that interpolates values
 only for those cells of the input raster map which have non-zero values and
-outputs the difference (see <a href="#minuse.html">NOTES</a> below).
+outputs the difference (see <a href="#minuse">NOTES</a> below).
 <p>The <b>npoints</b> parameter defines the number of nearest data points used
 to determine the interpolated value of an output raster cell.
 
@@ -66,8 +66,8 @@ irregularly spaced input data.  However, the output result
 for the former may include unacceptable nonconformities in
 the surface pattern.
 
-<a name="minuse.html"></a>
-<p>
+<h3 id="minuse">Surface-generation error analysis</h3>
+
 The <b>-e</b> flag option provides a standard
 surface-generation error analysis facility. It produces an output raster map
 of the difference of interpolated values minus input values for those cells

--- a/temporal/t.vect.univar/t.vect.univar.html
+++ b/temporal/t.vect.univar/t.vect.univar.html
@@ -5,7 +5,7 @@ space time vector dataset based on a single attribute row.
 
 <h2>EXAMPLE</h2>
 
-The example is based on the <a herf="t.vect.observe.strds.html">t.vect.observe.strds</a>
+The example is based on the <a href="t.vect.observe.strds.html">t.vect.observe.strds</a>
 example; so create the <b>precip_stations</b> space time vector dataset
 and after run the following command:
 


### PR DESCRIPTION
This small PR fixes

- HTML id attributes
- a `href` typo