### PR TITLE
v.in.ascii: Fix Resource Leak issue in points.c

### DIFF
--- a/vector/v.in.ascii/points.c
+++ b/vector/v.in.ascii/points.c
@@ -494,6 +494,9 @@ int points_to_bin(FILE *ascii, int rowlen, struct Map_info *Map,
         G_free_tokens(tokens);
     }
     G_percent(nrows, nrows, 2);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
+    G_free(buf);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issues identified by Coverity Scan (CID : 1207778, 1207779, 1207780)
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct(), G_free()