### PR TITLE
v.univar: Fix Resource Leak issue in main.c

### DIFF
--- a/vector/v.univar/main.c
+++ b/vector/v.univar/main.c
@@ -358,6 +358,8 @@ void select_from_geometry(void)
             G_debug(3, "i=%d j=%d sum = %f val=%f", i, j, sum, val);
         }
     }
+    Vect_destroy_line_struct(jPoints);
+    Vect_destroy_line_struct(iPoints);
 }
 
 void select_from_database(void)


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207787, 1207788)
Used Vect_destroy_line_struct() to fix this issue.