### PR TITLE
CI(Travis): Set python version to 3.10 through pyenv global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,15 @@ env:
     - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
+  - pyenv
+  - pyenv --version
+  - pyenv version-origin
+  - pyenv version-name
+  - pyenv version-file
+  - pyenv version
+  - pyenv shell
+  - pyenv prefix
+  - pyenv shims
   - python --version
   - python --version -VV
   - pyenv root
@@ -62,6 +71,32 @@ install:
 
 before_script:
   - which python
+  - uv python list
+  - uv python find
+  - uv python find --system
+  - uv python dir
+  - ls -la $(uv python dir)
+  - uv python dir --bin
+  - ls -la $(uv python dir --bin)
+  - python --version -VV
+  - python3 --version -VV
+  - python3.9 --version -VV
+  - python3.9 --version -VV
+  - python3.10 --version -VV
+  - pyenv rehash
+  - pyenv
+  - pyenv --version
+  - pyenv version-origin
+  - pyenv version-name
+  - pyenv version-file
+  - pyenv version
+  - pyenv shell
+  - pyenv prefix
+  - pyenv shims
+  - which python
+  - which python3
+  - which python3.9
+  - which python3.10
   - uv python list
   - uv python find
   - uv python find --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,13 @@ env:
     - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
+  - python --version
   - pyenv root
   - which pyenv && pyenv versions
   - which python
+  - ls -la /etc/alternatives
+  - ls -la /opt/pyenv/
+  - cat /opt/pyenv/version
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh
 
 install:
@@ -41,10 +45,16 @@ install:
   - uv python list
   - uv python find
   - uv python find --system
+  - python --version
   - ./.travis/$TRAVIS_OS_NAME.install.sh
   # - pyenv install 3.9
   - uv python install 3.9
   - which python
+  - python --version
+  - printenv | grep PY | sort
+  - printenv | grep python | sort
+  - printenv | grep py | sort
+  - printenv | grep PATH | sort
 
 before_script:
   - which python

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,7 @@ before_script:
   - ls -la $(uv python dir --bin)
   - python --version -VV
   - python3 --version -VV
-  - python3.9 --version -VV
-  - python3.9 --version -VV
+  # - python3.9 --version -VV
   - python3.10 --version -VV
   - pyenv rehash
   - pyenv
@@ -95,7 +94,6 @@ before_script:
   - pyenv shims
   - which python
   - which python3
-  - which python3.9
   - which python3.10
   - uv python list
   - uv python find
@@ -106,9 +104,9 @@ before_script:
   - ls -la $(uv python dir --bin)
   - python --version -VV
   - python3 --version -VV
-  - python3.9 --version -VV
-  - python3.9 --version -VV
   - python3.10 --version -VV
+  - python3.9 --version -VV
+  - which python3.9
   # see https://github.com/astral-sh/uv/issues/6265
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - ls -la /opt/pyenv/
   - ls -la /opt/pyenv/shims
   - cat /opt/pyenv/version
-  - cat /opt/python
+  - ls -la /opt/python
   - ls -ls /opt/
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,31 @@ env:
     - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
+  - pyenv root
+  - which pyenv && pyenv versions
+  - which python
+  - pip install uv --upgrade
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh
 
 install:
+  - pip install uv
+  - uv python list
+  - uv python find
+  - uv python find --system
   - ./.travis/$TRAVIS_OS_NAME.install.sh
+  # - pyenv install 3.9
+  - uv python install 3.9
+  - which python
+
+before_script:
+  - which python
+  - uv python list
+  - uv python find
+  - uv python find --system
+  - uv python dir
+  - uv python dir --bin
+  - python --version
+  # see https://github.com/astral-sh/uv/issues/6265
 
 script:
   - ./.travis/$TRAVIS_OS_NAME.script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
-  - pyenv
+  - pyenv help
   - pyenv --version
   - pyenv version-origin
   - pyenv version-name
@@ -83,7 +83,7 @@ before_script:
   # - python3.9 --version -VV
   - python3.10 --version -VV
   - pyenv rehash
-  - pyenv
+  - pyenv help
   - pyenv --version
   - pyenv version-origin
   - pyenv version-name

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,10 @@ before_install:
   - pyenv root
   - which pyenv && pyenv versions
   - which python
-  - pip install uv --upgrade
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh
 
 install:
-  - pip install uv
+  - curl -LsSf https://astral.sh/uv/install.sh | sh
   - uv python list
   - uv python find
   - uv python find --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,84 +31,15 @@ env:
     - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
+  # Show available versions if ever pyenv global fails
+  - pyenv versions
   - pyenv global 3.10
-  - pyenv help
-  - pyenv --version
-  - pyenv version-origin
-  - pyenv version-name
-  - pyenv version-file
-  - pyenv version
-  - pyenv shell
-  - pyenv prefix
-  - pyenv shims
-  - python --version
-  - python --version -VV
-  - pyenv root
-  - which pyenv && pyenv versions
-  - which python
-  - ls -la /etc/alternatives
-  - ls -la /opt/pyenv/
-  - ls -la /opt/pyenv/shims
-  - cat /opt/pyenv/version
-  - ls -la /opt/python
-  - ls -ls /opt/
+  # Show that the selected version is correctly set
+  - pyenv versions
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh
 
 install:
-  - curl -LsSf https://astral.sh/uv/install.sh | sh
-  - uv python list
-  - uv python find
-  - uv python find --system
-  - python --version
   - ./.travis/$TRAVIS_OS_NAME.install.sh
-  # - pyenv install 3.9
-  - uv python install 3.9
-  - which python
-  - python --version -VV
-  - printenv | grep PY | sort
-  - printenv | grep python | sort
-  - printenv | grep py | sort
-  - printenv | grep PATH | sort
-
-before_script:
-  - which python
-  - uv python list
-  - uv python find
-  - uv python find --system
-  - uv python dir
-  - ls -la $(uv python dir)
-  - uv python dir --bin
-  - ls -la $(uv python dir --bin)
-  - python --version -VV
-  - python3 --version -VV
-  # - python3.9 --version -VV
-  - python3.10 --version -VV
-  - pyenv rehash
-  - pyenv help
-  - pyenv --version
-  - pyenv version-origin
-  - pyenv version-name
-  - pyenv version-file
-  - pyenv version
-  - pyenv shell
-  - pyenv prefix
-  - pyenv shims
-  - which python
-  - which python3
-  - which python3.10
-  - uv python list
-  - uv python find
-  - uv python find --system
-  - uv python dir
-  - ls -la $(uv python dir)
-  - uv python dir --bin
-  - ls -la $(uv python dir --bin)
-  - python --version -VV
-  - python3 --version -VV
-  - python3.10 --version -VV
-  # - python3.9 --version -VV
-  # - which python3.9
-  # see https://github.com/astral-sh/uv/issues/6265
 
 script:
   - ./.travis/$TRAVIS_OS_NAME.script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,16 @@ env:
 
 before_install:
   - python --version
+  - python --version -VV
   - pyenv root
   - which pyenv && pyenv versions
   - which python
   - ls -la /etc/alternatives
   - ls -la /opt/pyenv/
+  - ls -la /opt/pyenv/shims
   - cat /opt/pyenv/version
+  - cat /opt/python
+  - ls -ls /opt/
   - ./.travis/$TRAVIS_OS_NAME.before_install.sh
 
 install:
@@ -50,7 +54,7 @@ install:
   # - pyenv install 3.9
   - uv python install 3.9
   - which python
-  - python --version
+  - python --version -VV
   - printenv | grep PY | sort
   - printenv | grep python | sort
   - printenv | grep py | sort
@@ -62,8 +66,14 @@ before_script:
   - uv python find
   - uv python find --system
   - uv python dir
+  - ls -la $(uv python dir)
   - uv python dir --bin
-  - python --version
+  - ls -la $(uv python dir --bin)
+  - python --version -VV
+  - python3 --version -VV
+  - python3.9 --version -VV
+  - python3.9 --version -VV
+  - python3.10 --version -VV
   # see https://github.com/astral-sh/uv/issues/6265
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - GRASS_EXTRA_CXXFLAGS="-Werror -fPIC -Wfatal-errors"
 
 before_install:
+  - pyenv global 3.10
   - pyenv help
   - pyenv --version
   - pyenv version-origin
@@ -105,8 +106,8 @@ before_script:
   - python --version -VV
   - python3 --version -VV
   - python3.10 --version -VV
-  - python3.9 --version -VV
-  - which python3.9
+  # - python3.9 --version -VV
+  # - which python3.9
   # see https://github.com/astral-sh/uv/issues/6265
 
 script:


### PR DESCRIPTION
_**TL;DR:** I resigned myself to use the pyenv available on the Travis runner to set the global python version to 3.10, already installed in the image._



-------



I don't understand why or how Travis does this. Without any announcements, github repo activity, community forum post, docs update or nothing, in the last image update yesterday, the default python version went from python 3.10.2 (https://app.travis-ci.com/github/OSGeo/grass/jobs/628247792#L121) with gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, to Python 3.7.17 (https://app.travis-ci.com/github/OSGeo/grass/jobs/628271965#L119). Python 3.10 is supposed to be the default version from ubuntu jammy's apt repos, so something is going on with how they create their images, or don't control enough.


Complicated by the fact that the availability to select what version of a language/tool depends on the "language: " set in the config. https://config.travis-ci.com/ref/language. Using "c" here doesn't have any configurable keys (https://config.travis-ci.com/ref/language/c), but if we took ["python"](https://config.travis-ci.com/ref/language/python) or ["ruby"](https://config.travis-ci.com/ref/language/ruby), or many others, it allows to set various keys of what versions to use. From what I read (mostly users complaining), the keys aren't respected when the "wrong" language type is used, including generic. Since most of the partial docs they have consist on linking to examples of projects that used Travis, without any permalinks, and these projects don't use Travis anymore, the only hints I got was that they use or used pyenv in at least one of their language build-environments. I encounter pyenv and use it when working on a cloud env on github (most of my grass programming time is on gitpod). So I know how it works, but it can be slow to have a different version, as you end up downloading and compiling from source. There was a hint somewhere talking about caching that build pyenv python version, but it isn't clear how to cache that on Travis, unless I go explicit and find the correct folders for that. 

There's also many community posts complaining and requesting other python versions when they were released, with various time spans taken after release to be available. So I'm not sure whether I'd want to depend on them for these builds to work.



So, my approach would be to use "[uv](https://docs.astral.sh/uv/)" to install python, and is way faster since they have some standalone builds. The thing is, full replacement of pyenv isn't quite there yet. If I look at what uv was even a month or 2 before on that subject, I suppose that it is a question of weeks for what I expect to do to work out of the box. 

In the meantime, I'll be doing a couple of pushes to reverse-engineer what the Travis config is, and how it interacts with the pyenv installed (if it is there), and how to make sure the `uv`-installed python is sawn and used without any other aliasing or PATH changes. If this PR is ready, we might need to revisit in a month or two to make sure that we still use the best pattern for us.

`uv` is from the same authors of ruff, and since publicly announced in february, have made an incredibly fast  and very versatile python dependency manager, package installer, venv creator, tool runner (like pipx), and all, but at the same fraction of the time as ruff. Its marvellous (on the things they do support).

