### PR TITLE
v.build.polylines: Fix Resource Leak issue in walk.c

### DIFF
--- a/vector/v.build.polylines/walk.c
+++ b/vector/v.build.polylines/walk.c
@@ -166,7 +166,8 @@ int walk_forward_and_pick_up_coords(struct Map_info *map, int start_line,
             next_node = n2; /* continue at end node */
         }
         else {
-            Vect_destroy_cats_struct(cats_tmp);
+            if (cats_tmp)
+                Vect_destroy_cats_struct(cats_tmp);
             return 1; /* no other line */
         }
     }

--- a/vector/v.build.polylines/walk.c
+++ b/vector/v.build.polylines/walk.c
@@ -166,6 +166,7 @@ int walk_forward_and_pick_up_coords(struct Map_info *map, int start_line,
             next_node = n2; /* continue at end node */
         }
         else {
+            Vect_destroy_cats_struct(cats_tmp);
             return 1; /* no other line */
         }
     }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207763)
Used Vect_destroy_cats_struct() to fix the issue.