### PR TITLE
v.net: Fix Resource Leak issue in arcs.c

### DIFF
--- a/vector/v.net/arcs.c
+++ b/vector/v.net/arcs.c
@@ -68,6 +68,7 @@ int create_arcs(FILE *file, struct Map_info *Pnts, struct Map_info *Out,
 
     Vect_destroy_line_struct(points);
     Vect_destroy_cats_struct(cats);
+    Vect_destroy_line_struct(points2);
 
     return narcs;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207755)
Used Vect_destroy_line_struct() to fix this issue.