### PR TITLE
man: fix KeyError: 'MDDIR' in man/build_md.py

### DIFF
--- a/man/build_md.py
+++ b/man/build_md.py
@@ -261,6 +261,6 @@ def get_desc(cmd):
 
 ############################################################################
 
-man_dir = os.path.join(os.environ["MDDIR"], "source")
+man_dir = os.path.join(os.environ["ARCH_DISTDIR"], "docs", "mkdocs", "source")
 
 ############################################################################


### PR DESCRIPTION
At time the GRASS GIS main compilation with addons with `cron_grass_preview_build_binaries.sh` is broken:

https://grass.osgeo.org/grass85/binary/linux/snapshot/build.log.txt

```
...
Parsing <v.what.strds.timestamp>... SUCCESS
Parsing <wx.metadata>... FAILED
Parsing <wx.mwprecip>... FAILED
Parsing <wx.stream>... FAILED
Parsing <wx.wms>... FAILED
+ cp /home/neteler/.grass8/addons/modules.xml /var/www/code_and_data/addons/grass8/modules.xml
+ export ARCH
+ export ARCH_DISTDIR=/home/neteler/src//main/dist.x86_64-pc-linux-gnu
+ export GISBASE=/home/neteler/src//main/dist.x86_64-pc-linux-gnu
+ export VERSION_NUMBER=8.5
+ python3 /home/neteler/src//main/man/build_keywords.py /var/www/code_and_data/grass85/manuals/ /var/www/code_and_data/grass85/manuals/addons/
Traceback (most recent call last):
  File "/home/neteler/src//main/man/build_keywords.py", line 202, in <module>
    build_keywords("md")
  File "/home/neteler/src//main/man/build_keywords.py", line 68, in build_keywords
    from build_md import (
  File "/home/neteler/src/main/man/build_md.py", line 264, in <module>
    man_dir = os.path.join(os.environ["MDDIR"], "source")
  File "/usr/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'MDDIR'
```

This PR attemps to fix this bug (inspired by `man/build_html.py`). Tested on grass.osgeo.org (without log file).

Originally reported in https://github.com/OSGeo/grass-addons/pull/1241#issuecomment-2486906272