### PR TITLE
lib/gis: markdown parser lowercase and extension fixes

### DIFF
--- a/lib/gis/parser_rest_md.c
+++ b/lib/gis/parser_rest_md.c
@@ -517,7 +517,7 @@ void print_escaped_for_md_keywords(FILE *f, const char *str)
                 fputc(*s, f);
             }
         }
-        fprintf(f, ".html)");
+        fprintf(f, ".md)");
     }
     else { /* first and other than second keyword */
         if (st->n_keys > 0 && strcmp(st->module_info.keywords[0], str) == 0) {
@@ -532,13 +532,14 @@ void print_escaped_for_md_keywords(FILE *f, const char *str)
                     fputc(*s, f);
                 }
             }
-            fprintf(f, ".html)");
+            fprintf(f, ".md)");
         }
         else {
             /* keyword index */
             char *str_link;
             str_link = G_str_replace(str_s, " ", "%20");
-            fprintf(f, "[%s](keywords.html#%s)", str_s, str_link);
+            G_str_to_lower(str_link);
+            fprintf(f, "[%s](keywords.md#%s)", str_s, str_link);
             G_free(str_link);
         }
     }


### PR DESCRIPTION
This PR updates the Markdown support in the parser for the manual in terms of

- converting keywords to lowercase in manual pages so that e.g. `dist.x86_64-pc-linux-gnu/docs/mkdocs/site/keywords.html#modis` works
- replacing of `.html` with `.md` in certain cases