### PR TITLE
make: Update DB.make for markdown support

### DIFF
--- a/include/Make/DB.make
+++ b/include/Make/DB.make
@@ -10,7 +10,7 @@ include $(MODULE_TOPDIR)/include/Make/Compile.make
 
 dbmi: $(DBDRIVERDIR)/$(PGM)$(EXE) db_html
 
-db_html: $(MDDIR)/source/grass-$(PGM).md $(HTMLDIR)/grass-$(PGM).html $(MANDIR)/grass-$(PGM).$(MANSECT)
+db_html: $(HTMLDIR)/grass-$(PGM).html $(MANDIR)/grass-$(PGM).$(MANSECT) # $(MDDIR)/source/grass-$(PGM).md
 
 $(DBDRIVERDIR)/$(PGM)$(EXE): $(ARCH_OBJS) $(DEPENDENCIES)
 	$(call linker)

--- a/include/Make/DB.make
+++ b/include/Make/DB.make
@@ -10,7 +10,7 @@ include $(MODULE_TOPDIR)/include/Make/Compile.make
 
 dbmi: $(DBDRIVERDIR)/$(PGM)$(EXE) db_html
 
-db_html: $(HTMLDIR)/grass-$(PGM).html $(MANDIR)/grass-$(PGM).$(MANSECT)
+db_html: $(MDDIR)/source/grass-$(PGM).md $(HTMLDIR)/grass-$(PGM).html $(MANDIR)/grass-$(PGM).$(MANSECT)
 
 $(DBDRIVERDIR)/$(PGM)$(EXE): $(ARCH_OBJS) $(DEPENDENCIES)
 	$(call linker)


### PR DESCRIPTION
This PR fixes https://github.com/OSGeo/grass/pull/4740#issuecomment-2493971349

Note that links remain broken if GRASS is not built with specific driver support. See broken MySQL links in https://grass.osgeo.org/grass84/manuals/databaseintro.html#creating-a-database. This issue should be addressed by separated PR or at least reported as GitHub issue.