### PR TITLE
docs: add Intro: Graphical User Interface

### DIFF
--- a/db/databaseintro.html
+++ b/db/databaseintro.html
@@ -101,4 +101,5 @@ the original MAPSET to the current MAPSET with <a href="g.copy.html">g.copy</a>.
   <li><a href="imageryintro.html">Introduction into image processing</a></li>
   <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
   <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
 </ul>

--- a/doc/projectionintro.html
+++ b/doc/projectionintro.html
@@ -76,4 +76,5 @@ A graphical user interface is provided by <a href="wxGUI.html">wxGUI</a>.
   <li><a href="imageryintro.html">Introduction into image processing</a></li>
   <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
   <li><a href="databaseintro.html">Database management</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
 </ul>

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,7 +1,11 @@
 MODULE_TOPDIR = ..
 
+PGM = wxguiintro
+
 SUBDIRS = icons images scripts xml wxpython
 
 include $(MODULE_TOPDIR)/include/Make/Dir.make
 
-default: parsubdirs
+default: htmldir
+
+htmldir: parsubdirs

--- a/gui/wxguiintro.html
+++ b/gui/wxguiintro.html
@@ -1,0 +1,75 @@
+<!-- meta page description: wxGUI in GRASS GIS -->
+<!-- meta page index: wxgui -->
+
+<h3>Introduction to the GRASS GIS Graphical User Interface</h3>
+
+<h4>Overview</h4>
+
+The wxGUI (wxPython-based Graphical User Interface) is the primary user
+interface for GRASS GIS. Designed for efficiency and ease of use, the
+wxGUI provides an intuitive way to interact with spatial data and the
+powerful tools available in GRASS GIS.
+
+The GUI supports the visualisation of spatial data, the execution of
+geoprocessing tasks or the management of complex workflows and offers a
+comprehensive set of tools.
+
+<h4>Features</h4>
+
+The wxGUI is designed to cater to both novice and advanced users with
+the following features:
+
+<ul>
+<li>A clean and customizable layout for efficient workspace management.</li>
+<li>Integrated support for both raster and vector data operations.</li>
+<li>Drag-and-drop capabilities for quick layer addition and arrangement.</li>
+<li>Support for live previews of data and processing results.</li>
+<li>Direct access to GRASS GIS modules, complete with user-friendly
+    dialog windows.</li>
+<li>Advanced debugging and scripting capabilities for developers and
+    power users.</li>
+</ul>
+
+<h4>Getting Started</h4>
+
+To launch the wxGUI, simply start GRASS GIS. Upon startup, the wxGUI will
+load, providing access to its various components.
+
+The wxGUI usage is explained in greater detail <a href="wxGUI.html">here</a>.
+
+New GRASS GIS users can explore the integrated help system or visit the
+<a href="https://grass.osgeo.org/documentation/">GRASS GIS documentation</a>
+for tutorials and guides.
+
+<h4>Key Components</h4>
+
+The wxGUI is composed of several modules and features:
+
+<ul>
+<li><strong>Map Display</strong>: Visualize raster, vector, and 3D data
+    layers in an interactive map viewer.</li>
+<li><strong>Layer Manager</strong>: Organize and control the visibility,
+    styling, and properties of your data layers.</li>
+<li><strong>Data Catalog</strong>: Explore and manage GRASS GIS mapsets
+    and spatial data with ease.</li>
+<li><strong>Geoprocessing Tools</strong>: Access a wide range of geospatial
+     analysis and modeling tools through an easy-to-use interface.</li>
+<li><strong>Command Console</strong>: Run GRASS GIS commands directly,
+    with syntax highlighting and autocompletion support.</li>
+<li><strong>3D View</strong>: Analyze and visualize 3D landscapes
+    using NVIZ.</li>
+</ul>
+
+The wxGUI components are explained in greater detail
+<a href="wxGUI.components.html">here</a>.
+
+<h3>See also</h3>
+
+<ul>
+  <li><a href="rasterintro.html">Introduction to raster data processing</a></li>
+  <li><a href="raster3dintro.html">Introduction to 3D raster data (voxel) processing</a></li>
+  <li><a href="imageryintro.html">Introduction to image processing</a></li>
+  <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
+  <li><a href="databaseintro.html">Introduction to database management</a></li>
+  <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+</ul>

--- a/gui/wxpython/docs/wxGUI.html
+++ b/gui/wxpython/docs/wxGUI.html
@@ -693,7 +693,7 @@ using <a href="http://www.wxpython.org">wxPython</a> library.
 
 <em>
   <a href="wxGUI.components.html">wxGUI components</a><br>
-  <a href="wxGUI.modules.html">wxGUI module dialogs</a>
+  <a href="wxGUI.modules.html">wxGUI module dialogs</a><br>
   <a href="wxGUI.toolboxes.html">wxGUI toolboxes (menu customization)</a>
 </em>
 

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -293,4 +293,5 @@ Several modules support the calculation of the energy balance:
   <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
   <li><a href="databaseintro.html">Database management</a></li>
   <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
 </ul>

--- a/man/build_html.py
+++ b/man/build_html.py
@@ -79,7 +79,8 @@ overview_tmpl = string.Template(
       </td>
       <td width="33%" valign="top" class="box"><h3>&nbsp;Graphical User Interface</h3>
        <ul>
-        <li class="box"><span><a href="wxGUI.html">wxGUI</a></span></li>
+        <li class="box"><a href="wxguiintro.html">Intro: Graphical User Interface</a></li>
+        <li class="box"><span><a href="wxGUI.html">wxGUI details</a></span></li>
         <li class="box"><a href="wxGUI.components.html">wxGUI components</a></li>
         <li class="box"><a href="wxGUI.toolboxes.html">wxGUI toolboxes</a></li>
        </ul>

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -66,6 +66,7 @@ overview_tmpl = string.Template(
       </td>
       <td width="33%" valign="top" class="box"><h3>&nbsp;Graphical User Interface</h3>
        <ul>
+        <li class="box"><a href="wxguiintro.html">Intro: Graphical User Interface</a></li>
         <li class="box"><span><a href="wxGUI.html">wxGUI</a></span></li>
         <li class="box"><a href="wxGUI.components.html">wxGUI components</a></li>
         <li class="box"><a href="wxGUI.toolboxes.html">wxGUI toolboxes</a></li>

--- a/man/build_rest.py
+++ b/man/build_rest.py
@@ -78,6 +78,7 @@ Quick Introduction
         Intro vector map processing and network analysis <vectorintro>
         Intro database management <databaseintro>
         Intro temporal data processing <temporalintro>
+        Intro Graphical User Interface <wxguiintro>
 
 Display/Graphical User Interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -22,6 +22,7 @@ plugins:
   - glightbox
 use_directory_urls: false
 nav:
+  - GUI: wxGUI.md
   - Startup: grass.md
   - Databases: database.md
   - Display: display.md

--- a/raster/rasterintro.html
+++ b/raster/rasterintro.html
@@ -361,4 +361,5 @@ not the environment variable.
   <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
   <li><a href="databaseintro.html">Database management</a></li>
   <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
 </ul>

--- a/raster3d/raster3dintro.html
+++ b/raster3d/raster3dintro.html
@@ -203,6 +203,7 @@ and the double-precision one "DCELL" or "double".
   <li><a href="imageryintro.html">Introduction into image processing</a></li>
   <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
   <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
   <li><a href="wxGUI.nviz.html">wxGUI 3D View Mode</a></li>
   <li><em><a href="m.nviz.image.html">m.nviz.image</a></em></li>
 </ul>

--- a/temporal/temporalintro.html
+++ b/temporal/temporalintro.html
@@ -281,3 +281,13 @@ their raster pendants, but with 3D raster map layers:
 
 <li> <a href="http://www.geostat-course.org/Topic_Gebbert">GEOSTAT 2012 GRASS Course</a></li>
 </ul>
+
+<ul>
+  <li><a href="rasterintro.html">Introduction into raster data processing</a></li>
+  <li><a href="raster3dintro.html">Introduction into 3D raster data (voxel) processing</a></li>
+  <li><a href="vectorintro.html">Introduction into vector data processing</a></li>
+  <li><a href="imageryintro.html">Introduction into image processing</a></li>
+  <li><a href="databaseintro.html">Database management</a></li>
+  <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
+</ul>

--- a/vector/vectorintro.html
+++ b/vector/vectorintro.html
@@ -394,4 +394,5 @@ a point cloud.
   <li><a href="temporalintro.html">Introduction into temporal data processing</a></li>
   <li><a href="databaseintro.html">Introduction to database management</a></li>
   <li><a href="projectionintro.html">Projections and spatial transformations</a></li>
+  <li><a href="wxguiintro.html">Graphical User Interface</a></li>
 </ul>


### PR DESCRIPTION
While the Graphical User Interface is important it lacked an own "landing page" which also appears in the markdown sidebar.

This PR adds a wxGUI introduction page.

### HTML manual

New menu entry:

![image](https://github.com/user-attachments/assets/7e908753-aefa-4639-a5b5-b054137030f2)

New page:

![image](https://github.com/user-attachments/assets/a9adc7ff-dab7-449b-a563-cbb63eabdf7d)

### MD manual 

New menu entry:

![image](https://github.com/user-attachments/assets/1c871679-e58d-46e7-81df-5c3d901c8fa4)

New page:

![image](https://github.com/user-attachments/assets/e9cb95f6-8402-47d1-a28e-c9485f868d1d)

Notes:
- the content may still be improved. Scope is not to replicate wxGUI.html but to give a general overview which was missing so far.
- the missing caps in the MD page first heading is a general issue which affects all "meta" pages (to be fixed in a new PR).