### PR TITLE
CI(OSGeo4w): Sort and split msys packages into separate lines

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -49,21 +49,21 @@ jobs:
             tar
             zip
           pacboy: >-
-            bzip2:p
-            ccache:p
-            fftw:p
-            gcc:p
-            gettext:p
-            libiconv:p
-            libpng:p
-            libsystre:p
-            libtre-git:p
-            libwinpthread-git:p
-            openblas:p
-            pcre:p
-            pkgconf:p
-            toolchain:p
-            zlib:p
+            bzip2
+            ccache
+            fftw
+            gcc
+            gettext
+            libiconv
+            libpng
+            libsystre
+            libtre-git
+            libwinpthread-git
+            openblas
+            pcre
+            pkgconf
+            toolchain
+            zlib
 
       - name: Setup OSGeo4W environment
         uses: echoix/setup-OSGeo4W@17deecd39e077a80bf1081443998ea8edd6f15bf  # v0.1.0


### PR DESCRIPTION
In the numerous times I've rebased and merged branches containing changes to the msys2 packages used, it has always been hard to follow what changed and always causing conflicts.

This PR splits the package list into separate lines, and are sorted. Just like the action's readme, it uses `>-` instead of `|` or `|-` to collapse newlines together with spaces (it's a yaml-defined feature, useful in GitHub Actions).
It also makes use of the `pacboy: ` input. This allows to avoid using long, repetitive package prefixes. Without any prefixes, the pacboy wrapper script rewrites package names according to the current environment used before forwarding it to pacman. (The page https://www.msys2.org/docs/package-naming/#avoiding-writing-long-package-names is outdated since https://github.com/msys2/pactoys/pull/6 was merged in may 2024).

This makes our package list environment-independent, so in theory that part of our CI is ready for an eventual switch to any of the other 4 msys2 envs, like UCRT64 for example, or a matrix strategy testing them all out. https://www.msys2.org/docs/environments/#overview

The time used is about the same between using pacboy or not (I cannot tell a difference as runner speed variation can account for these < 5-8 seconds difference I see). Cache with or without pacboy, and no cache with or without pacboy are similar, so pacboy isn't a factor here. Only easier to read.