### PR TITLE
v.out.dxf: Fix Resource Leak issue in main.c

### DIFF
--- a/vector/v.out.dxf/main.c
+++ b/vector/v.out.dxf/main.c
@@ -195,6 +195,8 @@ int add_plines(struct Map_info *Map, int field, double textsize)
         }
         nlines_dxf++;
     }
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
 
     return nlines_dxf;
 }


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207804, 1207805)
Vect_destroy_line_struct(), Vect_destroy_cats_struct() are used to fix these issues