### PR TITLE
lib/raster3d: Fix Resource Leak issue

### DIFF
--- a/lib/raster3d/index.c
+++ b/lib/raster3d/index.c
@@ -117,6 +117,7 @@ int Rast3d_flush_index(RASTER3D_Map *map)
     indexLength = map->nTiles * sizeof(long);
     if (write(map->data_fd, tmp, indexLength) != indexLength) {
         Rast3d_error("Rast3d_flush_index: can't write file");
+        Rast3d_free(tmp);
         return 0;
     }
 

--- a/lib/raster3d/index.c
+++ b/lib/raster3d/index.c
@@ -37,6 +37,7 @@ static int Rast3d_readIndex(RASTER3D_Map *map)
     if (indexLength == map->indexLongNbytes * map->nTiles) {
         if (read(map->data_fd, tmp, indexLength) != indexLength) {
             Rast3d_error("Rast3d_readIndex: can't read file");
+            Rast3d_free(tmp);
             return 0;
         }
     }
@@ -52,6 +53,7 @@ static int Rast3d_readIndex(RASTER3D_Map *map)
                 tmp2 = Rast3d_malloc(indexLength);
                 if (tmp2 == NULL) {
                     Rast3d_error("Rast3d_readIndex: error in Rast3d_malloc");
+                    Rast3d_free(tmp);
                     return 0;
                 }
             }
@@ -60,6 +62,8 @@ static int Rast3d_readIndex(RASTER3D_Map *map)
 
             if (read(map->data_fd, tmp2, indexLength) != indexLength) {
                 Rast3d_error("Rast3d_readIndex: can't read file");
+                Rast3d_free(tmp);
+                Rast3d_free(tmp2);
                 return 0;
             }
 


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207806)
Used Rast3d_free() to fix the issue.