### PR TITLE
manual: fix broken HTML tags

### DIFF
--- a/raster/r.texture/r.texture.html
+++ b/raster/r.texture/r.texture.html
@@ -200,7 +200,7 @@ in the source code for more details.
   <br>
   <i>Figure 1: Benchmark shows execution time for different
     number of cells (1M, 2M, 4M, and 8M) and
-    the fixed size of window (3<span>&#215</span>3).
+    the fixed size of window (3<span>&#215;</span>3).
 </div>
 <div align="center" style="margin: 10px">
   <img src="r_texture_mapsize_efficiency.png"
@@ -208,7 +208,7 @@ in the source code for more details.
   <br>
   <i>Figure 2: Benchmark shows efficiency for different
     numbers of cells (1M, 2M, 4M, and 8M) and
-    the fixed size of window (3<span>&#215</span>3).
+    the fixed size of window (3<span>&#215;</span>3).
 </div>
 <div align="center" style="margin: 10px">
   <img src="r_texture_window_time.png"
@@ -216,8 +216,8 @@ in the source code for more details.
   <br>
   <i>Figure 3: Benchmark shows execution time for different
     sizes of windows
-    (3<span>&#215</span>3, 9<span>&#215</span>9,
-    15<span>&#215</span>15, and 27<span>&#215</span>27)
+    (3<span>&#215;</span>3, 9<span>&#215;</span>9,
+    15<span>&#215;</span>15, and 27<span>&#215;</span>27)
     and the fixed number of cells (1M).
 </div>
 <div align="center" style="margin: 10px">
@@ -225,8 +225,8 @@ in the source code for more details.
   alt="efficiency benchmark for r.texture with different window sizes"  border="0">
   <br>
   <i>Figure 4: Benchmark shows efficiency for different
-    sizes of windows (3<span>&#215</span>3, 9<span>&#215</span>9,
-    15<span>&#215</span>15, and 27<span>&#215</span>27)
+    sizes of windows (3<span>&#215;</span>3, 9<span>&#215;</span>9,
+    15<span>&#215;</span>15, and 27<span>&#215;</span>27)
     and the fixed number of cells (1M).
 </div>
 

--- a/scripts/v.clip/v.clip.html
+++ b/scripts/v.clip/v.clip.html
@@ -22,7 +22,7 @@ as <em><a href="v.select.html">v.select</a></em>. Clipping of areas
 and/or lines can be achieved
 using <em><a href="v.overlay.html">v.overlay</a></em>. Clipping of
 points can be performed
-with <em><a href="v.select.html">v.select<a></em>.
+with <em><a href="v.select.html">v.select</a></em>.
 
 <h2>EXAMPLES</h2>
 

--- a/temporal/t.rast.extract/t.rast.extract.html
+++ b/temporal/t.rast.extract/t.rast.extract.html
@@ -27,16 +27,16 @@ side, eg.:
 
 
 <div class="code"><pre>
-t.rast.extract input=tempmean_monthly where="start_time > '2010-01-05'" \
+t.rast.extract input=tempmean_monthly where="start_time &gt; '2010-01-05'" \
                output=selected_tempmean_monthly basename=new_tmean_month \
-               expression="if(tempmean_monthly < 0, null(), tempmean_monthly)"
+               expression="if(tempmean_monthly &lt; 0, null(), tempmean_monthly)"
 </div>
 
 <h2>EXAMPLE</h2>
 
 <div class="code"><pre>
 t.rast.extract input=tempmean_monthly output=tempmean_monthly_later_2012 \
-               where="start_time >= '2012-01-01'"
+               where="start_time &gt;= '2012-01-01'"
 
 t.rast.list tempmean_monthly_later_2012
 name|mapset|start_time|end_time

--- a/vector/v.surf.rst/v.surf.rst.html
+++ b/vector/v.surf.rst/v.surf.rst.html
@@ -305,14 +305,14 @@ in the source code for more details.
   <img src="vsurfrst_benchmark.png" alt="benchmark for v.surf.rst" border="0">
   <br>
   <i>Figure 1: Benchmark shows execution time for different
-    number of cells (1M, 2M, 4M, and 8M).
+    number of cells (1M, 2M, 4M, and 8M).</i>
 </div>
 <div align="center" style="margin: 10px">
     <img src="vsurfrst_cv_benchmark.png" alt="benchmark for cross-validation of
      v.surf.rst" border="0">
     <br>
     <i>Figure 2: Benchmark shows execution time for running cross-validation on
-     different number of cells (100k, 200k, 400k, and 800k).
+     different number of cells (100k, 200k, 400k, and 800k).</i>
 </div>
 
 <h2>EXAMPLE</h2>
@@ -355,10 +355,10 @@ d.vect elevrand
 v.db.univar -e elevrand column=value
 
 # interpolation based on subset of points (only those over 1st quartile)
-v.surf.rst input=elevrand zcolumn=value elevation=elev_partial npmin=100 where="value > 94.9"
+v.surf.rst input=elevrand zcolumn=value elevation=elev_partial npmin=100 where="value &gt; 94.9"
 r.colors map=elev_partial raster=elevation
 d.rast elev_partial
-d.vect elevrand where="value > 94.9"
+d.vect elevrand where="value &gt; 94.9"
 </pre></div>
 
 <h2>REFERENCES</h2>


### PR DESCRIPTION
This PR fixes some broken HTML tags identified during a test run of [adding HTML validation with super-linter](https://github.com/echoix/grass/pull/303).

See logs showing the errors at
https://github.com/echoix/grass/actions/runs/12001379426/job/33451802353?pr=303#step:4:8310