### PR TITLE
wxGUI: Fixed PEP8 error in startup/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -40,7 +40,6 @@ per-file-ignores =
     gui/wxpython/mapwin/base.py: E722
     gui/wxpython/mapwin/buffered.py: E722
     gui/wxpython/mapwin/graphics.py: E722
-    gui/wxpython/startup/locdownload.py: E722, E402
     gui/wxpython/timeline/g.gui.timeline.py: E501
     # Generated file
     gui/wxpython/menustrings.py: E501

--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -32,9 +32,12 @@ from grass.script.setup import set_gui_path
 
 set_gui_path()
 
+# flake8: noqa: E402
 from core.debug import Debug
 from core.gthread import gThread
 from gui_core.wrap import Button, StaticText
+
+# flakes8: qa
 
 
 # TODO: labels (and descriptions) translatable?
@@ -93,7 +96,7 @@ class RedirectText:
                 heigth = self._get_heigth(string)
                 wx.CallAfter(self.out.SetLabel, string)
                 self._resize(heigth)
-        except:
+        except wx.PyDeadObjectError:
             # window closed -> PyDeadObjectError
             pass
 


### PR DESCRIPTION
Fixed following errors:
- Removed `try-except` for `E722` since except module didn't perform any specific error handling
- Added `noqa` for `F401` since `set_gui_path()` might be required to import the modules