### PR TITLE
v.external.out: Fix Resource Leak issue in link.c

### DIFF
--- a/vector/v.external.out/link.c
+++ b/vector/v.external.out/link.c
@@ -100,6 +100,7 @@ void make_link(const char *dsn_opt, const char *format, char *option_str,
         G_verbose_message(_("Switched to PostGIS format"));
 
     G_free_key_value(key_val);
+    G_free(dsn);
 }
 
 int parse_option_pg(const char *option, char **key, char **value)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207761).
Used G_free() to fix this issue.