### PR TITLE
lib/gpde: Fix Resource Leak issue in n_arrays_io.c

### DIFF
--- a/lib/gpde/n_arrays_io.c
+++ b/lib/gpde/n_arrays_io.c
@@ -219,6 +219,9 @@ void N_write_array_2d_to_rast(N_array_2d *array, char *name)
 
     /* Close file */
     Rast_close(map);
+    G_free(rast);
+    G_free(frast);
+    G_free(drast);
 }
 
 /* ******************** 3D ARRAY FUNCTIONS *********************** */

--- a/lib/gpde/n_arrays_io.c
+++ b/lib/gpde/n_arrays_io.c
@@ -150,6 +150,7 @@ N_array_2d *N_read_rast_to_array_2d(char *name, N_array_2d *array)
 
     /* Close file */
     Rast_close(map);
+    G_free(rast);
 
     return data;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID: 1207769, 1207770, 1207771)
Used G_free() to fix this issue.