### PR TITLE
db/MySQL: fix HTML manual nested `<ul></ul>` element position

### DIFF
--- a/db/drivers/mysql/grass-mysql.html
+++ b/db/drivers/mysql/grass-mysql.html
@@ -29,12 +29,13 @@ The parameter 'database' can be given in two formats:
 <ul>
     <li> Database name - in case of connection from localhost</li>
     <li> String of comma separated list of kye=value options.
-         Supported options are:</li>
-     <ul>
-         <li> dbname - database name</li>
-         <li> host - host name or IP address</li>
-         <li> port - server port number</li>
-     </ul>
+         Supported options are:
+        <ul>
+            <li> dbname - database name</li>
+            <li> host - host name or IP address</li>
+            <li> port - server port number</li>
+        </ul>
+    </li>
 </ul>
 <p>
 Examples of connection parameters:


### PR DESCRIPTION
Fix `HTMLParser()` class instance find nested `<ul>` end element `</ul>` error during compilation GRASS GIS source code:

```
Error (IndexError('pop from empty list'))
```

Problematic is nested `<ul></ul>` HTML element inside parent `<ul></ul>` element:

```
 <ul>
     <li></li>
     <li></li>
      <ul>
          <li></li>
          <li></li>
          <li></li>
      </ul>
 </ul>
```

Expected nested `<ul></ul>` HTML element inside parent `<ul></ul>` is nested position inside `<li></li>` element.

```
<ul>
    <li></li>
    <li>
        <ul>
            <li></li>
            <li></li>
            <li></li>
        </ul>
    </li>
</ul>
```

Fixes #4777.