### PR TITLE
r.in.pdal: use different variable name to avoid confusion

### DIFF
--- a/raster/r.in.pdal/info.cpp
+++ b/raster/r.in.pdal/info.cpp
@@ -115,9 +115,9 @@ void print_lasinfo(struct StringList *infiles)
         std::cout << "Point format: " << (int)h.pointFormat() << "\n";
         std::cout << "Point offset: " << h.pointOffset() << "\n";
         std::cout << "Point count: " << h.pointCount() << "\n";
-        for (size_t i = 0; i < pdal::LasHeader::RETURN_COUNT; ++i)
-            std::cout << "Point count by return[" << i + 1 << "]: "
-                      << const_cast<pdal::LasHeader &>(h).pointCountByReturn(i)
+        for (size_t k = 0; k < pdal::LasHeader::RETURN_COUNT; ++k)
+            std::cout << "Point count by return[" << k + 1 << "]: "
+                      << const_cast<pdal::LasHeader &>(h).pointCountByReturn(k)
                       << "\n";
         std::cout << "Scales X/Y/Z: " << h.scaleX() << "/" << h.scaleY() << "/"
                   << h.scaleZ() << "\n";


### PR DESCRIPTION
Just fixing a warning.