### PR TITLE
r.in.pdal: replace HAVE_PDAL_NOFILENAMEWRITER configure definition

### DIFF
--- a/configure
+++ b/configure
@@ -10411,38 +10411,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 printf "%s\n" "#define HAVE_PDAL 1" >>confdefs.h
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to use PDAL NoFilenameWriter" >&5
-printf %s "checking whether to use PDAL NoFilenameWriter... " >&6; }
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <pdal/Writer.hpp>
-  class St:public pdal::NoFilenameWriter {};
-int
-main (void)
-{
-
-  class NFWTest : public pdal::NoFilenameWriter {};
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-
-
-printf "%s\n" "#define HAVE_PDAL_NOFILENAMEWRITER 1" >>confdefs.h
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-
   LIBS=${ac_save_libs}
   CFLAGS=${ac_save_cflags}
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1092,16 +1092,6 @@ else
 
   AC_DEFINE(HAVE_PDAL, 1, [Define to 1 if PDAL exists.])
 
-  AC_MSG_CHECKING(whether to use PDAL NoFilenameWriter)
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pdal/Writer.hpp>
-  class St:public pdal::NoFilenameWriter {};]], [[
-  class NFWTest : public pdal::NoFilenameWriter {};
-  ]])],
-  [
-    AC_DEFINE(HAVE_PDAL_NOFILENAMEWRITER, 1, [Define to 1 if PDAL NoFilenameWriter is present.])
-    AC_MSG_RESULT(yes)
-  ],[AC_MSG_RESULT(no)])
-
   LIBS=${ac_save_libs}
   CFLAGS=${ac_save_cflags}
 fi

--- a/include/grass/config.h.in
+++ b/include/grass/config.h.in
@@ -152,9 +152,6 @@
 /* Define to 1 if PDAL exists. */
 #undef HAVE_PDAL
 
-/* Define to 1 if PDAL NoFilenameWriter is present. */
-#undef HAVE_PDAL_NOFILENAMEWRITER
-
 /* Define to 1 if glXCreateGLXPixmap exists. */
 #undef HAVE_PIXMAPS
 

--- a/raster/r.in.pdal/grassrasterwriter.h
+++ b/raster/r.in.pdal/grassrasterwriter.h
@@ -32,7 +32,7 @@ extern "C" {
 #include <pdal/Writer.hpp>
 
 /* Binning code wrapped as a PDAL Writer class */
-#ifdef HAVE_PDAL_NOFILENAMEWRITER
+#if PDAL_VERSION_MAJOR >= 2 && PDAL_VERSION_MINOR >= 7
 class GrassRasterWriter : public pdal::NoFilenameWriter,
                           public pdal::Streamable {
 #else


### PR DESCRIPTION
with a simple version check in the code to speed up configure process

As discussed in the https://github.com/OSGeo/grass/pull/4750