### PR TITLE
lib/gpde: Fix Resource Leak issue in n_les_assemble.c

### DIFF
--- a/lib/gpde/n_les_assemble.c
+++ b/lib/gpde/n_les_assemble.c
@@ -875,6 +875,8 @@ int N_les_integrate_dirichlet_2d(N_les *les, N_geom_data *geom,
                 count++;
         }
     }
+    G_free(dvect1);
+    G_free(dvect2);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207646, 1207645)
Used G_free() to fix this issue.