### PR TITLE
lib/btree2: add kdtree test

### DIFF
--- a/lib/btree2/Makefile
+++ b/lib/btree2/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 include $(MODULE_TOPDIR)/include/Make/Vars.make
 
-MOD_OBJS := $(filter-out try.o,$(AUTO_OBJS))
+MOD_OBJS := $(filter-out test.o,$(AUTO_OBJS))
 
 LIB = BTREE2
 
@@ -11,12 +11,25 @@ include $(MODULE_TOPDIR)/include/Make/Doxygen.make
 
 HEADERS := $(ARCH_INCDIR)/kdtree.h
 
-default: headers
-	$(MAKE) lib
-
 headers: $(HEADERS)
+
+default: lib headers
+	$(MAKE) lib
+	@echo "==============TEST============="
+ifeq ($(strip $(CROSS_COMPILING)),)
+	$(MAKE) test
+endif
 
 $(ARCH_INCDIR)/kdtree.h: kdtree.h
 	$(INSTALL_DATA) $< $@
+
+test: $(OBJDIR)/test$(EXE)
+	$(call run_grass,$(OBJDIR)/test$(EXE))
+
+#  Test functions
+$(OBJDIR)/test$(EXE): $(OBJDIR)/test.o $(GISDEP) $(BTREE2DEP)
+	$(call linker)
+
+$(OBJDIR)/test$(EXE): LIBES = $(GISLIB) $(BTREE2LIB)
 
 DOXNAME = btree2

--- a/lib/btree2/test.c
+++ b/lib/btree2/test.c
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ * MODULE:       kdtree test
+ * AUTHOR(S):    林永 ynkan
+ * PURPOSE:      test the kdtree.c method for logical operations such as
+ *               kdtree_create=>kdtree_insert=>kdtree_dnn=>kdtree_remove=>kdtree_destroy
+ *               loop executionbalanced tree
+ *               See https://github.com/OSGeo/grass/issues/4779
+ * COPYRIGHT:    (C) 2024 by the GRASS Development Team
+ *
+ *               This program is free software under the GNU General Public
+ *               License (>=v2). Read the file COPYING that comes with GRASS
+ *               for details.
+ *
+ *****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <time.h>
+#include "kdtree.h"
+
+#define MAX_POINTS 5
+
+void generate_random_points(double points[][2], int num_points)
+{
+    for (int i = 0; i < num_points; i++) {
+        points[i][0] = (rand() % 2000) / 100.0;
+        points[i][1] = (rand() % 2000) / 100.0;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+
+    srand(time(NULL));
+
+    while (1) {
+        int num = MAX_POINTS;
+        double points[MAX_POINTS][2];
+        generate_random_points(points, num);
+
+        double target[2] = {(rand() % 2000) / 100.0, (rand() % 2000) / 100.0};
+
+        struct kdtree *kdt = kdtree_create(2, NULL);
+
+        for (int i = 0; i < num; i++) {
+            int result = kdtree_insert(kdt, points[i], i, 0);
+            printf("kdtree insert[uid:%d](%.2f, %.2f) :[%d][%s]\r\n", i,
+                   points[i][0], points[i][1], result,
+                   result ? "success" : "failure");
+        }
+
+        for (int i = 0; i < num; i++) {
+            int result = kdtree_remove(kdt, points[i], i);
+            printf("kdtree remove[uid:%d](%.2f, %.2f) :[%d][%s]\r\n", i,
+                   points[i][0], points[i][1], result,
+                   result ? "success" : "failure");
+        }
+
+        kdtree_destroy(kdt);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds the kdtree test proposed by @ynkan in https://github.com/OSGeo/grass/issues/4779.

At time the test triggers a segmentation fault:

```bash
make
[...]
make lib
make[1]: Entering directory '/home/mneteler/software/grass_main/lib/btree2'
if [ "" != "" -a -f "".html ] ; then make html ; fi
make[1]: Leaving directory '/home/mneteler/software/grass_main/lib/btree2'
==============TEST=============
make test
make[1]: Entering directory '/home/mneteler/software/grass_main/lib/btree2'
gcc  -g -Wall -Wstringop-truncation -Wshadow -Wlogical-op -Werror-implicit-function-declaration -fPIC -fno-common -fno-omit-frame-pointer -fexceptions -Wextra -Wunused -Wreturn-type -Wfatal-errors -march=native -std=gnu99 -fexceptions -fstack-protector -m64 -fdiagnostics-color  -fPIC  -I/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/include -I/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/include    -DPACKAGE=\""grasslibs"\"   -I/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/include -I/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/include -DRELDIR=\"lib/btree2\" -o OBJ.x86_64-pc-linux-gnu/test.o -c test.c
test.c: In function ‘main’:
test.c:18:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
   18 | int main(int argc, char *argv[])
      |          ~~~~^~~~
test.c:18:26: warning: unused parameter ‘argv’ [-Wunused-parameter]
   18 | int main(int argc, char *argv[])
      |                    ~~~~~~^~~~~~
: && gcc -L/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/lib -L/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/lib -Wl,--no-undefined -Wl,-z,now -Wl,--export-dynamic -Wl,-rpath-link,/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/lib -Wl,-rpath,/usr/local/grass85/lib -Wl,-soname,test -o OBJ.x86_64-pc-linux-gnu/test OBJ.x86_64-pc-linux-gnu/test.o    -lgrass_gis.8.5 -lgrass_btree2.8.5  -lgrass_gis.8.5 -lm
GISRC=/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/demolocation/.grassrc85 GISBASE=/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu PATH="/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/scripts:$PATH" PYTHONPATH="/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/etc/python:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/gui/wxpython:$PYTHONPATH" LD_LIBRARY_PATH="/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/bin:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/scripts:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/lib:/home/mneteler/software/grass_main/dist.x86_64-pc-linux-gnu/lib:" LC_ALL=C LANG=C LANGUAGE=C OBJ.x86_64-pc-linux-gnu/test
kdtree insert[uid:0](7.43, 5.41) :[1][success]
kdtree insert[uid:1](16.27, 13.36) :[1][success]
kdtree insert[uid:2](15.87, 19.59) :[1][success]
kdtree insert[uid:3](12.32, 3.86) :[1][success]
[...]
kdtree insert[uid:2](3.67, 10.96) :[1][success]
kdtree insert[uid:3](5.67, 6.99) :[1][success]
kdtree insert[uid:4](5.67, 6.99) :[0][failure]
kdtree remove[uid:0](19.78, 18.10) :[1][success]
kdtree remove[uid:1](4.44, 10.85) :[1][success]
kdtree remove[uid:2](3.67, 10.96) :[1][success]
kdtree remove[uid:3](5.67, 6.99) :[1][success]
make[1]: *** [Makefile:27: test] Segmentation fault (core dumped)
```