### PR TITLE
v.to.db: Fix Resource Leak issue in query.c

### DIFF
--- a/vector/v.to.db/query.c
+++ b/vector/v.to.db/query.c
@@ -191,6 +191,9 @@ int query(struct Map_info *Map)
     }
 
     db_close_database_shutdown_driver(driver);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
+    Vect_destroy_field_info(Fi);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207656, 1207657, 1207658)
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct(), Vect_destroy_field_info().