### PR TITLE
raster: Fixed E402 by adding `noqa` exception

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -47,7 +47,6 @@ per-file-ignores =
     # C wrappers call libgis.G_gisinit before importing other modules.
     # TODO: Is this really needed?
     python/grass/pygrass/vector/__init__.py: E402
-    python/grass/pygrass/raster/__init__.py: E402
     python/grass/pygrass/vector/__init__.py: E402
     python/grass/pygrass/utils.py: E402
     python/grass/temporal/abstract_space_time_dataset.py: E722

--- a/python/grass/pygrass/raster/__init__.py
+++ b/python/grass/pygrass/raster/__init__.py
@@ -13,6 +13,7 @@ import grass.lib.rowio as librowio
 
 libgis.G_gisinit("")
 
+# flake8: noqa: E402
 # import pygrass modules
 from grass.pygrass.errors import must_be_open
 from grass.pygrass.gis.region import Region
@@ -24,6 +25,8 @@ from grass.pygrass.raster.raster_type import TYPE as RTYPE, RTYPE_STR
 from grass.pygrass.raster.buffer import Buffer
 from grass.pygrass.raster.segment import Segment
 from grass.pygrass.raster.rowio import RowIO
+
+# flake8: qa
 
 WARN_OVERWRITE = "Raster map <{0}> already exists and will be overwritten"
 


### PR DESCRIPTION
Added to `noqa` for this flake8 to preserve module load order