### PR TITLE
manual: markdown support fixes and HTML fixes

### DIFF
--- a/gui/wxpython/rlisetup/g.gui.rlisetup.html
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.html
@@ -328,7 +328,7 @@ Gen. Tech. Rep. PNW-351. (<a href="http://treesearch.fs.fed.us/pubs/3064">PDF</a
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="r.li.daemon.html">r.li.daemon</a>
 </em>
 <p>

--- a/imagery/i.rectify/i.rectify.html
+++ b/imagery/i.rectify/i.rectify.html
@@ -144,9 +144,9 @@ with categorical data, since the cell values will be altered.
 <p>In the bilinear, cubic and lanczos methods, if any of the surrounding cells used to
 interpolate the new cell value are NULL, the resulting cell will be NULL, even if
 the nearest cell is not NULL. This will cause some thinning along NULL borders,
-such as the coasts of land areas in a DEM. The bilinear_f, cubic_f and lanczos_f
-interpolation methods can be used if thinning along NULL edges is not desired.
-These methods "fall back" to simpler interpolation methods along NULL borders.
+such as the coasts of land areas in a DEM. The <em>bilinear_f</em>, <em>cubic_f</em>
+and <em>lanczos_f</em> interpolation methods can be used if thinning along NULL edges is
+not desired. These methods "fall back" to simpler interpolation methods along NULL borders.
 That is, from lanczos to cubic to bilinear to nearest.
 <p>If nearest neighbor assignment is used, the output map has the same raster
 format as the input map. If any of the other interpolations is used, the

--- a/imagery/i.smap/i.smap.html
+++ b/imagery/i.smap/i.smap.html
@@ -10,18 +10,17 @@ covariance parameters.
 
 <p>
 <em>i.smap</em> has two modes of operation. The first mode
-is the sequential maximum a posteriori (SMAP) mode
-[<a href="#ref1">1</a>,<a href="#ref2">2</a>].  The SMAP
+is the sequential maximum a posteriori (SMAP) mode (see
+Bouman and Shapiro, 1992; Bouman and Shapiro, 1994). The SMAP
 segmentation algorithm attempts to improve segmentation
 accuracy by segmenting the image into regions rather than
-segmenting each pixel separately
-(see <a href="#notes">NOTES</a>).
+segmenting each pixel separately (see NOTES below).
 
 <p>
 The second mode is the more conventional maximum likelihood (ML)
 classification which classifies each pixel separately,
 but requires somewhat less computation. This mode is selected with
-the <b>-m</b> flag (see <a href="#mflag.html">below</a>).
+the <b>-m</b> flag (see below).
 
 <h2>OPTIONS</h2>
 
@@ -30,9 +29,7 @@ the <b>-m</b> flag (see <a href="#mflag.html">below</a>).
 <dl>
 <dt><b>-m</b>
 <dd>Use maximum likelihood estimation (instead of smap).
-Normal operation is to use SMAP estimation (see
-<a href="#notes">NOTES</a>).
-
+Normal operation is to use SMAP estimation (see NOTES below).
 </dl>
 
 <h3>Parameters:</h3>
@@ -57,7 +54,7 @@ The signature file that contains the spectral signatures (i.e., the
 statistics) for the classes to be identified in the image.
 This signature file is produced by the program
 <em><a href="i.gensigset.html">i.gensigset</a></em>
-(see <a href="#notes">NOTES</a>).
+(see NOTES below).
 
 <dt><b>blocksize=</b><em>value</em>
 
@@ -102,7 +99,7 @@ categories on the ground.
 </dl>
 
 
-<h2 id="notes">NOTES</h2>
+<h2>NOTES</h2>
 
 The SMAP algorithm exploits the fact that nearby pixels in
 an image are likely to have the same class.  It works by
@@ -129,8 +126,9 @@ of fit output map. Lower values indicate a better fit. The largest 5 to
 <p>
 The module <em>i.smap</em> does not support MASKed or NULL cells. Therefore
 it might be necessary to create a copy of the classification results
-using e.g. r.mapcalc:
-<p><div class="code"><pre>
+using e.g. <em>r.mapcalc</em>:
+<p>
+<div class="code"><pre>
 r.mapcalc "MASKed_map = classification_results"
 </pre></div>
 
@@ -216,10 +214,10 @@ pp. III-565 - III-568, San Francisco, California, March 23-26, 1992.</li>
 <a href="r.support.html">r.support</a></em> for setting semantic labels,
 <br>
 <em>
-<a href="i.group.html">i.group</a></em> for creating groups and subgroups
+<a href="i.group.html">i.group</a></em> for creating groups and subgroups,
 <br>
 <em><a href="r.mapcalc.html">r.mapcalc</a></em>
-to copy classification result in order to cut out MASKed subareas
+to copy classification result in order to cut out MASKed subareas,
 <br>
 <em><a href="i.gensigset.html">i.gensigset</a></em>
 to generate the signature file required by this program

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -246,8 +246,8 @@ top-of-atmosphere radiance or reflectance and temperature (<a href="i.aster.toar
 
 <h3>Time series processing</h3>
 
-GRASS also offers support for time series processing (<a
-href="r.series.html">r.series</a>). Statistics can be derived from a
+GRASS also offers support for time series processing
+(<a href="r.series.html">r.series</a>). Statistics can be derived from a
 set of coregistered input maps such as multitemporal satellite
 data. The common univariate statistics and also linear regression can
 be calculated.

--- a/lib/btree2/btree2lib.dox
+++ b/lib/btree2/btree2lib.dox
@@ -1,4 +1,4 @@
-/*! \page btree2 btree2 library
+/*! \page btree2 GRASS Btree2 and k-d tree libraries
 
 \tableofcontents
 

--- a/lib/gis/parser_rest_md.c
+++ b/lib/gis/parser_rest_md.c
@@ -503,7 +503,7 @@ void print_escaped_for_md_keywords(FILE *f, const char *str)
     str_s = G_store(str);
     G_strip(str_s);
 
-    /* HTML link only for second keyword */
+    /* HTML link only for second keyword = topic */
     if (st->n_keys > 1 && strcmp(st->module_info.keywords[1], str) == 0) {
 
         const char *s;
@@ -535,7 +535,7 @@ void print_escaped_for_md_keywords(FILE *f, const char *str)
             fprintf(f, ".md)");
         }
         else {
-            /* keyword index */
+            /* keyword index, mkdocs expects dash */
             char *str_link;
             str_link = G_str_replace(str_s, " ", "-");
             G_str_to_lower(str_link);

--- a/lib/gis/parser_rest_md.c
+++ b/lib/gis/parser_rest_md.c
@@ -537,7 +537,7 @@ void print_escaped_for_md_keywords(FILE *f, const char *str)
         else {
             /* keyword index */
             char *str_link;
-            str_link = G_str_replace(str_s, " ", "%20");
+            str_link = G_str_replace(str_s, " ", "-");
             G_str_to_lower(str_link);
             fprintf(f, "[%s](keywords.md#%s)", str_s, str_link);
             G_free(str_link);

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -193,7 +193,7 @@ desc1_tmpl = string.Template(
 )
 
 modclass_intro_tmpl = string.Template(
-    r"""Go to [${modclass} introduction](${modclass_lower}intro.html) | [topics](topics.html)
+    r"""Go to [${modclass} introduction](${modclass_lower}intro.md) | [topics](topics.md)
 """
 )
 # "
@@ -201,7 +201,7 @@ modclass_intro_tmpl = string.Template(
 
 modclass_tmpl = string.Template(
     r"""Go [back to help overview](index.md)
-### ${modclass} commands:
+### ${modclass} commands
 | Module | Description |
 |--------|-------------|
 """
@@ -217,7 +217,7 @@ full_index_header = r"""Go [back to help overview](index.md)
 
 moduletopics_tmpl = string.Template(
     r"""
-- [${name}](topic_${key}.html)
+- [${name}](topic_${key}.md)
 """
 )
 

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -127,7 +127,7 @@ def build_topics(ext):
                         "*See also the corresponding keyword"
                         " [{key}](keywords.md#{key})"
                         " for additional references.*\n".format(
-                            key=key.replace("_", "-").lower()
+                            key=key.replace(" ", "-").replace("_", "-").lower()
                         )
                     )
 

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -78,7 +78,9 @@ def build_topics(ext):
         topicsfile.write(headertopics_tmpl)
 
         for key, values in sorted(keywords.items(), key=lambda s: s[0].lower()):
-            with Path(man_dir, f"topic_%s.{ext}" % key).open("w") as keyfile:
+            with Path(man_dir, f"topic_%s.{ext}" % key.replace(" ", "_")).open(
+                "w"
+            ) as keyfile:
                 if ext == "html":
                     keyfile.write(
                         header1_tmpl.substitute(
@@ -125,7 +127,7 @@ def build_topics(ext):
                         "*See also the corresponding keyword"
                         " [{key}](keywords.md#{key})"
                         " for additional references.*\n".format(
-                            key=key.replace("_", " ")
+                            key=key.replace("_", "-").lower()
                         )
                     )
 

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -28,14 +28,16 @@ nav:
   - Display: display.md
   - General: general.md
   - Imagery: imagery.md
-  - Keywords: keywords.md
   - Misc: miscellaneous.md
+  - Postscript: postscript.md
   - Raster: raster.md
   - Raster 3D: raster3d.md
   - SQL: sql.md
   - Temporal: temporal.md
   - Variables: variables.md
   - Vector: vector.md
+  - Keywords: keywords.md
+  - Topics: topics.md
 markdown_extensions:
   - admonition
   - pymdownx.details

--- a/raster/r.basins.fill/r.basins.fill.html
+++ b/raster/r.basins.fill/r.basins.fill.html
@@ -31,8 +31,8 @@ map layer is used.
 
 <h2>SEE ALSO</h2>
 
-See Appendix A of the <b>GRASS</b> <a
-href="https://grass.osgeo.org/gdp/raster/r.watershed.ps">Tutorial:
+See Appendix A of the <b>GRASS</b>
+<a href="https://grass.osgeo.org/gdp/raster/r.watershed.ps">Tutorial:
 r.watershed</a> for further details on the combined use of
 <em>r.basins.fill</em> and <em>r.watershed</em>.
 

--- a/raster/r.in.poly/r.in.poly.html
+++ b/raster/r.in.poly/r.in.poly.html
@@ -8,7 +8,7 @@ containing polygon, linear, and point features.
 The <b>input</b> file is an ASCII text file containing the
 polygon, linear, and point feature definitions.
 The format of this file is described in the
-<a href="#format"><i>INPUT FORMAT</i></a> section below.
+<em>INPUT FORMAT</em> section below.
 
 <p>
 The number of raster <b>rows</b> to hold in memory is per default 4096.
@@ -31,7 +31,7 @@ format used by <em>v.in.ascii</em>.
 <p>
 Polygons are filled, i.e. they define an area.
 
-<h3 id="format">Input Format</h3>
+<h3>Input Format</h3>
 
 The input format for the <b>input</b> file consists of
 sections describing either polygonal areas, linear features, or

--- a/raster/r.li/r.li.cwed/r.li.cwed.html
+++ b/raster/r.li/r.li.cwed/r.li.cwed.html
@@ -60,7 +60,7 @@ r.li.cwed input=my_map conf=my_conf output=my_out \
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.dominance/r.li.dominance.html
+++ b/raster/r.li/r.li.dominance/r.li.dominance.html
@@ -60,7 +60,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.edgedensity/r.li.edgedensity.html
+++ b/raster/r.li/r.li.edgedensity/r.li.edgedensity.html
@@ -81,7 +81,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.mpa/r.li.mpa.html
+++ b/raster/r.li/r.li.mpa/r.li.mpa.html
@@ -68,7 +68,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.mps/r.li.mps.html
+++ b/raster/r.li/r.li.mps/r.li.mps.html
@@ -70,7 +70,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.padcv/r.li.padcv.html
+++ b/raster/r.li/r.li.padcv/r.li.padcv.html
@@ -60,7 +60,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.padrange/r.li.padrange.html
+++ b/raster/r.li/r.li.padrange/r.li.padrange.html
@@ -62,7 +62,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.padsd/r.li.padsd.html
+++ b/raster/r.li/r.li.padsd/r.li.padsd.html
@@ -62,7 +62,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.patchdensity/r.li.patchdensity.html
+++ b/raster/r.li/r.li.patchdensity/r.li.patchdensity.html
@@ -73,7 +73,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.patchnum/r.li.patchnum.html
+++ b/raster/r.li/r.li.patchnum/r.li.patchnum.html
@@ -56,7 +56,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.pielou/r.li.pielou.html
+++ b/raster/r.li/r.li.pielou/r.li.pielou.html
@@ -59,7 +59,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.renyi/r.li.renyi.html
+++ b/raster/r.li/r.li.renyi/r.li.renyi.html
@@ -62,7 +62,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.richness/r.li.richness.html
+++ b/raster/r.li/r.li.richness/r.li.richness.html
@@ -59,7 +59,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.shannon/r.li.shannon.html
+++ b/raster/r.li/r.li.shannon/r.li.shannon.html
@@ -60,7 +60,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.shape/r.li.shape.html
+++ b/raster/r.li/r.li.shape/r.li.shape.html
@@ -61,7 +61,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.li/r.li.simpson/r.li.simpson.html
+++ b/raster/r.li/r.li.simpson/r.li.simpson.html
@@ -60,7 +60,7 @@ d.vect forests type=boundary
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.li.html">r.li</a> - package overview,
+<a href="r.li.html">r.li</a> (package overview),
 <a href="g.gui.rlisetup.html">g.gui.rlisetup</a>
 </em>
 

--- a/raster/r.quantile/r.quantile.html
+++ b/raster/r.quantile/r.quantile.html
@@ -30,10 +30,9 @@ r.quantile elevation quantiles=5 -r --quiet | r.recode elevation \
 <ul>
 <li>Hyndman and Fan (1996) <i>Sample Quantiles in Statistical
 Packages</i>, <b>American Statistician</b>. American Statistical
-Association. 50 (4): 361-365. DOI: <a
-href="https://doi.org/10.2307/2684934>10.2307/2684934">10.2307/2684934</a></li>
-<li><a
-href="https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm"><i>Engineering
+Association. 50 (4): 361-365. DOI:
+<a href="https://doi.org/10.2307/2684934>10.2307/2684934">10.2307/2684934</a></li>
+<li> <a href="https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm"><i>Engineering
 Statistics Handbook: Percentile</i></a>, NIST</li>
 </ul>
 

--- a/raster/r.stats.quantile/r.stats.quantile.html
+++ b/raster/r.stats.quantile/r.stats.quantile.html
@@ -46,10 +46,9 @@ r.stats.quantile base=zipcodes cover=elevation percentiles=25,50,75 \
 <ul>
 <li>Hyndman and Fan (1996) <i>Sample Quantiles in Statistical
 Packages</i>, <b>American Statistician</b>. American Statistical
-Association. 50 (4): 361-365. DOI: <a
-href="https://doi.org/10.2307/2684934>10.2307/2684934">10.2307/2684934</a></li>
-<li><a
-href="https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm"><i>Engineering
+Association. 50 (4): 361-365. DOI:
+<a href="https://doi.org/10.2307/2684934>10.2307/2684934">10.2307/2684934</a></li>
+<li><a href="https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm"><i>Engineering
 Statistics Handbook: Percentile</i></a>, NIST</li>
 </ul>
 

--- a/raster/r.support/r.support.html
+++ b/raster/r.support/r.support.html
@@ -15,31 +15,45 @@ Raster semantic label is suggested to work with imagery classification tools.
 
 <h2>EXAMPLES</h2>
 
-These examples are based on the North Carolina dataset, more specifically the <em>landuse</em> raster map.
+These examples are based on the North Carolina dataset, more specifically
+the <em>landuse</em> raster map.
 
 Copy the landuse map to the current mapset
-<div class="code"><pre>g.copy raster=landuse,my_landuse
+
+<div class="code"><pre>
+g.copy raster=landuse,my_landuse
 </pre></div>
 
 <h3>Update statistics</h3>
-<div class="code"><pre>r.support -s map=my_landuse
+
+<div class="code"><pre>
+r.support -s map=my_landuse
 </pre></div>
 
 <h3>Update Title</h3>
-<div class="code"><pre>r.support map=my_landuse title="Landuse copied"
+
+<div class="code"><pre>
+r.support map=my_landuse title="Landuse copied"
 </pre></div>
 
 <h3>Append to History Metadata</h3>
-<div class="code"><pre>r.support map=my_landuse history="Copied from PERMANENT mapset"
+
+<div class="code"><pre>
+r.support map=my_landuse history="Copied from PERMANENT mapset"
 </pre></div>
 
 <h3>Update Units Display</h3>
-<div class="code"><pre>r.support map=my_landuse units=meter
+
+<div class="code"><pre>
+r.support map=my_landuse units=meter
 </pre></div>
 
 <h3>Set semantic label</h3>
+
 Note: landuse map doesn't confirm to CORINE specification. This is an example only.
-<div class="code"><pre>r.support map=my_landuse semantic_label=CORINE_LULC
+
+<div class="code"><pre>
+r.support map=my_landuse semantic_label=CORINE_LULC
 </pre></div>
 
 <h2>NOTES</h2>

--- a/raster/rasterintro.html
+++ b/raster/rasterintro.html
@@ -198,8 +198,8 @@ Profiles and transects can be generated
 (<a href="d.polar.html">d.polar</a>).
 
 Univariate statistics (<a href="r.univar.html">r.univar</a>) and
-reports are also available (<a href="r.report.html">r.report</a>,<a
-href="r.stats.html">r.stats</a>, <a href="r.volume.html">r.volume</a>).
+reports are also available (<a href="r.report.html">r.report</a>,
+<a href="r.stats.html">r.stats</a>, <a href="r.volume.html">r.volume</a>).
 
 Since <a href="r.univar.html">r.univar</a> may be slow for extended
 statistics these can be calculated using

--- a/scripts/r.semantic.label/r.semantic.label.html
+++ b/scripts/r.semantic.label/r.semantic.label.html
@@ -79,7 +79,7 @@ raster maps.
 <em>
   <a href="i.band.library.html">i.band.library</a>,
   <a href="r.info.html">r.info</a>,
-  <a href="r.support">r.support</a>
+  <a href="r.support.html">r.support</a>
 </em>
 
 <h2>AUTHORS</h2>

--- a/scripts/v.db.univar/v.db.univar.html
+++ b/scripts/v.db.univar/v.db.univar.html
@@ -15,7 +15,7 @@ features have more than one category value.  For feature-based, instead of
 attribute table-based, univariate statistics on attributes see
 <a href="v.univar.html">v.univar</a>.
 
-<em>NOTES</em>
+<h2>NOTES</h2>
 
 A database connection must be defined for the selected vector layer.
 

--- a/scripts/v.db.univar/v.db.univar.html
+++ b/scripts/v.db.univar/v.db.univar.html
@@ -12,8 +12,8 @@ the attribute table, not based on the features in the map. One attribute value
 is read from each line in the attribute table, whether there are no, one or
 several features with the category value referenced by that line, or whether any
 features have more than one category value.  For feature-based, instead of
-attribute table-based, univariate statistics on attributes see <a
-href="v.univar.html">v.univar</a>.
+attribute table-based, univariate statistics on attributes see
+<a href="v.univar.html">v.univar</a>.
 
 <em>NOTES</em>
 

--- a/scripts/v.dissolve/v.dissolve.html
+++ b/scripts/v.dissolve/v.dissolve.html
@@ -57,13 +57,13 @@ When <em>univar</em> is used, the methods available are the ones which
 
 When the <em>sql</em> backend is used, the methods depend on the SQL
 database backend used for the attribute table of the input vector. For
-SQLite, there are at least the following <a
-href="https://www.sqlite.org/lang_aggfunc.html">built-in aggregate
+SQLite, there are at least the following
+<a href="https://www.sqlite.org/lang_aggfunc.html">built-in aggregate
 functions</a>: <em>count</em>, <em>min</em>, <em>max</em>,
 <em>avg</em>, <em>sum</em>, and <em>total</em>.
 
-For PostgreSQL, the list of <a
-href="https://www.postgresql.org/docs/current/functions-aggregate.html">aggregate
+For PostgreSQL, the list of
+<a href="https://www.postgresql.org/docs/current/functions-aggregate.html">aggregate
 functions</a> is much longer and includes, e.g., <em>count</em>,
 <em>min</em>, <em>max</em>, <em>avg</em>, <em>sum</em>,
 <em>stddev</em>, and <em>variance</em>.

--- a/temporal/t.list/t.list.html
+++ b/temporal/t.list/t.list.html
@@ -50,8 +50,8 @@ tempmean@climate_2000_2012
 </pre></div>
 
 The <em>where</em> option can also be used to list the stds with a
-certain pattern in their name, i.e. as the pattern option in <a
-href="g.list.html">g.list</a>.
+certain pattern in their name, i.e. as the pattern option in
+<a href="g.list.html">g.list</a>.
 
 <div class="code"><pre>
 # strds whose name start with "precip"

--- a/temporal/t.rast.series/t.rast.series.html
+++ b/temporal/t.rast.series/t.rast.series.html
@@ -20,8 +20,7 @@ files exceeds this number, the <b>-z</b> flag will be invoked. Because this
 will slow down processing, the user can set a higher limit with the
 <b>file_limit</b> parameter. Note that <b>file_limit</b> limit should not exceed the
 user-specific limit on open files set by your operating system. See the
-<a
-href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing#Number_of_open_files_limitation">Wiki</a>
+<a href="https://grasswiki.osgeo.org/wiki/Large_raster_data_processing#Number_of_open_files_limitation">Wiki</a>
 for more information.
 
 <h2>Performance</h2>

--- a/vector/v.cluster/v.cluster.html
+++ b/vector/v.cluster/v.cluster.html
@@ -45,8 +45,8 @@ own maximum distance. This method can identify clusters with different
 densities and can create nested clusters.
 
 <h4>optics</h4>
-This method is <a
-href="https://en.wikipedia.org/wiki/OPTICS_algorithm">Ordering Points to
+This method is
+<a href="https://en.wikipedia.org/wiki/OPTICS_algorithm">Ordering Points to
 Identify the Clustering Structure</a>. It is controlled by the number
 of neighbor points (option <i>min</i> - 1). The core distance of a
 point is the distance to the farthest neighbor. The reachability of a

--- a/vector/v.net.allpairs/v.net.allpairs.html
+++ b/vector/v.net.allpairs/v.net.allpairs.html
@@ -50,8 +50,8 @@ from\to	1		3		4		5
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="v.net.path">v.net.path</a>,
-<a href="v.net.distance">v.net.distance</a>
+<a href="v.net.path.html">v.net.path</a>,
+<a href="v.net.distance.html">v.net.distance</a>
 </em>
 
 <h2>AUTHORS</h2>

--- a/vector/v.patch/v.patch.html
+++ b/vector/v.patch/v.patch.html
@@ -13,8 +13,8 @@ edited or removed after <em>v.patch</em> is run. Such
 editing can be done automatically using
 <em><a href="v.clean.html">v.clean</a></em>.
 <p>
-Lines may need to be snapped with <em><a
-href="v.clean.html">v.clean</a> tool=snap,break,rmdupl</em>.
+Lines may need to be snapped with
+<em><a href="v.clean.html">v.clean</a> tool=snap,break,rmdupl</em>.
 <p>
 Boundaries may need to be cleaned with
 <em><a href="v.clean.html">v.clean</a> tool=break,rmdupl,rmsa</em>

--- a/vector/vectorintro.html
+++ b/vector/vectorintro.html
@@ -268,8 +268,8 @@ Unprojected maps can be geocoded with <a href="v.transform.html">v.transform</a>
 Based on the control points, <a href="v.rectify.html">v.rectify</a> rectifies a
 vector map by computing a coordinate transformation for each vector object.
 
-Triangulation and point-to-polygon conversions can be done with <a
-href="v.delaunay.html">v.delaunay</a>, <a href="v.hull.html">v.hull</a>,
+Triangulation and point-to-polygon conversions can be done with
+<a href="v.delaunay.html">v.delaunay</a>, <a href="v.hull.html">v.hull</a>,
 and <a href="v.voronoi.html">v.voronoi</a>.
 
 The <a href="v.random.html">v.random</a> command generated random points.
@@ -310,7 +310,7 @@ Vector maps can be queried with <a href="v.what.html">v.what</a> and
 <h3>Vector-Raster queries</h3>
 
 Raster values can be transferred to vector maps with
- <a href="v.what.rast.html">v.what.rast</a> and
+<a href="v.what.rast.html">v.what.rast</a> and
 <a href="v.rast.stats">v.rast.stats</a>.
 
 <h3>Vector network analysis</h3>

--- a/vector/vectorintro.html
+++ b/vector/vectorintro.html
@@ -311,7 +311,7 @@ Vector maps can be queried with <a href="v.what.html">v.what</a> and
 
 Raster values can be transferred to vector maps with
 <a href="v.what.rast.html">v.what.rast</a> and
-<a href="v.rast.stats">v.rast.stats</a>.
+<a href="v.rast.stats.html">v.rast.stats</a>.
 
 <h3>Vector network analysis</h3>
 


### PR DESCRIPTION
This PR addresses issues identified in #4748:

Manual pages:
- fixes of broken HTML tags, href entries and broken URLs not converted properly
- fix title of `lib/btree2/btree2lib.dox`

Markdown support in build system:
- `.html` -> `.md` file extension fixes
- replace white space in keyword anchors with dash (expected by mkdocs)
- avoid white space in "topics" file names
- avoid ":" in title (looks bad in side menu)
- reorder mkdocs navigation menu and add missing entries (`man/mkdocs/mkdocs.yml`)