### PR TITLE
wxGUI: Fix bare except in graphics.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -37,7 +37,6 @@ per-file-ignores =
     gui/wxpython/mapswipe/g.gui.mapswipe.py: E501
     gui/wxpython/mapwin/base.py: E722
     gui/wxpython/mapwin/buffered.py: E722
-    gui/wxpython/mapwin/graphics.py: E722
     gui/wxpython/timeline/g.gui.timeline.py: E501
     # Generated file
     gui/wxpython/menustrings.py: E501

--- a/gui/wxpython/mapwin/graphics.py
+++ b/gui/wxpython/mapwin/graphics.py
@@ -388,7 +388,7 @@ class GraphicsSet:
         """Clears old object before drawing new object."""
         try:
             self.pdc.ClearId(drawid)
-        except:
+        except (wx.PyDeadObjectError, KeyError):
             pass
 
 


### PR DESCRIPTION
Replace bare except with specific exception handling (wx.PyDeadObjectError, KeyError) to handle cases where the PDC object is destroyed or ID doesn't exist.