### PR TITLE
CQ: optimise if conditions in gmodeler.canvas

### DIFF
--- a/gui/wxpython/gmodeler/canvas.py
+++ b/gui/wxpython/gmodeler/canvas.py
@@ -329,10 +329,10 @@ class ModelEvtHandler(ogl.ShapeEvtHandler):
                 self.frame.Bind(wx.EVT_MENU, self.OnEnable, id=self.popupID["enable"])
         if isinstance(shape, (ModelAction, ModelComment)):
             popupMenu.AppendSeparator()
-        if isinstance(shape, ModelAction):
-            popupMenu.Append(self.popupID["label"], _("Set label"))
-            self.frame.Bind(wx.EVT_MENU, self.OnSetLabel, id=self.popupID["label"])
-        if isinstance(shape, (ModelAction, ModelComment)):
+            if isinstance(shape, ModelAction):
+                popupMenu.Append(self.popupID["label"], _("Set label"))
+                self.frame.Bind(wx.EVT_MENU, self.OnSetLabel, id=self.popupID["label"])
+
             popupMenu.Append(self.popupID["comment"], _("Set comment"))
             self.frame.Bind(wx.EVT_MENU, self.OnSetComment, id=self.popupID["comment"])
 


### PR DESCRIPTION
no need to run the same `if` condition twice when the interluding one could be inserted in