### PR TITLE
ps.map: Fix Resource Leak issue in ps_vlines.c

### DIFF
--- a/ps/ps.map/ps_vlines.c
+++ b/ps/ps.map/ps_vlines.c
@@ -206,5 +206,8 @@ int PS_vlines_plot(struct Map_info *P_map, int vec, int type)
     }
     fprintf(PS.fp, "\n");
     fprintf(PS.fp, "0 setlinejoin\n"); /* reset line join to miter */
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_line_struct(nPoints);
+    Vect_destroy_cats_struct(Cats);
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID: 1207641, 1207642, 1207643)
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix this issue.