### PR TITLE
v.net: Fix Resource Leak issue in report.c

### DIFF
--- a/vector/v.net/report.c
+++ b/vector/v.net/report.c
@@ -128,6 +128,9 @@ int report(struct Map_info *In, int afield, int nfield, int action)
             }
         }
     }
+    Vect_destroy_cats_struct(Cats);
+    Vect_destroy_cats_struct(Cats2);
+    Vect_destroy_line_struct(Points);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID: 1207652,1207653)
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix this issue.

