### PR TITLE
r.what: Update to handle more than 400 bands

### DIFF
--- a/raster/r.what/main.c
+++ b/raster/r.what/main.c
@@ -18,7 +18,7 @@
  *               for details.
  *
  *****************************************************************************/
-#define NFILES 400
+#define NFILES 1000
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
AVIRIS-NG has 425 bands, i.spectral is using r.what in the background has fails for hyperspectral imagery having bands more than 400.