### PR TITLE
docker: Do not ignore certain git folder for docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ dist.*
 !.git/refs/heads
 !.git/objects
 .git/objects/*
+!.git/objects/pack


### PR DESCRIPTION
For docker alpine build, this fix prevents the following error during GRASS GIS configure step:
`checking for GRASS GIS headers commit date... fatal: bad object HEAD 2024-12-10T08:46:00+00:00`

With this fix it correctly returns:
`checking for GRASS GIS headers commit date... 2024-11-29T10:01:48+00:00`