### PR TITLE
style: Define `import grass.temporal as tgis` as an import convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -394,6 +394,7 @@ ignore = [
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 # Declare a custom aliases, checked with rule ICN001
 "grass.script" = "gs"
+"grass.temporal" = "tgis"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/python/grass/temporal/testsuite/test_temporal_doctests.py
+++ b/python/grass/temporal/testsuite/test_temporal_doctests.py
@@ -8,8 +8,7 @@ import sys
 import grass.gunittest.case
 import grass.gunittest.main
 import grass.gunittest.utils
-
-import grass.temporal
+import grass.temporal as tgis
 
 doctest.DocFileCase = type(
     "DocFileCase", (grass.gunittest.case.TestCase,), dict(doctest.DocFileCase.__dict__)
@@ -23,35 +22,31 @@ doctest.SkipDocTestCase = type(
 
 def load_tests(loader, tests, ignore):
     grass.gunittest.utils.do_doctest_gettext_workaround()
-    tests.addTests(doctest.DocTestSuite(grass.temporal.abstract_dataset))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.abstract_map_dataset))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.abstract_space_time_dataset))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.base))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.core))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.datetime_math))
+    tests.addTests(doctest.DocTestSuite(tgis.abstract_dataset))
+    tests.addTests(doctest.DocTestSuite(tgis.abstract_map_dataset))
+    tests.addTests(doctest.DocTestSuite(tgis.abstract_space_time_dataset))
+    tests.addTests(doctest.DocTestSuite(tgis.base))
+    tests.addTests(doctest.DocTestSuite(tgis.core))
+    tests.addTests(doctest.DocTestSuite(tgis.datetime_math))
     # Unexpected error here
-    # tests.addTests(doctest.DocTestSuite(grass.temporal.list_stds))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.metadata))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.register))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.space_time_datasets))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.spatial_extent))
-    tests.addTests(
-        doctest.DocTestSuite(grass.temporal.spatial_topology_dataset_connector)
-    )
-    tests.addTests(doctest.DocTestSuite(grass.temporal.spatio_temporal_relationships))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_extent))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_granularity))
-    tests.addTests(
-        doctest.DocTestSuite(grass.temporal.temporal_topology_dataset_connector)
-    )
+    # tests.addTests(doctest.DocTestSuite(tgis.list_stds))
+    tests.addTests(doctest.DocTestSuite(tgis.metadata))
+    tests.addTests(doctest.DocTestSuite(tgis.register))
+    tests.addTests(doctest.DocTestSuite(tgis.space_time_datasets))
+    tests.addTests(doctest.DocTestSuite(tgis.spatial_extent))
+    tests.addTests(doctest.DocTestSuite(tgis.spatial_topology_dataset_connector))
+    tests.addTests(doctest.DocTestSuite(tgis.spatio_temporal_relationships))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_extent))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_granularity))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_topology_dataset_connector))
     # Algebra is still very experimental
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_algebra))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_raster3d_algebra))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_raster_algebra))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_raster_base_algebra))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_operator))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.temporal_vector_algebra))
-    tests.addTests(doctest.DocTestSuite(grass.temporal.c_libraries_interface))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_algebra))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_raster3d_algebra))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_raster_algebra))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_raster_base_algebra))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_operator))
+    tests.addTests(doctest.DocTestSuite(tgis.temporal_vector_algebra))
+    tests.addTests(doctest.DocTestSuite(tgis.c_libraries_interface))
     return tests
 
 


### PR DESCRIPTION
All files except one were using `import grass.temporal as tgis` naming convention.
This PR fixes the only file not using this pattern, and adds `tgis` as the expected alias for importing `grass.temporal`.