### PR TITLE
temporal: Adjust typing annotation for `datetime_to_grass_datetime_string()`

### DIFF
--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -836,7 +836,7 @@ def string_to_datetime(time_string: str) -> datetime | None:
     return time_object
 
 
-def datetime_to_grass_datetime_string(dt: datetime) -> str:
+def datetime_to_grass_datetime_string(dt: datetime | None) -> str:
     """Convert a python datetime object into a GRASS datetime string
 
     .. code-block:: python


### PR DESCRIPTION
`grass.temporal.datetime_math.datetime_to_grass_datetime_string()` checks for `None`, and handles the case where it is `None`, so the `dt` argument can safely be `None`.

This fixes some pylance type checking errors in `_pretifyTimeLabels()`  of gui/wxpython/animation/temporal_manager.py, which rightfully detected that the result of `tgis.string_to_datetime(start)` can be either `datetime` or `None` and that `None` wouldn't be accepted into `datetime_to_grass_datetime_string()`.