### PR TITLE
temporal: Use ScriptError from grass.exceptions in grass.temporal.gui_support

### DIFF
--- a/python/grass/temporal/gui_support.py
+++ b/python/grass/temporal/gui_support.py
@@ -11,6 +11,7 @@ for details.
 """
 
 import grass.script as gs
+from grass.exceptions import ScriptError
 
 from .core import get_available_temporal_mapsets, init_dbif
 from .factory import dataset_factory
@@ -45,7 +46,7 @@ def tlist_grouped(type, group_type: bool = False, dbif=None):
     for type_ in types:
         try:
             tlist_result = tlist(type=type_, dbif=dbif)
-        except gs.ScriptError as e:
+        except ScriptError as e:
             gs.warning(e)
             continue
 


### PR DESCRIPTION
Relates to #4838.

In all of our python library code (mostly under grass.script), `ScriptError` is used from an import of `grass.exceptions`, instead of relying on that it might be imported through grass.script.

This PR uses an explicit import of grass.exceptions.

See all usages of `ScriptError` in the following screenshot (collapsed the results in gui/ subfolder)
![image](https://github.com/user-attachments/assets/d3e9d268-3484-4872-ba9a-0afff56d6ea8)
