### PR TITLE
temporal: Rename duplicate test name in unittests_temporal_raster_algebra.py

### DIFF
--- a/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
+++ b/python/grass/temporal/testsuite/unittests_temporal_raster_algebra.py
@@ -677,8 +677,8 @@ class TestTemporalRasterAlgebra(TestCase):
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
 
-    def test_temporal_select(self) -> None:
-        """Testing the temporal select operator."""
+    def test_temporal_select_same_left_right(self) -> None:
+        """Testing the temporal select operator with the same map for left and right."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
         tra.parse(expression="R = A : A", basename="r", overwrite=True)
 


### PR DESCRIPTION
Fixes the following Pylance error: Method declaration "test_temporal_select" is obscured by a declaration of the same name

Two tests one right after the other had the same name.

The difference between the two tests with the same name are:

```diff
     def test_temporal_select(self) -> None:
         """Testing the temporal select operator."""
         tra = tgis.TemporalRasterAlgebraParser(run=True, debug=True)
-        tra.parse(expression="R = A : A", basename="r", overwrite=True)
+        tra.parse(expression="R = A : D", basename="r", overwrite=True)
 
         D = tgis.open_old_stds("R", type="strds")
         D.select()
-        self.assertEqual(D.metadata.get_number_of_maps(), 4)
-        self.assertEqual(D.metadata.get_min_min(), 1)
+        self.assertEqual(D.metadata.get_number_of_maps(), 2)
+        self.assertEqual(D.metadata.get_min_min(), 3)
         self.assertEqual(D.metadata.get_max_max(), 4)
         start, end = D.get_absolute_time()
-        self.assertEqual(start, datetime.datetime(2001, 1, 1))
+        self.assertEqual(start, datetime.datetime(2001, 1, 3))
         self.assertEqual(end, datetime.datetime(2001, 1, 5))
         self.assertEqual(D.check_temporal_topology(), True)
         self.assertEqual(D.get_granularity(), "1 day")
```

I assumed that the first test, the one with "R = A : A" tests for selecting all maps when the left and right references are the same, while the one with "R = A : D" is a normal usage of the select operator.
Let me know if I misinterpreted the intention of the first test, or if you have a really better name suggestion.