### PR TITLE
r.out.vtk: replace dead WMS server with NASA GIBS WMS in docs (#4844)

### DIFF
--- a/python/grass/jupyter/map.py
+++ b/python/grass/jupyter/map.py
@@ -188,9 +188,18 @@ class Map:
     def show(self):
         """Displays a PNG image of map"""
         # Lazy import to avoid an import-time dependency on IPython.
+<<<<<<< Updated upstream
         from IPython.display import Image  # pylint: disable=import-outside-toplevel
 
         return Image(self._filename)
+=======
+        from IPython.display import (
+            
+            Image,
+            display,  # pylint: disable=import-outside-toplevel
+        )
+        display(Image(self._filename))
+>>>>>>> Stashed changes
 
     def save(self, filename):
         """Saves a PNG image of map to the specified *filename*"""

--- a/python/grass/jupyter/map.py
+++ b/python/grass/jupyter/map.py
@@ -188,21 +188,10 @@ class Map:
     def show(self):
         """Displays a PNG image of map"""
         # Lazy import to avoid an import-time dependency on IPython.
-        from IPython.display import Image ,display # pylint: disable=import-outside-toplevel
+        from IPython.display import Image  # pylint: disable=import-outside-toplevel
 
         return Image(self._filename)
 
     def save(self, filename):
         """Saves a PNG image of map to the specified *filename*"""
         shutil.copy(self._filename, filename)
-    
-    def _repr_pretty_(self, p, cycle):
-        """Pretty representation of the object in IPython/Jupyter."""
-        # Lazy import to avoid an import-time dependency on IPython.
-        from IPython.display import Image, display  # pylint: disable=import-outside-toplevel
-
-        if cycle:
-            # Handles recursive display
-            p.text("Map(...)")
-        else:
-            display(Image(self._filename))

--- a/python/grass/jupyter/map3d.py
+++ b/python/grass/jupyter/map3d.py
@@ -229,6 +229,15 @@ class Map3D:
     def show(self):
         """Displays a PNG image of map"""
         # Lazy import to avoid an import-time dependency on IPython.
+<<<<<<< Updated upstream
         from IPython.display import Image  # pylint: disable=import-outside-toplevel
 
         return Image(self._filename)
+=======
+        from IPython.display import (
+            
+            Image,
+            display,
+        )  # pylint: disable=import-outside-toplevel
+        display(Image(self._filename))
+>>>>>>> Stashed changes

--- a/python/grass/jupyter/map3d.py
+++ b/python/grass/jupyter/map3d.py
@@ -229,16 +229,6 @@ class Map3D:
     def show(self):
         """Displays a PNG image of map"""
         # Lazy import to avoid an import-time dependency on IPython.
-        from IPython.display import Image, display  # pylint: disable=import-outside-toplevel
+        from IPython.display import Image  # pylint: disable=import-outside-toplevel
 
         return Image(self._filename)
-    def _repr_pretty_(self, p, cycle):
-        """Pretty representation of the object in IPython/Jupyter."""
-        # Lazy import to avoid an import-time dependency on IPython.
-        from IPython.display import Image, display  # pylint: disable=import-outside-toplevel
-
-        if cycle:
-            p.text("Map(...)")
-        else:
-            display(Image(self._filename))
-

--- a/raster/r.out.vtk/r.out.vtk.html
+++ b/raster/r.out.vtk/r.out.vtk.html
@@ -97,7 +97,7 @@ paraview --data=/tmp/out.vtk
 g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p
 
 # using r.in.wms to create RGB data to get a satellite coverage
-r.in.wms layers=BlueMarbleNG mapserver=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi?	
+r.in.wms layers=BlueMarbleNG url=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi? \	
          output=wms_BlueMarbleNG
 
 # export the data to VTK

--- a/raster/r.out.vtk/r.out.vtk.html
+++ b/raster/r.out.vtk/r.out.vtk.html
@@ -97,11 +97,11 @@ paraview --data=/tmp/out.vtk
 g.region n=4926990 s=4914840 w=591570 e=607800 res=30 -p
 
 # using r.in.wms to create RGB data to get a satellite coverage
-r.in.wms layers=global_mosaic mapserver=http://wms.jpl.nasa.gov/wms.cgi \
-         output=wms_global_mosaic
+r.in.wms layers=BlueMarbleNG mapserver=https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi?	
+         output=wms_BlueMarbleNG
 
 # export the data to VTK
-r.out.vtk rgbmaps=wms_global_mosaic.red,wms_global_mosaic.green,wms_global_mosaic.blue \
+r.out.vtk rgbmaps=wms_BlueMarbleNG.red,wms_BlueMarbleNG.green,wms_BlueMarbleNG.blue \
           elevation=elevation.10m output=/tmp/out.vtk
 
 # visualize in Paraview or other VTK viewer:


### PR DESCRIPTION
This pull request updates the example in the ` r.out.vtk` documentation. The previous WMS server (http://wms.jpl.nasa.gov/wms.cgi) is no longer available, causing the example to fail.

**Changes made:**

Replaced the dead WMS server with NASA GIBS WMS (https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi).
Used the `BlueMarbleNG` layer for global imagery, which closely matches the original intent of the example.