### PR TITLE
i18n: fix translation sentence in po/grassmods_es.po

### DIFF
--- a/locale/po/grassmods_es.po
+++ b/locale/po/grassmods_es.po
@@ -57136,7 +57136,7 @@ msgstr "categoría del elemento más cercano"
 
 #: ../vector/v.distance/main.c:202
 msgid "minimum distance to nearest feature"
-msgstr "distancia máxima al punto más cercano"
+msgstr "distancia mínima al punto más cercano"
 
 #: ../vector/v.distance/main.c:203
 msgid "x coordinate of the nearest point on the 'to' feature"


### PR DESCRIPTION
Fix wrong message translation in `v.distance`:

"distancia máxima --> distancia mínima"

Fixes #4855