### PR TITLE
r.statistics: Fix Resource Leak issue in o_adev.c

### DIFF
--- a/raster/r.statistics/o_adev.c
+++ b/raster/r.statistics/o_adev.c
@@ -71,6 +71,7 @@ int o_adev(const char *basemap, const char *covermap, const char *outputmap,
 
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
+    G_free(tab);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID: 1207914)
Used G_free() to fix this issue.