### PR TITLE
ps.map: Fix Resource Leak issue in ps_vpoints.c

### DIFF
--- a/ps/ps.map/ps_vpoints.c
+++ b/ps/ps.map/ps_vpoints.c
@@ -269,5 +269,7 @@ int PS_vpoints_plot(struct Map_info *P_map, int vec)
 
     fprintf(PS.fp, "\n");
     Vect_destroy_cats_struct(Cats);
+    Vect_destroy_line_struct(Points);
+    G_free(Symb);
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207905, 1207907)
Used Vect_destroy_line_struct(), G_free() to fix this issue.