### PR TITLE
gui: Fix possibly unbound variables in psmap.utils.BBoxAfterRotation

### DIFF
--- a/gui/wxpython/psmap/utils.py
+++ b/gui/wxpython/psmap/utils.py
@@ -16,8 +16,14 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com>
 """
 
+from __future__ import annotations
+
+from math import ceil, cos, floor, fmod, radians, sin
+
 import wx
-from math import ceil, floor, sin, cos, pi
+from core.gcmd import GError, RunCommand
+
+import grass.script as gs
 
 try:
     from PIL import Image as PILImage  # noqa
@@ -25,9 +31,6 @@ try:
     havePILImage = True
 except ImportError:
     havePILImage = False
-
-import grass.script as gs
-from core.gcmd import RunCommand, GError
 
 
 class Rect2D(wx.Rect2D):
@@ -396,23 +399,27 @@ def getRasterType(map):
     return None
 
 
-def BBoxAfterRotation(w, h, angle):
-    """Compute bounding box or rotated rectangle
+def BBoxAfterRotation(w: float, h: float, angle: float) -> tuple[int, int]:
+    """Compute the bounding box of a rotated rectangle
 
     :param w: rectangle width
     :param h: rectangle height
     :param angle: angle (0, 360) in degrees
     """
-    angleRad = angle / 180.0 * pi
-    ct = cos(angleRad)
-    st = sin(angleRad)
 
-    hct = h * ct
-    wct = w * ct
-    hst = h * st
-    wst = w * st
+    angle = fmod(angle, 360)
+    angleRad: float = radians(angle)
+    ct: float = cos(angleRad)
+    st: float = sin(angleRad)
+
+    hct: float = h * ct
+    wct: float = w * ct
+    hst: float = h * st
+    wst: float = w * st
     y = x = 0
 
+    if angle == 0:
+        return (ceil(w), ceil(h))
     if 0 < angle <= 90:
         y_min = y
         y_max = y + hct + wst
@@ -433,7 +440,10 @@ def BBoxAfterRotation(w, h, angle):
         y_max = y + hct
         x_min = x
         x_max = x + wct - hst
+    else:
+        msg = "The angle argument should be between 0 and 360 degrees"
+        raise ValueError(msg)
 
-    width = ceil(abs(x_max) + abs(x_min))
-    height = ceil(abs(y_max) + abs(y_min))
-    return width, height
+    width: int = ceil(abs(x_max) + abs(x_min))
+    height: int = ceil(abs(y_max) + abs(y_min))
+    return (width, height)


### PR DESCRIPTION
Current code didn't handle the case where angle is 0, nor if out of range. For example, calling with an angle of 375.7 will try to compute the width and height on variables not set yet.

Adding fmod (https://docs.python.org/3/library/math.html#math.fmod, better suited for floats than the modulo operator), will help the case of 360 degrees, that will become 0 degrees, and return the width and height directly. Technically the angle could be bigger than 360 and still handled correctly, but, contrary to the modulo operator, the mathematical definition used by fmod means that a negative angle will (could) return a negative angle, that isn't handled in the previous code, nor this small improvement. Something close to https://numpy.org/doc/stable/reference/generated/numpy.unwrap.html could help too, but the logic still doesn't handle -180 to 180 degrees.

That said, that's the justification on keeping the range in the docstring to 0-360.

Changed the conversions to radians with the python math.radians (https://docs.python.org/3/library/math.html#math.radians), as it is implemented in C, and we are not manually doing python multiplication and division by constants.

For typing annotations, specifying `int | float` triggers a simplification by ruff to only `float`, as it is redundant https://docs.astral.sh/ruff/rules/redundant-numeric-union/
I explored the annotations used by math.radians, sin, and cos, the SupportsFloat and SupportsIndex, numbers.Number, numbers.Real, numbers.Rational, but full typing coverage wasn't possible (multiplication wasn't supported). So simple floats was best.

I explored with numpy functions too to see if the results for a simple rotation to be the different, as some simple calls where I would expect the width and height to not change changed by 1 unit, because of floating points and the ceiling operation. Numpy functions didn't change anything (as I would expect for machine floating points). Example: `BBoxAfterRotation(10,30,360)` gives (11,31), because 0 and -10.000000000000005, applying abs and ceil gives 11, and the other dimension would be something close to 0, but at 10^-15, and 30.

```python
In [1]: from __future__ import annotations
   ...: 
   ...: from math import ceil, cos, floor, fmod, radians, sin

   ...:         y_min = y
   ...:         y_max = y + hct + wst
   ...:         x_min = x - hst
   ...:         x_max = x + wct
   ...:     elif 90 < angle <= 180:
   ...:         y_min = y + hct
   ...:         y_max = y + wst
   ...:         x_min = x - hst + wct
   ...:         x_max = x
   ...:     elif 180 < angle <= 270:
   ...:         y_min = y + wst + hct
   ...:         y_max = y
   ...:         x_min = x + wct
   ...:         x_max = x - hst
   ...:     elif 270 < angle <= 360:
   ...:         y_min = y + wst
   ...:         y_max = y + hct
   ...:         x_min = x
   ...:         x_max = x + wct - hst
   ...:     else:
   ...:         msg = "The angle argument should be between 0 and 360 degrees"
   ...:         raise ValueError(msg)
   ...: 
   ...:     width: int = ceil(abs(x_max) + abs(x_min))
   ...:     height: int = ceil(abs(y_max) + abs(y_min))
   ...:     return (width, height)
   ...: 

In [3]: BBoxAfterRotation(11,31,180+90)
Out[3]: (32, 12)

In [4]: BBoxAfterRotation(10,30,180+90)
Out[4]: (31, 11)

In [8]: BBoxAfterRotation(10,30,180+90)
> <ipython-input-6-b098ef8fb00b>(46)BBoxAfterRotation()
-> width: int = ceil(abs(x_max) + abs(x_min))
(Pdb) s
> <ipython-input-6-b098ef8fb00b>(47)BBoxAfterRotation()
-> height: int = ceil(abs(y_max) + abs(y_min))
(Pdb) s
> <ipython-input-6-b098ef8fb00b>(48)BBoxAfterRotation()
-> return (width, height)
(Pdb) p x_min, x_max
(-1.8369701987210296e-15, 30.0)
(Pdb) p y_min, y_max
(-10.000000000000005, 0)
(Pdb) 
```
![image](https://github.com/user-attachments/assets/34282c6d-ef75-4297-acce-2f6935fbd522)

This motivated the short-circuiting for 0 angle.
