### PR TITLE
gui: Fix using formatting for a string that does not have any interpolated variables in core.menutree

### DIFF
--- a/gui/wxpython/core/menutree.py
+++ b/gui/wxpython/core/menutree.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
     else:
         import grass.script.core as gscore
 
-        gscore.fatal("Unknown value for parameter menu: " % menu)
+        gscore.fatal("Unknown value for parameter menu: %s" % menu)
 
     if action == "strings":
         menudata.PrintStrings(sys.stdout)
@@ -269,6 +269,6 @@ if __name__ == "__main__":
     else:
         import grass.script.core as gscore
 
-        gscore.fatal("Unknown value for parameter action: " % action)
+        gscore.fatal("Unknown value for parameter action: %s" % action)
 
     sys.exit(0)


### PR DESCRIPTION
Fixes format-string-without-interpolation / W1310.

Pylint rule: https://pylint.pycqa.org/en/latest/user_guide/messages/warning/format-string-without-interpolation.html

No other violation was found with pylint 3.3.2 (that I'm setting up)
