### PR TITLE
gui: Handle GRASS_INFO_END in line in gui/wxpython/core/gcmd.py

### DIFF
--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -25,17 +25,20 @@ This program is free software under the GNU General Public License
 @author Martin Landa <landa.martin gmail.com>
 """
 
+from __future__ import annotations
+
+import errno
+import locale
 import os
+import signal
+import subprocess
 import sys
 import time
-import errno
-import signal
 import traceback
-import locale
-import subprocess
 from threading import Thread
-import wx
+from typing import TYPE_CHECKING, LiteralString, TextIO
 
+import wx
 from core.debug import Debug
 from core.globalvar import SCT_EXT
 
@@ -44,12 +47,24 @@ from grass.script.utils import decode, encode
 
 is_mswindows = sys.platform == "win32"
 if is_mswindows:
+    import msvcrt
+
     from win32file import ReadFile, WriteFile
     from win32pipe import PeekNamedPipe
-    import msvcrt
 else:
-    import select
     import fcntl
+    import select
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from io import TextIOWrapper
+
+    StrOrBytesPath = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+
+    if sys.platform == "win32":
+        _ENV = Mapping[str, str]
+    else:
+        _ENV = Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath]
 
 
 def DecodeString(string):
@@ -298,7 +313,7 @@ class Popen(subprocess.Popen):
 message = "Other end disconnected!"
 
 
-def recv_some(p, t=0.1, e=1, tr=5, stderr=0):
+def recv_some(p, t=0.1, e=1, tr=5, stderr=0) -> LiteralString:
     tr = max(tr, 1)
     x = time.time() + t
     y = []
@@ -342,7 +357,7 @@ class Command:
         stdin=None,
         verbose=None,
         wait=True,
-        rerr=False,
+        rerr: bool | None = False,
         stdout=None,
         stderr=None,
     ):
@@ -510,7 +525,14 @@ class CommandThread(Thread):
     """Create separate thread for command. Used for commands launched
     on the background."""
 
-    def __init__(self, cmd, env=None, stdin=None, stdout=sys.stdout, stderr=sys.stderr):
+    def __init__(
+        self,
+        cmd,
+        env=None,
+        stdin: TextIOWrapper | None = None,
+        stdout: TextIO = sys.stdout,
+        stderr: TextIO = sys.stderr,
+    ) -> None:
         """
         :param cmd: command (given as list)
         :param env: environmental variables
@@ -522,11 +544,11 @@ class CommandThread(Thread):
 
         self.cmd = cmd
         self.stdin = stdin
-        self.stdout = stdout
-        self.stderr = stderr
+        self.stdout: TextIO = stdout
+        self.stderr: TextIO = stderr
         self.env = env
 
-        self.module = None
+        self.module: Popen | None = None
         self.error = ""
 
         self._want_abort = False
@@ -584,7 +606,7 @@ class CommandThread(Thread):
             print(e, file=sys.stderr)
             return 1
 
-        if self.stdin:  # read stdin if requested ...
+        if self.stdin and self.module.stdin is not None:  # read stdin if requested...
             self.module.stdin.write(self.stdin)
             self.module.stdin.close()
 
@@ -593,14 +615,14 @@ class CommandThread(Thread):
 
     def _redirect_stream(self):
         """Redirect stream"""
-        if self.stdout:
+        if self.stdout and self.module is not None and self.module.stdout is not None:
             # make module stdout/stderr non-blocking
             out_fileno = self.module.stdout.fileno()
             if not is_mswindows:
                 flags = fcntl.fcntl(out_fileno, fcntl.F_GETFL)
                 fcntl.fcntl(out_fileno, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
-        if self.stderr:
+        if self.stderr and self.module is not None and self.module.stderr is not None:
             # make module stdout/stderr non-blocking
             out_fileno = self.module.stderr.fileno()
             if not is_mswindows:
@@ -608,19 +630,20 @@ class CommandThread(Thread):
                 fcntl.fcntl(out_fileno, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
         # wait for the process to end, sucking in stuff until it does end
-        while self.module.poll() is None:
-            if self._want_abort:  # abort running process
-                self.module.terminate()
-                self.aborted = True
-                return
-            if self.stdout:
-                line = recv_some(self.module, e=0, stderr=0)
-                self.stdout.write(line)
-            if self.stderr:
-                line = recv_some(self.module, e=0, stderr=1)
-                self.stderr.write(line)
-                if len(line) > 0:
-                    self.error = line
+        if self.module is not None:
+            while self.module.poll() is None:
+                if self._want_abort:  # abort running process
+                    self.module.terminate()
+                    self.aborted = True
+                    return
+                if self.stdout:
+                    line = recv_some(self.module, e=0, stderr=0)
+                    self.stdout.write(line)
+                if self.stderr:
+                    line = recv_some(self.module, e=0, stderr=1)
+                    self.stderr.write(line)
+                    if len(line) > 0:
+                        self.error = line
 
         # get the last output
         if self.stdout:
@@ -632,12 +655,12 @@ class CommandThread(Thread):
             if len(line) > 0:
                 self.error = line
 
-    def abort(self):
+    def abort(self) -> None:
         """Abort running process, used by main thread to signal an abort"""
         self._want_abort = True
 
 
-def _formatMsg(text):
+def _formatMsg(text: str) -> str:
     """Format error messages for dialogs"""
     message = ""
     for line in text.splitlines():
@@ -660,14 +683,14 @@ def _formatMsg(text):
 def RunCommand(
     prog,
     flags="",
-    overwrite=False,
-    quiet=False,
-    verbose=False,
+    overwrite: bool = False,
+    quiet: bool = False,
+    verbose: bool = False,
     parent=None,
-    read=False,
+    read: bool = False,
     parse=None,
-    stdin=None,
-    getErrorMsg=False,
+    stdin: TextIO | None = None,
+    getErrorMsg: bool = False,
     env=None,
     **kwargs,
 ):
@@ -717,7 +740,7 @@ def RunCommand(
 
     ps = grass.start_command(prog, flags, overwrite, quiet, verbose, env=env, **kwargs)
 
-    if stdin:
+    if stdin and ps.stdin:
         ps.stdin.write(encode(stdin))
         ps.stdin.close()
         ps.stdin = None
@@ -764,7 +787,7 @@ def RunCommand(
     return stdout, _formatMsg(stderr)
 
 
-def GetDefaultEncoding(forceUTF8=False):
+def GetDefaultEncoding(forceUTF8: bool = False) -> str:
     """Get default system encoding
 
     :param bool forceUTF8: force 'UTF-8' if encoding is not defined
@@ -786,4 +809,4 @@ def GetDefaultEncoding(forceUTF8=False):
     return enc
 
 
-_enc = GetDefaultEncoding()  # define as global variable
+_enc: str = GetDefaultEncoding()  # define as global variable

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -36,7 +36,7 @@ import sys
 import time
 import traceback
 from threading import Thread
-from typing import TYPE_CHECKING, LiteralString, TextIO
+from typing import TYPE_CHECKING, TextIO
 
 import wx
 from core.debug import Debug
@@ -313,7 +313,7 @@ class Popen(subprocess.Popen):
 message = "Other end disconnected!"
 
 
-def recv_some(p, t=0.1, e=1, tr=5, stderr=0) -> LiteralString:
+def recv_some(p, t=0.1, e=1, tr=5, stderr=0) -> str:  # TODO: use LiteralString on 3.11+
     tr = max(tr, 1)
     x = time.time() + t
     y = []

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -482,7 +482,7 @@ class Command:
                     type = "WARNING"
                 elif "GRASS_INFO_ERROR" in line:  # error
                     type = "ERROR"
-                elif "GRASS_INFO_END":  # end of message
+                elif "GRASS_INFO_END" in line:  # end of message
                     msg.append((type, content))
                     type = None
                     content = ""

--- a/gui/wxpython/core/gcmd.py
+++ b/gui/wxpython/core/gcmd.py
@@ -56,15 +56,7 @@ else:
     import select
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from io import TextIOWrapper
-
-    StrOrBytesPath = str | bytes | os.PathLike[str] | os.PathLike[bytes]
-
-    if sys.platform == "win32":
-        _ENV = Mapping[str, str]
-    else:
-        _ENV = Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath]
 
 
 def DecodeString(string):


### PR DESCRIPTION
The condition using `GRASS_INFO_END` here is always true, and is in an else if without a condition to check. A string, that is non-empty, would always be true (see https://www.geeksforgeeks.org/g-fact-43-logical-operators-on-string-in-python/ for a reminder).

I tried to infer the intention here. Since the first commits (welcome to grass 7 SVN), it was like that. Based on the very few other usages of `GRASS_INFO_END` shown below, I think being always true is wrong. 

https://github.com/OSGeo/grass/blob/5cbcbc687d7880a7d4a99b1c0880a7b6bfee60b6/gui/wxpython/core/gconsole.py#L306-L351
https://github.com/OSGeo/grass/blob/5cbcbc687d7880a7d4a99b1c0880a7b6bfee60b6/gui/wxpython/core/gcmd.py#L640-L657

I understood that it would be line a token that should be after the message, as for the two places of C library code that it is used, and that the lines of message wouldn't be added to the "content" variable once entered in the always-truthy elif as the `type` variable would be set to `None`, and the `if type:` condition below wouldn't get entered. I imagine multi-line messages to not be handled currently.
https://github.com/OSGeo/grass/blob/5cbcbc687d7880a7d4a99b1c0880a7b6bfee60b6/lib/gis/error.c#L487-L528
https://github.com/OSGeo/grass/blob/5cbcbc687d7880a7d4a99b1c0880a7b6bfee60b6/lib/gis/parser.c#L1676-L1770
https://github.com/OSGeo/grass/blob/5cbcbc687d7880a7d4a99b1c0880a7b6bfee60b6/lib/gis/percent.c#L25-L184

As for my suggestion, I'm not too sure of the effects. I didn't understand enough what to do if there was a line with some text containing "GRASS_", and it wasn't `GRASS_INFO_WARNING`, `GRASS_INFO_ERROR`, or `GRASS_INFO_END`. For `GRASS_INFO_` only as an example, there's also `GRASS_INFO_PERCENT`, `GRASS_INFO_PROGRESS` and `GRASS_INFO_MESSAGE` that exist, that aren't handled here, but would only add the line's content (after the first `:`) if a  `GRASS_INFO_WARNING` or `GRASS_INFO_ERROR` would have appeared beforehand (and no `GRASS_INFO_END` after that occurrence), so the `type` variable of line 490 would not be `None`. I see a potential problem if a message contains an explanation containing `GRASS_`, like an env var, and thus would enter the `if "GRASS_" in line: ` but does not have an else.

