### PR TITLE
gui: Add types for lmgr constructor argument of GLWindow (3D) and MapPanel (2D)

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -24,9 +24,8 @@ This program is free software under the GNU General Public License
 
 from __future__ import annotations
 
-
-import os
 import copy
+import os
 from typing import TYPE_CHECKING
 
 from core import globalvar
@@ -44,16 +43,16 @@ from gui_core.mapdisp import SingleMapPanel, FrameMixin
 from gui_core.query import QueryDialog, PrepareQueryResults
 from mapwin.buffered import BufferedMapWindow
 from mapwin.decorations import (
-    LegendController,
-    BarscaleController,
     ArrowController,
+    BarscaleController,
     DtextController,
+    LegendController,
     LegendVectController,
 )
 from mapwin.analysis import (
-    ProfileController,
-    MeasureDistanceController,
     MeasureAreaController,
+    MeasureDistanceController,
+    ProfileController,
 )
 from gui_core.forms import GUI
 from core.giface import Notification
@@ -63,12 +62,11 @@ from mapdisp import statusbar as sb
 from main_window.page import MainPageBase
 
 import grass.script as gs
-
 from grass.pydispatch.signal import Signal
 
 if TYPE_CHECKING:
-    import main_window.frame
     import lmgr.frame
+    import main_window.frame
 
 
 class MapPanel(SingleMapPanel, MainPageBase):
@@ -304,7 +302,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
 
     def _addToolbarVDigit(self):
         """Add vector digitizer toolbar"""
-        from vdigit.main import haveVDigit, VDigit
+        from vdigit.main import VDigit, haveVDigit
         from vdigit.toolbars import VDigitToolbar
 
         if not haveVDigit:
@@ -409,7 +407,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
 
     def AddNviz(self):
         """Add 3D view mode window"""
-        from nviz.main import haveNviz, GLWindow, errorMsg
+        from nviz.main import GLWindow, errorMsg, haveNviz
 
         # check for GLCanvas and OpenGL
         if not haveNviz:
@@ -1611,7 +1609,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
     def AddRDigit(self):
         """Adds raster digitizer: creates toolbar and digitizer controller,
         binds events and signals."""
-        from rdigit.controller import RDigitController, EVT_UPDATE_PROGRESS
+        from rdigit.controller import EVT_UPDATE_PROGRESS, RDigitController
         from rdigit.toolbars import RDigitToolbar
 
         self.rdigit = RDigitController(self._giface, mapWindow=self.GetMapWindow())

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -67,7 +67,8 @@ import grass.script as gs
 from grass.pydispatch.signal import Signal
 
 if TYPE_CHECKING:
-    from main_window.frame import GMFrame
+    import main_window.frame
+    import lmgr.frame
 
 
 class MapPanel(SingleMapPanel, MainPageBase):
@@ -83,7 +84,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
         toolbars=["map"],
         statusbar=True,
         tree=None,
-        lmgr: GMFrame | None = None,
+        lmgr: main_window.frame.GMFrame | lmgr.frame.GMFrame | None = None,
         Map=None,
         auimgr=None,
         dockable=False,

--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -22,8 +22,12 @@ This program is free software under the GNU General Public License
 @author Stepan Turek <stepan.turek seznam.cz> (handlers support)
 """
 
+from __future__ import annotations
+
+
 import os
 import copy
+from typing import TYPE_CHECKING
 
 from core import globalvar
 import wx
@@ -62,6 +66,9 @@ import grass.script as gs
 
 from grass.pydispatch.signal import Signal
 
+if TYPE_CHECKING:
+    from main_window.frame import GMFrame
+
 
 class MapPanel(SingleMapPanel, MainPageBase):
     """Main panel for map display window. Drawing takes place in
@@ -76,7 +83,7 @@ class MapPanel(SingleMapPanel, MainPageBase):
         toolbars=["map"],
         statusbar=True,
         tree=None,
-        lmgr=None,
+        lmgr: GMFrame | None = None,
         Map=None,
         auimgr=None,
         dockable=False,

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -20,19 +20,18 @@ This program is free software under the GNU General Public License
 
 from __future__ import annotations
 
+import copy
+import math
 import os
 import sys
 import time
-import copy
-import math
-
 from threading import Thread
 from typing import TYPE_CHECKING
 
 import wx
 from wx.lib.newevent import NewEvent
 from wx import glcanvas
-from wx.glcanvas import WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE
+from wx.glcanvas import WX_GL_DEPTH_SIZE, WX_GL_DOUBLEBUFFER, WX_GL_RGBA
 
 import grass.script as gs
 from grass.pydispatch.signal import Signal
@@ -49,8 +48,8 @@ from core.utils import str2rgb
 from core.giface import Notification
 
 if TYPE_CHECKING:
-    import main_window.frame
     import lmgr.frame
+    import main_window.frame
 
 wxUpdateProperties, EVT_UPDATE_PROP = NewEvent()
 wxUpdateView, EVT_UPDATE_VIEW = NewEvent()

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -18,6 +18,8 @@ This program is free software under the GNU General Public License
 @author Anna Kratochvilova <kratochanna gmail.com> (Google SoC 2011)
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import time
@@ -25,6 +27,7 @@ import copy
 import math
 
 from threading import Thread
+from typing import TYPE_CHECKING
 
 import wx
 from wx.lib.newevent import NewEvent
@@ -44,6 +47,9 @@ from nviz import wxnviz
 from core.globalvar import CheckWxVersion
 from core.utils import str2rgb
 from core.giface import Notification
+
+if TYPE_CHECKING:
+    from main_window.frame import GMFrame
 
 wxUpdateProperties, EVT_UPDATE_PROP = NewEvent()
 wxUpdateView, EVT_UPDATE_VIEW = NewEvent()
@@ -74,7 +80,9 @@ class NvizThread(Thread):
 class GLWindow(MapWindowBase, glcanvas.GLCanvas):
     """OpenGL canvas for Map Display Window"""
 
-    def __init__(self, parent, giface, frame, Map, tree, lmgr, id=wx.ID_ANY):
+    def __init__(
+        self, parent, giface, frame, Map, tree, lmgr: GMFrame, id=wx.ID_ANY
+    ) -> None:
         """All parameters except for id are mandatory. The todo is to remove
         them completely."""
         self.parent = parent

--- a/gui/wxpython/nviz/mapwindow.py
+++ b/gui/wxpython/nviz/mapwindow.py
@@ -49,7 +49,8 @@ from core.utils import str2rgb
 from core.giface import Notification
 
 if TYPE_CHECKING:
-    from main_window.frame import GMFrame
+    import main_window.frame
+    import lmgr.frame
 
 wxUpdateProperties, EVT_UPDATE_PROP = NewEvent()
 wxUpdateView, EVT_UPDATE_VIEW = NewEvent()
@@ -81,7 +82,14 @@ class GLWindow(MapWindowBase, glcanvas.GLCanvas):
     """OpenGL canvas for Map Display Window"""
 
     def __init__(
-        self, parent, giface, frame, Map, tree, lmgr: GMFrame, id=wx.ID_ANY
+        self,
+        parent,
+        giface,
+        frame,
+        Map,
+        tree,
+        lmgr: main_window.frame.GMFrame | lmgr.frame.GMFrame,
+        id=wx.ID_ANY,
     ) -> None:
         """All parameters except for id are mandatory. The todo is to remove
         them completely."""


### PR DESCRIPTION
In preparation for my next PR, this only adds some typing to the lmgr argument, as it was really hard to figure out where it came from and what is allowed to be called with it. I ended up needing to do some runtime inspection. There are two types that I found that this lmgr could be: GMFrame from lmgr.frame (multiple windows), or GMFrame from main_window.frame (single window).

Adding these types here help to resolve **ALOT** of typing checks, since otherwise nothing is known (even by a human reading). I consider this a sort of documentation improvement.



- [gui: Add typing for layer manager lmgr argument](https://github.com/OSGeo/grass/commit/d619a7a9463f180c4c1ae57ce08f254154032019) 
  The runtime type is main_window.frame.GMFrame, for both mapdisp.frame.MapPanel and nviz.mapwindow.GLWindow
- [gui: Add typing for layer manager lmgr argument when using single window](https://github.com/OSGeo/grass/commit/c32a1473c52d5a4a28239b0262a20cf8bf3af7dc) 
  The runtime type can also be lmgr.frame.GMFrame, for both mapdisp.frame.MapPanel and nviz.mapwindow.GLWindow when using single window mode