### PR TITLE
utils: Allow scopes for gui PR titles

### DIFF
--- a/utils/release.yml
+++ b/utils/release.yml
@@ -6,7 +6,7 @@ notes:
       example: 'r.slope.aspect:'
 
     - title: Graphical User Interface
-      regexp: '(wxGUI.*|gui|GUI): '
+      regexp: '(wxGUI.*|gui|GUI)(\(\w[\w.-]*\))?: '
       example: 'wxGUI:'
 
     - title: Python

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -14,7 +14,7 @@ notes:
       example: 'grass.script:'
 
     - title: Documentation and Messages
-      regexp: '(docs?|man|manual|manual pages|[Ss]phinx|mkhtml|messages?): '
+      regexp: '(docs?|man|manual|manual pages|[Ss]phinx|mkhtml|MkDocs|mkdocs|messages?): '
       example: 'doc:'
 
     - title: Libraries and General Functionality


### PR DESCRIPTION
There isn't a lot a flexibility in the allowed titles for GUI PRs. the prefix wxGUI is not adapted for everything, so allow convential-commits -styled scopes on gui PRs, like other of our categories.

Edit: I also expect us to have PRs for MkDocs specifically soon, so added them as recognized in the docs category