### PR TITLE
manual: db.in.ogr add column type detection for CSV

### DIFF
--- a/general/g.tempfile/g.tempfile.html
+++ b/general/g.tempfile/g.tempfile.html
@@ -42,7 +42,7 @@ Although GRASS does eventually get around to removing
 tempfiles that have been left behind, the programmer should
 make every effort to remove these files. They often get
 large and take up disk space. If you write <code>/bin/sh</code> scripts,
-learn to use the <code>/bin/sh<code> related <code>trap</code> command. If you
+learn to use the <code>/bin/sh</code> related <code>trap</code> command. If you
 write <code>/bin/csh</code> scripts, learn to use the <code>/bin/csh</code>
 related <code>onintr</code> command.
 

--- a/imagery/i.ortho.photo/i.ortho.transform/i.ortho.transform.html
+++ b/imagery/i.ortho.photo/i.ortho.transform/i.ortho.transform.html
@@ -28,7 +28,7 @@ coordinates are transformed to target coordinates.
 
 <h2>TODO</h2>
 
-Update this document with x,y,z<->E,N,H information
+Update this document with x,y,z&lt;-&gt;E,N,H information
 
 <h2>AUTHORS</h2>
 

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -209,11 +209,13 @@ GRASS supports the following methods:
   <li> Supervised classification (<a href="i.gensigset.html">i.gensigset</a>,
    <a href="i.smap.html">i.smap</a>)</li>
   </ul>
+  </li>
 <li> Object-oriented classification:
   <ul>
   <li> Unsupervised classification (segmentation based:
        <a href="i.segment.html">i.segment</a>)</li>
   </ul>
+  </li>
 </ul>
 
 Kappa statistic can be calculated to validate the results

--- a/imagery/imageryintro.html
+++ b/imagery/imageryintro.html
@@ -48,7 +48,7 @@ influences the signal as recorded at the sensor. This atmospheric
 interaction with the sun energy reflected back into space by
 ground/vegetation/soil needs to be corrected. The need of
 removing atmospheric artifacts stems from the fact that the
-atmosphericic conditions are changing over time. Hence, to gain
+atmospheric conditions are changing over time. Hence, to gain
 comparability between Earth surface images taken at different
 times, atmospheric need to be removed converting at-sensor values
 which are top of atmosphere to surface reflectance values.
@@ -114,7 +114,7 @@ signature files of one imagery or raster group can be used to classify
 a different group with identical semantic labels.
 
 <div align="center" style="margin: 10px">
-<img src="band_references_scheme.png" width="600" height="435" border="0"><br>
+<img src="band_references_scheme.png" alt="GRASS GIS band references scheme" width="600" height="435" border="0"><br>
 <i>
     New enhanced classification workflow involving semantic labels.
 </i>
@@ -204,6 +204,7 @@ GRASS supports the following methods:
     or <a href="g.gui.iclass.html">g.gui.iclass</a>, <a href="i.maxlik.html">i.maxlik</a>)
    using the Maximum Likelihood classification method</li>
   </ul>
+  </li>
 <li> Combined radiometric/geometric (segmentation based) classification:
   <ul>
   <li> Supervised classification (<a href="i.gensigset.html">i.gensigset</a>,

--- a/raster3d/r3.to.rast/r3.to.rast.html
+++ b/raster3d/r3.to.rast/r3.to.rast.html
@@ -69,5 +69,5 @@ the <b>add</b> option should be set to 0.5.
 
 <h2>AUTHORS</h2>
 
-S&ouml;ren Gebbert
+S&ouml;ren Gebbert<br>
 Vaclav Petras, <a href="https://geospatial.ncsu.edu/geoforall/">NCSU GeoForAll Lab</a>

--- a/scripts/db.in.ogr/db.in.ogr.html
+++ b/scripts/db.in.ogr/db.in.ogr.html
@@ -16,7 +16,8 @@ columns through a descriptive file with same name as the CSV file, but .csvt ext
 
 <div class="code"><pre>
 # NOTE: create koeppen_gridcode.csvt first for automated type recognition
-db.in.ogr input=koeppen_gridcode.csv output=koeppen_gridcode
+db.in.ogr input=koeppen_gridcode.csv output=koeppen_gridcode gdal_doo="AUTODETECT_TYPE=YES"
+db.describe koeppen_gridcode -c
 db.select table=koeppen_gridcode
 </pre></div>
 

--- a/scripts/r.mapcalc.simple/r.mapcalc.simple.html
+++ b/scripts/r.mapcalc.simple/r.mapcalc.simple.html
@@ -44,7 +44,7 @@ Differences to <em>r.mapcalc.simple</em> module in GRASS GIS 5 and 6:
     <li>The variable names are case-insensitive to allow the original
         uppercase as well as lowercase as in option names
         (unless the <b>-c</b> flag is used).</li>
-    <li>Option names for each map are just one letter (not amap, etc.).
+    <li>Option names for each map are just one letter (not amap, etc.).</li>
     <li>Output option name is <b>output</b> as for other modules
         (not outfile).</li>
     <li>Raster map names can be optionally quoted (the <b>-q</b> flag).</li>

--- a/vector/v.edit/v.edit.html
+++ b/vector/v.edit/v.edit.html
@@ -139,7 +139,7 @@ Additional parameters for vector feature specification are:
 
     <li><b>chtype</b> - Change feature type of selected geometry
     objects. Points are converted to centroids, centroids to points,
-    lines to boundaries and boundaries to lines.
+    lines to boundaries and boundaries to lines.</li>
 
     <li><b>vertexadd</b> - Add vertex(ces) to the given vector lines
     or boundaries. Location of the new vertex is given by <b>coord</b>


### PR DESCRIPTION
Improve CSV import example with GDAL related column type autodetection (suggested by @cmbarton).

Fixes #4674 (see also related issue #4593).

Additionally:
- minor HTML fixes in some manual pages