### PR TITLE
style: Fix C0123: Use isinstance() rather than type() for a typecheck (unidiomatic-typecheck)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -578,7 +578,6 @@ disable = [
     "C0115",  # Missing class docstring (missing-class-docstring)
     "C0116",  # Missing function or method docstring (missing-function-docstring)
     "C0117",  # Consider changing "not self.optype == 'boolean'" to "self.optype != 'boolean'" (unnecessary-negation)
-    "C0123",  # Use isinstance() rather than type() for a typecheck. (unidiomatic-typecheck)
     "C0200",  # Consider using enumerate instead of iterating with range and len (consider-using-enumerate)
     "C0201",  # Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
     "C0204",  # Metaclass class method %s should have %s as first argument (bad-mcs-classmethod-argument)

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -760,7 +760,7 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
             # TODO: replace by better handling of potential lists when parsing
             # TODO: create link to module if running in grass or in addons
             # alternatively a link to module test summary
-            if type(modules) is not list:
+            if not isinstance(modules, list):
                 modules = [modules]
 
         # here we would have also links to coverage, profiling, ...
@@ -1129,7 +1129,7 @@ class TestsuiteDirReporter:
                 test_file_authors = summary.get("test_file_authors")
                 if not test_file_authors:
                     test_file_authors = []
-                if type(test_file_authors) is not list:
+                if not isinstance(test_file_authors, list):
                     test_file_authors = [test_file_authors]
                 test_files_authors.extend(test_file_authors)
 


### PR DESCRIPTION
Pylint rule: https://pylint.pycqa.org/en/latest/user_guide/messages/convention/unidiomatic-typecheck.html