### PR TITLE
gui: Add type hints to bound WizardEvent handlers

### DIFF
--- a/gui/wxpython/core/globalvar.py
+++ b/gui/wxpython/core/globalvar.py
@@ -242,7 +242,7 @@ toolbarSize = (24, 24)
 
 # Check version of wxPython, use agwStyle for 2.8.11+
 hasAgw = CheckWxVersion([2, 8, 11, 0])
-wxPythonPhoenix = CheckWxPhoenix()
+wxPythonPhoenix: bool = CheckWxPhoenix()
 
 gtk3 = "gtk3" in wx.PlatformInfo
 

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -27,10 +27,13 @@ This program is free software under the GNU General Public License
 @author Support for GraphicsSet added by Stepan Turek <stepan.turek seznam.cz> (2012)
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import shutil
 from copy import copy
+from typing import TYPE_CHECKING
 
 import wx
 from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
@@ -38,7 +41,7 @@ import wx.lib.colourselect as csel
 
 from core import globalvar
 
-if globalvar.wxPythonPhoenix:
+if globalvar.wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
 else:
     from wx import wizard as wiz
@@ -69,6 +72,9 @@ from gui_core.wrap import (
 )
 
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
+
+if TYPE_CHECKING:
+    from wx.adv import WizardEvent
 
 #
 # global variables
@@ -510,7 +516,7 @@ class LocationPage(TitledPage):
         if not wx.FindWindowById(wx.ID_FORWARD).IsEnabled():
             wx.FindWindowById(wx.ID_FORWARD).Enable(True)
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         if event.GetDirection() and (self.xylocation == "" or self.xymapset == ""):
             GMessage(
                 _(
@@ -524,7 +530,7 @@ class LocationPage(TitledPage):
 
         self.parent.SetSrcEnv(self.xylocation, self.xymapset)
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         if self.xylocation == "" or self.xymapset == "":
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
         else:
@@ -684,7 +690,7 @@ class GroupPage(TitledPage):
     def OnExtension(self, event):
         self.extension = self.ext_txt.GetValue()
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         if event.GetDirection() and self.xygroup == "":
             GMessage(
                 _("You must select a valid image/map group in order to continue"),
@@ -701,7 +707,7 @@ class GroupPage(TitledPage):
             event.Veto()
             return
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         global maptype
 
         self.groupList = []
@@ -888,7 +894,7 @@ class DispMapPage(TitledPage):
 
         tgt_map["vector"] = self.tgtvectselection.GetValue()
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         global src_map, tgt_map
 
         if event.GetDirection() and (src_map == ""):
@@ -900,7 +906,7 @@ class DispMapPage(TitledPage):
 
         self.parent.SwitchEnv("target")
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         global maptype, src_map, tgt_map
 
         self.srcselection.SetElementList(maptype)

--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -30,16 +30,15 @@ This program is free software under the GNU General Public License
 from __future__ import annotations
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 from typing import TYPE_CHECKING
 
 import wx
-from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 import wx.lib.colourselect as csel
-
 from core import globalvar
+from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 
 if globalvar.wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
@@ -48,29 +47,29 @@ else:
 
 import grass.script as gs
 
+# isort: split
 
 from core import utils
+from core.gcmd import GError, GMessage, GWarning, RunCommand
+from core.giface import Notification
 from core.render import Map
-from gui_core.gselect import Select, LocationSelect, MapsetSelect
-from gui_core.dialogs import GroupDialog
-from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from gcp.mapdisplay import MapPanel
-from core.giface import Notification
+from gui_core.dialogs import GroupDialog
+from gui_core.gselect import LocationSelect, MapsetSelect, Select
+from gui_core.mapdisp import FrameMixin
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    CheckListBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
+    CheckListBox,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 
 if TYPE_CHECKING:

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -31,12 +31,13 @@ This program is free software under the GNU General Public License
 # TODO: i.ortho.transform has 6 appearances, check each of them and configure
 # TODO: i.ortho.transform looks for REF_POINTS/CONTROL_POINTS and not POINTS
 # TODO: CHECK CONTROL_POINTS format and create it for i.ortho.transform to use.
-
+from __future__ import annotations
 
 import os
 import sys
 import shutil
 from copy import copy
+from typing import TYPE_CHECKING
 
 import wx
 from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
@@ -44,7 +45,7 @@ import wx.lib.colourselect as csel
 
 from core import globalvar
 
-if globalvar.wxPythonPhoenix:
+if globalvar.wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
 else:
     from wx import wizard as wiz
@@ -75,6 +76,9 @@ from gui_core.wrap import (
 )
 
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
+
+if TYPE_CHECKING:
+    from wx.adv import WizardEvent
 
 #
 # global variables
@@ -529,7 +533,7 @@ class LocationPage(TitledPage):
         if not wx.FindWindowById(wx.ID_FORWARD).IsEnabled():
             wx.FindWindowById(wx.ID_FORWARD).Enable(True)
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         if event.GetDirection() and (self.xylocation == "" or self.xymapset == ""):
             GMessage(
                 _(
@@ -543,7 +547,7 @@ class LocationPage(TitledPage):
 
         self.parent.SetSrcEnv(self.xylocation, self.xymapset)
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         if self.xylocation == "" or self.xymapset == "":
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
         else:
@@ -690,7 +694,7 @@ class GroupPage(TitledPage):
     def OnExtension(self, event):
         self.extension = self.ext_txt.GetValue()
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         if event.GetDirection() and self.xygroup == "":
             GMessage(
                 _("You must select a valid image/map group in order to continue"),
@@ -707,7 +711,7 @@ class GroupPage(TitledPage):
             event.Veto()
             return
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         global maptype
 
         self.groupList = []
@@ -892,7 +896,7 @@ class DispMapPage(TitledPage):
 
         tgt_map["vector"] = self.tgtvectselection.GetValue()
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         global src_map, tgt_map
 
         if event.GetDirection() and (src_map == ""):
@@ -904,7 +908,7 @@ class DispMapPage(TitledPage):
 
         self.parent.SwitchEnv("target")
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         global maptype, src_map, tgt_map
 
         self.srcselection.SetElementList(maptype)

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -34,16 +34,15 @@ This program is free software under the GNU General Public License
 from __future__ import annotations
 
 import os
-import sys
 import shutil
+import sys
 from copy import copy
 from typing import TYPE_CHECKING
 
 import wx
-from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 import wx.lib.colourselect as csel
-
 from core import globalvar
+from wx.lib.mixins.listctrl import ColumnSorterMixin, ListCtrlAutoWidthMixin
 
 if globalvar.wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
@@ -52,29 +51,29 @@ else:
 
 import grass.script as gs
 
+# isort: split
 
 from core import utils
+from core.gcmd import GError, GMessage, GWarning, RunCommand
+from core.giface import Notification
 from core.render import Map
-from gui_core.gselect import Select, LocationSelect, MapsetSelect
-from gui_core.dialogs import GroupDialog
-from gui_core.mapdisp import FrameMixin
-from core.gcmd import RunCommand, GMessage, GError, GWarning
 from core.settings import UserSettings
 from gcp.mapdisplay import MapPanel
-from core.giface import Notification
+from gui_core.dialogs import GroupDialog
+from gui_core.gselect import LocationSelect, MapsetSelect, Select
+from gui_core.mapdisp import FrameMixin
 from gui_core.wrap import (
-    SpinCtrl,
-    Button,
-    StaticText,
-    StaticBox,
-    CheckListBox,
-    TextCtrl,
-    Menu,
-    ListCtrl,
     BitmapFromImage,
+    Button,
+    CheckListBox,
     CheckListCtrlMixin,
+    ListCtrl,
+    Menu,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
-
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 
 if TYPE_CHECKING:
@@ -1501,6 +1500,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
                 )
                 # Get the elevation height from the map given by i.ortho.elev
                 from subprocess import PIPE
+
                 from grass.pygrass.modules import Module
 
                 rwhat = Module(

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -34,17 +34,20 @@ This program is free software under the GNU General Public License
 @author Hamish Bowman (planetary ellipsoids)
 """
 
+from __future__ import annotations
+
 import os
 import locale
 import functools
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import wx
 import wx.lib.mixins.listctrl as listmix
 from core import globalvar
 
-if globalvar.wxPythonPhoenix:
+if globalvar.wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
     from wx.adv import Wizard
     from wx.adv import WizardPageSimple
@@ -83,6 +86,9 @@ if globalvar.CheckWxVersion(version=[4, 1, 0]):
     search_cancel_evt = wx.EVT_SEARCH_CANCEL
 else:
     search_cancel_evt = wx.EVT_SEARCHCTRL_CANCEL_BTN
+
+if TYPE_CHECKING:
+    from wx.adv import WizardEvent
 
 
 class TitledPage(WizardPageSimple):
@@ -331,7 +337,7 @@ class DatabasePage(TitledPage):
 
         dlg.Destroy()
 
-    def OnPageChanging(self, event=None):
+    def OnPageChanging(self, event: WizardEvent | None = None) -> None:
         self.location = self.tlocation.GetValue()
         self.grassdatabase = self.tgisdbase.GetLabel()
         self.locTitle = self.tlocTitle.GetValue()
@@ -416,7 +422,7 @@ class CoordinateSystemPage(TitledPage):
         self.Bind(wx.EVT_RADIOBUTTON, self.SetVal, id=self.radioXy.GetId())
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         global coordsys
 
         if not coordsys:
@@ -566,7 +572,7 @@ class ProjectionsPage(TitledPage):
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent) -> None:
         if event.GetDirection() and self.proj not in self.parent.projections.keys():
             event.Veto()
 
@@ -598,7 +604,7 @@ class ProjectionsPage(TitledPage):
             self.projdesc = self.parent.projections[self.proj][0]
             nextButton.Enable()
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         if len(self.proj) == 0:
             # disable 'next' button by default
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
@@ -892,7 +898,7 @@ class ProjParamsPage(TitledPage):
 
         event.Skip()
 
-    def OnPageChange(self, event=None):
+    def OnPageChange(self, event: WizardEvent | None = None) -> None:
         """Go to next page"""
         if event.GetDirection():
             self.p4projparams = ""
@@ -914,7 +920,7 @@ class ProjParamsPage(TitledPage):
                         " +" + param["proj4"] + "=" + str(param["value"])
                     )
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Page entered"""
         self.projdesc = self.parent.projections[self.parent.projpage.proj][0]
         if self.prjParamSizer is None:
@@ -1115,7 +1121,7 @@ class DatumPage(TitledPage):
         # do page layout
         # self.DoLayout()
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent):
         self.proj4params = ""
         proj = self.parent.projpage.p4proj
 
@@ -1159,7 +1165,7 @@ class DatumPage(TitledPage):
                 self.ellipse
             ][1]
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         self.parent.datum_trans = None
         if event.GetDirection():
             if len(self.datum) == 0:
@@ -1330,7 +1336,7 @@ class EllipsePage(TitledPage):
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         if len(self.ellipse) == 0:
             # disable 'next' button by default
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
@@ -1339,7 +1345,7 @@ class EllipsePage(TitledPage):
         self.scope = "earth"
         event.Skip()
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent) -> None:
         if (
             event.GetDirection()
             and self.ellipse not in self.parent.ellipsoids
@@ -1465,7 +1471,7 @@ class GeoreferencedFilePage(TitledPage):
         # do page layout
         # self.DoLayout()
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         if len(self.georeffile) == 0:
             # disable 'next' button by default
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
@@ -1474,7 +1480,7 @@ class GeoreferencedFilePage(TitledPage):
 
         event.Skip()
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent) -> None:
         if event.GetDirection() and not os.path.isfile(self.georeffile):
             event.Veto()
         self.GetNext().SetPrev(self)
@@ -1540,7 +1546,7 @@ class WKTPage(TitledPage):
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         if len(self.wktstring) == 0:
             # disable 'next' button by default
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
@@ -1549,7 +1555,7 @@ class WKTPage(TitledPage):
 
         event.Skip()
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent) -> None:
         if event.GetDirection() and not self.wktstring.strip():
             event.Veto()
         self.GetNext().SetPrev(self)
@@ -1641,7 +1647,7 @@ class EPSGPage(TitledPage):
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         self.parent.datum_trans = None
         if event.GetDirection():
             if not self.epsgcode:
@@ -1654,7 +1660,7 @@ class EPSGPage(TitledPage):
 
         event.Skip()
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent):
         if event.GetDirection():
             if not self.epsgcode:
                 event.Veto()
@@ -1859,7 +1865,7 @@ class IAUPage(TitledPage):
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         self.parent.datum_trans = None
         if event.GetDirection():
             if not self.epsgcode:
@@ -1873,7 +1879,7 @@ class IAUPage(TitledPage):
 
         event.Skip()
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent):
         if event.GetDirection():
             if not self.epsgcode:
                 event.Veto()
@@ -2070,14 +2076,14 @@ class CustomPage(TitledPage):
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnPageChanging)
         self.Bind(wiz.EVT_WIZARD_PAGE_CHANGED, self.OnEnterPage)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         if len(self.customstring) == 0:
             # disable 'next' button by default
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
         else:
             wx.FindWindowById(wx.ID_FORWARD).Enable(True)
 
-    def OnPageChanging(self, event):
+    def OnPageChanging(self, event: WizardEvent):
         if event.GetDirection():
             self.custom_dtrans_string = ""
 
@@ -2268,7 +2274,7 @@ class SummaryPage(TitledPage):
         self.sizer.AddGrowableRow(4, 1)
         self.sizer.AddGrowableRow(5, 5)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Insert values into text controls for summary of location
         creation options
         """
@@ -2769,7 +2775,7 @@ class LocationWizard(wx.Object):
 
         return "%s +no_defs" % proj4string
 
-    def OnHelp(self, event):
+    def OnHelp(self, event: WizardEvent) -> None:
         """'Help' button clicked"""
 
         # help text in lib/init/helptext.html

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -36,10 +36,9 @@ This program is free software under the GNU General Public License
 
 from __future__ import annotations
 
-import os
-import locale
 import functools
-
+import locale
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -49,36 +48,35 @@ from core import globalvar
 
 if globalvar.wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
-    from wx.adv import Wizard
-    from wx.adv import WizardPageSimple
+    from wx.adv import Wizard, WizardPageSimple
 else:
     from wx import wizard as wiz
     from wx.wizard import Wizard
     from wx.wizard import WizardPageSimple
-import wx.lib.scrolledpanel as scrolled
 
+import wx.lib.scrolledpanel as scrolled
 from core import utils
+from core.gcmd import GError, GWarning, RunCommand
 from core.utils import cmp
-from core.gcmd import RunCommand, GError, GWarning
 from gui_core.widgets import GenericMultiValidator
 from gui_core.wrap import (
-    SpinCtrl,
-    SearchCtrl,
-    StaticText,
-    TextCtrl,
     Button,
     CheckBox,
-    StaticBox,
-    NewId,
-    ListCtrl,
     HyperlinkCtrl,
+    ListCtrl,
+    NewId,
+    SearchCtrl,
+    SpinCtrl,
+    StaticBox,
+    StaticText,
+    TextCtrl,
 )
 from location_wizard.dialogs import SelectTransformDialog
 
-from grass.grassdb.checks import location_exists
-from grass.script import decode
-from grass.script import core as grass
 from grass.exceptions import OpenError
+from grass.grassdb.checks import location_exists
+from grass.script import core as grass
+from grass.script import decode
 
 global coordsys, north, south, east, west, resolution, wizerror, translist
 

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -34,17 +34,19 @@ if wxPythonPhoenix or TYPE_CHECKING:
 else:
     from wx import wizard as wiz
     from wx.wizard import Wizard
-import wx.lib.scrolledpanel as scrolled
 
+import wx.lib.scrolledpanel as scrolled
+from core.gcmd import GError, GMessage, RunCommand
 from gui_core import gselect
 from gui_core.wrap import Button, StaticText, TextCtrl
 from location_wizard.wizard import GridBagSizerTitledPage as TitledPage
 from rlisetup.functions import checkValue, retRLiPath
 from rlisetup.sampling_frame import RLiSetupMapPanel
+
+from grass.exceptions import CalledModuleError
 from grass.script import core as grass
 from grass.script import raster as grast
 from grass.script import vector as gvect
-from grass.exceptions import CalledModuleError
 
 from .functions import (
     SamplingType,
@@ -53,7 +55,6 @@ from .functions import (
     obtainCategories,
     sampleAreaVector,
 )
-from core.gcmd import GError, GMessage, RunCommand
 
 if TYPE_CHECKING:
     from wx.adv import WizardEvent

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -20,12 +20,15 @@ This program is free software under the GNU General Public License
 @author Luca Delucchi <lucadeluge gmail com>
 """
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 import wx
 from core.globalvar import wxPythonPhoenix
 
-if wxPythonPhoenix:
+if wxPythonPhoenix or TYPE_CHECKING:
     from wx import adv as wiz
     from wx.adv import Wizard
 else:
@@ -51,6 +54,9 @@ from .functions import (
     sampleAreaVector,
 )
 from core.gcmd import GError, GMessage, RunCommand
+
+if TYPE_CHECKING:
+    from wx.adv import WizardEvent
 
 
 class RLIWizard:
@@ -692,7 +698,7 @@ class FirstPage(TitledPage):
         next = wx.FindWindowById(wx.ID_FORWARD)
         next.Enable(self.CheckInput())
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Sets the default values, for the entire map"""
         next = wx.FindWindowById(wx.ID_FORWARD)
         next.Enable(self.CheckInput())
@@ -735,7 +741,7 @@ class FirstPage(TitledPage):
         """
         return bool(self.conf_name and bool(self.rast and bool(self.VectorEnabled)))
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
         next = wx.FindWindowById(wx.ID_FORWARD)
         next.Enable(self.CheckInput())
@@ -891,7 +897,7 @@ class KeyboardPage(TitledPage):
         self.ColLentxt.SetValue(self.col_len)
         self.RowLentxt.SetValue(self.row_len)
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
         if (
             self.row_len == ""
@@ -923,7 +929,7 @@ class DrawSampleFramePage(TitledPage):
         else:
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Function during entering"""
         if self.mapPanel is None:
             self.mapPanel = RLiSetupMapPanel(self, samplingType="drawFrame")
@@ -951,7 +957,7 @@ class DrawSampleFramePage(TitledPage):
                 render=True,
             )
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
         if event.GetDirection():
             self.SetNext(self.parent.samplingareapage)
@@ -1071,7 +1077,7 @@ class SamplingAreasPage(TitledPage):
         else:
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Insert values into text controls for summary of location
         creation options
         """
@@ -1230,7 +1236,7 @@ class DrawRegionsPage(TitledPage):
             )
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Function during entering"""
         if self.parent.samplingareapage.samplingtype == SamplingType.WHOLE:
             self.title.SetLabel(_("Draw moving windows region"))
@@ -1265,12 +1271,12 @@ class DrawRegionsPage(TitledPage):
                 render=True,
             )
 
-    # def OnExitPage(self, event=None):
-    # Function during exiting
-    # print event.GetDirection()
-    # if event.GetDirection():
-    #    self.SetNext(self.parent.samplingareapage)
-    #    self.parent.samplingareapage.SetPrev(self)
+    # def OnExitPage(self, event: WizardEvent | None = None) -> None:
+    #     """Function during exiting"""
+    #     print(event.GetDirection())
+    #     if event.GetDirection():
+    #         self.SetNext(self.parent.samplingareapage)
+    #         self.parent.samplingareapage.SetPrev(self)
 
 
 class SampleUnitsKeyPage(TitledPage):
@@ -1400,14 +1406,14 @@ class SampleUnitsKeyPage(TitledPage):
         # self.Bind(wiz.EVT_WIZARD_PAGE_CHANGING, self.OnExitPage)
         self.OnType(None)
 
-    def OnEnterPage(self, event=None):
+    def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         """Function during entering"""
         # This is an hack to force the user to choose Rectangle or Circle
         self.typeBox.SetSelection(2),
         self.typeBox.ShowItem(2, False)
         self.panelSizer.Layout()
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
         if event.GetDirection():
             self.SetNext(self.parent.summarypage)
@@ -1545,7 +1551,7 @@ class MovingKeyPage(TitledPage):
         self.heightTxt.Bind(wx.EVT_TEXT, self.OnHeight)
         wx.FindWindowById(wx.ID_FORWARD).Enable(False)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         # This is an hack to force the user to choose Rectangle or Circle
         #        self.typeBox.SetSelection(2),
         #        self.typeBox.ShowItem(2, False)
@@ -1634,7 +1640,7 @@ class UnitsMousePage(TitledPage):
         self.OnType(None)
         self.regionNumTxt.SetValue("")
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Function during entering"""
         if self.numregions:
             wx.FindWindowById(wx.ID_FORWARD).Enable(True)
@@ -1693,7 +1699,7 @@ class UnitsMousePage(TitledPage):
         else:
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
         if event.GetDirection():
             self.SetNext(self.drawsampleunitspage)
@@ -1730,7 +1736,7 @@ class DrawSampleUnitsPage(TitledPage):
             )
             wx.FindWindowById(wx.ID_FORWARD).Enable(False)
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Function during entering"""
 
         if self.parent.samplingareapage.samplingtype in {
@@ -1777,9 +1783,8 @@ class DrawSampleUnitsPage(TitledPage):
                 render=True,
             )
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
-
         # if event.GetDirection():
         #    self.SetNext(self.parent.samplingareapage)
         #    self.parent.samplingareapage.SetPrev(self)
@@ -1889,7 +1894,7 @@ class VectorAreasPage(TitledPage):
                 self.map_.DeleteLayer(layer)
         self.areaText.SetLabel("Is this area (cat={n}) ok?".format(n=cat))
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Function during entering: draw the raster map and the first vector
         feature"""
         if self.mapPanel is None:
@@ -1929,7 +1934,7 @@ class VectorAreasPage(TitledPage):
             )
         self.newCat()
 
-    def OnExitPage(self, event=None):
+    def OnExitPage(self, event: WizardEvent | None = None) -> None:
         """Function during exiting"""
         grass.del_temp_region()
 
@@ -2136,7 +2141,7 @@ class SummaryPage(TitledPage):
             flag=wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL,
         )
 
-    def OnEnterPage(self, event):
+    def OnEnterPage(self, event: WizardEvent) -> None:
         """Insert values into text controls for summary of location
         creation options
         """


### PR DESCRIPTION
See https://docs.wxpython.org/wx.adv.WizardEvent.html for the event type, that contains the GetDirections()


I skipped annotating the return type on some event handlers that also returned a string. It is better to only add type hints when it is certain rather than add misleading type hints. (Type checkers try to deduce the types when there are no type hints). It is probably an error of some sort, as handlers shouldn't be returning something. I tried to go back like 15 years ago and still couldn't find the correct solution. (15 years ago that text was in a function returning messages, I didn't investigate to see if it was the correct place now.  Search for "Datum transform is required" in 9228877d8bdfd680e9c7bdfd44a06213585988fe and 8a40775763203d7c546b682de937984cfb096abb)
