### PR TITLE
style: Fix R1711: Useless return at end of function or method (useless-return)

### DIFF
--- a/gui/wxpython/animation/anim.py
+++ b/gui/wxpython/animation/anim.py
@@ -93,11 +93,11 @@ class Animation(wx.EvtHandler):
 
     def Start(self):
         if not self.IsActive():
-            return
+            pass
 
     def Pause(self, paused):
         if not self.IsActive():
-            return
+            pass
 
     def Stop(self):
         if not self.IsActive():

--- a/gui/wxpython/animation/controller.py
+++ b/gui/wxpython/animation/controller.py
@@ -627,7 +627,6 @@ class AnimationController(wx.EvtHandler):
                 del self.busy
                 if error:
                     GError(parent=self.frame, message=error)
-                    return
 
             if exportInfo["method"] == "sequence":
                 filename = os.path.join(

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -1144,7 +1144,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         """Print final message"""
         global maptype
         if maptype == "raster":
-            return
+            pass
 
     def OnSettings(self, event):
         """GCP Manager settings"""

--- a/gui/wxpython/rdigit/dialogs.py
+++ b/gui/wxpython/rdigit/dialogs.py
@@ -91,7 +91,7 @@ class NewRasterDialog(wx.Dialog):
             ret = grast.raster_info(value)
             self._typeChoice.SetStringSelection(ret["datatype"])
         except CalledModuleError:
-            return
+            pass
 
     def OnOK(self, event):
         mapName = self.GetMapName()

--- a/gui/wxpython/rdigit/toolbars.py
+++ b/gui/wxpython/rdigit/toolbars.py
@@ -207,7 +207,7 @@ class RDigitToolbar(BaseToolbar):
             value = float(value)
             self._controller.SetCellValue(value)
         except ValueError:
-            return
+            pass
 
     def _widthValueChanged(self):
         value = self._widthValue.GetValue()
@@ -216,7 +216,6 @@ class RDigitToolbar(BaseToolbar):
             self._controller.SetWidthValue(value)
         except ValueError:
             self._controller.SetWidthValue(0)
-            return
 
     def _changeDrawColor(self):
         color = self._color.GetColour()

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -749,7 +749,6 @@ class FirstPage(TitledPage):
             elif self.region == "draw":
                 self.SetNext(self.parent.drawsampleframepage)
                 self.parent.samplingareapage.SetPrev(self.parent.drawsampleframepage)
-                return
 
 
 class KeyboardPage(TitledPage):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -636,7 +636,6 @@ disable = [
     "R1704",  # Redefining argument with the local name %r (redefined-argument-from-local)
     "R1705",  # Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
     "R1710",  # Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
-    "R1711",  # Useless return at end of function or method (useless-return)
     "R1712",  # Consider using tuple unpacking for swapping variables (consider-swap-variables)
     "R1713",  # Consider using str.join(sequence) for concatenating strings from an iterable (consider-using-join)
     "R1714",  # Consider merging these comparisons with 'in' by using '%s %sin (%s)'. Use a set instead if elements are hashable. (consider-using-in)

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1134,8 +1134,6 @@ class Line(Geo):
             self.reset()
             for coord in match.groups()[0].strip().split(","):
                 self.append(tuple(float(e) for e in coord.split(" ")))
-        else:
-            return None
 
     def buffer(
         self,


### PR DESCRIPTION
Pylint rule: https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/useless-return.html

Some event handlers were surprisingly empty. For these I kept the condition to leave a clue for future edits, but needed to use "pass" in order to keep correct syntax.

For example, the "OnGeoRectDone", introduced in 22f86d9e4645938a2d5d879ebf6f31eb2eefc8d6, was empty there too. However, it seems like a mostly a copy from another active file in the repo, shown below, but the remaining of the function doesn't make sense in the context of the new file.
https://github.com/OSGeo/grass/blob/93a5f04df7bdb13c74eaef63c5a4443133482d46/gui/wxpython/image2target/ii2t_manager.py#L1823-L1839

