### PR TITLE
style: Fix W0231: __init__ method from base class is not called (super-init-not-called)

### DIFF
--- a/gui/wxpython/gcp/manager.py
+++ b/gui/wxpython/gcp/manager.py
@@ -1026,6 +1026,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         Map=None,
         lmgr=None,
     ):
+        # pylint: disable=super-init-not-called; See InitMapDisplay()
         self.grwiz = grwiz  # GR Wizard
         self._giface = giface
 

--- a/gui/wxpython/image2target/ii2t_manager.py
+++ b/gui/wxpython/image2target/ii2t_manager.py
@@ -1003,6 +1003,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         Map=None,
         lmgr=None,
     ):
+        # pylint: disable=super-init-not-called; See InitMapDisplay()
         self.grwiz = grwiz  # GR Wizard
         self._giface = giface
 

--- a/gui/wxpython/photo2image/ip2i_manager.py
+++ b/gui/wxpython/photo2image/ip2i_manager.py
@@ -308,6 +308,7 @@ class GCPPanel(MapPanel, ColumnSorterMixin):
         lmgr=None,
         camera=None,
     ):
+        # pylint: disable=super-init-not-called; See InitMapDisplay()
         self.grwiz = grwiz  # GR Wizard
         self._giface = giface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -665,7 +665,6 @@ disable = [
     "W0221",  # (arguments-differ)
     "W0222",  # Signature differs from %s %r method (signature-differs)
     "W0223",  # Method %r is abstract in class %r but is not overridden in child class %r (abstract-method)
-    "W0231",  # __init__ method from base class %r is not called (super-init-not-called)
     "W0237",  # (arguments-renamed)
     "W0401",  # Wildcard import %s (wildcard-import)
     "W0404",  # Reimport %r (imported line %s) (reimported)

--- a/python/grass/imaging/images2swf.py
+++ b/python/grass/imaging/images2swf.py
@@ -486,6 +486,7 @@ class SetBackgroundTag(ControlTag):
     """Set the color in 0-255, or 0-1 (if floats given)."""
 
     def __init__(self, *rgb):
+        super().__init__()
         self.tagtype = 9
         if len(rgb) == 1:
             rgb = rgb[0]


### PR DESCRIPTION
Pylint rule: https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/super-init-not-called.html