### PR TITLE
style: Ignore R1721: Unnecessary use of a comprehension, use list(self) instead. (unnecessary-comprehension)

### DIFF
--- a/gui/wxpython/lmgr/giface.py
+++ b/gui/wxpython/lmgr/giface.py
@@ -56,7 +56,7 @@ class LayerList:
     def __len__(self):
         # The list constructor calls __len__ as an optimization if available,
         # causing a RecursionError
-        return len([layer for layer in self])  # noqa: C416
+        return len([layer for layer in self])  # noqa: C416 # pylint: disable=R1721
 
     def __iter__(self):
         """Iterates over the contents of the list."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -642,7 +642,6 @@ disable = [
     "R1714",  # Consider merging these comparisons with 'in' by using '%s %sin (%s)'. Use a set instead if elements are hashable. (consider-using-in)
     "R1715",  # Consider using dict.get for getting values from a dict if a key is present or a default if not (consider-using-get)
     "R1716",  # Simplify chained comparison between the operands (chained-comparison)
-    "R1721",  # Unnecessary use of a comprehension, use %s instead. (unnecessary-comprehension)
     "R1724",  # Unnecessary "%s" after "continue", %s (no-else-continue)
     "R1727",  # Boolean condition '%s' will always evaluate to '%s' (condition-evals-to-constant)
     "R1732",  # Consider using 'with' for resource-allocating operations (consider-using-with)

--- a/python/grass/pygrass/gis/__init__.py
+++ b/python/grass/pygrass/gis/__init__.py
@@ -272,7 +272,7 @@ class Location:
             [...]
 
         """
-        mapsets = [mapset for mapset in self]  # noqa: C416
+        mapsets = [mapset for mapset in self]  # noqa: C416 # pylint: disable=R1721
         if permissions:
             mapsets = [
                 mapset


### PR DESCRIPTION
Pylint rule: https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/unnecessary-comprehension.html

These two occurrences already disabled an equivalent Ruff rule coming from flake8 in #4453, as there was a recursion issue