### PR TITLE
lib: Fix safeRef regression after removing `__cmp__` in #4684

### DIFF
--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -164,21 +164,6 @@ class BoundMethodWeakref:
 
     __bool__ = __nonzero__
 
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-        return self.key == other.key
-
-    def __lt__(self, other):
-        if not isinstance(other, self.__class__):
-            return self.__class__.__name__ < other.__class__.__name__
-        return self.key < other.key
-
-    def __gt__(self, other):
-        if not isinstance(other, self.__class__):
-            return self.__class__.__name__ > other.__class__.__name__
-        return self.key > other.key
-
     def __call__(self):
         """Return a strong reference to the bound method
 


### PR DESCRIPTION
After stepping through a lot with PDB, I suggest this to fix the hang described in https://github.com/OSGeo/grass/pull/4684#issuecomment-2564316815 and https://github.com/OSGeo/grass/pull/4684#issuecomment-2564383430

It isn't a question of missing `__le__`, `__ge__`, `__ne__` as the replacement of `__cmp__` with all rich comparisons. They don't get called. The current (before #4684) `__cmp__` method isn't called at all in Python 3 (breakpoint isn't hit, while other do).
In #4684, the `__eq__` method gets called by the `list.index` from the receivers.index(receiver) in here:

https://github.com/OSGeo/grass/blob/7f1934ffcd5011d1df1bddb5c13a9f0456233823/python/grass/pydispatch/dispatcher.py#L448-L478

Looking at the locals() available in debugging at various stack levels, I see no real difference between having the `__eq__` method after #4684, or removing it completly (by memory of what I saw multiple dozens of times per code-change though, so I might be wrong). However, without any extra method, it works, on Linux (ubuntu 22.04 container on WSL) and on windows (editing the saferef.py  file in an OSGeo4W grass-dev build 432). I cannot test on macOS, but I suppose it is the same.

This PR effectively has the same behavior as before #4684 for python 3, as that method didn't get called.
From what I searched, it really should have only been called, in python 2, if a list was sorted. I didn't find any other ways the methods in saferef could get triggered.

I consider this change safe.

Additionnaly, in my first attempts to debug this, I also tried raising warnings (similar to [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning)), with PYTHONWARNINGS=always env var on all methods in saferef, and other methos appeared, but never `__cmp__`, or the others added in #4684, of course, `__eq__` was called, as it was the problematic part
