### PR TITLE
grass.script.utils: Add type hints to KeyValue class and parse_key_val function

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -35,7 +35,7 @@ import io
 from collections.abc import Mapping
 from tempfile import NamedTemporaryFile
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from .utils import KeyValue, parse_key_val, basename, encode, decode, try_remove
 from grass.exceptions import ScriptError, CalledModuleError

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -32,12 +32,22 @@ import shlex
 import json
 import csv
 import io
+from collections.abc import Mapping
 from tempfile import NamedTemporaryFile
 from pathlib import Path
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from .utils import KeyValue, parse_key_val, basename, encode, decode, try_remove
 from grass.exceptions import ScriptError, CalledModuleError
 from grass.grassdb.manage import resolve_mapset_path
+
+
+if TYPE_CHECKING:
+    from _typeshed import StrPath
+
+
+T = TypeVar("T")
+_Env = Mapping[str, str]
 
 
 # subprocess wrapper that uses shell on Windows
@@ -1032,20 +1042,22 @@ def _compare_units(dic):
 
 
 def _text_to_key_value_dict(
-    filename, sep=":", val_sep=",", checkproj=False, checkunits=False
-):
+    filename: StrPath,
+    sep: str = ":",
+    val_sep: str = ",",
+    checkproj: bool = False,
+    checkunits: bool = False,
+) -> KeyValue[list[int | float | str]]:
     """Convert a key-value text file, where entries are separated by newlines
     and the key and value are separated by `sep', into a key-value dictionary
     and discover/use the correct data types (float, int or string) for values.
 
-    :param str filename: The name or name and path of the text file to convert
-    :param str sep: The character that separates the keys and values, default
-                    is ":"
-    :param str val_sep: The character that separates the values of a single
+    :param filename: The name or name and path of the text file to convert
+    :param sep: The character that separates the keys and values, default is ":"
+    :param val_sep: The character that separates the values of a single
                         key, default is ","
-    :param bool checkproj: True if it has to check some information about
-                           projection system
-    :param bool checkproj: True if it has to check some information about units
+    :param checkproj: True if it has to check some information about projection system
+    :param checkunits: True if it has to check some information about units
 
     :return: The dictionary
 
@@ -1066,7 +1078,7 @@ def _text_to_key_value_dict(
     """
     with Path(filename).open() as f:
         text = f.readlines()
-    kvdict = KeyValue()
+    kvdict: KeyValue[list[int | float | str]] = KeyValue()
 
     for line in text:
         if line.find(sep) >= 0:
@@ -1077,7 +1089,7 @@ def _text_to_key_value_dict(
             # Jump over empty values
             continue
         values = value.split(val_sep)
-        value_list = []
+        value_list: list[int | float | str] = []
 
         for value in values:
             not_float = False
@@ -1173,7 +1185,7 @@ def compare_key_value_text_files(
 # interface to g.gisenv
 
 
-def gisenv(env=None):
+def gisenv(env: _Env | None = None) -> KeyValue[str | None]:
     """Returns the output from running g.gisenv (with no arguments), as a
     dictionary. Example:
 
@@ -1191,14 +1203,14 @@ def gisenv(env=None):
 # interface to g.region
 
 
-def locn_is_latlong(env=None) -> bool:
+def locn_is_latlong(env: _Env | None = None) -> bool:
     """Tests if location is lat/long. Value is obtained
     by checking the "g.region -pu" projection code.
 
     :return: True for a lat/long region, False otherwise
     """
     s = read_command("g.region", flags="pu", env=env)
-    kv = parse_key_val(s, ":")
+    kv: KeyValue[str | None] = parse_key_val(s, ":")
     return kv["projection"].split(" ")[0] == "3"
 
 
@@ -1246,7 +1258,9 @@ def region(region3d=False, complete=False, env=None):
     return reg
 
 
-def region_env(region3d=False, flags=None, env=None, **kwargs):
+def region_env(
+    region3d: bool = False, flags: str | None = None, env: _Env | None = None, **kwargs
+) -> str:
     """Returns region settings as a string which can used as
     GRASS_REGION environmental variable.
 
@@ -1256,8 +1270,8 @@ def region_env(region3d=False, flags=None, env=None, **kwargs):
     See also :func:`use_temp_region()` for alternative method how to define
     temporary region used for raster-based computation.
 
-    :param bool region3d: True to get 3D region
-    :param string flags: for example 'a'
+    :param region3d: True to get 3D region
+    :param flags: for example 'a'
     :param env: dictionary with system environment variables (`os.environ` by default)
     :param kwargs: g.region's parameters like 'raster', 'vector' or 'region'
 
@@ -1271,7 +1285,7 @@ def region_env(region3d=False, flags=None, env=None, **kwargs):
     :return: empty string on error
     """
     # read proj/zone from WIND file
-    gis_env = gisenv(env)
+    gis_env: KeyValue[str | None] = gisenv(env)
     windfile = os.path.join(
         gis_env["GISDBASE"], gis_env["LOCATION_NAME"], gis_env["MAPSET"], "WIND"
     )


### PR DESCRIPTION
This PR annotates KeyValue, a subclass of dict that can use attribute syntax, using generic type variables, so it can be used with different types but still knowing exactly what type it would be.

Annotating KeyValue allows to add type hint parse_key_val. However, even by trying for at least two days, it doesn't seem possible for now to properly annotate the 5 kinds of return types with overloads, as the dflt and val_type are optional, confusing type checkers (not only one, but multiple). So, the closest I can get is by combining the cases were dflt is None or has a value in the same overload.

This PR also uses these new annotations in grass.script.core.


Additional info:
- typing.cast is used here to override the type considered by type-checkers, it is a no-op at runtime, there is no conversion or casting actually done: https://docs.python.org/3/library/typing.html#typing.cast
- I extracted the some conditions out of the loop in the parse_key_val method to be evaluated once, which has the advantage of having the type of KeyValue values known at that point.
- There was a bug in parse_key_val when using val_type and having a dflt=None used. For example, `int("34")` works, but `int(None)` doesn't, and the old code was able to call that.
- The condition to know if to convert the value with val_type was improved to use `if callable(val_type):`, which is considered by mypy in its static checking (it allows type narrowing): https://mypy.readthedocs.io/en/latest/type_narrowing.html#callable. I also tried out some ipython examples on the side to confirm it works for `val_type=int`, `val_type=float`, but not `val_type=math.pi` (non callable) (with `import math`)

```python
$ ipython
Python 3.12.7 (main, Nov  3 2024, 17:54:48) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.30.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import math

In [2]: s = """nodes=2724
   ...: points=0
   ...: lines=0
   ...: boundaries=3649
   ...: centroids=1832
   ...: areas=1832
   ...: islands=907
   ...: primitives=5481
   ...: map3d=0"""

In [3]: def parse_key_val3(s, sep="=", dflt=None, val_type=None,vsep=None):
   ...:     if callable(val_type):
   ...:         print("is callable")
   ...:     else:
   ...:         print("is not callable")
   ...: 

In [4]: parse_key_val3(s,val_type=int)
is callable

In [5]: parse_key_val3(s,val_type=float)
is callable

In [6]: parse_key_val3(s,val_type=str)
is callable

In [7]: parse_key_val3(s,val_type=math.pi)
is not callable

In [8]: 
``` 