### PR TITLE
utils: Use context managers for subprocesses and opening files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,8 +386,8 @@ ignore = [
 "temporal/t.register/testsuite/test_t_register_raster_file.py" = ["FLY002"]
 "temporal/t.remove/t.remove.py" = ["SIM115"]
 "temporal/t.unregister/t.unregister.py" = ["SIM115"]
-"utils/**.py" = ["SIM115"]
 "utils/generate_release_notes.py" = ["PGH004"]
+"utils/gitlog2changelog.py" = ["SIM115"]
 "utils/thumbnails.py" = ["PTH208"]
 "vector/v.fill.holes/examples.ipynb" = ["PTH201"]
 

--- a/utils/create_python_init_file.py
+++ b/utils/create_python_init_file.py
@@ -32,15 +32,11 @@ def main(path):
             continue
         modules.append(os.path.splitext(os.path.basename(f))[0])
 
-    fd = open(os.path.join(path, "__init__.py"), "w")
-    try:
+    with open(os.path.join(path, "__init__.py"), "w") as fd:
         fd.write("all = [%s" % os.linesep)
         for m in modules:
             fd.write("    '%s',%s" % (m, os.linesep))
         fd.write("    ]%s" % os.linesep)
-    finally:
-        fd.close()
-
     return 0
 
 

--- a/utils/g.html2man/g.html2man.py
+++ b/utils/g.html2man/g.html2man.py
@@ -26,18 +26,17 @@ def fix(content):
 def main():
     # parse HTML
     infile = sys.argv[1]
-    inf = open(infile)
-    p = HTMLParser(entities)
-    for n, line in enumerate(inf):
-        try:
-            p.feed(line)
-        except Exception as err:
-            sys.stderr.write(
-                "%s:%d:0: Error (%s): %s\n" % (infile, n + 1, repr(err), line)
-            )
-            sys.exit(1)
-    p.close()
-    inf.close()
+    with open(infile) as inf:
+        p = HTMLParser(entities)
+        for n, line in enumerate(inf):
+            try:
+                p.feed(line)
+            except Exception as err:
+                sys.stderr.write(
+                    "%s:%d:0: Error (%s): %s\n" % (infile, n + 1, repr(err), line)
+                )
+                sys.exit(1)
+        p.close()
 
     # generate groff
     sf = StringIO()

--- a/utils/md_isvalid.py
+++ b/utils/md_isvalid.py
@@ -14,8 +14,8 @@ import grass.script as gs
 
 
 def check_md(filename):
-    p = subprocess.Popen(["mdl", filename])
-    p.wait()
+    with subprocess.Popen(["mdl", filename]) as p:
+        p.wait()
 
 
 def print_line():
@@ -27,20 +27,18 @@ def check_module(module):
     print(module)
     tmp_file = gs.tempfile()
     with open(tmp_file, "w") as fp:
-        p = subprocess.Popen([module, "--md-description"], stdout=fp)
-        p.wait()
-
-        p = subprocess.Popen(
+        with subprocess.Popen([module, "--md-description"], stdout=fp) as p:
+            p.wait()
+        with subprocess.Popen(
             [
                 "mdl",
                 "--style",
                 os.path.join(os.path.dirname(__file__), "mdl_style.rb"),
                 fp.name,
             ]
-        )
-        p.wait()
-
-        return p.returncode
+        ) as p:
+            p.wait()
+            return p.returncode
 
 
 if __name__ == "__main__":

--- a/utils/mkrest.py
+++ b/utils/mkrest.py
@@ -79,8 +79,9 @@ if tmp_data:
     sys.stdout.write(tmp_data)
 
 arguments = ["pandoc", "-s", "-r", "html", src_file, "-w", "rst"]
-process = subprocess.Popen(arguments, stdout=subprocess.PIPE)
-html_text = process.communicate()[0]
+with subprocess.Popen(arguments, stdout=subprocess.PIPE) as process:
+    html_text = process.communicate()[0]
+
 if html_text:
     for k, v in replacement.iteritems():
         html_text = html_text.replace(k, v)

--- a/utils/mkrest.py
+++ b/utils/mkrest.py
@@ -19,6 +19,7 @@ import string
 import re
 import subprocess
 from datetime import datetime
+from pathlib import Path
 
 pgm = sys.argv[1]
 year = sys.argv[2] if len(sys.argv) > 1 else str(datetime.now().year)
@@ -47,10 +48,7 @@ footer_noindex = string.Template(
 
 def read_file(name):
     try:
-        f = open(name, "rb")
-        s = f.read()
-        f.close()
-        return s
+        return Path(name).read_bytes()
     except OSError:
         return ""
 

--- a/utils/ppmrotate.py
+++ b/utils/ppmrotate.py
@@ -17,6 +17,8 @@ import sys
 import os
 import atexit
 import array
+from pathlib import Path
+
 import grass.script as gs
 
 tmp_img = None
@@ -36,9 +38,7 @@ def cleanup():
 
 def read_ppm(src):
     global width, height
-
-    with open(src, "rb") as fh:
-        text = fh.read()
+    text = Path(src).read_bytes()
 
     i = 0
     j = text.find("\n", i)

--- a/utils/ppmrotate.py
+++ b/utils/ppmrotate.py
@@ -37,9 +37,9 @@ def cleanup():
 def read_ppm(src):
     global width, height
 
-    fh = open(src, "rb")
-    text = fh.read()
-    fh.close()
+    with open(src, "rb") as fh:
+        text = fh.read()
+
     i = 0
     j = text.find("\n", i)
     if text[i:j] != "P6":
@@ -62,10 +62,9 @@ def read_ppm(src):
 def write_ppm(dst, data):
     w = height
     h = width
-    fh = open(dst, "wb")
-    fh.write("P6\n%d %d\n%d\n" % (w, h, 255))
-    data.tofile(fh)
-    fh.close()
+    with open(dst, "wb") as fh:
+        fh.write("P6\n%d %d\n%d\n" % (w, h, 255))
+        data.tofile(fh)
 
 
 def rotate_ppm(srcd):
@@ -92,9 +91,8 @@ def ppmtopng(dst, src):
     if gs.find_program("g.ppmtopng", "--help"):
         gs.run_command("g.ppmtopng", input=src, output=dst, quiet=True)
     elif gs.find_program("pnmtopng"):
-        fh = open(dst, "wb")
-        gs.call(["pnmtopng", src], stdout=fh)
-        fh.close()
+        with open(dst, "wb") as fh:
+            gs.call(["pnmtopng", src], stdout=fh)
     elif gs.find_program("convert"):
         gs.call(["convert", src, dst])
     else:

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -15,6 +15,8 @@
 
 import os
 import atexit
+from pathlib import Path
+
 import grass.script as gs
 
 
@@ -35,9 +37,7 @@ def cleanup():
 
 
 def make_gradient(path):
-    with open(path) as fh:
-        text = fh.read()
-
+    text = Path(path).read_text()
     lines = text.splitlines()
     records = []
     for line in lines:

--- a/utils/thumbnails.py
+++ b/utils/thumbnails.py
@@ -35,9 +35,8 @@ def cleanup():
 
 
 def make_gradient(path):
-    fh = open(path)
-    text = fh.read()
-    fh.close()
+    with open(path) as fh:
+        text = fh.read()
 
     lines = text.splitlines()
     records = []


### PR DESCRIPTION
I tried out a tool called pyrefact. While not that safe and stable (hanged on some files if not changed), it still found out some places where context managers could be used and applied these transformations. The changes by pyrefact plus some manual tweaks were enough to unlock existing ruff simplifications afterwards.

I include here some changes that were appropriate for us