### PR TITLE
python: Fix typos and formatting of docstring parameters

### DIFF
--- a/python/grass/imaging/images2gif.py
+++ b/python/grass/imaging/images2gif.py
@@ -230,9 +230,9 @@ class GifWriter:
 
           * 0 - No disposal specified.
           * 1 - Do not dispose. The graphic is to be left in place.
-          * 2 -	Restore to background color. The area used by the graphic
+          * 2 - Restore to background color. The area used by the graphic
             must be restored to the background color.
-          * 3 -	Restore to previous. The decoder is required to restore the
+          * 3 - Restore to previous. The decoder is required to restore the
             area overwritten by the graphic with what was there prior to
             rendering the graphic.
           * 4-7 -To be defined.
@@ -254,7 +254,6 @@ class GifWriter:
         """Handle the sub-rectangle stuff. If the rectangles are given by the
         user, the values are checked. Otherwise the subrectangles are
         calculated automatically.
-
         """
 
         if isinstance(subRectangles, (tuple, list)):
@@ -406,9 +405,7 @@ class GifWriter:
         Requires different handling of palette for PIL and Pillow:
         based on https://github.com/rec/echomesh/blob/master/
         code/python/external/images2gif.py
-
         """
-
         # Obtain palette for all images and count each occurrence
         palettes, occur = [], []
         for im in images:
@@ -547,7 +544,7 @@ def writeGifVisvis(
                         integer types, and between 0 and 1 for float types.
     :param duration: scalar or list of scalars The duration for all frames, or
                      (if a list) for each frame.
-    :param repeat: bool or integer The amount of loops. If True, loops infinitetely.
+    :param repeat: bool or integer The amount of loops. If True, loops infinitely.
     :param bool dither: whether to apply dithering
     :param int nq: If nonzero, applies the NeuQuant quantization algorithm to
                    create the color palette. This algorithm is superior, but

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -309,14 +309,13 @@ def estimate_resolution(
 ) -> float:
     """Estimates resolution of reprojected raster.
 
-    :param str raster: name of raster
-    :param str mapset: mapset of raster
-    :param str location: name of source location
-    :param str dbase: path to source database
+    :param raster: name of raster
+    :param mapset: mapset of raster
+    :param location: name of source location
+    :param dbase: path to source database
     :param dict env: target environment
 
-    :return float estimate: estimated resolution of raster in destination
-                            environment
+    :return estimate: estimated resolution of raster in destination environment
     """
     output = gs.read_command(
         "r.proj",

--- a/python/grass/pygrass/modules/grid/grid.py
+++ b/python/grass/pygrass/modules/grid/grid.py
@@ -163,8 +163,7 @@ def copy_groups(groups, gisrc_src, gisrc_dst, region=None):
     :param gisrc_dst: path of the GISRC file where the groups will be created
     :type gisrc_dst: str
     :param region: a region like object or a dictionary with the region
-                   parameters that will be used to crop the rasters of the
-                   groups
+                   parameters that will be used to crop the rasters of the groups
     :type region: Region object or dictionary
     :returns: None
 
@@ -204,8 +203,7 @@ def set_region(region, gisrc_src, gisrc_dst, env):
     """Set a region into two different mapsets.
 
     :param region: a region like object or a dictionary with the region
-                   parameters that will be used to crop the rasters of the
-                   groups
+                   parameters that will be used to crop the rasters of the groups
     :type region: Region object or dictionary
     :param gisrc_src: path of the GISRC file from where we want to copy the groups
     :type gisrc_src: str
@@ -238,8 +236,7 @@ def copy_rasters(rasters, gisrc_src, gisrc_dst, region=None):
     :param gisrc_dst: path of the GISRC file where the groups will be created
     :type gisrc_dst: str
     :param region: a region like object or a dictionary with the region
-                   parameters that will be used to crop the rasters of the
-                   groups
+                   parameters that will be used to crop the rasters of the groups
     :type region: Region object or dictionary
     :returns: None
     """
@@ -411,7 +408,7 @@ class GridModule:
     :param overlap: overlap between tiles, in pixel.
     :type overlap: int
     :param processes: number of threads, default value is equal to the number
-                      of processor available.
+                      of processors available.
     :param split: if True use r.tile to split all the inputs.
     :type split: bool
     :param mapset_prefix: if specified created mapsets start with this prefix

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -127,8 +127,7 @@ class Vector(Info):
         :param geo_obj: a geometry grass object define in
                         grass.pygrass.vector.geometry
         :type geo_obj: geometry GRASS object
-        :param attrs: a list with the values that will be insert in the
-                      attribute table.
+        :param attrs: a list with the values that will be insert in the attribute table.
         :type attrs: list
         :param cat: The category of the geometry feature, otherwise the
                          c_cats attribute of the geometry object will be used.

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -127,7 +127,8 @@ class Vector(Info):
         :param geo_obj: a geometry grass object define in
                         grass.pygrass.vector.geometry
         :type geo_obj: geometry GRASS object
-        :param attrs: a list with the values that will be insert in the attribute table.
+        :param attrs: a list with the values that will be inserted in the
+                      attribute table.
         :type attrs: list
         :param cat: The category of the geometry feature, otherwise the
                          c_cats attribute of the geometry object will be used.

--- a/python/grass/pygrass/vector/abstract.py
+++ b/python/grass/pygrass/vector/abstract.py
@@ -337,12 +337,11 @@ class Info:
         :param tab_name: define the name of the table that will be generate
         :type tab_name: str
         :param tab_cols: define the name and type of the columns of the
-                         attribute table of the vecto map
+                         attribute table of the vector map
         :type tab_cols: list of pairs
-        :param link_name: define the name of the link connection with the
-                          database
+        :param link_name: define the name of the link connection with the database
         :type link_name: str
-        :param link_key: define the nema of the column that will be use as
+        :param link_key: define the name of the column that will be use as
                          vector category
         :type link_key: str
         :param link_db: define the database connection parameters

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -594,8 +594,7 @@ class Point(Geo):
         :type angle: num
         :param round_: to make corners round
         :type round_: bool
-        :param tol: fix the maximum distance between theoretical arc and
-                    output segments
+        :param tol: fix the maximum distance between theoretical arc and output segments
         :type tol: float
         :returns: the buffer as Area object
 
@@ -1051,11 +1050,9 @@ class Line(Geo):
     def segment(self, start, end):
         """Create line segment. using the ``Vect_line_segment`` C function.
 
-        :param start: distance from the beginning of the line where
-                      the segment start
+        :param start: distance from the beginning of the line where the segment starts
         :type start: float
-        :param end: distance from the beginning of the line where
-                    the segment end
+        :param end: distance from the beginning of the line where the segment ends
         :type end: float
 
         ::
@@ -1158,8 +1155,7 @@ class Line(Geo):
         :type angle: num
         :param round_: to make corners round
         :type round_: bool
-        :param tol: fix the maximum distance between theoretical arc and
-                    output segments
+        :param tol: fix the maximum distance between theoretical arc and output segments
         :type tol: float
         :returns: the buffer as Area object
 
@@ -1720,8 +1716,7 @@ class Area(Geo):
         :type angle: num
         :param round_: to make corners round
         :type round_: bool
-        :param tol: fix the maximum distance between theoretical arc and
-                    output segments
+        :param tol: fix the maximum distance between theoretical arc and output segments
         :type tol: float
         :returns: the buffer as line, centroid, isles object tuple
 

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -1125,8 +1125,7 @@ class Table:
         :param cursor: the cursor to connect, if None it use the cursor
                        of connection table object
         :type cursor: Cursor object
-        :param force: True to remove the table, by default False to print
-                      advice
+        :param force: True to remove the table, by default False to print advice
         :type force: bool
         """
 
@@ -1165,8 +1164,7 @@ class Table:
         """Execute SQL code from a given string or build with filters and
         return a cursor object.
 
-        :param sql_code: the SQL code to execute, if not pass it use filters
-                         variable
+        :param sql_code: the SQL code to execute, if not pass it use filters variable
         :type sql_code: str
         :param cursor: the cursor to connect, if None it use the cursor
                      of connection table object

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -218,8 +218,7 @@ def raster_what(map, coord, env=None, localized=False):
     [{'elevation': {'color': '255:214:000', 'label': '', 'value': '102.479'}}]
 
     :param str map: the map name
-    :param list coord: a list of list containing all the point that you want
-                       query
+    :param list coord: a list of list containing all the point that you want to query
     :param env:
     """
     map_list = [map] if isinstance(map, (bytes, str)) else map

--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -74,7 +74,7 @@ class AbstractDataset(
         topologies must be build first using the SpatioTemporalTopologyBuilder.
 
         :return: The dictionary with relations as keys and number as values or
-                 None in case the topology  wasn't build
+                 None in case the topology wasn't built
         """
         if self.is_temporal_topology_build() and not self.is_spatial_topology_build():
             return self.get_number_of_temporal_relations()
@@ -342,8 +342,7 @@ class AbstractDataset(
         Top and bottom are set to 0 in case of a two dimensional spatial
         extent.
 
-        :return: A the spatial extent as tuple (north, south, east, west,
-                 top, bottom)
+        :return: A the spatial extent as tuple (north, south, east, west, top, bottom)
         """
         return self.spatial_extent.get_spatial_extent_as_tuple()
 

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -176,8 +176,7 @@ class AbstractMapDataset(AbstractDataset):
         the keyword arguments.
 
         :param name: The name of the map
-        :param layer: The layer of the vector map, use None in case no
-                      layer exists
+        :param layer: The layer of the vector map, use None in case no layer exists
         :param mapset: The mapset in which the map is located
 
         :return: tuple of three elements name, layer, mapset e(:layer)@mapset" while
@@ -244,11 +243,9 @@ class AbstractMapDataset(AbstractDataset):
 
         :param name: The name of the map
         :param mapset: The mapset in which the map is located
-        :param layer: The layer of the vector map, use None in case no
-                      layer exists
+        :param layer: The layer of the vector map, use None in case no layer exists
 
-        :return: the id of the map as "name(:layer)@mapset" where layer is
-                 optional
+        :return: the id of the map as "name(:layer)@mapset" where layer is optional
         """
 
         # Split given name into relevant parts
@@ -421,8 +418,7 @@ class AbstractMapDataset(AbstractDataset):
          This method only modifies this object and does not commit
          the modifications to the temporal database.
 
-        :param start_time: A datetime object specifying the start time of
-                           the map
+        :param start_time: A datetime object specifying the start time of the map
         :param end_time: A datetime object specifying the end time of the
                          map, None in case or time instance
 
@@ -512,8 +508,7 @@ class AbstractMapDataset(AbstractDataset):
         grass file system based database in addition to the temporal
         database entry.
 
-        :param start_time: A datetime object specifying the start time of
-                                      the map
+        :param start_time: A datetime object specifying the start time of the map
         :param end_time: A datetime object specifying the end time of the
                                      map, None in case or time instance
         :param dbif: The database interface to be used
@@ -669,8 +664,7 @@ class AbstractMapDataset(AbstractDataset):
         """Convenient method to set the temporal extent from a temporal extent
         object
 
-        :param extent: The temporal extent that should be set for
-                                this object
+        :param extent: The temporal extent that should be set for this object
 
         .. code-block: : python
 
@@ -853,8 +847,7 @@ class AbstractMapDataset(AbstractDataset):
          This method only modifies this object and does not commit
          the modifications to the temporal database.
 
-         :param spatial_extent: An object of type SpatialExtent or its
-                                subclasses
+         :param spatial_extent: An object of type SpatialExtent or its subclasses
 
         .. code-block: : python
 

--- a/python/grass/temporal/list_stds.py
+++ b/python/grass/temporal/list_stds.py
@@ -500,7 +500,7 @@ def list_maps_of_stds(
                   e.g: start_time < "2001-01-01" and end_time > "2001-01-01"
     :param separator: The field separator character between the columns
     :param method: String identifier to select a method out of cols,
-                   comma,delta or deltagaps
+                   comma, delta or deltagaps
     :param dbif: The database interface to be used
 
         - "cols" Print preselected columns specified by columns

--- a/python/grass/temporal/mapcalc.py
+++ b/python/grass/temporal/mapcalc.py
@@ -87,7 +87,7 @@ def dataset_mapcalculator(
     :param type: The type of the dataset: "raster" or "raster3d"
     :param expression: The r(3).mapcalc expression
     :param base: The base name of the new created maps in case a
-           mapclac expression is provided
+           mapcalc expression is provided
     :param method: The method to be used for temporal sampling
     :param nprocs: The number of parallel processes to be used for
            mapcalc processing

--- a/python/grass/temporal/sampling.py
+++ b/python/grass/temporal/sampling.py
@@ -49,10 +49,8 @@ def sample_stds_by_stds_topology(
 
      Attention: Do not use the comma as separator for printing
 
-     :param intype: Type of the input space time dataset (strds, stvds or
-                    str3ds)
-     :param sampletype: Type of the sample space time datasets (strds,
-                        stvds or str3ds)
+     :param intype: Type of the input space time dataset (strds, stvds or str3ds)
+     :param sampletype: Type of the sample space time datasets (strds, stvds or str3ds)
      :param inputs: Name or comma separated names of space time datasets or
                     a list of map names
      :param sampler: Name of a space time dataset used for temporal sampling

--- a/python/grass/temporal/spatial_extent.py
+++ b/python/grass/temporal/spatial_extent.py
@@ -1712,8 +1712,7 @@ class SpatialExtent(SQLDatabaseInterface):
     def set_spatial_extent(self, spatial_extent) -> None:
         """Set the three dimensional spatial extent
 
-        :param spatial_extent: An object of type SpatialExtent or its
-                               subclasses
+        :param spatial_extent: An object of type SpatialExtent or its subclasses
         """
 
         self.set_north(spatial_extent.get_north())
@@ -1749,8 +1748,7 @@ class SpatialExtent(SQLDatabaseInterface):
     def set_spatial_extent_2d(self, spatial_extent) -> None:
         """Set the three dimensional spatial extent
 
-        :param spatial_extent: An object of type SpatialExtent or its
-                               subclasses
+        :param spatial_extent: An object of type SpatialExtent or its subclasses
         """
 
         self.set_north(spatial_extent.north)

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -417,7 +417,7 @@ class SpatioTemporalTopologyBuilder:
         The maps will be added to the object, so they can be
         accessed using the iterator of this class
 
-        :param maps: A sorted (by start_time)list of abstract_dataset
+        :param maps: A sorted (by start_time) list of abstract_dataset
                      objects with initiated temporal extent
         """
         self._build_iteratable(maps, spatial)

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -230,8 +230,7 @@ def import_stds(
     :param output: The name of the output space time dataset
     :param directory: The extraction directory
     :param title: The title of the new created space time dataset
-    :param descr: The description of the new created
-                 space time dataset
+    :param descr: The description of the new created space time dataset
     :param location: The name of the location that should be created,
                     maps are imported into this location
     :param link: Switch to link raster maps instead importing them
@@ -240,8 +239,7 @@ def import_stds(
     :param create: Create the location specified by the "location"
                   parameter and exit.
                   Do not import the space time datasets.
-    :param stds_type: The type of the space time dataset that
-                     should be imported
+    :param stds_type: The type of the space time dataset that should be imported
     :param base: The base name of the new imported maps, it will be
                  extended using a numerical index.
     :param memory: Cache size for raster rows, used in r.in.gdal

--- a/python/grass/temporal/temporal_raster_base_algebra.py
+++ b/python/grass/temporal/temporal_raster_base_algebra.py
@@ -227,9 +227,9 @@ class TemporalRasterBaseAlgebraParser(TemporalAlgebraParser):
         :param count_map: Boolean if the number of topological related maps
                        should be returned.
         :param compare_bool: Boolean for comparing boolean map values based on
-                        related map list and compariosn operator.
+                        related map list and comparison operator.
         :param compare_cmd: Boolean for comparing command list values based on
-                        related map list and compariosn operator.
+                        related map list and comparison operator.
         :param compop: Comparison operator, && or ||.
         :param aggregate: Aggregation operator for relation map list, & or |.
         :param new: Boolean if new temporary maps should be created.

--- a/python/grass/temporal/temporal_vector_algebra.py
+++ b/python/grass/temporal/temporal_vector_algebra.py
@@ -297,7 +297,7 @@ class TemporalVectorAlgebraParser(TemporalAlgebraParser):
         :param function: Overlay operator, &|+^~.
 
         :return: Map object with command list with  operators that has been
-                      evaluated by implicit aggregration.
+                      evaluated by implicit aggregation.
         """
         # Build comandlist list with elements from related maps and given relation
         # operator.


### PR DESCRIPTION
PR containing only typos and formatting changes for docstrings in python/grass