### PR TITLE
gui(core.layerlist): Fix returning active layers in GetSelectedLayers()

### DIFF
--- a/gui/wxpython/core/layerlist.py
+++ b/gui/wxpython/core/layerlist.py
@@ -38,8 +38,9 @@ class LayerList:
         layers = []
         for layer in self._list:
             if layer.IsSelected():
-                if activeOnly and layer.IsActive():
-                    layers.append(layer)
+                if activeOnly:
+                    if layer.IsActive():
+                        layers.append(layer)
                 else:
                     layers.append(layer)
         return layers


### PR DESCRIPTION
The previous code was appending the selected layer whether it was active or not. It doesn't seem expected, as it could be simplified to the following below. These lines were there since the file was introduced like 11 years ago.

A simplified version of the previous code:
```python
    def GetSelectedLayers(self, activeOnly=True):
        """Returns list of selected layers.
        :param bool activeOnly: return only active layers
        """
        layers = []
        for layer in self._list:
            if layer.IsSelected():
                layers.append(layer)
                if activeOnly and layer.IsActive():
                    pass
                else:
                    pass
        return layers
``` 
