### PR TITLE
r.describe: Add JSON support

### DIFF
--- a/raster/r.describe/Makefile
+++ b/raster/r.describe/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.describe
 
-LIBES = $(RASTERLIB) $(GISLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.describe/describe.c
+++ b/raster/r.describe/describe.c
@@ -18,10 +18,12 @@
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
+
 #include "local_proto.h"
 
 int describe(const char *name, int compact, char *no_data_str, int range,
-             int windowed, int nsteps, int as_int, int skip_nulls)
+             int windowed, int nsteps, int as_int, int skip_nulls,
+             enum OutputFormat format)
 {
     int fd;
     struct Cell_stats statf;
@@ -127,20 +129,20 @@ int describe(const char *name, int compact, char *no_data_str, int range,
     if (range) {
         if (compact)
             compact_range_list(negmin, negmax, zero, posmin, posmax, null,
-                               no_data_str, skip_nulls);
+                               no_data_str, skip_nulls, format);
         else
             range_list(negmin, negmax, zero, posmin, posmax, null, no_data_str,
-                       skip_nulls);
+                       skip_nulls, format);
     }
     else {
         Rast_rewind_cell_stats(&statf);
 
         if (compact)
             compact_list(&statf, dmin, dmax, no_data_str, skip_nulls, map_type,
-                         nsteps);
+                         nsteps, format);
         else
             long_list(&statf, dmin, dmax, no_data_str, skip_nulls, map_type,
-                      nsteps);
+                      nsteps, format);
 
         Rast_free_cell_stats(&statf);
     }

--- a/raster/r.describe/dumplist.c
+++ b/raster/r.describe/dumplist.c
@@ -18,43 +18,136 @@
 #include <string.h>
 #include <grass/gis.h>
 #include <grass/raster.h>
+#include <grass/glocale.h>
 
-static int show(CELL, CELL, int *, DCELL, DCELL, RASTER_MAP_TYPE, int);
+#include "local_proto.h"
+
+static int show(CELL, CELL, int *, DCELL, DCELL, RASTER_MAP_TYPE, int,
+                enum OutputFormat, JSON_Array *);
+static void initialize_json_array(JSON_Value **, JSON_Array **);
+static void json_append_category_value(JSON_Array *, const char *);
+static void output_pretty_json(JSON_Value *);
+
+void initialize_json_array(JSON_Value **root_value, JSON_Array **root_array)
+{
+    *root_value = json_value_init_array();
+    if (*root_value == NULL) {
+        G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+    }
+    *root_array = json_array(*root_value);
+}
+
+void json_append_category_value(JSON_Array *root_array, const char *cat_str)
+{
+    JSON_Value *category_value;
+    JSON_Object *category;
+
+    category_value = json_value_init_object();
+    if (category_value == NULL) {
+        G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+    }
+    category = json_object(category_value);
+
+    json_object_set_string(category, "value", cat_str);
+    json_array_append_value(root_array, category_value);
+}
+
+void output_pretty_json(JSON_Value *root_value)
+{
+    char *serialized_string = json_serialize_to_string_pretty(root_value);
+    if (!serialized_string) {
+        json_value_free(root_value);
+        G_fatal_error(_("Failed to initialize pretty JSON string."));
+    }
+    puts(serialized_string);
+
+    json_free_serialized_string(serialized_string);
+    json_value_free(root_value);
+}
 
 int long_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
               char *no_data_str, int skip_nulls, RASTER_MAP_TYPE map_type,
-              int nsteps)
+              int nsteps, enum OutputFormat format)
 {
     CELL cat;
     long count; /* not used, but required by cell stats call */
+    char cat_str[MAX_STR_LEN];
+    JSON_Value *root_value;
+    JSON_Array *root_array;
+
+    if (format == JSON) {
+        initialize_json_array(&root_value, &root_array);
+    }
 
     Rast_get_stats_for_null_value(&count, statf);
-    if (count != 0 && !skip_nulls)
-        fprintf(stdout, "%s\n", no_data_str);
+    if (count != 0 && !skip_nulls) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%s\n", no_data_str);
+            break;
+        case JSON:
+            json_append_category_value(root_array, no_data_str);
+            break;
+        }
+    }
 
     while (Rast_next_cell_stat(&cat, &count, statf)) {
-        if (map_type != CELL_TYPE)
-            fprintf(stdout, "%f-%f\n",
-                    dmin + (double)(cat - 1) * (dmax - dmin) / nsteps,
-                    dmin + (double)cat * (dmax - dmin) / nsteps);
-        else
-            fprintf(stdout, "%ld\n", (long)cat);
+        switch (format) {
+        case PLAIN:
+            if (map_type != CELL_TYPE)
+                fprintf(stdout, "%f-%f\n",
+                        dmin + (double)(cat - 1) * (dmax - dmin) / nsteps,
+                        dmin + (double)cat * (dmax - dmin) / nsteps);
+            else
+                fprintf(stdout, "%ld\n", (long)cat);
+            break;
+        case JSON:
+            if (map_type != CELL_TYPE) {
+                snprintf(cat_str, sizeof(cat_str), "%f-%f",
+                         dmin + (double)(cat - 1) * (dmax - dmin) / nsteps,
+                         dmin + (double)cat * (dmax - dmin) / nsteps);
+            }
+            else {
+                snprintf(cat_str, sizeof(cat_str), "%ld", (long)cat);
+            }
+            json_append_category_value(root_array, cat_str);
+            break;
+        }
     }
+
+    if (format == JSON) {
+        output_pretty_json(root_value);
+    }
+
     return (0);
 }
 
 int compact_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
                  char *no_data_str, int skip_nulls, RASTER_MAP_TYPE map_type,
-                 int nsteps)
+                 int nsteps, enum OutputFormat format)
 {
     CELL cat1, cat2, temp;
     int len;
     long count; /* not used, but required by cell stats call */
+    JSON_Value *root_value;
+    JSON_Array *root_array;
+
+    if (format == JSON) {
+        initialize_json_array(&root_value, &root_array);
+    }
 
     len = 0;
     Rast_get_stats_for_null_value(&count, statf);
-    if (count != 0 && !skip_nulls)
-        fprintf(stdout, "%s ", no_data_str);
+    if (count != 0 && !skip_nulls) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%s ", no_data_str);
+            break;
+        case JSON:
+            json_append_category_value(root_array, no_data_str);
+            break;
+        }
+    }
 
     if (!Rast_next_cell_stat(&cat1, &count, statf))
         /* map doesn't contain any non-null data */
@@ -63,94 +156,244 @@ int compact_list(struct Cell_stats *statf, DCELL dmin, DCELL dmax,
     cat2 = cat1;
     while (Rast_next_cell_stat(&temp, &count, statf)) {
         if (temp != cat2 + (CELL)1) {
-            show(cat1, cat2, &len, dmin, dmax, map_type, nsteps);
+            show(cat1, cat2, &len, dmin, dmax, map_type, nsteps, format,
+                 root_array);
             cat1 = temp;
         }
         cat2 = temp;
     }
-    show(cat1, cat2, &len, dmin, dmax, map_type, nsteps);
-    fprintf(stdout, "\n");
+    show(cat1, cat2, &len, dmin, dmax, map_type, nsteps, format, root_array);
+
+    switch (format) {
+    case PLAIN:
+        fprintf(stdout, "\n");
+        break;
+    case JSON:
+        output_pretty_json(root_value);
+        break;
+    }
+
     return (0);
 }
 
 static int show(CELL low, CELL high, int *len, DCELL dmin, DCELL dmax,
-                RASTER_MAP_TYPE map_type, int nsteps)
+                RASTER_MAP_TYPE map_type, int nsteps, enum OutputFormat format,
+                JSON_Array *root_array)
 {
-    char text[100];
+    char text[MAX_STR_LEN];
     char xlen;
 
     if (low + 1 == high) {
-        show(low, low, len, dmin, dmax, map_type, nsteps);
-        show(high, high, len, dmin, dmax, map_type, nsteps);
+        show(low, low, len, dmin, dmax, map_type, nsteps, format, root_array);
+        show(high, high, len, dmin, dmax, map_type, nsteps, format, root_array);
         return 0;
     }
 
     if (map_type != CELL_TYPE) {
-        sprintf(text, "%f%s%f ", dmin + (low - 1) * (dmax - dmin) / nsteps,
-                dmin < 0 ? " thru " : "-",
-                dmin + high * (dmax - dmin) / nsteps);
+        switch (format) {
+        case PLAIN:
+            sprintf(text, "%f%s%f ", dmin + (low - 1) * (dmax - dmin) / nsteps,
+                    dmin < 0 ? " thru " : "-",
+                    dmin + high * (dmax - dmin) / nsteps);
+            break;
+        case JSON:
+            sprintf(text, "%f%s%f", dmin + (low - 1) * (dmax - dmin) / nsteps,
+                    dmin < 0 ? " thru " : "-",
+                    dmin + high * (dmax - dmin) / nsteps);
+            break;
+        }
     }
     else {
-        if (low == high)
-            sprintf(text, "%ld ", (long)low);
-        else
-            sprintf(text, "%ld%s%ld ", (long)low, low < 0 ? " thru " : "-",
-                    (long)high);
+        switch (format) {
+        case PLAIN:
+            if (low == high)
+                sprintf(text, "%ld ", (long)low);
+            else
+                sprintf(text, "%ld%s%ld ", (long)low, low < 0 ? " thru " : "-",
+                        (long)high);
+            break;
+        case JSON:
+            if (low == high)
+                sprintf(text, "%ld", (long)low);
+            else
+                sprintf(text, "%ld%s%ld", (long)low, low < 0 ? " thru " : "-",
+                        (long)high);
+            break;
+        }
     }
 
     xlen = strlen(text);
     if (xlen + *len > 78) {
-        fprintf(stdout, "\n");
+        if (format == PLAIN)
+            fprintf(stdout, "\n");
         *len = 0;
     }
-    fprintf(stdout, "%s", text);
+
+    switch (format) {
+    case PLAIN:
+        fprintf(stdout, "%s", text);
+        break;
+    case JSON:
+        json_append_category_value(root_array, text);
+        break;
+    }
+
     *len += xlen;
     return (0);
 }
 
 int compact_range_list(CELL negmin, CELL negmax, CELL zero, CELL posmin,
                        CELL posmax, CELL null, char *no_data_str,
-                       int skip_nulls)
+                       int skip_nulls, enum OutputFormat format)
 {
-    if (negmin) {
-        fprintf(stdout, "%ld", (long)negmin);
-        if (negmin != negmax)
-            fprintf(stdout, " thru %ld", (long)negmax);
-        fprintf(stdout, "\n");
-    }
-    if (zero)
-        fprintf(stdout, "0\n");
-    if (posmin) {
-        fprintf(stdout, "%ld", (long)posmin);
-        if (posmin != posmax)
-            fprintf(stdout, " thru %ld", (long)posmax);
-        fprintf(stdout, "\n");
+    char cat_str[MAX_STR_LEN];
+    JSON_Value *root_value;
+    JSON_Array *root_array;
+
+    if (format == JSON) {
+        initialize_json_array(&root_value, &root_array);
     }
 
-    if (null && !skip_nulls)
-        fprintf(stdout, "%s\n", no_data_str);
+    if (negmin) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%ld", (long)negmin);
+            if (negmin != negmax)
+                fprintf(stdout, " thru %ld", (long)negmax);
+            fprintf(stdout, "\n");
+            break;
+        case JSON:
+            snprintf(cat_str, sizeof(cat_str), "%ld", (long)negmin);
+            if (negmin != negmax)
+                snprintf(cat_str, sizeof(cat_str), "%ld thru %ld", (long)negmin,
+                         (long)negmax);
+
+            json_append_category_value(root_array, cat_str);
+            break;
+        }
+    }
+    if (zero) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "0\n");
+            break;
+        case JSON:
+            json_append_category_value(root_array, "0");
+            break;
+        }
+    }
+    if (posmin) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%ld", (long)posmin);
+            if (posmin != posmax)
+                fprintf(stdout, " thru %ld", (long)posmax);
+            fprintf(stdout, "\n");
+            break;
+        case JSON:
+            snprintf(cat_str, sizeof(cat_str), "%ld", (long)posmin);
+            if (posmin != posmax)
+                snprintf(cat_str, sizeof(cat_str), "%ld thru %ld", (long)posmin,
+                         (long)posmax);
+
+            json_append_category_value(root_array, cat_str);
+            break;
+        }
+    }
+
+    if (null && !skip_nulls) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%s\n", no_data_str);
+            break;
+        case JSON:
+            json_append_category_value(root_array, no_data_str);
+            break;
+        }
+    }
+
+    if (format == JSON) {
+        output_pretty_json(root_value);
+    }
 
     return (0);
 }
 
 int range_list(CELL negmin, CELL negmax, CELL zero, CELL posmin, CELL posmax,
-               CELL null, char *no_data_str, int skip_nulls)
+               CELL null, char *no_data_str, int skip_nulls,
+               enum OutputFormat format)
 {
-    if (negmin) {
-        fprintf(stdout, "%ld\n", (long)negmin);
-        if (negmin != negmax)
-            fprintf(stdout, "%ld\n", (long)negmax);
-    }
-    if (zero)
-        fprintf(stdout, "0\n");
-    if (posmin) {
-        fprintf(stdout, "%ld\n", (long)posmin);
-        if (posmin != posmax)
-            fprintf(stdout, "%ld\n", (long)posmax);
+    char cat_str[MAX_STR_LEN];
+    JSON_Value *root_value;
+    JSON_Array *root_array;
+
+    if (format == JSON) {
+        initialize_json_array(&root_value, &root_array);
     }
 
-    if (null && !skip_nulls)
-        fprintf(stdout, "%s\n", no_data_str);
+    if (negmin) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%ld\n", (long)negmin);
+            if (negmin != negmax)
+                fprintf(stdout, "%ld\n", (long)negmax);
+            break;
+        case JSON:
+            snprintf(cat_str, sizeof(cat_str), "%ld", (long)negmin);
+            json_append_category_value(root_array, cat_str);
+
+            if (negmin != negmax) {
+                snprintf(cat_str, sizeof(cat_str), "%ld", (long)negmax);
+                json_append_category_value(root_array, cat_str);
+            }
+            break;
+        }
+    }
+
+    if (zero) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "0\n");
+            break;
+        case JSON:
+            json_append_category_value(root_array, "0");
+            break;
+        }
+    }
+
+    if (posmin) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%ld\n", (long)posmin);
+            if (posmin != posmax)
+                fprintf(stdout, "%ld\n", (long)posmax);
+            break;
+        case JSON:
+            snprintf(cat_str, sizeof(cat_str), "%ld", (long)posmin);
+            json_append_category_value(root_array, cat_str);
+
+            if (posmin != posmax) {
+                snprintf(cat_str, sizeof(cat_str), "%ld", (long)posmax);
+                json_append_category_value(root_array, cat_str);
+            }
+            break;
+        }
+    }
+
+    if (null && !skip_nulls) {
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%s\n", no_data_str);
+            break;
+        case JSON:
+            json_append_category_value(root_array, no_data_str);
+            break;
+        }
+    }
+
+    if (format == JSON) {
+        output_pretty_json(root_value);
+    }
 
     return (0);
 }

--- a/raster/r.describe/local_proto.h
+++ b/raster/r.describe/local_proto.h
@@ -19,17 +19,25 @@
 #define __R_DESC_LOCAL_PROTO_H__
 
 #include <grass/raster.h>
+#include <grass/parson.h>
+
+#define MAX_STR_LEN 100
+
+enum OutputFormat { PLAIN, JSON };
 
 /* describe.c */
-int describe(const char *, int, char *, int, int, int, int, int);
+int describe(const char *, int, char *, int, int, int, int, int,
+             enum OutputFormat);
 
 /* dumplist.c */
 int long_list(struct Cell_stats *, DCELL, DCELL, char *, int, RASTER_MAP_TYPE,
-              int);
+              int, enum OutputFormat);
 int compact_list(struct Cell_stats *, DCELL, DCELL, char *, int,
-                 RASTER_MAP_TYPE, int);
-int compact_range_list(CELL, CELL, CELL, CELL, CELL, CELL, char *, int);
-int range_list(CELL, CELL, CELL, CELL, CELL, CELL, char *, int);
+                 RASTER_MAP_TYPE, int, enum OutputFormat);
+int compact_range_list(CELL, CELL, CELL, CELL, CELL, CELL, char *, int,
+                       enum OutputFormat);
+int range_list(CELL, CELL, CELL, CELL, CELL, CELL, char *, int,
+               enum OutputFormat);
 
 /* main.c */
 int main(int, char *[]);

--- a/raster/r.describe/main.c
+++ b/raster/r.describe/main.c
@@ -19,8 +19,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <grass/gis.h>
-#include "local_proto.h"
 #include <grass/glocale.h>
+
+#include "local_proto.h"
 
 int main(int argc, char *argv[])
 {
@@ -42,7 +43,9 @@ int main(int argc, char *argv[])
         struct Option *map;
         struct Option *nv;
         struct Option *nsteps;
+        struct Option *format;
     } option;
+    enum OutputFormat format;
 
     G_gisinit(argv[0]);
 
@@ -65,6 +68,9 @@ int main(int argc, char *argv[])
     option.nsteps->multiple = NO;
     option.nsteps->answer = "255";
     option.nsteps->description = _("Number of quantization steps");
+
+    option.format = G_define_standard_option(G_OPT_F_FORMAT);
+    option.format->guisection = _("Print");
 
     /*define the different flags */
 
@@ -97,12 +103,19 @@ int main(int argc, char *argv[])
     as_int = flag.i->answer;
     no_data_str = option.nv->answer;
 
+    if (strcmp(option.format->answer, "json") == 0) {
+        format = JSON;
+    }
+    else {
+        format = PLAIN;
+    }
+
     if (sscanf(option.nsteps->answer, "%d", &nsteps) != 1 || nsteps < 1)
         G_fatal_error(_("%s = %s -- must be greater than zero"),
                       option.nsteps->key, option.nsteps->answer);
 
     describe(option.map->answer, compact, no_data_str, range, windowed, nsteps,
-             as_int, flag.n->answer);
+             as_int, flag.n->answer, format);
 
     return EXIT_SUCCESS;
 }

--- a/raster/r.describe/testsuite/test_r_describe.py
+++ b/raster/r.describe/testsuite/test_r_describe.py
@@ -1,0 +1,400 @@
+import json
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+from grass.gunittest.gmodules import SimpleModule
+
+
+class TestRDescribe(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up a temporary region and generate test data."""
+        cls.use_temp_region()
+        cls.runModule("g.region", n=10, s=0, e=10, w=0, res=1)
+
+        cls.runModule(
+            "r.mapcalc",
+            expression="map = if(row() == 5 && col() == 5, null(), if(row() % 2 == 0, col() * 0.5, -col() * 0.5))",
+            overwrite=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up after tests."""
+        cls.runModule(
+            "g.remove", flags="f", type="raster", name=["map"]
+        )
+        cls.del_temp_region()
+
+    def test_plain_describe(self):
+        """Test r.describe with the default output format."""
+        module = SimpleModule("r.describe", map="map")
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "* -5.000000 thru -4.960784 -4.529412 thru -4.490196 -4.019608 thru -3.980392 ", 
+            "-3.509804 thru -3.470588 -3.039216 thru -3.000000 -2.529412 thru -2.490196 ", 
+            "-2.019608 thru -1.980392 -1.549020 thru -1.509804 -1.039216 thru -1.000000 ", 
+            "-0.529412 thru -0.490196 0.450980 thru 0.490196 0.960784 thru 1.000000 ",
+            "1.470588 thru 1.509804 1.941176 thru 1.980392 2.450980 thru 2.490196 ", 
+            "2.960784 thru 3.000000 3.431373 thru 3.470588 3.941176 thru 3.980392 ", 
+            "4.450980 thru 4.490196 4.960784 thru 5.000000"
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+            
+    def test_plain_describe_with_one_flag(self):
+        """Test r.describe with the plain output format and the -1 flag."""
+        module = SimpleModule("r.describe", map="map",flags="1")
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "*",
+            "-5.000000--4.960784",
+            "-4.529412--4.490196",
+            "-4.019608--3.980392",
+            "-3.509804--3.470588",
+            "-3.039216--3.000000",
+            "-2.529412--2.490196",
+            "-2.019608--1.980392",
+            "-1.549020--1.509804",
+            "-1.039216--1.000000",
+            "-0.529412--0.490196",
+            "0.450980-0.490196",
+            "0.960784-1.000000",
+            "1.470588-1.509804",
+            "1.941176-1.980392",
+            "2.450980-2.490196",
+            "2.960784-3.000000",
+            "3.431373-3.470588",
+            "3.941176-3.980392",
+            "4.450980-4.490196",
+            "4.960784-5.000000"
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+            
+    def test_plain_describe_with_r_flag(self):
+        """Test r.describe with the plain output format and the -r flag."""
+        module = SimpleModule("r.describe", map="map",flags="r")
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = ["* -5.000000 thru 5.000000"]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+    
+    def test_plain_describe_with_i_flag(self):
+        """Test r.describe with the plain output format and the -i flag."""
+        module = SimpleModule("r.describe", map="map",flags="i")
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = ["* -5 thru -1 1-5"]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+            
+    def test_plain_describe_with_n_flag(self):
+        """Test r.describe with the plain output format and the -n flag."""
+        module = SimpleModule("r.describe", map="map",flags="n")
+        self.assertModule(module)
+
+        result = module.outputs.stdout.strip().splitlines()
+
+        expected_results = [
+            "-5.000000 thru -4.960784 -4.529412 thru -4.490196 -4.019608 thru -3.980392 ", 
+            "-3.509804 thru -3.470588 -3.039216 thru -3.000000 -2.529412 thru -2.490196 ", 
+            "-2.019608 thru -1.980392 -1.549020 thru -1.509804 -1.039216 thru -1.000000 ", 
+            "-0.529412 thru -0.490196 0.450980 thru 0.490196 0.960784 thru 1.000000 ",
+            "1.470588 thru 1.509804 1.941176 thru 1.980392 2.450980 thru 2.490196 ", 
+            "2.960784 thru 3.000000 3.431373 thru 3.470588 3.941176 thru 3.980392 ", 
+            "4.450980 thru 4.490196 4.960784 thru 5.000000"
+        ]
+
+        for i, component in enumerate(result):
+            self.assertEqual(
+                component, expected_results[i], f"Mismatch at line {i + 1}"
+            )
+            
+    def test_json_describe(self):
+        """Test r.describe with the json output format."""
+        module = SimpleModule("r.describe", map="map",format="json")
+        self.assertModule(module)
+
+        result = json.loads(module.outputs.stdout)
+
+        expected_results = [
+            {
+                "value": "*"
+            },
+            {
+                "value": "-5.000000 thru -4.960784"
+            },
+            {
+                "value": "-4.529412 thru -4.490196"
+            },
+            {
+                "value": "-4.019608 thru -3.980392"
+            },
+            {
+                "value": "-3.509804 thru -3.470588"
+            },
+            {
+                "value": "-3.039216 thru -3.000000"
+            },
+            {
+                "value": "-2.529412 thru -2.490196"
+            },
+            {
+                "value": "-2.019608 thru -1.980392"
+            },
+            {
+                "value": "-1.549020 thru -1.509804"
+            },
+            {
+                "value": "-1.039216 thru -1.000000"
+            },
+            {
+                "value": "-0.529412 thru -0.490196"
+            },
+            {
+                "value": "0.450980 thru 0.490196"
+            },
+            {
+                "value": "0.960784 thru 1.000000"
+            },
+            {
+                "value": "1.470588 thru 1.509804"
+            },
+            {
+                "value": "1.941176 thru 1.980392"
+            },
+            {
+                "value": "2.450980 thru 2.490196"
+            },
+            {
+                "value": "2.960784 thru 3.000000"
+            },
+            {
+                "value": "3.431373 thru 3.470588"
+            },
+            {
+                "value": "3.941176 thru 3.980392"
+            },
+            {
+                "value": "4.450980 thru 4.490196"
+            },
+            {
+                "value": "4.960784 thru 5.000000"
+            }
+        ]
+
+        self.assertListEqual(expected_results, result)
+            
+    def test_json_describe_with_one_flag(self):
+        """Test r.describe with the json output format and the -1 flag."""
+        module = SimpleModule("r.describe", map="map",flags="1",format="json")
+        self.assertModule(module)
+
+        result = json.loads(module.outputs.stdout)
+
+        expected_results = [
+            {
+                "value": "*"
+            },
+            {
+                "value": "-5.000000--4.960784"
+            },
+            {
+                "value": "-4.529412--4.490196"
+            },
+            {
+                "value": "-4.019608--3.980392"
+            },
+            {
+                "value": "-3.509804--3.470588"
+            },
+            {
+                "value": "-3.039216--3.000000"
+            },
+            {
+                "value": "-2.529412--2.490196"
+            },
+            {
+                "value": "-2.019608--1.980392"
+            },
+            {
+                "value": "-1.549020--1.509804"
+            },
+            {
+                "value": "-1.039216--1.000000"
+            },
+            {
+                "value": "-0.529412--0.490196"
+            },
+            {
+                "value": "0.450980-0.490196"
+            },
+            {
+                "value": "0.960784-1.000000"
+            },
+            {
+                "value": "1.470588-1.509804"
+            },
+            {
+                "value": "1.941176-1.980392"
+            },
+            {
+                "value": "2.450980-2.490196"
+            },
+            {
+                "value": "2.960784-3.000000"
+            },
+            {
+                "value": "3.431373-3.470588"
+            },
+            {
+                "value": "3.941176-3.980392"
+            },
+            {
+                "value": "4.450980-4.490196"
+            },
+            {
+                "value": "4.960784-5.000000"
+            }
+        ]
+
+        self.assertListEqual(expected_results, result)
+            
+    def test_json_describe_with_r_flag(self):
+        """Test r.describe with the json output format and the -r flag."""
+        module = SimpleModule("r.describe", map="map",flags="r",format="json")
+        self.assertModule(module)
+
+        result = json.loads(module.outputs.stdout)
+
+        expected_results = [
+            {
+                "value": "*"
+            },
+            {
+                "value": "-5.000000 thru 5.000000"
+            }
+        ]
+
+        self.assertListEqual(expected_results, result)
+    
+    def test_json_describe_with_i_flag(self):
+        """Test r.describe with the json output format and the -i flag."""
+        module = SimpleModule("r.describe", map="map",flags="i",format="json")
+        self.assertModule(module)
+
+        result = json.loads(module.outputs.stdout)
+
+        expected_results = [
+            {
+                "value": "*"
+            },
+            {
+                "value": "-5 thru -1"
+            },
+            {
+                "value": "1-5"
+            }
+        ]
+
+        self.assertListEqual(expected_results, result)
+            
+    def test_json_describe_with_n_flag(self):
+        """Test r.describe with the json output format and the -n flag."""
+        module = SimpleModule("r.describe", map="map",flags="n",format="json")
+        self.assertModule(module)
+
+        result = json.loads(module.outputs.stdout)
+
+        expected_results = [
+            {
+                "value": "-5.000000 thru -4.960784"
+            },
+            {
+                "value": "-4.529412 thru -4.490196"
+            },
+            {
+                "value": "-4.019608 thru -3.980392"
+            },
+            {
+                "value": "-3.509804 thru -3.470588"
+            },
+            {
+                "value": "-3.039216 thru -3.000000"
+            },
+            {
+                "value": "-2.529412 thru -2.490196"
+            },
+            {
+                "value": "-2.019608 thru -1.980392"
+            },
+            {
+                "value": "-1.549020 thru -1.509804"
+            },
+            {
+                "value": "-1.039216 thru -1.000000"
+            },
+            {
+                "value": "-0.529412 thru -0.490196"
+            },
+            {
+                "value": "0.450980 thru 0.490196"
+            },
+            {
+                "value": "0.960784 thru 1.000000"
+            },
+            {
+                "value": "1.470588 thru 1.509804"
+            },
+            {
+                "value": "1.941176 thru 1.980392"
+            },
+            {
+                "value": "2.450980 thru 2.490196"
+            },
+            {
+                "value": "2.960784 thru 3.000000"
+            },
+            {
+                "value": "3.431373 thru 3.470588"
+            },
+            {
+                "value": "3.941176 thru 3.980392"
+            },
+            {
+                "value": "4.450980 thru 4.490196"
+            },
+            {
+                "value": "4.960784 thru 5.000000"
+            }
+        ]
+
+        self.assertListEqual(expected_results, result)
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
fixes: #4903 
Use parson to add json output format support to the r.describe module.
The JSON output looks like as follows:
```json
[
	{
		"value": "*"
	},
	{
		"value": "-5.000000 thru -4.960784"
	},
	{
		"value": "-4.529412 thru -4.490196"
	},
	{
		"value": "-4.019608 thru -3.980392"
	},
	{
		"value": "-3.509804 thru -3.470588"
	},
	{
		"value": "-3.039216 thru -3.000000"
	},
	{
		"value": "-2.529412 thru -2.490196"
	},
	{
		"value": "-2.019608 thru -1.980392"
	},
	{
		"value": "-1.549020 thru -1.509804"
	},
	{
		"value": "-1.039216 thru -1.000000"
	},
	{
		"value": "-0.529412 thru -0.490196"
	},
	{
		"value": "0.450980 thru 0.490196"
	},
	{
		"value": "0.960784 thru 1.000000"
	},
	{
		"value": "1.470588 thru 1.509804"
	},
	{
		"value": "1.941176 thru 1.980392"
	},
	{
		"value": "2.450980 thru 2.490196"
	},
	{
		"value": "2.960784 thru 3.000000"
	},
	{
		"value": "3.431373 thru 3.470588"
	},
	{
		"value": "3.941176 thru 3.980392"
	},
	{
		"value": "4.450980 thru 4.490196"
	},
	{
		"value": "4.960784 thru 5.000000"
	}
]
```