### PR TITLE
temporal: Fixed E722 in temporal_granularity

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -46,7 +46,6 @@ per-file-ignores =
     python/grass/temporal/datetime_math.py: E722
     python/grass/temporal/spatial_topology_dataset_connector.py: E722
     python/grass/temporal/temporal_algebra.py: E722
-    python/grass/temporal/temporal_granularity.py: E722
     # Current benchmarks/tests are changing sys.path before import.
     # Possibly, a different approach should be taken there anyway.
     python/grass/pygrass/tests/benchmark.py: F821

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -90,19 +90,19 @@ def check_granularity_string(granularity, temporal_type) -> bool:
     if temporal_type == "absolute":
         try:
             num, unit = granularity.split(" ")
-        except:
+        except ValueError:
             return False
         if unit not in SUPPORTED_GRAN:
             return False
 
         try:
             int(num)
-        except:
+        except ValueError:
             return False
     elif temporal_type == "relative":
         try:
             int(granularity)
-        except:
+        except ValueError:
             return False
     else:
         return False

--- a/python/grass/temporal/temporal_granularity.py
+++ b/python/grass/temporal/temporal_granularity.py
@@ -90,7 +90,7 @@ def check_granularity_string(granularity, temporal_type) -> bool:
     if temporal_type == "absolute":
         try:
             num, unit = granularity.split(" ")
-        except ValueError:
+        except (ValueError, AttributeError):
             return False
         if unit not in SUPPORTED_GRAN:
             return False


### PR DESCRIPTION
Add specific exceptions for E722 in `temporal_granularity.py` i.e `ValueError`. Didn't add `TypeError` for `None` objects which seemed less likely to occur via code error.