### PR TITLE
gui: Add Copy command feature on right-click to GUI History panel

### DIFF
--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -216,6 +216,10 @@ class HistoryBrowserTree(CTreeView):
         """Create popup menu for commands"""
         menu = Menu()
 
+        copyItem = wx.MenuItem(menu, wx.ID_ANY, _("&Copy"))
+        menu.AppendItem(copyItem)
+        self.Bind(wx.EVT_MENU, self.OnCopyCmd, copyItem)
+
         item = wx.MenuItem(menu, wx.ID_ANY, _("&Remove"))
         menu.AppendItem(item)
         self.Bind(wx.EVT_MENU, self.OnRemoveCmd, item)
@@ -658,3 +662,27 @@ class HistoryBrowserTree(CTreeView):
             self.CollapseNode(node, recursive=False)
         else:
             self.ExpandNode(node, recursive=False)
+
+    def OnCopyCmd(self, event):
+        """Copy selected cmd to clipboard"""
+        self.DefineItems(self.GetSelected())
+        if not self.selected_command:
+            return
+
+        selected_command = self.selected_command[0]
+        command = selected_command.data["name"]
+
+        # Copy selected command to clipboard
+        try:
+            if wx.TheClipboard.Open():
+                try:
+                    wx.TheClipboard.SetData(wx.TextDataObject(command))
+                    self.showNotification.emit(
+                        message=_("Command <{}> copied to clipboard").format(command)
+                    )
+                finally:
+                    wx.TheClipboard.Close()
+        except wx.PyWidgetError:
+            self.showNotification.emit(
+                message=_("Failed to copy command to clipboard")
+            )

--- a/gui/wxpython/history/tree.py
+++ b/gui/wxpython/history/tree.py
@@ -683,6 +683,4 @@ class HistoryBrowserTree(CTreeView):
                 finally:
                     wx.TheClipboard.Close()
         except wx.PyWidgetError:
-            self.showNotification.emit(
-                message=_("Failed to copy command to clipboard")
-            )
+            self.showNotification.emit(message=_("Failed to copy command to clipboard"))


### PR DESCRIPTION
## Description: 
Provide `Copy` command feature on right-click for commands in the GUI History panel.

## Motivation and context: 
For reporting bugs it's helpful to copy particular commands from history. Presently, there is just the `Remove` command.

## How has this been tested?
Compiled and executed the Grass application locally. Can observe the new `Copy` command in the History Panel on right-clicking a command.

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/ae548e70-d263-42cb-8357-98b834ce4b2c)

![image](https://github.com/user-attachments/assets/fdfba468-69eb-45ec-8234-488f8e8f3cef)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist
- [x] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](../../utils/release.yml)
- [x] My code follows the [code style](../../doc/development/style_guide.md)
of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

## Fixes
#4385 