### PR TITLE
docs: remove trunk from paths

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -40,7 +40,7 @@ Database
 
 streams attributes screenshot
 
-DIR="../trunk-commands/doc/"
+DIR="../doc/"
 for FILE in *.png; do convert $FILE -resize 200x200 $DIR/`basename -s .png $FILE`.jpg; done;
 
 

--- a/doc/examples/gui/wxpython/frame.py
+++ b/doc/examples/gui/wxpython/frame.py
@@ -41,7 +41,7 @@ from example.toolbars import ExampleMapToolbar, ExampleMiscToolbar, ExampleMainT
 from example.dialogs import ExampleMapDialog
 
 # It is possible to call grass library functions (in C) directly via ctypes
-# however this is less stable. Example is available in trunk/doc/examples/python/,
+# however this is less stable. Example is available in doc/examples/python/,
 # ctypes are used in nviz, vdigit, iclass gui modules.
 
 # from ctypes import *

--- a/doc/examples/gui/wxpython/toolbars.py
+++ b/doc/examples/gui/wxpython/toolbars.py
@@ -43,7 +43,7 @@ class ExampleMapToolbar(BaseToolbar):
     def _toolbarData(self):
         """!Returns toolbar data (name, icon, handler)"""
         # BaseIcons are a set of often used icons. It is possible
-        # to reuse icons in ./trunk/gui/icons/grass or add new ones there.
+        # to reuse icons in gui/icons/grass or add new ones there.
         icons = BaseIcons
         return self._getToolbarData(
             (

--- a/gui/wxpython/animation/toolbars.py
+++ b/gui/wxpython/animation/toolbars.py
@@ -74,7 +74,7 @@ class MainToolbar(BaseToolbar):
     def _toolbarData(self):
         """Returns toolbar data (name, icon, handler)"""
         # BaseIcons are a set of often used icons. It is possible
-        # to reuse icons in ./trunk/gui/icons/grass or add new ones there.
+        # to reuse icons in gui/icons/grass or add new ones there.
         icons = ganimIcons
         return self._getToolbarData(
             (
@@ -120,7 +120,7 @@ class AnimationToolbar(BaseToolbar):
     def _toolbarData(self):
         """Returns toolbar data (name, icon, handler)"""
         # BaseIcons are a set of often used icons. It is possible
-        # to reuse icons in ./trunk/gui/icons/grass or add new ones there.
+        # to reuse icons in gui/icons/grass or add new ones there.
         icons = ganimIcons
         return self._getToolbarData(
             (

--- a/gui/wxpython/datacatalog/toolbars.py
+++ b/gui/wxpython/datacatalog/toolbars.py
@@ -112,7 +112,7 @@ class DataCatalogToolbar(BaseToolbar):
     def _toolbarData(self):
         """Returns toolbar data (name, icon, handler)"""
         # BaseIcons are a set of often used icons. It is possible
-        # to reuse icons in ./trunk/gui/icons/grass or add new ones there.
+        # to reuse icons in gui/icons/grass or add new ones there.
         return self._getToolbarData(
             (
                 (

--- a/gui/wxpython/mapswipe/toolbars.py
+++ b/gui/wxpython/mapswipe/toolbars.py
@@ -55,7 +55,7 @@ class SwipeMapToolbar(BaseToolbar):
     def _toolbarData(self):
         """Returns toolbar data (name, icon, handler)"""
         # BaseIcons are a set of often used icons. It is possible
-        # to reuse icons in ./trunk/gui/icons/grass or add new ones there.
+        # to reuse icons in gui/icons/grass or add new ones there.
         icons = BaseIcons
         return self._getToolbarData(
             (


### PR DESCRIPTION
We don't have `trunk` anymore since we departed from SVN.