### PR TITLE
CI(CodeQL): Add `actions` language support in CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,7 @@ jobs:
         language:
           - c-cpp
           - python
+          - actions
 
     concurrency:
       group: ${{ github.workflow }}-${{


### PR DESCRIPTION
GitHub Actions was recently added to CodeQL https://github.blog/changelog/2024-12-17-find-and-fix-actions-workflows-vulnerabilities-with-codeql-public-preview/

This enables it. I'm already working on some little fixes on default permissions, but nothing stood out here