### PR TITLE
CI: Restrict default permissions on GitHub Actions workflows

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -17,6 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   additional-checks:
     name: Additional checks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,8 +22,9 @@ on:
   release:
     types: [published]
 
-jobs:
+permissions: {}
 
+jobs:
   # Run for push to configured branches and all published releases.
   # Take care of different os.
   # For main branch, created tags are:
@@ -46,6 +47,10 @@ jobs:
           - ubuntu
           - ubuntu_wxgui
       fail-fast: false
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -8,6 +8,8 @@ on:
       - releasebranch_*
   pull_request:
 
+permissions: {}
+
 jobs:
   build:
     name: ${{ matrix.c }} & ${{ matrix.cpp }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,9 @@ env:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   macos_build:
     name: macOS build

--- a/.github/workflows/milestones.yml
+++ b/.github/workflows/milestones.yml
@@ -5,12 +5,17 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}
+
 jobs:
   assign-milestone:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      # Retreiving the current milestoone from API instead of github context,
+      # Retrieving the current milestone from API instead of github context,
       # so up-to-date information is used when running after being queued or for reruns
       # Otherwise, the information should be available using
       # ${{ github.event.pull_request.milestone.title }}

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -8,6 +8,8 @@ on:
       - releasebranch_*
   pull_request:
 
+permissions: {}
+
 jobs:
   build:
     name: ${{ matrix.os }} build and tests

--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -10,11 +10,17 @@ on:
     # See https://crontab.guru/#32_10_*/100,1-7_*_WED
     - cron: "32 10 */100,1-7 * WED"
 
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   update-configure:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,8 @@ on:
       - releasebranch_*
   pull_request:
 
+permissions: {}
+
 jobs:
   pytest:
     concurrency:

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -8,6 +8,8 @@ on:
       - releasebranch_*
   pull_request:
 
+permissions: {}
+
 jobs:
   python-checks:
     name: Python Code Quality Checks

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,6 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   super-linter:
     name: GitHub Super Linter

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,6 +10,8 @@ on:
       - releasebranch_*
   pull_request:
 
+permissions: {}
+
 jobs:
   ubuntu:
     concurrency:

--- a/.github/workflows/verify-success.yml
+++ b/.github/workflows/verify-success.yml
@@ -45,33 +45,35 @@ on:
         type: string
         required: true
         # Can't escape the handlebars in the description
-        description:
+        description: >-
           In the calling job that defines all the needed jobs,
           send `toJson(needs)` inside `$` followed by `{{ }}`
       fail_if_failure:
         type: boolean
         default: true
-        description:
+        description: >-
           If true, this workflow will fail if any job from 'needs_context was
           failed
       fail_if_cancelled:
         type: boolean
         default: true
-        description:
+        description: >-
           If true, this workflow will fail if any job from 'needs_context' was
           cancelled
       fail_if_skipped:
         type: boolean
         default: false
-        description:
+        description: >-
           If true, this workflow will fail if any job from 'needs_context' was
           skipped
       require_success:
         type: boolean
         default: true
-        description:
+        description: >-
           If true, this workflow will fail if no job from 'needs_context' was
           successful
+
+permissions: {}
 
 jobs:
   verify-success:


### PR DESCRIPTION
This PR makes some fixes to the new security issues found by CodeQL for the `actions` (GitHub Actions) language, added in #4940.

I searched for the needed permissions as much as I could find, and I tested this PR as much as I could, even using my default branch. Why I say as much as I could? Well, my fork is a fork, and it is not in an organization, and I do not know exactly the remaining settings that are applied, but I still changed my actions settings (https://github.com/OSGeo/grass/settings/actions) to "Read repository contents and packages permissions", which is the new default for new repos after some date in 2023.
![image](https://github.com/user-attachments/assets/8b15b330-14c9-450d-9bf4-e4c84f10763b)

I suggest changing our settings to that, if possible (cc @neteler or @wenzeslaus). For organizations, it might be different, and I hope it isn't only possible at the org-level. 