### PR TITLE
r.path: Support bitmask encoding CW from East

### DIFF
--- a/raster/r.path/main.c
+++ b/raster/r.path/main.c
@@ -122,6 +122,8 @@ int main(int argc, char **argv)
         struct Option *vect;
     } opt;
     struct {
+        struct Flag *east;
+        struct Flag *brk;
         struct Flag *copy;
         struct Flag *accum;
         struct Flag *count;
@@ -196,6 +198,18 @@ int main(int argc, char **argv)
     opt.vpoint->label = _("Name of starting vector points map(s)");
     opt.vpoint->guisection = _("Start");
 
+    flag.east = G_define_flag();
+    flag.east->key = 'e';
+    flag.east->description =
+        _("Start bitmask encoded directions from East (e.g., r.terraflow)");
+    flag.east->guisection = _("Direction settings");
+
+    flag.brk = G_define_flag();
+    flag.brk->key = 'b';
+    flag.brk->description =
+        _("Do not break lines (faster for single-direction bitmask encoding)");
+    flag.brk->guisection = _("Direction settings");
+
     flag.copy = G_define_flag();
     flag.copy->key = 'c';
     flag.copy->description = _("Copy input cell values on output");
@@ -216,6 +230,7 @@ int main(int argc, char **argv)
     G_option_requires_all(flag.copy, opt.rast, opt.val, NULL);
     G_option_requires_all(flag.accum, opt.rast, opt.val, NULL);
     G_option_requires_all(flag.count, opt.rast, NULL);
+    G_option_requires(flag.brk, opt.vect, NULL);
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
@@ -457,6 +472,13 @@ int main(int argc, char **argv)
         dir_buf = Rast_allocate_c_buf();
         for (i = 0; i < nrows; i++) {
             Rast_get_c_row(dir_id, dir_buf, i);
+            if (flag.east->answer) {
+                CELL *p;
+
+                p = (CELL *)dir_buf;
+                for (j = 0; j < ncols; j++, p++)
+                    *p = pow(2, ((int)log2(*p) + 1) % 8);
+            }
             if (write(dir_fd, dir_buf, ncols * sizeof(CELL)) !=
                 ncols * (int)sizeof(CELL)) {
                 G_fatal_error(_("Unable to write to tempfile"));
@@ -503,7 +525,7 @@ int main(int argc, char **argv)
         if (dir_format == DIR_BIT) {
             struct Map_info Tmp;
 
-            if (pvout) {
+            if (!flag.brk->answer && pvout) {
                 if (Vect_open_tmp_new(&Tmp, NULL, 0) < 0)
                     G_fatal_error(_("Unable to create temporary vector map"));
                 pvout = &Tmp;
@@ -514,7 +536,7 @@ int main(int argc, char **argv)
                 G_warning(_("No path at row %d, col %d"), next_start_pt->row,
                           next_start_pt->col);
             }
-            if (pvout) {
+            if (!flag.brk->answer && pvout) {
                 Vect_build_partial(&Tmp, GV_BUILD_BASE);
                 G_message(_("Breaking lines..."));
                 Vect_break_lines(&Tmp, GV_LINE, NULL);
@@ -711,8 +733,8 @@ int dir_bitmask(int dir_fd, int val_fd, struct point *startp,
     struct ppoint pp;
     int is_stack;
     int cur_dir, i, npaths;
-    struct line_pnts *Points;
-    struct line_cats *Cats;
+    struct line_pnts *Points = NULL;
+    struct line_cats *Cats = NULL;
     double x, y;
     double value;
 


### PR DESCRIPTION
This PR adds support for the power-of-two encoding CW from East (e.g., r.terraflow, ArcGIS).
![image](https://github.com/HuidaeCho/mefa/assets/7456117/6268b904-24a4-482e-8f6d-9ec9c4edf143)

The default bitmask encoding starts CW from NE, some programs use a 45-degree rotated (one bit shifted) version of the bitmask encoding (e.g. r.terraflow, ArcGIS). The new `-e` (East) flag uses `y=2^((log2(x)+1)%8)` to convert the latter encoding to the default one before tracing.

The PR also adds `-b` flag to avoid breaking lines unnecessarily for single-direction paths.

How to test in the NC sample dataset
```bash
r.terraflow elevation direction=dir -s
r.path dir vec=path scoor=638317.91,220399.94 -be
```
<img width="567" alt="image" src="https://github.com/user-attachments/assets/a18c83fa-b04d-4ade-99b0-a9577ff1d7ce" />