### PR TITLE
temporal: Fix bare except clauses in datetime_math.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -42,7 +42,6 @@ per-file-ignores =
     # TODO: Is this really needed?
     python/grass/jupyter/__init__.py: E501
     python/grass/pygrass/vector/__init__.py: E402
-    python/grass/temporal/datetime_math.py: E722
     python/grass/temporal/spatial_topology_dataset_connector.py: E722
     python/grass/temporal/temporal_algebra.py: E722
     python/grass/temporal/temporal_granularity.py: E722

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -21,7 +21,7 @@ try:
     from dateutil import parser
 
     has_dateutil = True
-except (ImportError, ModuleNotFoundError):  # More comprehensive exception handling
+except (ImportError, ModuleNotFoundError):
     has_dateutil = False
 
 
@@ -811,7 +811,7 @@ def check_datetime_string(time_string: str, use_dateutil: bool = True):
 
     try:
         return datetime.strptime(time_string, time_format)
-    except (ValueError, TypeError):  # Handle both format and type errors
+    except (ValueError, TypeError):
         return _("Unable to parse time string: %s") % time_string
 
 

--- a/python/grass/temporal/datetime_math.py
+++ b/python/grass/temporal/datetime_math.py
@@ -21,7 +21,7 @@ try:
     from dateutil import parser
 
     has_dateutil = True
-except:
+except (ImportError, ModuleNotFoundError):  # More comprehensive exception handling
     has_dateutil = False
 
 
@@ -811,7 +811,7 @@ def check_datetime_string(time_string: str, use_dateutil: bool = True):
 
     try:
         return datetime.strptime(time_string, time_format)
-    except:
+    except (ValueError, TypeError):  # Handle both format and type errors
         return _("Unable to parse time string: %s") % time_string
 
 


### PR DESCRIPTION
This PR addresses flake8 E722 warnings by replacing bare `except` clauses with specific exception handling in the datetime_math.py module.
- Replace bare `except` after dateutil import with explicit `(ImportError, ModuleNotFoundError)`
- Replace bare `except` in datetime parsing with explicit `(ValueError, TypeError)`