### PR TITLE
temporal: Fixed bare except clauses in spatial_topology_dataset_connector.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -43,7 +43,6 @@ per-file-ignores =
     python/grass/jupyter/__init__.py: E501
     python/grass/pygrass/vector/__init__.py: E402
     python/grass/temporal/datetime_math.py: E722
-    python/grass/temporal/spatial_topology_dataset_connector.py: E722
     python/grass/temporal/temporal_algebra.py: E722
     python/grass/temporal/temporal_granularity.py: E722
     # Current benchmarks/tests are changing sys.path before import.

--- a/python/grass/temporal/spatial_topology_dataset_connector.py
+++ b/python/grass/temporal/spatial_topology_dataset_connector.py
@@ -118,31 +118,31 @@ class SpatialTopologyDatasetConnector:
         relations = {}
         try:
             relations["equivalent"] = len(self._spatial_topology["EQUIVALENT"])
-        except:
+        except KeyError:
             relations["equivalent"] = 0
         try:
             relations["overlap"] = len(self._spatial_topology["OVERLAP"])
-        except:
+        except KeyError:
             relations["overlap"] = 0
         try:
             relations["in"] = len(self._spatial_topology["IN"])
-        except:
+        except KeyError:
             relations["in"] = 0
         try:
             relations["contain"] = len(self._spatial_topology["CONTAIN"])
-        except:
+        except KeyError:
             relations["contain"] = 0
         try:
             relations["meet"] = len(self._spatial_topology["MEET"])
-        except:
+        except KeyError:
             relations["meet"] = 0
         try:
             relations["cover"] = len(self._spatial_topology["COVER"])
-        except:
+        except KeyError:
             relations["cover"] = 0
         try:
             relations["covered"] = len(self._spatial_topology["COVERED"])
-        except:
+        except KeyError:
             relations["covered"] = 0
 
         return relations


### PR DESCRIPTION
Fix flake8 E722 errors in spatial topology connector
Replace bare 'except' clauses with explicit 'except KeyError' in get_number_of_spatial_relations() method