### PR TITLE
wxGUI: Add specific exception handling in vdigit/mapwindow.py

### DIFF
--- a/gui/wxpython/vdigit/mapwindow.py
+++ b/gui/wxpython/vdigit/mapwindow.py
@@ -290,7 +290,7 @@ class VDigitWindow(BufferedMapWindow):
         """Left mouse button pressed - add new feature"""
         try:
             mapLayer = self.toolbar.GetLayer().GetName()
-        except:
+        except AttributeError:
             return
 
         if self.toolbar.GetAction("type") in {"point", "centroid"}:
@@ -482,7 +482,7 @@ class VDigitWindow(BufferedMapWindow):
         """
         try:
             mapLayer = self.toolbar.GetLayer().GetName()
-        except:
+        except AttributeError:
             return
 
         coords = self.Pixel2Cell(self.mouse["begin"])
@@ -624,8 +624,7 @@ class VDigitWindow(BufferedMapWindow):
                         removed,
                     ],
                 )
-                # self.mouse['begin'] = self.Cell2Pixel(self.polycoords[-1])
-            except:
+            except IndexError:
                 pass
 
         if action == "editLine":
@@ -691,7 +690,7 @@ class VDigitWindow(BufferedMapWindow):
         """Left mouse button donw - vector digitizer various actions"""
         try:
             self.toolbar.GetLayer().GetName()
-        except:
+        except AttributeError:
             GMessage(parent=self, message=_("No vector map selected for editing."))
             event.Skip()
             return
@@ -1095,7 +1094,7 @@ class VDigitWindow(BufferedMapWindow):
             # -> add new line / boundary
             try:
                 mapName = self.toolbar.GetLayer().GetName()
-            except:
+            except AttributeError:
                 mapName = None
                 GError(parent=self, message=_("No vector map selected for editing."))
 


### PR DESCRIPTION
Updates exception handling in several methods to catch specific error cases:

1. `AttributeError` in layer access operations (GetLayer().GetName()):
   - Occurs when toolbar or layer is None

2. `IndexError`  in undo operation:
   - `IndexError`: Occurs when trying to pop from empty polycoords list (e.g., multiple undo attempts)