### PR TITLE
lib/vector/Vlib: Fix Resource Leak issue in build_nat.c

### DIFF
--- a/lib/vector/Vlib/build_nat.c
+++ b/lib/vector/Vlib/build_nat.c
@@ -169,8 +169,10 @@ int Vect_build_nat(struct Map_info *Map, int build)
         plus->built = GV_BUILD_AREAS;
     }
 
-    if (build < GV_BUILD_ATTACH_ISLES)
+    if (build < GV_BUILD_ATTACH_ISLES) {
+        Vect_destroy_cats_struct(Cats);
         return 1;
+    }
 
     /* Attach isles to areas */
     if (plus->built < GV_BUILD_ATTACH_ISLES) {
@@ -186,8 +188,10 @@ int Vect_build_nat(struct Map_info *Map, int build)
         plus->built = GV_BUILD_ATTACH_ISLES;
     }
 
-    if (build < GV_BUILD_CENTROIDS)
+    if (build < GV_BUILD_CENTROIDS) {
+        Vect_destroy_cats_struct(Cats);
         return 1;
+    }
 
     /* Attach centroids to areas */
     if (plus->built < GV_BUILD_CENTROIDS) {


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207631)
Used Vect_destroy_cats_struct() to fix this issue. 