### PR TITLE
v.generalize: Fix Resource Leak issue in network.c

### DIFF
--- a/vector/v.generalize/network.c
+++ b/vector/v.generalize/network.c
@@ -258,5 +258,7 @@ int graph_generalization(struct Map_info *In, struct Map_info *Out,
         Vect_destroy_list(prev[i]);
     G_free(prev);
     graph_free(&g);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
     return output;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207721,1207722)
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix this issue.