### PR TITLE
v.to.rast: Fix Resource Leak issue in do_areas.c

### DIFF
--- a/vector/v.to.rast/do_areas.c
+++ b/vector/v.to.rast/do_areas.c
@@ -94,14 +94,13 @@ int sort_areas(struct Map_info *Map, struct line_pnts *Points, int field,
     CELL cat;
 
     G_begin_polygon_area_calculations();
-    Cats = Vect_new_cats_struct();
 
     /* first count valid areas */
     nareas = Vect_get_num_areas(Map);
-    if (nareas == 0) {
-        Vect_destroy_cats_struct(Cats);
+    if (nareas == 0)
         return 0;
-    }
+
+    Cats = Vect_new_cats_struct();
 
     /* allocate list to hold valid area info */
     list = (struct list *)G_calloc(nareas * sizeof(char), sizeof(struct list));

--- a/vector/v.to.rast/do_areas.c
+++ b/vector/v.to.rast/do_areas.c
@@ -98,8 +98,10 @@ int sort_areas(struct Map_info *Map, struct line_pnts *Points, int field,
 
     /* first count valid areas */
     nareas = Vect_get_num_areas(Map);
-    if (nareas == 0)
+    if (nareas == 0) {
+        Vect_destroy_cats_struct(Cats);
         return 0;
+    }
 
     /* allocate list to hold valid area info */
     list = (struct list *)G_calloc(nareas * sizeof(char), sizeof(struct list));
@@ -155,6 +157,7 @@ int sort_areas(struct Map_info *Map, struct line_pnts *Points, int field,
         /* sort the list by size */
         qsort(list, nareas * sizeof(char), sizeof(struct list), compare);
     }
+    Vect_destroy_cats_struct(Cats);
 
     return nareas_selected;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207750)
Used Vect_destroy_cats_struct() to fix this issue.