### PR TITLE
d.barscale: Fix Resource Leak issue in draw_scale.c

### DIFF
--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -634,8 +634,10 @@ int draw_scale(double east, double north, int length, int seg, int units,
     }
     D_stroke();
 
-    if (fontsize < 0)
+    if (fontsize < 0) {
+        G_free(label);
         return 0;
+    }    
 
     /* draw the distance + units text */
 
@@ -676,6 +678,7 @@ int draw_scale(double east, double north, int length, int seg, int units,
         D_pos_abs(x_pos + 5 - (tr - tl), y_pos + ysize / 2 + (tt - tb) / 2);
         D_text(label);
     }
+    G_free(label);
 
     return 0;
 }

--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -635,7 +635,9 @@ int draw_scale(double east, double north, int length, int seg, int units,
     D_stroke();
 
     if (fontsize < 0) {
-        G_free(label);
+        if (length != 0) {
+            G_free(label);
+        }
         return 0;
     }    
 

--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -678,6 +678,9 @@ int draw_scale(double east, double north, int length, int seg, int units,
         D_pos_abs(x_pos + 5 - (tr - tl), y_pos + ysize / 2 + (tt - tb) / 2);
         D_text(label);
     }
+    if (length != 0) {
+        G_free(label);
+    }
 
     return 0;
 }

--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -678,7 +678,6 @@ int draw_scale(double east, double north, int length, int seg, int units,
         D_pos_abs(x_pos + 5 - (tr - tl), y_pos + ysize / 2 + (tt - tb) / 2);
         D_text(label);
     }
-    G_free(label);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1415718)
Used G_free() to fix this issue. 