### PR TITLE
wxGUI: Updated exception handling to fix AttributeNotFound error

### DIFF
--- a/gui/wxpython/startup/locdownload.py
+++ b/gui/wxpython/startup/locdownload.py
@@ -96,8 +96,8 @@ class RedirectText:
                 heigth = self._get_heigth(string)
                 wx.CallAfter(self.out.SetLabel, string)
                 self._resize(heigth)
-        except wx.PyDeadObjectError:
-            # window closed -> PyDeadObjectError
+        except (RuntimeError, AttributeError):
+            # window closed or destroyed
             pass
 
     def flush(self):


### PR DESCRIPTION
An error was highlighted mentioning error `module 'wx' has no attribute 'PyDeadObjectError'` in the relevant code. This PR is to update the code with other relevant exceptions to replace that