### PR TITLE
v.to.db: Fix Resource Leak issue in lines.c

### DIFF
--- a/vector/v.to.db/lines.c
+++ b/vector/v.to.db/lines.c
@@ -264,6 +264,11 @@ int read_lines(struct Map_info *Map)
         }
         G_percent(line_num, nlines, 2);
     }
+    Vect_destroy_line_struct(EndPoints);
+    Vect_destroy_cats_struct(RCats);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(LCats);
+    Vect_destroy_cats_struct(Cats);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207675, 1207676, 1207677, 1207678, 1207679)
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct() to fix this issue.