### PR TITLE
r.sim.water: build topology for vector output

### DIFF
--- a/raster/r.sim/simlib/output.c
+++ b/raster/r.sim/simlib/output.c
@@ -71,6 +71,7 @@ void output_walker_as_vector(int tt_minutes, int ndigit,
             Vect_append_point(Points, x, y, z);
             Vect_write_line(&Out, GV_POINT, Points, Cats);
         }
+        Vect_build(&Out);
         /* Close vector file */
         Vect_close(&Out);
 


### PR DESCRIPTION
Topology was not built for the vector output `walkers_output`. This is within GRASS not a problem, but the QGIS interface fails because a vector without topology can not be exported with `v.out.ogr`, consequently QGIS complains about a missing output. With this PR, topology is built for the vector output which should not have any effects otherwise because it is only a points vector with simple topology.  