### PR TITLE
lib/gmath: Fix Resource Leak issue in solvers_classic_iter.c

### DIFF
--- a/lib/gmath/solvers_classic_iter.c
+++ b/lib/gmath/solvers_classic_iter.c
@@ -228,6 +228,8 @@ int G_math_solver_jacobi(double **A, double *x, double *b, int rows, int maxit,
             break;
     }
 
+    G_free(Enew);
+
     return 1;
 }
 
@@ -284,6 +286,8 @@ int G_math_solver_gs(double **A, double *x, double *b, int rows, int maxit,
         if (err < error)
             break;
     }
+
+    G_free(Enew);
 
     return 1;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207773, 1207774 )
Used G_free() to fix this issue.