### PR TITLE
Windows: Apply OSGeo4W patches for Postgres

### DIFF
--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -21,6 +21,11 @@ export C_INCLUDE_PATH=".:${OSGEO4W_ROOT_MSYS}/include:${SRC}/dist.${ARCH}/includ
 export PYTHONHOME=${OSGEO4W_ROOT_MSYS}/apps/Python312
 export ARCH=x86_64-w64-mingw32
 
+
+mkdir -p mswindows/osgeo4w/lib
+rm -f $OSGEO4W_ROOT_MSYS/lib/libpq.a
+cp -uv $OSGEO4W_ROOT_MSYS/lib/libpq.lib mswindows/osgeo4w/lib/libpq.lib
+
 CFLAGS="$CFLAGS -pipe" \
 CXXFLAGS="$CXXFLAGS -pipe" \
 ./configure \

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -55,7 +55,7 @@ CXXFLAGS="$CXXFLAGS -pipe" \
     --with-openmp \
     --with-postgres \
     --with-postgres-includes=${OSGEO4W_ROOT_MSYS}/include \
-    --with-postgres-libs=${OSGEO4W_ROOT_MSYS}/lib \
+    --with-postgres-libs=${SRC}/mswindows/osgeo4w/lib \
     --with-proj-includes=${OSGEO4W_ROOT_MSYS}/include \
     --with-proj-libs=${OSGEO4W_ROOT_MSYS}/lib \
     --with-proj-share=${OSGEO4W_ROOT_MSYS}/share/proj \

--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -117,6 +117,8 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 	rm -f mswindows/osgeo4w/package.log.*
 
 	mkdir -p mswindows/osgeo4w/lib
+	rm -f $OSGEO4W_ROOT_MSYS/lib/libpq.a
+	cp -uv $OSGEO4W_ROOT_MSYS/lib/libpq.lib mswindows/osgeo4w/lib/libpq.lib
 	cp -uv $OSGEO4W_ROOT_MSYS/lib/sqlite3_i.lib mswindows/osgeo4w/lib/sqlite3.lib
 
 

--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -157,7 +157,7 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 		--with-openmp \
 		--with-postgres \
 		--with-postgres-includes=${OSGEO4W_ROOT_MSYS}/include \
-		--with-postgres-libs=${OSGEO4W_ROOT_MSYS}/lib \
+		--with-postgres-libs=${SRC}/mswindows/osgeo4w/lib \
 		--with-proj-includes=${OSGEO4W_ROOT_MSYS}/include \
 		--with-proj-libs=${OSGEO4W_ROOT_MSYS}/lib \
 		--with-proj-share=${OSGEO4W_ROOT_MSYS}/share/proj \


### PR DESCRIPTION
Solves #4990 
(Hopefully)

I quickly applied the patch that changed downstream. I didn’t test it in CI yet, I’m just launching it here quickly.

It seems like Postgres is compiled with a different compiler now, so removing and copying a lib seems necessary. 


I also launched https://github.com/echoix/grass/pull/351