### PR TITLE
doc: Use lowercase for 2D raster mask

### DIFF
--- a/doc/examples/notebooks/parallelization_tutorial.ipynb
+++ b/doc/examples/notebooks/parallelization_tutorial.ipynb
@@ -331,7 +331,7 @@
     " * write output maps/files with identical names (common mistake, but easy to fix)\n",
     " * modify computational region\n",
     " * modify vector attribute database\n",
-    " * modify MASK\n",
+    " * modify raster mask\n",
     " * use [r.reclass](https://grass.osgeo.org/grass-stable/manuals/r.reclass.html) to reclassify from the same base map\n",
     "\n",
     "The following sections provide solutions, starting with the option to execute tools in separate mapsets, which addresses all of the issues above, except r.reclass."

--- a/imagery/i.pca/main.c
+++ b/imagery/i.pca/main.c
@@ -4,7 +4,7 @@
  *
  * AUTHOR(S):    Original author Center for Space Research (Uni. of TX)
  *               Rewritten by Brad Douglas <rez touchofmadness com>
- *               NULL value/MASK handling and speed up by Markus Metz
+ *               NULL value/mask handling and speed up by Markus Metz
  *
  * PURPOSE:      Principal Component Analysis transform of raster data.
  *

--- a/raster/r.out.gdal/r.out.gdal.html
+++ b/raster/r.out.gdal/r.out.gdal.html
@@ -18,7 +18,7 @@ a group, when the imagery group's name is entered as input.
 (created imagery groups with the <em><a href="i.group.html">i.group</a></em>
 module)
 <p>As with most GRASS raster modules, the current region extents and region
-resolution are used, and a MASK is respected if present.
+resolution are used, and a raster mask is respected if present.
 Use <em><a href="g.region.html">g.region</a></em>'s "align=", or "raster="
 options if you need to realign the region settings to match the original
 map's before export.
@@ -267,7 +267,8 @@ value (specific parameter of the module) means that any band values
 equal to this nodata value will be interpreted as nodata. Using an additional
 alpha channel means that all pixels with an alpha value of 0 are
 transparent. The alpha channel thus represents per-pixel encoding of
-nodata, just like the GRASS MASK (null file). That means when using an alpha
+nodata, just like the GRASS raster mask or per-raster null file.
+That means when using an alpha
 channel, you do not need to "free up" any particular value, but you can
 use any value you like to replace NULL cells, as long as the value can be
 represented by the Byte data type. It does not matter if that value is
@@ -298,7 +299,7 @@ r.mapcalc "out_b = if(isnull($BMAP), 0, #$BMAP)"
 # create group for export
 i.group group=out_rgba input=out_r,out_g,out_b,out_a
 
-# remove any MASK because this works only if there are
+# remove any mask because this works only if there are
 # no NULL cells in the bands to be exported
 r.mask -r
 

--- a/raster/r.resamp.bspline/r.resamp.bspline.html
+++ b/raster/r.resamp.bspline/r.resamp.bspline.html
@@ -9,8 +9,9 @@ interpolate NULL cells will considerably speed up the module.
 <p>
 The input raster map is read at its native resolution, the output raster
 map will be produced for the current computational region set with
-<em><a href="g.region.html">g.region</a></em>. Any MASK will be respected, masked
-values will be treated as NULL cells in both the input and the output map.
+<em><a href="g.region.html">g.region</a></em>. A raster mask, if present,
+will be respected. Masked values will be treated like other NULL cells
+in both the input and output maps.
 <p>Spline step values <b>ew_step</b> for the east-west direction and
 <b>ns_step</b> for the north-south direction should not be smaller than
 the east-west and north-south resolutions of the input map. For a raster

--- a/vector/vectorintro.html
+++ b/vector/vectorintro.html
@@ -298,7 +298,7 @@ into database tables.
 
 With <a href="v.to.points.html">v.to.points</a>,
 <a href="v.to.rast.html">v.to.rast</a> and <a href="v.to.rast3.html">v.to.rast3</a>
-conversions are performed. Note that a raster mask ("MASK") will not be
+conversions are performed. Note that a raster mask will not be
 respected since it is only applied when <em>reading</em> an existing
 GRASS raster map.
 


### PR DESCRIPTION
Similarly to #4401 and #4495, this replaces usage of MASK by mask or raster mask. It removes uppercase MASK when not needed.
