### PR TITLE
r.watershed: Use r.mask, not MASK in the example

### DIFF
--- a/raster/r.watershed/front/r.watershed.html
+++ b/raster/r.watershed/front/r.watershed.html
@@ -467,13 +467,13 @@ cut-off value. This only works with SFD, not with MFD.
 <div class="code"><pre>
   r.watershed elev=elevation.dem accum=rwater.accum
 
-  r.mapcalc 'MASK = if(!isnull(elevation.dem))'
+  r.mask raster=elevation.dem
   r.mapcalc "rwater.course = \
    if( abs(rwater.accum) &gt; $mean_of_abs, \
        abs(rwater.accum), \
        null() )"
   r.colors -g rwater.course col=bcyr
-  g.remove -f type=raster name=MASK
+  r.mask -r
 
   # <i>Thinning is required before converting raster lines to vector</i>
   r.thin in=rwater.course out=rwater.course.Thin


### PR DESCRIPTION
The original example uses r.mapcalc to directly create MASK and then g.remove to disable it. This now uses r.mask to activate and deactive the mask. NULLs are used in the original expression which is also what r.mask is using by default.
