### PR TITLE
doc: Use lowercase for 2D raster mask

### DIFF
--- a/imagery/i.smap/i.smap.html
+++ b/imagery/i.smap/i.smap.html
@@ -228,7 +228,7 @@ pp. III-565 - III-568, San Francisco, California, March 23-26, 1992.</li>
 <a href="i.group.html">i.group</a></em> for creating groups and subgroups,
 <br>
 <em><a href="r.mapcalc.html">r.mapcalc</a></em>
-to copy classification result in order to cut out MASKed subareas,
+to copy classification result in order to cut out masked subareas,
 <br>
 <em><a href="i.gensigset.html">i.gensigset</a></em>
 to generate the signature file required by this program

--- a/python/grass/grassdb/history.py
+++ b/python/grass/grassdb/history.py
@@ -257,10 +257,10 @@ def get_initial_command_info(env_run):
     # Execution timestamp in ISO 8601 format
     exec_time = datetime.now().isoformat()
 
-    # 2D raster MASK presence
+    # 2D raster mask presence
     mask2d_status = gs.parse_command("r.mask.status", format="json", env=env_run)
 
-    # 3D raster MASK presence
+    # 3D raster mask presence
     env = gs.gisenv(env_run)
     mapset_path = Path(env["GISDBASE"]) / env["LOCATION_NAME"] / env["MAPSET"]
     mask3d_present = (mapset_path / "grid3" / "RASTER3D_MASK").exists()

--- a/raster/r.surf.contour/r.surf.contour.html
+++ b/raster/r.surf.contour/r.surf.contour.html
@@ -39,7 +39,7 @@ a smooth (e.g., elevation) surface generated from
 the known category values in the input raster map layer.
 </dl>
 
-<p>An existing MASK raster map is respected for both reading <em>input</em>
+<p>An existing mask raster map is respected for both reading <em>input</em>
 and writing <em>output</em>.
 
 <h2>NOTES</h2>

--- a/scripts/r.fillnulls/r.fillnulls.html
+++ b/scripts/r.fillnulls/r.fillnulls.html
@@ -34,7 +34,7 @@ When using the default RST method, the algorithm is based
 on <em><a href="v.surf.rst.html">v.surf.rst</a></em> regularized
 splines with tension interpolation module which interpolates the
 raster cell values for NULL data areas from the boundary values of the
-NULL data area. An eventual raster MASK is respected during the NULL
+NULL data area. An eventual raster mask is respected during the NULL
 data area(s) filling. The interpolated values are patched into the
 NULL data area(s) of the input map and saved into a new raster map.
 


### PR DESCRIPTION
Similarly to #4401, #4495, and #5000 this replaces usage of MASK by (raster) mask. This should be the last one or close to last one which does the cosmetics of MASK to mask switch.
