### PR TITLE
v.in.dxf: Fix Resource Leak issue in read_dxf.c

### DIFF
--- a/vector/v.in.dxf/read_dxf.c
+++ b/vector/v.in.dxf/read_dxf.c
@@ -10,11 +10,19 @@ struct dxf_file *dxf_open(char *file)
     struct dxf_file *dxf;
 
     dxf = (struct dxf_file *)G_malloc(sizeof(struct dxf_file));
-
-    dxf->name = G_store(file);
-    if (!(dxf->fp = fopen(file, "r")))
+    if (!dxf) 
         return NULL;
 
+    dxf->name = G_store(file);
+    if (!dxf->name) {
+        G_free(dxf);
+        return NULL;
+    }
+    if (!(dxf->fp = fopen(file, "r"))) {
+        G_free(dxf->name);
+        G_free(dxf);
+        return NULL;
+    }
     /* get the file size */
     G_fseek(dxf->fp, 0L, SEEK_END);
     dxf->size = G_ftell(dxf->fp);

--- a/vector/v.in.dxf/read_dxf.c
+++ b/vector/v.in.dxf/read_dxf.c
@@ -10,7 +10,7 @@ struct dxf_file *dxf_open(char *file)
     struct dxf_file *dxf;
 
     dxf = (struct dxf_file *)G_malloc(sizeof(struct dxf_file));
-    if (!dxf) 
+    if (!dxf)
         return NULL;
 
     dxf->name = G_store(file);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207848)
Used G_free() to fix this issue.