### PR TITLE
r.mapcalc: Fix Resource Leak issue in expression.c

### DIFF
--- a/raster/r.mapcalc/expression.c
+++ b/raster/r.mapcalc/expression.c
@@ -403,6 +403,7 @@ static char *format_function(const expression *e, int prec)
         G_free(args[i]);
     }
     strcat(result, ")");
+    G_free(args);
 
     return result;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207893)
Used G_free() to fix this issue.