### PR TITLE
d.mon: Fix SIM115 linter warnings by using context managers for file operations

### DIFF
--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -39,22 +39,17 @@ def remove_mapfile(mapfile):
 # read environment variables from file
 def read_env_file(env_file):
     width = height = legfile = None
-    fd = open(env_file)
-    if fd is None:
-        grass.fatal("Unable to open file '{0}'".format(env_file))
-    lines = fd.readlines()
-    for line in lines:
-        if line.startswith("#"):
-            continue
-        k, v = line.rstrip("\n").split("#", 1)[0].strip().split("=", 1)
-        os.environ[k] = v
-        if width is None and k == "GRASS_RENDER_WIDTH":
-            width = int(v)
-        if height is None and k == "GRASS_RENDER_HEIGHT":
-            height = int(v)
-        if legfile is None and k == "GRASS_LEGEND_FILE":
-            legfile = v
-    fd.close()
+    try:
+        with open(env_file) as fd:
+            for line in fd:
+                if line.startswith("width:"):
+                    width = int(line.split(":")[1])
+                elif line.startswith("height:"):
+                    height = int(line.split(":")[1])
+                elif line.startswith("legfile:"):
+                    legfile = line.split(":")[1].strip()
+    except OSError:
+        grass.fatal(f"Unable to open file '{env_file}'")
 
     if width is None or height is None:
         grass.fatal("Unknown monitor size")
@@ -86,20 +81,20 @@ def update_cmd_file(cmd_file, cmd, mapfile):
 
     mode = "w" if cmd[0] == "d.erase" else "a"
     # update cmd file
-    fd = open(cmd_file, mode)
-    if fd is None:
-        grass.fatal("Unable to open file '{0}'".format(cmd_file))
-    if mode == "a":
-        frame = os.getenv("GRASS_RENDER_FRAME", None)
-        if frame:
-            fd.write("# GRASS_RENDER_FRAME={0}\n".format(frame))
-        if mapfile:
-            fd.write("# GRASS_RENDER_FILE={0}\n".format(mapfile))
-        fd.write(" ".join(gtask.cmdtuple_to_list(cmd)))
-        fd.write("\n")
-    else:
-        fd.write("")
-    fd.close()
+    try:
+        with open(cmd_file, mode) as fd:
+            if mode == "a":
+                frame = os.getenv("GRASS_RENDER_FRAME", None)
+                if frame:
+                    fd.write("# GRASS_RENDER_FRAME={0}\n".format(frame))
+                if mapfile:
+                    fd.write("# GRASS_RENDER_FILE={0}\n".format(mapfile))
+                fd.write(" ".join(gtask.cmdtuple_to_list(cmd)))
+                fd.write("\n")
+            else:
+                fd.write("")
+    except OSError:
+        grass.fatal(f"Unable to open file '{cmd_file}'")
 
 
 # adjust region
@@ -152,14 +147,15 @@ def read_stdin(cmd):
         opt = "input"
 
     if opt:
-        tmpfile = tempfile.NamedTemporaryFile(dir=path).name + ".txt"
-        fd = open(tmpfile, "w")
-        while 1:
-            line = sys.stdin.readline()
-            if not line:
-                break
-            fd.write(line)
-        fd.close()
+        with tempfile.NamedTemporaryFile(
+            dir=path, suffix=".txt", mode="w", delete=False
+        ) as fd:
+            while True:
+                line = sys.stdin.readline()
+                if not line:
+                    break
+                fd.write(line)
+            tmpfile = fd.name
         cmd[1][opt] = tmpfile
 
 
@@ -172,11 +168,13 @@ if __name__ == "__main__":
 
     width, height, legfile = read_env_file(os.path.join(path, "env"))
     if mon.startswith("wx"):
-        mapfile = tempfile.NamedTemporaryFile(dir=path).name
         if cmd[0] in {"d.barscale", "d.legend", "d.northarrow", "d.legend.vect"}:
-            mapfile += ".png"
+            suffix = ".png"
         else:
-            mapfile += ".ppm"
+            suffix = ".ppm"
+
+        with tempfile.NamedTemporaryFile(dir=path, suffix=suffix) as tmpfile:
+            mapfile = tmpfile.name
         # to force rendering by wx monitors, but don't create a map file for
         # non-rendering modules
         if cmd[0] not in non_rendering_modules:

--- a/display/d.mon/render_cmd.py
+++ b/display/d.mon/render_cmd.py
@@ -42,12 +42,18 @@ def read_env_file(env_file):
     try:
         with open(env_file) as fd:
             for line in fd:
-                if line.startswith("width:"):
-                    width = int(line.split(":")[1])
-                elif line.startswith("height:"):
-                    height = int(line.split(":")[1])
-                elif line.startswith("legfile:"):
-                    legfile = line.split(":")[1].strip()
+                line = line.strip()
+                if line.startswith("#") or not line:
+                    continue
+                # Split on comment and parse key=value
+                k, v = line.split("#", 1)[0].strip().split("=", 1)
+                os.environ[k] = v
+                if width is None and k == "GRASS_RENDER_WIDTH":
+                    width = int(v)
+                if height is None and k == "GRASS_RENDER_HEIGHT":
+                    height = int(v)
+                if legfile is None and k == "GRASS_LEGEND_FILE":
+                    legfile = v
     except OSError:
         grass.fatal(f"Unable to open file '{env_file}'")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,6 @@ ignore = [
 # Other ignores:
 "**.py" = ["PYI066"]
 "*/testsuite/**.py" = ["PT009", "PT027"]
-"display/d.mon/render_cmd.py" = ["SIM115"]
 "gui/wxpython/core/globalvar.py" = ["PTH208"]
 "gui/wxpython/core/render.py" = ["SIM115"]
 "gui/wxpython/core/settings.py" = ["PTH208", "SIM115"]


### PR DESCRIPTION
This PR addresses SIM115 linter warnings by replacing manual file handling with context managers in `d.mon/render_cmd.py`, ensuring proper resource management. 

**Changes**:
- Use `with open(...)` context managers in `update_cmd_file`, `read_stdin`, and temporary file creation.
- Remove redundant `fd is None` checks (Python’s `open()` raises exceptions on failure).
- Simplify temporary file creation with appropriate suffixes and `delete=False` where needed