### PR TITLE
python: Partial reverts to still have empty lists in certain situations, solve #5013

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2409,9 +2409,15 @@ class CmdPanel(wx.Panel):
                 pSqlWhere.append(p)
 
         # collect ids
-        pColumnIds = [p["wxId"] for p in pColumn]
-        pLayerIds = [p["wxId"] for p in pLayer]
-        pSqlWhereIds = [p["wxId"] for p in pSqlWhere]
+        pColumnIds = []
+        for p in pColumn:
+            pColumnIds += p["wxId"]
+        pLayerIds = []
+        for p in pLayer:
+            pLayerIds += p["wxId"]
+        pSqlWhereIds = []
+        for p in pSqlWhere:
+            pSqlWhereIds += p["wxId"]
 
         # set wxId-bindings
         if pMap:

--- a/python/grass/grassdb/checks.py
+++ b/python/grass/grassdb/checks.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import grass.grassdb.config as cfg
 import grass.script as gs
 from grass.script import gisenv
-from itertools import starmap
 
 
 def mapset_exists(path: str | os.PathLike[str], location=None, mapset=None) -> bool:
@@ -537,7 +536,10 @@ def get_reasons_locations_not_removable(locations):
 
     Returns messages as list if there were any failed checks, otherwise empty list.
     """
-    return list(starmap(get_reasons_location_not_removable, locations))
+    messages = []
+    for grassdb, location in locations:
+        messages += get_reasons_location_not_removable(grassdb, location)
+    return messages
 
 
 def get_reasons_location_not_removable(grassdb, location):
@@ -568,7 +570,9 @@ def get_reasons_location_not_removable(grassdb, location):
     )
 
     # Append to the list of tuples
-    mapsets = [(grassdb, location, g_mapset) for g_mapset in g_mapsets]
+    mapsets = []
+    for g_mapset in g_mapsets:
+        mapsets.append((grassdb, location, g_mapset))
 
     # Concentenate both checks
     messages += get_reasons_mapsets_not_removable(mapsets, check_permanent=False)
@@ -597,7 +601,9 @@ def get_reasons_grassdb_not_removable(grassdb):
     g_locations = get_list_of_locations(grassdb)
 
     # Append to the list of tuples
-    locations = [(grassdb, g_location) for g_location in g_locations]
+    locations = []
+    for g_location in g_locations:
+        locations.append((grassdb, g_location))
     return get_reasons_locations_not_removable(locations)
 
 
@@ -608,11 +614,12 @@ def get_list_of_locations(dbase):
 
     :return: list of locations (sorted)
     """
-    locations = [
-        os.path.basename(location)
-        for location in glob.glob(os.path.join(dbase, "*"))
-        if os.path.join(location, "PERMANENT") in glob.glob(os.path.join(location, "*"))
-    ]
+    locations = []
+    for location in glob.glob(os.path.join(dbase, "*")):
+        if os.path.join(location, "PERMANENT") in glob.glob(
+            os.path.join(location, "*")
+        ):
+            locations.append(os.path.basename(location))
 
     locations.sort(key=lambda x: x.lower())
 


### PR DESCRIPTION
Solves #5013

I simply partially reverted some problematic parts of https://github.com/OSGeo/grass/commit/ed80a6eaebcde94215032255e3c39980eea740d6#diff-4ca781eff286bb7a34be0b9e82378a7ee303213cfb1ce88da659d2be7c7c5b3fL539 and https://github.com/OSGeo/grass/commit/3f98304d0d7bbc71727d07f3530370bcd7cdbbde.
I didn't go and investigate really deep, but this should be enough for issues mentioned in #5013. It's a safe PR, it is going back to what was there before.