### PR TITLE
style: Use `ruff format` instead of `black .` for improved user experience

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 ignore =
     # whitespace before ':' (Black)
     E203,
+    E501, # E501 line too long
     # line break before binary operator (Black)
     W503,
 

--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,8 @@
 ignore =
     # whitespace before ':' (Black)
     E203,
-    E501, # E501 line too long
+    # E501 line too long
+    E501,
     # line break before binary operator (Black)
     W503,
 

--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -29,8 +29,6 @@ jobs:
       # renovate: datasource=python-version depName=python
       PYTHON_VERSION: "3.13"
       MIN_PYTHON_VERSION: "3.9"
-      # renovate: datasource=pypi depName=black
-      BLACK_VERSION: "25.1.0"
       # renovate: datasource=pypi depName=flake8
       FLAKE8_VERSION: "7.1.1"
       # renovate: datasource=pypi depName=pylint
@@ -73,6 +71,14 @@ jobs:
         continue-on-error: true
       - name: Run Ruff (apply fixes for suggestions)
         run: ruff check . --preview --fix --unsafe-fixes
+      - name: Run `ruff format` showing diff without failing
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: ruff format --diff
+      - name: Run `ruff format` fixing files
+        # Run `ruff format` even when `ruff check` fixed files: fixes can require formatting
+        if: ${{ !cancelled() }}
+        run: ruff format --diff
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff
@@ -83,21 +89,6 @@ jobs:
           tool-name: ruff
           # To keep repo's file structure in formatted changes artifact
           extra-upload-changes: pyproject.toml
-
-      - name: Install Black only
-        run: pip install black[jupyter]==${{ env.BLACK_VERSION }}
-
-      - name: Run Black
-        run: black .
-
-      - name: Create and uploads code suggestions to apply for Black
-        # Will fail fast here if there are changes required
-        id: diff-black
-        uses: ./.github/actions/create-upload-suggestions
-        with:
-          tool-name: black
-          # To keep repo's file structure in formatted changes artifact
-          extra-upload-changes: .clang-format
 
       - name: Install non-Python dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,19 +42,12 @@ repos:
       # Run the linter.
       - id: ruff
         args: [--fix, --preview]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.44.0
     hooks:
       - id: markdownlint-fix
-  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black-jupyter
-        exclude: |
-          (?x)^(
-                python/libgrass_interface_generator/
-          )
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/general/g.version/tests/g_version_test.py
+++ b/general/g.version/tests/g_version_test.py
@@ -4,18 +4,18 @@ import grass.script as gs
 def test_g_version_no_flag(session):
     """Test that g.version output contains the word 'GRASS'."""
     output = gs.read_command("g.version", env=session.env).strip()
-    assert (
-        "GRASS" in output
-    ), "Expected 'GRASS' in g.version output, but it was not found."
+    assert "GRASS" in output, (
+        "Expected 'GRASS' in g.version output, but it was not found."
+    )
 
 
 def test_c_flag(session):
     """Test the output of g.version -c for Copyright and License Statement."""
     expected_text = "Copyright and License Statement"
     output = gs.read_command("g.version", flags="c", env=session.env).strip()
-    assert (
-        expected_text in output
-    ), f"Expected '{expected_text}' in g.version -c output, but got: '{output}'"
+    assert expected_text in output, (
+        f"Expected '{expected_text}' in g.version -c output, but got: '{output}'"
+    )
 
 
 def test_e_flag(session):
@@ -23,17 +23,17 @@ def test_e_flag(session):
     expected_keys = ["PROJ:", "GDAL/OGR:", "SQLite:"]
     output = gs.read_command("g.version", flags="e", env=session.env).strip()
     for key in expected_keys:
-        assert (
-            key in output
-        ), f"Expected key '{key}' in g.version -e output, but it was not found."
+        assert key in output, (
+            f"Expected key '{key}' in g.version -e output, but it was not found."
+        )
 
 
 def test_b_flag(session):
     """Test that g.version -b output contains the word 'GRASS'."""
     output = gs.read_command("g.version", flags="b", env=session.env).strip()
-    assert (
-        "GRASS" in output
-    ), "Expected 'GRASS' in g.version -b output, but it was not found."
+    assert "GRASS" in output, (
+        "Expected 'GRASS' in g.version -b output, but it was not found."
+    )
 
 
 def test_g_flag(session):
@@ -48,9 +48,9 @@ def test_g_flag(session):
     ]
     output = gs.parse_command("g.version", flags="g", env=session.env)
     for key in expected_keys:
-        assert (
-            key in output
-        ), f"Expected key '{key}' in g.version -g output, but it was not found."
+        assert key in output, (
+            f"Expected key '{key}' in g.version -g output, but it was not found."
+        )
 
 
 def test_r_flag(session):
@@ -58,9 +58,9 @@ def test_r_flag(session):
     expected_texts = ["libgis revision:", "libgis date:"]
     output = gs.read_command("g.version", flags="r", env=session.env).strip()
     for text in expected_texts:
-        assert (
-            text in output
-        ), f"Expected key '{text}' in g.version -r output, but it was not found."
+        assert text in output, (
+            f"Expected key '{text}' in g.version -r output, but it was not found."
+        )
 
 
 def test_x_flag(session):
@@ -78,6 +78,6 @@ def test_x_flag(session):
                 return False
         return counter == 0
 
-    assert curly_brackets_paired(
-        output
-    ), "Curly brackets are not properly paired in the g.version -x output."
+    assert curly_brackets_paired(output), (
+        "Curly brackets are not properly paired in the g.version -x output."
+    )

--- a/gui/wxpython/core/settings.py
+++ b/gui/wxpython/core/settings.py
@@ -816,9 +816,9 @@ class Settings:
         )
 
         self.internalSettings["display"]["driver"]["choices"] = ["cairo", "png"]
-        self.internalSettings["display"]["statusbarMode"][
-            "choices"
-        ] = None  # set during MapFrame init
+        self.internalSettings["display"]["statusbarMode"]["choices"] = (
+            None  # set during MapFrame init
+        )
         self.internalSettings["display"]["mouseWheelZoom"]["choices"] = (
             _("Zoom and recenter"),
             _("Zoom to mouse cursor"),

--- a/gui/wxpython/dbmgr/base.py
+++ b/gui/wxpython/dbmgr/base.py
@@ -2223,9 +2223,11 @@ class DbMgrBrowsePage(DbMgrNotebookBase):
 
         tablelen = len(self.dbMgrData["mapDBInfo"].layers[self.selLayer]["table"])
 
-        if statement[index + 1 : index + 6].lower() != "from " or statement[
-            index + 6 : index + 6 + tablelen
-        ] != "%s" % (self.dbMgrData["mapDBInfo"].layers[self.selLayer]["table"]):
+        if (
+            statement[index + 1 : index + 6].lower() != "from "
+            or statement[index + 6 : index + 6 + tablelen]
+            != "%s" % (self.dbMgrData["mapDBInfo"].layers[self.selLayer]["table"])
+        ):
             return None
 
         if len(statement[index + 7 + tablelen :]) > 0:

--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -3307,9 +3307,7 @@ class WritePythonFile(WriteScriptFile):
 # %module
 # % description: {description}
 # %end
-""".format(
-                description=" ".join(properties["description"].splitlines())
-            )
+""".format(description=" ".join(properties["description"].splitlines()))
         )
 
         modelItems = self.model.GetItems(ModelAction)

--- a/gui/wxpython/gui_core/vselect.py
+++ b/gui/wxpython/gui_core/vselect.py
@@ -332,9 +332,7 @@ class VectorSelectBase:
             GMessage(_("No features selected"))
             return
         lst = ""
-        for (
-            cat
-        ) in (
+        for cat in (
             self.selectedFeatures
         ):  # build text string of categories for v.extract input
             lst += str(cat["Category"]) + ","

--- a/gui/wxpython/nviz/tools.py
+++ b/gui/wxpython/nviz/tools.py
@@ -1610,12 +1610,12 @@ class NvizToolWindow(GNotebook):
         checkThematicWidth = wx.CheckBox(
             parent=panel, id=wx.ID_ANY, label=_("use width for thematic mapping")
         )
-        self.win["vector"]["lines"]["thematic"][
-            "checkcolor"
-        ] = checkThematicColor.GetId()
-        self.win["vector"]["lines"]["thematic"][
-            "checkwidth"
-        ] = checkThematicWidth.GetId()
+        self.win["vector"]["lines"]["thematic"]["checkcolor"] = (
+            checkThematicColor.GetId()
+        )
+        self.win["vector"]["lines"]["thematic"]["checkwidth"] = (
+            checkThematicWidth.GetId()
+        )
         checkThematicColor.Bind(wx.EVT_CHECKBOX, self.OnCheckThematic)
         checkThematicWidth.Bind(wx.EVT_CHECKBOX, self.OnCheckThematic)
         checkThematicColor.SetValue(False)
@@ -1825,12 +1825,12 @@ class NvizToolWindow(GNotebook):
         checkThematicSize = wx.CheckBox(
             parent=panel, id=wx.ID_ANY, label=_("use size for thematic mapping")
         )
-        self.win["vector"]["points"]["thematic"][
-            "checkcolor"
-        ] = checkThematicColor.GetId()
-        self.win["vector"]["points"]["thematic"][
-            "checksize"
-        ] = checkThematicSize.GetId()
+        self.win["vector"]["points"]["thematic"]["checkcolor"] = (
+            checkThematicColor.GetId()
+        )
+        self.win["vector"]["points"]["thematic"]["checksize"] = (
+            checkThematicSize.GetId()
+        )
         checkThematicColor.Bind(wx.EVT_CHECKBOX, self.OnCheckThematic)
         checkThematicSize.Bind(wx.EVT_CHECKBOX, self.OnCheckThematic)
         checkThematicColor.SetValue(False)

--- a/gui/wxpython/nviz/workspace.py
+++ b/gui/wxpython/nviz/workspace.py
@@ -385,8 +385,9 @@ class NvizSettings:
         # arrow
         if type == "arrow":
             data["arrow"] = copy.deepcopy(UserSettings.Get(group="nviz", key="arrow"))
-            data["arrow"]["color"] = "%d:%d:%d" % (
-                UserSettings.Get(group="nviz", key="arrow", subkey="color")[:3]
+            data["arrow"]["color"] = (
+                "%d:%d:%d"
+                % (UserSettings.Get(group="nviz", key="arrow", subkey="color")[:3])
             )
             data["arrow"].update(
                 copy.deepcopy(
@@ -402,8 +403,9 @@ class NvizSettings:
             data["scalebar"] = copy.deepcopy(
                 UserSettings.Get(group="nviz", key="scalebar")
             )
-            data["scalebar"]["color"] = "%d:%d:%d" % (
-                UserSettings.Get(group="nviz", key="scalebar", subkey="color")[:3]
+            data["scalebar"]["color"] = (
+                "%d:%d:%d"
+                % (UserSettings.Get(group="nviz", key="scalebar", subkey="color")[:3])
             )
             data["scalebar"].update(
                 copy.deepcopy(

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -1405,7 +1405,7 @@ class SampleUnitsKeyPage(TitledPage):
     def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         """Function during entering"""
         # This is an hack to force the user to choose Rectangle or Circle
-        self.typeBox.SetSelection(2),
+        (self.typeBox.SetSelection(2),)
         self.typeBox.ShowItem(2, False)
         self.panelSizer.Layout()
 
@@ -1608,7 +1608,7 @@ class UnitsMousePage(TitledPage):
             choices=[_("Rectangle"), _("Circle"), ("")],
         )
         # This is an hack to force the user to choose Rectangle or Circle
-        self.typeBox.SetSelection(2),
+        (self.typeBox.SetSelection(2),)
         self.typeBox.ShowItem(2, False)
         self.sizer.Add(self.typeBox, flag=wx.ALIGN_LEFT, pos=(0, 0), span=(1, 2))
 

--- a/gui/wxpython/rlisetup/wizard.py
+++ b/gui/wxpython/rlisetup/wizard.py
@@ -1405,7 +1405,7 @@ class SampleUnitsKeyPage(TitledPage):
     def OnEnterPage(self, event: WizardEvent | None = None) -> None:
         """Function during entering"""
         # This is an hack to force the user to choose Rectangle or Circle
-        (self.typeBox.SetSelection(2),)
+        self.typeBox.SetSelection(2)
         self.typeBox.ShowItem(2, False)
         self.panelSizer.Layout()
 
@@ -1608,7 +1608,7 @@ class UnitsMousePage(TitledPage):
             choices=[_("Rectangle"), _("Circle"), ("")],
         )
         # This is an hack to force the user to choose Rectangle or Circle
-        (self.typeBox.SetSelection(2),)
+        self.typeBox.SetSelection(2)
         self.typeBox.ShowItem(2, False)
         self.sizer.Add(self.typeBox, flag=wx.ALIGN_LEFT, pos=(0, 0), span=(1, 2))
 

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -271,9 +271,7 @@ class TimelineFrame(wx.Frame):
         self.axes3d.clear()
         self.axes3d.grid(False)
         # self.axes3d.grid(True)
-        convert = (
-            mdates.date2num if self.temporalType == "absolute" else lambda x: x
-        )  # noqa: E731
+        convert = mdates.date2num if self.temporalType == "absolute" else lambda x: x  # noqa: E731
 
         colors = cycle(COLORS)
         plots = []
@@ -319,9 +317,7 @@ class TimelineFrame(wx.Frame):
         """Draws 2D plot (temporal extents)"""
         self.axes2d.clear()
         self.axes2d.grid(True)
-        convert = (
-            mdates.date2num if self.temporalType == "absolute" else lambda x: x
-        )  # noqa: E731
+        convert = mdates.date2num if self.temporalType == "absolute" else lambda x: x  # noqa: E731
 
         colors = cycle(COLORS)
 

--- a/imagery/i.atcorr/create_iwave.py
+++ b/imagery/i.atcorr/create_iwave.py
@@ -88,9 +88,9 @@ def interpolate_band(values, step=2.5):
 
     wavelengths = values_clean[:, 0]  # 1st column of input array
     responses = values_clean[:, 1]  # 2nd column
-    assert len(wavelengths) == len(
-        responses
-    ), "Number of wavelength slots and spectral responses are not equal!"
+    assert len(wavelengths) == len(responses), (
+        "Number of wavelength slots and spectral responses are not equal!"
+    )
 
     # spectral responses are written out with .4f in pretty_print()
     # anything smaller than 0.0001 will become 0.0000 -> discard with ...

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -603,13 +603,10 @@ def read_gui(gisrc, default_gui):
 
 def create_initial_gisrc(filename):
     # for convenience, define GISDBASE as pwd:
-    s = (
-        r"""GISDBASE: %s
+    s = r"""GISDBASE: %s
 LOCATION_NAME: <UNKNOWN>
 MAPSET: <UNKNOWN>
-"""
-        % Path.cwd()
-    )
+""" % Path.cwd()
     writefile(filename, s)
 
 
@@ -1662,9 +1659,7 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
         fc -R
         _grass_old_mapset="$MAPSET_PATH"
     fi
-    """.format(
-            sh_history=sh_history
-        )
+    """.format(sh_history=sh_history)
     elif sh == "bash":
         # Append existing history to file ("flush").
         # Clear the (in-memory) history.
@@ -1678,9 +1673,7 @@ def sh_like_startup(location, location_name, grass_env_file, sh):
         history -r
         _grass_old_mapset="$MAPSET_PATH"
     fi
-    """.format(
-            sh_history=sh_history
-        )
+    """.format(sh_history=sh_history)
         # Ubuntu sudo creates a file .sudo_as_admin_successful and bash checks
         # for this file in the home directory from /etc/bash.bashrc and prints a
         # message if it's not detected. This can be suppressed with either

--- a/python/grass/experimental/tests/conftest.py
+++ b/python/grass/experimental/tests/conftest.py
@@ -40,9 +40,7 @@ def unique_id():
 
 
 @pytest.fixture
-def xy_mapset_session(
-    xy_session_for_module, unique_id
-):  # pylint: disable=redefined-outer-name
+def xy_mapset_session(xy_session_for_module, unique_id):  # pylint: disable=redefined-outer-name
     """Active session in a mapset of an XY location
 
     Mapset scope is function, while the location scope is module.

--- a/python/grass/experimental/tests/grass_script_mapset_session_test.py
+++ b/python/grass/experimental/tests/grass_script_mapset_session_test.py
@@ -155,9 +155,9 @@ def test_create_multiple(xy_session):
     assert sorted(collected) == sorted(create_names)
     existing_mapsets = get_mapset_names(env=xy_session.env)
     assert sorted(existing_mapsets) == sorted(create_names + original_mapsets)
-    assert (
-        len(set(top_level_collected)) == 1
-    ), f"Top level mapset changed: {top_level_collected}"
+    assert len(set(top_level_collected)) == 1, (
+        f"Top level mapset changed: {top_level_collected}"
+    )
 
 
 def test_nested_top_env(xy_session):

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -504,9 +504,7 @@ class InteractiveRegionController:
         changed_region (dict): The dictionary to store the changed region.
     """
 
-    def __init__(
-        self, map_object, ipyleaflet, ipywidgets, **kwargs
-    ):  # pylint: disable=unused-argument
+    def __init__(self, map_object, ipyleaflet, ipywidgets, **kwargs):  # pylint: disable=unused-argument
         """Initializes the InteractiveRegionController.
 
         :param map_object: The map object.

--- a/python/grass/pygrass/raster/category.py
+++ b/python/grass/pygrass/raster/category.py
@@ -271,9 +271,9 @@ class Category(list):
         :type category: Category object
         """
         libraster.Rast_copy_cats(
-            ctypes.byref(self.c_cats),
-            ctypes.byref(category.c_cats),  # to
-        )  # from
+            ctypes.byref(self.c_cats),  # to
+            ctypes.byref(category.c_cats),  # from
+        )
         self._read_cats()
 
     def ncats(self):

--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -35,9 +35,7 @@ def create_and_get_srid(tmp_path):
     """Create location on the same path as the current one"""
     bootstrap_location = "bootstrap"
     desired_location = "desired"
-    gs.core._create_location_xy(
-        tmp_path, bootstrap_location
-    )  # pylint: disable=protected-access
+    gs.core._create_location_xy(tmp_path, bootstrap_location)  # pylint: disable=protected-access
     with gs.setup.init(tmp_path / bootstrap_location, env=os.environ.copy()) as session:
         gs.create_location(tmp_path, desired_location, epsg="3358")
         assert (tmp_path / desired_location).exists()
@@ -101,9 +99,7 @@ def test_with_different_path(tmp_path):
     tmp_path_a = tmp_path / "a"
     tmp_path_b = tmp_path / "b"
     tmp_path_a.mkdir()
-    gs.core._create_location_xy(
-        tmp_path_a, bootstrap_location
-    )  # pylint: disable=protected-access
+    gs.core._create_location_xy(tmp_path_a, bootstrap_location)  # pylint: disable=protected-access
     with gs.setup.init(
         tmp_path_a / bootstrap_location, env=os.environ.copy()
     ) as session:
@@ -149,9 +145,7 @@ def test_files(tmp_path):
     """Check expected files are created"""
     bootstrap_location = "bootstrap"
     desired_location = "desired"
-    gs.core._create_location_xy(
-        tmp_path, bootstrap_location
-    )  # pylint: disable=protected-access
+    gs.core._create_location_xy(tmp_path, bootstrap_location)  # pylint: disable=protected-access
     with gs.setup.init(tmp_path / bootstrap_location, env=os.environ.copy()):
         description = "This is a test (not Gauss-Krüger or Křovák)"
         gs.create_location(tmp_path, desired_location, epsg="3358", desc=description)

--- a/python/grass/temporal/spatial_extent.py
+++ b/python/grass/temporal/spatial_extent.py
@@ -1323,7 +1323,9 @@ class SpatialExtent(SQLDatabaseInterface):
             or self.meet(extent)
         )
 
-    def spatial_relation_2d(self, extent) -> Literal[
+    def spatial_relation_2d(
+        self, extent
+    ) -> Literal[
         "equivalent",
         "contain",
         "in",
@@ -1370,7 +1372,9 @@ class SpatialExtent(SQLDatabaseInterface):
 
         return "unknown"
 
-    def spatial_relation(self, extent) -> Literal[
+    def spatial_relation(
+        self, extent
+    ) -> Literal[
         "equivalent",
         "contain",
         "in",

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -592,7 +592,9 @@ class TemporalAlgebraLexer:
 
     # Regular expression rules for simple tokens
     t_T_SELECT_OPERATOR = r"\{[!]?[:][,]?[a-zA-Z\| ]*([,])?([lrudi]|left|right|union|disjoint|intersect)?\}"  # noqa: E501
-    t_T_HASH_OPERATOR = r"\{[#][,]?[a-zA-Z\| ]*([,])?([lrudi]|left|right|union|disjoint|intersect)?\}"  # noqa: E501
+    t_T_HASH_OPERATOR = (
+        r"\{[#][,]?[a-zA-Z\| ]*([,])?([lrudi]|left|right|union|disjoint|intersect)?\}"  # noqa: E501
+    )
     t_T_COMP_OPERATOR = r"\{(\|\||&&)[,][a-zA-Z\| ]*[,]?[\|&]?([,])?([lrudi]|left|right|union|disjoint|intersect)?\}"  # noqa: E501
     t_T_REL_OPERATOR = r"\{([a-zA-Z\| ])+\}"
     t_T_SELECT = r":"

--- a/raster/r.coin/tests/test_coin.py
+++ b/raster/r.coin/tests/test_coin.py
@@ -3,9 +3,9 @@ import grass.script as gs
 
 def validate_r_coin_output(actual_results, expected_results):
     """Validate r.coin output against expected results."""
-    assert set(actual_results) == set(
-        expected_results
-    ), f"Expected {expected_results}, but got {actual_results}"
+    assert set(actual_results) == set(expected_results), (
+        f"Expected {expected_results}, but got {actual_results}"
+    )
 
 
 def test_r_coin(setup_maps):

--- a/raster/r.colors.out/tests/r3_colors_out_test.py
+++ b/raster/r.colors.out/tests/r3_colors_out_test.py
@@ -17,9 +17,9 @@ def validate_plain_text_output(data):
         "nv 255:255:255",
         "default 255:255:255",
     }
-    assert (
-        expected == data.keys()
-    ), f"test failed: expected {expected} but got {data.keys()}"
+    assert expected == data.keys(), (
+        f"test failed: expected {expected} but got {data.keys()}"
+    )
 
 
 def test_r3_colors_out_plain_output(raster3_color_dataset):
@@ -52,17 +52,17 @@ def test_r3_colors_out_with_p_flag(raster3_color_dataset):
         "nv 255:255:255",
         "default 255:255:255",
     }
-    assert (
-        expected == data.keys()
-    ), f"test failed: expected {expected} but got {data.keys()}"
+    assert expected == data.keys(), (
+        f"test failed: expected {expected} but got {data.keys()}"
+    )
 
 
 def validate_common_json_structure(data):
     """Validate the common structure and content of the JSON output."""
     assert isinstance(data, list), "Output data should be a list of entries."
-    assert (
-        len(data) == 8
-    ), "The length of the output JSON does not match the expected value of 8."
+    assert len(data) == 8, (
+        "The length of the output JSON does not match the expected value of 8."
+    )
 
 
 def test_r3_colors_out_json_with_default_option(raster3_color_dataset):

--- a/raster/r.colors.out/tests/r_colors_out_test.py
+++ b/raster/r.colors.out/tests/r_colors_out_test.py
@@ -17,9 +17,9 @@ def validate_plain_text_output(data):
         "nv 255:255:255",
         "default 255:255:255",
     }
-    assert (
-        expected == data.keys()
-    ), f"test failed: expected {expected} but got {data.keys()}"
+    assert expected == data.keys(), (
+        f"test failed: expected {expected} but got {data.keys()}"
+    )
 
 
 def test_r_colors_out_plain_output(raster_color_dataset):
@@ -52,17 +52,17 @@ def test_r_colors_out_with_p_flag(raster_color_dataset):
         "nv 255:255:255",
         "default 255:255:255",
     }
-    assert (
-        expected == data.keys()
-    ), f"test failed: expected {expected} but got {data.keys()}"
+    assert expected == data.keys(), (
+        f"test failed: expected {expected} but got {data.keys()}"
+    )
 
 
 def validate_common_json_structure(data):
     """Validate the common structure and content of the JSON output."""
     assert isinstance(data, list), "Output data should be a list of entries."
-    assert (
-        len(data) == 8
-    ), "The length of the output JSON does not match the expected value of 8."
+    assert len(data) == 8, (
+        "The length of the output JSON does not match the expected value of 8."
+    )
 
 
 def test_r_colors_out_json_with_default_option(raster_color_dataset):

--- a/scripts/g.extension/testsuite/test_addons_modules.py
+++ b/scripts/g.extension/testsuite/test_addons_modules.py
@@ -44,9 +44,7 @@ v.in.redwg
 v.neighborhoodmatrix
 v.transects
 wx.metadata
-""".replace(
-    "\n", os.linesep
-)
+""".replace("\n", os.linesep)
 
 
 class TestModulesMetadata(TestCase):

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -150,9 +150,7 @@ def main():
     mapset = gs.gisenv()["MAPSET"]
     unique = str(os.getpid())  # Shouldn't we use temp name?
     prefix = "r_fillnulls_%s_" % unique
-    failed_list = (
-        []
-    )  # a list of failed holes. Caused by issues with v.surf.rst. Connected with #1813
+    failed_list = []  # a list of failed holes. Caused by issues with v.surf.rst. Connected with #1813
 
     # check if input file exists
     if not gs.find_file(input)["file"]:

--- a/scripts/r.pack/r.pack.py
+++ b/scripts/r.pack/r.pack.py
@@ -101,9 +101,7 @@ def main():
                         map_basedir = os.path.sep.join(
                             os.path.normpath(
                                 map_file["file"],
-                            ).split(
-                                os.path.sep
-                            )[:-2],
+                            ).split(os.path.sep)[:-2],
                         )
                         vrt_files[map] = map_basedir
 

--- a/scripts/r.tileset/testsuite/test_r_tileset.py
+++ b/scripts/r.tileset/testsuite/test_r_tileset.py
@@ -16,9 +16,7 @@ import os
 output = """\
 -78.77462049|35.6875073|-78.60830318|35.74855834|1506|678
 -78.77462049|35.74855834|-78.60830318|35.80960938|1506|678
-""".replace(
-    "\n", os.linesep
-)
+""".replace("\n", os.linesep)
 
 
 class TestRTileset(TestCase):

--- a/scripts/v.dissolve/tests/v_dissolve_aggregate_test.py
+++ b/scripts/v.dissolve/tests/v_dissolve_aggregate_test.py
@@ -102,9 +102,9 @@ def test_aggregate_column_result(dataset, backend):
         assert stats_column in columns
         column_info = columns[stats_column]
         correct_type = "integer" if stats_column.endswith("_n") else "double precision"
-        assert (
-            columns[stats_column]["type"].lower() == correct_type
-        ), f"{stats_column} has a wrong type"
+        assert columns[stats_column]["type"].lower() == correct_type, (
+            f"{stats_column} has a wrong type"
+        )
     assert dataset.str_column_name in columns
     column_info = columns[dataset.str_column_name]
     assert column_info["type"].lower() == "character"
@@ -219,9 +219,9 @@ def test_sqlite_agg_accepted(dataset):
         assert stats_column in columns
         column_info = columns[stats_column]
         correct_type = "integer" if method == "count" else "double precision"
-        assert (
-            columns[stats_column]["type"].lower() == correct_type
-        ), f"{stats_column} has a wrong type"
+        assert columns[stats_column]["type"].lower() == correct_type, (
+            f"{stats_column} has a wrong type"
+        )
     assert dataset.str_column_name in columns
     column_info = columns[dataset.str_column_name]
     assert column_info["type"].lower() == "character"

--- a/scripts/v.dissolve/tests/v_dissolve_layers_test.py
+++ b/scripts/v.dissolve/tests/v_dissolve_layers_test.py
@@ -51,9 +51,9 @@ def test_layer_2(dataset_layer_2):
         assert stats_column in columns
         column_info = columns[stats_column]
         correct_type = "integer" if method == "count" else "double precision"
-        assert (
-            columns[stats_column]["type"].lower() == correct_type
-        ), f"{stats_column} has a wrong type"
+        assert columns[stats_column]["type"].lower() == correct_type, (
+            f"{stats_column} has a wrong type"
+        )
     assert dataset.str_column_name in columns
     column_info = columns[dataset.str_column_name]
     assert column_info["type"].lower() == "character"

--- a/temporal/t.rast.list/tests/t_rast_list_test.py
+++ b/temporal/t.rast.list/tests/t_rast_list_test.py
@@ -289,6 +289,6 @@ def test_gran_json(space_time_raster_dataset):
             item["name"] in space_time_raster_dataset.raster_names
             or item["name"] is None
         )
-    assert len(result["data"]) > len(
-        space_time_raster_dataset.raster_names
-    ), "There should be more entries because of finer granularity"
+    assert len(result["data"]) > len(space_time_raster_dataset.raster_names), (
+        "There should be more entries because of finer granularity"
+    )

--- a/vector/v.colors.out/tests/v_colors_out_test.py
+++ b/vector/v.colors.out/tests/v_colors_out_test.py
@@ -17,9 +17,9 @@ def validate_plain_text_output(data):
         "nv 255:255:255",
         "default 255:255:255",
     }
-    assert (
-        expected == data.keys()
-    ), f"test failed: expected {expected} but got {data.keys()}"
+    assert expected == data.keys(), (
+        f"test failed: expected {expected} but got {data.keys()}"
+    )
 
 
 def test_v_colors_out_plain_output(vector_color_dataset):
@@ -52,17 +52,17 @@ def test_v_colors_out_with_p_flag(vector_color_dataset):
         "nv 255:255:255",
         "default 255:255:255",
     }
-    assert (
-        expected == data.keys()
-    ), f"test failed: expected {expected} but got {data.keys()}"
+    assert expected == data.keys(), (
+        f"test failed: expected {expected} but got {data.keys()}"
+    )
 
 
 def validate_common_json_structure(data):
     """Validate the common structure and content of the JSON output."""
     assert isinstance(data, list), "Output data should be a list of entries."
-    assert (
-        len(data) == 8
-    ), "The length of the output JSON does not match the expected value of 8."
+    assert len(data) == 8, (
+        "The length of the output JSON does not match the expected value of 8."
+    )
 
 
 def test_v_colors_out_json_with_default_option(vector_color_dataset):


### PR DESCRIPTION
Closes #4922 

As discussed in #4922, I'm implementing the switch from black to [ruff format](https://docs.astral.sh/ruff/formatter/). It is a drop in replacement with some [limited known deviations ](https://docs.astral.sh/ruff/formatter/black/)

From ruff's docs: https://docs.astral.sh/ruff/formatter/#philosophy

> The initial goal of the Ruff formatter is not to innovate on code style, but rather, to innovate on performance, and provide a unified toolchain across Ruff's linter, formatter, and any and all future tools.
> 
> As such, the formatter is designed as a drop-in replacement for [Black](https://github.com/psf/black), but with an excessive focus on performance and direct integration with Ruff. Given Black's popularity within the Python ecosystem, targeting Black compatibility ensures that formatter adoption is minimally disruptive for the vast majority of projects.
> 
> Specifically, the formatter is intended to emit near-identical output when run over existing Black-formatted code. When run over extensive Black-formatted projects like Django and Zulip, > 99.9% of lines are formatted identically. (See: [_Style Guide](https://docs.astral.sh/ruff/formatter/#style-guide).)
> 
> Given this focus on Black compatibility, the formatter thus adheres to [Black's (stable) code style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html), which aims for "consistency, generality, readability and reducing git diffs".
> 
> 

Like black, ruff format commits to keeping a stable style for a year, and they work together to stay aligned with black choices, if black does it in time.

Black, while faster that it was, is still python, and was becoming slow sometimes, and if used regularly, or even as a save hook on your IDE, is slow.

For example, just before preparing this PR, I compared black 25 and ruff 0.9.4, **_both without cache_**, on a performing computer from 2019:
black:
```
vscode ➜ ~/grass (black-25) $ rm -r  ~/.cache/black
vscode ➜ ~/grass (black-25) $ time black .
reformatted /home/vscode/grass/python/grass/exceptions/__init__.py
reformatted /home/vscode/grass/gui/wxpython/tplot/frame.py
reformatted /home/vscode/grass/python/grass/pydispatch/errors.py
reformatted /home/vscode/grass/python/grass/script/__init__.py
reformatted /home/vscode/grass/python/grass/imaging/images2gif.py

All done! ✨ 🍰 ✨
5 files reformatted, 951 files left unchanged.

real    0m21.272s
user    2m42.879s
sys     0m3.288s
``` 

ruff:

```
vscode ➜ ~/grass (ruff-format) $ ruff clean
vscode ➜ ~/grass (ruff-format) $ time ruff format --no-cache
99 files reformatted, 857 files left unchanged

real    0m0.255s
user    0m1.643s
sys     0m0.300s
``` 

The experience is simply unmatched.



As for concerns about immatureness: Black has slow developpement, and this repo started when it was young. Ruff is still new, but rapid development. ruff format has been available since their 0.0.289 release in september 2023 (according to their pre-commit repo), which is found on the 8th page of tags on github: https://github.com/astral-sh/ruff/tags?after=v0.1.3. They announced the availability in october 2023 https://astral.sh/blog/the-ruff-formatter. At their developpement cadence, and from following them since a while (before their formatter existed), I estimate that it equates to more than  3 years maturity. I don't see any fear to go there, its way "simpler" that the rules and fixes we rely on here from ruff itself.


For the differences, its a one-time change, and this PR here contains the deviations that they choose to be better than black, amongst other enabling work and fixes. 
Some other nice additions ruff format brings that black doesn't yet:
- Ruff can format the expressions inside f-strings, that otherwise either a pylint or flake8 rule would flag and require manual fixes
- Can format code in docstrings: doctests, inside markdown fenced code blocks, inside rst style, etc. (Disabled by default, opt-in). Skips formatting if it cannot parse or the formatted text produces invalid code.

Upcoming work, after introducing ruff format:
- Enable docstring formatting 


This PR also includes 2 small fixes noted in the black 25 preparatory PR:
- Comments of "# to" and "# from" that were already misplaced since grass82 at least (https://grass.osgeo.org/grass82/manuals/libpython/_modules/pygrass/raster/category.html) for a `libraster.Rast_copy_cats()` invocation
- An extra comma since it was introduced 11 years ago that meant to create a tuple without using it, in rlisetup.wizard. Formatting with ruff format introduces parentheses to make the tuple obvious, that made it possible to catch that unexpected behavior (that's another + for ruff format here :) )

Other:
- disables flake8 E501 (line too long) checks, as now it is checked by other means. Ruff format current style sometimes choses to   exceed the line length if it is only for an inline exclusion, and breaking the line would be worse. Flake8 line length check would be way stricter, and isn't relevant anymore.
- Adapts the CI to use ruff formatting with suggestions. It is batched with the ruff rules suggestions, as ruff fixes may require formatting (as explained and suggested in their pre-commit docs). Ruff formatting doesn't introduce new linting errors.
- Adapts pre-commit config to use ruff format.

