### PR TITLE
v.to.3d: Fix Resource Leak issue in trans3.c

### DIFF
--- a/vector/v.to.3d/trans3.c
+++ b/vector/v.to.3d/trans3.c
@@ -148,6 +148,7 @@ void trans3d(struct Map_info *In, struct Map_info *Out, int type,
 
     Vect_destroy_line_struct(Points);
     Vect_destroy_cats_struct(Cats);
+    Vect_destroy_field_info(Fi);
 }
 
 int srch(const void *pa, const void *pb)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207711)
Used Vect_destroy_field_info() to fix this issue.