### PR TITLE
r.resamp.stats: Fix Resource Leak issue in main.c

### DIFF
--- a/raster/r.resamp.stats/main.c
+++ b/raster/r.resamp.stats/main.c
@@ -149,6 +149,9 @@ static void resamp_unweighted(void)
 
         Rast_put_d_row(outfile, outbuf);
     }
+    G_free(row_map);
+    G_free(col_map);
+    G_free(values);
 }
 
 static void resamp_weighted(void)
@@ -233,6 +236,9 @@ static void resamp_weighted(void)
 
         Rast_put_d_row(outfile, outbuf);
     }
+    G_free(row_map);
+    G_free(col_map);
+    G_free(values);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207686 , 1207687, 1207688 , 1207689, 1207690, 1207691).
Used G_free() to fix this issue. 