### PR TITLE
lib/nviz: Fix Resource Leak issue in exag.c

### DIFF
--- a/lib/nviz/exag.c
+++ b/lib/nviz/exag.c
@@ -63,6 +63,8 @@ int Nviz_get_exag_height(double *val, double *min, double *max)
 
     G_debug(1, "Nviz_get_exag_height(): value = %f min = %f max = %f", *val,
             min ? *min : 0.0, max ? *max : 0.0);
+    if (nsurfs > 0)
+        G_free(surf_list);
 
     return 1;
 }

--- a/lib/nviz/exag.c
+++ b/lib/nviz/exag.c
@@ -64,8 +64,7 @@ int Nviz_get_exag_height(double *val, double *min, double *max)
 
     G_debug(1, "Nviz_get_exag_height(): value = %f min = %f max = %f", *val,
             min ? *min : 0.0, max ? *max : 0.0);
-    if (nsurfs > 0)
-        G_free(surf_list);
+    G_free(surf_list);
 
     return 1;
 }
@@ -95,9 +94,7 @@ double Nviz_get_exag(void)
 
     if (exag == 0.0)
         exag = 1.0;
-
-    if (nsurfs > 0)
-        G_free(surf_list);
+    G_free(surf_list);
 
     G_debug(1, "Nviz_get_exag(): value = %f", exag);
     return exag;

--- a/lib/nviz/exag.c
+++ b/lib/nviz/exag.c
@@ -29,7 +29,8 @@
 int Nviz_get_exag_height(double *val, double *min, double *max)
 {
     float longdim, exag, texag, hmin, hmax, fmin, fmax;
-    int nsurfs, i, *surf_list;
+    int nsurfs, i;
+    int *surf_list = NULL;
 
     surf_list = GS_get_surf_list(&nsurfs);
     if (nsurfs) {
@@ -79,7 +80,8 @@ int Nviz_get_exag_height(double *val, double *min, double *max)
 double Nviz_get_exag(void)
 {
     float exag, texag;
-    int nsurfs, i, *surf_list;
+    int nsurfs, i;
+    int *surf_list = NULL;
 
     surf_list = GS_get_surf_list(&nsurfs);
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207695)
Used G_free() to fix this issue.