### PR TITLE
d.vect.chart: Fix Resource Leak issue in plot.c

### DIFF
--- a/display/d.vect.chart/plot.c
+++ b/display/d.vect.chart/plot.c
@@ -40,6 +40,9 @@ int plot(int ctype, struct Map_info *Map, int type, int field, char *columns,
     if (driver == NULL) {
         G_warning(_("Unable to open database <%s> by driver <%s>"),
                   Fi->database, Fi->driver);
+        Vect_destroy_line_struct(Points);
+        Vect_destroy_cats_struct(Cats);
+        Vect_destroy_field_info(Fi);
         return 1;
     }
     db_set_error_handler_driver(driver);
@@ -134,6 +137,8 @@ int plot(int ctype, struct Map_info *Map, int type, int field, char *columns,
     db_close_database_shutdown_driver(driver);
     Vect_destroy_line_struct(Points);
     Vect_destroy_cats_struct(Cats);
+    Vect_destroy_field_info(Fi);
+    G_free(val);
 
     return 0;
 }

--- a/display/d.vect.chart/plot.c
+++ b/display/d.vect.chart/plot.c
@@ -27,8 +27,6 @@ int plot(int ctype, struct Map_info *Map, int type, int field, char *columns,
     dbTable *table;
     dbColumn *column;
 
-    Points = Vect_new_line_struct();
-    Cats = Vect_new_cats_struct();
     db_init_string(&sql);
 
     Fi = Vect_get_field(Map, field);
@@ -40,11 +38,11 @@ int plot(int ctype, struct Map_info *Map, int type, int field, char *columns,
     if (driver == NULL) {
         G_warning(_("Unable to open database <%s> by driver <%s>"),
                   Fi->database, Fi->driver);
-        Vect_destroy_line_struct(Points);
-        Vect_destroy_cats_struct(Cats);
         Vect_destroy_field_info(Fi);
         return 1;
     }
+    Points = Vect_new_line_struct();
+    Cats = Vect_new_cats_struct();
     db_set_error_handler_driver(driver);
 
     val =


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207639, 1207640, 1270285, 1270286).
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct(), Vect_destroy_field_info(), G_free() to fix this issue.