### PR TITLE
r.sim: fix turning off parallelization with mask on

### DIFF
--- a/raster/r.sim/r.sim.sediment/main.c
+++ b/raster/r.sim/r.sim.sediment/main.c
@@ -388,15 +388,15 @@ int main(int argc, char *argv[])
                   threads, abs(threads));
         threads = abs(threads);
     }
+    if (threads > 1 && Rast_mask_is_present()) {
+        G_warning(_("Parallel processing disabled due to active mask."));
+        threads = 1;
+    }
 #if defined(_OPENMP)
     omp_set_num_threads(threads);
 #else
     threads = 1;
 #endif
-    if (threads > 1 && Rast_mask_is_present()) {
-        G_warning(_("Parallel processing disabled due to active mask."));
-        threads = 1;
-    }
     G_message(_("Number of threads: %d"), threads);
 
     /*      sscanf(parm.nwalk->answer, "%d", &wp.maxwa); */

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -416,15 +416,15 @@ int main(int argc, char *argv[])
                   threads, abs(threads));
         threads = abs(threads);
     }
+    if (threads > 1 && Rast_mask_is_present()) {
+        G_warning(_("Parallel processing disabled due to active mask."));
+        threads = 1;
+    }
 #if defined(_OPENMP)
     omp_set_num_threads(threads);
 #else
     threads = 1;
 #endif
-    if (threads > 1 && Rast_mask_is_present()) {
-        G_warning(_("Parallel processing disabled due to active mask."));
-        threads = 1;
-    }
     G_message(_("Number of threads: %d"), threads);
 
     /* if no rain map input, then: */


### PR DESCRIPTION
The mask test was in a wrong place, so it didn't turn off parallelization when mask was active.