### PR TITLE
lib/vector/Vlib: Fix Resource Leak issue in net_build.c

### DIFF
--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -666,6 +666,8 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
     dglInitializeSPCache(gr, &(Map->dgraph.spCache));
 
     G_message(_("Graph was built"));
+    Vect_destroy_field_info(Fi);
+    db_free_column(Column);
     return 0;
 }
 
@@ -1061,6 +1063,8 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
     dglInitializeSPCache(gr, &(Map->dgraph.spCache));
 
     G_message(_("Graph was built"));
+    Vect_destroy_field_info(Fi);
+    db_free_column(Column);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207632, 1207633, 1207634, 1207635)
Used Vect_destroy_field_info(), db_free_column() to fix this issue.