### PR TITLE
v.to.3d: initialize some variables

### DIFF
--- a/vector/v.to.3d/trans3.c
+++ b/vector/v.to.3d/trans3.c
@@ -27,11 +27,12 @@ void trans3d(struct Map_info *In, struct Map_info *Out, int type,
     struct line_pnts *Points;
     struct line_cats *Cats;
 
-    struct field_info *Fi;
+    struct field_info *Fi = NULL;
     dbDriver *driver;
     dbString stmt;
-    char buf[2000];
-    int ncats, *cats, cat, *cex;
+    char buf[2000] = {0};
+    int *cats, *cex;
+    int ncats = -1, cat = -1;
 
     Points = Vect_new_line_struct();
     Cats = Vect_new_cats_struct();
@@ -106,9 +107,10 @@ void trans3d(struct Map_info *In, struct Map_info *Out, int type,
                       line, cat);
         }
 
-        if (zcolumn && ltype & (GV_POINT | GV_LINE) && cat > -1) {
+        if (zcolumn && ltype & (GV_POINT | GV_LINE) && cat > -1 && ncats > -1) {
             /* category exist in table ? */
-            cex = (int *)bsearch((void *)&cat, cats, ncats, sizeof(int), srch);
+            cex = (int *)bsearch((void *)&cat, cats, (size_t)ncats, sizeof(int),
+                                 srch);
 
             /* store height to the attribute table */
             if (ctype == DB_C_TYPE_INT)
@@ -151,7 +153,7 @@ void trans3d(struct Map_info *In, struct Map_info *Out, int type,
     Vect_destroy_field_info(Fi);
 }
 
-int srch(const void *pa, const void *pb)
+static int srch(const void *pa, const void *pb)
 {
     int *p1 = (int *)pa;
 


### PR DESCRIPTION
`v.to.3d`: initialize some variables, addressing warnings raised by Coverity Scan.

In addition:
- make sure the bsearch() count argument (ncats) is not negative
- add missing static specifier to function declaration