### PR TITLE
manual: multi-tools lack short descriptions

### DIFF
--- a/general/g.setproj/g.setproj.html
+++ b/general/g.setproj/g.setproj.html
@@ -1,32 +1,8 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
-<head>
-<title>g.setproj - GRASS GIS manual</title>
- <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
- <link rel="stylesheet" href="grassdocs.css" type="text/css">
- <meta http-equiv="content-language" content="en-us">
- <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-<body bgcolor="white">
-
-<img src="grass_logo.png" alt="GRASS logo"><hr align="center" size="6" noshade>
-
-<h2>NAME</h2>
-
-<em><b>g.setproj</b></em> allows the user to create the PROJ_INFO and the
-PROJ_UNITS files to record the coordinate reference system (CRS) information
-associated with a current project (previously called location).
-<br>
-
-<h2>SYNOPSIS</h2>
-
-<b>g.setproj</b>
-
 <h2>DESCRIPTION</h2>
 
-Allows a user to create a PROJ_INFO file in the PERMANENT mapset of the
-current project. PROJ_INFO file is used to record the CRS information
-associated with the specified project.
+<em>g.setproj</em> allows the user to create the PROJ_INFO and the
+PROJ_UNITS files to record the coordinate reference system (CRS) information
+associated with a current project (previously called location).
 
 <h2>NOTES</h2>
 
@@ -82,11 +58,6 @@ parallel for the output map.
 
 <h2>AUTHORS</h2>
 
-Irina Kosinovsky,
-U.S. Army Construction Engineering
-Research Laboratory<br>
+Irina Kosinovsky, U.S. Army Construction Engineering Research Laboratory<br>
 Morten Hulden, morten at untamo.net - rewrote module and added 121 projections <br>
 Andreas Lange, andreas.lange at rhein-main.de - added prelimnary map datum support
-
-</body>
-</html>

--- a/raster/r.li/r.li.html
+++ b/raster/r.li/r.li.html
@@ -1,4 +1,6 @@
-<!-- meta page description: Landscape structure analysis package overview -->
+<!-- meta page name: r.li -->
+<!-- meta page name description: Landscape structure analysis package overview -->
+
 <h2>DESCRIPTION</h2>
 
 The <em>r.li</em> suite is a toolset for multiscale analysis of

--- a/vector/v.lrs/lrs.html
+++ b/vector/v.lrs/lrs.html
@@ -1,4 +1,6 @@
-<!-- meta page description: LRS (Linear Referencing System) -->
+<!-- meta page name: LRS -->
+<!-- meta page name description: Toolset for LRS (Linear Referencing System) -->
+
 <h2>DESCRIPTION</h2>
 
 A Linear Referencing System (LRS) is a system


### PR DESCRIPTION
This PR cleans up remaining HTML headers:

- `g.setproj.html`: remove full header (note that `g.setproj` is deprecated
- `r.li.html` and `lrs.html`: fix meta declarations

Now the `r.li` description is no longer empty:

![image](https://github.com/user-attachments/assets/7cda6803-40ef-4e80-8070-1dff4344c391)

Addresses #4972