### PR TITLE
g.proj: fix resource leaks

### DIFF
--- a/general/g.proj/datumtrans.c
+++ b/general/g.proj/datumtrans.c
@@ -78,6 +78,9 @@ int set_datum(char *datum)
     /* Destroy original key/value structure and replace with new one */
     G_free_key_value(projinfo);
     projinfo = temp_projinfo;
+    G_free(dstruct.ellps);
+    G_free(dstruct.longname);
+    G_free(dstruct.name);
 
     return 1;
 }
@@ -188,8 +191,10 @@ int set_datumtrans(int datumtrans, int force)
                     do {
                         struct gpj_datum_transform_list *old = list;
 
-                        if (list->count == datumtrans)
+                        if (list->count == datumtrans) {
+                            G_free(chosenparams);
                             chosenparams = G_store(list->params);
+                        }
                         list = list->next;
                         GPJ_free_datum_transform(old);
                     } while (list != NULL);

--- a/general/g.proj/input.c
+++ b/general/g.proj/input.c
@@ -191,6 +191,7 @@ int input_wkt(char *wktfile)
 #else
     OSRExportToPrettyWkt(hSRS, &tmpwkt, FALSE);
 #endif
+    G_free(projwkt);
     projwkt = G_store(tmpwkt);
     CPLFree(tmpwkt);
     set_authnamecode(hSRS);

--- a/general/g.proj/output.c
+++ b/general/g.proj/output.c
@@ -172,7 +172,7 @@ void print_proj4(int dontprettify)
         if (pj_get_kv(&pjinfo, projinfo, projunits) == -1)
             G_fatal_error(
                 _("Unable to convert projection information to PROJ format"));
-        projstr = pjinfo.def;
+        projstr = G_store(pjinfo.def);
 #if PROJ_VERSION_MAJOR >= 5
         proj_destroy(pjinfo.pj);
 #else

--- a/general/g.proj/output.c
+++ b/general/g.proj/output.c
@@ -85,7 +85,7 @@ void print_projinfo(int shell)
 /* DEPRECATED: datum transformation is handled by PROJ */
 void print_datuminfo(void)
 {
-    char *datum, *params;
+    char *datum = NULL, *params = NULL;
     struct gpj_datum dstruct;
     int validdatum = 0;
 
@@ -126,13 +126,16 @@ void print_datuminfo(void)
     if (validdatum > 0)
         GPJ_free_datum(&dstruct);
 
+    G_free(datum);
+    G_free(params);
+
     return;
 }
 
 /* print input projection information in PROJ format */
 void print_proj4(int dontprettify)
 {
-    struct pj_info pjinfo;
+    struct pj_info pjinfo = {0};
     char *i, *projstrmod;
     const char *projstr;
     const char *unfact;
@@ -199,6 +202,9 @@ void print_proj4(int dontprettify)
     }
     fputc('\n', stdout);
     G_free(projstrmod);
+    G_free(pjinfo.srid);
+    G_free(pjinfo.def);
+    G_free((void *)projstr);
 
     return;
 }


### PR DESCRIPTION
Fix resource leaks in `g.proj` as reported by Coverity Scan.