### PR TITLE
v.distance: initialize variable; remove unused variables

### DIFF
--- a/vector/v.distance/distance.c
+++ b/vector/v.distance/distance.c
@@ -131,7 +131,7 @@ int line2line(struct line_pnts *FPoints, int ftype, struct line_pnts *TPoints,
                 *falong = Vect_line_length(FPoints);
                 FPoints->n_points = np;
             }
-            np = fseg;
+            // np = fseg;
             if (fseg == 0)
                 fseg = 1;
             *fangle = sangle(FPoints, fseg);
@@ -176,7 +176,7 @@ int line2line(struct line_pnts *FPoints, int ftype, struct line_pnts *TPoints,
                 *talong = Vect_line_length(TPoints);
                 TPoints->n_points = np;
             }
-            np = tseg;
+            // np = tseg;
             if (tseg == 0)
                 tseg = 1;
             *tangle = sangle(TPoints, tseg);
@@ -231,7 +231,8 @@ int line2area(struct Map_info *To, struct line_pnts *Points, int type, int area,
     int i, j;
     double tmp_dist;
     int isle, nisles;
-    int all_inside_outer, all_outside_outer, all_outside_inner;
+    int all_inside_outer, all_outside_inner;
+    // int all_outside_outer;
     static struct line_pnts *aPoints = NULL;
     static struct line_pnts **iPoints = NULL;
     static struct bound_box *ibox = NULL;
@@ -272,7 +273,8 @@ int line2area(struct Map_info *To, struct line_pnts *Points, int type, int area,
     }
 
     /* inside area ? */
-    all_inside_outer = all_outside_outer = 1;
+    all_inside_outer = 1;
+    // all_outside_outer = 1;
     all_outside_inner = 1;
 
     int in_box;
@@ -291,7 +293,7 @@ int line2area(struct Map_info *To, struct line_pnts *Points, int type, int area,
 
             if (poly > 0) {
                 /* inside outer ring */
-                all_outside_outer = 0;
+                // all_outside_outer = 0;
             }
             else {
                 /* outside outer ring */

--- a/vector/v.distance/local_proto.h
+++ b/vector/v.distance/local_proto.h
@@ -6,44 +6,40 @@
 #define _LOCAL_PROTO_
 
 /* define codes for characteristics of relation between two nearest features */
-#define CAT        1  /* category of nearest feature */
-#define FROM_X     2  /* x coordinate of nearest point on 'from' */
-                      /* feature */
-#define FROM_Y     3  /* y coordinate of nearest point on 'from' */
-                      /* feature */
-#define TO_X       4  /* x coordinate of nearest point on 'to' */
-                      /* feature */
-#define TO_Y       5  /* y coordinate of nearest point on 'to' */
-                      /* feature */
-#define FROM_ALONG 6  /* distance to nearest point on 'from' along */
-                      /* linear feature */
-#define TO_ALONG   7  /* distance to nearest point on 'to' along */
-                      /* linear feature */
-#define DIST       8  /* minimum distance to nearest feature */
-#define TO_ANGLE   9  /* angle of linear feature in nearest point */
-#define TO_ATTR    10 /* attribute of nearest feature */
-#define END        11 /* end of list */
+enum Code {
+    CAT = 1,        // category of nearest feature
+    FROM_X = 2,     // x coordinate of nearest point on 'from' feature
+    FROM_Y = 3,     // y coordinate of nearest point on 'from' feature
+    TO_X = 4,       // x coordinate of nearest point on 'to' feature
+    TO_Y = 5,       // y coordinate of nearest point on 'to' feature
+    FROM_ALONG = 6, // distance to nearest point on 'from' along linear feature
+    TO_ALONG = 7,   // distance to nearest point on 'to' along linear feature
+    DIST = 8,       // minimum distance to nearest feature
+    TO_ANGLE = 9,   // angle of linear feature in nearest point
+    TO_ATTR = 10,   // attribute of nearest feature
+    END = 11        // end of list
+};
 
 enum OutputFormat { PLAIN, JSON };
 
 /* Structure to store info about nearest feature for each category */
 typedef struct {
-    int from_cat;                  /* category (from) */
-    int count;                     /* number of features already found */
-    int to_cat;                    /* category (to) */
-    double from_x, from_y, from_z; /* coordinates of nearest 'from' point */
-    double to_x, to_y, to_z;       /* coordinates of nearest 'to' point */
+    int from_cat;                  // category (from)
+    int count;                     // number of features already found
+    int to_cat;                    // category (to)
+    double from_x, from_y, from_z; // coordinates of nearest 'from' point
+    double to_x, to_y, to_z;       // coordinates of nearest 'to' point
     double from_along,
-        to_along; /* distance along a linear feature to the nearest point */
-    double from_angle; /* angle of linear feature in nearest point */
-    double to_angle;   /* angle of linear feature in nearest point */
-    double dist;       /* distance to nearest feature */
+        to_along;      // distance along a linear feature to the nearest point
+    double from_angle; // angle of linear feature in nearest point
+    double to_angle;   // angle of linear feature in nearest point
+    double dist;       // distance to nearest feature
 } NEAR;
 
 /* Upload and column store */
 typedef struct {
-    int upload;   /* code */
-    char *column; /* column name */
+    enum Code upload; // code
+    char *column;     // column name
 } UPLOAD;
 
 typedef int dist_func(const struct line_pnts *, double, double, double, int,

--- a/vector/v.distance/main.c
+++ b/vector/v.distance/main.c
@@ -1454,6 +1454,8 @@ int main(int argc, char *argv[])
                 break;
             case TO_ATTR:
                 sprintf(buf2, "%s %s", Upload[j].column, to_attr_sqltype);
+            default:
+                break;
             }
             db_append_string(&stmt, buf2);
             j++;
@@ -1641,6 +1643,8 @@ int main(int argc, char *argv[])
                         sprintf(buf2, " null");
                     }
                     break;
+                default:
+                    break;
                 }
                 db_append_string(&stmt, buf2);
                 j++;
@@ -1741,6 +1745,8 @@ int main(int argc, char *argv[])
                         else {
                             sprintf(buf2, " null");
                         }
+                        break;
+                    default:
                         break;
                     }
                     db_append_string(&stmt, buf2);

--- a/vector/v.distance/print.c
+++ b/vector/v.distance/print.c
@@ -10,7 +10,7 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
     JSON_Value *relations_value, *relation_value;
     JSON_Array *relations;
     JSON_Object *relation_object;
-    char *name;
+    char *name = NULL;
 
     if (format == JSON) {
         relations_value = json_value_init_array();
@@ -105,6 +105,8 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
                         json_object_set_null(relation_object, "value");
                     }
                     break;
+                default:
+                    break;
                 }
                 json_object_set_string(relation_object, "name", name);
                 json_array_append_value(relations, relation_value);
@@ -166,6 +168,8 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
                     else {
                         fprintf(stdout, "%snull", sep);
                     }
+                    break;
+                default:
                     break;
                 }
                 break;


### PR DESCRIPTION
Addresses issues reported by Coverity Scan and scan-build. Unused variables are only commented out (keep them as reminders just in case).

In addition; a list of macros is converted to enum, for better handling of code by compilers.