### PR TITLE
wxGUI: Fixed ruff error `PTH208` in datacatalog/

### DIFF
--- a/gui/wxpython/datacatalog/catalog.py
+++ b/gui/wxpython/datacatalog/catalog.py
@@ -17,7 +17,6 @@ for details.
 """
 
 import wx
-import os
 
 from pathlib import Path
 
@@ -212,7 +211,7 @@ class DataCatalog(wx.Panel):
             grassdb_node = self.tree.InsertGrassDb(name=grassdatabase)
 
             # Offer to create a new location
-            if grassdb_node and not os.listdir(grassdatabase):
+            if grassdb_node and not any(Path(grassdatabase).iterdir()):
                 message = _(
                     "Do you want to create a new project (also known as location)?"
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,6 @@ ignore = [
 # Other ignores:
 "**.py" = ["PYI066"]
 "*/testsuite/**.py" = ["PT009", "PT027"]
-"gui/wxpython/datacatalog/catalog.py" = ["PTH208"]
 "gui/wxpython/dbmgr/base.py" = ["SIM115"]
 "gui/wxpython/gcp/manager.py" = ["PTH208"]
 "gui/wxpython/gmodeler/panels.py" = ["SIM115"]


### PR DESCRIPTION
Fixed `PTH208` to use `pathlib.Path.iterdir()`