### PR TITLE
r.sim: properly fix turning off parallelization with mask on

### DIFF
--- a/raster/r.sim/r.sim.sediment/main.c
+++ b/raster/r.sim/r.sim.sediment/main.c
@@ -387,7 +387,7 @@ int main(int argc, char *argv[])
                   threads, abs(threads));
         threads = abs(threads);
     }
-    if (threads > 1 && Rast_mask_is_present()) {
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
         G_warning(_("Parallel processing disabled due to active mask."));
         threads = 1;
     }

--- a/raster/r.sim/r.sim.water/main.c
+++ b/raster/r.sim/r.sim.water/main.c
@@ -415,7 +415,7 @@ int main(int argc, char *argv[])
                   threads, abs(threads));
         threads = abs(threads);
     }
-    if (threads > 1 && Rast_mask_is_present()) {
+    if (threads > 1 && G_find_raster("MASK", G_mapset()) != NULL) {
         G_warning(_("Parallel processing disabled due to active mask."));
         threads = 1;
     }


### PR DESCRIPTION
Fixes e495352, which was using new function available only in main.
