### PR TITLE
doc: fix various issues in html pages in preparation for markdown

### DIFF
--- a/imagery/i.gensigset/i.gensigset.html
+++ b/imagery/i.gensigset/i.gensigset.html
@@ -61,7 +61,7 @@ a combination of
 and
 <em><a href="v.to.rast.html">v.to.rast</a></em>,
 or some other import/development process (e.g.,
-<em><a href="v.transects.html">v.transects</a>)</em>
+<em><a href="https://grass.osgeo.org/grass-stable/manuals/addons/v.transects.html">v.transects</a>)</em>
 to define the areas representative of the classes in the image.
 
 <p>

--- a/imagery/i.landsat.toar/i.landsat.toar.html
+++ b/imagery/i.landsat.toar/i.landsat.toar.html
@@ -29,7 +29,7 @@ the equations.
 region settings, in order to have the largest possible sample of pixels
 from where to get the darkest one of the scene and perform the DOS
 correction. To limit the results to a custom region, the user is
-advised to clip the results (with <a href="r.clip.html">r.clip</a>, for
+advised to clip the results (with <a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.clip.html">r.clip</a>, for
 instance) or to define the region first, import the images with region
 cropping, and then running the module.
 

--- a/imagery/i.ortho.photo/i.ortho.init/i.ortho.init.html
+++ b/imagery/i.ortho.photo/i.ortho.init/i.ortho.init.html
@@ -16,7 +16,7 @@ station file for imagery group referenced by a sub-block.  These entries
 include: the (XC,YC,ZC) standard (e.g. UTM) approximate coordinates of the camera exposure
 station; initial roll, pitch, and yaw angles (in degrees) of the cameras
 attitude; and the <em>a priori</em> standard deviations for these
-parameters. During the imagery program, <em>i.photo.rectify</em>, the initial camera
+parameters. During the imagery program, <em>i.ortho.rectify</em>, the initial camera
 exposure station file is used for computation of the ortho-rectification
 parameters.  If no initial camera exposure station file exist, the default
 values are computed from the control points file created in
@@ -107,7 +107,7 @@ values in this menu are not used.
 <a href="i.ortho.elev.html">i.ortho.elev</a>,
 <a href="i.ortho.camera.html">i.ortho.camera</a>,
 <a href="i.ortho.transform.html">i.ortho.transform</a>,
-<a href="i.photo.rectify.html">i.photo.rectify</a>
+<a href="i.ortho.rectify.html">i.ortho.rectify</a>
 </em>
 
 <h2>AUTHOR</h2>

--- a/imagery/i.ortho.photo/i.ortho.rectify/i.ortho.rectify.html
+++ b/imagery/i.ortho.photo/i.ortho.rectify/i.ortho.rectify.html
@@ -1,11 +1,11 @@
 <h2>DESCRIPTION</h2>
 
-<em>i.photo.rectify</em> rectifies an image by using the image to photo
+<em>i.ortho.rectify</em> rectifies an image by using the image to photo
 coordinate transformation matrix created by <a href="g.gui.photo2image.html">g.gui.photo2image</a>
 and the rectification parameters created by <a href="g.gui.image2target.html">g.gui.image2target</a>.
 Rectification is the process by which the geometry of an image is made
 planimetric.  This is accomplished by mapping an image from one coordinate
-system to another. In <em>i.photo.rectify</em> the parameters computed by
+system to another. In <em>i.ortho.rectify</em> the parameters computed by
 <a href="g.gui.photo2image.html">g.gui.photo2image</a> and
 <a href="g.gui.image2target.html">g.gui.image2target</a> are used in equations to
 convert x,y image coordinates to standard map coordinates for each pixel in
@@ -38,7 +38,7 @@ appear blurred. Because terrain shadowing effects are not considered,
 areas with high camera angles may also appear blurred if they are located
 (viewed from the camera position) behind mountain ridges or peaks.
 <p>
-<em>i.photo.rectify</em> can be run directly, specifying options in the
+<em>i.ortho.rectify</em> can be run directly, specifying options in the
 command line or the GUI, or it can be invoked as OPTION 8 through
 <a href="i.ortho.photo.html">i.ortho.photo</a>. If invoked though
 <a href="i.ortho.photo.html">i.ortho.photo</a>, an interactive terminal
@@ -70,7 +70,7 @@ The next prompt asks you to select one of two windows:
 <p>
 If you choose option 2, you can also specify a desired target resolution.
 <p>
-<em>i.photo.rectify</em> will only rectify that portion of the
+<em>i.ortho.rectify</em> will only rectify that portion of the
 image that occurs within the chosen window.  Only that portion will be
 relocated in the target database. It is therefore important to check the
 current window in the target project if choice number one is selected.
@@ -87,7 +87,7 @@ Next you are asked to select an interpolation method.
 </pre>
 <p>
 The last prompt will ask you about the amount of memory to be used by
-<em>i.photo.rectify</em>.
+<em>i.ortho.rectify</em>.
 
 <h2>SEE ALSO</h2>
 

--- a/imagery/i.pca/i.pca.html
+++ b/imagery/i.pca/i.pca.html
@@ -96,7 +96,7 @@ Space Research Center, University of Texas, Austin, 1990.
 <a href="g.gui.iclass.html">g.gui.iclass</a>,
 <a href="i.fft.html">i.fft</a>,
 <a href="i.ifft.html">i.ifft</a>,
-<a href="m.eigensystem.html">m.eigensystem</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/m.eigensystem.html">m.eigensystem</a>,
 <a href="r.covar.html">r.covar</a>,
 <a href="r.mapcalc.html">r.mapcalc</a>
 <p>

--- a/raster/r.clump/r.clump.html
+++ b/raster/r.clump/r.clump.html
@@ -131,7 +131,6 @@ d.rast lsat7_2002_clump_min10
 <h2>SEE ALSO</h2>
 
 <em>
-<a href="r.average.html">r.average</a>,
 <a href="r.buffer.html">r.buffer</a>,
 <a href="r.distance.html">r.distance</a>,
 <a href="r.grow.html">r.grow</a>,

--- a/raster/r.covar/r.covar.html
+++ b/raster/r.covar/r.covar.html
@@ -88,7 +88,7 @@ This can be done with <em><a href="r.rescale.html">r.rescale</a></em>.
 
 <em>
 <a href="i.pca.html">i.pca</a>,
-<a href="m.eigensystem.html">m.eigensystem</a> (Addon),
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/m.eigensystem.html">m.eigensystem</a> (Addon),
 <a href="r.mapcalc.html">r.mapcalc</a>,
 <a href="r.rescale.html">r.rescale</a>
 </em>

--- a/raster/r.fill.stats/r.fill.stats.html
+++ b/raster/r.fill.stats/r.fill.stats.html
@@ -395,10 +395,10 @@ http://fatra.cnr.ncsu.edu/uav-lidar-analytics-course/midpines_2015_spm.las
 -->
 
 Inspect the point density and determine the extent of the point cloud
-using the <em><a href="r.in.lidar.html">r.in.lidar</a></em> module:
+using the <em><a href="r.in.pdal.html">r.in.pdal</a></em> module:
 
 <div class="code"><pre>
-r.in.lidar -e input=points.las output=density method=n resolution=5 class_filter=2
+r.in.pdal -e input=points.las output=density method=n resolution=5 class_filter=2
 </pre></div>
 
 Based on the result, set computational region extent and desired
@@ -411,7 +411,7 @@ g.region -pa raster=density res=1
 Import the point cloud as raster using binning:
 
 <div class="code"><pre>
-r.in.lidar input=points.las output=ground_raw method=mean class_filter=2
+r.in.pdal input=points.las output=ground_raw method=mean class_filter=2
 </pre></div>
 
 Check that there are more non-NULL cells than NULL ("no data") cells:

--- a/raster/r.in.xyz/r.in.xyz.html
+++ b/raster/r.in.xyz/r.in.xyz.html
@@ -310,7 +310,7 @@ Development Team.
 <a href="m.proj.html">m.proj</a>,
 <a href="r.fillnulls.html">r.fillnulls</a>,
 <a href="r.in.ascii.html">r.in.ascii</a>,
-<a href="r.in.lidar.html">r.in.lidar</a>,
+<a href="r.in.pdal.html">r.in.pdal</a>,
 <a href="r3.in.xyz.html">r3.in.xyz</a>,
 <a href="r.mapcalc.html">r.mapcalc</a>,
 <a href="r.neighbors.html">r.neighbors</a>,

--- a/raster/r.mapcalc/r.mapcalc.html
+++ b/raster/r.mapcalc/r.mapcalc.html
@@ -842,7 +842,7 @@ by Anil K. Jain (Prentice Hall, NJ, 1989; p 67).
 
 <em>
 <a href="g.region.html">g.region</a>,
-<a href="r.bitpattern.html">r.bitpattern</a>,
+<a href="https://grass.osgeo.org/grass-stable/manuals/addons/r.bitpattern.html">r.bitpattern</a>,
 <a href="r.blend.html">r.blend</a>,
 <a href="r.colors.html">r.colors</a>,
 <a href="r.fillnulls.html">r.fillnulls</a>,

--- a/scripts/g.download.project/g.download.project.html
+++ b/scripts/g.download.project/g.download.project.html
@@ -38,7 +38,7 @@ grass --tmp-project XY --exec g.download.project url=https://grass.osgeo.org/sam
   <a href="g.mapsets.html">g.mapsets</a>,
   <a href="r.proj.html">r.proj</a>,
   <a href="v.proj.html">v.proj</a>,
-  <a href="g.proj.all.html">g.proj.all</a>
+  <a href="https://grass.osgeo.org/grass-stable/manuals/addons/g.proj.all.html">g.proj.all</a>
 </em>
 
 <h2>AUTHOR</h2>

--- a/vector/v.decimate/v.decimate.html
+++ b/vector/v.decimate/v.decimate.html
@@ -132,7 +132,7 @@ d.vect map=points color=none width=1 icon=basic/point
 <a href="v.select.html">v.select</a>,
 <a href="v.category.html">v.category</a>,
 <a href="v.build.html">v.build</a>,
-<a href="v.in.lidar.html">v.in.lidar</a>,
+<a href="v.in.pdal.html">v.in.pdal</a>,
 <a href="g.region.html">g.region</a>
 </em>
 

--- a/vector/v.lidar.correction/v.lidar.correction.html
+++ b/vector/v.lidar.correction/v.lidar.correction.html
@@ -100,7 +100,7 @@ report by Sithole, G. and Vosselman, G., 2003.
 <a href="v.lidar.growing.html">v.lidar.growing</a>,
 <a href="v.surf.bspline.html">v.surf.bspline</a>,
 <a href="v.surf.rst.html">v.surf.rst</a>,
-<a href="v.in.lidar.html">v.in.lidar</a>,
+<a href="v.in.pdal.html">v.in.pdal</a>,
 <a href="v.in.ascii.html">v.in.ascii</a>
 </em>
 

--- a/vector/v.lidar.edgedetection/v.lidar.edgedetection.html
+++ b/vector/v.lidar.edgedetection/v.lidar.edgedetection.html
@@ -79,8 +79,8 @@ v.lidar.edgedetection input=vector_last output=edge ew_step=8 ns_step=8 lambda_g
 g.region raster=elev_lid792_1m
 
 # import
-v.in.lidar -tr input=points.las output=points
-v.in.lidar -tr input=points.las output=points_first return_filter=first
+v.in.pdal -r input=points.las output=points
+v.in.pdal -r input=points.las output=points_first return_filter=first
 
 # detection
 v.lidar.edgedetection input=points output=edge ew_step=8 ns_step=8 lambda_g=0.5
@@ -153,7 +153,7 @@ report by Sithole, G. and Vosselman, G., 2003.</li>
 <a href="v.lidar.correction.html">v.lidar.correction</a>,
 <a href="v.surf.bspline.html">v.surf.bspline</a>,
 <a href="v.surf.rst.html">v.surf.rst</a>,
-<a href="v.in.lidar.html">v.in.lidar</a>,
+<a href="v.in.pdal.html">v.in.pdal</a>,
 <a href="v.in.ascii.html">v.in.ascii</a>
 </em>
 

--- a/vector/v.lidar.growing/v.lidar.growing.html
+++ b/vector/v.lidar.growing/v.lidar.growing.html
@@ -78,7 +78,7 @@ report by Sithole, G. and Vosselman, G., 2003.
 <a href="v.lidar.correction.html">v.lidar.correction</a>,
 <a href="v.surf.bspline.html">v.surf.bspline</a>,
 <a href="v.surf.rst.html">v.surf.rst</a>,
-<a href="v.in.lidar.html">v.in.lidar</a>,
+<a href="v.in.pdal.html">v.in.pdal</a>,
 <a href="v.in.ascii.html">v.in.ascii</a>
 </em>
 

--- a/vector/vectorintro.html
+++ b/vector/vectorintro.html
@@ -371,7 +371,7 @@ approximation (also called interpolation):
 
 Lidar point clouds (first and last return) are imported from text files
 with <a href="v.in.ascii.html">v.in.ascii</a> or from LAS files with
-<a href="v.in.lidar.html"> v.in.lidar</a>. Both modules recognize the
+<a href="v.in.pdal.html"> v.in.pdal</a>. Both modules recognize the
 -b flag to not build topology. Outlier detection is done with
 <a href="v.outlier.html">v.outlier</a> on both first and last return data.
 Then, with <a href="v.lidar.edgedetection.html">v.lidar.edgedetection</a>,

--- a/visualization/ximgview/ximgview.html
+++ b/visualization/ximgview/ximgview.html
@@ -33,7 +33,7 @@ d.vect roads
 <em>
 <a href="pngdriver.html">PNG driver</a>,
 <a href="cairodriver.html">cairo driver</a>,
-<a href="wximgview.html">wximgview</a>
+<a href="wxpyimgview.html">wxpyimgview</a>
 </em>
 <br>
 <em>


### PR DESCRIPTION
Solves couple issues that showed up when building markdown documentation.
* Fix links to addons
* fix i.ortho.rectify name, wximgview
* r.average doesn't exist anymore
* replace v/r.in.lidar with v/r.in.pdal in examples and see also