### PR TITLE
doc: Hide only general and misc keywords in index

### DIFF
--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -22,17 +22,9 @@ import os
 import sys
 import glob
 
-blacklist = [
-    "Display",
-    "Database",
+keywords_to_hide_in_overview = [
     "General",
-    "Imagery",
     "Misc",
-    "Postscript",
-    "Raster",
-    "Raster3D",
-    "Temporal",
-    "Vector",
 ]
 
 addons_path = None
@@ -114,12 +106,12 @@ def build_keywords(ext):
             elif fname not in keywords[key]:
                 keywords[key].append(fname)
 
-    for black in blacklist:
+    for keyword in keywords_to_hide_in_overview:
         try:
-            del keywords[black]
+            del keywords[keyword]
         except Exception:
             try:
-                del keywords[black.lower()]
+                del keywords[keyword.lower()]
             except Exception:
                 continue
 


### PR DESCRIPTION
When a tool links raster or vector as a standard keyword, the link to keyword page does not go anywhere because first keyword (aka class or family) is hidden in the keywords index (overview).

This enables most of the keywords with the exception of general and misc which I assume will not be used by non-general tools as keywords.

Fixes #5049.

In addition, this changes the variable names for better documentation.
