### PR TITLE
doc: Remove extra space

### DIFF
--- a/raster/r.geomorphon/r.geomorphon.html
+++ b/raster/r.geomorphon/r.geomorphon.html
@@ -34,7 +34,7 @@ different from the horizon. Two lines-of-sight are necessary due to zenith
 LOS only, does not detect positive forms correctly.
 
 <p> There are 3**8 = 6561 possible ternary patterns (8-tuples). By removing
-all patterns that are the result of either rotation or reflection of other 
+all patterns that are the result of either rotation or reflection of other
 patterns, a set of 498 patterns remains, referred to as geomorphons.
 This is a comprehensive and exhaustive set of idealized landforms that are
 independent of the size, relief, and orientation of the actual landform.


### PR DESCRIPTION
There is only one trailing space in all HTML files, but there is one. This change removes it.