### PR TITLE
doc: Fix parson lib test first keyword

### DIFF
--- a/lib/external/parson/test/test_main.c
+++ b/lib/external/parson/test/test_main.c
@@ -53,7 +53,8 @@ int main(int argc, char *argv[])
     G_gisinit(argv[0]);
 
     module = G_define_module();
-    G_add_keyword(_("gjson"));
+    G_add_keyword(_("general"));
+    G_add_keyword(_("json"));
     G_add_keyword(_("unit test"));
     module->description = _("Performs unit tests "
                             "for the gjson library");


### PR DESCRIPTION
The first keyword needs to be one of the (recognized) tool categories (families), not a custom keyword. r3.flow and raster3d lib tests are using this style.
