### PR TITLE
CI: Run ruff format with file fixes for PR suggestions

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run `ruff format` fixing files
         # Run `ruff format` even when `ruff check` fixed files: fixes can require formatting
         if: ${{ !cancelled() }}
-        run: ruff format --diff
+        run: ruff format
       - name: Create and uploads code suggestions to apply for Ruff
         # Will fail fast here if there are changes required
         id: diff-ruff


### PR DESCRIPTION
It seems there was a copy-paste error, it didn't even match my comments and the title of the step, where the first run showing the diff in the CI logs was also the same call as the one that was supposed to actually change the files in order to upload the suggestions for formatting fixes too