### PR TITLE
raster/r.statistics: Fix Resource Leak issue in o_sdev.c , o_skew.c , o_var.c , o_kurt.c

### DIFF
--- a/raster/r.statistics/o_kurt.c
+++ b/raster/r.statistics/o_kurt.c
@@ -70,6 +70,7 @@ int o_kurt(const char *basemap, const char *covermap, const char *outputmap,
 
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
+    G_free(tab);
 
     return 0;
 }

--- a/raster/r.statistics/o_sdev.c
+++ b/raster/r.statistics/o_sdev.c
@@ -71,6 +71,7 @@ int o_sdev(const char *basemap, const char *covermap, const char *outputmap,
 
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
+    G_free(tab);
 
     return 0;
 }

--- a/raster/r.statistics/o_skew.c
+++ b/raster/r.statistics/o_skew.c
@@ -70,6 +70,7 @@ int o_skew(const char *basemap, const char *covermap, const char *outputmap,
 
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
+    G_free(tab);
 
     return 0;
 }

--- a/raster/r.statistics/o_var.c
+++ b/raster/r.statistics/o_var.c
@@ -73,6 +73,7 @@ int o_var(const char *basemap, const char *covermap, const char *outputmap,
 
     G_popen_close(&stats_child);
     G_popen_close(&reclass_child);
+    G_free(tab);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207718, 1207719, 1207720)
Used G_free() to fix this issue.