### PR TITLE
lib/vector/Vlib: Fix Resource leak issue in remove_areas.c

### DIFF
--- a/lib/vector/Vlib/remove_areas.c
+++ b/lib/vector/Vlib/remove_areas.c
@@ -192,6 +192,10 @@ int Vect_remove_small_areas_ext(struct Map_info *Map, double thresh,
         *removed_area = size_removed;
 
     G_message(_("%d areas of total size %g removed"), nremoved, size_removed);
+    Vect_destroy_list(AList);
+    Vect_destroy_list(List);
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
 
     return (nremoved);
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207724, 1207725, 1207726, 1207727)
Used Vect_destroy_list(), Vect_destroy_line_struct(), Vect_destroy_cats_struct()