### PR TITLE
Fix package.sh: there is no SRC variable

### DIFF
--- a/mswindows/osgeo4w/package.sh
+++ b/mswindows/osgeo4w/package.sh
@@ -174,7 +174,7 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
 		--with-proj-libs=$OSGEO4W_ROOT_MSYS/lib \
 		--with-postgres \
 		--with-postgres-includes=$OSGEO4W_ROOT_MSYS/include \
-		--with-postgres-libs=${SRC}/mswindows/osgeo4w/lib \
+		--with-postgres-libs=$PWD/mswindows/osgeo4w/lib \
 		--with-gdal=$PWD/mswindows/osgeo4w/gdal-config \
 		--with-geos=$PWD/mswindows/osgeo4w/geos-config \
 		--with-sqlite \


### PR DESCRIPTION
This PR fixes compilation on Windows when using `mswindows/osgeo4w/package.sh`:

```
checking for location of PostgreSQL library... /mswindows/osgeo4w/lib
configure: error: *** PostgreSQL library directory /mswindows/osgeo4w/lib does not exist.

```
This bug was introduced by ec54064cb4f83a52951ff61e6c3afafa5654e977 while other related parts (where` SRC` variable is introduced) haven't been backported).