### PR TITLE
docs: Added command to serve mkdocs locally

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -258,3 +258,8 @@ build-mkdocs:
 	@cd $(MDDIR) ; SITE_NAME="GRASS GIS $(GRASS_VERSION_NUMBER) Reference Manual" \
 	COPYRIGHT="&copy; 2003-$(GRASS_VERSION_DATE) GRASS Development Team, GRASS GIS $(GRASS_VERSION_NUMBER) Reference Manual" \
 	mkdocs build
+
+serve-mkdocs:
+	@cd $(MDDIR) ; SITE_NAME="GRASS GIS $(GRASS_VERSION_NUMBER) Reference Manual" \
+	COPYRIGHT="&copy; 2003-$(GRASS_VERSION_DATE) GRASS Development Team, GRASS GIS $(GRASS_VERSION_NUMBER) Reference Manual" \
+	mkdocs serve


### PR DESCRIPTION
Addressing comment from PR https://github.com/OSGeo/grass/pull/5048.

I've added a command to the Makefile to serve mkdocs locally.

To run make sure to follow the steps from  PR https://github.com/OSGeo/grass/pull/5048 and then you can run:

```sh
cd man
make serve-mkdocs
```