### PR TITLE
docs: fix markdown image syntax in imagery, display, misc, ps tools and scripts

### DIFF
--- a/display/d.geodesic/d.geodesic.md
+++ b/display/d.geodesic/d.geodesic.md
@@ -32,8 +32,7 @@ d.geodesic coordinates=55:58W,33:18S,26:43E,60:37N \
   line_color=yellow text_color=red units=kilometers
 ```
 
-<img src="d_geodesic.png" data-border="1"
-alt="Geodesic line (great circle line)" />  
+![Geodesic line (great circle line)](d_geodesic.png)  
 *Geodesic line (great circle line)*
 
 ## NOTES

--- a/display/d.grid/d.grid.md
+++ b/display/d.grid/d.grid.md
@@ -39,8 +39,7 @@ or
 d.grid -g size=0.5 color=255:0:0
 ```
 
-<img src="d_grid_red_grid.png" data-border="0"
-alt="d.grid red grid example" />  
+![d.grid red grid example](d_grid_red_grid.png)  
 *Figure: Showing a geographic grid in red line color*
 
 To draw a blue standard rectangular grid at a 500 (meter) spacing run
@@ -50,8 +49,7 @@ the following:
 d.grid size=500 color=blue
 ```
 
-<img src="d_grid_blue_grid.png" data-border="0"
-alt="d.grid blue grid example" />  
+![d.grid blue grid example](d_grid_blue_grid.png)  
 *Figure: Showing a rectangular grid in blue line color*
 
 ## SEE ALSO

--- a/display/d.histogram/d.histogram.md
+++ b/display/d.histogram/d.histogram.md
@@ -26,8 +26,7 @@ d.mon wx0
 d.histogram map=elevation
 ```
 
-<img src="d_histogram_bar.png" data-border="0"
-alt="d.histogram bar graph example" />  
+![d.histogram bar graph example](d_histogram_bar.png)  
 *Figure: Bar graph histogram for elevation map*
 
 Running the command below will generate the pie graph shown in the
@@ -38,8 +37,7 @@ g.region raster=landuse96_28m -p
 d.histogram map=landuse96_28m style=pie
 ```
 
-<img src="d_histogram_pie.png" data-border="0"
-alt="d.histogram pie graph example" />  
+![d.histogram pie graph example](d_histogram_pie.png)  
 *Figure: Pie graph histogram for landuse map*
 
 ## SEE ALSO

--- a/display/d.legend/d.legend.md
+++ b/display/d.legend/d.legend.md
@@ -111,8 +111,7 @@ d.rast elevation
 d.legend -d elevation
 ```
 
-<img src="d_legend.png" data-border="1"
-alt="Elevation map with legend" />
+![Elevation map with legend](d_legend.png)
 
 Displaying the legend with custom labels and background:
 
@@ -122,8 +121,7 @@ d.rast elevation
 d.legend raster=elevation -t label_step=20 label_values=108 title=Legend -b bgcolor=255:255:204 border_color=gray
 ```
 
-<img src="d_legend_custom_labels_and_background.png" data-border="1"
-alt="Elevation map with custom legend" />
+![Elevation map with custom legend](d_legend_custom_labels_and_background.png)
 
 Displaying the legend with logarithmic scale:
 
@@ -134,8 +132,7 @@ d.rast flowacc
 d.legend raster=flowacc -t -l label_step=1
 ```
 
-<img src="d_legend_logarithmic.png" data-border="1"
-alt="Flow accumulation map with logarithmic legend" />
+![Flow accumulation map with logarithmic legend](d_legend_logarithmic.png)
 
 ## SEE ALSO
 

--- a/display/d.mon/d.mon.md
+++ b/display/d.mon/d.mon.md
@@ -64,7 +64,7 @@ display](wxGUI.md#map-display-window)*, run
 d.mon start=wx0
 ```
 
-<img src="d_mon_wx0.png" data-border="0" alt="Blank wx0 display" />  
+![Blank wx0 display](d_mon_wx0.png)  
 *Figure: The initialization of display monitor wx0*
 
 All subsequently displayed data will be rendered on monitor `wx0`.
@@ -74,8 +74,7 @@ g.region raster=elevation -p
 d.rast map=elevation
 ```
 
-<img src="d_mon_wx0_raster.png" data-border="0"
-alt="Display wx0 with raster map" />  
+![Display wx0 with raster map](d_mon_wx0_raster.png)  
 *Figure: The display wx0 showing an elevation raster map*
 
 ### CAIRO file renderer monitor

--- a/display/d.rast.num/d.rast.num.md
+++ b/display/d.rast.num/d.rast.num.md
@@ -31,8 +31,7 @@ r.grow.distance input=streams_derived distance=dist_from_streams
 d.rast.num dist_from_streams -a
 ```
 
-<img src="d_rast_num_zoom.png" data-border="0"
-alt="Euclidean distance from the streams network in meters" />  
+![Euclidean distance from the streams network in meters](d_rast_num_zoom.png)  
 *Euclidean distance from the streams network in meters (detail, numbers
 shown with d.rast.num)*
 

--- a/display/d.rast/d.rast.md
+++ b/display/d.rast/d.rast.md
@@ -11,8 +11,7 @@ Display raster map "elevation":
 d.rast map=elevation
 ```
 
-<img src="d_rast_elevation.png" data-border="0"
-alt="d.rast elevation" />  
+![d.rast elevation](d_rast_elevation.png)  
 *Figure: elevation raster map visualization*
 
 Display raster map "elevation" but only the raster cells with values
@@ -22,8 +21,7 @@ between 75 and 80 meters:
 d.rast map=elevation values=75-80
 ```
 
-<img src="d_rast_elevation_values.png" data-border="0"
-alt="d.rast elevation with values" />  
+![d.rast elevation with values](d_rast_elevation_values.png)  
 *Figure: elevation raster map showing values between 75 and 80 meters*
 
 Display raster map "landuse96_28m" but only categories 1 and 2:
@@ -32,7 +30,7 @@ Display raster map "landuse96_28m" but only categories 1 and 2:
 d.rast landuse96_28m values=1,2
 ```
 
-<img src="d_rast_landuse.png" data-border="0" alt="d.rast landuse" />  
+![d.rast landuse](d_rast_landuse.png)  
 *Figure: landuse raster map showing categories 1 and 2*
 
 ## SEE ALSO

--- a/display/d.rgb/d.rgb.md
+++ b/display/d.rgb/d.rgb.md
@@ -49,7 +49,7 @@ g.region raster=lsat7_2002_10 -p
 d.rgb blue=lsat7_2002_10 green=lsat7_2002_20 red=lsat7_2002_30
 ```
 
-<img src="d_rgb.png" data-border="0" alt="d.rgb example" />  
+![d.rgb example](d_rgb.png)  
 *Figure: Visual color composite of a LANDSAT scene (North Carolina
 sample dataset)*
 

--- a/display/d.vect.thematic/d.vect.thematic.md
+++ b/display/d.vect.thematic/d.vect.thematic.md
@@ -78,8 +78,7 @@ d.vect.thematic map=schools_wake@PERMANENT column=CORECAPACI algorithm=std \
 d.legend.vect -b at=2,80 font=Sans symbol_size=25
 ```
 
-[<img src="d_vect_thematic.png" width="600" height="377"
-alt="d_vect_thematic example" />](d_vect_thematic.png)  
+![d_vect_thematic example](d_vect_thematic.png)  
 *Thematic map of average elevation and school capacity*
 
 ## SEE ALSO

--- a/imagery/i.atcorr/i.atcorr.md
+++ b/imagery/i.atcorr/i.atcorr.md
@@ -882,8 +882,7 @@ To apply atmospheric correction to the remaining bands, only the last
 line in the 6S parameters file (i.e., the sensor band) needs to be
 changed. The other parameters will remain the same.
 
-[<img src="i_atcorr_B02_atcorr.png" data-border="0" width="600"
-height="486" alt="i.atcorr example" />](i_atcorr_B02_atcorr.png)  
+![i.atcorr example](i_atcorr_B02_atcorr.png)  
 *Figure: Sentinel-2A Band 02 with applied atmospheric correction
 (histogram equalization grayscale color scheme)*
 

--- a/imagery/i.ortho.photo/i.ortho.photo/i.ortho.photo.md
+++ b/imagery/i.ortho.photo/i.ortho.photo/i.ortho.photo.md
@@ -49,8 +49,7 @@ Five groups of input parameters are required for ortho-rectification:
   points and/or,
 - Coordinates of ground control points in the target coordinate system.
 
-[<img src="i_ortho_photo_step1.png" data-border="0" width="600"
-height="512" alt="i.ortho.photo example" />](i_ortho_photo_step1.png)  
+![i.ortho.photo example](i_ortho_photo_step1.png)  
 *Example of an input oblique image in a source project*
 
 To ortho-rectify aerial images the user has to follow the menu options
@@ -188,8 +187,7 @@ The steps to follow are described below:
     2728 0.0     0.0 -7.7     1
     ```
 
-    [<img src="i_ortho_photo_step5.png" data-border="0" width="600"
-    height="636" alt="i.ortho.photo example" />](i_ortho_photo_step5.png)  
+    ![i.ortho.photo example](i_ortho_photo_step5.png)  
     *Step 5: Image-to-photo transformation of an oblique image*
 
 6. *Initialize parameters of camera: [i.ortho.init](i.ortho.init.md)*
@@ -210,8 +208,7 @@ The steps to follow are described below:
       north: needs to be denoted as +90° for clockwise turn and -90° for
       a counter-clockwise turn.
 
-    [<img src="i_ortho_photo_step6.png" data-border="0" width="394"
-    height="182" alt="i.ortho.photo example" />](i_ortho_photo_step6.png)  
+    ![i.ortho.photo example](i_ortho_photo_step6.png)  
     *Principle of pitch and yaw*
 
     In Step 6, a new file *mapset/group/name_of_group/**INIT_EXP*** is
@@ -265,8 +262,7 @@ The steps to follow are described below:
     1570.09788497 2790.06537829 0.0     3.0 11.0 100.0             1
     ```
 
-    [<img src="i_ortho_photo_step7.png" data-border="0" width="600"
-    height="689" alt="i.ortho.photo example" />](i_ortho_photo_step7.png)  
+    ![i.ortho.photo example](i_ortho_photo_step7.png)  
     *Step 7: Detail of ground control points matching in an oblique
     image and terrain model*
 
@@ -281,8 +277,7 @@ The steps to follow are described below:
     current window in the target project or the minimal bounding window
     for the ortho-rectified image.
 
-    [<img src="i_ortho_photo_step8.png" data-border="0" width="600"
-    height="459" alt="i.ortho.photo example" />](i_ortho_photo_step8.png)  
+    ![i.ortho.photo example](i_ortho_photo_step8.png)  
     *Step 8: Ortho-rectified oblique image*
 
     As a result, the ortho-rectified raster map is available for

--- a/imagery/imageryintro.md
+++ b/imagery/imageryintro.md
@@ -102,8 +102,7 @@ signature files of imagery classification tools. Therefore, signature
 files of one imagery or raster group can be used to classify a different
 group with identical semantic labels.
 
-<img src="band_references_scheme.png" data-border="0" width="600"
-height="435" alt="GRASS GIS band references scheme" />  
+![GRASS GIS band references scheme](band_references_scheme.png)  
 *New enhanced classification workflow involving semantic labels.*
 
 With [r.support](r.support.md) any sort of semantic label the user

--- a/misc/m.measure/m.measure.md
+++ b/misc/m.measure/m.measure.md
@@ -17,10 +17,8 @@ m.measure coordinates="$Bonn_DE,$Philadelphia_US" units=kilometers
 Length:  6217.916452 kilometers
 ```
 
-[<img src="m_measure_distance.png" data-border="0" width="600"
-height="290"
-alt="Visualization (with d.geodesic) of m.measure distance example" />  
-](m_measure_distance.png) *Visualization (with d.geodesic) of m.measure
+![Visualization (with d.geodesic) of m.measure distance example](m_measure_distance.png)  
+*Visualization (with d.geodesic) of m.measure
 distance example*
 
 As an example for the North Carolina sample dataset, here four points

--- a/ps/ps.map/ps.map.md
+++ b/ps/ps.map/ps.map.md
@@ -1491,7 +1491,6 @@ ps.map input=simple_map.txt output=simple_map.ps
 ```
 
 ![](ps_map_basic.png)
-
 *Figure: Result of for the a simple Wake county terrain and roads
 example*
 
@@ -1570,7 +1569,6 @@ ps.map input=elevation_map.txt output=elevation.ps
 ```
 
 ![](ps_map.png)
-
 *Figure: Result of for the more complicated Wake county, NC example*
 
 More examples can be found on the [GRASS

--- a/scripts/d.correlate/d.correlate.md
+++ b/scripts/d.correlate/d.correlate.md
@@ -23,9 +23,8 @@ g.region raster=lsat7_2002_30 -p
 d.correlate map=lsat7_2002_30,lsat7_2002_40
 ```
 
-<img src="d_correlate_plot.png" data-border="1"
-alt="Scatterplot of two LANDSAT TM7 channels" />  
-Scatterplot of two LANDSAT TM7 channels
+![Scatterplot of two LANDSAT TM7 channels](d_correlate_plot.png)  
+*Scatterplot of two LANDSAT TM7 channels*
 
 ## SEE ALSO
 

--- a/scripts/d.rast.edit/d.rast.edit.md
+++ b/scripts/d.rast.edit/d.rast.edit.md
@@ -77,8 +77,7 @@ r.univar -g elev_lid792_1m
 r.univar -g elev_lid792_1m_modified
 ```
 
-[<img src="d_rast_edit.png" data-border="0" width="600" height="281"
-alt="d.rast.edit example" />](d_rast_edit.png)  
+![d.rast.edit example](d_rast_edit.png)  
 *Figure: Editing of pixels in an elevation raster map using d.rast.edit*
 
 ## TODO

--- a/scripts/i.pansharpen/i.pansharpen.md
+++ b/scripts/i.pansharpen/i.pansharpen.md
@@ -181,32 +181,17 @@ d.rgb b=ihs542_blue g=ihs542_green r=ihs542_red
 
 ***Results:***
 
-<table data-border="1">
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td style="text-align: center;"> <img
-src="i_pansharpen_rgb_landsat542.jpg"
-alt="R, G, B composite of Landsat at 30m" /><br />
-<em>R, G, B composite of Landsat at 30m</em></td>
-<td style="text-align: center;"> <img
-src="i_pansharpen_rgb_brovey542.jpg"
-alt="R, G, B composite of Brovey sharpened image at 15m" /><br />
-<em>R, G, B composite of Brovey sharpened image at 15m</em></td>
-</tr>
-<tr class="even">
-<td style="text-align: center;"> <img src="i_pansharpen_rgb_ihs542.jpg"
-alt="R, G, B composite of IHS sharpened image at 15m" /><br />
-<em>R, G, B composite of IHS sharpened image at 15m</em></td>
-<td style="text-align: center;"> <img src="i_pansharpen_rgb_pca542.jpg"
-alt="R, G, B composite of PCA sharpened image at 15m" /><br />
-<em>R, G, B composite of PCA sharpened image at 15m"</em></td>
-</tr>
-</tbody>
-</table>
+![R, G, B composite of Landsat at 30m](i_pansharpen_rgb_landsat542.jpg)  
+*R, G, B composite of Landsat at 30m*  
+
+![R, G, B composite of Brovey sharpened image at 15m](i_pansharpen_rgb_brovey542.jpg)  
+*R, G, B composite of Brovey sharpened image at 15m*  
+
+![R, G, B composite of IHS sharpened image at 15m](i_pansharpen_rgb_ihs542.jpg)  
+*R, G, B composite of IHS sharpened image at 15m*  
+
+![R, G, B composite of PCA sharpened image at 15m](i_pansharpen_rgb_pca542.jpg)  
+*R, G, B composite of PCA sharpened image at 15m*  
 
 ## REFERENCES
 

--- a/scripts/i.tasscap/i.tasscap.md
+++ b/scripts/i.tasscap/i.tasscap.md
@@ -35,30 +35,17 @@ i.tasscap sensor=landsat7_etm \
 
 Results:
 
-<table data-border="1">
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td style="text-align: center;"> <img src="i_tasscap_brightness.jpg"
-alt="&#39;Brightness&#39; Tasseled Cap component 1" /><br />
-<em>'Brightness' Tasseled Cap component 1</em></td>
-<td style="text-align: center;"> <img src="i_tasscap_greenness.jpg"
-alt="&#39;Greenness&#39; Tasseled Cap component 2" /><br />
-<em>'Greenness' Tasseled Cap component 2</em></td>
-</tr>
-<tr class="even">
-<td style="text-align: center;"> <img src="i_tasscap_wetness.jpg"
-alt="&#39;Wetness&#39; Tasseled Cap component 3" /><br />
-<em>'Wetness' Tasseled Cap component 3</em></td>
-<td style="text-align: center;"> <img src="i_tasscap_haze.jpg"
-alt="&#39;Atmospheric haze&#39; Tasseled Cap component 4" /><br />
-<em>'Atmospheric haze' Tasseled Cap component 4</em></td>
-</tr>
-</tbody>
-</table>
+![Brightness Tasseled Cap component 1](i_tasscap_brightness.jpg)  
+*'Brightness' Tasseled Cap component 1*  
+
+![Greenness Tasseled Cap component 2](i_tasscap_greenness.jpg)  
+*'Greenness' Tasseled Cap component 2*  
+
+![Wetness Tasseled Cap component 3](i_tasscap_wetness.jpg)  
+*'Wetness' Tasseled Cap component 3*  
+
+![Atmospheric haze Tasseled Cap component 4](i_tasscap_haze.jpg)  
+*'Atmospheric haze' Tasseled Cap component 4*  
 
 ## REFERENCES
 

--- a/scripts/r.blend/r.blend.md
+++ b/scripts/r.blend/r.blend.md
@@ -14,8 +14,7 @@ r.relief input=elevation output=relief zscale=10
 r.blend -c first=elevation second=relief output=blend percent=75
 ```
 
-[<img src="r_blend.png" data-border="0" width="600" height="540"
-alt="r.blend example" />](r_blend.png)  
+![r.blend example](r_blend.png)  
 *Figure: Elevation blended with shaded relief*
 
 ## SEE ALSO

--- a/scripts/r.colors.stddev/r.colors.stddev.md
+++ b/scripts/r.colors.stddev/r.colors.stddev.md
@@ -23,8 +23,7 @@ g.region raster=elevation -p
 r.colors.stddev elevation
 ```
 
-[<img src="r_colors_stddev.png" data-border="0" width="600" height="540"
-alt="r.colors.stddev example" />](r_colors_stddev.png)  
+![r.colors.stddev example](r_colors_stddev.png)  
 *Figure: Standard deviations from mean elevation*
 
 ## SEE ALSO

--- a/scripts/r.drain/r.drain.md
+++ b/scripts/r.drain/r.drain.md
@@ -215,8 +215,7 @@ d.vect map=start color=none fill_color=224:0:0 icon=basic/circle size=15 legend_
 d.legend.vect -b
 ```
 
-[<img src="r_drain.png" width="300" height="280"
-alt="drainage using r.watershed" />](r_drain.png)  
+![drainage using r.watershed](r_drain.png)  
 *Figure: Drainage paths from two points flowing into the points with
 lowest values*
 
@@ -255,8 +254,7 @@ r.drain -d input=const1 direction=drain_deg output=drain_path_2 drain=drain_2 st
 
 We visualize the result in the same way as in the previous example.
 
-[<img src="r_drain_with_r_watershed_direction.png" width="300"
-height="280" alt="drainage using r.watershed" />](r_drain_with_r_watershed_direction.png)  
+![drainage using r.watershed](r_drain_with_r_watershed_direction.png)  
 *Figure: Drainage paths from two points where directions from
 r.watershed were used*
 

--- a/scripts/r.plane/r.plane.md
+++ b/scripts/r.plane/r.plane.md
@@ -39,8 +39,7 @@ r.plane myplane30 dip=30 az=75 east=638650.0 north=220375.0 \
         elev=116.7734 type=FCELL
 ```
 
-[<img src="r_plane_3d.png" data-border="0" width="600" height="360"
-alt="r.plane example" />](r_plane_3d.png)  
+![r.plane example](r_plane_3d.png)  
 *Figure: Tilted plane shown in NVIZ along with elevation map*
 
 ## AUTHORS

--- a/scripts/v.centroids/v.centroids.md
+++ b/scripts/v.centroids/v.centroids.md
@@ -28,8 +28,7 @@ v.type input=busroute11 output=busroute11_boundary from_type=line to_type=bounda
 v.centroids input=busroute11_boundary output=busroute11_area
 ```
 
-[<img src="v_centroids.png" data-border="0" width="600" height="300"
-alt="v.centroids example" />](v_centroids.png)  
+![v.centroids example](v_centroids.png)  
 *Figure: Creating area from closed line*
 
 ## SEE ALSO

--- a/scripts/v.clip/v.clip.md
+++ b/scripts/v.clip/v.clip.md
@@ -33,8 +33,7 @@ v.extract input=boundary_county where="NAME='WAKE' OR NAME='JOHNSTON'" output=co
 v.clip input=railroads clip=county_WAKE_JOHNSTON output=railroads_WAKE_JOHNSTON
 ```
 
-<img src="v_clip_poly.png" width="600" height="255"
-alt="v.clip example" />  
+![v.clip example](v_clip_poly.png)  
 *Figure: v.clip example - basic use*
 
 ### Retain boundaries of clip map
@@ -55,8 +54,7 @@ v.extract input=boundary_county where="NAME='WAKE' OR NAME='JOHNSTON'" output=co
 v.clip -r input=hospitals output=hospitals_clip
 ```
 
-<img src="v_clip_region.png" width="600" height="259"
-alt="v.clip example" />  
+![v.clip example](v_clip_region.png)  
 *Figure: v.clip example - clip by computational region*
 
 ## SEE ALSO


### PR DESCRIPTION
Fixing image syntax in tools after automatic conversion (all except raster and vector tools that are in #5092 and #5093).