### PR TITLE
docker: build gdal-grass with CMake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,11 +297,9 @@ RUN ./configure $GRASS_CONFIG \
 # Build the GDAL-GRASS plugin
 RUN git clone https://github.com/OSGeo/gdal-grass \
     && cd "gdal-grass" \
-    && ./configure \
-      --with-gdal=/usr/bin/gdal-config \
-      --with-grass=/usr/local/grass85 \
-    && make -j $NUMTHREADS \
-    && make install -j $NUMTHREADS \
+    && cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF \
+    && cmake --build build \
+    && cmake --install build \
     && cd /src \
     && rm -rf "gdal-grass"
 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -180,11 +180,9 @@ RUN cp /usr/local/grass/gui/wxpython/xml/module_items.xml module_items.xml; \
 
 RUN git clone https://github.com/OSGeo/gdal-grass /src/gdal-grass
 WORKDIR /src/gdal-grass
-RUN ./configure \
-    --with-gdal=/usr/bin/gdal-config \
-    --with-grass=/usr/local/grass && \
-    make -j $NUMTHREADS && \
-    make install -j $NUMTHREADS
+RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
+    cmake --build build && \
+    cmake --install build
 
 
 FROM common as grass

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -297,11 +297,9 @@ RUN ./configure $GRASS_CONFIG \
 # Build the GDAL-GRASS plugin
 RUN git clone https://github.com/OSGeo/gdal-grass \
     && cd "gdal-grass" \
-    && ./configure \
-      --with-gdal=/usr/bin/gdal-config \
-      --with-grass=/usr/local/grass85 \
-    && make -j $NUMTHREADS \
-    && make install -j $NUMTHREADS \
+    && cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF \
+    && cmake --build build \
+    && cmake --install build \
     && cd /src \
     && rm -rf "gdal-grass"
 


### PR DESCRIPTION
After gdal-grass' drop of Autotools support with
https://github.com/OSGeo/gdal-grass/commit/fa4b0450d26f6f4791e3eca0332b1650b400e00b.

I can't test these changes, but it should be good. Either someone could test it manually, or we merge and see...