### PR TITLE
lib/vector/Vlib: free allocated field_info and dbColumn objects (net_build.c)

### DIFF
--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -167,6 +167,7 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                           tcols[i], Fi->table);
 
         tctype[i] = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+        db_free_column(Column);
 
         if ((tctype[i] == DB_C_TYPE_INT || tctype[i] == DB_C_TYPE_DOUBLE) &&
             !strcmp(tcols[i], "cost"))
@@ -183,6 +184,8 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                                        NULL, &tvarrs[i]);
         ++i;
     }
+
+    Vect_destroy_field_info(Fi);
 
     G_debug(1, "forward costs: nrec = %d", nturns);
 
@@ -212,6 +215,7 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                           Fi->table);
 
         fctype = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+        db_free_column(Column);
 
         if (fctype != DB_C_TYPE_INT && fctype != DB_C_TYPE_DOUBLE)
             G_fatal_error(
@@ -223,6 +227,7 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
         nrec = db_select_CatValArray(driver, Fi->table, Fi->key, ncol, NULL,
                                      &fvarr);
         G_debug(1, "node costs: nrec = %d", nrec);
+        Vect_destroy_field_info(Fi);
 
         tucfield_idx = Vect_cidx_get_field_index(Map, tucfield);
     }
@@ -504,6 +509,7 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                           Fi->table);
 
         fctype = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+        db_free_column(Column);
 
         if (fctype != DB_C_TYPE_INT && fctype != DB_C_TYPE_DOUBLE)
             G_fatal_error(
@@ -521,6 +527,7 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                               Fi->table);
 
             bctype = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+            db_free_column(Column);
 
             if (bctype != DB_C_TYPE_INT && bctype != DB_C_TYPE_DOUBLE)
                 G_fatal_error(_("Data type of column <%s> not supported (must "
@@ -532,6 +539,7 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                                          NULL, &bvarr);
             G_debug(1, "backward costs: nrec = %d", nrec);
         }
+        Vect_destroy_field_info(Fi);
     }
 
     skipped = 0;
@@ -666,12 +674,6 @@ int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
     dglInitializeSPCache(gr, &(Map->dgraph.spCache));
 
     G_message(_("Graph was built"));
-    if (Fi) {
-        Vect_destroy_field_info(Fi);
-    }
-    if (Column) {
-        db_free_column(Column);
-    }
 
     return 0;
 }
@@ -804,6 +806,7 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
                           Fi->table);
 
         fctype = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+        db_free_column(Column);
 
         if (fctype != DB_C_TYPE_INT && fctype != DB_C_TYPE_DOUBLE)
             G_fatal_error(
@@ -821,6 +824,7 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
                               Fi->table);
 
             bctype = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+            db_free_column(Column);
 
             if (bctype != DB_C_TYPE_INT && bctype != DB_C_TYPE_DOUBLE)
                 G_fatal_error(_("Data type of column <%s> not supported (must "
@@ -832,6 +836,7 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
                                          NULL, &bvarr);
             G_debug(1, "backward costs: nrec = %d", nrec);
         }
+        Vect_destroy_field_info(Fi);
     }
 
     skipped = 0;
@@ -977,6 +982,7 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
                           Fi->table);
 
         fctype = db_sqltype_to_Ctype(db_get_column_sqltype(Column));
+        db_free_column(Column);
 
         if (fctype != DB_C_TYPE_INT && fctype != DB_C_TYPE_DOUBLE)
             G_fatal_error(
@@ -987,6 +993,7 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
         nrec = db_select_CatValArray(driver, Fi->table, Fi->key, ncol, NULL,
                                      &fvarr);
         G_debug(1, "node costs: nrec = %d", nrec);
+        Vect_destroy_field_info(Fi);
 
         for (i = 1; i <= nnodes; i++) {
             /* TODO: what happens if we set attributes of not existing node
@@ -1068,12 +1075,6 @@ int Vect_net_build_graph(struct Map_info *Map, int ltype, int afield,
     dglInitializeSPCache(gr, &(Map->dgraph.spCache));
 
     G_message(_("Graph was built"));
-    if (Fi) {
-        Vect_destroy_field_info(Fi);
-    }
-    if (Column) {
-        db_free_column(Column);
-    }
 
     return 0;
 }


### PR DESCRIPTION
I was just about to check #5109 when it was merged. So I figure I'll give my review in this form :).

`Fi` always get set by `Vect_get_field()`, and its result is always checked and is G_fatal_error()'ed if NULL. So we can always expect Fi to be not NULL. Furthermore, `Vect_destroy_field_info()` is safe with a NULL as argument (just like `free()`), but it mustn't be bogus address (it should be initialised to NULL at declaration). Thus, no need to check `if (Fi) Vect_destroy_field_info(Fi);`

`db_get_column()` allocates Column and G_fatal_errors if the call fails. So also here there is no real need for NULL check before `db_free_column()` _if freed at the right place_.

There are several calls to both Vect_get_field() and db_get_column(), which must _each_ be accompanied by freeing up allocated memory. I believe I got it right this time.



