### PR TITLE
docker: build gdal-grass with grass in working condition

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -167,6 +167,15 @@ RUN echo "  => Configure and compile grass" && \
     make install && \
     ldconfig /etc/ld.so.conf.d
 
+# Build the GDAL-GRASS plugin
+# renovate: datasource=github-tags depName=OSGeo/gdal-grass
+ARG GDAL_GRASS_VERSION=1.0.3
+RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gdal-grass.git /src/gdal-grass
+WORKDIR /src/gdal-grass
+RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
+    cmake --build build && \
+    cmake --install build
+
 # Get rid of version number here, restore in next stage via symbolic link
 RUN mv $(grass --config path) /usr/local/grass
 
@@ -178,14 +187,6 @@ RUN cp /usr/local/grass/gui/wxpython/xml/module_items.xml module_items.xml; \
     rm -rf /usr/local/grass/share; \
     mkdir -p /usr/local/grass/gui/wxpython/xml/; \
     mv module_items.xml /usr/local/grass/gui/wxpython/xml/module_items.xml;
-
-# renovate: datasource=github-tags depName=OSGeo/gdal-grass
-ARG GDAL_GRASS_VERSION=1.0.3
-RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gdal-grass.git /src/gdal-grass
-WORKDIR /src/gdal-grass
-RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
-    cmake --build build && \
-    cmake --install build
 
 
 FROM common as grass

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -222,7 +222,10 @@ RUN ln -sf /usr/local/grass $(grass --config path); \
     apk del --no-cache gettext pdal-dev; \
     grass --tmp-project XY --exec g.version -rge \
     && pdal --version \
-    && python --version
+    && python --version; \
+    echo "Check GDAL plugins.."; \
+    gdalinfo --formats | grep -p "GRASS Rasters" \
+    && ogrinfo --formats | grep -p "GRASS Vectors" || echo "..failed.";
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -222,10 +222,7 @@ RUN ln -sf /usr/local/grass $(grass --config path); \
     apk del --no-cache gettext pdal-dev; \
     grass --tmp-project XY --exec g.version -rge \
     && pdal --version \
-    && python --version; \
-    echo "Check GDAL plugins.."; \
-    gdalinfo --formats | grep -p "GRASS Rasters" \
-    && ogrinfo --formats | grep -p "GRASS Vectors" || echo "..failed.";
+    && python --version
 
 # Data workdir
 WORKDIR /grassdb

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -5,6 +5,10 @@
 # add dependency
 apk add --no-cache py3-scikit-learn
 
+echo "Testing the GDAL-GRASS plugins:"
+gdalinfo --formats | grep -p "GRASS Rasters" && \
+ogrinfo --formats | grep -p "GRASS Vectors" || echo "...failed"
+
 # Test grass-session
 /usr/bin/python3 /scripts/test_grass_session.py
 # Test PDAL


### PR DESCRIPTION
#5111 was not enough to fix the Alpine docker build. `gdal-grass` CMake config uses `grass` for setting paths and requires a working state of grass.

This was not the case because of:

https://github.com/OSGeo/grass/blob/d3993e2852b8ef4d0de1c748aa6376db4db54d26/docker/alpine/Dockerfile#L171

just before the gdal-grass build started.

This moves the gdal-grass build immediately after grass is built, this hopefully will solve this issue.