### PR TITLE
docker: move gdal-grass driver build stage after grass build relocation

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -167,15 +167,6 @@ RUN echo "  => Configure and compile grass" && \
     make install && \
     ldconfig /etc/ld.so.conf.d
 
-# Build the GDAL-GRASS plugin
-# renovate: datasource=github-tags depName=OSGeo/gdal-grass
-ARG GDAL_GRASS_VERSION=1.0.3
-RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gdal-grass.git /src/gdal-grass
-WORKDIR /src/gdal-grass
-RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
-    cmake --build build && \
-    cmake --install build
-
 # Get rid of version number here, restore in next stage via symbolic link
 RUN mv $(grass --config path) /usr/local/grass
 
@@ -200,12 +191,22 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8" \
     PYTHONPATH="/usr/local/grass/etc/python:$PYTHONPATH"
 
-# Copy GRASS GIS and GDAL GRASS driver from build image
+# Copy GRASS GIS from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
-COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
 # Set GISBASE
 ENV GISBASE /usr/local/grass
+
+# Build the GDAL-GRASS plugin
+# renovate: datasource=github-tags depName=OSGeo/gdal-grass
+ARG GDAL_GRASS_VERSION=1.0.3
+RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gdal-grass.git /src/gdal-grass
+WORKDIR /src/gdal-grass
+RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
+    cmake --build build && \
+    cmake --install build
+# Copy GDAL GRASS driver from build image
+COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
 
 # run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/

--- a/docker/alpine/grass_tests.sh
+++ b/docker/alpine/grass_tests.sh
@@ -6,8 +6,8 @@
 apk add --no-cache py3-scikit-learn
 
 echo "Testing the GDAL-GRASS plugins:"
-gdalinfo --formats | grep -p "GRASS Rasters" && \
-ogrinfo --formats | grep -p "GRASS Vectors" || echo "...failed"
+gdalinfo --formats | grep "GRASS Rasters" && \
+ogrinfo --formats | grep "GRASS Vectors" || echo "...failed"
 
 # Test grass-session
 /usr/bin/python3 /scripts/test_grass_session.py


### PR DESCRIPTION
https://github.com/OSGeo/grass/commit/d657e54da3cdf0a341d6c69e49678fb12db2366b didn't quite work out . The drivers were linked to grass libraries which was later moved. 

```
#23 3.342 ERROR 1: Error loading shared library libgrass_raster.8.5.so: No such file or directory (needed by /usr/lib/gdalplugins/gdal_GRASS.so)
#23 3.342 ERROR 1: Error loading shared library libgrass_raster.8.5.so: No such file or directory (needed by /usr/lib/gdalplugins/gdal_GRASS.so)
#23 3.344 ERROR 1: Error loading shared library libgrass_vector.8.5.so: No such file or directory (needed by /usr/lib/gdalplugins/ogr_GRASS.so)
#23 3.344 ERROR 1: Error loading shared library libgrass_vector.8.5.so: No such file or directory (needed by /usr/lib/gdalplugins/ogr_GRASS.so)
```

Moving the `gdal-grass` building stage to after the move, might work better.....