### PR TITLE
docker: gdal-grass autoconf workaround (G84)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -288,7 +288,7 @@ RUN ./configure $GRASS_CONFIG \
     mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
 
 # Build the GDAL-GRASS plugin
-RUN git clone https://github.com/OSGeo/gdal-grass \
+RUN git clone --depth 1 -b 1.0.3 https://github.com/OSGeo/gdal-grass \
     && cd "gdal-grass" \
     && ./configure \
       --with-gdal=/usr/bin/gdal-config \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -178,8 +178,9 @@ RUN cp /usr/local/grass/gui/wxpython/xml/module_items.xml module_items.xml; \
     mkdir -p /usr/local/grass/gui/wxpython/xml/; \
     mv module_items.xml /usr/local/grass/gui/wxpython/xml/module_items.xml;
 
-RUN git clone https://github.com/OSGeo/gdal-grass /src/gdal-grass
+RUN git clone --depth 1 -b 1.0.3 https://github.com/OSGeo/gdal-grass /src/gdal-grass
 WORKDIR /src/gdal-grass
+
 RUN ./configure \
     --with-gdal=/usr/bin/gdal-config \
     --with-grass=/usr/local/grass && \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -288,7 +288,7 @@ RUN ./configure $GRASS_CONFIG \
     mv module_items.xml /usr/local/grass84/gui/wxpython/xml/module_items.xml;
 
 # Build the GDAL-GRASS plugin
-RUN git clone https://github.com/OSGeo/gdal-grass \
+RUN git clone --depth 1 -b 1.0.3 https://github.com/OSGeo/gdal-grass \
     && cd "gdal-grass" \
     && ./configure \
       --with-gdal=/usr/bin/gdal-config \


### PR DESCRIPTION
This PR hardcodes the [gdal-grass 1.0.3](https://github.com/OSGeo/gdal-grass/releases/tag/1.0.3) release in the Alpine and Ubuntu Dockerfile to continue using its `autoconf` support.

This PR may be replaced by a future backport of a `cmake` based solution which is  being worked on in the `main` branch.

The intention of this PR is not to further delay the GRASS 8.4.1 release due to currently broken Dockerfiles.