### PR TITLE
CI: Fix Docker caching with GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,7 +88,7 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile
-          cache-from: gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.os }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.os }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
There was missing a `type=gha` for `cache-from:`.

Also, add scopes to GitHub Actions cache. Otherwise, only one of the images will have the cache available.

This PR is separate from my other work that will enable to run on PRs. I have tested this with a trimmed down version that could run on PRs.
Cache utilization was 19%, 24% and 26% (no info for the failed Alpine image). Times were reduced to about 7 minutes for all three of these jobs, instead of 8-18 minutes. No further optimization of the Dockerfiles to maximize caching was done, yet.