### PR TITLE
CI(Docker): Docker workflow improvements

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
   # For a release, e.g. 8.3.0, created tags are:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
-    name: build and push ${{ matrix.os }} for ${{ github.ref }}
+    name: ${{ matrix.os }} for ${{ github.ref }}
     # if: github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       - name: Login to DockerHub
-        if: github.repository_owner == 'OSGeo'
+        if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           # push: true
-          pull: true
+          # pull: true
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,8 +138,8 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
-          # push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
+          # push: true
           pull: true
           context: .
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,13 @@ on:
       - "!releasebranch_7_*"
     # tags: ['*.*.*']
     paths-ignore: [doc/**]
+  pull_request:
+    paths:
+      - .github/workflows/docker.yml
+      - Dockerfile
+      - docker/**
+      - "!docker/**.md"
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,9 +69,10 @@ jobs:
           # Make sure tags are fetched
           git fetch --tags
           # Get sorted list of tags, keep the first that has a semver pattern (not RCs)
-          echo "LATEST_TAG=\"$(git tag --sort=-v:refname \
+          LATEST_TAG="$(git tag --sort=-v:refname \
             | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-            | head -n 1)\"" >> "${GITHUB_ENV}"
+            | head -n 1)"
+          echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
           echo "LATEST_TAG is: ${LATEST_TAG}"
       - run: git branch -l
       - run: git branch -l --sort=-v:refname

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
       - name: Login to DockerHub
+        if: github.repository_owner == 'OSGeo'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,6 +93,7 @@ jobs:
       - run: git show-ref
       - run: git branch --all --list '*releasebranch_*' --abbrev --remotes
       - run: git branch --all --list '*releasebranch_*' --remotes --contains "${LATEST_TAG}"
+      - run: git branch --all --list '*releasebranch_*' --contains "${LATEST_TAG}"
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,9 +49,6 @@ jobs:
       group: >-
         ${{ github.workflow }}-${{ matrix.os }}-${{ github.event_name }}-
         ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
-      # ${{ github.workflow }}-${{ github.event_name }}-
-      # ${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-      # ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{ matrix.os }}
       # Cancel in progress in pull requests.
       # Otherwise, limit to one in progress and one queued for each type.
       # Only the latest queued job per type and will be kept, older will be cancelled.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,6 +92,7 @@ jobs:
       # - run: git branch --all --contains "${LATEST_TAG_INVALID}"
       - run: git show-ref
       - run: git branch --all --list '*releasebranch_*' --abbrev --remotes
+      - run: git branch --all --list '*releasebranch_*' --remotes --contains "${LATEST_TAG}"
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,7 +117,7 @@ jobs:
       - run: echo $meta
         env:
           meta: ${{ toJson(steps.meta.outputs.json) }}
-      - run: exit 1
+      # - run: exit 1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,8 +139,6 @@ jobs:
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
           push: ${{ github.event_name != 'pull_request' }}
-          # push: true
-          # pull: true
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,6 +66,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,6 +94,17 @@ jobs:
       - run: git branch --all --list '*releasebranch_*' --abbrev --remotes
       - run: git branch --all --list '*releasebranch_*' --remotes --contains "${LATEST_TAG}"
       - run: git branch --all --list '*releasebranch_*' --contains "${LATEST_TAG}"
+      - run: |
+          branches=$(git branch --all --list '*releasebranch_*' --contains "${LATEST_TAG}")
+          echo "branches is $branches"
+          branches1=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}")
+          echo "branches1 is $branches1"
+          branches2=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}" \
+            | grep -E '^/remotes/origin/.*$'
+          )
+          echo "branches2 is $branches2"
+          branch="$(git branch --all --list 'origin/*' --contains 8.4.0  --format "%(refname:lstrip=3)")"
+          echo "branch is $branch"
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,7 @@ jobs:
       - run: git branch -l --sort=-v:refname
       - run: git branch --all --sort=-v:refname
       - run: git branch --all --contains "${LATEST_TAG}"
+      - run: git branch --all --contains "${LATEST_TAG_INVALID}"
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,8 +156,8 @@ jobs:
           no-cache: ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && true }}
           # Don't use cache for releases. Cache is not used if `cache-from:` is empty
           cache-from: >-
-            ${{ !contains(fromJSON('["tag", "release"]'), github.event_name) && ''
-              || format('type=gha,scope={0}', matrix.os) || '' }}
+            ${{ !contains(fromJSON('["tag", "release"]'), github.event_name)
+                && format('type=gha,scope={0}', matrix.os) || '' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
           provenance: mode=max
           sbom: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,18 +82,6 @@ jobs:
             | head -n 1)"
           echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
           echo "LATEST_TAG is: ${LATEST_TAG}"
-      - run: git branch -l
-      - run: git branch -l --sort=-v:refname
-      - run: git branch --all --sort=-v:refname
-      - run: git branch --all --contains "${LATEST_TAG}"
-      # - run: git branch --all --contains "${LATEST_TAG_INVALID}"
-      - run: git show-ref
-      - run: git branch --all --list '*releasebranch_*' --abbrev --remotes
-      - run: git branch --all --list '*releasebranch_*' --remotes --contains "${LATEST_TAG}"
-      - run: git branch --all --list '*releasebranch_*' --contains "${LATEST_TAG}"
-      - run: |
-          branch="$(git branch --all --list 'origin/*' --contains 8.4.0  --format "%(refname:lstrip=3)")"
-          echo "branch is $branch"
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,7 +118,6 @@ jobs:
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}
-      # - run: exit 1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,7 @@ jobs:
       - run: git branch -l
       - run: git branch -l --sort=-v:refname
       - run: git branch --all --sort=-v:refname
+      - run: git branch --all --contains "${LATEST_TAG}"
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,6 +152,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile
           annotations: ${{ steps.meta.outputs.annotations }}
+          # Don't use cache for releases.
+          no-cache: ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && true }}
           # Don't use cache for releases. Cache is not used if `cache-from:` is empty
           cache-from: >-
             ${{ !contains(fromJSON('["tag", "release"]'), github.event_name) && ''

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,7 +104,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
-          images: osgeo/grass-gis
+          images: |
+            name=docker.io/osgeo/grass-gis,enable=${{ github.repository_owner == 'OSGeo' 
+              && github.event_name != 'pull_request' }}
+            name=ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=tag
             type=ref,event=branch
@@ -119,6 +122,12 @@ jobs:
         uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to DockerHub
         if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
     name: build and push ${{ matrix.os }} for ${{ github.ref }}
-    if: github.repository_owner == 'OSGeo'
+    # if: github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,10 @@ jobs:
             | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
             | head -n 1)\"" >> "${GITHUB_ENV}"
           echo "LATEST_TAG is: ${LATEST_TAG}"
+      - run: git branch -l
+      - run: git branch -l --sort=-v:refname
+      - run: git branch --all --sort=-v:refname
+      - run: exit 1
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,6 +79,7 @@ jobs:
       - run: git branch --all --sort=-v:refname
       - run: git branch --all --contains "${LATEST_TAG}"
       - run: git branch --all --contains "${LATEST_TAG_INVALID}"
+      - run: git show-ref
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           pull: true
           context: .
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,9 +114,6 @@ jobs:
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}
-      - run: echo $meta
-        env:
-          meta: ${{ toJson(steps.meta.outputs.json) }}
       # - run: exit 1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,14 +95,6 @@ jobs:
       - run: git branch --all --list '*releasebranch_*' --remotes --contains "${LATEST_TAG}"
       - run: git branch --all --list '*releasebranch_*' --contains "${LATEST_TAG}"
       - run: |
-          branches=$(git branch --all --list '*releasebranch_*' --contains "${LATEST_TAG}")
-          echo "branches is $branches"
-          branches1=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}")
-          echo "branches1 is $branches1"
-          # branches2=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}" \
-          #   | grep -E '^/remotes/origin/.*$'
-          # )
-          # echo "branches2 is $branches2"
           branch="$(git branch --all --list 'origin/*' --contains 8.4.0  --format "%(refname:lstrip=3)")"
           echo "branch is $branch"
       - run: exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,10 +99,10 @@ jobs:
           echo "branches is $branches"
           branches1=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}")
           echo "branches1 is $branches1"
-          branches2=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}" \
-            | grep -E '^/remotes/origin/.*$'
-          )
-          echo "branches2 is $branches2"
+          # branches2=$(git branch --all '*releasebranch_*' --contains "${LATEST_TAG}" \
+          #   | grep -E '^/remotes/origin/.*$'
+          # )
+          # echo "branches2 is $branches2"
           branch="$(git branch --all --list 'origin/*' --contains 8.4.0  --format "%(refname:lstrip=3)")"
           echo "branch is $branch"
       - run: exit 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,7 +89,7 @@ jobs:
       - run: git branch -l --sort=-v:refname
       - run: git branch --all --sort=-v:refname
       - run: git branch --all --contains "${LATEST_TAG}"
-      - run: git branch --all --contains "${LATEST_TAG_INVALID}"
+      # - run: git branch --all --contains "${LATEST_TAG_INVALID}"
       - run: git show-ref
       - run: exit 1
       - name: Docker meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,6 +91,7 @@ jobs:
       - run: git branch --all --contains "${LATEST_TAG}"
       # - run: git branch --all --contains "${LATEST_TAG_INVALID}"
       - run: git show-ref
+      - run: git branch --all --list '*releasebranch_*' --abbrev --remotes
       - run: exit 1
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ on:
     branches:
       - main
       - releasebranch_*
-      - '!releasebranch_7_*'
+      - "!releasebranch_7_*"
     # tags: ['*.*.*']
     paths-ignore: [doc/**]
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,6 +64,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+      - name: Get the latest tag
+        run: |
+          # Make sure tags are fetched
+          git fetch --tags
+          # Get sorted list of tags, keep the first that has a semver pattern (not RCs)
+          echo "LATEST_TAG=\"$(git tag --sort=-v:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -n 1)\"" >> "${GITHUB_ENV}"
+          echo "LATEST_TAG is: ${LATEST_TAG}"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
@@ -73,7 +82,7 @@ jobs:
             type=ref,event=tag
             type=ref,event=branch
             type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/8.3') && matrix.os == 'ubuntu' }},suffix=
+            type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', env.LATEST_TAG ) && matrix.os == 'ubuntu' }},suffix=
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -96,14 +96,10 @@ jobs:
               == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
             && matrix.os == 'ubuntu' }}"
           current="${{
-            ( github.event_name == 'tag'
-              && github.ref == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
-            )
-            || (
-              github.event_name == 'release'
+            ( contains(fromJSON('["tag", "release"]'), github.event_name)
               && (github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name))
                   == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
-              )
+            )
             || github.ref == format('refs/heads/{0}', steps.tag-branch.outputs.latest_rel_branch)
           }}"
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,6 +108,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=ref,event=branch
+            type=ref,event=pr
             type=raw,value=current,enable=${{ steps.enable.outputs.current }}
             type=raw,value=latest,enable=${{ steps.enable.outputs.latest }},suffix=
           flavor: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,17 +72,34 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - name: Get the latest tag
+      - name: Get the latest tag and release branches
+        id: tag-branch
         run: |
           # Make sure tags are fetched
           git fetch --tags
           # Get sorted list of tags, keep the first that has a semver pattern (not RCs)
-          LATEST_TAG="$(git tag --sort=-v:refname \
+          latest_tag="$(git tag --sort=-v:refname \
             | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
             | head -n 1)"
-          echo "LATEST_TAG=${LATEST_TAG}" >> "${GITHUB_ENV}"
-          echo "LATEST_TAG is: ${LATEST_TAG}"
-      - run: exit 1
+          latest_rel_branch="$(git branch --all --list 'origin/*' \
+            --contains "${latest_tag}" --format "%(refname:lstrip=3)")"
+          echo "latest_tag=${latest_tag}" >> "${GITHUB_OUTPUT}"
+          echo "latest_tag is: ${latest_tag}"
+          echo "latest_rel_branch=${latest_rel_branch}" >> "${GITHUB_OUTPUT}"
+          echo "latest_rel_branch is: ${latest_rel_branch}"
+      - name: Get enable values for meta step
+        id: enable
+        run: |
+          latest="${{ github.ref == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
+            && matrix.os == 'ubuntu' }}"
+          current="${{ github.event_name == 'tag'
+            && github.ref == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
+            || github.ref == format('refs/heads/{0}', steps.tag-branch.outputs.latest_rel_branch)
+          }}"
+          echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
+          echo "latest is $latest"
+          echo "current=${current}" >> "${GITHUB_OUTPUT}"
+          echo "current is $current"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
@@ -91,11 +108,15 @@ jobs:
           tags: |
             type=ref,event=tag
             type=ref,event=branch
-            type=raw,value=current,enable=${{ github.ref == format('refs/heads/{0}', 'releasebranch_8_3') }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', env.LATEST_TAG ) && matrix.os == 'ubuntu' }},suffix=
+            type=raw,value=current,enable=${{ steps.enable.outputs.current }}
+            type=raw,value=latest,enable=${{ steps.enable.outputs.latest }},suffix=
           flavor: |
             latest=false
             suffix=-${{ matrix.os }}
+      - run: echo $meta
+        env:
+          meta: ${{ toJson(steps.meta.outputs.json) }}
+      - run: exit 1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,7 +154,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           # Don't use cache for releases. Cache is not used if `cache-from:` is empty
           cache-from: >-
-            ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && ''
+            ${{ !contains(fromJSON('["tag", "release"]'), github.event_name) && ''
               || format('type=gha,scope={0}', matrix.os) || '' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
           provenance: mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,7 +152,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile
           annotations: ${{ steps.meta.outputs.annotations }}
-          cache-from: type=gha,scope=${{ matrix.os }}
+          # Don't use cache for releases. Cache is not used if `cache-from:` is empty
+          cache-from: >-
+            ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && ''
+              || format('type=gha,scope={0}', matrix.os) || '' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
           provenance: mode=max
           sbom: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,18 @@ jobs:
     name: ${{ matrix.os }} for ${{ github.ref }}
     # if: github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
-
+    concurrency:
+      group: >-
+        ${{ github.workflow }}-${{ matrix.os }}-${{ github.event_name }}-
+        ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+      # ${{ github.workflow }}-${{ github.event_name }}-
+      # ${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+      # ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{ matrix.os }}
+      # Cancel in progress in pull requests.
+      # Otherwise, limit to one in progress and one queued for each type.
+      # Only the latest queued job per type and will be kept, older will be cancelled.
+      # The already running job will be completed.
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     strategy:
       matrix:
         os:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,10 +91,19 @@ jobs:
       - name: Get enable values for meta step
         id: enable
         run: |
-          latest="${{ github.ref == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
+          latest="${{
+            (github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name))
+              == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
             && matrix.os == 'ubuntu' }}"
-          current="${{ github.event_name == 'tag'
-            && github.ref == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
+          current="${{
+            ( github.event_name == 'tag'
+              && github.ref == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
+            )
+            || (
+              github.event_name == 'release'
+              && (github.ref || format('{0}{1}', 'refs/tags/', github.event.release.tag_name))
+                  == format('refs/tags/{0}', steps.tag-branch.outputs.latest_tag)
+              )
             || github.ref == format('refs/heads/{0}', steps.tag-branch.outputs.latest_rel_branch)
           }}"
           echo "latest=${latest}" >> "${GITHUB_OUTPUT}"
@@ -106,7 +115,7 @@ jobs:
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         with:
           images: |
-            name=docker.io/osgeo/grass-gis,enable=${{ github.repository_owner == 'OSGeo' 
+            name=docker.io/osgeo/grass-gis,enable=${{ github.repository_owner == 'OSGeo'
               && github.event_name != 'pull_request' }}
             name=ghcr.io/${{ github.repository }}
           tags: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,7 +138,8 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
           pull: true
           context: .
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,7 +154,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           # Don't use cache for releases.
           no-cache: ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && true }}
-          # Don't use cache for releases. Cache is not used if `cache-from:` is empty
+          # Don't use gha cache for releases. Cache is not used if `cache-from:` is empty
           cache-from: >-
             ${{ !contains(fromJSON('["tag", "release"]'), github.event_name)
                 && format('type=gha,scope={0}', matrix.os) || '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -164,7 +164,7 @@ jobs:
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
         # If there isn't a digest, an annotation cannot be added
         if: >-
-          ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' 
+          ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request'
             && steps.docker_build.outputs.digest }}
         id: attest
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,6 @@ jobs:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
     name: ${{ matrix.os }} for ${{ github.ref }}
-    # if: github.repository_owner == 'OSGeo'
     runs-on: ubuntu-latest
     concurrency:
       group: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -162,7 +162,10 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Attest docker.io image
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
-        if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
+        # If there isn't a digest, an annotation cannot be added
+        if: >-
+          ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' 
+            && steps.docker_build.outputs.digest }}
         id: attest
         with:
           subject-name: docker.io/osgeo/grass-gis
@@ -170,6 +173,8 @@ jobs:
           push-to-registry: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
       - name: Attest ghcr.io image
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        # If there isn't a digest, an annotation cannot be added
+        if: ${{ steps.docker_build.outputs.digest }}
         id: attest-ghcr
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -174,4 +174,3 @@ jobs:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: ${{ github.event_name != 'pull_request' }}
-          # push-to-registry: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -162,12 +162,11 @@ jobs:
         env:
           docker_build_imageid: ${{ steps.docker_build.outputs.imageid }}
           docker_build_metadata: ${{ steps.docker_build.outputs.metadata }}
-      - name: Attest
+      - name: Attest docker.io image
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
-        # if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
+        if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
         id: attest
         with:
-          # subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-name: docker.io/osgeo/grass-gis
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,7 +156,7 @@ jobs:
           no-cache: ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && true }}
           # Don't use gha cache for releases. Cache is not used if `cache-from:` is empty
           cache-from: >-
-            ${{ !contains(fromJSON('["tag", "release"]'), github.event_name)
+            ${{ contains(fromJSON('["tag", "release"]'), github.event_name)
                 && format('type=gha,scope={0}', matrix.os) || '' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
           provenance: mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,6 +95,7 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha,scope=${{ matrix.os }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -159,6 +159,9 @@ jobs:
           sbom: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+        env:
+          docker_build_imageid: ${{ steps.docker_build.outputs.imageid }}
+          docker_build_metadata: ${{ steps.docker_build.outputs.metadata }}
       - name: Attest
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
         # if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,9 +64,10 @@ jobs:
       fail-fast: false
 
     permissions:
+      attestations: write
       contents: read
-      packages: write
       id-token: write
+      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,5 +147,6 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha,scope=${{ matrix.os }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
+          provenance: mode=max
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
         ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
       # Cancel in progress in pull requests.
       # Otherwise, limit to one in progress and one queued for each type.
-      # Only the latest queued job per type and will be kept, older will be cancelled.
+      # Only the latest queued job per event type will be kept, older will be cancelled.
       # The already running job will be completed.
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -148,5 +148,6 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.os }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
           provenance: mode=max
+          sbom: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -148,6 +148,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/${{ matrix.os }}/Dockerfile
           annotations: ${{ steps.meta.outputs.annotations }}
+          provenance: mode=max
+          sbom: true
           # Don't use cache for releases.
           no-cache: ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && true }}
           # Don't use gha cache for releases. Cache is not used if `cache-from:` is empty
@@ -155,8 +157,6 @@ jobs:
             ${{ !contains(fromJSON('["tag", "release"]'), github.event_name)
                 && format('type=gha,scope={0}', matrix.os) || '' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
-          provenance: mode=max
-          sbom: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Attest docker.io image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -159,3 +159,12 @@ jobs:
           sbom: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Attest
+        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        # if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
+        id: attest
+        with:
+          # subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-name: docker.io/osgeo/grass-gis
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,3 +170,11 @@ jobs:
           subject-name: docker.io/osgeo/grass-gis
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
+      - name: Attest ghcr.io image
+        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        id: attest-ghcr
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: ${{ github.event_name != 'pull_request' }}
+          # push-to-registry: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,7 +156,7 @@ jobs:
           no-cache: ${{ contains(fromJSON('["tag", "release"]'), github.event_name) && true }}
           # Don't use gha cache for releases. Cache is not used if `cache-from:` is empty
           cache-from: >-
-            ${{ contains(fromJSON('["tag", "release"]'), github.event_name)
+            ${{ !contains(fromJSON('["tag", "release"]'), github.event_name)
                 && format('type=gha,scope={0}', matrix.os) || '' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.os }}
           provenance: mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,7 +133,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -159,9 +159,6 @@ jobs:
           sbom: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-        env:
-          docker_build_imageid: ${{ steps.docker_build.outputs.imageid }}
-          docker_build_metadata: ${{ steps.docker_build.outputs.metadata }}
       - name: Attest docker.io image
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
         if: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' }}


### PR DESCRIPTION
Multiple very small related improvements, that end up being big. It was easier to test all the pieces with the same setup in a common branch, making one final PR, rather than trying to do dozens of PRs. A first set of changes making GitHub Actions Cache work was already merged in #5126.



Main features/changes:
- Allow manually launching a workflow (workflow_dispatch)
- Run workflow on pull requests, but only when a file inside docker/ (except markdown files), or the docker workflow file is changed.
- Support running the workflow on forks. (So someone can test docker builds in a PR or merged on his fork, without having it merged in the main repo)
- Add concurrency group to limit and cancel jobs.
  - In a pull request, pushing a new commit will cancel in progress jobs.
  - When not in a pull request, do not cancel in progress jobs, but still use concurrency groups. Since the group name includes the event, this means that we limit to one _in progress_ and one _queued_ job per event type. Only the latest queued job per event type will be kept, older queued jobs (not started) will be cancelled. The already running jobs will be completed. 
    - **This is a change from what we usually currently use on other workflows.** Since we're starting to have longer queue times,  publishing Docker images for each single commit on main when the queue is already full is useless, or at least questionable. The compromise here is to create the docker images by default, but if it would be immediately replaced by a two later commits, skip the commit that isn't even started yet. If ever we get so active that there is constantly more than one queued commit on main/releasebranch for Docker builds, then we should adapt and maybe go for daily docker builds instead.
    - We already used this pattern with a simplified concurrency group pattern last year, before realizing that not every single commit on main was built and we adjusted after. Introduced: https://github.com/OSGeo/grass/pull/3483, Reverted: https://github.com/OSGeo/grass/pull/3904
- Correctly sets the "latest" tag if it is run for a tag, and that tag is the latest one. Publishing a tag for an older patch version, when there is a more recent tag published, is correctly handled. If the tag isn't a pure semver version, it isn't the _latest_ tag (For example, currently the latest tag is 8.4.0, even if we have a 8.4.1RC1 tag).
  - Note: If someone's personal fork runs that situation (creating a release), and they don't have the tags on their fork (like if they checked the "Copy `main` branch only"), then the git command used will fail, as it would try to get the branches that contains the tag `''` (empty string). Probably a same problem if there are no branches found. Since it is unlikely, I didn't work 3x extra to address that edge case.
- Correctly labels the "current" tags when commits are pushed to release branches. I decided that the "current" branch is the branch that contains the tag identified as the latest tag just above.
  - Note: I assumed that the latest tag is found only on one branch. I tried multiple searches for older tags, and the way we release, the tags are set from a releasebranch, not from main, or other branches. Thus, I couldn't see what happens if that assumption isn't true, meaning if there are multiple branches returned.
  -  @neteler: These last two features means that this PR would improve the experience for the next releases, and we should consider backporting this soon after. The two PRs introducing and fixing caching should be included too, as this PR ends up changing these lines, so it would conflict.
- Disable caching on real "releases"/tags. In case something happens, or the cache is poisoned by some sort, explicitly disable all caching when creating a build for a release.
- Properly handles the case if the "tags" event type would be re-enabled. It was disabled 18 months ago as it was mentioned in https://github.com/OSGeo/grass/pull/3075 that there were duplicated runs. The workflow is ready for both cases.
- Shorten the job name for the matrix elements
- Also push to GitHub Container Registry (GitHub Packages).
  - To fully support building and testing on forks, with all features, I added pushes to the GitHub Container Registry. It is separate for each user/org, and no configuration is needed. 
  - It also creates an alternative backup in case Docker Hub is down, which is a great thing.
  - It works very well in GitHub actions (fast and simple), as the authentication can be made with GITHUB_TOKEN. To use locally, I think a PAT is needed; it is not as "public" as the Docker Hub. Having this enabled meant that the workflow didn't have to disable almost all special features, that would've meant that we would only see that it breaks when doing releases or tags.
  - The usual pattern for the package name is to use `${{ github.repository }}`. The packages are shown for an organization, and appear on the repo too. This also coincides with a recent RFC that was started to be voted to refer to GRASS as only "GRASS" instead of "GRASS GIS", so I didn't change the name to be grass-gis for now, nor did I place both (as we could).
    - OSGeo's org packages: https://github.com/orgs/OSGeo/packages
- Add more metadata, attestations, SBOM, and provenance to the built images. Follows some newer practices and we have a rich manifest that can use all the features offered by Docker, if the tooling wants to use it.
- Create (and upload when available) build attestations, that attest that the image was built. Uploaded to GitHub's attestation's API and associated with the repo. Can be verified afterwards. https://github.com/actions/attest-build-provenance. https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
  - The step needing access to Docker Hub credentials wasn't tested, but the same pattern as shown in the docs, but for ghcr.io was tested.
  - Attestations only work when a digest exists. Since on pull requests, I set to not push to a registry, there is no digest, and can't create the attestation. I tested with pushes allowed on pull requests, and when that branch was merged to my main too.



Nice to haves remaining to do (ideas for later):
- Update Docker Hub description automatically
  - https://docs.docker.com/build/ci/github-actions/update-dockerhub-desc/
  - https://github.com/peter-evans/dockerhub-description
- Use image-specific READMEs if possible (like for GHCR) => excluding docker/**.md files from PRs would be removed
- Optimize caching of Dockerfiles by using build stages and less changed contents before frequently changed content.
- See what steps can be done in parallel in other build stages to speed up builds.
- Set the licence annotation label as the metadata action adds `org.opencontainers.image.licenses=NOASSERTION`, probably because on GitHub, our licence is not detected as a standard one through our COPYING file.
  - It should be an [SPDX License Expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/).