### PR TITLE
v.extract: Fix Resource Leak Issue in extract.c

### DIFF
--- a/vector/v.extract/extract.c
+++ b/vector/v.extract/extract.c
@@ -468,6 +468,8 @@ int extract_line(int num_index, int *num_array, struct Map_info *In,
 
     if (driver)
         db_close_database_shutdown_driver(driver);
+    Vect_destroy_cats_struct(CCats);
+    Vect_destroy_field_info(Fi);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207858, 1415586)
Used  `Vect_destroy_cats_struct(), Vect_destroy_field_info()` to fix this issue.