### PR TITLE
lib/vector/Vlib: Fix Resource Leak Issue in cindex.c

### DIFF
--- a/lib/vector/Vlib/cindex.c
+++ b/lib/vector/Vlib/cindex.c
@@ -543,7 +543,7 @@ int Vect_cidx_open(struct Map_info *Map, int head_only)
     fp.file = G_fopen_old(path, GV_CIDX_ELEMENT, Map->mapset);
 
     if (fp.file == NULL) { /* category index file is not available */
-        const char *map_name = Vect_get_full_name(Map)
+        const char *map_name = Vect_get_full_name(Map);
         G_warning(_("Unable to open category index file for vector map <%s>"),
                   map_name);
         G_free((void *)map_name);

--- a/lib/vector/Vlib/cindex.c
+++ b/lib/vector/Vlib/cindex.c
@@ -501,6 +501,7 @@ int Vect_cidx_save(struct Map_info *Map)
 
     if (0 > dig_write_cidx(&fp, plus)) {
         G_warning(_("Error writing out category index file"));
+        fclose(fp.file);
         return 1;
     }
 
@@ -542,8 +543,10 @@ int Vect_cidx_open(struct Map_info *Map, int head_only)
     fp.file = G_fopen_old(path, GV_CIDX_ELEMENT, Map->mapset);
 
     if (fp.file == NULL) { /* category index file is not available */
+        const char *map_name = Vect_get_full_name(Map)
         G_warning(_("Unable to open category index file for vector map <%s>"),
-                  Vect_get_full_name(Map));
+                  map_name);
+        G_free((void *)map_name);
         return -1;
     }
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208155, 1588938)
Used fclose(), G_free() to fix this issue