### PR TITLE
gui(web_services): Fix not all arguments converted during string formatting

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -376,7 +376,7 @@ class WSDialogBase(wx.Dialog):
             self.Fit()
 
         self.statusbar.SetStatusText(
-            _("Connecting to <$s>...") % self.server.GetValue().strip()
+            _("Connecting to <%s>...") % self.server.GetValue().strip()
         )
 
         # number of panels already connected


### PR DESCRIPTION
Fixes a string causing problems after #4052, reported in https://github.com/OSGeo/grass/pull/4052#issuecomment-2663928328

It was a simple typo, on my keyboard layout, `$%` are right next to each other.