### PR TITLE
docker: hardcode versioned GISBASE path on Alpine

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -57,7 +57,6 @@ ENV GRASS_RUN_PACKAGES="\
       pdal \
       pdal-dev \
       postgresql15-client \
-      proj-dev \
       proj-util \
       py3-numpy \
       py3-pillow \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -57,6 +57,7 @@ ENV GRASS_RUN_PACKAGES="\
       pdal \
       pdal-dev \
       postgresql15-client \
+      proj-dev \
       proj-util \
       py3-numpy \
       py3-pillow \
@@ -167,8 +168,17 @@ RUN echo "  => Configure and compile grass" && \
     make install && \
     ldconfig /etc/ld.so.conf.d
 
+# Build the GDAL-GRASS plugin
+# renovate: datasource=github-tags depName=OSGeo/gdal-grass
+ARG GDAL_GRASS_VERSION=1.0.3
+RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gdal-grass.git /src/gdal-grass
+WORKDIR /src/gdal-grass
+RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
+    cmake --build build && \
+    cmake --install build
+
 # Get rid of version number here, restore in next stage via symbolic link
-RUN mv $(grass --config path) /usr/local/grass
+RUN mv /usr/local/grass85 /usr/local/grass
 
 # Reduce the image size - Remove unnecessary grass files
 RUN cp /usr/local/grass/gui/wxpython/xml/module_items.xml module_items.xml; \
@@ -191,22 +201,13 @@ ENV GRASS_SKIP_MAPSET_OWNER_CHECK=1 \
     LC_ALL="en_US.UTF-8" \
     PYTHONPATH="/usr/local/grass/etc/python:$PYTHONPATH"
 
-# Copy GRASS GIS from build image
+# Copy GRASS GIS and GDAL GRASS driver from build image
 COPY --from=build /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=build /usr/local/grass* /usr/local/grass/
+COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
 # Set GISBASE
 ENV GISBASE /usr/local/grass
-
-# Build the GDAL-GRASS plugin
-# renovate: datasource=github-tags depName=OSGeo/gdal-grass
-ARG GDAL_GRASS_VERSION=1.0.3
-RUN git clone --branch $GDAL_GRASS_VERSION --depth 1 https://github.com/OSGeo/gdal-grass.git /src/gdal-grass
-WORKDIR /src/gdal-grass
-RUN cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF && \
-    cmake --build build && \
-    cmake --install build
-# Copy GDAL GRASS driver from build image
-COPY --from=build /usr/lib/gdalplugins/*_GRASS.so /usr/lib/gdalplugins/
+ENV GRASS_GISBASE /usr/local/grass
 
 # run simple LAZ test
 COPY docker/testdata/simple.laz /tmp/
@@ -214,7 +215,7 @@ COPY docker/testdata/test_grass_python.py docker/testdata/test_grass_session.py 
 
 # run GRASS GIS python session and scan the test LAZ file; some cleanup
 # also show installed version
-RUN ln -sf /usr/local/grass $(grass --config path); \
+RUN ln -sf /usr/local/grass /usr/local/grass85; \
     rm -rf /tmp/grasstest_epsg_25832; \
     $SHELL /scripts/grass_tests.sh; \
     python /scripts/test_grass_session.py && rm -rf /tmp/grasstest_epsg_25832; \


### PR DESCRIPTION
Partially reverts 61e38c2, but more importantly hardcodes versioned GISBASE path on Alpine.