### PR TITLE
docs: fix no-emphasis-as-heading in markdown files

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -12,6 +12,3 @@ no-inline-html: false
 no-alt-text: false
 line-length: false
 # The block above this is to be eventually removed.
-
-link-fragments: false
-no-space-in-links: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -13,6 +13,5 @@ no-alt-text: false
 line-length: false
 # The block above this is to be eventually removed.
 
-no-emphasis-as-heading: false
 link-fragments: false
 no-space-in-links: false

--- a/general/g.proj/g.proj.md
+++ b/general/g.proj/g.proj.md
@@ -226,7 +226,7 @@ ogr2ogr -t_srs "`g.proj -wf`" polbnda_italy_GB_ovest.shp polbnda_italy_LL.shp
 [GDAL raster library and toolset](https://gdal.org)  
 [OGR vector library and toolset](https://gdal.org/)
 
-**Further reading**
+Further reading:
 
 - [ASPRS Grids and
   Datum](https://www.asprs.org/asprs-publications/grids-and-datums)

--- a/general/g.setproj/g.setproj.md
+++ b/general/g.setproj/g.setproj.md
@@ -41,7 +41,7 @@ output map.
 *[g.proj](g.proj.md), [m.proj](m.proj.md), [r.proj](r.proj.md),
 [v.proj](v.proj.md), [PROJ](https://proj.org) site*
 
-**Further reading**
+Further reading:
 
 - A guide to [Map
   Projections](https://web.archive.org/web/20080513234144/http://erg.usgs.gov/isb/pubs/MapProjections/projections.html)

--- a/gui/wxpython/docs/wxGUI.md
+++ b/gui/wxpython/docs/wxGUI.md
@@ -456,7 +456,7 @@ Quit
 Ctrl+R:
 Render map in all map displays
 
-**Workspace**
+##### Workspace
 
 Ctrl+N:
 Create new workspace
@@ -467,7 +467,7 @@ Load workspace from file
 Ctrl+S:
 Close workspace
 
-**Layers**
+##### Layers
 
 Ctrl+Shift+L:
 Add multiple raster or vector map layers to current map display
@@ -481,7 +481,7 @@ Add vector map layer to current map display
 Ctrl+W:
 Close current map display
 
-**Console**
+##### Console
 
 Tab:
 Show command tooltips

--- a/gui/wxpython/docs/wxGUI.nviz.md
+++ b/gui/wxpython/docs/wxGUI.nviz.md
@@ -334,7 +334,7 @@ Command-line module *[m.nviz.image](m.nviz.image.md)*.
 
 ## AUTHORS
 
-**The wxNviz GUI**
+### The wxNviz GUI
 
 [Martin Landa](http://geo.fsv.cvut.cz/gwiki/Landa), [Google Summer of
 Code 2008](https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2008) (mentor:
@@ -345,7 +345,7 @@ Anna Kratochvilova, [Google Summer of Code
 2011](https://grasswiki.osgeo.org/wiki/WxNviz_GSoC_2011) (mentor: Martin
 Landa)
 
-**The OGSF library and NVIZ engine**
+### The OGSF library and NVIZ engine
 
 NVIZ (GRASS's *n*-dimensional visualization suite) was written by Bill
 Brown, Terry Baker, Mark Astley, and David Gerdes, U.S. Army Corps of

--- a/gui/wxpython/image2target/g.gui.image2target.md
+++ b/gui/wxpython/image2target/g.gui.image2target.md
@@ -29,12 +29,12 @@ The GCP Manager is structured into three panels:
 
 ![GCP Manager](wxGUI_gcp_frame.jpg)
   
-*Toolbars*
+#### Toolbars
 
 Two toolbars are provided with the GCP Manager, one for managing the map
 displays and one for managing the GCP list.
 
-*List of ground control points*
+#### List of ground control points
 
 The list of Ground Control Points can be sorted by clicking on a column
 header. Clicking on a column header will sort the GCPs ascending, a
@@ -48,7 +48,7 @@ is only used for RMS error calculation and georectification if its
 checkbox on the left is checked. Uncheck to deactivate a GCP (mark as
 unused GCP).
 
-*Two panels for map display*
+#### Two panels for map display
 
 The left panel is used to display a map from the source project, the
 right panel to display a map from the target project. Zooming in and out
@@ -59,7 +59,7 @@ GCPs are displayed in different colors, depending on whether a GCP has a
 high RMS error, is currently unused or is currently selected.
 Optionally, currently unused GCPs are not shown on the map display.
 
-*Statusbar*
+#### Statusbar
 
 At the bottom of the GCP Manager is a statusbar providing several
 functions. The default is set to *Go to GCP No.* (see also below).

--- a/gui/wxpython/rlisetup/g.gui.rlisetup.md
+++ b/gui/wxpython/rlisetup/g.gui.rlisetup.md
@@ -36,8 +36,6 @@ Definition of region for analysis:
 
 The startup window shows your configuration files, you can:
 
-**TODO: description below needs further updates**
-
 1. ***View/Edit*** (Load a file) from the shown list: the configuration
     is shown in a small text editor window. Configuration files are
     saved in the folder `C:\Users\userxy\AppData\Roaming\GRASS8\r.li\`

--- a/imagery/i.atcorr/i.atcorr.md
+++ b/imagery/i.atcorr/i.atcorr.md
@@ -747,7 +747,7 @@ Carolina project. The computational region was set to the extent of the
 individual bands (*B01-B12*) that we want to apply the atmospheric
 correction to. The following steps are applied to each band separately.
 
-**Create the parameters file for i.atcorr**
+#### Create the parameters file for i.atcorr
 
 In the first step we create a file containing the 6S parameters for a
 particular scene and band. To create a 6S file, we need to obtain the
@@ -851,7 +851,7 @@ text file, for example `params_B02.txt`.
 167
 ```
 
-**Compute atmospheric correction**
+#### Compute atmospheric correction
 
 In the next step we run *i.atcorr* for the selected band *B02* of our
 Sentinel 2 scene. We have to specify the following parameters:
@@ -986,7 +986,7 @@ r.mapcalc "lsat7_2002_40_rad = ((241.1 - (-5.1)) / (255.0 - 1.0)) * (lsat7_2002_
 Again, the *r.mapcalc* calculation is only needed when working with
 satellite data other than Landsat or ASTER.
 
-#### Create the parameters file for i.atcorr
+#### Create the parameters file for i.atcorr for Landsat
 
 The underlying 6S model is parametrized through a control file,
 indicated with the **parameters** option. This is a text file defining

--- a/imagery/imageryintro.md
+++ b/imagery/imageryintro.md
@@ -36,7 +36,7 @@ transforms Landsat DN to radiance-at-sensor (top of atmosphere, TOA).
 The equivalent module for ASTER data is [i.aster.toar](i.aster.toar.md).
 For other satellites, [r.mapcalc](r.mapcalc.md) can be employed.
 
-**Reflection/radiance-at-sensor and surface reflectance**
+#### Reflection/radiance-at-sensor and surface reflectance
 
 When radiance-at-sensor has been obtained, still the atmosphere
 influences the signal as recorded at the sensor. This atmospheric

--- a/raster/r.in.pdal/r.in.pdal.md
+++ b/raster/r.in.pdal/r.in.pdal.md
@@ -471,8 +471,7 @@ r.in.pdal input="Serpent Mound Model LAS Data.laz" \
            output=Serpent_Mound_Model_LAS_Data method=mean
 ```
 
-![](r_in_lidar.png)
-
+![Elevation for the whole area of Serpent Mound dataset](r_in_lidar.png)  
 *Figure: Elevation for the whole area of Serpent Mound dataset*
 
 ### Height above ground

--- a/raster/r.mfilter/r.mfilter.md
+++ b/raster/r.mfilter/r.mfilter.md
@@ -4,8 +4,7 @@
 according to the matrix *filter* designed by the user (see *FILTERS*
 below).
 
-![](r_mfilter.png)
-
+![Illustration for a custom 3x3 filter](r_mfilter.png)  
 *Figure: Illustration for a custom 3x3 filter*
 
 The filter is applied *repeat* times (default *value* is 1). The

--- a/raster/r.neighbors/r.neighbors.md
+++ b/raster/r.neighbors/r.neighbors.md
@@ -9,8 +9,7 @@ might be assigned a value equal to the average of the values appearing
 in its 3 x 3 cell "neighborhood" in the input layer. Note that the
 centre cell is also included in the calculation.
 
-![](r_neighbors.png)
-
+![Illustration for an 3x3 average neighborhood](r_neighbors.png)  
 *Figure: Illustration for an 3x3 average neighborhood*
 
 ### OPTIONS

--- a/raster/r.out.vtk/r.out.vtk.md
+++ b/raster/r.out.vtk/r.out.vtk.md
@@ -68,6 +68,16 @@ r.out.vtk can export raster cells with different representations.
   hold different values, but the user can only visualize one value at a
   time.
 
+### Paraview RGB visualization notes
+
+To achieve proper RGB overlay:
+
+- In Paraview, click "Apply"
+- Select the "Display" tab and choose "Color by" to switch from input
+  scalars to rgb scalars
+- Disable the "Map Scalars" check button in the display tab to avoid the
+  use of a lookup table
+
 ## EXAMPLE
 
 ### Simple Spearfish example
@@ -100,16 +110,6 @@ r.out.vtk rgbmaps=wms_global_mosaic.red,wms_global_mosaic.green,wms_global_mosai
 # visualize in Paraview or other VTK viewer:
 paraview --data=/tmp/out.vtk
 ```
-
-**Paraview RGB visualization notes**
-
-To achieve proper RGB overlay:
-
-- In Paraview, click "Apply"
-- Select the "Display" tab and choose "Color by" to switch from input
-  scalars to rgb scalars
-- Disable the "Map Scalars" check button in the display tab to avoid the
-  use of a lookup table
 
 ## SEE ALSO
 

--- a/raster/r.proj/r.proj.md
+++ b/raster/r.proj/r.proj.md
@@ -273,7 +273,7 @@ r.proj input=elevation.dem output=elevation.dem.reproj \
 
 [PROJ](https://proj.org): Projection/datum support library
 
-**Further reading**
+Further reading:
 
 - [ASPRS Grids and
   Datum](https://www.asprs.org/asprs-publications/grids-and-datums)

--- a/raster/r.series/r.series.md
+++ b/raster/r.series/r.series.md
@@ -3,8 +3,7 @@
 *r.series* makes each output cell value a function of the values
 assigned to the corresponding cells in the input raster map layers.
 
-![](r_series.png)
-
+![Illustration for an average of three input rasters](r_series.png)  
 *Figure: Illustration for an average of three input rasters*
 
 Following methods are available:

--- a/scripts/g.extension/testsuite/data/sample_modules/r.plus.example/r.plus.example.md
+++ b/scripts/g.extension/testsuite/data/sample_modules/r.plus.example/r.plus.example.md
@@ -1,6 +1,6 @@
 ## DESCRIPTION
 
-*r.plus.example*
+The tool *r.plus.example* adds two raster maps.
 
 ## NOTES
 

--- a/temporal/t.rast.algebra/t.rast.algebra.md
+++ b/temporal/t.rast.algebra/t.rast.algebra.md
@@ -6,7 +6,9 @@ space time raster datasets (STRDS) using the temporal raster algebra.
 The module expects an **expression** as input parameter in the following
 form:
 
-**"result = expression"**
+```sh
+"result = expression"
+```
 
 The statement structure is similar to that of [r.mapcalc](r.mapcalc.md).
 In this statement, **result** represents the name of the space time

--- a/vector/v.clean/v.clean.md
+++ b/vector/v.clean/v.clean.md
@@ -8,9 +8,7 @@ erroneous geometries.
 
 ### Break lines/boundaries
 
-*tool=break*
-
-The *break* tool breaks lines/boundaries at intersections and it also
+Setting *tool=break* breaks lines/boundaries at intersections and it also
 breaks lines/boundaries forming a collapsed loop. For example,
 0.0;1.0;0.0 is broken at 1.0.
 
@@ -23,9 +21,7 @@ Hint: Breaking lines should be followed by removing duplicates, e.g.
 
 ### Remove duplicate geometry features
 
-*tool=rmdupl*
-
-The *rmdupl* tool removes geometry features with identical coordinates.
+Setting *tool=rmdupl* removes geometry features with identical coordinates.
 Categories are merged. If a point and a centroid have identical
 coordinates, one of them will be removed if both points and centroids
 are selected with *v.clean ... type=point,centroid*. The same applies
@@ -39,12 +35,10 @@ polygons.
 
 ### Remove dangles or change boundary dangles to type line
 
-*tool=rmdangle* and *tool=chdangle*
-
 A line/boundary is considered to be a dangle if no other line of given
 *type* is on at least one end node. If a dangle is formed by several
 lines, such a string of lines is taken as one dangle and line lengths
-are summarized. The *rmdangle* tool deletes a dangle if the (combined)
+are summarized. Setting *tool=rmdangle* deletes a dangle if the (combined)
 length is shorter than *thresh* or *thresh* \< 0. If the combined length
 is larger than *thresh*, nothing is deleted.
 
@@ -63,18 +57,16 @@ small *thresh* value can be followed by subsequent passes with higher
 *thresh* values. This can be done as one *v.clean* job by listing the
 tool several times and by defining a list of increasing *thresh* values.
 
-The *chdangle* tool is similar to the *rmdangle* tool, but works only on
+Setting *tool=chdangle* is similar to the *rmdangle* tool, but works only on
 boundaries and changes dangling boundaries to lines instead of removing
 them.
 
 ### Remove or change bridges connecting an area and an island or two islands
 
-*tool=rmbridge* and *tool=chbridge*
-
 A bridge is an area type connection of an island (polygon in a polygon)
 to the outer polygon. This is topologically incorrect (but OGC Simple
-Features allow it). The *rmbridge* tool removes bridges and the
-*chbridge* tool changes bridges to type line:
+Features allow it). Setting *tool=rmbridge* removes bridges and setting
+*tool=chbridge* changes bridges to type line:
 
 ```sh
     +-------------+             +-------------+   +-------------+
@@ -98,9 +90,7 @@ Threshold does not apply (it is ignored), use an arbitrary value (e.g.,
 
 ### Snap lines to vertex in threshold
 
-*tool=snap*
-
-The *snap* tool snaps vertices to another vertex not farther away than
+Setting *tool=snap* snaps vertices to another vertex not farther away than
 *thresh*. If there is no other vertex within *thresh*, no snapping will
 be done. The *type* option can have a strong influence on the result. A
 too large threshold and *type=boundary* can severely damage area
@@ -117,9 +107,7 @@ more small angles a left. Additional cleaning with e.g.
 
 ### Remove duplicate area centroids
 
-*tool=rmdac*
-
-The *rmdac* tool removes duplicate area centroids that can result from
+Setting *tool=rmdac* removes duplicate area centroids that can result from
 deleting boundaries.
 
 Threshold does not apply (it is ignored), use an arbitrary value (e.g.,
@@ -127,9 +115,7 @@ Threshold does not apply (it is ignored), use an arbitrary value (e.g.,
 
 ### Break (topologically clean) areas (imported from a non topological format like ShapeFile)
 
-*tool=bpol*
-
-The *bpol* tool breaks boundaries on each point shared between 2 and
+Setting *tool=bpol* breaks boundaries on each point shared between 2 and
 more areas where angles of boundary segments are different and on all
 boundary nodes (start and end points of each boundary). The *bpol* tool
 behaves similar to *break* for boundaries, but does not break collapsed
@@ -144,9 +130,7 @@ with *v.clean ... tool=bpol*, duplicates are automatically removed.
 
 ### Remove vertices in threshold from lines and boundaries
 
-*tool=prune*
-
-The *prune* tool simplifies lines and boundaries by removing vertices
+Setting *tool=prune* simplifies lines and boundaries by removing vertices
 according to threshold. This tool preserves area topology, areas are
 never deleted and centroid attachment is never changed.
 *[v.generalize](v.generalize.md)* offers much more functionality for
@@ -154,9 +138,7 @@ line simplification but does not preserve area topology.
 
 ### Remove small areas
 
-*tool=rmarea*
-
-The *rmarea* tool removes all areas \<= *thresh*. The longest boundary
+Setting *tool=rmarea* removes all areas \<= *thresh*. The longest boundary
 with an adjacent area is removed or all boundaries if there is no
 adjacent area. Area categories are not combined when a small area is
 merged with a larger area.
@@ -166,9 +148,7 @@ projects or projects with units other than meters.
 
 ### Remove all lines or boundaries of zero length
 
-*tool=rmline*
-
-The *rmline* tool removes all lines or boundaries of zero length that
+Setting *tool=rmline* removes all lines or boundaries of zero length that
 may have resulted from other cleaning operations. Zero length boundaries
 are redundant and do not influence area topology.
 
@@ -177,9 +157,7 @@ Threshold does not apply (it is ignored), use an arbitrary value (e.g.,
 
 ### Remove small angles between lines at nodes
 
-*tool=rmsa*
-
-The *rmsa* tool only concerns angles which are so small that the
+Setting *tool=rmsa* only concerns angles which are so small that the
 calculated angle is 0. The following figure should help demonstrate what
 the tool does.
 

--- a/vector/v.proj/v.proj.md
+++ b/vector/v.proj/v.proj.md
@@ -63,7 +63,7 @@ v.proj in=mymap project=latlong mapset=user1
 
 [PROJ](https://proj.org): Projection/datum support library.
 
-**Further reading**
+Further reading:
 
 - [ASPRS Grids and
   Datum](https://www.asprs.org/asprs-publications/grids-and-datums)


### PR DESCRIPTION
Continued cleanup of markdown code.

Items `link-fragments: false` and `no-space-in-links: false` seem to be already solved.