### PR TITLE
v.overlay: Fix Resource Leak Issue in line_area.c

### DIFF
--- a/vector/v.overlay/area_area.c
+++ b/vector/v.overlay/area_area.c
@@ -213,7 +213,7 @@ int area_area(struct Map_info *In, int *field, struct Map_info *Tmp,
 
     /* Query input maps */
     for (input = 0; input < 2; input++) {
-        const char *mname = Vect_get_full_name(&(In[input]))
+        const char *mname = Vect_get_full_name(&(In[input]));
         G_message(_("Querying vector map <%s>..."), mname);
         G_free((void *)mname);
 

--- a/vector/v.overlay/area_area.c
+++ b/vector/v.overlay/area_area.c
@@ -213,8 +213,9 @@ int area_area(struct Map_info *In, int *field, struct Map_info *Tmp,
 
     /* Query input maps */
     for (input = 0; input < 2; input++) {
-        G_message(_("Querying vector map <%s>..."),
-                  Vect_get_full_name(&(In[input])));
+        const char *mname = Vect_get_full_name(&(In[input]))
+        G_message(_("Querying vector map <%s>..."), mname);
+        G_free((void *)mname);
 
         nareas = Vect_get_num_areas(&(In[input]));
         G_percent(0, nareas, 1);
@@ -491,6 +492,15 @@ int area_area(struct Map_info *In, int *field, struct Map_info *Tmp,
         if (centr[0] || centr[1])
             Vect_write_line(Out, GV_BOUNDARY, Points, Cats);
     }
+    G_free(Centr);
+    if (IPoints) {
+        for (isle = 0; isle < nisles_alloc; isle++) {
+            if (IPoints[isle])
+                Vect_destroy_line_struct(IPoints[isle]);
+        }
+        G_free(IPoints);
+    }
+    Vect_destroy_line_struct(APoints);
 
     return 0;
 }

--- a/vector/v.overlay/line_area.c
+++ b/vector/v.overlay/line_area.c
@@ -473,6 +473,10 @@ int line_area(struct Map_info *In, int *field, struct Map_info *Tmp,
             Vect_write_line(Out, ltype, Points, OCats);
         }
     }
+    Vect_destroy_cats_struct(ACats);
+    Vect_destroy_cats_struct(Cats);
+    Vect_destroy_cats_struct(OCats);
+    Vect_destroy_line_struct(Points);
 
     return 0;
 }


### PR DESCRIPTION
This pull request fixes issues identified by Coverity Scan (CID : 1207775, 1270302, 1270303, 1270305)
Used Vect_destroy_cats_struct(), Vect_destroy_line_struct() to fix this issue