### PR TITLE
lib/vector/Vlib: Fix Resource Leak Issue in build.c

### DIFF
--- a/lib/vector/Vlib/build.c
+++ b/lib/vector/Vlib/build.c
@@ -655,8 +655,11 @@ int Vect_topo_check(struct Map_info *Map, struct Map_info *Err)
                   n_zero_boundaries);
 
     /* remaining checks are for areas only */
-    if (Vect_get_num_primitives(Map, GV_BOUNDARY) == 0)
+    if (Vect_get_num_primitives(Map, GV_BOUNDARY) == 0) {
+        Vect_destroy_line_struct(Points);
+        Vect_destroy_cats_struct(Cats);
         return 1;
+    }
 
     /* intersecting boundaries -> overlapping areas */
     nerrors = Vect_check_line_breaks(Map, GV_BOUNDARY, Err);
@@ -885,8 +888,9 @@ int Vect_build_partial(struct Map_info *Map, int build)
     plus = &(Map->plus);
     if (build > GV_BUILD_NONE && !Map->temporary &&
         Map->format != GV_FORMAT_POSTGIS) {
-        G_message(_("Building topology for vector map <%s>..."),
-                  Vect_get_full_name(Map));
+        const char *map_name = Vect_get_full_name(Map);
+        G_message(_("Building topology for vector map <%s>..."), map_name);
+        G_free((void *)map_name);
     }
     plus->with_z = Map->head.with_z;
     plus->spidx_with_z = Map->head.with_z;
@@ -1034,6 +1038,7 @@ int Vect_save_topo(struct Map_info *Map)
 
     if (0 > dig_write_plus_file(&fp, plus)) {
         G_warning(_("Error writing out topo file"));
+        fclose(fp.file);
         return 0;
     }
 
@@ -1065,7 +1070,9 @@ int Vect_topo_dump(struct Map_info *Map, FILE *out)
     plus = &(Map->plus);
 
     fprintf(out, "---------- TOPOLOGY DUMP ----------\n");
-    fprintf(out, "Map:             %s\n", Vect_get_full_name(Map));
+    const char *map_name = Vect_get_full_name(Map);
+    fprintf(out, "Map:             %s\n", map_name);
+    G_free((void *)map_name);
     fprintf(out, "Topology format: ");
     if (Map->format == GV_FORMAT_NATIVE)
         fprintf(out, "native");
@@ -1243,7 +1250,9 @@ int Vect_build_sidx(struct Map_info *Map)
  */
 int Vect_build_sidx_from_topo(struct Map_info *Map)
 {
-    G_debug(3, "Vect_build_sidx_from_topo(): name=%s", Vect_get_full_name(Map));
+    const char *map_name = Vect_get_full_name(Map);
+    G_debug(3, "Vect_build_sidx_from_topo(): name=%s", map_name);
+    G_free((void *)map_name);
 
     G_warning(_("%s is no longer supported"), "Vect_build_sidx_from_topo()");
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208147, 1208148, 1208149, 1208150, 1208151, 1588926).
Used Vect_destroy_line_struct(), Vect_destroy_cats_struct(), G_free() to fix this issue.