### PR TITLE
CI(Docker): Simplify job names with only the os

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,7 @@ jobs:
   # For a release, e.g. 8.3.0, created tags are:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
+    name: ${{ matrix.os }}
     runs-on: ubuntu-latest
     concurrency:
       group: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
   # For a release, e.g. 8.3.0, created tags are:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
-    name: ${{ matrix.os }} for ${{ github.ref }}
+    name: ${{ matrix.os }} for ${{ github.event_name }}
     runs-on: ubuntu-latest
     concurrency:
       group: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,6 @@ jobs:
   # For a release, e.g. 8.3.0, created tags are:
   #     8.3.0-alpine, 8.3.0-debian, 8.3.0-ubuntu and latest (with ubuntu)
   docker-os-matrix:
-    name: ${{ matrix.os }} for ${{ github.event_name }}
     runs-on: ubuntu-latest
     concurrency:
       group: >-


### PR DESCRIPTION
Looking at the actions performance metrics/actions usage metrics, and the current way the job names are made, even shortened up by my last PR, makes these metrics useless.

Each PR has a different ref, so no grouping could be done in the metrics.

This PR fixes this, by having constant names that can be grouped up and searched against.
