### PR TITLE
build: Continue build when a keyword is empty

### DIFF
--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -100,6 +100,13 @@ def build_keywords(ext):
                     break
 
         for key in keys:
+            if not key:
+                # Skip empty keywords.
+                print(
+                    f"Warning: Empty keyword in {in_file}. All keywords: {keys}",
+                    file=sys.stderr,
+                )
+                continue
             if key not in keywords.keys():
                 keywords[key] = []
                 keywords[key].append(fname)


### PR DESCRIPTION
This skips over empty keywords in tool documentation when building keyword index.

This is a draft. I'm actually not sure if this is a good idea because it does not bring the issues with keywords to light (one needs to inspect the log after noticing the issue in some way). I'll continue evaluating this.