### PR TITLE
CI(python): Fix A005: Rename array module to avoid shadowing standard library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,7 +341,6 @@ ignore = [
 "python/grass/pygrass/vector/geometry.py" = ["PYI024"]
 "python/grass/pygrass/vector/sql.py" = ["FLY002"]
 "python/grass/pygrass/vector/testsuite/test_table.py" = ["PLW0108"]
-"python/grass/script/array.py" = ["A005"]
 "python/grass/script/core.py" = ["PTH208"]
 "python/grass/script/utils.py" = ["FURB189"]
 "python/grass/temporal/aggregation.py" = ["SIM115"]

--- a/python/grass/script/array.py
+++ b/python/grass/script/array.py
@@ -4,7 +4,7 @@ Functions to use GRASS 2D and 3D rasters with NumPy.
 Usage:
 
 >>> import grass.script as gs
->>> from grass.script import array as garray
+>>> from grass.script import garray
 >>>
 >>> # We create a temporary region that is only valid in this python session
 ... gs.use_temp_region()
@@ -130,7 +130,7 @@ class _tempfile:
 ###############################################################################
 
 
-class array(np.memmap):
+class garray(np.memmap):  # renamed from array to garray
     # pylint: disable-next=signature-differs; W0222
     def __new__(cls, mapname=None, null=None, dtype=np.double, env=None):
         """Define new numpy array


### PR DESCRIPTION
Fixed a code style issue where the array module was shadowing Python's standard library module of the same name. The fix renames the module to garray to prevent namespace conflicts.