### PR TITLE
docs: Add mkdocs social meta tags

### DIFF
--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -57,7 +57,7 @@ extra_css:
 plugins:
   - search
   - glightbox
-  # - social
+  - social
   # - tags
   # - git-revision-date-localized:
   #     enable_creation_date: true

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -57,7 +57,10 @@ extra_css:
 plugins:
   - search
   - glightbox
-  - social
+  - social:
+      cards_layout_options:
+        background_image: null
+
   # - tags
   # - git-revision-date-localized:
   #     enable_creation_date: true

--- a/man/mkdocs/requirements.txt
+++ b/man/mkdocs/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-glightbox
 mkdocs-material
 pymdown-extensions
 pyyaml-env-tag
+mkdocs-material[imaging]


### PR DESCRIPTION
Added support for social meta tags for each page in mkdocs addressing part of issue https://github.com/OSGeo/grass/issues/5162 .

docs: https://squidfunk.github.io/mkdocs-material/plugins/social/

```html
<meta charset="utf-8">
      <meta name="viewport" content="width=device-width,initial-scale=1">
        <meta name="description" content="Overland flow hydrologic simulation using path sampling method (SIMWE).">
        <link rel="canonical" href="http://0.0.0.0:8000/grass-stable/manuals/r.sim.water.html">
        <link rel="icon" href="[favicon.ico](http://127.0.0.1:8000/grass-stable/manuals/favicon.ico)">
        <meta name="generator" content="mkdocs-1.6.1, mkdocs-material-9.6.2">
        <title>r.sim.water - GRASS GIS 8.5.0dev Reference Manual</title>
        <meta  property="og:type"  content="website" >
        <meta  property="og:title"  content="r.sim.water - GRASS GIS 8.5.0dev Reference Manual" >
        <meta  property="og:description"  content="Overland flow hydrologic simulation using path sampling method (SIMWE)." >
        <meta  property="og:image"  content="http://0.0.0.0:8000/grass-stable/manuals/assets/images/social/r.sim.water.png" >
        <meta  property="og:image:type"  content="image/png" >
        <meta  property="og:image:width"  content="1200" >
        <meta  property="og:image:height"  content="630" >
        <meta  property="og:url"  content="http://0.0.0.0:8000/grass-stable/manuals/r.sim.water.html" >
        <meta  name="twitter:card"  content="summary_large_image" >
        <meta  name="twitter:title"  content="r.sim.water - GRASS GIS 8.5.0dev Reference Manual" >
        <meta  name="twitter:description"  content="Overland flow hydrologic simulation using path sampling method (SIMWE)." >
        <meta  name="twitter:image"  content="http://0.0.0.0:8000/grass-stable/manuals/assets/images/social/r.sim.water.png" >
````

The images are not setup yet, but the background color looks nice.

<img src="https://github.com/user-attachments/assets/5b3b3843-b6b0-40c9-967e-8f142ec757f3" width="400"/>
<img src="https://github.com/user-attachments/assets/36ea20ca-2905-497e-96e8-461687233690" height="600"/>