### PR TITLE
CI: Run verify-success jobs on macOS

### DIFF
--- a/.github/workflows/verify-success.yml
+++ b/.github/workflows/verify-success.yml
@@ -78,7 +78,7 @@ permissions: {}
 jobs:
   verify-success:
     name: Success
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     continue-on-error: true
     steps:
       - name: Set outputs for each job result type


### PR DESCRIPTION
Since we observe that macOS and windows jobs are started before other jobs, effectively skipping the queue, running the small 0-second reusable workflow "verify-success" on macOS will prevent having to wait the whole queue a second time when only that is remaining.
We use the "verify-success" reusable workflow to ensure skipped/cancelled jobs aren't considered passes + allowing us to not edit the required checks at each version change in a strategy matrix.

Since it is only plain bash, macOS has no difference compared to Ubuntu runners.
I can confirm it skips the queue on my fork when busy (not immediatly, but when there's a runner change, and we are under our max macOS jobs in parallel), with "older" linux jobs of other PRs that should've run before the newly added success job, and still works fine.
