### PR TITLE
CI: use SQLite <3.49.0 on macOS (G84)

### DIFF
--- a/.github/workflows/macos_dependencies.txt
+++ b/.github/workflows/macos_dependencies.txt
@@ -44,6 +44,6 @@ python
 python.app
 setuptools
 six
-sqlite
+sqlite<3.49.0
 wxpython
 zstd


### PR DESCRIPTION
Use SQLite <3.49.0 on macOS CI runner, attempt for workaround for issue reported at
https://discourse.osgeo.org/t/re-release-planning-grass-gis-8-4-1/112698/18

