### PR TITLE
CI(CMake): Do not cancel in progress jobs when not in PRs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,7 @@ on:
             - 'doc/**'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
 env:


### PR DESCRIPTION
I observed that the CMake jobs were cancelled when a new PR was merged. For the time being, when stabilizing CMake, adjust the concurrency groups so that we see that job run on all commits separately. 