### PR TITLE
Windows: Use rand() in quicksort.h for Windows

### DIFF
--- a/include/grass/iostream/quicksort.h
+++ b/include/grass/iostream/quicksort.h
@@ -56,7 +56,7 @@ void partition(T *data, size_t n, size_t &pivot, CMPR &cmp)
     // Try to get a good partition value and avoid being bitten by already
     // sorted input.
     // ptpart = data + (random() % n);
-#ifdef __MINGW32__
+#ifdef _WIN32
     ptpart = data + (rand() % n);
 #else
     ptpart = data + (random() % n);


### PR DESCRIPTION
This PR resolves the following error using MSVC on Windows by using `rand()` (switched `#ifdef __MINGW32__` to `#ifdef _WIN32`):
```
build\output\lib\grass85\include\grass\iostream\quicksort.h(62,22): error C3861: 'random': identifier not found
```