### PR TITLE
Windows: Wrapper header files for MSVC

### DIFF
--- a/include/config.h.cmake.in
+++ b/include/config.h.cmake.in
@@ -409,17 +409,6 @@
 #define fstat _fstati64
 #endif /* _MSC_VER LFS */
 
-#define strncasecmp _strnicmp
-#define strcasecmp _stricmp
-#define fdopen _fdopen
-/* _open() and _creat() are wrapped by msvc/open.c and msvc/creat.c,
-* respectively, for compatible permission mode */
-#define read _read
-#define write _write
-#define close _close
-#define unlink _unlink
-#define getpid _getpid
-
 /* define gid_t type */
 typedef @GID_TYPE@ gid_t;
 
@@ -428,16 +417,6 @@ typedef @UID_TYPE@ uid_t;
 
 /* define pid_t type */
 typedef @PID_TYPE@ pid_t;
-
-#ifndef S_ISDIR
-#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
-#endif
-
-#include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-
-/* open for reading, writing, or both (not in fcntl.h) */
-#define O_ACCMODE (_O_RDONLY | _O_WRONLY | _O_RDWR)
 
 #endif //_MSC_VER
 

--- a/msvc/dirent.h
+++ b/msvc/dirent.h
@@ -1,5 +1,5 @@
-#ifndef DIRENT_INCLUDED
-#define DIRENT_INCLUDED
+#ifndef GRASS_MSVC_DIRENT_H
+#define GRASS_MSVC_DIRENT_H
 
 /*
 

--- a/msvc/fcntl.h
+++ b/msvc/fcntl.h
@@ -1,5 +1,5 @@
 /*!
- * \file msvc/io.h
+ * \file msvc/fcntl.h
  *
  * \brief Header file for msvc/open.c and msvc/creat.c
  *
@@ -12,10 +12,10 @@
  * \date 2025
  */
 
-#ifndef GRASS_MSVC_IO_H
-#define GRASS_MSVC_IO_H
+#ifndef GRASS_MSVC_FCNTL_H
+#define GRASS_MSVC_FCNTL_H
 
-#include <../ucrt/io.h>
+#include <../ucrt/fcntl.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,9 +29,11 @@ int __creat(const char *, int);
 }
 #endif
 
+#include <io.h>
 #define open      __open
 #define creat     __creat
 
 #define O_TMPFILE O_TEMPORARY
+#define O_ACCMODE (_O_RDONLY | _O_WRONLY | _O_RDWR)
 
 #endif

--- a/msvc/stdio.h
+++ b/msvc/stdio.h
@@ -3,11 +3,9 @@
 
 #include <../ucrt/stdio.h>
 
-/* if not defined by another GRASS header */
-#ifndef ssize_t_defined
-#define ssize_t_defined
+#define fdopen _fdopen
+
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
-#endif
 
 #endif

--- a/msvc/stdio.h
+++ b/msvc/stdio.h
@@ -1,0 +1,13 @@
+#ifndef GRASS_MSVC_STDIO_H
+#define GRASS_MSVC_STDIO_H
+
+#include <../ucrt/stdio.h>
+
+/* if not defined by another GRASS header */
+#ifndef ssize_t_defined
+#define ssize_t_defined
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
+#endif

--- a/msvc/stdlib.h
+++ b/msvc/stdlib.h
@@ -1,0 +1,8 @@
+#ifndef GRASS_MSVC_STDLIB_H
+#define GRASS_MSVC_STDLIB_H
+
+#include <../ucrt/stdlib.h>
+
+#define random rand
+
+#endif

--- a/msvc/string.h
+++ b/msvc/string.h
@@ -1,0 +1,6 @@
+#ifndef GRASS_MSVC_STRING_H
+#define GRASS_MSVC_STRING_H
+
+#include <strings.h>
+
+#endif

--- a/msvc/strings.h
+++ b/msvc/strings.h
@@ -1,5 +1,10 @@
 /* MSVC does not have strings.h */
-#ifndef _INC_STRINGS_H
-#define _INC_STRINGS_H 1
-#include <string.h>
+#ifndef GRASS_MSVC_STRINGS_H
+#define GRASS_MSVC_STRINGS_H
+
+#include <../ucrt/string.h>
+
+#define strncasecmp _strnicmp
+#define strcasecmp  _stricmp
+
 #endif

--- a/msvc/sys/stat.h
+++ b/msvc/sys/stat.h
@@ -1,0 +1,8 @@
+#ifndef GRASS_MSVC_SYS_STAT_H
+#define GRASS_MSVC_SYS_STAT_H
+
+#include <../ucrt/sys/stat.h>
+
+#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+
+#endif

--- a/msvc/unistd.h
+++ b/msvc/unistd.h
@@ -2,6 +2,8 @@
 #define GRASS_MSVC_UNISTD_H
 
 #include <io.h>
+#define read   _read
+#define write  _write
 #define access _access
 #define close  _close
 #define dup    _dup

--- a/raster/r.coin/format.c
+++ b/raster/r.coin/format.c
@@ -19,11 +19,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef _MSC_VER
-#include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-#endif
-
 int format_double(double v, char *buf, int n)
 {
     char fmt[15];

--- a/raster/r.coin/format.c
+++ b/raster/r.coin/format.c
@@ -19,6 +19,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 int format_double(double v, char *buf, int n)
 {
     char fmt[15];


### PR DESCRIPTION
This PR introduces additional wrapper header files for MSVC:
* msvc/stdlib.h
* msvc/string.h
* msvc/sys/stat.h

It also `#define`s necessary constants, macros, and data types (e.g., `ssize_t`) to align with their definitions in Linux headers. The objective is to avoid `#ifdef _MSC_VER` in C files as much as possible by providing compatibility through these files.

With this PR, `cmake .. -DWITH_OPENGL=OFF` + `msbuild grass.sln` compiles without errors.