### PR TITLE
checks: Add CMake/conda/macOS titles prefixes and labels, and allow revert PR titles

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -83,10 +83,17 @@ vector:
 CI:
   - changed-files:
       - any-glob-to-any-file:
+          - "**/.editorconfig"
+          - .clang-format
+          - .codecov.yml
+          - .coveragerc
+          - .cppcheck-suppressions
+          - .flake8
           - .github/**
+          - .pre-commit-config.yaml
+          - .yamllint
           - binder/**
           - renovate.json
-          - .pre-commit-config.yaml
 CMake:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -103,8 +103,12 @@ CMake:
 Windows:
   - changed-files:
       - any-glob-to-any-file:
-          - mswindows/**
+          - "**/**.bat"
+          - "**/**.bat.*"
+          - "**/*OSGeo4W**"
+          - "**/*osgeo4w**"
           - msvc/**
+          - mswindows/**
 macOS:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -112,6 +112,7 @@ Windows:
 macOS:
   - changed-files:
       - any-glob-to-any-file:
+          - "**/*macos**"
           - macos/**
 Linux:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -188,7 +188,9 @@ JavaScript:
       - any-glob-to-any-file: '**/*.js'
 markdown:
   - changed-files:
-      - any-glob-to-any-file: "**/*.md"
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - .markdownlint.yml
 # test suite
 tests:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -181,4 +181,11 @@ markdown:
 tests:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/testsuite/**'
+          - "**/*_gunittest.cfg"
+          - "**/.gunittest*.cfg"
+          - "**/test/**"
+          - "**/tests/**"
+          - "**/testsuite/**"
+          - "**test**"
+          - .codecov.yml
+          - .coveragerc

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -87,6 +87,12 @@ CI:
           - binder/**
           - renovate.json
           - .pre-commit-config.yaml
+CMake:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/**.cmake*"
+          - "**/CMakeLists.txt"
+          - cmake/**
 Windows:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -160,7 +160,9 @@ HTML:
 JavaScript:
   - changed-files:
       - any-glob-to-any-file: '**/*.js'
-
+markdown:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"
 # test suite
 tests:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -91,6 +91,7 @@ Windows:
   - changed-files:
       - any-glob-to-any-file:
           - mswindows/**
+          - msvc/**
 macOS:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -126,6 +126,13 @@ docker:
           - '**/*Dockerfile*'
           - '**/*dockerfile*'
           - .dockerignore
+nix:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/test-nix.yml
+          - flake.lock
+          - flake.nix
+          - package.nix
 
 docs:
   - all:

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -2,6 +2,7 @@
 notes:
   categories:
     - title: Tools
+      # yamllint disable-line rule:line-length
       regexp: '(?:Revert \")?((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools|temporal): '
       example: 'r.slope.aspect:'
 
@@ -50,6 +51,7 @@ notes:
       example: 'Singularity:'
 
     - title: Continuous Integration, Infrastructure, Tests and Code Quality
+      # yamllint disable-line rule:line-length
       regexp: '(?:Revert \")?(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest|chore)(\(\w[\w.-]*\))?: '
       example: 'CI:'
 

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -50,7 +50,7 @@ notes:
       example: 'Singularity:'
 
     - title: Continuous Integration, Infrastructure, Tests and Code Quality
-      regexp: '(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest)(\(\w[\w.-]*\))?: '
+      regexp: '(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest|chore)(\(\w[\w.-]*\))?: '
       example: 'CI:'
 
     - title: Contributing and Management

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -38,7 +38,7 @@ notes:
       example: 'macOS:'
 
     - title: Packaging, Configuration, Portability, and Compilation
-      regexp: '(packaging|pkg|rpm|deb|nix|pkg-config|configure|config|[Mm]ake|build): '
+      regexp: '(packaging|pkg|rpm|deb|nix|pkg-config|configure|config|[Cc]?[Mm]ake|build|conda): '
       example: 'build:'
 
     - title: Docker

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -33,6 +33,10 @@ notes:
       regexp: '(winGRASS|win|[Ww]indows): '
       example: 'win:'
 
+    - title: macOS
+      regexp: '(macOS): '
+      example: 'macOS:'
+
     - title: Packaging, Configuration, Portability, and Compilation
       regexp: '(packaging|pkg|rpm|deb|nix|pkg-config|configure|config|[Mm]ake|build): '
       example: 'build:'

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -30,7 +30,7 @@ notes:
       example: 'i18n:'
 
     - title: Windows
-      regexp: '(?:Revert \")?(winGRASS|win|[Ww]indows): '
+      regexp: '(?:Revert \")?(winGRASS|win|[Ww]indows|msvc|MSVC): '
       example: 'win:'
 
     - title: macOS

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -2,59 +2,59 @@
 notes:
   categories:
     - title: Tools
-      regexp: '((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools|temporal): '
+      regexp: '(?:Revert \")?((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools|temporal): '
       example: 'r.slope.aspect:'
 
     - title: Graphical User Interface
-      regexp: '(wxGUI.*|gui|GUI)(\(\w[\w.-]*\))?: '
+      regexp: '(?:Revert \")?(wxGUI.*|gui|GUI)(\(\w[\w.-]*\))?: '
       example: 'wxGUI:'
 
     - title: Python
-      regexp: '(grass\.[^ ]*|libpython.*|pythonlib.*|ctypesgen|ctypes|[Pp]ython|[Bb]inder): '
+      regexp: '(?:Revert \")?(grass\.[^ ]*|libpython.*|pythonlib.*|ctypesgen|ctypes|[Pp]ython|[Bb]inder): '
       example: 'grass.script:'
 
     - title: Documentation and Messages
-      regexp: '(docs?|man|manual|manual pages|[Ss]phinx|mkhtml|MkDocs|mkdocs|messages?): '
+      regexp: '(?:Revert \")?(docs?|man|manual|manual pages|[Ss]phinx|mkhtml|MkDocs|mkdocs|messages?): '
       example: 'doc:'
 
     - title: Libraries and General Functionality
-      regexp: '(grass_|lib|TGIS|tgis|raster|vector)[^ ]*: '
+      regexp: '(?:Revert \")?(grass_|lib|TGIS|tgis|raster|vector)[^ ]*: '
       example: 'grass_btree: or lib/btree:'
 
     - title: Startup, Initialization, and Environment
-      regexp: '(init|startup): '
+      regexp: '(?:Revert \")?(init|startup): '
       example: 'startup:'
 
     - title: Translations, Internationalization, and Localization
-      regexp: '(i18n|i18N|L10n|L10N|t9n|translations?): |Translations update from '
+      regexp: '(?:Revert \")?(i18n|i18N|L10n|L10N|t9n|translations?): |Translations update from '
       example: 'i18n:'
 
     - title: Windows
-      regexp: '(winGRASS|win|[Ww]indows): '
+      regexp: '(?:Revert \")?(winGRASS|win|[Ww]indows): '
       example: 'win:'
 
     - title: macOS
-      regexp: '(macOS): '
+      regexp: '(?:Revert \")?(macOS): '
       example: 'macOS:'
 
     - title: Packaging, Configuration, Portability, and Compilation
-      regexp: '(packaging|pkg|rpm|deb|nix|pkg-config|configure|config|[Cc]?[Mm]ake|build|conda): '
+      regexp: '(?:Revert \")?(packaging|pkg|rpm|deb|nix|pkg-config|configure|config|[Cc]?[Mm]ake|build|conda): '
       example: 'build:'
 
     - title: Docker
-      regexp: '[Dd]ocker(/[^ ]+)?(\(\w[\w.-]*\))?: '
+      regexp: '(?:Revert \")?[Dd]ocker(/[^ ]+)?(\(\w[\w.-]*\))?: '
       example: 'Docker:'
 
     - title: Singularity
-      regexp: '[Ss]ingularity(\(\w[\w.-]*\))?: '
+      regexp: '(?:Revert \")?[Ss]ingularity(\(\w[\w.-]*\))?: '
       example: 'Singularity:'
 
     - title: Continuous Integration, Infrastructure, Tests and Code Quality
-      regexp: '(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest|chore)(\(\w[\w.-]*\))?: '
+      regexp: '(?:Revert \")?(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest|chore)(\(\w[\w.-]*\))?: '
       example: 'CI:'
 
     - title: Contributing and Management
-      regexp: '(contributing|CONTRIBUTING.md|contributors|contributors.csv): '
+      regexp: '(?:Revert \")?(contributing|CONTRIBUTING.md|contributors|contributors.csv): '
       example: 'contributing:'
 
   exclude:


### PR DESCRIPTION
Tuned up the allowed titles regexes.
- Allow CMake prefix
- Allow conda prefix
- Allow chore (possibly a good choice for changing something like the .gitignore: what prefix would it be? config isn't really accurate)
- Section for macOS like Windows
- Allow titles of reverted PRs like the ones made by GitHub's UI.

Also refreshed the paths and labels from the labeler, including:
- Add nix label
- Add cmake label
- Add msvc to windows
- Add more patterns to tests, CI, macOS, markdown

![image](https://github.com/user-attachments/assets/a8772709-6456-4c6c-b736-67b1ea8cce3c)
![image](https://github.com/user-attachments/assets/662536fa-9275-4dc9-b5b3-5dbbf3aa8d46)

