### PR TITLE
wxGUI: Fix Unchecked return value in main.c

### DIFF
--- a/visualization/ximgview/main.c
+++ b/visualization/ximgview/main.c
@@ -120,11 +120,15 @@ static void redraw(void)
 {
     struct timeval tv0, tv1;
 
-    gettimeofday(&tv0, NULL);
+    if (gettimeofday(&tv0, NULL) == -1) {
+        G_fatal_error(_("gettimeofday failed: %s"), strerror(errno));
+    }
 
     draw();
 
-    gettimeofday(&tv1, NULL);
+    if (gettimeofday(&tv1, NULL) == -1) {
+        G_fatal_error(_("gettimeofday failed: %s"), strerror(errno));
+    }
     last = (tv1.tv_sec - tv0.tv_sec) * 1000000L + (tv1.tv_usec - tv0.tv_usec);
 }
 

--- a/visualization/ximgview/main.c
+++ b/visualization/ximgview/main.c
@@ -120,14 +120,14 @@ static void redraw(void)
 {
     struct timeval tv0, tv1;
 
-    if (gettimeofday(&tv0, NULL) == -1) {
-        G_fatal_error(_("gettimeofday failed: %s"), strerror(errno));
+    if (gettimeofday(&tv0, NULL) != 0) {
+        G_fatal_error(_("gettimeofday failed"));
     }
 
     draw();
 
-    if (gettimeofday(&tv1, NULL) == -1) {
-        G_fatal_error(_("gettimeofday failed: %s"), strerror(errno));
+    if (gettimeofday(&tv1, NULL) != 0) {
+        G_fatal_error(_("gettimeofday failed"));
     }
     last = (tv1.tv_sec - tv0.tv_sec) * 1000000L + (tv1.tv_usec - tv0.tv_usec);
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan ( CID : 1501249)
If the return value == -1 then G_fatal_error