### PR TITLE
chore: Update .gitignore for cmake in Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ OBJ.*
 locale/scriptstrings/*
 bin.*/*
 build
+/out/
 dist.*/*
 config.log
 config.status*
@@ -53,6 +54,9 @@ env/
 
 # VSCode Settings
 .vscode/
+
+# Visual Studio
+/.vs
 
 # ignore gunittest helper and result files
 testreport/*


### PR DESCRIPTION
By default, CMake in Visual Studio creates its build directory in out/build/. Visual Studio also creates multiple files, not intended to be shared, in a .vs folder.

Ignore both of these in .gitignore, like Kitware uses in its own CMake repo
https://github.com/Kitware/CMake/blob/ce1f8420559f408aef642bbcc9c4049b4e790e46/.gitignore#L34-L37

They also have different patterns for CLion, but I don't use it, so I can't tell if it is appropriate for us here, they could be added if needed. 
https://github.com/Kitware/CMake/blob/ce1f8420559f408aef642bbcc9c4049b4e790e46/.gitignore#L22-L25

