### PR TITLE
CI: Install Python deps with pip in doc workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,6 +45,14 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
+      - name: Install Python dependencies
+        # We install both core and addon dependencies, but we don't install any
+        # dependencies from the extra list in addons because we don't actually
+        # run them (and they should be lazy-imported).
+        run: |
+          pip install -r grass/.github/workflows/python_requirements.txt
+          pip install -r grass-addons/.github/workflows/python_requirements.txt
+
       - name: Create installation directory
         run: |
           mkdir "$HOME/install"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -67,7 +67,7 @@ jobs:
         # run them (and they should be lazy-imported).
         run: |
           pip install -r grass/.github/workflows/python_requirements.txt
-          pip install -r grass-addons/.github/workflows/python_requirements.txt
+          pip install -r grass-addons/.github/workflows/requirements.txt
 
       - name: Create installation directory
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,6 +45,22 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
+      - name: Set version variables
+        run: |
+          cd grass
+          eval $(./utils/update_version.py status --bash)
+          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
+          echo "MINOR=$MINOR" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "YEAR=$YEAR" >> $GITHUB_ENV
+
+      - name: Checkout addons
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: OSGeo/grass-addons
+          ref: grass${{ env.MAJOR }}
+          path: grass-addons
+
       - name: Install Python dependencies
         # We install both core and addon dependencies, but we don't install any
         # dependencies from the extra list in addons because we don't actually
@@ -80,22 +96,6 @@ jobs:
 
       - name: Test executing of the grass command
         run: ./grass/.github/workflows/test_simple.sh
-
-      - name: Set version variables
-        run: |
-          cd grass
-          eval $(./utils/update_version.py status --bash)
-          echo "MAJOR=$MAJOR" >> $GITHUB_ENV
-          echo "MINOR=$MINOR" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "YEAR=$YEAR" >> $GITHUB_ENV
-
-      - name: Checkout addons
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: OSGeo/grass-addons
-          ref: grass${{ env.MAJOR }}
-          path: grass-addons
 
       - name: Compile addons
         run: |


### PR DESCRIPTION
This mainly adds numpy which is an import-time dependency for many addons. The custom Python setup does not use the apt dependencies which otherwise work in plain Ubuntu workflows.
