### PR TITLE
utils: Fix incorrect gettimeofday() return value check

### DIFF
--- a/utils/timer/main.c
+++ b/utils/timer/main.c
@@ -26,7 +26,7 @@ int main(void)
 {
     struct timeval t;
 
-    if (gettimeofday(&t, NULL) == -1) {
+    if (gettimeofday(&t, NULL) != 0) {
         fprintf(stderr, "gettimeofday error");
         return 1;
     }


### PR DESCRIPTION
This PR corrects the return value check for gettimeofday() in utils/timer/main.c to align with the POSIX specification. According to POSIX, gettimeofday() returns 0 on success, while any nonzero value indicates failure. Therefore, checking specifically for -1 is incorrect.
[The gettimeofday() function shall return 0 and no value shall be reserved to indicate an error](https://pubs.opengroup.org/onlinepubs/9699919799/)
This pull request is in reference to #5204 