### PR TITLE
lib/gis: fix potential integer overflow issues

### DIFF
--- a/lib/gis/copy_dir.c
+++ b/lib/gis/copy_dir.c
@@ -101,7 +101,7 @@ int G_recursive_copy(const char *src, const char *dst)
         }
 
         while ((len = read(fd, buf, sizeof(buf))) > 0) {
-            while ((len >= 0) && (len2 = write(fd2, buf, len)) >= 0)
+            while ((len > 0) && (len2 = write(fd2, buf, (size_t)len)) >= 0)
                 len -= len2;
         }
 

--- a/lib/gis/copy_dir.c
+++ b/lib/gis/copy_dir.c
@@ -101,7 +101,7 @@ int G_recursive_copy(const char *src, const char *dst)
         }
 
         while ((len = read(fd, buf, sizeof(buf))) > 0) {
-            while (len && (len2 = write(fd2, buf, len)) >= 0)
+            while ((len >= 0) && (len2 = write(fd2, buf, len)) >= 0)
                 len -= len2;
         }
 


### PR DESCRIPTION
Addresses issues of type [CWE-190](https://cwe.mitre.org/data/definitions/190.html): Integer Overflow or Wraparound, reported by Coverity Scan.