### PR TITLE
r.topmodel: Handle CRLF and empty lines properly

### DIFF
--- a/raster/r.topmodel/file_io.c
+++ b/raster/r.topmodel/file_io.c
@@ -10,9 +10,8 @@ void get_line(FILE *fp, char *buffer)
     char *str;
 
     buffer[0] = 0;
-    if (fscanf(fp, "%[^\n]", buffer) != 1)
+    if (fscanf(fp, "%[^\r\n]\n", buffer) != 1)
         G_fatal_error(_("Error reading data"));
-    getc(fp);
 
     if ((str = (char *)strchr(buffer, '#')))
         *str = 0;

--- a/raster/r.topmodel/file_io.c
+++ b/raster/r.topmodel/file_io.c
@@ -10,7 +10,7 @@ void get_line(FILE *fp, char *buffer)
     char *str;
 
     buffer[0] = 0;
-    if (fscanf(fp, "%[^\r\n]\n", buffer) != 1)
+    if (fscanf(fp, " %[^\r\n] ", buffer) != 1)
         G_fatal_error(_("Error reading data"));
 
     if ((str = (char *)strchr(buffer, '#')))


### PR DESCRIPTION
This PR corrects the handling of `\r\n` and ensures empty lines are properly skipped. `fscanf(fp, " %[^\r\n] ", buffer)` will skip any empty lines (e.g., at the beginning of a file) (1st white space in the format), read a non-empty line into `buffer` (`%[^\r\n]`), and skip any amount of white spaces (2nd white space) until the next non-empty line.

Without this PR, `r.topmodel` would fail to skip empty lines in an LF-EOL input files and fail to stop reading a no-EOL file.

A small program for fixing this issue is provided at https://github.com/HuidaeCho/fix_rtopmodel until this PR is merged and released.