### PR TITLE
i.landsat.toar: Fix string not null terminated issue

### DIFF
--- a/imagery/i.landsat.toar/landsat_met.c
+++ b/imagery/i.landsat.toar/landsat_met.c
@@ -107,7 +107,7 @@ void get_mtlformat(const char metadata[], char *key, char value[])
 void lsat_metadata(char *metafile, lsat_data *lsat)
 {
     FILE *f;
-    char mtldata[METADATA_SIZE] = {'\0'};;
+    char mtldata[METADATA_SIZE] = {'\0'};
     char key[MAX_STR], value[MAX_STR];
     void (*get_mtldata)(const char[], char *, char[]);
 

--- a/imagery/i.landsat.toar/landsat_met.c
+++ b/imagery/i.landsat.toar/landsat_met.c
@@ -107,7 +107,7 @@ void get_mtlformat(const char metadata[], char *key, char value[])
 void lsat_metadata(char *metafile, lsat_data *lsat)
 {
     FILE *f;
-    char mtldata[METADATA_SIZE];
+    char mtldata[METADATA_SIZE] = {'\0'};;
     char key[MAX_STR], value[MAX_STR];
     void (*get_mtldata)(const char[], char *, char[]);
 
@@ -117,13 +117,7 @@ void lsat_metadata(char *metafile, lsat_data *lsat)
     /* store metadata in ram */
     if ((f = fopen(metafile, "r")) == NULL)
         G_fatal_error(_("Metadata file <%s> not found"), metafile);
-    i = fread(mtldata, 1, METADATA_SIZE - 1, f);
-    if (i < METADATA_SIZE - 1) {
-        if (ferror(f)) {
-            G_fatal_error(_("Error reading metadata file <%s>"), metafile);
-        }
-    }
-    mtldata[i] = '\0';
+    i = fread(mtldata, METADATA_SIZE - 1, 1, f);
     (void)fclose(f);
 
     /* set version of the metadata file */

--- a/imagery/i.landsat.toar/landsat_met.c
+++ b/imagery/i.landsat.toar/landsat_met.c
@@ -117,7 +117,13 @@ void lsat_metadata(char *metafile, lsat_data *lsat)
     /* store metadata in ram */
     if ((f = fopen(metafile, "r")) == NULL)
         G_fatal_error(_("Metadata file <%s> not found"), metafile);
-    i = fread(mtldata, METADATA_SIZE, 1, f);
+    i = fread(mtldata, 1, METADATA_SIZE - 1, f);
+    if (i < METADATA_SIZE - 1) {
+        if (ferror(f)) {
+            G_fatal_error(_("Error reading metadata file <%s>"), metafile);
+        }
+    }
+    mtldata[i] = '\0';
     (void)fclose(f);
 
     /* set version of the metadata file */


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208229)
fread does not automatically null-terminate the buffer, leading to undefined behavior in string functions.
Solution:
- Reads up to METADATA_SIZE - 1 bytes to leave space for \0
- Checks for read errors and stops execution if necessary
- Ensures null termination to prevent undefined behavior