### PR TITLE
CI(macOS): only run 'macOS distribute app' on OSGeo repo

### DIFF
--- a/.github/workflows/macos_distribute_app.yml
+++ b/.github/workflows/macos_distribute_app.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   macos_build:
     name: macOS distribute
+    if: ${{ github.repository == 'OSGeo/grass' }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{


### PR DESCRIPTION
Avoid attempts to run _macOS distribute app_ workflow on forks.