### PR TITLE
cmake: add missing include paths to ctypesgen

### DIFF
--- a/cmake/ctypesgen.cmake
+++ b/cmake/ctypesgen.cmake
@@ -32,6 +32,11 @@ foreach(HDR ${HDRS})
   list(APPEND HEADERS "${OUTDIR}/${GRASS_INSTALL_INCLUDEDIR}/grass/${HDR}")
 endforeach()
 
+set(SYSHEADERS)
+foreach(SYSHDR ${SYSHDRS})
+  list(APPEND SYSHEADERS "--includedir=${SYSHDR}")
+endforeach()
+
 foreach(req OUT_FILE HDRS LIBS CTYPESGEN_PY COMPILER)
   if(NOT DEFINED ${req} OR "${${req}}" STREQUAL "")
     message(FATAL_ERROR "you must set ${req}")
@@ -46,15 +51,15 @@ else()
 endif()
 
 message(
-  STATUS
-    "Running ${PYTHON_EXECUTABLE} ${CTYPESGEN_PY} --cpp=${CTYPESFLAGS} --no-embed-preamble --strip-build-path ${RUNTIME_GISBASE} --includedir=\"${OUTDIR}/${GRASS_INSTALL_INCLUDEDIR}\" ${LIBRARIES} ${HEADERS} --output=${OUT_FILE}"
-)
+  STATUS "Running ${PYTHON_EXECUTABLE} ${CTYPESGEN_PY} --cpp=${CTYPESFLAGS} \
+    --no-embed-preamble --strip-build-path ${RUNTIME_GISBASE} ${SYSHEADERS} \
+    ${C_FLAGS} ${LIBRARIES} ${HEADERS} --output=${OUT_FILE}")
 execute_process(
   COMMAND
     ${PYTHON_EXECUTABLE} ${CTYPESGEN_PY} --cpp=${CTYPESFLAGS}
-    --no-embed-preamble --strip-build-path ${RUNTIME_GISBASE}
-    --includedir="${OUTDIR}/${GRASS_INSTALL_INCLUDEDIR}" ${LIBRARIES} ${HEADERS}
-    --output=${OUT_FILE}
+    --no-embed-preamble --strip-build-path ${RUNTIME_GISBASE} ${SYSHEADERS}
+    --includedir="${OUTDIR}/${GRASS_INSTALL_INCLUDEDIR}" ${C_FLAGS} ${LIBRARIES}
+    ${HEADERS} --output=${OUT_FILE}
   OUTPUT_VARIABLE ctypesgen_OV
   ERROR_VARIABLE ctypesgen_EV
   RESULT_VARIABLE ctypesgen_RV)

--- a/gui/wxpython/CMakeLists.txt
+++ b/gui/wxpython/CMakeLists.txt
@@ -55,7 +55,7 @@ if(WITH_DOCS)
   add_subdirectory(docs)
 endif()
 
-install(FILES README DESTINATION ${GRASS_INSTALL_GUIDIR}/wxpython)
+install(FILES README.md DESTINATION ${GRASS_INSTALL_GUIDIR}/wxpython)
 
 # copy all python files gui/ lib/python compile all python files so below target
 # depends on MODULD_LIST

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ build_library_in_subdir(
 add_subdirectory(proj)
 
 build_library_in_subdir(external/parson NAME grass_parson HEADERS "gjson.h" "parson.h")
+build_program_in_subdir(external/parson/test NAME test.gjson.lib DEPENDS grass_gis grass_parson)
 
 build_library_in_subdir(
   raster

--- a/python/libgrass_interface_generator/CMakeLists.txt
+++ b/python/libgrass_interface_generator/CMakeLists.txt
@@ -49,9 +49,9 @@ set(stats_HDRS stats.h defs/stats.h)
 set(raster3d_HDRS raster3d.h defs/raster3d.h)
 set(cluster_HDRS cluster.h defs/cluster.h)
 
-# TODO set(VECT_INC         ${PQINCPATH} ) set(proj_INC "${PROJ_INCLUDE_DIR}")
-# set(vector_INC      "${PQINCPATH};${GDAL_INCLUDE_DIR}") set(vedit_INC
-# "${GDAL_INCLUDE_DIR}")
+set(proj_SYSHDRS ${PROJ_INCLUDE_DIR} ${GDAL_INCLUDE_DIR})
+set(vector_SYSHDRS ${PostgreSQL_INCLUDE_DIR} ${GDAL_INCLUDE_DIR})
+set(vedit_SYSHDRS ${PostgreSQL_INCLUDE_DIR} ${GDAL_INCLUDE_DIR})
 
 foreach(module ${MODULES})
   if(NOT ${module}_LIBS)
@@ -62,7 +62,13 @@ foreach(module ${MODULES})
     message(FATAL_ERROR "${module}_HDRS is not set")
   endif()
 
-#[[
+  if(NOT ${module}_SYSHDRS)
+    set(${module}_SYSHDRS})
+  endif()
+  list(INSERT ${module}_SYSHDRS 0 ${CMAKE_INSTALL_PREFIX})
+  list(REMOVE_DUPLICATES ${module}_SYSHDRS)
+
+  #[[
   foreach(${module}_LIB ${${module}_LIBS})
     if(NOT TARGET ${${module}_LIB})
       message(FATAL_ERROR "${${module}_LIB} is not a target")
@@ -87,6 +93,7 @@ foreach(module ${MODULES})
       ${CMAKE_COMMAND} -DCTYPESGEN_PY=${CMAKE_CURRENT_SOURCE_DIR}/run.py
       -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -DCOMPILER=${CMAKE_C_COMPILER}
       "-DHDRS=${${module}_HDRS}" "-DLIBS=${${module}_LIBS}" -DOUTDIR=${OUTDIR}
+      "-DSYSHDRS=${${module}_SYSHDRS}" -DC_FLAGS=${CMAKE_C_FLAGS}
       -DGRASS_INSTALL_INCLUDEDIR=${GRASS_INSTALL_INCLUDEDIR}
       -DGRASS_INSTALL_SCRIPTDIR=${GRASS_INSTALL_SCRIPTDIR}
       -DGRASS_INSTALL_DEMODIR=${GRASS_INSTALL_DEMODIR}


### PR DESCRIPTION
This addresses incomplete generation of python.lib.[vector|proj|vedit].py files, and fixes most of the failing tests.

In addition some minor, not directly related, fixes:
- add libparson test
- copy wxpython/README.md