### PR TITLE
docs: Replace table by sections for standard parser options

### DIFF
--- a/man/build_md.py
+++ b/man/build_md.py
@@ -237,7 +237,7 @@ headerkey_tmpl = string.Template(
 
 
 headerpso_tmpl = r"""
-## Parser standard options
+# Standard Parser Options
 """
 
 header_graphical_index_tmpl = """# Graphical index of GRASS GIS modules


### PR DESCRIPTION
This changes representation of the generated documentation of the standard parser options (parameters). The table did not work great in the original HTML documentation, but it was not useable in the new mkdoc-rendered documentation.

The options (parameters) are now represented as individual sections (level 3 headings). The individual key-value pairs for the defaults are represented as rows in a small table for each option. Examples are included to demonstrate basic Python usage and allow copy-pasting.

The page now starts with a short introduction and links to g.parser for more context.

The C code parsing is now strictly split between the line ingesting and value cleanup. The cleanup is now done with regular expressions. This fixes several truncated values when parentheses were present. Some additional adjustments to the values are done in the Markdown representation for clarity on the C constants and function calls.

## Images

### Intro

![image](https://github.com/user-attachments/assets/ac2e1c19-cba6-46ef-82c0-10bda95ee712)

### Raster input

![image](https://github.com/user-attachments/assets/5ea2ca85-c9cf-43a1-80ed-933791f749f9)

### Default value in the example

![image](https://github.com/user-attachments/assets/c9309ee3-9f94-4b23-9d82-6c21852e3717)

### Value generated by a function

![image](https://github.com/user-attachments/assets/0f23da1f-79ee-4b70-8558-4d4f424e6b45)

### Current state in old HTML doc

![image](https://github.com/user-attachments/assets/9a4a58fc-8049-459b-a138-a3070a69621a)

### Current state in MkDoc doc

![image](https://github.com/user-attachments/assets/cc1d55f3-0e55-4869-ac24-743bc231d7f3)
