### PR TITLE
docs: Add proxy settings to Markdown build

### DIFF
--- a/utils/mkdocs.py
+++ b/utils/mkdocs.py
@@ -37,13 +37,25 @@ def read_file(name):
         return ""
 
 
+def set_proxy():
+    """Set proxy"""
+    proxy = os.getenv("GRASS_PROXY")
+    if proxy:
+        proxies = {}
+        for ptype, purl in (p.split("=") for p in proxy.split(",")):
+            proxies[ptype] = purl
+        urlrequest.install_opener(
+            urlrequest.build_opener(urlrequest.ProxyHandler(proxies))
+        )
+
+
 def get_version_branch(major_version, addons_git_repo_url):
     """Check if version branch for the current GRASS version exists,
     if not, take branch for the previous version
     For the official repo we assume that at least one version branch is present
 
     :param major_version int: GRASS GIS major version
-    :param addons_git_repo_url str: Addons Git ropository URL
+    :param addons_git_repo_url str: Addons Git repository URL
 
     :return version_branch str: version branch
     """

--- a/utils/mkhtml.py
+++ b/utils/mkhtml.py
@@ -25,7 +25,6 @@ import locale
 
 from html.parser import HTMLParser
 
-from urllib import request as urlrequest
 import urllib.parse as urlparse
 
 try:
@@ -40,6 +39,7 @@ from mkdocs import (
     get_last_git_commit,
     top_dir as topdir,
     get_addon_path,
+    set_proxy,
 )
 
 grass_version = os.getenv("VERSION_NUMBER", "unknown")
@@ -80,20 +80,7 @@ def _get_encoding():
     return encoding
 
 
-def set_proxy():
-    """Set proxy"""
-    proxy = os.getenv("GRASS_PROXY")
-    if proxy:
-        proxies = {}
-        for ptype, purl in (p.split("=") for p in proxy.split(",")):
-            proxies[ptype] = purl
-        urlrequest.install_opener(
-            urlrequest.build_opener(urlrequest.ProxyHandler(proxies))
-        )
-
-
 set_proxy()
-
 
 html_page_footer_pages_path = os.getenv("HTML_PAGE_FOOTER_PAGES_PATH") or ""
 

--- a/utils/mkmarkdown.py
+++ b/utils/mkmarkdown.py
@@ -34,6 +34,7 @@ from mkdocs import (
     get_last_git_commit,
     top_dir,
     get_addon_path,
+    set_proxy,
 )
 
 
@@ -200,6 +201,8 @@ def merge_md_files(md1, md2, content_modifier1, content_modifier2):
 
 def main():
     pgm = sys.argv[1]
+
+    set_proxy()
 
     src_file = f"{pgm}.md"
     tmp_file = f"{pgm}.tmp.md"


### PR DESCRIPTION
The initial port of HTML code to Markdown didn't include GRASS_PROXY support for the build. This moves the proxy function out of HTML to the common code and calls that function the Markdown build script.

It also fixes typo in a docstring.
