### PR TITLE
build: Fix basic gallery build issues for Markdown

### DIFF
--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -100,7 +100,7 @@ def img_in_file(filename: str | os.PathLike[str], imagename: str, ext: str) -> b
         pattern = re.compile("<img .*src=.{0}.*>".format(imagename))
     else:
         # expecting markdown
-        pattern = re.compile(r"!\[(.*?)\]\({0}\)".format(imagename), flags=re.MULTILINE | re.DOTALL)
+        pattern = re.compile(r"\]\({0}\)".format(imagename))
     return bool(re.search(pattern, Path(filename).read_text()))
 
 
@@ -171,6 +171,7 @@ def main(ext):
                 if img_in_file(Path(man_dir, man_filename), filename, ext):
                     img_files[filename] = man_filename
                     # for now suppose one image per manual filename
+                    continue
 
     with open(Path(man_dir, output_name), "w") as output:
         if ext == "html":

--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -100,7 +100,7 @@ def img_in_file(filename: str | os.PathLike[str], imagename: str, ext: str) -> b
         pattern = re.compile("<img .*src=.{0}.*>".format(imagename))
     else:
         # expecting markdown
-        pattern = re.compile(r"!\[(.*?)\]\({0}\)".format(imagename))
+        pattern = re.compile(r"!\[(.*?)\]\({0}\)".format(imagename), flags=re.MULTILINE | re.DOTALL)
     return bool(re.search(pattern, Path(filename).read_text()))
 
 
@@ -173,9 +173,13 @@ def main(ext):
                     # for now suppose one image per manual filename
 
     with open(Path(man_dir, output_name), "w") as output:
+        if ext == "html":
+            title = "GRASS GIS %s Reference Manual: Manual gallery" % grass_version
+        else:
+            title = "Manual gallery"
         output.write(
             header1_tmpl.substitute(
-                title="GRASS GIS %s Reference Manual: Manual gallery" % grass_version
+                title=title
             )
         )
         if ext == "html":
@@ -197,7 +201,7 @@ def main(ext):
                 output.write(f'[![{name}]({image} "{title}")]({filename})\n')
         if ext == "html":
             output.write("</ul>")
-        write_footer(output, f"index.{ext}", year)
+        write_footer(output, f"index.{ext}", year, template=ext)
 
     return img_files
 

--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -178,11 +178,7 @@ def main(ext):
             title = "GRASS GIS %s Reference Manual: Manual gallery" % grass_version
         else:
             title = "Manual gallery"
-        output.write(
-            header1_tmpl.substitute(
-                title=title
-            )
-        )
+        output.write(header1_tmpl.substitute(title=title))
         if ext == "html":
             output.write(header_graphical_index_tmpl)
             output.write('<ul class="img-list">\n')


### PR DESCRIPTION
This fixes build of header and footer by avoiding YAML syntax issue in title (colon) and writing of HTML footer. It also does multiline matching for the image capture which results in capturing (presumably) all images in the Markdown docs.

## Before

![image](https://github.com/user-attachments/assets/f54c5443-11d1-4d73-b0c3-cbfbaabb860d)

## After

![image](https://github.com/user-attachments/assets/f9183637-5c23-4802-bcc0-5afc935c69f5)
