### PR TITLE
temporal: fix typos

### DIFF
--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -45,7 +45,7 @@
 
 # %option G_OPT_STRDS_OUTPUT
 # % key: occurrence
-# % description: The output space time raster dataset that stores the occurrence of the the accumulation pattern using the provided data range
+# % description: The output space time raster dataset that stores the occurrence of the accumulation pattern using the provided data range
 # % required: yes
 # %end
 

--- a/temporal/t.rast.algebra/t.rast.algebra.py
+++ b/temporal/t.rast.algebra/t.rast.algebra.py
@@ -101,7 +101,7 @@ def main():
     granularity = flags["g"]
     dry_run = flags["d"]
 
-    # Check for PLY istallation
+    # Check for PLY installation
     try:
         # Intentionally unused imports
         from ply import lex  # noqa: F401

--- a/temporal/t.rast.contour/t.rast.contour.py
+++ b/temporal/t.rast.contour/t.rast.contour.py
@@ -200,7 +200,7 @@ def main(options, flags):
             nprocs = 1
             gs.warning(
                 _(
-                    "The number of parellel r.contour processes was "
+                    "The number of parallel r.contour processes was "
                     "reduced to 1 because of the table attribute "
                     "creation"
                 )

--- a/temporal/t.rast.list/t.rast.list.html
+++ b/temporal/t.rast.list/t.rast.list.html
@@ -216,7 +216,7 @@ for item in result["data"]:
 
 Semantic label can be assigned to raster maps
 by <em><a href="r.semantic.label.html">r.semantic.label</a></em> module or even when
-registrating raster maps into STRDS
+registering raster maps into STRDS
 by <em><a href="t.register.html#support-for-semantic-labels">t.register</a></em>.
 
 <p>

--- a/temporal/t.rast.list/t.rast.list.md
+++ b/temporal/t.rast.list/t.rast.list.md
@@ -208,7 +208,7 @@ for item in result["data"]:
 
 Semantic label can be assigned to raster maps by
 *[r.semantic.label](r.semantic.label.md)* module or even when
-registrating raster maps into STRDS by
+registering raster maps into STRDS by
 *[t.register](t.register.md#support-for-semantic-labels)*.
 
 Name of STRDS can be extended by semantic label used for filtering. Name

--- a/temporal/t.rast.to.rast3/t.rast.to.rast3.md
+++ b/temporal/t.rast.to.rast3/t.rast.to.rast3.md
@@ -29,7 +29,7 @@ voxel cube layers!
 ### Management of open file limits
 
 The maximum number of raster maps that can be processed is given by the
-per-user limit of the operating system. For example, both the the hard
+per-user limit of the operating system. For example, both the hard
 and soft limit for users is typically 1024. The soft limit can be
 changed with e.g. ulimit -n 4096 (UNIX-based operating systems) but not
 higher than the hard limit. If the latter is too low, you can as

--- a/temporal/t.rast.to.vect/t.rast.to.vect.py
+++ b/temporal/t.rast.to.vect/t.rast.to.vect.py
@@ -199,7 +199,7 @@ def main(options, flags):
             nprocs = 1
             gs.warning(
                 _(
-                    "The number of parellel r.to.vect processes was "
+                    "The number of parallel r.to.vect processes was "
                     "reduced to 1 because of the table attribute "
                     "creation"
                 )

--- a/temporal/t.rast3d.algebra/t.rast3d.algebra.py
+++ b/temporal/t.rast3d.algebra/t.rast3d.algebra.py
@@ -87,7 +87,7 @@ def main():
     register_null = flags["n"]
     granularity = flags["g"]
 
-    # Check for PLY istallation
+    # Check for PLY installation
     try:
         # Intentionally unused imports
         from ply import lex  # noqa: F401

--- a/temporal/t.register/t.register.html
+++ b/temporal/t.register/t.register.html
@@ -69,7 +69,7 @@ database.
 
 There are several options to register maps by means of a file. The input file
 consists of a list of map names, optionally along with timestamps. Each map
-name (and timestaps if provided) should be stored in a new line in this file.
+name (and timestamps if provided) should be stored in a new line in this file.
 <p>
 When only map names are provided, the <em>increment</em> option and the <b>-i</b>
 flag are supported. However, when along with map names any kind of timestamp is

--- a/temporal/t.register/t.register.md
+++ b/temporal/t.register/t.register.md
@@ -68,7 +68,7 @@ have no access to the temporal database.
 
 There are several options to register maps by means of a file. The input
 file consists of a list of map names, optionally along with timestamps.
-Each map name (and timestaps if provided) should be stored in a new line
+Each map name (and timestamps if provided) should be stored in a new line
 in this file.
 
 When only map names are provided, the *increment* option and the **-i**

--- a/temporal/t.select/t.select.py
+++ b/temporal/t.select/t.select.py
@@ -68,7 +68,7 @@ def main():
     dry_run = flags["d"]
     stdstype = options["type"]
 
-    # Check for PLY istallation
+    # Check for PLY installation
     try:
         # Intentionally unused imports
         from ply import lex  # noqa: F401

--- a/temporal/t.vect.algebra/t.vect.algebra.py
+++ b/temporal/t.vect.algebra/t.vect.algebra.py
@@ -65,7 +65,7 @@ def main():
     basename = options["basename"]
     spatial = flags["s"]
 
-    # Check for PLY istallation
+    # Check for PLY installation
     try:
         # Intentionally unused imports
         from ply import lex  # noqa: F401


### PR DESCRIPTION
Fix user-facing and non-user-facing typos
Found via `codespell -q 3 -S "*.po,*.pot,*.ps,*.raw,*.svg,./contributors_extra.csv,./translators.csv,./mswindows/external,./lib/external,./utils/fix_typos.sh" -L aline,alle,alog,anull,apoints,asnd,attch,bufer,buffr,bui,buildin,build-in,bund,clen,co-ordinate,co-ordinates,datas,delt,doubleclick,dout,dudo,dum,dyin,enew,entrys,eto,fle,flor,fpr,fromm,greif,huld,ihs,indx,ine,ines,infex,infp,inout,inpt,ist,linke,linz,lsat,makin,mapp,mis,modul,nam,nams,nd,neast,ned,nin,numer,observ,offsetp,oint,ons,ontext,parm,parms,partialy,redner,re-use,re-used,rin,selectin,sistem,siz,strin,strng,tht,vas,vizual`