### PR TITLE
db: fix typos

### DIFF
--- a/db/databaseintro.html
+++ b/db/databaseintro.html
@@ -30,7 +30,7 @@ In order to test a driver, run <a href="db.test.html">db.test</a>.
 
 Attribute data can be imported with <a href="db.in.ogr.html">db.in.ogr</a> from
 various formats and exported with <a href="db.out.ogr.html">db.out.ogr</a>. To internally
-copy a a full table or selectively parts of it, use <a href="db.copy.html">db.copy</a>.
+copy a full table or selectively parts of it, use <a href="db.copy.html">db.copy</a>.
 <p>
 
 Further conversion tools:

--- a/db/databaseintro.md
+++ b/db/databaseintro.md
@@ -36,7 +36,7 @@ a user/password for driver/database to be set with
 
 Attribute data can be imported with [db.in.ogr](db.in.ogr.md) from
 various formats and exported with [db.out.ogr](db.out.ogr.md). To
-internally copy a a full table or selectively parts of it, use
+internally copy a full table or selectively parts of it, use
 [db.copy](db.copy.md).
 
 Further conversion tools:

--- a/db/db.columns/db.columns.html
+++ b/db/db.columns/db.columns.html
@@ -7,7 +7,7 @@ databases are supported through dbf, shp, odbc and pg drivers.
 
 If parameters for database connection are already set with
 <a href="db.connect.html">db.connect</a>, they are taken as default values
-and do not need to be spcified each time.
+and do not need to be specified each time.
 
 <h2>EXAMPLES</h2>
 

--- a/db/db.columns/db.columns.md
+++ b/db/db.columns/db.columns.md
@@ -7,7 +7,7 @@ are supported through dbf, shp, odbc and pg drivers.
 
 If parameters for database connection are already set with
 [db.connect](db.connect.md), they are taken as default values and do not
-need to be spcified each time.
+need to be specified each time.
 
 ## EXAMPLES
 

--- a/db/db.describe/db.describe.html
+++ b/db/db.describe/db.describe.html
@@ -7,7 +7,7 @@ is used only column names instead of full column descriptions is given.
 
 If parameters for database connection are already set with
 <a href="db.connect.html">db.connect</a>, they are taken as default values and
-do not need to be spcified each time.
+do not need to be specified each time.
 
 <h2>EXAMPLES</h2>
 

--- a/db/db.describe/db.describe.md
+++ b/db/db.describe/db.describe.md
@@ -7,7 +7,7 @@ only column names instead of full column descriptions is given.
 
 If parameters for database connection are already set with
 [db.connect](db.connect.md), they are taken as default values and do not
-need to be spcified each time.
+need to be specified each time.
 
 ## EXAMPLES
 

--- a/db/db.tables/db.tables.html
+++ b/db/db.tables/db.tables.html
@@ -6,7 +6,7 @@
 
 If parameters for database connection are already set with
 <a href="db.connect.html">db.connect</a>, they are taken as default values and
-do not need to be spcified each time.
+do not need to be specified each time.
 
 <h2>EXAMPLES</h2>
 

--- a/db/db.tables/db.tables.md
+++ b/db/db.tables/db.tables.md
@@ -6,7 +6,7 @@
 
 If parameters for database connection are already set with
 [db.connect](db.connect.md), they are taken as default values and do not
-need to be spcified each time.
+need to be specified each time.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.ps,*.raw,*.svg,./contributors_extra.csv,./translators.csv,./mswindows/external,./lib/external,./utils/fix_typos.sh" -L aline,alle,alog,anull,apoints,asnd,attch,bufer,buffr,bui,buildin,build-in,bund,clen,co-ordinate,co-ordinates,datas,delt,doubleclick,dout,dudo,dum,dyin,enew,entrys,eto,fle,flor,fpr,fromm,greif,huld,ihs,indx,ine,ines,infex,infp,inout,inpt,ist,linke,linz,lsat,makin,mapp,mis,modul,nam,nams,nd,neast,ned,nin,numer,observ,offsetp,oint,ons,ontext,parm,parms,partialy,redner,re-use,re-used,rin,selectin,sistem,siz,strin,strng,tht,vas,vizual`