### PR TITLE
lib/psdriver: Fix printf format specifier issue

### DIFF
--- a/lib/psdriver/draw_bitmap.c
+++ b/lib/psdriver/draw_bitmap.c
@@ -4,7 +4,7 @@ void PS_Bitmap(int ncols, int nrows, int threshold, const unsigned char *buf)
 {
     int i, j;
 
-    output("%d %d %d %d BITMAP\n", cur_x, cur_y, ncols, nrows);
+    output("%f %f %d %d BITMAP\n", cur_x, cur_y, ncols, nrows);
 
     for (j = 0; j < nrows; j++) {
         unsigned int bit = 0x80;

--- a/lib/psdriver/erase.c
+++ b/lib/psdriver/erase.c
@@ -3,7 +3,7 @@
 void PS_Erase(void)
 {
     if (ps.encapsulated)
-        output("%d %d %d %d BOX\n", ps.left, ps.top, ps.right, ps.bot);
+        output("%f %f %f %f BOX\n", ps.left, ps.top, ps.right, ps.bot);
     else
         output("ERASE\n");
 }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1415568, 1415601, 1415712, 1415744, 1415767,1415773)
Some of the variables were declared as double but the format specifier use was of int.