### PR TITLE
v.colors: Fix Resource Leak issue in write_rgb.c

### DIFF
--- a/vector/v.colors/write_rgb.c
+++ b/vector/v.colors/write_rgb.c
@@ -65,6 +65,8 @@ void write_rgb_values(struct Map_info *Map, int layer, const char *column_name,
     nrec = db_select_int(driver, fi->table, fi->key, NULL, &pval);
     if (nrec < 1) {
         G_warning(_("No categories found"));
+        G_free(pval);
+        Vect_destroy_field_info(fi);
         return;
     }
 

--- a/vector/v.colors/write_rgb.c
+++ b/vector/v.colors/write_rgb.c
@@ -91,4 +91,6 @@ void write_rgb_values(struct Map_info *Map, int layer, const char *column_name,
     db_commit_transaction(driver);
 
     db_close_database_shutdown_driver(driver);
+    G_free(pval);
+    Vect_destroy_field_info(fi);
 }

--- a/vector/v.colors/write_rgb.c
+++ b/vector/v.colors/write_rgb.c
@@ -9,7 +9,7 @@ void write_rgb_values(struct Map_info *Map, int layer, const char *column_name,
 {
     int ctype, nrec, i;
     int red, grn, blu;
-    int *pval;
+    int *pval = NULL;
     char buf[1024];
     struct field_info *fi;
     dbDriver *driver;


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207647,1207649)
Used Vect_destroy_field_info(), G_free() to fix this issue.