### PR TITLE
raster: fix typos

### DIFF
--- a/raster/r.category/r.category.html
+++ b/raster/r.category/r.category.html
@@ -177,7 +177,7 @@ r.category diseasemap separator=":" rules=- &lt;&lt; EOF
 EOF
 </pre></div>
 
-This sets the categoy values 1 and 2 to respective text labels.
+This sets the category values 1 and 2 to respective text labels.
 
 Alternatively, the rules can be stored in an ASCII text file and loaded
 via the <em>rules</em> parameter.

--- a/raster/r.category/r.category.md
+++ b/raster/r.category/r.category.md
@@ -178,7 +178,7 @@ r.category diseasemap separator=":" rules=- << EOF
 EOF
 ```
 
-This sets the categoy values 1 and 2 to respective text labels.
+This sets the category values 1 and 2 to respective text labels.
 Alternatively, the rules can be stored in an ASCII text file and loaded
 via the *rules* parameter.
 

--- a/raster/r.contour/main.c
+++ b/raster/r.contour/main.c
@@ -29,7 +29,7 @@
  *   value is added a small quantity (the smaller one that makes cell[i] +
  *   small != cell[i], I've taken into consideration double encoding)
  * o one can specify a minimum number of point for a contour line to be put
- *   into outout, so that small spurs, single points and so on won't be
+ *   into output, so that small spurs, single points and so on won't be
  *   present and the output will be more clear (that's optional anyway);
  * o in my opinion there were minor memory handling problems in r.contour,
  *   I've corrected them (Head.map_name was not guaranteed to be properly

--- a/raster/r.describe/r.describe.html
+++ b/raster/r.describe/r.describe.html
@@ -31,7 +31,7 @@ report will generally run faster than the full list (the default output).
 
 <p>
 The <b>-d</b> flag can be used to force <em>r.describe</em> to respect the current region
-extents when repoting raster map categories. The default behavior is to read the full
+extents when reporting raster map categories. The default behavior is to read the full
 extent of the input raster map.
 
 <p>If the <b>-1</b> flag is specified, the output appears with one category value/range per line.

--- a/raster/r.describe/r.describe.md
+++ b/raster/r.describe/r.describe.md
@@ -29,7 +29,7 @@ occurs, this will be indicated. The range report will generally run
 faster than the full list (the default output).
 
 The **-d** flag can be used to force *r.describe* to respect the current
-region extents when repoting raster map categories. The default behavior
+region extents when reporting raster map categories. The default behavior
 is to read the full extent of the input raster map.
 
 If the **-1** flag is specified, the output appears with one category

--- a/raster/r.gwflow/main.c
+++ b/raster/r.gwflow/main.c
@@ -377,7 +377,7 @@ int main(int argc, char *argv[])
     N_convert_array_2d_null_to_zero(data->phead);
 
     /****************************************************/
-    /*explicite calculation of free groundwater surface */
+    /*explicit calculation of free groundwater surface  */
 
     /****************************************************/
     if (data->gwtype == N_GW_UNCONFINED) {
@@ -446,7 +446,7 @@ int main(int argc, char *argv[])
         N_write_array_2d_to_rast(budget, param.budget->answer);
     }
 
-    /*Compute the the velocity field if required and write the result into two
+    /*Compute the velocity field if required and write the result into two
      * raster maps */
     if (param.vector_x->answer && param.vector_y->answer) {
         field = N_compute_gradient_field_2d(data->phead, data->hc_x, data->hc_y,

--- a/raster/r.gwflow/r.gwflow.html
+++ b/raster/r.gwflow/r.gwflow.html
@@ -60,11 +60,11 @@ solve the resulting non-linear equation system.
 <p>Two different boundary conditions are implemented,
 the Dirichlet and Neumann conditions. By default the calculation area is surrounded by homogeneous Neumann boundary conditions.
 The calculation and boundary status of single cells must be set with a status map,
-the following states are supportet:
+the following states are supported:
 
 <ul>
 <li>0 == inactive - the cell with status 0 will not be calculated, active cells will have a no flow boundary to this cell</li>
-<li>1 == active - this cell is used for groundwater floaw calculation, inner sources and recharge can be defined for those cells</li>
+<li>1 == active - this cell is used for groundwater flow calculation, inner sources and recharge can be defined for those cells</li>
 <li>2 == Dirichlet - cells of this type will have a fixed piezometric head value which do not change over the time </li>
 </ul>
 <br>

--- a/raster/r.gwflow/r.gwflow.md
+++ b/raster/r.gwflow/r.gwflow.md
@@ -61,11 +61,11 @@ Two different boundary conditions are implemented, the Dirichlet and
 Neumann conditions. By default the calculation area is surrounded by
 homogeneous Neumann boundary conditions. The calculation and boundary
 status of single cells must be set with a status map, the following
-states are supportet:
+states are supported:
 
 - 0 == inactive - the cell with status 0 will not be calculated, active
   cells will have a no flow boundary to this cell
-- 1 == active - this cell is used for groundwater floaw calculation,
+- 1 == active - this cell is used for groundwater flow calculation,
   inner sources and recharge can be defined for those cells
 - 2 == Dirichlet - cells of this type will have a fixed piezometric head
   value which do not change over the time

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -523,7 +523,7 @@ int main(int argc, char *argv[])
             settings.fixedMaxLength); /* predefined as BIG */
 
     /* TODO: fixing BIG, there is a bug with distant mountains not being seen:
-       attempt to contrain to current region
+       attempt to constrain to current region
 
        fixedMaxLength = (fixedMaxLength < AMAX1(deltx, delty)) ? fixedMaxLength
        : AMAX1(deltx, delty); G_debug(1,"Using maxdistance %f", fixedMaxLength);
@@ -846,7 +846,7 @@ void calculate_point_mode(const Settings *settings, const Geometry *geometry,
     double printangle = settings->single_direction;
 
     origin_point.maxlength = settings->fixedMaxLength;
-    /* JSON variables and formating */
+    /* JSON variables and formatting */
 
     JSON_Value *horizons_value;
     JSON_Array *horizons;

--- a/raster/r.in.ascii/gethead.c
+++ b/raster/r.in.ascii/gethead.c
@@ -172,7 +172,7 @@ int gethead(FILE *fd, struct Cell_head *cellhd, RASTER_MAP_TYPE *d_type,
 
         if (strcmp(label, "multiplier") == 0) {
             if (Rast_is_d_null_value(
-                    mult)) { /* if mult not set on commant line */
+                    mult)) { /* if mult not set on command line */
                 if (sscanf(value, "%lf", mult) != 1) {
                     G_warning(_("illegal multiplier field: using 1.0"));
                     *mult = 1.0;

--- a/raster/r.in.lidar/local_proto.h
+++ b/raster/r.in.lidar/local_proto.h
@@ -8,7 +8,7 @@
  * PURPOSE:      Imports LAS LiDAR point clouds to a raster map using
  *               aggregate statistics.
  *
- * COPYRIGHT:    (C) 2011 Markus Metz and the The GRASS Development Team
+ * COPYRIGHT:    (C) 2011 Markus Metz and The GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS

--- a/raster/r.in.lidar/main.c
+++ b/raster/r.in.lidar/main.c
@@ -9,7 +9,7 @@
  * PURPOSE:      Imports LAS LiDAR point clouds to a raster map using
  *               aggregate statistics.
  *
- * COPYRIGHT:    (C) 2011-2015 Markus Metz and the The GRASS Development Team
+ * COPYRIGHT:    (C) 2011-2015 Markus Metz and The GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS

--- a/raster/r.in.pdal/grassrasterwriter.h
+++ b/raster/r.in.pdal/grassrasterwriter.h
@@ -98,7 +98,7 @@ public:
 
         // TODO: check the bounds and report discrepancies in
         // number of filtered out vs processed to the user
-        // (alternativelly, change the spatial bounds test to
+        // (alternatively, change the spatial bounds test to
         // give same results as this, but it might be actually helpful
         // to tell user that they have points right on the border)
         int arr_row = (int)((region_->north - y) / region_->ns_res);

--- a/raster/r.in.pdal/string_list.c
+++ b/raster/r.in.pdal/string_list.c
@@ -7,7 +7,7 @@
  * PURPOSE:      Imports LAS LiDAR point clouds to a raster map using
  *               aggregate statistics.
  *
- * COPYRIGHT:    (C) 2019 Vaclav Petras and the The GRASS Development Team
+ * COPYRIGHT:    (C) 2019 Vaclav Petras and The GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS

--- a/raster/r.in.pdal/string_list.h
+++ b/raster/r.in.pdal/string_list.h
@@ -7,7 +7,7 @@
  * PURPOSE:      Imports LAS LiDAR point clouds to a raster map using
  *               aggregate statistics.
  *
- * COPYRIGHT:    (C) 2019 Vaclav Petras and the The GRASS Development Team
+ * COPYRIGHT:    (C) 2019 Vaclav Petras and The GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS

--- a/raster/r.in.poly/r.in.poly.html
+++ b/raster/r.in.poly/r.in.poly.html
@@ -21,7 +21,7 @@ Usually the default value is fine.
 <p>
 The data will be imported using the current region settings to set the
 new raster map's bounds and resolution. Any features falling outside
-the current region will be cropped. The region settings are contolled
+the current region will be cropped. The region settings are controlled
 with the <em>g.region</em> module.
 
 <p>

--- a/raster/r.in.poly/r.in.poly.md
+++ b/raster/r.in.poly/r.in.poly.md
@@ -17,7 +17,7 @@ is fine.
 
 The data will be imported using the current region settings to set the
 new raster map's bounds and resolution. Any features falling outside the
-current region will be cropped. The region settings are contolled with
+current region will be cropped. The region settings are controlled with
 the *g.region* module.
 
 The format is a simplified version of the standard GRASS vector ASCII

--- a/raster/r.li/r.li.daemon/daemon.h
+++ b/raster/r.li/r.li.daemon/daemon.h
@@ -113,7 +113,7 @@ struct area_entry {
 
 /**
  * \brief function prototype for index calculation
- * \param fd file descripter of opened raster map
+ * \param fd file descriptor of opened raster map
  * \param par optional parameters
  * \param ad definition of the sample area
  * \param result pointer to store the result

--- a/raster/r.mapcalc/map.c
+++ b/raster/r.mapcalc/map.c
@@ -293,7 +293,7 @@ static void translate_from_colors(struct map *m, DCELL *rast, CELL *cell,
  * category file.
  *
  * This requires performing sscanf() of the category label
- * and only do it it for new categories. Must maintain
+ * and only do it for new categories. Must maintain
  * some kind of maps of already scanned values.
  *
  * This maps is a hybrid tree, where the data in each node

--- a/raster/r.mapcalc/map3.c
+++ b/raster/r.mapcalc/map3.c
@@ -242,7 +242,7 @@ static void translate_from_colors(map *m, DCELL *rast, CELL *cell, int ncols,
  * category file.
  *
  * This requires performing sscanf() of the category label
- * and only do it it for new categories. Must maintain
+ * and only do it for new categories. Must maintain
  * some kind of maps of already scanned values.
  *
  * This maps is a hybrid tree, where the data in each node

--- a/raster/r.mapcalc/testsuite/const_map_test.sh
+++ b/raster/r.mapcalc/testsuite/const_map_test.sh
@@ -97,7 +97,7 @@ compare_result()
  fi
 }
 
-# Deactive the current mask, by using our own mask name,
+# Deactivate the current mask, by using our own mask name,
 # but not creating any mask.
 MASKTMP=mask.$TMPNAME
 export GRASS_MASK=$MASKTMP

--- a/raster/r.mask.status/r.mask.status.html
+++ b/raster/r.mask.status/r.mask.status.html
@@ -46,7 +46,7 @@ This returns a dictionary with keys <code>present</code>,
 The POSIX <em>test</em> utility uses return code 0 to indicate presence
 and 1 to indicate absence of a file, so testing existence of a file with
 <code>test -f</code> gives return code 0 when the file exists.
-<em>r.mask.status</em> can be used in the same with the the <b>-t</b> flag:
+<em>r.mask.status</em> can be used in the same with the <b>-t</b> flag:
 
 <div class="code"><pre>
 r.mask.status -t

--- a/raster/r.mask.status/r.mask.status.md
+++ b/raster/r.mask.status/r.mask.status.md
@@ -43,7 +43,7 @@ This returns a dictionary with keys `present`, `full_name`, and
 The POSIX *test* utility uses return code 0 to indicate presence and 1
 to indicate absence of a file, so testing existence of a file with
 `test -f` gives return code 0 when the file exists. *r.mask.status* can
-be used in the same with the the **-t** flag:
+be used in the same with the **-t** flag:
 
 ```sh
 r.mask.status -t

--- a/raster/r.out.ppm3/r.out.ppm3.html
+++ b/raster/r.out.ppm3/r.out.ppm3.html
@@ -4,9 +4,9 @@
 image file, using the current region.
 
 <p>This program converts a GRASS raster map to a PPM image file
-using the the current region settings.
+using the current region settings.
 
-<p>To get the full area and resolutin of the raster map, run:
+<p>To get the full area and resolution of the raster map, run:
 
 <div class="code"><pre>
 g.region raster=[mapname]

--- a/raster/r.out.ppm3/r.out.ppm3.md
+++ b/raster/r.out.ppm3/r.out.ppm3.md
@@ -6,7 +6,7 @@ file, using the current region.
 This program converts a GRASS raster map to a PPM image file using the
 the current region settings.
 
-To get the full area and resolutin of the raster map, run:
+To get the full area and resolution of the raster map, run:
 
 ```sh
 g.region raster=[mapname]

--- a/raster/r.out.vrml/put_grid.c
+++ b/raster/r.out.vrml/put_grid.c
@@ -3,7 +3,7 @@
 #include "pv.h"
 
 /*
- * Use centers of GRASS CELLS as vertexes for grid.
+ * Use centers of GRASS CELLS as vertices for grid.
  * Currently, grid space is "unitized" so that the
  * largest dimension of the current region in GRASS == 1.0
  */

--- a/raster/r.param.scale/interface.c
+++ b/raster/r.param.scale/interface.c
@@ -72,7 +72,7 @@ void interface(int argc, char **argv)
 
     /* Each option has a 'key' (short descriptn), a 'description` (longer one)
      */
-    /* a 'type' (eg int, or string), and an indication whether manditory or not
+    /* a 'type' (eg int, or string), and an indication whether mandatory or not
      */
 
     rast_out->description =

--- a/raster/r.param.scale/main.c
+++ b/raster/r.param.scale/main.c
@@ -27,7 +27,7 @@ int fd_in,  /* File descriptor for input and        */
 double resoln, /* Planimetric resolution.              */
     exponent,  /* Distance weighting exponent.         */
     zscale,    /* Vertical scaling factor.             */
-    slope_tol, /* Vertical tolerences for surface      */
+    slope_tol, /* Vertical tolerances for surface      */
     curve_tol; /* feature identification.              */
 
 int main(int argc, char **argv)

--- a/raster/r.param.scale/param.h
+++ b/raster/r.param.scale/param.h
@@ -93,5 +93,5 @@ extern int fd_in, /* File descriptor for input and        */
 extern double resoln, /* Planimetric resolution.              */
     exponent,         /* Distance weighting exponent.         */
     zscale,           /* Vertical scaling factor.             */
-    slope_tol,        /* Vertical tolerences for surface      */
+    slope_tol,        /* Vertical tolerances for surface      */
     curve_tol;        /* feature identification.              */

--- a/raster/r.profile/r.profile.html
+++ b/raster/r.profile/r.profile.html
@@ -68,7 +68,7 @@ This filters out everything except the numbers.
 
 <h3>Extraction of values along profile defined by coordinates (variant 1)</h3>
 
-Extract a profile with coordinates (wayoints) provided on the command line
+Extract a profile with coordinates (waypoints) provided on the command line
 (North Carolina data set):
 
 <div class="code"><pre>

--- a/raster/r.profile/r.profile.md
+++ b/raster/r.profile/r.profile.md
@@ -65,7 +65,7 @@ This filters out everything except the numbers.
 
 ### Extraction of values along profile defined by coordinates (variant 1)
 
-Extract a profile with coordinates (wayoints) provided on the command
+Extract a profile with coordinates (waypoints) provided on the command
 line (North Carolina data set):
 
 ```sh

--- a/raster/r.resamp.bspline/r.resamp.bspline.html
+++ b/raster/r.resamp.bspline/r.resamp.bspline.html
@@ -39,7 +39,7 @@ is defined by <b>ew_step</b> for the east-west direction and
 spline step values should be no less than the east-west and north-south
 resolutions of the input map. Each non-NULL cell observation is modeled as a
 linear function of the non-zero splines in the area around the observation.
-The least squares regression predicts the the coefficients of these linear functions.
+The least squares regression predicts the coefficients of these linear functions.
 Regularization avoids the need to have one one observation and one coefficient
 for each spline (in order to avoid instability).
 

--- a/raster/r.resamp.bspline/r.resamp.bspline.md
+++ b/raster/r.resamp.bspline/r.resamp.bspline.md
@@ -41,7 +41,7 @@ north-south direction. For optimal performance, the spline step values
 should be no less than the east-west and north-south resolutions of the
 input map. Each non-NULL cell observation is modeled as a linear
 function of the non-zero splines in the area around the observation. The
-least squares regression predicts the the coefficients of these linear
+least squares regression predicts the coefficients of these linear
 functions. Regularization avoids the need to have one one observation
 and one coefficient for each spline (in order to avoid instability).
 

--- a/raster/r.resamp.rst/DESCRIPTION
+++ b/raster/r.resamp.rst/DESCRIPTION
@@ -150,7 +150,7 @@ IL_write_temp_2d(ngstc,nszc,offset2,Tmp_fd_z,Tmp_fd_dx,Tmp_fd_dy,Tmp_fd_xx,
     FILE   *Tmp_fd_z,*Tmp_fd_dx,*Tmp_fd_dy,  /* Temp files */
            *Tmp_fd_xx,*Tmp_fd_yy,*Tmp_fd_xy;
     double *az,*adx,*ady,*adxx,*adyy,*adxy;  /* interpolated values */
-    int    scik1,scik2,scik3;                /* mutipliers for interp. values */
+    int    scik1,scik2,scik3;                /* multipliers for interp. values */
 
 Writes az,adx,...,adxy into appropriate place (depending on ngstc, nszc and
 offset) in corresponding temp file */

--- a/raster/r.resamp.rst/main.c
+++ b/raster/r.resamp.rst/main.c
@@ -79,7 +79,7 @@ static int fdinp, fdsmooth = -1;
  * for output grid xmin ... - coordinates of corners of output grid
  *
  * subroutines input_data - input of data x,y,z (test function or measured
- * data) iterpolate - interpolation of z-values and derivatives to grid
+ * data) interpolate - interpolation of z-values and derivatives to grid
  * secpar_loop- computation of secondary(morphometric) parameters output -
  * output of gridded data and derivatives/sec.parameters check_at_points -
  * interpolation of z-values to given point x,y

--- a/raster/r.ros/main.c
+++ b/raster/r.ros/main.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
         etaM_dead,              /*dead fuel misture damping coefficient */
         etaM_live,              /*live fuel misture damping coefficient */
         xmext,                  /*live fuel moisture of extinction */
-        phi_ws,                 /*wind and slope conbined coefficient */
+        phi_ws,                 /*wind and slope combined coefficient */
         wmfd, fdmois, fined, finel;
 
     /*other local variables */

--- a/raster/r.sim/simlib/input.c
+++ b/raster/r.sim/simlib/input.c
@@ -452,7 +452,7 @@ float **create_float_matrix(int rows, int cols, float fill_value)
 
     G_verbose_message("Creating float matrix with value %g", fill_value);
 
-    /* Allocate the float marix */
+    /* Allocate the float matrix */
     matrix = G_alloc_fmatrix(rows, cols);
 
     for (row = 0; row < rows; row++) {
@@ -473,7 +473,7 @@ double **create_double_matrix(int rows, int cols, double fill_value)
 
     G_verbose_message("Creating double matrix with value %g", fill_value);
 
-    /* Allocate the float marix */
+    /* Allocate the float matrix */
     matrix = G_alloc_matrix(rows, cols);
 
     for (row = 0; row < rows; row++) {
@@ -502,7 +502,7 @@ float **read_float_raster_map(int rows, int cols, char *name, float unitconv)
     /* Allocate the row buffer */
     row_buff = Rast_allocate_f_buf();
 
-    /* Allocate the float marix */
+    /* Allocate the float matrix */
     matrix = G_alloc_fmatrix(rows, cols);
 
     for (row = 0; row < rows; row++) {
@@ -545,7 +545,7 @@ double **read_double_raster_map(int rows, int cols, char *name, double unitconv)
     /* Allocate the row buffer */
     row_buff = Rast_allocate_d_buf();
 
-    /* Allocate the double marix */
+    /* Allocate the double matrix */
     matrix = G_alloc_matrix(rows, cols);
 
     for (row = 0; row < rows; row++) {

--- a/raster/r.solute.transport/main.c
+++ b/raster/r.solute.transport/main.c
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
     /*write the result to the output file */
     N_write_array_2d_to_rast(data->c, param.output->answer);
 
-    /*Compute the the velocity field if required and write the result into three
+    /*Compute the velocity field if required and write the result into three
      * rast maps */
     if (param.vector_x->answer || param.vector_y->answer) {
         xcomp = N_alloc_array_2d(geom->cols, geom->rows, 1, DCELL_TYPE);

--- a/raster/r.spread/main.c
+++ b/raster/r.spread/main.c
@@ -426,7 +426,7 @@ int main(int argc, char *argv[])
     ncols = Rast_window_cols();
 
     /*transfor measurement unit from meters to centimeters due to ROS unit
-     *if the input ROSs are in m/min units, cancell the following*/
+     *if the input ROSs are in m/min units, cancel the following*/
     window.ns_res = 100 * window.ns_res;
     window.ew_res = 100 * window.ew_res;
 

--- a/raster/r.spread/replaceHa.c
+++ b/raster/r.spread/replaceHa.c
@@ -4,7 +4,7 @@
  *  This routine is to delete a cell in a heap.
  *  It 1) searches the cell backward and sequentially from
  *        the heap (if not found, returns a error message),
- *     2) repalce that cell with the new min_cost and
+ *     2) replace that cell with the new min_cost and
  *        restore a heap order.
  *
  ************************************************************/

--- a/raster/r.spread/spread.c
+++ b/raster/r.spread/spread.c
@@ -97,7 +97,7 @@ void spread(void)
             to_cell = to_cell->next;
         }
 #endif
-        /*Get a cell in the list each time, and compute culmulative costs
+        /*Get a cell in the list each time, and compute cumulative costs
          *via the current spread cell*/
         to_cell = front_cell;
         while (to_cell != NULL) {
@@ -206,7 +206,7 @@ int cumulative(struct costHa *pres_cell, struct cell_ptrHa *to_cell,
     cost = 0.0;
     count = 1;
     while (count <= xsteps) {
-        /*Can't go through a barrer in a path */
+        /*Can't go through a barrier in a path */
         if (DATA(map_base, xrow, xcol) <= 0)
             return -1;
 

--- a/raster/r.stats/cell_stats.c
+++ b/raster/r.stats/cell_stats.c
@@ -54,7 +54,7 @@ int cell_stats(int fd[], int with_percents, int with_counts, int with_areas,
 
             /* we can't compute hash on null values, so we change all
                nulls to max+1, set NULL_CELL to max+1, and later compare
-               with NULL_CELL to chack for nulls */
+               with NULL_CELL to check for nulls */
             reset_null_vals(cell[i], ncols);
         }
 

--- a/raster/r.stats/stats.c
+++ b/raster/r.stats/stats.c
@@ -105,7 +105,7 @@ void fix_max_fp_val(CELL *cell, int ncols)
 
 /* we can't compute hash on null values, so we change all
  *  nulls to max+1, set NULL_CELL to max+1, and later compare
- *  with NULL_CELL to chack for nulls */
+ *  with NULL_CELL to check for nulls */
 void reset_null_vals(CELL *cell, int ncols)
 {
     while (ncols-- > 0) {

--- a/raster/r.stream.extract/dseg.c
+++ b/raster/r.stream.extract/dseg.c
@@ -106,7 +106,7 @@ int dseg_read_raster(DSEG *dseg, char *map_name, char *mapset)
         if (Segment_put_row(&(dseg->seg), (DCELL *)dbuffer, row) < 0) {
             G_free(dbuffer);
             Rast_close(map_fd);
-            G_warning(_("Inable to segment put row %d for raster <%s>"), row,
+            G_warning(_("Unable to segment put row %d for raster <%s>"), row,
                       map_name);
             return -1;
         }

--- a/raster/r.stream.extract/main.c
+++ b/raster/r.stream.extract/main.c
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
     ncols = Rast_window_cols();
     sides = 8; /* not a user option */
     c_fac =
-        5; /* not a user option, MFD covergence factor 5 gives best results */
+        5; /* not a user option, MFD convergence factor 5 gives best results */
 
     /* segment structures */
     seg_rows = seg_cols = 64;

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -198,7 +198,7 @@ int ll_correction = FALSE;
 double coslatsq;
 
 /* why not use G_distance() here which switches to geodesic/great
-   circle distace as needed? */
+   circle distance as needed? */
 double distance(double x1, double x2, double y1, double y2)
 {
     if (ll_correction) {

--- a/raster/r.surf.contour/r.surf.contour.html
+++ b/raster/r.surf.contour/r.surf.contour.html
@@ -45,7 +45,7 @@ and writing <em>output</em>.
 <h2>NOTES</h2>
 
 <em>r.surf.contour</em> works well under the following circumstances:
-1) the contour lines extend to the the edge of the current region,
+1) the contour lines extend to the edge of the current region,
 2) the program is run at the same resolution as that of the input map,
 3) there are no disjointed contour lines,
 and 4) no spot elevation data BETWEEN contour lines exist.  Spot elevations at

--- a/raster/r.surf.contour/r.surf.contour.md
+++ b/raster/r.surf.contour/r.surf.contour.md
@@ -37,7 +37,7 @@ writing *output*.
 ## NOTES
 
 *r.surf.contour* works well under the following circumstances: 1) the
-contour lines extend to the the edge of the current region, 2) the
+contour lines extend to the edge of the current region, 2) the
 program is run at the same resolution as that of the input map, 3) there
 are no disjointed contour lines, and 4) no spot elevation data BETWEEN
 contour lines exist. Spot elevations at the tops of hills and the

--- a/raster/r.texture/r.texture.html
+++ b/raster/r.texture/r.texture.html
@@ -42,7 +42,7 @@ tree species. The usefulness and use of texture is highly dependent on the
 resolution of satellite imagery and on the scale of the human intervention or
 the phenomenon that created the texture (also see the discussion of scale
 dependency below). The user should observe the phenomenon visually in order to
-determine an adequat setting of the <em>size</em> parameter.
+determine an adequate setting of the <em>size</em> parameter.
 
 <p>
 The output of <em>r.texture</em> can constitute very useful additional variables

--- a/raster/r.texture/r.texture.md
+++ b/raster/r.texture/r.texture.md
@@ -39,7 +39,7 @@ species. The usefulness and use of texture is highly dependent on the
 resolution of satellite imagery and on the scale of the human
 intervention or the phenomenon that created the texture (also see the
 discussion of scale dependency below). The user should observe the
-phenomenon visually in order to determine an adequat setting of the
+phenomenon visually in order to determine an adequate setting of the
 *size* parameter.
 
 The output of *r.texture* can constitute very useful additional

--- a/raster/r.thin/io.c
+++ b/raster/r.thin/io.c
@@ -59,7 +59,7 @@ CELL *get_a_row(int row)
 
 int put_a_row(int row, CELL *buf)
 {
-    /* rowio.h defines this withe 2nd argument as char * */
+    /* rowio.h defines this with the 2nd argument as char * */
     Rowio_put(&row_io, (char *)buf, row);
 
     return 0;

--- a/raster/r.thin/r.thin.html
+++ b/raster/r.thin/r.thin.html
@@ -46,15 +46,15 @@ Intelligence</em>, vol. 12, No. 6, June 1990.  The
 definition Jang and Chin give of the thinning process is
 "successive removal of outer layers of pixels from an
 object while retaining any pixels whose removal would alter
-the connectivity or shorten the legs of the sceleton."
+the connectivity or shorten the legs of the skeleton."
 
 <p>
-The sceleton is finally thinned when the thinning process
+The skeleton is finally thinned when the thinning process
 converges; i.e., "no further pixels can be removed without
-altering the connectivity or shortening the sceleton legs"
+altering the connectivity or shortening the skeleton legs"
 (p. 541).  The authors prove that the thinning process
 described always converges and produces one-pixel thick
-sceletons.  The number of iterations depends on the
+skeletons.  The number of iterations depends on the
 original thickness of the object.  Each iteration peels off
 the outside pixels from the object.  Therefore, if the
 object is &lt;= n pixels thick, the algorithm should

--- a/raster/r.thin/r.thin.md
+++ b/raster/r.thin/r.thin.md
@@ -33,13 +33,13 @@ Ronlad T. Chin in *Transactions on Pattern Analysis and Machine
 Intelligence*, vol. 12, No. 6, June 1990. The definition Jang and Chin
 give of the thinning process is "successive removal of outer layers of
 pixels from an object while retaining any pixels whose removal would
-alter the connectivity or shorten the legs of the sceleton."
+alter the connectivity or shorten the legs of the skeleton."
 
-The sceleton is finally thinned when the thinning process converges;
+The skeleton is finally thinned when the thinning process converges;
 i.e., "no further pixels can be removed without altering the
-connectivity or shortening the sceleton legs" (p. 541). The authors
+connectivity or shortening the skeleton legs" (p. 541). The authors
 prove that the thinning process described always converges and produces
-one-pixel thick sceletons. The number of iterations depends on the
+one-pixel thick skeletons. The number of iterations depends on the
 original thickness of the object. Each iteration peels off the outside
 pixels from the object. Therefore, if the object is \<= n pixels thick,
 the algorithm should converge in \<= iterations.

--- a/raster/r.timestamp/test_suite/test.r.timestamp.sh
+++ b/raster/r.timestamp/test_suite/test.r.timestamp.sh
@@ -6,7 +6,7 @@
 # The region setting should work for UTM and LL test locations
 g.region s=0 n=80 w=0 e=120 b=0 t=50 res=10 res3=10 -p3
 
-# Lets gerenate a test map
+# Lets generate a test map
 r.mapcalc --o expr="map = 1"
 
 # The first @test uses several different absolute datum formats

--- a/raster/r.uslek/prct2tex.c
+++ b/raster/r.uslek/prct2tex.c
@@ -22,7 +22,7 @@ double point_in_triangle(double point_x, double point_y, double point_z,
     double answer2_x, answer2_y, answer2_z;
     double answer3_x, answer3_y, answer3_z;
 
-    /* Consider three points forming a trinagle from a given soil class boundary
+    /* Consider three points forming a triangle from a given soil class boundary
      * ABC */
     /* Consider F an additional point in space */
     double af1, af2, af3; /*Points for vector AF */

--- a/raster/r.viewshed/distribute.cpp
+++ b/raster/r.viewshed/distribute.cpp
@@ -1089,7 +1089,7 @@ int is_center_gradient_occluded(AEvent *e, double gradient, Viewpoint *vp)
 }
 
 /***********************************************************************
-called when dropping an event e, high is the highest gradiant value
+called when dropping an event e, high is the highest gradient value
 //in its sector*/
 void print_dropped(AEvent *e, Viewpoint *vp, double high)
 {

--- a/raster/r.viewshed/distribute.h
+++ b/raster/r.viewshed/distribute.h
@@ -127,8 +127,7 @@ void insert_event_in_sector_no_drop(AEvent *e, int s, AMI_STREAM<AEvent> *str,
 /* returns 1 if the center of event is occluded by the gradient, which
    is assumed to be in line with the event  */
 int is_center_gradient_occluded(AEvent *e, double gradient, Viewpoint *vp);
-
-/* called when dropping an event e, high is the highest gradiant value
+/* called when dropping an event e, high is the highest gradient value
    in its sector */
 void print_dropped(AEvent *e, Viewpoint *vp, double high);
 

--- a/raster/r.viewshed/grass.cpp
+++ b/raster/r.viewshed/grass.cpp
@@ -116,7 +116,7 @@ GridHeader *read_header(char *rastName, Cell_head *region)
         G_warning(
             _("East-west resolution does not equal north-south resolution. "
               "The viewshed computation assumes the cells are square, so in "
-              "this case this may result in innacuracies."));
+              "this case this may result in inaccuracies."));
         //    exit(EXIT_FAILURE);
     }
     hd->ew_res = region->ew_res;

--- a/raster/r.viewshed/main.cpp
+++ b/raster/r.viewshed/main.cpp
@@ -300,8 +300,8 @@ int main(int argc, char *argv[])
             BASE_CASE = 1;
 
             /*if the user set the FORCE_DISTRIBUTION flag, then the
-               algorithm runs in the fuly recursive mode (even if this is
-               not necessary). This is used solely for debugging purpses  */
+               algorithm runs in the fully recursive mode (even if this is
+               not necessary). This is used solely for debugging purposes */
 #ifdef FORCE_DISTRIBUTION
         BASE_CASE = 0;
 #endif

--- a/raster/r.viewshed/visibility.cpp
+++ b/raster/r.viewshed/visibility.cpp
@@ -238,7 +238,7 @@ float angleVisibilityOutput(float x)
 /* ------------------------------------------------------------ */
 /* visgrid is the structure that records the visibility information
    after the sweep is done.  Use it to write the visibility output
-   grid and then distroy it.
+   grid and then destroy it.
  */
 void save_inmem_visibilitygrid(MemoryVisibilityGrid *visgrid,
                                ViewOptions viewOptions, Viewpoint vp)

--- a/raster/r.walk/TODO
+++ b/raster/r.walk/TODO
@@ -11,7 +11,7 @@ path, because "cost" right now is ("time travel in seconds" + Lamba *
 
 it would be interesting to model all the aspects that influence the
 speed movement "inside" the a,b,c,d (see the r.walk documentation)
-parameters going back to a phisical meaning (speed in a specific
+parameters going back to a physical meaning (speed in a specific
 condition) of the formula (the real time in second that the subject
 need to move between two points).
 

--- a/raster/r.watershed/shed/com_line.c
+++ b/raster/r.watershed/shed/com_line.c
@@ -274,8 +274,8 @@ int com_line_Gwater(INPUT *input, OUTPUT *output)
        r.stats), but the format is supposed to be "user-friendly" to
        hydrologists. For the stats to be created, the armsed file output needs
        to exist. For the stats to be an option in this program: 1) it should be
-       querried before the armsed file query, and 2) make the armsed file query
-       manditory if this option is invoked.
+       queried before the armsed file query, and 2) make the armsed file query
+       mandatory if this option is invoked.
      */
 
     G_message(_("\n%s will generate a lot of output.  Indicate a file"),

--- a/raster/r.watershed/testsuite/r_watershed_test.py
+++ b/raster/r.watershed/testsuite/r_watershed_test.py
@@ -124,7 +124,7 @@ class TestWatershed(TestCase):
             stream=self.stream_2,
             length_slope=self.lengthslope_2,
         )
-        # Use the assertRastersNoDifference with precsion 100 to see if close
+        # Use the assertRastersNoDifference with precision 100 to see if close
         # Compare stream output
         self.assertRastersNoDifference(self.stream_2, self.stream, 100)
         # Compare length_slope output

--- a/raster/rasterintro.html
+++ b/raster/rasterintro.html
@@ -89,7 +89,7 @@ and other metadata.
 Metadata such as map title, units, vertical datum etc. can be updated
 with <a href="r.support.html">r.support</a>. Timestamps are managed
 with <a href="r.timestamp.html">r.timestamp</a>. Region extent and
-resolution are mangaged with <a href="r.region.html">r.region</a>.
+resolution are managed with <a href="r.region.html">r.region</a>.
 
 
 <h3>Raster map operations</h3>

--- a/raster/rasterintro.md
+++ b/raster/rasterintro.md
@@ -87,7 +87,7 @@ such as region extent, data range, data type, creation history, and
 other metadata. Metadata such as map title, units, vertical datum etc.
 can be updated with [r.support](r.support.md). Timestamps are managed
 with [r.timestamp](r.timestamp.md). Region extent and resolution are
-mangaged with [r.region](r.region.md).
+managed with [r.region](r.region.md).
 
 ## Raster map operations
 

--- a/raster3d/r3.gwflow/main.c
+++ b/raster3d/r3.gwflow/main.c
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
         N_write_array_3d_to_rast3d(budget, param.budget->answer, 1);
     }
 
-    /*Compute the the velocity field if required and write the result into three
+    /*Compute the velocity field if required and write the result into three
      * rast3d maps */
     if (param.vector_x->answer || param.vector_y->answer ||
         param.vector_z->answer) {

--- a/raster3d/r3.in.lidar/main.c
+++ b/raster3d/r3.in.lidar/main.c
@@ -7,7 +7,7 @@
  * PURPOSE:      Imports LAS LiDAR point clouds to a 3D raster map using
  *               aggregate statistics.
  *
- * COPYRIGHT:    (C) 2016 Vaclav Petras and the The GRASS Development Team
+ * COPYRIGHT:    (C) 2016 Vaclav Petras and The GRASS Development Team
  *
  *               This program is free software under the GNU General Public
  *               License (>=v2). Read the file COPYING that comes with GRASS

--- a/raster3d/r3.in.v5d/r3.in.v5d.html
+++ b/raster3d/r3.in.v5d/r3.in.v5d.html
@@ -9,7 +9,7 @@ for interactive visualization of large 5D gridded data sets such as those
 produced by numerical weather models. The user can make isosurfaces, contour
 line slices, colored slices, volume renderings, etc. of data in a 3D raster map,
 then rotate and animate the images in real time. There's also a feature
-for wind trajectory tracing, a way to make text anotations for publications,
+for wind trajectory tracing, a way to make text annotations for publications,
 support for interactive data analysis, etc.
 
 <h2>SEE ALSO</h2>

--- a/raster3d/r3.in.v5d/r3.in.v5d.md
+++ b/raster3d/r3.in.v5d/r3.in.v5d.md
@@ -9,7 +9,7 @@ visualization of large 5D gridded data sets such as those produced by
 numerical weather models. The user can make isosurfaces, contour line
 slices, colored slices, volume renderings, etc. of data in a 3D raster
 map, then rotate and animate the images in real time. There's also a
-feature for wind trajectory tracing, a way to make text anotations for
+feature for wind trajectory tracing, a way to make text annotations for
 publications, support for interactive data analysis, etc.
 
 ## SEE ALSO

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -408,7 +408,7 @@ void v5dPrintStruct(const v5dstruct *v)
         printf("Rotated equidistant projection:\n");
         printf("\tLatitude of grid(0,0): %f\n", v->ProjArgs[0]);
         printf("\tLongitude of grid(0,0): %f\n", v->ProjArgs[1]);
-        printf("\tRow Increment: %f degress\n", v->ProjArgs[2]);
+        printf("\tRow Increment: %f degrees\n", v->ProjArgs[2]);
         printf("\tColumn Increment: %f degrees\n", v->ProjArgs[3]);
         printf("\tCenter Latitude: %f\n", v->ProjArgs[4]);
         printf("\tCenter Longitude: %f\n", v->ProjArgs[5]);

--- a/raster3d/r3.info/main.c
+++ b/raster3d/r3.info/main.c
@@ -18,7 +18,7 @@
 
 /* \todo
  *    History support still not full implemented.
- *    Only parts of the timestep functionality are implemented, the timzone is
+ *    Only parts of the timestep functionality are implemented, the timezone is
  * missed ;).
  */
 

--- a/raster3d/r3.out.ascii/main.c
+++ b/raster3d/r3.out.ascii/main.c
@@ -164,7 +164,7 @@ void writeHeaderString3(FILE *fp, char *valueString, const char *value)
 
 /*---------------------------------------------------------------------------*/
 
-/* Opens the output acsii file and writes the header.
+/* Opens the output ascii file and writes the header.
  * Returns the file handle for the output file.
  */
 FILE *openAscii(char *asciiFile, RASTER3D_Region region)

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -212,8 +212,8 @@ void convert(char *fileout, int rows, int cols, int depths, int trueCoords)
        for loops are different to r3.out.ascii and r3.to.sites - hmpf */
 
     /*AV*/
-    /* IT WORKS WHIT A PARTICULAR FOR LOOP PROBABLY BECAUSE THE DATA
-       ARE NOT STORED IN A 3D MATRIX [z,y,x] BUT IN A POINTER
+    /* IT WORKS WITH A PARTICULAR FOR LOOP PROBABLY BECAUSE THE DATA
+       IS NOT STORED IN A 3D MATRIX [z,y,x] BUT IN A POINTER
        MANAGED AS (z,x,y) */
     for (z = 0; z < depths; z++) {
         G_percent(z, depths, 1);

--- a/raster3d/r3.out.v5d/r3.out.v5d.html
+++ b/raster3d/r3.out.v5d/r3.out.v5d.html
@@ -10,7 +10,7 @@ for interactive visualization of large 5D gridded data sets such as those
 produced by numerical weather models. The user can make isosurfaces, contour
 line slices, colored slices, volume renderings, etc. of data in a 3D raster map,
 then rotate and animate the images in real time. There's also a feature
-for wind trajectory tracing, a way to make text anotations for publications,
+for wind trajectory tracing, a way to make text annotations for publications,
 support for interactive data analysis, etc.
 
 <h2>SEE ALSO</h2>

--- a/raster3d/r3.out.v5d/r3.out.v5d.md
+++ b/raster3d/r3.out.v5d/r3.out.v5d.md
@@ -10,7 +10,7 @@ visualization of large 5D gridded data sets such as those produced by
 numerical weather models. The user can make isosurfaces, contour line
 slices, colored slices, volume renderings, etc. of data in a 3D raster
 map, then rotate and animate the images in real time. There's also a
-feature for wind trajectory tracing, a way to make text anotations for
+feature for wind trajectory tracing, a way to make text annotations for
 publications, support for interactive data analysis, etc.
 
 ## SEE ALSO

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -405,7 +405,7 @@ void v5dPrintStruct(const v5dstruct *v)
         printf("Rotated equidistant projection:\n");
         printf("\tLatitude of grid(0,0): %f\n", v->ProjArgs[0]);
         printf("\tLongitude of grid(0,0): %f\n", v->ProjArgs[1]);
-        printf("\tRow Increment: %f degress\n", v->ProjArgs[2]);
+        printf("\tRow Increment: %f degrees\n", v->ProjArgs[2]);
         printf("\tColumn Increment: %f degrees\n", v->ProjArgs[3]);
         printf("\tCenter Latitude: %f\n", v->ProjArgs[4]);
         printf("\tCenter Longitude: %f\n", v->ProjArgs[5]);

--- a/raster3d/r3.out.vtk/testsuite/test_r3_out_vtk.sh
+++ b/raster3d/r3.out.vtk/testsuite/test_r3_out_vtk.sh
@@ -27,7 +27,7 @@ r3.out.vtk --o input=volume_null output=test_volume_null_1_cells.vtk precision=3
 r3.out.vtk -p --o input=volume_null output=test_volume_null_1_points.vtk precision=3 null=0
 
 # The second @test adds rgb and vector maps. We re-use the created volume map
-# for vector creation. The rgb value must range fom 0 - 255. The generated @files
+# for vector creation. The rgb value must range from 0 - 255. The generated @files
 # should be compared with the reference data.
 r3.out.vtk --o rgbmaps=volume_rgb,volume_rgb,volume_rgb vectormaps=volume_null,volume_null,volume_null input=volume_null output=test_volume_null_1_cells_rgb_vect.vtk precision=3 null=-1.0
 r3.out.vtk -p --o rgbmaps=volume_rgb,volume_rgb,volume_rgb vectormaps=volume_null,volume_null,volume_null input=volume_null output=test_volume_null_1_points_rgb_vect.vtk precision=3 null=-1.0

--- a/raster3d/r3.timestamp/test_suite/test.r3.timestamp.sh
+++ b/raster3d/r3.timestamp/test_suite/test.r3.timestamp.sh
@@ -6,7 +6,7 @@
 # The region setting should work for UTM and LL test locations
 g.region s=0 n=80 w=0 e=120 b=0 t=50 res=10 res3=10 -p3
 
-# Lets gerenate a test map
+# Lets generate a test map
 r3.mapcalc --o expr="map3d = 1"
 
 # The first @test uses several different absolute datum formats


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.ps,*.raw,*.svg,./contributors_extra.csv,./translators.csv,./mswindows/external,./lib/external,./utils/fix_typos.sh" -L aline,alle,alog,ans,anull,apoints,asnd,attch,bufer,buffr,bui,buildin,build-in,bund,clen,co-ordinate,co-ordinates,datas,delt,doubleclick,dout,dudo,dum,dyin,enew,entrys,eto,fle,flor,fpr,fromm,greif,huld,ihs,indx,ine,ines,infex,infp,inout,inpt,ist,linke,linz,lsat,makin,mapp,mis,modul,nam,nams,nd,neast,ned,nin,numer,observ,offsetp,oint,ons,ontext,parm,parms,partialy,redner,re-use,re-used,rin,selectin,sistem,siz,strin,strng,tht,vas,vizual`