### PR TITLE
cmake: increase required version to 3.22

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,15 +27,16 @@ jobs:
     build-cmake:
         runs-on: ubuntu-22.04
         env:
-            CMakeVersion: "3.16.0"
+            CMakeVersion: "3.22.0"
         steps:
             - name: Checkout GRASS
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install CMake
               run: |
                 cd ${GITHUB_WORKSPACE}
-                arch=$(uname -s)-$(uname -m)
-                wget https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-${arch}.tar.gz
+                arch=$(echo $(uname -s)-$(uname -m) | awk '{print tolower($0)}')
+                v=v${{ env.CMakeVersion }}/cmake-${{ env.CMakeVersion }}-${arch}.tar.gz
+                wget https://github.com/Kitware/CMake/releases/download/$v
                 tar xzf cmake-${{ env.CMakeVersion }}-${arch}.tar.gz
                 echo "CMAKE_DIR=$GITHUB_WORKSPACE/cmake-${{ env.CMakeVersion }}-${arch}/bin" >> $GITHUB_ENV
                 echo "$GITHUB_WORKSPACE/cmake-${{ env.CMakeVersion }}-${arch}/bin" >> $GITHUB_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 #[[


### PR DESCRIPTION
Increase required CMake version to 3.22 (Nov 2021), replacing current version 3.16 (Nov 2019).

That version would be supported out-of-the-box with, e.g.:
- Debian 12 Bookworm (current stable)
- Fedora 36 (EOL)
- Slackware 15.0 (current stable)
- Ubuntu 22.04 (Jammy Jellyfish, EOL in Apr 2027)

See further platforms: https://repology.org/project/cmake/versions 

Otherwise it may be installed through pip.

Version 3.22 comes with a number of useful improvements, among others for Apple ARM platform support, FindGDAL and FindPostgreSQL. See links below for news posts for each upgrade:

https://cmake.org/cmake/help/latest/release/3.17.html
https://cmake.org/cmake/help/latest/release/3.18.html
https://cmake.org/cmake/help/latest/release/3.19.html
https://cmake.org/cmake/help/latest/release/3.20.html
https://cmake.org/cmake/help/latest/release/3.21.html
https://cmake.org/cmake/help/latest/release/3.22.html