### PR TITLE
v.net: Fix Resource Leak Issue in report.c

### DIFF
--- a/vector/v.net/report.c
+++ b/vector/v.net/report.c
@@ -69,6 +69,7 @@ int report(struct Map_info *In, int afield, int nfield, int action)
             }
             fprintf(stdout, "%d %d %d\n", cat_line, cat_node[0], cat_node[1]);
         }
+        Vect_destroy_boxlist(List);
     }
     else { /* node report */
         int elem, nelem, type, k, l;
@@ -127,6 +128,7 @@ int report(struct Map_info *In, int afield, int nfield, int action)
                 }
             }
         }
+        Vect_destroy_list(List);
     }
     Vect_destroy_cats_struct(Cats);
     Vect_destroy_cats_struct(Cats2);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207655)
Used `Vect_destroy_boxlist(), Vect_destroy_list()` to fix this issue.