### PR TITLE
grass.gunittest: Allow floating point for `--min-success` argument

### DIFF
--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -194,7 +194,7 @@ def main():
         dest="min_success",
         action="store",
         default="100",
-        type=int,
+        type=float,
         help=(
             "Minimum success percentage (lower percentage"
             " than this will result in a non-zero return code; values 0-100)"

--- a/python/grass/gunittest/reporters.py
+++ b/python/grass/gunittest/reporters.py
@@ -9,6 +9,8 @@ for details.
 :authors: Vaclav Petras
 """
 
+from __future__ import annotations
+
 import os
 import datetime
 from pathlib import Path
@@ -437,7 +439,7 @@ def percent_to_html(percent):
         color = "orange"
     else:
         color = "green"
-    return '<span style="color: {color}">{percent:.0f}%</span>'.format(
+    return '<span style="color: {color}">{percent:.1f}%</span>'.format(
         percent=percent, color=color
     )
 
@@ -528,6 +530,12 @@ def success_to_html_percent(total, successes):
     return UNKNOWN_NUMBER_HTML
 
 
+def format_percentage(percentage: float | None) -> str:
+    if percentage is not None:
+        return "{nsper:.1f}%".format(nsper=percentage)
+    return "unknown percentage"
+
+
 class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
     unknown_number = UNKNOWN_NUMBER_HTML
 
@@ -602,17 +610,9 @@ class GrassTestFilesHtmlReporter(GrassTestFilesCountingReporter):
             )
         )
 
-        # this is the second place with this function
-        # TODO: provide one implementation
-        def format_percentage(percentage):
-            if percentage is not None:
-                return "{nsper:.0f}%".format(nsper=percentage)
-            return "unknown percentage"
-
         summary_sentence = (
             "\nExecuted {nfiles} test files in {time:}."
-            "\nFrom them"
-            " {nsfiles} files ({nsper}) were successful"
+            "\nFrom them, {nsfiles} files ({nsper}) were successful"
             " and {nffiles} files ({nfper}) failed.\n".format(
                 nfiles=self.test_files,
                 time=self.main_time,
@@ -949,11 +949,6 @@ class GrassTestFilesTextReporter(GrassTestFilesCountingReporter):
 
     def finish(self):
         super().finish()
-
-        def format_percentage(percentage):
-            if percentage is not None:
-                return "{nsper:.0f}%".format(nsper=percentage)
-            return "unknown percentage"
 
         summary_sentence = (
             "\nExecuted {nfiles} test files in {time:}."


### PR DESCRIPTION
Making gunittest accept floating points for `--min-success` was a one word change, and already worked correctly.

I just followed up by making the percentage displayed with a decimal point, and extracting the repeated nested function as noted in a todo note; they were exactly the same and didn't use anything from the outer context, both were "[pure functions](https://en.wikipedia.org/wiki/Pure_function)", and could've been static functions in other languages.

I tried it out on the vector folder, making sure I didn't compile with some required libraries so some tests would fail (for example, no pdal, so v.in.lidar and v.in.pdal would fail)

For 19/31=0.6129032258064516, using 66.7 fails:
```
grass --tmp-project XY --exec     python3 -m grass.gunittest.main     --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc     --min-success 66.7
``` 
![image](https://github.com/user-attachments/assets/9eaeb002-7279-4282-98a4-9e50cfc63c16)

For 19/31=0.6129032258064516, using 61.2 passes:
```
grass --tmp-project XY --exec     python3 -m grass.gunittest.main     --grassdata $HOME --location nc_spm_full_v2alpha2 --location-type nc     --min-success 61.2
``` 
![image](https://github.com/user-attachments/assets/8b7a2421-63ef-4a2d-9ed5-7b3373c8604f)
