### PR TITLE
cmake: use imported PNG::PNG target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 option(WITH_X11 "Build with X11 support ." ${x11_default_option_enabled})
 option(WITH_OPENGL "Build with opengl support ." ON)
 option(WITH_CAIRO "Build with cairo support ." ON)
-option(WITH_LIBPNG "Build with libpng support ." OFF)
+option(WITH_LIBPNG "Build with libpng support ." ON)
 
 # Data storage options
 option(WITH_SQLITE "Build with SQLite support" ON)

--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -117,13 +117,6 @@ endif()
 
 if(WITH_LIBPNG)
   find_package(PNG REQUIRED)
-  if(PNG_FOUND)
-    add_library(LIBPNG INTERFACE IMPORTED GLOBAL)
-    set_property(TARGET LIBPNG PROPERTY INTERFACE_LINK_LIBRARIES
-                                        ${PNG_LIBRARY${find_library_suffix}})
-    set_property(TARGET LIBPNG PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                                        ${PNG_INCLUDE_DIR})
-  endif()
 endif()
 
 # Data storage options
@@ -367,7 +360,7 @@ check_target(GDAL::GDAL HAVE_GDAL)
 check_target(GDAL::GDAL HAVE_OGR)
 check_target(ZLIB HAVE_ZLIB_H)
 check_target(ICONV HAVE_ICONV_H)
-check_target(LIBPNG HAVE_PNG_H)
+check_target(PNG::PNG HAVE_PNG_H)
 check_target(LIBJPEG HAVE_JPEGLIB_H)
 check_target(SQLITE HAVE_SQLITE)
 check_target(POSTGRES HAVE_POSTGRES)

--- a/general/CMakeLists.txt
+++ b/general/CMakeLists.txt
@@ -19,9 +19,7 @@ install(FILES ${OUTDIR}/${GRASS_INSTALL_ETCDIR}/fontcap
         DESTINATION ${GRASS_INSTALL_ETCDIR})
 build_program_in_subdir(g.parser DEPENDS grass_gis FREETYPE)
 build_program_in_subdir(g.pnmcomp DEPENDS grass_gis)
-if(WITH_LIBPNG)
-  build_program_in_subdir(g.ppmtopng DEPENDS grass_gis LIBPNG)
-endif()
+build_program_in_subdir(g.ppmtopng DEPENDS grass_gis PRIMARY_DEPENDS PNG::PNG)
 build_program_in_subdir(g.proj DEPENDS grass_gis grass_gproj PROJ OPTIONAL_DEPENDS GDAL::GDAL)
 
 build_program_in_subdir(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -78,7 +78,7 @@ build_library_in_subdir(
   grass_gis
   ZLIB
   OPTIONAL_DEPENDS
-  LIBPNG)
+  PNG::PNG)
 
 build_library_in_subdir(
   psdriver

--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -292,9 +292,14 @@ build_program_in_subdir(
   PRIMARY_DEPENDS
   PDAL)
 
-if(WITH_LIBPNG)
-  build_program_in_subdir(r.in.png DEPENDS grass_gis grass_raster LIBPNG)
-endif()
+build_program_in_subdir(
+  r.in.png
+  DEPENDS
+  grass_gis
+  grass_raster
+  ${LIBM}
+  PRIMARY_DEPENDS
+  PNG::PNG)
 
 build_program_in_subdir(r.in.poly DEPENDS grass_gis grass_raster)
 
@@ -376,9 +381,8 @@ build_program_in_subdir(r.out.mat DEPENDS grass_gis grass_raster)
 
 build_program_in_subdir(r.out.mpeg DEPENDS grass_gis grass_raster)
 
-if(WITH_LIBPNG)
-  build_program_in_subdir(r.out.png DEPENDS grass_gis grass_raster LIBPNG)
-endif()
+build_program_in_subdir(r.out.png DEPENDS grass_gis grass_raster
+                        PRIMARY_DEPENDS PNG::PNG)
 
 build_program_in_subdir(r.out.pov DEPENDS grass_gis grass_raster)
 


### PR DESCRIPTION
Use the imported PNG::PNG target from CMake's FindPNG.