### PR TITLE
cmake: fix Native Language Support (NLS) support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Install dependencies
               run: |
                 sudo apt-get update -y
-                sudo apt-get install -y wget git gawk findutils ninja-build libpq-dev unixodbc-dev
+                sudo apt-get install -y wget git gawk findutils ninja-build libpq-dev gettext unixodbc-dev
                 xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
                     sudo apt-get install -y --no-install-recommends --no-install-suggests
             - name: Print build environment variables
@@ -60,7 +60,7 @@ jobs:
             - name: Configure
               run: |
                 cmake ${CMAKE_OPTIONS} -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -G Ninja \
-                  -DCMAKE_INSTALL_PREFIX=$HOME/install -DWITH_NLS=OFF -DWITH_GUI=OFF -DWITH_DOCS=OFF \
+                  -DCMAKE_INSTALL_PREFIX=$HOME/install -DWITH_NLS=ON -DWITH_GUI=OFF -DWITH_DOCS=OFF \
                   -DWITH_READLINE=ON -DWITH_ODBC=ON
             - name: Print CMakeCache.txt
               shell: bash -el {0}

--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -171,12 +171,6 @@ if(WITH_NLS)
     set(MSGMERGE ${GETTEXT_MSGMERGE_EXECUTABLE})
   endif()
   find_package(Intl REQUIRED)
-  if(Intl_FOUND AND NOT TARGET Intl::Intl)
-    add_library(Intl::Intl INTERFACE IMPORTED GLOBAL)
-    set_target_properties(
-      Intl::Intl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Intl_INCLUDE_DIR}"
-                            INTERFACE_LINK_LIBRARIES "${Intl_LIBRARY}")
-  endif()
 endif()
 
 # Computing options

--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -170,6 +170,13 @@ if(WITH_NLS)
     set(MSGFMT ${GETTEXT_MSGFMT_EXECUTABLE})
     set(MSGMERGE ${GETTEXT_MSGMERGE_EXECUTABLE})
   endif()
+  find_package(Intl REQUIRED)
+  if(Intl_FOUND AND NOT TARGET Intl::Intl)
+    add_library(Intl::Intl INTERFACE IMPORTED GLOBAL)
+    set_target_properties(
+      Intl::Intl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Intl_INCLUDE_DIR}"
+                            INTERFACE_LINK_LIBRARIES "${Intl_LIBRARY}")
+  endif()
 endif()
 
 # Computing options

--- a/lib/gis/CMakeLists.txt
+++ b/lib/gis/CMakeLists.txt
@@ -26,6 +26,7 @@ build_module(
   BZIP2
   ZSTD
   Iconv::Iconv
+  Intl::Intl
   # REGEX
   PostgreSQL::PostgreSQL
   DEFS

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -3,31 +3,48 @@
   TODO: implement update and creation
 #]===========================================================================]
 
-add_custom_target(generate_mo_files ALL COMMENT "Generate mo files")
+file(GLOB po_files "${CMAKE_CURRENT_SOURCE_DIR}/po/*.po")
 
+add_custom_target(generate_mo_files_dir ALL COMMENT "Create locale directory")
 add_custom_command(
-  TARGET generate_mo_files
+  TARGET generate_mo_files_dir
   PRE_BUILD
   COMMAND ${CMAKE_COMMAND} -E make_directory
           ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}
   BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR})
 
-file(GLOB po_files "${CMAKE_CURRENT_SOURCE_DIR}/po/*.po")
+set(_locales ${po_files})
+list(TRANSFORM _locales REPLACE "^([^_]+)_(.*)\.po$" "\\2")
+list(REMOVE_DUPLICATES _locales)
+foreach(_locale ${_locales})
+  add_custom_target(
+    generate_mo_files_dir_${_locale}
+    DEPENDS generate_mo_files_dir
+    COMMENT "Create locale specific directories")
+  add_custom_command(
+    OUTPUT generate_mo_files_dir_${_locale}
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+            ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale})
+endforeach()
+unset(_locales)
+
 foreach(po_file ${po_files})
   get_filename_component(po_file_name ${po_file} NAME)
+  string(REGEX REPLACE "^([^_]+)_(.*)\.po$" "\\2" _locale ${po_file_name})
   string(REGEX REPLACE "^([^_]+)_(.*)\.po" "\\2/LC_MESSAGES/\\1.mo" mo_file
                        ${po_file_name})
   get_filename_component(mo_dir ${mo_file} DIRECTORY)
 
+  add_custom_target(
+    generate_mo_files_${po_file_name} ALL
+    DEPENDS generate_mo_files_dir_${_locale}
+    COMMENT "Generate mo files")
+
   add_custom_command(
-    TARGET generate_mo_files
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-            ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_dir}
+    TARGET generate_mo_files_${po_file_name}
     COMMAND ${MSGFMT} --statistics -o
             ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_file} ${po_file}
-    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_file}
-               ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_dir})
+    BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_file})
 endforeach()
 
 install(DIRECTORY ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/


### PR DESCRIPTION
Fix Native Language Support (NLS) support with CMake builds.

~~This is another reason to increase CMake required version to 3.22 (#5269). The version of FindIntl from 3.16 is not particularly good and we'll have to use a custom one if staying with 3.16.
I included here the version of 3.22, for "proof of concept".~~