### PR TITLE
docs: Build Markdown addon index using core index tooling

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -116,11 +116,13 @@ jobs:
           mkdir "$MKDOCS_DIR/source/addons"
           mv -v addons-build-dir/docs/md/source/* "$MKDOCS_DIR/source/addons"
 
-      - name: Rebuild keywords
+      - name: Build index and rebuild keywords
         run: |
           export ARCH="$(grass --config arch)"
           export ARCH_DISTDIR="$(grass --config path)"
           export VERSION_NUMBER="$VERSION"
+          grass --tmp-project XY --exec \
+            python ./man/build_full_index.py md index "$MKDOCS_DIR/source/addons"
           grass --tmp-project XY --exec \
             python grass/man/build_keywords.py md "$MKDOCS_DIR/source" "$MKDOCS_DIR/source/addons"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -122,7 +122,7 @@ jobs:
           export ARCH_DISTDIR="$(grass --config path)"
           export VERSION_NUMBER="$VERSION"
           grass --tmp-project XY --exec \
-            python ./man/build_full_index.py md index "$MKDOCS_DIR/source/addons" addons
+            python grass/man/build_full_index.py md index "$MKDOCS_DIR/source/addons" addons
           grass --tmp-project XY --exec \
             python grass/man/build_keywords.py md "$MKDOCS_DIR/source" "$MKDOCS_DIR/source/addons"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -122,7 +122,7 @@ jobs:
           export ARCH_DISTDIR="$(grass --config path)"
           export VERSION_NUMBER="$VERSION"
           grass --tmp-project XY --exec \
-            python ./man/build_full_index.py md index "$MKDOCS_DIR/source/addons"
+            python ./man/build_full_index.py md index "$MKDOCS_DIR/source/addons" addons
           grass --tmp-project XY --exec \
             python grass/man/build_keywords.py md "$MKDOCS_DIR/source" "$MKDOCS_DIR/source/addons"
 

--- a/man/Makefile
+++ b/man/Makefile
@@ -151,7 +151,7 @@ $(HTMLDIR)/full_index.html: $(ALL_HTML) build_full_index.py build_html.py
 	$(call build,full_index)
 	touch $@
 
-$(MDDIR)/source/full_index.md: $(ALL_MD) build_full_index.py build_html.py
+$(MDDIR)/source/full_index.md: $(ALL_MD) build_full_index.py build_md.py
 	$(call build,full_index)
 	touch $@
 

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -119,7 +119,7 @@ def main():
         year = sys.argv[4]
 
     if ext is None:
-        build_full_index("html", index_name=index_name, year=year)
+        build_full_index("html", index_name=index_name, year=year, source_dir=None)
         build_full_index("md", index_name=index_name, year=year, source_dir=None)
     elif ext == "html":
         build_full_index(

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -212,9 +212,6 @@ desc2_tmpl = string.Template(
 """
 )
 
-full_index_header = r"""Go [back to help overview](index.md)
-"""
-
 moduletopics_tmpl = string.Template(
     r"""
 - [${name}](topic_${key}.md)


### PR DESCRIPTION
This builds addon index (for `addons` subdirectory) in CI using the tooling from core, specifically the script to build full tool index. The intro text is different for addons and for the core. The addons version is derived from the current addon index page.
