### PR TITLE
build: Add colortables and other files to addon doc

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -124,6 +124,15 @@ jobs:
           grass --tmp-project XY --exec \
             python grass/man/build_keywords.py md "$MKDOCS_DIR/source" "$MKDOCS_DIR/source/addons"
 
+      - name: Copy shared files to addons
+        run: |
+          cd "$MKDOCS_DIR/source"
+          # This should match directories with color tables and other files
+          # linked from the pages.
+          for name in $(ls -1d */ | grep -vE "^(addons|libpython)/$"); do
+            cp -rv $name addons
+          done
+
       - name: Get mkdocs
         run: |
           pip install -r "grass/man/mkdocs/requirements.txt"


### PR DESCRIPTION
This adds missing files to the addons subdirectory when the documentation is build in the CI. It gets all the directories in the parent dir and copies them over except the addons directory itself and libpython directory (filtering the two know unwanted ones out rather than trying to capture all directory names). An alternative solution would be to generate the links differently when compiling addons, but that would need post-processing like for keywords or changes to the parser code.
