### PR TITLE
tests: Ignore gunittest.main.test() when collecting with pytest

### DIFF
--- a/python/grass/gunittest/main.py
+++ b/python/grass/gunittest/main.py
@@ -113,6 +113,9 @@ def test():
     sys.exit(not program.result.wasSuccessful())
 
 
+test.__test__ = False  # prevent running this function as a test in pytest
+
+
 def discovery():
     """Recursively find all tests in testsuite directories and run them
 


### PR DESCRIPTION
This is an old bit of work that I’m carrying on since the last 2024 community meeting in Prague.

I’ve made some progress on the matter, that is running gunittest-based tests with pytest, so it is time to file some preparatory work.


Pytest will respect this attribute and not consider that function to be a test (which fails and duplicates the tests, it is supposed to be used if the scripts are run directly, but when it is imported, pytest sees it.). See the end of https://docs.pytest.org/en/latest/example/pythoncollection.html#customizing-test-collection



It shouldn’t be impacting doctest too, even if it is mentioned here: https://docs.python.org/3/library/doctest.html#doctest.testmod