### PR TITLE
docs: Use YAML list for keywords in front matter

### DIFF
--- a/gui/wxpython/timeline/g.gui.timeline.py
+++ b/gui/wxpython/timeline/g.gui.timeline.py
@@ -24,7 +24,7 @@
 # % keyword: general
 # % keyword: GUI
 # % keyword: temporal
-# % keywords: plot
+# % keyword: plot
 # %end
 # %option G_OPT_STDS_INPUTS
 # % required: no

--- a/gui/wxpython/tplot/g.gui.tplot.py
+++ b/gui/wxpython/tplot/g.gui.tplot.py
@@ -22,10 +22,10 @@
 
 # %module
 # % description: Plots the values of temporal datasets.
-# % keywords: general
-# % keywords: GUI
-# % keywords: temporal
-# % keywords: plot
+# % keyword: general
+# % keyword: GUI
+# % keyword: temporal
+# % keyword: plot
 # %end
 
 # %flag

--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -52,6 +52,9 @@ void G__usage_markdown(void)
     fprintf(stdout, "keywords: [ ");
     G__print_keywords(stdout, NULL, FALSE);
     fprintf(stdout, " ]");
+    fprintf(stdout, "tags: [ ");
+    G__print_keywords(stdout, NULL, FALSE);
+    fprintf(stdout, " ]");
     fprintf(stdout, "\n---\n\n");
 
     /* main header */

--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -49,10 +49,7 @@ void G__usage_markdown(void)
     fprintf(stdout, "---\n");
     fprintf(stdout, "name: %s\n", st->pgm_name);
     fprintf(stdout, "description: %s\n", st->module_info.description);
-    fprintf(stdout, "keywords: ");
-    G__print_keywords(stdout, NULL, FALSE);
-    fprintf(stdout, "\n");
-    fprintf(stdout, "tags: [ ");
+    fprintf(stdout, "keywords: [ ");
     G__print_keywords(stdout, NULL, FALSE);
     fprintf(stdout, " ]");
     fprintf(stdout, "\n---\n\n");

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -106,7 +106,10 @@ def build_keywords(ext, main_path, addons_path):
         else:
             keys = []
             for line in lines:
-                match = re.match(r"keywords:\s*(.*)", line)
+                # We accept, but don't require, YAML inline list syntax.
+                match = re.match(r"keywords:\s*\[\s*(.*)\s*\]\s*", line)
+                if not match:
+                    match = re.match(r"keywords:\s*(.*)\s*", line)
                 if match:
                     text = match.group(1)
                     if not text:
@@ -114,6 +117,7 @@ def build_keywords(ext, main_path, addons_path):
                             f"Warning: Empty keyword list in {fname}", file=sys.stderr
                         )
                         break
+                    # We accept only non-quoted YAML strings.
                     keys = [item.strip() for item in text.split(",")]
                     break
 

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -75,7 +75,8 @@ extra_css:
 plugins:
   - search
   - glightbox
-  - tags
+  - tags:
+      tags_name_property: keywords
   - social:
       cards_layout_options:
         background_color: rgb(76, 176, 91)

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -75,8 +75,7 @@ extra_css:
 plugins:
   - search
   - glightbox
-  - tags:
-      tags_name_property: keywords
+  - tags
   - social:
       cards_layout_options:
         background_color: rgb(76, 176, 91)

--- a/man/mkdocs/tags.md
+++ b/man/mkdocs/tags.md
@@ -2,4 +2,4 @@
 
 Following is a list of relevant tags:
 
-<!-- material/tags -->
+<!-- material/tags { exclude: [unit test] } -->


### PR DESCRIPTION
To use the keywords directly in MkDocs, keywords property needs to be proper YAML list, not a plain comma-separated list as a string. The keywords are now generated like that, and the custom keyword parsing now accepts both version (with and without []).

This does not include any keywords entered manually to Markdown because there are none in this repo, but they are in grass-addons repo which will break the MkDocs reading of the tags from the keywords property (for r.pi, r.green). Addons are addressed in https://github.com/OSGeo/grass-addons/pull/1357.

This includes cleanup of keywords tool metadata syntax which is supposed to use multiple keyword keys now rather than keywords (for a single keyword).

For the tags page generated by MkDocs, this adds an exclude of keyword 'unit test' which does not need to appear in the documentation.

This covers only the YAML changes for keywords. The MkDocs change for tags to keywords is in #5318.
