### PR TITLE
CI: Fetch all Git history for building docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           repository: OSGeo/grass
           path: grass
+          fetch-depth: 0
 
       - name: Get dependencies
         run: |
@@ -60,6 +61,7 @@ jobs:
           repository: OSGeo/grass-addons
           ref: grass${{ env.MAJOR }}
           path: grass-addons
+          fetch-depth: 0
 
       - name: Install Python dependencies
         # We install both core and addon dependencies, but we don't install any


### PR DESCRIPTION
Get all the history when cloning Git repos to have all commits when asking about the lastest change for the Source code section in the doc.

See #5323
