### PR TITLE
docs: Fixed mkdocs GitHub stats issue #5237

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -21,6 +21,7 @@ DSTFILES := \
 	$(MDDIR)/scripts/hook_list_scripts.py \
 	$(MDDIR)/overrides/partials/footer.html \
 	$(MDDIR)/overrides/partials/actions.html \
+	$(MDDIR)/overrides/partials/source.html \
 	$(MDDIR)/source/tags.md
 
 categories = \
@@ -272,6 +273,9 @@ $(MDDIR)/overrides/partials/footer.html: mkdocs/overrides/partials/footer.html |
 	$(INSTALL_DATA) $< $@
 
 $(MDDIR)/overrides/partials/actions.html: mkdocs/overrides/partials/actions.html | $(MDDIR)/overrides/partials
+	$(INSTALL_DATA) $< $@
+
+$(MDDIR)/overrides/partials/source.html: mkdocs/overrides/partials/source.html | $(MDDIR)/overrides/partials
 	$(INSTALL_DATA) $< $@
 
 $(MDDIR)/overrides/partials:

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -5,7 +5,7 @@ site_name: !ENV SITE_NAME
 site_url: https://grass.osgeo.org/grass-stable/manuals/
 
 # Repository information
-repo_name: GitHub
+repo_name: OSGeo/grass
 repo_url: https://github.com/OSGeo # Set to OSGeo so we can added grass and grass-addons
 edit_uri_template: edit/main/{path!q}
 
@@ -63,6 +63,10 @@ extra:
       link: https://x.com/GRASSGIS
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/@grass-gis
+  github:
+    repos:
+      - grass: grass
+      - grass_addons: grass-addons
 
 # Hooks
 hooks:

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -65,8 +65,8 @@ extra:
       link: https://www.youtube.com/@grass-gis
   github:
     repos:
-      - grass: grass
-      - grass_addons: grass-addons
+      grass: grass
+      grass_addons: grass-addons
 
 # Hooks
 hooks:

--- a/man/mkdocs/overrides/partials/source.html
+++ b/man/mkdocs/overrides/partials/source.html
@@ -1,9 +1,10 @@
-<a href="{{ config.repo_url }}" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
+{% set grass_url = config.repo_url ~ "/" ~ config.extra.github.repos.grass %}
+<a href="{{ grass_url }}" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
     <div class="md-source__icon md-icon">
       {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
       {% include ".icons/" ~ icon ~ ".svg" %}
     </div>
     <div class="md-source__repository">
-      {{ config.repo_name ~ config.extra.github.repos.grass }}
+        {{ config.repo_name }}
     </div>
   </a>

--- a/man/mkdocs/overrides/partials/source.html
+++ b/man/mkdocs/overrides/partials/source.html
@@ -7,4 +7,4 @@
     <div class="md-source__repository">
         {{ config.repo_name }}
     </div>
-  </a>
+</a>

--- a/man/mkdocs/overrides/partials/source.html
+++ b/man/mkdocs/overrides/partials/source.html
@@ -1,0 +1,9 @@
+<a href="{{ config.repo_url }}" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
+    <div class="md-source__icon md-icon">
+      {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </div>
+    <div class="md-source__repository">
+      {{ config.repo_name ~ config.extra.github.repos.grass }}
+    </div>
+  </a>


### PR DESCRIPTION

I've addresses issue #5237. The issue was caused when setting the mkdocs config variable `repo_url` to  https://github.com/OSGeo. We do this because we are combining two GitHub repos (grass, grass-addons) into one MkDocs site. To fix the issue I've added new extra variables to the MKDocs config file.

```yml
extra:
  github:
    repos:
      grass: grass
      grass_addons: grass-addons
```

And added a new partial `source.html` to point the Github stats header to `OSGeo/grass` instead of `OSGeo`.


