### PR TITLE
style: Fix SIM115 linting errors using context managers for file operationsadding context managers in `scripts/`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,13 +354,9 @@ ignore = [
 "scripts/i.in.spotvgt/i.in.spotvgt.py" = ["SIM115"]
 "scripts/i.oif/i.oif*.py" = ["SIM115"]
 "scripts/i.pansharpen/i.pansharpen.py" = ["SIM115"]
-"scripts/i.spectral/i.spectral.py" = ["SIM115"]
 "scripts/m.proj/m.proj.py" = ["SIM115"]
-"scripts/r.fillnulls/r.fillnulls.py" = ["SIM115"]
 "scripts/r.in.wms/wms_*.py" = ["SIM115"]
-"scripts/r.tileset/r.tileset.py" = ["SIM115"]
 "scripts/v.*/v.*.py" = ["SIM115"]
-"scripts/wxpyimgview/wxpyimgview_gui.py" = ["SIM115"]
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 # Declare a custom aliases, checked with rule ICN001

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -89,8 +89,8 @@ def cleanup():
 
 
 def write2textf(what, output):
+    i = 0
     with open(output, "w") as outf:
-        i = 0
         for row in enumerate(what):
             i += 1
             outf.write("%d, %s\n" % (i, row))
@@ -101,8 +101,8 @@ def draw_gnuplot(what, xlabels, output, img_format, coord_legend):
 
     for i, row in enumerate(what):
         outfile = os.path.join(tmp_dir, "data_%d" % i)
+        xrange = max(xrange, len(row) - 2)
         with open(outfile, "w") as outf:
-            xrange = max(xrange, len(row) - 2)
             outf.writelines("%d %s\n" % (j + 1, val) for j, val in enumerate(row[3:]))
 
     # build gnuplot script

--- a/scripts/i.spectral/i.spectral.py
+++ b/scripts/i.spectral/i.spectral.py
@@ -89,12 +89,11 @@ def cleanup():
 
 
 def write2textf(what, output):
-    outf = open(output, "w")
-    i = 0
-    for row in enumerate(what):
-        i += 1
-        outf.write("%d, %s\n" % (i, row))
-    outf.close()
+    with open(output, "w") as outf:
+        i = 0
+        for row in enumerate(what):
+            i += 1
+            outf.write("%d, %s\n" % (i, row))
 
 
 def draw_gnuplot(what, xlabels, output, img_format, coord_legend):
@@ -102,10 +101,9 @@ def draw_gnuplot(what, xlabels, output, img_format, coord_legend):
 
     for i, row in enumerate(what):
         outfile = os.path.join(tmp_dir, "data_%d" % i)
-        outf = open(outfile, "w")
-        xrange = max(xrange, len(row) - 2)
-        outf.writelines("%d %s\n" % (j + 1, val) for j, val in enumerate(row[3:]))
-        outf.close()
+        with open(outfile, "w") as outf:
+            xrange = max(xrange, len(row) - 2)
+            outf.writelines("%d %s\n" % (j + 1, val) for j, val in enumerate(row[3:]))
 
     # build gnuplot script
     lines = []
@@ -145,9 +143,8 @@ def draw_gnuplot(what, xlabels, output, img_format, coord_legend):
     lines.append(cmd)
 
     plotfile = os.path.join(tmp_dir, "spectrum.gnuplot")
-    plotf = open(plotfile, "w")
-    plotf.writelines(line + "\n" for line in lines)
-    plotf.close()
+    with open(plotfile, "w") as plotf:
+        plotf.writelines(line + "\n" for line in lines)
 
     if output:
         gcore.call(["gnuplot", plotfile])
@@ -160,15 +157,13 @@ def draw_linegraph(what):
 
     xfile = os.path.join(tmp_dir, "data_x")
 
-    xf = open(xfile, "w")
-    xf.writelines("%d\n" % (j + 1) for j, val in enumerate(what[0][3:]))
-    xf.close()
+    with open(xfile, "w") as xf:
+        xf.writelines("%d\n" % (j + 1) for j, val in enumerate(what[0][3:]))
 
     for i, row in enumerate(what):
         yfile = os.path.join(tmp_dir, "data_y_%d" % i)
-        yf = open(yfile, "w")
-        yf.writelines("%s\n" % val for j, val in enumerate(row[3:]))
-        yf.close()
+        with open(yfile, "w") as yf:
+            yf.writelines("%s\n" % val for j, val in enumerate(row[3:]))
         yfiles.append(yfile)
 
     sienna = "#%02x%02x%02x" % (160, 82, 45)

--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -267,10 +267,9 @@ def main():
             quiet=quiet,
         )
         cat_list = []
-        cats_file = open(cats_file_name)
-        for line in cats_file:
-            cat_list.append(line.rstrip("\n"))
-        cats_file.close()
+        with open(cats_file_name) as cats_file:
+            for line in cats_file:
+                cat_list.append(line.rstrip("\n"))
         os.remove(cats_file_name)
 
         if len(cat_list) < 1:

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -189,14 +189,15 @@ def projectPoints(points, source, dest):
     """Projects a list of points"""
     dest_points = []
 
-    input = tempfile.NamedTemporaryFile(mode="wt")
-    for point in points:
-        input.file.write(
-            "%f;%f\n" % (point[0] * source["scale"], point[1] * source["scale"])
-        )
-    input.file.flush()
+    with tempfile.NamedTemporaryFile(mode="wt", delete=False) as temp_file:
+        for point in points:
+            temp_file.write(
+                "%f;%f\n" % (point[0] * source["scale"], point[1] * source["scale"])
+            )
+        temp_file.flush()
+        temp_filename = temp_file.name
 
-    dest_points, errors = project(input.name, source, dest)
+    dest_points, errors = project(temp_filename, source, dest)
 
     return dest_points, errors
 

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -189,15 +189,14 @@ def projectPoints(points, source, dest):
     """Projects a list of points"""
     dest_points = []
 
-    with tempfile.NamedTemporaryFile(mode="wt", delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile(mode="wt") as input:
         for point in points:
-            temp_file.write(
+            input.write(
                 "%f;%f\n" % (point[0] * source["scale"], point[1] * source["scale"])
             )
-        temp_file.flush()
-        temp_filename = temp_file.name
+        input.flush()
 
-    dest_points, errors = project(temp_filename, source, dest)
+        dest_points, errors = project(input.name, source, dest)
 
     return dest_points, errors
 

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -164,12 +164,13 @@ class Application(wx.App):
             raise SyntaxError(msg)
 
     def map_file(self):
-        f = open(self.image, "rb")
+        with open(self.image, "rb") as f:
+            header = f.read(self.HEADER_SIZE)
+            self.read_bmp_header(header)
 
-        header = f.read(self.HEADER_SIZE)
-        self.read_bmp_header(header)
-
-        self.imgbuf = np.memmap(f, mode="r", offset=self.HEADER_SIZE)
+        self.imgbuf = np.memmap(
+            self.image, mode="r", offset=self.HEADER_SIZE, dtype=np.uint8
+        )
 
     def signal_handler(self, sig, frame):
         wx.CallAfter(self.mainwin.Refresh)

--- a/scripts/wxpyimgview/wxpyimgview_gui.py
+++ b/scripts/wxpyimgview/wxpyimgview_gui.py
@@ -166,7 +166,7 @@ class Application(wx.App):
     def map_file(self):
         with open(self.image, "rb") as f:
             header = f.read(self.HEADER_SIZE)
-            self.read_bmp_header(header)
+        self.read_bmp_header(header)
 
         self.imgbuf = np.memmap(
             self.image, mode="r", offset=self.HEADER_SIZE, dtype=np.uint8


### PR DESCRIPTION
This PR fixes SIM115 linting errors across several modules by replacing direct file operations with proper context managers (with statements)
