### PR TITLE
doc: add missing newline between generated synopsis and description heading

### DIFF
--- a/utils/mkmarkdown.py
+++ b/utils/mkmarkdown.py
@@ -192,7 +192,7 @@ def merge_md_files(md1, md2, content_modifier1, content_modifier2):
     combined_yaml = "\n".join(yaml_items)
 
     # Attach the rest of the document.
-    return ["---\n", combined_yaml, "\n---\n\n", content1, "\n", content2, "\n"]
+    return ["---\n", combined_yaml, "\n---\n\n", content1, "\n\n", content2, "\n"]
 
 
 def main():


### PR DESCRIPTION
Fixes merging markdown header with the rest. Before:

```markdown
**units**=*string*  
&nbsp;&nbsp;&nbsp;&nbsp;Elevation units (overrides scale factor)  
&nbsp;&nbsp;&nbsp;&nbsp;Options: *intl, survey*  
&nbsp;&nbsp;&nbsp;&nbsp;**intl**: international feet  
&nbsp;&nbsp;&nbsp;&nbsp;**survey**: survey feet
## DESCRIPTION

*r.relief* creates a raster shaded relief map based on current
resolution settings and on sun altitude, azimuth, and z-exaggeration
values entered by the user.
```

After:

```markdown
**units**=*string*  
&nbsp;&nbsp;&nbsp;&nbsp;Elevation units (overrides scale factor)  
&nbsp;&nbsp;&nbsp;&nbsp;Options: *intl, survey*  
&nbsp;&nbsp;&nbsp;&nbsp;**intl**: international feet  
&nbsp;&nbsp;&nbsp;&nbsp;**survey**: survey feet

## DESCRIPTION

*r.relief* creates a raster shaded relief map based on current
resolution settings and on sun altitude, azimuth, and z-exaggeration
values entered by the user.
```

The context is preparation for markdown to man conversion.