### PR TITLE
docs: Tell MkDocs about pages linked from other pages

### DIFF
--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -173,3 +173,26 @@ nav:
       - Miscellaneous Tools: miscellaneous.md
 
   - Development: development_intro.md
+
+not_in_nav: |
+  r.*
+  v.*
+  r3.*
+  i.*
+  t.*
+  db.*
+  d.*
+  g.*
+  m.*
+  ps.*
+  wxGUI.*
+  test.*
+  topic_*
+  *_graphical.md
+  *driver.md
+  grass-dbf.md
+  grass-ogr.md
+  grass-pg.md
+  grass-sqlite.md
+  wxpyimgview.md
+  ximgview.md


### PR DESCRIPTION
We have a long list of pages we are linking from other pages, but currently not including from the menu. For all or most of these, we have a high confidence we are linking all, so we just silence the MkDocs warning about these pages missing in the nav.

Fixes #5215
