### PR TITLE
CI: Remove Sphinx build from Python QC

### DIFF
--- a/.github/workflows/python-code-quality.yml
+++ b/.github/workflows/python-code-quality.yml
@@ -187,20 +187,6 @@ jobs:
           ( cd doc/examples/raster/r.example/ && make )
           ( cd doc/examples/vector/v.example/ && make )
 
-      - name: Run Sphinx to check API documentation build
-        run: |
-          pip install sphinx
-          make sphinxdoclib
-          ARCH=$(cat include/Make/Platform.make | grep ^ARCH | cut -d'=' -f2 | xargs)
-          cp -rp dist.$ARCH/docs/html/libpython sphinx-grass
-
-      - name: Make Sphinx documentation available
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: sphinx-grass
-          path: sphinx-grass
-          retention-days: 3
-
   python-success:
     name: Python Code Quality Result
     needs:


### PR DESCRIPTION
Remove Sphinx Python doc build from Python quality check CI workflow. It is now build in the Documentation workflow.
