### PR TITLE
tests: Fix xfail_windows decorator not executing tests when not on Windows

### DIFF
--- a/python/grass/gunittest/utils.py
+++ b/python/grass/gunittest/utils.py
@@ -90,7 +90,7 @@ def xfail_windows(test_item):
     on Windows.
     """
     if not sys.platform.startswith("win"):
-        return lambda func: func
+        return test_item
     warnings.warn(
         "Once the test is fixed and passing, remove the @xfail_windows decorator",
         stacklevel=2,


### PR DESCRIPTION
When closely debugging and comparing running a same fille with pytest vs gunittest, I noticed a flaw in the xfail_windows decorator used in gunittest-based tests.

Lets consider only v.univar. Using pytest, some warnings were displayed: (needs the whole work I'm getting ready to push, so it won't work as is on your side yet, but for future reference I used `grass $HOME/nc_spm_full_v2alpha2/PERMANENT --exec pytest -v --durations-min=0.5 --tb=short --timeout=10 -k "testsuite and univar" -s`)
```
===================================================================================== warnings summary =====================================================================================
vector/v.univar/testsuite/test_v_univar.py::TestProfiling::test_flagd
  /usr/local/python/3.12.7/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <test_v_univar.TestProfiling testMethod=test_flagd>>)
    return self.run(*args, **kwds)

vector/v.univar/testsuite/test_v_univar.py::TestProfiling::test_flage
  /usr/local/python/3.12.7/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <test_v_univar.TestProfiling testMethod=test_flage>>)
    return self.run(*args, **kwds)

vector/v.univar/testsuite/test_v_univar.py::TestProfiling::test_flagg
  /usr/local/python/3.12.7/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <test_v_univar.TestProfiling testMethod=test_flagg>>)
    return self.run(*args, **kwds)

vector/v.univar/testsuite/test_v_univar.py::TestProfiling::test_flagw
  /usr/local/python/3.12.7/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <test_v_univar.TestProfiling testMethod=test_flagw>>)
    return self.run(*args, **kwds)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
``` 

Looking closer in the generated reports, we can see the same warnings when running locally (Ubuntu 22.04, python 3.12):
stderr.txt:
```
/usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flagd>>)
  return self.run(*args, **kwds)
./usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flage>>)
  return self.run(*args, **kwds)
./usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flagg>>)
  return self.run(*args, **kwds)
./usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flagw>>)
  return self.run(*args, **kwds)
....
----------------------------------------------------------------------
Ran 7 tests in 0.904s
OK
``` 

If I take a Ubuntu test report CI artifact I had downloaded dated march 3, 2025, I see:
stderr.txt:
```
.......
----------------------------------------------------------------------
Ran 7 tests in 0.300s
OK
``` 

These are impressive runtimes! (foreshadowing...) On macOS, taking the artifacts from a run on main, https://github.com/OSGeo/grass/actions/runs/13740438119/job/38428998397, it takes 0.249 seconds too! On Windows, taking the artifacts from a run on main https://github.com/OSGeo/grass/actions/runs/13740438122/job/38428998461, it takes 2.774 seconds, and we get:
stderr.txt:
```
vector\v.univar\testsuite\test_v_univar.py:22: UserWarning: Once the test is fixed and passing, remove the @xfail_windows decorator

  @xfail_windows

vector\v.univar\testsuite\test_v_univar.py:45: UserWarning: Once the test is fixed and passing, remove the @xfail_windows decorator

  @xfail_windows

vector\v.univar\testsuite\test_v_univar.py:74: UserWarning: Once the test is fixed and passing, remove the @xfail_windows decorator

  @xfail_windows

vector\v.univar\testsuite\test_v_univar.py:90: UserWarning: Once the test is fixed and passing, remove the @xfail_windows decorator

  @xfail_windows

xxxx...

----------------------------------------------------------------------

Ran 7 tests in 2.774s

OK (expected_failures=4)
``` 
Locally, on Windows 11, hacking my installed OSGeo4W grass-dev install and a cloned repo, it takes around 8 seconds after warming up. 



Now, let's add some prints at the end of each of the 7 test functions, after the asserts, like `print("Ed: ran test_flagw")` for  the `test_flagw` test.
With gunittest locally, I get:
stderr.txt:
```
/usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flagd>>)
  return self.run(*args, **kwds)
./usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flage>>)
  return self.run(*args, **kwds)
./usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flagg>>)
  return self.run(*args, **kwds)
./usr/local/python/current/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method xfail_windows.<locals>.<lambda> of <__main__.TestProfiling testMethod=test_flagw>>)
  return self.run(*args, **kwds)
....
----------------------------------------------------------------------
Ran 7 tests in 1.987s
OK
``` 
stdout.txt:
```
Ed: ran test_json
Ed: ran test_output
Ed: ran test_output2
``` 
-> There's only 3 prints here instead of 7?


That DeprecationWarning seems to have been introduced in Python 3.11, see the end of https://docs.python.org/3/library/unittest.html#basic-example

Could we have seen this in CI before, with the best of the knowledge we had then?
I made a couple example runs for this, in three PRs in my fork.
1. Add prints to v.univar test functions, but before the fix of this PR: https://github.com/echoix/grass/pull/385
2. Add prints to v.univar test functions, with the fix of this PR: https://github.com/echoix/grass/pull/383
3. Only the fix of this PR: https://github.com/echoix/grass/pull/384

| Situation | OS | Python version | Duration | Summary of stderr.txt | Summary of stdout.txt | links |
|--------|--------|--------|--------|--------|--------|--------|
| 1. before fix | Ubuntu 22.04 | 3.10.12 | 0.302s | 7 dots, no warnings | 3 prints: for test_json, test_output, test_output2 |  [logs](https://github.com/echoix/grass/actions/runs/13741881473/job/38432196676?pr=385)  | 
| 1. before fix | macOS 14.7.4 arm64  | 3.12.9 | 0.233s | 4 warnings: for test_flagd, test_flage, test_flagg, test_flagw | 3 prints: for test_json, test_output, test_output2 |  [logs](https://github.com/echoix/grass/actions/runs/13741881458/job/38432101729?pr=385) | 
| 2. after fix | Ubuntu 22.04 | 3.10.12 | 2.214s | 7 dots, no warnings |  7 prints: for test_flagd, test_flage, test_flagg, test_flagw, test_json, test_output, test_output2 |   [logs](https://github.com/echoix/grass/actions/runs/13741802162/job/38431922365?pr=383) | 
| 2. after fix | macOS 14.7.4 arm64 | 3.10.12 | 1.482s | 7 dots, no warnings |  7 prints: for test_flagd, test_flage, test_flagg, test_flagw, test_json, test_output, test_output2 |   [logs](https://github.com/echoix/grass/actions/runs/13741802158/job/38431922369?pr=383) | 
| 3. This PR | Ubuntu 22.04 | 3.10.12 | 2.173s | 7 dots, no warnings |  empty |   [logs](https://github.com/echoix/grass/actions/runs/13741833033/job/38432223080?pr=384) | 
| 3. This PR | macOS 14.7.4 arm64 | 3.10.12 | 1.853s |  7 dots, no warnings |  empty |   [logs](https://github.com/echoix/grass/actions/runs/13741833006/job/38431991689?pr=384) | 

(I'm skipping windows CI from the table, they aren't done yet and there's no problem on windows as tried locally, and the condition isn't entered).

With the fix of this PR, (plus prints), in gunittest (locally, ubuntu 22.04, python 3.12.7), we get:
stderr.txt:
```
.......
----------------------------------------------------------------------
Ran 7 tests in 7.626s
OK
```
stdout.txt:
```
Ed: ran test_flagd
Ed: ran test_flage
Ed: ran test_flagg
Ed: ran test_flagw
Ed: ran test_json
Ed: ran test_output
Ed: ran test_output2
```
Yay! This is the expected output! We see that it is similar to CI results (obtained later).
Locally, on windows, the same situation takes about the same time as before (7-8 seconds), and theres still the 4 xfailed + three passed, with, because the condition isn't entered.
stdout.txt (yes, with the extra doubled newlines)
```
Ed: ran test_json

Ed: ran test_output

Ed: ran test_output2


``` 

We see that it is similar to CI.



**So, conclusion:** The problem was there before the depreciation warnings, but we didn't catch that the test wasn't really executed, as it wasn't ever called (so didn't fail). 


It wasn't a callable that was supposed to be returned (like the equivalent of an empty wrapped function, a lambda here), but the unevaluated callable that was passed as an argument. It is a function, as tested out with 
```python
    if isinstance(test_item, types.FunctionType):
        warnings.warn("Ed: in xfail_windows, is functiontype")
    else:
        warnings.warn("Ed: in xfail_windows, is not functiontype")
``` 

So, it was the other set of patterns of code from https://github.com/python/cpython/blob/a3990df6121880e8c67824a101bb1316de232898/Lib/unittest/case.py that was needed to use. It is not like https://github.com/python/cpython/blob/a3990df6121880e8c67824a101bb1316de232898/Lib/test/support/__init__.py#L146-L154, but rather like the end of https://github.com/python/cpython/blob/a3990df6121880e8c67824a101bb1316de232898/Lib/unittest/case.py#L148-L166, plus https://github.com/python/cpython/blob/a3990df6121880e8c67824a101bb1316de232898/Lib/unittest/case.py#L184-L186, where in our two possible branches, we end up with returning the equivalent of  "test_item", that we saw that was working  in one of the branches.
