### PR TITLE
g.download.project: Fix string formatting error when download already exists

### DIFF
--- a/scripts/g.download.project/g.download.project.py
+++ b/scripts/g.download.project/g.download.project.py
@@ -103,7 +103,7 @@ def main(options, unused_flags):
     if destination.exists():
         gs.fatal(
             _(
-                "Project named <{}> already exists in <{directory}>, download canceled"
+                "Project named <{name}> already exists in <{directory}>, download canceled"
             ).format(name=name, directory=database)
         )
 


### PR DESCRIPTION
When trying to test locally for #5338, I stumbled across an error on Windows, but couldn't see it. The translated string contained both named placeholders and empty placeholder, but used keyword arguments. I don't know why I never noticed on Linux, but on Windows, there was no indication of what was happening.

```
d:\repos\grass_repo\grass\vector\v.univar>grass85 --tmp-project XY --exec g.download.project url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=%USERPROFILE%
WARNING: Concurrent mapset locking is not supported on Windows
Traceback (most recent call last):
  File "C:\OSGeo4W\apps\grass\grass85/scripts/g.download.project.py", line 153, in <module>
    main(*gs.parser())
  File "C:\OSGeo4W\apps\grass\grass85/scripts/g.download.project.py", line 107, in main
    ).format(name=name, directory=database)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IndexError: Replacement index 0 out of range for positional args tuple
Appuyez sur une touche pour continuer...
``` 


After this fix:
```
d:\repos\grass_repo\grass\vector\v.univar>grass85 --tmp-project XY --exec g.download.project url=https://grass.osgeo.org/sampledata/north_carolina/nc_spm_full_v2alpha2.tar.gz path=%USERPROFILE%
WARNING: Concurrent mapset locking is not supported on Windows
ERROR: Project named <nc_spm_full_v2alpha2> already exists in
       <C:\Users\E-C>, download canceled
Appuyez sur une touche pour continuer...
``` 

