### PR TITLE
v.what: Fix test failures from trailing space after map name

### DIFF
--- a/.github/workflows/macos_gunittest.cfg
+++ b/.github/workflows/macos_gunittest.cfg
@@ -30,8 +30,6 @@ exclude =
     vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
     vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
     vector/v.out.lidar/testsuite/test_v_out_lidar.py
-    vector/v.what/testsuite/test_vwhat_layers.py
-    vector/v.what/testsuite/test_vwhat_ncspm.py
 
 # Maximum time for execution of one test file (not a test function)
 # after which test is terminated (which may not terminate child processes

--- a/.github/workflows/osgeo4w_gunittest.cfg
+++ b/.github/workflows/osgeo4w_gunittest.cfg
@@ -21,8 +21,6 @@ exclude =
     vector/v.in.lidar/testsuite/test_v_in_lidar_basic.py
     vector/v.in.lidar/testsuite/test_v_in_lidar_filter.py
     vector/v.what.rast3/testsuite/test.v.what.rast3.sh
-    vector/v.what/testsuite/test_vwhat_layers.py
-    vector/v.what/testsuite/test_vwhat_ncspm.py
 
 # Maximum time for execution of one test file (not a test function)
 # after which test is terminated (which may not terminate child processes

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -25,8 +25,6 @@ exclude =
     vector/v.in.pdal/testsuite/test_v_in_pdal_basic.py
     vector/v.in.pdal/testsuite/test_v_in_pdal_filter.py
     vector/v.out.lidar/testsuite/test_v_out_lidar.py
-    vector/v.what/testsuite/test_vwhat_layers.py
-    vector/v.what/testsuite/test_vwhat_ncspm.py
 
 # Maximum time for execution of one test file (not a test function)
 # after which test is terminated (which may not terminate child processes

--- a/vector/v.what/testsuite/test_vwhat_layers.py
+++ b/vector/v.what/testsuite/test_vwhat_layers.py
@@ -1,3 +1,5 @@
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
@@ -183,10 +185,12 @@ class TestMultiLayerMap(TestCase):
             "v.what", map="test_vector", coordinates=[634243, 226193], distance=10
         )
 
+    @unittest.expectedFailure
     def test_run(self):
         self.assertModule(self.vwhat)
         self.assertLooksLike(reference=out1, actual=self.vwhat.outputs.stdout)
 
+    @unittest.expectedFailure
     def test_print_options(self):
         self.vwhat.flags["a"].value = True
         self.assertModule(self.vwhat)
@@ -209,6 +213,7 @@ class TestMultiLayerMap(TestCase):
                 msg="No JSON object could be decoded:\n" + self.vwhat.outputs.stdout
             )
 
+    @unittest.expectedFailure
     def test_selected_layers(self):
         self.vwhat.inputs.layer = -1
         self.vwhat.flags["g"].value = True

--- a/vector/v.what/testsuite/test_vwhat_layers.py
+++ b/vector/v.what/testsuite/test_vwhat_layers.py
@@ -185,7 +185,6 @@ class TestMultiLayerMap(TestCase):
             "v.what", map="test_vector", coordinates=[634243, 226193], distance=10
         )
 
-    @unittest.expectedFailure
     def test_run(self):
         self.assertModule(self.vwhat)
         self.assertLooksLike(reference=out1, actual=self.vwhat.outputs.stdout)

--- a/vector/v.what/testsuite/test_vwhat_ncspm.py
+++ b/vector/v.what/testsuite/test_vwhat_ncspm.py
@@ -184,12 +184,10 @@ class TestNCMaps(TestCase):
             distance=1000,
         )
 
-    @unittest.expectedFailure
     def test_multiple_maps(self):
         self.assertModule(self.vwhat)
         self.assertMultiLineEqual(first=out1, second=self.vwhat.outputs.stdout)
 
-    @unittest.expectedFailure
     def test_print_options(self):
         self.vwhat.flags["a"].value = True
         self.assertModule(self.vwhat)
@@ -199,7 +197,6 @@ class TestNCMaps(TestCase):
         self.assertModule(self.vwhat)
         self.assertLooksLike(reference=out3, actual=self.vwhat.outputs.stdout)
 
-    @unittest.expectedFailure
     def test_threshold(self):
         self.vwhat.inputs["distance"].value = 100
         self.assertModule(self.vwhat)

--- a/vector/v.what/testsuite/test_vwhat_ncspm.py
+++ b/vector/v.what/testsuite/test_vwhat_ncspm.py
@@ -1,5 +1,7 @@
 # Author: Anna Petrasova
 
+import unittest
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
@@ -182,10 +184,12 @@ class TestNCMaps(TestCase):
             distance=1000,
         )
 
+    @unittest.expectedFailure
     def test_multiple_maps(self):
         self.assertModule(self.vwhat)
         self.assertMultiLineEqual(first=out1, second=self.vwhat.outputs.stdout)
 
+    @unittest.expectedFailure
     def test_print_options(self):
         self.vwhat.flags["a"].value = True
         self.assertModule(self.vwhat)
@@ -195,6 +199,7 @@ class TestNCMaps(TestCase):
         self.assertModule(self.vwhat)
         self.assertLooksLike(reference=out3, actual=self.vwhat.outputs.stdout)
 
+    @unittest.expectedFailure
     def test_threshold(self):
         self.vwhat.inputs["distance"].value = 100
         self.assertModule(self.vwhat)

--- a/vector/v.what/testsuite/test_vwhat_ncspm.py
+++ b/vector/v.what/testsuite/test_vwhat_ncspm.py
@@ -1,4 +1,5 @@
 # Author: Anna Petrasova
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule

--- a/vector/v.what/testsuite/test_vwhat_ncspm.py
+++ b/vector/v.what/testsuite/test_vwhat_ncspm.py
@@ -1,7 +1,4 @@
 # Author: Anna Petrasova
-
-import unittest
-
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule

--- a/vector/v.what/what.c
+++ b/vector/v.what/what.c
@@ -370,7 +370,7 @@ void what(struct Map_info *Map, int nvects, char **vect, double east,
                     Map[i].name, Map[i].mapset);
             break;
         default:
-            fprintf(stdout, "%s\nMap: %s \nMapset: %s\n", SEP, Map[i].name,
+            fprintf(stdout, "%s\nMap: %s\nMapset: %s\n", SEP, Map[i].name,
                     Map[i].mapset);
             break;
         }


### PR DESCRIPTION
A part of the failures of v.what that I suppose was the reason that they got disabled, was because the output had an extra whitespace after the map name. 

I want to know if it is safe to do this change, as I don’t know the repercussions of changing that.
It’s been like this since at least the welcome to grass 7.0 SVN commit 17 years ago. https://github.com/OSGeo/grass/blame/b659313166fc5f26fb12b94898dfcefd59ce23a3/vector/v.what/what.c#L76C36-L77C41


This PR contains #5342, but could replace #5342 of it is ok. That other PR was to show the tests working. 


Closes #5342