### PR TITLE
db.univar: Use python sort fallback on Windows

### DIFF
--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,16 @@
+"""General pytest test fixtures
+
+Author: Edouard Choinière (2025-03-09)
+SPDX-License-Identifier: GPL-2.0-or-later
+"""
+
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def monkeypatch_module() -> Generator[pytest.MonkeyPatch]:
+    """Yield a monkeypatch context, through a module-scoped fixture"""
+    with pytest.MonkeyPatch.context() as mp:
+        yield mp

--- a/scripts/db.univar/db.univar.py
+++ b/scripts/db.univar/db.univar.py
@@ -80,7 +80,7 @@ def sortfile(infile, outfile):
     inf = open(infile)
     outf = open(outfile, "w")
 
-    if gs.find_program("sort", "--help"):
+    if (not gs.setup.WINDOWS) and gs.find_program("sort", "--help"):
         gs.run_command("sort", flags="n", stdin=inf, stdout=outf)
     else:
         # FIXME: we need a large-file sorting function

--- a/scripts/v.db.univar/tests/conftest.py
+++ b/scripts/v.db.univar/tests/conftest.py
@@ -1,12 +1,13 @@
 """Fixtures for v.db.univar tests"""
 
 import os
-
+from collections.abc import Generator
 from types import SimpleNamespace
 
 import pytest
 
 import grass.script as gs
+from grass.script.setup import SessionHandle
 
 
 def updates_as_transaction(table, cat_column, column, cats, values):
@@ -38,49 +39,59 @@ def value_update_by_category(map_name, layer, column_name, cats, values, env):
 
 
 @pytest.fixture(scope="module")
-def simple_dataset(tmp_path_factory):
-    """Creates a session with a mapset which has vector with a float column"""
+def setup_session(
+    tmp_path_factory, monkeypatch_module: pytest.MonkeyPatch
+) -> Generator[SessionHandle]:
+    """Creates a session with a mapset"""
     tmp_path = tmp_path_factory.mktemp("simple_dataset")
     location = "test"
+    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
+    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+        for key, value in session.env.items():
+            monkeypatch_module.setenv(key, value)
+        yield session
+
+
+@pytest.fixture(scope="module")
+def simple_dataset(setup_session: SessionHandle) -> SimpleNamespace:
+    """Configures a session with a mapset which has vector with a float column"""
     map_name = "points"
     column_name = "double_value"
     num_points = 10
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
-        gs.run_command(
-            "g.region",
-            s=0,
-            n=80,
-            w=0,
-            e=120,
-            b=0,
-            t=50,
-            res=10,
-            res3=10,
-            env=session.env,
-        )
-        gs.run_command(
-            "v.random", output=map_name, npoints=num_points, seed=42, env=session.env
-        )
-        gs.run_command(
-            "v.db.addtable",
-            map=map_name,
-            columns=f"{column_name} double precision",
-            env=session.env,
-        )
-        cats = list(range(1, 1 + num_points))
-        values = [float(i) + 0.11 for i in range(100, 100 + num_points)]
-        value_update_by_category(
-            map_name=map_name,
-            layer=1,
-            column_name=column_name,
-            cats=cats,
-            values=values,
-            env=session.env,
-        )
-        yield SimpleNamespace(
-            session=session,
-            vector_name=map_name,
-            column_name=column_name,
-            values=values,
-        )
+    gs.run_command(
+        "g.region",
+        s=0,
+        n=80,
+        w=0,
+        e=120,
+        b=0,
+        t=50,
+        res=10,
+        res3=10,
+        env=setup_session.env,
+    )
+    gs.run_command(
+        "v.random", output=map_name, npoints=num_points, seed=42, env=setup_session.env
+    )
+    gs.run_command(
+        "v.db.addtable",
+        map=map_name,
+        columns=f"{column_name} double precision",
+        env=setup_session.env,
+    )
+    cats = list(range(1, 1 + num_points))
+    values = [float(i) + 0.11 for i in range(100, 100 + num_points)]
+    value_update_by_category(
+        map_name=map_name,
+        layer=1,
+        column_name=column_name,
+        cats=cats,
+        values=values,
+        env=setup_session.env,
+    )
+    return SimpleNamespace(
+        session=setup_session,
+        vector_name=map_name,
+        column_name=column_name,
+        values=values,
+    )


### PR DESCRIPTION
Closes #3778

I cherry picked some changes I had queued up that fixed some errors that appeared in normal pytest when running with random order (plugin pytest-randomly), similar to what I reported in https://github.com/OSGeo/grass/issues/4480. Since then, I had found a workaround that was used in 
https://github.com/OSGeo/grass/blob/582d100897c67807399e318bce10cfc4f70c4b73/python/grass/script/tests/test_script_task.py#L9-L19

So, with this, most of the test problems I know of are addressed. Plus, tests pass on Windows locally. It will also unblock failing tests on Windows that depended on db.univar.