### PR TITLE
lib/gis: fix typos

### DIFF
--- a/lib/gis/area.c
+++ b/lib/gis/area.c
@@ -33,7 +33,7 @@ static struct state *st = &state;
  * \brief Begin cell area calculations.
  *
  * This routine must be called once before any call to
- * G_area_of_cell_at_row(). It perform all inititalizations needed to
+ * G_area_of_cell_at_row(). It perform all initializations needed to
  * do area calculations for grid cells, based on the current window
  * "projection" field. It can be used in either planimetric
  * projections or the latitude-longitude projection.

--- a/lib/gis/datum.table
+++ b/lib/gis/datum.table
@@ -23,7 +23,7 @@
 #
 # If 99999 or above is given for all 3 parameters, then the parameters
 # listed in this file will not be offered to the user and there
-# must be at least one set of parameters for the corrseponding datum
+# must be at least one set of parameters for the corresponding datum
 # in the datumtransform.table file
 #
 # Please comment and cite the source if you add new parameters

--- a/lib/gis/distance.c
+++ b/lib/gis/distance.c
@@ -35,7 +35,7 @@ static struct state *st = &state;
    Initializes the distance calculations. It is used both for the
    planimetric and latitude-longitude projections.
 
-   \return 0 if projection has no metrix (ie. imagery)
+   \return 0 if projection has no metrics (ie. imagery)
    \return 1 if projection is planimetric
    \return 2 if projection is latitude-longitude
  */

--- a/lib/gis/env.c
+++ b/lib/gis/env.c
@@ -90,7 +90,7 @@ void G_init_env(void)
  * \brief Force to read the mapset environment file VAR
  *
  * The mapset specific VAR file of the mapset set with G_setenv()
- * will be read into memory, ignoring if it was readed before.
+ * will be read into memory, ignoring if it was read before.
  * Existing values will be overwritten, new values appended.
  *
  * \return
@@ -104,7 +104,7 @@ void G__read_mapset_env(void)
  * \brief Force to read the GISRC environment file
  *
  * The GISRC file
- * will be read into memory, ignoring if it was readed before.
+ * will be read into memory, ignoring if it was read before.
  * Existing values will be overwritten, new values appended.
  *
  * \return

--- a/lib/gis/gislib.dox
+++ b/lib/gis/gislib.dox
@@ -275,7 +275,7 @@ exit(). G_setenv_nogisrc() just returns the NULL pointer.
 
  - G_setenv_nogisrc()
 
-These routines set the the GRASS environment variable <em>name</em> to
+These routines set the GRASS environment variable <em>name</em> to
 <em>value</em>. If <em>value</em> is NULL, the <em>name</em> is unset.
 
 Both routines set the value in module memory, but only G_setenv()

--- a/lib/gis/parser_wps.c
+++ b/lib/gis/parser_wps.c
@@ -384,7 +384,7 @@ void G__wps_print_process_description(void)
                                             abstract, 2048, data_type);
                 }
                 else {
-                    /* The keyword array is missused for options, type means the
+                    /* The keyword array is misused for options, type means the
                      * type of the value (integer, float ... ) */
                     wps_print_literal_input_output(
                         WPS_INPUT, min, max, identifier, title, abstract, type,
@@ -553,7 +553,7 @@ void G__wps_print_process_description(void)
 /**************************************************************************
  *
  * The remaining routines are all local (static) routines used to support
- * the the creation of the WPS process_description document.
+ * the creation of the WPS process_description document.
  *
  **************************************************************************/
 
@@ -1213,7 +1213,7 @@ static void wps_print_bounding_box_data(void)
     fprintf(stdout, "\t\t\t<Input minOccurs=\"0\" maxOccurs=\"1\">\n");
     wps_print_ident_title_abstract(
         "BoundingBox", "Bounding box to process data",
-        "The bounding box is uesed to create the reference coordinate system "
+        "The bounding box is used to create the reference coordinate system "
         "in grass, as well as the lower left and upper right corner of the "
         "processing area.");
     fprintf(stdout, "\t\t\t\t<BoundingBoxData>\n");

--- a/lib/gis/timestamp.c
+++ b/lib/gis/timestamp.c
@@ -25,7 +25,7 @@
  * year is 4 digit year
  * [bc] if present, indicates dates is BC
  * hour is 0-23 (24 hour clock)
- * mintue is 0-59
+ * minute is 0-59
  * second is 0-59.9999 (fractions of second allowed)
  * timezone is +hhmm or -hhmm (eg, -0600)
  *

--- a/lib/gis/wind_overlap.c
+++ b/lib/gis/wind_overlap.c
@@ -69,7 +69,7 @@ int G_window_overlap(const struct Cell_head *window, double N, double S,
  * level-two startup so only those arcs that enter the window are
  * actually read.
  *
- * \param[in] window pointer to widnow structure
+ * \param[in] window pointer to window structure
  * \param[in] N north
  * \param[in] S south
  * \param[in] E east


### PR DESCRIPTION
Found via codespell

Also contains the same issue as https://github.com/OSGeo/grass/pull/5346#pullrequestreview-2669452703