### PR TITLE
CI: update cachix public key for Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   nixConfig = {
     extra-substituters = [ "https://osgeo-grass.cachix.org" ];
-    extra-trusted-public-keys = [ "osgeo-grass.cachix.org-1:rLnUl3u0ikSIudZ/oBfTqTL7mb3qwYmfmtuwexPpHjw=" ];
+    extra-trusted-public-keys = [ "osgeo-grass.cachix.org-1:gSGWYIC69ccAr9aP7vnvr5g5JG3l0zER3Z061vYbe50=" ];
 
     bash-prompt = "\\[\\033[1m\\][grass-dev]\\[\\033\[m\\]\\040\\w >\\040";
   };


### PR DESCRIPTION
Update cachix public key for Nix after recreation of cache.

Following instructions at https://github.com/OSGeo/grass/pull/3906#issuecomment-2188589331