### PR TITLE
python: `gs.message` doesn't support an empty string

### DIFF
--- a/scripts/db.dropcolumn/db.dropcolumn.py
+++ b/scripts/db.dropcolumn/db.dropcolumn.py
@@ -87,7 +87,6 @@ def main():
 
     if not force:
         gs.message(_("Column <%s> would be deleted.") % column)
-        gs.message("")
         gs.message(
             _("You must use the force flag (-f) to actually remove it. Exiting.")
         )

--- a/scripts/db.droptable/db.droptable.py
+++ b/scripts/db.droptable/db.droptable.py
@@ -79,7 +79,6 @@ def main():
 
     if not force:
         gs.message(_("The table <%s> would be deleted.") % table)
-        gs.message("")
         gs.message(_("You must use the force flag to actually remove it. Exiting."))
         sys.exit(0)
 

--- a/scripts/i.in.spotvgt/i.in.spotvgt.py
+++ b/scripts/i.in.spotvgt/i.in.spotvgt.py
@@ -263,7 +263,6 @@ def main():
             _("Note: A snow map can be extracted by category 252 (d.rast %s cat=252)")
             % smfile
         )
-        gs.message("")
         gs.message(_("Filtering NDVI map by Status Map quality layer..."))
 
         filtfile = "%s_filt" % name


### PR DESCRIPTION
I don’t really expect this to be merged as is, but I wanted to provoke some discussions.

In the scope of enhancing our tests with pytest (I’m close to 100 commits ahead on that work), some tests were failing because the backing c library doesn’t support receiving an empty value for a required argument, message. It happens in our repo three times, but more in grass-addons.

Since the problem might be in the python wrapping functions, that don’t play well with empty strings (I didn’t try in C directly), the other way to solve the problem is by not causing it. That is what this PR is doing.

If there’s a better solution for this, please update this PR or create a new one ;) 