### PR TITLE
lib/vector/Vlib: Fix Resource Leak Issue in array.c

### DIFF
--- a/lib/vector/Vlib/array.c
+++ b/lib/vector/Vlib/array.c
@@ -145,6 +145,7 @@ int Vect_set_varray_from_cat_list(struct Map_info *Map, int field,
 
         if (n > varray->size) { /* not enough space */
             G_warning(_("Not enough space in vector array"));
+            Vect_destroy_cats_struct(Cats);
             return 0;
         }
 
@@ -168,6 +169,7 @@ int Vect_set_varray_from_cat_list(struct Map_info *Map, int field,
 
         if (n > varray->size) { /* not enough space */
             G_warning(_("Not enough space in vector array"));
+            Vect_destroy_cats_struct(Cats);
             return 0;
         }
 
@@ -261,8 +263,6 @@ int Vect_set_varray_from_db(struct Map_info *Map, int field, const char *where,
         return 0;
     }
 
-    Cats = Vect_new_cats_struct();
-
     /* Select categories from DB to array */
     Fi = Vect_get_field(Map, field);
     if (Fi == NULL) {
@@ -274,6 +274,7 @@ int Vect_set_varray_from_db(struct Map_info *Map, int field, const char *where,
     if (driver == NULL) {
         G_warning(_("Unable to open database <%s> by driver <%s>"),
                   Fi->database, Fi->driver);
+        Vect_destroy_field_info(Fi);
         return -1;
     }
 
@@ -285,8 +286,11 @@ int Vect_set_varray_from_db(struct Map_info *Map, int field, const char *where,
         G_warning(
             _("Unable to select record from table <%s> (key %s, where %s)"),
             Fi->table, Fi->key, where);
+        Vect_destroy_field_info(Fi);
         return -1;
     }
+    Vect_destroy_field_info(Fi);
+    Cats = Vect_new_cats_struct();
 
     if (type & GV_AREA) { /* Areas */
         n = Vect_get_num_areas(Map);
@@ -297,6 +301,8 @@ int Vect_set_varray_from_db(struct Map_info *Map, int field, const char *where,
            it for all features. */
         if (n > varray->size) { /* not enough space */
             G_warning(_("Not enough space in vector array"));
+            Vect_destroy_cats_struct(Cats);
+            G_free(cats);
             return 0;
         }
 
@@ -329,6 +335,8 @@ int Vect_set_varray_from_db(struct Map_info *Map, int field, const char *where,
 
         if (n > varray->size) { /* not enough space */
             G_warning(_("Not enough space in vector array"));
+            Vect_destroy_cats_struct(Cats);
+            G_free(cats);
             return 0;
         }
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207956, 1207957, 1207958, 1207959)
Used `Vect_destroy_cats_struct(), Vect_destroy_field_info(), G_free()` to fix this issue.