### PR TITLE
pythonlib: Add missing docstring summary lines to fix D402 errors

### DIFF
--- a/python/grass/gunittest/checkers.py
+++ b/python/grass/gunittest/checkers.py
@@ -260,7 +260,8 @@ def text_to_keyvalue(
 # TODO: decide if None is valid, and use some default or no compare
 # TODO: is None a valid value for precision?
 def values_equal(value_a, value_b, precision: float = 0.000001) -> bool:
-    """
+    """Compare two values for equality within a given precision.
+
     >>> values_equal(1.022, 1.02, precision=0.01)
     True
     >>> values_equal([1.2, 5.3, 6.8], [1.1, 5.2, 6.9], precision=0.2)
@@ -506,7 +507,8 @@ def proj_units_equals(text_a, text_b):
 # TODO: change parameter order?
 # TODO: the behavior with last \n is strange but now using DOTALL and $
 def check_text_ellipsis(reference, actual) -> bool:
-    r"""
+    r"""Check if actual text matches reference text with ellipsis as wildcards.
+
     >>> check_text_ellipsis(
     ...     "Vector map <...> contains ... points.",
     ...     "Vector map <bridges> contains 5268 points.",
@@ -551,7 +553,8 @@ def check_text_ellipsis(reference, actual) -> bool:
 
 
 def check_text_ellipsis_doctest(reference, actual):
-    """
+    """Check if actual text matches reference with ellipsis using doctest's matching.
+
     >>> check_text_ellipsis_doctest(
     ...     "user: ...\\nname: elevation", "user: some_user\\nname: elevation"
     ... )


### PR DESCRIPTION
This error popped up post updating `ruff` to latest version