### PR TITLE
v.voronoi: Fix resource leak issue in skeleton.c

### DIFF
--- a/vector/v.voronoi/skeleton.c
+++ b/vector/v.voronoi/skeleton.c
@@ -375,8 +375,11 @@ int thin_skeleton(double thresh)
             Vect_merge_lines(&Out, GV_LINE, NULL, NULL);
     }
 
-    if (thresh >= 0)
+    if (thresh >= 0) {
+        Vect_destroy_line_struct(Points);
+        Vect_destroy_list(list);
         return 0;
+    }
 
     for (node = 1; node <= Vect_get_num_nodes(&Out); node++) {
         if (!Vect_node_alive(&Out, node))
@@ -470,6 +473,8 @@ int thin_skeleton(double thresh)
         else
             Vect_merge_lines(&Out, GV_LINE, NULL, NULL);
     }
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_list(list);
 
     return 0;
 }
@@ -573,6 +578,14 @@ int tie_up(void)
             ntied++;
         }
     }
+    Vect_destroy_line_struct(Points);
+    Vect_destroy_cats_struct(Cats);
+    for (i = 0; i < isl_allocated; i++) {
+        if (IPoints[i]) {
+            Vect_destroy_line_struct(IPoints[i]);
+        }
+    }
+    G_free(IPoints);
 
     return ntied;
 }


### PR DESCRIPTION
This pull request fixes issue identified by coverity scan (CID : 1207960, 1207961, 1207962, 1207963, 1207964)
Vect_destroy_line_struct(), Vect_destroy_list(), Vect_destroy_cats_struct(), G_free() to fix this issue