### PR TITLE
cmake: use of imported PDAL target

### DIFF
--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -201,14 +201,15 @@ if(WITH_GEOS)
 endif()
 
 if(WITH_PDAL)
-  find_package(PDAL REQUIRED)
-  if(PDAL_FOUND)
-    add_library(PDAL INTERFACE IMPORTED GLOBAL)
-    set_property(TARGET PDAL PROPERTY INTERFACE_LINK_LIBRARIES
-                                      ${PDAL_LIBRARIES})
-    set_property(TARGET PDAL PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                                      ${PDAL_INCLUDE_DIRS})
+  find_package(PDAL REQUIRED CONFIG)
+  set(PDAL pdalcpp)
+  if(NOT TARGET pdalcpp
+     AND TARGET pdal_base
+     AND TARGET pdal_util)
+    # Workaround for PDAL <2.6
+    set(PDAL pdal_base pdal_util)
   endif()
+  message(STATUS "Found PDAL: ${PDAL_DIR} (found version \"${PDAL_VERSION}\")")
 endif()
 
 if(WITH_LIBLAS)

--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -290,7 +290,7 @@ build_program_in_subdir(
   grass_gproj
   ${LIBM}
   PRIMARY_DEPENDS
-  PDAL)
+  ${PDAL})
 
 build_program_in_subdir(
   r.in.png

--- a/vector/CMakeLists.txt
+++ b/vector/CMakeLists.txt
@@ -325,7 +325,7 @@ build_program_in_subdir(
   grass_vector
   ${LIBM}
   PRIMARY_DEPENDS
-  PDAL)
+  ${PDAL})
 
 build_program_in_subdir(
   v.in.region


### PR DESCRIPTION
Use imported PDAL target(s) from find_package in config mode.

A workaround is needed for PDAL pre-2.6, which exports two targets.