### PR TITLE
r.fill.dir: Fix uninitialized pointer

### DIFF
--- a/raster/r.fill.dir/ppupdate.c
+++ b/raster/r.fill.dir/ppupdate.c
@@ -35,8 +35,8 @@ void ppupdate(int fe, int fb, int nl, int nbasins, struct band3 *elev,
     CELL *here;
     CELL that_basin;
     void *barrier_height;
-    void *this_elev;
-    void *that_elev;
+    void *this_elev = NULL;
+    void *that_elev = NULL;
 
     struct links *list;
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208481, 1208482)
Initialized to `NULL` to fix this issue.