### PR TITLE
lib/vector/Vlib: Fix Resource Leak issue in close.c

### DIFF
--- a/lib/vector/Vlib/close.c
+++ b/lib/vector/Vlib/close.c
@@ -216,8 +216,9 @@ int Vect_close(struct Map_info *Map)
     /* close level 1 files / data sources if not head_only */
     if (!Map->head_only) {
         if (create_link && ((*Close_array[Map->format][1])(Map)) != 0) {
-            G_warning(_("Unable to close vector <%s>"),
-                      Vect_get_full_name(Map));
+            const char *mname = Vect_get_full_name(Map);
+            G_warning(_("Unable to close vector <%s>"), mname);
+            G_free((void *)mname);
             return 1;
         }
     }


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan ( CID : 1207965)
Used G_free() to fix this issue.