### PR TITLE
cmake: remove OpenDWG related unused code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,6 @@ option(WITH_NETCDF "Build with NetCDF support" OFF)
 option(WITH_GEOS "Build with GEOS support" ON)
 option(WITH_PDAL "Build with PDAL support" ON)
 option(WITH_LIBLAS "Build with libLAS support" OFF)
-option(WITH_OPENDWG "Build with OpenDWG support" OFF)
 
 # Other options
 option(WITH_LARGEFILES "Build with large file support"

--- a/vector/CMakeLists.txt
+++ b/vector/CMakeLists.txt
@@ -102,9 +102,6 @@ set(vector_modules_list
     v.what.rast
     v.what.rast3)
 
-if(WITH_OPENDWG)
-  list(APPEND vector_modules_list v.in.dwg)
-endif()
 if(WITH_GEOS)
   list(APPEND vector_modules_list v.buffer)
 endif()
@@ -983,7 +980,3 @@ build_program_in_subdir(
   grass_vector
   PRIMARY_DEPENDS
   PostgreSQL::PostgreSQL)
-
-if(WITH_OPENDWG)
-  build_program_in_subdir(v.in.dwg DEPENDS grass_gis grass_vector ${LIBM})
-endif()


### PR DESCRIPTION
Remove OpenDWG related unused CMake code.

`v.in.dwg` was removed with 7dc46cdadd53399c566cf0a496632c80ea03db81.