### PR TITLE
r.fill.dir: avoid null pointer dereferences

### DIFF
--- a/raster/r.fill.dir/ppupdate.c
+++ b/raster/r.fill.dir/ppupdate.c
@@ -152,6 +152,9 @@ void ppupdate(int fe, int fb, int nl, int nbasins, struct band3 *elev,
 
     } /* end row */
 
+    if (!this_elev || !that_elev)
+        G_fatal_error(_("Unexpected NULL pointer in %s"), __func__);
+
     /* Look for pairs of basins that drain to each other */
     for (i = 1; i <= nbasins; i += 1) {
         if (list[i].next <= 0)


### PR DESCRIPTION
This most likely addresses a false positive static analyser issue, which was raised after merge of 9fdce5ae068d245ee78d3422ae4f216054409be3.

But it doesn't hurt to add this simple check either.

```
*** CID 1593959:  Null pointer dereferences  (FORWARD_NULL)
/raster/r.fill.dir/ppupdate.c: 165 in ppupdate()
159     
160             n = list[i].next;
161             if (list[n].next == i) {
162                 /* we have a pair */
163                 /* find out how large the elevation difference would be for a change
164                  * in each basin */
   CID 1593959:  Null pointer dereferences  (FORWARD_NULL)
   Passing null pointer "that_elev" to "memcpy", which dereferences it.
165                 memcpy(that_elev, list[n].pp_alt, bpe());
166                 diff(that_elev, list[n].pp);
167     
168                 memcpy(this_elev, list[i].pp_alt, bpe());
169                 diff(this_elev, list[i].pp);
170     

** CID 1593958:  Null pointer dereferences  (FORWARD_NULL)
/raster/r.fill.dir/ppupdate.c: 168 in ppupdate()


________________________________________________________________________________________________________
*** CID 1593958:  Null pointer dereferences  (FORWARD_NULL)
/raster/r.fill.dir/ppupdate.c: 168 in ppupdate()
162                 /* we have a pair */
163                 /* find out how large the elevation difference would be for a change
164                  * in each basin */
165                 memcpy(that_elev, list[n].pp_alt, bpe());
166                 diff(that_elev, list[n].pp);
167     
   CID 1593958:  Null pointer dereferences  (FORWARD_NULL)
   Passing null pointer "this_elev" to "memcpy", which dereferences it.
168                 memcpy(this_elev, list[i].pp_alt, bpe());
169                 diff(this_elev, list[i].pp);
170     
171                 /* switch pour points in the basin where it makes the smallest
172                  * change */
173                 if (get_min(this_elev, that_elev) == this_elev) {
```