### PR TITLE
docs: Remove old footer links from MkDocs site

### DIFF
--- a/man/mkdocs/overrides/partials/footer.html
+++ b/man/mkdocs/overrides/partials/footer.html
@@ -86,9 +86,6 @@
 
   <!-- Further information -->
    <div class="md-footer-meta md-typeset">
-      <center>
-        <a href="{{ config.site_url }}index.html">Main index</a> | <a href="{{ config.site_url }}topics.html">Topics index</a> | <a href="{{ config.site_url }}keywords.html">Keywords index</a> | <a href="{{ config.site_url }}tags.html">Tags index</a> | <a href="{{ config.site_url }}graphical_index.html">Graphical index</a> | <a href="{{ config.site_url }}full_index.html">Full index</a><br>
-      </center>
      <div class="md-footer-meta__inner md-grid">
       {% include "partials/copyright.html" %}
       <!-- Social links -->


### PR DESCRIPTION
This is removing the series of links in the footer of the new documentation which go to the various index pages. These links to index pages served as a menu in the custom HTML documentation, but don't have much use in the new documentation which is using MkDocs navigation with a top bar menu being the main navigation place. In very special cases, the bottom bar contained extra link to GUI and the link to tool category would be generated dynamically. This has a limited use as menus are not expected to be changing, instead you expect to find things in the same place there. (So this is something which the new MkDocs menus don't have, but it is not a problem.) In the future, if anything from this footer links should be linked from menu, it should be added to the new menu. The full index having links to all tools is part of the menu.

Closes #5314

Before and after:

![Screenshot from 2025-03-21 15-32-54](https://github.com/user-attachments/assets/49b8f406-ebb7-45e4-9f29-fcfa9b2e5eaa)

