### PR TITLE
grass.app: Use sys.executable as a GRASS_PYTHON default

### DIFF
--- a/python/grass/app/runtime.py
+++ b/python/grass/app/runtime.py
@@ -179,10 +179,7 @@ def set_python_path_variable(install_path, env):
 def set_path_to_python_executable(env):
     """Set GRASS_PYTHON environment variable"""
     if not env.get("GRASS_PYTHON"):
-        if WINDOWS:
-            env["GRASS_PYTHON"] = "python3.exe"
-        else:
-            env["GRASS_PYTHON"] = "python3"
+        env["GRASS_PYTHON"] = sys.executable
 
 
 def set_defaults(config_projshare_path):


### PR DESCRIPTION
Instead of hardcoding python3 and python3.exe (based on the platform), use sys.executable for the GRASS_PYTHON variable when not set externally. This switches from command-name-only to full path because sys.executable is 'absolute path  of the executable binary', so when displayed, it will be little less nice, but likely more correct, e.g., /usr/bin/python (no version) instead of python3, following system configuration. Absolute path is prefered for subprocess execution by tools like bandit and sys.executable, even if we would not be using it here, would be an relevant example of absolute path usage. This will also make the code Python 4 ready and removes the need to handle Windows separately. sys.executable may be empty or None, but we already have a mechanism to set GRASS_PYTHON in special cases which is simply using GRASS_PYTHON externally, so I'm not adding any fallback for sys.executable being empty.
