### PR TITLE
docs: Remove Keywords sec from generated doc

### DIFF
--- a/general/g.mkfontcap/main.c
+++ b/general/g.mkfontcap/main.c
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
 
     module = G_define_module();
     G_add_keyword(_("general"));
+    G_add_keyword(_("display"));
     module->description = _(
         "Generates the font configuration file by scanning various directories "
         "for fonts.");

--- a/general/g.parser/g.parser.md
+++ b/general/g.parser/g.parser.md
@@ -1,14 +1,10 @@
 ---
 name: g.parser
 description: Provides full parser support for GRASS scripts.
+keywords: [general, support, scripts]
 ---
 
 # Provides full parser support for GRASS scripts
-
-## KEYWORDS
-
-[general](general.md), [support](topic_support.md),
-[scripts](keywords.md#scripts)
 
 ## SYNOPSIS
 

--- a/gui/wxpython/docs/wxGUI.components.md
+++ b/gui/wxpython/docs/wxGUI.components.md
@@ -1,13 +1,10 @@
 ---
 description: wxGUI Components
 index: wxGUI
+keywords: [general, GUI]
 ---
 
 # wxGUI Components
-
-## KEYWORDS
-
-[general](general.md), [GUI](topic_GUI.md)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/docs/wxGUI.iscatt.md
+++ b/gui/wxpython/docs/wxGUI.iscatt.md
@@ -1,15 +1,10 @@
 ---
 description: wxGUI Interactive Scatter Plot Tool
 index: wxGUI
+keywords: [display, GUI, imagery, scatterplot, plot]
 ---
 
 # wxGUI Interactive Scatter Plot Tool
-
-## KEYWORDS
-
-[display](display.md), [GUI](topic_GUI.md),
-[imagery](keywords.md#imagery), [scatterplot](keywords.md),
-[plot](keywords.md#plot)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/docs/wxGUI.modules.md
+++ b/gui/wxpython/docs/wxGUI.modules.md
@@ -1,13 +1,10 @@
 ---
 description: wxGUI Module dialogs
 index: wxGUI
+keywords: [general, GUI]
 ---
 
 # wxGUI Module dialogs
-
-## KEYWORDS
-
-[general](general.md), [GUI](topic_GUI.md)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/docs/wxGUI.nviz.md
+++ b/gui/wxpython/docs/wxGUI.nviz.md
@@ -1,16 +1,11 @@
 ---
 description: wxGUI 3D View Mode
 index: wxGUI
+keywords: [display, GUI, visualization, graphics, raster, vector, raster3d]
+
 ---
 
 # wxGUI 3D View Mode
-
-## KEYWORDS
-
-[display](display.md), [GUI](topic_GUI.md),
-[visualization](keywords.md#visualization),
-[graphics](keywords.md#graphics), [raster](keywords.md#raster),
-[vector](keywords.md#vector), [raster3d](keywords.md#raster3d)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/docs/wxGUI.toolboxes.md
+++ b/gui/wxpython/docs/wxGUI.toolboxes.md
@@ -1,13 +1,10 @@
 ---
 description: wxGUI Toolboxes
 index: wxGUI
+keywords: [general, GUI]
 ---
 
 # wxGUI Toolboxes
-
-## KEYWORDS
-
-[general](general.md), [GUI](topic_GUI.md)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/docs/wxGUI.vnet.md
+++ b/gui/wxpython/docs/wxGUI.vnet.md
@@ -1,14 +1,10 @@
 ---
 description: wxGUI Vector Network Analysis Tool
 index: wxGUI
+keywords: [vector, GUI, network]
 ---
 
 # wxGUI Vector Network Analysis Tool
-
-## KEYWORDS
-
-[vector](vector.md), [network](topic_network.md),
-[vector](keywords.md#vector)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/iclass/g.gui.iclass.md
+++ b/gui/wxpython/iclass/g.gui.iclass.md
@@ -1,16 +1,11 @@
 ---
 description: wxGUI Supervised Classification Tool
 index: topic_GUI|GUI
+keywords: [display, GUI, imagery, classification, supervised classification]
+
 ---
 
 # wxGUI Supervised Classification Tool
-
-## KEYWORDS
-
-[display](display.md), [GUI](topic_GUI.md),
-[imagery](keywords.md#imagery),
-[classification](keywords.md#classification), [supervised
-classification](keywords.md#supervised-classification)
 
 ## DESCRIPTION
 

--- a/gui/wxpython/rdigit/g.gui.rdigit.md
+++ b/gui/wxpython/rdigit/g.gui.rdigit.md
@@ -1,15 +1,10 @@
 ---
 description: wxGUI Raster Digitizer
 index: wxGUI
+keywords: [display, GUI, raster, editing, digitizer]
 ---
 
 # wxGUI Raster Digitizer
-
-## KEYWORDS
-
-[display](display.md), [GUI](topic_GUI.md),
-[raster](keywords.md#raster), [editing](keywords.md#editing),
-[digitizer](keywords.md#digitizer)
 
 ## DESCRIPTION
 

--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -76,11 +76,6 @@ void G__usage_markdown(void)
     }
     fprintf(stdout, "\n");
     fprintf(stdout, "### ");
-    fprintf(stdout, "%s\n", _("KEYWORDS"));
-    fprintf(stdout, "\n");
-    if (st->module_info.keywords) {
-        G__print_keywords(stdout, print_escaped_for_md_keywords, TRUE);
-    }
     fprintf(stdout, "\n");
     fprintf(stdout, "### ");
     fprintf(stdout, "%s\n", _("SYNOPSIS"));

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -4,6 +4,8 @@
 # (c) 2012-2025 by the GRASS Development Team
 
 import os
+import re
+import sys
 import glob
 from pathlib import Path
 
@@ -43,25 +45,56 @@ def build_topics(ext):
             if ext == "html":
                 index_keys = lines.index("<h2>KEYWORDS</h2>\n") + 1
                 index_desc = lines.index("<h2>NAME</h2>\n") + 1
-            else:
-                # expecting markdown
-                index_keys = lines.index("### KEYWORDS\n") + 3
-                index_desc = lines.index("## NAME\n") + 2
         except Exception:
             continue
         try:
             if ext == "html":
                 key = lines[index_keys].split(",")[1].strip().replace(" ", "_")
                 key = key.split(">")[1].split("<")[0]
-            else:
-                # expecting markdown
-                key = lines[index_keys].split("]")[0].lstrip("[")
         except Exception:
             continue
         try:
-            desc = lines[index_desc].split("-", 1)[1].strip()
+            if ext == "html":
+                desc = lines[index_desc].split("-", 1)[1].strip()
         except Exception:
-            desc = desc.strip()
+            if ext == "html":
+                desc = desc.strip()
+
+        if ext == "md":
+            key = None
+            desc = None
+            for line in lines:
+                # We accept, but don't require, YAML inline list syntax.
+                match = re.match(r"keywords:\s*\[\s*(.*)\s*\]\s*", line)
+                if not match:
+                    match = re.match(r"keywords:\s*(.*)\s*", line)
+                if match:
+                    text = match.group(1)
+                    if not text:
+                        print(
+                            f"Warning: Empty keyword list in {fname}", file=sys.stderr
+                        )
+                        break
+                    # We accept only non-quoted YAML strings.
+                    keys = [item.strip() for item in text.split(",")]
+                    if len(keys) < 2:
+                        print(
+                            f"Warning: File {fname} has only one keyword",
+                            file=sys.stderr,
+                        )
+                        break
+                    key = keys[1]  # Second keyword is topic.
+                match = re.match(r"description:\s*(.*)\s*", line)
+                if match:
+                    text = match.group(1)
+                    if not text:
+                        print(f"Warning: Empty tile in {fname}", file=sys.stderr)
+                        break
+                    desc = text
+                if desc and key:
+                    break
+            if not desc or not key:
+                continue
 
         # Line ending can appear here on Windows.
         key = key.strip()


### PR DESCRIPTION
This removes the Keywords section from the generated documentation in favor of showing MkDocs generated tags.

This also adds keywords to metadata of some files replacing a hard-coded Keywords section and adding keywords so there is at least two keywords when keywords are present.

There are two major differences:

1. The MkDocs tags are alphabetically ordered and are at the top of the page as "bubbles" instead of priority ordered tags as text inside a section.
2. All the tags go to the same page with a list of tags and a list of pages with each tag. This is like the original keywords index just with bubbles instead of plain headings. There is no distinction made for the first keyword being a category (raster, vector, ...) - going to category index - and second keyword being a topic - going to a topic page.

This preserves the current topic functionality which depends on the presence of keywords which are now obtained from the metadata rather than from parsing the Markdown text. Unlike the tool categories (raster, vector, ...), the topics are not linked from the menu at this point.

## Old doc - new doc - no Keywords section

![image](https://github.com/user-attachments/assets/e9d2d99d-0fad-4bf4-b743-0d64692f2f7d)
