### PR TITLE
docs: Replace keywords index by MkDocs tags

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -118,15 +118,13 @@ jobs:
           mkdir "$MKDOCS_DIR/source/addons"
           mv -v addons-build-dir/docs/md/source/* "$MKDOCS_DIR/source/addons"
 
-      - name: Build index and rebuild keywords
+      - name: Build index
         run: |
           export ARCH="$(grass --config arch)"
           export ARCH_DISTDIR="$(grass --config path)"
           export VERSION_NUMBER="$VERSION"
           grass --tmp-project XY --exec \
             python grass/man/build_full_index.py md index "$MKDOCS_DIR/source/addons" addons
-          grass --tmp-project XY --exec \
-            python grass/man/build_keywords.py md "$MKDOCS_DIR/source" "$MKDOCS_DIR/source/addons"
 
       - name: Copy shared files to addons
         run: |

--- a/man/Makefile
+++ b/man/Makefile
@@ -23,7 +23,7 @@ DSTFILES := \
 	$(MDDIR)/overrides/partials/footer.html \
 	$(MDDIR)/overrides/partials/actions.html \
 	$(MDDIR)/overrides/partials/source.html \
-	$(MDDIR)/source/tags.md \
+	$(MDDIR)/source/keywords.md \
 	$(MDDIR)/source/development_intro.md \
 	$(MDDIR)/source/interfaces_overview.md \
 	$(MDDIR)/source/jupyter_intro.md \
@@ -50,7 +50,7 @@ IDXSRC = full_index index topics keywords graphical_index manual_gallery class_g
 
 INDICES := $(patsubst %,$(HTMLDIR)/%.html,$(IDXSRC))
 
-IDXSRC_MD = full_index index topics keywords graphical_index manual_gallery class_graphical parser_standard_options $(IDXCATS)
+IDXSRC_MD = full_index index topics graphical_index manual_gallery class_graphical parser_standard_options $(IDXCATS)
 INDICES_MD := $(patsubst %,$(MDDIR)/source/%.md,$(IDXSRC_MD))
 
 ALL_HTML := $(wildcard $(HTMLDIR)/*.*.html)
@@ -170,10 +170,6 @@ $(HTMLDIR)/keywords.html: $(ALL_HTML)
 	$(call build_keywords)
 	touch $@
 
-$(MDDIR)/source/keywords.md: $(ALL_MD)
-	$(call build_keywords)
-	touch $@
-
 $(HTMLDIR)/graphical_index.html: $(ALL_HTML)
 	$(call build_graphical_index)
 	touch $@
@@ -265,7 +261,7 @@ $(MDDIR)/source/favicon.ico: favicon.ico
 $(MDDIR)/source/grassdocs.css: mkdocs/grassdocs.css
 	$(INSTALL_DATA) $< $@
 
-$(MDDIR)/source/tags.md: mkdocs/tags.md
+$(MDDIR)/source/keywords.md: mkdocs/keywords.md
 	$(INSTALL_DATA) $< $@
 
 $(MDDIR)/source/development_intro.md: mkdocs/docs/development_intro.md

--- a/man/Makefile
+++ b/man/Makefile
@@ -23,6 +23,7 @@ DSTFILES := \
 	$(MDDIR)/overrides/partials/footer.html \
 	$(MDDIR)/overrides/partials/actions.html \
 	$(MDDIR)/overrides/partials/source.html \
+	$(MDDIR)/overrides/fragments/tags/default/listing.html \
 	$(MDDIR)/source/keywords.md \
 	$(MDDIR)/source/development_intro.md \
 	$(MDDIR)/source/interfaces_overview.md \
@@ -296,6 +297,12 @@ $(MDDIR)/overrides/partials/source.html: mkdocs/overrides/partials/source.html |
 
 $(MDDIR)/overrides/partials:
 	$(MKDIR) $@
+
+$(MDDIR)/overrides/fragments/tags/default:
+	$(MKDIR) $@
+
+$(MDDIR)/overrides/fragments/tags/default/listing.html: mkdocs/overrides/fragments/tags/default/listing.html | $(MDDIR)/overrides/fragments/tags/default
+	$(INSTALL_DATA) $< $@
 
 build-mkdocs:
 	@cd $(MDDIR) ; SITE_NAME="GRASS GIS $(GRASS_VERSION_NUMBER) Reference Manual" \

--- a/man/build_keywords.py
+++ b/man/build_keywords.py
@@ -224,10 +224,8 @@ def build_keywords(ext, main_path, addons_path):
 
 def main():
     if len(sys.argv) == 1:
-        # Usage according to a Makefile in core after the initial Markdown doc
-        # implementation.
+        # Build only HTML by default.
         build_keywords("html", main_path=None, addons_path=None)
-        build_keywords("md", main_path=None, addons_path=None)
         return
 
     if len(sys.argv) >= 2:

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -94,6 +94,8 @@ def build_topics(ext):
                             % (grass_version, key.replace("_", " "))
                         )
                     )
+                if ext == "md":
+                    keyfile.write("---\nhide:\n  - toc\n---\n\n")
                 keyfile.write(headerkey_tmpl.substitute(keyword=key.replace("_", " ")))
                 num_modules = 0
                 for mod, desc in sorted(values.items()):
@@ -130,10 +132,9 @@ def build_topics(ext):
                     # expecting markdown
                     keyfile.write(
                         "*See also the corresponding keyword"
-                        " [{name}](keywords.md#{key})"
-                        " for additional references.*\n".format(
-                            key=key.replace(" ", "-").replace("_", "-").lower(),
-                            name=key.replace("_", " "),
+                        " for additional references:*\n"
+                        "\n<!-- material/tags {{ include: [{key}] }} -->\n".format(
+                            key=key,
                         )
                     )
 

--- a/man/mkdocs/keywords.md
+++ b/man/mkdocs/keywords.md
@@ -1,5 +1,3 @@
-# Tags
-
-Following is a list of relevant tags:
+# Tools by keywords
 
 <!-- material/tags { exclude: [unit test] } -->

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -85,6 +85,7 @@ plugins:
   - glightbox
   - tags:
       tags_name_property: keywords
+      tags_slugify_format: "{slug}"
   - social:
       cards_layout_options:
         background_color: rgb(76, 176, 91)

--- a/man/mkdocs/overrides/fragments/tags/default/listing.html
+++ b/man/mkdocs/overrides/fragments/tags/default/listing.html
@@ -1,0 +1,53 @@
+<!--
+  AUTHOR(S): Vaclav Petras <wenzeslaus gmail com>
+
+  PURPOSE:   Tag listings
+
+  COPYRIGHT: (C) 2025 by Vaclav Petras and the GRASS Development Team
+             This program is free software under the GNU General Public
+             License (>=v2). Read the file COPYING that comes with GRASS
+             for details.
+
+  Original file license:
+
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+{% macro render(listing) %}
+  {{ listing.content }}
+  <ul>
+    {% for mapping in listing.mappings %}
+      <li>
+        <a href="{{ mapping.item.url | url }}">
+          <em>{{ mapping.item.title }}</em>
+        </a>
+        - {{ mapping.item.meta.description }}
+      </li>
+    {% endfor %}
+    {% for child in listing %}
+    <li style="list-style-type: none">{{ render(child) }}</li>
+    {% endfor %}
+  </ul>
+{% endmacro %}
+
+<!-- ---------------------------------------------------------------------- -->
+
+{{ render(listing) }}


### PR DESCRIPTION
This removes custom keywords index and replaces the keywords.html page by a MkDocs tags listing.

The default MkDocs tag anchor contains tag: prefix to help distinguishing tag headings from others, but we likely won't have a heading of the same name on the same page. However, we were using anchors without any prefix, so this will make most of the anchor links work (if there are any external ones anywhere). It also makes the anchor little simple to read and write if managed manually for any reason.

The check for anchor existence is done by MkDocs before the tags page is generated. This creates false positive for the Keywords section (to be removed) and for topics. To avoid this warning for topics, and perhaps to be little more helpful, instead of linking to the keyword, this new code uses MkDocs tags listing to list pages with that keyword right on the topic page. Unless MkDocs changes when or how the check is done, we will get a warning for manually included links to keywords (tags), e.g., from the See also section.

This disables custom keywords build and disables the addons keyword integration in the CI workflow. The Python code to generate the keywords in Markdown is still in place, but it can be removed in the future possibly together with the custom HTML code (they are mixed together).

## keywords.html: old doc - custom keyword index - MkDocs tag listing

![image](https://github.com/user-attachments/assets/7ef8b07f-3fce-4ecf-8cf6-9dbbf02c45ab)

(The difference in listed tools in the example is given by doc build with and without addons. The tag listing includes addons automatically since MkDocs processes all Markdown files at once in a separate build step.)

## Topic page

![image](https://github.com/user-attachments/assets/29746e87-d400-45bd-89ba-a0e0be386e11)

(We may remove or completely redo the topics in the future, but this keeps external links working if any and the resulting pages look okay.)