### PR TITLE
docs: Unify tool index wording

### DIFF
--- a/man/build.py
+++ b/man/build.py
@@ -135,8 +135,10 @@ def write_footer(f, index_url, year=None, template="html"):
 
 def to_title(name):
     """Convert name of command class/family to form suitable for title"""
-    if name == "PostScript":
-        return name
+    if name.lower() == "postscript":
+        return "PostScript"
+    if name.lower() == "3d raster":
+        return "3D raster"
     return name.capitalize()
 
 

--- a/man/build_class.py
+++ b/man/build_class.py
@@ -34,19 +34,17 @@ def build_class(ext):
 
     filename = modclass + f".{ext}"
     with open(filename + ".tmp", "w") as f:
+        modclass_lower = modclass.lower()
+        # convert keyword to nice form
+        modclass_visible = "3D raster" if modclass_lower == "raster3d" else modclass
         write_header(
             f,
-            "{} modules - GRASS GIS {} Reference Manual".format(
-                modclass.capitalize(), grass_version
+            "{} tools - GRASS GIS {} Reference Manual".format(
+                to_title(modclass_visible), grass_version
             ),
             template=ext,
         )
-        modclass_lower = modclass.lower()
-        modclass_visible = modclass
         if modclass_lower not in no_intro_page_classes:
-            if modclass_visible == "raster3d":
-                # convert keyword to nice form
-                modclass_visible = "3D raster"
             f.write(
                 modclass_intro_tmpl.substitute(
                     modclass=modclass_visible, modclass_lower=modclass_lower

--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -151,7 +151,8 @@ def generate_page_for_category(
                 module_family = "3D raster"
             output.write(
                 modclass_intro_tmpl.substitute(
-                    modclass=module_family, modclass_lower=module_family.lower()
+                    modclass=to_title(module_family),
+                    modclass_lower=module_family.lower(),
                 )
             )
         if module_family == "wxGUI":

--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -16,7 +16,6 @@ from build import (
     get_files,
     write_footer,
     write_header,
-    to_title,
     grass_version,
     grass_version_major,
     grass_version_minor,
@@ -25,7 +24,7 @@ from build import (
 )
 
 CORE_TEXT = """\
-# Processing Tools
+# Tools
 """
 
 ADDONS_TEXT = """\
@@ -82,23 +81,28 @@ def build_full_index(ext, index_name, source_dir, year, text_type):
 
     # TODO: create some master function/dict somewhere
     class_labels = {
-        "d": "display",
-        "db": "database",
-        "g": "general",
-        "i": "imagery",
-        "m": "miscellaneous",
+        "d": "Display",
+        "db": "Database",
+        "g": "General",
+        "i": "Imagery",
+        "m": "Miscellaneous",
         "ps": "PostScript",
-        "r": "raster",
+        "r": "Raster",
         "r3": "3D raster",
-        "t": "temporal",
-        "v": "vector",
+        "t": "Temporal",
+        "v": "Vector",
     }
+
+    ignore_classes = ["test"]
 
     classes = []
     for cmd in get_files(source_dir, "*", extension=ext):
         prefix = cmd.split(".")[0]
+        if prefix in ignore_classes:
+            continue
         if prefix not in [item[0] for item in classes]:
             classes.append((prefix, class_labels.get(prefix, prefix)))
+    # Sort by prefix.
     classes.sort(key=itemgetter(0))
 
     # begin full index:
@@ -132,7 +136,7 @@ def build_full_index(ext, index_name, source_dir, year, text_type):
 
         # for all module groups:
         for cls, cls_label in classes:
-            f.write(cmd2_tmpl.substitute(cmd_label=to_title(cls_label), cmd=cls))
+            f.write(cmd2_tmpl.substitute(cmd_label=cls_label, cmd=cls))
             # for all modules:
             for cmd in get_files(source_dir, cls, extension=ext):
                 basename = os.path.splitext(cmd)[0]

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -58,7 +58,7 @@ footer_tmpl = string.Template("")
 
 cmd2_tmpl = string.Template(
     r"""
-### ${cmd_label} commands (${cmd}.*)
+### ${cmd_label} tools (${cmd}.*)
 
 | Module | Description |
 |--------|-------------|
@@ -74,12 +74,10 @@ modclass_intro_tmpl = string.Template(
     r"""Go to [${modclass} introduction](${modclass_lower}intro.md) | [topics](topics.md)
 """
 )
-# "
-
 
 modclass_tmpl = string.Template(
-    r"""Go [back to help overview](index.md)
-### ${modclass} commands
+    r"""
+## ${modclass} tools
 | Module | Description |
 |--------|-------------|
 """

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -58,9 +58,9 @@ footer_tmpl = string.Template("")
 
 cmd2_tmpl = string.Template(
     r"""
-### ${cmd_label} tools (${cmd}.*)
+### ${cmd_label} tools (${cmd}.)
 
-| Module | Description |
+| Name | Description |
 |--------|-------------|
 """
 )
@@ -78,7 +78,7 @@ modclass_intro_tmpl = string.Template(
 modclass_tmpl = string.Template(
     r"""
 ## ${modclass} tools
-| Module | Description |
+| Name | Description |
 |--------|-------------|
 """
 )
@@ -103,7 +103,7 @@ headerkeywords_tmpl = r"""# Keywords - Index of GRASS GIS modules
 headerkey_tmpl = string.Template(
     r"""# Topic: ${keyword}
 
-| Module | Description |
+| Tool | Description |
 |--------|-------------|
 """
 )

--- a/man/mkdocs/index.md
+++ b/man/mkdocs/index.md
@@ -24,7 +24,7 @@ with the software. The most common interfaces are:
 - [Jupyter Notebooks](jupyter_intro.md)
 - [Graphical user interface](helptext.md)
 
-## Processing Tools
+## Tools
 
 GRASS provides a wide range of tools for geospatial processing, modeling,
 analysis, and visualization. The tools are organized into categories based
@@ -40,14 +40,14 @@ matter (e.g. hydrology, landscape).
 |--------|-----------------------------------|------------------------------------|
 | `g.`   | [General](general.md)             | General GIS management tools       |
 | `r.`   | [Raster](raster.md)               | Raster data processing tools       |
-| `r3.`  | [3D Raster](raster3d.md)          | 3D Raster data processing tools    |
+| `r3.`  | [3D raster](raster3d.md)          | 3D Raster data processing tools    |
 | `v.`   | [Vector](vector.md)               | Vector data processing tools       |
 | `i.`   | [Imagery](imagery.md)             | Imagery processing tools           |
 | `t.`   | [Temporal](temporal.md)           | Temporal data processing tools     |
 | `db.`  | [Database](database.md)           | Database management tools          |
 | `d.`   | [Display](display.md)             | Display and visualization tools    |
 | `m.`   | [Miscellaneous](miscellaneous.md) | Miscellaneous tools                |
-| `ps.`  | [Postscript](postscript.md)       | Postscript tools                   |
+| `ps.`  | [PostScript](postscript.md)       | PostScript tools                   |
 
 ## Development
 

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -164,18 +164,18 @@ nav:
       - GRASS Projects: grass_database.md
       - Projection and Transformations: projectionintro.md
 
-  - Processing Tools:
-      - Processing Tools: full_index.md
-      - General Tools: general.md
-      - Raster Tools: raster.md
-      - Raster 3D Tools: raster3d.md
-      - Vector Tools: vector.md
-      - Database Tools: database.md
-      - Imagery Tools: imagery.md
-      - Temporal Tools: temporal.md
-      - Display Tools: display.md
-      - Postscript Tools: postscript.md
-      - Miscellaneous Tools: miscellaneous.md
+  - Tools:
+      - Tools: full_index.md
+      - General tools: general.md
+      - Raster tools: raster.md
+      - Raster 3D tools: raster3d.md
+      - Vector tools: vector.md
+      - Database tools: database.md
+      - Imagery tools: imagery.md
+      - Temporal tools: temporal.md
+      - Display tools: display.md
+      - Postscript tools: postscript.md
+      - Miscellaneous tools: miscellaneous.md
 
   - Development: development_intro.md
 

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -152,29 +152,29 @@ nav:
               - Temporal Plot: wxGUI.tplot.md
           - List of Components: wxGUI.components.md
 
-  - Key Concepts:
-      - Raster Overview: rasterintro.md
-      - Raster 3D Overview: raster3dintro.md
-      - Vector Overview: vectorintro.md
-      - Databases Overview: databaseintro.md
-      - Database Drivers: sql.md
-      - Imagery Overview: imageryintro.md
-      - Temporal Overview: temporalintro.md
-      - Display Drivers: displaydrivers.md
-      - GRASS Projects: grass_database.md
-      - Projection and Transformations: projectionintro.md
+  - Key concepts:
+      - Raster overview: rasterintro.md
+      - 3D raster overview: raster3dintro.md
+      - Vector overview: vectorintro.md
+      - Databases overview: databaseintro.md
+      - Database drivers: sql.md
+      - Imagery overview: imageryintro.md
+      - Temporal overview: temporalintro.md
+      - Display drivers: displaydrivers.md
+      - GRASS projects: grass_database.md
+      - Projections and transformations: projectionintro.md
 
   - Tools:
       - Tools: full_index.md
       - General tools: general.md
       - Raster tools: raster.md
-      - Raster 3D tools: raster3d.md
+      - 3D raster tools: raster3d.md
       - Vector tools: vector.md
       - Database tools: database.md
       - Imagery tools: imagery.md
       - Temporal tools: temporal.md
       - Display tools: display.md
-      - Postscript tools: postscript.md
+      - PostScript tools: postscript.md
       - Miscellaneous tools: miscellaneous.md
 
   - Development: development_intro.md


### PR DESCRIPTION
Use tool instead of command, use tools instead of processing tools, and use sentence case instead of title case.

Also fix heading levels and remove backlinks to index in tool category pages.

## full_index.html (main menu > Tools): old doc - new doc

![image](https://github.com/user-attachments/assets/35ea4769-be68-417c-86ab-541603f97224)
