### PR TITLE
d.barscale: Fix uninitialized Variable in draw_scale.c

### DIFF
--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -66,7 +66,7 @@ int draw_scale(double east, double north, int length, int seg, int units,
     int i, incr;
     double x_pos, y_pos;
     double t, b, l, r;
-    double pt, pb, pl, pr; /* background box */
+    double pt = 0.0, pb = 0.0, pl = 0.0, pr = 0.0; /* background box */
     double tt, tb, tl, tr; /* text box */
     double xarr[5], yarr[5];
     double seg_len;

--- a/display/d.barscale/draw_scale.c
+++ b/display/d.barscale/draw_scale.c
@@ -67,7 +67,7 @@ int draw_scale(double east, double north, int length, int seg, int units,
     double x_pos, y_pos;
     double t, b, l, r;
     double pt = 0.0, pb = 0.0, pl = 0.0, pr = 0.0; /* background box */
-    double tt, tb, tl, tr; /* text box */
+    double tt, tb, tl, tr;                         /* text box */
     double xarr[5], yarr[5];
     double seg_len;
     const struct scale *scales = all_scales[use_feet];


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208451, 1208454)
initialized variables with 0.0