### PR TITLE
r3.out.vtk: Fix Resource Leak Issue in writeVTKData.c

### DIFF
--- a/raster3d/r3.out.vtk/writeVTKData.c
+++ b/raster3d/r3.out.vtk/writeVTKData.c
@@ -251,7 +251,6 @@ void write_vtk_points(input_maps *in, FILE *fp, RASTER3D_Region region, int dp,
                     region.depths); /*We have pointdata */
     G_free(rast_top);
     G_free(rast_bottom);
-    
     return;
 }
 

--- a/raster3d/r3.out.vtk/writeVTKData.c
+++ b/raster3d/r3.out.vtk/writeVTKData.c
@@ -249,7 +249,9 @@ void write_vtk_points(input_maps *in, FILE *fp, RASTER3D_Region region, int dp,
         fprintf(fp, "POINT_DATA %i\n",
                 region.cols * region.rows *
                     region.depths); /*We have pointdata */
-
+    G_free(rast_top);
+    G_free(rast_bottom);
+    
     return;
 }
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208000, 1208001)
Used G_free() to fix this issue.