### PR TITLE
docs: Fix basic graphical index issues in Markdown

### DIFF
--- a/man/build_class_graphical.py
+++ b/man/build_class_graphical.py
@@ -70,6 +70,8 @@ graphical_index_style = """\
 
 .img-list li img.default-img {
     max-height: 5ex;
+    background-color: var(--gs-primary-color);
+    padding: 5px;
 }
 
 .img-list li .desc {
@@ -234,7 +236,7 @@ def generate_page_for_category_md(
             if skip_no_image and not img:
                 continue
             if not img:
-                img = "grass_logo.png"
+                img = "grass_logo.svg"
                 img_class = "default-img"
             if basename.startswith("wxGUI"):
                 basename = basename.replace(".", " ")

--- a/man/build_graphical_index.py
+++ b/man/build_graphical_index.py
@@ -87,7 +87,7 @@ def main(ext):
                 )
             else:
                 output.write(
-                    "- [![{name}]({img})]({link}.md)".format(
+                    "[![{name}]({img})]({link}.md)\n".format(
                         link=html_file.removesuffix(".html"), img=image, name=label
                     )
                 )

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -113,7 +113,7 @@ headerpso_tmpl = r"""
 # Standard Parser Options
 """
 
-header_graphical_index_tmpl = """# Graphical index of GRASS GIS modules
+header_graphical_index_tmpl = """# Graphical index
 """
 
 ############################################################################


### PR DESCRIPTION
The generated Markdown for index was broken and the the individual pages were missing the default image. The page title for index was too long. This is making the pages legible.

...even if may remove it in the future, let's evaluate it in the best possible light:

![image](https://github.com/user-attachments/assets/059a80d8-a23e-4f87-9595-f4022cdab795)

![image](https://github.com/user-attachments/assets/98fd4cbd-ba38-4637-a449-50240f3f7404)
