### PR TITLE
wxGUI: Fix PTH208 use pathlib Path instead of os module

### DIFF
--- a/gui/wxpython/icons/grass_icons.py
+++ b/gui/wxpython/icons/grass_icons.py
@@ -7,15 +7,18 @@ https://svn.osgeo.org/osgeo/graphics/toolbar-icons/24x24/
 __author__ = "Robert Szczepanek"
 
 import os
+from pathlib import Path  # Import Path
 
 from core import globalvar
 
 iconPath = os.path.join(globalvar.ICONDIR, "grass")
+iconPathObj = Path(iconPath)  # Create a Path object
 
 iconSet = {}
 
-for icon in os.listdir(iconPath):
-    name, ext = os.path.splitext(icon)
+for icon in iconPathObj.iterdir():  # Use iterdir()
+    name = icon.stem  # Use Path.stem to get the name
+    ext = icon.suffix  # Use Path.suffix to get the extension
     if ext != ".png":
         continue
-    iconSet[name] = icon
+    iconSet[name] = icon.name  # Store the full filename (name + ext)

--- a/gui/wxpython/icons/grass_icons.py
+++ b/gui/wxpython/icons/grass_icons.py
@@ -7,18 +7,18 @@ https://svn.osgeo.org/osgeo/graphics/toolbar-icons/24x24/
 __author__ = "Robert Szczepanek"
 
 import os
-from pathlib import Path  # Import Path
+from pathlib import Path
 
 from core import globalvar
 
 iconPath = os.path.join(globalvar.ICONDIR, "grass")
-iconPathObj = Path(iconPath)  # Create a Path object
+iconPathObj = Path(iconPath)
 
 iconSet = {}
 
-for icon in iconPathObj.iterdir():  # Use iterdir()
-    name = icon.stem  # Use Path.stem to get the name
-    ext = icon.suffix  # Use Path.suffix to get the extension
+for icon in iconPathObj.iterdir():
+    name = icon.stem
+    ext = icon.suffix
     if ext != ".png":
         continue
-    iconSet[name] = icon.name  # Store the full filename (name + ext)
+    iconSet[name] = icon.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,7 +284,6 @@ ignore = [
 "**.py" = ["PYI066"]
 "*/testsuite/**.py" = ["PT009", "PT027"]
 "gui/wxpython/iclass/statistics.py" = ["A005"]
-"gui/wxpython/icons/grass_icons.py" = ["PTH208"]
 "gui/wxpython/image2target/ii2t_manager.py" = ["PTH208", "SIM115"]
 "gui/wxpython/photo2image/ip2i_manager.py" = ["SIM115"]
 "gui/wxpython/psmap/dialogs.py" = ["PTH208"]


### PR DESCRIPTION
PR addresses the PTH208 linting error in gui/wxpython/icons/grass_icons.py by replacing os.listdir and os.path.splitext with their pathlib equivalents.
- Imports Path from pathlib.
- Converts the iconPath string to a Path object.
- Uses Path.iterdir() to iterate over directory contents.
- Uses Path.stem and Path.suffix to get the filename components.
- Uses Path.name to get the full filename for storage in iconSet