### PR TITLE
docs: Separate topics from keywords by 2nd tags plugin

### DIFF
--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -166,7 +166,7 @@ def build_topics(ext):
                     keyfile.write(
                         "*See also the corresponding keyword"
                         " for additional references:*\n"
-                        "\n<!-- material/tags {{ include: [{key}] }} -->\n".format(
+                        "\n<!-- topic_keyword {{ include: [{key}] }} -->\n".format(
                             key=key,
                         )
                     )

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -86,6 +86,11 @@ plugins:
   - tags:
       tags_name_property: keywords
       tags_slugify_format: "{slug}"
+  - tags:
+      tags: false
+      tags_name_property: keywords
+      tags_slugify_format: "{slug}"
+      listings_directive: topic_keyword
   - social:
       cards_layout_options:
         background_color: rgb(76, 176, 91)


### PR DESCRIPTION
The additional change in #5446 adding tag listing for topic pages turned out to be harmful as it makes the tags (aka keywords) on top of pages link to the tag heading in the topic pages if the listing exists. While this sort of looks like the original custom HTML behavior of second keyword being a tag, this creates inconsistency with an seemingly arbitrary keyword (not just the second or 'topic' keyword) linking to a different page than the list of keywords, but not even to the topic page itself, but to a heading inside the page because instead of a a topic, the link goes to the keyword (tag) in the listing.

This preserves the additional list of tools for topic pages introduced in #5446 by creating another instance of the material tags plugin in MkDocs using the same front matter metadata item, but different listing directive name and disabling tags for pages. This introduces a second independent tag system so keywords and topics don't mix.

This is still easy to remove or modify if we decide to change or remove topics in the future.

The display link would go to the display topic page while general would go to keywords. Now both go to keywords.

![image](https://github.com/user-attachments/assets/135e638c-61f8-4d83-abd2-9b37bc97aa80)
