### PR TITLE
docs: fix typos in include

### DIFF
--- a/include/Make/Doxyfile_arch_html.in
+++ b/include/Make/Doxyfile_arch_html.in
@@ -1683,7 +1683,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/include/Make/Doxyfile_arch_latex.in
+++ b/include/Make/Doxyfile_arch_latex.in
@@ -1683,7 +1683,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -505,7 +505,7 @@ struct G_3dview {
     float from_to[2][3]; /* eye position & lookat position */
     float fov;           /* field of view */
     float twist;         /* right_hand rotation about from_to */
-    float exag;          /* terrain elevation exageration */
+    float exag;          /* terrain elevation exaggeration */
     int mesh_freq;       /* cells per grid line */
     int poly_freq;       /* cells per polygon */
     int display_type;    /* 1 for mesh, 2 for poly, 3 for both */

--- a/include/grass/iostream/embuffer.h
+++ b/include/grass/iostream/embuffer.h
@@ -341,7 +341,7 @@ public:
     // (pow(arity,level-1)*basesize); the <nextstream> pointer of buffer
     // is set to point to the argument stream; (in this way no stream
     // copying is done, just one pointer copy). The user should be aware
-    // the the argument stream is 'lost' - that is a stream cannot be
+    // the argument stream is 'lost' - that is a stream which cannot be
     // inserted repeatedly into many buffers because this would lead to
     // several buffers pointing to the same stream.
 
@@ -1068,10 +1068,10 @@ long em_buffer<T, Key>::insert(T *a, long n)
 
    the <nextstream> pointer of buffer is set to point to the argument
    stream; (in this way no stream copying is done, just one pointer
-   copy). The user should be aware the the argument stream is 'lost' -
-   that is a stream cannot be inserted repeatedly into many buffers
-   because this would lead to several buffers pointing to the same
-   stream.
+   copy). The user should be aware the argument stream is 'lost' -
+   that is a stream which cannot be inserted repeatedly into many
+   buffers because this would lead to several buffers pointing to the
+   same stream.
 
    stream is assume stream is sorted; bos = how many elements must be
    skipped (were deleted) from the beginning of stream;

--- a/include/grass/iostream/imbuffer.h
+++ b/include/grass/iostream/imbuffer.h
@@ -196,7 +196,7 @@ private:
     // sort the buffer (recursively)
     void sort_rec(unsigned long start, unsigned long end);
 
-    // partition the buffer and return the the position of the pivot
+    // partition the buffer and return the position of the pivot
     unsigned long partition(unsigned long start, unsigned long end);
 };
 
@@ -286,7 +286,7 @@ void im_buffer<T>::sort_rec(unsigned long start, unsigned long end)
 }
 
 /************************************************************/
-// partition the buffer in place and return the the position of the
+// partition the buffer in place and return the position of the
 // pivot
 template <class T>
 unsigned long im_buffer<T>::partition(unsigned long start, unsigned long end)

--- a/include/grass/vect/dig_macros.h
+++ b/include/grass/vect/dig_macros.h
@@ -4,7 +4,7 @@
    \brief Macros for diglib (part of vector library
  */
 
-/* ALIVE MACROS take a pointer the the structure in question */
+/* ALIVE MACROS take a pointer of the structure in question */
 /*  and return 0 or non-zero */
 #define LINE_ALIVE(p)   ((p)->type < 16) /* assume DEAD are .GT. 1 << 3 */
 #define NODE_ALIVE(p)   ((p)->alive) /* simple enuf                         */

--- a/include/grass/vect/dig_structs.h
+++ b/include/grass/vect/dig_structs.h
@@ -1306,7 +1306,7 @@ struct Map_info {
     /*!
        \brief Support files were updated
 
-       Non-zero code to indicate that supoort file were updated
+       Non-zero code to indicate that support files were updated
      */
     int support_updated;
 


### PR DESCRIPTION
Found via codespell