### PR TITLE
docker: add package to docker image to be able to run gui

### DIFF
--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get upgrade -y && \
     libpython3-all-dev \
     libreadline-dev \
     librsvg2-common \
+    libsecret-1-0 \
     libsdl2-2.0-0 \
     libsqlite3-dev \
     libtiff-dev \


### PR DESCRIPTION
See issue:
https://github.com/OSGeo/grass/issues/5458

Gui did not run from docker ubuntu gui image.

After adding this package, gui starts again without error message.

By the way, needs this PR also be applied on release branch 8.4? Same problem.
I don't know the policies about fixing release branches. And which..