### PR TITLE
CQ: remove misused gisprompt options

### DIFF
--- a/imagery/i.aster.toar/main.c
+++ b/imagery/i.aster.toar/main.c
@@ -112,14 +112,12 @@ int main(int argc, char *argv[])
     input1->key = "dayofyear";
     input1->type = TYPE_DOUBLE;
     input1->required = YES;
-    input1->gisprompt = "value";
     input1->description = _("Day of Year of satellite overpass [0-366]");
 
     input2 = G_define_option();
     input2->key = "sun_elevation";
     input2->type = TYPE_DOUBLE;
     input2->required = YES;
-    input2->gisprompt = "value";
     input2->description = _("Sun elevation angle (degrees, < 90.0)");
 
     output = G_define_standard_option(G_OPT_R_OUTPUT);

--- a/imagery/i.eb.hsebal01/main.c
+++ b/imagery/i.eb.hsebal01/main.c
@@ -138,7 +138,6 @@ int main(int argc, char *argv[])
     input_ustar->key = "frictionvelocitystar";
     input_ustar->type = TYPE_DOUBLE;
     input_ustar->required = YES;
-    input_ustar->gisprompt = "old,value";
     input_ustar->answer = "0.32407";
     input_ustar->description =
         _("Value of the height independent friction velocity (u*) [m/s]");

--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -94,7 +94,7 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
+# #% gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.accdetect/t.rast.accdetect.py
+++ b/temporal/t.rast.accdetect/t.rast.accdetect.py
@@ -94,7 +94,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# #% gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -95,7 +95,7 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
+# #% gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.accumulate/t.rast.accumulate.py
+++ b/temporal/t.rast.accumulate/t.rast.accumulate.py
@@ -95,7 +95,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# #% gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.aggregate.ds/t.rast.aggregate.ds.py
+++ b/temporal/t.rast.aggregate.ds/t.rast.aggregate.ds.py
@@ -50,7 +50,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.aggregate/t.rast.aggregate.py
+++ b/temporal/t.rast.aggregate/t.rast.aggregate.py
@@ -41,7 +41,6 @@
 # % description: Either a numerical suffix or the start time (s-flag) separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.extract/t.rast.extract.py
+++ b/temporal/t.rast.extract/t.rast.extract.py
@@ -52,7 +52,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: no
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.gapfill/t.rast.gapfill.py
+++ b/temporal/t.rast.gapfill/t.rast.gapfill.py
@@ -42,7 +42,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast.import/t.rast.import.py
+++ b/temporal/t.rast.import/t.rast.import.py
@@ -42,7 +42,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: no
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option G_OPT_M_DIR

--- a/temporal/t.rast.neighbors/t.rast.neighbors.py
+++ b/temporal/t.rast.neighbors/t.rast.neighbors.py
@@ -116,7 +116,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
+++ b/temporal/t.rast3d.mapcalc/t.rast3d.mapcalc.py
@@ -55,7 +55,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: yes
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/temporal/t.vect.extract/t.vect.extract.py
+++ b/temporal/t.vect.extract/t.vect.extract.py
@@ -54,7 +54,6 @@
 # % description: A numerical suffix separated by an underscore will be attached to create a unique identifier
 # % required: no
 # % multiple: no
-# % gisprompt:
 # %end
 
 # %option

--- a/vector/v.label.sa/main.c
+++ b/vector/v.label.sa/main.c
@@ -67,7 +67,6 @@ int main(int argc, char *argv[])
     p.font->required = YES;
     p.font->description = _("Name of TrueType font (as listed in the fontcap)");
     p.font->guisection = _("Font");
-    p.font->gisprompt = "font";
 
     p.size = G_define_option();
     p.size->key = "size";


### PR DESCRIPTION
Remove misused gisprompt option, which is expected to be a [comma separated three part value](https://grass.osgeo.org/programming8/gislib_cmdline_parsing.html#gisprompt_Member).