### PR TITLE
r.series: Say pipe in addition to showing the symbol

### DIFF
--- a/raster/r.series/main.c
+++ b/raster/r.series/main.c
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
     parm.file->key = "file";
     parm.file->description =
         _("Input file with one raster map name and optional one weight per "
-          "line, field separator between name and weight is |");
+          "line, field separator between name and weight is | (pipe)");
     parm.file->required = NO;
 
     parm.output = G_define_standard_option(G_OPT_R_OUTPUT);


### PR DESCRIPTION
At least some of ASCII symbols are better described by a word than just by showing the symbol itself. This way it is clear that what the symbol is while also being able to copy the symbol. When pipe is a parameter, we allow, even promote, using the word rather than the symbol itself.
