### PR TITLE
CI: Run pre-commit in CI when config files or workflows change

### DIFF
--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -36,7 +36,13 @@ jobs:
         with:
           filters: |
             precommit:
+              - '.clang-format'
+              - '.flake8'
+              - '.github/**'
+              - '.markdownlint.yml'
               - '.pre-commit-config.yaml'
+              - '.yamllint'
+              - 'pyproject.toml'
 
       - name: Check for CRLF endings
         uses: erclu/check-crlf@94acb86c2a41b0a46bd8087b63a06f0457dd0c6c # v1.2.0

--- a/mswindows/external/rbatch/el.js
+++ b/mswindows/external/rbatch/el.js
@@ -1,5 +1,5 @@
-/* global ActiveXObject, Application:writeable, Arguments:writeable,
- * Index:writeable, WScript */
+/* global ActiveXObject, WScript */
+/* global Application:writeable, Arguments:writeable, Index:writeable */
 // elevate.js -- runs target command line elevated
 // Arguments should not have embedded spaces.
 // http://blogs.msdn.com/b/aaron_margosis/archive/2007/07/01/scripting-elevation-on-vista.aspx

--- a/mswindows/external/rbatch/el.js
+++ b/mswindows/external/rbatch/el.js
@@ -1,4 +1,5 @@
-/* global ActiveXObject, Application:writeable, Arguments:writeable, Index:writeable, WScript */
+/* global ActiveXObject, Application:writeable, Arguments:writeable,
+ * Index:writeable, WScript */
 // elevate.js -- runs target command line elevated
 // Arguments should not have embedded spaces.
 // http://blogs.msdn.com/b/aaron_margosis/archive/2007/07/01/scripting-elevation-on-vista.aspx


### PR DESCRIPTION
I thought I had already made this PR, but it might have stayed unpushed on my phone. Oh well, doing it now.

I've been bitten a few times where we don't see any signs of differences of pre-commit fixes in CI when a version or config file changes, but doesn't affect the .pre-commit.yaml file. The latest one is that a fix for super-linter had some more changes from pre-commit. I'm fixing them here, as it should have been made in #5241 