### PR TITLE
db.drivers: Fix Resource Leak Issue in select.c

### DIFF
--- a/db/drivers/sqlite/select.c
+++ b/db/drivers/sqlite/select.c
@@ -62,6 +62,7 @@ int db__driver_open_select_cursor(dbString *sel, dbCursor *dbc, int mode)
                               db_get_string(sel),
                               (char *)sqlite3_errmsg(sqlite));
             db_d_report_error();
+            G_free(str);
             return DB_FAILED;
         }
 
@@ -78,6 +79,7 @@ int db__driver_open_select_cursor(dbString *sel, dbCursor *dbc, int mode)
                               (char *)sqlite3_errmsg(sqlite));
             db_d_report_error();
             sqlite3_finalize(c->statement);
+            G_free(str);
             return DB_FAILED;
         }
         else


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1415582)
Used G_free() to fix this issue.