### PR TITLE
docs: Use Documentation instead of Reference Manual

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -144,8 +144,8 @@ jobs:
           cd grass
           eval $(./utils/update_version.py status --bash)
           cd ..
-          export SITE_NAME="GRASS GIS $VERSION Reference Manual"
-          export COPYRIGHT="&copy; 2003-$YEAR GRASS Development Team, GRASS GIS $VERSION Reference Manual"
+          export SITE_NAME="GRASS $VERSION Documentation"
+          export COPYRIGHT="&copy; 2003-$YEAR GRASS Development Team, GRASS $VERSION Documentation"
           cd $MKDOCS_DIR
           mkdocs build
 

--- a/doc/grass_database.md
+++ b/doc/grass_database.md
@@ -203,10 +203,7 @@ using import options in the *File* menu in *Layer Manager* or
 
 ## See also
 
-*[GRASS GIS Reference Manual](index.md)  
-[GRASS GIS startup program manual page](grass.md)  
-[Importing data on GRASS
-Wiki](https://grasswiki.osgeo.org/wiki/Importing_data)  
-[r.import](r.import.md), [v.import](v.import.md),
-[r.external](r.external.md), [v.external](v.external.md),
-[r.proj](r.proj.md), [v.proj](v.proj.md),*
+- [The grass command](grass.md)
+- *[r.import](r.import.md), [v.import](v.import.md), [r.external](r.external.md),*
+  *[v.external](v.external.md), [r.proj](r.proj.md), [v.proj](v.proj.md)*
+- [Importing data on GRASS Wiki](https://grasswiki.osgeo.org/wiki/Importing_data)

--- a/doc/projectionintro.md
+++ b/doc/projectionintro.md
@@ -70,6 +70,10 @@ A graphical user interface is provided by [wxGUI](wxGUI.md).
   Europe](https://mapref.org)
 - [Information and Service System for European Coordinate Reference
   Systems - CRS](https://www.crs-geo.eu/)
+- [List of EPSG codes](https://spatialreference.org/)
+  (Database of worldwide coordinate systems)
+- [CRS Explorer - PROJ codes](https://crs-explorer.proj.org/)
+- [EPSG Geodetic Parameter Dataset](https://epsg.org/)
 
 ## See also
 

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -22,7 +22,7 @@ footer_tmpl = string.Template(
 | <a href="../keywords.html">Keywords Index</a>
 | <a href="../full_index.html">Full Index</a></p>
 <p>&copy; 2003-${year} <a href="https://grass.osgeo.org">GRASS Development Team</a>,
-GRASS GIS ${grass_version} Documentation</p>
+GRASS ${grass_version} Documentation</p>
 {% endblock %}
 """
 )

--- a/gui/wxpython/docs/wxgui_sphinx/conf.py
+++ b/gui/wxpython/docs/wxgui_sphinx/conf.py
@@ -22,7 +22,7 @@ footer_tmpl = string.Template(
 | <a href="../keywords.html">Keywords Index</a>
 | <a href="../full_index.html">Full Index</a></p>
 <p>&copy; 2003-${year} <a href="https://grass.osgeo.org">GRASS Development Team</a>,
-GRASS GIS ${grass_version} Reference Manual</p>
+GRASS GIS ${grass_version} Documentation</p>
 {% endblock %}
 """
 )

--- a/lib/init/helptext.md
+++ b/lib/init/helptext.md
@@ -80,11 +80,6 @@ line.
 
 ## See also
 
-*[GRASS GIS Reference Manual](index.md)  
-[GRASS GIS startup program manual page](grass.md)  
-[GRASS GIS tutorials and books](https://grass.osgeo.org/learn/)*
-
-[List of EPSG codes](https://spatialreference.org/) (Database of
-worldwide coordinate systems), [CRS Explorer - PROJ
-codes](https://crs-explorer.proj.org/), and [EPSG Geodetic Parameter
-Dataset](https://epsg.org/)
+- [The grass command](grass.md)
+- [GRASS tutorials and books](https://grass.osgeo.org/learn/)
+- [Intro to projections and transformations](projectionintro.md)

--- a/man/Makefile
+++ b/man/Makefile
@@ -299,11 +299,11 @@ $(MDDIR)/overrides/fragments/tags/default/listing.html: mkdocs/overrides/fragmen
 	$(INSTALL_DATA) $< $@
 
 build-mkdocs:
-	@cd $(MDDIR) ; SITE_NAME="GRASS $(GRASS_VERSION_NUMBER) Reference Manual" \
-	COPYRIGHT="&copy; 2003-$(GRASS_VERSION_DATE) GRASS Development Team, GRASS $(GRASS_VERSION_NUMBER) Reference Manual" \
+	@cd $(MDDIR) ; SITE_NAME="GRASS $(GRASS_VERSION_NUMBER) Documentation" \
+	COPYRIGHT="&copy; 2003-$(GRASS_VERSION_DATE) GRASS Development Team, GRASS $(GRASS_VERSION_NUMBER) Documentation" \
 	mkdocs build
 
 serve-mkdocs:
-	@cd $(MDDIR) ; SITE_NAME="GRASS $(GRASS_VERSION_NUMBER) Reference Manual" \
-	COPYRIGHT="&copy; 2003-$(GRASS_VERSION_DATE) GRASS Development Team, GRASS $(GRASS_VERSION_NUMBER) Reference Manual" \
+	@cd $(MDDIR) ; SITE_NAME="GRASS $(GRASS_VERSION_NUMBER) Documentation" \
+	COPYRIGHT="&copy; 2003-$(GRASS_VERSION_DATE) GRASS Development Team, GRASS $(GRASS_VERSION_NUMBER) Documentation" \
 	mkdocs serve

--- a/man/build_graphical_index.py
+++ b/man/build_graphical_index.py
@@ -67,11 +67,10 @@ def main(ext):
         )
 
     with open(os.path.join(man_dir, output_name + f".{ext}"), "w") as output:
-        output.write(
-            header1_tmpl.substitute(
-                title=f"GRASS {grass_version} Reference Manual - Graphical index"
-            )
-        )
+        title = "Graphical index"
+        if ext == "html":
+            title = f"GRASS {grass_version} Reference Manual - {title}"
+        output.write(header1_tmpl.substitute(title=title))
         output.write(header_graphical_index_tmpl)
         if ext == "html":
             output.write('<ul class="img-list">\n')

--- a/man/build_md.py
+++ b/man/build_md.py
@@ -72,7 +72,7 @@ headerpso_tmpl = r"""
 # Standard Parser Options
 """
 
-header_graphical_index_tmpl = """# Graphical index of GRASS tools
+header_graphical_index_tmpl = """# Graphical index of tools
 """
 
 ############################################################################

--- a/man/build_topics.py
+++ b/man/build_topics.py
@@ -108,11 +108,10 @@ def build_topics(ext):
             keywords[key][fname] = desc
 
     with Path(man_dir, f"topics.{ext}").open("w") as topicsfile:
-        topicsfile.write(
-            header1_tmpl.substitute(
-                title="GRASS %s Reference Manual - Topics index" % grass_version
-            )
-        )
+        title = "Topics index"
+        if ext == "html":
+            title = f"GRASS {grass_version} Reference Manual - {title}"
+        topicsfile.write(header1_tmpl.substitute(title=title))
         topicsfile.write(headertopics_tmpl)
 
         for key, values in sorted(keywords.items(), key=lambda s: s[0].lower()):

--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -439,7 +439,7 @@ FunctionEnd
     !define MUI_FINISHPAGE_RUN_FUNCTION "LaunchGrass"
     !define MUI_FINISHPAGE_SHOWREADME
     !define MUI_FINISHPAGE_SHOWREADME_NOTCHECKED
-    !define MUI_FINISHPAGE_SHOWREADME_TEXT "View the reference manual"
+    !define MUI_FINISHPAGE_SHOWREADME_TEXT "View the documentation"
     !define MUI_FINISHPAGE_SHOWREADME_FUNCTION "ViewReadme"
 !insertmacro MUI_PAGE_FINISH
 
@@ -466,7 +466,7 @@ FunctionEnd
 
 ;----------------------------------------------------------------------------------------------------------------------------
 
-;launch reference manual by exit the installation wizard
+;open documentation by exit the installation wizard
 
 Function ViewReadme
 

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -83,7 +83,7 @@ footer_tmpl = string.Template(
  | <a href="../keywords.html">Keywords Index</a>
  | <a href="../full_index.html">Full Index</a></p>
 <p>&copy; 2003-${year} <a href="https://grass.osgeo.org">
-GRASS Development Team</a>, GRASS GIS ${grass_version} Reference Manual</p>
+GRASS Development Team</a>, GRASS ${grass_version} Documentation</p>
 {% endblock %}
 """
 )


### PR DESCRIPTION
Use simpler Documentation instead of loaded Reference Manual. We call it both doc and ref man and using doc in the doc itself should lead to just one name although a less specific one. Doc is also just one work so it avoids title case versus sentence case inconsistencies.

This shuffles things around in a couple of the See also sections which were linking the index page which now is simply linked from the navigation, mainly it moves EPSG links from helptext aka quick start aka GUI intro) into projectionintro page.

## New

![image](https://github.com/user-attachments/assets/7a48c746-1ec2-4b4c-949c-501a32fe4382)

## Old

![image](https://github.com/user-attachments/assets/65f5f888-edac-4d42-a3a1-69282b2a3772)
