### PR TITLE
lib/arraystats: re-enable "Discont" algorithm

### DIFF
--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
              * algorithms */
             class_info =
                 AS_class_apply_algorithm(AS_option_to_algorithm(algo_opt), data,
-                                         nrec, &nbreaks, &breakpoints);
+                                         nrec, &nbreaks, breakpoints);
         }
         else {
 

--- a/display/d.vect.thematic/main.c
+++ b/display/d.vect.thematic/main.c
@@ -119,11 +119,10 @@ int main(int argc, char **argv)
     algo_opt->options = "int,std,qua,equ,dis";
     algo_opt->description = _("Algorithm to use for classification");
     desc = NULL;
-    G_asprintf(&desc, "int;%s;std;%s;qua;%s;equ;%s", _("simple intervals"),
-               _("standard deviations"), _("quantiles"),
-               _("equiprobable (normal distribution)"));
+    G_asprintf(&desc, "int;%s;std;%s;qua;%s;equ;%s;dis;%s",
+               _("simple intervals"), _("standard deviations"), _("quantiles"),
+               _("equiprobable (normal distribution)"), _("discontinuities"));
     algo_opt->descriptions = desc;
-    /*currently disabled because of bugs       "dis;discontinuities"); */
     algo_opt->guisection = _("Classes");
 
     nbclass_opt = G_define_option();
@@ -415,7 +414,7 @@ int main(int argc, char **argv)
              * algorithms */
             class_info =
                 AS_class_apply_algorithm(AS_option_to_algorithm(algo_opt), data,
-                                         nrec, &nbreaks, breakpoints);
+                                         nrec, &nbreaks, &breakpoints);
         }
         else {
 

--- a/include/grass/defs/arraystats.h
+++ b/include/grass/defs/arraystats.h
@@ -2,17 +2,17 @@
 #define GRASS_ARRAYSTATSDEFS_H
 
 /* basic.c */
-void AS_eqdrt(double[], double[], int, int, double *);
+void AS_eqdrt(double[], double[], int, int, double *, double *, double *);
 void AS_basic_stats(double *, int, struct GASTATS *);
 
 /* class.c */
 int AS_option_to_algorithm(const struct Option *);
-double AS_class_apply_algorithm(int, double *, int, int *, double *);
-int AS_class_interval(double *, int, int, double *);
-int AS_class_quant(double *, int, int, double *);
-double AS_class_discont(double *, int, int, double *);
-double AS_class_stdev(double *, int, int, double *);
-int AS_class_equiprob(double *, int, int *, double *);
+double AS_class_apply_algorithm(int, double *, int, int *, double **);
+int AS_class_interval(double *, int, int, double **);
+int AS_class_quant(double *, int, int, double **);
+double AS_class_discont(double *, int, int, double **);
+double AS_class_stdev(double *, int, int, double **);
+int AS_class_equiprob(double *, int, int *, double **);
 int AS_class_frequencies(double *, int, int, double *, int *);
 
 #endif

--- a/include/grass/defs/arraystats.h
+++ b/include/grass/defs/arraystats.h
@@ -3,16 +3,16 @@
 
 /* basic.c */
 void AS_eqdrt(double[], double[], int, int, double *, double *, double *);
-void AS_basic_stats(double *, int, struct GASTATS *);
+void AS_basic_stats(const double[], int, struct GASTATS *);
 
 /* class.c */
 int AS_option_to_algorithm(const struct Option *);
-double AS_class_apply_algorithm(int, double *, int, int *, double **);
-int AS_class_interval(double *, int, int, double **);
-int AS_class_quant(double *, int, int, double **);
-double AS_class_discont(double *, int, int, double **);
-double AS_class_stdev(double *, int, int, double **);
-int AS_class_equiprob(double *, int, int *, double **);
-int AS_class_frequencies(double *, int, int, double *, int *);
+double AS_class_apply_algorithm(int, const double[], int, int *, double[]);
+int AS_class_interval(const double[], int, int, double[]);
+int AS_class_quant(const double[], int, int, double[]);
+double AS_class_discont(const double[], int, int, double[]);
+double AS_class_stdev(const double[], int, int, double[]);
+int AS_class_equiprob(const double[], int, int *, double[]);
+int AS_class_frequencies(const double[], int, int, double[], int[]);
 
 #endif

--- a/lib/arraystats/basic.c
+++ b/lib/arraystats/basic.c
@@ -62,7 +62,7 @@ void AS_eqdrt(double vectx[], double vecty[], int i1, int i2, double *a,
 
     if (fabs(bd) < GRASS_EPSILON) {
         if (fabs(bn) < GRASS_EPSILON) {
-            printf("Points are equal\n");
+            G_debug(3, "Points are equal\n");
         }
         else {
             *c = x1;

--- a/lib/arraystats/basic.c
+++ b/lib/arraystats/basic.c
@@ -1,5 +1,7 @@
 #include <math.h>
+
 #include <grass/arraystats.h>
+#include <grass/gis.h>
 
 /*provides basic univar stats */
 void AS_basic_stats(double *data, int count, struct GASTATS *stats)
@@ -34,31 +36,40 @@ void AS_basic_stats(double *data, int count, struct GASTATS *stats)
     return;
 }
 
-void AS_eqdrt(double vectx[], double vecty[], int i1, int i2, double *vabc)
+void AS_eqdrt(double vectx[], double vecty[], int i1, int i2, double *a,
+              double *b, double *c)
 {
-    double bn = 0, bd = 0, x1 = 0, y1 = 0;
+    double x1 = vectx[i1];
+    double y1 = vecty[i1];
+    double x2 = vectx[i2];
+    double y2 = vecty[i2];
 
-    vabc[0] = 0;
-    vabc[1] = 0;
-    vabc[2] = 0;
     if (i1 == 0) {
-        x1 = 0;
-        y1 = 0;
+        x1 = 0.0;
+        y1 = 0.0;
     }
     else {
         x1 = vectx[i1];
         y1 = vecty[i1];
     }
-    bn = y1 - vecty[i2];
-    bd = x1 - vectx[i2];
-    if (bd != 0) {
-        vabc[1] = bn / bd;
-        vabc[0] = y1 - vabc[1] * x1;
-        return;
+
+    *a = 0.0;
+    *b = 0.0;
+    *c = 0.0;
+
+    double bn = y1 - y2;
+    double bd = x1 - x2;
+
+    if (fabs(bd) < GRASS_EPSILON) {
+        if (fabs(bn) < GRASS_EPSILON) {
+            printf("Points are equal\n");
+        }
+        else {
+            *c = x1;
+        }
     }
-    if (bn != 0)
-        vabc[2] = x1;
-    else
-        G_debug(3, "Points are equal\n");
-    return;
+    else {
+        *b = bn / bd;
+        *a = y1 - *b * x1;
+    }
 }

--- a/lib/arraystats/basic.c
+++ b/lib/arraystats/basic.c
@@ -4,7 +4,7 @@
 #include <grass/gis.h>
 
 /*provides basic univar stats */
-void AS_basic_stats(double *data, int count, struct GASTATS *stats)
+void AS_basic_stats(const double data[], int count, struct GASTATS *stats)
 {
     int i = 1;
     double sum = 0, sumsq = 0, sumabs = 0;

--- a/lib/arraystats/class.c
+++ b/lib/arraystats/class.c
@@ -22,8 +22,8 @@ int AS_option_to_algorithm(const struct Option *option)
     G_fatal_error(_("Unknown algorithm '%s'"), option->answer);
 }
 
-double AS_class_apply_algorithm(int algo, double *data, int nrec, int *nbreaks,
-                                double **classbreaks)
+double AS_class_apply_algorithm(int algo, const double data[], int nrec,
+                                int *nbreaks, double classbreaks[])
 {
     double finfo = 0.0;
 
@@ -53,12 +53,12 @@ double AS_class_apply_algorithm(int algo, double *data, int nrec, int *nbreaks,
     return finfo;
 }
 
-int AS_class_interval(double *data, int count, int nbreaks, double **clbrks_in)
+int AS_class_interval(const double data[], int count, int nbreaks,
+                      double classbreaks[])
 {
     double min, max;
     double step;
     int i = 0;
-    double *classbreaks = *clbrks_in;
 
     min = data[0];
     max = data[count - 1];
@@ -71,13 +71,13 @@ int AS_class_interval(double *data, int count, int nbreaks, double **clbrks_in)
     return (1);
 }
 
-double AS_class_stdev(double *data, int count, int nbreaks, double **clbrks_in)
+double AS_class_stdev(const double data[], int count, int nbreaks,
+                      double classbreaks[])
 {
     struct GASTATS stats;
     int i;
     int nbclass;
     double scale = 1.0;
-    double *classbreaks = *clbrks_in;
 
     AS_basic_stats(data, count, &stats);
 
@@ -136,10 +136,10 @@ double AS_class_stdev(double *data, int count, int nbreaks, double **clbrks_in)
     return (scale);
 }
 
-int AS_class_quant(double *data, int count, int nbreaks, double **clbrks_in)
+int AS_class_quant(const double data[], int count, int nbreaks,
+                   double classbreaks[])
 {
     int i, step;
-    double *classbreaks = *clbrks_in;
 
     step = count / (nbreaks + 1);
 
@@ -149,14 +149,14 @@ int AS_class_quant(double *data, int count, int nbreaks, double **clbrks_in)
     return (1);
 }
 
-int AS_class_equiprob(double *data, int count, int *nbreaks, double **clbrks_in)
+int AS_class_equiprob(const double data[], int count, int *nbreaks,
+                      double classbreaks[])
 {
     int i, j;
     double *lequi; /*Vector of scale factors for probabilities of the normal
                       distribution */
     struct GASTATS stats;
     int nbclass;
-    double *classbreaks = *clbrks_in;
 
     nbclass = *nbreaks + 1;
 
@@ -251,9 +251,8 @@ int AS_class_equiprob(double *data, int count, int *nbreaks, double **clbrks_in)
             _("There are classbreaks outside the range min-max. Number of "
               "classes reduced to %i, but using probabilities for %i classes."),
             j + 1, *nbreaks + 1);
-        classbreaks = G_realloc(classbreaks, j * sizeof(double));
         for (i = 0; i < j; i++)
-            classbreaks[i] = 0;
+            classbreaks[i] = 0.0;
     }
 
     j = 0;
@@ -264,18 +263,16 @@ int AS_class_equiprob(double *data, int count, int *nbreaks, double **clbrks_in)
             j++;
         }
     }
-    *clbrks_in = classbreaks;
     *nbreaks = j;
 
     G_free(lequi);
     return (1);
 }
 
-double AS_class_discont(double *data, int count, int nbreaks,
-                        double **clbrks_in)
+double AS_class_discont(const double data[], int count, int nbreaks,
+                        double classbreaks[])
 {
     int i, j;
-    double *classbreaks = *clbrks_in;
     double chi2 = 1000.0;
 
     /* get the number of values */
@@ -437,8 +434,8 @@ double AS_class_discont(double *data, int count, int nbreaks,
     return (chi2);
 }
 
-int AS_class_frequencies(double *data, int count, int nbreaks,
-                         double *classbreaks, int *frequencies)
+int AS_class_frequencies(const double data[], int count, int nbreaks,
+                         double classbreaks[], int frequencies[])
 {
     int i, j;
 

--- a/lib/arraystats/class.c
+++ b/lib/arraystats/class.c
@@ -1,6 +1,8 @@
 /* functions to classify sorted arrays of doubles and fill a vector of
  * classbreaks */
 
+#include <stdbool.h>
+
 #include <grass/glocale.h>
 #include <grass/arraystats.h>
 
@@ -21,7 +23,7 @@ int AS_option_to_algorithm(const struct Option *option)
 }
 
 double AS_class_apply_algorithm(int algo, double *data, int nrec, int *nbreaks,
-                                double *classbreaks)
+                                double **classbreaks)
 {
     double finfo = 0.0;
 
@@ -39,10 +41,7 @@ double AS_class_apply_algorithm(int algo, double *data, int nrec, int *nbreaks,
         finfo = AS_class_equiprob(data, nrec, nbreaks, classbreaks);
         break;
     case CLASS_DISCONT:
-        /*      finfo = class_discont(data, nrec, *nbreaks, classbreaks);
-         * disabled because of bugs */
-        G_fatal_error(
-            _("Discont algorithm currently not available because of bugs"));
+        finfo = AS_class_discont(data, nrec, *nbreaks, classbreaks);
         break;
     default:
         break;
@@ -54,11 +53,12 @@ double AS_class_apply_algorithm(int algo, double *data, int nrec, int *nbreaks,
     return finfo;
 }
 
-int AS_class_interval(double *data, int count, int nbreaks, double *classbreaks)
+int AS_class_interval(double *data, int count, int nbreaks, double **clbrks_in)
 {
     double min, max;
     double step;
     int i = 0;
+    double *classbreaks = *clbrks_in;
 
     min = data[0];
     max = data[count - 1];
@@ -71,12 +71,13 @@ int AS_class_interval(double *data, int count, int nbreaks, double *classbreaks)
     return (1);
 }
 
-double AS_class_stdev(double *data, int count, int nbreaks, double *classbreaks)
+double AS_class_stdev(double *data, int count, int nbreaks, double **clbrks_in)
 {
     struct GASTATS stats;
     int i;
     int nbclass;
     double scale = 1.0;
+    double *classbreaks = *clbrks_in;
 
     AS_basic_stats(data, count, &stats);
 
@@ -135,9 +136,10 @@ double AS_class_stdev(double *data, int count, int nbreaks, double *classbreaks)
     return (scale);
 }
 
-int AS_class_quant(double *data, int count, int nbreaks, double *classbreaks)
+int AS_class_quant(double *data, int count, int nbreaks, double **clbrks_in)
 {
     int i, step;
+    double *classbreaks = *clbrks_in;
 
     step = count / (nbreaks + 1);
 
@@ -147,14 +149,14 @@ int AS_class_quant(double *data, int count, int nbreaks, double *classbreaks)
     return (1);
 }
 
-int AS_class_equiprob(double *data, int count, int *nbreaks,
-                      double *classbreaks)
+int AS_class_equiprob(double *data, int count, int *nbreaks, double **clbrks_in)
 {
     int i, j;
     double *lequi; /*Vector of scale factors for probabilities of the normal
                       distribution */
     struct GASTATS stats;
     int nbclass;
+    double *classbreaks = *clbrks_in;
 
     nbclass = *nbreaks + 1;
 
@@ -249,7 +251,7 @@ int AS_class_equiprob(double *data, int count, int *nbreaks,
             _("There are classbreaks outside the range min-max. Number of "
               "classes reduced to %i, but using probabilities for %i classes."),
             j + 1, *nbreaks + 1);
-        G_realloc(classbreaks, j * sizeof(double));
+        classbreaks = G_realloc(classbreaks, j * sizeof(double));
         for (i = 0; i < j; i++)
             classbreaks[i] = 0;
     }
@@ -262,60 +264,44 @@ int AS_class_equiprob(double *data, int count, int *nbreaks,
             j++;
         }
     }
-
+    *clbrks_in = classbreaks;
     *nbreaks = j;
 
     G_free(lequi);
     return (1);
 }
 
-/* FIXME: there seems to a problem with array overflow, probably due to
-   the fact that the code was ported from fortran which has 1-based arrays */
 double AS_class_discont(double *data, int count, int nbreaks,
-                        double *classbreaks)
+                        double **clbrks_in)
 {
-    int *num, nbclass;
-    double *no, *zz, /* *nz, */ *xn, *co;
-    double *x; /* Vector standardized observations */
-    int i, j, k;
-    double min = 0, max = 0, rangemax = 0;
-    int n = 0;
-    double rangemin = 0, xlim = 0;
-    double dmax = 0.0 /*, d2 = 0.0, dd = 0.0, p = 0.0 */;
-    int nf = 0, nmax = 0;
-    double *abc;
-    int nd = 0;
-    double den = 0, d = 0;
-    int im = 0, ji = 0;
-    int tmp = 0;
-    int nff = 0, jj = 0, no1 = 0, no2 = 0;
-    double f = 0, xt1 = 0, xt2 = 0, chi2 = 1000.0, xnj_1 = 0, xj_1 = 0;
+    int i, j;
+    double *classbreaks = *clbrks_in;
+    double chi2 = 1000.0;
 
-    /*get the number of values */
-    n = count;
+    /* get the number of values */
+    int n = count;
 
-    nbclass = nbreaks + 1;
+    int nbclass = nbreaks + 1;
 
-    num = G_malloc((nbclass + 1) * sizeof(int));
-    no = G_malloc((nbclass + 1) * sizeof(double));
-    zz = G_malloc((nbclass + 1) * sizeof(double));
-    /* nz = G_malloc(3 * sizeof(double)); */
-    xn = G_malloc((n + 1) * sizeof(double));
-    co = G_malloc((nbclass + 1) * sizeof(double));
+    int *num = G_calloc((nbclass + 2), sizeof(int));
+    int *no = G_calloc((nbclass + 1), sizeof(int));
+    double *zz = G_malloc((nbclass + 1) * sizeof(double));
+    double *xn = G_malloc((n + 1) * sizeof(double));
+    double *co = G_malloc((nbclass + 1) * sizeof(double));
 
-    /* We copy the array of values to x, in order to be able to standardize it
-     */
-    x = G_malloc((n + 1) * sizeof(double));
-    x[0] = n;
-    xn[0] = 0;
+    /* We copy the array of values to x, in order to be able
+       to standardize it */
+    double *x = G_malloc((n + 1) * sizeof(double));
+    x[0] = 0.0;
+    xn[0] = 0.0;
 
-    min = data[0];
-    max = data[count - 1];
+    double min = data[0];
+    double max = data[count - 1];
     for (i = 1; i <= n; i++)
         x[i] = data[i - 1];
 
-    rangemax = max - min;
-    rangemin = rangemax;
+    double rangemax = max - min;
+    double rangemin = rangemax;
 
     for (i = 2; i <= n; i++) {
         if (x[i] != x[i - 1] && x[i] - x[i - 1] < rangemin)
@@ -329,35 +315,34 @@ double AS_class_discont(double *data, int count, int nbreaks,
         x[i] = (x[i] - min) / rangemax;
         xn[i] = i / (double)n;
     }
-    xlim = rangemin / rangemax;
+    double xlim = rangemin / rangemax;
     rangemin = rangemin / 2.0;
-
     /* Searching for the limits */
     num[1] = n;
-    abc = G_malloc(3 * sizeof(double));
 
-    /*     Loop through possible solutions */
+    /* Loop through possible solutions */
     for (i = 1; i <= nbclass; i++) {
-        nmax = 0;
-        dmax = 0.0;
-        /* d2 = 0.0; */
-        nf = 0; /*End number */
+        double dmax = 0.0;
+        int nmax = 0;
+        int nf = 0; /* End number */
 
-        /*           Loop through classes */
+        /* Loop through classes */
         for (j = 1; j <= i; j++) {
-            nd = nf; /*Start number */
+            double a = 0.0, b = 0.0, c = 0.0, d = 0.0;
+            int nd = nf; /* Start number */
+
             nf = num[j];
             co[j] = 10e37;
-            AS_eqdrt(x, xn, nd, nf, abc);
-            den = sqrt(pow(abc[1], 2) + 1.0);
+            AS_eqdrt(x, xn, nd, nf, &a, &b, &c);
+            double den = sqrt(pow(b, 2) + 1.0);
             nd++;
-            /*              Loop through observations */
-            for (k = nd; k <= nf; k++) {
-                if (abc[2] == 0.0)
-                    d = fabs((-1.0 * abc[1] * x[k]) + xn[k] - abc[0]) / den;
+            /* Loop through observations */
+            for (int k = nd; k <= nf; k++) {
+                if (fabs(c) >= GRASS_EPSILON)
+                    d = fabs(x[k] - c);
                 else
-                    d = fabs(x[k] - abc[2]);
-                /* d2 += pow(d, 2); */
+                    d = fabs((-1.0 * b * x[k]) + xn[k] - a) / den;
+
                 if (x[k] - x[nd] < xlim)
                     continue;
                 if (x[nf] - x[k] < xlim)
@@ -367,17 +352,10 @@ double AS_class_discont(double *data, int count, int nbreaks,
                 dmax = d;
                 nmax = k;
             }
-            nd--; /* A VERIFIER! */
-            if (x[nf] != x[nd]) {
-                if (nd != 0)
-                    co[j] = (xn[nf] - xn[nd]) / (x[nf] - x[nd]);
-                else
-                    co[j] = (xn[nf]) / (x[nf]); /* A VERIFIER! */
-            }
+            nd--;
+            if (fabs(x[nf] - x[nd]) > GRASS_EPSILON)
+                co[j] = (xn[nf] - xn[nd]) / (x[nf] - x[nd]);
         }
-        /* if (i == 1)
-           dd = d2;
-           p = d2 / dd; */
         for (j = 1; j <= i; j++) {
             no[j] = num[j];
             zz[j] = x[num[j]] * rangemax + min;
@@ -387,67 +365,74 @@ double AS_class_discont(double *data, int count, int nbreaks,
                 zz[j] = zz[j] + rangemin;
                 continue;
             }
-            zz[j] = zz[j] - rangemin;
-            no[j] = no[j] - 1;
+            else {
+                zz[j] = zz[j] - rangemin;
+                no[j] = no[j] - 1;
+            }
         }
-        im = i - 1;
-        if (im != 0.0) {
+        int im = i - 1;
+        if (im != 0) {
             for (j = 1; j <= im; j++) {
-                ji = i + 1 - j;
+                int ji = i + 1 - j;
                 no[ji] -= no[ji - 1];
             }
         }
         if (nmax == 0) {
             break;
         }
-        nff = i + 2;
-        tmp = 0;
+
+        int jj = 0;
+        int nff = i + 2;
+        bool do_reset = true;
         for (j = 1; j <= i; j++) {
             jj = nff - j;
             if (num[jj - 1] < nmax) {
                 num[jj] = nmax;
-                tmp = 1;
+                do_reset = false;
                 break;
             }
             num[jj] = num[jj - 1];
         }
-        if (tmp == 0) {
+        if (do_reset) {
             num[1] = nmax;
             jj = 1;
         }
-        if (jj == 1) {
-            xnj_1 = 0;
-            xj_1 = 0;
-        }
-        else {
-            xnj_1 = xn[num[jj - 1]];
-            xj_1 = x[num[jj - 1]];
-        }
-        no1 = (xn[num[jj]] - xnj_1) * n;
-        no2 = (xn[num[jj + 1]] - xn[num[jj]]) * n;
-        f = (xn[num[jj + 1]] - xnj_1) / (x[num[jj + 1]] - xj_1);
+        int no1 = (int)((xn[num[jj]] - xn[num[jj - 1]]) * n);
+        int no2 = (int)((xn[num[jj + 1]] - xn[num[jj]]) * n);
+        double f = (xn[num[jj + 1]] - xn[num[jj - 1]]) /
+                   (x[num[jj + 1]] - x[num[jj - 1]]);
         f *= n;
-        xt1 = (x[num[jj]] - xj_1) * f;
-        xt2 = (x[num[jj + 1]] - x[num[jj]]) * f;
-        if (xt2 == 0) {
-            xt2 = rangemin / 2.0 / rangemax * f;
-            xt1 -= xt2;
-        }
-        else if (xt1 * xt2 == 0) {
-            xt1 = rangemin / 2.0 / rangemax * f;
-            xt2 -= xt1;
+        double xt1 = (x[num[jj]] - x[num[jj - 1]]) * f;
+        double xt2 = (x[num[jj + 1]] - x[num[jj]]) * f;
+        if (fabs(xt1 * xt2) <= GRASS_EPSILON) {
+            if (fabs(xt2) > GRASS_EPSILON) {
+                xt2 = rangemin / 2.0 / rangemax * f;
+                xt1 = xt1 - xt2;
+            }
+            else {
+                xt1 = rangemin / 2.0 / rangemax * f;
+                xt2 = xt2 - xt1;
+            }
         }
 
         /* calculate chi-square to indicate statistical significance of new
          * class, i.e. how probable would it be that the new class could be the
          * result of purely random choice */
-        if (chi2 > pow((double)((no1 - no2) - (xt1 - xt2)), 2) / (xt1 + xt2))
-            chi2 = pow((double)((no1 - no2) - (xt1 - xt2)), 2) / (xt1 + xt2);
+        double ch = pow((double)((no1 - no2) - (xt1 - xt2)), 2) / (xt1 + xt2);
+        if (chi2 > ch)
+            chi2 = ch;
     }
 
-    /*  Fill up classbreaks of i <=nbclass classes */
-    for (j = 0; j <= (i - 1); j++)
-        classbreaks[j] = zz[j + 1];
+    /*  Fill up classbreaks of i <nbclass classes */
+    for (j = 1; j < nbclass; j++)
+        classbreaks[j - 1] = zz[j];
+
+    G_free(co);
+    G_free(no);
+    G_free(num);
+    G_free(x);
+    G_free(xn);
+    G_free(zz);
 
     return (chi2);
 }

--- a/vector/v.class/main.c
+++ b/vector/v.class/main.c
@@ -70,11 +70,10 @@ int main(int argc, char *argv[])
                "int;%s;"
                "std;%s;"
                "qua;%s;"
-               "equ;%s",
-               /* "dis;%s" */
+               "equ;%s;"
+               "dis;%s",
                _("simple intervals"), _("standard deviations"), _("quantiles"),
-               _("equiprobable (normal distribution)"));
-    /* _("discontinuities"));currently disabled because of bugs */
+               _("equiprobable (normal distribution)"), _("discontinuities"));
     algo_opt->descriptions = desc;
 
     nbclass_opt = G_define_option();
@@ -151,15 +150,15 @@ int main(int argc, char *argv[])
     nbreaks = nbclass - 1; /* we need one less classbreaks (min and max
                               excluded) than classes */
 
-    classbreaks = (double *)G_malloc((nbreaks) * sizeof(double));
-    for (i = 0; i < nbreaks; i++)
+    classbreaks = (double *)G_malloc((nbclass) * sizeof(double));
+    for (i = 0; i < nbclass; i++)
         classbreaks[i] = 0;
 
     /* Get classbreaks for given algorithm and number of classbreaks.
      * finfo takes any info coming from the classification algorithms
      * equ algorithm can alter number of class breaks */
     finfo = AS_class_apply_algorithm(AS_option_to_algorithm(algo_opt), data,
-                                     nrec, &nbreaks, classbreaks);
+                                     nrec, &nbreaks, &classbreaks);
 
     if (G_strcasecmp(algo_opt->answer, "dis") == 0 && finfo < 3.84148)
         G_warning(

--- a/vector/v.class/main.c
+++ b/vector/v.class/main.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
      * finfo takes any info coming from the classification algorithms
      * equ algorithm can alter number of class breaks */
     finfo = AS_class_apply_algorithm(AS_option_to_algorithm(algo_opt), data,
-                                     nrec, &nbreaks, &classbreaks);
+                                     nrec, &nbreaks, classbreaks);
 
     if (G_strcasecmp(algo_opt->answer, "dis") == 0 && finfo < 3.84148)
         G_warning(


### PR DESCRIPTION
Addresses heap buffer overflow in previously disabled 'Discont' algorithm.

The immediate cause was too small allocation of variable `num` in `AS_class_discont()`, which was fixed by an increase of its size (broadly mirroring the original Fortran code).

This fix was complemented by some code related improvements:

- Code clean up and restructure of `AS_class_discont()`
- Re-enable "dis" algorithm in v.class and d.vect.thematic
- Pass `classbreaks` array by pointer to pointer to enable in- and output.

For this PR I had the original Fortran code at my disposal.

See: https://lists.osgeo.org/pipermail/grass-dev/2008-July/038951.html

Fixes: https://github.com/OSGeo/grass/issues/5486