### PR TITLE
tests: Fix collection errors when importing tests have side effects

### DIFF
--- a/python/grass/script/testsuite/test_script_raster.py
+++ b/python/grass/script/testsuite/test_script_raster.py
@@ -14,11 +14,11 @@ class TestRaster(TestCase):
     """Test raster functions"""
 
     raster = "testrasterscript"
-    region = gs.region()
-    coords = (region["e"] - 1, region["n"] - 1)
 
     @classmethod
     def setUpClass(cls):
+        cls.region = gs.region()
+        cls.coords = (cls.region["e"] - 1, cls.region["n"] - 1)
         cls.runModule("r.mapcalc", expression="testrasterscript = 100", overwrite=True)
 
     @classmethod

--- a/raster/r.his/testsuite/test_r_his.py
+++ b/raster/r.his/testsuite/test_r_his.py
@@ -87,5 +87,5 @@ class TestRHis(TestCase):
         )
 
 
-if __import__("__main__"):
+if __name__ == "__main__":
     test()

--- a/scripts/r.blend/testsuite/test_r_blend_quoting.py
+++ b/scripts/r.blend/testsuite/test_r_blend_quoting.py
@@ -23,13 +23,14 @@ class TestRBlend(TestCase):
     mapsets_to_remove = []
     # mapset with a name is also a valid mathematical expression
     mapset_name = "1234-56-78"
-    gisenv = SimpleModule("g.gisenv", get="MAPSET")
-    TestCase.runModule(gisenv, expecting_stdout=True)
-    old_mapset = gisenv.outputs.stdout.strip()
 
     @classmethod
     def setUpClass(cls):
         """Create maps in a small region."""
+        gisenv = SimpleModule("g.gisenv", get="MAPSET")
+        TestCase.runModule(gisenv, expecting_stdout=True)
+        cls.old_mapset = gisenv.outputs.stdout.strip()
+
         # create a mapset with a name is also a valid mathematical expression
         cls.runModule("g.mapset", flags="c", mapset=cls.mapset_name)
         cls.mapsets_to_remove.append(cls.mapset_name)

--- a/scripts/r.grow/testsuite/test_r_grow_quoting.py
+++ b/scripts/r.grow/testsuite/test_r_grow_quoting.py
@@ -20,13 +20,13 @@ class TestRGrow(TestCase):
     mapsets_to_remove = []
     # mapset with a name is also a valid mathematical expression
     mapset_name = "1234-56-78"
-    gisenv = SimpleModule("g.gisenv", get="MAPSET")
-    TestCase.runModule(gisenv, expecting_stdout=True)
-    old_mapset = gisenv.outputs.stdout.strip()
 
     @classmethod
     def setUpClass(cls):
         """Create maps in a small region."""
+        gisenv = SimpleModule("g.gisenv", get="MAPSET")
+        TestCase.runModule(gisenv, expecting_stdout=True)
+        cls.old_mapset = gisenv.outputs.stdout.strip()
         # create a mapset with a name is also a valid mathematical expression
         cls.runModule("g.mapset", flags="c", mapset=cls.mapset_name)
         cls.mapsets_to_remove.append(cls.mapset_name)

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_raster.py
@@ -19,12 +19,12 @@ from grass.gunittest.utils import silent_rmtree
 class TestRasterExtraction(TestCase):
     mapsets_to_remove = []
     outfile = "rastlist.txt"
-    gisenv = SimpleModule("g.gisenv", get="MAPSET")
-    TestCase.runModule(gisenv, expecting_stdout=True)
-    old_mapset = gisenv.outputs.stdout.strip()
 
     @classmethod
     def setUpClass(cls):
+        gisenv = SimpleModule("g.gisenv", get="MAPSET")
+        TestCase.runModule(gisenv, expecting_stdout=True)
+        cls.old_mapset = gisenv.outputs.stdout.strip()
         os.putenv("GRASS_OVERWRITE", "1")
         for i in range(1, 7):
             mapset_name = "test%i" % i

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_raster3d.py
@@ -19,12 +19,12 @@ from grass.gunittest.utils import silent_rmtree
 class testRaster3dExtraction(TestCase):
     mapsets_to_remove = []
     outfile = "rast3dlist.txt"
-    gisenv = SimpleModule("g.gisenv", get="MAPSET")
-    TestCase.runModule(gisenv, expecting_stdout=True)
-    old_mapset = gisenv.outputs.stdout.strip()
 
     @classmethod
     def setUpClass(cls):
+        gisenv = SimpleModule("g.gisenv", get="MAPSET")
+        TestCase.runModule(gisenv, expecting_stdout=True)
+        cls.old_mapset = gisenv.outputs.stdout.strip()
         os.putenv("GRASS_OVERWRITE", "1")
         for i in range(1, 5):
             mapset_name = "test3d%i" % i

--- a/temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
+++ b/temporal/t.connect/testsuite/test_distr_tgis_db_vector.py
@@ -19,12 +19,12 @@ from grass.gunittest.utils import silent_rmtree
 class TestRasterExtraction(TestCase):
     mapsets_to_remove = []
     outfile = "vectlist.txt"
-    gisenv = SimpleModule("g.gisenv", get="MAPSET")
-    TestCase.runModule(gisenv, expecting_stdout=True)
-    old_mapset = gisenv.outputs.stdout.strip()
 
     @classmethod
     def setUpClass(cls):
+        gisenv = SimpleModule("g.gisenv", get="MAPSET")
+        cls.runModule(gisenv, expecting_stdout=True)
+        cls.old_mapset = gisenv.outputs.stdout.strip()
         os.putenv("GRASS_OVERWRITE", "1")
         for i in range(1, 5):
             mapset_name = "testvect%i" % i

--- a/temporal/t.rast.export/testsuite/test_rast_export.py
+++ b/temporal/t.rast.export/testsuite/test_rast_export.py
@@ -20,13 +20,13 @@ class TestRasterExport(TestCase):
         tmp = gs.tempdir()
         self.addCleanup(gs.try_rmdir, tmp)
         self.float_ = os.path.join(tmp, "geotiffloat")
-        self.addCleanup(os.remove, self.float_)
+        self.addCleanup(gs.try_remove, self.float_)
         self.int_ = os.path.join(tmp, "geotifint")
-        self.addCleanup(os.remove, self.int_)
+        self.addCleanup(gs.try_remove, self.int_)
         self.grid = os.path.join(tmp, "grid")
-        self.addCleanup(os.remove, self.grid)
+        self.addCleanup(gs.try_remove, self.grid)
         self.pack = os.path.join(tmp, "pack")
-        self.addCleanup(os.remove, self.pack)
+        self.addCleanup(gs.try_remove, self.pack)
 
     @classmethod
     def setUpClass(cls):

--- a/temporal/t.rast.export/testsuite/test_rast_export.py
+++ b/temporal/t.rast.export/testsuite/test_rast_export.py
@@ -16,11 +16,17 @@ from grass.gunittest.case import TestCase
 
 
 class TestRasterExport(TestCase):
-    tmp = gs.tempdir()
-    float_ = os.path.join(tmp, "geotiffloat")
-    int_ = os.path.join(tmp, "geotifint")
-    grid = os.path.join(tmp, "grid")
-    pack = os.path.join(tmp, "pack")
+    def setUp(self):
+        tmp = gs.tempdir()
+        self.addCleanup(gs.try_rmdir, tmp)
+        self.float_ = os.path.join(tmp, "geotiffloat")
+        self.addCleanup(os.remove, self.float_)
+        self.int_ = os.path.join(tmp, "geotifint")
+        self.addCleanup(os.remove, self.int_)
+        self.grid = os.path.join(tmp, "grid")
+        self.addCleanup(os.remove, self.grid)
+        self.pack = os.path.join(tmp, "pack")
+        self.addCleanup(os.remove, self.pack)
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Some test files do some actions, like set up steps outside the set up functions. So, simply importing them for collection, even with pure unittest `python -m unittest discover`, would have side effects and possibly fail.

With the following change in pyproject.toml for allowing to discover gunittest tests with pytest:
```diff
-python_files = "*/tests/*_test.py */tests/test_*.py"
+python_files = """
+    */tests/*_test.py
+    */tests/test_*.py
+    **/testsuite/*test*.py
+"""
```

These errors are now pointed out.
This PR fixes these collection errors, so at least pytest, if configured correctly to be able to find and import grass from python, doesn't fail anymore.