### PR TITLE
chore: Format yaml and workflow files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,7 @@
 ---
 name: CodeQL config
 paths-ignore:
-  - '**/testsuite/**'
+  - "**/testsuite/**"
   - bin.*
   - dist.*
   - node_modules

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,7 +27,7 @@ database:
           - db/**
           - lib/db/**
           - scripts/db.*/**
-          - '**.sql'
+          - "**.sql"
 display:
   - changed-files:
       - any-glob-to-any-file:
@@ -123,8 +123,8 @@ docker:
   - changed-files:
       - any-glob-to-any-file:
           - docker/**
-          - '**/*Dockerfile*'
-          - '**/*dockerfile*'
+          - "**/*Dockerfile*"
+          - "**/*dockerfile*"
           - .dockerignore
 nix:
   - changed-files:
@@ -140,17 +140,17 @@ docs:
           - any-glob-to-any-file:
               - doc/**
               - man/**
-              - '**/*.md'
-              - '**/*.rst'
-              - '**/*.html'
-              - '**/*.dox'
-              - '**/*.png'
-              - '**.cff'
+              - "**/*.md"
+              - "**/*.rst"
+              - "**/*.html"
+              - "**/*.dox"
+              - "**/*.png"
+              - "**.cff"
               - CITING
               - AUTHORS
               - TODO
           - all-globs-to-all-files:
-              - '!doc/development/rfc/**'
+              - "!doc/development/rfc/**"
 RFC:
   - changed-files:
       - any-glob-to-any-file:
@@ -163,29 +163,29 @@ translation:
 Python:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/*.py'
-          - '**/pyproject.toml'
+          - "**/*.py"
+          - "**/pyproject.toml"
 notebook:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/*.ipynb'
+          - "**/*.ipynb"
           - doc/examples/notebooks/**
           - python/grass/jupyter/**
 C:
   - changed-files:
-      - any-glob-to-any-file: '**/*.c'
+      - any-glob-to-any-file: "**/*.c"
 C++:
   - changed-files:
-      - any-glob-to-any-file: '**/*.cpp'
+      - any-glob-to-any-file: "**/*.cpp"
 CSS:
   - changed-files:
-      - any-glob-to-any-file: '**/*.css'
+      - any-glob-to-any-file: "**/*.css"
 HTML:
   - changed-files:
-      - any-glob-to-any-file: '**/*.html'
+      - any-glob-to-any-file: "**/*.html"
 JavaScript:
   - changed-files:
-      - any-glob-to-any-file: '**/*.js'
+      - any-glob-to-any-file: "**/*.js"
 markdown:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Check that files with the same content are the same
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,13 +4,13 @@ name: CMake
 on:
     push:
         paths-ignore:
-            - 'doc/**'
+          - "doc/**"
         branches:
-            - main
-            - releasebranch_*
+          - main
+          - releasebranch_*
     pull_request:
         paths-ignore:
-            - 'doc/**'
+          - "doc/**"
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,91 +2,90 @@
 name: CMake
 
 on:
-    push:
-        paths-ignore:
-          - "doc/**"
-        branches:
-          - main
-          - releasebranch_*
-    pull_request:
-        paths-ignore:
-          - "doc/**"
+  push:
+    paths-ignore:
+      - "doc/**"
+    branches:
+      - main
+      - releasebranch_*
+  pull_request:
+    paths-ignore:
+      - "doc/**"
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 env:
-    CMAKE_UNITY_BUILD: OFF
+  CMAKE_UNITY_BUILD: OFF
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-
-    build-cmake:
-        runs-on: ubuntu-22.04
-        env:
-            CMakeVersion: "3.22.0"
-        steps:
-            - name: Checkout GRASS
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-            - name: Install CMake
-              run: |
-                cd ${GITHUB_WORKSPACE}
-                arch=$(echo $(uname -s)-$(uname -m) | awk '{print tolower($0)}')
-                v=v${{ env.CMakeVersion }}/cmake-${{ env.CMakeVersion }}-${arch}.tar.gz
-                wget https://github.com/Kitware/CMake/releases/download/$v
-                tar xzf cmake-${{ env.CMakeVersion }}-${arch}.tar.gz
-                echo "CMAKE_DIR=$GITHUB_WORKSPACE/cmake-${{ env.CMakeVersion }}-${arch}/bin" >> $GITHUB_ENV
-                echo "$GITHUB_WORKSPACE/cmake-${{ env.CMakeVersion }}-${arch}/bin" >> $GITHUB_PATH
-            - run: |
-                cmake --version
-            - name: Install dependencies
-              run: |
-                sudo apt-get update -y
-                sudo apt-get install -y wget git gawk findutils ninja-build libpq-dev \
-                  gettext unixodbc-dev libnetcdf-dev
-                xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
-                    sudo apt-get install -y --no-install-recommends --no-install-suggests
-            - name: Print build environment variables
-              shell: bash -el {0}
-              run: |
-                printenv | sort
-                gcc --version
-                ldd --version
-            - name: Create installation directory
-              run: |
-                mkdir $HOME/install
-            - name: Configure
-              run: |
-                cmake ${CMAKE_OPTIONS} -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -G Ninja \
-                  -DCMAKE_INSTALL_PREFIX=$HOME/install -DWITH_NLS=ON -DWITH_GUI=OFF -DWITH_DOCS=OFF \
-                  -DWITH_READLINE=ON -DWITH_ODBC=ON -DWITH_NETCDF=ON -DWITH_BZLIB=ON
-            - name: Print CMakeCache.txt
-              shell: bash -el {0}
-              run: |
-                cat ${GITHUB_WORKSPACE}/build/CMakeCache.txt
-            - name: Build
-              run: |
-                cmake --build build --verbose -j$(nproc)
-            - name: Install
-              run: |
-                cmake --install $GITHUB_WORKSPACE/build --verbose
-            - name: Add the bin directory to PATH
-              run: |
-                echo "$HOME/install/bin" >> $GITHUB_PATH
-            - name: Print installed versions
-              if: always()
-              run: .github/workflows/print_versions.sh
-            - name: Test executing of the grass command
-              run: .github/workflows/test_simple.sh
-            - name: Run tests
-              run: .github/workflows/test_thorough.sh --config .gunittest.cfg --min-success 98
-            - name: Make HTML test report available
-              if: ${{ !cancelled() }}
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-              with:
-                  name: testreport-CMake
-                  path: testreport
-                  retention-days: 3
+  build-cmake:
+    runs-on: ubuntu-22.04
+    env:
+      CMakeVersion: "3.22.0"
+    steps:
+      - name: Checkout GRASS
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install CMake
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          arch=$(echo $(uname -s)-$(uname -m) | awk '{print tolower($0)}')
+          v=v${{ env.CMakeVersion }}/cmake-${{ env.CMakeVersion }}-${arch}.tar.gz
+          wget https://github.com/Kitware/CMake/releases/download/$v
+          tar xzf cmake-${{ env.CMakeVersion }}-${arch}.tar.gz
+          echo "CMAKE_DIR=$GITHUB_WORKSPACE/cmake-${{ env.CMakeVersion }}-${arch}/bin" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/cmake-${{ env.CMakeVersion }}-${arch}/bin" >> $GITHUB_PATH
+      - run: |
+          cmake --version
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y wget git gawk findutils ninja-build libpq-dev \
+            gettext unixodbc-dev libnetcdf-dev
+          xargs -a <(awk '! /^ *(#|$)/' ".github/workflows/apt.txt") -r -- \
+              sudo apt-get install -y --no-install-recommends --no-install-suggests
+      - name: Print build environment variables
+        shell: bash -el {0}
+        run: |
+          printenv | sort
+          gcc --version
+          ldd --version
+      - name: Create installation directory
+        run: |
+          mkdir $HOME/install
+      - name: Configure
+        run: |
+          cmake ${CMAKE_OPTIONS} -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -G Ninja \
+            -DCMAKE_INSTALL_PREFIX=$HOME/install -DWITH_NLS=ON -DWITH_GUI=OFF -DWITH_DOCS=OFF \
+            -DWITH_READLINE=ON -DWITH_ODBC=ON -DWITH_NETCDF=ON -DWITH_BZLIB=ON
+      - name: Print CMakeCache.txt
+        shell: bash -el {0}
+        run: |
+          cat ${GITHUB_WORKSPACE}/build/CMakeCache.txt
+      - name: Build
+        run: |
+          cmake --build build --verbose -j$(nproc)
+      - name: Install
+        run: |
+          cmake --install $GITHUB_WORKSPACE/build --verbose
+      - name: Add the bin directory to PATH
+        run: |
+          echo "$HOME/install/bin" >> $GITHUB_PATH
+      - name: Print installed versions
+        if: always()
+        run: .github/workflows/print_versions.sh
+      - name: Test executing of the grass command
+        run: .github/workflows/test_simple.sh
+      - name: Run tests
+        run: .github/workflows/test_thorough.sh --config .gunittest.cfg --min-success 98
+      - name: Make HTML test report available
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: testreport-CMake
+          path: testreport
+          retention-days: 3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,9 +7,9 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - '**/*.html'
-      - '**/*.md'
-      - '**/*.txt'
+      - "**/*.html"
+      - "**/*.md"
+      - "**/*.txt"
   schedule:
     # Check every Saturday at 18:36
     - cron: 36 18 * * 6
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install non-Python dependencies
         if: ${{ matrix.language == 'c-cpp' }}
         run: |

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -15,7 +15,8 @@ jobs:
     name: ${{ matrix.c }} & ${{ matrix.cpp }}
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
+      group: >-
+        ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
         matrix.c }}-${{ matrix.cpp }}
       cancel-in-progress: true
 

--- a/.github/workflows/macos_distribute_app.yml
+++ b/.github/workflows/macos_distribute_app.yml
@@ -11,7 +11,7 @@ on:
     - cron: "30 7 * * THU"
   push:
     tags:
-      - '**'
+      - "**"
 
 permissions: {}
 
@@ -24,7 +24,8 @@ jobs:
     if: ${{ github.repository == 'OSGeo/grass' }}
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
+      group: >-
+        ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
         matrix.name }}-${{ matrix.os }}
       cancel-in-progress: true
 

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -15,7 +15,8 @@ jobs:
     name: ${{ matrix.os }} build and tests
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
+      group: >-
+        ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
         matrix.os }}
       cancel-in-progress: true
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,8 @@ permissions: {}
 jobs:
   pytest:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
+      group: >-
+        ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
         matrix.os }}-${{ matrix.python-version }}
       cancel-in-progress: true
 
@@ -22,9 +23,9 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
-          - '3.9'
-          - '3.12'
-          - '3.13'
+          - "3.9"
+          - "3.12"
+          - "3.13"
       fail-fast: true
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -3,16 +3,16 @@ name: Nix package and environment
 
 on:
   schedule:
-    - cron: '0 1 * * 1'
+    - cron: "0 1 * * 1"
   push:
     tags:
-      - '*'
+      - "*"
   pull_request:
     paths:
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'package.nix'
-      - '.github/workflows/test-nix.yml'
+      - ".github/workflows/test-nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "package.nix"
   workflow_dispatch:
 
 concurrency:
@@ -37,7 +37,7 @@ jobs:
         uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: osgeo-grass
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build package
         run: nix build -L --accept-flake-config .#grass

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,7 +15,8 @@ permissions: {}
 jobs:
   ubuntu:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
+      group: >-
+        ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}-${{
         matrix.name }}-${{ matrix.os }}-${{ matrix.extra-include }}
       cancel-in-progress: true
 

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,5 +1,4 @@
 ---
-
 default: true
 
 # Fix any fixable errors (depending on the markdownlint wrapper tool used)

--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,4 @@
 ---
-
 extends: default
 
 rules:

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -1,6 +1,6 @@
 ---
 # Project information
-site_author: The GRASS Development Team  # Default author to all pages
+site_author: The GRASS Development Team # Default author to all pages
 site_name: !ENV SITE_NAME
 site_url: https://grass.osgeo.org/grass-stable/manuals/
 

--- a/utils/release.yml
+++ b/utils/release.yml
@@ -4,63 +4,63 @@ notes:
     - title: Tools
       # yamllint disable-line rule:line-length
       regexp: '(?:Revert \")?((d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)(, (d|db|g|i|m|ps|r|r3|t|v)\.[^ ]*)?: |(modules|tools|temporal): '
-      example: 'r.slope.aspect:'
+      example: "r.slope.aspect:"
 
     - title: Graphical User Interface
       regexp: '(?:Revert \")?(wxGUI.*|gui|GUI)(\(\w[\w.-]*\))?: '
-      example: 'wxGUI:'
+      example: "wxGUI:"
 
     - title: Python
       regexp: '(?:Revert \")?(grass\.[^ ]*|libpython.*|pythonlib.*|ctypesgen|ctypes|[Pp]ython|[Bb]inder): '
-      example: 'grass.script:'
+      example: "grass.script:"
 
     - title: Documentation and Messages
       regexp: '(?:Revert \")?(docs?|man|manual|manual pages|[Ss]phinx|mkhtml|MkDocs|mkdocs|messages?): '
-      example: 'doc:'
+      example: "doc:"
 
     - title: Libraries and General Functionality
       regexp: '(?:Revert \")?(grass_|lib|TGIS|tgis|raster|vector)[^ ]*: '
-      example: 'grass_btree: or lib/btree:'
+      example: "grass_btree: or lib/btree:"
 
     - title: Startup, Initialization, and Environment
       regexp: '(?:Revert \")?(init|startup): '
-      example: 'startup:'
+      example: "startup:"
 
     - title: Translations, Internationalization, and Localization
       regexp: '(?:Revert \")?(i18n|i18N|L10n|L10N|t9n|translations?): |Translations update from '
-      example: 'i18n:'
+      example: "i18n:"
 
     - title: Windows
       regexp: '(?:Revert \")?(winGRASS|win|[Ww]indows|msvc|MSVC): '
-      example: 'win:'
+      example: "win:"
 
     - title: macOS
       regexp: '(?:Revert \")?(macOS): '
-      example: 'macOS:'
+      example: "macOS:"
 
     - title: Packaging, Configuration, Portability, and Compilation
       regexp: '(?:Revert \")?(packaging|pkg|rpm|deb|nix|pkg-config|configure|config|[Cc]?[Mm]ake|build|conda): '
-      example: 'build:'
+      example: "build:"
 
     - title: Docker
       regexp: '(?:Revert \")?[Dd]ocker(/[^ ]+)?(\(\w[\w.-]*\))?: '
-      example: 'Docker:'
+      example: "Docker:"
 
     - title: Singularity
       regexp: '(?:Revert \")?[Ss]ingularity(\(\w[\w.-]*\))?: '
-      example: 'Singularity:'
+      example: "Singularity:"
 
     - title: Continuous Integration, Infrastructure, Tests and Code Quality
       # yamllint disable-line rule:line-length
       regexp: '(?:Revert \")?(CI|ci|[Tt]ests|[Cc]hecks|style|perf|CQ|[Rr]efactoring|utils|pytest|unittest|chore)(\(\w[\w.-]*\))?: '
-      example: 'CI:'
+      example: "CI:"
 
     - title: Contributing and Management
       regexp: '(?:Revert \")?(contributing|CONTRIBUTING.md|contributors|contributors.csv): '
-      example: 'contributing:'
+      example: "contributing:"
 
   exclude:
     regexp:
-      - '[Hh]appy [Nn]ew [Yy]ear'
-      - 'version: '
-      - 'RFC: '
+      - "[Hh]appy [Nn]ew [Yy]ear"
+      - "version: "
+      - "RFC: "


### PR DESCRIPTION
Simple changes that I've been continuously reverting for over a year each time I format the file with my IDE (for workflow files).

The formatting has its roots with the yaml language server, that uses "prettier" for actual parsing and formatting.

I've then applied to other yaml files.

The cmake workflow was using 4 spaces instead of 2 like our other workflows, so the changes seem bigger for this file.