### PR TITLE
CI(pytest): Refactor common pytest arguments to files

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -95,18 +95,17 @@ jobs:
         run: |
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
-            --numprocesses auto \
-            -ra . \
-            -m 'not needs_solo_run'
+          pytest \
+            @.github/workflows/pytest_args_ci.txt \
+            @.github/workflows/pytest_args_parallel.txt
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
         shell: micromamba-shell {0}
         run: |
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
-            -ra . \
-            -m 'needs_solo_run'
+          pytest \
+            @.github/workflows/pytest_args_ci.txt \
+            @.github/workflows/pytest_args_not_parallel.txt
 
       - name: Cache GRASS Sample Dataset
         id: cached-data

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -89,7 +89,6 @@ jobs:
             python3-numpy
             python3-pip
             python3-ply
-            python3-pytest
             python3-pywin32
             python3-six
             python3-wxpython
@@ -120,8 +119,11 @@ jobs:
         shell: msys2 {0}
         run: .github/workflows/test_simple.sh
 
-      - name: Install pytest plugins
-        run: python -m pip install pytest-timeout
+      - name: Install additional python packages
+        run: |
+          python -m pip install ^
+            pytest ^
+            pytest-timeout
         shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
       - name: Run pytest with a single worker
         run: |

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -128,9 +128,7 @@ jobs:
           call %OSGEO4W_ROOT%\opt\grass\etc\env.bat
           set PYTHONPATH=%GISBASE%\etc\python;%PYTHONPATH%
           path %GISBASE%\lib;%GISBASE%\bin;%PATH%
-          pytest --verbose --color=yes ^
-            --durations=0 --durations-min=0.5 ^
-            -ra .
+          pytest @.github/workflows/pytest_args_ci.txt
         shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
 
       - name: Run tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -87,12 +87,10 @@ jobs:
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
           export INITIAL_GISBASE="$(grass --config path)"
           export INITIAL_PWD="${PWD}"
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
-            --numprocesses auto \
-            --cov \
-            --cov-context=test \
-            -ra . \
-            -m 'not needs_solo_run'
+          pytest \
+            @.github/workflows/pytest_args_ci.txt \
+            @.github/workflows/pytest_args_cov.txt \
+            @.github/workflows/pytest_args_parallel.txt
 
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
         run: |
@@ -100,12 +98,10 @@ jobs:
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
           export INITIAL_GISBASE="$(grass --config path)"
           export INITIAL_PWD="${PWD}"
-          pytest --verbose --color=yes --durations=0 --durations-min=0.5 \
-            --cov \
-            --cov-context=test \
-            --cov-append \
-            -ra . \
-            -m 'needs_solo_run'
+          pytest \
+            @.github/workflows/pytest_args_ci.txt \
+            @.github/workflows/pytest_args_cov.txt \
+            @.github/workflows/pytest_args_not_parallel.txt
       - name: Fix non-standard installed script paths in coverage data
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH

--- a/.github/workflows/pytest_args_ci.txt
+++ b/.github/workflows/pytest_args_ci.txt
@@ -1,0 +1,5 @@
+--verbose
+--color=yes
+--durations=0
+--durations-min=0.5
+-ra

--- a/.github/workflows/pytest_args_cov.txt
+++ b/.github/workflows/pytest_args_cov.txt
@@ -1,0 +1,3 @@
+--cov
+--cov-context=test
+--cov-append

--- a/.github/workflows/pytest_args_not_parallel.txt
+++ b/.github/workflows/pytest_args_not_parallel.txt
@@ -1,0 +1,1 @@
+-m needs_solo_run

--- a/.github/workflows/pytest_args_parallel.txt
+++ b/.github/workflows/pytest_args_parallel.txt
@@ -1,0 +1,2 @@
+--numprocesses=auto
+-m not needs_solo_run


### PR DESCRIPTION
Since pytest 8.2, pytest allows using a file to send an argument list (https://docs.pytest.org/en/stable/how-to/usage.html#args-from-file), using native argparse functionality (https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars).

Since the different invocations of pytest in CI are repeated a couple times, and quoting rules is different in between shells (like the cmd vs powershell on Windows vs the other platforms), using argument files makes sense.
It allows to factor out duplicated arguments that needs to get updated at each place.

It is possible to use an argument file multiple times, and it is also possible to use an argument file inside an argument file, but I decided against, as for another use case, it was easier to have independent "building blocks" of common arguments when needing to not have one of them, but keep the other parts.


I had to update the pytest version on Windows, as the one provided by OSGeo4W is too old (8.1.1, it's been a little while).

TLDR: Changing pytest arguments in CI can be done once, and applied to all our files using arguments defined in separate files