### PR TITLE
style: Fix raise-without-from-inside-except (B904) for pygrass Module

### DIFF
--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -555,7 +555,7 @@ class Module:
         except OSError as e:
             print("OSError error({0}): {1}".format(e.errno, e.strerror))
             str_err = "Error running: `%s --interface-description`."
-            raise GrassError(str_err % self.name)
+            raise GrassError(str_err % self.name) from e
         # get the xml of the module
         self.xml = get_cmd_xml.communicate()[0]
         # transform and parse the xml into an Element class:


### PR DESCRIPTION
Ruff rule: https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/

Since #4032 has essentially been stalled for 9 months now, I'm extracting only one of the changes as I encountered a situation that justifies it sooner than waiting for the existing PR to get back to life, if ever.

With this PR, a traceback that looked before like:
![image](https://github.com/user-attachments/assets/30b398ab-5690-45fd-8c27-c0ba6ad48a85)
Now looks like:
![image](https://github.com/user-attachments/assets/cca27226-5975-453c-9d14-da480a151664)


<details><summary>Text version:</summary>
<p>

Before:
```
____________________________________________________________________ TestGdalImportFails.test_error_handling_2 ____________________________________________________________________
/usr/local/grass85/etc/python/grass/pygrass/modules/interface/module.py:554: in __init__
    get_cmd_xml = Popen([cmd, "--interface-description"], stdout=PIPE)
/usr/local/grass85/etc/python/grass/script/core.py:84: in __init__
    subprocess.Popen.__init__(self, args, **kwargs)
/usr/local/python/3.12.7/lib/python3.12/subprocess.py:1026: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
/usr/local/python/3.12.7/lib/python3.12/subprocess.py:1955: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'r.in.gdal'

During handling of the above exception, another exception occurred:
raster/r.in.gdal/testsuite/test_r_in_gdal.py:366: in test_error_handling_2
    self.assertModuleFail(
/usr/local/grass85/etc/python/grass/gunittest/case.py:1425: in assertModuleFail
    module = _module_from_parameters(module, **kwargs)
/usr/local/grass85/etc/python/grass/gunittest/case.py:1457: in _module_from_parameters
    module = SimpleModule(module, **kwargs)
/usr/local/grass85/etc/python/grass/gunittest/gmodules.py:55: in __init__
    Module.__init__(self, cmd, *args, **kargs)
/usr/local/grass85/etc/python/grass/pygrass/modules/interface/module.py:558: in __init__
    raise GrassError(str_err % self.name)
E   grass.exceptions.GrassError: Error running: `r.in.gdal --interface-description`.
------------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------------
OSError error(2): No such file or directory
``` 


after:

```
____________________________________________________________________ TestGdalImportFails.test_error_handling_2 ____________________________________________________________________
/usr/local/grass85/etc/python/grass/pygrass/modules/interface/module.py:554: in __init__
    get_cmd_xml = Popen([cmd, "--interface-description"], stdout=PIPE)
/usr/local/grass85/etc/python/grass/script/core.py:84: in __init__
    subprocess.Popen.__init__(self, args, **kwargs)
/usr/local/python/3.12.7/lib/python3.12/subprocess.py:1026: in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
/usr/local/python/3.12.7/lib/python3.12/subprocess.py:1955: in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
E   FileNotFoundError: [Errno 2] No such file or directory: 'r.in.gdal'

The above exception was the direct cause of the following exception:
raster/r.in.gdal/testsuite/test_r_in_gdal.py:366: in test_error_handling_2
    self.assertModuleFail(
/usr/local/grass85/etc/python/grass/gunittest/case.py:1425: in assertModuleFail
    module = _module_from_parameters(module, **kwargs)
/usr/local/grass85/etc/python/grass/gunittest/case.py:1457: in _module_from_parameters
    module = SimpleModule(module, **kwargs)
/usr/local/grass85/etc/python/grass/gunittest/gmodules.py:55: in __init__
    Module.__init__(self, cmd, *args, **kargs)
/usr/local/grass85/etc/python/grass/pygrass/modules/interface/module.py:558: in __init__
    raise GrassError(str_err % self.name) from e
E   grass.exceptions.GrassError: Error running: `r.in.gdal --interface-description`.
------------------------------------------------------------------------------ Captured stdout call -------------------------------------------------------------------------------
OSError error(2): No such file or directory
``` 


</p>
</details> 

