### PR TITLE
tests: Load "msvcrt" instead of "c" ctypes library on Windows

### DIFF
--- a/imagery/i.maxlik/testsuite/test_i_maxlik.py
+++ b/imagery/i.maxlik/testsuite/test_i_maxlik.py
@@ -20,7 +20,6 @@ from grass.script.core import tempname
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.gunittest.utils import xfail_windows
 
 from grass.lib.gis import G_mapset_path
 from grass.lib.raster import Rast_write_semantic_label
@@ -176,7 +175,6 @@ class SuccessTest(TestCase):
         )
         cls.runModule("g.remove", flags="f", type="group", name=cls.group, quiet=True)
 
-    @xfail_windows
     def test_v1(self):
         """Test v1 signature"""
         self.assertModule(
@@ -198,7 +196,6 @@ class SuccessTest(TestCase):
         self.assertEqual(res.get_cat(0)[1], 1)
         res.close()
 
-    @xfail_windows
     def test_v2(self):
         """Test v2 signature"""
         self.assertModule(

--- a/imagery/i.maxlik/testsuite/test_i_maxlik.py
+++ b/imagery/i.maxlik/testsuite/test_i_maxlik.py
@@ -10,6 +10,7 @@ Licence:   This program is free software under the GNU General Public
 """
 
 import ctypes
+import os
 import shutil
 
 from grass.pygrass import utils
@@ -45,7 +46,10 @@ class SuccessTest(TestCase):
         """Ensures expected computational region and generated data"""
         cls.use_temp_region()
         cls.runModule("g.region", n=5, s=0, e=5, w=0, res=1)
-        cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == "nt":
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("msvcrt"))
+        else:
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
         cls.mpath = utils.decode(G_mapset_path())
         cls.mapset_name = Mapset().name
         cls.sig_name1 = tempname(10)

--- a/lib/gis/testsuite/test_gis_lib_getl.py
+++ b/lib/gis/testsuite/test_gis_lib_getl.py
@@ -3,6 +3,7 @@
 @author Vaclav Petras
 """
 
+import os
 import ctypes
 import pathlib
 import unittest
@@ -17,7 +18,10 @@ class TestNewlinesWithGetlFunctions(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == "nt":
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("msvcrt"))
+        else:
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
         cls.libc.fopen.restype = ctypes.POINTER(libgis.FILE)
         cls.libc.fopen.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
         cls.file_path = pathlib.Path("test.txt")

--- a/lib/imagery/testsuite/test_imagery_sigfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigfile.py
@@ -11,6 +11,7 @@ for details
 
 import stat
 import ctypes
+import os
 import shutil
 from pathlib import Path
 
@@ -43,7 +44,10 @@ from grass.lib.imagery import (
 class SignatureFileTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == "nt":
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("msvcrt"))
+        else:
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
         cls.mpath = utils.decode(G_mapset_path())
         cls.mapset_name = Mapset().name
         cls.sig_name = tempname(10)
@@ -331,7 +335,10 @@ class SignatureFileTestCase(TestCase):
 class SortSignaturesBysemantic_labelTest(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == "nt":
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("msvcrt"))
+        else:
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
         cls.mapset = Mapset().name
         cls.map1 = tempname(10)
         cls.semantic_label1 = "The_Doors"

--- a/lib/imagery/testsuite/test_imagery_sigsetfile.py
+++ b/lib/imagery/testsuite/test_imagery_sigsetfile.py
@@ -11,6 +11,7 @@ for details
 
 import stat
 import ctypes
+import os
 import shutil
 from pathlib import Path
 
@@ -44,7 +45,10 @@ from grass.lib.imagery import (
 class SigSetFileTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == "nt":
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("msvcrt"))
+        else:
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
         cls.mpath = utils.decode(G_mapset_path())
         cls.mapset_name = Mapset().name
         cls.sig_name = tempname(10)
@@ -224,7 +228,10 @@ class SigSetFileTestCase(TestCase):
 class SortSigSetBySemanticLabelTest(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == "nt":
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("msvcrt"))
+        else:
+            cls.libc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
         cls.mapset = Mapset().name
         cls.map1 = tempname(10)
         cls.semantic_label1 = "The_Doors"


### PR DESCRIPTION
Fixes some expected failures, and removes the decorator to not have unexpected successes.

"libc" just doesn't make sense on Windows. The functionality comes from msvc. As stated in the Python docs, and some old threads, we shouldn't use CDLL to get the library on Windows, as a really old version would be returned, and not the one Python would be compiled with. This PR uses a suggested approach, that works.