### PR TITLE
tests: Import CalledModuleError from grass.exceptions in test_names.py

### DIFF
--- a/python/grass/script/testsuite/test_names.py
+++ b/python/grass/script/testsuite/test_names.py
@@ -1,6 +1,7 @@
 import os
 import platform
 
+from grass.exceptions import CalledModuleError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 
@@ -115,7 +116,7 @@ class TestLegalizeVectorName(TestCase):
                 columns=f"{name} integer",
             )
             works = True
-        except gs.CalledModuleError:
+        except CalledModuleError:
             works = False
         finally:
             gs.run_command("g.remove", name=name, type="vector", flags="f")

--- a/python/grass/script/testsuite/test_names.py
+++ b/python/grass/script/testsuite/test_names.py
@@ -1,13 +1,11 @@
 import os
 import platform
 
+import grass.script as gs
 from grass.exceptions import CalledModuleError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-
-import grass.script as gs
-from grass.script import legal_name
-from grass.script import utils
+from grass.script import legal_name, utils
 
 
 class TestUnique(TestCase):


### PR DESCRIPTION
In the same spirit of the changes made for https://github.com/OSGeo/grass/issues/4838 with ScriptError, there's a CalledModuleError that doesn't (and shouldn't) come from grass.script, but from grass.exceptions.

This PR adjusts the import so it is not an unknown attribute of grass.script.

Other instances that exists, but I couldn't verify them (I was only in the tests side of things today, didn't manage to trigger on a GUI):
https://github.com/OSGeo/grass/blob/d850a9fd8c7b9c9181aa5a09e9b07bf601b7e8ad/gui/wxpython/psmap/frame.py#L1247
https://github.com/OSGeo/grass/blob/d850a9fd8c7b9c9181aa5a09e9b07bf601b7e8ad/gui/wxpython/psmap/utils.py#L244
Will be fixed in #5526
https://github.com/OSGeo/grass/blob/d850a9fd8c7b9c9181aa5a09e9b07bf601b7e8ad/man/mkdocs/docs/python_intro.md#L771-L779

In addons:
https://github.com/OSGeo/grass-addons/blob/cafc53f49233dd09433ffc7ae8597416b1f0a920/src/raster/r.null.all/r.null.all.py#L164
https://github.com/OSGeo/grass-addons/blob/cafc53f49233dd09433ffc7ae8597416b1f0a920/src/vector/v.rast.move/tests/test_v_rast_move.py#L64