### PR TITLE
i.smap: bug fix

### DIFF
--- a/imagery/i.smap/testsuite/test_i_smap.py
+++ b/imagery/i.smap/testsuite/test_i_smap.py
@@ -32,7 +32,7 @@ class TestISmap(TestCase):
         )
         cls.runModule(
             "r.mapcalc",
-            expression=f"{cls.input_maps[2]} = 20 * exp(-((row() - 50)^2 + (col() - 50)^2) / 500)",
+            expression=f"{cls.input_maps[2]} = 20 * exp(-(((row() - 50)^2 + (col() - 50)^2) / 500))",
             overwrite=True,
         )
         cls.temp_rasters.extend(cls.input_maps)


### PR DESCRIPTION
This PR fixes the test file which failed occasionally due to ambiguity in the arithmetic expression.

**Issue:**  
The `i.smap` regression test was exhibiting flaky behavior due to an ambiguity in the arithmetic expression used to compute `synth_map3` during test setup. The problematic line:

```python
20 * exp(-((row() - 50)^2 + (col() - 50)^2) / 500)
```

was incorrectly evaluated due to operator precedence. The exponentiation applied only to the numerator, and the division by 500 happened *after* `exp`, resulting in much smaller values than intended. This led to inconsistent behavior in `i.gensigset` and subsequent variation in `i.smap` classification, especially affecting the `goodness` map.

**Fix:**  
The arithmetic expression was corrected by adding parentheses to ensure the division is part of the exponent:

```python
20 * exp(-(((row() - 50)^2 + (col() - 50)^2) / 500))
```

This should resolves the nondeterministic output and ensures the test consistently passes.