### PR TITLE
wxGUI: use context manager for file append in writeData() (SIM115)

### DIFF
--- a/gui/wxpython/tools/update_menudata.py
+++ b/gui/wxpython/tools/update_menudata.py
@@ -121,11 +121,8 @@ def writeData(data, file=None):
         return
 
     try:
-        f = open(file, "a")
-        try:
+        with open(file, "a") as f:
             f.write("\n")
-        finally:
-            f.close()
     except OSError:
         print("ERROR: Unable to write to menudata file.", file=sys.stderr)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,6 @@ ignore = [
 "**.py" = ["PYI066"]
 "*/testsuite/**.py" = ["PT009", "PT027"]
 "gui/wxpython/iclass/statistics.py" = ["A005"]
-"gui/wxpython/tools/update_menudata.py" = ["SIM115"]
 "gui/wxpython/vnet/vnet_data.py" = ["SIM115"]
 "gui/wxpython/web_services/dialogs.py" = ["SIM115"]
 "gui/wxpython/wxplot/profile.py" = ["A005", "SIM115"]


### PR DESCRIPTION
Ensure writeData() uses a with‐statement for appending the trailing newline