### PR TITLE
wxGUI: use context manager for deleting file content in _setRevertCapFiles (SIM115)

### DIFF
--- a/gui/wxpython/web_services/dialogs.py
+++ b/gui/wxpython/web_services/dialogs.py
@@ -680,8 +680,8 @@ class WSPropertiesDialog(WSDialogBase):
                 shutil.copyfile(f, self.revert_ws_cap_files[ws])
             else:
                 # delete file content
-                f_o = open(f, "w")
-                f_o.close()
+                with open(f, "w"):
+                    pass
 
     def _createWidgets(self):
         WSDialogBase._createWidgets(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,6 @@ ignore = [
 "gui/wxpython/iclass/statistics.py" = ["A005"]
 "gui/wxpython/tools/update_menudata.py" = ["SIM115"]
 "gui/wxpython/vnet/vnet_data.py" = ["SIM115"]
-"gui/wxpython/web_services/dialogs.py" = ["SIM115"]
 "gui/wxpython/wxplot/profile.py" = ["A005", "SIM115"]
 "lib/imagery/testsuite/test_imagery_signature_management.py" = ["SIM115"]
 "lib/imagery/testsuite/test_imagery_sigsetfile.py" = ["FURB152"]


### PR DESCRIPTION
Replace manual `open()`/`close()` with a `with`‑statement in `_setRevertCapFiles()` for proper resource handling.
