### PR TITLE
lib/imagery: use context manager for file writes in tests (SIM115)

### DIFF
--- a/lib/imagery/testsuite/test_imagery_signature_management.py
+++ b/lib/imagery/testsuite/test_imagery_signature_management.py
@@ -21,6 +21,7 @@ from grass.script.core import tempname
 import grass.script as gs
 from grass.pygrass import utils
 from grass.pygrass.gis import Mapset, make_mapset
+from pathlib import Path
 
 from grass.lib.gis import (
     G_mapset_path,
@@ -138,19 +139,22 @@ class SignaturesRemoveTestCase(TestCase):
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
-        open(sigfile_name1, "a").close()
+        with open(sigfile_name1, "a"):
+            pass
         sig_name2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sig/{sig_name2}"
         os.makedirs(sig_dir2)
         self.sigdirs.append(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
-        open(sigfile_name2, "a").close()
+        with open(sigfile_name2, "a"):
+            pass
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
         os.makedirs(sig_dir3)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
-        open(sigfile_name3, "a").close()
+        with open(sigfile_name3, "a"):
+            pass
         # Try to remove with wrong type
         ret = I_signatures_remove(I_SIGFILE_TYPE_SIGSET, sig_name2)
         self.assertEqual(ret, 1)
@@ -185,7 +189,8 @@ class SignaturesRemoveTestCase(TestCase):
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
-        open(sigfile_name1, "a").close()
+        with open(sigfile_name1, "a"):
+            pass
         sig_name2 = tempname(10)
         # Do not create sig_name2 matching file
         sig_name3 = tempname(10)
@@ -193,7 +198,8 @@ class SignaturesRemoveTestCase(TestCase):
         os.makedirs(sig_dir3)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
-        open(sigfile_name3, "a").close()
+        with open(sigfile_name3, "a"):
+            pass
         # Now remove one (should fail as file is absent)
         ret = I_signatures_remove(I_SIGFILE_TYPE_SIG, sig_name2)
         self.assertEqual(ret, 1)
@@ -217,19 +223,22 @@ class SignaturesRemoveTestCase(TestCase):
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
-        open(sigfile_name1, "a").close()
+        with open(sigfile_name1, "a"):
+            pass
         sig_name2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sigset/{sig_name2}"
         os.makedirs(sig_dir2)
         self.sigdirs.append(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
-        open(sigfile_name2, "a").close()
+        with open(sigfile_name2, "a"):
+            pass
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
         os.makedirs(sig_dir3)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
-        open(sigfile_name3, "a").close()
+        with open(sigfile_name3, "a"):
+            pass
         # Try to remove with wrong type
         ret = I_signatures_remove(I_SIGFILE_TYPE_SIG, sig_name2)
         self.assertEqual(ret, 1)
@@ -264,7 +273,8 @@ class SignaturesRemoveTestCase(TestCase):
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
-        open(sigfile_name1, "a").close()
+        with open(sigfile_name1, "a"):
+            pass
         sig_name2 = tempname(10)
         # Do not create sig_name2 matching file
         sig_name3 = tempname(10)
@@ -272,7 +282,8 @@ class SignaturesRemoveTestCase(TestCase):
         os.makedirs(sig_dir3)
         self.sigdirs.append(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
-        open(sigfile_name3, "a").close()
+        with open(sigfile_name3, "a"):
+            pass
         # Now remove one (should fail as file doesn't exist)
         ret = I_signatures_remove(I_SIGFILE_TYPE_SIGSET, sig_name2)
         self.assertEqual(ret, 1)
@@ -296,19 +307,22 @@ class SignaturesRemoveTestCase(TestCase):
         sig_dir1 = f"{self.mpath}/signatures/libsvm/{sig_name1}"
         os.makedirs(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
-        open(sigfile_name1, "a").close()
+        with open(sigfile_name1, "a"):
+            pass
         self.sigdirs.append(sig_dir1)
         sig_name2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/libsvm/{sig_name2}"
         os.makedirs(sig_dir2)
         sigfile_name2 = f"{sig_dir2}/sig"
-        open(sigfile_name2, "a").close()
+        with open(sigfile_name2, "a"):
+            pass
         self.sigdirs.append(sig_dir2)
         sig_name3 = tempname(10)
         sig_dir3 = f"{self.mpath}/signatures/sig/{sig_name3}"
         os.makedirs(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
-        open(sigfile_name3, "a").close()
+        with open(sigfile_name3, "a"):
+            pass
         self.sigdirs.append(sig_dir3)
         # Try to remove with wrong type
         ret = I_signatures_remove(I_SIGFILE_TYPE_SIG, sig_name2)
@@ -343,7 +357,8 @@ class SignaturesRemoveTestCase(TestCase):
         sig_dir1 = f"{self.mpath}/signatures/sigset/{sig_name1}"
         os.makedirs(sig_dir1)
         sigfile_name1 = f"{sig_dir1}/sig"
-        open(sigfile_name1, "a").close()
+        with open(sigfile_name1, "a"):
+            pass
         self.sigdirs.append(sig_dir1)
         sig_name2 = tempname(10)
         # Do not create sig_name2 matching file
@@ -351,7 +366,8 @@ class SignaturesRemoveTestCase(TestCase):
         sig_dir3 = f"{self.mpath}/signatures/libsvm/{sig_name3}"
         os.makedirs(sig_dir3)
         sigfile_name3 = f"{sig_dir3}/sig"
-        open(sigfile_name3, "a").close()
+        with open(sigfile_name3, "a"):
+            pass
         self.sigdirs.append(sig_dir3)
         # Now remove one (should fail as file is absent)
         ret = I_signatures_remove(I_SIGFILE_TYPE_LIBSVM, sig_name2)
@@ -393,25 +409,19 @@ class SignaturesCopyTestCase(TestCase):
         cls.src_sig_dir = f"{cls.src_mapset_path}/signatures/sig/{cls.src_sig}"
         os.makedirs(cls.src_sig_dir)
         cls.sigdirs.append(cls.src_sig_dir)
-        f = open(f"{cls.src_sig_dir}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{cls.src_sig_dir}/sig").write_text("A sig file")
         os.makedirs(f"{cls.src_mapset_path}/signatures/sigset/")
         cls.src_sigset = tempname(10)
         cls.src_sigset_dir = f"{cls.src_mapset_path}/signatures/sigset/{cls.src_sigset}"
         os.makedirs(cls.src_sigset_dir)
         cls.sigdirs.append(cls.src_sigset_dir)
-        f = open(f"{cls.src_sigset_dir}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{cls.src_sigset_dir}/sig").write_text("A sigset file")
         os.makedirs(f"{cls.src_mapset_path}/signatures/libsvm/")
         cls.src_libsvm = tempname(10)
         cls.src_libsvm_dir = f"{cls.src_mapset_path}/signatures/libsvm/{cls.src_libsvm}"
         os.makedirs(cls.src_libsvm_dir)
         cls.sigdirs.append(cls.src_libsvm_dir)
-        f = open(f"{cls.src_libsvm_dir}/sig", "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(f"{cls.src_libsvm_dir}/sig").write_text("A libsvm file")
 
     @classmethod
     def tearDownClass(cls):
@@ -615,9 +625,7 @@ class SignaturesRenameTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/sig/{src_sig}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sig file")
         dst = tempname(10)
         self.sigdirs.append(f"{self.mpath}/signatures/sig/{dst}")
         ret = I_find_signature(I_SIGFILE_TYPE_SIG, dst, self.mapset_name)
@@ -637,9 +645,7 @@ class SignaturesRenameTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/sig/{src_sig}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sig file")
         dst_name = tempname(10)
         self.sigdirs.append(f"{self.mpath}/signatures/sig/{dst_name}")
         dst = dst_name + "@" + self.mapset_name
@@ -664,9 +670,7 @@ class SignaturesRenameTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/sigset/{src_sigset}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sigset file")
         dst = tempname(10)
         self.sigdirs.append(f"{self.mpath}/signatures/sigset/{dst}")
         ret = I_find_signature(I_SIGFILE_TYPE_SIGSET, dst, self.mapset_name)
@@ -686,9 +690,7 @@ class SignaturesRenameTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/sigset/{src_sigset}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sigset file")
         dst_name = tempname(10)
         self.sigdirs.append(f"{self.mpath}/signatures/sigset/{dst_name}")
         dst = dst_name + "@" + self.mapset_name
@@ -715,9 +717,7 @@ class SignaturesRenameTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/libsvm/{src_sig}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A libsvm file")
         dst = tempname(10)
         self.sigdirs.append(f"{self.mpath}/signatures/libsvm/{dst}")
         ret = I_find_signature(I_SIGFILE_TYPE_LIBSVM, dst, self.mapset_name)
@@ -737,9 +737,7 @@ class SignaturesRenameTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/libsvm/{src_sig}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A libsvm file")
         dst = tempname(10)
         dst_dir = f"{self.mpath}/signatures/libsvm/{dst}"
         self.sigdirs.append(dst_dir)
@@ -817,9 +815,7 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/sig/{local_sig}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sig file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIG, self.rnd_mapset_name, ctypes.byref(sig_list)
@@ -832,9 +828,7 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir = f"{self.mpath}/signatures/sigset/{local_sigset}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sigset file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIGSET, self.rnd_mapset_name, ctypes.byref(sig_list)
@@ -848,9 +842,7 @@ class SignaturesListByTypeTestCase(TestCase):
         os.makedirs(sig_dir)
         sig_file = f"{sig_dir}/sig"
         self.sigdirs.append(sig_dir)
-        f = open(sig_file, "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(sig_file).write_text("A libsvm file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_LIBSVM, self.rnd_mapset_name, ctypes.byref(sig_list)
@@ -866,9 +858,7 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sig file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIG, self.rnd_mapset_name, ctypes.byref(sig_list)
@@ -884,9 +874,7 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sigset}"
         os.makedirs(sig_dir)
         self.sigdirs.append(sig_dir)
-        f = open(f"{sig_dir}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir}/sig").write_text("A sigset file")
         sigset_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIGSET, self.rnd_mapset_name, ctypes.byref(sigset_list)
@@ -901,9 +889,7 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig}"
         os.makedirs(sig_dir)
         sig_file = f"{sig_dir}/sig"
-        f = open(sig_file, "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(sig_file).write_text("A libsvm file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_LIBSVM, self.rnd_mapset_name, ctypes.byref(sig_list)
@@ -921,16 +907,12 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig1}"
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
-        f = open(f"{sig_dir1}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir1}/sig").write_text("A sig file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig2}"
         os.makedirs(sig_dir2)
         self.sigdirs.append(sig_dir2)
-        f = open(f"{sig_dir2}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir2}/sig").write_text("A sig file")
         # POINTER(POINTER(c_char))
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
@@ -951,16 +933,12 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sigset1}"
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
-        f = open(f"{sig_dir1}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir1}/sig").write_text("A sigset file")
         rnd_sigset2 = tempname(10)
         sig_dir2 = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sigset2}"
         os.makedirs(sig_dir2)
         self.sigdirs.append(sig_dir2)
-        f = open(f"{sig_dir2}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir2}/sig").write_text("A sigset file")
         sigset_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIGSET, self.rnd_mapset_name, ctypes.byref(sigset_list)
@@ -980,16 +958,12 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig1}"
         os.makedirs(sig_dir1)
         sig_file1 = f"{sig_dir1}/sig"
-        f = open(sig_file1, "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(sig_file1).write_text("A libsvm file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig2}"
         os.makedirs(sig_dir2)
         sig_file2 = f"{sig_dir2}/sig"
-        f = open(sig_file2, "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(sig_file2).write_text("A libsvm file")
         # POINTER(POINTER(c_char))
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
@@ -1012,16 +986,12 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sig/{rnd_sig1}"
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
-        f = open(f"{sig_dir1}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir1}/sig").write_text("A sig file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sig/{rnd_sig2}"
         os.makedirs(sig_dir2)
         self.sigdirs.append(sig_dir2)
-        f = open(f"{sig_dir2}/sig", "w")
-        f.write("A sig file")
-        f.close()
+        Path(f"{sig_dir2}/sig").write_text("A sig file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIG, None, ctypes.byref(sig_list)
@@ -1063,16 +1033,12 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/sigset/{rnd_sig1}"
         os.makedirs(sig_dir1)
         self.sigdirs.append(sig_dir1)
-        f = open(f"{sig_dir1}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir1}/sig").write_text("A sigset file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/sigset/{rnd_sig2}"
         os.makedirs(sig_dir2)
         self.sigdirs.append(sig_dir2)
-        f = open(f"{sig_dir2}/sig", "w")
-        f.write("A sigset file")
-        f.close()
+        Path(f"{sig_dir2}/sig").write_text("A sigset file")
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(
             I_SIGFILE_TYPE_SIGSET, None, ctypes.byref(sig_list)
@@ -1114,16 +1080,12 @@ class SignaturesListByTypeTestCase(TestCase):
         sig_dir1 = f"{self.rnd_mapset_path}/signatures/libsvm/{rnd_sig1}"
         os.makedirs(sig_dir1)
         sig_file1 = f"{sig_dir1}/sig"
-        f = open(sig_file1, "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(sig_file1).write_text("A libsvm file")
         rnd_sig2 = tempname(10)
         sig_dir2 = f"{self.mpath}/signatures/libsvm/{rnd_sig2}"
         os.makedirs(sig_dir2)
         sig_file2 = f"{sig_dir2}/sig"
-        f = open(sig_file2, "w")
-        f.write("A libsvm file")
-        f.close()
+        Path(sig_file2).write_text("A libsvm file")
         self.sigdirs.append(sig_dir2)
         sig_list = self.list_ptr()
         ret = I_signatures_list_by_type(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,7 +290,6 @@ ignore = [
 "gui/wxpython/vnet/vnet_data.py" = ["SIM115"]
 "gui/wxpython/web_services/dialogs.py" = ["SIM115"]
 "gui/wxpython/wxplot/profile.py" = ["A005", "SIM115"]
-"lib/imagery/testsuite/test_imagery_signature_management.py" = ["SIM115"]
 "lib/imagery/testsuite/test_imagery_sigsetfile.py" = ["FURB152"]
 "lib/init/grass.py" = ["SIM115"]
 "lib/init/testsuite/test_grass_tmp_mapset.py" = ["PTH208"]


### PR DESCRIPTION
Replace all `open(...)`/`write(...)`/`close()` sequences in test_imagery_signature_management.py with `with open(...) as f:` to satisfy Ruff’s SIM115.
