### PR TITLE
man: Use context manager when opening image file

### DIFF
--- a/man/build_manual_gallery.py
+++ b/man/build_manual_gallery.py
@@ -103,8 +103,8 @@ def image_width(filename):
         from PIL import Image
     except ImportError:
         return None
-
-    return Image.open(filename).size[0]  # First element is width.
+    with Image.open(filename) as img:
+        return img.size[0]  # First element is width.
 
 
 def img_in_file(filename: str | os.PathLike[str], imagename: str, ext: str) -> bool:


### PR DESCRIPTION
Image from pillow supports using context managers, but wasn't used yet.
Solves more than 100 ResourceWarning at least for macOS builds (log search returns 100 results)

Errors looked like:
```
GISBASE="/Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0" ARCH="aarch64-apple-darwin20.0.0" ARCH_DISTDIR="/Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0" MDDIR="/Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0/docs/mkdocs" VERSION_NUMBER=8.5.0dev VERSION_DATE=2025 python3 ./build_class.py m miscellaneous
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/runner/work/grass/grass/man/./build_manual_gallery.py:107: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0/docs/html/v_dissolve_zipcodes.png'>
  return Image.open(filename).size[0]  # First element is width.
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/runner/work/grass/grass/man/./build_manual_gallery.py:107: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0/docs/html/i_pansharpen_rgb_ihs542.jpg'>
touch /Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0/docs/html/imagery.html
  return Image.open(filename).size[0]  # First element is width.
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/runner/work/grass/grass/man/./build_manual_gallery.py:107: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/runner/work/grass/grass/dist.aarch64-apple-darwin20.0.0/docs/html/jupyter_map.png'>
```

![image](https://github.com/user-attachments/assets/a0d53d32-4f32-4e2a-8ef6-70372d404204)
