### PR TITLE
man: Remove FileType argument types in parser standard options arguments

### DIFF
--- a/man/build.py
+++ b/man/build.py
@@ -7,10 +7,16 @@
 #   Glynn Clements
 #   Luca Delucchi
 
+from __future__ import annotations
+
 import os
 import string
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import IO
 
 # TODO: better fix this in include/Make/Html.make, see bug RT #5361
 
@@ -82,7 +88,7 @@ def copy_file(src, dst):
     write_file(dst, read_file(src))
 
 
-def get_files(man_dir, cls=None, ignore_gui=True, extension="html"):
+def get_files(man_dir, cls=None, ignore_gui=True, extension: str = "html"):
     for cmd in sorted(os.listdir(man_dir)):
         if (
             cmd.endswith(f".{extension}")
@@ -95,7 +101,7 @@ def get_files(man_dir, cls=None, ignore_gui=True, extension="html"):
             yield cmd
 
 
-def write_header(f, title, ismain=False, body_width="99%", template="html"):
+def write_header(f: IO, title, ismain=False, body_width="99%", template: str = "html"):
     if template == "html":
         from build_html import header1_tmpl, macosx_tmpl, header2_tmpl
     else:
@@ -108,7 +114,7 @@ def write_header(f, title, ismain=False, body_width="99%", template="html"):
     f.write(header2_tmpl.substitute(grass_version=grass_version, body_width=body_width))
 
 
-def write_cmd_overview(f, template="html"):
+def write_cmd_overview(f: IO, template: str = "html"):
     from build_html import overview_tmpl
 
     if template == "html":
@@ -120,7 +126,7 @@ def write_cmd_overview(f, template="html"):
         )
 
 
-def write_footer(f, index_url, year=None, template="html"):
+def write_footer(f: IO, index_url, year=None, template: str = "html"):
     if template == "html":
         from build_html import footer_tmpl
 

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -336,7 +336,7 @@ if __name__ == "__main__":
         default=sys.stdout,
         dest="output",
         type=argparse.FileType("w"),
-        help="Provide the url with the file to parse",
+        help="The file where the output should be written (default: stdout)",
     )
     parser.add_argument(
         "-s",

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -360,9 +360,7 @@ if __name__ == "__main__":
             if args.output is not None
             else contextlib.nullcontext(sys.stdout)
         ) as outfile,
-        open(args.text)
-        if args.text is not None
-        else urlopen(args.url, proxies=None) as cfile,
+        open(args.text) if args.text is not None else urlopen(args.url) as cfile,
     ):
         options = OptTable(parse_options(cfile.readlines(), startswith=args.startswith))
         outform = args.format

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -379,7 +379,7 @@ if __name__ == "__main__":
             print(getattr(options, outform)(), file=outfile)
         else:
             year = os.getenv("VERSION_DATE")
-            name = args.output.name
+            name = outfile.name
 
             def write_output(f: IO[str], ext: str) -> None:
                 f.write(header1_tmpl.substitute(title="Standard Parser Options"))

--- a/man/parser_standard_options.py
+++ b/man/parser_standard_options.py
@@ -5,24 +5,35 @@ Copyright 2015-2025 by Pietro Zambelli and the GRASS Development Team
 @author: Vaclav Petras (Markdown output)
 """
 
+from __future__ import annotations
+
 import argparse
 import contextlib
 import os
 import re
 import sys
 
+from typing import IO, TYPE_CHECKING
 from urllib.request import urlopen
 from collections import defaultdict
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-def parse_options(lines, startswith="Opt"):
-    def split_in_groups(lines):
-        def count_par_diff(line):
+
+def parse_options(
+    lines: list[str], startswith="Opt"
+) -> list[tuple[str, dict[str, str | list[str]]]]:
+    def split_in_groups(
+        lines: list[str],
+    ) -> Generator[tuple[str, list[str] | None], None]:
+        def count_par_diff(line: str) -> int:
             open_par = line.count("(")
             close_par = line.count(")")
             return open_par - close_par
 
-        res = None
+        res: list[str] | None = None
+        optname: str = ""
         diff = 0
         for line in lines:
             if line.startswith("case"):
@@ -35,17 +46,17 @@ def parse_options(lines, startswith="Opt"):
                 diff = count_par_diff(line)
             elif diff > 0:
                 diff -= count_par_diff(line)
-            else:
-                res.append(line) if res is not None else None
+            elif res is not None:
+                res.append(line)
 
-    def split_opt_line(line):
+    def split_opt_line(line: str) -> tuple[str, str]:
         index = line.index("=")
         key = line[:index].strip()
         default = line[index + 1 :].strip()
         return key, default
 
-    def parse_glines(glines):
-        res = {}
+    def parse_glines(glines: list[str]) -> dict[str, str | list[str]]:
+        res: dict[str, str | list[str]] = {}
         key = None
         dynamic_answer = False
         for line in glines:
@@ -59,8 +70,6 @@ def parse_options(lines, startswith="Opt"):
                 dynamic_answer = False
             if dynamic_answer or line.startswith("/*"):
                 continue
-            if line.startswith("/*"):
-                continue
             if line.startswith(startswith) and line.endswith(";"):
                 key, default = (w.strip() for w in split_opt_line(line[5:]))
                 res[key] = default
@@ -72,10 +81,12 @@ def parse_options(lines, startswith="Opt"):
             elif key is not None:
                 if key not in res:
                     res[key] = []
+                # TODO: Possible problem to do .append() on a string, if the value is
+                # a string, previously set with `res[key] = default` above
                 res[key].append(line)
         return res
 
-    def clean_value(val):
+    def clean_value(val: list | str) -> str:
         if isinstance(val, list):
             val = "".join(val)
         val = val.strip()
@@ -91,10 +102,10 @@ def parse_options(lines, startswith="Opt"):
         return val.replace(r"\"", '"')
 
     lines = [line.strip() for line in lines]
-    result = []
+    result: list[tuple[str, dict[str, str | list[str]]]] = []
     for optname, glines in split_in_groups(lines):
         if glines:
-            res = parse_glines(glines)
+            res: dict[str, str | list[str]] = parse_glines(glines)
             if res:
                 for key, val in res.items():
                     res[key] = clean_value(val)
@@ -272,7 +283,7 @@ class OptTable:
     def markdown(self, endline="\n"):
         return markdown(options=self.options, columns=self.columns, endline=endline)
 
-    def html(self, endline="\n", indent="  ", toptions="border=1"):
+    def html(self, endline="\n", indent="  ", toptions: str | None = "border=1"):
         """Return a HTML table with the options"""
         html = ["<table{0}>".format(" " + toptions if toptions else "")]
         # write headers
@@ -370,7 +381,7 @@ if __name__ == "__main__":
             year = os.getenv("VERSION_DATE")
             name = args.output.name
 
-            def write_output(f, ext) -> None:
+            def write_output(f: IO[str], ext: str) -> None:
                 f.write(header1_tmpl.substitute(title="Standard Parser Options"))
                 f.write(headerpso_tmpl)
                 if ext == "html":


### PR DESCRIPTION
There was another ResourceWarning error in manual generation that I solved after #5560. The unclosed files were defined in the argparse arguments with FileType type.

The argparse FileType argument type will be deprecated in Python 3.14. It does not properly close files if a subsequent error in another FileType argument occurs when parsing. The suggestion is to use context managers after parsing the arguments. The implementation of the changes is inspired by [a PR](https://github.com/python/cpython/pull/113649) doing the same in the CPython repo.


Other small changes included in (wasn't worth a separate PR):
- Removing `urlopen()`'s proxies argument. It was for the old interface. Default proxy handling is used now. It allowed correct type checking.
- Invalid None assignment to nothing in `res.append(line) if res is not None else None`, replaced with `elif res is not None:` and `res.append(line)`, as intended 10+ years ago.
- Initialized `optname` variable in function `split_in_groups` if ever the first condition wasn't executed for a previous line (for type checking, as it was unbounded otherwise)
- Renamed variable of argument destination with typo from `htmlparmas` to `htmlparams` (two occurrences only, used once)
- Added a note to an append operation where type checking clearly indicates an error, but changes would be out of scope here.
- Collapsed a `if line.startswith("/*"):`  `continue` that was not required because of the condition above, that already checked for this situation just above.

Type checking was added to touched/impacted functions to validate correct usages.