### PR TITLE
r3.mkdspf: Fix copy into fixed buffer size issue in r3_find.c

### DIFF
--- a/raster3d/r3.mkdspf/r3_find.c
+++ b/raster3d/r3.mkdspf/r3_find.c
@@ -5,6 +5,7 @@
  **************************************************************/
 #include <string.h>
 #include <grass/gis.h>
+#include <grass/glocale.h>
 #include <grass/raster3d.h>
 
 int g3_find_dsp_file(const char *cell, const char *file, const char *mset)
@@ -15,7 +16,9 @@ int g3_find_dsp_file(const char *cell, const char *file, const char *mset)
     if (file == NULL || *file == 0)
         return 0;
 
-    strcpy(tofind, file);
+    if (G_strlcpy(tofind, file, sizeof(tofind)) >= sizeof(tofind)) {
+        G_fatal_error(_("File name <%s> is too long"), file);
+    }
 
     if (G_name_is_fully_qualified(cell, name, mapset))
         sprintf(element, "grid3/%s/dsp", name);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity scan (CID : 1208251)
Used G_strlcpy() to fix this issue