### PR TITLE
lib/cairodriver:  Fix unchecked return value from library

### DIFF
--- a/lib/cairodriver/read_ppm.c
+++ b/lib/cairodriver/read_ppm.c
@@ -30,7 +30,8 @@ void cairo_read_ppm(void)
     if (fscanf(input, "P6 %d %d %d", &i_width, &i_height, &maxval) != 3)
         G_fatal_error(_("Cairo: invalid input file <%s>"), ca.file_name);
 
-    fgetc(input);
+    if (fgetc(input) == EOF)
+        G_fatal_error(_("Cairo: unexpected EOF reading <%s>"), ca.file_name);
 
     if (i_width != ca.width || i_height != ca.height)
         G_fatal_error(_("Cairo: input file has incorrect dimensions: "
@@ -47,7 +48,8 @@ void cairo_read_ppm(void)
     if (fscanf(mask, "P5 %d %d %d", &i_width, &i_height, &maxval) != 3)
         G_fatal_error(_("Cairo: invalid input mask file <%s>"), mask_name);
 
-    fgetc(mask);
+    if (fgetc(mask) == EOF)
+        G_fatal_error(_("Cairo: unexpected EOF reading mask <%s>"), mask_name);
 
     if (i_width != ca.width || i_height != ca.height)
         G_fatal_error(_("Cairo: input mask file has incorrect dimensions: "


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1207199)
added a check to fgetc()
