### PR TITLE
grass.script: Reveal the failed type passed to decode

### DIFF
--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -209,7 +209,7 @@ def decode(bytes_: AnyStr, encoding: str | None = None) -> str:
         enc = _get_encoding() if encoding is None else encoding
         return bytes_.decode(enc)
     # only text should be used
-    msg = "can only accept types str and bytes"
+    msg = f"can only accept types str and bytes, not {type(bytes_).__name__}"
     raise TypeError(msg)
 
 


### PR DESCRIPTION
The decode function from utils raises TypeError when the type is not bytes or str. This also makes it include the type of the passed object in the message. Practically, this will be often NoneType (you use decode, but you don't have Popen configured properly).
