### PR TITLE
i.evapo.mh: fix radiation conversion factor

### DIFF
--- a/imagery/i.evapo.mh/mh_eto.c
+++ b/imagery/i.evapo.mh/mh_eto.c
@@ -12,7 +12,7 @@ double mh_eto(double ra, double tavg, double tmax, double tmin, double p)
     if (tavg > 100.0) {
         tavg = tavg - 273.15; /*in case temperature is in Kelvin */
     }
-    ra = ra * (24.0 * 60.0 * 60.0 / 1000.0); /*convert W -> MJ/d */
+    ra = ra * (24.0 * 60.0 * 60.0 / 1000000.0); /*convert W -> MJ/d */
     result = 0.0013 * 0.408 * ra * (tavg + 17.0) * pow((td - 0.0123 * p), 0.76);
     return result;
 }

--- a/imagery/i.evapo.mh/mh_original.c
+++ b/imagery/i.evapo.mh/mh_original.c
@@ -13,7 +13,7 @@ double mh_original(double ra, double tavg, double tmax, double tmin,
     if (tavg > 100.0) {
         tavg = tavg - 273.15; /*in case Temperature is in Kelvin */
     }
-    ra = ra * (24.0 * 60.0 * 60.0 / 1000.0); /*convert W -> MJ/d */
+    ra = ra * (24.0 * 60.0 * 60.0 / 1000000.0); /*convert W -> MJ/d */
     result = 0.0023 * 0.408 * ra * (tavg + 17.8) * pow(td, 0.5);
     return result;
 }

--- a/imagery/i.evapo.mh/mh_samani.c
+++ b/imagery/i.evapo.mh/mh_samani.c
@@ -11,7 +11,7 @@ double mh_samani(double ra, double tavg, double tmax, double tmin)
     if (tavg > 100.0) {
         tavg = tavg - 273.15; /*in case Temperature is in Kelvin */
     }
-    ra = ra * (24.0 * 60.0 * 60.0 / 1000.0); /* convert W -> MJ/d */
+    ra = ra * (24.0 * 60.0 * 60.0 / 1000000.0); /* convert W -> MJ/d */
     result =
         0.0023 * 0.408 * ra * pow(td, 0.5) * ((tmax + tmin) / 2 + 17.8) / 2.45;
     return result;


### PR DESCRIPTION
This PR fixes an incorrect radiation conversion applied in the evapotranspiration calculations of the `i.evapo.mh` module.

Previously, the radiation input (`ra`) was multiplied by `86.4`, incorrectly boosting the energy input and resulting in overestimated evapotranspiration values.

This PR corrects the unit conversion:

- Changes `ra = ra * (24.0 * 60.0 * 60.0 / 1000.0);`  to  `ra = ra * (24.0 * 60.0 * 60.0 / 1000000.0);`
- This matches the correct SI conversion where 1 W/m² = 0.0864 MJ/m²/day

The correction is applied consistently across the following functions:
- `mh_eto()`
- `mh_original()`
- `mh_samani()`


Fixes https://github.com/OSGeo/grass/issues/5520