### PR TITLE
r.plane: remove misused gisprompt option

### DIFF
--- a/scripts/r.plane/r.plane.py
+++ b/scripts/r.plane/r.plane.py
@@ -27,7 +27,6 @@
 # %option
 # % key: dip
 # % type: double
-# % gisprompt: -90-90
 # % answer: 0.0
 # % description: Dip of plane in degrees
 # % required : yes
@@ -35,7 +34,6 @@
 # %option
 # % key: azimuth
 # % type: double
-# % gisprompt: 0-360
 # % answer: 0.0
 # % description: Azimuth of the plane in degrees
 # % required : yes

--- a/scripts/r.plane/r.plane.py
+++ b/scripts/r.plane/r.plane.py
@@ -27,6 +27,7 @@
 # %option
 # % key: dip
 # % type: double
+# % options: -90-90
 # % answer: 0.0
 # % description: Dip of plane in degrees
 # % required : yes
@@ -34,6 +35,7 @@
 # %option
 # % key: azimuth
 # % type: double
+# % options: 0-360
 # % answer: 0.0
 # % description: Azimuth of the plane in degrees
 # % required : yes


### PR DESCRIPTION
As the option does not contain a comma separated three part string, this causes heap buffer overflow. This is probably the cause of some random CI failures with `r.plane`.

Follow-up to #5493.

