### PR TITLE
r.li: fix resource leak issues

### DIFF
--- a/raster/r.li/r.li.daemon/avl.c
+++ b/raster/r.li/r.li.daemon/avl.c
@@ -42,7 +42,6 @@ avl_tree avl_make(const generic_cell k, const long n)
     root = G_malloc(sizeof(avl_node));
     if (root == NULL) {
         G_fatal_error("avl.c: avl_make: malloc error");
-        return NULL;
     }
 
     /* initialize root */
@@ -117,7 +116,6 @@ int avl_add(avl_tree *root, const generic_cell k, const long n)
 
     if ((root == NULL) || (*root == NULL)) {
         G_fatal_error("\navl.c: avl_add: param NULL");
-        return AVL_ERR;
     }
 
     /* search position where insert the new node */
@@ -131,7 +129,6 @@ int avl_add(avl_tree *root, const generic_cell k, const long n)
     node_temp = avl_make(k, n);
     if (node_temp == NULL) {
         G_fatal_error("\navl.c:  avl_add: create node error");
-        return AVL_ERR;
     }
 
     /* link the new node */
@@ -147,7 +144,6 @@ int avl_add(avl_tree *root, const generic_cell k, const long n)
         else {
             G_free(node_temp);
             G_fatal_error("avl.c: avl_add: new node position unknown");
-            return AVL_ERR;
         }
     }
 
@@ -172,7 +168,6 @@ int avl_add(avl_tree *root, const generic_cell k, const long n)
         break;
     default:
         G_fatal_error("avl, avl_add: balancing error\n");
-        return AVL_ERR;
     }
 
     /* if after rotation the root is changed modufy the pointer to the root */
@@ -227,11 +222,9 @@ static avl_node *avl_individua(const avl_tree root, const generic_cell k,
     }
     case GC_DIFFERENT_TYPE: {
         G_fatal_error("\avl.c: avl_individua: different type");
-        return NULL;
     }
     default: {
         G_fatal_error("\avl.c: avl_individua: error");
-        return NULL;
     }
     }
 }

--- a/raster/r.li/r.li.daemon/avlID.c
+++ b/raster/r.li/r.li.daemon/avlID.c
@@ -172,7 +172,6 @@ int avlID_add(avlID_tree *root, const long k, const long n)
         break;
     default:
         G_fatal_error("avl, avlID_add: balancing error\n");
-        return AVL_ERR;
     }
 
     /* if after rotation there is a new root update the root pointer */

--- a/raster/r.li/r.li.daemon/worker.c
+++ b/raster/r.li/r.li.daemon/worker.c
@@ -213,7 +213,7 @@ void worker_end(void)
 
 char *mask_preprocessing(char *mask, char *raster, struct area_entry *ad)
 {
-    const char *tmp_file;
+    char *tmp_file;
     int mask_fd, old_fd, *buf, i, j;
     CELL *old;
 
@@ -237,8 +237,11 @@ char *mask_preprocessing(char *mask, char *raster, struct area_entry *ad)
             /* NULL -> 0, else 1 */
             buf[j] = !Rast_is_c_null_value(&old[j + ad->x]);
         }
-        if (write(mask_fd, buf, ad->cl * sizeof(int)) < 0)
-            return NULL;
+        if (write(mask_fd, buf, ad->cl * sizeof(int)) < 0) {
+            G_free(tmp_file);
+            tmp_file = NULL;
+            break;
+        }
     }
 
     close(mask_fd);
@@ -247,7 +250,7 @@ char *mask_preprocessing(char *mask, char *raster, struct area_entry *ad)
     G_free(buf);
     G_free(old);
 
-    return G_store(tmp_file);
+    return tmp_file;
 }
 
 CELL *RLI_get_cell_raster_row(int fd, int row, struct area_entry *ad)

--- a/raster/r.li/r.li.edgedensity/edgedensity.c
+++ b/raster/r.li/r.li.edgedensity/edgedensity.c
@@ -106,7 +106,6 @@ int edgedensity(int fd, char **par, struct area_entry *ad, double *result)
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
     if (ris != RLI_OK) {
@@ -139,13 +138,13 @@ int calculate(int fd, struct area_entry *ad, char **par, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -155,8 +154,9 @@ int calculate(int fd, struct area_entry *ad, char **par, double *result)
 
     buf_null = Rast_allocate_c_buf();
     if (buf_null == NULL) {
+        if (masked)
+            close(mask_fd);
         G_fatal_error("malloc buf_null failed");
-        return RLI_ERRORE;
     }
 
     /* the first time buf_sup is all null */
@@ -189,8 +189,13 @@ int calculate(int fd, struct area_entry *ad, char **par, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
+                G_free(mask_buf);
+                G_free(mask_sup);
+                G_free(buf_null);
                 return RLI_ERRORE;
+            }
         }
 
         Rast_set_c_null_value(&precCell, 1);
@@ -333,13 +338,13 @@ int calculateD(int fd, struct area_entry *ad, char **par, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -349,8 +354,8 @@ int calculateD(int fd, struct area_entry *ad, char **par, double *result)
 
     buf_null = Rast_allocate_d_buf();
     if (buf_null == NULL) {
+        close(mask_fd);
         G_fatal_error("malloc buf_null failed");
-        return RLI_ERRORE;
     }
 
     /* the first time buf_sup is all null */
@@ -383,8 +388,13 @@ int calculateD(int fd, struct area_entry *ad, char **par, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
+                G_free(mask_buf);
+                G_free(mask_sup);
+                G_free(buf_null);
                 return RLI_ERRORE;
+            }
         }
 
         Rast_set_d_null_value(&precCell, 1);
@@ -527,13 +537,13 @@ int calculateF(int fd, struct area_entry *ad, char **par, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -543,8 +553,8 @@ int calculateF(int fd, struct area_entry *ad, char **par, double *result)
 
     buf_null = Rast_allocate_f_buf();
     if (buf_null == NULL) {
+        close(mask_fd);
         G_fatal_error("malloc buf_null failed");
-        return RLI_ERRORE;
     }
 
     /* the first time buf_sup is all null */
@@ -577,8 +587,13 @@ int calculateF(int fd, struct area_entry *ad, char **par, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
+                G_free(mask_buf);
+                G_free(mask_sup);
+                G_free(buf_null);
                 return RLI_ERRORE;
+            }
         }
 
         Rast_set_f_null_value(&precCell, 1);

--- a/raster/r.li/r.li.mpa/mpa.c
+++ b/raster/r.li/r.li.mpa/mpa.c
@@ -82,7 +82,6 @@ int meanPixelAttribute(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
     if (ris != RLI_OK) {
@@ -109,12 +108,11 @@ int calculate(int fd, struct area_entry *ad, double *result)
     if (ad->mask == 1) {
         if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
             G_fatal_error("can't open mask");
-            return RLI_ERRORE;
         }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -124,8 +122,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
 
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -168,12 +166,11 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     if (ad->mask == 1) {
         if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
             G_fatal_error("can't open mask");
-            return RLI_ERRORE;
         }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -183,8 +180,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
 
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -227,12 +224,11 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     if (ad->mask == 1) {
         if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
             G_fatal_error("can't open mask");
-            return RLI_ERRORE;
         }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -242,8 +238,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
 
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 

--- a/raster/r.li/r.li.mps/mps.c
+++ b/raster/r.li/r.li.mps/mps.c
@@ -92,7 +92,6 @@ int meanPatchSize(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -115,6 +114,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -138,17 +138,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -185,8 +189,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -316,6 +322,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
         *result = 0;
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -326,7 +333,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -339,6 +346,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -362,17 +370,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -409,8 +421,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -540,6 +554,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
         *result = 0;
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -550,7 +565,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -563,6 +578,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -586,17 +602,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -633,8 +653,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -764,6 +786,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
         *result = 0;
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -774,5 +797,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.padcv/padcv.c
+++ b/raster/r.li/r.li.padcv/padcv.c
@@ -91,7 +91,6 @@ int patchAreaDistributionCV(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -115,6 +114,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -138,17 +138,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -185,8 +189,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -235,6 +241,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -336,6 +344,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -346,7 +355,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -359,6 +368,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -382,17 +392,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -429,8 +443,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -479,6 +495,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -580,6 +598,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -590,7 +609,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -603,6 +622,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -626,17 +646,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -673,8 +697,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -723,6 +749,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -824,6 +852,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -834,5 +863,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.padrange/padrange.c
+++ b/raster/r.li/r.li.padrange/padrange.c
@@ -91,7 +91,6 @@ int patchAreaDistributionRANGE(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
     if (ris != RLI_OK) {
@@ -114,6 +113,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -137,17 +137,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -183,8 +187,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -231,6 +237,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -325,6 +333,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -335,7 +344,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -348,6 +357,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -371,17 +381,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -417,8 +431,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -465,6 +481,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -559,6 +577,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -569,7 +588,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -582,6 +601,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -605,17 +625,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -651,8 +675,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -699,6 +725,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -793,6 +821,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -803,5 +832,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.padsd/padsd.c
+++ b/raster/r.li/r.li.padsd/padsd.c
@@ -91,7 +91,6 @@ int patchAreaDistributionSD(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
     if (ris != RLI_OK) {
@@ -114,6 +113,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -137,17 +137,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -184,8 +188,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -234,6 +240,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -333,6 +341,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -343,7 +352,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -356,6 +365,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -379,17 +389,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -426,8 +440,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -476,6 +492,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -575,6 +593,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -585,7 +604,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -598,6 +617,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -621,17 +641,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -668,8 +692,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -718,6 +744,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -817,6 +845,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -827,5 +856,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.patchdensity/main.c
+++ b/raster/r.li/r.li.patchdensity/main.c
@@ -90,7 +90,6 @@ int patch_density(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -113,6 +112,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -136,17 +136,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -183,8 +187,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -233,6 +239,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -314,6 +322,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
         Rast_set_d_null_value(result, 1);
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -324,7 +333,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -337,6 +346,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -360,17 +370,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -407,8 +421,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -457,6 +473,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -538,6 +556,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
         Rast_set_d_null_value(result, 1);
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -548,7 +567,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -561,6 +580,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -584,17 +604,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -631,8 +655,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -681,6 +707,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -762,6 +790,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
         Rast_set_d_null_value(result, 1);
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -772,5 +801,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.patchnum/main.c
+++ b/raster/r.li/r.li.patchnum/main.c
@@ -89,7 +89,6 @@ int patch_number(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -112,6 +111,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -135,17 +135,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -181,8 +185,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -229,6 +235,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -288,6 +296,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
 
     *result = npatch;
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -298,7 +307,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -311,6 +320,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -334,17 +344,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -380,8 +394,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -428,6 +444,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -487,6 +505,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
 
     *result = npatch;
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -497,7 +516,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -510,6 +529,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     long nalloc, incr;
     int i, j, k;
     int connected;
+    int res = RLI_OK;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
     struct Cell_head hd;
 
@@ -533,17 +553,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -579,8 +603,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -627,6 +653,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -686,6 +714,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
 
     *result = npatch;
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -696,5 +725,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.pielou/pielou.c
+++ b/raster/r.li/r.li.pielou/pielou.c
@@ -85,7 +85,6 @@ int pielou(int fd, char **par UNUSED, struct area_entry *ad, double *result)
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -108,6 +107,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     int mask_fd = -1, *mask_buf = NULL;
     int ris = 0;
     int masked = FALSE;
+    int res = RLI_OK;
 
     long m = 0;
     long tot = 0;
@@ -128,8 +128,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -138,8 +138,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -170,8 +170,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                     uc.val.c = precCell;
                     albero = avl_make(uc, totCorr);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -180,8 +181,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, totCorr);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -191,8 +193,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -208,8 +211,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
             uc.val.c = precCell;
             albero = avl_make(uc, totCorr);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -218,8 +222,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, totCorr);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -229,8 +234,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -243,14 +249,17 @@ int calculate(int fd, struct area_entry *ad, double *result)
 
         array = G_malloc(m * sizeof(AVL_tableRow));
         if (array == NULL) {
+            if (masked)
+                close(mask_fd);
             G_fatal_error("malloc array failed");
-            return RLI_ERRORE;
         }
         tot = avl_to_array(albero, zero, array);
         if (tot != m) {
             G_warning(
                 "avl_to_array unexpected value. the result could be wrong");
-            return RLI_ERRORE;
+            res = RLI_ERRORE;
+            G_free(array);
+            goto free_exit;
         }
 
         /* calculate shannon */
@@ -268,13 +277,14 @@ int calculate(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     avl_destroy(albero);
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
     }
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -287,6 +297,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     int mask_fd = -1, *mask_buf = NULL;
     int ris = 0;
     int masked = FALSE;
+    int res = RLI_OK;
 
     long m = 0;
     long tot = 0;
@@ -307,8 +318,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -317,8 +328,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -349,8 +360,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                     uc.val.dc = precCell;
                     albero = avl_make(uc, totCorr);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -359,8 +371,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, totCorr);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -370,8 +383,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -387,8 +401,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             uc.val.dc = precCell;
             albero = avl_make(uc, totCorr);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -397,8 +412,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, totCorr);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -408,8 +424,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -422,14 +439,17 @@ int calculateD(int fd, struct area_entry *ad, double *result)
 
         array = G_malloc(m * sizeof(AVL_tableRow));
         if (array == NULL) {
+            if (masked)
+                close(mask_fd);
             G_fatal_error("malloc array failed");
-            return RLI_ERRORE;
         }
         tot = avl_to_array(albero, zero, array);
         if (tot != m) {
             G_warning(
                 "avl_to_array unexpected value. the result could be wrong");
-            return RLI_ERRORE;
+            res = RLI_ERRORE;
+            G_free(array);
+            goto free_exit;
         }
 
         /* calculate shannon */
@@ -447,13 +467,14 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     avl_destroy(albero);
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
     }
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -466,6 +487,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     int mask_fd = -1, *mask_buf = NULL;
     int ris = 0;
     int masked = FALSE;
+    int res = RLI_OK;
 
     long m = 0;
     long tot = 0;
@@ -486,8 +508,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -496,8 +518,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -528,8 +550,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                     uc.val.fc = precCell;
                     albero = avl_make(uc, totCorr);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -538,8 +561,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, totCorr);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -549,8 +573,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -566,8 +591,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             uc.val.fc = precCell;
             albero = avl_make(uc, totCorr);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -576,8 +602,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, totCorr);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -587,8 +614,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -601,14 +629,17 @@ int calculateF(int fd, struct area_entry *ad, double *result)
 
         array = G_malloc(m * sizeof(AVL_tableRow));
         if (array == NULL) {
+            if (masked)
+                close(mask_fd);
             G_fatal_error("malloc array failed");
-            return RLI_ERRORE;
         }
         tot = avl_to_array(albero, zero, array);
         if (tot != m) {
             G_warning(
                 "avl_to_array unexpected value. the result could be wrong");
-            return RLI_ERRORE;
+            res = RLI_ERRORE;
+            G_free(array);
+            goto free_exit;
         }
 
         /* calculate shannon */
@@ -626,11 +657,12 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     avl_destroy(albero);
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
     }
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.richness/richness.c
+++ b/raster/r.li/r.li.richness/richness.c
@@ -81,7 +81,6 @@ int richness(int fd, char **par UNUSED, struct area_entry *ad, double *result)
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -117,8 +116,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -127,8 +126,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -152,8 +151,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                     uc.val.c = precCell;
                     albero = avl_make(uc, (long)1);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -162,8 +162,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, (long)1);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -173,8 +174,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -189,8 +191,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
             uc.val.c = precCell;
             albero = avl_make(uc, (long)1);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -199,8 +202,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, (long)1);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -210,8 +214,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -254,8 +259,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -264,8 +269,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -289,8 +294,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                     uc.val.dc = precCell;
                     albero = avl_make(uc, (long)1);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -299,8 +305,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, (long)1);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -310,8 +317,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -326,8 +334,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             uc.val.dc = precCell;
             albero = avl_make(uc, (long)1);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -336,8 +345,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, (long)1);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -347,8 +357,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -391,8 +402,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -401,8 +412,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -427,8 +438,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                     uc.val.fc = precCell;
                     albero = avl_make(uc, (long)1);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -437,8 +449,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, (long)1);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -448,8 +461,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -465,8 +479,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             uc.val.fc = precCell;
             albero = avl_make(uc, (long)1);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -475,8 +490,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, (long)1);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -486,8 +502,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }

--- a/raster/r.li/r.li.shannon/shannon.c
+++ b/raster/r.li/r.li.shannon/shannon.c
@@ -85,7 +85,6 @@ int shannon(int fd, char **par UNUSED, struct area_entry *ad, double *result)
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -108,6 +107,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     int mask_fd = -1, *mask_buf = NULL;
     int ris = 0;
     int masked = FALSE;
+    int res = RLI_OK;
 
     long m = 0;
     long tot = 0;
@@ -128,8 +128,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -138,8 +138,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -170,8 +170,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                     uc.val.c = precCell;
                     albero = avl_make(uc, totCorr);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -180,8 +181,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, totCorr);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -191,8 +193,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -208,8 +211,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
             uc.val.c = precCell;
             albero = avl_make(uc, totCorr);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -218,8 +222,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, totCorr);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -229,8 +234,9 @@ int calculate(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -243,14 +249,17 @@ int calculate(int fd, struct area_entry *ad, double *result)
 
         array = G_malloc(m * sizeof(AVL_tableRow));
         if (array == NULL) {
+            if (masked)
+                close(mask_fd);
             G_fatal_error("malloc array failed");
-            return RLI_ERRORE;
         }
         tot = avl_to_array(albero, zero, array);
         if (tot != m) {
             G_warning(
                 "avl_to_array unexpected value. the result could be wrong");
-            return RLI_ERRORE;
+            res = RLI_ERRORE;
+            G_free(array);
+            goto free_exit;
         }
 
         /* calculate shannon */
@@ -268,13 +277,14 @@ int calculate(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     avl_destroy(albero);
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
     }
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -287,6 +297,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     int mask_fd = -1, *mask_buf = NULL;
     int ris = 0;
     int masked = FALSE;
+    int res = RLI_OK;
 
     long m = 0;
     long tot = 0;
@@ -307,8 +318,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -317,8 +328,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -349,8 +360,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                     uc.val.dc = precCell;
                     albero = avl_make(uc, totCorr);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -359,8 +371,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, totCorr);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -370,8 +383,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -387,8 +401,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             uc.val.dc = precCell;
             albero = avl_make(uc, totCorr);
             if (albero == NULL) {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_make error");
-                return RLI_ERRORE;
             }
             m++;
         }
@@ -397,8 +412,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, totCorr);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -408,8 +424,9 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -422,14 +439,17 @@ int calculateD(int fd, struct area_entry *ad, double *result)
 
         array = G_malloc(m * sizeof(AVL_tableRow));
         if (array == NULL) {
+            if (masked)
+                close(mask_fd);
             G_fatal_error("malloc array failed");
-            return RLI_ERRORE;
         }
         tot = avl_to_array(albero, zero, array);
         if (tot != m) {
             G_warning(
                 "avl_to_array unexpected value. the result could be wrong");
-            return RLI_ERRORE;
+            res = RLI_ERRORE;
+            G_free(array);
+            goto free_exit;
         }
 
         /* calculate shannon */
@@ -447,13 +467,14 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     avl_destroy(albero);
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
     }
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -466,6 +487,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     int mask_fd = -1, *mask_buf = NULL;
     int ris = 0;
     int masked = FALSE;
+    int res = RLI_OK;
 
     long m = 0;
     long tot = 0;
@@ -486,8 +508,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             return RLI_ERRORE;
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         masked = TRUE;
     }
@@ -496,8 +518,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     for (j = 0; j < ad->rl; j++) { /* for each row */
         if (masked) {
             if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                close(mask_fd);
                 G_fatal_error("mask read failed");
-                return RLI_ERRORE;
             }
         }
 
@@ -528,8 +550,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                     uc.val.fc = precCell;
                     albero = avl_make(uc, totCorr);
                     if (albero == NULL) {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make error");
-                        return RLI_ERRORE;
                     }
                     m++;
                 }
@@ -538,8 +561,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                     ris = avl_add(&albero, uc, totCorr);
                     switch (ris) {
                     case AVL_ERR: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_add error");
-                        return RLI_ERRORE;
                     }
                     case AVL_ADD: {
                         m++;
@@ -549,8 +573,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         break;
                     }
                     default: {
+                        if (masked)
+                            close(mask_fd);
                         G_fatal_error("avl_make unknown error");
-                        return RLI_ERRORE;
                     }
                     }
                 }
@@ -576,8 +601,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             ris = avl_add(&albero, uc, totCorr);
             switch (ris) {
             case AVL_ERR: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add error");
-                return RLI_ERRORE;
             }
             case AVL_ADD: {
                 m++;
@@ -587,8 +613,9 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                 break;
             }
             default: {
+                if (masked)
+                    close(mask_fd);
                 G_fatal_error("avl_add unknown error");
-                return RLI_ERRORE;
             }
             }
         }
@@ -601,14 +628,17 @@ int calculateF(int fd, struct area_entry *ad, double *result)
 
         array = G_malloc(m * sizeof(AVL_tableRow));
         if (array == NULL) {
+            if (masked)
+                close(mask_fd);
             G_fatal_error("malloc array failed");
-            return RLI_ERRORE;
         }
         tot = avl_to_array(albero, zero, array);
         if (tot != m) {
             G_warning(
                 "avl_to_array unexpected value. the result could be wrong");
-            return RLI_ERRORE;
+            res = RLI_ERRORE;
+            G_free(array);
+            goto free_exit;
         }
 
         /* calculate shannon */
@@ -626,11 +656,12 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     else
         Rast_set_d_null_value(result, 1);
 
+free_exit:
     avl_destroy(albero);
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
     }
 
-    return RLI_OK;
+    return res;
 }

--- a/raster/r.li/r.li.shape/main.c
+++ b/raster/r.li/r.li.shape/main.c
@@ -90,7 +90,6 @@ int shape_index(int fd, char **par UNUSED, struct area_entry *ad,
     }
     default: {
         G_fatal_error("data type unknown");
-        return RLI_ERRORE;
     }
     }
 
@@ -112,6 +111,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     struct pst *pst;
     long nalloc, incr;
     int i, j, k;
+    int res = RLI_OK;
     int connected;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
 
@@ -133,17 +133,21 @@ int calculate(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -180,8 +184,10 @@ int calculate(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -232,6 +238,8 @@ int calculate(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -325,6 +333,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
         Rast_set_d_null_value(result, 1);
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -335,7 +344,7 @@ int calculate(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateD(int fd, struct area_entry *ad, double *result)
@@ -347,6 +356,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     struct pst *pst;
     long nalloc, incr;
     int i, j, k;
+    int res = RLI_OK;
     int connected;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
 
@@ -368,17 +378,21 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -415,8 +429,10 @@ int calculateD(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -467,6 +483,8 @@ int calculateD(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -560,6 +578,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
         Rast_set_d_null_value(result, 1);
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -570,7 +589,7 @@ int calculateD(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }
 
 int calculateF(int fd, struct area_entry *ad, double *result)
@@ -582,6 +601,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     struct pst *pst;
     long nalloc, incr;
     int i, j, k;
+    int res = RLI_OK;
     int connected;
     int mask_fd, *mask_buf, *mask_sup, *mask_tmp, masked;
 
@@ -603,17 +623,21 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     mask_buf = mask_sup = NULL;
     masked = FALSE;
     if (ad->mask == 1) {
-        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0)
+        if ((mask_fd = open(ad->mask_name, O_RDONLY, 0755)) < 0) {
+            G_free(buf_null);
+            G_free(pid_corr);
+            G_free(pid_sup);
             return RLI_ERRORE;
+        }
         mask_buf = G_malloc(ad->cl * sizeof(int));
         if (mask_buf == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         mask_sup = G_malloc(ad->cl * sizeof(int));
         if (mask_sup == NULL) {
+            close(mask_fd);
             G_fatal_error("malloc mask_buf failed");
-            return RLI_ERRORE;
         }
         for (j = 0; j < ad->cl; j++)
             mask_buf[j] = 0;
@@ -650,8 +674,10 @@ int calculateF(int fd, struct area_entry *ad, double *result)
             mask_tmp = mask_sup;
             mask_sup = mask_buf;
             mask_buf = mask_tmp;
-            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0)
-                return 0;
+            if (read(mask_fd, mask_buf, (ad->cl * sizeof(int))) < 0) {
+                res = 0;
+                goto free_exit;
+            }
         }
 
         ltmp = pid_sup;
@@ -702,6 +728,8 @@ int calculateF(int fd, struct area_entry *ad, double *result)
                         npatch--;
 
                         if (npatch == 0) {
+                            if (masked)
+                                close(mask_fd);
                             G_fatal_error("npatch == 0 at row %d, col %d", i,
                                           j);
                         }
@@ -795,6 +823,7 @@ int calculateF(int fd, struct area_entry *ad, double *result)
         Rast_set_d_null_value(result, 1);
     }
 
+free_exit:
     if (masked) {
         close(mask_fd);
         G_free(mask_buf);
@@ -805,5 +834,5 @@ int calculateF(int fd, struct area_entry *ad, double *result)
     G_free(pid_sup);
     G_free(pst);
 
-    return RLI_OK;
+    return res;
 }


### PR DESCRIPTION
Fix resource leak issues in `r.li[.*]` modules. In addition remove return after G_fatal_error().

This may look like a lot of changes in one PR, but the code in `r.li` is very repetitive (which even Coverity Scan have problem to handle).

(This module group could probably gain a lot by major refactoring and re-use of repetitive code).