### PR TITLE
r.li: only close files that are opened

### DIFF
--- a/raster/r.li/r.li.daemon/worker.c
+++ b/raster/r.li/r.li.daemon/worker.c
@@ -217,15 +217,19 @@ char *mask_preprocessing(char *mask, char *raster, struct area_entry *ad)
     int mask_fd, old_fd, *buf, i, j;
     CELL *old;
 
-    buf = G_malloc(ad->cl * sizeof(int));
-
     G_debug(3, "daemon mask preproc: raster=[%s] mask=[%s]  rl=%d cl=%d",
             raster, mask, ad->rl, ad->cl);
 
     tmp_file = G_tempfile();
-    mask_fd = open(tmp_file, O_RDWR | O_CREAT, 0755);
+    if ((mask_fd = open(tmp_file, O_RDWR | O_CREAT, 0755) < 0)) {
+        G_free(tmp_file);
+        return NULL;
+    }
+
     old_fd = Rast_open_old(mask, "");
     old = Rast_allocate_c_buf();
+
+    buf = G_malloc(ad->cl * sizeof(int));
 
     /* write out sample area size: ad->rl rows and ad->cl columns */
 

--- a/raster/r.li/r.li.edgedensity/edgedensity.c
+++ b/raster/r.li/r.li.edgedensity/edgedensity.c
@@ -354,7 +354,8 @@ int calculateD(int fd, struct area_entry *ad, char **par, double *result)
 
     buf_null = Rast_allocate_d_buf();
     if (buf_null == NULL) {
-        close(mask_fd);
+        if (masked)
+            close(mask_fd);
         G_fatal_error("malloc buf_null failed");
     }
 
@@ -553,7 +554,8 @@ int calculateF(int fd, struct area_entry *ad, char **par, double *result)
 
     buf_null = Rast_allocate_f_buf();
     if (buf_null == NULL) {
-        close(mask_fd);
+        if (masked)
+            close(mask_fd);
         G_fatal_error("malloc buf_null failed");
     }
 


### PR DESCRIPTION
Fix two new and one old issue in `r.li` closing potentially un-opened files.