### PR TITLE
CQ: always include stdbool.h if bool is used in C code

### DIFF
--- a/general/g.region/main.c
+++ b/general/g.region/main.c
@@ -14,6 +14,7 @@
  ****************************************************************************/
 
 #include <string.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <math.h>
 #include <grass/gis.h>

--- a/include/grass/defs/raster.h
+++ b/include/grass/defs/raster.h
@@ -1,6 +1,8 @@
 #ifndef GRASS_RASTERDEFS_H
 #define GRASS_RASTERDEFS_H
 
+#include <stdbool.h>
+
 #include <grass/gis.h>
 
 /* --- ANSI prototypes for the lib/raster functions --- */

--- a/include/grass/defs/vector.h
+++ b/include/grass/defs/vector.h
@@ -1,6 +1,8 @@
 #ifndef GRASS_VECTORDEFS_H
 #define GRASS_VECTORDEFS_H
 
+#include <stdbool.h>
+
 /*
  * "Public" functions, for use in modules
  */

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -22,7 +22,6 @@
 /* System include files */
 #include <stdio.h>
 #include <stdarg.h>
-#include <stdbool.h>
 
 /* Grass and local include files */
 #include <grass/config.h>
@@ -76,11 +75,11 @@ static const char *GRASS_copyright UNUSED = "GRASS GNU GPL licensed Software";
  */
 /* and 'false' For historical reasons 'TRUE' and 'FALSE' are still valid. */
 #ifndef TRUE
-#define TRUE true
+#define TRUE 1
 #endif
 
 #ifndef FALSE
-#define FALSE false
+#define FALSE 0
 #endif
 
 /*! \brief Cross-platform Newline Character */

--- a/lib/gis/mapset_msc.c
+++ b/lib/gis/mapset_msc.c
@@ -12,6 +12,7 @@
 #include <grass/config.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/types.h>

--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -10,6 +10,7 @@
 
    \author Vaclav Petras
  */
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/lib/raster/mask_info.c
+++ b/lib/raster/mask_info.c
@@ -14,6 +14,7 @@
  */
 
 #include <string.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include <grass/gis.h>

--- a/lib/raster/raster_metadata.c
+++ b/lib/raster/raster_metadata.c
@@ -13,6 +13,7 @@
    \author Hamish Bowman
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/lib/rst/interp_float/init2d.c
+++ b/lib/rst/interp_float/init2d.c
@@ -19,6 +19,7 @@
  *
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>

--- a/raster/r.horizon/main.c
+++ b/raster/r.horizon/main.c
@@ -35,6 +35,7 @@ Program was refactored by Anna Petrasova to remove most global variables.
 #include <omp.h>
 #endif
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/raster/r.kappa/print_json.c
+++ b/raster/r.kappa/print_json.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stdlib.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>

--- a/raster/r.mask.status/main.c
+++ b/raster/r.mask.status/main.c
@@ -11,6 +11,7 @@
  *
  *****************************************************************************/
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/raster/r.out.gdal/attr.c
+++ b/raster/r.out.gdal/attr.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>

--- a/raster/r.series/main.c
+++ b/raster/r.series/main.c
@@ -17,6 +17,8 @@
  *****************************************************************************/
 
 #if defined(_OPENMP)
+#include <stdbool.h>
+
 #include <omp.h>
 #endif
 #include <stdlib.h>

--- a/raster/r.slope.aspect/main.c
+++ b/raster/r.slope.aspect/main.c
@@ -28,6 +28,7 @@
 #endif
 
 #include <math.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/raster/r.sun/main.c
+++ b/raster/r.sun/main.c
@@ -37,6 +37,7 @@ email: hofierka@geomodel.sk,marcel.suri@jrc.it,
 #include <omp.h>
 #endif
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/raster/r.sun/sunradstruct.h
+++ b/raster/r.sun/sunradstruct.h
@@ -28,6 +28,8 @@ email: hofierka@geomodel.sk,marcel.suri@jrc.it,suri@geomodel.sk
 /*v. 2.0 July 2002, NULL data handling, JH */
 /*v. 2.1 January 2003, code optimization by Thomas Huld, JH */
 
+#include <stdbool.h>
+
 #define EPS       1.e-4
 #define HOURANGLE M_PI / 12.
 

--- a/raster/r.thin/thin_lines.c
+++ b/raster/r.thin/thin_lines.c
@@ -19,13 +19,6 @@
 #include <grass/glocale.h>
 #include "local_proto.h"
 
-#define LEFT        1
-#define RIGHT       2
-
-#define true        1
-#define false       0
-#define DELETED_PIX 9999
-
 static int n_rows, n_cols, pad_size;
 static int box_right, box_left, box_top, box_bottom;
 

--- a/raster/r.volume/main.c
+++ b/raster/r.volume/main.c
@@ -25,6 +25,7 @@
  *
  *****************************************************************************/
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <grass/gis.h>

--- a/vector/v.db.select/main.c
+++ b/vector/v.db.select/main.c
@@ -18,6 +18,7 @@
  *
  *****************************************************************************/
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/vector/v.fill.holes/main.c
+++ b/vector/v.fill.holes/main.c
@@ -15,6 +15,7 @@
  *
  ****************************************************************/
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <grass/gis.h>

--- a/vector/v.hull/chull.c
+++ b/vector/v.hull/chull.c
@@ -19,6 +19,7 @@
    not removed.
    --------------------------------------------------------------------
  */
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -26,6 +26,7 @@
 #if defined(_OPENMP)
 #include <omp.h>
 #endif
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
Always `#include <stdbool.h>` where `bool` is used.

For the same reason, revert (part of 1e0c11f526f64755f877957ce6c14b2159c3823f) definition of `TRUE` and `FALSE` (in gis.h) to `1` and `0`, in order to avoid the inclusion everywhere it may/should have been needed. In addition, starting with C23 `bool` is not an int, but a type of its own, making it not interchangeable with int.

Fixes #5585