### PR TITLE
docs: Fixed mkdocs fg-footer color

### DIFF
--- a/man/mkdocs/grassdocs.css
+++ b/man/mkdocs/grassdocs.css
@@ -153,7 +153,7 @@
 
   /* Footer */
   /* ----------------------------------------------------------------------------- */
-  --md-footer-fg-color: var(--gs-white-color--light);
+  --md-footer-fg-color: var(--gs-secondary-color);
   --md-footer-fg-color--light: var(--gs-white-color);
   --md-footer-fg-color--lighter: var(--gs-white-color);
   --md-footer-bg-color: var(--gs-primary-light-color--lightest);


### PR DESCRIPTION
The nav footer font color was set incorrectly to white when it should have been set as the secondary color (blue).

The change made the previous and next text visible.

![Screenshot from 2025-05-06 22-41-14](https://github.com/user-attachments/assets/5d821d06-af25-4812-b158-f5f42dc247b8)
