### PR TITLE
ctypesgen: Add 'bool' to ctypes type map, needed for C23

### DIFF
--- a/python/libgrass_interface_generator/README.md
+++ b/python/libgrass_interface_generator/README.md
@@ -20,6 +20,24 @@ Currently installed version:
 It is highly encouraged to report [upstreams](https://github.com/ctypesgen/ctypesgen)
 necessary patches for GRASS.
 
+#### Add `bool` ctypes type map for C23 support
+
+Add bool to ctypes type map. This change is needed for C23 support, where
+_Bool is not necessarily defined by default.
+
+```diff
+--- python/libgrass_interface_generator/ctypesgen/ctypedescs.py.orig
++++ python/libgrass_interface_generator/ctypesgen/ctypedescs.py
+@@ -58,6 +58,7 @@
+     ("__uint64", False, 0): "c_uint64",
+     ("__uint64_t", False, 0): "c_uint64",
+     ("_Bool", True, 0): "c_bool",
++    ("bool", True, 0): "c_bool",
+ }
+ 
+ ctypes_type_map_python_builtin = {
+```
+
 #### Ctypes "unnamed structure member with 0 bit size"-patch
 
 Using unnamed zero bit sized structure members, e.g.:

--- a/python/libgrass_interface_generator/ctypesgen/ctypedescs.py
+++ b/python/libgrass_interface_generator/ctypesgen/ctypedescs.py
@@ -58,6 +58,7 @@ ctypes_type_map = {
     ("__uint64", False, 0): "c_uint64",
     ("__uint64_t", False, 0): "c_uint64",
     ("_Bool", True, 0): "c_bool",
+    ("bool", True, 0): "c_bool",
 }
 
 ctypes_type_map_python_builtin = {


### PR DESCRIPTION
This change is needed for C23 support, where _Bool is not necessarily defined by default.

See e.g., [GCC](https://gcc.gnu.org/onlinedocs/gcc/Boolean-Type.html):

> C23 added bool as the preferred name of the boolean type, but _Bool also remains a standard keyword in the language and is supported as such by GCC with -std=c23.

GCC 15 now [defaults](https://gcc.gnu.org/gcc-15/changes.html#c) to C23.

This patch is submitted upstream (https://github.com/ctypesgen/ctypesgen/pull/225).