### PR TITLE
cmake: Fix CMP0175 warning by adding `POST_BUILD` to `TARGET` form of `add_custom_command()`

### DIFF
--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -46,6 +46,7 @@ foreach(po_file ${po_files})
 
   add_custom_command(
     TARGET generate_mo_files_${po_file_name}
+    POST_BUILD
     COMMAND ${MSGFMT} --statistics -o
             ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_file} ${po_file}
     BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${mo_file})


### PR DESCRIPTION
I tried to explore using a cmake build for generating documentation, but fails for addons. But when exploring, I found a simple fix to one of the warnings that are displayed since CMake 3.31. Starting from CMake 3.31, more rigourous argument checking is done, and it complains that with the `TARGET` form of `add_custom_command()`, the type of event must be specified, like `POST_BUILD`.

This PR adds `POST_BUILD`, the default assumed when it was missing.

See https://cmake.org/cmake/help/latest/policy/CMP0175.html