### PR TITLE
CI(docs): Remove repository input when checking-out grass core

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout core
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: OSGeo/grass
           path: grass
           fetch-depth: 0
 


### PR DESCRIPTION
This allows to see the changes made in the PR even when on a fork. Otherwise, it is using the default branch without the changes (except for the workflow file itself).