### PR TITLE
CI(docs): Use mold linker

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -71,6 +71,8 @@ jobs:
           pip install -r grass/.github/workflows/python_requirements.txt
           pip install -r grass-addons/.github/workflows/requirements.txt
 
+      - uses: rui314/setup-mold@e16410e7f8d9e167b74ad5697a9089a35126eb50 # v1
+
       - name: Create installation directory
         run: |
           mkdir "$HOME/install"


### PR DESCRIPTION
Similar to other workflows we have here, we can use the mold linker for the docs workflow. The impact can be seen even more with the addons linking time taken.

Combined with enhancements in #5641, I observed a full minute time reduced just for the addons step, and another 30 seconds for grass core for a total of 9m 30s and 8m 52s -- I'm doing another rerun to make sure I just wasn't lucky with the runner hardware twice. https://github.com/echoix/grass/actions/runs/14963217790/job/42028582740
https://github.com/echoix/grass/actions/runs/14963217790/job/42029041917
