### PR TITLE
wxGUI: Fix uninitialized variables in DOutFile() method

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -784,6 +784,10 @@ class MapPanel(SingleMapPanel, MainPageBase):
         if not ltype:
             return
         width, height = self.MapWindow.GetClientSize()
+
+        name = None
+        extType = None
+
         for param in command[1:]:
             try:
                 p, val = param.split("=")


### PR DESCRIPTION
This PR fixes a bug in the DOutFile() method used when running d.out.file.

**Problem**
When executing a command like:
`d.out.file output=/home/user/image.png format=png resolution=300`
the GUI crashes with the following error:
`UnboundLocalError: local variable 'extType' referenced before assignment`

This issue does not affect a command like:
`d.out.file output=/home/user/image.tif format=GTiff resolution=300`
because of different file extensions and order of parameters.