### PR TITLE
r.resamp.filter: correct typo in warning message

### DIFF
--- a/raster/r.resamp.filter/main.c
+++ b/raster/r.resamp.filter/main.c
@@ -495,7 +495,7 @@ int main(int argc, char *argv[])
     nprocs = 1;
 #endif
     if (nprocs > 1 && Rast_mask_is_present()) {
-        G_warning(_("Parallel processing disabled due to active make."));
+        G_warning(_("Parallel processing disabled due to active mask."));
         nprocs = 1;
     }
     if (parm.radius->answer) {


### PR DESCRIPTION
In line 498:

_WARNING: Parallel processing disabled due to active make._

should be:

_WARNING: Parallel processing disabled due to active mask._