### PR TITLE
CI: Temporarily disable jobs for optimizing CI time during sprint

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - releasebranch_*
-  pull_request:
+  # pull_request:
 
 permissions: {}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
           - ubuntu-22.04
         python-version:
           - "3.9"
-          - "3.12"
+          # - "3.12"
           - "3.13"
       fail-fast: true
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         name:
           - "22.04"
-          - minimum config
+          # - minimum config
 
         # Only run tests for these folders in this matrix job.
         extra-include:
@@ -56,9 +56,9 @@ jobs:
           # This is without optional things but it still keeps things useful,
           # so, e.g., without OpenMP, but with PDAL. Code or tests should be written
           # so that test pass even when these optional things are not present.
-          - name: minimum config
-            os: ubuntu-22.04
-            config: ubuntu-22.04_without_x
+          # - name: minimum config
+          #   os: ubuntu-22.04
+          #   config: ubuntu-22.04_without_x
       fail-fast: false
 
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -53,6 +53,8 @@ jobs:
           - name: "22.04"
             os: ubuntu-22.04
             config: ubuntu-22.04
+            c: gnu17
+            cxx: c++17
           # This is without optional things but it still keeps things useful,
           # so, e.g., without OpenMP, but with PDAL. Code or tests should be written
           # so that test pass even when these optional things are not present.
@@ -131,10 +133,12 @@ jobs:
       - name: Build
         env:
           # TODO: -pedantic-errors here won't go through ./configure (with GNU C)
-          CFLAGS: -fPIC -Wvla -ffp-contract=off
+          CFLAGS: -std=${{ matrix.c }} -fPIC -Wvla -ffp-contract=off -Wall -Wextra
           # TODO: -pedantic-errors here won't compile
-          CXXFLAGS: -fPIC -ffp-contract=off
-        run: .github/workflows/build_${{ matrix.config }}.sh $HOME/install -Werror
+          CXXFLAGS: -std=${{ matrix.cxx }} -fPIC -ffp-contract=off -Wall -Wextra
+        run: |
+          .github/workflows/build_${{ matrix.config }}.sh $HOME/install \
+            -isystem/usr/include/gdal -Wpedantic -Werror
 
       - name: Add the bin directory to PATH
         run: |


### PR DESCRIPTION
This PR is intended to be merged soon and ideally before the sprint. It is also expected to be reverted at the end of the week, except if some parts are desired to be kept. This is why the lines are commented rather than removed.


Justifications:
- Disabling pytest job with Python 3.12: Python 3.12 is fully tested out on macOS and Windows. We are keeping the upper and lower bounds of the supported Python versions
  - Effect: Slashing 10 minutes of CI time per PR/commit 
- Disabling minimal config for Ubuntu tests: We rarely, if ever, caught failures that existed in only one of these combinations and not both. For the duration of the sprint, assuming this small risk seems reasonable given the benefits.
  - Effect: Slashing near 62 minutes of CI time per PR/commit
- Combining compiler flags used in the gcc standards checks workflow with the Ubuntu job, and disabling gcc standards checks on PRs. For an added 30 seconds x 2, we can remove 8 minutes of CI time by not running the previous gcc jobs. The gcc standards check wasn’t a required check anyways. However, an added benefit is that the full gunittest test suite is ran on it.
  - Effect: Adds 30 seconds of compile time to Ubuntu jobs, but slashes 8 minutes of CI time per PR run (kept on main). (Net 7 minutes slashed)
  - The compilation with stricter flags is not in single job anymore (i.e. not `-j 1` like the gcc one).
  - A normal build without the extra strict flags + standards version is still executed for the documentation workflow, but without running the test suite.

  