### PR TITLE
libgis: G__usage_markdown() include tool label in metadata if defined

### DIFF
--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -32,7 +32,14 @@ void G__usage_markdown(void)
     /* print metadata used by man/build*.py */
     fprintf(stdout, "---\n");
     fprintf(stdout, "name: %s\n", st->pgm_name);
-    fprintf(stdout, "description: %s\n", st->module_info.description);
+    fprintf(stdout, "description: ");
+    if (st->module_info.label)
+        fprintf(stdout, "%s", st->module_info.label);
+    if (st->module_info.label && st->module_info.description)
+        fprintf(stdout, " ");
+    if (st->module_info.description)
+        fprintf(stdout, "%s", st->module_info.description);
+    fprintf(stdout, "\n");
     fprintf(stdout, "keywords: [ ");
     G__print_keywords(stdout, NULL, FALSE);
     fprintf(stdout, " ]");


### PR DESCRIPTION
Some tools (modules) have defined `label` instead of `description` (eg. https://github.com/OSGeo/grass/blob/main/raster/r.relief/main.c#L109). Currently `G__usage_markdown() ` doesn't handle metadata correctly in this case:

```
r.relief --md-description | grep description
description: (null)
```

This bug also affects mkdocs-generated manual pages:

![image](https://github.com/user-attachments/assets/29089b63-1755-4f90-93e2-b8981690b912)


This PR solves it:

```
r.relief --md-description | grep description
description: Creates shaded relief map from an elevation map (DEM).
```