### PR TITLE
CMake: Recognize conda installation path at runtime

### DIFF
--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -99,7 +99,9 @@ if "GISBASE" in os.environ and len(os.getenv("GISBASE")) > 0:
     GISBASE = os.path.normpath(os.environ["GISBASE"])
 else:
     if "CONDA_PREFIX" in os.environ and len(os.getenv("CONDA_PREFIX")) > 0:
-        GISBASE = os.path.normpath(f"{os.environ['CONDA_PREFIX']}/lib64/grass85")
+        GISBASE = os.path.normpath(
+            f"{os.environ['CONDA_PREFIX']}/lib64/grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@"
+        )
     else:
         GISBASE = os.path.normpath("@GISBASE_INSTALL_PATH@")
     os.environ["GISBASE"] = GISBASE

--- a/lib/init/grass.py
+++ b/lib/init/grass.py
@@ -98,7 +98,10 @@ if ENCODING is None:
 if "GISBASE" in os.environ and len(os.getenv("GISBASE")) > 0:
     GISBASE = os.path.normpath(os.environ["GISBASE"])
 else:
-    GISBASE = os.path.normpath("@GISBASE_INSTALL_PATH@")
+    if "CONDA_PREFIX" in os.environ and len(os.getenv("CONDA_PREFIX")) > 0:
+        GISBASE = os.path.normpath(f"{os.environ['CONDA_PREFIX']}/lib64/grass85")
+    else:
+        GISBASE = os.path.normpath("@GISBASE_INSTALL_PATH@")
     os.environ["GISBASE"] = GISBASE
 CMD_NAME = "@START_UP@"
 GRASS_VERSION = "@GRASS_VERSION_NUMBER@"


### PR DESCRIPTION
This PR changes the grass script so it can recognize the dynamic conda installation path at runtime.