### PR TITLE
Windows: Install MSVC runtime before using g.mkfontcap which requires it

### DIFF
--- a/mswindows/GRASS-Installer.nsi.tmpl
+++ b/mswindows/GRASS-Installer.nsi.tmpl
@@ -488,6 +488,88 @@ Var /GLOBAL ARCHIVE_SIZE_KB
 Var /GLOBAL ARCHIVE_SIZE_MB
 Var /GLOBAL DOWNLOAD_MESSAGE_
 
+;--------------------------------------------------------------------------
+
+Function DownloadInstallMSRuntime
+
+	IntOp $ARCHIVE_SIZE_MB $ARCHIVE_SIZE_KB / 1024
+
+	StrCpy $DOWNLOAD_MESSAGE_ "The installer will download the $EXTENDED_ARCHIVE_NAME.$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_These system libraries from Microsoft are needed for programs"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ built with Microsoft's Visual C++ compiler, such as Python and"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ GDAL which ship with GRASS, since MS does not include them by"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ default. You might already have them installed by other software,"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ if so you don't need to install them again, but if not GRASS will"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ fail to start and you will see errors like 'Missing MSVCR71.dll"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ or MSVCP100.dll'.$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_The archive is about $ARCHIVE_SIZE_MB MB and may take"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ several minutes to download.$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_The $EXTENDED_ARCHIVE_NAME will be copied to:$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$TEMP\$CUSTOM_UNTAR_FOLDER.$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_Press OK to continue and install the runtimes, or Cancel"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ to skip the download and complete the GRASS"
+	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ installation without the $EXTENDED_ARCHIVE_NAME.$\r$\n"
+
+	MessageBox MB_OKCANCEL "$DOWNLOAD_MESSAGE_" IDOK download IDCANCEL cancel_download
+
+	download:
+	SetShellVarContext current
+	InitPluginsDir
+	NSISdl::download "$HTTP_PATH/$ARCHIVE_NAME" "$TEMP\$ARCHIVE_NAME"
+
+	Pop $0
+	StrCmp $0 "success" download_ok download_failed
+
+	download_ok:
+	InitPluginsDir
+	untgz::extract -d "$TEMP\$ORIGINAL_UNTAR_FOLDER" -zbz2 "$TEMP\$ARCHIVE_NAME"
+	Pop $0
+	StrCmp $0 "success" untar_ok untar_failed
+
+	download_failed:
+	DetailPrint "$0" ;print error message to log
+	MessageBox MB_OK "Download Failed.$\r$\nGRASS will be installed without the $EXTENDED_ARCHIVE_NAME."
+	Goto end
+
+	cancel_download:
+	MessageBox MB_OK "Download Cancelled.$\r$\nGRASS will be installed without the $EXTENDED_ARCHIVE_NAME."
+	Goto end
+
+	untar_failed:
+	DetailPrint "$0" ;print error message to log
+
+	untar_ok:
+	DetailPrint "Archive successfully unzipped."
+	DetailPrint "Copying runtime files ..."
+	CopyFiles "$TEMP\$ORIGINAL_UNTAR_FOLDER\bin\*.dll" "$INSTALL_DIR\extrabin"
+	DetailPrint "MS runtime files installed."
+	Goto end
+
+	end:
+
+FunctionEnd
+
+Section "Important Microsoft Runtime DLLs" SecMSRuntime
+
+	;Set the size (in KB)  of the archive file
+	StrCpy $ARCHIVE_SIZE_KB 833
+
+	;Set the size (in KB) of the unpacked archive file
+	AddSize 13500
+
+	StrCpy $HTTP_PATH "http://download.osgeo.org/osgeo4w/v2/${PLATFORM}/release/msvcrt2019/"
+        StrCpy $ARCHIVE_NAME "msvcrt2019-14.2-1.tar.bz2"
+	StrCpy $EXTENDED_ARCHIVE_NAME "Microsoft Visual C++ Redistributable Packages"
+	StrCpy $ORIGINAL_UNTAR_FOLDER "install_msruntime"
+
+	Call DownloadInstallMSRuntime
+
+SectionEnd
+
 Section "GRASS" SecGRASS
 
 	SectionIn RO
@@ -760,88 +842,6 @@ Section "GRASS" SecGRASS
 
 	;replace BU with numeric group name for local users. Users  S-1-5-32-545 does not work for Windows Enterprise. Try Authenticated Users S-1-5-11
         AccessControl::SetOnFile "$INSTDIR\etc\grass@GRASS_VERSION_MAJOR@@GRASS_VERSION_MINOR@.py" "(S-1-5-11)" "GenericRead + GenericExecute"
-SectionEnd
-
-;--------------------------------------------------------------------------
-
-Function DownloadInstallMSRuntime
-
-	IntOp $ARCHIVE_SIZE_MB $ARCHIVE_SIZE_KB / 1024
-
-	StrCpy $DOWNLOAD_MESSAGE_ "The installer will download the $EXTENDED_ARCHIVE_NAME.$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_These system libraries from Microsoft are needed for programs"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ built with Microsoft's Visual C++ compiler, such as Python and"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ GDAL which ship with GRASS, since MS does not include them by"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ default. You might already have them installed by other software,"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ if so you don't need to install them again, but if not GRASS will"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ fail to start and you will see errors like 'Missing MSVCR71.dll"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ or MSVCP100.dll'.$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_The archive is about $ARCHIVE_SIZE_MB MB and may take"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ several minutes to download.$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_The $EXTENDED_ARCHIVE_NAME will be copied to:$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$TEMP\$CUSTOM_UNTAR_FOLDER.$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_$\r$\n"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_Press OK to continue and install the runtimes, or Cancel"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ to skip the download and complete the GRASS"
-	StrCpy $DOWNLOAD_MESSAGE_ "$DOWNLOAD_MESSAGE_ installation without the $EXTENDED_ARCHIVE_NAME.$\r$\n"
-
-	MessageBox MB_OKCANCEL "$DOWNLOAD_MESSAGE_" IDOK download IDCANCEL cancel_download
-
-	download:
-	SetShellVarContext current
-	InitPluginsDir
-	NSISdl::download "$HTTP_PATH/$ARCHIVE_NAME" "$TEMP\$ARCHIVE_NAME"
-
-	Pop $0
-	StrCmp $0 "success" download_ok download_failed
-
-	download_ok:
-	InitPluginsDir
-	untgz::extract -d "$TEMP\$ORIGINAL_UNTAR_FOLDER" -zbz2 "$TEMP\$ARCHIVE_NAME"
-	Pop $0
-	StrCmp $0 "success" untar_ok untar_failed
-
-	download_failed:
-	DetailPrint "$0" ;print error message to log
-	MessageBox MB_OK "Download Failed.$\r$\nGRASS will be installed without the $EXTENDED_ARCHIVE_NAME."
-	Goto end
-
-	cancel_download:
-	MessageBox MB_OK "Download Cancelled.$\r$\nGRASS will be installed without the $EXTENDED_ARCHIVE_NAME."
-	Goto end
-
-	untar_failed:
-	DetailPrint "$0" ;print error message to log
-
-	untar_ok:
-	DetailPrint "Archive successfully unzipped."
-	DetailPrint "Copying runtime files ..."
-	CopyFiles "$TEMP\$ORIGINAL_UNTAR_FOLDER\bin\*.dll" "$INSTALL_DIR\extrabin"
-	DetailPrint "MS runtime files installed."
-	Goto end
-
-	end:
-
-FunctionEnd
-
-Section "Important Microsoft Runtime DLLs" SecMSRuntime
-
-	;Set the size (in KB)  of the archive file
-	StrCpy $ARCHIVE_SIZE_KB 833
-
-	;Set the size (in KB) of the unpacked archive file
-	AddSize 13500
-
-	StrCpy $HTTP_PATH "http://download.osgeo.org/osgeo4w/v2/${PLATFORM}/release/msvcrt2019/"
-        StrCpy $ARCHIVE_NAME "msvcrt2019-14.2-1.tar.bz2"
-	StrCpy $EXTENDED_ARCHIVE_NAME "Microsoft Visual C++ Redistributable Packages"
-	StrCpy $ORIGINAL_UNTAR_FOLDER "install_msruntime"
-
-	Call DownloadInstallMSRuntime
-
 SectionEnd
 
 Function DownloadDataSet


### PR DESCRIPTION
Closes #5663

Waiting upon a standalone installer to be generated in order to test it works as intended. The issue in #5663 was reproduced by accident by simply trying to install with the standalone installer on a Windows sandbox instance. These are disposable VMs, that contain a trimmed down version of the OS, and really has nothing in it (not even a notepad now). 