### PR TITLE
cmake: Group locale and man into folders for IDEs

### DIFF
--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -6,6 +6,7 @@
 file(GLOB po_files "${CMAKE_CURRENT_SOURCE_DIR}/po/*.po")
 
 add_custom_target(generate_mo_files_dir ALL COMMENT "Create locale directory")
+set_target_properties(generate_mo_files_dir PROPERTIES FOLDER locale)
 add_custom_command(
   TARGET generate_mo_files_dir
   PRE_BUILD
@@ -29,6 +30,8 @@ foreach(_locale ${_locales})
     OUTPUT ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES
     COMMAND ${CMAKE_COMMAND} -E make_directory
             ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES)
+  set_target_properties(generate_mo_files_dir_${_locale} PROPERTIES FOLDER
+                                                                    locale)
 endforeach()
 unset(_locales)
 
@@ -43,7 +46,8 @@ foreach(po_file ${po_files})
     generate_mo_files_${po_file_name} ALL
     DEPENDS ${OUTDIR}/${GRASS_INSTALL_LOCALEDIR}/${_locale}/LC_MESSAGES
     COMMENT "Generate mo files")
-
+  set_target_properties(generate_mo_files_${po_file_name} PROPERTIES FOLDER
+                                                                     locale)
   add_custom_command(
     TARGET generate_mo_files_${po_file_name}
     POST_BUILD

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -9,6 +9,7 @@ add_custom_target(
   BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/full_index.html
   DEPENDS ALL_MODULES LIB_PYTHON GUI_WXPYTHON
   COMMENT "man generation: build full index")
+set_target_properties(build_full_index PROPERTIES FOLDER man)
 
 set(data_files
     ${CMAKE_CURRENT_SOURCE_DIR}/jquery.fixedheadertable.min.js
@@ -36,6 +37,7 @@ add_custom_target(
   BYPRODUCTS ${OUTDIR}/${GRASS_INSTALL_DOCDIR}/index.html
   DEPENDS build_full_index
   COMMENT "man generation: build index")
+set_target_properties(build_index PROPERTIES FOLDER man)
 
 set(target_names build_topics build_keywords build_graphical_index
                  build_manual_gallery)
@@ -47,6 +49,7 @@ foreach(target_name ${target_names})
       ${CMAKE_CURRENT_SOURCE_DIR}/${target_name}.py
     DEPENDS build_index
     COMMENT "man generation: ${target_name}")
+  set_target_properties(${target_name} PROPERTIES FOLDER man)
 endforeach()
 
 add_custom_target(
@@ -58,6 +61,7 @@ add_custom_target(
     ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
   DEPENDS build_index
   COMMENT "man generation: build_class_graphical")
+set_target_properties(build_class_graphical PROPERTIES FOLDER man)
 
 add_custom_target(
   build_pso
@@ -69,6 +73,7 @@ add_custom_target(
     "id='opts_table' class='scroolTable'"
   DEPENDS ${target_names}
   COMMENT "man generation: parser standard options")
+set_target_properties(build_pso PROPERTIES FOLDER man)
 
 set(categories
     d:display
@@ -95,6 +100,7 @@ foreach(category ${categories})
       ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
     DEPENDS build_pso
     COMMENT "man generation: build class ${class_name}")
+  set_target_properties(build_class_${class_name} PROPERTIES FOLDER man)
 endforeach()
 
 # TODO: this shouldn't depend on GUI_WXPYTHON
@@ -105,6 +111,7 @@ add_custom_target(
     ${CMAKE_CURRENT_SOURCE_DIR}/build_check.py ${OUTDIR}/${GRASS_INSTALL_DOCDIR}
   DEPENDS ${category_targets} ALL_MODULES LIB_PYTHON GUI_WXPYTHON
   COMMENT "man generation: check output")
+set_target_properties(build_check PROPERTIES FOLDER man)
 
 #[=======[ TODO: implement somehow...
 add_custom_target(


### PR DESCRIPTION
Small quality of life PR here.
IDEs can make use of a folder structure when displaying cmake projects. Interfaces that don't support it keeps working normally.

See the short docs for the FOLDER property here: https://cmake.org/cmake/help/latest/prop_tgt/FOLDER.html

The same pattern was already used for other folders like lib, gui, scripts. I added them for locale and man, so that the targets aren't at the top level, like ALL_VECTOR_MODULES. See how it looks like in my VSCode extension
![image](https://github.com/user-attachments/assets/bbaea0db-167d-4b65-b922-7a60094d1074)

Extracted from #5643 
