### PR TITLE
docs: Trim and left strip blocks in mkdocs output

### DIFF
--- a/man/mkdocs/scripts/hook_list_scripts.py
+++ b/man/mkdocs/scripts/hook_list_scripts.py
@@ -27,6 +27,8 @@ def on_env(env: Environment, config, files):
     """Enable loopcontrols extension in Jinja2"""
     env.add_extension("jinja2.ext.loopcontrols")
     env.globals["github_path"] = github_path
+    env.trim_blocks = True
+    env.lstrip_blocks = True
     return env
 
 


### PR DESCRIPTION
This simple config trims and left strips lines in the Jinja templates. See docs section https://jinja.palletsprojects.com/en/stable/templates/#whitespace-control

This makes the generated html look more like human generated html, like the following diff:
![image](https://github.com/user-attachments/assets/aec8d9f6-a604-4834-b6ee-da69738d5f58)

The space savings (if HTML server doesn't serve with gzip compression enabled) would be kinda small, and look like shown in this comparison:
![image](https://github.com/user-attachments/assets/58b57962-fe7d-449e-bcf0-9ae07b7ec19c)

The downloaded artifacts are of similar size, as it gets compressed well. It mostly only affects the header and footer of a page, but they are repeated at each file.

The screenshots were made using artifacts made two weeks ago or so, but are representative.

There's a possibility of real size decrease by adding a minimizer plugin, that condenses the html way more, the goal being to decrease the bytes to send. It is not included here.