### PR TITLE
v.surf.rst: Corrected defaults parameters and documentation

### DIFF
--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
     parm.rsm->required = NO;
     parm.rsm->label = _("Smoothing parameter");
     parm.rsm->description =
-        _("Smoothing is by default 0.5 unless smooth_column is specified");
+        _("Smoothing is by default 0.1 unless smooth_column is specified");
     parm.rsm->guisection = _("Parameters");
 
     parm.scol = G_define_option();
@@ -319,8 +319,10 @@ int main(int argc, char *argv[])
     parm.dmin->key = "dmin";
     parm.dmin->type = TYPE_DOUBLE;
     parm.dmin->required = NO;
-    parm.dmin->description = _(
-        "Minimum distance between points (to remove almost identical points)");
+    parm.dmin->description =
+        _("Minimum distance between points (to remove almost identical "
+          "points). Default vaule is half of "
+          " the smaller resolution of the current region");
     parm.dmin->guisection = _("Parameters");
 
     parm.dmax = G_define_option();

--- a/vector/v.surf.rst/main.c
+++ b/vector/v.surf.rst/main.c
@@ -321,7 +321,7 @@ int main(int argc, char *argv[])
     parm.dmin->required = NO;
     parm.dmin->description =
         _("Minimum distance between points (to remove almost identical "
-          "points). Default vaule is half of "
+          "points). Default value is half of "
           " the smaller resolution of the current region");
     parm.dmin->guisection = _("Parameters");
 

--- a/vector/v.surf.rst/v.surf.rst.html
+++ b/vector/v.surf.rst/v.surf.rst.html
@@ -103,7 +103,7 @@ are preserved. The equations for computation of these parameters and
 their interpretation is described in
 <a href="http://fatra.cnr.ncsu.edu/~hmitaso/gmslab/papers/hmg.rev1.ps">
  Mitasova and Hofierka, 1993</a>
-or Neteler and Mitasova, 2004).
+or Neteler and Mitasova, 2004.
 Slopes and aspect are computed in degrees (0-90 and 1-360 respectively).
 The aspect raster map has value 0 assigned to flat areas (with slope less
 than 0.1%) and to singular points with undefined aspect. Aspect points
@@ -292,7 +292,9 @@ and when minimizing the predictive error is the goal.  The parameters
 found by minimizing the predictive (CV) error may not not be the best
 for for poorly sampled phenomena (result could be strongly smoothed
 with lost details and fluctuations) or when significant noise is
-present that needs to be smoothed out.
+present that needs to be smoothed out. The addon
+<a href="addons/v.surf.rst.cv.html">v.surf.rst.cv</a> provides an ease of use wrapper for the
+cross-validation procedure.
 
 <h3>Performance</h3>
 To enable parallel processing, the user can specify the number of threads

--- a/vector/v.surf.rst/v.surf.rst.md
+++ b/vector/v.surf.rst/v.surf.rst.md
@@ -88,7 +88,7 @@ function so that the important relationships between these parameters
 are preserved. The equations for computation of these parameters and
 their interpretation is described in [Mitasova and Hofierka,
 1993](http://fatra.cnr.ncsu.edu/~hmitaso/gmslab/papers/hmg.rev1.ps) or
-Neteler and Mitasova, 2004). Slopes and aspect are computed in degrees
+Neteler and Mitasova, 2004. Slopes and aspect are computed in degrees
 (0-90 and 1-360 respectively). The aspect raster map has value 0
 assigned to flat areas (with slope less than 0.1%) and to singular
 points with undefined aspect. Aspect points downslope and is 90 to the
@@ -235,7 +235,9 @@ well only for well-sampled phenomena and when minimizing the predictive
 error is the goal. The parameters found by minimizing the predictive
 (CV) error may not not be the best for for poorly sampled phenomena
 (result could be strongly smoothed with lost details and fluctuations)
-or when significant noise is present that needs to be smoothed out.
+or when significant noise is present that needs to be smoothed out. The addon
+[v.surf.rst.cv](addons/v.surf.rst.cv.md) provides an ease of use wrapper for the
+cross-validation procedure.
 
 ### Performance
 


### PR DESCRIPTION
I've corrected the default parameters for smoothing and dmin to match the code and updated the documentation.  