### PR TITLE
v.select: create output also when no features found 

### DIFF
--- a/vector/v.select/main.c
+++ b/vector/v.select/main.c
@@ -152,65 +152,54 @@ int main(int argc, char *argv[])
         AAreas = NULL;
     }
 
-    if ((!flag.reverse->answer && nfound > 0) ||
-        (flag.reverse->answer && nlines + nareas - nfound > 0)) {
-        /* Open output */
-        if (Vect_open_new(&Out, parm.output->answer, Vect_is_3d(&(In[0]))) < 0)
-            G_fatal_error(_("Unable to create vector map <%s>"),
-                          parm.output->answer);
+    /* Open output */
+    if (Vect_open_new(&Out, parm.output->answer, Vect_is_3d(&(In[0]))) < 0)
+        G_fatal_error(_("Unable to create vector map <%s>"),
+                      parm.output->answer);
 
-        Vect_set_map_name(&Out, _("Output from v.select"));
-        Vect_set_person(&Out, G_whoami());
-        Vect_copy_head_data(&(In[0]), &Out);
-        Vect_hist_copy(&(In[0]), &Out);
-        Vect_hist_command(&Out);
+    Vect_set_map_name(&Out, _("Output from v.select"));
+    Vect_set_person(&Out, G_whoami());
+    Vect_copy_head_data(&(In[0]), &Out);
+    Vect_hist_copy(&(In[0]), &Out);
+    Vect_hist_command(&Out);
 
-        native = Vect_maptype(&Out) == GV_FORMAT_NATIVE;
+    native = Vect_maptype(&Out) == GV_FORMAT_NATIVE;
 
-        nfields = Vect_cidx_get_num_fields(&(In[0]));
-        cats = (int **)G_malloc(nfields * sizeof(int *));
-        ncats = (int *)G_malloc(nfields * sizeof(int));
-        fields = (int *)G_malloc(nfields * sizeof(int));
+    nfields = Vect_cidx_get_num_fields(&(In[0]));
+    cats = (int **)G_malloc(nfields * sizeof(int *));
+    ncats = (int *)G_malloc(nfields * sizeof(int));
+    fields = (int *)G_malloc(nfields * sizeof(int));
 
-        /* Write lines */
-        if (!flag.table->answer && !native) {
-            /* Copy attributes for OGR output */
-            Vect_copy_map_dblinks(&(In[0]), &Out, TRUE);
-        }
-
-        write_lines(&(In[0]), IFi, ALines, AAreas, &Out,
-                    flag.table->answer ? 1 : 0, flag.reverse->answer ? 1 : 0,
-                    nfields, fields, ncats, cats);
-
-        /* Copy tables */
-        if (!flag.table->answer && native) {
-            copy_tabs(&(In[0]), &Out, nfields, fields, ncats, cats);
-        }
-
-        /* print info about skipped features & close input maps */
-        for (iopt = 0; iopt < 2; iopt++) {
-            if (nskipped[iopt] > 0) {
-                G_warning(_("%d features from <%s> without category skipped"),
-                          nskipped[iopt], Vect_get_full_name(&(In[iopt])));
-            }
-            Vect_set_release_support(&In[iopt]);
-            Vect_close(&(In[iopt]));
-        }
-
-        Vect_build(&Out);
-        nfound = Vect_get_num_lines(&Out);
-        Vect_set_release_support(&Out);
-        Vect_close(&Out);
-
-        G_done_msg(_("%d features written to output."), nfound);
+    /* Write lines */
+    if (!flag.table->answer && !native) {
+        /* Copy attributes for OGR output */
+        Vect_copy_map_dblinks(&(In[0]), &Out, TRUE);
     }
-    else {
-        Vect_set_release_support(&In[0]);
-        Vect_set_release_support(&In[1]);
-        Vect_close(&In[0]);
-        Vect_close(&In[1]);
-        G_done_msg(_("No features found !"));
+
+    write_lines(&(In[0]), IFi, ALines, AAreas, &Out, flag.table->answer ? 1 : 0,
+                flag.reverse->answer ? 1 : 0, nfields, fields, ncats, cats);
+
+    /* Copy tables */
+    if (!flag.table->answer && native) {
+        copy_tabs(&(In[0]), &Out, nfields, fields, ncats, cats);
     }
+
+    /* print info about skipped features & close input maps */
+    for (iopt = 0; iopt < 2; iopt++) {
+        if (nskipped[iopt] > 0) {
+            G_warning(_("%d features from <%s> without category skipped"),
+                      nskipped[iopt], Vect_get_full_name(&(In[iopt])));
+        }
+        Vect_set_release_support(&In[iopt]);
+        Vect_close(&(In[iopt]));
+    }
+
+    Vect_build(&Out);
+    nfound = Vect_get_num_lines(&Out);
+    Vect_set_release_support(&Out);
+    Vect_close(&Out);
+
+    G_done_msg(_("%d features written to output."), nfound);
 
     exit(EXIT_SUCCESS);
 }

--- a/vector/v.select/testsuite/test_v_select.py
+++ b/vector/v.select/testsuite/test_v_select.py
@@ -53,7 +53,8 @@ class TestRasterReport(TestCase):
             output=self.output,
             operator="equals",
         )
-        self.assertVectorDoesNotExist(self.output)
+        topology = {"areas": 0}
+        self.assertVectorFitsTopoInfo(self.output, topology)
 
     def test_opt(self):
         """Testing operator touches"""
@@ -64,7 +65,8 @@ class TestRasterReport(TestCase):
             output=self.output,
             operator="touches",
         )
-        self.assertVectorDoesNotExist(self.output)
+        topology = {"areas": 0}
+        self.assertVectorFitsTopoInfo(self.output, topology)
 
     def test_opw(self):
         """Testing operator within"""


### PR DESCRIPTION
Currently `v.select` doesn't create output vector map when no features found. This behaviour is not consistent with other GRASS tools as eg. `v.extract`. 

`v.extract` creates output regardless how many features found:

```
v.extract in=schools out=extract cat=0
v.info -t extract | grep point
points=0
```

Current behaviour -> no output vector map created:

```
v.select ainput=schools binput=roadsmajor out=select_output
v.info -t select_output | grep point
ERROR: Vector map <select_output> not found
```

New behaviour introduced by this PR is consistent with `v.extract` (output is created also when no features found):

```
v.select ainput=schools binput=roadsmajor out=select_output
v.info -t select_output | grep point
points=0
```