### PR TITLE
wxGUI: avoid creating nested list of errors (Graphical modeler)

### DIFF
--- a/gui/wxpython/gmodeler/model.py
+++ b/gui/wxpython/gmodeler/model.py
@@ -2673,7 +2673,7 @@ class ModelParamDialog(wx.Dialog):
 
     def GetErrors(self):
         """Check for errors, get list of messages"""
-        return [task.get_cmd_error() for task in self.tasks]
+        return [err for task in self.tasks for err in task.get_cmd_error()]
 
     def DeleteIntermediateData(self) -> bool:
         """Check if to delete intermediate data"""

--- a/python/grass/script/task.py
+++ b/python/grass/script/task.py
@@ -159,7 +159,7 @@ class grassTask:
                 return f
         raise ValueError(_("Flag not found: %s") % aFlag)
 
-    def get_cmd_error(self):
+    def get_cmd_error(self) -> list[str]:
         """Get error string produced by get_cmd(ignoreErrors = False)
 
         :return: list of errors


### PR DESCRIPTION
This PR fixes regression caused by 3f98304d0d7bbc71727d07f3530370bcd7cdbbde:

Steps to reproduce:

1. create model with parameterized option (see attached [model.zip](https://github.com/user-attachments/files/20354205/model.zip))

2. run model

It fails with:

```py
Traceback (most recent call last):
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/panels.py", line 966, in OnRunModel
    self.model.Run(self._gconsole, self.OnModelDone, parent=self)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/martin/src/grass/dist.x86_64-pc-linux-gnu/gui/wxpython/gmodeler/model.py", line 668, in Run
    GError(parent=parent, message="\n".join(err))
                                  ~~~~~~~~~^^^^^
TypeError: sequence item 0: expected str instance, list found
```