### PR TITLE
CMake: Define custom complex types for MSVC LAPACKE

### DIFF
--- a/cmake/find_scripts/FindLAPACKE.cmake
+++ b/cmake/find_scripts/FindLAPACKE.cmake
@@ -75,7 +75,12 @@ if(CBLAS_PREFER_PKGCONFIG)
     if(PKGC_LAPACKE_FOUND)
       set(LAPACKE_FOUND ${PKGC_LAPACKE_FOUND})
       set(LAPACKE_LIBRARIES "${PKGC_LAPACKE_LINK_LIBRARIES}")
-      set(LAPACKE_INCLUDEDIR "${PKGC_LAPACKE_INCLUDEDIR}")
+      if(MSVC)
+        # MSVC needs msvc/lapacke.h to define custom complex types
+        set(LAPACKE_INCLUDEDIR "${CMAKE_SOURCE_DIR}/msvc;${PKGC_LAPACKE_INCLUDEDIR}")
+      else()
+        set(LAPACKE_INCLUDEDIR "${PKGC_LAPACKE_INCLUDEDIR}")
+      endif()
       set(LAPACKE_INCLUDE_DIRS ${PKGC_LAPACKE_INCLUDEDIR}
                                ${PKGC_LAPACKE_INCLUDE_DIRS})
       set(LAPACKE_VERSION ${PKGC_LAPACKE_VERSION})

--- a/msvc/lapacke.h
+++ b/msvc/lapacke.h
@@ -1,0 +1,13 @@
+#ifndef GRASS_MSVC_LAPACKE_H
+#define GRASS_MSVC_LAPACKE_H
+
+#if defined(_MSC_VER)
+#include <complex.h>
+#define LAPACK_COMPLEX_CUSTOM
+#define lapack_complex_float  _Fcomplex
+#define lapack_complex_double _Dcomplex
+#endif
+
+#include <../openblas/lapacke.h>
+
+#endif

--- a/msvc/lapacke.h
+++ b/msvc/lapacke.h
@@ -1,12 +1,11 @@
 #ifndef GRASS_MSVC_LAPACKE_H
 #define GRASS_MSVC_LAPACKE_H
 
-#if defined(_MSC_VER)
 #include <complex.h>
+
 #define LAPACK_COMPLEX_CUSTOM
 #define lapack_complex_float  _Fcomplex
 #define lapack_complex_double _Dcomplex
-#endif
 
 #include <../openblas/lapacke.h>
 


### PR DESCRIPTION
This PR defines a wrapper `lapacke.h` to define custom complex types for MSVC. Without it, `FindLAPACKE` fails.

See https://github.com/Reference-LAPACK/lapack/issues/683#issuecomment-1179338751