### PR TITLE
docs: Added GRASS mono font to md-code-font-family

### DIFF
--- a/man/mkdocs/grassdocs.css
+++ b/man/mkdocs/grassdocs.css
@@ -8,6 +8,7 @@
   --gs-grass-font--medium: 'Fira Sans Medium', sans-serif;
   --gs-grass-font--bold: 'Fira Sans Bold', sans-serif;
   --gs-grass-font--light: 'Fira Sans ExtraLight', sans-serif;
+  --gs-grass-font--mono: 'Fira Sans Mono', monospace;
 
   /* Primary Color */
   --gs-primary-color: rgb(76, 176, 91);
@@ -176,7 +177,7 @@
 
   /* Mermaid colors */
   /* ----------------------------------------------------------------------------- */
-  --md-mermaid-font-family: var(--md-text-font-family), sans-serif;
+  --md-mermaid-font-family: var(--md-text-font-family);
   --md-mermaid-edge-color: var(--md-code-fg-color);
   --md-mermaid-node-bg-color: var(--md-primary-fg-color--light);
   --md-mermaid-node-fg-color: var(--md-primary-fg-color);
@@ -206,6 +207,7 @@
 
   /* Code Highlighting */
   /* ----------------------------------------------------------------------------- */
+  --md-code-font-family: var(--gs-grass-font--mono);
   --md-code-fg-color: var(--gs-secondary-color);
   --md-code-bg-color: var(--gs-grey-light-color);
   --md-code-hl-color: var(--gs-secondary-light-color);


### PR DESCRIPTION
Addressing issue #5718 

I've added the grass mono font to the `md-code-font-family` variable correcting code block displays.

![Screenshot from 2025-05-21 10-53-55](https://github.com/user-attachments/assets/305eba2b-5b94-4c50-a5c3-d479db031028)
