### PR TITLE
g.proj: upgrade to format=proj4 style text output

### DIFF
--- a/general/g.proj/testsuite/test_g_proj.py
+++ b/general/g.proj/testsuite/test_g_proj.py
@@ -60,7 +60,7 @@ class GProjTestCase(TestCase):
 
     def test_proj4_output(self):
         """Test if g.proj returns consistent PROJ4 output."""
-        module_flag = SimpleModule("g.proj", flags="j")
+        module_flag = SimpleModule("g.proj", flags="p", format="proj4")
         self.assertModule(module_flag)
         result_flag = module_flag.outputs.stdout
         self.assert_keys_in_output(result_flag, "+")

--- a/gui/wxpython/location_wizard/wizard.py
+++ b/gui/wxpython/location_wizard/wizard.py
@@ -1916,7 +1916,8 @@ class IAUPage(TitledPage):
             # convert them:
             ret, projlabel, err = RunCommand(
                 "g.proj",
-                flags="jft",
+                flags="ftp",
+                format="proj4",
                 proj4=self.epsgparams,
                 datum_trans=self.parent.datum_trans,
                 getErrorMsg=True,
@@ -2133,7 +2134,8 @@ class CustomPage(TitledPage):
                 # convert them:
                 ret, projlabel, err = RunCommand(
                     "g.proj",
-                    flags="jft",
+                    flags="ftp",
+                    format="proj4",
                     proj4=self.customstring,
                     datum_trans=dtrans,
                     getErrorMsg=True,
@@ -2297,7 +2299,11 @@ class SummaryPage(TitledPage):
                     extra_opts["datum_trans"] = dtrans
 
                 ret, projlabel, err = RunCommand(
-                    "g.proj", flags="jf", proj4=proj4string, **extra_opts
+                    "g.proj",
+                    flags="fp",
+                    format="proj4",
+                    proj4=proj4string,
+                    **extra_opts,
                 )
             elif coordsys == "iau":
                 if len(datum) > 0:
@@ -2305,12 +2311,17 @@ class SummaryPage(TitledPage):
                     extra_opts["datum_trans"] = dtrans
 
                 ret, projlabel, err = RunCommand(
-                    "g.proj", flags="jf", proj4=iauproj4string, **extra_opts
+                    "g.proj",
+                    flags="fp",
+                    format="proj4",
+                    proj4=iauproj4string,
+                    **extra_opts,
                 )
             elif coordsys == "epsg":
                 ret, projlabel, err = RunCommand(
                     "g.proj",
-                    flags="jft",
+                    flags="ftp",
+                    format="proj4",
                     epsg=epsgcode,
                     datum_trans=dtrans,
                     **extra_opts,
@@ -2318,14 +2329,16 @@ class SummaryPage(TitledPage):
             elif coordsys == "file":
                 ret, projlabel, err = RunCommand(
                     "g.proj",
-                    flags="jft",
+                    flags="ftp",
+                    format="proj4",
                     georef=self.parent.filepage.georeffile,
                     **extra_opts,
                 )
             elif coordsys == "wkt":
                 ret, projlabel, err = RunCommand(
                     "g.proj",
-                    flags="jft",
+                    flags="ftp",
+                    format="proj4",
                     wkt="-",
                     stdin=self.parent.wktpage.wktstring,
                     **extra_opts,

--- a/gui/wxpython/mapdisp/statusbar.py
+++ b/gui/wxpython/mapdisp/statusbar.py
@@ -546,7 +546,7 @@ class SbGoTo(SbItem):
                 raise SbException(_("Projection not defined (check the settings)"))
             # reproject values
             projIn = settings
-            projOut = RunCommand("g.proj", flags="jf", read=True)
+            projOut = RunCommand("g.proj", flags="fp", format="proj4", read=True)
             proj = projIn.split(" ")[0].split("=")[1]
             if proj in {"ll", "latlong", "longlat"}:
                 e, n = utils.DMS2Deg(e, n)

--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -37,7 +37,7 @@ def get_region(env=None):
 
 def get_location_proj_string(env=None):
     """Returns projection of environment in PROJ.4 format"""
-    out = gs.read_command("g.proj", flags="jf", env=env)
+    out = gs.read_command("g.proj", flags="fp", format="proj4", env=env)
     return out.strip()
 
 

--- a/python/grass/temporal/stds_export.py
+++ b/python/grass/temporal/stds_export.py
@@ -394,7 +394,7 @@ def export_stds(
                 _export_raster3d_maps(rows, tar, list_file, new_cwd, fs)
 
     # Write projection and metadata
-    proj = gs.read_command("g.proj", flags="j")
+    proj = gs.read_command("g.proj", flags="p", format="proj4")
 
     Path(proj_file_name).write_text(proj)
 

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -324,7 +324,7 @@ def import_stds(
         Path(proj_name_tmp).write_text(proj_content)
 
         with open(temp_name, "w") as temp_file:
-            p = gs.start_command("g.proj", flags="j", stdout=temp_file)
+            p = gs.start_command("g.proj", flags="p", format="proj4", stdout=temp_file)
             p.communicate()
 
         if not gs.compare_key_value_text_files(temp_name, proj_name_tmp, sep="="):

--- a/scripts/m.proj/m.proj.py
+++ b/scripts/m.proj/m.proj.py
@@ -161,7 +161,7 @@ def main():
     ofs = separator(ofs)
 
     # set up projection params
-    s = gcore.read_command("g.proj", flags="j")
+    s = gcore.read_command("g.proj", flags="p", format="proj4")
     kv = parse_key_val(s)
     if "XY location" in kv:
         gcore.fatal(_("Unable to project to or from a XY location"))
@@ -173,7 +173,7 @@ def main():
         gcore.verbose("Assuming LL WGS84 as input, current projection as output ")
 
     if ll_out:
-        in_proj = gcore.read_command("g.proj", flags="jf")
+        in_proj = gcore.read_command("g.proj", flags="fp", format="proj4")
 
     if proj_in:
         if "+" in proj_in:
@@ -183,7 +183,7 @@ def main():
 
     if not in_proj:
         gcore.verbose("Assuming current location as input")
-        in_proj = gcore.read_command("g.proj", flags="jf")
+        in_proj = gcore.read_command("g.proj", flags="fp", format="proj4")
 
     in_proj = in_proj.strip()
     gcore.verbose("Input parameters: '%s'" % in_proj)
@@ -195,7 +195,7 @@ def main():
         gcore.verbose("Assuming current projection as input, LL WGS84 as output ")
 
     if ll_in:
-        out_proj = gcore.read_command("g.proj", flags="jf")
+        out_proj = gcore.read_command("g.proj", flags="fp", format="proj4")
 
     if proj_out:
         if "+" in proj_out:

--- a/scripts/r.buffer.lowmem/r.buffer.lowmem.py
+++ b/scripts/r.buffer.lowmem/r.buffer.lowmem.py
@@ -90,7 +90,7 @@ def main():
     distances1 = [scale * float(d) for d in distances]
     distances2 = [d * d for d in distances1]
 
-    s = gs.read_command("g.proj", flags="j")
+    s = gs.read_command("g.proj", flags="p", format="proj4")
     kv = gs.parse_key_val(s)
     metric = "geodesic" if kv["+proj"] == "longlat" else "squared"
 

--- a/scripts/r.in.aster/r.in.aster.py
+++ b/scripts/r.in.aster/r.in.aster.py
@@ -122,7 +122,7 @@ def main():
     tempfile = gs.read_command("g.tempfile", pid=os.getpid()).strip() + ".tif"
 
     # get projection information for current GRASS location
-    proj = gs.read_command("g.proj", flags="jf").strip()
+    proj = gs.read_command("g.proj", flags="fp", format="proj4").strip()
 
     # currently only runs in projected location
     if "XY location" in proj:

--- a/scripts/r.in.srtm/r.in.srtm.py
+++ b/scripts/r.in.srtm/r.in.srtm.py
@@ -156,7 +156,7 @@ def main():
     one = flags["1"]
 
     # are we in LatLong location?
-    s = gs.read_command("g.proj", flags="j")
+    s = gs.read_command("g.proj", flags="p", format="proj4")
     kv = gs.parse_key_val(s)
     if "+proj" not in kv.keys() or kv["+proj"] != "longlat":
         gs.fatal(_("This module only operates in LatLong locations"))

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -120,7 +120,9 @@ class WMSBase:
             self.params["proj_name"] = "SRS"
 
         # read projection info
-        self.proj_location = gs.read_command("g.proj", flags="jf").rstrip("\n")
+        self.proj_location = gs.read_command(
+            "g.proj", flags="fp", format="proj4"
+        ).rstrip("\n")
         self.proj_location = self._modifyProj(self.proj_location)
 
         self.source_epsg = str(GetEpsg(self.params["srs"]))
@@ -138,7 +140,7 @@ class WMSBase:
                 )
 
         self.proj_srs = gs.read_command(
-            "g.proj", flags="jf", epsg=str(GetEpsg(self.params["srs"]))
+            "g.proj", flags="fp", format="proj4", epsg=str(GetEpsg(self.params["srs"]))
         )
         self.proj_srs = self.proj_srs.rstrip("\n")
 

--- a/scripts/r.tileset/r.tileset.py
+++ b/scripts/r.tileset/r.tileset.py
@@ -259,7 +259,7 @@ def main():
         )
     # destination projection
     if not options["destproj"]:
-        dest_proj = gcore.read_command("g.proj", quiet=True, flags="jf")
+        dest_proj = gcore.read_command("g.proj", quiet=True, flags="fp", format="proj4")
         dest_proj = decode(dest_proj).rstrip("\n")
         if not dest_proj:
             gcore.fatal(_("g.proj failed"))
@@ -269,7 +269,7 @@ def main():
 
     # projection scale
     if not options["destscale"]:
-        ret = gcore.parse_command("g.proj", quiet=True, flags="j")
+        ret = gcore.parse_command("g.proj", quiet=True, flags="p", format="proj4")
         if not ret:
             gcore.fatal(_("g.proj failed"))
 

--- a/scripts/v.in.geonames/v.in.geonames.py
+++ b/scripts/v.in.geonames/v.in.geonames.py
@@ -44,7 +44,7 @@ def main():
     outfile = options["output"]
 
     # are we in LatLong location?
-    s = gs.read_command("g.proj", flags="j")
+    s = gs.read_command("g.proj", flags="p", format="proj4")
     kv = gs.parse_key_val(s)
     if kv["+proj"] != "longlat":
         gs.fatal(_("This module only operates in LatLong/WGS84 locations"))


### PR DESCRIPTION
This PR gets rid of the warning (initially found when using the Jupyter Notebook) when in the g.proj module the 'j' is deprecated and will be removed in a future release. Instead, the format=proj4 style is used.

The change was applied in the whole GRASS repository, the occurrences were found using 
`grep -Irni 'flags="[^"]*j[^"]*"'`

The info about deprecation can be found here: https://grass.osgeo.org/grass-devel/manuals/g.proj.html .