### PR TITLE
g.proj: upgrade to format=wkt style text output

### DIFF
--- a/general/g.proj/testsuite/test_g_proj.py
+++ b/general/g.proj/testsuite/test_g_proj.py
@@ -38,7 +38,7 @@ class GProjTestCase(TestCase):
 
     def test_wkt_output(self):
         """Test if g.proj returns WKT"""
-        module_flag = SimpleModule("g.proj", flags="w")
+        module_flag = SimpleModule("g.proj", flags="p", format="wkt")
         self.assertModule(module_flag)
         result_flag = module_flag.outputs.stdout
         self.assertIn("PROJCRS", result_flag)

--- a/gui/wxpython/core/ws.py
+++ b/gui/wxpython/core/ws.py
@@ -381,7 +381,7 @@ class GDALRasterMerger:
 
     def SetGeorefAndProj(self):
         """Set georeference and projection to target file"""
-        projection = grass.read_command("g.proj", flags="wf")
+        projection = grass.read_command("g.proj", flags="fp", format="wkt")
         self.tDataset.SetProjection(projection)
 
         self.tDataset.SetGeoTransform(self.tGeotransform)

--- a/scripts/r.in.wms/wms_drv.py
+++ b/scripts/r.in.wms/wms_drv.py
@@ -242,7 +242,7 @@ class WMSDrv(WMSBase):
             return temp_map
         # georeferencing and setting projection of temp_map
         projection = gs.read_command(
-            "g.proj", flags="wf", epsg=GetEpsg(self.params["srs"])
+            "g.proj", flags="fp", format="wkt", epsg=GetEpsg(self.params["srs"])
         )
         projection = projection.rstrip("\n")
         temp_map_dataset.SetProjection(projection)


### PR DESCRIPTION
This PR gets rid of the warning when in the g.proj module the 'w' is deprecated and will be removed in a future release. Instead, the format=wkt style is used.

The change was applied in the whole GRASS repository, the occurrences were replaced by 
find . -type f -name "*.py" -exec sed -i 's/"g.proj", flags="wf"/"g.proj", flags="fp", format="wkt"/g' {} +
find . -type f -name "*.py" -exec sed -i 's/"g.proj", flags="w"/"g.proj", flags="p", format="wkt"/g' {} +

The info about deprecation can be found here: https://grass.osgeo.org/grass-devel/manuals/g.proj.html .
