### PR TITLE
 g.proj: upgrade to format=shell style text output

### DIFF
--- a/general/g.proj/testsuite/test_g_proj.py
+++ b/general/g.proj/testsuite/test_g_proj.py
@@ -74,7 +74,7 @@ class GProjTestCase(TestCase):
 
     def test_shell_output(self):
         """Test if g.proj returns consistent shell output."""
-        module_flag = SimpleModule("g.proj", flags="g")
+        module_flag = SimpleModule("g.proj", flags="p", format="shell")
         self.assertModule(module_flag)
         result_flag = module_flag.outputs.stdout
         self.assert_keys_in_output(result_flag)

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -2258,7 +2258,9 @@ class GdalSelect(wx.Panel):
                     )
                 if ret:
                     raster_srid = gs.utils.decode(ret).replace(os.linesep, "")
-                    location_srid = gs.parse_command("g.proj", flags="g")
+                    location_srid = gs.parse_command(
+                        "g.proj", flags="p", format="shell"
+                    )
                     if raster_srid == location_srid["srid"].split(":")[-1]:
                         projectionMatch = "1"
             else:

--- a/gui/wxpython/timeline/frame.py
+++ b/gui/wxpython/timeline/frame.py
@@ -295,7 +295,7 @@ class TimelineFrame(wx.Frame):
                 )
             )
 
-        params = gs.read_command("g.proj", flags="g")
+        params = gs.read_command("g.proj", flags="p", format="shell")
         params = gs.parse_key_val(params)
         if "unit" in params:
             self.axes3d.set_xlabel(_("X [%s]") % params["unit"])

--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -46,7 +46,9 @@ def create_and_get_srid(tmp_path):
             "g.gisenv", set=f"LOCATION_NAME={desired_location}", env=session.env
         )
         gs.run_command("g.gisenv", set="MAPSET=PERMANENT", env=session.env)
-        return gs.parse_command("g.proj", flags="g", env=session.env)["srid"]
+        return gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
+            "srid"
+        ]
 
 
 def test_with_same_path(tmp_path):
@@ -88,7 +90,9 @@ def test_without_session(tmp_path):
     wkt_file = tmp_path / name / "PERMANENT" / "PROJ_WKT"
     assert wkt_file.exists()
     with gs.setup.init(tmp_path / name, env=os.environ.copy()) as session:
-        epsg = gs.parse_command("g.proj", flags="g", env=session.env)["srid"]
+        epsg = gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
+            "srid"
+        ]
         assert epsg == "EPSG:3358"
 
 
@@ -112,7 +116,9 @@ def test_with_different_path(tmp_path):
             "g.gisenv", set=f"LOCATION_NAME={desired_location}", env=session.env
         )
         gs.run_command("g.gisenv", set="MAPSET=PERMANENT", env=session.env)
-        epsg = gs.parse_command("g.proj", flags="g", env=session.env)["srid"]
+        epsg = gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
+            "srid"
+        ]
         assert epsg == "EPSG:3358"
 
 
@@ -126,7 +132,9 @@ def test_path_only(tmp_path):
     assert mapset_path.exists()
     assert wkt_file.exists()
     with gs.setup.init(full_path, env=os.environ.copy()) as session:
-        epsg = gs.parse_command("g.proj", flags="g", env=session.env)["srid"]
+        epsg = gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
+            "srid"
+        ]
         assert epsg == "EPSG:3358"
 
 
@@ -137,7 +145,9 @@ def test_create_project(tmp_path):
     wkt_file = tmp_path / name / "PERMANENT" / "PROJ_WKT"
     assert wkt_file.exists()
     with gs.setup.init(tmp_path / name, env=os.environ.copy()) as session:
-        epsg = gs.parse_command("g.proj", flags="g", env=session.env)["srid"]
+        epsg = gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
+            "srid"
+        ]
         assert epsg == "EPSG:3358"
 
 

--- a/scripts/r.import/r.import.py
+++ b/scripts/r.import/r.import.py
@@ -214,7 +214,10 @@ def main():
     tgtloc = grassenv["LOCATION_NAME"]
 
     # make sure target is not xy
-    if gs.parse_command("g.proj", flags="g")["name"] == "xy_location_unprojected":
+    if (
+        gs.parse_command("g.proj", flags="p", format="shell")["name"]
+        == "xy_location_unprojected"
+    ):
         gs.fatal(
             _("Coordinate reference system not available for current project <%s>")
             % tgtloc
@@ -261,7 +264,7 @@ def main():
 
     # make sure input is not xy
     if (
-        gs.parse_command("g.proj", flags="g", env=src_env)["name"]
+        gs.parse_command("g.proj", flags="p", format="shell", env=src_env)["name"]
         == "xy_location_unprojected"
     ):
         gs.fatal(

--- a/scripts/r.in.wms/wms_base.py
+++ b/scripts/r.in.wms/wms_base.py
@@ -125,7 +125,9 @@ class WMSBase:
 
         self.source_epsg = str(GetEpsg(self.params["srs"]))
         self.target_epsg = None
-        target_crs = gs.parse_command("g.proj", flags="g", delimiter="=")
+        target_crs = gs.parse_command(
+            "g.proj", flags="p", format="shell", delimiter="="
+        )
         if "epsg" in target_crs.keys():
             self.target_epsg = target_crs["epsg"]
             if self.source_epsg != self.target_epsg:

--- a/scripts/r.reclass.area/r.reclass.area.py
+++ b/scripts/r.reclass.area/r.reclass.area.py
@@ -207,7 +207,7 @@ def main():
     diagonal = flags["d"]
 
     # check for unsupported locations
-    in_proj = gs.parse_command("g.proj", flags="g")
+    in_proj = gs.parse_command("g.proj", flags="p", format="shell")
     if in_proj["unit"].lower() == "degree":
         gs.fatal(_("Latitude-longitude locations are not supported"))
     if in_proj["name"].lower() == "xy_location_unprojected":

--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -237,7 +237,10 @@ def main():
     tgtloc = grassenv["LOCATION_NAME"]
 
     # make sure target is not xy
-    if gs.parse_command("g.proj", flags="g")["name"] == "xy_location_unprojected":
+    if (
+        gs.parse_command("g.proj", flags="p", format="shell")["name"]
+        == "xy_location_unprojected"
+    ):
         gs.fatal(
             _("Coordinate reference system not available for current project <%s>")
             % tgtloc
@@ -297,7 +300,10 @@ def main():
     gs.verbose(gs.read_command("g.proj", flags="p").rstrip(os.linesep))
 
     # make sure input is not xy
-    if gs.parse_command("g.proj", flags="g")["name"] == "xy_location_unprojected":
+    if (
+        gs.parse_command("g.proj", flags="p", format="shell")["name"]
+        == "xy_location_unprojected"
+    ):
         gs.fatal(
             _("Coordinate reference system not available for input <%s>")
             % OGRdatasource


### PR DESCRIPTION
This PR gets rid of the warning when in the g.proj module the 'g' is deprecated and will be removed in a future release. Instead, the format=shell style is used.

The change was applied in the whole GRASS repository, the occurrences were replaced by
find . -type f -name ".py" -exec sed -i 's/"g.proj", flags="g"/"g.proj", flags="p", format="shell"/g' {} +

The info about deprecation can be found here: https://grass.osgeo.org/grass-devel/manuals/g.proj.html .
