### PR TITLE
parser: set OpenMP default thread count to 0 to use all cores by default

### DIFF
--- a/lib/gis/parser_standard_options.c
+++ b/lib/gis/parser_standard_options.c
@@ -777,7 +777,7 @@ struct Option *G_define_standard_option(int opt)
         Opt->type = TYPE_INTEGER;
         Opt->required = NO;
         Opt->multiple = NO;
-        Opt->answer = "1";
+        Opt->answer = "0";
         /* start dynamic answer */
         /* check NPROCS in GISRC, set with g.gisenv */
         memstr = G_store(G_getenv_nofatal("NPROCS"));


### PR DESCRIPTION
It doesn't make sense to default to a single thread execution of parallel code. Most of users will not check this setting and thus end running slow version of fast code.