### PR TITLE
grass.temporal: allow change of mapset in a single script

### DIFF
--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -603,8 +603,9 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
     msgr.debug(1, ("Raise on error id: %s" % str(raise_on_error)))
 
     ciface = get_tgis_c_library_interface()
-    driver_string = ciface.get_driver_name()
-    database_string = ciface.get_database_name()
+    current_mapset = decode(gs.gisenv().get("MAPSET"))
+    driver_string = ciface.get_driver_name(current_mapset)
+    database_string = ciface.get_database_name(current_mapset)
 
     # Set the mapset check and the timestamp write
     if "TGIS_DISABLE_MAPSET_CHECK" in grassenv:
@@ -657,8 +658,9 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
     else:
         # Set the default sqlite3 connection in case nothing was defined
         gs.run_command("t.connect", flags="d")
-        driver_string = ciface.get_driver_name()
-        database_string = ciface.get_database_name()
+        current_mapset = decode(gs.gisenv().get("MAPSET"))
+        driver_string = ciface.get_driver_name(current_mapset)
+        database_string = ciface.get_database_name(current_mapset)
         tgis_backend = driver_string
         try:
             import sqlite3
@@ -789,7 +791,6 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
                         "not supported any more. {m}"
                     ).format(m=message)
                 )
-
         return
 
     create_temporal_database(dbif)

--- a/python/grass/temporal/testsuite/test_mapset_change.py
+++ b/python/grass/temporal/testsuite/test_mapset_change.py
@@ -1,0 +1,31 @@
+"""Test wether a switch of mapset is taken into account
+
+(C) 2025 by the GRASS Development Team
+This program is free software under the GNU General Public
+License (>=v2). Read the file COPYING that comes with GRASS
+for details.
+
+:authors: Laurent Courty
+"""
+
+import grass.script as gs
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+import grass.temporal as tgis
+
+
+class TestMapsetChange(TestCase):
+    def test_change_mapset(self):
+        gs.run_command("g.mapset", mapset="mapset_test1", flags="c")
+        mapsets = gs.parse_command("g.mapsets", flags="p", format="json")["mapsets"]
+        assert mapsets == ["mapset_test1", "PERMANENT"]
+        tgis.init()
+        gs.run_command("g.mapset", mapset="mapset_test2", flags="c")
+        tgis.init()  # If the mapset change is not working, the test fails here
+        mapsets = gs.parse_command("g.mapsets", flags="p", format="json")["mapsets"]
+        assert mapsets == ["mapset_test2", "PERMANENT"]
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
## Description
This introduces the possibility of using the temporal framework and switching mapset within the same session.

## Motivation and context
This should address issue #629.

## How has this been tested?
I created a specific test for this feature, and ran the other tgis tests locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
functionality to not work as before)

## Checklist
<!-- See the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, please ask. We're here to help! -->
- [x] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](../../utils/release.yml)

- [x] My code follows the [code style](../../doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.