### PR TITLE
CMake: Fix the parameter is incorrect: . error for MSVC

### DIFF
--- a/python/libgrass_interface_generator/ctypesgen/libraryloader.py
+++ b/python/libgrass_interface_generator/ctypesgen/libraryloader.py
@@ -376,7 +376,7 @@ class WindowsLibraryLoader(LibraryLoader):
         super().__init__()
         for p in os.getenv("PATH").split(";"):
             if os.path.exists(p) and hasattr(os, "add_dll_directory"):
-                os.add_dll_directory(p)
+                os.add_dll_directory(os.path.abspath(p))
 
     class Lookup(LibraryLoader.Lookup):
         """Lookup class for Windows libraries..."""


### PR DESCRIPTION
This PR fixes:
```
  CMake Error at C:/Users/hcho/usr/grass/grass/cmake/ctypesgen.cmake:72 (message):
    C:/Users/hcho/usr/grass/grass/python/libgrass_interface_generator/run.py:
    Traceback (most recent call last):

      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\run.py", line 10, in <module>
        import ctypesgen.main  # noqa: E402
        ^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\ctypesgen\__init__.py", line 57, in <module>
        from . import processor
      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\ctypesgen\processor\__init__.py", line 10, in <module> 
        from .pipeline import process
      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\ctypesgen\processor\pipeline.py", line 40, in <module> 
        from ctypesgen.processor.operations import (
        ...<8 lines>...
        )
      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\ctypesgen\processor\operations.py", line 11, in <module>
        from ctypesgen import libraryloader
      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\ctypesgen\libraryloader.py", line 401, in <module>     
        load_library = loaderclass.get(sys.platform, PosixLibraryLoader)()
      File "C:\Users\hcho\usr\grass\grass\python\libgrass_interface_generator\ctypesgen\libraryloader.py", line 379, in __init__
        os.add_dll_directory(p)
        ~~~~~~~~~~~~~~~~~~~~^^^
      File "<frozen os>", line 1164, in add_dll_directory

    OSError: [WinError 87] The parameter is incorrect: '.'
```

See https://github.com/ros2/rpyutils/issues/7.