### PR TITLE
r.relief: module label changed to description

### DIFF
--- a/raster/r.relief/main.c
+++ b/raster/r.relief/main.c
@@ -106,7 +106,8 @@ int main(int argc, char *argv[])
     G_add_keyword(_("relief"));
     G_add_keyword(_("terrain"));
     G_add_keyword(_("hillshade"));
-    module->label = _("Creates shaded relief map from an elevation map (DEM).");
+    module->description =
+        _("Creates shaded relief map from an elevation map (DEM).");
 
     parm.elevation = G_define_standard_option(G_OPT_R_INPUT);
     parm.elevation->description =


### PR DESCRIPTION
`r.relief` is the only module in the main repo which doesn't have `description` defined.