### PR TITLE
t.rast.mapcalc: Improved formatting in documentation

### DIFF
--- a/temporal/t.rast.mapcalc/t.rast.mapcalc.md
+++ b/temporal/t.rast.mapcalc/t.rast.mapcalc.md
@@ -31,46 +31,49 @@ A mapcalc expression must be provided to process the temporal sampled
 maps. Temporal internal variables are available in addition to the
 *[r.mapcalc](r.mapcalc.md)* spatial operators and functions:
 
-The supported internal variables for relative and absolute time are:
 
-- *td()* - This internal variable represents the size of the current
-  sample time interval in days and fraction of days for absolute time,
-  and in relative units in case of relative time.
-- *start_time()* - This internal variable represents the time difference
-  between the start time of the sample space time raster dataset and the
-  start time of the current sample interval or instance. The time is
-  measured in days and fraction of days for absolute time, and in
-  relative units in case of relative time.
-- *end_time()* - This internal variable represents the time difference
-  between the start time of the sample space time raster dataset and the
-  end time of the current sample interval. The time is measured in days
-  and fraction of days for absolute time, and in relative units in case
-  of relative time. The end_time() will be represented by null() in case
-  of a time instance.
+### Supported internal variables
 
-The supported internal variables for the current sample interval or
-instance for absolute time are:
+The supported internal variables for **relative** and **absolute time** are:
 
-- *start_doy()* - Day of year (doy) from the start time \[1 - 366\]
-- *start_dow()* - Day of week (dow) from the start time \[1 - 7\], the
-  start of the week is Monday == 1
-- *start_year()* - The year of the start time \[0 - 9999\]
-- *start_month()* - The month of the start time \[1 - 12\]
-- *start_week()* - Week of year of the start time \[1 - 54\]
-- *start_day()* - Day of month from the start time \[1 - 31\]
-- *start_hour()* - The hour of the start time \[0 - 23\]
-- *start_minute()* - The minute of the start time \[0 - 59\]
-- *start_second()* - The second of the start time \[0 - 59\]
-- *end_doy()* - Day of year (doy) from the end time \[1 - 366\]
-- *end_dow()* - Day of week (dow) from the end time \[1 - 7\], the start
-  of the week is Monday == 1
-- *end_year()* - The year of the end time \[0 - 9999\]
-- *end_month()* - The month of the end time \[1 - 12\]
-- *end_woy()* - Week of year (woy) of the end time \[1 - 54\]
-- *end_day()* - Day of month from the start time \[1 - 31\]
-- *end_hour()* - The hour of the end time \[0 - 23\]
-- *end_minute()* - The minute of the end time \[0 - 59\]
-- *end_second()* - The second of the end time \[0 - 59\].
+#### Time interval
+
+*td()* - This internal variable represents the size of the current
+sample time interval in days and fraction of days for absolute time,
+and in relative units in case of relative time.
+
+#### Start time
+
+*start_time()* - This internal variable represents the time difference
+between the start time of the sample space time raster dataset and the start time of the current sample interval or instance. The time is measured in days and fraction of days for absolute time, and in relative units in case of relative time.
+
+#### End time
+
+*end_time()* - This internal variable represents the time difference between the start time of the sample space time raster dataset and the end time of the current sample interval. The time is measured in days and fraction of days for absolute time, and in relative units in case of relative time. The end_time() will be represented by null() in case of a time instance.
+
+The supported internal variables for the **current sample interval** or
+**instance for absolute time** are:
+
+| **Variable**   | **Description**   |
+|:-------------- |:----------------- |
+| *start_doy()*| Day of year (doy) from the start time \[1 - 366\] |
+| *start_dow()*| Day of week (dow) from the start time \[1 - 7\], the start of the week is Monday == 1 |
+| *start_year()* | The year of the start time \[0 - 9999\] |
+| *start_month()* |The month of the start time \[1 - 12\] |
+| *start_week()* |Week of year of the start time \[1 - 54\] |
+| *start_day()* |Day of month from the start time \[1 - 31\] |
+| *start_hour()* |The hour of the start time \[0 - 23\] |
+| *start_minute()* |The minute of the start time \[0 - 59\] |
+|*start_second()* |The second of the start time \[0 - 59\] |
+|*end_doy()* |Day of year (doy) from the end time \[1 - 366\] |
+|*end_dow()* |Day of week (dow) from the end time \[1 - 7\], the start of the week is Monday == 1 |
+|*end_year()* |The year of the end time \[0 - 9999\] |
+|*end_month()* |The month of the end time \[1 - 12\] |
+|*end_woy()* |Week of year (woy) of the end time \[1 - 54\] |
+|*end_day()* |Day of month from the start time \[1 - 31\] |
+|*end_hour()* |The hour of the end time \[0 - 23\] |
+|*end_minute()* |The minute of the end time \[0 - 59\] |
+|*end_second()* |The second of the end time \[0 - 59\] |
 
 The *end\_\** functions are represented by the null() internal variable
 in case of time instances.


### PR DESCRIPTION
I improved the readability of the documentation by converting the internal variables list into a table. I also converted the headings to sentence case.

## Original Docs

![image](https://github.com/user-attachments/assets/d564a1d2-187b-42d4-ad82-fcfc7a61c982)

## New Docs

![image](https://github.com/user-attachments/assets/a7ffbdf1-0f49-491c-b7aa-5f3a402bd534)
