### PR TITLE
GUI: propagate previously defined where option value

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2297,6 +2297,7 @@ class CmdPanel(wx.Panel):
 
                 elif prompt == "sql_query":
                     win = gselect.SqlWhereSelect(parent=which_panel, param=p)
+                    value = self._getValue(p)
                     if value:
                         win.SetValue(value)  # parameter previously set
                     p["wxId"] = [win.GetTextWin().GetId()]

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -2297,6 +2297,8 @@ class CmdPanel(wx.Panel):
 
                 elif prompt == "sql_query":
                     win = gselect.SqlWhereSelect(parent=which_panel, param=p)
+                    if value:
+                        win.SetValue(value)  # parameter previously set
                     p["wxId"] = [win.GetTextWin().GetId()]
                     win.GetTextWin().Bind(wx.EVT_TEXT, self.OnSetValue)
                     which_sizer.Add(


### PR DESCRIPTION
Previously defined value for `where` option is not propageted.

Steps to reproduce:

1. Create model which contains a tool with a `where` option (see attached model [select.gxm.zip](https://github.com/user-attachments/files/20401553/select.gxm.zip))

2. Define `where` option
3. Close dialog
4. Re--open dialog

A `where` option is empty

![Screenshot From 2025-05-22 18-39-12](https://github.com/user-attachments/assets/6e92fe07-e9e2-4115-ae96-fb114df139e7)

The PR solves this bug:

![image](https://github.com/user-attachments/assets/1d7c0a61-17bc-4e1c-8c2e-ca39b23595fe)
