### PR TITLE
r.univar: Correct testing

### DIFF
--- a/raster/r.univar/testsuite/test_r_univar.py
+++ b/raster/r.univar/testsuite/test_r_univar.py
@@ -76,7 +76,7 @@ class TestRasterUnivar(TestCase):
         sum=1547100"""
 
         self.assertRasterFitsUnivar(
-            raster="map_a", reference=univar_string, precision=6
+            raster="map_a", reference=univar_string, precision=1e-6
         )
         self.assertModuleKeyValue(
             module="r.univar",
@@ -84,7 +84,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -102,7 +102,7 @@ class TestRasterUnivar(TestCase):
 
         self.runModule("g.region", res=10)
         self.assertRasterFitsUnivar(
-            raster="map_a", reference=univar_string, precision=6
+            raster="map_a", reference=univar_string, precision=1e-6
         )
         self.assertModuleKeyValue(
             module="r.univar",
@@ -110,7 +110,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -136,7 +136,7 @@ class TestRasterUnivar(TestCase):
             map="map_a",
             flags="rg",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -145,7 +145,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -174,12 +174,12 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=1,
             reference=univar_string_float,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
         univar_string_double = """
-        n=8101
+        n=8100
         null_cells=0
         cells=8100
         min=402
@@ -202,7 +202,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=1,
             reference=univar_string_double,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -223,7 +223,7 @@ class TestRasterUnivar(TestCase):
             map=["map_a", "map_b"],
             flags="rg",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -232,7 +232,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -244,8 +244,8 @@ class TestRasterUnivar(TestCase):
         min=112
         max=372
         range=260
-        mean=241
-        mean_of_abs=241
+        mean=242
+        mean_of_abs=242
         sum=39204"""
 
         self.runModule("g.region", res=10)
@@ -254,7 +254,7 @@ class TestRasterUnivar(TestCase):
             map=["map_a", "map_b"],
             flags="g",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -263,7 +263,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -290,7 +290,7 @@ class TestRasterUnivar(TestCase):
             map=["map_a", "map_b"],
             flags="rg",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -299,7 +299,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -328,7 +328,7 @@ class TestRasterUnivar(TestCase):
             map="map_negative",
             flags="rg",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -337,7 +337,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -376,7 +376,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map",
             flags="g",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -386,7 +386,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -430,7 +430,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map",
             flags="g",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -440,7 +440,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -492,7 +492,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map",
             flags="ge",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -502,7 +502,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 
@@ -554,7 +554,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map_with_gap",
             flags="ge",
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -564,7 +564,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=4,
             reference=univar_string,
-            precision=6,
+            precision=1e-6,
             sep="=",
         )
 

--- a/raster/r.univar/testsuite/test_r_univar.py
+++ b/raster/r.univar/testsuite/test_r_univar.py
@@ -76,7 +76,7 @@ class TestRasterUnivar(TestCase):
         sum=1547100"""
 
         self.assertRasterFitsUnivar(
-            raster="map_a", reference=univar_string, precision=1e-6
+            raster="map_a", reference=univar_string, precision=1e-10
         )
         self.assertModuleKeyValue(
             module="r.univar",
@@ -84,7 +84,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -102,7 +102,7 @@ class TestRasterUnivar(TestCase):
 
         self.runModule("g.region", res=10)
         self.assertRasterFitsUnivar(
-            raster="map_a", reference=univar_string, precision=1e-6
+            raster="map_a", reference=univar_string, precision=1e-10
         )
         self.assertModuleKeyValue(
             module="r.univar",
@@ -110,7 +110,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -136,7 +136,7 @@ class TestRasterUnivar(TestCase):
             map="map_a",
             flags="rg",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -145,7 +145,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -174,7 +174,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=1,
             reference=univar_string_float,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -202,7 +202,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=1,
             reference=univar_string_double,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -223,7 +223,7 @@ class TestRasterUnivar(TestCase):
             map=["map_a", "map_b"],
             flags="rg",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -232,7 +232,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -254,7 +254,7 @@ class TestRasterUnivar(TestCase):
             map=["map_a", "map_b"],
             flags="g",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -263,7 +263,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -290,7 +290,7 @@ class TestRasterUnivar(TestCase):
             map=["map_a", "map_b"],
             flags="rg",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -299,7 +299,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -328,7 +328,7 @@ class TestRasterUnivar(TestCase):
             map="map_negative",
             flags="rg",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -337,7 +337,7 @@ class TestRasterUnivar(TestCase):
             flags="rg",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -376,7 +376,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map",
             flags="g",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -386,7 +386,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -430,7 +430,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map",
             flags="g",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -440,7 +440,7 @@ class TestRasterUnivar(TestCase):
             flags="g",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -492,7 +492,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map",
             flags="ge",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -502,7 +502,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 
@@ -554,7 +554,7 @@ class TestRasterUnivar(TestCase):
             zones="zone_map_with_gap",
             flags="ge",
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
         self.assertModuleKeyValue(
@@ -564,7 +564,7 @@ class TestRasterUnivar(TestCase):
             flags="ge",
             nprocs=4,
             reference=univar_string,
-            precision=1e-6,
+            precision=1e-10,
             sep="=",
         )
 


### PR DESCRIPTION
The precision used for testing was 6, which is very high. It is changed to 1e-10.

Some reference values are wrong in testing.
1.  Line 182: the number of cells is 8100 (from r.info).
2. Line 247, Line 248: mean = sum / n, 39204 / 162 = 242 
