### PR TITLE
GUI: always show 'Close dialog on finish' option

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -677,13 +677,7 @@ class TaskFrame(wx.Frame):
                     border=5,
                 )
 
-        hasNew = False
-        for p in self.task.params:
-            if p.get("age", "old") == "new":
-                hasNew = True
-                break
-
-        if self.get_dcmd is None and hasNew:
+        if self.get_dcmd is None:
             # close dialog when command is terminated
             self.closebox = CheckBox(
                 parent=self.panel, label=_("Close dialog on finish"), style=wx.NO_BORDER


### PR DESCRIPTION
Currently an option to close the dialog

![image](https://github.com/user-attachments/assets/17f8206a-543d-4165-989d-160bed7bfafa)

is shown only for tools which are producing some output data. It's seems to be like a bug. This option should be shown always. Compare eg. `r.compress` (no output) with `r.buffer` (raster output).