### PR TITLE
GUI: do not remove parameter value on dialog update event

### DIFF
--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -208,10 +208,6 @@ class UpdateThread(Thread):
 
             # @todo: replace name by isinstance() and signals
 
-            pBind = self.task.get_param(uid, element="wxId", raiseError=False)
-            if pBind:
-                pBind["value"] = ""
-
             # set appropriate types in t.* modules and g.list/remove element
             # selections
             if name == "Select":

--- a/gui/wxpython/gui_core/forms.py
+++ b/gui/wxpython/gui_core/forms.py
@@ -332,6 +332,7 @@ class UpdateThread(Thread):
                         "vector": map,
                         "layer": layer,
                         "dbInfo": cparams[map]["dbInfo"],
+                        "setDefaultValue": False,
                     }
                 # table
                 elif driver and db:
@@ -339,10 +340,12 @@ class UpdateThread(Thread):
                         "table": pTable.get("value"),
                         "driver": driver,
                         "database": db,
+                        "setDefaultValue": False,
                     }
                 elif pTable:
                     self.data[win.GetParent().InsertTableColumns] = {
-                        "table": pTable.get("value")
+                        "table": pTable.get("value"),
+                        "setDefaultValue": False,
                     }
 
             elif name == "SubGroupSelect":

--- a/gui/wxpython/gui_core/gselect.py
+++ b/gui/wxpython/gui_core/gselect.py
@@ -1141,7 +1141,14 @@ class ColumnSelect(ComboCtrl):
         self.SetValue("")
 
     def InsertColumns(
-        self, vector, layer, excludeKey=False, excludeCols=None, type=None, dbInfo=None
+        self,
+        vector,
+        layer,
+        excludeKey=False,
+        excludeCols=None,
+        type=None,
+        dbInfo=None,
+        setDefaultValue=True,
     ):
         """Insert columns for a vector attribute table into the columns combobox
 
@@ -1150,6 +1157,8 @@ class ColumnSelect(ComboCtrl):
         :param excludeKey: exclude key column from the list?
         :param excludeCols: list of columns to be removed from the list
         :param type: only columns of given type (given as list)
+        :param dbInfo: dbInfo object
+        :param setDefaultValue: True to set default value
         """
         if not dbInfo:
             dbInfo = VectorDBInfo(vector)
@@ -1187,7 +1196,8 @@ class ColumnSelect(ComboCtrl):
         for col in self.columns:
             self.tcp.AddItem(col)
 
-        self.SetValue(self.defaultValue)
+        if setDefaultValue:
+            self.SetValue(self.defaultValue)
 
         if self.param:
             value = self.param.get("value", "")


### PR DESCRIPTION
Currently when `map/input` option is changed than also all depending widgets (`layer`, `columns`, `where`) are updated. It includes also setting value to an empty string.

## Steps to reproduce

1. Launch ` v.db.select map=schools where="TAG = '001'" --ui`
2. Change `map` option

-> `where` option is removed

https://github.com/user-attachments/assets/456adaab-ebb1-4277-97dc-da9b2322b021

This PR changes current behaviour 

-> `where` option is kept


https://github.com/user-attachments/assets/dd5795b1-c990-45a0-bff1-ca508a91fe44

## Backround reasons

- keep decision to remove or update eg. `where` option on the user
- user may have multiple maps with the same column. When switching between maps, a `where` statement must be set again from the scratch (which is not desired in this case)
- solves #5759
