### PR TITLE
docs: add miscellaneous tools to full index (markdown)

### DIFF
--- a/man/build_full_index.py
+++ b/man/build_full_index.py
@@ -41,6 +41,7 @@ the main tool categories:
 | `t.`   | [Temporal](temporal.md)           | Temporal data processing tools     |
 | `db.`  | [Database](database.md)           | Database management tools          |
 | `d.`   | [Display](display.md)             | Display and visualization tools    |
+| `m.`   | [Miscellaneous](miscellaneous.md) | Miscellaneous tools                |
 """
 
 ADDONS_TEXT = """\


### PR DESCRIPTION
Currently miscellaneous tools  are missing in full index:

![image](https://github.com/user-attachments/assets/f11c0244-72ef-4b8d-9c7d-f03322035483)

This PR adds this tools:

![image](https://github.com/user-attachments/assets/008e9699-0fb7-4c5e-9ff3-999778b98cd1)
