### PR TITLE
utils: Refactor regex split to use maxsplit parameter

### DIFF
--- a/utils/gitlog2changelog.py
+++ b/utils/gitlog2changelog.py
@@ -59,7 +59,7 @@ with open("ChangeLog", "w") as fout:
         # Match the author line and extract the part we want
         # (Don't use startswith to allow Author override inside commit message.)
         elif "Author:" in line:
-            authorList = re.split(r": ", line, 1)
+            authorList = re.split(r": ", line, maxsplit=1)
             try:
                 author = authorList[1]
                 author = author[0 : len(author) - 1]
@@ -69,7 +69,7 @@ with open("ChangeLog", "w") as fout:
 
         # Match the date line
         elif line.startswith("Date:"):
-            dateList = re.split(r":   ", line, 1)
+            dateList = re.split(r":   ", line, maxsplit=1)
             try:
                 date = dateList[1]
                 date = date[0 : len(date) - 1]
@@ -103,7 +103,7 @@ with open("ChangeLog", "w") as fout:
             continue
         # Collect the files for this commit. FIXME: Still need to add +/- to files
         elif authorFound & dateFound & messageFound:
-            fileList = re.split(r" \| ", line, 2)
+            fileList = re.split(r" \| ", line, maxsplit=2)
             if len(fileList) > 1:
                 if len(files) > 0:
                     files = files + ", " + fileList[0].strip()


### PR DESCRIPTION
I saw three DeprecationWarnings in the workflow that runs the utils/gitlog2changelog.py script:
```
2m 7s
Run python utils/gitlog2changelog.py
/home/runner/work/grass/grass/utils/gitlog2changelog.py:62: DeprecationWarning: 'maxsplit' is passed as positional argument
  authorList = re.split(r": ", line, [1](https://github.com/OSGeo/grass/actions/runs/15225443473/job/42826909240#step:5:1))
/home/runner/work/grass/grass/utils/gitlog2changelog.py:72: DeprecationWarning: 'maxsplit' is passed as positional argument
  dateList = re.split(r":   ", line, 1)
/home/runner/work/grass/grass/utils/gitlog2changelog.py:106: DeprecationWarning: 'maxsplit' is passed as positional argument
  fileList = re.split(r" \| ", line, 2)
```

The fix is to use keyword argument for maxsplit