### PR TITLE
MSVC: Use the same M_PI_4 value to avoid redefinition warnings

### DIFF
--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -160,7 +160,11 @@ static const char *GRASS_copyright UNUSED = "GRASS GNU GPL licensed Software";
 #define M_PI_2 1.57079632679489661923 /* pi/2 */
 
 #undef M_PI_4
+#ifdef _MSC_VER
+#define M_PI_4 0.785398163397448309616 /* pi/4 */
+#else
 #define M_PI_4 0.78539816339744830962 /* pi/4 */
+#endif
 
 #undef M_R2D
 #define M_R2D 57.295779513082320877 /* 180/pi */

--- a/include/grass/gis.h
+++ b/include/grass/gis.h
@@ -161,6 +161,8 @@ static const char *GRASS_copyright UNUSED = "GRASS GNU GPL licensed Software";
 
 #undef M_PI_4
 #ifdef _MSC_VER
+/* use the same value from ucrt\corecrt_math_defines.h to avoid redefinition
+ * warnings */
 #define M_PI_4 0.785398163397448309616 /* pi/4 */
 #else
 #define M_PI_4 0.78539816339744830962 /* pi/4 */


### PR DESCRIPTION
This PR fixes `M_PI_4` redefinition warnings for MSVC by using the same value as the system macro:
```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\ucrt\corecrt_math_defines.h(30,9): warning C4005: 'M_PI_4': macro redefinition [C:\Users\hcho\usr\grass\grass\build21\display\d.grid.vcxproj]
```