### PR TITLE
r.what.color: Add test file

### DIFF
--- a/raster/r.proj/testsuite/test_rproj.py
+++ b/raster/r.proj/testsuite/test_rproj.py
@@ -240,12 +240,7 @@ class TestRasterreport(TestCase):
             mapset="PERMANENT",
             input=self.input,
             flags="p",
-        )
-
-        # Replacing '\r' because Windows uses '\r\n' for line endings, but we
-        # want to remove the '\r' (carriage return) to standardize line endings
-        result = result.replace("\r", "")
-        result_lines = [line for line in result.split("\n") if line.strip() != ""]
+        ).splitlines()
 
         expected = [
             "Source cols: 1500",
@@ -256,7 +251,7 @@ class TestRasterreport(TestCase):
             "Local east: 78:36:29.891436W",
         ]
 
-        self.assertListEqual(result_lines, expected, "Mismatch in print output (plain)")
+        self.assertListEqual(result, expected, "Mismatch in print output (plain)")
 
     def test_print_output_json(self):
         """Test printing input map bounds in the current projection (JSON format)."""

--- a/raster/r.what.color/testsuite/test_r_what_color.py
+++ b/raster/r.what.color/testsuite/test_r_what_color.py
@@ -21,7 +21,7 @@ class TestRWhatColor(TestCase):
             "r.what.color", input=self.input, flags="i", stdin=self.value
         )
         self.assertModule(module)
-        result = module.outputs.stdout
+        result = module.outputs.stdout.splitlines()
         expected = [
             "50: *",
             "100: 255:229:0",
@@ -31,11 +31,7 @@ class TestRWhatColor(TestCase):
             "*: *",
         ]
 
-        result_lines = [line for line in result.split("\n") if line.strip() != ""]
-
-        self.assertListEqual(
-            result_lines, expected, "Mismatch in printed output (plain)"
-        )
+        self.assertListEqual(result, expected, "Mismatch in printed output (plain)")
 
     def test_r_what_color_plain_with_format_option(self):
         """Test the r.what.color command with the format option for plain text output."""
@@ -47,7 +43,7 @@ class TestRWhatColor(TestCase):
             format="#%02X%02X%02X",
         )
         self.assertModule(module)
-        result = module.outputs.stdout
+        result = module.outputs.stdout.splitlines()
         expected = [
             "50: *",
             "100: #FFE500",
@@ -57,10 +53,8 @@ class TestRWhatColor(TestCase):
             "*: *",
         ]
 
-        result_lines = [line for line in result.split("\n") if line.strip() != ""]
-
         self.assertListEqual(
-            result_lines,
+            result,
             expected,
             "Mismatch in printed output (plain) with the format option",
         )


### PR DESCRIPTION
This PR adds a regression test suite for the `r.what.color` module. These tests are intended to serve as regression checks for upcoming PRs that add JSON support to `r.what.color`.

The tests include unit tests for the plain text output format using the `format`(printf-based) option, as well as the `-i` flag with input values from stdin.