### PR TITLE
g.mapset: Add test file

### DIFF
--- a/general/g.mapset/tests/conftest.py
+++ b/general/g.mapset/tests/conftest.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+import os
+import grass.script as gs
+import pytest
+
+TEST_MAPSETS = ["PERMANENT", "test1", "test2", "test3"]
+
+
+@pytest.fixture(scope="module")
+def simple_dataset(tmp_path_factory):
+    """Set up a GRASS session for the tests."""
+    tmp_path = tmp_path_factory.mktemp("simple_dataset")
+    location = "test"
+    gs.core._create_location_xy(tmp_path, location)
+    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+        # Create Mock Mapsets
+        for mapset in TEST_MAPSETS:
+            gs.run_command(
+                "g.mapset", project=location, mapset=mapset, flags="c", env=session.env
+            )
+
+        # Set current mapset to test1
+        gs.run_command("g.mapset", project=location, mapset="test1", env=session.env)
+
+        yield SimpleNamespace(
+            session=session,
+            mapsets=TEST_MAPSETS,
+            project=location,
+            current_mapset="test1",
+        )

--- a/general/g.mapset/tests/g_mapset_test.py
+++ b/general/g.mapset/tests/g_mapset_test.py
@@ -1,0 +1,18 @@
+import grass.script as gs
+
+
+def test_list_output(simple_dataset):
+    """Test g.mapset with list flag"""
+    mapsets = simple_dataset.mapsets
+    text = gs.read_command("g.mapset", flags="l", env=simple_dataset.session.env)
+    parsed_list = text.strip().split()
+
+    assert len(parsed_list) == len(mapsets)
+    for mapset in mapsets:
+        assert mapset in parsed_list
+
+
+def test_print_output(simple_dataset):
+    """Test g.mapset with print flag"""
+    text = gs.read_command("g.mapset", flags="p", env=simple_dataset.session.env)
+    assert text.strip() == simple_dataset.current_mapset


### PR DESCRIPTION
This PR adds a regression test suite for the `g.mapset` module. These tests are intended to serve as regression checks for upcoming PRs that add JSON support to `g.mapset`.

The tests include pytests for the plain text output format using `-p` and `-l` flags.