### PR TITLE
CQ: we should check the return value of lseek

### DIFF
--- a/imagery/i.ortho.photo/i.ortho.rectify/readcell.c
+++ b/imagery/i.ortho.photo/i.ortho.rectify/readcell.c
@@ -135,7 +135,7 @@ block *get_block(struct cache *c, int idx)
     c->grid[idx] = p;
     c->refs[replace] = idx;
 
-    if (lseek(c->fd, offset, SEEK_SET) < 0)
+    if (lseek(c->fd, offset, SEEK_SET) == (off_t)-1)
         G_fatal_error(_("Error seeking on segment file"));
 
     if (read(c->fd, p, sizeof(block)) < 0)

--- a/imagery/i.rectify/readcell.c
+++ b/imagery/i.rectify/readcell.c
@@ -119,7 +119,7 @@ block *get_block(struct cache *c, int idx)
     c->grid[idx] = p;
     c->refs[replace] = idx;
 
-    if (lseek(c->fd, offset, SEEK_SET) < 0)
+    if (lseek(c->fd, offset, SEEK_SET) == (off_t)-1)
         G_fatal_error(_("Error seeking on segment file"));
 
     if (read(c->fd, p, sizeof(block)) < 0)

--- a/imagery/i.segment/cluster.c
+++ b/imagery/i.segment/cluster.c
@@ -22,6 +22,9 @@
 #include <unistd.h>
 #include <math.h>
 #include <time.h>
+#include <string.h>
+#include <errno.h>
+
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -421,7 +424,12 @@ CELL cluster_bands(struct globals *globals)
         G_fatal_error(_("Too many objects: integer overflow"));
 
     /* rewind temp file */
-    lseek(cfd, 0, SEEK_SET);
+    if (lseek(cfd, 0, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
 
     /****************************************************
      *                      PASS 2                      *

--- a/lib/gis/open.c
+++ b/lib/gis/open.c
@@ -194,7 +194,13 @@ int G_open_update(const char *element, const char *name)
 
     fd = G__open(element, name, G_mapset(), 2);
     if (fd >= 0)
-        lseek(fd, 0L, SEEK_END);
+        if (lseek(fd, 0L, SEEK_END) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+            return -1;
+        }
 
     return fd;
 }
@@ -282,7 +288,13 @@ FILE *G_fopen_append(const char *element, const char *name)
     fd = G__open(element, name, G_mapset(), 2);
     if (fd < 0)
         return (FILE *)0;
-    lseek(fd, 0L, SEEK_END);
+    if (lseek(fd, 0L, SEEK_END) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return NULL;
+    }
 
     G_debug(2, "\tfile open: append (mode = a)");
     return fdopen(fd, "a");
@@ -310,7 +322,13 @@ FILE *G_fopen_modify(const char *element, const char *name)
     fd = G__open(element, name, G_mapset(), 2);
     if (fd < 0)
         return (FILE *)0;
-    lseek(fd, 0L, SEEK_END);
+    if (lseek(fd, 0L, SEEK_END) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return NULL;
+    }
 
     G_debug(2, "\tfile open: modify (mode = r+)");
     return fdopen(fd, "r+");

--- a/lib/gis/open_misc.c
+++ b/lib/gis/open_misc.c
@@ -155,7 +155,13 @@ int G_open_update_misc(const char *dir, const char *element, const char *name)
 
     fd = G__open_misc(dir, element, name, G_mapset(), 2);
     if (fd >= 0)
-        lseek(fd, 0L, SEEK_END);
+        if (lseek(fd, 0L, SEEK_END) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+            return -1;
+        }
 
     return fd;
 }
@@ -222,7 +228,13 @@ FILE *G_fopen_append_misc(const char *dir, const char *element,
     fd = G__open_misc(dir, element, name, G_mapset(), 2);
     if (fd < 0)
         return (FILE *)0;
-    lseek(fd, 0L, SEEK_END);
+    if (lseek(fd, 0L, SEEK_END) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return (FILE *)-1;
+    }
 
     return fdopen(fd, "a");
 }
@@ -235,7 +247,13 @@ FILE *G_fopen_modify_misc(const char *dir, const char *element,
     fd = G__open_misc(dir, element, name, G_mapset(), 2);
     if (fd < 0)
         return (FILE *)0;
-    lseek(fd, 0L, SEEK_END);
+    if (lseek(fd, 0L, SEEK_END) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return (FILE *)-1;
+    }
 
     return fdopen(fd, "r+");
 }

--- a/lib/raster/close.c
+++ b/lib/raster/close.c
@@ -396,6 +396,12 @@ static int close_new(int fd, int ok)
         if (fcb->null_row_ptr) { /* compressed nulls */
             fcb->null_row_ptr[fcb->cellhd.rows] =
                 lseek(fcb->null_fd, 0L, SEEK_CUR);
+            if (fcb->null_row_ptr[fcb->cellhd.rows] == (off_t)-1) {
+                int err = errno;
+                /* GTC seek refers to reading/writing from a different position
+                 * in a file */
+                G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+            }
             Rast__write_null_row_ptrs(fd, fcb->null_fd);
         }
 

--- a/lib/raster/format.c
+++ b/lib/raster/format.c
@@ -190,7 +190,12 @@ static int write_row_ptrs(int nrows, off_t *row_ptr, int fd)
     unsigned char *buf, *b;
     int len, row, result;
 
-    lseek(fd, 0L, SEEK_SET);
+    if (lseek(fd, 0L, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
 
     len = (nrows + 1) * nbytes + 1;
     b = buf = G_malloc(len);

--- a/lib/raster/get_row.c
+++ b/lib/raster/get_row.c
@@ -93,7 +93,7 @@ static void read_data_fp_compressed(int fd, int row, unsigned char *data_buf,
     size_t bufsize = fcb->cellhd.cols * fcb->nbytes;
     int ret;
 
-    if (lseek(fcb->data_fd, t1, SEEK_SET) < 0)
+    if (lseek(fcb->data_fd, t1, SEEK_SET) == (off_t)-1)
         G_fatal_error(
             _("Error seeking fp raster data file for row %d of <%s>: %s"), row,
             fcb->name, strerror(errno));
@@ -138,7 +138,7 @@ static void read_data_compressed(int fd, int row, unsigned char *data_buf,
     unsigned char *cmp, *cmp2;
     int n;
 
-    if (lseek(fcb->data_fd, t1, SEEK_SET) < 0)
+    if (lseek(fcb->data_fd, t1, SEEK_SET) == (off_t)-1)
         G_fatal_error(
             _("Error seeking raster data file for row %d of <%s>: %s"), row,
             fcb->name, strerror(errno));
@@ -192,7 +192,7 @@ static void read_data_uncompressed(int fd, int row, unsigned char *data_buf,
 
     *nbytes = fcb->nbytes;
 
-    if (lseek(fcb->data_fd, (off_t)row * bufsize, SEEK_SET) == -1)
+    if (lseek(fcb->data_fd, (off_t)row * bufsize, SEEK_SET) == (off_t)-1)
         G_fatal_error(_("Error reading raster data for row %d of <%s>"), row,
                       fcb->name);
 
@@ -854,7 +854,7 @@ static int read_null_bits_compressed(int null_fd, unsigned char *flags, int row,
     unsigned char *compressed_buf;
     int res;
 
-    if (lseek(null_fd, t1, SEEK_SET) < 0)
+    if (lseek(null_fd, t1, SEEK_SET) == (off_t)-1)
         G_fatal_error(
             _("Error seeking compressed null data for row %d of <%s>"), row,
             fcb->name);
@@ -914,7 +914,7 @@ int Rast__read_null_bits(int fd, int row, unsigned char *flags)
 
     offset = (off_t)size * R;
 
-    if (lseek(null_fd, offset, SEEK_SET) < 0)
+    if (lseek(null_fd, offset, SEEK_SET) == (off_t)-1)
         G_fatal_error(_("Error seeking null row %d for <%s>"), R, fcb->name);
 
     if (read(null_fd, flags, size) != size)

--- a/lib/raster/put_row.c
+++ b/lib/raster/put_row.c
@@ -140,6 +140,12 @@ static void set_file_pointer(int fd, int row)
     struct fileinfo *fcb = &R__.fileinfo[fd];
 
     fcb->row_ptr[row] = lseek(fcb->data_fd, 0L, SEEK_CUR);
+    if (fcb->row_ptr[row] == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
 }
 
 static void convert_float(float *work_buf, char *null_buf, const FCELL *rast,
@@ -514,6 +520,12 @@ static void write_null_bits_compressed(const unsigned char *flags, int row,
     int res;
 
     fcb->null_row_ptr[row] = lseek(fcb->null_fd, 0L, SEEK_CUR);
+    if (fcb->null_row_ptr[row] == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
 
     /* get upper bound of compressed size */
     cmax = G_compress_bound(size, 3);
@@ -567,7 +579,7 @@ void Rast__write_null_bits(int fd, const unsigned char *flags)
 
     offset = (off_t)size * row;
 
-    if (lseek(fcb->null_fd, offset, SEEK_SET) < 0)
+    if (lseek(fcb->null_fd, offset, SEEK_SET) == (off_t)-1)
         G_fatal_error(_("Error writing null row %d of <%s>"), row, fcb->name);
 
     if ((res = write(fcb->null_fd, flags, size)) < 0 ||

--- a/lib/raster3d/cache.c
+++ b/lib/raster3d/cache.c
@@ -80,7 +80,7 @@ static int cacheWrite_readFun(int tileIndex, void *tileBuf, void *closure)
 
     /* seek tile and read it into buffer */
 
-    if (lseek(map->cacheFD, offs, SEEK_SET) == -1) {
+    if (lseek(map->cacheFD, offs, SEEK_SET) == (off_t)-1) {
         Rast3d_error("cacheWrite_readFun: can't position file");
         return 0;
     }
@@ -107,7 +107,7 @@ static int cacheWrite_readFun(int tileIndex, void *tileBuf, void *closure)
 
     offsLast = map->cachePosLast * (nBytes + sizeof(int));
 
-    if (lseek(map->cacheFD, offsLast, SEEK_SET) == -1) {
+    if (lseek(map->cacheFD, offsLast, SEEK_SET) == (off_t)-1) {
         Rast3d_error("cacheWrite_readFun: can't position file");
         return 0;
     }
@@ -117,7 +117,7 @@ static int cacheWrite_readFun(int tileIndex, void *tileBuf, void *closure)
         return 0;
     }
 
-    if (lseek(map->cacheFD, offs, SEEK_SET) == -1) {
+    if (lseek(map->cacheFD, offs, SEEK_SET) == (off_t)-1) {
         Rast3d_error("cacheWrite_readFun: can't position file");
         return 0;
     }
@@ -152,7 +152,7 @@ static int cacheWrite_writeFun(int tileIndex, const void *tileBuf,
     nBytes = map->tileSize * map->numLengthIntern;
     offs = map->cachePosLast * (nBytes + sizeof(int));
 
-    if (lseek(map->cacheFD, offs, SEEK_SET) == -1) {
+    if (lseek(map->cacheFD, offs, SEEK_SET) == (off_t)-1) {
         Rast3d_error("cacheWrite_writeFun: can't position file");
         return 0;
     }
@@ -304,7 +304,7 @@ int Rast3d_flush_all_tiles(RASTER3D_Map *map)
     while (map->cachePosLast >= 0) {
         offs = map->cachePosLast * (nBytes + sizeof(int)) + nBytes;
 
-        if (lseek(map->cacheFD, offs, SEEK_SET) == -1) {
+        if (lseek(map->cacheFD, offs, SEEK_SET) == (off_t)-1) {
             Rast3d_error("Rast3d_flush_all_tiles: can't position file");
             return 0;
         }

--- a/lib/raster3d/close.c
+++ b/lib/raster3d/close.c
@@ -91,7 +91,7 @@ static int close_cell_new(RASTER3D_Map *map)
     /* opening time */
 
     if (lseek(map->data_fd, (long)(map->offset - sizeof(int) - sizeof(long)),
-              SEEK_SET) == -1) {
+              SEEK_SET) == (off_t)-1) {
         G_warning(_("Unable to position file"));
         return 0;
     }

--- a/lib/raster3d/header.c
+++ b/lib/raster3d/header.c
@@ -445,7 +445,8 @@ int Rast3d_fill_header(RASTER3D_Map *map, int operation, int compression,
 
     map->offset = nofHeaderBytes;
 
-    if ((map->fileEndPtr = lseek(map->data_fd, (long)0, SEEK_END)) == -1) {
+    if ((map->fileEndPtr = lseek(map->data_fd, (long)0, SEEK_END)) ==
+        (off_t)-1) {
         Rast3d_error("Rast3d_fill_header: can't position file");
         return 0;
     }

--- a/lib/raster3d/index.c
+++ b/lib/raster3d/index.c
@@ -21,7 +21,7 @@ static int Rast3d_readIndex(RASTER3D_Map *map)
 
     indexLength = indexLast - map->indexOffset;
 
-    if (lseek(map->data_fd, map->indexOffset, SEEK_SET) == -1) {
+    if (lseek(map->data_fd, map->indexOffset, SEEK_SET) == (off_t)-1) {
         Rast3d_error("Rast3d_readIndex: can't position file");
         return 0;
     }

--- a/lib/raster3d/open.c
+++ b/lib/raster3d/open.c
@@ -3,6 +3,9 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
 #include <grass/raster3d.h>
 #include <grass/glocale.h>
 #include "raster3d_intern.h"
@@ -99,7 +102,7 @@ void *Rast3d_open_cell_old(const char *name, const char *mapset,
         return (void *)NULL;
     }
 
-    if (lseek(map->data_fd, (long)0, SEEK_SET) == -1) {
+    if (lseek(map->data_fd, (long)0, SEEK_SET) == (off_t)-1) {
         Rast3d_error(_("Rast3d_open_cell_old: can't rewind file"));
         return (void *)NULL;
     }
@@ -297,6 +300,13 @@ void *Rast3d_open_cell_new(const char *name, int typeIntern, int cache,
 
     /* can't use a constant since this depends on sizeof (long) */
     nofHeaderBytes = lseek(map->data_fd, (long)0, SEEK_CUR);
+    if (nofHeaderBytes == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        Rast3d_error(_("Unable to seek: %d %s"), err, strerror(err));
+        return (void *)NULL;
+    }
 
     Rast3d_range_init(map);
     Rast3d_adjust_region(region);

--- a/lib/raster3d/tileread.c
+++ b/lib/raster3d/tileread.c
@@ -164,7 +164,7 @@ int Rast3d_read_tile(RASTER3D_Map *map, int tileIndex, void *tile, int type)
                                                     &cols, &depths, &xRedundant,
                                                     &yRedundant, &zRedundant);
 
-    if (lseek(map->data_fd, map->index[tileIndex], SEEK_SET) == -1) {
+    if (lseek(map->data_fd, map->index[tileIndex], SEEK_SET) == (off_t)-1) {
         Rast3d_error("Rast3d_read_tile: can't position file");
         return 0;
     }

--- a/lib/segment/format.c
+++ b/lib/segment/format.c
@@ -260,7 +260,7 @@ static int seek_only(int fd, off_t nbytes)
 
     G_debug(3, "Using new segmentation code...");
     errno = 0;
-    if (lseek(fd, nbytes - 1, SEEK_CUR) < 0) {
+    if (lseek(fd, nbytes - 1, SEEK_CUR) == (off_t)-1) {
         int err = errno;
 
         G_warning("segment zero_fill(): Unable to seek (%s)", strerror(err));

--- a/lib/segment/init.c
+++ b/lib/segment/init.c
@@ -59,7 +59,7 @@ int Segment_init(SEGMENT *SEG, int fd, int nseg)
     SEG->fd = fd;
     SEG->nseg = nseg;
 
-    if (lseek(fd, 0L, SEEK_SET) < 0) {
+    if (lseek(fd, 0L, SEEK_SET) == (off_t)-1) {
         int err = errno;
 
         G_warning("Segment_init: %s", strerror(err));

--- a/raster/r.compress/main.c
+++ b/raster/r.compress/main.c
@@ -41,6 +41,9 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -162,6 +165,13 @@ static int process(char *name, int uncompress)
         data_fd = G_open_old("cell", name, G_mapset());
 
     oldsize = lseek(data_fd, (off_t)0, SEEK_END);
+    if (oldsize == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return 1;
+    }
     close(data_fd);
 
     if (doit(name, uncompress, map_type))
@@ -188,6 +198,13 @@ static int process(char *name, int uncompress)
         data_fd = G_open_old("cell", name, G_mapset());
 
     newsize = lseek(data_fd, (off_t)0, SEEK_END);
+    if (newsize == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return 1;
+    }
     close(data_fd);
 
     sizestr = "bytes";

--- a/raster/r.grow.distance/main.c
+++ b/raster/r.grow.distance/main.c
@@ -387,7 +387,12 @@ int main(int argc, char **argv)
 
         G_percent(row, nrows, 2);
 
-        lseek(temp_fd, offset, SEEK_SET);
+        if (lseek(temp_fd, offset, SEEK_SET) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+        }
 
         if (read(temp_fd, new_x_row, ncols * sizeof(CELL)) < 0)
             G_fatal_error(_("File reading error in %s() %d:%s"), __func__,

--- a/raster/r.mfilter/execute.c
+++ b/raster/r.mfilter/execute.c
@@ -3,8 +3,12 @@
 #endif
 
 #include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
 #include <grass/rowio.h>
 #include <grass/raster.h>
+#include <grass/glocale.h>
 #include "glob.h"
 #include "filter.h"
 
@@ -73,7 +77,12 @@ int execute_filter(ROWIO *r, int *out, FILTER *filter, DCELL **cell)
     ccount = ncols - (size - 1);
 
     /* rewind output */
-    lseek(out[MASTER], 0L, SEEK_SET);
+    if (lseek(out[MASTER], 0L, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
 
     /* copy border rows to output */
     row = starty;
@@ -101,7 +110,13 @@ int execute_filter(ROWIO *r, int *out, FILTER *filter, DCELL **cell)
             end = rcount * (id + 1) / nprocs;
             cellp = cell[id];
             starty += start * dy;
-            lseek(out[id], (off_t)buflen * (mid + start), SEEK_SET);
+            if (lseek(out[id], (off_t)buflen * (mid + start), SEEK_SET) ==
+                (off_t)-1) {
+                int err = errno;
+                /* GTC seek refers to reading/writing from a different position
+                 * in a file */
+                G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+            }
         }
 #endif
 
@@ -148,7 +163,13 @@ int execute_filter(ROWIO *r, int *out, FILTER *filter, DCELL **cell)
     }
     G_percent(work, rcount, 2);
     starty = rcount * dy;
-    lseek(out[MASTER], (off_t)buflen * (mid + rcount), SEEK_SET);
+    if (lseek(out[MASTER], (off_t)buflen * (mid + rcount), SEEK_SET) ==
+        (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
 
     /* copy border rows to output */
     row = starty + mid * dy;

--- a/raster/r.mfilter/getrow.c
+++ b/raster/r.mfilter/getrow.c
@@ -1,6 +1,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <string.h>
+#include <errno.h>
+
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -15,10 +18,22 @@ int getmaprow(int fd, void *buf, int row, int len UNUSED)
 
 int getrow(int fd, void *buf, int row, int len)
 {
-    if (direction > 0)
-        lseek(fd, (off_t)row * len, 0);
-    else
-        lseek(fd, (off_t)(nrows - row - 1) * len, 0);
+    if (direction > 0) {
+        if (lseek(fd, (off_t)row * len, 0) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+        }
+    }
+    else {
+        if (lseek(fd, (off_t)(nrows - row - 1) * len, 0) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+        }
+    }
     if (read(fd, (DCELL *)buf, len) != len)
         G_fatal_error(_("Error reading temporary file"));
     return 1;

--- a/raster/r.proj/readcell.c
+++ b/raster/r.proj/readcell.c
@@ -133,7 +133,7 @@ block *get_block(struct cache *c, int idx)
     c->grid[idx] = p;
     c->refs[replace] = idx;
 
-    if (lseek(fd, offset, SEEK_SET) < 0)
+    if (lseek(fd, offset, SEEK_SET) == (off_t)-1)
         G_fatal_error(_("Error seeking on segment file"));
 
     if (read(fd, p, sizeof(block)) < 0)

--- a/raster/r.random/count.c
+++ b/raster/r.random/count.c
@@ -2,6 +2,9 @@
 #include <float.h>
 #include <math.h>
 #include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
 #include <grass/gis.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
@@ -96,9 +99,19 @@ void get_stats(struct rr_state *theState)
     G_percent(1, 1, 1);
 
     /* rewind the in raster map descriptor for later use */
-    lseek(theState->fd_old, 0, SEEK_SET);
+    if (lseek(theState->fd_old, 0, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+    }
     if (theState->docover == 1)
-        lseek(theState->fd_cold, 0, SEEK_SET);
+        if (lseek(theState->fd_cold, 0, SEEK_SET) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_fatal_error(_("Unable to seek: %d %s"), err, strerror(err));
+        }
 
     /* Set the NULL value replacement */
     switch (theState->nulls.type) {

--- a/raster/r.smooth.edgepreserve/row_cache.c
+++ b/raster/r.smooth.edgepreserve/row_cache.c
@@ -24,13 +24,19 @@
 /* For rowio */
 int rowio_get_row(int fd, void *buf, int row, int buf_len)
 {
-    lseek(fd, ((off_t)row) * buf_len, SEEK_SET);
-    errno = 0;
+    if (lseek(fd, ((off_t)row) * buf_len, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        G_fatal_error(_("Seek error on temp file. %d: %s"), err, strerror(err));
+    }
+
     ssize_t reads = read(fd, buf, (size_t)buf_len);
-    if (reads == -1)
+    if (reads == -1) {
+        int err = errno;
         G_fatal_error(
             _("There was an error reading data from a temporary file. %d: %s"),
-            errno, strerror(errno));
+            err, strerror(err));
+    }
+
     return (reads == buf_len);
 }
 
@@ -38,13 +44,19 @@ int rowio_get_row(int fd, void *buf, int row, int buf_len)
 int rowio_put_row(int fd, const void *buf, int row, int buf_len)
 {
     // can't use G_fseek, as rowio operates on file descriptors
-    lseek(fd, ((off_t)row) * buf_len, SEEK_SET);
-    errno = 0;
+    if (lseek(fd, ((off_t)row) * buf_len, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        G_fatal_error(_("Seek error on temp file. %d: %s"), err, strerror(err));
+    }
+
     ssize_t writes = write(fd, buf, (size_t)buf_len);
-    if (writes == -1)
+    if (writes == -1) {
+        int err = errno;
         G_fatal_error(
             _("There was an error writing data from a temporary file. %d: %s"),
-            errno, strerror(errno));
+            err, strerror(err));
+    }
+
     return (writes == buf_len);
 }
 

--- a/raster/r.thin/io.c
+++ b/raster/r.thin/io.c
@@ -67,7 +67,7 @@ int put_a_row(int row, CELL *buf)
 
 static int read_row(int file, void *buf, int row, int buf_len)
 {
-    if (lseek(file, ((off_t)row) * buf_len, 0) == -1) {
+    if (lseek(file, ((off_t)row) * buf_len, 0) == (off_t)-1) {
         G_fatal_error(_("Unable to seek: %s"), strerror(errno));
     }
     return (read(file, buf, buf_len) == buf_len);
@@ -75,7 +75,7 @@ static int read_row(int file, void *buf, int row, int buf_len)
 
 static int write_row(int file, const void *buf, int row, int buf_len)
 {
-    if (lseek(file, ((off_t)row) * buf_len, 0) == -1) {
+    if (lseek(file, ((off_t)row) * buf_len, 0) == (off_t)-1) {
         G_fatal_error(_("Unable to seek: %s"), strerror(errno));
     }
     return (write(file, buf, buf_len) == buf_len);

--- a/raster3d/r3.in.v5d/v5d.c
+++ b/raster3d/r3.in.v5d/v5d.c
@@ -1187,8 +1187,11 @@ static int read_comp_header(int f, v5dstruct *v)
     unsigned int id;
 
     /* reset file position to start of file */
-    if (lseek(f, 0, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
+    if (lseek(f, 0, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
         return 0;
     }
 
@@ -1291,7 +1294,7 @@ static int read_comp_header(int f, v5dstruct *v)
                 read_float4(f, &gb);
 
                 /* skip ahead by 'gridsize' bytes */
-                if (lseek(f, gridsize, SEEK_CUR) == -1) {
+                if (lseek(f, gridsize, SEEK_CUR) == (off_t)-1) {
                     G_warning(_("Error: Unexpected end of file, file may be "
                                 "corrupted."));
                     return 0;
@@ -1436,8 +1439,11 @@ static int read_comp_grid(v5dstruct *v, int time, int var, float *ga, float *gb,
 
     /* move to position in file */
     pos = grid_position(v, time, var);
-    if (lseek(f, pos, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
+    if (lseek(f, pos, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
         return 0;
     }
 
@@ -1512,12 +1518,15 @@ static int read_comp_grid(v5dstruct *v, int time, int var, float *ga, float *gb,
  */
 static int read_v5d_header(v5dstruct *v)
 {
-#define SKIP(N)                                                  \
-    do {                                                         \
-        if (lseek(f, N, SEEK_CUR) == -1) {                       \
-            G_warning(_("Unable to seek: %s"), strerror(errno)); \
-            return 0;                                            \
-        }                                                        \
+#define SKIP(N)                                                        \
+    do {                                                               \
+        if (lseek(f, N, SEEK_CUR) == (off_t) - 1) {                    \
+            int err = errno;                                           \
+            /* GTC seek refers to reading/writing from a               \
+             * different position in a file */                         \
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err)); \
+            return 0;                                                  \
+        }                                                              \
     } while (0)
     int end_of_header = 0;
     unsigned int id;
@@ -1837,8 +1846,11 @@ static int read_v5d_header(v5dstruct *v)
         case TAG_END:
             /* end of header */
             end_of_header = 1;
-            if (lseek(f, length, SEEK_CUR) == -1) {
-                G_warning(_("Unable to seek: %s"), strerror(errno));
+            if (lseek(f, length, SEEK_CUR) == (off_t)-1) {
+                int err = errno;
+                /* GTC seek refers to reading/writing from a different position
+                 * in a file */
+                G_warning(_("Unable to seek: %d %s"), err, strerror(err));
                 return 0;
             }
             break;
@@ -1846,7 +1858,7 @@ static int read_v5d_header(v5dstruct *v)
         default:
             /* unknown tag, skip to next tag */
             printf("Unknown tag: %d  length=%d\n", tag, length);
-            if (lseek(f, length, SEEK_CUR) == -1) {
+            if (lseek(f, length, SEEK_CUR) == (off_t)-1) {
                 G_warning(_("Unable to seek: %s"), strerror(errno));
                 return 0;
             }
@@ -1939,8 +1951,11 @@ int v5dReadCompressedGrid(v5dstruct *v, int time, int var, float *ga, float *gb,
 
     /* move to position in file */
     pos = grid_position(v, time, var);
-    if (lseek(v->FileDesc, pos, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
+    if (lseek(v->FileDesc, pos, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
         return 0;
     }
 
@@ -2094,8 +2109,11 @@ static int write_v5d_header(v5dstruct *v)
     }
 
     /* set file pointer to start of file */
-    if (lseek(f, 0, SEEK_SET) == -1) {
-        G_warning(_("Unable to seek: %s"), strerror(errno));
+    if (lseek(f, 0, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
         return 0;
     }
     v->CurPos = 0;
@@ -2201,8 +2219,11 @@ static int write_v5d_header(v5dstruct *v)
         /* We're writing to a brand new file.  Reserve 10000 bytes */
         /* for future header growth. */
         WRITE_TAG(v, TAG_END, 10000);
-        if (lseek(f, 10000, SEEK_CUR) == -1) {
-            G_warning(_("Unable to seek: %s"), strerror(errno));
+        if (lseek(f, 10000, SEEK_CUR) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
             return 0;
         }
 
@@ -2316,9 +2337,11 @@ int v5dWriteCompressedGrid(const v5dstruct *v, int time, int var,
 
     /* move to position in file */
     pos = grid_position(v, time, var);
-    if (lseek(v->FileDesc, pos, SEEK_SET) < 0) {
-        /* lseek failed, return error */
-        G_warning(_("Unable to seek: %s"), strerror(errno));
+    if (lseek(v->FileDesc, pos, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
         return 0;
     }
 
@@ -2434,13 +2457,19 @@ int v5dCloseFile(v5dstruct *v)
     if (v->Mode == 'w') {
         /* rewrite header because writing grids updates the minval and */
         /* maxval fields */
-        if (lseek(v->FileDesc, 0, SEEK_SET) == -1) {
-            G_warning(_("Unable to seek: %s"), strerror(errno));
+        if (lseek(v->FileDesc, 0, SEEK_SET) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
             return 0;
         }
         status = write_v5d_header(v);
-        if (lseek(v->FileDesc, 0, SEEK_END) == -1) {
-            G_warning(_("Unable to seek: %s"), strerror(errno));
+        if (lseek(v->FileDesc, 0, SEEK_END) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
             return 0;
         }
         close(v->FileDesc);

--- a/raster3d/r3.out.v5d/v5d.c
+++ b/raster3d/r3.out.v5d/v5d.c
@@ -55,7 +55,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <errno.h>
+
 #include <grass/gis.h>
+#include <grass/glocale.h>
+
 #include "binio.h"
 #include "v5d.h"
 #include "vis5d.h"
@@ -1185,7 +1189,13 @@ static int read_comp_header(int f, v5dstruct *v)
     unsigned int id;
 
     /* reset file position to start of file */
-    lseek(f, 0, SEEK_SET);
+    if (lseek(f, 0, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return 0;
+    }
 
     /* read file ID */
     read_int4(f, (int *)&id);
@@ -1286,9 +1296,9 @@ static int read_comp_header(int f, v5dstruct *v)
                 read_float4(f, &gb);
 
                 /* skip ahead by 'gridsize' bytes */
-                if (lseek(f, gridsize, SEEK_CUR) == -1) {
-                    printf("Error:  Unexpected end of file, ");
-                    printf("file may be corrupted.\n");
+                if (lseek(f, gridsize, SEEK_CUR) == (off_t)-1) {
+                    G_warning(
+                        _("Unexpected end of file, file may be corrupted."));
                     return 0;
                 }
                 min = -(125.0 + gb) / ga;
@@ -1430,7 +1440,13 @@ static int read_comp_grid(v5dstruct *v, int time, int var, float *ga, float *gb,
 
     /* move to position in file */
     pos = grid_position(v, time, var);
-    lseek(f, pos, SEEK_SET);
+    if (lseek(f, pos, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return 0;
+    }
 
     if (v->FileFormat == 0x80808083) {
         /* read McIDAS grid and file numbers */
@@ -1822,13 +1838,25 @@ static int read_v5d_header(v5dstruct *v)
         case TAG_END:
             /* end of header */
             end_of_header = 1;
-            lseek(f, length, SEEK_CUR);
+            if (lseek(f, length, SEEK_CUR) == (off_t)-1) {
+                int err = errno;
+                /* GTC seek refers to reading/writing from a different position
+                 * in a file */
+                G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+                return 0;
+            }
             break;
 
         default:
             /* unknown tag, skip to next tag */
             printf("Unknown tag: %d  length=%d\n", tag, length);
-            lseek(f, length, SEEK_CUR);
+            if (lseek(f, length, SEEK_CUR) == (off_t)-1) {
+                int err = errno;
+                /* GTC seek refers to reading/writing from a different position
+                 * in a file */
+                G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+                return 0;
+            }
             break;
         }
     }
@@ -1919,7 +1947,13 @@ int v5dReadCompressedGrid(v5dstruct *v, int time, int var, float *ga, float *gb,
 
     /* move to position in file */
     pos = grid_position(v, time, var);
-    lseek(v->FileDesc, pos, SEEK_SET);
+    if (lseek(v->FileDesc, pos, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return 0;
+    }
 
     /* read ga, gb arrays */
     read_float4_array(v->FileDesc, ga, v->Nl[var]);
@@ -2072,7 +2106,13 @@ static int write_v5d_header(v5dstruct *v)
     }
 
     /* set file pointer to start of file */
-    lseek(f, 0, SEEK_SET);
+    if (lseek(f, 0, SEEK_SET) == (off_t)-1) {
+        int err = errno;
+        /* GTC seek refers to reading/writing from a different position
+         * in a file */
+        G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+        return 0;
+    }
     v->CurPos = 0;
 
     /*
@@ -2176,7 +2216,13 @@ static int write_v5d_header(v5dstruct *v)
         /* We're writing to a brand new file.  Reserve 10000 bytes */
         /* for future header growth. */
         WRITE_TAG(v, TAG_END, 10000);
-        lseek(f, 10000, SEEK_CUR);
+        if (lseek(f, 10000, SEEK_CUR) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+            return 0;
+        }
 
         /* Let file pointer indicate where first grid is stored */
         v->FirstGridPos = ltell(f);
@@ -2289,7 +2335,7 @@ int v5dWriteCompressedGrid(const v5dstruct *v, int time, int var,
 
     /* move to position in file */
     pos = grid_position(v, time, var);
-    if (lseek(v->FileDesc, pos, SEEK_SET) < 0) {
+    if (lseek(v->FileDesc, pos, SEEK_SET) == (off_t)-1) {
         /* lseek failed, return error */
         printf("Error in v5dWrite[Compressed]Grid: seek failed, disk full?\n");
         return 0;
@@ -2407,9 +2453,21 @@ int v5dCloseFile(v5dstruct *v)
     if (v->Mode == 'w') {
         /* rewrite header because writing grids updates the minval and */
         /* maxval fields */
-        lseek(v->FileDesc, 0, SEEK_SET);
+        if (lseek(v->FileDesc, 0, SEEK_SET) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+            return 0;
+        }
         status = write_v5d_header(v);
-        lseek(v->FileDesc, 0, SEEK_END);
+        if (lseek(v->FileDesc, 0, SEEK_END) == (off_t)-1) {
+            int err = errno;
+            /* GTC seek refers to reading/writing from a different position
+             * in a file */
+            G_warning(_("Unable to seek: %d %s"), err, strerror(err));
+            return 0;
+        }
         close(v->FileDesc);
     }
     else if (v->Mode == 'r') {


### PR DESCRIPTION
An attempt to unify checks and error messages.

There are more places where `lseek` return value should be checked, but I don't have time to work on them now.