### PR TITLE
docs: Fix reStructuredText admonitions syntax (notes, warnings, error boxes)

### DIFF
--- a/gui/wxpython/nviz/wxnviz.py
+++ b/gui/wxpython/nviz/wxnviz.py
@@ -940,7 +940,7 @@ class Nviz:
     ) -> Literal[1, -1, -2]:
         """Set surface mask
 
-        ..todo::
+        .. todo::
             invert
 
         :param id: surface id

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1790,7 +1790,7 @@ class Area(Geo):
 
         int Vect_get_area_cat(const struct Map_info \*Map, int area, int field)
 
-        ..warning: Not implemented
+        .. warning:: Not implemented
         """
 
     @mapinfo_must_be_set

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -2026,7 +2026,7 @@ def legal_name(s):
 
     This is the Python implementation of :func:`G_legal_filename()` function.
 
-    ..note::
+    .. note::
 
         It is not clear when exactly use this function, but it might be
         useful anyway for checking map names and column names.

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -599,7 +599,7 @@ def append_node_pid(name):
 
     >>> append_node_pid("tmp_raster_1")
 
-    ..note::
+    .. note::
 
         Before you use this function for creating temporary files (i.e., normal
         files on disk, not maps and other mapset elements), see functions
@@ -632,7 +632,7 @@ def append_uuid(name):
 
     >>> append_uuid("tmp")
 
-    ..note::
+    .. note::
 
         See the note about creating temporary files in the
         :func:`append_node_pid()` description.
@@ -647,12 +647,12 @@ def append_random(name, suffix_length=None, total_length=None):
     >>> append_random("tmp", 8)
     >>> append_random("tmp", total_length=16)
 
-    ..note::
+    .. note::
 
         Note that this will be influenced by the random seed set for the Python
         random package.
 
-    ..note::
+    .. note::
 
         See the note about creating temporary files in the
         :func:`append_node_pid()` description.

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -544,7 +544,7 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
      - GRASS_TGIS_PROFILE (True, False, 1, 0)
      - GRASS_TGIS_RAISE_ON_ERROR (True, False, 1, 0)
 
-     ..warning::
+     .. warning::
 
          This functions must be called before any spatio-temporal processing
          can be started

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -211,7 +211,7 @@ def get_enable_mapset_check():
     database.
     Overwrite this global variable by: g.gisenv set="TGIS_DISABLE_MAPSET_CHECK=True"
 
-    ..warning::
+    .. warning::
 
         Be aware to face corrupted temporal database in case this
         global variable is set to False. This feature is highly
@@ -231,7 +231,7 @@ def get_enable_timestamp_write():
     the temporal database using the C-library timestamp interface.
     Overwrite this global variable by: g.gisenv set="TGIS_DISABLE_TIMESTAMP_WRITE=True"
 
-    ..warning::
+    .. warning::
 
         Be aware that C-libraries can not access timestamp information if
         they are not written as spatial database metadata, hence modules


### PR DESCRIPTION
I fixed all invalid admonitions (warning/notes boxes) in the docstrings. I searched for all instances where there were two dots followed by a letter, missing a space. I also found some in addons, I will report them too.

Note that it might not be enough to have all the syntax rendered correctly in the files python/grass/temporal/spatio_temporal_relationships.py (function: create_temporal_relation_sql_where_statement) and python/grass/temporal/core.py (function: init). However the rest of the changes are kinda big, as it is unindenting by one space, and other docstrings might need the same attentions. Keeping it for another time.