### PR TITLE
build: Fix %lu *printf format string to %zu for size_t

### DIFF
--- a/general/g.version/main.c
+++ b/general/g.version/main.c
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
         fprintf(stdout, "revision=%s\n", GRASS_VERSION_GIT);
         fprintf(stdout, "build_date=%d-%02d-%02d\n", YEAR, MONTH, DAY);
         fprintf(stdout, "build_platform=%s\n", ARCH);
-        fprintf(stdout, "build_off_t_size=%lu\n", sizeof(off_t));
+        fprintf(stdout, "build_off_t_size=%zu\n", sizeof(off_t));
     }
     else {
         fprintf(stdout, "GRASS %s (%s)\n", GRASS_VERSION_NUMBER,

--- a/include/grass/iostream/ami_stream.h
+++ b/include/grass/iostream/ami_stream.h
@@ -413,7 +413,7 @@ off_t AMI_STREAM<T>::stream_len(void)
     }
 
     // debug stream_len:
-    DEBUG_STREAM_LEN fprintf(stderr, "%s: length = %lld   sizeof(T)=%lud\n",
+    DEBUG_STREAM_LEN fprintf(stderr, "%s: length = %lld   sizeof(T)=%zud\n",
                              path, (long long int)statbuf.st_size, sizeof(T));
 
     return (statbuf.st_size / sizeof(T));

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -137,9 +137,9 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                 fprintf(stdout, "\nzone %d %s\n\n", z_cat,
                         Rast_get_c_cat(&z_cat, &(zone_info.cats)));
             }
-            fprintf(stdout, "total null and non-null cells: %lu\n",
+            fprintf(stdout, "total null and non-null cells: %zu\n",
                     stats[z].size);
-            fprintf(stdout, "total null cells: %lu\n\n",
+            fprintf(stdout, "total null cells: %zu\n\n",
                     stats[z].size - stats[z].n);
             fprintf(stdout, "Of the non-null cells:\n----------------------\n");
         }
@@ -167,9 +167,9 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
             }
             switch (format) {
             case PLAIN:
-                fprintf(stdout, "n=%lu\n", stats[z].n);
-                fprintf(stdout, "null_cells=%lu\n", stats[z].size - stats[z].n);
-                fprintf(stdout, "cells=%lu\n", stats[z].size);
+                fprintf(stdout, "n=%zu\n", stats[z].n);
+                fprintf(stdout, "null_cells=%zu\n", stats[z].size - stats[z].n);
+                fprintf(stdout, "cells=%zu\n", stats[z].size);
                 fprintf(stdout, "min=%.15g\n", stats[z].min);
                 fprintf(stdout, "max=%.15g\n", stats[z].max);
                 fprintf(stdout, "range=%.15g\n", stats[z].max - stats[z].min);
@@ -201,7 +201,7 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
             }
         }
         else {
-            fprintf(stdout, "n: %lu\n", stats[z].n);
+            fprintf(stdout, "n: %zu\n", stats[z].n);
             fprintf(stdout, "minimum: %g\n", stats[z].min);
             fprintf(stdout, "maximum: %g\n", stats[z].max);
             fprintf(stdout, "range: %g\n", stats[z].max - stats[z].min);
@@ -498,9 +498,9 @@ int print_stats_table(univar_stat *stats)
         }
 
         /* non-null cells cells */
-        fprintf(stdout, "%lu%s", stats[z].n, zone_info.sep);
+        fprintf(stdout, "%zu%s", stats[z].n, zone_info.sep);
         /* null cells */
-        fprintf(stdout, "%lu%s", stats[z].size - stats[z].n, zone_info.sep);
+        fprintf(stdout, "%zu%s", stats[z].size - stats[z].n, zone_info.sep);
         /* min */
         fprintf(stdout, "%.15g%s", stats[z].min, zone_info.sep);
         /* max */


### PR DESCRIPTION
This PR fixes warnings about using `%lu` instead of `%zu` for `size_t` in `*printf`.