### PR TITLE
Build: Fix warnings about control paths

### DIFF
--- a/lib/arraystats/class.c
+++ b/lib/arraystats/class.c
@@ -20,6 +20,8 @@ int AS_option_to_algorithm(const struct Option *option)
         return CLASS_DISCONT;
 
     G_fatal_error(_("Unknown algorithm '%s'"), option->answer);
+
+    return 0;
 }
 
 double AS_class_apply_algorithm(int algo, const double data[], int nrec,

--- a/lib/gis/parser_dependencies.c
+++ b/lib/gis/parser_dependencies.c
@@ -124,6 +124,8 @@ static int is_flag(const void *p)
     }
 
     G_fatal_error(_("Internal error: option or flag not found"));
+
+    return -1;
 }
 
 static int is_present(const void *p)

--- a/ps/ps.map/scale.c
+++ b/ps/ps.map/scale.c
@@ -17,9 +17,9 @@
 static double do_scale(char *);
 
 #ifdef __GNUC_MINOR__
-static int OOPS(void) __attribute__((__noreturn__));
+static void OOPS(void) __attribute__((__noreturn__));
 #else
-static int OOPS();
+static void OOPS();
 #endif
 
 double scale(char *text)
@@ -131,9 +131,10 @@ static double do_scale(char *text)
         return METERS_TO_INCHES * distance(PS.w.east, PS.w.west) * u1 / u2;
     }
     OOPS();
+    return 0;
 }
 
-static int OOPS(void)
+static void OOPS(void)
 {
     G_fatal_error(_("PSmap: do_scale(): shouldn't happen"));
 }

--- a/raster/r.li/r.li.daemon/avl.c
+++ b/raster/r.li/r.li.daemon/avl.c
@@ -208,7 +208,6 @@ static avl_node *avl_individua(const avl_tree root, const generic_cell k,
     switch (ris) {
     case GC_EQUAL: {
         return root;
-        break;
     }
     case GC_HIGHER: {
         *father = root;
@@ -227,6 +226,7 @@ static avl_node *avl_individua(const avl_tree root, const generic_cell k,
         G_fatal_error("\avl.c: avl_individua: error");
     }
     }
+    return NULL;
 }
 
 static int avl_height(const avl_tree root)


### PR DESCRIPTION
This PR fixes control path warnings by adding a return statement after fatal. For noreturn functions, use `void`. See https://gcc.gnu.org/onlinedocs/gcc-3.4.3/gcc/Function-Attributes.html.

> It does not make sense for a noreturn function to have a return type other than void.