### PR TITLE
g.mapset: Add JSON support

### DIFF
--- a/general/CMakeLists.txt
+++ b/general/CMakeLists.txt
@@ -5,7 +5,7 @@ build_program_in_subdir(g.filename DEPENDS grass_gis)
 build_program_in_subdir(g.findetc DEPENDS grass_gis)
 build_program_in_subdir(g.findfile DEPENDS grass_gis grass_manage)
 build_program_in_subdir(g.gisenv DEPENDS grass_gis)
-build_program_in_subdir(g.mapset DEPENDS grass_gis)
+build_program_in_subdir(g.mapset DEPENDS grass_gis grass_parson)
 build_program_in_subdir(g.mapsets DEPENDS grass_gis grass_parson)
 build_program_in_subdir(g.message DEPENDS grass_gis)
 build_program_in_subdir(g.mkfontcap DEPENDS grass_gis PRIMARY_DEPENDS

--- a/general/g.mapset/Makefile
+++ b/general/g.mapset/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = g.mapset
 
-LIBES = $(GISLIB)
+LIBES = $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/general/g.mapset/g.mapset.md
+++ b/general/g.mapset/g.mapset.md
@@ -27,7 +27,28 @@ To print the name of the current mapset, use the **-p** command as shown
 below:
 
 ```sh
+# In plain format:
 g.mapset -p
+
+# In JSON format:
+g.mapset -p format=json
+```
+
+To print the name of the current mapset in JSON format using python:
+
+```python
+import grass.script as gs
+
+# Run the g.mapset command with -p flag to print the current mapset using JSON
+# output format
+data = gs.parse_command(
+    "g.mapset",
+    flags="p",
+    format="json",
+)
+
+print(f"project: {data['project']}")
+print(f"mapset: {data['mapset']}")
 ```
 
 ### List available mapsets
@@ -35,11 +56,32 @@ g.mapset -p
 To list available mapsets, use the **-l** command as shown below:
 
 ```sh
+# In plain format:
 g.mapset -l
+
+# In JSON format:
+g.mapset -l format=json
 ```
 
 This should list all the mapsets, such as: "landsat new PERMANENT
 user1."
+
+To print the list of available mapsets in JSON format using python:
+
+```python
+import grass.script as gs
+
+# Run the g.mapset command with -l flag to list available mapsets using JSON
+# output format
+data = gs.parse_command(
+    "g.mapset",
+    flags="l",
+    format="json",
+)
+
+print(f"project: {data['project']}")
+print(f"mapsets: {' '.join(data['mapsets'])}")
+```
 
 ### Change the current mapset
 

--- a/general/g.mapset/main.c
+++ b/general/g.mapset/main.c
@@ -23,14 +23,31 @@
 #include <unistd.h>
 #include <grass/gis.h>
 #include <grass/glocale.h>
+#include <grass/parson.h>
 #include <grass/spawn.h>
+
+enum OutputFormat { PLAIN, JSON };
+
+// Function to serialize and print JSON value
+static void serialize_and_print_json_object(JSON_Value *root_value)
+{
+    char *serialized_string = json_serialize_to_string_pretty(root_value);
+    if (!serialized_string) {
+        json_value_free(root_value);
+        G_fatal_error(_("Failed to serialize JSON to pretty format."));
+    }
+
+    puts(serialized_string);
+    json_free_serialized_string(serialized_string);
+    json_value_free(root_value);
+}
 
 int main(int argc, char *argv[])
 {
     int ret;
     struct GModule *module;
     struct {
-        struct Option *gisdbase, *location, *mapset;
+        struct Option *gisdbase, *location, *mapset, *format;
     } opt;
     struct {
         struct Flag *add, *list, *curr;
@@ -42,6 +59,9 @@ int main(int argc, char *argv[])
     char *lock_prog;
     const char *shell;
     char path[GPATH_MAX];
+    enum OutputFormat format;
+    JSON_Object *root_object = NULL;
+    JSON_Value *root_value = NULL;
 
     G_gisinit(argv[0]);
 
@@ -64,6 +84,9 @@ int main(int argc, char *argv[])
     opt.gisdbase = G_define_standard_option(G_OPT_M_DBASE);
     opt.gisdbase->guisection = _("Mapset");
 
+    opt.format = G_define_standard_option(G_OPT_F_FORMAT);
+    opt.format->guisection = _("Print");
+
     flag.add = G_define_flag();
     flag.add->key = 'c';
     flag.add->description = _("Create mapset if it doesn't exist");
@@ -85,13 +108,37 @@ int main(int argc, char *argv[])
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
+    if (strcmp(opt.format->answer, "json") == 0) {
+        format = JSON;
+
+        root_value = json_value_init_object();
+        if (root_value == NULL) {
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        root_object = json_object(root_value);
+    }
+    else {
+        format = PLAIN;
+    }
+
     /* Store original values */
     gisdbase_old = G_getenv_nofatal("GISDBASE");
     location_old = G_getenv_nofatal("LOCATION_NAME");
     mapset_old = G_getenv_nofatal("MAPSET");
 
     if (flag.curr->answer) {
-        fprintf(stdout, "%s\n", mapset_old);
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "%s\n", mapset_old);
+            break;
+
+        case JSON:
+            json_object_set_string(root_object, "project", location_old);
+            json_object_set_string(root_object, "mapset", mapset_old);
+            serialize_and_print_json_object(root_value);
+            break;
+        }
         exit(EXIT_SUCCESS);
     }
 
@@ -112,18 +159,47 @@ int main(int argc, char *argv[])
     if (flag.list->answer) {
         char **ms;
         int nmapsets;
+        JSON_Array *mapsets_array = NULL;
+        JSON_Value *mapsets_value = NULL;
 
         G_setenv_nogisrc("LOCATION_NAME", location_new);
         G_setenv_nogisrc("GISDBASE", gisdbase_new);
 
         ms = G_get_available_mapsets();
+        if (format == JSON) {
+            mapsets_value = json_value_init_array();
+            if (mapsets_value == NULL) {
+                G_fatal_error(
+                    _("Failed to initialize JSON array. Out of memory?"));
+            }
+            mapsets_array = json_array(mapsets_value);
+
+            json_object_set_string(root_object, "project", location_new);
+        }
 
         for (nmapsets = 0; ms[nmapsets]; nmapsets++) {
             if (G_mapset_permissions(ms[nmapsets]) > 0) {
-                fprintf(stdout, "%s ", ms[nmapsets]);
+                switch (format) {
+                case PLAIN:
+                    fprintf(stdout, "%s ", ms[nmapsets]);
+                    break;
+
+                case JSON:
+                    json_array_append_string(mapsets_array, ms[nmapsets]);
+                    break;
+                }
             }
         }
-        fprintf(stdout, "\n");
+        switch (format) {
+        case PLAIN:
+            fprintf(stdout, "\n");
+            break;
+
+        case JSON:
+            json_object_set_value(root_object, "mapsets", mapsets_value);
+            serialize_and_print_json_object(root_value);
+            break;
+        }
 
         exit(EXIT_SUCCESS);
     }

--- a/general/g.mapset/tests/conftest.py
+++ b/general/g.mapset/tests/conftest.py
@@ -26,5 +26,6 @@ def simple_dataset(tmp_path_factory):
 
         yield SimpleNamespace(
             mapsets=TEST_MAPSETS,
+            project=project,
             current_mapset="test1",
         )

--- a/general/g.mapset/tests/g_mapset_test.py
+++ b/general/g.mapset/tests/g_mapset_test.py
@@ -1,10 +1,10 @@
 import grass.script as gs
 
 
-def test_list_output(simple_dataset):
-    """Test g.mapset with list flag"""
+def test_plain_list_output(simple_dataset):
+    """Test g.mapset with list flag and plain format"""
     mapsets = simple_dataset.mapsets
-    text = gs.read_command("g.mapset", flags="l")
+    text = gs.read_command("g.mapset", format="plain", flags="l")
     parsed_list = text.strip().split()
 
     assert len(parsed_list) == len(mapsets)
@@ -12,7 +12,26 @@ def test_list_output(simple_dataset):
         assert mapset in parsed_list
 
 
-def test_print_output(simple_dataset):
-    """Test g.mapset with print flag"""
-    text = gs.read_command("g.mapset", flags="p")
+def test_plain_print_output(simple_dataset):
+    """Test g.mapset with print flag and plain format"""
+    text = gs.read_command("g.mapset", format="plain", flags="p")
     assert text.strip() == simple_dataset.current_mapset
+
+
+def test_json_list_ouput(simple_dataset):
+    """Test g.mapset with list flag and JSON format"""
+    mapsets = simple_dataset.mapsets
+    data = gs.parse_command("g.mapset", format="json", flags="l")
+    assert list(data.keys()) == ["project", "mapsets"]
+    assert isinstance(data["mapsets"], list)
+    assert len(data["mapsets"]) == len(mapsets)
+    for mapset in mapsets:
+        assert mapset in data["mapsets"]
+
+
+def test_json_print_ouput(simple_dataset):
+    """Test g.mapset with print flag and JSON format"""
+    data = gs.parse_command("g.mapset", format="json", flags="p")
+    assert list(data.keys()) == ["project", "mapset"]
+    assert data["mapset"] == simple_dataset.current_mapset
+    assert data["project"] == simple_dataset.project


### PR DESCRIPTION
Fixes: #5518 
This PR adds JSON support to the `g.mapset` module. The JSON output looks like:

1. `g.mapset -p format=json`

```json
{
    "project": "nc_spm_08_grass7",
    "mapset": "user1"
}
````

2. `g.mapset -l format=json`

```json
{
    "project": "nc_spm_08_grass7",
    "mapsets": ["landsat", "new", "PERMANENT", "user1"]
}
````

This PR includes the following changes:

1. Adds JSON support to `g.mapset` by introducing the `format` option to specify either `plain` or `json` output.
2. Adds corresponding tests for the change.
3. Updates the documentation to include a JSON output example and a Python example demonstrating JSON parsing.
