### PR TITLE
docs: Fix docstring syntax for return values

### DIFF
--- a/python/grass/jupyter/utils.py
+++ b/python/grass/jupyter/utils.py
@@ -214,7 +214,7 @@ def query_raster(coord, raster_list):
     :param coord: Coordinates given as a tuple (latitude, longitude).
     :param list raster_list: List of raster names to query.
 
-    :return: str: HTML formatted string containing the results of the raster queries.
+    :return str: HTML formatted string containing the results of the raster queries.
     """
     output_list = ["""<table>"""]
 

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -118,7 +118,7 @@ def db_connection(force=False, env=None):
     >>> db_connection()
     {'group': '', 'schema': '', 'driver': 'sqlite', 'database': '$GISDBASE/$LOCATION_NAME/$MAPSET/sqlite/sqlite.db'}
 
-    :param force True to set up default DB connection if not defined
+    :param force: True to set up default DB connection if not defined
     :param env: environment
 
     :return: parsed output of db.connect

--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -301,6 +301,7 @@ class AbstractDataset(
 
     def get_relative_time_unit(self):
         """Returns the relative time unit
+
         :return: The relative time unit as string, None if not present
         """
         return self.relative_time.get_unit()

--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -233,18 +233,21 @@ class AbstractDataset(
 
     def get_id(self):
         """Return the unique identifier of the dataset
+
         :return: The id of the dataset "name(:layer)@mapset" as string
         """
         return self.base.get_id()
 
     def get_name(self):
         """Return the name
+
         :return: The name of the dataset as string
         """
         return self.base.get_name()
 
     def get_mapset(self):
         """Return the mapset
+
         :return: The mapset in which the dataset was created as string
         """
         return self.base.get_mapset()

--- a/python/grass/temporal/abstract_map_dataset.py
+++ b/python/grass/temporal/abstract_map_dataset.py
@@ -66,7 +66,7 @@ class AbstractMapDataset(AbstractDataset):
         """Return a new space time dataset instance that store maps with the
         type of this map object (raster, raster_3d or vector)
 
-        :param ident The identifier of the space time dataset
+        :param ident: The identifier of the space time dataset
         :return: The new space time dataset instance
         """
 

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -115,6 +115,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
     @abstractmethod
     def get_map_register(self):
         """Return the name of the map register table
+
         :return: The map register table name
         """
 
@@ -290,6 +291,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
 
     def get_semantic_type(self):
         """Return the semantic type of this dataset
+
         :return: The semantic type
         """
         return self.base.get_semantic_type()

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -266,12 +266,14 @@ class SQLDatabaseInterface(DictSQLSerializer):
     def get_table_name(self):
         """Return the name of the table in which the internal
         data are inserted, updated or selected
+
         :return: The name of the table
         """
         return self.table
 
     def get_delete_statement(self):
         """Return the delete string
+
         :return: The DELETE string
         """
         return (
@@ -305,6 +307,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
     def get_is_in_db_statement(self):
         """Return the selection string that checks if this object is registered in the
         temporal database
+
         :return: The SELECT string
         """
         return (
@@ -349,6 +352,7 @@ class SQLDatabaseInterface(DictSQLSerializer):
     def get_select_statement(self):
         """Return the sql statement and the argument list in
         database specific style
+
         :return: The SELECT string
         """
         return self.serialize(
@@ -778,13 +782,16 @@ class DatasetBase(SQLDatabaseInterface):
 
     def get_name(self):
         """Get the name of the dataset
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "name" in self.D:
             return self.D["name"]
         return None
 
     def get_mapset(self):
         """Get the name of mapset of this dataset
+
         :return: None if not found"""
         if "mapset" in self.D:
             return self.D["mapset"]
@@ -792,21 +799,27 @@ class DatasetBase(SQLDatabaseInterface):
 
     def get_creator(self):
         """Get the creator of the dataset
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "creator" in self.D:
             return self.D["creator"]
         return None
 
     def get_ctime(self):
         """Get the creation time of the dataset, datatype is datetime
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "creation_time" in self.D:
             return self.D["creation_time"]
         return None
 
     def get_ttype(self):
         """Get the temporal type of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "temporal_type" in self.D:
             return self.D["temporal_type"]
         return None
@@ -1014,6 +1027,7 @@ class STDSBase(DatasetBase):
 
     def get_semantic_type(self):
         """Get the semantic type of the space time dataset
+
         :return: None if not found
         """
         if "semantic_type" in self.D:

--- a/python/grass/temporal/base.py
+++ b/python/grass/temporal/base.py
@@ -420,7 +420,9 @@ class SQLDatabaseInterface(DictSQLSerializer):
     def get_insert_statement(self):
         """Return the sql statement and the argument
         list in database specific style
-        :return: The INSERT string"""
+
+        :return: The INSERT string
+        """
         return self.serialize("INSERT", self.get_table_name())
 
     def get_insert_statement_mogrified(self, dbif=None):
@@ -466,7 +468,6 @@ class SQLDatabaseInterface(DictSQLSerializer):
 
         :param ident: The identifier to be updated, useful for renaming
         :return: The UPDATE string
-
         """
         if ident:
             return self.serialize(
@@ -792,7 +793,8 @@ class DatasetBase(SQLDatabaseInterface):
     def get_mapset(self):
         """Get the name of mapset of this dataset
 
-        :return: None if not found"""
+        :return: None if not found
+        """
         if "mapset" in self.D:
             return self.D["mapset"]
         return None

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -364,6 +364,7 @@ def get_raise_on_error():
 
 def get_tgis_version():
     """Get the supported version of the temporal framework
+
     :returns: The version number of the temporal framework as integer
     """
     global tgis_version
@@ -375,6 +376,7 @@ def get_tgis_version():
 
 def get_tgis_db_version():
     """Get the supported version of the temporal database
+
     :returns: The version number of the temporal database as integer
     """
     global tgis_db_version

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -178,56 +178,72 @@ class RasterMetadataBase(SQLDatabaseInterface):
 
     def get_datatype(self):
         """Get the map type
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "datatype" in self.D:
             return self.D["datatype"]
         return None
 
     def get_cols(self):
         """Get number of cols
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "cols" in self.D:
             return self.D["cols"]
         return None
 
     def get_rows(self):
         """Get number of rows
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "rows" in self.D:
             return self.D["rows"]
         return None
 
     def get_number_of_cells(self):
         """Get number of cells
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "number_of_cells" in self.D:
             return self.D["number_of_cells"]
         return None
 
     def get_nsres(self):
         """Get the north-south resolution
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "nsres" in self.D:
             return self.D["nsres"]
         return None
 
     def get_ewres(self):
         """Get east-west resolution
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "ewres" in self.D:
             return self.D["ewres"]
         return None
 
     def get_min(self):
         """Get the minimum cell value
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "min" in self.D:
             return self.D["min"]
         return None
 
     def get_max(self):
         """Get the maximum cell value
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "max" in self.D:
             return self.D["max"]
         return None
@@ -389,7 +405,9 @@ class RasterMetadata(RasterMetadataBase):
 
     def get_semantic_label(self):
         """Get the semantic label identifier
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "semantic_label" in self.D:
             return self.D["semantic_label"]
         return None
@@ -536,14 +554,18 @@ class Raster3DMetadata(RasterMetadataBase):
 
     def get_depths(self):
         """Get number of depths
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "depths" in self.D:
             return self.D["depths"]
         return None
 
     def get_tbres(self):
         """Get top-bottom resolution
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "tbres" in self.D:
             return self.D["tbres"]
         return None
@@ -750,6 +772,7 @@ class VectorMetadata(SQLDatabaseInterface):
 
     def get_id(self):
         """Convenient method to get the unique identifier (primary key)
+
         :return: None if not found
         """
         if "id" in self.D:
@@ -765,84 +788,108 @@ class VectorMetadata(SQLDatabaseInterface):
 
     def get_number_of_points(self):
         """Get the number of points of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "points" in self.D:
             return self.D["points"]
         return None
 
     def get_number_of_lines(self):
         """Get the number of lines of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "lines" in self.D:
             return self.D["lines"]
         return None
 
     def get_number_of_boundaries(self):
         """Get the number of boundaries of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "boundaries" in self.D:
             return self.D["boundaries"]
         return None
 
     def get_number_of_centroids(self):
         """Get the number of centroids of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "centroids" in self.D:
             return self.D["centroids"]
         return None
 
     def get_number_of_faces(self):
         """Get the number of faces of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "faces" in self.D:
             return self.D["faces"]
         return None
 
     def get_number_of_kernels(self):
         """Get the number of kernels of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "kernels" in self.D:
             return self.D["kernels"]
         return None
 
     def get_number_of_primitives(self):
         """Get the number of primitives of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "primitives" in self.D:
             return self.D["primitives"]
         return None
 
     def get_number_of_nodes(self):
         """Get the number of nodes of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "nodes" in self.D:
             return self.D["nodes"]
         return None
 
     def get_number_of_areas(self):
         """Get the number of areas of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "areas" in self.D:
             return self.D["areas"]
         return None
 
     def get_number_of_islands(self):
         """Get the number of islands of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "islands" in self.D:
             return self.D["islands"]
         return None
 
     def get_number_of_holes(self):
         """Get the number of holes of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "holes" in self.D:
             return self.D["holes"]
         return None
 
     def get_number_of_volumes(self):
         """Get the number of volumes of the vector map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "volumes" in self.D:
             return self.D["volumes"]
         return None
@@ -972,6 +1019,7 @@ class STDSMetadataBase(SQLDatabaseInterface):
 
     def get_id(self):
         """Convenient method to get the unique identifier (primary key)
+
         :return: None if not found
         """
         if "id" in self.D:
@@ -980,21 +1028,27 @@ class STDSMetadataBase(SQLDatabaseInterface):
 
     def get_title(self):
         """Get the title
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "title" in self.D:
             return self.D["title"]
         return None
 
     def get_description(self):
         """Get description
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "description" in self.D:
             return self.D["description"]
         return None
 
     def get_command(self):
         """Get command
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "command" in self.D:
             return self.D["command"]
         return None
@@ -1003,7 +1057,9 @@ class STDSMetadataBase(SQLDatabaseInterface):
         """Get the number of registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "number_of_maps" in self.D:
             return self.D["number_of_maps"]
         return None
@@ -1185,6 +1241,7 @@ class STDSRasterMetadataBase(STDSMetadataBase):
 
     def get_aggregation_type(self):
         """Get the aggregation type of the dataset (mean, min, max, ...)
+
         :return: None if not found
         """
         if "aggregation_type" in self.D:
@@ -1195,7 +1252,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the minimal maximum of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "max_min" in self.D:
             return self.D["max_min"]
         return None
@@ -1204,7 +1263,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the minimal minimum of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "min_min" in self.D:
             return self.D["min_min"]
         return None
@@ -1213,7 +1274,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the maximal maximum of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "max_max" in self.D:
             return self.D["max_max"]
         return None
@@ -1222,7 +1285,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the maximal minimum of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "min_max" in self.D:
             return self.D["min_max"]
         return None
@@ -1231,7 +1296,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the minimal north-south resolution of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "nsres_min" in self.D:
             return self.D["nsres_min"]
         return None
@@ -1240,7 +1307,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the maximal north-south resolution of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "nsres_max" in self.D:
             return self.D["nsres_max"]
         return None
@@ -1249,7 +1318,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the minimal east-west resolution of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "ewres_min" in self.D:
             return self.D["ewres_min"]
         return None
@@ -1258,7 +1329,9 @@ class STDSRasterMetadataBase(STDSMetadataBase):
         """Get the maximal east-west resolution of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "ewres_max" in self.D:
             return self.D["ewres_max"]
         return None
@@ -1582,7 +1655,9 @@ class STR3DSMetadata(STDSRasterMetadataBase):
 
     def get_raster3d_register(self):
         """Get the raster3d map register table name
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "raster3d_register" in self.D:
             return self.D["raster3d_register"]
         return None
@@ -1591,7 +1666,9 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         """Get the minimal top-bottom resolution of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "tbres_min" in self.D:
             return self.D["tbres_min"]
         return None
@@ -1600,7 +1677,9 @@ class STR3DSMetadata(STDSRasterMetadataBase):
         """Get the maximal top-bottom resolution of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "tbres_max" in self.D:
             return self.D["tbres_max"]
         return None
@@ -1745,7 +1824,9 @@ class STVDSMetadata(STDSMetadataBase):
 
     def get_vector_register(self):
         """Get the vector map register table name
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "vector_register" in self.D:
             return self.D["vector_register"]
         return None
@@ -1754,7 +1835,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of points of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "points" in self.D:
             return self.D["points"]
         return None
@@ -1763,7 +1846,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of lines of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "lines" in self.D:
             return self.D["lines"]
         return None
@@ -1772,7 +1857,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of boundaries of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "boundaries" in self.D:
             return self.D["boundaries"]
         return None
@@ -1781,7 +1868,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of centroids of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "centroids" in self.D:
             return self.D["centroids"]
         return None
@@ -1790,7 +1879,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of faces of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "faces" in self.D:
             return self.D["faces"]
         return None
@@ -1799,7 +1890,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of kernels of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "kernels" in self.D:
             return self.D["kernels"]
         return None
@@ -1808,7 +1901,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of primitives of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "primitives" in self.D:
             return self.D["primitives"]
         return None
@@ -1817,7 +1912,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of nodes of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "nodes" in self.D:
             return self.D["nodes"]
         return None
@@ -1826,7 +1923,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of areas of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "areas" in self.D:
             return self.D["areas"]
         return None
@@ -1835,7 +1934,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of islands of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "islands" in self.D:
             return self.D["islands"]
         return None
@@ -1844,7 +1945,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of holes of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "holes" in self.D:
             return self.D["holes"]
         return None
@@ -1853,7 +1956,9 @@ class STVDSMetadata(STDSMetadataBase):
         """Get the number of volumes of all registered maps,
         this value is set in the database
         automatically via SQL, so no setter exists
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "volumes" in self.D:
             return self.D["volumes"]
         return None

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -170,6 +170,7 @@ class RasterMetadataBase(SQLDatabaseInterface):
 
     def get_id(self):
         """Convenient method to get the unique identifier (primary key)
+
         :return: None if not found
         """
         if "id" in self.D:

--- a/python/grass/temporal/metadata.py
+++ b/python/grass/temporal/metadata.py
@@ -1394,13 +1394,16 @@ class STRDSMetadata(STDSRasterMetadataBase):
 
     def get_raster_register(self):
         """Get the raster map register table name
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "raster_register" in self.D:
             return self.D["raster_register"]
         return None
 
     def get_number_of_semantic_labels(self):
         """Get the number of registered semantic labels
+
         :return: None if not found
         """
         if "number_of_semantic_labels" in self.D:
@@ -1411,6 +1414,7 @@ class STRDSMetadata(STDSRasterMetadataBase):
         """Get the distinct semantic labels of registered maps
            The distinct semantic labels are not stored in the metadata table
            and fetched on-the-fly
+
         :return: None if not found
         """
         if get_tgis_db_version_from_metadata() <= 2:

--- a/python/grass/temporal/space_time_datasets.py
+++ b/python/grass/temporal/space_time_datasets.py
@@ -224,7 +224,7 @@ class RasterDataset(AbstractMapDataset):
         """Return the two dimensional union as spatial_extent
         object or None in case the extents does not overlap or meet.
 
-        :param dataset :The abstract dataset to create a union with
+        :param dataset: The abstract dataset to create a union with
         :return: The union spatial extent or None
         """
         return self.spatial_extent.union_2d(dataset.spatial_extent)

--- a/python/grass/temporal/spatial_extent.py
+++ b/python/grass/temporal/spatial_extent.py
@@ -366,8 +366,8 @@ class SpatialExtent(SQLDatabaseInterface):
              | Bottom:..................... -30.0
 
 
-         :param extent: The spatial extent to intersect with
-         :return: The intersection spatial extent
+        :param extent: The spatial extent to intersect with
+        :return: The intersection spatial extent
         """  # noqa: E501
 
         if not self.overlapping(extent):
@@ -556,8 +556,8 @@ class SpatialExtent(SQLDatabaseInterface):
              | Bottom:..................... -50.0
 
 
-         :param extent: The spatial extent to create a disjoint union with
-         :return: The union spatial extent
+        :param extent: The spatial extent to create a disjoint union with
+        :return: The union spatial extent
         """  # noqa: E501
 
         new = self.disjoint_union_2d(extent)
@@ -1809,6 +1809,7 @@ class SpatialExtent(SQLDatabaseInterface):
 
     def get_id(self):
         """Convenient method to get the unique identifier (primary key)
+
         :return: None if not found
         """
         if "id" in self.D:
@@ -1862,42 +1863,54 @@ class SpatialExtent(SQLDatabaseInterface):
 
     def get_north(self):
         """Get the northern edge of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "north" in self.D:
             return self.D["north"]
         return None
 
     def get_south(self):
         """Get the southern edge of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "south" in self.D:
             return self.D["south"]
         return None
 
     def get_east(self):
         """Get the eastern edge of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "east" in self.D:
             return self.D["east"]
         return None
 
     def get_west(self):
         """Get the western edge of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "west" in self.D:
             return self.D["west"]
         return None
 
     def get_top(self):
         """Get the top edge of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "top" in self.D:
             return self.D["top"]
         return None
 
     def get_bottom(self):
         """Get the bottom edge of the map
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "bottom" in self.D:
             return self.D["bottom"]
         return None

--- a/python/grass/temporal/temporal_algebra.py
+++ b/python/grass/temporal/temporal_algebra.py
@@ -1749,11 +1749,10 @@ class TemporalAlgebraParser:
     def eval_toperator(self, operator, optype="relation"):
         """This function evaluates a string containing temporal operations.
 
-         :param operator: String of temporal operations, e.g. {!=,equal|during,l}.
-         :param optype: String to define operator type.
-
-         :return :List of temporal relations (equal, during), the given function
-          (!:) and the interval/instances (l).
+        :param operator: String of temporal operations, e.g. {!=,equal|during,l}.
+        :param optype: String to define operator type.
+        :return: List of temporal relations (equal, during), the given function
+            (!:) and the interval/instances (l).
 
         .. code-block:: python
 

--- a/python/grass/temporal/temporal_extent.py
+++ b/python/grass/temporal/temporal_extent.py
@@ -982,6 +982,7 @@ class TemporalExtent(SQLDatabaseInterface):
 
     def get_id(self):
         """Convenient method to get the unique identifier (primary key)
+
         :return: None if not found
         """
         if "id" in self.D:
@@ -990,14 +991,18 @@ class TemporalExtent(SQLDatabaseInterface):
 
     def get_start_time(self):
         """Get the valid start time of the extent
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "start_time" in self.D:
             return self.D["start_time"]
         return None
 
     def get_end_time(self):
         """Get the valid end time of the extent
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "end_time" in self.D:
             return self.D["end_time"]
         return None
@@ -1147,7 +1152,9 @@ class STDSAbsoluteTime(AbsoluteTemporalExtent):
 
     def get_granularity(self):
         """Get the granularity of the space time dataset
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "granularity" in self.D:
             return self.D["granularity"]
         return None
@@ -1275,7 +1282,9 @@ class RelativeTemporalExtent(TemporalExtent):
 
     def get_unit(self):
         """Get the unit of the relative time
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "unit" in self.D:
             return self.D["unit"]
         return None
@@ -1424,7 +1433,9 @@ class STDSRelativeTime(RelativeTemporalExtent):
 
     def get_granularity(self):
         """Get the granularity of the space time dataset
-        :return: None if not found"""
+
+        :return: None if not found
+        """
         if "granularity" in self.D:
             return self.D["granularity"]
         return None


### PR DESCRIPTION
With only this, the number of warnings down to 407 warnings (from 415).
The number of actual issues fixed is way more.

Before:
![image](https://github.com/user-attachments/assets/0853cdd9-d723-40a5-bb62-f0355a72f4e3)

After:
![image](https://github.com/user-attachments/assets/19b19213-178f-4fe6-b48d-30a9e0badbae)


I have lots and lots more to file later, my combined branch has 47 commits for now: https://github.com/echoix/grass/tree/docstrings-fix-syntax-1