### PR TITLE
doc: be more explicit about 2D vs 3D region resolution

### DIFF
--- a/general/g.region/g.region.md
+++ b/general/g.region/g.region.md
@@ -20,10 +20,16 @@ projection. Each region also has associated with it the specific
 east-west and north-south resolutions of its smallest units (rectangular
 units called "cells").
 
+The region extent is common between 2D and 3D maps.
+However, the 2D resolution, used for 2D raster maps, is set separately
+from the 3D resolution, used for 3D raster maps.
+Updating the 2D resolution of the region will not affect its 3D resolution,
+and vice versa.
+
 The region's boundaries are given as the northernmost, southernmost,
-easternmost, and westernmost points that define its extent (cell edges).
-The north and south boundaries are commonly called *northings*, while
-the east and west boundaries are called *eastings*.
+easternmost, westernmost, bottommost, and topmost points that define
+its extent (cell edges). The north and south boundaries are commonly
+called *northings*, while the east and west boundaries are called *eastings*.
 
 The region's cell resolution defines the size of the smallest piece of
 data recognized (imported, analyzed, displayed, stored, etc.) by GRASS

--- a/general/g.region/g.region.md
+++ b/general/g.region/g.region.md
@@ -99,7 +99,7 @@ options for changing region is used (**res=**, **raster=**, etc). This
 can be used for example to print modified region values for further use
 without actually modifying the current region. Similarly, **-o** flag
 forces to update current region file even when e.g., only printing was
-specified. Flag **-o** was added in GRASS GIS version 8 to simulate
+specified. Flag **-o** was added in GRASS version 8 to simulate
 *g.region* behavior in prior versions when current region file was
 always updated unless **-u** was specified.
 

--- a/general/g.region/g.region.md
+++ b/general/g.region/g.region.md
@@ -20,12 +20,6 @@ projection. Each region also has associated with it the specific
 east-west and north-south resolutions of its smallest units (rectangular
 units called "cells").
 
-The region extent is common between 2D and 3D maps.
-However, the 2D resolution, used for 2D raster maps, is set separately
-from the 3D resolution, used for 3D raster maps.
-Updating the 2D resolution of the region will not affect its 3D resolution,
-and vice versa.
-
 The region's boundaries are given as the northernmost, southernmost,
 easternmost, westernmost, bottommost, and topmost points that define
 its extent (cell edges). The north and south boundaries are commonly
@@ -71,6 +65,17 @@ geographic region. Users may also access saved region definitions stored
 under other mapsets in the current project, if these mapsets are
 included in the user's mapset search path or the '@' operator is used
 (`region_name@mapset`).
+
+### 3D region
+
+The region extent is common between 2D and 3D maps.
+However, the 3D resolution, used for 3D raster maps, is set separately
+from the 2D resolution that is used for 2D raster maps.
+Updating the 2D resolution of the region will not affect its 3D resolution,
+and vice versa.
+
+Therefore, people working with 3D raster maps should take care to adjust the
+3D resolution of the region using the **res3** and **tbres** parameters.
 
 ## NOTES
 

--- a/raster3d/raster3dintro.md
+++ b/raster3d/raster3dintro.md
@@ -115,6 +115,10 @@ this is not desired, the input map(s) has/have to be reinterpolated
 beforehand with one of the dedicated modules. Masks can be set
 ([r3.mask](r3.mask.md)).
 
+The 3D resolution of the computational region is distinct from its
+2D resolution. Setting one does not affect the other.
+They both share the same extent, however.
+
 ## 3D raster analyses and operations
 
 Powerful 3D raster map algebra is implemented in

--- a/raster3d/raster3dintro.md
+++ b/raster3d/raster3dintro.md
@@ -1,20 +1,20 @@
 ---
-description: 3D raster data in GRASS GIS
+description: 3D raster data in GRASS
 index: raster3d
 ---
 
-# 3D raster data in GRASS GIS
+# 3D raster data in GRASS
 
 ## 3D raster maps in general
 
-GRASS GIS is one of the few GIS software packages with 3D raster data
+GRASS is one of the few GIS software packages with 3D raster data
 support. Data are stored as a 3D raster with 3D cells of a given volume.
 3D rasters are designed to support representations of trivariate
 continuous fields. The vertical dimension supports spatial and temporal
 units. Hence space time 3D raster with different temporal resolutions
 can be created and processed.
 
-GRASS GIS 3D raster maps use the same coordinate system as 2D raster
+GRASS 3D raster maps use the same coordinate system as 2D raster
 maps (row count from north to south) with an additional z dimension
 (depth) counting from bottom to top. The upper left corner (NW) is the
 origin. 3D rasters are stored using a tile cache based approach. This
@@ -29,7 +29,7 @@ RASTER3D library*
 
 ## Terminology and naming
 
-In GRASS GIS terminology, continuous 3D data represented by regular grid
+In GRASS terminology, continuous 3D data represented by regular grid
 or lattice is called *3D raster map*. 3D raster map works in 3D in the
 same was as (2D) raster map in 2D, so it is called the same except for
 the additional 3D. Some literature or other software may use terms such
@@ -38,7 +38,7 @@ or voxel cube. Note that terms volume and volumetric often refer to
 measuring volume (amount) of some substance which may or may not be
 related to 3D rasters.
 
-Note that GRASS GIS uses the term 3D raster map or just 3D raster for
+Note that GRASS uses the term 3D raster map or just 3D raster for
 short, rather than 3D raster layer because term map emphasizes the
 mapping of positions to values which is the purpose of 3D raster map (in
 mathematics, map or mapping is close to a term function) On the other
@@ -54,13 +54,13 @@ volumetric pixel, volume pixel, or voxel. Note that voxel can be
 sometimes used to refer to a whole 3D raster and that for example in 3D
 computer graphics, voxel can denote object with some complicated shape.
 
-Type of map and element name in GRASS GIS is called `raster_3d`. The
+Type of map and element name in GRASS is called `raster_3d`. The
 module family prefix is `r3`. Occasionally, 3D raster related things can
 be referred differently, for example according to a programming language
 standards. This might be the case of some functions or classes in
 Python.
 
-In GRASS GIS 3D rasters as stored in tiles which are hidden from user
+In GRASS, 3D rasters are stored in tiles which are hidden from user
 most of the time. When analyzing or visualizing 3D rasters user can
 create slices or cross sections. Slices can be horizontal, vertical, or
 general plains going through a 3D raster. Slices, especially the
@@ -106,7 +106,7 @@ raster map ([r.to.rast3](r.to.rast3.md)).
 
 ## 3D region settings and 3D mask
 
-GRASS GIS 3D raster map processing is always performed in the current 3D
+GRASS 3D raster map processing is always performed in the current 3D
 region settings (see [g.region](g.region.md), *-p3* flags), i.e. the
 current region extent, vertical extent and current 3D resolution are
 used. If the 3D resolution differs from that of the input raster map(s),
@@ -152,15 +152,15 @@ spatial dimensions and temporal (vertical) dimension.
 
 ## Working with 3D visualization software
 
-GRASS GIS can be used for visualization of 3D rasters, however it has
+GRASS can be used for visualization of 3D rasters, however it has
 also tools to easily export the data into other visualization packages.
 
-GRASS GIS 3D raster maps can be exported to VTK using
+GRASS 3D raster maps can be exported to VTK using
 [r3.out.vtk](r3.out.vtk.md). VTK files can be visualized with the *[VTK
 Toolkit](https://vtk.org)*, *[Paraview](https://www.paraview.org)* and
-*[MayaVi](https://github.com/enthought/mayavi)*. Moreover, GRASS GIS 2D
+*[MayaVi](https://github.com/enthought/mayavi)*. Moreover, GRASS 2D
 raster maps can be exported to VTK with [r.out.vtk](r.out.vtk.md) and
-GRASS GIS vector maps can be exported to VTK with
+GRASS vector maps can be exported to VTK with
 [v.out.vtk](v.out.vtk.md).
 
 Alternatively, GRASS 3D raster maps can be imported and exported from/to


### PR DESCRIPTION
Add information in the docs about the differences between the 2D and 3D resolution.
See issue #5801.
I also took the opportunity to rename GRASS GIS to GRASS.