### PR TITLE
docs: Fixes issues in docstrings related to parameter list rendering

### DIFF
--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -338,7 +338,7 @@ class InteractiveMap:
         :param str name: name of vector to be added to map;
                          positional-only parameter
         :param str title: vector name for layer control
-        :**kwargs: keyword arguments passed to GeoJSON overlay
+        :param kwargs: keyword arguments passed to GeoJSON overlay
         """
         self.vector_name.append(name)
         Vector(name, title=title, renderer=self._renderer, **kwargs).add_to(self.map)
@@ -357,7 +357,7 @@ class InteractiveMap:
 
         :param str name: name of raster to add to display; positional-only parameter
         :param str title: raster name for layer control
-        :**kwargs: keyword arguments passed to image overlay
+        :param kwargs: keyword arguments passed to image overlay
         """
         self.raster_name.append(name)
         Raster(name, title=title, renderer=self._renderer, **kwargs).add_to(self.map)

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -445,21 +445,21 @@ def create_test_vector_map(map_name="test_vector"):
     11 boundaries and 4 centroids. The attribute table contains cat, name
     and value columns.
 
-     param map_name: The vector map name that should be used
+    :param map_name: The vector map name that should be used
 
+    .. code-block:: none
 
-
-                               P1 P2 P3
-        6                       *  *  *
-        5
-        4    _______ ___ ___   L1 L2 L3
-     Y  3   |A1___ *|  *|  *|   |  |  |
-        2   | |A2*| |   |   |   |  |  |
-        1   | |___| |A3 |A4 |   |  |  |
-        0   |_______|___|___|   |  |  |
-       -1
-         -1 0 1 2 3 4 5 6 7 8 9 10 12 14
-                        X
+                                   P1 P2 P3
+            6                       *  *  *
+            5
+            4    _______ ___ ___   L1 L2 L3
+         Y  3   |A1___ *|  *|  *|   |  |  |
+            2   | |A2*| |   |   |   |  |  |
+            1   | |___| |A3 |A4 |   |  |  |
+            0   |_______|___|___|   |  |  |
+           -1
+             -1 0 1 2 3 4 5 6 7 8 9 10 12 14
+                            X
     """
 
     from grass.pygrass.vector import VectorTopo

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -517,14 +517,16 @@ def create_test_vector_map(map_name="test_vector"):
 def create_test_stream_network_map(map_name="streams"):
     R"""Create test data
 
-       This functions creates a vector map layer with lines that represent
-       a stream network with two different graphs. The first graph
-       contains a loop, the second can be used as directed graph.
+    This functions creates a vector map layer with lines that represent
+    a stream network with two different graphs. The first graph
+    contains a loop, the second can be used as directed graph.
 
-       This should be used in doc and unit tests to create location/mapset
-       independent vector map layer.
+    This should be used in doc and unit tests to create location/mapset
+    independent vector map layer.
 
-        param map_name: The vector map name that should be used
+    :param map_name: The vector map name that should be used
+
+    .. code-block:: output
 
        1(0,2)  3(2,2)
         \     /

--- a/python/grass/pygrass/utils.py
+++ b/python/grass/pygrass/utils.py
@@ -526,30 +526,30 @@ def create_test_stream_network_map(map_name="streams"):
 
     :param map_name: The vector map name that should be used
 
-    .. code-block:: output
+    .. code-block:: none
 
-       1(0,2)  3(2,2)
-        \     /
-       1 \   / 2
-          \ /
-           2(1,1)
-    6(0,1) ||  5(2,1)
-       5 \ || / 4
-          \||/
-           4(1,0)
-           |
-           | 6
-           |7(1,-1)
+           1(0,2)  3(2,2)
+            \     /
+           1 \   / 2
+              \ /
+               2(1,1)
+        6(0,1) ||  5(2,1)
+           5 \ || / 4
+              \||/
+               4(1,0)
+               |
+               | 6
+               |7(1,-1)
 
-       7(0,-1) 8(2,-1)
-        \     /
-       8 \   / 9
-          \ /
-           9(1, -2)
-           |
-           | 10
-           |
-          10(1,-3)
+           7(0,-1) 8(2,-1)
+            \     /
+           8 \   / 9
+              \ /
+               9(1, -2)
+               |
+               | 10
+               |
+              10(1,-3)
     """
 
     from grass.pygrass.vector import VectorTopo

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1286,11 +1286,11 @@ class Node:
         return (x.value, y.value) if self.is2D else (x.value, y.value, z.value)
 
     def to_wkt(self):
-        """Return a "well know text" (WKT) geometry string. ::"""
+        """Return a "well know text" (WKT) geometry string."""
         return "POINT(%s)" % " ".join(["%f" % coord for coord in self.coords()])
 
     def to_wkb(self):
-        """Return a "well know binary" (WKB) geometry array. ::
+        """Return a "well know binary" (WKB) geometry array.
 
         TODO: Must be implemented
         """
@@ -1504,7 +1504,7 @@ class Isle(Geo):
         )
 
     def to_wkb(self):
-        """Return a "well know text" (WKB) geometry array. ::"""
+        """Return a "well know text" (WKB) geometry array"""
         msg = "Not implemented"
         raise Exception(msg)
 
@@ -1760,13 +1760,13 @@ class Area(Geo):
 
     def to_wkt(self):
         """Return a "well know text" (WKT) area string, this method uses
-        the GEOS implementation in the vector library. ::
+        the GEOS implementation in the vector library.
         """
         return decode(libvect.Vect_read_area_to_wkt(self.c_mapinfo, self.id))
 
     def to_wkb(self):
         """Return a "well know binary" (WKB) area byte array, this method uses
-        the GEOS implementation in the vector library. ::
+        the GEOS implementation in the vector library.
         """
         size = ctypes.c_size_t()
         barray = libvect.Vect_read_area_to_wkb(

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -679,6 +679,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  located in the selection granule:
 
                  .. code-block:: output
+
                      map    :        s
                      granule:  s-----------------e
 
@@ -692,6 +693,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  during the selection granule:
 
                  .. code-block:: output
+
                      map    :     s-----------e
                      granule:  s-----------------e
 
@@ -700,6 +702,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  overlapped:
 
                  .. code-block:: output
+
                      map    :     s-----------e
                      granule:        s-----------------e
 
@@ -710,6 +713,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  the selection granule:
 
                  .. code-block:: output
+
                      map    :  s-----------------e
                      granule:     s-----------e
 
@@ -717,6 +721,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  to the selection granule:
 
                  .. code-block:: output
+
                      map    :  s-----------e
                      granule:  s-----------e
 
@@ -724,6 +729,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  the selection granule:
 
                  .. code-block:: output
+
                      map    :              s-----------e
                      granule:  s-----------e
 
@@ -731,6 +737,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  the selection granule:
 
                  .. code-block:: output
+
                      map    :  s-----------e
                      granule:              s-----------e
 
@@ -901,6 +908,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  located in the selection granule:
 
                  .. code-block:: output
+
                      map    :        s
                      granule:  s-----------------e
 
@@ -914,6 +922,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  during the selection granule:
 
                  .. code-block:: output
+
                      map    :     s-----------e
                      granule:  s-----------------e
 
@@ -922,6 +931,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  overlapped:
 
                  .. code-block:: output
+
                      map    :     s-----------e
                      granule:        s-----------------e
 
@@ -932,6 +942,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  the selection granule:
 
                  .. code-block:: output
+
                      map    :  s-----------------e
                      granule:     s-----------e
 
@@ -939,6 +950,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  to the selection granule:
 
                  .. code-block:: output
+
                      map    :  s-----------e
                      granule:  s-----------e
 
@@ -946,6 +958,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  the selection granule:
 
                  .. code-block:: output
+
                      map    :              s-----------e
                      granule:  s-----------e
 
@@ -953,6 +966,7 @@ class AbstractSpaceTimeDataset(AbstractDataset):
                  the selection granule:
 
                  .. code-block:: output
+
                      map    :  s-----------e
                      granule:              s-----------e
 

--- a/python/grass/temporal/abstract_space_time_dataset.py
+++ b/python/grass/temporal/abstract_space_time_dataset.py
@@ -1427,10 +1427,11 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             "n", "s", "e", "w", "b", "t", and  "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
-            "overlaps": maps that spatially overlap ("intersect")
-                        within the provided spatial extent
-            "is_contained": maps that are fully within the provided spatial extent
-            "contains": maps that contain (fully cover) the provided spatial extent
+
+            - "overlaps": maps that spatially overlap ("intersect")
+              within the provided spatial extent
+            - "is_contained": maps that are fully within the provided spatial extent
+            - "contains": maps that contain (fully cover) the provided spatial extent
 
         :return: ordered object list, in case nothing found None is returned
         """
@@ -1502,10 +1503,11 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             "n", "s", "e", "w", "b", "t", and  "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
-            "overlaps": maps that spatially overlap ("intersect")
-                        within the provided spatial extent
-            "is_contained": maps that are fully within the provided spatial extent
-            "contains": maps that contain (fully cover) the provided spatial extent
+
+            - "overlaps": maps that spatially overlap ("intersect")
+              within the provided spatial extent
+            - "is_contained": maps that are fully within the provided spatial extent
+            - "contains": maps that contain (fully cover) the provided spatial extent
 
         :return: The ordered map object list,
                 In case nothing found None is returned
@@ -1556,10 +1558,11 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             "n", "s", "e", "w", "b", "t", and  "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
-            "overlaps": maps that spatially overlap ("intersect")
-                        within the provided spatial extent
-            "is_contained": maps that are fully within the provided spatial extent
-            "contains": maps that contain (fully cover) the provided spatial extent
+
+            - "overlaps": maps that spatially overlap ("intersect")
+              within the provided spatial extent
+            - "is_contained": maps that are fully within the provided spatial extent
+            - "contains": maps that contain (fully cover) the provided spatial extent
 
         :return: The ordered map object list,
                 In case nothing is found, an empty list is returned
@@ -1717,10 +1720,11 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             e.g. from g.region -ug3
         :param str spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
-            "overlaps": maps that spatially overlap ("intersect")
-                        within the provided spatial extent
-            "is_contained": maps that are fully within the provided spatial extent
-            "contains": maps that contain (fully cover) the provided spatial extent
+
+            - "overlaps": maps that spatially overlap ("intersect")
+              within the provided spatial extent
+            - "is_contained": maps that are fully within the provided spatial extent
+            - "contains": maps that contain (fully cover) the provided spatial extent
 
         :return: updated SQL WHERE statement
 
@@ -1840,10 +1844,11 @@ class AbstractSpaceTimeDataset(AbstractDataset):
             "n", "s", "e", "w", "b", "t", and  "projection".
         :param spatial_relation: Spatial relation to the provided
             spatial extent as a string with one of the following values:
-            "overlaps": maps that spatially overlap ("intersect")
-                        within the provided spatial extent
-            "is_contained": maps that are fully within the provided spatial extent
-            "contains": maps that contain (fully cover) the provided spatial extent
+
+            - "overlaps": maps that spatially overlap ("intersect")
+              within the provided spatial extent
+            - "is_contained": maps that are fully within the provided spatial extent
+            - "contains": maps that contain (fully cover) the provided spatial extent
         :param dbif: The database interface to be used
 
         :return: SQL rows of all registered maps grouped by the columns given in

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -543,22 +543,22 @@ def init(raise_fatal_error: bool = False, skip_db_version_check: bool = False):
 
     The following environmental variables are checked:
 
-     - GRASS_TGIS_PROFILE (True, False, 1, 0)
-     - GRASS_TGIS_RAISE_ON_ERROR (True, False, 1, 0)
+    - GRASS_TGIS_PROFILE (True, False, 1, 0)
+    - GRASS_TGIS_RAISE_ON_ERROR (True, False, 1, 0)
 
-     .. warning::
+    .. warning::
 
-         This functions must be called before any spatio-temporal processing
-         can be started
+        This functions must be called before any spatio-temporal processing
+        can be started
 
-     :param raise_fatal_error: Set this True to assure that the init()
+    :param raise_fatal_error: Set this True to assure that the init()
                                function does not kill a persistent process
                                like the GUI. If set True a
                                grass.pygrass.messages.FatalError
                                exception will be raised in case a fatal
                                error occurs in the init process, otherwise
                                sys.exit(1) will be called.
-     :param skip_db_version_check: Set this True to skip mismatch temporal
+    :param skip_db_version_check: Set this True to skip mismatch temporal
                                    database version check.
                                    Recommended to be used only for
                                    upgrade_temporal_database().

--- a/python/grass/temporal/core.py
+++ b/python/grass/temporal/core.py
@@ -1229,15 +1229,15 @@ class DBConnection:
 
     The following DBMS are supported:
 
-      - sqlite via the sqlite3 standard library
-      - postgresql via psycopg2
+    - sqlite via the sqlite3 standard library
+    - postgresql via psycopg2
     """
 
     def __init__(self, backend=None, dbstring: str | None = None) -> None:
         """Constructor of a database connection
 
-        param backend:The database backend sqlite or pg
-        param dbstring: The database connection string
+        :param backend: The database backend sqlite or pg
+        :param dbstring: The database connection string
         """
         self.connected = False
         if backend is None:

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -796,13 +796,12 @@ def count_temporal_topology_relationships(maps1, maps2=None, dbif=None):
     """Count the temporal relations of a single list of maps or between two
     lists of maps
 
-
-     :param maps1: A list of abstract_dataset
-                   objects with initiated temporal extent
-     :param maps2: A list of abstract_dataset
-                   objects with initiated temporal extent
-     :param dbif: The database interface to be used
-     :return: A dictionary with counted temporal relationships
+    :param maps1: A list of abstract_dataset
+                objects with initiated temporal extent
+    :param maps2: A list of abstract_dataset
+                objects with initiated temporal extent
+    :param dbif: The database interface to be used
+    :return: A dictionary with counted temporal relationships
     """
 
     tb = SpatioTemporalTopologyBuilder()

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -842,153 +842,158 @@ def create_temporal_relation_sql_where_statement(
     """Create a SQL WHERE statement for temporal relation selection of maps in
     space time datasets
 
-     :param start: The start time
-     :param end: The end time
-     :param use_start: Select maps of which the start time is located in
-                       the selection granule:
+    :param start: The start time
+    :param end: The end time
+    :param use_start: Select maps of which the start time is located in
+                        the selection granule:
 
-                       .. code-block:: output
-                           map    :        s
-                           granule:  s-----------------e
+                        .. code-block:: output
 
-                           map    :        s--------------------e
-                           granule:  s-----------------e
+                            map    :        s
+                            granule:  s-----------------e
 
-                           map    :        s--------e
-                           granule:  s-----------------e
-     :param use_during: Select maps which are temporal during the selection
+                            map    :        s--------------------e
+                            granule:  s-----------------e
+
+                            map    :        s--------e
+                            granule:  s-----------------e
+    :param use_during: Select maps which are temporal during the selection
                         granule:
 
                         .. code-block:: output
+
                             map    :     s-----------e
                             granule:  s-----------------e
-     :param use_overlap: Select maps which temporal overlap the selection
-                         granule:
+    :param use_overlap: Select maps which temporal overlap the selection
+                        granule:
 
-                         .. code-block:: output
-                             map    :     s-----------e
-                             granule:        s-----------------e
+                        .. code-block:: output
 
-                             map    :     s-----------e
-                             granule:  s----------e
-     :param use_contain: Select maps which temporally contain the selection
-                         granule:
+                            map    :     s-----------e
+                            granule:        s-----------------e
 
-                         .. code-block:: output
-                             map    :  s-----------------e
-                             granule:     s-----------e
-     :param use_equal: Select maps which temporally equal to the selection
-                       granule:
+                            map    :     s-----------e
+                            granule:  s----------e
+    :param use_contain: Select maps which temporally contain the selection
+                        granule:
 
-                       .. code-block:: output
-                           map    :  s-----------e
-                           granule:  s-----------e
-     :param use_follows: Select maps which temporally follow the selection
-                         granule:
+                        .. code-block:: output
 
-                         .. code-block:: output
-                             map    :              s-----------e
-                             granule:  s-----------e
-     :param use_precedes: Select maps which temporally precedes the
-                          selection granule:
+                            map    :  s-----------------e
+                            granule:     s-----------e
+    :param use_equal: Select maps which temporally equal to the selection
+                        granule:
 
-                          .. code-block:: output
-                              map    :  s-----------e
-                              granule:              s-----------e
+                        .. code-block:: output
 
-     Usage:
+                            map    :  s-----------e
+                            granule:  s-----------e
+    :param use_follows: Select maps which temporally follow the selection
+                        granule:
 
-     .. code-block:: python
+                        .. code-block:: output
 
-         >>> # Relative time
-         >>> start = 1
-         >>> end = 2
-         >>> create_temporal_relation_sql_where_statement(start, end, use_start=False)
-         >>> create_temporal_relation_sql_where_statement(start, end)
-         '((start_time >= 1 and start_time < 2) )'
-         >>> create_temporal_relation_sql_where_statement(start, end, use_start=True)
-         '((start_time >= 1 and start_time < 2) )'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_during=True
-         ... )
-         '(((start_time > 1 and end_time < 2) OR (start_time >= 1 and end_time < 2) OR (start_time > 1 and end_time <= 2)))'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_overlap=True
-         ... )
-         '(((start_time < 1 and end_time > 1 and end_time < 2) OR (start_time < 2 and start_time > 1 and end_time > 2)))'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_contain=True
-         ... )
-         '(((start_time < 1 and end_time > 2) OR (start_time <= 1 and end_time > 2) OR (start_time < 1 and end_time >= 2)))'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_equal=True
-         ... )
-         '((start_time = 1 and end_time = 2))'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_follows=True
-         ... )
-         '((start_time = 2))'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_precedes=True
-         ... )
-         '((end_time = 1))'
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start,
-         ...     end,
-         ...     use_start=True,
-         ...     use_during=True,
-         ...     use_overlap=True,
-         ...     use_contain=True,
-         ...     use_equal=True,
-         ...     use_follows=True,
-         ...     use_precedes=True,
-         ... )
-         '((start_time >= 1 and start_time < 2)  OR ((start_time > 1 and end_time < 2) OR (start_time >= 1 and end_time < 2) OR (start_time > 1 and end_time <= 2)) OR ((start_time < 1 and end_time > 1 and end_time < 2) OR (start_time < 2 and start_time > 1 and end_time > 2)) OR ((start_time < 1 and end_time > 2) OR (start_time <= 1 and end_time > 2) OR (start_time < 1 and end_time >= 2)) OR (start_time = 1 and end_time = 2) OR (start_time = 2) OR (end_time = 1))'
+                            map    :              s-----------e
+                            granule:  s-----------e
+    :param use_precedes: Select maps which temporally precedes the
+                        selection granule:
 
-         >>> # Absolute time
-         >>> start = datetime(2001, 1, 1, 12, 30)
-         >>> end = datetime(2001, 3, 31, 14, 30)
-         >>> create_temporal_relation_sql_where_statement(start, end, use_start=False)
-         >>> create_temporal_relation_sql_where_statement(start, end)
-         "((start_time >= '2001-01-01 12:30:00' and start_time < '2001-03-31 14:30:00') )"
-         >>> create_temporal_relation_sql_where_statement(start, end, use_start=True)
-         "((start_time >= '2001-01-01 12:30:00' and start_time < '2001-03-31 14:30:00') )"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_during=True
-         ... )
-         "(((start_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time >= '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time > '2001-01-01 12:30:00' and end_time <= '2001-03-31 14:30:00')))"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_overlap=True
-         ... )
-         "(((start_time < '2001-01-01 12:30:00' and end_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time < '2001-03-31 14:30:00' and start_time > '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00')))"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_contain=True
-         ... )
-         "(((start_time < '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time <= '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time < '2001-01-01 12:30:00' and end_time >= '2001-03-31 14:30:00')))"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_equal=True
-         ... )
-         "((start_time = '2001-01-01 12:30:00' and end_time = '2001-03-31 14:30:00'))"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_follows=True
-         ... )
-         "((start_time = '2001-03-31 14:30:00'))"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start, end, use_start=False, use_precedes=True
-         ... )
-         "((end_time = '2001-01-01 12:30:00'))"
-         >>> create_temporal_relation_sql_where_statement(
-         ...     start,
-         ...     end,
-         ...     use_start=True,
-         ...     use_during=True,
-         ...     use_overlap=True,
-         ...     use_contain=True,
-         ...     use_equal=True,
-         ...     use_follows=True,
-         ...     use_precedes=True,
-         ... )
-         "((start_time >= '2001-01-01 12:30:00' and start_time < '2001-03-31 14:30:00')  OR ((start_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time >= '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time > '2001-01-01 12:30:00' and end_time <= '2001-03-31 14:30:00')) OR ((start_time < '2001-01-01 12:30:00' and end_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time < '2001-03-31 14:30:00' and start_time > '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00')) OR ((start_time < '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time <= '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time < '2001-01-01 12:30:00' and end_time >= '2001-03-31 14:30:00')) OR (start_time = '2001-01-01 12:30:00' and end_time = '2001-03-31 14:30:00') OR (start_time = '2001-03-31 14:30:00') OR (end_time = '2001-01-01 12:30:00'))"
+                        .. code-block:: output
+
+                            map    :  s-----------e
+                            granule:              s-----------e
+
+    Usage:
+
+    >>> # Relative time
+    >>> start = 1
+    >>> end = 2
+    >>> create_temporal_relation_sql_where_statement(start, end, use_start=False)
+    >>> create_temporal_relation_sql_where_statement(start, end)
+    '((start_time >= 1 and start_time < 2) )'
+    >>> create_temporal_relation_sql_where_statement(start, end, use_start=True)
+    '((start_time >= 1 and start_time < 2) )'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_during=True
+    ... )
+    '(((start_time > 1 and end_time < 2) OR (start_time >= 1 and end_time < 2) OR (start_time > 1 and end_time <= 2)))'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_overlap=True
+    ... )
+    '(((start_time < 1 and end_time > 1 and end_time < 2) OR (start_time < 2 and start_time > 1 and end_time > 2)))'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_contain=True
+    ... )
+    '(((start_time < 1 and end_time > 2) OR (start_time <= 1 and end_time > 2) OR (start_time < 1 and end_time >= 2)))'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_equal=True
+    ... )
+    '((start_time = 1 and end_time = 2))'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_follows=True
+    ... )
+    '((start_time = 2))'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_precedes=True
+    ... )
+    '((end_time = 1))'
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start,
+    ...     end,
+    ...     use_start=True,
+    ...     use_during=True,
+    ...     use_overlap=True,
+    ...     use_contain=True,
+    ...     use_equal=True,
+    ...     use_follows=True,
+    ...     use_precedes=True,
+    ... )
+    '((start_time >= 1 and start_time < 2)  OR ((start_time > 1 and end_time < 2) OR (start_time >= 1 and end_time < 2) OR (start_time > 1 and end_time <= 2)) OR ((start_time < 1 and end_time > 1 and end_time < 2) OR (start_time < 2 and start_time > 1 and end_time > 2)) OR ((start_time < 1 and end_time > 2) OR (start_time <= 1 and end_time > 2) OR (start_time < 1 and end_time >= 2)) OR (start_time = 1 and end_time = 2) OR (start_time = 2) OR (end_time = 1))'
+
+    >>> # Absolute time
+    >>> start = datetime(2001, 1, 1, 12, 30)
+    >>> end = datetime(2001, 3, 31, 14, 30)
+    >>> create_temporal_relation_sql_where_statement(start, end, use_start=False)
+    >>> create_temporal_relation_sql_where_statement(start, end)
+    "((start_time >= '2001-01-01 12:30:00' and start_time < '2001-03-31 14:30:00') )"
+    >>> create_temporal_relation_sql_where_statement(start, end, use_start=True)
+    "((start_time >= '2001-01-01 12:30:00' and start_time < '2001-03-31 14:30:00') )"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_during=True
+    ... )
+    "(((start_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time >= '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time > '2001-01-01 12:30:00' and end_time <= '2001-03-31 14:30:00')))"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_overlap=True
+    ... )
+    "(((start_time < '2001-01-01 12:30:00' and end_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time < '2001-03-31 14:30:00' and start_time > '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00')))"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_contain=True
+    ... )
+    "(((start_time < '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time <= '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time < '2001-01-01 12:30:00' and end_time >= '2001-03-31 14:30:00')))"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_equal=True
+    ... )
+    "((start_time = '2001-01-01 12:30:00' and end_time = '2001-03-31 14:30:00'))"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_follows=True
+    ... )
+    "((start_time = '2001-03-31 14:30:00'))"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start, end, use_start=False, use_precedes=True
+    ... )
+    "((end_time = '2001-01-01 12:30:00'))"
+    >>> create_temporal_relation_sql_where_statement(
+    ...     start,
+    ...     end,
+    ...     use_start=True,
+    ...     use_during=True,
+    ...     use_overlap=True,
+    ...     use_contain=True,
+    ...     use_equal=True,
+    ...     use_follows=True,
+    ...     use_precedes=True,
+    ... )
+    "((start_time >= '2001-01-01 12:30:00' and start_time < '2001-03-31 14:30:00')  OR ((start_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time >= '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time > '2001-01-01 12:30:00' and end_time <= '2001-03-31 14:30:00')) OR ((start_time < '2001-01-01 12:30:00' and end_time > '2001-01-01 12:30:00' and end_time < '2001-03-31 14:30:00') OR (start_time < '2001-03-31 14:30:00' and start_time > '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00')) OR ((start_time < '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time <= '2001-01-01 12:30:00' and end_time > '2001-03-31 14:30:00') OR (start_time < '2001-01-01 12:30:00' and end_time >= '2001-03-31 14:30:00')) OR (start_time = '2001-01-01 12:30:00' and end_time = '2001-03-31 14:30:00') OR (start_time = '2001-03-31 14:30:00') OR (end_time = '2001-01-01 12:30:00'))"
 
     """  # noqa: E501
 

--- a/python/grass/temporal/univar_statistics.py
+++ b/python/grass/temporal/univar_statistics.py
@@ -127,6 +127,7 @@ def print_gridded_dataset_univar_statistics(
     nprocs: int = 1,
 ) -> None:
     """Print univariate statistics for a space time raster or raster3d dataset.
+
     Returns None if the space time raster dataset is empty or if applied
     filters (where, region_relation) do not return any maps to process.
 
@@ -143,10 +144,11 @@ def print_gridded_dataset_univar_statistics(
            and use the raster map regions for univar statistical calculation.
     :param region_relation: Process only maps with the given spatial relation
            to the computational region. A string with one of the following values:
-           "overlaps": maps that spatially overlap ("intersect")
-                       within the provided spatial extent
-           "is_contained": maps that are fully within the provided spatial extent
-           "contains": maps that contain (fully cover) the provided spatial extent
+
+           - "overlaps": maps that spatially overlap ("intersect")
+             within the provided spatial extent
+           - "is_contained": maps that are fully within the provided spatial extent
+           - "contains": maps that contain (fully cover) the provided spatial extent
     :param zones: raster map with zones to calculate statistics for
     """
     # We need a database interface


### PR DESCRIPTION
With this, the number of warnings in the sphinx build is down to 245 (on the base of this PR, the number of warnings is 407).

Various issues here are grouped together, for example:
- Missing colon (`:`) in the field list (e.g.: `:param arg1:`), 
- Bad indent of some paragraph, resulting in a quote/citation-like rendering
- Lists inside a parameter description displayed as a continuous block of text
- ASCII diagrams not rendered as code (keeping lines together), some in the parameter description section
- Invalid code block started without any content

Some examples of before:
![image](https://github.com/user-attachments/assets/5a215949-d08d-434f-b7c3-824be4c3d483)
![image](https://github.com/user-attachments/assets/469b64aa-eaba-47a7-acca-556bae570794)
![image](https://github.com/user-attachments/assets/0dfd45f5-c9e5-4cb7-b1a3-e680fdb5359b)

Some examples of after:
![image](https://github.com/user-attachments/assets/df78b91a-2f2b-4a4c-bb08-4489ba68e4e2)
![image](https://github.com/user-attachments/assets/3ff0eb38-f0fd-4a1f-815a-965265b5a230)
![image](https://github.com/user-attachments/assets/deda1d29-e16f-4fb7-a132-aa163d1db62c)


