### PR TITLE
docs: Adapt docstrings of pydispatch.saferef for good-looking Sphinx rendering

### DIFF
--- a/python/grass/docs/Makefile
+++ b/python/grass/docs/Makefile
@@ -19,6 +19,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c 
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 SPHINXBUILD     = sphinx-build
 SPHINXAPIDOC    = sphinx-apidoc
+SPHINX_APIDOC_OPTIONS = members,show-inheritance,undoc-members,special-members,private-members
 
 # some distros come with a different name
 BUILD  := $(type $(SPHINXBUILD) >/dev/null)  || (SPHINXBUILD  = sphinx-build2)
@@ -63,7 +64,7 @@ libpythonapidoc:
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../imaging/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../exceptions/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../gunittest/ ../gunittest/multireport.py ../gunittest/multirunner.py ../gunittest/main.py)
-	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../pydispatch/)
+	$(call run_grass,SPHINX_APIDOC_OPTIONS="$(SPHINX_APIDOC_OPTIONS)" $(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../pydispatch/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../pygrass/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../script/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../temporal/)

--- a/python/grass/docs/Makefile
+++ b/python/grass/docs/Makefile
@@ -19,7 +19,6 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) -c 
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 SPHINXBUILD     = sphinx-build
 SPHINXAPIDOC    = sphinx-apidoc
-SPHINX_APIDOC_OPTIONS = members,show-inheritance,undoc-members,special-members,private-members
 
 # some distros come with a different name
 BUILD  := $(type $(SPHINXBUILD) >/dev/null)  || (SPHINXBUILD  = sphinx-build2)
@@ -64,7 +63,7 @@ libpythonapidoc:
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../imaging/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../exceptions/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../gunittest/ ../gunittest/multireport.py ../gunittest/multirunner.py ../gunittest/main.py)
-	$(call run_grass,SPHINX_APIDOC_OPTIONS="$(SPHINX_APIDOC_OPTIONS)" $(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../pydispatch/)
+	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../pydispatch/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../pygrass/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../script/)
 	$(call run_grass,$(SPHINXAPIDOC) -T -f -t _templates/sphinx/apidoc/ -o src/ ../temporal/)

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -15,13 +15,13 @@ else:
 def safeRef(target, onDelete=None):
     """Return a *safe* weak reference to a callable target
 
-    target -- the object to be weakly referenced, if it's a
-        bound method reference, will create a BoundMethodWeakref,
+    :param target: The object to be weakly referenced, if it's a
+        bound method reference, will create a :py:class:`BoundMethodWeakref`,
         otherwise creates a simple weakref.
-    onDelete -- if provided, will have a hard reference stored
+    :param onDelete: If provided, will have a hard reference stored
         to the callable to be called after the safe reference
         goes out of scope with the reference object, (either a
-        weakref or a BoundMethodWeakref) as argument.
+        weakref or a :py:class:`BoundMethodWeakref`) as argument.
     """
     if hasattr(target, im_self):
         if getattr(target, im_self) is not None:
@@ -41,34 +41,49 @@ def safeRef(target, onDelete=None):
 class BoundMethodWeakref:
     """'Safe' and reusable weak references to instance methods
 
-    BoundMethodWeakref objects provide a mechanism for
+    :py:class:`BoundMethodWeakref` objects provide a mechanism for
     referencing a bound method without requiring that the
     method object itself (which is normally a transient
-    object) is kept alive.  Instead, the BoundMethodWeakref
+    object) is kept alive.  Instead, the :py:class:`BoundMethodWeakref`
     object keeps weak references to both the object and the
     function which together define the instance method.
 
-    Attributes:
-        key -- the identity key for the reference, calculated
-            by the class's calculateKey method applied to the
+    :Attributes:
+
+        .. attribute:: key
+
+            the identity key for the reference, calculated
+            by the class's :py:meth:`.calculateKey` method applied to the
             target instance method
-        deletionMethods -- sequence of callable objects taking
+
+        .. attribute:: deletionMethods
+
+            sequence of callable objects taking
             single argument, a reference to this object which
             will be called when *either* the target object or
             target function is garbage collected (i.e. when
             this object becomes invalid).  These are specified
-            as the onDelete parameters of safeRef calls.
-        weakSelf -- weak reference to the target object
-        weakFunc -- weak reference to the target function
+            as the onDelete parameters of :py:func:`safeRef` calls.
 
-    Class Attributes:
-        _allInstances -- class attribute pointing to all live
-            BoundMethodWeakref objects indexed by the class's
+        .. attribute:: weakSelf
+
+            weak reference to the target object
+
+        .. attribute:: weakFunc
+
+            weak reference to the target function
+
+    :Class Attributes:
+
+        .. attribute:: _allInstances
+
+            class attribute pointing to all live
+            :py:class:`BoundMethodWeakref` objects indexed by the class's
             calculateKey(target) method applied to the target
             objects.  This weak value dictionary is used to
             short-circuit creation so that multiple references
             to the same (object, function) pair produce the
-            same BoundMethodWeakref instance.
+            same :py:class:`BoundMethodWeakref` instance.
 
     """
 
@@ -82,7 +97,7 @@ class BoundMethodWeakref:
         referenced instance methods.  The key corresponding
         to the target is calculated, and if there is already
         an existing reference, that is returned, with its
-        deletionMethods attribute updated.  Otherwise the
+        :attr:`deletionMethods` attribute updated.  Otherwise the
         new instance is created and registered in the table
         of already-referenced methods.
         """
@@ -99,12 +114,14 @@ class BoundMethodWeakref:
     def __init__(self, target, onDelete=None):
         """Return a weak-reference-like instance for a bound method
 
-        target -- the instance-method target for the weak
+        :param target: the instance-method target for the weak
             reference, must have <im_self> and <im_func> attributes
-            and be reconstructable via:
+            and be reconstructable via::
+
                 target.<im_func>.__get__( target.<im_self> )
+
             which is true of built-in instance methods.
-        onDelete -- optional callback which will be called
+        :param onDelete: optional callback which will be called
             when this weak reference ceases to be valid
             (i.e. either the object or the function is garbage
             collected).  Should take a single argument,

--- a/python/grass/pydispatch/saferef.py
+++ b/python/grass/pydispatch/saferef.py
@@ -188,7 +188,7 @@ class BoundMethodWeakref:
         return None, otherwise returns a bound instance
         method for our object and function.
 
-        Note:
+        .. note::
             You may call this method any number of times,
             as it does not invalidate the reference.
         """


### PR DESCRIPTION
Since there were a couple of issues with the saferef docstrings, and really didn't look that great and the docstrings before wasn't rendered using the rich semantic features to convey meaning of the parts of code, I tuned this one a fair bit to practice myself. It was a nice challenge since the attributes to describe were dynamic and not collected by normal introspection (even static parsing would have had a hard time).

Now, it even renders anchors for these attributes, shows up in TOC, can be referenced with links (and used in other docstrings of the file), so the meaning is well conveyed. I also tried it out if some special members (like `__call__()`) were ever rendered if changing the settings. I needed to make sure the note was rendered correctly anyways.

Take note that the "Attributes" and "Class Attributes" inside a pair of colons doesn't have a particular meaning, other than the fact that the rendering is not the same as applying a bold text by surrounding with double stars. Using the field-list syntax, even if not one of the special ones recognized by Sphinx, makes the contents indented as expected and adds the colon at the end. It is the best I could do for this special case.

Number of warnings with this PR is down to 401, (base of this PR has 407 warnings). This PR is independent of #5818 and the issues resolved will combine themselves.


Example of before:
![image](https://github.com/user-attachments/assets/bdbd9e6b-97e1-4e16-8643-d22ca580b8ac)

Example of after:
(Note the white anchor on a white background, I hovered over to make the tooltip appear)
![image](https://github.com/user-attachments/assets/3bd83a10-0999-400d-aa15-a1c7e119770b)
(in the grass.pydispatch.html file:)
![image](https://github.com/user-attachments/assets/ebc8c0bf-f7de-406b-9219-ca430b0cf934)
![image](https://github.com/user-attachments/assets/c1d210b8-fa06-4a18-9c27-adde6ab5950b)


Example of after if ever the special members (like the dunder methods/attributes etc.) are enabled:
(in the pydispatch.html file, that I modified the makefile to see the changes when looking at the rendering, it is reverted in the same PR)
![image](https://github.com/user-attachments/assets/e35dbdf2-9664-4fac-b2e6-f5ec2cd449a7)
![image](https://github.com/user-attachments/assets/dfda1b19-7f21-4b12-888f-882605705c1a)
