### PR TITLE
docs: Convert docstrings to use note and warning admonitions

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -643,7 +643,7 @@ class TestCase(unittest.TestCase):
     ):
         """Test the existence of a file.
 
-        .. note:
+        .. note::
             By default this also checks if the file size is greater than 0
             since we rarely want a file to be empty. It also checks
             if the file is accessible for reading since we expect that user
@@ -696,7 +696,7 @@ class TestCase(unittest.TestCase):
             hasher.update(open("original_result.png", "rb").read())
             hasher.hexdigest()
 
-        .. note:
+        .. note::
             For text files, always create MD5 sum using ``\n`` (LF)
             as newline characters for consistency. Also use newline
             at the end of file (as for example, Git or PEP8 requires).
@@ -1158,11 +1158,11 @@ class TestCase(unittest.TestCase):
     def assertVectorEqualsVector(self, actual, reference, digits, precision, msg=None):
         """Test that two vectors are equal.
 
-        .. note:
+        .. note::
             This test should not be used to test ``v.in.ascii`` and
             ``v.out.ascii`` modules.
 
-        .. warning:
+        .. warning::
             ASCII files for vectors are loaded into memory, so this
             function works well only for "not too big" vector maps.
         """
@@ -1187,11 +1187,11 @@ class TestCase(unittest.TestCase):
     def assertVectorEqualsAscii(self, actual, reference, digits, precision, msg=None):
         """Test that vector is equal to the vector stored in GRASS ASCII file.
 
-        .. note:
+        .. note::
             This test should not be used to test ``v.in.ascii`` and
             ``v.out.ascii`` modules.
 
-        .. warning:
+        .. warning::
             ASCII files for vectors are loaded into memory, so this
             function works well only for "not too big" vector maps.
         """
@@ -1225,11 +1225,11 @@ class TestCase(unittest.TestCase):
     ):
         """Test that two GRASS ASCII vector files are equal.
 
-        .. note:
+        .. note::
             This test should not be used to test ``v.in.ascii`` and
             ``v.out.ascii`` modules.
 
-        .. warning:
+        .. warning::
             ASCII files for vectors are loaded into memory, so this
             function works well only for "not too big" vector maps.
         """

--- a/python/grass/pydispatch/dispatcher.py
+++ b/python/grass/pydispatch/dispatcher.py
@@ -60,7 +60,7 @@ class _Anonymous(_Parameter):
     with anonymous will only send messages to those receivers
     registered for Any or Anonymous.
 
-    Note:
+    .. note::
         The default sender for connect is Any, while the
         default sender for send is Anonymous.  This has
         the effect that if you do not specify any senders
@@ -96,8 +96,8 @@ def connect(receiver, signal=Any, sender=Any, weak=True):
         subsets of the sent arguments to apply to a given
         receiver.
 
-        Note:
-            if receiver is itself a weak reference (a callable),
+        .. note::
+            If receiver is itself a weak reference (a callable),
             it will be de-referenced by the system's machinery,
             so *generally* weak references are not suitable as
             receivers, though some use might be found for the
@@ -193,7 +193,7 @@ def disconnect(receiver, signal=Any, sender=Any, weak=True):
     (The actual process is slightly more complex
     but the semantics are basically the same).
 
-    Note:
+    .. note::
         Using disconnect is not required to cleanup
         routing when an object is deleted, the framework
         will remove routes for deleted objects
@@ -235,8 +235,8 @@ def getReceivers(sender=Any, signal=Any):
     raw list of receivers from the connections table
     for the given sender and signal pair.
 
-    Note:
-        there is no guarantee that this is the actual list
+    .. note::
+        There is no guarantee that this is the actual list
         stored in the connections table, so the value
         should be treated as a simple iterable/truth value
         rather than, for instance a list to which you

--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -548,11 +548,12 @@ class Region:
         error message is printed and exit() is called if there is a problem
         reading the region.
 
-        <b>Note:</b> GRASS applications that read or write raster maps
-        should not use this routine since its use implies that the active
-        module region will not be used. Programs that read or write raster
-        map data (or vector data) can query the active module region using
-        Rast_window_rows() and Rast_window_cols().
+        .. warning::
+            GRASS applications that read or write raster maps
+            should not use this routine since its use implies that the active
+            module region will not be used. Programs that read or write raster
+            map data (or vector data) can query the active module region using
+            Rast_window_rows() and Rast_window_cols().
 
         :param force_read: If True the WIND file of the current mapset
                            is re-readed, otherwise the initial region

--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -373,7 +373,7 @@ class Region:
     def zoom(self, raster_name):
         """Shrink region until it meets non-NULL data from this raster map
 
-        Warning: This will change the user GRASS region settings
+        .. warning:: This will change the user GRASS region settings
 
         :param raster_name: the name of raster
         :type raster_name: str
@@ -384,7 +384,7 @@ class Region:
     def align(self, raster_name):
         """Adjust region cells to cleanly align with this raster map
 
-        Warning: This will change the user GRASS region settings
+        .. warning:: This will change the user GRASS region settings
 
         :param raster_name: the name of raster
         :type raster_name: str

--- a/python/grass/pygrass/messages/__init__.py
+++ b/python/grass/pygrass/messages/__init__.py
@@ -121,14 +121,14 @@ class Messenger:
     C-library message functions like: G_message(), G_warning(),
     G_important_message(), G_verbose_message(), G_percent() and G_debug().
 
-    Note:
+    .. note::
 
-    The C-library message functions a called via ctypes in a subprocess
-    using a pipe (multiprocessing.Pipe) to transfer the text messages.
-    Hence, the process that uses the Messenger interface will not be
-    exited, if a G_fatal_error() was invoked in the subprocess.
-    In this case the Messenger object will simply start a new subprocess
-    and restarts the pipeline.
+        The C-library message functions a called via ctypes in a subprocess
+        using a pipe (multiprocessing.Pipe) to transfer the text messages.
+        Hence, the process that uses the Messenger interface will not be
+        exited, if a G_fatal_error() was invoked in the subprocess.
+        In this case the Messenger object will simply start a new subprocess
+        and restarts the pipeline.
 
 
     Usage:

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -872,7 +872,7 @@ class MultiModule:
                       region environment, hence invoking g.region will not alter the
                       current region or the region of other MultiModule runs.
 
-                      Note:
+                      .. note::
 
                           Modules run in asynchronous mode can only be accessed via the
                           wait() method. The wait() method will return all finished
@@ -971,8 +971,7 @@ g.region format=plain -p ; g.region format=plain -p'
                                 run, hence region settings in the process list will not
                                 affect the current computation region.
 
-                                Note:
-
+                                .. note::
                                     This flag is only available in asynchronous mode!
         :return:
         """
@@ -989,7 +988,7 @@ g.region format=plain -p ; g.region format=plain -p'
     def get_modules(self):
         """Return the list of modules that have been run in synchronous mode
 
-        Note: Asynchronously run module can only be accessed via the wait() method.
+        .. note:: Asynchronously run module can only be accessed via the wait() method.
 
         :return: The list of modules
         """

--- a/python/grass/pygrass/raster/segment.py
+++ b/python/grass/pygrass/raster/segment.py
@@ -131,6 +131,8 @@ class Segment:
     def release(self):
         """Free memory allocated to segment.
         Releases the allocated memory associated with the segment file seg.
-        Note: Does not close the file. Does not flush the data which may be
-        pending from previous Segment_put() calls."""
+
+        .. note:: Does not close the file. Does not flush the data which may be
+                  pending from previous Segment_put() calls.
+        """
         libseg.Segment_release(self.c_seg)

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1001,7 +1001,7 @@ class Line(Geo):
                   Point(1.000000, 1.000000),
                   Point(2.000000, 2.000000)])
 
-        .. warning ::
+        .. warning::
 
             prune_thresh is not working yet.
         """

--- a/python/grass/pygrass/vector/table.py
+++ b/python/grass/pygrass/vector/table.py
@@ -553,7 +553,7 @@ class Columns:
         'float8'
         >>> remove("mycensus", "vect")
 
-        .. warning ::
+        .. warning::
 
            It is not possible to cast a column with sqlite
 

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -149,7 +149,7 @@ def db_select(sql=None, filename=None, table=None, env=None, **args):
     >>> db_select(sql="SELECT cat,CITY FROM myfirestations WHERE cat < 4")
     (('1', 'Morrisville'), ('2', 'Morrisville'), ('3', 'Apex'))
 
-    Simplified usage (it performs <tt>SELECT * FROM myfirestations</tt>.)
+    Simplified usage (it performs ``SELECT * FROM myfirestations``.)
 
     >>> db_select(table="myfirestations")  # doctest: +ELLIPSIS
     (('1', '24', 'Morrisville #3', ... 'HS2A', '1.37'))

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -139,8 +139,8 @@ def db_connection(force=False, env=None):
 def db_select(sql=None, filename=None, table=None, env=None, **args):
     """Perform SQL select statement
 
-    Note: one of <em>sql</em>, <em>filename</em>, or <em>table</em>
-    arguments must be provided.
+    .. note:: One of **sql**, **filename**, or **table**
+        arguments must be provided.
 
     Examples:
 

--- a/python/grass/temporal/c_libraries_interface.py
+++ b/python/grass/temporal/c_libraries_interface.py
@@ -1098,8 +1098,8 @@ def _convert_timestamp_from_grass(ts):
     In case of relative time a tuple with start time, end time and the
     relative unit (start, end, unit) will be returned.
 
-    Note:
-    The end time will be set to None in case of a time instance.
+    .. note::
+        The end time will be set to None in case of a time instance.
 
     :param ts grass.lib.gis.TimeStamp object created by G_read_*_timestamp
     """
@@ -1599,7 +1599,7 @@ class CLibrariesInterface(RPCServerBase):
         Please have a look at the documentation G_write_raster_timestamp
         for the return values description.
 
-        Note:
+        .. note::
             Only timestamps of maps from the current mapset can written.
 
         :param name: The name of the map
@@ -1651,7 +1651,7 @@ class CLibrariesInterface(RPCServerBase):
     def write_raster_semantic_label(self, name, mapset, semantic_label):
         """Write a file based raster semantic label
 
-        Note:
+        .. note::
             Only semantic labels of maps from the current mapset can be written.
 
         :param name: The name of the map
@@ -1773,7 +1773,7 @@ class CLibrariesInterface(RPCServerBase):
         Please have a look at the documentation G_write_raster3d_timestamp
         for the return values description.
 
-        Note:
+        .. note::
             Only timestamps of maps from the current mapset can written.
 
         :param name: The name of the map
@@ -1913,7 +1913,7 @@ class CLibrariesInterface(RPCServerBase):
         Please have a look at the documentation G_write_vector_timestamp
         for the return values description.
 
-        Note:
+        .. note::
             Only timestamps pf maps from the current mapset can written.
 
         :param name: The name of the map

--- a/scripts/g.extension/g.extension.py
+++ b/scripts/g.extension/g.extension.py
@@ -1675,7 +1675,7 @@ def install_extension_win(name):
 def download_source_code_svn(url, name, outdev, directory=None):
     """Download source code from a Subversion repository
 
-    .. note:
+    .. note::
         Stdout is passed to to *outdev* while stderr is will be just printed.
 
     :param url: URL of the repository
@@ -1704,7 +1704,7 @@ def download_source_code_svn(url, name, outdev, directory=None):
 def download_source_code_official_github(url, name, branch, directory=None):
     """Download source code from a official GitHub repository
 
-    .. note:
+    .. note::
         Stdout is passed to to *outdev* while stderr is just printed.
 
     :param url: URL of the repository


### PR DESCRIPTION
Makes use of admonitions for notes and warnings. I searched "note" and "warning" in .py files for candidates to better displaying the notes. I didn't find other candidates for "caution", "warn", "info",

The number of warnings does not change here.

This does not include the note admonition changes in pydispatch.saferef that is made in #5819, so it is independent of that PR.

Example before:
![image](https://github.com/user-attachments/assets/05aeb6eb-cb84-4101-aeda-686e30cddcd1)
![image](https://github.com/user-attachments/assets/6241d2d7-8b12-4fd6-97dd-382ca70ff188)
![image](https://github.com/user-attachments/assets/4bc7e66c-c75a-4e99-af35-6ae91a856c67)
![image](https://github.com/user-attachments/assets/5a94b22f-d615-49aa-ac99-29c3053c6f13)
![image](https://github.com/user-attachments/assets/c5a86747-fc4b-40fc-9c22-63764c307d08)


Example after:
![image](https://github.com/user-attachments/assets/4575285b-510e-4e14-9e8e-89ea38dd205c)
![image](https://github.com/user-attachments/assets/80acaf50-a317-4ee0-9b24-cf5a2a3e6ba9)
![image](https://github.com/user-attachments/assets/7dafbb0d-9b74-4d2c-bb4d-f4f9e3f07a2c)
![image](https://github.com/user-attachments/assets/fb7a4841-75db-4fc7-87e8-8bcb951b7577)

Upgraded note to warning following the context and severity of the message conveyed 
![image](https://github.com/user-attachments/assets/ca7bc365-e815-45e6-812d-171dd6541f74)

