### PR TITLE
docs: Render todo boxes, other code blocks formatting and label syntax

### DIFF
--- a/doc/python_intro.md
+++ b/doc/python_intro.md
@@ -133,7 +133,7 @@ For error handling, please refer to the [documentation](https://grass.osgeo.org/
     import os
     os.environ["GRASS_OVERWRITE"] = "1"
     ```
-    See related [best practices](style_guide.html#overwriting-existing-data)
+    See related [best practices](style_guide.md#overwriting-existing-data)
     when writing a Python tool.
 
 ### Helper functions
@@ -741,10 +741,10 @@ To learn more about the `Module` class, see the Full Documentation:
 
 When you are ready to take your scripts to the next level,
 such as turning them into GRASS addons, check out
-[GRASS Python development best practices](style_guide.html#developing-python-scripts).
+[GRASS Python development best practices](style_guide.md#developing-python-scripts).
 Following the gudelines ensures your tools integrate smoothly with the GRASS environment,
 and work in parallel processing workflows.
 To turn your script into an addon, see the [GRASS Addon Cookiecutter Template](https://github.com/OSGeo/grass-addon-cookiecutter).
 
 <!-- markdownlint-disable-next-line line-length -->
-[GRASS Python best practices :material-arrow-right-bold:](style_guide.html#developing-python-scripts){ .md-button }
+[GRASS Python best practices :material-arrow-right-bold:](style_guide.md#developing-python-scripts){ .md-button }

--- a/python/grass/docs/conf.py
+++ b/python/grass/docs/conf.py
@@ -485,6 +485,8 @@ epub_exclude_files = ["search.html"]
 
 # Where class documentation comes from (class or __init__ docstring).
 autoclass_content = "both"
+# Render todo boxes instead of hiding them
+todo_include_todos = True
 
 # sphinx-sitemap extension config
 # https://sphinx-sitemap.readthedocs.io/en/latest/advanced-configuration.html

--- a/python/grass/docs/src/temporal_framework.rst
+++ b/python/grass/docs/src/temporal_framework.rst
@@ -423,4 +423,4 @@ References
 
 :Authors: Soeren Gebbert
 
-:TODO: add more documentation
+.. TODO:: add more documentation

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -23,22 +23,22 @@ class ParallelModuleQueue:
     """This class is designed to run an arbitrary number of pygrass Module or
     MultiModule processes in parallel.
 
-    Objects of type grass.pygrass.modules.Module or
-    grass.pygrass.modules.MultiModule can be put into the
-    queue using put() method. When the queue is full with the maximum
+    Objects of type :py:class:`grass.pygrass.modules.Module` or
+    :py:class:`grass.pygrass.modules.MultiModule` can be put into the
+    queue using :py:meth:`put` method. When the queue is full with the maximum
     number of parallel processes it will wait for all processes to finish,
     sets the stdout and stderr of the Module object and removes it
     from the queue when its finished.
 
     To finish the queue before the maximum number of parallel
-    processes was reached call wait() .
+    processes was reached, call :py:meth:`wait`.
 
     This class will raise a GrassError in case a Module process exits
     with a return code other than 0.
 
-    Processes that were run asynchronously with the MultiModule class
+    Processes that were run asynchronously with the :py:class:`MultiModule` class
     will not raise a GrassError in case of failure. This must be manually checked
-    by accessing finished modules by calling get_finished_modules().
+    by accessing finished modules by calling :py:meth:`get_finished_modules`.
 
     Usage:
 
@@ -536,7 +536,7 @@ class Module:
     os = 'linux'
     language = 'python'
 
-    In the Module class we heavily use this language feature to pass arguments
+    In the :py:class:`Module` class we heavily use this language feature to pass arguments
     and keyword arguments to the grass module.
     """  # noqa: E501
 

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -48,7 +48,7 @@ class ParallelModuleQueue:
     >>> from grass.pygrass.modules import Module, MultiModule, ParallelModuleQueue
     >>> mapcalc_list = []
 
-    Setting run_ to False is important, otherwise a parallel processing is not possible
+    Setting ``run_`` to False is important, otherwise a parallel processing is not possible
 
     >>> mapcalc = Module("r.mapcalc", overwrite=True, run_=False)
     >>> queue = ParallelModuleQueue(nprocs=3)
@@ -227,11 +227,11 @@ class ParallelModuleQueue:
     def put(self, module):
         r"""Put the next Module or MultiModule object in the queue
 
-        To run the Module objects in parallel the run\_ and finish\_ options
+        To run the Module objects in parallel the ``run_`` and ``finish_`` options
         of the Module must be set to False.
 
         :param module: a preconfigured Module or MultiModule object that were configured
-                       with run\_ and finish\_ set to False,
+                       with ``run_`` and ``finish_`` set to False,
         :type module: Module or MultiModule object
         """
         self._list[self._proc_count] = module
@@ -480,7 +480,7 @@ class Module:
     'r.colors map=test_a color=byg offset=0.0 scale=1.0'
 
     Often in the Module class you can find ``*args`` and ``kwargs`` annotation
-    in methods, like in the __call__ method.
+    in methods, like in the ``__call__`` method.
     Python allow developers to not specify all the arguments and
     keyword arguments of a method or function.
 
@@ -622,10 +622,10 @@ class Module:
         self.__call__.__func__.__doc__ = self.__doc__
 
     def __call__(self, *args, **kargs):
-        """Set module parameters to the class and, if run_ is True execute the
+        """Set module parameters to the class and, if ``run_`` is True execute the
         module, therefore valid parameters are all the module parameters
-        plus some extra parameters that are: run_, stdin_, stdout_, stderr_,
-        env_ and finish_.
+        plus some extra parameters that are: ``run_``, ``stdin_``, ``stdout_``, ``stderr_``,
+        ``env_`` and ``finish_``.
         """
         if not args and not kargs:
             self.run()
@@ -645,8 +645,8 @@ class Module:
         """Update module parameters and selected object attributes.
 
         Valid parameters are all the module parameters
-        and additional parameters, namely: run_, stdin_, stdout_, stderr_,
-        env_, and finish_.
+        and additional parameters, namely: ``run_``, ``stdin_``, ``stdout_``, ``stderr_``,
+        ``env_``, and ``finish_``.
         """
         #
         # check for extra kargs, set attribute and remove from dictionary
@@ -832,7 +832,7 @@ class Module:
 
     def wait(self):
         """Wait for the module to finish. Call this method if
-        the run() call was performed with self.false_ = False.
+        the run() call was performed with :code:`self.false_ = False`.
 
         :return: A reference to this object
         """
@@ -1007,15 +1007,15 @@ class MultiModule:
         return self.module_list
 
     def run(self):
-        """Start the modules in the list. If self.finished_ is set True
+        """Start the modules in the list. If ``self.finished_`` is set True
         this method will return after all processes finished.
 
-        If self.finish_ is set False, this method will return
+        If ``self.finish_`` is set False, this method will return
         after the process list was started for execution.
         In a background process, the processes in the list will
         be run one after the another.
 
-        :return: None in case of self.finish_ is True,
+        :return: None in case of ``self.finish_`` is True,
                  otherwise a multiprocessing.Process object that invokes the modules
         """
 

--- a/python/grass/pygrass/vector/__init__.py
+++ b/python/grass/pygrass/vector/__init__.py
@@ -538,28 +538,30 @@ class VectorTopo(Vector):
 
         :param int feature_id: the id of feature to obtain
 
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open(mode="r")
-        >>> feature1 = test_vect.read(0)  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-            ...
-        ValueError: The index must be >0, 0 given.
-        >>> feature1 = test_vect.read(5)
-        >>> feature1
-        Line([Point(12.000000, 4.000000), Point(12.000000, 2.000000), Point(12.000000, 0.000000)])
-        >>> feature1.length()
-        4.0
-        >>> test_vect.read(-1)
-        Centroid(7.500000, 3.500000)
-        >>> len(test_vect)
-        21
-        >>> test_vect.read(21)
-        Centroid(7.500000, 3.500000)
-        >>> test_vect.read(22)  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-          ...
-        IndexError: Index out of range
-        >>> test_vect.close()
+        .. code-block:: pycon
+
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open(mode="r")
+            >>> feature1 = test_vect.read(0)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: The index must be >0, 0 given.
+            >>> feature1 = test_vect.read(5)
+            >>> feature1
+            Line([Point(12.000000, 4.000000), Point(12.000000, 2.000000), Point(12.000000, 0.000000)])
+            >>> feature1.length()
+            4.0
+            >>> test_vect.read(-1)
+            Centroid(7.500000, 3.500000)
+            >>> len(test_vect)
+            21
+            >>> test_vect.read(21)
+            Centroid(7.500000, 3.500000)
+            >>> test_vect.read(22)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+              ...
+            IndexError: Index out of range
+            >>> test_vect.close()
 
         """  # noqa: E501
         return read_line(
@@ -759,7 +761,9 @@ class VectorTopo(Vector):
 
         The well known binary are stored in byte arrays.
 
-         Examples:
+        Examples:
+
+        .. code-block:: pycon
 
          >>> from grass.pygrass.vector import VectorTopo
          >>> from grass.pygrass.vector.basic import Bbox
@@ -880,7 +884,9 @@ class VectorTopo(Vector):
 
         The well known binary are stored in byte arrays.
 
-         Examples:
+        Examples:
+
+        .. code-block:: pycon
 
          >>> from grass.pygrass.vector import VectorTopo
          >>> from grass.pygrass.vector.basic import Bbox
@@ -911,8 +917,6 @@ class VectorTopo(Vector):
          (4, 3, 141)
 
          >>> test_vect.close()
-
-
         """
         if bbox is None:
             bbox = self.bbox()

--- a/python/grass/pygrass/vector/find.py
+++ b/python/grass/pygrass/vector/find.py
@@ -423,7 +423,7 @@ class BboxFinder(AbstractFinder):
                  If bboxlist_only is True a BoxList
                  object will be returned, or None if nothing was found.
 
-        This methods uses libvect.Vect_select_lines_by_box()
+        This methods uses :py:meth:`libvect.Vect_select_lines_by_box`
 
         Examples:
 

--- a/python/grass/pygrass/vector/find.py
+++ b/python/grass/pygrass/vector/find.py
@@ -74,24 +74,26 @@ class PointFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.geometry import Point
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find nearest node
-        >>> points = (Point(10, 0), Point(10, 4), Point(14, 0))
-        >>> result = []
-        >>> for point in points:
-        ...     f = test_vect.find_by_point.node(point=point, maxdist=1)
-        ...     if f:
-        ...         result.append(f)
-        >>> result
-        [Node(2), Node(1), Node(6)]
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.geometry import Point
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> test_vect.find_by_point.node(point=Point(20, 20), maxdist=0)
+            # Find nearest node
+            >>> points = (Point(10, 0), Point(10, 4), Point(14, 0))
+            >>> result = []
+            >>> for point in points:
+            ...     f = test_vect.find_by_point.node(point=point, maxdist=1)
+            ...     if f:
+            ...         result.append(f)
+            >>> result
+            [Node(2), Node(1), Node(6)]
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_point.node(point=Point(20, 20), maxdist=0)
+
+            >>> test_vect.close()
         """
         node_id = libvect.Vect_find_node(
             self.c_mapinfo,
@@ -132,31 +134,33 @@ class PointFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.geometry import Point
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find single features
-        >>> points = (Point(10, 0), Point(10, 6), Point(14, 2))
-        >>> result = []
-        >>> for point in points:
-        ...     f = test_vect.find_by_point.geo(point=point, maxdist=1)
-        ...     if f:
-        ...         result.append(f)
-        >>> for f in result:
-        ...     print(f.to_wkt_p())  # doctest: +NORMALIZE_WHITESPACE
-        LINESTRING(10.000000 4.000000,
-                   10.000000 2.000000,
-                   10.000000 0.000000)
-        POINT(10.000000 6.000000)
-        LINESTRING(14.000000 4.000000,
-                   14.000000 2.000000,
-                   14.000000 0.000000)
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.geometry import Point
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> test_vect.find_by_point.geo(point=Point(20, 20), maxdist=0)
+            # Find single features
+            >>> points = (Point(10, 0), Point(10, 6), Point(14, 2))
+            >>> result = []
+            >>> for point in points:
+            ...     f = test_vect.find_by_point.geo(point=point, maxdist=1)
+            ...     if f:
+            ...         result.append(f)
+            >>> for f in result:
+            ...     print(f.to_wkt_p())  # doctest: +NORMALIZE_WHITESPACE
+            LINESTRING(10.000000 4.000000,
+                       10.000000 2.000000,
+                       10.000000 0.000000)
+            POINT(10.000000 6.000000)
+            LINESTRING(14.000000 4.000000,
+                       14.000000 2.000000,
+                       14.000000 0.000000)
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_point.geo(point=Point(20, 20), maxdist=0)
+
+            >>> test_vect.close()
         """
         feature_id = libvect.Vect_find_line(
             self.c_mapinfo,
@@ -195,56 +199,58 @@ class PointFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.geometry import Point
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find multiple features
-        >>> points = (Point(10, 0), Point(10, 5), Point(14, 2))
-        >>> result = []
-        >>> for point in points:
-        ...     f = test_vect.find_by_point.geos(point=point, maxdist=1.5)
-        ...     if f:
-        ...         result.append(f)
-        >>> for f in result:
-        ...     print(f)  # doctest: +NORMALIZE_WHITESPACE
-        [Line([Point(10.000000, 4.000000),
-               Point(10.000000, 2.000000),
-               Point(10.000000, 0.000000)])]
-        [Line([Point(10.000000, 4.000000),
-               Point(10.000000, 2.000000),
-               Point(10.000000, 0.000000)]),
-         Point(10.000000, 6.000000)]
-        [Line([Point(14.000000, 4.000000),
-               Point(14.000000, 2.000000),
-               Point(14.000000, 0.000000)])]
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.geometry import Point
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        # Find multiple boundaries
-        >>> point = Point(3, 3)
-        >>> result = test_vect.find_by_point.geos(
-        ...     point=Point(3, 3), type="boundary", maxdist=1.5
-        ... )
-        >>> result  # doctest: +NORMALIZE_WHITESPACE
-        [Boundary([Point(0.000000, 4.000000), Point(4.000000, 4.000000)]),
-         Boundary([Point(4.000000, 4.000000), Point(4.000000, 0.000000)]),
-         Boundary([Point(1.000000, 1.000000), Point(1.000000, 3.000000),
-                   Point(3.000000, 3.000000), Point(3.000000, 1.000000),
-                   Point(1.000000, 1.000000)]),
-         Boundary([Point(4.000000, 4.000000), Point(6.000000, 4.000000)])]
+            # Find multiple features
+            >>> points = (Point(10, 0), Point(10, 5), Point(14, 2))
+            >>> result = []
+            >>> for point in points:
+            ...     f = test_vect.find_by_point.geos(point=point, maxdist=1.5)
+            ...     if f:
+            ...         result.append(f)
+            >>> for f in result:
+            ...     print(f)  # doctest: +NORMALIZE_WHITESPACE
+            [Line([Point(10.000000, 4.000000),
+                   Point(10.000000, 2.000000),
+                   Point(10.000000, 0.000000)])]
+            [Line([Point(10.000000, 4.000000),
+                   Point(10.000000, 2.000000),
+                   Point(10.000000, 0.000000)]),
+             Point(10.000000, 6.000000)]
+            [Line([Point(14.000000, 4.000000),
+                   Point(14.000000, 2.000000),
+                   Point(14.000000, 0.000000)])]
 
-        # Find multiple centroids
-        >>> point = Point(3, 3)
-        >>> result = test_vect.find_by_point.geos(
-        ...     point=Point(3, 3), type="centroid", maxdist=1.5
-        ... )
-        >>> result  # doctest: +NORMALIZE_WHITESPACE
-        [Centroid(2.500000, 2.500000),
-         Centroid(3.500000, 3.500000)]
+            # Find multiple boundaries
+            >>> point = Point(3, 3)
+            >>> result = test_vect.find_by_point.geos(
+            ...     point=Point(3, 3), type="boundary", maxdist=1.5
+            ... )
+            >>> result  # doctest: +NORMALIZE_WHITESPACE
+            [Boundary([Point(0.000000, 4.000000), Point(4.000000, 4.000000)]),
+             Boundary([Point(4.000000, 4.000000), Point(4.000000, 0.000000)]),
+             Boundary([Point(1.000000, 1.000000), Point(1.000000, 3.000000),
+                       Point(3.000000, 3.000000), Point(3.000000, 1.000000),
+                       Point(1.000000, 1.000000)]),
+             Boundary([Point(4.000000, 4.000000), Point(6.000000, 4.000000)])]
 
-        >>> test_vect.find_by_point.geos(point=Point(20, 20), maxdist=0)
+            # Find multiple centroids
+            >>> point = Point(3, 3)
+            >>> result = test_vect.find_by_point.geos(
+            ...     point=Point(3, 3), type="centroid", maxdist=1.5
+            ... )
+            >>> result  # doctest: +NORMALIZE_WHITESPACE
+            [Centroid(2.500000, 2.500000),
+             Centroid(3.500000, 3.500000)]
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_point.geos(point=Point(20, 20), maxdist=0)
+
+            >>> test_vect.close()
         """
         excl = Ilist(exclude) if exclude else Ilist([])
         found = Ilist()
@@ -277,54 +283,56 @@ class PointFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.geometry import Point
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find AREAS
-        >>> points = (Point(0.5, 0.5), Point(5, 1), Point(7, 1))
-        >>> result = []
-        >>> for point in points:
-        ...     area = test_vect.find_by_point.area(point)
-        ...     result.append(area)
-        >>> result
-        [Area(1), Area(2), Area(4)]
-        >>> for area in result:
-        ...     print(area.to_wkt())  # doctest: +NORMALIZE_WHITESPACE
-        POLYGON ((0.0000000000000000 0.0000000000000000,
-                  0.0000000000000000 4.0000000000000000,
-                  0.0000000000000000 4.0000000000000000,
-                  4.0000000000000000 4.0000000000000000,
-                  4.0000000000000000 4.0000000000000000,
-                  4.0000000000000000 0.0000000000000000,
-                  4.0000000000000000 0.0000000000000000,
-                  0.0000000000000000 0.0000000000000000),
-                 (1.0000000000000000 1.0000000000000000,
-                  3.0000000000000000 1.0000000000000000,
-                  3.0000000000000000 3.0000000000000000,
-                  1.0000000000000000 3.0000000000000000,
-                  1.0000000000000000 1.0000000000000000))
-        POLYGON ((4.0000000000000000 0.0000000000000000,
-                  4.0000000000000000 4.0000000000000000,
-                  4.0000000000000000 4.0000000000000000,
-                  6.0000000000000000 4.0000000000000000,
-                  6.0000000000000000 4.0000000000000000,
-                  6.0000000000000000 0.0000000000000000,
-                  6.0000000000000000 0.0000000000000000,
-                  4.0000000000000000 0.0000000000000000))
-        POLYGON ((6.0000000000000000 0.0000000000000000,
-                  6.0000000000000000 4.0000000000000000,
-                  6.0000000000000000 4.0000000000000000,
-                  8.0000000000000000 4.0000000000000000,
-                  8.0000000000000000 4.0000000000000000,
-                  8.0000000000000000 0.0000000000000000,
-                  8.0000000000000000 0.0000000000000000,
-                  6.0000000000000000 0.0000000000000000))
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.geometry import Point
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> test_vect.find_by_point.area(Point(20, 20))
+            # Find AREAS
+            >>> points = (Point(0.5, 0.5), Point(5, 1), Point(7, 1))
+            >>> result = []
+            >>> for point in points:
+            ...     area = test_vect.find_by_point.area(point)
+            ...     result.append(area)
+            >>> result
+            [Area(1), Area(2), Area(4)]
+            >>> for area in result:
+            ...     print(area.to_wkt())  # doctest: +NORMALIZE_WHITESPACE
+            POLYGON ((0.0000000000000000 0.0000000000000000,
+                      0.0000000000000000 4.0000000000000000,
+                      0.0000000000000000 4.0000000000000000,
+                      4.0000000000000000 4.0000000000000000,
+                      4.0000000000000000 4.0000000000000000,
+                      4.0000000000000000 0.0000000000000000,
+                      4.0000000000000000 0.0000000000000000,
+                      0.0000000000000000 0.0000000000000000),
+                     (1.0000000000000000 1.0000000000000000,
+                      3.0000000000000000 1.0000000000000000,
+                      3.0000000000000000 3.0000000000000000,
+                      1.0000000000000000 3.0000000000000000,
+                      1.0000000000000000 1.0000000000000000))
+            POLYGON ((4.0000000000000000 0.0000000000000000,
+                      4.0000000000000000 4.0000000000000000,
+                      4.0000000000000000 4.0000000000000000,
+                      6.0000000000000000 4.0000000000000000,
+                      6.0000000000000000 4.0000000000000000,
+                      6.0000000000000000 0.0000000000000000,
+                      6.0000000000000000 0.0000000000000000,
+                      4.0000000000000000 0.0000000000000000))
+            POLYGON ((6.0000000000000000 0.0000000000000000,
+                      6.0000000000000000 4.0000000000000000,
+                      6.0000000000000000 4.0000000000000000,
+                      8.0000000000000000 4.0000000000000000,
+                      8.0000000000000000 4.0000000000000000,
+                      8.0000000000000000 0.0000000000000000,
+                      8.0000000000000000 0.0000000000000000,
+                      6.0000000000000000 0.0000000000000000))
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_point.area(Point(20, 20))
+
+            >>> test_vect.close()
         """
         area_id = libvect.Vect_find_area(self.c_mapinfo, point.x, point.y)
         if area_id:
@@ -348,30 +356,32 @@ class PointFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.geometry import Point
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find ISLANDS
-        >>> points = (Point(2, 2), Point(5, 1))
-        >>> result = []
-        >>> for point in points:
-        ...     area = test_vect.find_by_point.island(point)
-        ...     result.append(area)
-        >>> result
-        [Isle(2), Isle(1)]
-        >>> for isle in result:
-        ...     print(isle.to_wkt())  # doctest: +NORMALIZE_WHITESPACE
-        Polygon((1.000000 1.000000, 3.000000 1.000000,
-                 3.000000 3.000000, 1.000000 3.000000, 1.000000 1.000000))
-        Polygon((0.000000 4.000000, 0.000000 0.000000, 4.000000 0.000000,
-                 6.000000 0.000000, 8.000000 0.000000, 8.000000 4.000000,
-                 6.000000 4.000000, 4.000000 4.000000, 0.000000 4.000000))
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.geometry import Point
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> test_vect.find_by_point.island(Point(20, 20))
+            # Find ISLANDS
+            >>> points = (Point(2, 2), Point(5, 1))
+            >>> result = []
+            >>> for point in points:
+            ...     area = test_vect.find_by_point.island(point)
+            ...     result.append(area)
+            >>> result
+            [Isle(2), Isle(1)]
+            >>> for isle in result:
+            ...     print(isle.to_wkt())  # doctest: +NORMALIZE_WHITESPACE
+            Polygon((1.000000 1.000000, 3.000000 1.000000,
+                     3.000000 3.000000, 1.000000 3.000000, 1.000000 1.000000))
+            Polygon((0.000000 4.000000, 0.000000 0.000000, 4.000000 0.000000,
+                     6.000000 0.000000, 8.000000 0.000000, 8.000000 4.000000,
+                     6.000000 4.000000, 4.000000 4.000000, 0.000000 4.000000))
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_point.island(Point(20, 20))
+
+            >>> test_vect.close()
         """
         isle_id = libvect.Vect_find_island(self.c_mapinfo, point.x, point.y)
         if isle_id:
@@ -417,51 +427,53 @@ class BboxFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.basic import Bbox
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        >>> bbox = Bbox(north=5, south=-1, east=3, west=-1)
-        >>> result = test_vect.find_by_bbox.geos(bbox=bbox)
-        >>> [bbox for bbox in result]  # doctest: +NORMALIZE_WHITESPACE
-        [Boundary([Point(4.000000, 0.000000), Point(0.000000, 0.000000)]),
-         Boundary([Point(0.000000, 0.000000), Point(0.000000, 4.000000)]),
-         Boundary([Point(0.000000, 4.000000), Point(4.000000, 4.000000)]),
-         Boundary([Point(1.000000, 1.000000), Point(1.000000, 3.000000),
-                   Point(3.000000, 3.000000), Point(3.000000, 1.000000),
-                   Point(1.000000, 1.000000)]),
-         Centroid(2.500000, 2.500000)]
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.basic import Bbox
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> bbox = Bbox(north=5, south=-1, east=3, west=-1)
-        >>> result = test_vect.find_by_bbox.geos(bbox=bbox, bboxlist_only=True)
-        >>> result  # doctest: +NORMALIZE_WHITESPACE
-        Boxlist([Bbox(0.0, 0.0, 4.0, 0.0),
-                 Bbox(4.0, 0.0, 0.0, 0.0),
-                 Bbox(4.0, 4.0, 4.0, 0.0),
-                 Bbox(3.0, 1.0, 3.0, 1.0),
-                 Bbox(2.5, 2.5, 2.5, 2.5)])
+            >>> bbox = Bbox(north=5, south=-1, east=3, west=-1)
+            >>> result = test_vect.find_by_bbox.geos(bbox=bbox)
+            >>> [bbox for bbox in result]  # doctest: +NORMALIZE_WHITESPACE
+            [Boundary([Point(4.000000, 0.000000), Point(0.000000, 0.000000)]),
+             Boundary([Point(0.000000, 0.000000), Point(0.000000, 4.000000)]),
+             Boundary([Point(0.000000, 4.000000), Point(4.000000, 4.000000)]),
+             Boundary([Point(1.000000, 1.000000), Point(1.000000, 3.000000),
+                       Point(3.000000, 3.000000), Point(3.000000, 1.000000),
+                       Point(1.000000, 1.000000)]),
+             Centroid(2.500000, 2.500000)]
 
-        >>> bbox = Bbox(north=7, south=-1, east=15, west=9)
-        >>> result = test_vect.find_by_bbox.geos(bbox=bbox)
-        >>> [bbox for bbox in result]  # doctest: +NORMALIZE_WHITESPACE
-        [Line([Point(10.000000, 4.000000), Point(10.000000, 2.000000),
-               Point(10.000000, 0.000000)]),
-         Point(10.000000, 6.000000),
-         Line([Point(12.000000, 4.000000), Point(12.000000, 2.000000),
-               Point(12.000000, 0.000000)]),
-         Point(12.000000, 6.000000),
-         Line([Point(14.000000, 4.000000), Point(14.000000, 2.000000),
-               Point(14.000000, 0.000000)]),
-         Point(14.000000, 6.000000)]
+            >>> bbox = Bbox(north=5, south=-1, east=3, west=-1)
+            >>> result = test_vect.find_by_bbox.geos(bbox=bbox, bboxlist_only=True)
+            >>> result  # doctest: +NORMALIZE_WHITESPACE
+            Boxlist([Bbox(0.0, 0.0, 4.0, 0.0),
+                     Bbox(4.0, 0.0, 0.0, 0.0),
+                     Bbox(4.0, 4.0, 4.0, 0.0),
+                     Bbox(3.0, 1.0, 3.0, 1.0),
+                     Bbox(2.5, 2.5, 2.5, 2.5)])
 
-        >>> bbox = Bbox(north=20, south=18, east=20, west=18)
-        >>> test_vect.find_by_bbox.geos(bbox=bbox)
+            >>> bbox = Bbox(north=7, south=-1, east=15, west=9)
+            >>> result = test_vect.find_by_bbox.geos(bbox=bbox)
+            >>> [bbox for bbox in result]  # doctest: +NORMALIZE_WHITESPACE
+            [Line([Point(10.000000, 4.000000), Point(10.000000, 2.000000),
+                   Point(10.000000, 0.000000)]),
+             Point(10.000000, 6.000000),
+             Line([Point(12.000000, 4.000000), Point(12.000000, 2.000000),
+                   Point(12.000000, 0.000000)]),
+             Point(12.000000, 6.000000),
+             Line([Point(14.000000, 4.000000), Point(14.000000, 2.000000),
+                   Point(14.000000, 0.000000)]),
+             Point(14.000000, 6.000000)]
 
-        >>> bbox = Bbox(north=20, south=18, east=20, west=18)
-        >>> test_vect.find_by_bbox.geos(bbox=bbox, bboxlist_only=True)
+            >>> bbox = Bbox(north=20, south=18, east=20, west=18)
+            >>> test_vect.find_by_bbox.geos(bbox=bbox)
 
-        >>> test_vect.close()
+            >>> bbox = Bbox(north=20, south=18, east=20, west=18)
+            >>> test_vect.find_by_bbox.geos(bbox=bbox, bboxlist_only=True)
+
+            >>> test_vect.close()
         """
         found = BoxList()
         if libvect.Vect_select_lines_by_box(
@@ -487,21 +499,23 @@ class BboxFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.basic import Bbox
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find nodes in box
-        >>> bbox = Bbox(north=5, south=-1, east=15, west=9)
-        >>> result = test_vect.find_by_bbox.nodes(bbox=bbox)
-        >>> [node for node in result]
-        [Node(2), Node(1), Node(4), Node(3), Node(5), Node(6)]
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.basic import Bbox
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> bbox = Bbox(north=20, south=18, east=20, west=18)
-        >>> test_vect.find_by_bbox.nodes(bbox=bbox)
+            # Find nodes in box
+            >>> bbox = Bbox(north=5, south=-1, east=15, west=9)
+            >>> result = test_vect.find_by_bbox.nodes(bbox=bbox)
+            >>> [node for node in result]
+            [Node(2), Node(1), Node(4), Node(3), Node(5), Node(6)]
 
-        >>> test_vect.close()
+            >>> bbox = Bbox(north=20, south=18, east=20, west=18)
+            >>> test_vect.find_by_bbox.nodes(bbox=bbox)
+
+            >>> test_vect.close()
         """
         found = Ilist()
         if libvect.Vect_select_nodes_by_box(self.c_mapinfo, bbox.c_bbox, found.c_ilist):
@@ -536,31 +550,33 @@ class BboxFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.basic import Bbox
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find areas in box
-        >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
-        >>> result = test_vect.find_by_bbox.areas(bbox=bbox)
-        >>> [area for area in result]
-        [Area(1), Area(2), Area(3), Area(4)]
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.basic import Bbox
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
-        >>> result = test_vect.find_by_bbox.areas(bbox=bbox, bboxlist_only=True)
-        >>> result  # doctest: +NORMALIZE_WHITESPACE
-        Boxlist([Bbox(4.0, 0.0, 4.0, 0.0),
-                 Bbox(4.0, 0.0, 6.0, 4.0),
-                 Bbox(3.0, 1.0, 3.0, 1.0),
-                 Bbox(4.0, 0.0, 8.0, 6.0)])
+            # Find areas in box
+            >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
+            >>> result = test_vect.find_by_bbox.areas(bbox=bbox)
+            >>> [area for area in result]
+            [Area(1), Area(2), Area(3), Area(4)]
 
-        >>> bbox = Bbox(north=20, south=18, east=20, west=18)
-        >>> test_vect.find_by_bbox.areas(bbox=bbox)
+            >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
+            >>> result = test_vect.find_by_bbox.areas(bbox=bbox, bboxlist_only=True)
+            >>> result  # doctest: +NORMALIZE_WHITESPACE
+            Boxlist([Bbox(4.0, 0.0, 4.0, 0.0),
+                     Bbox(4.0, 0.0, 6.0, 4.0),
+                     Bbox(3.0, 1.0, 3.0, 1.0),
+                     Bbox(4.0, 0.0, 8.0, 6.0)])
 
-        >>> test_vect.find_by_bbox.areas(bbox=bbox, bboxlist_only=True)
+            >>> bbox = Bbox(north=20, south=18, east=20, west=18)
+            >>> test_vect.find_by_bbox.areas(bbox=bbox)
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_bbox.areas(bbox=bbox, bboxlist_only=True)
+
+            >>> test_vect.close()
         """
         boxlist = boxlist or BoxList()
         if libvect.Vect_select_areas_by_box(
@@ -595,29 +611,31 @@ class BboxFinder(AbstractFinder):
 
         Examples:
 
-        >>> from grass.pygrass.vector import VectorTopo
-        >>> from grass.pygrass.vector.basic import Bbox
-        >>> test_vect = VectorTopo(test_vector_name)
-        >>> test_vect.open("r")
+        .. code-block:: pycon
 
-        # Find isles in box
-        >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
-        >>> result = test_vect.find_by_bbox.islands(bbox=bbox)
-        >>> [isle for isle in result]
-        [Isle(1), Isle(2)]
+            >>> from grass.pygrass.vector import VectorTopo
+            >>> from grass.pygrass.vector.basic import Bbox
+            >>> test_vect = VectorTopo(test_vector_name)
+            >>> test_vect.open("r")
 
-        >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
-        >>> result = test_vect.find_by_bbox.islands(bbox=bbox, bboxlist_only=True)
-        >>> result  # doctest: +NORMALIZE_WHITESPACE
-        Boxlist([Bbox(4.0, 0.0, 8.0, 0.0),
-                 Bbox(3.0, 1.0, 3.0, 1.0)])
+            # Find isles in box
+            >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
+            >>> result = test_vect.find_by_bbox.islands(bbox=bbox)
+            >>> [isle for isle in result]
+            [Isle(1), Isle(2)]
 
-        >>> bbox = Bbox(north=20, south=18, east=20, west=18)
-        >>> test_vect.find_by_bbox.islands(bbox=bbox)
+            >>> bbox = Bbox(north=5, south=-1, east=9, west=-1)
+            >>> result = test_vect.find_by_bbox.islands(bbox=bbox, bboxlist_only=True)
+            >>> result  # doctest: +NORMALIZE_WHITESPACE
+            Boxlist([Bbox(4.0, 0.0, 8.0, 0.0),
+                     Bbox(3.0, 1.0, 3.0, 1.0)])
 
-        >>> test_vect.find_by_bbox.islands(bbox=bbox, bboxlist_only=True)
+            >>> bbox = Bbox(north=20, south=18, east=20, west=18)
+            >>> test_vect.find_by_bbox.islands(bbox=bbox)
 
-        >>> test_vect.close()
+            >>> test_vect.find_by_bbox.islands(bbox=bbox, bboxlist_only=True)
+
+            >>> test_vect.close()
         """
         found = BoxList()
         if libvect.Vect_select_isles_by_box(

--- a/python/grass/pygrass/vector/geometry.py
+++ b/python/grass/pygrass/vector/geometry.py
@@ -1317,7 +1317,7 @@ class Node:
     def to_wkb(self):
         """Return a "well know binary" (WKB) geometry array.
 
-        TODO: Must be implemented
+        .. TODO:: Must be implemented
         """
         msg = "Not implemented"
         raise Exception(msg)
@@ -1520,7 +1520,7 @@ class Isle(Geo):
 
         For now the outer ring is returned
 
-        TODO: Implement inner rings detected from isles
+        .. TODO:: Implement inner rings detected from isles
         """
         line = self.points()
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -998,7 +998,7 @@ def tempdir(env=None):
 
 
 def tempname(length: int, lowercase: bool = False) -> str:
-    """Generate a GRASS and SQL compliant random name starting with tmp_
+    """Generate a GRASS and SQL compliant random name starting with ``tmp_``
     followed by a random part of length "length"
 
     :param length: length of the random part of the name to generate


### PR DESCRIPTION
- Enable rendering of TODO boxes (admonitions). Usually they are stripped out, but they seem to be part of the content more often then not, having them removed makes the docs not complete
- Other code blocks I had already fixed
- Using references to methods of a same class
- Use double backticks for parts of code that were interpreted as labels to something in reStructuredText, but didn't exist, so causing warnings (the underscores at the end have a meaning in reST). => Reducing warnings

I don't have much "real" other fixes queued up for docs after that. The rest isn't worth it for now