### PR TITLE
docs: Add format to example even when not required

### DIFF
--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -284,7 +284,8 @@ void print_python_example(FILE *file, const char *python_function,
                     type = "string";
                     break;
                 }
-            if (opt->required || first_required_rule_option == opt) {
+            if (opt->required || first_required_rule_option == opt ||
+                (strcmp(opt->key, "format") == 0 && output_format_default)) {
                 fprintf(file, ", %s=", opt->key);
                 if (output_format_default && strcmp(opt->key, "format") == 0) {
                     fprintf(file, "\"%s\"", output_format_default);


### PR DESCRIPTION
The Python example counts on format option being there, so we need to add that even if it is not required.
This allows for empty and not required format in v.info in #5844.
