### PR TITLE
g.mapset, g.mapsets: Specify stability of the outputs

### DIFF
--- a/general/g.mapset/g.mapset.md
+++ b/general/g.mapset/g.mapset.md
@@ -6,6 +6,9 @@ as location), or GISDBASE (directory with one or more projects).
 With *g.mapset*, the shell history (i.e. `.bash_history` file of the
 initial project will be used to record the command history.
 
+The *g.mapset* tool can also report the current mapset and all mapsets in
+the current project.
+
 ## NOTES
 
 By default, the shell continues to use the history for the old mapset.
@@ -18,6 +21,10 @@ history -w
 history -r /"$GISDBASE/$LOCATION/$MAPSET"/.bash_history
 HISTFILE=/"$GISDBASE/$LOCATION/$MAPSET"/.bash_history
 ```
+
+For parsing the outputs, always use the JSON output. The current *plain* format
+may change in a future major release. Please, open an issue if you need a
+stable parsable format which is not JSON.
 
 ## EXAMPLES
 

--- a/general/g.mapset/main.c
+++ b/general/g.mapset/main.c
@@ -68,8 +68,9 @@ int main(int argc, char *argv[])
     module = G_define_module();
     G_add_keyword(_("general"));
     G_add_keyword(_("settings"));
-    module->label = _("Changes/reports current mapset.");
-    module->description = _("Optionally create new mapset or list available "
+    G_add_keyword(_("project"));
+    module->label = _("Changes or reports current mapset.");
+    module->description = _("Optionally, creates new mapset or lists available "
                             "mapsets in given project (location).");
 
     opt.mapset = G_define_standard_option(G_OPT_M_MAPSET);

--- a/general/g.mapset/tests/g_mapset_test.py
+++ b/general/g.mapset/tests/g_mapset_test.py
@@ -18,7 +18,7 @@ def test_plain_print_output(simple_dataset):
     assert text.strip() == simple_dataset.current_mapset
 
 
-def test_json_list_ouput(simple_dataset):
+def test_json_list_output(simple_dataset):
     """Test g.mapset with list flag and JSON format"""
     mapsets = simple_dataset.mapsets
     data = gs.parse_command("g.mapset", format="json", flags="l")
@@ -29,7 +29,7 @@ def test_json_list_ouput(simple_dataset):
         assert mapset in data["mapsets"]
 
 
-def test_json_print_ouput(simple_dataset):
+def test_json_print_output(simple_dataset):
     """Test g.mapset with print flag and JSON format"""
     data = gs.parse_command("g.mapset", format="json", flags="p")
     assert list(data.keys()) == ["project", "mapset"]

--- a/general/g.mapsets/g.mapsets.md
+++ b/general/g.mapsets/g.mapsets.md
@@ -79,6 +79,10 @@ Users can restrict others' access to their mapset files through use of
 still be listed in another's mapset search path; however, access to
 these mapsets will remain restricted.
 
+For parsing the outputs, always use the JSON output. The current *plain* format
+may change in a future major release. Please, open an issue if you need a
+stable parsable format which is not JSON.
+
 ## EXAMPLES
 
 ### Selecting mapsets with the graphical mapset manager

--- a/general/g.mapsets/main.c
+++ b/general/g.mapsets/main.c
@@ -85,8 +85,10 @@ int main(int argc, char *argv[])
     module = G_define_module();
     G_add_keyword(_("general"));
     G_add_keyword(_("settings"));
+    G_add_keyword(_("project"));
     G_add_keyword(_("search path"));
-    module->label = _("Modifies/prints the user's current mapset search path.");
+    module->label =
+        _("Modifies or reports the user's current mapset search path.");
     module->description = _("Affects the user's access to data existing "
                             "under the other mapsets in the current project.");
 

--- a/general/g.mapsets/tests/g_mapsets_list_format_test.py
+++ b/general/g.mapsets/tests/g_mapsets_list_format_test.py
@@ -56,7 +56,7 @@ def test_plain_print_output(simple_dataset, separator):
 
 
 def test_json_list_output(simple_dataset):
-    """Chekc list of mapsets in JSON format"""
+    """Check list of mapsets in JSON format"""
     text = gs.read_command("g.mapsets", format="json", flags="l")
     data = json.loads(text)
     assert list(data.keys()) == ["mapsets"]

--- a/general/g.mapsets/tests/g_mapsets_list_format_test.py
+++ b/general/g.mapsets/tests/g_mapsets_list_format_test.py
@@ -2,7 +2,7 @@
 #
 # MODULE:       Test of g.mapsets
 # AUTHOR(S):    Corey White <smortopahri gmail com>
-# PURPOSE:      Test parsing and structure of CSV and JSON outputs
+# PURPOSE:      Test parsing and structure of outputs
 # COPYRIGHT:    (C) 2022 by Corey White the GRASS Development Team
 #
 #               This program is free software under the GNU General Public
@@ -11,7 +11,7 @@
 #
 #############################################################################
 
-"""Test parsing and structure of CSV and JSON outputs from g.mapsets"""
+"""Test parsing and structure of outputs from g.mapsets"""
 
 import json
 import sys
@@ -55,8 +55,8 @@ def test_plain_print_output(simple_dataset, separator):
     _check_parsed_list(mapsets, text, gutils.separator(separator))
 
 
-def test_json_list_ouput(simple_dataset):
-    """JSON format"""
+def test_json_list_output(simple_dataset):
+    """Chekc list of mapsets in JSON format"""
     text = gs.read_command("g.mapsets", format="json", flags="l")
     data = json.loads(text)
     assert list(data.keys()) == ["mapsets"]
@@ -66,8 +66,8 @@ def test_json_list_ouput(simple_dataset):
         assert mapset in data["mapsets"]
 
 
-def test_json_print_ouput(simple_dataset):
-    """JSON format"""
+def test_json_print_output(simple_dataset):
+    """Check search path mapsets in JSON format"""
     text = gs.read_command("g.mapsets", format="json", flags="p")
     data = json.loads(text)
     assert list(data.keys()) == ["mapsets"]


### PR DESCRIPTION
The current outputs are marked as plain and may possibly change in the future. For now, only with major release for backwards compatibility reasons, but in the future, any release can change the plain outputs. Implementing a separate, stable, shell-script-style output is a bigger endeavor, so the documentation now recommends JSON only.

This also changes the description of the tools to clarify what they do, and improves descriptions of the tests.
