### PR TITLE
grass.script: Fallback to print when g.message fails

### DIFF
--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -730,7 +730,18 @@ def message(msg, flag=None, env=None):
     :param str flag: flags (given as string)
     :param env: dictionary with system environment variables (`os.environ` by default)
     """
-    run_command("g.message", flags=flag, message=msg, errors="ignore", env=env)
+    try:
+        run_command("g.message", flags=flag, message=msg, errors="raise", env=env)
+    except (OSError, CalledModuleError) as error:
+        # Trying harder to show something, even when not adding the right message
+        # prefix. This allows for showing the original message to the user even when
+        # the tool cannot be found or errored for some reason.
+        print(
+            _(
+                "{message} (Additionally, there was an error: {additional_error})"
+            ).format(message=msg, additional_error=error),
+            file=sys.stderr,
+        )
 
 
 def debug(msg, debug=1, env=None):

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -731,8 +731,8 @@ def message(msg, flag=None, env=None):
     :param env: dictionary with system environment variables (`os.environ` by default)
     """
     try:
-        run_command("g.message", flags=flag, message=msg, errors="raise", env=env)
-    except (OSError, CalledModuleError) as error:
+        run_command("g.message", flags=flag, message=msg, errors="ignore", env=env)
+    except OSError as error:
         # Trying harder to show something, even when not adding the right message
         # prefix. This allows for showing the original message to the user even when
         # the tool cannot be found or errored for some reason.


### PR DESCRIPTION
A certain situation on Windows described in #5717 produces 'OSError: Cannot find the executable g.message' which is missing the original message. While such message is an indication of a deeper issue, the traceback misses the original message. This fallback approach show the message as the function was asked to do even when the subprocess had issues. It attaches the exception which may be confusing, but also may be quite helpful to understand the overall situation (which may not be related to the message itself).
