### PR TITLE
grass.script: More carefully setup env in create_project

### DIFF
--- a/general/g.mapsets/tests/conftest.py
+++ b/general/g.mapsets/tests/conftest.py
@@ -20,14 +20,15 @@ def simple_dataset(tmp_path_factory):
     Returns object with attributes about the dataset.
     """
     tmp_path = tmp_path_factory.mktemp("simple_dataset")
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project_name = "test"
+    project = tmp_path / project_name
+    gs.create_project(project)  # pylint: disable=protected-access
+    with gs.setup.init(project):
         gs.run_command("g.proj", flags="c", epsg=26917)
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         # Create Mock Mapsets
         for mapset in TEST_MAPSETS:
-            gs.run_command("g.mapset", project=location, mapset=mapset, flags="c")
+            gs.run_command("g.mapset", project=project_name, mapset=mapset, flags="c")
 
         yield SimpleNamespace(
             mapsets=TEST_MAPSETS, accessible_mapsets=ACCESSIBLE_MAPSETS

--- a/lib/gis/tests/lib_gis_env_test.py
+++ b/lib/gis/tests/lib_gis_env_test.py
@@ -45,13 +45,13 @@ def test_reading_respects_change_of_session(tmp_path):
         import grass.lib.gis as libgis
 
         names = []
-        for location_name in ["test1", "test2", "abc"]:
+        for project_name in ["test1", "test2", "abc"]:
             # pylint: disable=protected-access
-            gs.core._create_location_xy(tmp_path, location_name)
-            with gs.setup.init(tmp_path / location_name):
+            gs.create_project(tmp_path / project_name)
+            with gs.setup.init(tmp_path / project_name):
                 libgis.G__read_gisrc_path()
                 libgis.G__read_gisrc_env()
-                names.append((pygrass_utils.getenv("LOCATION_NAME"), location_name))
+                names.append((pygrass_utils.getenv("LOCATION_NAME"), project_name))
         queue.put(names)
 
     names = run_in_subprocess(switch_through_locations)

--- a/python/grass/experimental/tests/conftest.py
+++ b/python/grass/experimental/tests/conftest.py
@@ -12,9 +12,9 @@ from grass import experimental
 @pytest.fixture
 def xy_session(tmp_path):
     """Active session in an XY location (scope: function)"""
-    location = "xy_test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    project = tmp_path / "xy_test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         yield session
 
 
@@ -27,9 +27,9 @@ def xy_session_for_module(tmp_path_factory):
     directories.
     """
     tmp_path = tmp_path_factory.mktemp("xy_session_for_module")
-    location = "xy_test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    project = tmp_path / "xy_test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         yield session
 
 

--- a/python/grass/jupyter/tests/conftest.py
+++ b/python/grass/jupyter/tests/conftest.py
@@ -19,9 +19,9 @@ def space_time_raster_dataset(tmp_path_factory):
     Returns object with attributes about the dataset.
     """
     tmp_path = tmp_path_factory.mktemp("raster_time_series")
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         names = [f"precipitation_{i}" for i in range(1, 7)]
         max_values = [550, 450, 320, 510, 300, 650]
@@ -73,9 +73,9 @@ def simple_dataset(tmp_path_factory):
     Returns object with attributes about the dataset.
     """
     tmp_path = tmp_path_factory.mktemp("simple_dataset")
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.proj", flags="c", epsg=26917)
         gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
         # Create Vector

--- a/python/grass/jupyter/tests/grass_jupyter_session_test.py
+++ b/python/grass/jupyter/tests/grass_jupyter_session_test.py
@@ -22,13 +22,13 @@ def run_in_subprocess(file):
 
 def test_init_finish(tmp_path):
     """Check that init function works with an explicit session finish"""
-    location = "test"
+    project = tmp_path / "test"
     script = f"""
 import os
 import grass.script as gs
 import grass.jupyter as gj
-gs.core._create_location_xy(r"{tmp_path}", r"{location}")
-session = gj.init(r"{tmp_path / location}")
+gs.create_project(r"{project}")
+session = gj.init(r"{project}")
 gs.read_command("g.region", flags="p")
 print(os.environ["GISRC"])
 session.finish()
@@ -44,13 +44,13 @@ session.finish()
 
 def test_init_with_auto_finish(tmp_path):
     """Check that init function works with an implicit session finish"""
-    location = "test"
+    project = tmp_path / "test"
     script = f"""
 import os
 import grass.script as gs
 import grass.jupyter as gj
-gs.core._create_location_xy(r"{tmp_path}", r"{location}")
-session = gj.init(r"{tmp_path / location}")
+gs.create_project(r"{project}")
+session = gj.init(r"{project}")
 print(os.environ["GISRC"])
 """
 

--- a/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
+++ b/python/grass/pygrass/modules/tests/grass_pygrass_grid_test.py
@@ -35,9 +35,9 @@ def run_in_subprocess(function):
 @pytest.mark.parametrize("processes", list(range(1, max_processes() + 1)) + [None])
 def test_processes(tmp_path, processes):
     """Check that running with multiple processes works"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         surface = "surface"
@@ -70,9 +70,9 @@ def test_processes(tmp_path, processes):
 @pytest.mark.parametrize("height", [5, 10, 50])
 def test_tiling_schemes(tmp_path, width, height):
     """Check that different shapes of tiles work"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         surface = "surface"
@@ -101,9 +101,9 @@ def test_tiling_schemes(tmp_path, width, height):
 @pytest.mark.parametrize("overlap", [0, 1, 2, 5])
 def test_overlaps(tmp_path, overlap):
     """Check that overlap accepts different values"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
         surface = "surface"
         gs.run_command("r.surf.fractal", output=surface)
@@ -132,10 +132,10 @@ def test_overlaps(tmp_path, overlap):
 @pytest.mark.parametrize("surface", ["surface", "non_exist_surface"])
 def test_cleans(tmp_path, clean, surface):
     """Check that temporary mapsets are cleaned when appropriate"""
-    location = "test"
+    project = tmp_path / "test"
     mapset_prefix = "abc"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
         if surface == "surface":
             gs.run_command("r.surf.fractal", output=surface)
@@ -156,9 +156,8 @@ def test_cleans(tmp_path, clean, surface):
 
         run_in_subprocess(run_grid_module)
 
-        path = tmp_path / location
         prefixed = 0
-        for item in path.iterdir():
+        for item in project.iterdir():
             if item.is_dir():
                 if clean:
                     # We know right away something is wrong.
@@ -174,9 +173,9 @@ def test_cleans(tmp_path, clean, surface):
 @pytest.mark.parametrize("patch_backend", [None, "r.patch", "RasterRow"])
 def test_patching_backend(tmp_path, patch_backend):
     """Check patching backend works"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         points = "points"
@@ -219,9 +218,9 @@ def test_patching_backend(tmp_path, patch_backend):
 )
 def test_tiling(tmp_path, width, height, processes):
     """Check auto adjusted tile size based on processes"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=50, w=0, e=50, res=1)
 
         surface = "surface"
@@ -260,9 +259,9 @@ def test_tiling(tmp_path, width, height, processes):
 )
 def test_patching_error(tmp_path, processes, backend):
     """Check auto adjusted tile size based on processes"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location):
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project):
         gs.run_command("g.region", s=0, n=10, w=0, e=10, res=0.1)
         surface = "fractal"
 

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -237,6 +237,38 @@ def setup_runtime_env(gisbase=None, *, env=None):
     set_path_to_python_executable(env=env)
 
 
+def runtime_env_is_active(env=None):
+    """Check that GRASS runtime environment is set up.
+
+    On a best-effort basis, it determines whether the GRASS runtime environment
+    is set up. If so, it returns True; otherwise, it returns False.
+
+    If *env* is not provided, uses the global environment (os.environ).
+    """
+    if not env:
+        env = os.environ
+    gisbase = env.get("GISBASE")
+    if not gisbase:
+        return False
+    # Check also path to tools.
+    return gisbase in env["PATH"]
+
+
+def ensure_runtime_env(env=None):
+    """Ensure that GRASS runtime environment is set up.
+
+    If the environment is set up, does nothing. Otherwise, it modifies the
+    environment to activate the runtime environment.
+    It does not start a session connected to a project.
+
+    If *env* is not provided, uses the global environment (os.environ).
+    """
+    if not env:
+        env = os.environ
+    if not runtime_env_is_active(env=env):
+        setup_runtime_env(env=env)
+
+
 def init(
     path,
     location=None,

--- a/python/grass/script/tests/grass_script_core_location_test.py
+++ b/python/grass/script/tests/grass_script_core_location_test.py
@@ -33,18 +33,16 @@ def run_in_subprocess(function):
 
 def create_and_get_srid(tmp_path):
     """Create location on the same path as the current one"""
-    bootstrap_location = "bootstrap"
-    desired_location = "desired"
-    gs.core._create_location_xy(tmp_path, bootstrap_location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / bootstrap_location, env=os.environ.copy()) as session:
-        gs.create_location(tmp_path, desired_location, epsg="3358")
-        assert (tmp_path / desired_location).exists()
-        wkt_file = tmp_path / desired_location / "PERMANENT" / "PROJ_WKT"
+    bootstrap = "bootstrap"
+    desired = "desired"
+    gs.create_project(tmp_path / bootstrap)  # pylint: disable=protected-access
+    with gs.setup.init(tmp_path / bootstrap, env=os.environ.copy()) as session:
+        gs.create_location(tmp_path / desired, epsg="3358")
+        assert (tmp_path / desired).exists()
+        wkt_file = tmp_path / desired / "PERMANENT" / "PROJ_WKT"
         assert wkt_file.exists()
         gs.run_command("g.gisenv", set=f"GISDBASE={tmp_path}", env=session.env)
-        gs.run_command(
-            "g.gisenv", set=f"LOCATION_NAME={desired_location}", env=session.env
-        )
+        gs.run_command("g.gisenv", set=f"LOCATION_NAME={desired}", env=session.env)
         gs.run_command("g.gisenv", set="MAPSET=PERMANENT", env=session.env)
         return gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
             "srid"
@@ -98,23 +96,19 @@ def test_without_session(tmp_path):
 
 def test_with_different_path(tmp_path):
     """Check correct EPSG is created with different path"""
-    bootstrap_location = "bootstrap"
-    desired_location = "desired"
+    bootstrap = "bootstrap"
+    desired = "desired"
     tmp_path_a = tmp_path / "a"
     tmp_path_b = tmp_path / "b"
     tmp_path_a.mkdir()
-    gs.core._create_location_xy(tmp_path_a, bootstrap_location)  # pylint: disable=protected-access
-    with gs.setup.init(
-        tmp_path_a / bootstrap_location, env=os.environ.copy()
-    ) as session:
-        gs.create_location(tmp_path_b, desired_location, epsg="3358")
-        assert (tmp_path_b / desired_location).exists()
-        wkt_file = tmp_path_b / desired_location / "PERMANENT" / "PROJ_WKT"
+    gs.create_project(tmp_path_a / bootstrap)
+    with gs.setup.init(tmp_path_a / bootstrap, env=os.environ.copy()) as session:
+        gs.create_location(tmp_path_b, desired, epsg="3358")
+        assert (tmp_path_b / desired).exists()
+        wkt_file = tmp_path_b / desired / "PERMANENT" / "PROJ_WKT"
         assert wkt_file.exists()
         gs.run_command("g.gisenv", set=f"GISDBASE={tmp_path_b}", env=session.env)
-        gs.run_command(
-            "g.gisenv", set=f"LOCATION_NAME={desired_location}", env=session.env
-        )
+        gs.run_command("g.gisenv", set=f"LOCATION_NAME={desired}", env=session.env)
         gs.run_command("g.gisenv", set="MAPSET=PERMANENT", env=session.env)
         epsg = gs.parse_command("g.proj", flags="p", format="shell", env=session.env)[
             "srid"
@@ -123,8 +117,8 @@ def test_with_different_path(tmp_path):
 
 
 def test_path_only(tmp_path):
-    desired_location = "desired"
-    full_path = tmp_path / desired_location
+    desired = "desired"
+    full_path = tmp_path / desired
     gs.create_location(full_path, epsg="3358")
     mapset_path = full_path / "PERMANENT"
     wkt_file = mapset_path / "PROJ_WKT"
@@ -152,15 +146,15 @@ def test_create_project(tmp_path):
 
 
 def test_files(tmp_path):
-    """Check expected files are created"""
-    bootstrap_location = "bootstrap"
-    desired_location = "desired"
-    gs.core._create_location_xy(tmp_path, bootstrap_location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / bootstrap_location, env=os.environ.copy()):
+    """Check expected files are created with bootstrap and session"""
+    bootstrap = "bootstrap"
+    desired = "desired"
+    gs.create_project(tmp_path / bootstrap)
+    with gs.setup.init(tmp_path / bootstrap, env=os.environ.copy()):
         description = "This is a test (not Gauss-Krüger or Křovák)"
-        gs.create_location(tmp_path, desired_location, epsg="3358", desc=description)
-        assert (tmp_path / desired_location).exists()
-        base_path = tmp_path / desired_location / "PERMANENT"
+        gs.create_project(tmp_path, desired, epsg="3358", desc=description)
+        assert (tmp_path / desired).exists()
+        base_path = tmp_path / desired / "PERMANENT"
         assert (base_path / "PROJ_WKT").exists()
         assert (base_path / "PROJ_SRID").exists()
         assert (base_path / "PROJ_UNITS").exists()
@@ -175,9 +169,11 @@ def test_files(tmp_path):
 def set_and_test_description(tmp_path, text):
     """Set text as description and check the result"""
     name = "test"
-    gs.core._create_location_xy(tmp_path, name)  # pylint: disable=protected-access
-    gs.core._set_location_description(tmp_path, name, text)
+    gs.create_project(tmp_path / name, desc=text)
     description_file = tmp_path / name / "PERMANENT" / "MYNAME"
+    # The behavior inherited in the code is that the file always needs to exist,
+    # regardless of user setting the title or not. This may change in the future,
+    # but for now, we test for this specific behavior.
     assert description_file.exists()
     text = text or ""  # None and empty should both yield empty.
     assert description_file.read_text(encoding="utf-8").strip() == text

--- a/python/grass/script/tests/grass_script_setup_test.py
+++ b/python/grass/script/tests/grass_script_setup_test.py
@@ -39,9 +39,9 @@ def run_in_subprocess(function):
 
 def test_init_as_context_manager(tmp_path):
     """Check that init function return value works as a context manager"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         gs.run_command("g.region", flags="p", env=session.env)
         session_file = session.env["GISRC"]
         assert os.path.exists(session_file)
@@ -50,9 +50,9 @@ def test_init_as_context_manager(tmp_path):
 
 def test_init_session_finish(tmp_path):
     """Check that init works with finish on the returned session object"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    session = gs.setup.init(tmp_path / location, env=os.environ.copy())
+    project = tmp_path / "test"
+    gs.create_project(project)
+    session = gs.setup.init(project, env=os.environ.copy())
     gs.run_command("g.region", flags="p", env=session.env)
     session_file = session.env["GISRC"]
     session.finish()
@@ -64,10 +64,10 @@ def test_init_session_finish(tmp_path):
 
 def test_init_finish_global_functions_with_env(tmp_path):
     """Check that init and finish global functions work"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
+    project = tmp_path / "test"
+    gs.create_project(project)
     env = os.environ.copy()
-    gs.setup.init(tmp_path / location, env=env)
+    gs.setup.init(project, env=env)
     gs.run_command("g.region", flags="p", env=env)
     session_file = env["GISRC"]
     gs.setup.finish(env=env)
@@ -77,9 +77,9 @@ def test_init_finish_global_functions_with_env(tmp_path):
 
 def init_finish_global_functions_capture_strerr0_partial(tmp_path, queue):
     gs.set_capture_stderr(True)
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    gs.setup.init(tmp_path / location)
+    project = tmp_path / "test"
+    gs.create_project(project)
+    gs.setup.init(project)
     gs.run_command("g.region", flags="p")
     runtime_present = bool(os.environ.get("GISBASE"))
     queue.put((os.environ["GISRC"], runtime_present))
@@ -106,11 +106,9 @@ def test_init_finish_global_functions_capture_strerr0(tmp_path):
 
     def init_finish(queue):
         gs.set_capture_stderr(True)
-        location = "test"
-        gs.core._create_location_xy(  # pylint: disable=protected-access
-            tmp_path, location
-        )
-        gs.setup.init(tmp_path / location)
+        project = tmp_path / "test"
+        gs.create_project(project)
+        gs.setup.init(project)
         gs.run_command("g.region", flags="p")
         runtime_present = bool(os.environ.get("GISBASE"))
         queue.put((os.environ["GISRC"], runtime_present))
@@ -128,11 +126,9 @@ def test_init_finish_global_functions_capture_strerrX(tmp_path):
 
     def init_finish(queue):
         gs.set_capture_stderr(True)
-        location = "test"
-        gs.core._create_location_xy(  # pylint: disable=protected-access
-            tmp_path, location
-        )
-        gs.setup.init(tmp_path / location)
+        project = tmp_path / "test"
+        gs.create_project(project)
+        gs.setup.init(project)
         gs.run_command("g.region", flags="p")
         runtime_present = bool(os.environ.get("GISBASE"))
         session_file = os.environ["GISRC"]
@@ -157,11 +153,9 @@ def test_init_finish_global_functions_isolated(tmp_path):
 
     def init_finish(queue):
         gs.set_capture_stderr(True)
-        location = "test"
-        gs.core._create_location_xy(  # pylint: disable=protected-access
-            tmp_path, location
-        )
-        gs.setup.init(tmp_path / location)
+        project = tmp_path / "test"
+        gs.create_project(project)
+        gs.setup.init(project)
         gs.run_command("g.region", flags="p")
         runtime_present_during = bool(os.environ.get("GISBASE"))
         session_file_variable_present_during = bool(os.environ.get("GISRC"))
@@ -212,11 +206,9 @@ def test_init_as_context_manager_env_attribute(tmp_path):
     """Check that session has global environment as attribute"""
 
     def workload(queue):
-        location = "test"
-        gs.core._create_location_xy(  # pylint: disable=protected-access
-            tmp_path, location
-        )
-        with gs.setup.init(tmp_path / location) as session:
+        project = tmp_path / "test"
+        gs.create_project(project)
+        with gs.setup.init(project) as session:
             gs.run_command("g.region", flags="p", env=session.env)
             session_file = os.environ["GISRC"]
             runtime_present = bool(os.environ.get("GISBASE"))
@@ -234,10 +226,10 @@ def test_init_as_context_manager_env_attribute(tmp_path):
 @pytest.mark.usefixtures("mock_no_session")
 def test_init_environment_isolation(tmp_path):
     """Check that only the provided environment is modified"""
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
+    project = tmp_path / "test"
+    gs.create_project(project)
     env = os.environ.copy()
-    with gs.setup.init(tmp_path / location, env=env) as session:
+    with gs.setup.init(project, env=env) as session:
         gs.run_command("g.region", flags="p", env=session.env)
         assert env.get("GISBASE")
         assert env.get("GISRC")

--- a/python/grass/script/tests/test_script_task.py
+++ b/python/grass/script/tests/test_script_task.py
@@ -11,9 +11,9 @@ def xy_session_patched_env(tmp_path, monkeypatch):
     """Active session in an XY location (scope: function), patching env vars directly.
 
     This allows functions not accepting an env dictionary argument to work in tests"""
-    location = "xy_test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    project = tmp_path / "xy_test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         for key, value in session.env.items():
             monkeypatch.setenv(key, value)
         yield session

--- a/scripts/v.db.univar/tests/conftest.py
+++ b/scripts/v.db.univar/tests/conftest.py
@@ -44,9 +44,9 @@ def setup_session(
 ) -> Generator[SessionHandle]:
     """Creates a session with a mapset"""
     tmp_path = tmp_path_factory.mktemp("simple_dataset")
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         for key, value in session.env.items():
             monkeypatch_module.setenv(key, value)
         yield session

--- a/scripts/v.dissolve/tests/conftest.py
+++ b/scripts/v.dissolve/tests/conftest.py
@@ -49,7 +49,7 @@ def value_update_by_category(map_name, layer, column_name, cats, values, env):
 def dataset(tmp_path_factory):
     """Creates a session with a mapset which has vector with a float column"""
     tmp_path = tmp_path_factory.mktemp("dataset")
-    location = "test"
+    project = tmp_path / "test"
     point_map_name = "points"
     map_name = "areas"
     int_column_name = "int_value"
@@ -62,8 +62,8 @@ def dataset(tmp_path_factory):
     str_values = ["apples", "oranges", "oranges", "plumbs", "oranges", "plumbs"]
     num_points = len(cats)
 
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    gs.create_project(project)
+    with grass_setup.init(project, env=os.environ.copy()) as session:
         gs.run_command(
             "g.region",
             s=0,
@@ -136,7 +136,7 @@ def dataset(tmp_path_factory):
 def discontinuous_dataset(tmp_path_factory):
     """Creates a session with a mapset which has vector with a float column"""
     tmp_path = tmp_path_factory.mktemp("discontinuous_dataset")
-    location = "test"
+    project = tmp_path / "test"
     point_map_name = "points"
     map_name = "areas"
     int_column_name = "int_value"
@@ -149,8 +149,8 @@ def discontinuous_dataset(tmp_path_factory):
     str_values = ["apples", "plumbs", "apples", "plumbs", "oranges", "oranges"]
     num_points = len(cats)
 
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    gs.create_project(project)
+    with grass_setup.init(project, env=os.environ.copy()) as session:
         gs.run_command(
             "g.region",
             s=0,
@@ -223,7 +223,7 @@ def discontinuous_dataset(tmp_path_factory):
 def dataset_layer_2(tmp_path_factory):
     """Creates a session with a mapset which has vector with a float column"""
     tmp_path = tmp_path_factory.mktemp("dataset_layer_2")
-    location = "test"
+    project = tmp_path / "test"
     point_map_name = "points"
     point_map_name_layer_2 = "points2"
     map_name = "areas"
@@ -239,8 +239,8 @@ def dataset_layer_2(tmp_path_factory):
 
     layer = 2
 
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with grass_setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    gs.create_project(project)
+    with grass_setup.init(project, env=os.environ.copy()) as session:
         gs.run_command(
             "g.region",
             s=0,

--- a/temporal/t.rast.list/tests/conftest.py
+++ b/temporal/t.rast.list/tests/conftest.py
@@ -16,9 +16,9 @@ def space_time_raster_dataset(tmp_path_factory):
     Returns object with attributes about the dataset.
     """
     tmp_path = tmp_path_factory.mktemp("raster_time_series")
-    location = "test"
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    project = tmp_path / "test"
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         gs.run_command(
             "g.region",
             s=0,

--- a/vector/v.fill.holes/tests/conftest.py
+++ b/vector/v.fill.holes/tests/conftest.py
@@ -225,13 +225,13 @@ def import_data(path, areas_name, areas_with_space_in_between, env):
 def area_dataset(tmp_path_factory):
     """Create a session and fill mapset with data"""
     tmp_path = tmp_path_factory.mktemp("area_dataset")
-    location = "test"
+    project = tmp_path / "test"
 
     areas_name = "test_areas"
     areas_with_space_in_between = "areas_with_space_in_between"
 
-    gs.core._create_location_xy(tmp_path, location)  # pylint: disable=protected-access
-    with gs.setup.init(tmp_path / location, env=os.environ.copy()) as session:
+    gs.create_project(project)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         import_data(
             path=tmp_path,
             areas_name=areas_name,


### PR DESCRIPTION
This changes the condition used to create the runtime environment in create_project so that the environment is not set up not only when GISBASE is not set, but also when GISBASE is not in PATH which (at least at this point) indicates that no tools can run, so a call to g.proj later (and technically the potential g.message call before that) will fail.

This helps when GISBASE is set, even correctly, for some reason, but PATH is not. This may happen when someone is trying to GISBASE in some special way before GRASS actually runs. I have suspicion this is happening on Windows, but hard to tell without reading the setup scripts in details (when running on Windows you could print the environment and see). However, judging from @echoix experiments in #5717, this may be unrelated to the issues with create_project. Anyway, before this PR, the following results in a traceback, but with this PR it works.

```sh
GISBASE="/.../dist.x86_64-pc-linux-gnu/" python -c "import grass.script as gs; import tempfile; d = tempfile.TemporaryDirectory(); gs.create_project(d.name, 'project', epsg=3358); d.cleanup();"
```

```text
Traceback (most recent call last):
  File "<string>", line 1, in <module>
...
    raise OSError(_("Cannot find the executable {0}").format(args[0]))
OSError: Cannot find the executable g.proj
```

The env setup is done only when needed, so simple XY does not trigger creation of the environment, and so it is more lightweight in terms of things happening and simply faster.

| code | time | command |
| --- | --- | --- |
| original create_project | 558 usec per loop | `python -m timeit -n 1000 -- "import grass.script as gs; import tempfile; d = tempfile.TemporaryDirectory(); gs.create_project(d.name, 'project'); d.cleanup();"` |
| new create_project | 365 usec per loop | `python -m timeit -n 1000 -- "import grass.script as gs; import tempfile; d = tempfile.TemporaryDirectory(); gs.create_project(d.name, 'project'); d.cleanup();"` |
| low-level calls | 309 usec per loop | `python -m timeit -n 1000 -- "import grass.script as gs; import tempfile; d = tempfile.TemporaryDirectory(); gs.core._create_location_xy(d.name, 'project'); gs.core._set_location_description(d.name, 'project', None); d.cleanup();"` |

With faster create_project, I replaced the old gs.core._create_location_xy calls in tests by simple gs.create_project calls.

The code to ensure runtime environment is moved to grass.script.setup, broken down and made reusable. The difference for usage in create_project is that os.environ is now always copied even if it already has GISBASE (we saved that copy operation before if GISBASE was already present). The handling of env, however, is consistent with other functions in grass.script.setup.