### PR TITLE
doc: Generate zero, not type in Python examples

### DIFF
--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -298,8 +298,11 @@ void print_python_example(FILE *file, const char *python_function,
                     }
                 }
                 else {
-                    if (opt->type == TYPE_INTEGER || opt->type == TYPE_DOUBLE) {
-                        fprintf(file, "%s", type);
+                    if (opt->type == TYPE_INTEGER) {
+                        fprintf(file, "0");
+                    }
+                    else if (opt->type == TYPE_DOUBLE) {
+                        fprintf(file, "0.0");
                     }
                     else {
                         fprintf(file, "\"%s\"", type);


### PR DESCRIPTION
In the generated Python examples the type was leaking to the code, but does not make sense syntactically. For strings, we simply say string in quotes by default (if key description is not available), but for ints and floats, there is no such value (we don't have an example value), so this generates zero in the example. This will be likely wrong value for many cases, but it isvalid and also something the user will likely change (and it is easy to change).

Generated r.buffer example:

```python
gs.run_command("r.buffer", input="name", output="name", distances=0.0)
```