### PR TITLE
docs: Adjust more code-blocks syntax and inside example sections in docstrings

### DIFF
--- a/python/grass/exceptions/__init__.py
+++ b/python/grass/exceptions/__init__.py
@@ -32,13 +32,15 @@ class ParameterError(Exception):
 
 
 class ScriptError(Exception):
-    """Raised during script execution. ::
+    """Raised during script execution.
 
-    >>> error = ScriptError("My error message!")
-    >>> error.value
-    'My error message!'
-    >>> print(error)
-    My error message!
+    .. code-block:: pycon
+
+        >>> error = ScriptError("My error message!")
+        >>> error.value
+        'My error message!'
+        >>> print(error)
+        My error message!
     """
 
     def __init__(self, value):

--- a/python/grass/jupyter/interactivemap.py
+++ b/python/grass/jupyter/interactivemap.py
@@ -87,14 +87,16 @@ class Layer:  # pylint: disable=too-few-public-methods
 class Raster(Layer):
     """Overlays rasters on a folium or ipyleaflet map.
 
-    Basic Usage:
-    >>> m = folium.Map()
-    >>> gj.Raster("elevation", opacity=0.5).add_to(m)
-    >>> m
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> m = ipyleaflet.Map()
-    >>> gj.Raster("elevation", opacity=0.5).add_to(m)
-    >>> m
+        >>> m = folium.Map()
+        >>> gj.Raster("elevation", opacity=0.5).add_to(m)
+        >>> m
+
+        >>> m = ipyleaflet.Map()
+        >>> gj.Raster("elevation", opacity=0.5).add_to(m)
+        >>> m
     """
 
     def __init__(
@@ -145,14 +147,16 @@ class Raster(Layer):
 class Vector(Layer):
     """Adds vectors to a folium or ipyleaflet map.
 
-    Basic Usage:
-    >>> m = folium.Map()
-    >>> gj.Vector("roadsmajor").add_to(m)
-    >>> m
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> m = ipyleaflet.Map()
-    >>> gj.Vector("roadsmajor").add_to(m)
-    >>> m
+        >>> m = folium.Map()
+        >>> gj.Vector("roadsmajor").add_to(m)
+        >>> m
+
+        >>> m = ipyleaflet.Map()
+        >>> gj.Vector("roadsmajor").add_to(m)
+        >>> m
     """
 
     def __init__(
@@ -198,12 +202,13 @@ class Vector(Layer):
 class InteractiveMap:
     """This class creates interactive GRASS maps with folium or ipyleaflet.
 
-    Basic Usage:
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> m = InteractiveMap()
-    >>> m.add_vector("streams")
-    >>> m.add_raster("elevation")
-    >>> m.show()
+        >>> m = InteractiveMap()
+        >>> m.add_vector("streams")
+        >>> m.add_raster("elevation")
+        >>> m.show()
     """
 
     def __init__(

--- a/python/grass/jupyter/map.py
+++ b/python/grass/jupyter/map.py
@@ -29,22 +29,24 @@ class Map:
 
     Elements are added to the display by calling GRASS display modules.
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> m = Map()
-    >>> m.run("d.rast", map="elevation")
-    >>> m.run("d.legend", raster="elevation")
-    >>> m.show()
+        >>> m = Map()
+        >>> m.run("d.rast", map="elevation")
+        >>> m.run("d.legend", raster="elevation")
+        >>> m.show()
 
     GRASS display modules can also be called by using the name of module
     as a class method and replacing "." with "_" in the name.
 
-    Shortcut usage::
+    :Shortcut usage:
+      .. code-block:: pycon
 
-    >>> m = Map()
-    >>> m.d_rast(map="elevation")
-    >>> m.d_legend(raster="elevation")
-    >>> m.show()
+        >>> m = Map()
+        >>> m.d_rast(map="elevation")
+        >>> m.d_legend(raster="elevation")
+        >>> m.show()
 
     """
 

--- a/python/grass/jupyter/map3d.py
+++ b/python/grass/jupyter/map3d.py
@@ -33,12 +33,13 @@ class Map3D:
     placed on the image using the *overlay* attribute which is the 2D renderer, i.e.,
     has interface of the *Map* class.
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> img = Map()
-    >>> img.render(elevation_map="elevation", color_map="elevation", perspective=20)
-    >>> img.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
-    >>> img.show()
+        >>> img = Map()
+        >>> img.render(elevation_map="elevation", color_map="elevation", perspective=20)
+        >>> img.overlay.d_legend(raster="elevation", at=(60, 97, 87, 92))
+        >>> img.show()
 
     For the OpenGL rendering with *m.nviz.image* to work, a display (screen) is needed.
     This is not guaranteed on headless systems such as continuous integration (CI) or

--- a/python/grass/jupyter/seriesmap.py
+++ b/python/grass/jupyter/seriesmap.py
@@ -27,14 +27,15 @@ class SeriesMap(BaseSeriesMap):
     """Creates visualizations from a series of rasters or vectors in Jupyter
     Notebooks.
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> series = gj.SeriesMap(height=500)
-    >>> series.add_rasters(["elevation_shade", "geology", "soils"])
-    >>> series.add_vectors(["streams", "streets", "viewpoints"])
-    >>> series.d_barscale()
-    >>> series.show()  # Create Slider
-    >>> series.save("image.gif")
+        >>> series = gj.SeriesMap(height=500)
+        >>> series.add_rasters(["elevation_shade", "geology", "soils"])
+        >>> series.add_vectors(["streams", "streets", "viewpoints"])
+        >>> series.d_barscale()
+        >>> series.show()  # Create Slider
+        >>> series.save("image.gif")
 
     This class of grass.jupyter is experimental and under development. The API can
     change at anytime.

--- a/python/grass/jupyter/timeseriesmap.py
+++ b/python/grass/jupyter/timeseriesmap.py
@@ -115,12 +115,13 @@ class TimeSeriesMap(BaseSeriesMap):
     """Creates visualizations of time-space raster and vector datasets in Jupyter
     Notebooks.
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: pycon
 
-    >>> img = TimeSeriesMap("series_name")
-    >>> img.d_legend()  # Add legend
-    >>> img.show()  # Create TimeSlider
-    >>> img.save("image.gif")
+        >>> img = TimeSeriesMap("series_name")
+        >>> img.d_legend()  # Add legend
+        >>> img.show()  # Create TimeSlider
+        >>> img.save("image.gif")
 
     This class of grass.jupyter is experimental and under development. The API can
     change at anytime.

--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -19,7 +19,9 @@ test_raster_name = "Region_test_raster"
 
 class Region:
     """This class is design to easily access and modify GRASS computational
-    region. ::
+    region.
+
+    .. code-block:: pycon
 
         >>> r = Region()
         >>> r.north
@@ -98,7 +100,6 @@ class Region:
         >>> r.nsres
         0.04
 
-    ..
     """
 
     def __init__(self, default=False):
@@ -302,18 +303,18 @@ class Region:
         return self.__unicode__()
 
     def __eq__(self, reg):
-        """Compare two region. ::
+        """Compare two regions.
 
-        >>> r0 = Region()
-        >>> r1 = Region()
-        >>> r2 = Region()
-        >>> r2.nsres = 5
-        >>> r0 == r1
-        True
-        >>> r1 == r2
-        False
+        .. code-block:: pycon
 
-        ..
+            >>> r0 = Region()
+            >>> r1 = Region()
+            >>> r2 = Region()
+            >>> r2.nsres = 5
+            >>> r0 == r1
+            True
+            >>> r1 == r2
+            False
         """
         attrs = [
             "north",
@@ -340,13 +341,13 @@ class Region:
     __hash__ = object.__hash__
 
     def keys(self):
-        """Return a list of valid keys. ::
+        """Return a list of valid keys.
+
+        .. code-block:: pycon
 
             >>> reg = Region()
             >>> reg.keys()  # doctest: +ELLIPSIS
             ['proj', 'zone', ..., 'cols', 'cells']
-
-        ..
         """
         return [
             "proj",
@@ -405,17 +406,17 @@ class Region:
         :param vector_name: the name of vector
         :type vector_name: str
 
-        Example ::
+        :Example:
 
-        >>> reg = Region()
-        >>> reg.from_vect(test_vector_name)
-        >>> reg.get_bbox()
-        Bbox(6.0, 0.0, 14.0, 0.0)
-        >>> reg.read()
-        >>> reg.get_bbox()
-        Bbox(40.0, 0.0, 40.0, 0.0)
+          .. code-block:: pycon
 
-        ..
+            >>> reg = Region()
+            >>> reg.from_vect(test_vector_name)
+            >>> reg.get_bbox()
+            Bbox(6.0, 0.0, 14.0, 0.0)
+            >>> reg.read()
+            >>> reg.get_bbox()
+            Bbox(40.0, 0.0, 40.0, 0.0)
         """
         from grass.pygrass.vector import VectorTopo
 
@@ -433,19 +434,19 @@ class Region:
         :param mapset: the mapset of raster
         :type mapset: str
 
-        call C function `Rast_get_cellhd`
+        Call C function :c:func:`Rast_get_cellhd`
 
-        Example ::
+        :Example:
 
-        >>> reg = Region()
-        >>> reg.from_rast(test_raster_name)
-        >>> reg.get_bbox()
-        Bbox(50.0, 0.0, 60.0, 0.0)
-        >>> reg.read()
-        >>> reg.get_bbox()
-        Bbox(40.0, 0.0, 40.0, 0.0)
+          .. code-block:: pycon
 
-        ..
+            >>> reg = Region()
+            >>> reg.from_rast(test_raster_name)
+            >>> reg.get_bbox()
+            Bbox(50.0, 0.0, 60.0, 0.0)
+            >>> reg.read()
+            >>> reg.get_bbox()
+            Bbox(40.0, 0.0, 40.0, 0.0)
         """
         if not raster_name:
             msg = "Raster name or mapset are invalid"
@@ -476,18 +477,20 @@ class Region:
         Previous calls to read() affects values returned by this function
         only if the current working region is not initialized.
 
-         Example:
+        :Example:
 
-         >>> r = Region()
-         >>> r.north
-         40.0
+          .. code-block:: pycon
 
-         >>> r.north = 30
-         >>> r.north
-         30.0
-         >>> r.get_current()
-         >>> r.north
-         40.0
+            >>> r = Region()
+            >>> r.north
+            40.0
+
+            >>> r.north = 30
+            >>> r.north
+            30.0
+            >>> r.get_current()
+            >>> r.north
+            40.0
 
         """
         libgis.G_get_set_window(self.byref())
@@ -501,38 +504,40 @@ class Region:
         Attention: Only the current process is affected.
                    The GRASS computational region is not affected.
 
-         Example::
+        :Example:
 
-         >>> r = Region()
-         >>> r.north
-         40.0
-         >>> r.south
-         0.0
+          .. code-block:: pycon
 
-         >>> r.north = 30
-         >>> r.south = 20
-         >>> r.set_current()
-         >>> r.north
-         30.0
-         >>> r.south
-         20.0
-         >>> r.get_current()
-         >>> r.north
-         30.0
-         >>> r.south
-         20.0
+            >>> r = Region()
+            >>> r.north
+            40.0
+            >>> r.south
+            0.0
 
-         >>> r.read(force_read=False)
-         >>> r.north
-         40.0
-         >>> r.south
-         0.0
+            >>> r.north = 30
+            >>> r.south = 20
+            >>> r.set_current()
+            >>> r.north
+            30.0
+            >>> r.south
+            20.0
+            >>> r.get_current()
+            >>> r.north
+            30.0
+            >>> r.south
+            20.0
 
-         >>> r.read(force_read=True)
-         >>> r.north
-         40.0
-         >>> r.south
-         0.0
+            >>> r.read(force_read=False)
+            >>> r.north
+            40.0
+            >>> r.south
+            0.0
+
+            >>> r.read(force_read=True)
+            >>> r.north
+            40.0
+            >>> r.south
+            0.0
 
         """
         libgis.G_set_window(self.byref())
@@ -575,32 +580,33 @@ class Region:
         carefully used, since the user will ot notice if his region
         was changed and would expect that only g.region will do this.
 
-         Example ::
+        :Example:
 
-         >>> from copy import deepcopy
-         >>> r = Region()
-         >>> rn = deepcopy(r)
-         >>> r.north = 20
-         >>> r.south = 10
+          .. code-block:: pycon
 
-         >>> r.write()
-         >>> r.read()
-         >>> r.north
-         20.0
-         >>> r.south
-         10.0
+            >>> from copy import deepcopy
+            >>> r = Region()
+            >>> rn = deepcopy(r)
+            >>> r.north = 20
+            >>> r.south = 10
 
-         >>> rn.write()
-         >>> r.read()
-         >>> r.north
-         40.0
-         >>> r.south
-         0.0
+            >>> r.write()
+            >>> r.read()
+            >>> r.north
+            20.0
+            >>> r.south
+            10.0
 
-         >>> r.read_default()
-         >>> r.write()
+            >>> rn.write()
+            >>> r.read()
+            >>> r.north
+            40.0
+            >>> r.south
+            0.0
 
-         ..
+            >>> r.read_default()
+            >>> r.write()
+
         """
         self.adjust()
         if libgis.G_put_window(self.byref()) < 0:
@@ -620,13 +626,16 @@ class Region:
         libgis.G_get_default_window(self.byref())
 
     def get_bbox(self):
-        """Return a Bbox object with the extension of the region. ::
+        """Return a :py:class:`~grass.pygrass.vector.basic.Bbox` object with the extension of the region.
+
+        :returns: A :py:class:`~grass.pygrass.vector.basic.Bbox` object
+        :rtype: ~grass.pygrass.vector.basic.Bbox
+
+        .. code-block:: pycon
 
             >>> reg = Region()
             >>> reg.get_bbox()
             Bbox(40.0, 0.0, 40.0, 0.0)
-
-        ..
         """
         from grass.pygrass.vector.basic import Bbox
 
@@ -645,7 +654,7 @@ class Region:
         :param bbox: a Bbox object to set the extent
         :type bbox: Bbox object
 
-        ::
+        .. code-block:: pycon
 
             >>> from grass.pygrass.vector.basic import Bbox
             >>> b = Bbox(230963.640878, 212125.562878, 645837.437393, 628769.374393)
@@ -654,8 +663,6 @@ class Region:
             >>> reg.get_bbox()
             Bbox(230963.640878, 212125.562878, 645837.437393, 628769.374393)
             >>> reg.get_current()
-
-        ..
         """
         self.north = bbox.north
         self.south = bbox.south

--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -407,7 +407,6 @@ class Region:
         :type vector_name: str
 
         :Example:
-
           .. code-block:: pycon
 
             >>> reg = Region()
@@ -437,7 +436,6 @@ class Region:
         Call C function :c:func:`Rast_get_cellhd`
 
         :Example:
-
           .. code-block:: pycon
 
             >>> reg = Region()
@@ -478,7 +476,6 @@ class Region:
         only if the current working region is not initialized.
 
         :Example:
-
           .. code-block:: pycon
 
             >>> r = Region()
@@ -505,7 +502,6 @@ class Region:
                    The GRASS computational region is not affected.
 
         :Example:
-
           .. code-block:: pycon
 
             >>> r = Region()
@@ -581,7 +577,6 @@ class Region:
         was changed and would expect that only g.region will do this.
 
         :Example:
-
           .. code-block:: pycon
 
             >>> from copy import deepcopy

--- a/python/grass/pygrass/messages/__init__.py
+++ b/python/grass/pygrass/messages/__init__.py
@@ -131,46 +131,47 @@ class Messenger:
         and restarts the pipeline.
 
 
-    Usage:
+    :Usage:
+      .. code-block:: pycon
 
-    >>> msgr = Messenger()
-    >>> msgr.debug(0, "debug 0")
-    >>> msgr.verbose("verbose message")
-    >>> msgr.message("message")
-    >>> msgr.important("important message")
-    >>> msgr.percent(1, 1, 1)
-    >>> msgr.warning("Ohh")
-    >>> msgr.error("Ohh no")
+        >>> msgr = Messenger()
+        >>> msgr.debug(0, "debug 0")
+        >>> msgr.verbose("verbose message")
+        >>> msgr.message("message")
+        >>> msgr.important("important message")
+        >>> msgr.percent(1, 1, 1)
+        >>> msgr.warning("Ohh")
+        >>> msgr.error("Ohh no")
 
-    >>> msgr = Messenger()
-    >>> msgr.fatal("Ohh no no no!")
-    Traceback (most recent call last):
-      File "__init__.py", line 239, in fatal
-        sys.exit(1)
-    SystemExit: 1
+        >>> msgr = Messenger()
+        >>> msgr.fatal("Ohh no no no!")
+        Traceback (most recent call last):
+          File "__init__.py", line 239, in fatal
+            sys.exit(1)
+        SystemExit: 1
 
-    >>> msgr = Messenger(raise_on_error=True)
-    >>> msgr.fatal("Ohh no no no!")
-    Traceback (most recent call last):
-      File "__init__.py", line 241, in fatal
-        raise FatalError(message)
-    grass.exceptions.FatalError: Ohh no no no!
+        >>> msgr = Messenger(raise_on_error=True)
+        >>> msgr.fatal("Ohh no no no!")
+        Traceback (most recent call last):
+          File "__init__.py", line 241, in fatal
+            raise FatalError(message)
+        grass.exceptions.FatalError: Ohh no no no!
 
-    >>> msgr = Messenger(raise_on_error=True)
-    >>> msgr.set_raise_on_error(False)
-    >>> msgr.fatal("Ohh no no no!")
-    Traceback (most recent call last):
-      File "__init__.py", line 239, in fatal
-        sys.exit(1)
-    SystemExit: 1
+        >>> msgr = Messenger(raise_on_error=True)
+        >>> msgr.set_raise_on_error(False)
+        >>> msgr.fatal("Ohh no no no!")
+        Traceback (most recent call last):
+          File "__init__.py", line 239, in fatal
+            sys.exit(1)
+        SystemExit: 1
 
-    >>> msgr = Messenger(raise_on_error=False)
-    >>> msgr.set_raise_on_error(True)
-    >>> msgr.fatal("Ohh no no no!")
-    Traceback (most recent call last):
-      File "__init__.py", line 241, in fatal
-        raise FatalError(message)
-    grass.exceptions.FatalError: Ohh no no no!
+        >>> msgr = Messenger(raise_on_error=False)
+        >>> msgr.set_raise_on_error(True)
+        >>> msgr.fatal("Ohh no no no!")
+        Traceback (most recent call last):
+          File "__init__.py", line 241, in fatal
+            raise FatalError(message)
+        grass.exceptions.FatalError: Ohh no no no!
 
     """
 

--- a/python/grass/pygrass/modules/interface/module.py
+++ b/python/grass/pygrass/modules/interface/module.py
@@ -40,173 +40,187 @@ class ParallelModuleQueue:
     will not raise a GrassError in case of failure. This must be manually checked
     by accessing finished modules by calling :py:meth:`get_finished_modules`.
 
-    Usage:
+    :Usage:
 
-    Check with a queue size of 3 and 5 processes
+      Check with a queue size of 3 and 5 processes
 
-    >>> import copy
-    >>> from grass.pygrass.modules import Module, MultiModule, ParallelModuleQueue
-    >>> mapcalc_list = []
+      .. code-block:: pycon
 
-    Setting ``run_`` to False is important, otherwise a parallel processing is not possible
+        >>> import copy
+        >>> from grass.pygrass.modules import Module, MultiModule, ParallelModuleQueue
+        >>> mapcalc_list = []
 
-    >>> mapcalc = Module("r.mapcalc", overwrite=True, run_=False)
-    >>> queue = ParallelModuleQueue(nprocs=3)
-    >>> for i in range(5):
-    ...     new_mapcalc = copy.deepcopy(mapcalc)
-    ...     mapcalc_list.append(new_mapcalc)
-    ...     m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
-    ...     queue.put(m)
-    >>> queue.wait()
-    >>> mapcalc_list = queue.get_finished_modules()
-    >>> queue.get_num_run_procs()
-    0
-    >>> queue.get_max_num_procs()
-    3
-    >>> for mapcalc in mapcalc_list:
-    ...     print(mapcalc.returncode)
-    0
-    0
-    0
-    0
-    0
+      Setting ``run_`` to False is important, otherwise a parallel processing is not possible
 
-    Check with a queue size of 8 and 5 processes
+      .. code-block:: pycon
 
-    >>> queue = ParallelModuleQueue(nprocs=8)
-    >>> mapcalc_list = []
-    >>> for i in range(5):
-    ...     new_mapcalc = copy.deepcopy(mapcalc)
-    ...     mapcalc_list.append(new_mapcalc)
-    ...     m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
-    ...     queue.put(m)
-    >>> queue.wait()
-    >>> mapcalc_list = queue.get_finished_modules()
-    >>> queue.get_num_run_procs()
-    0
-    >>> queue.get_max_num_procs()
-    8
-    >>> for mapcalc in mapcalc_list:
-    ...     print(mapcalc.returncode)
-    0
-    0
-    0
-    0
-    0
+        >>> mapcalc = Module("r.mapcalc", overwrite=True, run_=False)
+        >>> queue = ParallelModuleQueue(nprocs=3)
+        >>> for i in range(5):
+        ...     new_mapcalc = copy.deepcopy(mapcalc)
+        ...     mapcalc_list.append(new_mapcalc)
+        ...     m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
+        ...     queue.put(m)
+        >>> queue.wait()
+        >>> mapcalc_list = queue.get_finished_modules()
+        >>> queue.get_num_run_procs()
+        0
+        >>> queue.get_max_num_procs()
+        3
+        >>> for mapcalc in mapcalc_list:
+        ...     print(mapcalc.returncode)
+        0
+        0
+        0
+        0
+        0
 
-    Check MultiModule approach with three by two processes running in a background process
+      Check with a queue size of 8 and 5 processes
 
-    >>> gregion = Module("g.region", flags="p", run_=False)
-    >>> queue = ParallelModuleQueue(nprocs=3)
-    >>> proc_list = []
-    >>> for i in range(3):
-    ...     new_gregion = copy.deepcopy(gregion)
-    ...     proc_list.append(new_gregion)
-    ...     new_mapcalc = copy.deepcopy(mapcalc)
-    ...     m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
-    ...     proc_list.append(new_mapcalc)
-    ...     mm = MultiModule(
-    ...         module_list=[new_gregion, new_mapcalc], sync=False, set_temp_region=True
-    ...     )
-    ...     queue.put(mm)
-    >>> queue.wait()
-    >>> proc_list = queue.get_finished_modules()
-    >>> queue.get_num_run_procs()
-    0
-    >>> queue.get_max_num_procs()
-    3
-    >>> for proc in proc_list:
-    ...     print(proc.returncode)
-    0
-    0
-    0
-    0
-    0
-    0
+      .. code-block:: pycon
 
-    Check with a queue size of 8 and 4 processes
+        >>> queue = ParallelModuleQueue(nprocs=8)
+        >>> mapcalc_list = []
+        >>> for i in range(5):
+        ...     new_mapcalc = copy.deepcopy(mapcalc)
+        ...     mapcalc_list.append(new_mapcalc)
+        ...     m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
+        ...     queue.put(m)
+        >>> queue.wait()
+        >>> mapcalc_list = queue.get_finished_modules()
+        >>> queue.get_num_run_procs()
+        0
+        >>> queue.get_max_num_procs()
+        8
+        >>> for mapcalc in mapcalc_list:
+        ...     print(mapcalc.returncode)
+        0
+        0
+        0
+        0
+        0
 
-    >>> queue = ParallelModuleQueue(nprocs=8)
-    >>> mapcalc_list = []
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_1 =1")
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    1
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_2 =2")
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    2
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_3 =3")
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    3
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_4 =4")
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    4
-    >>> queue.wait()
-    >>> mapcalc_list = queue.get_finished_modules()
-    >>> queue.get_num_run_procs()
-    0
-    >>> queue.get_max_num_procs()
-    8
-    >>> for mapcalc in mapcalc_list:
-    ...     print(mapcalc.returncode)
-    0
-    0
-    0
-    0
+      Check MultiModule approach with three by two processes running in a background process
 
-    Check with a queue size of 3 and 4 processes
+      .. code-block:: pycon
 
-    >>> queue = ParallelModuleQueue(nprocs=3)
-    >>> mapcalc_list = []
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_1 =1")
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    1
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_2 =2")
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    2
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_3 =3")
-    >>> queue.put(
-    ...     m
-    ... )  # Now it will wait until all procs finish and set the counter back to 0
-    >>> queue.get_num_run_procs()
-    0
-    >>> new_mapcalc = copy.deepcopy(mapcalc)
-    >>> mapcalc_list.append(new_mapcalc)
-    >>> m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
-    >>> queue.put(m)
-    >>> queue.get_num_run_procs()
-    1
-    >>> queue.wait()
-    >>> mapcalc_list = queue.get_finished_modules()
-    >>> queue.get_num_run_procs()
-    0
-    >>> queue.get_max_num_procs()
-    3
-    >>> for mapcalc in mapcalc_list:
-    ...     print(mapcalc.returncode)
-    0
-    0
-    0
-    0
+        >>> gregion = Module("g.region", flags="p", run_=False)
+        >>> queue = ParallelModuleQueue(nprocs=3)
+        >>> proc_list = []
+        >>> for i in range(3):
+        ...     new_gregion = copy.deepcopy(gregion)
+        ...     proc_list.append(new_gregion)
+        ...     new_mapcalc = copy.deepcopy(mapcalc)
+        ...     m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
+        ...     proc_list.append(new_mapcalc)
+        ...     mm = MultiModule(
+        ...         module_list=[new_gregion, new_mapcalc],
+        ...         sync=False,
+        ...         set_temp_region=True,
+        ...     )
+        ...     queue.put(mm)
+        >>> queue.wait()
+        >>> proc_list = queue.get_finished_modules()
+        >>> queue.get_num_run_procs()
+        0
+        >>> queue.get_max_num_procs()
+        3
+        >>> for proc in proc_list:
+        ...     print(proc.returncode)
+        0
+        0
+        0
+        0
+        0
+        0
+
+      Check with a queue size of 8 and 4 processes
+
+      .. code-block:: pycon
+
+        >>> queue = ParallelModuleQueue(nprocs=8)
+        >>> mapcalc_list = []
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_1 =1")
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        1
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_2 =2")
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        2
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_3 =3")
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        3
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_4 =4")
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        4
+        >>> queue.wait()
+        >>> mapcalc_list = queue.get_finished_modules()
+        >>> queue.get_num_run_procs()
+        0
+        >>> queue.get_max_num_procs()
+        8
+        >>> for mapcalc in mapcalc_list:
+        ...     print(mapcalc.returncode)
+        0
+        0
+        0
+        0
+
+      Check with a queue size of 3 and 4 processes
+
+      .. code-block:: pycon
+
+        >>> queue = ParallelModuleQueue(nprocs=3)
+        >>> mapcalc_list = []
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_1 =1")
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        1
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_2 =2")
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        2
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_3 =3")
+        >>> queue.put(
+        ...     m
+        ... )  # Now it will wait until all procs finish and set the counter back to 0
+        >>> queue.get_num_run_procs()
+        0
+        >>> new_mapcalc = copy.deepcopy(mapcalc)
+        >>> mapcalc_list.append(new_mapcalc)
+        >>> m = new_mapcalc(expression="test_pygrass_%i = %i" % (i, i))
+        >>> queue.put(m)
+        >>> queue.get_num_run_procs()
+        1
+        >>> queue.wait()
+        >>> mapcalc_list = queue.get_finished_modules()
+        >>> queue.get_num_run_procs()
+        0
+        >>> queue.get_max_num_procs()
+        3
+        >>> for mapcalc in mapcalc_list:
+        ...     print(mapcalc.returncode)
+        0
+        0
+        0
+        0
 
     """  # noqa: E501
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -422,15 +422,17 @@ def start_command(
     Accepts any of the arguments which Popen() accepts apart from "args"
     and "shell".
 
-    >>> p = start_command("g.gisenv", stdout=subprocess.PIPE)
-    >>> print(p)  # doctest: +ELLIPSIS
-    <...Popen object at 0x...>
-    >>> print(p.communicate()[0])  # doctest: +SKIP
-    GISDBASE='/opt/grass-data';
-    LOCATION_NAME='spearfish60';
-    MAPSET='glynn';
-    GUI='text';
-    MONITOR='x0';
+    .. code-block:: pycon
+
+        >>> p = start_command("g.gisenv", stdout=subprocess.PIPE)
+        >>> print(p)  # doctest: +ELLIPSIS
+        <...Popen object at 0x...>
+        >>> print(p.communicate()[0])  # doctest: +SKIP
+        GISDBASE='/opt/grass-data';
+        LOCATION_NAME='spearfish60';
+        MAPSET='glynn';
+        GUI='text';
+        MONITOR='x0';
 
     If the module parameter is the same as Python keyword, add
     underscore at the end of the parameter. For example, use
@@ -475,7 +477,9 @@ def run_command(*args, **kwargs):
     interface. By default, an exception is raised in case of a non-zero
     return code by default.
 
-    >>> run_command("g.region", raster="elevation")
+    .. code-block:: pycon
+
+        >>> run_command("g.region", raster="elevation")
 
     See :func:`start_command()` for details about parameters and usage.
 
@@ -526,15 +530,17 @@ def pipe_command(*args, **kwargs):
     """Passes all arguments to start_command(), but also adds
     "stdout = PIPE". Returns the Popen object.
 
-    >>> p = pipe_command("g.gisenv")
-    >>> print(p)  # doctest: +ELLIPSIS
-    <....Popen object at 0x...>
-    >>> print(p.communicate()[0])  # doctest: +SKIP
-    GISDBASE='/opt/grass-data';
-    LOCATION_NAME='spearfish60';
-    MAPSET='glynn';
-    GUI='text';
-    MONITOR='x0';
+    .. code-block:: pycon
+
+        >>> p = pipe_command("g.gisenv")
+        >>> print(p)  # doctest: +ELLIPSIS
+        <....Popen object at 0x...>
+        >>> print(p.communicate()[0])  # doctest: +SKIP
+        GISDBASE='/opt/grass-data';
+        LOCATION_NAME='spearfish60';
+        MAPSET='glynn';
+        GUI='text';
+        MONITOR='x0';
 
     :param list args: list of unnamed arguments (see start_command() for details)
     :param list kwargs: list of named arguments (see start_command() for details)
@@ -649,13 +655,15 @@ def write_command(*args, **kwargs):
     Passes all arguments to ``feed_command()``, with the string specified
     by the *stdin* argument fed to the process' standard input.
 
-    >>> write_command(
-    ...     "v.in.ascii",
-    ...     input="-",
-    ...     stdin="%s|%s" % (635818.8, 221342.4),
-    ...     output="view_point",
-    ... )
-    0
+    .. code-block:: pycon
+
+        >>> write_command(
+        ...     "v.in.ascii",
+        ...     input="-",
+        ...     stdin="%s|%s" % (635818.8, 221342.4),
+        ...     output="view_point",
+        ... )
+        0
 
     See ``start_command()`` for details about parameters and usage.
 
@@ -776,7 +784,7 @@ def info(msg, env=None):
 def percent(i, n, s, env=None):
     """Display a progress info message using `g.message -p`
 
-    ::
+    .. code-block:: python
 
         message(_("Percent complete..."))
         n = 100
@@ -932,7 +940,7 @@ def _parse_opts(lines: list) -> tuple[dict[str, str], dict[str, bool]]:
 def parser() -> tuple[dict[str, str], dict[str, bool]]:
     """Interface to g.parser, intended to be run from the top-level, e.g.:
 
-    ::
+    .. code-block:: python
 
         if __name__ == "__main__":
             options, flags = grass.parser()
@@ -1008,6 +1016,8 @@ def tempname(length: int, lowercase: bool = False) -> str:
     :return: String with a random name of length "length" starting with a letter
 
     :Example:
+
+      .. code-block:: pycon
 
         >>> tempname(12)
         'tmp_MxMa1kAS13s9'
@@ -1090,7 +1100,8 @@ def _text_to_key_value_dict(
     :return: The dictionary
 
     A text file with this content:
-    ::
+
+    .. code-block:: none
 
         a: Hello
         b: 1.0
@@ -1099,7 +1110,7 @@ def _text_to_key_value_dict(
 
     Will be represented as this dictionary:
 
-    ::
+    .. code-block:: python
 
         {"a": ["Hello"], "c": [1, 2, 3, 4, 5], "b": [1.0], "d": ["hello", 8, 0.1]}
 
@@ -1165,7 +1176,7 @@ def compare_key_value_text_files(
 
     An example key-value text file may have this content:
 
-    ::
+    .. code-block:: none
 
         a: Hello
         b: 1.0
@@ -1214,11 +1225,15 @@ def compare_key_value_text_files(
 
 def gisenv(env: _Env | None = None) -> KeyValue[str | None]:
     """Returns the output from running g.gisenv (with no arguments), as a
-    dictionary. Example:
+    dictionary.
 
-    >>> env = gisenv()
-    >>> print(env["GISDBASE"])  # doctest: +SKIP
-    /opt/grass-data
+    :Example:
+
+      .. code-block:: pycon
+
+        >>> env = gisenv()
+        >>> print(env["GISDBASE"])  # doctest: +SKIP
+        /opt/grass-data
 
     :param env: dictionary with system environment variables (`os.environ` by default)
     :return: list of GRASS variables
@@ -1249,13 +1264,15 @@ def region(region3d=False, complete=False, env=None):
     :param bool complete:
     :param env: dictionary with system environment variables (`os.environ` by default)
 
-    >>> curent_region = region()
-    >>> # obtain n, s, e and w values
-    >>> [curent_region[key] for key in "nsew"]  # doctest: +ELLIPSIS
-    [..., ..., ..., ...]
-    >>> # obtain ns and ew resolutions
-    >>> (curent_region["nsres"], curent_region["ewres"])  # doctest: +ELLIPSIS
-    (..., ...)
+    .. code-block:: pycon
+
+        >>> curent_region = region()
+        >>> # obtain n, s, e and w values
+        >>> [curent_region[key] for key in "nsew"]  # doctest: +ELLIPSIS
+        [..., ..., ..., ...]
+        >>> # obtain ns and ew resolutions
+        >>> (curent_region["nsres"], curent_region["ewres"])  # doctest: +ELLIPSIS
+        (..., ...)
 
     :return: dictionary of region values
     """
@@ -1302,7 +1319,7 @@ def region_env(
     :param env: dictionary with system environment variables (`os.environ` by default)
     :param kwargs: g.region's parameters like 'raster', 'vector' or 'region'
 
-    ::
+    .. code-block:: python
 
         os.environ["GRASS_REGION"] = grass.region_env(region="detail")
         grass.mapcalc("map=1", overwrite=True)
@@ -1422,18 +1439,20 @@ def find_file(name, element="cell", mapset=None, env=None):
     "raster3d": "grid3",
     "raster_3d": "grid3",
 
-    Example:
+    :Example:
 
-    >>> result = find_file("elevation", element="cell")
-    >>> print(result["fullname"])
-    elevation@PERMANENT
-    >>> print(result["file"])  # doctest: +ELLIPSIS
-    /.../PERMANENT/cell/elevation
-    >>> result = find_file("elevation", element="raster")
-    >>> print(result["fullname"])
-    elevation@PERMANENT
-    >>> print(result["file"])  # doctest: +ELLIPSIS
-    /.../PERMANENT/cell/elevation
+      .. code-block:: pycon
+
+        >>> result = find_file("elevation", element="cell")
+        >>> print(result["fullname"])
+        elevation@PERMANENT
+        >>> print(result["file"])  # doctest: +ELLIPSIS
+        /.../PERMANENT/cell/elevation
+        >>> result = find_file("elevation", element="raster")
+        >>> print(result["fullname"])
+        elevation@PERMANENT
+        >>> print(result["file"])  # doctest: +ELLIPSIS
+        /.../PERMANENT/cell/elevation
 
 
     :param str name: file name
@@ -1642,12 +1661,16 @@ def parse_color(
     """Parses the string "val" as a GRASS colour, which can be either one of
     the named colours or an R:G:B tuple e.g. 255:255:255. Returns an
     (r,g,b) triple whose components are floating point values between 0
-    and 1. Example:
+    and 1.
 
-    >>> parse_color("red")
-    (1.0, 0.0, 0.0)
-    >>> parse_color("255:0:0")
-    (1.0, 0.0, 0.0)
+    :Example:
+
+      .. code-block:: pycon
+
+        >>> parse_color("red")
+        (1.0, 0.0, 0.0)
+        >>> parse_color("255:0:0")
+        (1.0, 0.0, 0.0)
 
     :param val: color value
     :param dflt: default color value
@@ -1707,12 +1730,14 @@ def find_program(pgm, *args):
     valid CLI option, like "--help". For other programs a common
     valid do-little option is usually "--version".
 
-    Example:
+    :Example:
 
-    >>> find_program("r.sun", "--help")
-    True
-    >>> find_program("ls", "--version")
-    True
+      .. code-block:: pycon
+
+        >>> find_program("r.sun", "--help")
+        True
+        >>> find_program("ls", "--version")
+        True
 
     :param str pgm: program name
     :param args: list of arguments
@@ -1976,7 +2001,7 @@ def _create_location_xy(database, location):
 def version():
     """Get GRASS version as dictionary
 
-    ::
+    .. code-block:: pycon
 
         >>> print(version())
         {'proj4': '4.8.0', 'geos': '3.3.5', 'libgis_revision': '52468',

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -151,11 +151,12 @@ def get_commands(*, env=None):
     :return: list of commands (set) and directory of scripts (collected
              by extension - MS Windows only)
 
-    >>> cmds = list(get_commands()[0])
-    >>> cmds.sort()
-    >>> cmds[:5]
-    ['d.barscale', 'd.colorlist', 'd.colortable', 'd.correlate', 'd.erase']
+    .. code-block:: pycon
 
+        >>> cmds = list(get_commands()[0])
+        >>> cmds.sort()
+        >>> cmds[:5]
+        ['d.barscale', 'd.colorlist', 'd.colortable', 'd.correlate', 'd.erase']
     """
     if not env:
         env = os.environ
@@ -220,8 +221,10 @@ def get_real_command(cmd):
     For other cases it just returns a module (name).
     So, you can just use this function for all without further check.
 
-    >>> get_real_command("g.region")
-    'g.region'
+    .. code-block:: pycon
+
+        >>> get_real_command("g.region")
+        'g.region'
 
     :param cmd: the command
     """
@@ -605,14 +608,14 @@ def parse_command(*args, **kwargs):
     Similarly, with <em>format=csv</em> the output will be parsed into
     a list of lists (CSV rows).
 
-    ::
+    .. code-block:: python
 
         parse_command("v.db.select", ..., format="json")
 
     Custom parsing function can be optionally given by <em>parse</em> parameter
     including its arguments, e.g.
 
-    ::
+    .. code-block:: python
 
         parse_command(..., parse=(gs.parse_key_val, {"sep": ":"}))
 

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1,9 +1,8 @@
 """
 Core functions to be used in Python scripts.
 
-Usage:
-
-::
+:Usage:
+  .. code-block:: python
 
     from grass.script import core as grass
 
@@ -254,11 +253,13 @@ def make_command(
     **options,
 ):
     """Return a list of strings suitable for use as the args parameter to
-    Popen() or call(). Example:
+    Popen() or call().
 
+    :Example:
+      .. code-block:: pycon
 
-    >>> make_command("g.message", flags="w", message="this is a warning")
-    ['g.message', '-w', 'message=this is a warning']
+        >>> make_command("g.message", flags="w", message="this is a warning")
+        ['g.message', '-w', 'message=this is a warning']
 
 
     :param str prog: GRASS module
@@ -1016,7 +1017,6 @@ def tempname(length: int, lowercase: bool = False) -> str:
     :return: String with a random name of length "length" starting with a letter
 
     :Example:
-
       .. code-block:: pycon
 
         >>> tempname(12)
@@ -1228,7 +1228,6 @@ def gisenv(env: _Env | None = None) -> KeyValue[str | None]:
     dictionary.
 
     :Example:
-
       .. code-block:: pycon
 
         >>> env = gisenv()
@@ -1258,13 +1257,10 @@ def locn_is_latlong(env: _Env | None = None) -> bool:
 
 def region(region3d=False, complete=False, env=None):
     """Returns the output from running "g.region -gu", as a
-    dictionary. Example:
+    dictionary.
 
-    :param bool region3d: True to get 3D region
-    :param bool complete:
-    :param env: dictionary with system environment variables (`os.environ` by default)
-
-    .. code-block:: pycon
+    :Example:
+      .. code-block:: pycon
 
         >>> curent_region = region()
         >>> # obtain n, s, e and w values
@@ -1274,6 +1270,10 @@ def region(region3d=False, complete=False, env=None):
         >>> (curent_region["nsres"], curent_region["ewres"])  # doctest: +ELLIPSIS
         (..., ...)
 
+    :param bool region3d: True to get 3D region
+    :param bool complete:
+    :param env: dictionary with system environment variables
+                (:external:py:data:`os.environ` by default)
     :return: dictionary of region values
     """
     flgs = "gu"
@@ -1440,7 +1440,6 @@ def find_file(name, element="cell", mapset=None, env=None):
     "raster_3d": "grid3",
 
     :Example:
-
       .. code-block:: pycon
 
         >>> result = find_file("elevation", element="cell")
@@ -1554,10 +1553,13 @@ def list_grouped(
 
     Returns the output from running g.list, as a dictionary where the
     keys are mapset names and the values are lists of maps in that
-    mapset. Example:
+    mapset.
 
-    >>> list_grouped("vect", pattern="*roads*")["PERMANENT"]
-    ['railroads', 'roadsmajor']
+    :Example:
+      .. code-block:: pycon
+
+        >>> list_grouped("vect", pattern="*roads*")["PERMANENT"]
+        ['railroads', 'roadsmajor']
 
     :param str type: element type (raster, vector, raster_3d, region, ...)
                      or list of elements
@@ -1664,7 +1666,6 @@ def parse_color(
     and 1.
 
     :Example:
-
       .. code-block:: pycon
 
         >>> parse_color("red")
@@ -1731,7 +1732,6 @@ def find_program(pgm, *args):
     valid do-little option is usually "--version".
 
     :Example:
-
       .. code-block:: pycon
 
         >>> find_program("r.sun", "--help")

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1317,19 +1317,19 @@ def region_env(
     See also :func:`use_temp_region()` for alternative method how to define
     temporary region used for raster-based computation.
 
-    :param region3d: True to get 3D region
-    :param flags: for example 'a'
-    :param env: dictionary with system environment variables (`os.environ` by default)
-    :param kwargs: g.region's parameters like 'raster', 'vector' or 'region'
-
-    .. code-block:: python
+    :Example:
+      .. code-block:: python
 
         os.environ["GRASS_REGION"] = grass.region_env(region="detail")
         grass.mapcalc("map=1", overwrite=True)
         os.environ.pop("GRASS_REGION")
 
-    :return: string with region values
-    :return: empty string on error
+    :param region3d: True to get 3D region
+    :param flags: for example 'a'
+    :param env: dictionary with system environment variables
+                (:external:py:data:`os.environ` by default)
+    :param kwargs: g.region's parameters like 'raster', 'vector' or 'region'
+    :return: string with region values, or empty string on error
     """
     # read proj/zone from WIND file
     gis_env: KeyValue[str | None] = gisenv(env)

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -1,9 +1,8 @@
 """
 Database related functions to be used in Python scripts.
 
-Usage:
-
-::
+:Usage:
+  .. code-block:: python
 
     from grass.script import db as grass
 

--- a/python/grass/script/db.py
+++ b/python/grass/script/db.py
@@ -33,14 +33,17 @@ from grass.exceptions import CalledModuleError
 
 def db_describe(table, env=None, **args):
     """Return the list of columns for a database table
-    (interface to `db.describe -c`). Example:
+    (interface to `db.describe -c`).
 
-    >>> run_command("g.copy", vector="firestations,myfirestations")
-    0
-    >>> db_describe("myfirestations")  # doctest: +ELLIPSIS
-    {'nrows': 71, 'cols': [['cat', 'INTEGER', '20'], ... 'ncols': 22}
-    >>> run_command("g.remove", flags="f", type="vector", name="myfirestations")
-    0
+    :Example:
+      .. code-block:: pycon
+
+        >>> run_command("g.copy", vector="firestations,myfirestations")
+        0
+        >>> db_describe("myfirestations")  # doctest: +ELLIPSIS
+        {'nrows': 71, 'cols': [['cat', 'INTEGER', '20'], ... 'ncols': 22}
+        >>> run_command("g.remove", flags="f", type="vector", name="myfirestations")
+        0
 
     :param str table: table name
     :param list args:
@@ -112,10 +115,13 @@ def db_table_exist(table, env=None, **args):
 
 def db_connection(force=False, env=None):
     """Return the current database connection parameters
-    (interface to `db.connect -g`). Example:
+    (interface to `db.connect -g`).
 
-    >>> db_connection()
-    {'group': '', 'schema': '', 'driver': 'sqlite', 'database': '$GISDBASE/$LOCATION_NAME/$MAPSET/sqlite/sqlite.db'}
+    :Example:
+      .. code-block:: pycon
+
+        >>> db_connection()
+        {'group': '', 'schema': '', 'driver': 'sqlite', 'database': '$GISDBASE/$LOCATION_NAME/$MAPSET/sqlite/sqlite.db'}
 
     :param force: True to set up default DB connection if not defined
     :param env: environment
@@ -141,19 +147,22 @@ def db_select(sql=None, filename=None, table=None, env=None, **args):
     .. note:: One of **sql**, **filename**, or **table**
         arguments must be provided.
 
-    Examples:
+    :Example:
+      .. code-block:: pycon
 
-    >>> run_command("g.copy", vector="firestations,myfirestations")
-    0
-    >>> db_select(sql="SELECT cat,CITY FROM myfirestations WHERE cat < 4")
-    (('1', 'Morrisville'), ('2', 'Morrisville'), ('3', 'Apex'))
+        >>> run_command("g.copy", vector="firestations,myfirestations")
+        0
+        >>> db_select(sql="SELECT cat,CITY FROM myfirestations WHERE cat < 4")
+        (('1', 'Morrisville'), ('2', 'Morrisville'), ('3', 'Apex'))
 
-    Simplified usage (it performs ``SELECT * FROM myfirestations``.)
+      Simplified usage (it performs ``SELECT * FROM myfirestations``.)
 
-    >>> db_select(table="myfirestations")  # doctest: +ELLIPSIS
-    (('1', '24', 'Morrisville #3', ... 'HS2A', '1.37'))
-    >>> run_command("g.remove", flags="f", type="vector", name="myfirestations")
-    0
+      .. code-block:: pycon
+
+        >>> db_select(table="myfirestations")  # doctest: +ELLIPSIS
+        (('1', '24', 'Morrisville #3', ... 'HS2A', '1.37'))
+        >>> run_command("g.remove", flags="f", type="vector", name="myfirestations")
+        0
 
     :param str sql: SQL statement to perform (or None)
     :param str filename: name of file with SQL statements (or None)

--- a/python/grass/script/imagery.py
+++ b/python/grass/script/imagery.py
@@ -44,21 +44,22 @@ def group_to_dict(
     non-existing (or empty sub-group) is requested a warning is printed
     and an empty dictionary is returned (following the behavior of i.group).
 
-    Example::
+    :Example:
+      .. code-block:: pycon
 
-    >>> run_command("g.copy", raster="lsat7_2000_10,lsat7_2000_10")
-    >>> run_command("r.support", raster="lsat7_2000_10", semantic_label="L8_1")
-    >>> run_command("g.copy", raster="lsat7_2000_20,lsat7_2000_20")
-    >>> run_command("r.support", raster="lsat7_2000_20", semantic_label="L8_2")
-    >>> run_command("g.copy", raster="lsat7_2000_30,lsat7_2000_30")
-    >>> run_command("r.support", raster="lsat7_2000_30", semantic_label="L8_3")
-    >>> run_command("i.group", group="L8_group",
-    >>>             input="lsat7_2000_10,lsat7_2000_20,lsat7_2000_30")
-    >>> group_to_dict("L8_group")  # doctest: +ELLIPSIS
-    {"L8_1": "lsat7_2000_10", ... "L8_3": "lsat7_2000_30"}
-    >>> run_command("g.remove", flags="f", type="group", name="L8_group")
-    >>> run_command("g.remove", flags="f", type="raster",
-    >>>             name="lsat7_2000_10,lsat7_2000_20,lsat7_2000_30")
+        >>> run_command("g.copy", raster="lsat7_2000_10,lsat7_2000_10")
+        >>> run_command("r.support", raster="lsat7_2000_10", semantic_label="L8_1")
+        >>> run_command("g.copy", raster="lsat7_2000_20,lsat7_2000_20")
+        >>> run_command("r.support", raster="lsat7_2000_20", semantic_label="L8_2")
+        >>> run_command("g.copy", raster="lsat7_2000_30,lsat7_2000_30")
+        >>> run_command("r.support", raster="lsat7_2000_30", semantic_label="L8_3")
+        >>> run_command("i.group", group="L8_group",
+        >>>             input="lsat7_2000_10,lsat7_2000_20,lsat7_2000_30")
+        >>> group_to_dict("L8_group")  # doctest: +ELLIPSIS
+        {"L8_1": "lsat7_2000_10", ... "L8_3": "lsat7_2000_30"}
+        >>> run_command("g.remove", flags="f", type="group", name="L8_group")
+        >>> run_command("g.remove", flags="f", type="raster",
+        >>>             name="lsat7_2000_10,lsat7_2000_20,lsat7_2000_30")
 
     :param str imagery_group_name: Name of the imagery group to process (or None)
     :param str subgroup: Name of the imagery sub-group to process (or None)

--- a/python/grass/script/imagery.py
+++ b/python/grass/script/imagery.py
@@ -1,9 +1,8 @@
 """
 Imagery related functions to be used in Python scripts.
 
-Usage:
-
-::
+:Usage:
+  .. code-block:: python
 
     import grass.script as gs
 

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -1,9 +1,8 @@
 """
 Raster related functions to be used in Python scripts.
 
-Usage:
-
-::
+:Usage:
+  .. code-block:: python
 
     from grass.script import raster as grass
 

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -83,16 +83,17 @@ def raster_history(map, overwrite=False, env=None):
 
 def raster_info(map, env=None):
     """Return information about a raster map (interface to
-    `r.info -gre`). Example:
+    `r.info -gre`).
 
-    >>> raster_info("elevation")  # doctest: +ELLIPSIS
-    {'creator': '"helena"', 'cols': '1500' ... 'south': 215000.0}
+    :Example:
+      .. code-block:: pycon
+
+        >>> raster_info("elevation")  # doctest: +ELLIPSIS
+        {'creator': '"helena"', 'cols': '1500' ... 'south': 215000.0}
 
     :param str map: map name
     :param env: environment
-
     :return: parsed raster info
-
     """
 
     def float_or_null(s):

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -1,9 +1,9 @@
 """
 Raster3d related functions to be used in Python scripts.
 
-Usage:
+:Usage:
 
-::
+  .. code-block:: python
 
     from grass.script import raster3d as grass
 
@@ -32,13 +32,14 @@ from grass.exceptions import CalledModuleError
 def raster3d_info(map, env=None):
     """Return information about a raster3d map (interface to `r3.info`).
 
-    Example:
+    :Example:
+      .. code-block:: pycon
 
-    >>> mapcalc3d("volume = row() + col() + depth()")
-    >>> raster3d_info("volume")  # doctest: +ELLIPSIS
-    {'vertical_units': '"units"', 'tbres': 1.0, ... 'south': 185000.0}
-    >>> run_command("g.remove", flags="f", type="raster_3d", name="volume")
-    0
+        >>> mapcalc3d("volume = row() + col() + depth()")
+        >>> raster3d_info("volume")  # doctest: +ELLIPSIS
+        {'vertical_units': '"units"', 'tbres': 1.0, ... 'south': 185000.0}
+        >>> run_command("g.remove", flags="f", type="raster_3d", name="volume")
+        0
 
     :param str map: map name
     :param env: environment

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -2,7 +2,6 @@
 Raster3d related functions to be used in Python scripts.
 
 :Usage:
-
   .. code-block:: python
 
     from grass.script import raster3d as grass

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -1,9 +1,10 @@
-R"""Setup, initialization, and clean-up functions
+r"""Setup, initialization, and clean-up functions
 
 Functions can be used in Python scripts to setup a GRASS environment
 and session without using grassXY.
 
-Usage::
+:Usage:
+  .. code-block:: python
 
     import os
     import sys

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -273,7 +273,8 @@ def init(
     of the object is called explicitly. Using methods of the session object is
     preferred over calling the function :func:`finish`.
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: python
 
         # ... setup GISBASE and sys.path before import
         import grass.script as gs
@@ -286,19 +287,27 @@ def init(
         # end the session
         session.finish()
 
-    The returned object is a context manager, so the ``with`` statement can be used to
-    ensure that the session is finished (closed) at the end::
+      The returned object is a context manager, so the ``with`` statement can be used to
+      ensure that the session is finished (closed) at the end:
+
+      .. code-block:: python
 
         # ... setup sys.path before import
         import grass.script as gs
-        with gs.setup.init("~/grassdata/nc_spm_08/user1")
-            # ... use GRASS modules here
 
-    A mapset can be locked which will prevent other session from locking it. A timeout can be
-    specified to allow concurrent processes to wait for the lock to be released::
+        with gs.setup.init("~/grassdata/nc_spm_08/user1"):
+            # ... use GRASS modules here
+            pass
+
+
+      A mapset can be locked which will prevent other session from locking it. A timeout can be
+      specified to allow concurrent processes to wait for the lock to be released:
+
+      .. code-block:: python
 
         with gs.setup.init("~/grassdata/nc_spm_08/user1", lock=True, timeout=30):
             # ... use GRASS tools here
+            pass
 
     :param path: path to GRASS database
     :param location: location name
@@ -373,7 +382,8 @@ class SessionHandle:
     Do not create objects of this class directly. Use the *init* function
     to get a session object.
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: python
 
         # ... setup sys.path before import as needed
 
@@ -386,7 +396,9 @@ class SessionHandle:
         # end the session
         session.finish()
 
-    Context manager usage::
+      Context manager usage:
+
+      .. code-block:: python
 
         # ... setup sys.path before import as needed
 
@@ -394,7 +406,8 @@ class SessionHandle:
 
         with gs.setup.init("~/grassdata/nc_spm_08/user1"):
             # ... use GRASS modules here
-        # session ends automatically here
+            pass
+        # session ends automatically here when outside of the "with" block
 
     The example above is modifying the global, process environment (`os.environ`).
     If you don't want to modify the global environment, use the _env_ parameter
@@ -402,7 +415,9 @@ class SessionHandle:
     This environment is then available as an attribute of the session object.
     The attribute then needs to be passed to all calls of GRASS
     tools and functions that wrap them.
-    Context manager usage with custom environment::
+    Context manager usage with custom environment:
+
+    .. code-block:: python
 
         # ... setup sys.path before import as needed
 
@@ -536,7 +551,9 @@ def finish(*, env=None, start_time=None, unlock=False):
     GRASS commands can no longer be used after this function has been
     called
 
-    Basic usage::
+    :Basic usage:
+      .. code-block:: python
+
         import grass.script as gs
 
         gs.setup.finish()

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -153,15 +153,18 @@ class KeyValue(dict[str, VT]):
     """A general-purpose key-value store.
 
     KeyValue is a subclass of dict, but also allows entries to be read and
-    written using attribute syntax. Example:
+    written using attribute syntax.
 
-    >>> reg = KeyValue()
-    >>> reg["north"] = 489
-    >>> reg.north
-    489
-    >>> reg.south = 205
-    >>> reg["south"]
-    205
+    :Example:
+      .. code-block:: pycon
+
+        >>> reg = KeyValue()
+        >>> reg["north"] = 489
+        >>> reg.north
+        489
+        >>> reg.south = 205
+        >>> reg["south"]
+        205
 
     The keys of KeyValue are strings. To use other key types, use other mapping types.
     To use the attribute syntax, the keys must be valid Python attribute names.

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -34,10 +34,13 @@ from grass.exceptions import CalledModuleError, ScriptError
 
 def vector_db(map, env=None, **kwargs):
     """Return the database connection details for a vector map
-    (interface to `v.db.connect -g`). Example:
+    (interface to `v.db.connect -g`).
 
-    >>> vector_db("geology")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    {1: {'layer': 1, ... 'table': 'geology'}}
+    :Example:
+      .. code-block:: pycon
+
+        >>> vector_db("geology")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+        {1: {'layer': 1, ... 'table': 'geology'}}
 
     :param str map: vector map
     :param kwargs: other v.db.connect's arguments
@@ -165,12 +168,13 @@ def vector_history(map, replace=False, env=None):
 def vector_info_topo(map, layer=1, env=None):
     """Return information about a vector map (interface to `v.info -t`).
 
-    Example:
+    :Example:
+      .. code-block:: pycon
 
-    >>> vector_info_topo("geology")  # doctest: +NORMALIZE_WHITESPACE
-    {'lines': 0, 'centroids': 1832, 'boundaries': 3649, 'points': 0,
-    'primitives': 5481, 'islands': 907, 'nodes': 2724, 'map3d': False,
-    'areas': 1832}
+        >>> vector_info_topo("geology")  # doctest: +NORMALIZE_WHITESPACE
+        {'lines': 0, 'centroids': 1832, 'boundaries': 3649, 'points': 0,
+        'primitives': 5481, 'islands': 907, 'nodes': 2724, 'map3d': False,
+        'areas': 1832}
 
     :param str map: map name
     :param int layer: layer number
@@ -188,10 +192,13 @@ def vector_info_topo(map, layer=1, env=None):
 
 def vector_info(map, layer=1, env=None):
     """Return information about a vector map (interface to
-    `v.info`). Example:
+    `v.info`).
 
-    >>> vector_info("geology")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    {'comment': '', 'projection': 'Lambert Conformal Conic' ... 'south': 10875.8272320917}
+    :Example:
+      .. code-block:: pycon
+
+        >>> vector_info("geology")  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+        {'comment': '', 'projection': 'Lambert Conformal Conic' ... 'south': 10875.8272320917}
 
     :param str map: map name
     :param int layer: layer number
@@ -231,14 +238,17 @@ def vector_db_select(map, layer=1, env=None, **kwargs):
     """Get attribute data of selected vector map layer.
 
     Function returns list of columns and dictionary of values ordered by
-    key column value. Example:
+    key column value.
 
-    >>> print(vector_db_select("geology")["columns"])
-    ['cat', 'onemap_pro', 'PERIMETER', 'GEOL250_', 'GEOL250_ID', 'GEO_NAME', 'SHAPE_area', 'SHAPE_len']
-    >>> print(vector_db_select("geology")["values"][3])
-    ['3', '579286.875', '3335.55835', '4', '3', 'Zml', '579286.829631', '3335.557182']
-    >>> print(vector_db_select("geology", columns="GEO_NAME")["values"][3])
-    ['Zml']
+    :Example:
+      .. code-block:: pycon
+
+        >>> print(vector_db_select("geology")["columns"])
+        ['cat', 'onemap_pro', 'PERIMETER', 'GEOL250_', 'GEOL250_ID', 'GEO_NAME', 'SHAPE_area', 'SHAPE_len']
+        >>> print(vector_db_select("geology")["values"][3])
+        ['3', '579286.875', '3335.55835', '4', '3', 'Zml', '579286.829631', '3335.557182']
+        >>> print(vector_db_select("geology", columns="GEO_NAME")["values"][3])
+        ['Zml']
 
     :param str map: map name
     :param int layer: layer number

--- a/python/grass/temporal/abstract_dataset.py
+++ b/python/grass/temporal/abstract_dataset.py
@@ -580,9 +580,8 @@ class AbstractDatasetComparisonKeyStartTime:
     """This comparison key can be used to sort lists of abstract datasets
     by start time
 
-    Example:
-
-    .. code-block:: python
+    :Example:
+      .. code-block:: python
 
         # Return all maps in a space time raster dataset as map objects
         map_list = strds.get_registered_maps_as_objects()
@@ -632,9 +631,8 @@ class AbstractDatasetComparisonKeyEndTime:
     """This comparison key can be used to sort lists of abstract datasets
     by end time
 
-    Example:
-
-    .. code-block:: python
+    :Example:
+      .. code-block:: python
 
         # Return all maps in a space time raster dataset as map objects
         map_list = strds.get_registered_maps_as_objects()

--- a/python/grass/temporal/gui_support.py
+++ b/python/grass/temporal/gui_support.py
@@ -24,9 +24,10 @@ def tlist_grouped(type, group_type: bool = False, dbif=None):
 
     Returns a dictionary where the keys are mapset
     names and the values are lists of space time datasets in that
-    mapset. Example:
+    mapset.
 
-    .. code-block:: pycon
+    :Example:
+      .. code-block:: pycon
 
         >>> import grass.temporal as tgis
         >>> tgis.tlist_grouped("strds")["PERMANENT"]

--- a/python/grass/temporal/spatio_temporal_relationships.py
+++ b/python/grass/temporal/spatio_temporal_relationships.py
@@ -36,9 +36,8 @@ class SpatioTemporalTopologyBuilder:
     The abstract dataset objects must be provided as a single list, or in
     two lists.
 
-    Example:
-
-    .. code-block:: python
+    :Example:
+      .. code-block:: python
 
         # We have a space time raster dataset and build a map list
         # from all registered maps ordered by start time
@@ -74,7 +73,7 @@ class SpatioTemporalTopologyBuilder:
         # Dictionary like accessed
         map = tb["name@mapset"]
 
-    .. code-block:: pycon
+      .. code-block:: pycon
 
         >>> # Example with two lists of maps
         >>> import grass.temporal as tgis


### PR DESCRIPTION
This is another round of making the formatting of code blocks either valid, better, or semantically better represented in example sections headers (that is, indented, but also represented inside the field list element in the HTML render, not just underneath).

It will probably be boring to review, not much interesting things to highlight with screenshots in this.

One place, `Region.get_bbox()` (in python/grass/pygrass/gis/region.py), I created more docstring contents (for the return description and return type), to align with the rest around it.