### PR TITLE
docs: Use more crossrefs in grass.script.core

### DIFF
--- a/python/grass/pygrass/gis/region.py
+++ b/python/grass/pygrass/gis/region.py
@@ -462,17 +462,17 @@ class Region:
         Attention: All raster objects must be closed or the
                    process will be terminated.
 
-        The Raster library C function Rast_set_window() is called.
+        The Raster library C function :c:func:`Rast_set_window()` is called.
 
         """
         libraster.Rast_set_window(self.byref())
 
     def get_current(self):
         """Get the current working region of this process
-        and store it into this Region object
+        and store it into this :py:class:`Region` object
 
-        Previous calls to set_current() affects values returned by this function.
-        Previous calls to read() affects values returned by this function
+        Previous calls to :py:meth:`.set_current()` affects values returned by this function.
+        Previous calls to :py:meth:`.read()` affects values returned by this function
         only if the current working region is not initialized.
 
         :Example:
@@ -496,7 +496,7 @@ class Region:
         """Set the current working region from this region object
 
         This function adjusts the values before setting the region
-        so you don't have to call G_adjust_Cell_head().
+        so you don't have to call :c:func:`G_adjust_Cell_head()`.
 
         Attention: Only the current process is affected.
                    The GRASS computational region is not affected.
@@ -546,7 +546,7 @@ class Region:
         mapset into region.
 
         3D values are set to defaults if not available in WIND file.  An
-        error message is printed and exit() is called if there is a problem
+        error message is printed and :py:func:`exit()` is called if there is a problem
         reading the region.
 
         .. warning::
@@ -554,7 +554,7 @@ class Region:
             should not use this routine since its use implies that the active
             module region will not be used. Programs that read or write raster
             map data (or vector data) can query the active module region using
-            Rast_window_rows() and Rast_window_cols().
+            :c:func:`Rast_window_rows()` and :c:func:`Rast_window_cols()`.
 
         :param force_read: If True the WIND file of the current mapset
                            is re-readed, otherwise the initial region
@@ -612,7 +612,7 @@ class Region:
         """
         Get the default region
 
-        Reads the default region for the location in this Region object.
+        Reads the default region for the location in this :py:class:`Region` object.
         3D values are set to defaults if not available in WIND file.
 
         An error message is printed and exit() is called if there is a
@@ -644,10 +644,10 @@ class Region:
         )
 
     def set_bbox(self, bbox):
-        """Set region extent from Bbox
+        """Set region extent from :py:class:`~grass.pygrass.vector.basic.Bbox`
 
-        :param bbox: a Bbox object to set the extent
-        :type bbox: Bbox object
+        :param bbox: a py:class:`~grass.pygrass.vector.basic.Bbox` object to set the extent
+        :type bbox: :py:class:`~grass.pygrass.vector.basic.Bbox` object
 
         .. code-block:: pycon
 

--- a/python/grass/pygrass/raster/__init__.py
+++ b/python/grass/pygrass/raster/__init__.py
@@ -142,7 +142,7 @@ class RasterRow(RasterAbstractBase):
         :param row: the number of row to obtain
         :type row: int
         :param row_buffer: Buffer object instance with the right dim and type
-        :type row_buffer: Buffer
+        :type row_buffer: ~grass.pygrass.raster.buffer.Buffer
 
         >>> elev = RasterRow(test_raster_name)
         >>> elev.open()

--- a/python/grass/pygrass/vector/basic.py
+++ b/python/grass/pygrass/vector/basic.py
@@ -554,7 +554,7 @@ class CatsList:
         """Convert ordered array of integers to cat_list structure.
 
         :param array: the input array containing the cats
-        :type array: array
+        :type array: ~grass.script.array.array
         """
         # Vect_array_to_cat_list(const int *vals, int nvals, ***)
         # TODO: it's not working

--- a/python/grass/pygrass/vector/find.py
+++ b/python/grass/pygrass/vector/find.py
@@ -30,6 +30,7 @@ class AbstractFinder:
         :param c_mapinfo: Pointer to the vector layer mapinfo structure
         :type c_mapinfo: ctypes pointer to mapinfo structure
         :param table: Attribute table of the vector layer
+        :type table: ~grass.pygrass.vector.table.Table
         :param writable: True or False
         """
         self.c_mapinfo = c_mapinfo

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -254,9 +254,9 @@ def make_command(
     superquiet=False,
     errors=None,
     **options,
-):
+) -> list[str]:
     """Return a list of strings suitable for use as the args parameter to
-    Popen() or call().
+    :class:`~grass.script.core.Popen()` or :func:`~grass.script.core.call`.
 
     :Example:
       .. code-block:: pycon
@@ -329,7 +329,7 @@ def handle_errors(returncode, result, args, kwargs):
     The value ``errors="raise"`` is a default in which case a
     ``CalledModuleError`` exception is raised.
 
-    For ``errors="fatal"``, the function calls :func:`fatal()`
+    For ``errors="fatal"``, the function calls :func:`~grass.script.core.fatal()`
     which has its own rules on what happens next.
 
     For ``errors="status"``, the *returncode* will be returned.
@@ -392,7 +392,7 @@ def popen_args_command(
 
     Does the splitting based on known Popen parameter names, and then does the
     transformation from Python parameters to a list of command line arguments
-    for Popen.
+    for :py:class:`~grass.script.core.Popen`.
     """
     options = {}
     popen_kwargs = {}
@@ -422,8 +422,9 @@ def start_command(
     superquiet=False,
     **kwargs,
 ):
-    """Returns a Popen object with the command created by make_command.
-    Accepts any of the arguments which Popen() accepts apart from "args"
+    """Returns a :class:`~grass.script.core.Popen` object with the command created by
+    :py:func:`~grass.script.core.make_command`.
+    Accepts any of the arguments which :py:class:`Popen()` accepts apart from "args"
     and "shell".
 
     .. code-block:: pycon
@@ -451,6 +452,7 @@ def start_command(
     :param kwargs: module's parameters
 
     :return: Popen object
+    :rtype: ~grass.script.core.Popen
     """
     args, popts = popen_args_command(
         prog,
@@ -475,7 +477,7 @@ def start_command(
 def run_command(*args, **kwargs):
     """Execute a module synchronously
 
-    This function passes all arguments to ``start_command()``,
+    This function passes all arguments to :func:`~grass.script.core.start_command`,
     then waits for the process to complete. It is similar to
     ``subprocess.check_call()``, but with the :func:`make_command()`
     interface. By default, an exception is raised in case of a non-zero
@@ -531,8 +533,8 @@ def run_command(*args, **kwargs):
 
 
 def pipe_command(*args, **kwargs):
-    """Passes all arguments to start_command(), but also adds
-    "stdout = PIPE". Returns the Popen object.
+    """Passes all arguments to :func:`start_command()`, but also adds
+    "stdout = PIPE". Returns the :class:`~grass.script.core.Popen` object.
 
     .. code-block:: pycon
 
@@ -546,37 +548,39 @@ def pipe_command(*args, **kwargs):
         GUI='text';
         MONITOR='x0';
 
-    :param list args: list of unnamed arguments (see start_command() for details)
-    :param list kwargs: list of named arguments (see start_command() for details)
+    :param list args: list of unnamed arguments (see :func:`start_command` for details)
+    :param list kwargs: list of named arguments (see :func:`start_command` for details)
 
     :return: Popen object
+    :rtype: grass.script.core.Popen
     """
     kwargs["stdout"] = PIPE
     return start_command(*args, **kwargs)
 
 
 def feed_command(*args, **kwargs):
-    """Passes all arguments to start_command(), but also adds
-    "stdin = PIPE". Returns the Popen object.
+    """Passes all arguments to :func:`start_command()`, but also adds
+    "stdin = PIPE". Returns the :class:`~grass.script.core.Popen` object.
 
-    :param list args: list of unnamed arguments (see start_command() for details)
-    :param list kwargs: list of named arguments (see start_command() for details)
+    :param list args: list of unnamed arguments (see :func:`start_command` for details)
+    :param list kwargs: list of named arguments (see :func:`start_command` for details)
 
     :return: Popen object
+    :rtype: grass.script.core.Popen
     """
     kwargs["stdin"] = PIPE
     return start_command(*args, **kwargs)
 
 
 def read_command(*args, **kwargs):
-    """Passes all arguments to pipe_command, then waits for the process to
-    complete, returning its stdout (i.e. similar to shell `backticks`).
+    """Passes all arguments to :func:`~grass.script.core.pipe_command`, then waits for
+    the process to complete, returning its stdout (i.e. similar to shell `backticks`).
 
     The behavior on error can be changed using *errors* parameter
     which is passed to the :func:`handle_errors()` function.
 
-    :param list args: list of unnamed arguments (see start_command() for details)
-    :param list kwargs: list of named arguments (see start_command() for details)
+    :param list args: list of unnamed arguments (see :func:`start_command` for details)
+    :param list kwargs: list of named arguments (see :func:`start_command` for details)
 
     :return: stdout
     """
@@ -601,28 +605,33 @@ def read_command(*args, **kwargs):
 
 def parse_command(*args, **kwargs):
     """Passes all arguments to read_command, then parses the output
-    by default with parse_key_val().
+    by default with :func:`~grass.script.utils.parse_key_val`.
 
-    If the command has parameter <em>format</em> and is called with
-    <em>format=json</em>, the output will be parsed into a dictionary.
-    Similarly, with <em>format=csv</em> the output will be parsed into
+    If the command has parameter ``format`` and is called with
+    ``format="json"``, the output will be parsed into a dictionary.
+    Similarly, with ``format="csv"`` the output will be parsed into
     a list of lists (CSV rows).
 
     .. code-block:: python
 
         parse_command("v.db.select", ..., format="json")
 
-    Custom parsing function can be optionally given by <em>parse</em> parameter
+    Custom parsing function can be optionally given by ``parse`` parameter
     including its arguments, e.g.
 
     .. code-block:: python
 
         parse_command(..., parse=(gs.parse_key_val, {"sep": ":"}))
 
-    Parameter <em>delimiter</em> is deprecated.
+    Parameter ``delimiter`` is deprecated.
 
-    :param args: list of unnamed arguments (see start_command() for details)
-    :param kwargs: list of named arguments (see start_command() for details)
+    :param args: list of unnamed arguments (see :func:`start_command()` for details)
+    :param kwargs: list of named arguments
+        (see :func:`start_command()` for details)
+
+        .. deprecated:: 8.4.0
+            Parameter ``delimiter`` is deprecated. Use the command's ``format="json"``
+            or ``format="csv"`` parameter instead
 
     :return: parsed module output
     """
@@ -656,7 +665,7 @@ def parse_command(*args, **kwargs):
 def write_command(*args, **kwargs):
     """Execute a module with standard input given by *stdin* parameter.
 
-    Passes all arguments to ``feed_command()``, with the string specified
+    Passes all arguments to :py:func:`feed_command()`, with the string specified
     by the *stdin* argument fed to the process' standard input.
 
     .. code-block:: pycon
@@ -669,13 +678,13 @@ def write_command(*args, **kwargs):
         ... )
         0
 
-    See ``start_command()`` for details about parameters and usage.
+    See :func:`start_command()` for details about parameters and usage.
 
     The behavior on error can be changed using *errors* parameter
     which is passed to the :func:`handle_errors()` function.
 
-    :param args: unnamed arguments passed to ``start_command()``
-    :param kwargs: named arguments passed to ``start_command()``
+    :param args: unnamed arguments passed to :func:`start_command()`
+    :param kwargs: named arguments passed to :func:`start_command()`
 
     :returns: 0 with default parameters for backward compatibility only
 
@@ -845,7 +854,7 @@ def fatal(msg, env=None):
 
 
 def set_raise_on_error(raise_exp=True):
-    """Define behaviour on fatal error (fatal() called)
+    """Define behavior on fatal error (:py:func:`~grass.script.core.fatal` called)
 
     :param bool raise_exp: True to raise ScriptError instead of calling
                            sys.exit(1) in fatal()
@@ -883,8 +892,8 @@ def set_capture_stderr(capture=True):
         and interactive notebooks such as Jupyter Notebook.
 
     The capturing can be applied only in certain cases, for example
-    in case of run_command() it is applied because run_command() nor
-    its callers do not handle the streams, however feed_command()
+    in case of :func:`run_command` it is applied because :func:`run_command` nor
+    its callers do not handle the streams, however :func:`feed_command`
     cannot do capturing because its callers handle the streams.
 
     The previous state is returned. Passing ``False`` disables the
@@ -1025,7 +1034,8 @@ def tempname(length: int, lowercase: bool = False) -> str:
         >>> tempname(12)
         'tmp_MxMa1kAS13s9'
 
-    .. seealso:: functions :func:`append_uuid()`, :func:`append_random()`
+    .. seealso:: functions :func:`~grass.script.utils.append_uuid()`,
+        :func:`~grass.script.utils.append_random()`
     """
 
     chars = string.ascii_lowercase + string.digits

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1820,6 +1820,7 @@ def create_project(
     :param desc: description of the project (creates MYNAME file)
     :param bool overwrite: True to overwrite project if exists (WARNING:
                            ALL DATA from existing project ARE DELETED!)
+    :raises ~grass.exceptions.ScriptError: Raise ScriptError on error
     """
     # Add default mapset to project path if needed
     if not name:
@@ -1955,10 +1956,10 @@ def _set_location_description(path, location, text):
 def _create_location_xy(database, location):
     """Create unprojected location
 
-    Raise ScriptError on error.
 
     :param database: GRASS database where to create new location
     :param location: location name
+    :raises grass.exceptions.ScriptError: Raise ScriptError on error.
     """
     cur_dir = Path.cwd()
     try:

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -574,7 +574,7 @@ def feed_command(*args, **kwargs):
 
 def read_command(*args, **kwargs):
     """Passes all arguments to :func:`~grass.script.core.pipe_command`, then waits for
-    the process to complete, returning its stdout (i.e. similar to shell `backticks`).
+    the process to complete, returning its stdout (i.e. similar to shell ``backticks``).
 
     The behavior on error can be changed using *errors* parameter
     which is passed to the :func:`handle_errors()` function.

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -437,7 +437,7 @@ class RegionManager:
     ...     gs.run_command("g.region", n=226000, s=222000, w=634000, e=638000)
     ...     gs.parse_command("r.univar", map="elevation", format="json")
 
-    Example using set_region():
+    Example using :py:func:`.set_region`:
 
     >>> with gs.RegionManager() as manager:
     ...     manager.set_region(n=226000, s=222000, w=634000, e=638000)
@@ -477,7 +477,7 @@ class RegionManager:
     def __enter__(self):
         """Sets the `WIND_OVERRIDE` environment variable to the generated region name.
 
-        :return: Returns the RegionManager instance.
+        :return: Returns the :class:`RegionManager` instance.
         """
         self._original_value = self.env.get("WIND_OVERRIDE")
         run_command(
@@ -522,7 +522,7 @@ class RegionManagerEnv:
     >>> with gs.RegionManagerEnv(n=226000, s=222000, w=634000, e=638000):
     ...     gs.parse_command("r.univar", map="elevation", format="json")
 
-    Example with set_region():
+    Example with :py:meth:`.set_region`:
 
     >>> with gs.RegionManagerEnv() as manager:
     ...     manager.set_region(n=226000, s=222000, w=634000, e=638000)
@@ -536,7 +536,8 @@ class RegionManagerEnv:
 
     .. caution::
 
-        To set region within the context, do not call `g.region`, use `set_region` instead.
+        To set region within the context, do not call `g.region`,
+        use :py:meth:`.set_region` instead.
     """
 
     def __init__(self, env: dict[str, str] | None = None, **kwargs):
@@ -560,7 +561,7 @@ class RegionManagerEnv:
     def __enter__(self):
         """Sets the `GRASS_REGION` environment variable to the generated region name.
 
-        :return: Returns the RegionManagerEnv instance.
+        :return: Returns the :class:`RegionManagerEnv` instance.
         """
         self._original_value = self.env.get("GRASS_REGION")
         self.env["GRASS_REGION"] = region_env(**self._region_inputs, env=self.env)

--- a/python/grass/script/raster.py
+++ b/python/grass/script/raster.py
@@ -437,7 +437,7 @@ class RegionManager:
     ...     gs.run_command("g.region", n=226000, s=222000, w=634000, e=638000)
     ...     gs.parse_command("r.univar", map="elevation", format="json")
 
-    Example using :py:func:`.set_region`:
+    Example using :py:func:`~grass.script.raster.RegionManager.set_region`:
 
     >>> with gs.RegionManager() as manager:
     ...     manager.set_region(n=226000, s=222000, w=634000, e=638000)

--- a/python/grass/script/raster3d.py
+++ b/python/grass/script/raster3d.py
@@ -86,7 +86,7 @@ def mapcalc3d(
     :param bool verbose: True to run verbosely (<tt>--v</tt>)
     :param bool overwrite: True to enable overwriting the output (<tt>--o</tt>)
     :param seed: an integer used to seed the random-number generator for the
-                 rand() function, or 'auto' to generate a random seed
+                 :py:func:`rand()` function, or 'auto' to generate a random seed
     :param dict env: dictionary of environment variables for child process
     :param kwargs:
     """


### PR DESCRIPTION
This PR changes some function names, class names, etc. to use cross-references when applicable. Mostly centered around grass.script.core (the main topic, I reviewed that file completely), but includes related changes when searching for other instances to apply the same changes.

This does not include cross-references to exceptions, as it will be bundled separately, there's some original work (new text) created in these, so I didn't want to mix them up.