### PR TITLE
i.ortho.init: fix use flag bug

### DIFF
--- a/imagery/i.ortho.photo/i.ortho.init/main.c
+++ b/imagery/i.ortho.photo/i.ortho.init/main.c
@@ -230,7 +230,9 @@ int main(int argc, char *argv[])
     if (kappasd_opt->answer) {
         init_info->kappa_var = atof(kappasd_opt->answer) * deg2rad;
     }
-    init_info->status = use_flag->answer != 0;
+    if (use_flag->answer) {
+        init_info->status = 1; // update only if -r is passed
+    }
 
     if (print_flag->answer) {
         /* do not translate, scripts might want to parse the output */


### PR DESCRIPTION
This PR fixes a logic bug in the `i.ortho.init` module, it caused incorrect persistence and reporting of the use flag, even when the `-r` flag was passed by the user.

### Code change: 
The use flag is updated only when `-r` is explicitly passed:
> if (use_flag->answer) {
>     init_info->status = 1;
> }

### Tested Behaviour:
- use=1 is set when -r is passed.
- use remains unchanged when -r is omitted.
- Values persist correctly across multiple runs.

This PR fixes https://github.com/OSGeo/grass/issues/5853.