### PR TITLE
d.vect: Fix typo in documentation example 

### DIFF
--- a/display/d.vect/d.vect.html
+++ b/display/d.vect/d.vect.html
@@ -94,7 +94,7 @@ line/area bounding box):
 
 <div class="code"><pre>
 g.region raster=elevation.10m
-r.random input=elevation.10m n=5000 vector=random3d -d
+r.random input=elevation.10m n=5000 vector=random3d -z
 d.mon start=x0
 # display as black points
 d.vect map=random3d

--- a/display/d.vect/d.vect.md
+++ b/display/d.vect/d.vect.md
@@ -99,7 +99,7 @@ bounding box):
 
 ```sh
 g.region raster=elevation.10m
-r.random input=elevation.10m n=5000 vector=random3d -d
+r.random input=elevation.10m n=5000 vector=random3d -z
 d.mon start=x0
 # display as black points
 d.vect map=random3d


### PR DESCRIPTION
In the Examples section of the documentation, there's an example where random elevation points are sampled with `r.random` to create a 3D vector layer. The example uses:

```
r.random input=elevation.10m n=5000 vector=random3d -d
```

It should use the `-z` flag, as per the [r.random](https://grass.osgeo.org/grass-devel/manuals/r.random.html) documentation. There is no option for the a "-d" flag so the current example ends with an error.