### PR TITLE
g.region: accept ewres3 and nsres3 as parameters

### DIFF
--- a/general/g.region/main.c
+++ b/general/g.region/main.c
@@ -55,8 +55,8 @@ int main(int argc, char *argv[])
     } flag;
     struct {
         struct Option *north, *south, *east, *west, *top, *bottom, *res, *nsres,
-            *ewres, *res3, *tbres, *rows, *cols, *save, *region, *raster,
-            *raster3d, *align, *zoom, *vect, *grow, *format;
+            *ewres, *res3, *nsres3, *ewres3, *tbres, *rows, *cols, *save,
+            *region, *raster, *raster3d, *align, *zoom, *vect, *grow, *format;
     } parm;
 
     G_gisinit(argv[0]);
@@ -309,6 +309,24 @@ int main(int argc, char *argv[])
     parm.ewres->description = _("East-west 2D grid resolution");
     parm.ewres->guisection = _("Resolution");
 
+    parm.nsres3 = G_define_option();
+    parm.nsres3->key = "nsres3";
+    parm.nsres3->key_desc = "value";
+    parm.nsres3->required = NO;
+    parm.nsres3->multiple = NO;
+    parm.nsres3->type = TYPE_STRING;
+    parm.nsres3->description = _("North-south 3D grid resolution");
+    parm.nsres3->guisection = _("Resolution");
+
+    parm.ewres3 = G_define_option();
+    parm.ewres3->key = "ewres3";
+    parm.ewres3->key_desc = "value";
+    parm.ewres3->required = NO;
+    parm.ewres3->multiple = NO;
+    parm.ewres3->type = TYPE_STRING;
+    parm.ewres3->description = _("East-west 3D grid resolution");
+    parm.ewres3->guisection = _("Resolution");
+
     parm.tbres = G_define_option();
     parm.tbres->key = "tbres";
     parm.tbres->key_desc = "value";
@@ -370,14 +388,15 @@ int main(int argc, char *argv[])
                                   "json;JSON (JavaScript Object Notation);");
     parm.format->guisection = _("Print");
 
-    G_option_required(
-        flag.dflt, flag.savedefault, flag.print, flag.lprint, flag.eprint,
-        flag.center, flag.gmt_style, flag.wms_style, flag.dist_res, flag.nangle,
-        flag.z, flag.bbox, flag.gprint, flag.res_set, flag.noupdate,
-        parm.region, parm.raster, parm.raster3d, parm.vect, parm.north,
-        parm.south, parm.east, parm.west, parm.top, parm.bottom, parm.rows,
-        parm.cols, parm.res, parm.res3, parm.nsres, parm.ewres, parm.tbres,
-        parm.zoom, parm.align, parm.save, parm.grow, NULL);
+    G_option_required(flag.dflt, flag.savedefault, flag.print, flag.lprint,
+                      flag.eprint, flag.center, flag.gmt_style, flag.wms_style,
+                      flag.dist_res, flag.nangle, flag.z, flag.bbox,
+                      flag.gprint, flag.res_set, flag.noupdate, parm.region,
+                      parm.raster, parm.raster3d, parm.vect, parm.north,
+                      parm.south, parm.east, parm.west, parm.top, parm.bottom,
+                      parm.rows, parm.cols, parm.res, parm.res3, parm.nsres,
+                      parm.ewres, parm.nsres3, parm.ewres3, parm.tbres,
+                      parm.zoom, parm.align, parm.save, parm.grow, NULL);
     G_option_exclusive(flag.noupdate, flag.force, NULL);
     G_option_requires(flag.noupdate, flag.savedefault, flag.print, flag.lprint,
                       flag.eprint, flag.center, flag.gmt_style, flag.wms_style,
@@ -779,7 +798,7 @@ int main(int argc, char *argv[])
     if ((value = parm.res3->answer)) {
         update_file = true;
         if (!G_scan_resolution(value, &x, window.proj))
-            die(parm.res);
+            die(parm.res3);
         window.ns_res3 = x;
         window.ew_res3 = x;
         window.tb_res = x;
@@ -809,6 +828,22 @@ int main(int argc, char *argv[])
             window.east = ceil(window.east / x) * x;
             window.west = floor(window.west / x) * x;
         }
+    }
+
+    /* nsres3= */
+    if ((value = parm.nsres3->answer)) {
+        update_file = true;
+        if (sscanf(value, "%lf", &x) != 1)
+            die(parm.nsres3);
+        window.ns_res3 = x;
+    }
+
+    /* ewres3= */
+    if ((value = parm.ewres3->answer)) {
+        update_file = true;
+        if (sscanf(value, "%lf", &x) != 1)
+            die(parm.ewres3);
+        window.ew_res3 = x;
     }
 
     /* tbres= */

--- a/general/g.region/testsuite/test_g_region.py
+++ b/general/g.region/testsuite/test_g_region.py
@@ -4,6 +4,7 @@
 """
 
 import json
+from copy import deepcopy
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import call_module
@@ -115,6 +116,59 @@ class TestRegion(TestCase):
                 self.assertAlmostEqual(value, output_json[key], places=6)
             else:
                 self.assertEqual(value, output_json[key])
+
+    def test_3d_region(self):
+        region_before = deepcopy(gs.region(region3d=True))
+        test_nsres3 = 1.5
+        test_ewres3 = 3.2
+        test_tbres = 2.5
+        precision = 2
+        self.runModule(
+            "g.region", nsres3=test_nsres3, ewres3=test_ewres3, tbres=test_tbres
+        )
+        region_after = gs.region(region3d=True)
+        # Setting 3D resolution do not change the extent or 2D resolution
+        self.assertEqual(region_before["n"], region_after["n"])
+        self.assertEqual(region_before["s"], region_after["s"])
+        self.assertEqual(region_before["e"], region_after["e"])
+        self.assertEqual(region_before["w"], region_after["w"])
+        self.assertEqual(region_before["t"], region_after["t"])
+        self.assertEqual(region_before["b"], region_after["b"])
+        self.assertEqual(region_before["nsres"], region_after["nsres"])
+        self.assertEqual(region_before["ewres"], region_after["ewres"])
+
+        # 3D resolution settings are applied correctly
+        self.assertAlmostEqual(region_after["nsres3"], test_nsres3, places=precision)
+        self.assertAlmostEqual(region_after["ewres3"], test_ewres3, places=precision)
+        self.assertAlmostEqual(region_after["tbres"], test_tbres, places=precision)
+
+        # res3 is applied to all 3D resolutions
+        test_res3 = 2
+        self.runModule("g.region", res3=test_res3)
+        region_after = gs.region(region3d=True)
+        self.assertAlmostEqual(region_after["nsres3"], test_res3, places=precision)
+        self.assertAlmostEqual(region_after["ewres3"], test_res3, places=precision)
+        self.assertAlmostEqual(region_after["tbres"], test_res3, places=precision)
+
+        # res3 is overridden by individual settings
+        # tbres
+        self.runModule("g.region", res3=test_res3, tbres=test_tbres)
+        region_after = gs.region(region3d=True)
+        self.assertAlmostEqual(region_after["nsres3"], test_res3, places=precision)
+        self.assertAlmostEqual(region_after["ewres3"], test_res3, places=precision)
+        self.assertAlmostEqual(region_after["tbres"], test_tbres, places=precision)
+        # ewres3
+        self.runModule("g.region", res3=test_res3, ewres3=test_ewres3)
+        region_after = gs.region(region3d=True)
+        self.assertAlmostEqual(region_after["nsres3"], test_res3, places=precision)
+        self.assertAlmostEqual(region_after["ewres3"], test_ewres3, places=precision)
+        self.assertAlmostEqual(region_after["tbres"], test_res3, places=precision)
+        # nsres3
+        self.runModule("g.region", res3=test_res3, nsres3=test_nsres3)
+        region_after = gs.region(region3d=True)
+        self.assertAlmostEqual(region_after["nsres3"], test_nsres3, places=precision)
+        self.assertAlmostEqual(region_after["ewres3"], test_res3, places=precision)
+        self.assertAlmostEqual(region_after["tbres"], test_res3, places=precision)
 
 
 if __name__ == "__main__":

--- a/python/grass/script/utils.py
+++ b/python/grass/script/utils.py
@@ -171,7 +171,10 @@ class KeyValue(dict[str, VT]):
     """
 
     def __getattr__(self, key: str) -> VT:
-        return self[key]
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def __setattr__(self, key: str, value: VT) -> None:
         self[key] = value


### PR DESCRIPTION
Allows to set the East/West and North/South 3D resolution with `ewres3` and `nsres3` parameters, on top of the existing  `tbres` and `res3` parameters. This put the 3D resolution management more in line with the 2D resolution.
Addresses #5801

Existing tests `test_d_flag` and `test_format_json` where already failing before I made the changes.