### PR TITLE
i.eb.soilheatflux: add test file

### DIFF
--- a/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
+++ b/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
@@ -77,49 +77,47 @@ class TestIEbSoilHeatFlux(TestCase):
 
         self._run_soilheatflux(ndvi="ndvi_low", output="g0_low")
         self.tmp_rasters.append("g0_low")
-        g0_low = gs.parse_command("r.univar", map="g0_low", flags="g", format="json")[0]
+        g0_low = gs.parse_command("r.univar", map="g0_low", flags="g", format="json")
 
         self._create_raster("ndvi_high", "0.8")
         self.tmp_rasters.append("ndvi_high")
 
         self._run_soilheatflux(ndvi="ndvi_high", output="g0_high")
         self.tmp_rasters.append("g0_high")
-        g0_high = gs.parse_command("r.univar", map="g0_high", flags="g", format="json")[
-            0
-        ]
+        g0_high = gs.parse_command("r.univar", map="g0_high", flags="g", format="json")
 
         self.assertGreater(
-            g0_low["mean"],
-            g0_high["mean"],
+            float(g0_low["mean"]),
+            float(g0_high["mean"]),
             "Expected lower soil heat flux for higher NDVI.",
         )
 
     def test_heatflux_increases_with_time(self):
-        """Test that the -r flag applies the expected correction."""
+        """Check that soil heat flux increases with local overpass time."""
         self._create_raster("time_early", "8.0")
-        self._create_raster("time_noon", "12.0")
-        self.tmp_rasters.extend(["time_early", "time_noon"])
+        self.tmp_rasters.append("time_early")
 
         self._run_soilheatflux(time="time_early", output="g0_early")
         self.tmp_rasters.append("g0_early")
         g0_early = gs.parse_command(
             "r.univar", map="g0_early", flags="g", format="json"
-        )[0]
+        )
+
+        self._create_raster("time_noon", "12.0")
+        self.tmp_rasters.append("time_noon")
 
         self._run_soilheatflux(time="time_noon", output="g0_noon")
         self.tmp_rasters.append("g0_noon")
-        g0_noon = gs.parse_command("r.univar", map="g0_noon", flags="g", format="json")[
-            0
-        ]
+        g0_noon = gs.parse_command("r.univar", map="g0_noon", flags="g", format="json")
 
         self.assertGreater(
-            g0_noon["mean"],
-            g0_early["mean"],
+            float(g0_noon["mean"]),
+            float(g0_early["mean"]),
             "Soil heat flux should be higher at noon.",
         )
 
     def test_roerink_correction_flag(self):
-        """Verify that correction flag (-r) applies expected linear transformation."""
+        """Test that the -r flag applies the expected correction."""
         self._run_soilheatflux(output="g0_base")
         self.tmp_rasters.append("g0_base")
 
@@ -138,7 +136,7 @@ class TestIEbSoilHeatFlux(TestCase):
         )
         self.tmp_rasters.extend(["g0_expected", "g0_diff"])
 
-        stats = gs.parse_command("r.univar", map="g0_diff", flags="g", format="json")[0]
+        stats = gs.parse_command("r.univar", map="g0_diff", flags="g", format="json")
         self.assertLess(
             float(stats["max"]),
             1e-6,

--- a/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
+++ b/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
@@ -77,18 +77,18 @@ class TestIEbSoilHeatFlux(TestCase):
 
         self._run_soilheatflux(ndvi="ndvi_low", output="g0_low")
         self.tmp_rasters.append("g0_low")
-        g0_low = gs.parse_command("r.univar", map="g0_low", flags="g", format="json")
+        g0_low = gs.parse_command("r.univar", map="g0_low", format="json")[0]
 
         self._create_raster("ndvi_high", "0.8")
         self.tmp_rasters.append("ndvi_high")
 
         self._run_soilheatflux(ndvi="ndvi_high", output="g0_high")
         self.tmp_rasters.append("g0_high")
-        g0_high = gs.parse_command("r.univar", map="g0_high", flags="g", format="json")
+        g0_high = gs.parse_command("r.univar", map="g0_high", format="json")[0]
 
         self.assertGreater(
-            float(g0_low["mean"]),
-            float(g0_high["mean"]),
+            g0_low["mean"],
+            g0_high["mean"],
             "Expected lower soil heat flux for higher NDVI.",
         )
 
@@ -99,20 +99,18 @@ class TestIEbSoilHeatFlux(TestCase):
 
         self._run_soilheatflux(time="time_early", output="g0_early")
         self.tmp_rasters.append("g0_early")
-        g0_early = gs.parse_command(
-            "r.univar", map="g0_early", flags="g", format="json"
-        )
+        g0_early = gs.parse_command("r.univar", map="g0_early", format="json")[0]
 
         self._create_raster("time_noon", "12.0")
         self.tmp_rasters.append("time_noon")
 
         self._run_soilheatflux(time="time_noon", output="g0_noon")
         self.tmp_rasters.append("g0_noon")
-        g0_noon = gs.parse_command("r.univar", map="g0_noon", flags="g", format="json")
+        g0_noon = gs.parse_command("r.univar", map="g0_noon", format="json")[0]
 
         self.assertGreater(
-            float(g0_noon["mean"]),
-            float(g0_early["mean"]),
+            g0_noon["mean"],
+            g0_early["mean"],
             "Soil heat flux should be higher at noon.",
         )
 
@@ -136,9 +134,9 @@ class TestIEbSoilHeatFlux(TestCase):
         )
         self.tmp_rasters.extend(["g0_expected", "g0_diff"])
 
-        stats = gs.parse_command("r.univar", map="g0_diff", flags="g", format="json")
+        stats = gs.parse_command("r.univar", map="g0_diff", format="json")[0]
         self.assertLess(
-            float(stats["max"]),
+            stats["max"],
             1e-6,
             "Roerink correction did not match expected transformation.",
         )

--- a/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
+++ b/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
@@ -1,0 +1,150 @@
+import grass.script as gs
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+class TestIEbSoilHeatFlux(TestCase):
+    """Regression test suite for i.eb.soilheatflux."""
+
+    albedo = "test_albedo"
+    ndvi = "test_ndvi"
+    temperature = "test_temperature"
+    netradiation = "test_netradiation"
+    localutctime = "test_localutctime"
+    output = "test_soilheatflux"
+    tmp_rasters = []
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialize a temporary region and input rasters."""
+        cls.use_temp_region()
+        cls.runModule("g.region", e=10, w=0, s=0, n=10, rows=10, cols=10)
+
+        cls._create_raster(cls.albedo, "0.1 + 0.3 * (row() + col()) / 20.0")
+        cls._create_raster(cls.ndvi, "-0.2 + 0.8 * (row() + col()) / 20.0")
+        cls._create_raster(cls.temperature, "300.0 + 10.0 * sin((row() + col()) * 0.1)")
+        cls._create_raster(
+            cls.netradiation, "400.0 + 20.0 * sin((row() + col()) * 0.1)"
+        )
+        cls._create_raster(cls.localutctime, "12.0 + 1.0 * cos((row() + col()) * 0.2)")
+
+        cls.tmp_rasters.extend(
+            [cls.albedo, cls.ndvi, cls.temperature, cls.netradiation, cls.localutctime]
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove temporary raster maps and region after tests."""
+        cls.tmp_rasters.append(cls.output)
+        cls.runModule("g.remove", flags="f", type="raster", name=cls.tmp_rasters)
+        cls.del_temp_region()
+
+    @classmethod
+    def _create_raster(cls, name, expr):
+        """Helper method to create a raster map."""
+        cls.runModule("r.mapcalc", expression=f"{name} = float({expr})", overwrite=True)
+
+    def _run_soilheatflux(self, ndvi=None, output=None, time=None, flags=""):
+        """Run the i.eb.soilheatflux module with provided parameters."""
+        return self.assertModule(
+            "i.eb.soilheatflux",
+            flags=flags,
+            albedo=self.albedo,
+            ndvi=ndvi or self.ndvi,
+            temperature=self.temperature,
+            netradiation=self.netradiation,
+            localutctime=time or self.localutctime,
+            output=output or self.output,
+            overwrite=True,
+        )
+
+    def test_output_statistics(self):
+        """Verify statistics of the output map against reference values."""
+        self._run_soilheatflux()
+
+        reference = {
+            "min": 48.935794,
+            "max": 64.674187,
+            "mean": 59.542719,
+            "stddev": 4.095612,
+        }
+        self.assertRasterFitsUnivar(self.output, reference, precision=1e-6)
+
+    def test_heatflux_decreases_with_high_ndvi(self):
+        """Validate that soil heat flux is lower for higher NDVI (dense vegetation)."""
+        self._create_raster("ndvi_low", "0.2")
+        self.tmp_rasters.append("ndvi_low")
+
+        self._run_soilheatflux(ndvi="ndvi_low", output="g0_low")
+        self.tmp_rasters.append("g0_low")
+        g0_low = gs.parse_command("r.univar", map="g0_low", flags="g", format="json")[0]
+
+        self._create_raster("ndvi_high", "0.8")
+        self.tmp_rasters.append("ndvi_high")
+
+        self._run_soilheatflux(ndvi="ndvi_high", output="g0_high")
+        self.tmp_rasters.append("g0_high")
+        g0_high = gs.parse_command("r.univar", map="g0_high", flags="g", format="json")[
+            0
+        ]
+
+        self.assertGreater(
+            g0_low["mean"],
+            g0_high["mean"],
+            "Expected lower soil heat flux for higher NDVI.",
+        )
+
+    def test_heatflux_increases_with_time(self):
+        """Test that the -r flag applies the expected correction."""
+        self._create_raster("time_early", "8.0")
+        self._create_raster("time_noon", "12.0")
+        self.tmp_rasters.extend(["time_early", "time_noon"])
+
+        self._run_soilheatflux(time="time_early", output="g0_early")
+        self.tmp_rasters.append("g0_early")
+        g0_early = gs.parse_command(
+            "r.univar", map="g0_early", flags="g", format="json"
+        )[0]
+
+        self._run_soilheatflux(time="time_noon", output="g0_noon")
+        self.tmp_rasters.append("g0_noon")
+        g0_noon = gs.parse_command("r.univar", map="g0_noon", flags="g", format="json")[
+            0
+        ]
+
+        self.assertGreater(
+            g0_noon["mean"],
+            g0_early["mean"],
+            "Soil heat flux should be higher at noon.",
+        )
+
+    def test_roerink_correction_flag(self):
+        """Verify that correction flag (-r) applies expected linear transformation."""
+        self._run_soilheatflux(output="g0_base")
+        self.tmp_rasters.append("g0_base")
+
+        self._run_soilheatflux(output="g0_roerink", flags="r")
+        self.tmp_rasters.append("g0_roerink")
+
+        self.runModule(
+            "r.mapcalc",
+            expression="g0_expected = 1.43 * g0_base - 0.0845",
+            overwrite=True,
+        )
+        self.runModule(
+            "r.mapcalc",
+            expression="g0_diff = abs(g0_expected - g0_roerink)",
+            overwrite=True,
+        )
+        self.tmp_rasters.extend(["g0_expected", "g0_diff"])
+
+        stats = gs.parse_command("r.univar", map="g0_diff", flags="g", format="json")[0]
+        self.assertLess(
+            float(stats["max"]),
+            1e-6,
+            "Roerink correction did not match expected transformation.",
+        )
+
+
+if __name__ == "__main__":
+    test()

--- a/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
+++ b/imagery/i.eb.soilheatflux/testsuite/test_i_eb_soilheatflux.py
@@ -77,14 +77,14 @@ class TestIEbSoilHeatFlux(TestCase):
 
         self._run_soilheatflux(ndvi="ndvi_low", output="g0_low")
         self.tmp_rasters.append("g0_low")
-        g0_low = gs.parse_command("r.univar", map="g0_low", format="json")[0]
+        g0_low = gs.parse_command("r.univar", map="g0_low", format="json")
 
         self._create_raster("ndvi_high", "0.8")
         self.tmp_rasters.append("ndvi_high")
 
         self._run_soilheatflux(ndvi="ndvi_high", output="g0_high")
         self.tmp_rasters.append("g0_high")
-        g0_high = gs.parse_command("r.univar", map="g0_high", format="json")[0]
+        g0_high = gs.parse_command("r.univar", map="g0_high", format="json")
 
         self.assertGreater(
             g0_low["mean"],
@@ -99,14 +99,14 @@ class TestIEbSoilHeatFlux(TestCase):
 
         self._run_soilheatflux(time="time_early", output="g0_early")
         self.tmp_rasters.append("g0_early")
-        g0_early = gs.parse_command("r.univar", map="g0_early", format="json")[0]
+        g0_early = gs.parse_command("r.univar", map="g0_early", format="json")
 
         self._create_raster("time_noon", "12.0")
         self.tmp_rasters.append("time_noon")
 
         self._run_soilheatflux(time="time_noon", output="g0_noon")
         self.tmp_rasters.append("g0_noon")
-        g0_noon = gs.parse_command("r.univar", map="g0_noon", format="json")[0]
+        g0_noon = gs.parse_command("r.univar", map="g0_noon", format="json")
 
         self.assertGreater(
             g0_noon["mean"],
@@ -134,7 +134,7 @@ class TestIEbSoilHeatFlux(TestCase):
         )
         self.tmp_rasters.extend(["g0_expected", "g0_diff"])
 
-        stats = gs.parse_command("r.univar", map="g0_diff", format="json")[0]
+        stats = gs.parse_command("r.univar", map="g0_diff", format="json")
         self.assertLess(
             stats["max"],
             1e-6,


### PR DESCRIPTION
This PR introduces regression test suite for the `i.eb.soilheatflux` module. The suite validates both numerical consistency and functional correctness across different operating conditions.

### Tests Added

- `test_module_statistics`: It verifies that the output from `i.eb.soilheatflux` matches expected statistical properties. This catches unintentional changes in the computational logic due to internal formula changes or numerical instability.
- `test_heatflux_decreases_with_high_ndvi`: Test ensures that soil heat flux decreases with higher NDVI, which simulates vegetated surfaces. It validates the theoretical relationship in the model and confirms its responsiveness to input vegetation conditions.
- `test_heatflux_increases_with_time`: Test checks that soil heat flux is higher at solar noon compared to early morning, due to increased net radiation. This ensures the module correctly handles local overpass time, which is critical for accurate diurnal energy balance modeling.
- `test_roerink_correction_flag`: It confirms that the `-r` flag (Roerink correction) applies the expected transformation: 
`g0 = 1.43 * g0 - 0.0845`. Test ensures empirical corrections, ensuring cell-wise transformation is correctly applied under the flag.

Looking forward to feedback and suggestions.