### PR TITLE
docker: Improve default run behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -355,4 +355,8 @@ RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" outp
 WORKDIR /grassdb
 VOLUME /grassdb
 
-CMD ["$GRASSBIN", "--version"]
+CMD grass --version \
+    && printf "\nUsage:\n" \
+    && printf " - Shell: docker run -it [IMAGE] /bin/bash\n" \
+    && printf " - GRASS: docker run [IMAGE] grass [...args]\n" \
+    && printf "\nSee https://github.com/OSGeo/grass/blob/main/docker/README.md for more information.\n"

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c as common
+FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS common
 
 # Based on:
 # https://github.com/mundialis/docker-grass-gis/blob/master/Dockerfile
@@ -229,4 +229,8 @@ RUN ln -sf /usr/local/grass /usr/local/grass85; \
 WORKDIR /grassdb
 VOLUME /grassdb
 
-CMD ["$GRASSBIN", "--version"]
+CMD grass --version \
+    && printf "\nUsage:\n" \
+    && printf " - Shell: docker run -it [IMAGE] /bin/bash\n" \
+    && printf " - GRASS: docker run [IMAGE] grass [...args]\n" \
+    && printf "\nSee https://github.com/OSGeo/grass/blob/main/docker/README.md for more information.\n"

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -226,4 +226,8 @@ RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" outp
 
 WORKDIR /grassdb
 VOLUME /grassdb
-CMD ["$GRASSBIN", "--version"]
+CMD grass --version \
+    && printf "\nUsage:\n" \
+    && printf " - Shell: docker run -it [IMAGE] /bin/bash\n" \
+    && printf " - GRASS: docker run [IMAGE] grass [...args]\n" \
+    && printf "\nSee https://github.com/OSGeo/grass/blob/main/docker/README.md for more information.\n"

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -355,4 +355,8 @@ RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" outp
 WORKDIR /grassdb
 VOLUME /grassdb
 
-CMD ["$GRASSBIN", "--version"]
+CMD grass --version \
+    && printf "\nUsage:\n" \
+    && printf " - Shell: docker run -it [IMAGE] /bin/bash\n" \
+    && printf " - GRASS: docker run [IMAGE] grass [...args]\n" \
+    && printf "\nSee https://github.com/OSGeo/grass/blob/main/docker/README.md for more information.\n"

--- a/docker/ubuntu_wxgui/Dockerfile
+++ b/docker/ubuntu_wxgui/Dockerfile
@@ -267,4 +267,9 @@ RUN grass --tmp-project EPSG:25832 --exec r.in.pdal input="/tmp/simple.laz" outp
 
 WORKDIR /grassdb
 VOLUME /grassdb
-CMD ["$GRASSBIN", "--version"]
+
+CMD grass --version \
+    && printf "\nUsage:\n" \
+    && printf " - Shell: docker run -it [IMAGE] /bin/bash\n" \
+    && printf " - GRASS: docker run [IMAGE] grass [...args]\n" \
+    && printf "\nSee https://github.com/OSGeo/grass/blob/main/docker/README.md for more information.\n"


### PR DESCRIPTION
Updates the default docker run behavior to print version text, basic usage information, and a link to more information. This has no impact on anyone already providing custom commands to the container.

Currently calling `docker run` without a command results in an error (see #5592), this PR aims to improve the "out of the box" experience for new users without impacting any current workflows. 

**Current behavior:**
```
➜  ~ docker run osgeo/grass-gis:releasebranch_8_4-alpine
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "$GRASSBIN": executable file not found in $PATH: unknown

Run 'docker run --help' for more information
➜  ~
```

**New behavior:**
```
➜  ~ docker run grass-gis
GRASS 8.5.0dev
Geographic Resources Analysis Support System (GRASS) is Copyright,
1999-2025 by the GRASS Development Team, and licensed under terms of the
GNU General Public License (GPL) version >=2.

This GRASS 8.5.0dev release is coordinated and produced by
the GRASS Development Team with contributions from all over the world.

This program is distributed in the hope that it will be useful, but
WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
General Public License for more details.

Usage:
 - Shell: docker run -it [IMAGE] /bin/bash
 - GRASS: docker run [IMAGE] grass [...args]

See https://github.com/OSGeo/grass/blob/main/docker/README.md for more information.
➜  ~
```

Edits to the output usage information are welcome.