### PR TITLE
r.stats: Add tests for JSON output

### DIFF
--- a/raster/r.stats/stats.c
+++ b/raster/r.stats/stats.c
@@ -428,8 +428,12 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
                                     labels[i].labels[node->values[i]]);
                             }
                             else {
-                                json_object_set_string(category, "label",
-                                                       "from to");
+                                json_object_dotset_string(
+                                    category, "label.from",
+                                    Rast_get_d_cat(&dLow, &labels[i]));
+                                json_object_dotset_string(
+                                    category, "label.to",
+                                    Rast_get_d_cat(&dHigh, &labels[i]));
                             }
                         }
                         break;

--- a/raster/r.stats/testsuite/test_r_stats.py
+++ b/raster/r.stats/testsuite/test_r_stats.py
@@ -14,6 +14,7 @@ License (>=v2). Read the file COPYING that comes with GRASS
 for details.
 """
 
+import json
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 from grass.gunittest.main import test
@@ -359,6 +360,455 @@ class TestRStats(TestCase):
         ]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_percentage_flag_json_output(self):
+        """Verify that r.stats with the -p flag returns correct percentage values with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.test_raster_1,
+            flags="p",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"categories": [{"category": 1}], "percent": 21.73913043478261},
+            {"categories": [{"category": 2}], "percent": 86.95652173913044},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_count_flag_json_output(self):
+        """Verify that r.stats with the -c flag produces correct count for multiple raster inputs with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=[self.test_raster_1, self.test_raster_2],
+            flags="c",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"categories": [{"category": 1}, {"category": 1}], "count": 5},
+            {"categories": [{"category": 2}, {"category": 2}], "count": 5},
+            {"categories": [{"category": 2}, {"category": 3}], "count": 5},
+            {"categories": [{"category": 2}, {"category": 4}], "count": 5},
+            {"categories": [{"category": 2}, {"category": None}], "count": 5},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_area_calculation_flag_json_output(self):
+        """Verify that r.stats with the -a flag returns correct area calculations with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.test_raster_1,
+            flags="a",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"area": 2000, "categories": [{"category": 1}]},
+            {"area": 8000, "categories": [{"category": 2}]},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_label_flag_json_output(self):
+        """Verify that r.stats with the -l flag returns category labels correctly with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.float_raster, flags="l", format="json"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {
+                "categories": [
+                    {
+                        "label": {"from": "1 degrees", "to": "1 degrees"},
+                        "range": {"from": 0.5, "to": 0.5156862745098039},
+                    }
+                ]
+            },
+            {
+                "categories": [
+                    {
+                        "label": {"from": "1 degrees", "to": "2 degrees"},
+                        "range": {"from": 0.9862745098039216, "to": 1.0019607843137255},
+                    }
+                ]
+            },
+            {
+                "categories": [
+                    {
+                        "label": {"from": "2 degrees", "to": "3 degrees"},
+                        "range": {"from": 1.488235294117647, "to": 1.503921568627451},
+                    }
+                ]
+            },
+            {
+                "categories": [
+                    {
+                        "label": {"from": "3 degrees", "to": "4 degrees"},
+                        "range": {"from": 1.9901960784313726, "to": 2.0058823529411764},
+                    }
+                ]
+            },
+            {
+                "categories": [
+                    {
+                        "label": {"from": "7 degrees", "to": "7 degrees"},
+                        "range": {"from": 4.484313725490196, "to": 4.5},
+                    }
+                ]
+            },
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_grid_coordinates_json_output(self):
+        """Verify that r.stats with the -g flag produces correct grid coordinates with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.test_raster_1,
+            flags="g",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"categories": [{"category": 1}], "east": 10, "north": 90},
+            {"categories": [{"category": 2}], "east": 30, "north": 90},
+            {"categories": [{"category": 2}], "east": 50, "north": 90},
+            {"categories": [{"category": 2}], "east": 70, "north": 90},
+            {"categories": [{"category": 2}], "east": 90, "north": 90},
+            {"categories": [{"category": 1}], "east": 10, "north": 70},
+            {"categories": [{"category": 2}], "east": 30, "north": 70},
+            {"categories": [{"category": 2}], "east": 50, "north": 70},
+            {"categories": [{"category": 2}], "east": 70, "north": 70},
+            {"categories": [{"category": 2}], "east": 90, "north": 70},
+            {"categories": [{"category": 1}], "east": 10, "north": 50},
+            {"categories": [{"category": 2}], "east": 30, "north": 50},
+            {"categories": [{"category": 2}], "east": 50, "north": 50},
+            {"categories": [{"category": 2}], "east": 70, "north": 50},
+            {"categories": [{"category": 2}], "east": 90, "north": 50},
+            {"categories": [{"category": 1}], "east": 10, "north": 30},
+            {"categories": [{"category": 2}], "east": 30, "north": 30},
+            {"categories": [{"category": 2}], "east": 50, "north": 30},
+            {"categories": [{"category": 2}], "east": 70, "north": 30},
+            {"categories": [{"category": 2}], "east": 90, "north": 30},
+            {"categories": [{"category": 1}], "east": 10, "north": 10},
+            {"categories": [{"category": 2}], "east": 30, "north": 10},
+            {"categories": [{"category": 2}], "east": 50, "north": 10},
+            {"categories": [{"category": 2}], "east": 70, "north": 10},
+            {"categories": [{"category": 2}], "east": 90, "north": 10},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_cell_coordinates_json_output(self):
+        """Verify that r.stats with the -x flag outputs row, column, and category values with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.test_raster_1,
+            flags="x",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"categories": [{"category": 1}], "col": 1, "row": 1},
+            {"categories": [{"category": 2}], "col": 2, "row": 1},
+            {"categories": [{"category": 2}], "col": 3, "row": 1},
+            {"categories": [{"category": 2}], "col": 4, "row": 1},
+            {"categories": [{"category": 2}], "col": 5, "row": 1},
+            {"categories": [{"category": 1}], "col": 1, "row": 2},
+            {"categories": [{"category": 2}], "col": 2, "row": 2},
+            {"categories": [{"category": 2}], "col": 3, "row": 2},
+            {"categories": [{"category": 2}], "col": 4, "row": 2},
+            {"categories": [{"category": 2}], "col": 5, "row": 2},
+            {"categories": [{"category": 1}], "col": 1, "row": 3},
+            {"categories": [{"category": 2}], "col": 2, "row": 3},
+            {"categories": [{"category": 2}], "col": 3, "row": 3},
+            {"categories": [{"category": 2}], "col": 4, "row": 3},
+            {"categories": [{"category": 2}], "col": 5, "row": 3},
+            {"categories": [{"category": 1}], "col": 1, "row": 4},
+            {"categories": [{"category": 2}], "col": 2, "row": 4},
+            {"categories": [{"category": 2}], "col": 3, "row": 4},
+            {"categories": [{"category": 2}], "col": 4, "row": 4},
+            {"categories": [{"category": 2}], "col": 5, "row": 4},
+            {"categories": [{"category": 1}], "col": 1, "row": 5},
+            {"categories": [{"category": 2}], "col": 2, "row": 5},
+            {"categories": [{"category": 2}], "col": 3, "row": 5},
+            {"categories": [{"category": 2}], "col": 4, "row": 5},
+            {"categories": [{"category": 2}], "col": 5, "row": 5},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_area_statistics_json_output(self):
+        """Verify that r.stats with the -A and -a flags outputs area statistics with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="Aa",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"area": 2000, "categories": [{"average": 0.5078431372549019}]},
+            {"area": 2000, "categories": [{"average": 0.9941176470588236}]},
+            {"area": 2000, "categories": [{"average": 1.496078431372549}]},
+            {"area": 2000, "categories": [{"average": 1.9980392156862745}]},
+            {"area": 2000, "categories": [{"average": 4.492156862745098}]},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_raw_index_area_json_output(self):
+        """Verify that r.stats with -r and -a flags outputs raw indexes and corresponding area with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="ra",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"area": 2000, "categories": [{"category": 1}]},
+            {"area": 2000, "categories": [{"category": 32}]},
+            {"area": 2000, "categories": [{"category": 64}]},
+            {"area": 2000, "categories": [{"category": 96}]},
+            {"area": 2000, "categories": [{"category": 255}]},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_cats_range_json_output(self):
+        """Verify that r.stats with -C and -l flags computes cats ranges and outputs labels with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="Cl",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"categories": [{"label": "1 degrees", "range": {"from": 0.5, "to": 1}}]},
+            {"categories": [{"label": "2 degrees", "range": {"from": 1, "to": 1.5}}]},
+            {"categories": [{"label": "4 degrees", "range": {"from": 2, "to": 2.5}}]},
+            {"categories": [{"label": "7 degrees", "range": {"from": 4, "to": 4.5}}]},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_integer_category_counts_json_output(self):
+        """Verify that r.stats with -i and -c flags outputs integer-rounded category values and their counts with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="ic",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {"categories": [{"category": 1}], "count": 10},
+            {"categories": [{"category": 2}], "count": 10},
+            {"categories": [{"category": 5}], "count": 5},
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_multiple_raster_inputs_stats_json_output(self):
+        """Verify r.stats with multiple raster inputs using -nacp flags with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=[self.test_raster_1, self.test_raster_2],
+            flags="nacp",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {
+                "area": 2000,
+                "categories": [{"category": 1}, {"category": 1}],
+                "count": 5,
+                "percent": 33.333333333333336,
+            },
+            {
+                "area": 2000,
+                "categories": [{"category": 2}, {"category": 2}],
+                "count": 5,
+                "percent": 33.333333333333336,
+            },
+            {
+                "area": 2000,
+                "categories": [{"category": 2}, {"category": 3}],
+                "count": 5,
+                "percent": 33.333333333333336,
+            },
+            {
+                "area": 2000,
+                "categories": [{"category": 2}, {"category": 4}],
+                "count": 5,
+                "percent": 33.333333333333336,
+            },
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_per_cell_label_json_output(self):
+        """Test r.stats with -1ln flags to output per cell label with JSON format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=[self.test_raster_1, self.test_raster_2],
+            flags="1ln",
+            format="json",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            {
+                "categories": [
+                    {"category": 1, "label": "trees"},
+                    {"category": 1, "label": "trees"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 2, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 3, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 4, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 1, "label": "trees"},
+                    {"category": 1, "label": "trees"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 2, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 3, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 4, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 1, "label": "trees"},
+                    {"category": 1, "label": "trees"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 2, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 3, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 4, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 1, "label": "trees"},
+                    {"category": 1, "label": "trees"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 2, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 3, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 4, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 1, "label": "trees"},
+                    {"category": 1, "label": "trees"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 2, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 3, "label": "buildings"},
+                ]
+            },
+            {
+                "categories": [
+                    {"category": 2, "label": "water"},
+                    {"category": 4, "label": "buildings"},
+                ]
+            },
+        ]
+
+        actual_output = json.loads(rstats_module.outputs.stdout)
         self.assertEqual(actual_output, expected_output)
 
 


### PR DESCRIPTION
Closes: #5814 

### Description
- This PR adds tests for the JSON output format of the `r.stats` module. The added test cases are largely similar to those originally created for the `format=plain` option.
- While writing the tests, one bug related to the `-l` (label) flag for JSON format was found and fixed, and corresponding test cases were added.