### PR TITLE
v.distance: Update JSON format

### DIFF
--- a/vector/v.distance/main.c
+++ b/vector/v.distance/main.c
@@ -115,9 +115,9 @@ int main(int argc, char *argv[])
     dbColumn *column;
     char *sep;
     enum OutputFormat format;
-    JSON_Value *root_value, *object_value;
-    JSON_Array *root_array;
-    JSON_Object *root_object;
+    JSON_Value *root_value = NULL, *object_value = NULL;
+    JSON_Array *root_array = NULL;
+    JSON_Object *root_object = NULL;
 
     G_gisinit(argv[0]);
 
@@ -306,10 +306,18 @@ int main(int argc, char *argv[])
     if (strcmp(opt.format->answer, "json") == 0) {
         format = JSON;
         root_value = json_value_init_array();
+        if (root_value == NULL) {
+            G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+        }
         root_array = json_array(root_value);
     }
     else {
         format = PLAIN;
+    }
+
+    if (format == JSON && !print) {
+        G_fatal_error(_("The format option requires the -p flag; please re-run "
+                        "with -p to enable output."));
     }
 
     if (do_all && update_table)
@@ -1565,7 +1573,12 @@ int main(int argc, char *argv[])
                 break;
             case JSON:
                 object_value = json_value_init_object();
+                if (object_value == NULL) {
+                    G_fatal_error(
+                        _("Failed to initialize JSON object. Out of memory?"));
+                }
                 root_object = json_object(object_value);
+
                 json_object_set_number(root_object, "from_cat",
                                        Near[i].from_cat);
                 json_object_set_number(root_object, "to_cat", Near[i].to_cat);

--- a/vector/v.distance/print.c
+++ b/vector/v.distance/print.c
@@ -7,93 +7,67 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
                  dbCatVal *catval, char *sep, enum OutputFormat format,
                  JSON_Object *object)
 {
-    JSON_Value *relations_value, *relation_value;
-    JSON_Array *relations;
-    JSON_Object *relation_object;
-    char *name = NULL;
-
-    if (format == JSON) {
-        relations_value = json_value_init_array();
-        relations = json_array(relations_value);
-    }
-
     int j;
 
     j = 0;
     while (Upload[j].upload != END) {
         if (Near[i].count == 0) { /* no nearest found */
-            fprintf(stdout, "%snull", sep);
+            if (format == PLAIN)
+                fprintf(stdout, "%snull", sep);
         }
         else {
             switch (format) {
             case JSON:
-                relation_value = json_value_init_object();
-                relation_object = json_object(relation_value);
                 switch (Upload[j].upload) {
                 case CAT:
-                    name = "to_cat";
                     if (Near[i].to_cat >= 0)
-                        json_object_set_number(relation_object, "value",
+                        json_object_set_number(object, "to_cat",
                                                Near[i].to_cat);
                     else {
-                        json_object_set_null(relation_object, "value");
+                        json_object_set_null(object, "to_cat");
                     }
                     break;
                 case DIST:
-                    name = "dist";
-                    json_object_set_number(relation_object, "value",
-                                           Near[i].dist);
+                    json_object_set_number(object, "dist", Near[i].dist);
                     break;
                 case FROM_X:
-                    name = "from_x";
-                    json_object_set_number(relation_object, "value",
-                                           Near[i].from_x);
+                    json_object_set_number(object, "from_x", Near[i].from_x);
                     break;
                 case FROM_Y:
-                    name = "from_y";
-                    json_object_set_number(relation_object, "value",
-                                           Near[i].from_y);
+                    json_object_set_number(object, "from_y", Near[i].from_y);
                     break;
                 case TO_X:
-                    name = "to_x";
-                    json_object_set_number(relation_object, "value",
-                                           Near[i].to_x);
+                    json_object_set_number(object, "to_x", Near[i].to_x);
                     break;
                 case TO_Y:
-                    name = "to_y";
-                    json_object_set_number(relation_object, "value",
-                                           Near[i].to_y);
+                    json_object_set_number(object, "to_y", Near[i].to_y);
                     break;
                 case FROM_ALONG:
-                    name = "from_along";
-                    json_object_set_number(relation_object, "value",
+                    json_object_set_number(object, "from_along",
                                            Near[i].from_along);
                     break;
                 case TO_ALONG:
-                    name = "to_along";
-                    json_object_set_number(relation_object, "value",
+                    json_object_set_number(object, "to_along",
                                            Near[i].to_along);
                     break;
                 case TO_ANGLE:
-                    name = "to_angle";
-                    json_object_set_number(relation_object, "value",
+                    json_object_set_number(object, "to_angle",
                                            Near[i].to_angle);
                     break;
                 case TO_ATTR:
-                    name = "to_attr";
                     if (catval) {
                         switch (cvarr->ctype) {
                         case DB_C_TYPE_INT:
-                            json_object_set_number(relation_object, "value",
+                            json_object_set_number(object, "to_attr",
                                                    catval->val.i);
                             break;
                         case DB_C_TYPE_DOUBLE:
-                            json_object_set_number(relation_object, "value",
+                            json_object_set_number(object, "to_attr",
                                                    catval->val.d);
                             break;
                         case DB_C_TYPE_STRING:
                             json_object_set_string(
-                                relation_object, "value",
+                                object, "to_attr",
                                 db_get_string(catval->val.s));
                             break;
                         case DB_C_TYPE_DATETIME:
@@ -102,14 +76,12 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
                         }
                     }
                     else {
-                        json_object_set_null(relation_object, "value");
+                        json_object_set_null(object, "to_attr");
                     }
                     break;
                 default:
                     break;
                 }
-                json_object_set_string(relation_object, "name", name);
-                json_array_append_value(relations, relation_value);
                 break;
             case PLAIN:
                 switch (Upload[j].upload) {
@@ -178,8 +150,5 @@ int print_upload(NEAR *Near, UPLOAD *Upload, int i, dbCatValArray *cvarr,
         j++;
     }
 
-    if (format == JSON) {
-        json_object_set_value(object, "distances", relations_value);
-    }
     return 0;
 }

--- a/vector/v.distance/testsuite/test_v_distance.py
+++ b/vector/v.distance/testsuite/test_v_distance.py
@@ -1,5 +1,4 @@
 import json
-from itertools import zip_longest
 
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
@@ -13,18 +12,14 @@ class TestVDistance(TestCase):
             {
                 "from_cat": 1,
                 "to_cat": 112,
-                "distances": [
-                    {"value": 0.1428123184481199, "name": "dist"},
-                    {"value": "8,A", "name": "to_attr"},
-                ],
+                "dist": 0.1428123184481199,
+                "to_attr": "8,A",
             },
             {
                 "from_cat": 2,
                 "to_cat": 44,
-                "distances": [
-                    {"value": 0.10232660032693719, "name": "dist"},
-                    {"value": "9,A", "name": "to_attr"},
-                ],
+                "dist": 0.10232660032693719,
+                "to_attr": "9,A",
             },
         ]
 
@@ -40,13 +35,15 @@ class TestVDistance(TestCase):
         self.runModule(module)
         received = json.loads(module.outputs.stdout)
 
-        for first, second in zip_longest(reference, received):
-            self.assertEqual(first["from_cat"], second["from_cat"])
-            self.assertEqual(first["to_cat"], second["to_cat"])
-            for f_d, s_d in zip_longest(first["distances"], second["distances"]):
-                self.assertEqual(f_d["name"], s_d["name"])
-                self.assertAlmostEqual(f_d["value"], s_d["value"], places=6)
-            self.assertEqual(reference, received)
+        self.assertEqual(len(reference), len(received))
+        for expected, actual in zip(reference, received):
+            for key, expected_value in expected.items():
+                self.assertIn(key, actual)
+                actual_value = actual[key]
+                if isinstance(expected_value, float):
+                    self.assertAlmostEqual(expected_value, actual_value, places=6)
+                else:
+                    self.assertEqual(expected_value, actual_value)
 
 
 if __name__ == "__main__":

--- a/vector/v.distance/v.distance.md
+++ b/vector/v.distance/v.distance.md
@@ -217,37 +217,51 @@ from_cat to_cat       dist
 v.distance -p from=busroute_a to=busstopsall upload=dist,to_attr to_column=routes format=json
 ```
 
+Possible output:
+
 ```json
 [
     {
         "from_cat": 1,
         "to_cat": 112,
-        "distances": [
-            {
-                "value": 0.1428123184481199,
-                "name": "dist"
-            },
-            {
-                "value": "8,A",
-                "name": "to_attr"
-            }
-        ]
+        "dist": 0.1428123184481199,
+        "to_attr": "8,A"
     },
     {
         "from_cat": 2,
         "to_cat": 44,
-        "distances": [
-            {
-                "value": 0.10232660032693719,
-                "name": "dist"
-            },
-            {
-                "value": "9,A",
-                "name": "to_attr"
-            }
-        ]
+        "dist": 0.10232660032693719,
+        "to_attr": "9,A"
     }
 ]
+```
+
+### Print output as Pandas DataFrame
+
+```python
+import grass.script as gs
+import pandas as pd
+
+data = gs.parse_command(
+    "v.distance",
+    flags="p",
+    from_="busroute_a",
+    to="busstopsall",
+    upload="dist,to_attr",
+    to_column="routes",
+    format="json",
+)
+df = pd.DataFrame(data)
+
+print(df)
+```
+
+Possible output:
+
+```text
+   from_cat  to_cat      dist to_attr
+0         1     112  0.142812     8,A
+1         2      44  0.102327     9,A
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
Fixes: #5846 

This PR updates the JSON output format of `v.distance` module. The new format looks like:
```json
[
    {
        "from_cat": 1,
        "to_cat": 112,
        "dist": 0.1428123184481199,
        "to_attr": "8,A"
    },
    {
        "from_cat": 2,
        "to_cat": 44,
        "dist": 0.10232660032693719,
        "to_attr": "9,A"
    }
]
```
It also includes minor improvements to error handling and adds a pandas example for `v.distance`.