### PR TITLE
r.stats: fix uninitialised window value

### DIFF
--- a/raster/r.stats/raw_stats.c
+++ b/raster/r.stats/raw_stats.c
@@ -52,7 +52,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
         }
 
         double northing;
-        if (with_coordinates || format == JSON) {
+        if (with_coordinates) {
             northing = Rast_row_to_northing(row + .5, &window);
             G_format_northing(northing, nbuf,
                               G_projection() == PROJECTION_LL ? -1 : 0);


### PR DESCRIPTION
Ref: https://github.com/OSGeo/grass/pull/5892#issuecomment-2977188565

This fixes the issue of the uninitialized `window` variable by ensuring it is set and used only when `with_coordinates` is enabled, and not when `format == JSON`.
