### PR TITLE
CI(OSGeo4W): Upgrade image to windows-2022 (backport of #5562)

### DIFF
--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
+          - windows-2022
       fail-fast: false
 
     steps:
@@ -68,6 +68,8 @@ jobs:
           export CFLAGS="${CFLAGS} -pipe"
           export CXXFLAGS="${CXXFLAGS} -pipe"
           .github/workflows/build_osgeo4w.sh
+        env:
+          MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
 
       - name: Print installed versions
         if: always()

--- a/mswindows/osgeo4w/build_osgeo4w.sh
+++ b/mswindows/osgeo4w/build_osgeo4w.sh
@@ -20,6 +20,7 @@ export PATH=${OSGEO4W_ROOT_MSYS}/bin:/usr/bin:/mingw64/bin
 export C_INCLUDE_PATH=".:${OSGEO4W_ROOT_MSYS}/include:${SRC}/dist.${ARCH}/include:/c/msys64/mingw64/include"
 export PYTHONHOME=${OSGEO4W_ROOT_MSYS}/apps/Python312
 export ARCH=x86_64-w64-mingw32
+export MSYS2_LOCATION="${MSYS2_LOCATION:-C:/msys64}"
 
 mkdir -p mswindows/osgeo4w/lib
 rm -f $OSGEO4W_ROOT_MSYS/lib/libpq.a
@@ -133,7 +134,7 @@ opt_path=${OSGEO4W_ROOT_MSYS}/opt
 grass_path=$opt_path/grass
 
 if [ "$UNITTEST" ]; then
-    msys_path=";C:/msys64/usr/bin;C:/msys64/mingw64/bin"
+    msys_path=";$(cygpath -m ${MSYS2_LOCATION})/usr/bin;$(cygpath -m ${MSYS2_LOCATION})/mingw64/bin"
 fi
 
 mkdir -p $opt_path

--- a/mswindows/osgeo4w/mklibs.sh
+++ b/mswindows/osgeo4w/mklibs.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "$CI" ] ; then
 	# dumpbin in GH actions moved to sub-directory
-	export PATH="$PATH:$(cygpath -ua 'C:/Program Files (x86)\Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30133/bin/HostX64/x64/')"
+	export PATH="$PATH:$(cygpath -ua 'C:/Program Files\Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.42.34438/bin/HostX64/x64/')"
 	# dumpbin in GH actions does not support options starting with "-"
 	DUMPBIN_EXPORT="/EXPORTS"
 else


### PR DESCRIPTION
Backport of #5562

The windows-2019 image is being removed in less than a month. We need to use windows-2022. The changes needed in our build_osgeo4w.sh script relate to the msys2 paths added to path. They need to use the location defined in the CI step, otherwise, another version already installed in the runner, but normally not on path, is used. On windows-2019, we didn’t see errors of this misconfiguration, but we did for windows-2022.

* CI(OSGeo4W): Upgrade image to windows-2022

* mswindows: Update path for dumpbin in mklibs.sh

* windows: Use MSYS2_LOCATION env var to create script from templates in build_osgeo4w.sh

* CI(OSGeo4W): Add MSYS2_LOCATION env var to build stage