### PR TITLE
r.out.ppm: Fix buffer issues in main.c

### DIFF
--- a/raster/r.out.ppm/main.c
+++ b/raster/r.out.ppm/main.c
@@ -78,8 +78,10 @@ int main(int argc, char *argv[])
 
     if (strcmp(ppm_file->answer, "<rasterfilename>.ppm")) {
         if (strcmp(ppm_file->answer, "-")) {
-            if (G_strlcpy(ofile, ppm_file->answer, sizeof(ofile)) >= sizeof(ofile))
-                G_fatal_error(_("Output file name <%s> is too long"), ppm_file->answer);
+            if (G_strlcpy(ofile, ppm_file->answer, sizeof(ofile)) >=
+                sizeof(ofile))
+                G_fatal_error(_("Output file name <%s> is too long"),
+                              ppm_file->answer);
         }
         else
             do_stdout = 1;
@@ -94,7 +96,7 @@ int main(int argc, char *argv[])
         if (G_strlcpy(ofile, map, sizeof(ofile)) >= sizeof(ofile))
             G_fatal_error(_("File name <%s> is too long"), map);
         if (G_strlcat(ofile, ".ppm", sizeof(ofile)) >= sizeof(ofile))
-            G_fatal_error(_("File name <%s> is too long after appending .ppm"), map);
+            G_fatal_error(_("File name <%s> is too long"), map);
 
     }
 

--- a/raster/r.out.ppm/main.c
+++ b/raster/r.out.ppm/main.c
@@ -77,8 +77,10 @@ int main(int argc, char *argv[])
         rast->answer++;
 
     if (strcmp(ppm_file->answer, "<rasterfilename>.ppm")) {
-        if (strcmp(ppm_file->answer, "-"))
-            strcpy(ofile, ppm_file->answer);
+        if (strcmp(ppm_file->answer, "-")) {
+            if (G_strlcpy(ofile, ppm_file->answer, sizeof(ofile)) >= sizeof(ofile))
+                G_fatal_error(_("Output file name <%s> is too long"), ppm_file->answer);
+        }
         else
             do_stdout = 1;
     }
@@ -89,8 +91,11 @@ int main(int argc, char *argv[])
             if (p != map)
                 *p = '\0';
         }
-        strcpy(ofile, map);
-        strcat(ofile, ".ppm");
+        if (G_strlcpy(ofile, map, sizeof(ofile)) >= sizeof(ofile))
+            G_fatal_error(_("File name <%s> is too long"), map);
+        if (G_strlcat(ofile, ".ppm", sizeof(ofile)) >= sizeof(ofile))
+            G_fatal_error(_("File name <%s> is too long after appending .ppm"), map);
+
     }
 
     /*G_get_set_window (&w); */ /* 10/99 MN: check for current region */


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208236)
Used G_strlcpy() and G_strlcat() to fix this issue.
For G_strlcat(), added a return value check with G_fatal_error() instead of silencing it with (void) (not sure whether it would fit within 1000 characters), even though the buffer ofile is 1000 bytes wide.

