### PR TITLE
docs: Improved styling of search suggestion and added search sharing

### DIFF
--- a/man/mkdocs/grassdocs.css
+++ b/man/mkdocs/grassdocs.css
@@ -289,17 +289,6 @@
   color: var(--gs-secondary-alt-color);
 }
 
-/* Search */
-[dir="ltr"] .md-search__suggest {
-	padding-left: 2.1rem;
-}
-
-@media screen and (min-width: 60em) {
-  [dir="ltr"] .md-search__suggest {
-	  padding-left: 2.1rem;
-  }
-}
-
 /* Typesets */
 .md-typeset h1 {
   color: var(--gs-secondary-alt-color);

--- a/man/mkdocs/grassdocs.css
+++ b/man/mkdocs/grassdocs.css
@@ -289,6 +289,17 @@
   color: var(--gs-secondary-alt-color);
 }
 
+/* Search */
+[dir="ltr"] .md-search__suggest {
+	padding-left: 2.1rem;
+}
+
+@media screen and (min-width: 60em) {
+  [dir="ltr"] .md-search__suggest {
+	  padding-left: 2.1rem;
+  }
+}
+
 /* Typesets */
 .md-typeset h1 {
   color: var(--gs-secondary-alt-color);

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -29,7 +29,6 @@ theme:
     - content.code.copy
     - content.tabs.link
     - content.tooltips
-    - search.suggest
     - search.share
     - search.highlight
     - navigation.footer

--- a/man/mkdocs/mkdocs.yml
+++ b/man/mkdocs/mkdocs.yml
@@ -30,6 +30,7 @@ theme:
     - content.tabs.link
     - content.tooltips
     - search.suggest
+    - search.share
     - search.highlight
     - navigation.footer
     - navigation.instant


### PR DESCRIPTION
Improved styling of the search suggestions. The default style used an offset on the suggested text that made the suggestion harder to read, so I reduced the offset to improve the readability of the suggested text.

## Original Styling
![image](https://github.com/user-attachments/assets/fbebd971-a4bd-457e-905b-5017887d34b9)

## New Styling
![image](https://github.com/user-attachments/assets/3869e4fa-9b48-4711-998f-32107e092d35)

I also added in the ability to share a search by clicking the share button in the search box. Look at the **New Styling** example to see the implementation (top right corner next to the X).
