### PR TITLE
lib/gis: Fixes issues parsing YAML special characters in MkDocs

### DIFF
--- a/lib/gis/parser_md.c
+++ b/lib/gis/parser_md.c
@@ -32,14 +32,14 @@ void G__usage_markdown(void)
     /* print metadata used by man/build*.py */
     fprintf(stdout, "---\n");
     fprintf(stdout, "name: %s\n", st->pgm_name);
-    fprintf(stdout, "description: ");
+    fprintf(stdout, "description: \"");
     if (st->module_info.label)
         fprintf(stdout, "%s", st->module_info.label);
     if (st->module_info.label && st->module_info.description)
         fprintf(stdout, " ");
     if (st->module_info.description)
         fprintf(stdout, "%s", st->module_info.description);
-    fprintf(stdout, "\n");
+    fprintf(stdout, "\"\n");
     fprintf(stdout, "keywords: [ ");
     G__print_keywords(stdout, NULL, FALSE);
     fprintf(stdout, " ]");


### PR DESCRIPTION
YAML 1.2 special characters are not getting escaped by `parser_md.c`. These characters are causing errors in the markdown documentation. You can look at [r.regression.line](https://grass.osgeo.org/grass-devel/manuals/r.regression.line.html) as an example.

To address this I've enclosed the the text in quotes to resolve any issues with special characters.

