### PR TITLE
grass.script: deprecate vector_what encoding parameter

### DIFF
--- a/gui/wxpython/mapdisp/frame.py
+++ b/gui/wxpython/mapdisp/frame.py
@@ -1099,13 +1099,11 @@ class MapPanel(SingleMapPanel, MainPageBase):
                 map=raster, coord=(east, north), localized=True, env=env
             )
         if vect:
-            encoding = UserSettings.Get(group="atm", key="encoding", subkey="value")
             try:
                 vectQuery = gs.vector_what(
                     map=vect,
                     coord=(east, north),
                     distance=qdist,
-                    encoding=encoding,
                     multiple=True,
                 )
             except ScriptError:

--- a/python/grass/script/vector.py
+++ b/python/grass/script/vector.py
@@ -380,6 +380,9 @@ def vector_what(
     :param multiple: find multiple features within threshold distance
     :param env: environment
 
+        .. deprecated:: 8.5.0
+            Parameter ``encoding`` is deprecated.
+
     :return: parsed list
     """
     if not env:
@@ -449,9 +452,6 @@ def vector_what(
             orderedDict = dict
 
     kwargs = {}
-    if encoding:
-        kwargs["encoding"] = encoding
-
     kwargs["object_pairs_hook"] = orderedDict
 
     try:


### PR DESCRIPTION
Fixes #5911. But I am not sure how to handle different encodings than UTF. The C library would have to do the encoding.