### PR TITLE
grass.script: Pass env to debug_level

### DIFF
--- a/general/g.list/tests/conftest.py
+++ b/general/g.list/tests/conftest.py
@@ -5,8 +5,8 @@ import pytest
 TEST_MAPSETS = ["test_1", "test_2"]
 
 
-@pytest.fixture
-def simple_dataset(tmp_path_factory, monkeypatch):
+@pytest.fixture(scope="module")
+def simple_dataset(tmp_path_factory):
     """Set up a GRASS session for the tests."""
     tmp_path = tmp_path_factory.mktemp("simple_dataset")
     project = "test_project"
@@ -16,9 +16,6 @@ def simple_dataset(tmp_path_factory, monkeypatch):
 
     # Initialize the GRASS session
     with gs.setup.init(tmp_path / project, env=os.environ.copy()) as session:
-        for key, value in session.env.items():
-            monkeypatch.setenv(key, value)
-
         gs.run_command("g.region", rows=3, cols=3, env=session.env)
 
         # Create Mock Mapsets and data in each

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -2119,12 +2119,12 @@ def debug_level(force: bool = False, *, env: _Env = None):
             try:
                 _debug_level = int(gisenv(env=env).get("DEBUG", 0))
             except (CalledModuleError, OSError):
-                # We continute in case of an error. Default value is already set.
+                # We continue in case of an error. Default value is already set.
                 pass
             if _debug_level < 0 or _debug_level > 5:
                 raise ValueError(_("Debug level {0}").format(_debug_level))
         except ValueError as e:
-            # The exeception may come from the conversion or from the range,
+            # The exception may come from the conversion or from the range,
             # so we handle both in the same way.
             _debug_level = 0
             sys.stderr.write(

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -471,10 +471,10 @@ def start_command(
         **kwargs,
     )
 
-    if debug_level() > 0:
+    if debug_level(env=kwargs.get("env")) > 0:
         sys.stderr.write(
             "D1/{}: {}.start_command(): {}\n".format(
-                debug_level(), __name__, " ".join(args)
+                debug_level(env=kwargs.get("env")), __name__, " ".join(args)
             )
         )
         sys.stderr.flush()
@@ -790,7 +790,7 @@ def debug(msg, debug=1, env=None):
     :param env: dictionary with system environment variables
                 (:external:py:data:`os.environ` by default)
     """
-    if debug_level() >= debug:
+    if debug_level(env=env) >= debug:
         # TODO: quite a random hack here, do we need it somewhere else too?
         if sys.platform == "win32":
             msg = msg.replace("&", "^&")
@@ -1798,7 +1798,7 @@ def verbosity():
 # Various utilities, not specific to GRASS
 
 
-def find_program(pgm, *args):
+def find_program(pgm, *args, env: _Env = None):
     """Attempt to run a program, with optional arguments.
 
     You must call the program in a way that will return a successful
@@ -1816,6 +1816,7 @@ def find_program(pgm, *args):
 
     :param str pgm: program name
     :param args: list of arguments
+    :param env: environment
 
     :return: False if the attempt failed due to a missing executable
             or non-zero return code
@@ -1824,7 +1825,9 @@ def find_program(pgm, *args):
     with open(os.devnull, "w+") as nuldev:
         try:
             # TODO: the doc or impl is not correct, any return code is accepted
-            call([pgm] + list(args), stdin=nuldev, stdout=nuldev, stderr=nuldev)
+            call(
+                [pgm] + list(args), stdin=nuldev, stdout=nuldev, stderr=nuldev, env=env
+            )
             found = True
         except Exception:
             found = False
@@ -2104,17 +2107,25 @@ def version():
 _debug_level = None
 
 
-def debug_level(force=False):
+def debug_level(force: bool = False, *, env: _Env = None):
     global _debug_level
     if not force and _debug_level is not None:
         return _debug_level
     _debug_level = 0
-    if find_program("g.gisenv", "--help"):
+    # We attempt to access the environment only when there is a chance
+    # it will work.
+    if find_program("g.gisenv", "--help", env=env):
         try:
-            _debug_level = int(gisenv().get("DEBUG", 0))
+            try:
+                _debug_level = int(gisenv(env=env).get("DEBUG", 0))
+            except (CalledModuleError, OSError):
+                # We continute in case of an error. Default value is already set.
+                pass
             if _debug_level < 0 or _debug_level > 5:
                 raise ValueError(_("Debug level {0}").format(_debug_level))
         except ValueError as e:
+            # The exeception may come from the conversion or from the range,
+            # so we handle both in the same way.
             _debug_level = 0
             sys.stderr.write(
                 _(


### PR DESCRIPTION
To get a debug level Python code calls debug_level function which in turn needs to call g.gisenv because the debug level is stored in GRASS gisenv variable (and not as a system environment variable). For call to g.gisenv, one needs to have a session (GISRC) set up, so env is needed when it is only a local one (and not os.environ).

Experimentally, this also removes the monkeypatch fixture from the recently added test for g.list which, without the monkeypatch, failed on Windows with GISRC missing from g.gisenv indicating that os.environ was set up with the runtime (PATH etc.), but didn't have an active session (GISRC etc.). This should pass the correct local environment through env all the way to g.gisenv. (Additionally, the fixture scope is changed to module, so that it is created only once.)
