### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/locale/po/grasslibs_sv.po
+++ b/locale/po/grasslibs_sv.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-14 18:45+0000\n"
-"PO-Revision-Date: 2025-06-16 10:31+0000\n"
+"PO-Revision-Date: 2025-06-20 00:15+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
 "Language-Team: Swedish <https://weblate.osgeo.org/projects/grass-gis/grasslibs/sv/>\n"
 "Language: sv\n"
@@ -7958,7 +7958,7 @@ msgstr "Inkonsekvens i topologin: antal centroider %d (borde vara %d)"
 
 #: ../lib/vector/Vlib/overlay.c:74
 msgid "unknown operator"
-msgstr "okänd operatör"
+msgstr "okänd operator"
 
 #: ../lib/vector/Vlib/overlay.c:128
 msgid "Overlay: line/boundary types not supported by AND operator"
@@ -7966,7 +7966,7 @@ msgstr "Överlagring: linje-/gränstyper som inte stöds av AND-operatorn"
 
 #: ../lib/vector/Vlib/overlay.c:132
 msgid "Overlay: area x area types not supported by AND operator"
-msgstr "Overlay: område x område typer som inte stöds av AND-operatören"
+msgstr "Overlay: område x område typer som inte stöds av AND-operatorn"
 
 #: ../lib/vector/Vlib/poly.c:264
 msgid "Unable to find point in polygon"

--- a/locale/po/grassmods_sv.po
+++ b/locale/po/grassmods_sv.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-14 18:45+0000\n"
-"PO-Revision-Date: 2025-06-16 10:31+0000\n"
+"PO-Revision-Date: 2025-06-20 00:15+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
 "Language-Team: Swedish <https://weblate.osgeo.org/projects/grass-gis/grassmods/sv/>\n"
 "Language: sv\n"
@@ -840,7 +840,7 @@ msgstr "Värdeoperand för NOT"
 #: ../db/drivers/dbf/dbfexe.c:955 ../db/drivers/dbf/dbfexe.c:1156
 #, c-format
 msgid "Unknown operator %d"
-msgstr "Okänd operatör %d"
+msgstr "Okänd operator %d"
 
 #: ../db/drivers/dbf/dbfexe.c:1064
 msgid "Arithmetical operation with strings is not allowed"
@@ -11108,7 +11108,7 @@ msgstr "Inte tillräckligt med aktiva kontrollpunkter för aktuell order, %d kr�
 
 #: ../imagery/i.rectify/cp.c:60 ../vector/v.rectify/cp.c:365
 msgid "Invalid order"
-msgstr "Ogiltig beställning"
+msgstr "Ogiltig ordning"
 
 #: ../imagery/i.rectify/get_wind.c:181
 #, c-format
@@ -44147,7 +44147,7 @@ msgstr "Typ av objekt (vektorkarta B)"
 
 #: ../vector/v.overlay/main.c:107
 msgid "Operator defines features written to output vector map"
-msgstr "Operatören definierar funktioner som skrivs till utmatningsvektorkartan"
+msgstr "Operatorn definierar funktioner som skrivs till utmatningsvektorkartan"
 
 #: ../vector/v.overlay/main.c:110
 msgid "Feature is written to output if the result of operation 'ainput operator binput' is true. Input feature is considered to be true, if category of given layer is defined."
@@ -45122,7 +45122,7 @@ msgstr "Lagernummer (vektorkarta B)"
 
 #: ../vector/v.select/args.c:50
 msgid "Operator defines required relation between features"
-msgstr "Operatör definierar önskad relation mellan funktioner"
+msgstr "Operatorn definierar önskad relation mellan funktioner"
 
 #: ../vector/v.select/args.c:52
 msgid "A feature is written to output if the result of operation 'ainput operator binput' is true. An input feature is considered to be true, if category of given layer is defined."
@@ -45170,7 +45170,7 @@ msgstr "objekt A är spatialt relaterat till objekt B (med GEOS, kräver alterna
 
 #: ../vector/v.select/args.c:98
 msgid "Intersection Matrix Pattern used for 'relate' operator"
-msgstr "Intersection Matrix Mönster som används för operatören \"relate"
+msgstr "Intersection-matrismönster som används för operatorn \"relate\""
 
 #: ../vector/v.select/args.c:105
 msgid "Do not skip features without category"
@@ -45187,7 +45187,7 @@ msgstr "Väljer objekt från vektorkarta (A) med objekt från annan vektorkarta 
 
 #: ../vector/v.select/main.c:104
 msgid "Operator can only be 'overlap'"
-msgstr "Operatören kan bara vara \"överlappning"
+msgstr "Operatorn kan bara vara \"overlap\""
 
 #: ../vector/v.select/main.c:160
 msgid "Output from v.select"

--- a/locale/po/grasswxpy_sv.po
+++ b/locale/po/grasswxpy_sv.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-14 18:45+0000\n"
-"PO-Revision-Date: 2025-06-16 10:31+0000\n"
+"PO-Revision-Date: 2025-06-20 00:15+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
 "Language-Team: Swedish <https://weblate.osgeo.org/projects/grass-gis/grasswxpy/sv/>\n"
 "Language: sv\n"
@@ -4182,7 +4182,7 @@ msgstr "Inaktiverad:"
 
 #: ../gui/wxpython/gmodeler/preferences.py:88
 msgid "Python editor"
-msgstr "Python-editor"
+msgstr "Python-redigerare"
 
 #: ../gui/wxpython/gmodeler/preferences.py:95
 msgid "GRASS API:"
@@ -5861,7 +5861,7 @@ msgstr "Avaktivera överskrivning"
 
 #: ../gui/wxpython/gui_core/pyedit.py:876
 msgid "Simple Python Editor"
-msgstr "Enkel Python Editor"
+msgstr "Enkel Python-redigerare"
 
 #: ../gui/wxpython/gui_core/query.py:32
 msgid "Query results"
@@ -9953,7 +9953,7 @@ msgstr "mapcalc uttalande"
 
 #: ../gui/wxpython/modules/mcalc_builder.py:153
 msgid "Operators"
-msgstr "Operatörer"
+msgstr "Operatorer"
 
 #: ../gui/wxpython/modules/mcalc_builder.py:156
 #: ../gui/wxpython/vnet/dialogs.py:368


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GRASS GIS/grasslibs](https://weblate.osgeo.org/projects/grass-gis/grasslibs/).


It also includes following components:

* [GRASS GIS/grassmods](https://weblate.osgeo.org/projects/grass-gis/grassmods/)

* [GRASS GIS/grasswxpy](https://weblate.osgeo.org/projects/grass-gis/grasswxpy/)



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/grass-gis/grasslibs/horizontal-auto.svg)