### PR TITLE
g.region: Update JSON format

### DIFF
--- a/general/g.region/g.region.md
+++ b/general/g.region/g.region.md
@@ -101,10 +101,13 @@ the number of columns.
 The **-p** (or **-g**) option is recognized last. This means that all
 changes are applied to the region settings before printing occurs.
 
-The **-g** flag prints the current region settings in shell script
-style. This format can be given back to *g.region* on its command line.
+The ****format=shell** parameter prints the current region settings in shell
+script style. This format can be given back to *g.region* on its command line.
 This may also be used to save region settings as shell environment
-variables with the UNIX eval command, "`` eval `g.region -g` ``".
+variables with the UNIX eval command, "`` eval `g.region -p format=shell` ``".
+
+The **-g** flag is deprecated and will be removed in a future release. Please
+use **format=shell** instead.
 
 With **-u** flag current region is not updated even if one or more
 options for changing region is used (**res=**, **raster=**, etc). This
@@ -189,11 +192,11 @@ cols3:      950
 depths:     1
 ```
 
-The **-g** option prints the region in the following script style
+The **format=shell** option prints the region in the following script style
 (key=value) format:
 
 ```sh
-g.region -g
+g.region -p format=shell
 ```
 
 ```sh
@@ -207,11 +210,12 @@ rows=700
 cols=950
 ```
 
-The **-bg** option prints the region in the following script style
-(key=value) format plus the boundary box in latitude-longitude/WGS84:
+The **-b** flag with **format=shell** option prints the region in the following
+script style (key=value) format plus the boundary box in latitude-
+longitude/WGS84:
 
 ```sh
-g.region -bg
+g.region -b format=shell
 ```
 
 ```sh
@@ -343,7 +347,7 @@ Extracting a spatial subset of the external vector map `soils.shp` into
 new external vector map `soils_cut.shp` using the OGR *ogr2ogr* tool:  
 
 ```sh
-eval `g.region -g`
+eval `g.region -p format=shell`
 ogr2ogr -spat $w $s $e $n soils_cut.shp soils.shp
 ```
 
@@ -357,7 +361,7 @@ Extracting a spatial subset of the external raster map
 tool:  
 
 ```sh
-eval `g.region -g`
+eval `g.region -p format=shell`
 gdalwarp -t_srs "`g.proj -wf`" -te $w $s $e $n \
          p016r035_7t20020524_z17_nn30.tif \
          p016r035_7t20020524_nc_spm_wake_nn30.tif
@@ -372,41 +376,27 @@ coordinate reference system since it is reprojected on the fly.
 g.region -p format=json
 ```
 
+Possible output:
+
 ```sh
 {
-    "projection": {
-        "code": 99,
-        "name": "Lambert Conformal Conic"
-    },
-    "zone": 0,
-    "datum": "nad83",
-    "ellipsoid": "a=6378137 es=0.006694380022900787",
-    "region": {
-        "north": 320000,
-        "south": 10000,
-        "west": 120000,
-        "east": 935000,
-        "ns-res": 500,
-        "ns-res3": 1000,
-        "ew-res": 500,
-        "ew-res3": 1000
-    },
-    "top": 500,
-    "bottom": -500,
-    "tbres": 100,
-    "rows": 620,
-    "rows3": 310,
-    "cols": 1630,
-    "cols3": 815,
-    "depths": 10,
-    "cells": 1010600,
-    "cells3": 2526500
+    "north": 223550,
+    "south": 223480,
+    "west": 637830,
+    "east": 637900,
+    "nsres": 10,
+    "ewres": 10,
+    "rows": 7,
+    "cols": 7,
+    "cells": 49,
 }
 ```
 
 ```sh
 g.region -l format=json
 ```
+
+Possible output:
 
 ```sh
 {
@@ -458,7 +448,7 @@ import grass.script as gs
 # Get WGS84 bounding box
 region = gs.parse_command(
     "g.region",
-    flags="bg",
+    flags="b",
     format="json",
 )
 bbox = [region[k] for k in ("ll_w", "ll_s", "ll_e", "ll_n")]

--- a/general/g.region/main.c
+++ b/general/g.region/main.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
 {
     int i;
     int print_flag = 0;
-    int flat_flag;
+    int flat_flag = 0;
     double x, xs, ys, zs;
     int ival;
     int row_flag = 0, col_flag = 0;
@@ -144,13 +144,16 @@ int main(int argc, char *argv[])
 
     flag.gprint = G_define_flag();
     flag.gprint->key = 'g';
-    flag.gprint->description = _("Print in shell script style");
+    flag.gprint->label = _("Print in shell script style [deprecated]");
+    flag.gprint->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=shell instead.");
     flag.gprint->guisection = _("Print");
 
     flag.flprint = G_define_flag();
     flag.flprint->key = 'f';
-    flag.flprint->description =
-        _("Print in shell script style, but in one line (flat)");
+    flag.flprint->description = _("Print in one line (flat) in shell script "
+                                  "style (ignores format parameter)");
     flag.flprint->guisection = _("Print");
 
     flag.res_set = G_define_flag();
@@ -388,34 +391,41 @@ int main(int argc, char *argv[])
                                   "json;JSON (JavaScript Object Notation);");
     parm.format->guisection = _("Print");
 
-    G_option_required(flag.dflt, flag.savedefault, flag.print, flag.lprint,
-                      flag.eprint, flag.center, flag.gmt_style, flag.wms_style,
-                      flag.dist_res, flag.nangle, flag.z, flag.bbox,
-                      flag.gprint, flag.res_set, flag.noupdate, parm.region,
-                      parm.raster, parm.raster3d, parm.vect, parm.north,
-                      parm.south, parm.east, parm.west, parm.top, parm.bottom,
-                      parm.rows, parm.cols, parm.res, parm.res3, parm.nsres,
-                      parm.ewres, parm.nsres3, parm.ewres3, parm.tbres,
-                      parm.zoom, parm.align, parm.save, parm.grow, NULL);
+    G_option_required(
+        flag.dflt, flag.savedefault, flag.print, flag.lprint, flag.eprint,
+        flag.center, flag.gmt_style, flag.wms_style, flag.dist_res, flag.nangle,
+        flag.z, flag.bbox, flag.gprint, flag.res_set, flag.noupdate,
+        flag.flprint, parm.region, parm.raster, parm.raster3d, parm.vect,
+        parm.north, parm.south, parm.east, parm.west, parm.top, parm.bottom,
+        parm.rows, parm.cols, parm.res, parm.res3, parm.nsres, parm.ewres,
+        parm.nsres3, parm.ewres3, parm.tbres, parm.zoom, parm.align, parm.save,
+        parm.grow, NULL);
     G_option_exclusive(flag.noupdate, flag.force, NULL);
     G_option_requires(flag.noupdate, flag.savedefault, flag.print, flag.lprint,
                       flag.eprint, flag.center, flag.gmt_style, flag.wms_style,
                       flag.dist_res, flag.nangle, flag.z, flag.bbox,
-                      flag.gprint, parm.save, NULL);
-    G_option_requires(flag.flprint, flag.gprint, NULL);
+                      flag.gprint, flag.flprint, parm.save, NULL);
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
     G_get_default_window(&window);
 
-    flat_flag = flag.flprint->answer;
+    if (flag.flprint->answer) {
+        print_flag |= PRINT_SH;
+        flat_flag = 1;
+    }
 
     if (flag.print->answer)
         print_flag |= PRINT_REG;
 
-    if (flag.gprint->answer)
+    if (flag.gprint->answer) {
         print_flag |= PRINT_SH;
+
+        G_verbose_message(
+            _("Flag 'g' is deprecated and will be removed in a future "
+              "release. Please use format=shell instead."));
+    }
 
     if (flag.lprint->answer)
         print_flag |= PRINT_LL;

--- a/general/g.region/printwindow.c
+++ b/general/g.region/printwindow.c
@@ -36,9 +36,6 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
     double ew_dist1, ew_dist2, ns_dist1, ns_dist2;
     double longitude, latitude;
 
-    JSON_Value *region_value;
-    JSON_Object *region;
-
     if (print_flag & PRINT_SH) {
         x = G_projection() == PROJECTION_LL ? -1 : 0;
         if (flat_flag)
@@ -126,10 +123,6 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
             fprintf(stdout, "%-*s %d\n", width, "zone:", window->zone);
             break;
         case JSON:
-            json_object_dotset_number(root_object, "projection.code",
-                                      window->proj);
-            json_object_dotset_string(root_object, "projection.name", prj);
-            json_object_set_number(root_object, "zone", window->zone);
             break;
         }
 
@@ -166,8 +159,6 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
 
             switch (format) {
             case JSON:
-                json_object_set_string(root_object, "datum", datum);
-                json_object_set_string(root_object, "ellipsoid", ellps);
                 break;
             default:
                 if (!(print_flag & PRINT_SH)) {
@@ -267,38 +258,40 @@ void print_window(struct Cell_head *window, int print_flag, int flat_flag,
 #endif
             break;
         case JSON:
-            region_value = json_value_init_object();
-            region = json_object(region_value);
-            json_object_set_number(region, "north", window->north);
-            json_object_set_number(region, "south", window->south);
-            json_object_set_number(region, "west", window->west);
-            json_object_set_number(region, "east", window->east);
-            json_object_set_number(region, "ns-res", d_nsres);
-            json_object_set_number(region, "ns-res3", d_nsres3);
-            json_object_set_number(region, "ew-res", d_ewres);
-            json_object_set_number(region, "ew-res3", d_ewres3);
-            json_object_set_value(root_object, "region", region_value);
-            json_object_set_number(root_object, "top", window->top);
-            json_object_set_number(root_object, "bottom", window->bottom);
-            json_object_set_number(root_object, "tbres", d_tbres);
+            json_object_set_number(root_object, "north", window->north);
+            json_object_set_number(root_object, "south", window->south);
+            json_object_set_number(root_object, "west", window->west);
+            json_object_set_number(root_object, "east", window->east);
+            json_object_set_number(root_object, "nsres", d_nsres);
+            json_object_set_number(root_object, "ewres", d_ewres);
             json_object_set_number(root_object, "rows", window->rows);
-            json_object_set_number(root_object, "rows3", window->rows3);
             json_object_set_number(root_object, "cols", window->cols);
-            json_object_set_number(root_object, "cols3", window->cols3);
-            json_object_set_number(root_object, "depths", window->depths);
+
+            if (print_flag & PRINT_3D) {
+                json_object_set_number(root_object, "nsres3", d_nsres3);
+                json_object_set_number(root_object, "ewres3", d_ewres3);
+                json_object_set_number(root_object, "top", window->top);
+                json_object_set_number(root_object, "bottom", window->bottom);
+                json_object_set_number(root_object, "rows3", window->rows3);
+                json_object_set_number(root_object, "cols3", window->cols3);
+                json_object_set_number(root_object, "tbres", d_tbres);
+                json_object_set_number(root_object, "depths", window->depths);
+            }
 
 #ifdef HAVE_LONG_LONG_INT
             json_object_set_number(root_object, "cells",
                                    (long long)window->rows * window->cols);
-            json_object_set_number(root_object, "cells3",
-                                   (long long)window->rows3 * window->cols3 *
-                                       window->depths);
+            if (print_flag & PRINT_3D)
+                json_object_set_number(root_object, "cells3",
+                                       (long long)window->rows3 *
+                                           window->cols3 * window->depths);
 #else
             json_object_set_number(root_object, "cells",
                                    (long)window->rows * window->cols);
-            json_object_set_number(root_object, "cells3",
-                                   (long)window->rows3 * window->cols3 *
-                                       window->depths);
+            if (print_flag & PRINT_3D)
+                json_object_set_number(root_object, "cells3",
+                                       (long)window->rows3 * window->cols3 *
+                                           window->depths);
 #endif
             break;
         }

--- a/general/g.region/testsuite/test_g_region.py
+++ b/general/g.region/testsuite/test_g_region.py
@@ -46,70 +46,189 @@ class TestRegion(TestCase):
         self.assertEqual(res_default, region["nsres"])
 
     def test_f_flag(self):
-        line = call_module("g.region", flags="fglecn3", capture_stdout=True)
+        line = call_module("g.region", flags="flecn3", capture_stdout=True)
         self.assertEqual(1, len(line.splitlines()))
 
+    def test_plain_format(self):
+        """Test plain format with plectwmn3b flags"""
+        actual = call_module(
+            "g.region", flags="plectwmn3b", capture_stdout=True
+        ).splitlines()
+        expected = [
+            "projection:         99 (Lambert Conformal Conic)",
+            "zone:               0",
+            "datum:              nad83",
+            "ellipsoid:          a=6378137 es=0.006694380022900787",
+            "north:              320000",
+            "south:              10000",
+            "west:               120000",
+            "east:               935000",
+            "top:                500.00000000",
+            "bottom:             -500.00000000",
+            "nsres:              500",
+            "nsres3:             1000",
+            "ewres:              500",
+            "ewres3:             1000",
+            "tbres:              100",
+            "rows:               620",
+            "rows3:              310",
+            "cols:               1630",
+            "cols3:              815",
+            "depths:             10",
+            "cells:              1010600",
+            "cells3:             2526500",
+            "north-west corner:  long: 84:28:04.377741W lat: 36:30:46.34437N",
+            "north-east corner:  long: 75:21:49.978849W lat: 36:34:50.504N",
+            "south-east corner:  long: 75:29:11.170792W lat: 33:47:17.613554N",
+            "south-west corner:  long: 84:17:01.637788W lat: 33:43:21.583472N",
+            "center longitude:   79:54:07.438969W",
+            "center latitude:    35:14:02.62575N",
+            "north-south extent: 310000.000000",
+            "east-west extent:   815000.000000",
+            "center easting:     527500.000000",
+            "center northing:    165000.000000",
+            "120000/935000/10000/320000",
+            "bbox=120000,10000,935000,320000",
+            "convergence angle:  -0.520646",
+            "north latitude:      36:38:03.826722N",
+            "south latitude:      33:43:21.583472N",
+            "west longitude:      84:28:04.377741W",
+            "east longitude:      75:21:49.978849W",
+            "center longitude:   79:54:57.178295W",
+            "center latitude:     35:10:42.705097N",
+        ]
+        self.assertEqual(actual, expected)
+
+        plain_actual = call_module(
+            "g.region", flags="plectwmn3b", format="plain", capture_stdout=True
+        ).splitlines()
+        self.assertEqual(plain_actual, actual)
+
+    def test_shell_format(self):
+        """Test shell format with plectwmn3b flags"""
+        actual = call_module(
+            "g.region", flags="gplectwmn3b", capture_stdout=True
+        ).splitlines()
+        expected = [
+            "projection=99",
+            "zone=0",
+            "n=320000",
+            "s=10000",
+            "w=120000",
+            "e=935000",
+            "t=500",
+            "b=-500",
+            "nsres=500",
+            "nsres3=1000",
+            "ewres=500",
+            "ewres3=1000",
+            "tbres=100",
+            "rows=620",
+            "rows3=310",
+            "cols=1630",
+            "cols3=815",
+            "depths=10",
+            "cells=1010600",
+            "cells3=2526500",
+            "nw_long=-84.46788271",
+            "nw_lat=36.51287344",
+            "ne_long=-75.36388301",
+            "ne_lat=36.58069556",
+            "se_long=-75.48643633",
+            "se_lat=33.78822599",
+            "sw_long=-84.28378827",
+            "sw_lat=33.72266208",
+            "center_long=-79.90206638",
+            "center_lat=35.23406271",
+            "ns_extent=310000.000000",
+            "ew_extent=815000.000000",
+            "center_easting=527500.000000",
+            "center_northing=165000.000000",
+            "120000/935000/10000/320000",
+            "bbox=120000,10000,935000,320000",
+            "converge_angle=-0.520646",
+            "ll_n=36.63439631",
+            "ll_s=33.72266208",
+            "ll_w=-84.46788271",
+            "ll_e=-75.36388301",
+            "ll_clon=-79.91588286",
+            "ll_clat=35.17852919",
+        ]
+        self.assertEqual(actual, expected)
+
+        shell_actual = call_module(
+            "g.region", flags="plectwmn3b", format="shell", capture_stdout=True
+        ).splitlines()
+        self.assertEqual(shell_actual, actual)
+
     def test_format_json(self):
-        """Test json format"""
+        """Test default json format output"""
         expected = {
-            "projection": {"code": 99, "name": "Lambert Conformal Conic"},
-            "zone": 0,
-            "datum": "nad83",
-            "ellipsoid": "a=6378137 es=0.006694380022900787",
-            "region": {
-                "north": 320000,
-                "south": 10000,
-                "west": 120000,
-                "east": 935000,
-                "ns-res": 500,
-                "ns-res3": 1000,
-                "ew-res": 500,
-                "ew-res3": 1000,
-            },
+            "north": 320000,
+            "south": 10000,
+            "west": 120000,
+            "east": 935000,
+            "nsres": 500,
+            "ewres": 500,
+            "rows": 620,
+            "cols": 1630,
+            "cells": 1010600,
+        }
+
+        output = call_module("g.region", flags="p", format="json")
+        output_json = json.loads(output)
+
+        self.assertEqual(expected, output_json)
+
+    def test_json_with_flags(self):
+        """Test json format with plectwmn3b flags"""
+        expected = {
+            "north": 320000,
+            "south": 10000,
+            "west": 120000,
+            "east": 935000,
+            "nsres": 500,
+            "ewres": 500,
+            "rows": 620,
+            "cols": 1630,
+            "nsres3": 1000,
+            "ewres3": 1000,
             "top": 500,
             "bottom": -500,
-            "tbres": 100,
-            "rows": 620,
             "rows3": 310,
-            "cols": 1630,
             "cols3": 815,
+            "tbres": 100,
             "depths": 10,
             "cells": 1010600,
             "cells3": 2526500,
+            "nw_long": -84.46788270593447,
+            "nw_lat": 36.51287343603797,
+            "ne_long": -75.36388301356145,
+            "ne_lat": 36.58069555564893,
+            "se_long": -75.48643633119754,
+            "se_lat": 33.788225987168964,
+            "sw_long": -84.28378827453474,
+            "sw_lat": 33.72266207547134,
+            "center_long": -79.90206638014922,
+            "center_lat": 35.23406270825776,
+            "ns_extent": 310000,
+            "ew_extent": 815000,
+            "center_easting": 527500,
+            "center_northing": 165000,
             "GMT": "120000/935000/10000/320000",
             "WMS": "bbox=120000,10000,935000,320000",
-            "se_lat": 33.78822598716895,
-            "se_long": -75.48643633119754,
-            "sw_lat": 33.722662075471355,
-            "sw_long": -84.28378827453474,
-            "ew_extent": 815000,
-            "ll_clat": 35.17852919352316,
-            "ll_clon": -79.91588285974797,
-            "ll_e": -75.36388301356145,
-            "ll_n": 36.634396311574974,
-            "ll_s": 33.722662075471355,
+            "converge_angle": -0.5206458828749483,
+            "ll_n": 36.634396311574996,
+            "ll_s": 33.72266207547134,
             "ll_w": -84.46788270593447,
-            "ne_lat": 36.58069555564894,
-            "ne_long": -75.36388301356145,
-            "ns_extent": 310000,
-            "nw_lat": 36.51287343603797,
-            "nw_long": -84.46788270593447,
-            "center_easting": 527500,
-            "center_lat": 35.23406270825775,
-            "center_long": -79.90206638014922,
-            "center_northing": 165000,
-            "converge_angle": -0.5206458828734528,
+            "ll_e": -75.36388301356145,
+            "ll_clon": -79.91588285974797,
+            "ll_clat": 35.17852919352317,
         }
 
         output = call_module("g.region", flags="plectwmn3b", format="json")
         output_json = json.loads(output)
 
-        expected_ellps = expected.pop("ellipsoid").split(" ")
-        received_ellps = output_json.pop("ellipsoid").split(" ")
-        self.assertEqual(expected_ellps[0], received_ellps[0])
-        self.assertAlmostEqual(
-            float(expected_ellps[1][3:]), float(received_ellps[1][3:]), places=6
-        )
         self.assertCountEqual(list(expected.keys()), list(output_json.keys()))
         for key, value in expected.items():
             if isinstance(value, float):


### PR DESCRIPTION
Fixes: #5828 

This PR updates the JSON output format of the `g.region` module. The new format looks like this (with the `-p` flag):

```json
{
    "north": 223550,
    "south": 223480,
    "west": 637830,
    "east": 637900,
    "nsres": 10,
    "ewres": 10,
    "rows": 7,
    "cols": 7,
    "cells": 49
}
```

Other changes include:

1. 3D information is now printed in JSON only when the `-3` flag is used.
2. The `-g` flag is deprecated. Use `format=shell` instead.
3. The `-f` flag no longer requires the `-g` flag and ignores the `format` parameter.
4. Documentation has been updated to reflect these changes.