### PR TITLE
CI(i18n): Disable updating .po files, only submit .pot

### DIFF
--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -5,6 +5,11 @@ name: Periodic update
 # or API, or on a schedule.
 on:
   workflow_dispatch:
+    inputs:
+      update_po:
+        type: boolean
+        default: false
+        description: If true, also update .po files.
   schedule:
     # At 10:32 on every first Wednesday of the month.
     # See https://crontab.guru/#32_10_*/100,1-7_*_WED
@@ -89,7 +94,9 @@ jobs:
         run: make -j$(nproc)
       - name: Create .pot files (containing original messages)
         run: cd locale && make pot
-      - name: Merge new messages
+      - name: Merge new messages (Done by Weblate plugin)
+        # Default false, but will be true if manually chosen. See https://stackoverflow.com/a/73495922
+        if: ${{ inputs.update_po || false }}
         run: cd locale && make update-po
       - name: Verify the .po files
         run: cd locale && make verify

--- a/.github/workflows/periodic_update.yml
+++ b/.github/workflows/periodic_update.yml
@@ -11,9 +11,9 @@ on:
         default: false
         description: If true, also update .po files.
   schedule:
-    # At 10:32 on every first Wednesday of the month.
-    # See https://crontab.guru/#32_10_*/100,1-7_*_WED
-    - cron: "32 10 */100,1-7 * WED"
+    # At 15:32 (UTC) on Saturday.
+    # See https://crontab.guru/#32_15_*_*_SAT
+    - cron: "32 15 * * SAT"
 
 permissions: {}
 


### PR DESCRIPTION
Updating po files can be done by Weblate. This makes less review of super heavy PRs when updating strings; only the template files will be submitted to the PR.