### PR TITLE
i.cca: fix indexing, buffer size issues and matrix computation

### DIFF
--- a/imagery/i.cca/main.c
+++ b/imagery/i.cca/main.c
@@ -156,10 +156,10 @@ int main(int argc, char *argv[])
         cov[i] = G_alloc_matrix(bands, bands);
     }
 
-    outbandmax = (CELL *)G_calloc(nclass, sizeof(CELL));
-    outbandmin = (CELL *)G_calloc(nclass, sizeof(CELL));
-    datafds = (int *)G_calloc(nclass, sizeof(int));
-    outfds = (int *)G_calloc(nclass, sizeof(int));
+    outbandmax = (CELL *)G_calloc(bands, sizeof(CELL));
+    outbandmin = (CELL *)G_calloc(bands, sizeof(CELL));
+    datafds = (int *)G_calloc(bands, sizeof(int));
+    outfds = (int *)G_calloc(bands, sizeof(int));
 
     /*
        Here is where the information regarding
@@ -169,13 +169,13 @@ int main(int argc, char *argv[])
      */
 
     samptot = 0;
-    for (i = 1; i <= nclass; i++) {
-        nsamp[i] = sigs.sig[i - 1].npoints;
+    for (i = 0; i < nclass; i++) {
+        nsamp[i] = sigs.sig[i].npoints;
         samptot += nsamp[i];
-        for (j = 1; j <= bands; j++) {
-            mu[i][j] = sigs.sig[i - 1].mean[j - 1];
-            for (k = 1; k <= j; k++)
-                cov[i][j][k] = cov[i][k][j] = sigs.sig[i - 1].var[j - 1][k - 1];
+        for (j = 0; j < bands; j++) {
+            mu[i][j] = sigs.sig[i].mean[j];
+            for (k = 0; k <= j; k++)
+                cov[i][j][k] = cov[i][k][j] = sigs.sig[i].var[j][k];
         }
     }
 
@@ -200,12 +200,12 @@ int main(int argc, char *argv[])
     }
 
     /* open the cell maps */
-    for (i = 1; i <= bands; i++) {
+    for (i = 0; i < bands; i++) {
         outbandmax[i] = (CELL)0;
         outbandmin[i] = (CELL)0;
 
         datafds[i] =
-            Rast_open_old(refs.file[i - 1].name, refs.file[i - 1].mapset);
+            Rast_open_old(refs.file[i].name, refs.file[i].mapset);
 
         snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i);
         outfds[i] = Rast_open_c_new(tempname);
@@ -219,18 +219,18 @@ int main(int argc, char *argv[])
     Rast_init_colors(&color_tbl);
 
     /* close the cell maps */
-    for (i = 1; i <= bands; i++) {
+    for (i = 0; i < bands; i++) {
         Rast_close(datafds[i]);
         Rast_close(outfds[i]);
 
         if (outbandmin[i] < (CELL)0 || outbandmax[i] > (CELL)255) {
             G_warning(_("The output cell map <%s.%d> has values "
                         "outside the 0-255 range."),
-                      out_opt->answer, i);
+                      out_opt->answer, i+1);
         }
 
         Rast_make_grey_scale_colors(&color_tbl, 0, outbandmax[i]);
-        snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i);
+        snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i+1);
 
         /* write a color table */
         Rast_write_colors(tempname, G_mapset(), &color_tbl);

--- a/imagery/i.cca/main.c
+++ b/imagery/i.cca/main.c
@@ -192,6 +192,18 @@ int main(int argc, char *argv[])
     G_math_egvorder(eigval, eigmat, bands);
     G_math_d_AB(eigmat, w, q, bands, bands, bands);
 
+    /**Normalize each row (eigenvector) of the transformation matrix q */
+    for (i = 0; i < bands; i++) {
+        double norm = 0.0;
+        for (j = 0; j < bands; j++)
+            norm += q[i][j] * q[i][j];
+        norm = sqrt(norm);
+        if (norm > 0.0) {
+            for (j = 0; j < bands; j++)
+                q[i][j] /= norm;
+        }
+    }
+
     for (i = 0; i < bands; i++) {
         G_verbose_message("%i. eigen value: %+6.5f", i, eigval[i]);
         G_verbose_message("eigen vector:");
@@ -207,7 +219,7 @@ int main(int argc, char *argv[])
         datafds[i] = Rast_open_old(refs.file[i].name, refs.file[i].mapset);
 
         snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i + 1);
-        outfds[i] = Rast_open_c_new(tempname);
+        outfds[i] = Rast_open_new(tempname, DCELL_TYPE);
     }
 
     /* do the transform */

--- a/imagery/i.cca/main.c
+++ b/imagery/i.cca/main.c
@@ -204,10 +204,9 @@ int main(int argc, char *argv[])
         outbandmax[i] = (CELL)0;
         outbandmin[i] = (CELL)0;
 
-        datafds[i] =
-            Rast_open_old(refs.file[i].name, refs.file[i].mapset);
+        datafds[i] = Rast_open_old(refs.file[i].name, refs.file[i].mapset);
 
-        snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i);
+        snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i + 1);
         outfds[i] = Rast_open_c_new(tempname);
     }
 
@@ -226,11 +225,11 @@ int main(int argc, char *argv[])
         if (outbandmin[i] < (CELL)0 || outbandmax[i] > (CELL)255) {
             G_warning(_("The output cell map <%s.%d> has values "
                         "outside the 0-255 range."),
-                      out_opt->answer, i+1);
+                      out_opt->answer, i + 1);
         }
 
         Rast_make_grey_scale_colors(&color_tbl, 0, outbandmax[i]);
-        snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i+1);
+        snprintf(tempname, sizeof(tempname), "%s.%d", out_opt->answer, i + 1);
 
         /* write a color table */
         Rast_write_colors(tempname, G_mapset(), &color_tbl);

--- a/imagery/i.cca/testsuite/test_i_cca.py
+++ b/imagery/i.cca/testsuite/test_i_cca.py
@@ -1,0 +1,173 @@
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+import grass.script as gs
+
+
+class TestICCA(TestCase):
+    """Regression and invariance tests for the i.cca GRASS GIS module."""
+
+    group_name = "cca_group"
+    subgroup_name = "cca_subgroup"
+    input_maps = ["band1", "band2", "band3"]
+    training_map = "cca_training"
+    signature_file = "cca_sig"
+    output_prefix = "cca_output"
+    temp_rasters = []
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test environment and create input raster maps."""
+        cls.use_temp_region()
+        cls.runModule("g.region", n=20, s=0, e=20, w=0, rows=200, cols=200)
+
+        cls.runModule(
+            "r.mapcalc",
+            expression=f"{cls.input_maps[0]} = 50 + 30 * sin(row() / 20.0) + 20 * cos(col() / 15.0)",
+        )
+        cls.runModule(
+            "r.mapcalc",
+            expression=f"{cls.input_maps[1]} = 40 + 25 * exp(-(((row() - 100)^2 + (col() - 100)^2) / 2000.0))",
+        )
+        cls.runModule(
+            "r.mapcalc", expression=f"{cls.input_maps[2]} = 30 + (row() + col()) / 10.0"
+        )
+        cls.temp_rasters.extend(cls.input_maps)
+
+        cls.runModule(
+            "r.mapcalc",
+            expression=(
+                f"{cls.training_map} = if(row() < 60 && col() < 60, 1, "
+                f"if(row() >= 60 && row() < 140 && col() >= 60 && col() < 140, 2, "
+                f"if(row() >= 140 && col() >= 140, 3, null())))"
+            ),
+        )
+        cls.temp_rasters.append(cls.training_map)
+
+        cls.runModule(
+            "i.group",
+            group=cls.group_name,
+            subgroup=cls.subgroup_name,
+            input=",".join(cls.input_maps),
+        )
+        cls.runModule(
+            "i.gensig",
+            trainingmap=cls.training_map,
+            group=cls.group_name,
+            subgroup=cls.subgroup_name,
+            signaturefile=cls.signature_file,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up the test environment by removing created maps and signatures."""
+        cls.runModule("g.remove", flags="f", type="raster", name=cls.temp_rasters)
+        cls.runModule("g.remove", flags="f", type="group", name=cls.group_name)
+        cls.runModule("i.signatures", type="sig", remove=cls.signature_file)
+
+    def setUp(self):
+        """Run i.cca before each test and register outputs."""
+        self.assertModule(
+            "i.cca",
+            group=self.group_name,
+            subgroup=self.subgroup_name,
+            signature=self.signature_file,
+            output=self.output_prefix,
+        )
+
+        for i in range(1, 4):
+            name = f"{self.output_prefix}.{i}"
+            self.assertRasterExists(name)
+            if name not in self.temp_rasters:
+                self.temp_rasters.append(name)
+
+    def test_valid_outputs(self):
+        """Validate that i.cca output statistics match expected values."""
+        expected_stats = {
+            "cca_output.1": {
+                "min": 14.519806,
+                "max": 36.065579,
+                "mean": 25.303323,
+                "stddev": 4.515555,
+            },
+            "cca_output.2": {
+                "min": 5.936035,
+                "max": 29.925073,
+                "mean": 10.712231,
+                "stddev": 5.263790,
+            },
+            "cca_output.3": {
+                "min": 64.618755,
+                "max": 70.855162,
+                "mean": 68.056793,
+                "stddev": 1.238260,
+            },
+        }
+
+        for mapname, refstats in expected_stats.items():
+            self.assertRasterFitsUnivar(
+                mapname,
+                reference=refstats,
+                precision=1e-6,
+                msg=f"{mapname} stats diverge from expected output",
+            )
+
+    def test_orthogonality_of_components(self):
+        """Check that canonical components are approximately uncorrelated."""
+        lines = gs.read_command(
+            "r.covar", map="cca_output.1,cca_output.2,cca_output.3"
+        ).splitlines()[1:]
+        cov_matrix = [list(map(float, l.split())) for l in lines]
+
+        for i in range(3):
+            for j in range(3):
+                if i != j:
+                    self.assertAlmostEqual(
+                        cov_matrix[i][j],
+                        0.0,
+                        delta=0.5,
+                        msg=f"Cov[{i + 1},{j + 1}] = {cov_matrix[i][j]:.6f} exceeds orthogonality tolerance",
+                    )
+
+    def test_covariance_matrix_symmetry(self):
+        """Validate that the output covariance matrix is symmetric."""
+        lines = gs.read_command(
+            "r.covar", map="cca_output.1,cca_output.2,cca_output.3"
+        ).splitlines()[1:]
+        mat = [list(map(float, l.split())) for l in lines]
+        for i in range(3):
+            for j in range(3):
+                self.assertAlmostEqual(
+                    mat[i][j],
+                    mat[j][i],
+                    delta=1e-10,
+                    msg=f"Covariance matrix asymmetry at ({i},{j})",
+                )
+
+    def test_components_lack_linear_dependency(self):
+        """Use r.regression.line to confirm no strong linear relationships between components."""
+        for i in range(1, 4):
+            for j in range(1, 4):
+                if i == j:
+                    continue
+                mapx = f"{self.output_prefix}.{i}"
+                mapy = f"{self.output_prefix}.{j}"
+                out = gs.parse_command(
+                    "r.regression.line", mapx=mapx, mapy=mapy, flags="g"
+                )
+                R = float(out["R"])
+                slope = float(out["b"])
+                self.assertAlmostEqual(
+                    R,
+                    0.0,
+                    delta=0.1,
+                    msg=f"R({mapx},{mapy}) = {R:.4f} indicates correlation",
+                )
+                self.assertLess(
+                    abs(slope),
+                    0.5,
+                    msg=f"Slope({mapx}->{mapy}) = {slope:.4f} suggests dependence",
+                )
+
+
+if __name__ == "__main__":
+    test()

--- a/imagery/i.cca/transform.c
+++ b/imagery/i.cca/transform.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <limits.h>
 
 #include <grass/gis.h>
 #include <grass/gmath.h>
@@ -11,49 +12,60 @@ int transform(int *datafds, int *outfds, int rows, int cols, double **eigmat,
 {
     int i, j, k, l;
     double *sum;
-    CELL **rowbufs;
+    DCELL **rowbufs;
 
     sum = G_alloc_vector(bands);
-    rowbufs = (CELL **)G_calloc(bands, sizeof(CELL *));
+    rowbufs = (DCELL **)G_calloc(bands, sizeof(DCELL *));
 
     /* allocate row buffers for each band */
-    for (i = 0; i < bands; i++)
-        if ((rowbufs[i] = Rast_allocate_c_buf()) == NULL)
-            G_fatal_error(_("Unable to allocate cell buffers."));
+    for (i = 0; i < bands; i++) {
+        rowbufs[i] = Rast_allocate_d_buf();
+        if (!rowbufs[i])
+            G_fatal_error(_("Unable to allocate DCELL buffers."));
+        mins[i] = INT_MAX;
+        maxs[i] = INT_MIN;
+    }
 
     for (i = 0; i < rows; i++) {
-        /* get one row of data */
-        for (j = 0; j < bands; j++)
-            Rast_get_c_row(datafds[j], rowbufs[j], i);
+        /* read each input band as CELL, convert to DCELL */
+        for (j = 0; j < bands; j++) {
+            CELL *tmp = Rast_allocate_c_buf();
+            Rast_get_c_row(datafds[j], tmp, i);
+            for (l = 0; l < cols; l++)
+                rowbufs[j][l] = (DCELL)tmp[l];
+            G_free(tmp);
+        }
 
-        /* transform each cell in the row */
+        /* apply canonical transform */
         for (l = 0; l < cols; l++) {
             for (j = 0; j < bands; j++) {
                 sum[j] = 0.0;
                 for (k = 0; k < bands; k++) {
-                    sum[j] += eigmat[j][k] * (double)rowbufs[k][l];
+                    sum[j] += eigmat[j][k] * rowbufs[k][l];
                 }
             }
             for (j = 0; j < bands; j++) {
-                rowbufs[j][l] = (CELL)(sum[j] + 0.5);
-                if (rowbufs[j][l] > maxs[j])
-                    maxs[j] = rowbufs[j][l];
-                if (rowbufs[j][l] < mins[j])
-                    mins[j] = rowbufs[j][l];
+                rowbufs[j][l] = sum[j];
+                /*min/max are tracked as integer CELL */
+                if ((CELL)rowbufs[j][l] > maxs[j])
+                    maxs[j] = (CELL)rowbufs[j][l];
+                if ((CELL)rowbufs[j][l] < mins[j])
+                    mins[j] = (CELL)rowbufs[j][l];
             }
         }
 
-        /* output the row of data */
+        /* write each output band row as DCELL */
         for (j = 0; j < bands; j++)
-            Rast_put_row(outfds[j], rowbufs[j], CELL_TYPE);
+            Rast_put_d_row(outfds[j], rowbufs[j]);
     }
+
     for (i = 0; i < bands; i++)
         G_free(rowbufs[i]);
 
     G_free(rowbufs);
     G_free_vector(sum);
 
-    G_message(_("Transform completed.\n"));
+    G_message(_("Canonical transform completed."));
 
     return 0;
 }


### PR DESCRIPTION
This PR resolves a segmentation fault and memory misalignment in the `i.cca` module. (https://github.com/OSGeo/grass/issues/5947)

### Changes Made:

- Corrected all loops and array accesses to use zero-based indexing.
- Replaced incorrect memory allocations sized by `nclass` with allocations correctly sized by `bands`.
- Fixed off-by-one output raster naming to preserve the original `<prefix>.1`, `<prefix>.2`, etc.
- Ensured symmetric covariance matrices by correctly including diagonal elements in the computation.

### Testing:

The changes were tested using the same reproduction steps outlined in the linked issue. The module now runs successfully and produces canonical component outputs without error. This fix brings `i.cca` in line with standard C indexing practices, preventing both runtime crashes and silent memory corruption.

### Fix Matrix Calculation and Numeric Stability

### Summary of  new changes

- **Correct computation of between-class scatter matrix B**
  - The original implementation subtracted `μ̄ * μ̄ᵀ` in each loop iteration, which caused B to be mis-scaled.
  - This is replaced with the canonical formula, which matches theoretical expectations (validated with synthetic data).
>  B = (1 / (nclass - 1)) * [ ∑ nᵢ * μᵢ * μᵢᵀ  -  N * μ̄ * μ̄ᵀ ]

- **Normalize canonical vectors**
  - Added normalization step so each row of the transformation matrix q has unit norm.
  - This improves interpretability and stability.

- **Switch outputs to DCELL**
  - Output rasters now use DCELL precision instead of CELL.
  - Prevents rounding errors and loss of detail in canonical projections.


### Tests Added
- `test_valid_outputs`: Performs regression check by comparing the statistical properties of the generated canonical components against pre-calculated, expected values ensuring the numerical stability and correctness of the algorithm.
- `test_orthogonality_of_components`: Validates mathematical property of CCA, that the resulting components are uncorrelated. This is confirmed by computing the full covariance matrix of the output maps and asserting that the off-diagonal elements are approximately zero.
- `test_covariance_matrix_symmetry`: Confirms that the covariance matrix from is symmetric, as expected for valid linear transformations.
- `test_components_lack_linear_dependency`:  Complements the covariance check by assessing the statistical independence of components. 