### PR TITLE
grass.script: Allow a leading dash in flags parameter

### DIFF
--- a/python/grass/script/tests/grass_script_run_command_test.py
+++ b/python/grass/script/tests/grass_script_run_command_test.py
@@ -1,0 +1,172 @@
+"""Tests of run_command family of functions"""
+
+import pytest
+
+
+import grass.script as gs
+from grass.exceptions import CalledModuleError
+
+
+def test_run_command(session_2x2):
+    """Check run_command runs again with overwrite parameter"""
+    gs.run_command("r.random.surface", output="surface", seed=42, env=session_2x2.env)
+    gs.run_command(
+        "r.random.surface",
+        output="surface",
+        seed=42,
+        overwrite=True,
+        env=session_2x2.env,
+    )
+
+
+def test_run_command_status(session_2x2):
+    """Check that run_command gives returncode (aka status)"""
+    assert (
+        gs.run_command("r.mask.status", flags="t", env=session_2x2.env, errors="status")
+        == 1
+    )
+
+
+def test_run_command_ignore_default(session_2x2):
+    """Check that run_command raises by default"""
+    with pytest.raises(CalledModuleError, match=r"r\.slope\.aspect"):
+        gs.run_command(
+            "r.slope.aspect",
+            elevation="does_not_exist",
+            slope="slope",
+            env=session_2x2.env,
+        )
+
+
+def test_run_command_ignore_raise(session_2x2):
+    """Check that run_command raises when set to raise"""
+    with pytest.raises(CalledModuleError, match=r"r\.slope\.aspect"):
+        gs.run_command(
+            "r.slope.aspect",
+            elevation="does_not_exist",
+            slope="slope",
+            env=session_2x2.env,
+            errors="raise",
+        )
+
+
+def test_run_command_ignore(session_2x2):
+    """Check that run_command ignores errors"""
+    gs.run_command(
+        "r.slope.aspect",
+        elevation="does_not_exist",
+        slope="slope",
+        env=session_2x2.env,
+        errors="ignore",
+    )
+
+
+def test_run_command_fatal(session_2x2):
+    """Check that run_command results in a fatal error (which calls in sys.exit)"""
+    with pytest.raises(SystemExit):
+        gs.run_command(
+            "r.slope.aspect",
+            elevation="does_not_exist",
+            slope="slope",
+            env=session_2x2.env,
+            errors="fatal",
+        )
+
+
+def test_run_command_exit(session_2x2):
+    """Check that run_command calls sys.exit"""
+    with pytest.raises(SystemExit):
+        gs.run_command(
+            "r.slope.aspect",
+            elevation="does_not_exist",
+            slope="slope",
+            env=session_2x2.env,
+            errors="exit",
+        )
+
+
+def test_read_command_flag(session_2x2):
+    """Check a single flag character"""
+    assert "north" in gs.read_command(
+        "g.region", flags="p", format="json", env=session_2x2.env
+    )
+
+
+def test_read_command_flag_with_dash(session_2x2):
+    """Check flag with dash"""
+    assert "north" in gs.read_command(
+        "g.region", flags="-p", format="json", env=session_2x2.env
+    )
+
+
+def test_read_command_multiple_flags(session_2x2):
+    """Check multiple flag characters included a number"""
+    assert "north" in gs.read_command(
+        "g.region", flags="p3u", format="json", env=session_2x2.env
+    )
+
+
+def test_read_command_multiple_flags_with_dash(session_2x2):
+    """Check multiple flag characters included a number with dash"""
+    assert "north" in gs.read_command(
+        "g.region", flags="-p3u", format="json", env=session_2x2.env
+    )
+
+
+def test_read_command_multiple_flags_with_multiple_dashes(session_2x2):
+    with pytest.raises(CalledModuleError, match=r"g\.region"):
+        gs.read_command("g.region", flags="-p-u", format="json", env=session_2x2.env)
+
+
+def test_read_command_multiple_flags_with_multiple_dashes_and_spaces(session_2x2):
+    with pytest.raises(CalledModuleError, match=r"g\.region"):
+        gs.read_command("g.region", flags="-p -u", format="json", env=session_2x2.env)
+
+
+def test_read_command_number_as_a_string_flag(session_2x2):
+    """Number is a character just as any letter is"""
+    assert "top" in gs.read_command(
+        "g.region", flags="-3", format="json", env=session_2x2.env
+    )
+
+
+def test_read_command_number_as_a_int_flag(session_2x2):
+    """Integer is supported, because we support ints and floats for options"""
+    assert "top" in gs.read_command(
+        "g.region", flags=3, format="json", env=session_2x2.env
+    )
+
+
+def test_read_command_number_as_a_float_flag(session_2x2):
+    """Float is not supported as a flag even if its integer part is a valid flag"""
+    with pytest.raises(CalledModuleError, match=r"g\.region"):
+        gs.read_command("g.region", flags=3.0, env=session_2x2.env)
+
+
+def test_read_command_number_as_a_negative_int_flag(session_2x2):
+    """
+    Negative number works only as as a side effect of other processing,
+    but we test for it anyway since it is expected from the current implementation.
+    However, it is not how users should use it.
+    """
+    assert "top" in gs.read_command("g.region", flags=-3, env=session_2x2.env)
+
+
+def test_parse_command_key_value(session_2x2):
+    """Check parse_command parses shell-script style key-value pairs
+
+    Values are always strings even for numbers.
+    """
+    assert (
+        gs.parse_command("g.region", flags="g", env=session_2x2.env)["nsres"] == "0.5"
+    )
+
+
+def test_parse_command_json(session_2x2):
+    """Check parse_command parses JSON output"""
+    assert (
+        gs.parse_command("g.region", flags="g", format="json", env=session_2x2.env)[
+            "region"
+        ]["ns-res"]
+        == 0.5
+    )


### PR DESCRIPTION
Instead of raising a ScriptError, accept a leading dash for the flags parameter in run_command family of functions. While no dash is the best practice in Python, and therefore no examples or documentation are changed, leading dash is required in the command line and appears in documentation and messages, so allowing it in Python makes it little easier on the user.

In command line, leading dash is required for a group a flag letters which would be the most typical use of multiple flags. Since this requirement is not going away - it is part of the command line syntax itself, we ease the transition between the two environments by supporting the leading dash. Dashes inside the flags string, including space-separated flag characters with dashes, are not supported because that would basically mean processing the space separated command line syntax (trivial to process in this case, but does go too far from Python list of flag letters into full command line syntax). Even with a leading dash, the code looks sufficiently like Python.

In documentation and messages (typically warnings or errors), we use mix of standalone character (possibly in single or double quotes) and a dash followed by a character. While it may be worth polishing this across the documentation and code, and perhaps going with characters only (because they apply in both command line and Python), the command line examples will always have dashes, so supporting the dash for copy-pasting scenarious would be nice. (The new generated Python documentation for tools does not include the dashes, but command line examples are currently prevalent and will always be preset.)
