### PR TITLE
msvc: Add aliases S_IRUSR and S_IWUSR for _S_IREAD and _S_IWRITE

### DIFF
--- a/msvc/fcntl.h
+++ b/msvc/fcntl.h
@@ -36,4 +36,14 @@ int __creat(const char *, int);
 #define O_TMPFILE O_TEMPORARY
 #define O_ACCMODE (_O_RDONLY | _O_WRONLY | _O_RDWR)
 
+#if defined(_WIN32)
+#include <io.h> // _S_IREAD _S_IWRITE
+#ifndef S_IRUSR
+#define S_IRUSR _S_IREAD
+#endif // S_IRUSR
+#ifndef S_IWUSR
+#define S_IWUSR _S_IWRITE
+#endif // S_IWUSR
+#endif
+
 #endif

--- a/msvc/fcntl.h
+++ b/msvc/fcntl.h
@@ -29,7 +29,7 @@ int __creat(const char *, int);
 }
 #endif
 
-#include <io.h>
+#include <io.h> // Also for _S_IREAD and _S_IWRITE
 #define open      __open
 #define creat     __creat
 
@@ -37,7 +37,6 @@ int __creat(const char *, int);
 #define O_ACCMODE (_O_RDONLY | _O_WRONLY | _O_RDWR)
 
 #if defined(_WIN32)
-#include <io.h> // _S_IREAD _S_IWRITE
 #ifndef S_IRUSR
 #define S_IRUSR _S_IREAD
 #endif // S_IRUSR

--- a/msvc/fcntl.h
+++ b/msvc/fcntl.h
@@ -29,20 +29,11 @@ int __creat(const char *, int);
 }
 #endif
 
-#include <io.h> // Also for _S_IREAD and _S_IWRITE
+#include <io.h>
 #define open      __open
 #define creat     __creat
 
 #define O_TMPFILE O_TEMPORARY
 #define O_ACCMODE (_O_RDONLY | _O_WRONLY | _O_RDWR)
-
-#if defined(_WIN32)
-#ifndef S_IRUSR
-#define S_IRUSR _S_IREAD
-#endif // S_IRUSR
-#ifndef S_IWUSR
-#define S_IWUSR _S_IWRITE
-#endif // S_IWUSR
-#endif
 
 #endif

--- a/msvc/sys/stat.h
+++ b/msvc/sys/stat.h
@@ -5,4 +5,7 @@
 
 #define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
 
+#define S_IRUSR       _S_IREAD
+#define S_IWUSR       _S_IWRITE
+
 #endif


### PR DESCRIPTION
As per the documentation of _open() https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen, the correct modes to use are named differently than on UNIX. However, exposing the constants with the same name as used in the code, defined in a file with other file opening aliases are defined seems appropriate.

See the table at the end of https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen?view=msvc-170#generic-text-routine-mappings

Also look at this SO thread https://stackoverflow.com/questions/20773354/migrating-a-c-program-from-linux-to-windows.

At least r.smooth.edgepreserve was affected, but also some db code that in lib/gis/user_config.c (but the whole file is disabled with `#ifndef _WIN32 /* TODO */`), 
https://github.com/OSGeo/grass/blob/60e632933c8c701708b8f19db84d930e283c8ae5/lib/gis/user_config.c#L124-L126
https://github.com/OSGeo/grass/blob/60e632933c8c701708b8f19db84d930e283c8ae5/lib/gis/user_config.c#L43-L50

also some code here:
https://github.com/OSGeo/grass/blob/60e632933c8c701708b8f19db84d930e283c8ae5/lib/db/dbmi_base/login.c#L168-L172

