### PR TITLE
r.univar: Add shell and CSV format

### DIFF
--- a/imagery/i.eb.eta/testsuite/test_i_eb_eta.py
+++ b/imagery/i.eb.eta/testsuite/test_i_eb_eta.py
@@ -63,7 +63,7 @@ class TestEbEta(TestCase):
 
     def _get_univar_stats(self, raster):
         """Helper to get univariate statistics"""
-        return gs.parse_command("r.univar", map=raster, flags="g", format="json")
+        return gs.parse_command("r.univar", map=raster, format="json")
 
     def test_eta_model_output(self):
         """Basic test to verify output of i.eb.eta."""

--- a/imagery/i.eb.netrad/testsuite/test_i_eb_netrad.py
+++ b/imagery/i.eb.netrad/testsuite/test_i_eb_netrad.py
@@ -139,9 +139,7 @@ class TestIEbNetrad(TestCase):
         self.runModule("r.mapcalc", expression="zenith_low = 10.0", overwrite=True)
         self.run_netrad("rn_low_zen", sunzenithangle="zenith_low")
         self.tmp_rasters.extend(["zenith_low", "rn_low_zen"])
-        stats_low = gs.parse_command(
-            "r.univar", map="rn_low_zen", flags="g", format="json"
-        )
+        stats_low = gs.parse_command("r.univar", map="rn_low_zen", format="json")
 
         self.runModule("r.mapcalc", expression="zenith_high = 70.0", overwrite=True)
         self.run_netrad("rn_high_zen", sunzenithangle="zenith_high")

--- a/imagery/i.eb.netrad/testsuite/test_i_eb_netrad.py
+++ b/imagery/i.eb.netrad/testsuite/test_i_eb_netrad.py
@@ -125,14 +125,12 @@ class TestIEbNetrad(TestCase):
         self.runModule("r.mapcalc", expression="albedo_low = 0.1", overwrite=True)
         self.run_netrad("rn_low", albedo="albedo_low")
         self.tmp_rasters.extend(["albedo_low", "rn_low"])
-        stats_low = gs.parse_command("r.univar", map="rn_low", flags="g", format="json")
+        stats_low = gs.parse_command("r.univar", map="rn_low", format="json")
 
         self.runModule("r.mapcalc", expression="albedo_high = 0.5", overwrite=True)
         self.run_netrad("rn_high", albedo="albedo_high")
         self.tmp_rasters.extend(["albedo_high", "rn_high"])
-        stats_high = gs.parse_command(
-            "r.univar", map="rn_high", flags="g", format="json"
-        )
+        stats_high = gs.parse_command("r.univar", map="rn_high", format="json")
 
         self.assertGreater(stats_low["mean"], stats_high["mean"])
 
@@ -148,9 +146,7 @@ class TestIEbNetrad(TestCase):
         self.runModule("r.mapcalc", expression="zenith_high = 70.0", overwrite=True)
         self.run_netrad("rn_high_zen", sunzenithangle="zenith_high")
         self.tmp_rasters.extend(["zenith_high", "rn_high_zen"])
-        stats_high = gs.parse_command(
-            "r.univar", map="rn_high_zen", flags="g", format="json"
-        )
+        stats_high = gs.parse_command("r.univar", map="rn_high_zen", format="json")
 
         self.assertGreater(stats_low["mean"], stats_high["mean"])
 

--- a/imagery/i.evapo.mh/testsuite/test_i_evapo_mh.py
+++ b/imagery/i.evapo.mh/testsuite/test_i_evapo_mh.py
@@ -103,9 +103,7 @@ class TestEvapotranspirationMH(TestCase):
             precipitation=self.precipitation,
             output=self.output_map,
         )
-        stats = gs.parse_command(
-            "r.univar", map=self.output_map, flags="g", format="json"
-        )
+        stats = gs.parse_command("r.univar", map=self.output_map, format="json")
         self.assertGreaterEqual(stats["min"], 0)
 
     def test_h_flag_precipitation_ignored(self):
@@ -183,7 +181,7 @@ class TestEvapotranspirationMH(TestCase):
             maximum_temperature="tmax_test",
             output="et_const",
         )
-        stats = gs.parse_command("r.univar", map="et_const", flags="g", format="json")
+        stats = gs.parse_command("r.univar", map="et_const", format="json")
         self.assertAlmostEqual(stats["mean"], expected_et)
 
 

--- a/imagery/i.evapo.pm/testsuite/test_i_evapo_pm.py
+++ b/imagery/i.evapo.pm/testsuite/test_i_evapo_pm.py
@@ -157,12 +157,8 @@ class TestEvapoPMDetailed(TestCase):
             overwrite=True,
         )
         stats_diff = gs.parse_command("r.univar", map="diff_night_day", format="json")
-        stats_day = gs.parse_command(
-            "r.univar", map="evapo_day", flags="g", format="json"
-        )
-        stats_night = gs.parse_command(
-            "r.univar", map="evapo_night", flags="g", format="json"
-        )
+        stats_day = gs.parse_command("r.univar", map="evapo_day", format="json")
+        stats_night = gs.parse_command("r.univar", map="evapo_night", format="json")
         self.assertGreater(
             stats_day["mean"],
             stats_night["mean"],
@@ -202,11 +198,9 @@ class TestEvapoPMDetailed(TestCase):
             output="evapo_netrad_high",
             overwrite=True,
         )
-        stats_low = gs.parse_command(
-            "r.univar", map="evapo_netrad_low", flags="g", format="json"
-        )
+        stats_low = gs.parse_command("r.univar", map="evapo_netrad_low", format="json")
         stats_high = gs.parse_command(
-            "r.univar", map="evapo_netrad_high", flags="g", format="json"
+            "r.univar", map="evapo_netrad_high", format="json"
         )
         self.assertGreater(
             stats_high["mean"],
@@ -243,12 +237,8 @@ class TestEvapoPMDetailed(TestCase):
             output="evapo_rh_high",
             overwrite=True,
         )
-        stats_low = gs.parse_command(
-            "r.univar", map="evapo_rh_low", flags="g", format="json"
-        )
-        stats_high = gs.parse_command(
-            "r.univar", map="evapo_rh_high", flags="g", format="json"
-        )
+        stats_low = gs.parse_command("r.univar", map="evapo_rh_low", format="json")
+        stats_high = gs.parse_command("r.univar", map="evapo_rh_high", format="json")
         self.assertGreater(
             stats_low["mean"],
             stats_high["mean"],
@@ -282,15 +272,15 @@ class TestEvapoPMDetailed(TestCase):
                 output=output,
                 overwrite=True,
             )
-        mean_10 = gs.parse_command(
-            "r.univar", map="evapo_netrad_10", flags="g", format="json"
-        )["mean"]
-        mean_15 = gs.parse_command(
-            "r.univar", map="evapo_netrad_15", flags="g", format="json"
-        )["mean"]
-        mean_20 = gs.parse_command(
-            "r.univar", map="evapo_netrad_20", flags="g", format="json"
-        )["mean"]
+        mean_10 = gs.parse_command("r.univar", map="evapo_netrad_10", format="json")[
+            "mean"
+        ]
+        mean_15 = gs.parse_command("r.univar", map="evapo_netrad_15", format="json")[
+            "mean"
+        ]
+        mean_20 = gs.parse_command("r.univar", map="evapo_netrad_20", format="json")[
+            "mean"
+        ]
         self.assertAlmostEqual(
             2 * mean_15,
             mean_10 + mean_20,

--- a/imagery/i.evapo.pt/testsuite/test_i_evapo_pt.py
+++ b/imagery/i.evapo.pt/testsuite/test_i_evapo_pt.py
@@ -57,9 +57,7 @@ class TestEvapotranspirationPT(TestCase):
     def test_z_flag(self):
         """Ensure -z flag clamps all negative ET values to zero."""
         self.run_evapo_pt(output=self.output_map, flags="z")
-        stats = gs.parse_command(
-            "r.univar", map=self.output_map, flags="g", format="json"
-        )
+        stats = gs.parse_command("r.univar", map=self.output_map, format="json")
         self.assertGreaterEqual(stats["min"], 0)
 
     def test_default_alpha(self):

--- a/imagery/i.evapo.time/testsuite/test_i_evapo_time.py
+++ b/imagery/i.evapo.time/testsuite/test_i_evapo_time.py
@@ -104,11 +104,9 @@ class TestEvapoTimeDetailed(TestCase):
             overwrite=True,
         )
         stats_short = gs.parse_command(
-            "r.univar", map="evapo_time_short", flags="g", format="json"
+            "r.univar", map="evapo_time_short", format="json"
         )
-        stats_long = gs.parse_command(
-            "r.univar", map="evapo_time_long", flags="g", format="json"
-        )
+        stats_long = gs.parse_command("r.univar", map="evapo_time_long", format="json")
         self.assertGreater(
             stats_long["sum"],
             stats_short["sum"],
@@ -160,7 +158,7 @@ class TestEvapoTimeDetailed(TestCase):
                 overwrite=True,
             )
             stats = gs.parse_command(
-                "r.univar", map=f"evapo_time_{suffix}", flags="g", format="json"
+                "r.univar", map=f"evapo_time_{suffix}", format="json"
             )
             results[suffix] = stats["sum"]
         self.assertAlmostEqual(

--- a/raster/r.univar/globals.h
+++ b/raster/r.univar/globals.h
@@ -59,7 +59,7 @@ typedef struct {
 extern param_type param;
 extern zone_type zone_info;
 
-enum OutputFormat { PLAIN, JSON };
+enum OutputFormat { PLAIN, JSON, SHELL, CSV };
 
 /* fn prototypes */
 void heapsort_double(double *data, size_t n);

--- a/raster/r.univar/r.univar.md
+++ b/raster/r.univar/r.univar.md
@@ -7,8 +7,8 @@ deviation, coefficient of variation, and sum. Statistics are calculated
 separately for every category/zone found in the **zones** input map if
 given. If the **-e** extended statistics flag is given the 1st quartile,
 median, 3rd quartile, and given **percentile** are calculated. If the
-**-g** flag is given the results are presented in a format suitable for
-use in a shell script. If the **-t** flag is given the results are
+**format=shell** is given the results are presented in a format suitable for
+use in a shell script. If the **format=csv** is given the results are
 presented in tabular format with the given field separator. The table
 can immediately be converted to a vector attribute table which can then
 be linked to a vector, e.g. the vector that was rasterized to create the
@@ -43,6 +43,13 @@ maps.
 For calculating univariate statistics from a raster map based on vector
 polygon map and uploads statistics to new attribute columns, see
 *[v.rast.stats](v.rast.stats.md)*.
+
+The **g** flag has been deprecated and replaced by the **format=shell** option.
+Also, the **t** flag has been deprecated and replaced by the **format=csv**
+option.
+
+The default separator will be **pipe** to maintain backward compatibility;
+however, if **format=csv** is given, then the default separator will be **comma**.
 
 ### PERFORMANCE
 
@@ -94,7 +101,7 @@ median (even number of cells): 108.88
 
 
 # script style output, along with extended statistics
-r.univar -ge elevation percentile=98
+r.univar -e elevation percentile=98 format=shell
 n=2025000
 null_cells=0
 cells=2025000
@@ -213,7 +220,7 @@ Then statistics for elevation can be calculated separately for every
 zone, i.e. basin found in the **zones** parameter:
 
 ```sh
-r.univar -t map=elevation zones=basins separator=comma \
+r.univar map=elevation zones=basins format=csv \
          output=basin_elev_zonal.csv
 ```
 

--- a/raster/r.univar/r.univar_main.c
+++ b/raster/r.univar/r.univar_main.c
@@ -92,11 +92,17 @@ void set_params(void)
     param.nprocs = G_define_standard_option(G_OPT_M_NPROCS);
 
     param.separator = G_define_standard_option(G_OPT_F_SEP);
+    param.separator->answer = NULL;
     param.separator->guisection = _("Formatting");
 
     param.shell_style = G_define_flag();
     param.shell_style->key = 'g';
-    param.shell_style->description = _("Print the stats in shell script style");
+    param.shell_style->label =
+        _("Print the stats in shell script style [deprecated]");
+    param.shell_style->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=shell instead.");
+
     param.shell_style->guisection = _("Formatting");
 
     param.extended = G_define_flag();
@@ -106,11 +112,19 @@ void set_params(void)
 
     param.table = G_define_flag();
     param.table->key = 't';
-    param.table->description =
-        _("Table output format instead of standard output format");
+    param.table->label =
+        _("Table output format instead of standard output format [deprecated]");
+    param.table->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=csv instead.");
     param.table->guisection = _("Formatting");
 
     param.format = G_define_standard_option(G_OPT_F_FORMAT);
+    param.format->options = "plain,shell,csv,json";
+    param.format->descriptions = ("plain;Human readable text output;"
+                                  "shell;shell script style text output;"
+                                  "csv;CSV (Comma Separated Values);"
+                                  "json;JSON (JavaScript Object Notation);");
     param.format->guisection = _("Print");
 
     param.use_rast_region = G_define_flag();
@@ -125,7 +139,8 @@ void set_params(void)
 static int open_raster(const char *infile);
 static univar_stat *univar_stat_with_percentiles(int map_type);
 static void process_raster(univar_stat *stats, thread_workspace *tw,
-                           const struct Cell_head *region, int nprocs);
+                           const struct Cell_head *region, int nprocs,
+                           enum OutputFormat format);
 static void kahan_sum(double *sum, double *c, double x);
 
 /* *************************************************************** */
@@ -181,11 +196,49 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* For backward compatibility */
+    if (!param.separator->answer) {
+        if (strcmp(param.format->answer, "csv") == 0)
+            param.separator->answer = "comma";
+        else
+            param.separator->answer = "pipe";
+    }
+
     if (strcmp(param.format->answer, "json") == 0) {
         format = JSON;
     }
+    else if (strcmp(param.format->answer, "shell") == 0) {
+        format = SHELL;
+    }
+    else if (strcmp(param.format->answer, "csv") == 0) {
+        format = CSV;
+    }
     else {
         format = PLAIN;
+    }
+
+    if (param.shell_style->answer) {
+        G_verbose_message(
+            _("Flag 'g' is deprecated and will be removed in a future "
+              "release. Please use format=shell instead."));
+        if (format == JSON || format == CSV) {
+            G_fatal_error(
+                _("The -g flag cannot be used with format=json or format=csv. "
+                  "Please select only one output format."));
+        }
+        format = SHELL;
+    }
+
+    if (param.table->answer) {
+        G_verbose_message(
+            _("Flag 't' is deprecated and will be removed in a future "
+              "release. Please use format=csv instead."));
+        if (format == JSON || format == SHELL) {
+            G_fatal_error(_(
+                "The -t flag cannot be used with format=json or format=shell. "
+                "Please select only one output format."));
+        }
+        format = CSV;
     }
 
     /* set nprocs parameter */
@@ -269,7 +322,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        process_raster(stats, tw, &region, nprocs);
+        process_raster(stats, tw, &region, nprocs, format);
 
         /* close input raster */
         for (t = 0; t < nprocs; t++)
@@ -283,7 +336,7 @@ int main(int argc, char *argv[])
     }
 
     /* create the output */
-    if (param.table->answer)
+    if (format == CSV)
         print_stats_table(stats);
     else
         print_stats(stats, format);
@@ -333,7 +386,8 @@ static univar_stat *univar_stat_with_percentiles(int map_type)
 }
 
 static void process_raster(univar_stat *stats, thread_workspace *tw,
-                           const struct Cell_head *region, int nprocs)
+                           const struct Cell_head *region, int nprocs,
+                           enum OutputFormat format)
 {
     /* use G_window_rows(), G_window_cols() here? */
     const int rows = region->rows;
@@ -500,7 +554,7 @@ static void process_raster(univar_stat *stats, thread_workspace *tw,
                     zptr++;
                 zd->bucket.n++;
             } /* end column loop */
-            if (!(param.shell_style->answer)) {
+            if (format != SHELL) {
 #pragma omp atomic update
                 computed++;
                 G_percent(computed, rows, 2);
@@ -649,7 +703,7 @@ static void process_raster(univar_stat *stats, thread_workspace *tw,
             G_free(tw[t].zoneraster_row);
         }
     }
-    if (!(param.shell_style->answer))
+    if (format != SHELL)
         G_percent(rows, rows, 2);
 }
 

--- a/raster/r.univar/r3.univar_main.c
+++ b/raster/r.univar/r3.univar_main.c
@@ -52,10 +52,16 @@ void set_params(void)
         _("Percentile to calculate (requires extended statistics flag)");
 
     param.separator = G_define_standard_option(G_OPT_F_SEP);
+    param.separator->answer = NULL;
+    param.separator->guisection = _("Formatting");
 
     param.shell_style = G_define_flag();
     param.shell_style->key = 'g';
-    param.shell_style->description = _("Print the stats in shell script style");
+    param.shell_style->label =
+        _("Print the stats in shell script style [deprecated]");
+    param.shell_style->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=shell instead.");
 
     param.extended = G_define_flag();
     param.extended->key = 'e';
@@ -63,10 +69,18 @@ void set_params(void)
 
     param.table = G_define_flag();
     param.table->key = 't';
-    param.table->description =
-        _("Table output format instead of standard output format");
+    param.table->label =
+        _("Table output format instead of standard output format [deprecated]");
+    param.table->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=csv instead.");
 
     param.format = G_define_standard_option(G_OPT_F_FORMAT);
+    param.format->options = "plain,shell,csv,json";
+    param.format->descriptions = ("plain;Human readable text output;"
+                                  "shell;shell script style text output;"
+                                  "csv;CSV (Comma Separated Values);"
+                                  "json;JSON (JavaScript Object Notation);");
     param.format->guisection = _("Print");
 
     return;
@@ -134,11 +148,49 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* For backward compatibility */
+    if (!param.separator->answer) {
+        if (strcmp(param.format->answer, "csv") == 0)
+            param.separator->answer = "comma";
+        else
+            param.separator->answer = "pipe";
+    }
+
     if (strcmp(param.format->answer, "json") == 0) {
         format = JSON;
     }
+    else if (strcmp(param.format->answer, "shell") == 0) {
+        format = SHELL;
+    }
+    else if (strcmp(param.format->answer, "csv") == 0) {
+        format = CSV;
+    }
     else {
         format = PLAIN;
+    }
+
+    if (param.shell_style->answer) {
+        G_verbose_message(
+            _("Flag 'g' is deprecated and will be removed in a future "
+              "release. Please use format=shell instead."));
+        if (format == JSON || format == CSV) {
+            G_fatal_error(
+                _("The -g flag cannot be used with format=json or format=csv. "
+                  "Please select only one output format."));
+        }
+        format = SHELL;
+    }
+
+    if (param.table->answer) {
+        G_verbose_message(
+            _("Flag 't' is deprecated and will be removed in a future "
+              "release. Please use format=csv instead."));
+        if (format == JSON || format == SHELL) {
+            G_fatal_error(_(
+                "The -t flag cannot be used with format=json or format=shell. "
+                "Please select only one output format."));
+        }
+        format = CSV;
     }
 
     /* table field separator */
@@ -221,7 +273,7 @@ int main(int argc, char *argv[])
     }
 
     for (z = 0; z < depths; z++) { /* From the bottom to the top */
-        if (!(param.shell_style->answer))
+        if (format != SHELL)
             G_percent(z, depths - 1, 2);
         for (y = 0; y < rows; y++) {
             for (x = 0; x < cols; x++) {
@@ -327,7 +379,7 @@ int main(int argc, char *argv[])
         Rast3d_close(zmap);
 
     /* create the output */
-    if (param.table->answer)
+    if (format == CSV)
         print_stats_table(stats);
     else
         print_stats(stats, format);

--- a/raster/r.univar/stats.c
+++ b/raster/r.univar/stats.c
@@ -141,81 +141,45 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
         snprintf(sum_str, sizeof(sum_str), "%.15g", stats[z].sum);
         G_trim_decimal(sum_str);
 
-        if (!param.shell_style->answer && format == PLAIN) {
-            if (zone_info.n_zones) {
-                int z_cat = z + zone_info.min;
+        if (format == JSON && zone_info.n_zones) {
+            zone_value = json_value_init_object();
+            if (zone_value == NULL) {
+                G_fatal_error(
+                    _("Failed to initialize JSON object. Out of memory?"));
+            }
+            zone_object = json_object(zone_value);
+        }
+        if (zone_info.n_zones) {
+            int z_cat = z + zone_info.min;
 
+            switch (format) {
+            case PLAIN:
                 fprintf(stdout, "\nzone %d %s\n\n", z_cat,
                         Rast_get_c_cat(&z_cat, &(zone_info.cats)));
+                break;
+            case SHELL:
+                fprintf(stdout, "zone=%d;%s\n", z_cat,
+                        Rast_get_c_cat(&z_cat, &(zone_info.cats)));
+                break;
+            case JSON:
+                json_object_set_number(zone_object, "zone", z_cat);
+                json_object_set_string(
+                    zone_object, "zone_label",
+                    Rast_get_c_cat(&z_cat, &(zone_info.cats)));
+                break;
+            case CSV:
+                /* already addressed in print_stats_table */
+                break;
             }
+        }
+        switch (format) {
+        case PLAIN:
             fprintf(stdout, "total null and non-null cells: %zu\n",
                     stats[z].size);
             fprintf(stdout, "total null cells: %zu\n\n",
                     stats[z].size - stats[z].n);
             fprintf(stdout, "Of the non-null cells:\n----------------------\n");
-        }
 
-        if (param.shell_style->answer || format == JSON) {
-            if (format == JSON && zone_info.n_zones) {
-                zone_value = json_value_init_object();
-                if (zone_value == NULL) {
-                    G_fatal_error(
-                        _("Failed to initialize JSON object. Out of memory?"));
-                }
-                zone_object = json_object(zone_value);
-            }
-            if (zone_info.n_zones) {
-                int z_cat = z + zone_info.min;
-
-                switch (format) {
-                case PLAIN:
-                    fprintf(stdout, "zone=%d;%s\n", z_cat,
-                            Rast_get_c_cat(&z_cat, &(zone_info.cats)));
-                    break;
-                case JSON:
-                    json_object_set_number(zone_object, "zone", z_cat);
-                    json_object_set_string(
-                        zone_object, "zone_label",
-                        Rast_get_c_cat(&z_cat, &(zone_info.cats)));
-                    break;
-                }
-            }
-            switch (format) {
-            case PLAIN:
-                fprintf(stdout, "n=%zu\n", stats[z].n);
-                fprintf(stdout, "null_cells=%zu\n", stats[z].size - stats[z].n);
-                fprintf(stdout, "cells=%zu\n", stats[z].size);
-                fprintf(stdout, "min=%.15g\n", stats[z].min);
-                fprintf(stdout, "max=%.15g\n", stats[z].max);
-                fprintf(stdout, "range=%.15g\n", stats[z].max - stats[z].min);
-                fprintf(stdout, "mean=%.15g\n", mean);
-                fprintf(stdout, "mean_of_abs=%.15g\n",
-                        stats[z].sum_abs / stats[z].n);
-                fprintf(stdout, "stddev=%.15g\n", stdev);
-                fprintf(stdout, "variance=%.15g\n", variance);
-                fprintf(stdout, "coeff_var=%.15g\n", var_coef);
-                fprintf(stdout, "sum=%s\n", sum_str);
-                break;
-            case JSON:
-                json_object_set_number(zone_object, "n", stats[z].n);
-                json_object_set_number(zone_object, "null_cells",
-                                       stats[z].size - stats[z].n);
-                json_object_set_number(zone_object, "cells", stats[z].size);
-                json_object_set_number(zone_object, "min", stats[z].min);
-                json_object_set_number(zone_object, "max", stats[z].max);
-                json_object_set_number(zone_object, "range",
-                                       stats[z].max - stats[z].min);
-                json_object_set_number(zone_object, "mean", mean);
-                json_object_set_number(zone_object, "mean_of_abs",
-                                       stats[z].sum_abs / stats[z].n);
-                json_object_set_number(zone_object, "stddev", stdev);
-                json_object_set_number(zone_object, "variance", variance);
-                json_object_set_number(zone_object, "coeff_var", var_coef);
-                json_object_set_number(zone_object, "sum", stats[z].sum);
-                break;
-            }
-        }
-        else {
             fprintf(stdout, "n: %zu\n", stats[z].n);
             fprintf(stdout, "minimum: %g\n", stats[z].min);
             fprintf(stdout, "maximum: %g\n", stats[z].max);
@@ -227,6 +191,42 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
             fprintf(stdout, "variance: %g\n", variance);
             fprintf(stdout, "variation coefficient: %g %%\n", var_coef);
             fprintf(stdout, "sum: %s\n", sum_str);
+            break;
+        case SHELL:
+            fprintf(stdout, "n=%zu\n", stats[z].n);
+            fprintf(stdout, "null_cells=%zu\n", stats[z].size - stats[z].n);
+            fprintf(stdout, "cells=%zu\n", stats[z].size);
+            fprintf(stdout, "min=%.15g\n", stats[z].min);
+            fprintf(stdout, "max=%.15g\n", stats[z].max);
+            fprintf(stdout, "range=%.15g\n", stats[z].max - stats[z].min);
+            fprintf(stdout, "mean=%.15g\n", mean);
+            fprintf(stdout, "mean_of_abs=%.15g\n",
+                    stats[z].sum_abs / stats[z].n);
+            fprintf(stdout, "stddev=%.15g\n", stdev);
+            fprintf(stdout, "variance=%.15g\n", variance);
+            fprintf(stdout, "coeff_var=%.15g\n", var_coef);
+            fprintf(stdout, "sum=%s\n", sum_str);
+            break;
+        case JSON:
+            json_object_set_number(zone_object, "n", stats[z].n);
+            json_object_set_number(zone_object, "null_cells",
+                                   stats[z].size - stats[z].n);
+            json_object_set_number(zone_object, "cells", stats[z].size);
+            json_object_set_number(zone_object, "min", stats[z].min);
+            json_object_set_number(zone_object, "max", stats[z].max);
+            json_object_set_number(zone_object, "range",
+                                   stats[z].max - stats[z].min);
+            json_object_set_number(zone_object, "mean", mean);
+            json_object_set_number(zone_object, "mean_of_abs",
+                                   stats[z].sum_abs / stats[z].n);
+            json_object_set_number(zone_object, "stddev", stdev);
+            json_object_set_number(zone_object, "variance", variance);
+            json_object_set_number(zone_object, "coeff_var", var_coef);
+            json_object_set_number(zone_object, "sum", stats[z].sum);
+            break;
+        case CSV:
+            /* already addressed in print_stats_table */
+            break;
         }
 
         /* TODO: mode, skewness, kurtosis */
@@ -307,69 +307,8 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                 }
             }
 
-            if (param.shell_style->answer || format == JSON) {
-                switch (format) {
-                case PLAIN:
-                    fprintf(stdout, "first_quartile=%g\n", quartile_25);
-                    fprintf(stdout, "median=%g\n", median);
-                    fprintf(stdout, "third_quartile=%g\n", quartile_75);
-                    break;
-                case JSON:
-                    json_object_set_number(zone_object, "first_quartile",
-                                           quartile_25);
-                    json_object_set_number(zone_object, "median", median);
-                    json_object_set_number(zone_object, "third_quartile",
-                                           quartile_75);
-                    break;
-                }
-
-                JSON_Value *percentiles_array_value = NULL,
-                           *percentile_value = NULL;
-                JSON_Array *percentiles_array = NULL;
-                JSON_Object *percentile_object = NULL;
-
-                if (format == JSON) {
-                    percentiles_array_value = json_value_init_array();
-                    if (percentiles_array_value == NULL) {
-                        G_fatal_error(_(
-                            "Failed to initialize JSON array. Out of memory?"));
-                    }
-                    percentiles_array = json_array(percentiles_array_value);
-                }
-
-                for (i = 0; i < stats[z].n_perc; i++) {
-                    char buf[24];
-
-                    snprintf(buf, sizeof(buf), "%.15g", stats[z].perc[i]);
-                    G_strchg(buf, '.', '_');
-                    switch (format) {
-                    case PLAIN:
-                        fprintf(stdout, "percentile_%s=%g\n", buf,
-                                quartile_perc[i]);
-                        break;
-                    case JSON:
-                        percentile_value = json_value_init_object();
-                        if (percentile_value == NULL) {
-                            G_fatal_error(_("Failed to initialize JSON object. "
-                                            "Out of memory?"));
-                        }
-                        percentile_object = json_object(percentile_value);
-                        json_object_set_number(percentile_object, "percentile",
-                                               stats[z].perc[i]);
-                        json_object_set_number(percentile_object, "value",
-                                               quartile_perc[i]);
-                        json_array_append_value(percentiles_array,
-                                                percentile_value);
-                        break;
-                    }
-                }
-
-                if (format == JSON) {
-                    json_object_set_value(zone_object, "percentiles",
-                                          percentiles_array_value);
-                }
-            }
-            else {
+            switch (format) {
+            case PLAIN:
                 fprintf(stdout, "1st quartile: %g\n", quartile_25);
                 if (stats[z].n % 2)
                     fprintf(stdout, "median (odd number of cells): %g\n",
@@ -378,8 +317,45 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                     fprintf(stdout, "median (even number of cells): %g\n",
                             median);
                 fprintf(stdout, "3rd quartile: %g\n", quartile_75);
+                break;
+            case SHELL:
+                fprintf(stdout, "first_quartile=%g\n", quartile_25);
+                fprintf(stdout, "median=%g\n", median);
+                fprintf(stdout, "third_quartile=%g\n", quartile_75);
+                break;
+            case JSON:
+                json_object_set_number(zone_object, "first_quartile",
+                                       quartile_25);
+                json_object_set_number(zone_object, "median", median);
+                json_object_set_number(zone_object, "third_quartile",
+                                       quartile_75);
+                break;
+            case CSV:
+                /* already addressed in print_stats_table */
+                break;
+            }
 
-                for (i = 0; i < stats[z].n_perc; i++) {
+            JSON_Value *percentiles_array_value = NULL,
+                       *percentile_value = NULL;
+            JSON_Array *percentiles_array = NULL;
+            JSON_Object *percentile_object = NULL;
+
+            if (format == JSON) {
+                percentiles_array_value = json_value_init_array();
+                if (percentiles_array_value == NULL) {
+                    G_fatal_error(
+                        _("Failed to initialize JSON array. Out of memory?"));
+                }
+                percentiles_array = json_array(percentiles_array_value);
+            }
+
+            for (i = 0; i < stats[z].n_perc; i++) {
+                char buf[24];
+
+                snprintf(buf, sizeof(buf), "%.15g", stats[z].perc[i]);
+                G_strchg(buf, '.', '_');
+                switch (format) {
+                case PLAIN:
                     if (stats[z].perc[i] == (int)stats[z].perc[i]) {
                         /* percentile is an exact integer */
                         if ((int)stats[z].perc[i] % 10 == 1 &&
@@ -403,8 +379,36 @@ int print_stats(univar_stat *stats, enum OutputFormat format)
                         fprintf(stdout, "%.15g percentile: %g\n",
                                 stats[z].perc[i], quartile_perc[i]);
                     }
+                    break;
+                case SHELL:
+                    fprintf(stdout, "percentile_%s=%g\n", buf,
+                            quartile_perc[i]);
+                    break;
+                case JSON:
+                    percentile_value = json_value_init_object();
+                    if (percentile_value == NULL) {
+                        G_fatal_error(_("Failed to initialize JSON object. "
+                                        "Out of memory?"));
+                    }
+                    percentile_object = json_object(percentile_value);
+                    json_object_set_number(percentile_object, "percentile",
+                                           stats[z].perc[i]);
+                    json_object_set_number(percentile_object, "value",
+                                           quartile_perc[i]);
+                    json_array_append_value(percentiles_array,
+                                            percentile_value);
+                    break;
+                case CSV:
+                    /* already addressed in print_stats_table */
+                    break;
                 }
             }
+
+            if (format == JSON) {
+                json_object_set_value(zone_object, "percentiles",
+                                      percentiles_array_value);
+            }
+
             G_free((void *)quartile_perc);
             G_free((void *)qpos_perc);
         }

--- a/raster/r.univar/testsuite/test_r_univar.py
+++ b/raster/r.univar/testsuite/test_r_univar.py
@@ -87,6 +87,15 @@ class TestRasterUnivar(TestCase):
             precision=1e-10,
             sep="=",
         )
+        self.assertModuleKeyValue(
+            module="r.univar",
+            map="map_a",
+            format="shell",
+            nprocs=4,
+            reference=univar_string,
+            precision=1e-10,
+            sep="=",
+        )
 
     def test_2(self):
         # Output of r.univar
@@ -108,6 +117,15 @@ class TestRasterUnivar(TestCase):
             module="r.univar",
             map="map_a",
             flags="g",
+            nprocs=4,
+            reference=univar_string,
+            precision=1e-10,
+            sep="=",
+        )
+        self.assertModuleKeyValue(
+            module="r.univar",
+            map="map_a",
+            format="shell",
             nprocs=4,
             reference=univar_string,
             precision=1e-10,
@@ -260,6 +278,14 @@ class TestRasterUnivar(TestCase):
         self.assertModuleKeyValue(
             module="r.univar",
             map=["map_a", "map_b"],
+            format="shell",
+            reference=univar_string,
+            precision=1e-10,
+            sep="=",
+        )
+        self.assertModuleKeyValue(
+            module="r.univar",
+            map=["map_a", "map_b"],
             flags="g",
             nprocs=4,
             reference=univar_string,
@@ -384,6 +410,16 @@ class TestRasterUnivar(TestCase):
             map=["map_a"],
             zones="zone_map",
             flags="g",
+            nprocs=4,
+            reference=univar_string,
+            precision=1e-10,
+            sep="=",
+        )
+        self.assertModuleKeyValue(
+            module="r.univar",
+            map=["map_a"],
+            zones="zone_map",
+            format="shell",
             nprocs=4,
             reference=univar_string,
             precision=1e-10,
@@ -567,6 +603,37 @@ class TestRasterUnivar(TestCase):
             precision=1e-10,
             sep="=",
         )
+
+    def test_t_flag(self):
+        reference = """
+        zone|label|non_null_cells|null_cells|min|max|range|mean|mean_of_abs|stddev|variance|coeff_var|sum|sum_abs
+1||1710|0|102|209|107|155.5|155.5|26.5502667908755|704.916666666667|17.0741265536177|265905|265905
+2||6390|0|121|280|159|200.5|200.5|33.0895250293302|1094.91666666667|16.5035037552769|1281195|1281195
+        """
+        module = SimpleModule(
+            "r.univar",
+            map=["map_a"],
+            zones="zone_map",
+            flags="t",
+        )
+        self.runModule(module)
+        self.assertEqual(module.outputs.stdout.strip(), reference.strip())
+
+        # CSV takes precedence over the t flag
+        reference = """
+        zone,label,non_null_cells,null_cells,min,max,range,mean,mean_of_abs,stddev,variance,coeff_var,sum,sum_abs
+1,,1710,0,102,209,107,155.5,155.5,26.5502667908755,704.916666666667,17.0741265536177,265905,265905
+2,,6390,0,121,280,159,200.5,200.5,33.0895250293302,1094.91666666667,16.5035037552769,1281195,1281195
+        """
+        module = SimpleModule(
+            "r.univar", map=["map_a"], zones="zone_map", flags="t", format="csv"
+        )
+        self.runModule(module)
+        self.assertEqual(module.outputs.stdout.strip(), reference.strip())
+
+        module = SimpleModule("r.univar", map=["map_a"], zones="zone_map", format="csv")
+        self.runModule(module)
+        self.assertEqual(module.outputs.stdout.strip(), reference.strip())
 
     def test_json(self):
         reference = {


### PR DESCRIPTION
Fixes: #5824 

This PR includes the following changes:

* Adds `format = shell` option; the `-g` flag is now deprecated.
* Adds `format = csv` option; the `-t` flag is now deprecated.
* The default separator for all formats is `| (pipe)`, unless `format=csv` is specified in that case, it will be a `comma`.
* Added tests and updated the documentation.