### PR TITLE
v.label.sa: Fix Resource Leak issue

### DIFF
--- a/vector/v.label.sa/font.c
+++ b/vector/v.label.sa/font.c
@@ -44,7 +44,6 @@ struct GFONT_CAP *find_font_from_freetypecap(const char *font)
     char *capfile, file[GPATH_MAX];
     char buf[GPATH_MAX];
     FILE *fp;
-    int fonts_count = 0;
     struct GFONT_CAP *font_cap = NULL;
 
     fp = NULL;
@@ -81,12 +80,13 @@ struct GFONT_CAP *find_font_from_freetypecap(const char *font)
 
             font_cap = (struct GFONT_CAP *)G_malloc(sizeof(struct GFONT_CAP));
 
-            font_cap[fonts_count].name = G_store(name);
-            font_cap[fonts_count].longname = G_store(longname);
-            font_cap[fonts_count].type = type;
-            font_cap[fonts_count].path = G_store(path);
-            font_cap[fonts_count].index = index;
-            font_cap[fonts_count].encoding = G_store(encoding);
+            font_cap->name = G_store(name);
+            font_cap->longname = G_store(longname);
+            font_cap->type = type;
+            font_cap->path = G_store(path);
+            font_cap->index = index;
+            font_cap->encoding = G_store(encoding);
+            break;
         }
         fclose(fp);
     }

--- a/vector/v.label.sa/labels.c
+++ b/vector/v.label.sa/labels.c
@@ -216,6 +216,7 @@ label_t *labels_init(struct params *p, int *n_labels)
     G_percent(label_sz, label_sz, 10);
 
     *n_labels = i;
+    Vect_destroy_field_info(fi);
     return labels;
 }
 
@@ -714,6 +715,8 @@ static void label_line_candidates(label_t *label)
         label_point_candidates(label);
         label->shape = tmp_shape;
         Vect_destroy_line_struct(tmp);
+        G_free(above_candidates);
+        G_free(below_candidates);
         return;
     }
 
@@ -1027,6 +1030,7 @@ static double label_lineover(label_t *label, label_candidate_t *candidate,
     n = Vect_select_lines_by_polygon(&Map, trbb, 0, NULL, linetype, il);
 
     if (n == 0) {
+        Vect_destroy_list(il);
         return 0.0;
     }
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan(CID : 1415681, 1415703, 1415745, 1415754)
Used Vect_destroy_field_info(), G_free(), Vect_destroy_list() to fix this issue