### PR TITLE
tests: Use more env for session isolation

### DIFF
--- a/general/g.mapset/tests/conftest.py
+++ b/general/g.mapset/tests/conftest.py
@@ -25,7 +25,7 @@ def simple_dataset(tmp_path_factory):
             )
 
         # Set current mapset to test1
-        gs.run_command("g.mapset", project=project, mapset="test1")
+        gs.run_command("g.mapset", project=project, mapset="test1", env=session.env)
 
         yield SimpleNamespace(
             session=session,

--- a/general/g.mapset/tests/conftest.py
+++ b/general/g.mapset/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from types import SimpleNamespace
 
 import grass.script as gs
@@ -13,18 +14,21 @@ def simple_dataset(tmp_path_factory):
     project = "test"
 
     # Create a test project
-    gs.create_project(tmp_path, project)
+    gs.create_project(tmp_path / project)
 
     # Initialize the GRASS session
-    with gs.setup.init(tmp_path / project):
+    with gs.setup.init(tmp_path / project, env=os.environ.copy()) as session:
         # Create Mock Mapsets
         for mapset in TEST_MAPSETS:
-            gs.run_command("g.mapset", project=project, mapset=mapset, flags="c")
+            gs.run_command(
+                "g.mapset", project=project, mapset=mapset, flags="c", env=session.env
+            )
 
         # Set current mapset to test1
         gs.run_command("g.mapset", project=project, mapset="test1")
 
         yield SimpleNamespace(
+            session=session,
             mapsets=TEST_MAPSETS,
             project=project,
             current_mapset="test1",

--- a/general/g.mapset/tests/g_mapset_test.py
+++ b/general/g.mapset/tests/g_mapset_test.py
@@ -4,7 +4,9 @@ import grass.script as gs
 def test_plain_list_output(simple_dataset):
     """Test g.mapset with list flag and plain format"""
     mapsets = simple_dataset.mapsets
-    text = gs.read_command("g.mapset", format="plain", flags="l")
+    text = gs.read_command(
+        "g.mapset", format="plain", flags="l", env=simple_dataset.session.env
+    )
     parsed_list = text.strip().split()
 
     assert len(parsed_list) == len(mapsets)
@@ -14,14 +16,18 @@ def test_plain_list_output(simple_dataset):
 
 def test_plain_print_output(simple_dataset):
     """Test g.mapset with print flag and plain format"""
-    text = gs.read_command("g.mapset", format="plain", flags="p")
+    text = gs.read_command(
+        "g.mapset", format="plain", flags="p", env=simple_dataset.session.env
+    )
     assert text.strip() == simple_dataset.current_mapset
 
 
 def test_json_list_output(simple_dataset):
     """Test g.mapset with list flag and JSON format"""
     mapsets = simple_dataset.mapsets
-    data = gs.parse_command("g.mapset", format="json", flags="l")
+    data = gs.parse_command(
+        "g.mapset", format="json", flags="l", env=simple_dataset.session.env
+    )
     assert list(data.keys()) == ["project", "mapsets"]
     assert isinstance(data["mapsets"], list)
     assert len(data["mapsets"]) == len(mapsets)
@@ -31,7 +37,9 @@ def test_json_list_output(simple_dataset):
 
 def test_json_print_output(simple_dataset):
     """Test g.mapset with print flag and JSON format"""
-    data = gs.parse_command("g.mapset", format="json", flags="p")
+    data = gs.parse_command(
+        "g.mapset", format="json", flags="p", env=simple_dataset.session.env
+    )
     assert list(data.keys()) == ["project", "mapset"]
     assert data["mapset"] == simple_dataset.current_mapset
     assert data["project"] == simple_dataset.project

--- a/general/g.mapsets/tests/conftest.py
+++ b/general/g.mapsets/tests/conftest.py
@@ -5,6 +5,7 @@ Fixture for grass.jupyter.TimeSeries test
 Fixture for ReprojectionRenderer test with simple GRASS location, raster, vector.
 """
 
+import os
 from types import SimpleNamespace
 
 import grass.script as gs
@@ -23,13 +24,30 @@ def simple_dataset(tmp_path_factory):
     project_name = "test"
     project = tmp_path / project_name
     gs.create_project(project)
-    with gs.setup.init(project):
-        gs.run_command("g.proj", flags="c", epsg=26917)
-        gs.run_command("g.region", s=0, n=80, w=0, e=120, b=0, t=50, res=10, res3=10)
+    with gs.setup.init(project, env=os.environ.copy()) as session:
+        gs.run_command("g.proj", flags="c", epsg=26917, env=session.env)
+        gs.run_command(
+            "g.region",
+            s=0,
+            n=80,
+            w=0,
+            e=120,
+            b=0,
+            t=50,
+            res=10,
+            res3=10,
+            env=session.env,
+        )
         # Create Mock Mapsets
         for mapset in TEST_MAPSETS:
-            gs.run_command("g.mapset", project=project_name, mapset=mapset, flags="c")
+            gs.run_command(
+                "g.mapset",
+                project=project_name,
+                mapset=mapset,
+                flags="c",
+                env=session.env,
+            )
 
         yield SimpleNamespace(
-            mapsets=TEST_MAPSETS, accessible_mapsets=ACCESSIBLE_MAPSETS
+            session=session, mapsets=TEST_MAPSETS, accessible_mapsets=ACCESSIBLE_MAPSETS
         )

--- a/general/g.mapsets/tests/g_mapsets_list_format_test.py
+++ b/general/g.mapsets/tests/g_mapsets_list_format_test.py
@@ -39,7 +39,13 @@ def _check_parsed_list(mapsets, text, sep="|"):
 def test_plain_list_output(simple_dataset, separator):
     """Test that the separators are properly applied with list flag"""
     mapsets = simple_dataset.mapsets
-    text = gs.read_command("g.mapsets", format="plain", separator=separator, flags="l")
+    text = gs.read_command(
+        "g.mapsets",
+        format="plain",
+        separator=separator,
+        flags="l",
+        env=simple_dataset.session.env,
+    )
     _check_parsed_list(mapsets, text, gutils.separator(separator))
 
 
@@ -51,13 +57,21 @@ def test_plain_list_output(simple_dataset, separator):
 def test_plain_print_output(simple_dataset, separator):
     """Test that the separators are properly applied with print flag"""
     mapsets = simple_dataset.accessible_mapsets
-    text = gs.read_command("g.mapsets", format="plain", separator=separator, flags="p")
+    text = gs.read_command(
+        "g.mapsets",
+        format="plain",
+        separator=separator,
+        flags="p",
+        env=simple_dataset.session.env,
+    )
     _check_parsed_list(mapsets, text, gutils.separator(separator))
 
 
 def test_json_list_output(simple_dataset):
     """Check list of mapsets in JSON format"""
-    text = gs.read_command("g.mapsets", format="json", flags="l")
+    text = gs.read_command(
+        "g.mapsets", format="json", flags="l", env=simple_dataset.session.env
+    )
     data = json.loads(text)
     assert list(data.keys()) == ["mapsets"]
     assert isinstance(data["mapsets"], list)
@@ -68,7 +82,9 @@ def test_json_list_output(simple_dataset):
 
 def test_json_print_output(simple_dataset):
     """Check search path mapsets in JSON format"""
-    text = gs.read_command("g.mapsets", format="json", flags="p")
+    text = gs.read_command(
+        "g.mapsets", format="json", flags="p", env=simple_dataset.session.env
+    )
     data = json.loads(text)
     assert list(data.keys()) == ["mapsets"]
     assert isinstance(data["mapsets"], list)

--- a/python/grass/script/setup.py
+++ b/python/grass/script/setup.py
@@ -456,7 +456,9 @@ class SessionHandle:
 
         import grass.script as gs
 
-        with gs.setup.init("~/grassdata/nc_spm_08/user1", env=os.environ.copy()):
+        with gs.setup.init(
+            "~/grassdata/nc_spm_08/user1", env=os.environ.copy()
+        ) as session:
             # ... use GRASS modules here with env parameter
             gs.run_command("g.region", flags="p", env=session.env)
         # session ends automatically here, global environment was never modified

--- a/python/grass/script/tests/grass_script_core_get_commands.py
+++ b/python/grass/script/tests/grass_script_core_get_commands.py
@@ -1,5 +1,6 @@
 """Test grass.script.core.get_commands function"""
 
+import os
 import sys
 
 import pytest
@@ -42,6 +43,6 @@ def test_in_session(tmp_path):
     # TODO: Use env=os.environ.copy()
     project = tmp_path / "project"
     gs.create_project(project)
-    with gs.setup.init(project) as session:
+    with gs.setup.init(project, env=os.environ.copy()) as session:
         executables_set, scripts_dict = gs.get_commands(env=session.env)
     common_test_code(executables_set, scripts_dict)


### PR DESCRIPTION
In clear cases, pass a copy of os.environ to grass.script.setup.init instead of modifying the os.environ (and modifying it for all following tests).

There are couple complex cases which are not covered here (global/subprocess tests of grass.script.init, GridModule, grass.jupyter).
