### PR TITLE
grass.app: Use env in the lock program call

### DIFF
--- a/python/grass/app/data.py
+++ b/python/grass/app/data.py
@@ -209,8 +209,6 @@ def acquire_mapset_lock(
     The function assumes the `GISBASE` variable is in the environment. The variable is
     used to find the lock program. If *env* is not provided,
     :external:py:data:`os.environ` is used.
-
-    MapsetLockingException is raised when the lock program is not found.
     """
     if process_id is None:
         process_id = os.getpid()


### PR DESCRIPTION
While grass.py simply uses the global environment, grass.script.setup.init may use custom environment without any global runtime setup. In this case, the lock program needs to be called with that environment to load the dynamic libraries. Environment is already used to find the binary. (Other execution issues are already handled: If the program is not found, subprocess package raises an exception. Other runtime issues or issues reported by the lock program itself are handled by the caller function when reported using error code.
