### PR TITLE
r.mapcalc: fixed flag typo

### DIFF
--- a/raster/r.mapcalc/r.mapcalc.html
+++ b/raster/r.mapcalc/r.mapcalc.html
@@ -694,7 +694,7 @@ g.rename raster=newmap,oldmap
 be initialised to a specific value using the <b>seed</b> option.
 This can be used to replicate a previous calculation.
 <p>Alternatively, it can be initialised from the system time and the
-PID using the <b>-r</b> flag. This should result in a different seed
+PID using the <b>-s</b> flag. This should result in a different seed
 being used each time.
 <p>In either case, the seed will be written to the map's history, and
 can be seen using <em>r.info</em>.

--- a/raster/r.mapcalc/r.mapcalc.md
+++ b/raster/r.mapcalc/r.mapcalc.md
@@ -775,7 +775,7 @@ initialised to a specific value using the **seed** option. This can be
 used to replicate a previous calculation.
 
 Alternatively, it can be initialised from the system time and the PID
-using the **-r** flag. This should result in a different seed being used
+using the **-s** flag. This should result in a different seed being used
 each time.
 
 In either case, the seed will be written to the map's history, and can


### PR DESCRIPTION
This pull request address issue #5975 by replacing flag -r with flag -s in [r.mapcalc's](https://grass.osgeo.org/grass-stable/manuals/r.mapcalc.html) manual page. Edited both html and markdown manual pages. 
