### PR TITLE
MSVC: Fix comment in msvc/fcntl.h

### DIFF
--- a/msvc/fcntl.h
+++ b/msvc/fcntl.h
@@ -1,7 +1,7 @@
 /*!
  * \file msvc/fcntl.h
  *
- * \brief Header file for msvc/open.c and msvc/creat.c
+ * \brief Header file for msvc/fcntl.c
  *
  * (C) 2025 by the GRASS Development Team
  *


### PR DESCRIPTION
This PR fixes a comment about non-existing files (merged into `msvc/fcntl.c` previously).