### PR TITLE
r.regression.line: Add JSON support

### DIFF
--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -451,7 +451,7 @@ build_program_in_subdir(r.recode DEPENDS grass_gis grass_raster)
 
 build_program_in_subdir(r.region DEPENDS grass_gis grass_raster grass_vector)
 
-build_program_in_subdir(r.regression.line DEPENDS grass_gis grass_raster
+build_program_in_subdir(r.regression.line DEPENDS grass_gis grass_raster grass_parson
                         ${LIBM})
 
 build_program_in_subdir(r.regression.multi DEPENDS grass_gis grass_raster

--- a/raster/r.regression.line/Makefile
+++ b/raster/r.regression.line/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.regression.line
 
-LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB) $(PARSONLIB)
 DEPENDENCIES = $(GISDEP) $(RASTERDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.regression.line/main.c
+++ b/raster/r.regression.line/main.c
@@ -21,8 +21,11 @@
 #include <math.h>
 #include <string.h>
 #include <grass/gis.h>
+#include <grass/gjson.h>
 #include <grass/glocale.h>
 #include <grass/raster.h>
+
+enum OutputFormat { PLAIN, SHELL, JSON };
 
 int main(int argc, char *argv[])
 {
@@ -34,10 +37,13 @@ int main(int argc, char *argv[])
     long count = 0;
     DCELL *map1_buf, *map2_buf, map1_val, map2_val;
     char *name;
-    struct Option *input_map1, *input_map2, *output_opt;
+    struct Option *input_map1, *input_map2, *output_opt, *format_opt;
     struct Flag *shell_style;
     struct Cell_head region;
     struct GModule *module;
+    enum OutputFormat format;
+    JSON_Value *root_value = NULL;
+    JSON_Object *root_object = NULL;
 
     G_gisinit(argv[0]);
 
@@ -64,9 +70,18 @@ int main(int argc, char *argv[])
         (_("ASCII file for storing regression coefficients (output to screen "
            "if file not specified)."));
 
+    format_opt = G_define_standard_option(G_OPT_F_FORMAT);
+    format_opt->options = "plain,shell,json";
+    format_opt->descriptions = ("plain;Human readable text output;"
+                                "shell;shell script style text output;"
+                                "json;JSON (JavaScript Object Notation);");
+
     shell_style = G_define_flag();
     shell_style->key = 'g';
-    shell_style->description = _("Print in shell script style");
+    shell_style->label = _("Print in shell script style [deprecated]");
+    shell_style->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=shell instead.");
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
@@ -76,6 +91,33 @@ int main(int argc, char *argv[])
         if (NULL == freopen(name, "w", stdout)) {
             G_fatal_error(_("Unable to open file <%s> for writing"), name);
         }
+    }
+
+    if (strcmp(format_opt->answer, "json") == 0) {
+        format = JSON;
+        root_value = G_json_value_init_object();
+        if (root_value == NULL) {
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        root_object = G_json_object(root_value);
+    }
+    else if (strcmp(format_opt->answer, "shell") == 0) {
+        format = SHELL;
+    }
+    else {
+        format = PLAIN;
+    }
+
+    if (shell_style->answer) {
+        G_verbose_message(
+            _("Flag 'g' is deprecated and will be removed in a future "
+              "release. Please use format=shell instead."));
+        if (format == JSON) {
+            G_fatal_error(_("The -g flag cannot be used with format=json. "
+                            "Please select only one output format."));
+        }
+        format = SHELL;
     }
 
     G_get_window(&region);
@@ -132,7 +174,8 @@ int main(int argc, char *argv[])
     A = meanY - B * meanX;
     F = R * R / ((1 - R * R) / (count - 2));
 
-    if (shell_style->answer) {
+    switch (format) {
+    case SHELL:
         fprintf(stdout, "a=%f\n", A);
         fprintf(stdout, "b=%f\n", B);
         fprintf(stdout, "R=%f\n", R);
@@ -142,8 +185,9 @@ int main(int argc, char *argv[])
         fprintf(stdout, "sdX=%f\n", sdX);
         fprintf(stdout, "meanY=%f\n", meanY);
         fprintf(stdout, "sdY=%f\n", sdY);
-    }
-    else {
+        break;
+
+    case PLAIN:
         fprintf(stdout, "y = a + b*x\n");
         fprintf(stdout, "   a (Offset): %f\n", A);
         fprintf(stdout, "   b (Gain): %f\n", B);
@@ -154,6 +198,32 @@ int main(int argc, char *argv[])
         fprintf(stdout, "   sdX (Standard deviation of map1): %f\n", sdX);
         fprintf(stdout, "   meanY (Mean of map2): %f\n", meanY);
         fprintf(stdout, "   sdY (Standard deviation of map2): %f\n", sdY);
+        break;
+
+    case JSON:
+        G_json_object_set_number(root_object, "a", A);
+        G_json_object_set_number(root_object, "b", B);
+        G_json_object_set_number(root_object, "R", R);
+        G_json_object_set_number(root_object, "N", count);
+        G_json_object_set_number(root_object, "F", F);
+        G_json_object_set_number(root_object, "x_mean", meanX);
+        G_json_object_set_number(root_object, "x_stddev", sdX);
+        G_json_object_set_number(root_object, "y_mean", meanY);
+        G_json_object_set_number(root_object, "y_stddev", sdY);
+        break;
+    }
+
+    if (format == JSON) {
+        char *json_string = G_json_serialize_to_string_pretty(root_value);
+        if (!json_string) {
+            G_json_value_free(root_value);
+            G_fatal_error(_("Failed to serialize JSON to pretty format."));
+        }
+
+        puts(json_string);
+
+        G_json_free_serialized_string(json_string);
+        G_json_value_free(root_value);
     }
 
     exit(EXIT_SUCCESS);

--- a/raster/r.regression.line/r.regression.line.md
+++ b/raster/r.regression.line/r.regression.line.md
@@ -47,12 +47,12 @@ r.regression.line mapx=elev_ned_30m mapy=elev_srtm_30m
    sdY (Standard deviation of map2): 23.718307
 ```
 
-Using the script style flag AND *eval* to make results available in the
+Using the shell format option AND *eval* to make results available in the
 shell:
 
 ```sh
 g.region raster=elev_srtm_30m -p
-eval `r.regression.line -g mapx=elev_ned_30m mapy=elev_srtm_30m`
+eval `r.regression.line mapx=elev_ned_30m mapy=elev_srtm_30m format=shell`
 
 # print result stored in respective variables
 echo $a
@@ -63,6 +63,33 @@ echo $b
 
 echo $R
 0.894038
+```
+
+Using the JSON format option and Python to parse the output:
+
+```python
+import grass.script as gs
+
+data = gs.parse_command(
+    "r.regression.line", mapx="elev_ned_30m", mapy="elev_srtm_30m", format="json"
+)
+print(data)
+```
+
+Possible JSON Output:
+
+```json
+{
+ "a": -1.6592786233805945,
+ "b": 1.0439679629649166,
+ "R": 0.8940383063008781,
+ "N": 225000,
+ "F": 896093.366283,
+ "x_mean": 110.30757108713786,
+ "x_stddev": 20.311997672696272,
+ "y_mean": 113.49829166406644,
+ "y_stddev": 23.718306793642626
+}
 ```
 
 ## SEE ALSO

--- a/raster/r.regression.line/testsuite/test_rregression_line.py
+++ b/raster/r.regression.line/testsuite/test_rregression_line.py
@@ -1,3 +1,5 @@
+import json
+
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.gunittest.gmodules import SimpleModule
@@ -18,7 +20,7 @@ class TestRRegressionLine(TestCase):
         cls.del_temp_region()
 
     def test_default_format(self):
-        """Test default output format."""
+        """Test default and plain output formats."""
         module = SimpleModule(
             "r.regression.line", mapx="elev_ned_30m", mapy="elev_srtm_30m"
         )
@@ -38,8 +40,18 @@ class TestRRegressionLine(TestCase):
         ]
         self.assertEqual(module.outputs.stdout.splitlines(), expected)
 
+        # Test explicit plain format
+        module = SimpleModule(
+            "r.regression.line",
+            mapx="elev_ned_30m",
+            mapy="elev_srtm_30m",
+            format="plain",
+        )
+        self.assertModule(module)
+        self.assertEqual(module.outputs.stdout.splitlines(), expected)
+
     def test_shell_format(self):
-        """Test -g flag output format."""
+        """Test shell and -g flag output formats."""
         module = SimpleModule(
             "r.regression.line", mapx="elev_ned_30m", mapy="elev_srtm_30m", flags="g"
         )
@@ -57,6 +69,46 @@ class TestRRegressionLine(TestCase):
             "sdY=23.718307",
         ]
         self.assertEqual(module.outputs.stdout.splitlines(), expected)
+
+        # Using format=shell
+        module = SimpleModule(
+            "r.regression.line",
+            mapx="elev_ned_30m",
+            mapy="elev_srtm_30m",
+            format="shell",
+        )
+        self.assertModule(module)
+        self.assertEqual(module.outputs.stdout.splitlines(), expected)
+
+    def test_json_format(self):
+        """Test JSON output format."""
+        module = SimpleModule(
+            "r.regression.line",
+            mapx="elev_ned_30m",
+            mapy="elev_srtm_30m",
+            format="json",
+        )
+        self.assertModule(module)
+
+        expected = {
+            "a": -1.6592786233805945,
+            "b": 1.0439679629649166,
+            "R": 0.8940383063008781,
+            "N": 225000,
+            "F": 896093.366283,
+            "x_mean": 110.30757108713786,
+            "x_stddev": 20.311997672696272,
+            "y_mean": 113.49829166406644,
+            "y_stddev": 23.718306793642626,
+        }
+        output_json = json.loads(module.outputs.stdout)
+
+        self.assertCountEqual(list(expected.keys()), list(output_json.keys()))
+        for key, value in expected.items():
+            if isinstance(value, float):
+                self.assertAlmostEqual(value, output_json[key], places=6)
+            else:
+                self.assertEqual(value, output_json[key])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes: #5950 

This PR adds JSON support to the `r.regression.line` module. The JSON output looks like:

```json
{
	"a": -1.6592786233805945,
	"b": 1.0439679629649166,
	"R": 0.8940383063008781,
	"N": 225000,
	"F": 896093.366283,
	"x_mean": 110.30757108713786,
	"x_stddev": 20.311997672696272,
	"y_mean": 113.49829166406644,
	"y_stddev": 23.718306793642626
}
```

This PR includes the following changes:

1. Adds a `format` option with `plain`, `shell`, and `json` modes for output formatting.
2. Adds `format = shell` option; the `-g` flag is now deprecated.
3. Adds tests covering each of the new formats.
4. Adds a Python example to the documentation for parsing JSON output.