### PR TITLE
db.drivers/dbf: Fix uninitialized scalar variable

### DIFF
--- a/db/drivers/dbf/dbfexe.c
+++ b/db/drivers/dbf/dbfexe.c
@@ -661,12 +661,12 @@ int sel(SQLPSTMT *st, int tab, int **selset)
  */
 double eval_node(SQLPNODE *nptr, int tab, int row, SQLPVALUE *value)
 {
-    int left, right;
+    int left = NODE_ERROR, right = NODE_ERROR;
     SQLPVALUE left_value, right_value;
     int ccol;
     COLUMN *col;
     VALUE *val;
-    double left_dval, right_dval, dval;
+    double left_dval = 0.0, right_dval = 0.0, dval;
     char *rightbuf;
 
     /* Note: node types were previously checked by eval_node_type */
@@ -1010,7 +1010,7 @@ double eval_node(SQLPNODE *nptr, int tab, int row, SQLPVALUE *value)
  */
 int eval_node_type(SQLPNODE *nptr, int tab)
 {
-    int left, right;
+    int left = -1, right = -1;
     int ccol;
     COLUMN *col = NULL;
 

--- a/db/drivers/dbf/dbfexe.c
+++ b/db/drivers/dbf/dbfexe.c
@@ -661,7 +661,7 @@ int sel(SQLPSTMT *st, int tab, int **selset)
  */
 double eval_node(SQLPNODE *nptr, int tab, int row, SQLPVALUE *value)
 {
-    int left = NODE_ERROR, right = NODE_ERROR;
+    int left = NODE_FALSE, right = NODE_FALSE;
     SQLPVALUE left_value, right_value;
     int ccol;
     COLUMN *col;
@@ -1010,7 +1010,7 @@ double eval_node(SQLPNODE *nptr, int tab, int row, SQLPVALUE *value)
  */
 int eval_node_type(SQLPNODE *nptr, int tab)
 {
-    int left = -1, right = -1;
+    int left = 0, right = 0;
     int ccol;
     COLUMN *col = NULL;
 

--- a/db/drivers/dbf/table.c
+++ b/db/drivers/dbf/table.c
@@ -99,7 +99,7 @@ int find_table(char *table)
 
 int load_table_head(int t)
 {
-    int i, ncol, dtype, type, width, decimals;
+    int i, ncol, dtype, type = 0, width, decimals;
     DBFHandle dbf;
     char fname[20];
 


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208551, 1208571, 1208572, 1208573, 1208574, 1208575, 1208577)