### PR TITLE
g.findfile: use element aliases

### DIFF
--- a/general/g.findfile/main.c
+++ b/general/g.findfile/main.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
     struct Option *elem_opt;
     struct Option *mapset_opt;
     struct Option *file_opt;
-    struct Flag *n_flag, *l_flag;
+    struct Flag *n_flag, *l_flag, *t_flag;
     size_t len;
 
     module = G_define_module();
@@ -74,6 +74,12 @@ int main(int argc, char *argv[])
     l_flag->key = 'l';
     l_flag->description = _("List available elements and exit");
     l_flag->suppress_required = YES;
+
+    t_flag = G_define_flag();
+    t_flag->key = 't';
+    t_flag->label = _("Return code 0 when file found, 1 otherwise");
+    t_flag->description =
+        _("Behave like the test utility, 0 for true, 1 for false, no output");
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
@@ -126,6 +132,13 @@ int main(int argc, char *argv[])
         main_element = G_store(elem_opt->answer);
     }
     mapset = G_find_file2(main_element, name, search_mapset);
+
+    if (t_flag->answer) {
+        if (mapset)
+            return 0;
+        else
+            return 1;
+    }
     if (mapset) {
         char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
         const char *qchar = n_flag->answer ? "" : "'";
@@ -149,5 +162,8 @@ int main(int argc, char *argv[])
     }
 
     G_free(main_element);
+    G_verbose_message(_("In the next major release, g.findfile will no longer "
+                        "return exit code 1 when a file is not found. Please "
+                        "use the -t flag instead to get the error code."));
     return EXIT_FAILURE;
 }

--- a/general/g.findfile/main.c
+++ b/general/g.findfile/main.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <grass/gis.h>
+#include <grass/manage.h>
 #include <grass/glocale.h>
 
 #include "local_proto.h"
@@ -112,19 +113,32 @@ int main(int argc, char *argv[])
         }
     }
 
-    mapset = G_find_file2(elem_opt->answer, name, search_mapset);
+    const struct list *element;
+    int n;
+    M_read_list(FALSE, &n);
+    n = M_get_element(elem_opt->answer);
+    char *main_element;
+    if (n >= 0) {
+        element = M_get_list(n);
+        main_element = G_store(element->mainelem);
+    }
+    else {
+        main_element = G_store(elem_opt->answer);
+    }
+    mapset = G_find_file2(main_element, name, search_mapset);
     if (mapset) {
         char xname[GNAME_MAX], xmapset[GMAPSET_MAX];
         const char *qchar = n_flag->answer ? "" : "'";
         const char *qual = G_fully_qualified_name(name, mapset);
 
         G_unqualified_name(name, mapset, xname, xmapset);
-        G_file_name(file, elem_opt->answer, name, mapset);
+        G_file_name(file, main_element, name, mapset);
         fprintf(stdout, "name=%s%s%s\n", qchar, xname, qchar);
         fprintf(stdout, "mapset=%s%s%s\n", qchar, xmapset, qchar);
         fprintf(stdout, "fullname=%s%s%s\n", qchar, qual, qchar);
         fprintf(stdout, "file=%s%s%s\n", qchar, file, qchar);
 
+        G_free(main_element);
         return EXIT_SUCCESS;
     }
     else {
@@ -134,5 +148,6 @@ int main(int argc, char *argv[])
         fprintf(stdout, "file=\n");
     }
 
+    G_free(main_element);
     return EXIT_FAILURE;
 }

--- a/general/g.findfile/tests/test_g_findfile.py
+++ b/general/g.findfile/tests/test_g_findfile.py
@@ -1,0 +1,176 @@
+import os
+import pytest
+from pathlib import Path
+
+import grass.script as gs
+
+
+@pytest.fixture(scope="module")
+def session(tmp_path_factory):
+    """Set up a GRASS session for the tests."""
+    tmp_path = tmp_path_factory.mktemp("grass_session")
+    project = "test_project"
+
+    # Create a test location
+    gs.create_project(tmp_path, project)
+
+    # Initialize the GRASS session
+    with gs.setup.init(tmp_path / project, env=os.environ.copy()) as session:
+        gs.run_command("g.region", rows=3, cols=3, env=session.env)
+        gs.run_command("r.mapcalc", expression="test_raster = 1", env=session.env)
+        gs.run_command("r3.mapcalc", expression="test_raster_3d = 1", env=session.env)
+        gs.run_command("v.edit", map="test_vector", tool="create", env=session.env)
+        gs.run_command("g.region", save="test_region", env=session.env)
+        yield session
+
+
+def test_find_raster(session):
+    """Test that g.findfile found the raster"""
+    gisenv = gs.gisenv(env=session.env)
+    path = Path(gisenv["GISDBASE"]) / gisenv["LOCATION_NAME"] / gisenv["MAPSET"]
+    found = gs.read_command(
+        "g.findfile",
+        element="raster",
+        name="test_raster",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_raster"
+    assert result["file"] == path / "cell" / "test_raster"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="cell",
+        name="test_raster",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_raster"
+    assert result["file"] == path / "cell" / "test_raster"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="cats",
+        name="test_raster",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_raster"
+    assert result["file"] == path / "cats" / "test_raster"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="cell",
+        name="test_vector",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == ""
+    assert result["file"] == ""
+
+
+def test_find_vector(session):
+    """Test that g.findfile found the vector"""
+    gisenv = gs.gisenv(env=session.env)
+    path = Path(gisenv["GISDBASE"]) / gisenv["LOCATION_NAME"] / gisenv["MAPSET"]
+    found = gs.read_command(
+        "g.findfile",
+        element="vector",
+        name="test_vector",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_vector"
+    assert result["file"] == path / "vector" / "test_vector"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="vector",
+        name="test_raster",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == ""
+    assert result["file"] == ""
+
+
+def test_find_raster_3d(session):
+    """Test that g.findfile found the raster_3d"""
+    gisenv = gs.gisenv(env=session.env)
+    path = Path(gisenv["GISDBASE"]) / gisenv["LOCATION_NAME"] / gisenv["MAPSET"]
+    found = gs.read_command(
+        "g.findfile",
+        element="raster3d",
+        name="test_raster_3d",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_raster_3d"
+    assert result["file"] == path / "grid3" / "test_raster_3d"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="grid3",
+        name="test_raster_3d",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_raster_3d"
+    assert result["file"] == path / "grid3" / "test_raster_3d"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="grid3",
+        name="test_raster",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == ""
+    assert result["file"] == ""
+
+
+def test_find_region(session):
+    """Test that g.findfile found the region"""
+    gisenv = gs.gisenv(env=session.env)
+    path = Path(gisenv["GISDBASE"]) / gisenv["LOCATION_NAME"] / gisenv["MAPSET"]
+    found = gs.read_command(
+        "g.findfile",
+        element="region",
+        name="test_region",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_raster_3d"
+    assert result["file"] == path / "windows" / "test_region"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="windows",
+        name="test_region",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == "test_region"
+    assert result["file"] == path / "windows" / "test_region"
+
+    found = gs.read_command(
+        "g.findfile",
+        element="grid3",
+        name="test_raster",
+        errors="ignore",
+        env=session.env,
+    )
+    result = gs.parse_key_val(found, env=session.env)
+    assert result["name"] == ""
+    assert result["file"] == ""

--- a/general/g.findfile/tests/test_g_findfile.py
+++ b/general/g.findfile/tests/test_g_findfile.py
@@ -31,44 +31,48 @@ def test_find_raster(session):
     found = gs.read_command(
         "g.findfile",
         element="raster",
-        name="test_raster",
+        file="test_raster",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_raster"
-    assert result["file"] == path / "cell" / "test_raster"
+    assert result["file"] == str(path / "cell" / "test_raster")
 
     found = gs.read_command(
         "g.findfile",
         element="cell",
-        name="test_raster",
+        file="test_raster",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_raster"
-    assert result["file"] == path / "cell" / "test_raster"
+    assert result["file"] == str(path / "cell" / "test_raster")
 
     found = gs.read_command(
         "g.findfile",
         element="cats",
-        name="test_raster",
+        file="test_raster",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_raster"
-    assert result["file"] == path / "cats" / "test_raster"
+    assert result["file"] == str(path / "cats" / "test_raster")
 
     found = gs.read_command(
         "g.findfile",
         element="cell",
-        name="test_vector",
+        file="test_vector",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == ""
     assert result["file"] == ""
 
@@ -80,22 +84,24 @@ def test_find_vector(session):
     found = gs.read_command(
         "g.findfile",
         element="vector",
-        name="test_vector",
+        file="test_vector",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_vector"
-    assert result["file"] == path / "vector" / "test_vector"
+    assert result["file"] == str(path / "vector" / "test_vector")
 
     found = gs.read_command(
         "g.findfile",
         element="vector",
-        name="test_raster",
+        file="test_raster",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == ""
     assert result["file"] == ""
 
@@ -106,34 +112,37 @@ def test_find_raster_3d(session):
     path = Path(gisenv["GISDBASE"]) / gisenv["LOCATION_NAME"] / gisenv["MAPSET"]
     found = gs.read_command(
         "g.findfile",
-        element="raster3d",
-        name="test_raster_3d",
+        element="raster_3d",
+        file="test_raster_3d",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_raster_3d"
-    assert result["file"] == path / "grid3" / "test_raster_3d"
+    assert result["file"] == str(path / "grid3" / "test_raster_3d")
 
     found = gs.read_command(
         "g.findfile",
         element="grid3",
-        name="test_raster_3d",
+        file="test_raster_3d",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_raster_3d"
-    assert result["file"] == path / "grid3" / "test_raster_3d"
+    assert result["file"] == str(path / "grid3" / "test_raster_3d")
 
     found = gs.read_command(
         "g.findfile",
         element="grid3",
-        name="test_raster",
+        file="test_raster",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == ""
     assert result["file"] == ""
 
@@ -145,32 +154,57 @@ def test_find_region(session):
     found = gs.read_command(
         "g.findfile",
         element="region",
-        name="test_region",
+        file="test_region",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
-    assert result["name"] == "test_raster_3d"
-    assert result["file"] == path / "windows" / "test_region"
+    result = gs.parse_key_val(found)
+    assert result["name"] == "test_region"
+    assert result["file"] == str(path / "windows" / "test_region")
 
     found = gs.read_command(
         "g.findfile",
         element="windows",
-        name="test_region",
+        file="test_region",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == "test_region"
-    assert result["file"] == path / "windows" / "test_region"
+    assert result["file"] == str(path / "windows" / "test_region")
 
     found = gs.read_command(
         "g.findfile",
-        element="grid3",
-        name="test_raster",
+        element="windows",
+        file="test_raster",
+        flags="n",
         errors="ignore",
         env=session.env,
     )
-    result = gs.parse_key_val(found, env=session.env)
+    result = gs.parse_key_val(found)
     assert result["name"] == ""
     assert result["file"] == ""
+
+
+def test_t_flag(session):
+    found = gs.run_command(
+        "g.findfile",
+        element="region",
+        file="test_region",
+        flags="t",
+        errors="status",
+        env=session.env,
+    )
+    assert found == 0
+
+    found = gs.run_command(
+        "g.findfile",
+        element="region",
+        file="test_raster",
+        flags="t",
+        errors="status",
+        env=session.env,
+    )
+    assert found == 1

--- a/python/grass/script/core.py
+++ b/python/grass/script/core.py
@@ -1605,10 +1605,8 @@ def find_file(name, element="cell", mapset=None, env=None):
     """
     element_translation = {
         "rast": "cell",
-        "raster": "cell",
         "rast3d": "grid3",
         "raster3d": "grid3",
-        "raster_3d": "grid3",
     }
 
     if element in element_translation:


### PR DESCRIPTION
g.findfile didn't take raster/raster_3d/region, even though g.findfile -l lists them. This PR fixes that.

Also adds a new -t flag similarly to r.mask.status to get the error code without printing the results. In the future, without -t it should always return success.