### PR TITLE
r.stats.quantile: Add JSON support

### DIFF
--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -571,7 +571,7 @@ build_program_in_subdir(r.statistics DEPENDS grass_gis grass_raster ${LIBM})
 
 build_program_in_subdir(r.stats.zonal DEPENDS grass_gis grass_raster ${LIBM})
 
-build_program_in_subdir(r.stats.quantile DEPENDS grass_gis grass_raster ${LIBM})
+build_program_in_subdir(r.stats.quantile DEPENDS grass_gis grass_raster grass_parson ${LIBM})
 
 build_program_in_subdir(r.stats DEPENDS grass_gis grass_raster grass_parson ${LIBM})
 

--- a/raster/r.stats.quantile/Makefile
+++ b/raster/r.stats.quantile/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.stats.quantile
 
-LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(MATHLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.stats.quantile/r.stats.quantile.md
+++ b/raster/r.stats.quantile/r.stats.quantile.md
@@ -15,6 +15,12 @@ maps. It provides quantile calculations, which are absent from
 Quantiles are calculated following algorithm 7 from Hyndman and Fan
 (1996), which is also the default in R and numpy.
 
+The **t** flag has been deprecated and replaced by the **format=csv**
+option.
+
+The default separator will be **:** to maintain backward compatibility;
+however, if **format=csv** is given, then the default separator will be **comma**.
+
 ## EXAMPLE
 
 In this example, the raster polygon map `zipcodes` in the North Carolina
@@ -37,6 +43,58 @@ r.stats.quantile base=zipcodes cover=elevation quantiles=3 -p
 # write out percentile raster maps
 r.stats.quantile base=zipcodes cover=elevation percentiles=25,50,75 \
   output=zipcodes_elev_q25,zipcodes_elev_q50,zipcodes_elev_q75
+```
+
+Using the JSON format option and Python to parse the
+output:
+
+```python
+import grass.script as gs
+
+data = gs.parse_command(
+    "r.stats.quantile", base="zipcodes", cover="elevation", flags="p", format="json"
+)
+print(data[0])
+```
+
+Possible output:
+
+```text
+{'category': 27511, 'percentiles': [{'percentile': 50, 'value': 139.62598419189453}]}
+```
+
+The whole JSON may look like this:
+
+```json
+[
+ {
+  "category": 27511,
+  "percentiles": [
+   {
+    "percentile": 50,
+    "value": 139.62598419189453
+   }
+  ]
+ },
+ {
+  "category": 27513,
+  "percentiles": [
+   {
+    "percentile": 50,
+    "value": 143.7049102783203
+   }
+  ]
+ },
+ {
+  "category": 27518,
+  "percentiles": [
+   {
+    "percentile": 50,
+    "value": 122.53437805175781
+   }
+  ]
+ }
+]
 ```
 
 ## REFERENCES


### PR DESCRIPTION
Fixes: #5951 

This PR adds JSON support to the `r.stats.quantile` module. The JSON output looks like:

```json
[
	{
		"category": 27511,
		"percentiles": [
			{
				"percentile": 50,
				"value": 139.62598419189453
			}
		]
	},
	{
		"category": 27513,
		"percentiles": [
			{
				"percentile": 50,
				"value": 143.7049102783203
			}
		]
	},
	{
		"category": 27518,
		"percentiles": [
			{
				"percentile": 50,
				"value": 122.53437805175781
			}
		]
	}
]
```

This PR includes the following changes:

1. Adds a `format` option with `plain`, `csv`, and `json` modes for output formatting.
2. Adds `format = csv` option; the `-t` flag is now deprecated.
3. If no separator is specified, the default is `:`; If the format is `CSV`, the separator is a `comma`.
4. Adds tests covering each of the new formats.
5. Adds a Python example to the documentation for parsing JSON output.