### PR TITLE
r.kappa: Fix unchecked return value from library in stats.c

### DIFF
--- a/raster/r.kappa/stats.c
+++ b/raster/r.kappa/stats.c
@@ -60,7 +60,9 @@ int stats(void)
     argv[argc++] = NULL;
 
     if (G_vspawn_ex(argv[0], argv) != 0) {
-        remove(stats_file);
+        if (remove(stats_file) != 0) {
+            G_warning("Failed to remove file");
+        }
         G_fatal_error("error running r.stats");
     }
 

--- a/raster/r.kappa/stats.c
+++ b/raster/r.kappa/stats.c
@@ -61,9 +61,9 @@ int stats(void)
 
     if (G_vspawn_ex(argv[0], argv) != 0) {
         if (remove(stats_file) != 0) {
-            G_warning("Failed to remove file");
+            G_warning(_("Failed to remove file"));
         }
-        G_fatal_error("error running r.stats");
+        G_fatal_error(_("error running r.stats"));
     }
 
     fd = fopen(stats_file, "r");


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan ( CID : 1207210)
The warning was caused by an unchecked return value from the remove() function, which may fail and return a non-zero error code. In this fix, the return value of remove() is explicitly checked, and a warning is logged if the file removal fails. This follows a more defensive programming approach.

An alternative fix would have been to suppress the warning using a (void) cast, since the program exits immediately afterward via G_fatal_error().