### PR TITLE
i.oif: bug fix

### DIFF
--- a/scripts/i.oif/i.oif.py
+++ b/scripts/i.oif/i.oif.py
@@ -84,7 +84,7 @@ def main():
 
     if serial:
         for band in bands:
-            grass.verbose("band %d" % band)
+            grass.verbose("band %s" % band)
             s = grass.read_command("r.univar", flags="g", map=band)
             kv = parse_key_val(s)
             stddev[band] = float(kv["stddev"])


### PR DESCRIPTION
This PR fixes a bug in the `i.oif` script where running the module with the `-s` flag (serial mode) fails with a `TypeError` because the code uses an incorrect format specifier when logging the raster band name.

Closes #6061 