### PR TITLE
r.volume: fix -p flag behavior

### DIFF
--- a/raster/r.volume/main.c
+++ b/raster/r.volume/main.c
@@ -135,8 +135,10 @@ int main(int argc, char *argv[])
 
     flag.print = G_define_flag();
     flag.print->key = 'p';
-    flag.print->answer = 1;
     flag.print->description = _("Print report");
+
+    // Uncomment for GRASS v9
+    // G_option_required(flag.print, opt.centroids, NULL);
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
@@ -192,12 +194,9 @@ int main(int argc, char *argv[])
         }
         format = CSV;
     }
-
-    print = flag.print->answer || flag.report->answer;
-    if (format != PLAIN && !print) {
-        G_fatal_error(
-            _("The -p flag is required when using the format option."));
-    }
+    // print = flag.print->answer;
+    // currently prints always, change for GRASS v9
+    print = 1;
 
     /*
      * see if raster mask or a separate "clumpmap" raster map is to be used

--- a/raster/r.volume/r.volume.md
+++ b/raster/r.volume/r.volume.md
@@ -24,10 +24,10 @@ option.
 
 To print the volume report, use the **-p** flag along with the **format** option
 to specify the desired output format. The volume report is printed even without
-this flag to maintain backward compatibility; however, this behavior may change
+this flag to maintain backward compatibility; however, this behavior will change
 in the future.
 
-The default separator set to **:** for backward compatibility. However,
+The default separator is set to **:** for backward compatibility. However,
 if **format=csv** is specified, the default separator will be a **comma**.
 
 ### CENTROIDS
@@ -82,7 +82,7 @@ r.lake elevation=elev_lid792_1m water_level=113.7 lake=mylake coordinates=638684
 #  Lake volume 648.875328 cubic meters
 
 # compute water volume
-r.volume input=elev_lid792_1m clump=mylake
+r.volume input=elev_lid792_1m clump=mylake -p
 #
 # Category   Average   Data   # Cells        Centroid             Total
 # Number     in clump  Total  in clump   Easting     Northing     Volume
@@ -106,7 +106,7 @@ dataset):
 g.region raster=elevation -p
 
 # compute volume
-r.volume input=elevation clump=geology_30m
+r.volume input=elevation clump=geology_30m -p
 #
 # Volume report on data from <elevation> using clumps on <geology_30m> raster map
 #


### PR DESCRIPTION
This addresses a problem with the new p flag of r.volume - it renders incorrectly (https://grass.osgeo.org/grass-devel/manuals/r.volume.html).

It also removes a fatal error, currently that condition will never happen and I don't think we need to enforce that condition anyway.

Also fixes documentation by adding the -p flag.