### PR TITLE
lib/ogsf: Fix Resource Leak Issue in gvld.c

### DIFF
--- a/lib/ogsf/gvld.c
+++ b/lib/ogsf/gvld.c
@@ -257,7 +257,7 @@ int gvld_isosurf(geovol *gvl)
             gsd_blend(0);
             gsd_zwritemask(0xffffffff);
             ret = -1;
-            goto cleanup;
+            goto cleanup_exit;
         }
 
         for (y = 0; y < rows - 1; y++) {
@@ -397,7 +397,7 @@ int gvld_isosurf(geovol *gvl)
     gsd_popmatrix();
     gsd_blend(0);
     gsd_zwritemask(0xffffffff);
-cleanup:
+cleanup_exit:
     G_free(e_dl);
     G_free(nz);
     G_free(pos);


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208002, 1208003, 1208004, 1208005, 1208006, 1208007, 1208008, 1208009, 1208010, 1208011, 1208012, 1208013).
Used G_free() to fix this issue.