### PR TITLE
CQ: Replace crlf check with validation against an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,116 @@
+# EditorConfig: https://editorconfig.org
+# Rules are read from top to bottom, the most recent rule found applies
+# Some basic properties are supported by all editor plugins
+
+# top-most EditorConfig file
+root = true
+
+# General settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{htm,html,js,css,svg}]
+indent_size = 2
+
+[*.{xml,config}]
+indent_size = 2
+
+# Scripts
+[{*.sh,mswindows/osgeo4w/*config}]
+end_of_line = lf
+indent_size = 4
+
+# These are explicitly windows files and should use crlf
+[*.{bat,cmd,ps1}{.tmpl,}]
+end_of_line = crlf
+
+[*.{c,h,cpp,hpp}]
+indent_size = 2
+
+[{*.js,*.json,*.json5,*.mjs,*.cjs}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+block_comment_start = /**
+block_comment = *
+block_comment_end = */
+
+[*.ipynb]
+end_of_line = lf
+
+[{*.py, *.pyi}]
+charset = utf-8
+indent_style = space
+# TODO: To enable when files are fixed:
+# indent_size = 4
+# max_line_length = 88
+
+[{Makefile,*.make,*.make.in}]
+# TODO: To enable when files are fixed:
+# indent_style = tab
+indent_size = 4
+
+[*.y{a,}ml]
+indent_style = space
+indent_size = 2
+
+# Patch files
+[*.patch]
+trim_trailing_whitespace = false
+
+# TODO: To enable when files are fixed:
+# # CSVs use CRLF as defined in RFC 4180
+# [*.csv]
+# end_of_line = crlf
+
+[*.md]
+# Two trailing whitespace in markdown means to create a line break
+# https://www.markdownguide.org/basic-syntax/#line-breaks
+trim_trailing_whitespace = false
+indent_style = space
+# TODO: To enable when files are fixed:
+# indent_size = 2
+
+# Exclude some files from rules
+[*.{ascii,asc,ref,po,ps,svg}]
+trim_trailing_whitespace = unset
+end_of_line = unset
+charset = unset
+insert_final_newline = unset
+
+[{**/testsuite/data/**,mswindows/osgeo4w/envdiff.sed}]
+trim_trailing_whitespace = unset
+end_of_line = unset
+charset = unset
+insert_final_newline = unset
+
+[python/libgrass_interface_generator/ctypesgen/parser/parsetab.py]
+trim_trailing_whitespace = false
+
+[mswindows/{generic.manifest,Installer-Files/*.url}]
+end_of_line = crlf
+
+# Binary files
+[**/PERMANENT/vector/*/{cidx,coor,sidx,topo}]
+trim_trailing_whitespace = unset
+end_of_line = unset
+charset = unset
+insert_final_newline = unset
+
+[*.{laz,raw,rgb}]
+trim_trailing_whitespace = unset
+end_of_line = unset
+charset = unset
+insert_final_newline = unset
+
+[{lib/vector/diglib/test*.ok,**/*.nib/keyedobjects.nib}]
+trim_trailing_whitespace = unset
+end_of_line = unset
+charset = unset
+insert_final_newline = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,8 +32,9 @@ indent_size = 4
 end_of_line = crlf
 
 # TODO: remove when fixed
-[mswindows/{osgeo4w/,}*.{bat}{.tmpl,}]
+[mswindows/{osgeo4w,}/*.{bat}{.tmpl,}]
 end_of_line = unset
+insert_final_newline = unset
 
 [*.{c,h,cpp,hpp}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -111,7 +111,8 @@ charset = unset
 insert_final_newline = unset
 
 # TODO: remove when fixed:
-[.github/workflows/test_thorough.bat]
+[.github/workflows/*.bat]
+end_of_line = unset
 insert_final_newline = unset
 
 # Binary files

--- a/.editorconfig
+++ b/.editorconfig
@@ -98,7 +98,10 @@ insert_final_newline = unset
 trim_trailing_whitespace = false
 
 [mswindows/{generic.manifest,Installer-Files/*.url}]
+trim_trailing_whitespace = unset
 end_of_line = unset
+charset = unset
+insert_final_newline = unset
 
 # Binary files
 [**/PERMANENT/vector/*/{cidx,coor,sidx,topo}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -99,7 +99,10 @@ trim_trailing_whitespace = false
 
 [mswindows/{generic.manifest,Installer-Files/*.url}]
 #trim_trailing_whitespace = unset
-end_of_line = unset
+end_of_line = unset # TODO: remove when fixed
+insert_final_newline = unset # TODO: remove when fixed
+# TODO: To enable when files are fixed:
+# end_of_line = crlf
 
 # TODO: remove when .editorconfig is properly set up
 [mswindows/external/**]

--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,10 @@ indent_size = 2
 
 # Scripts
 [{*.sh,mswindows/osgeo4w/*config}]
+end_of_line = unset
+indent_size = unset
+
+[*.sh]
 end_of_line = lf
 indent_size = 4
 
@@ -94,7 +98,7 @@ insert_final_newline = unset
 trim_trailing_whitespace = false
 
 [mswindows/{generic.manifest,Installer-Files/*.url}]
-end_of_line = crlf
+end_of_line = unset
 
 # Binary files
 [**/PERMANENT/vector/*/{cidx,coor,sidx,topo}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,10 @@ indent_size = 4
 [*.{bat,cmd,ps1}{.tmpl,}]
 end_of_line = crlf
 
+# TODO: remove when fixed
+[mswindows/{osgeo4w/,}*.{bat}{.tmpl,}]
+end_of_line = unset
+
 [*.{c,h,cpp,hpp}]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -36,12 +36,12 @@ indent_size = 4
 end_of_line = crlf
 
 # TODO: remove when fixed
-[mswindows/osgeo4w/*.{bat}{.tmpl,}]
+[mswindows/GRASS-Packager.bat.tmpl]
 end_of_line = unset
 insert_final_newline = unset
 
 # TODO: remove when fixed
-[mswindows/*.{bat}{.tmpl,}]
+[mswindows/osgeo4w/*.{bat,bat.tmpl}]
 end_of_line = unset
 insert_final_newline = unset
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,11 @@ indent_size = 2
 [{*.sh,mswindows/osgeo4w/*config}]
 end_of_line = unset
 indent_size = unset
+# TODO: To enable when files are fixed:
+# end_of_line = lf
+# indent_size = 4
 
+# TODO: remove when the previous section is fixed
 [*.sh]
 end_of_line = lf
 indent_size = 4
@@ -108,7 +112,6 @@ insert_final_newline = unset
 trim_trailing_whitespace = false
 
 [mswindows/{generic.manifest,Installer-Files/*.url}]
-#trim_trailing_whitespace = unset
 end_of_line = unset # TODO: remove when fixed
 insert_final_newline = unset # TODO: remove when fixed
 # TODO: To enable when files are fixed:

--- a/.editorconfig
+++ b/.editorconfig
@@ -105,11 +105,14 @@ insert_final_newline = unset
 
 # TODO: remove when .editorconfig is properly set up
 [mswindows/**]
-# trim_trailing_whitespace = unset
 end_of_line = unset
 insert_final_newline = unset
 
-# TODO: remove when fixed:
+# TODO: remove when fixed
+[mswindows/external/rbatch/*.bat]
+trim_trailing_whitespace = unset
+
+# TODO: remove when fixed
 [.github/workflows/*.bat]
 end_of_line = unset
 insert_final_newline = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -104,7 +104,7 @@ charset = unset
 insert_final_newline = unset
 
 # TODO: remove when .editorconfig is properly set up
-[mswindows/*]
+[mswindows/**]
 trim_trailing_whitespace = unset
 end_of_line = unset
 charset = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -100,11 +100,9 @@ trim_trailing_whitespace = false
 [mswindows/{generic.manifest,Installer-Files/*.url}]
 #trim_trailing_whitespace = unset
 end_of_line = unset
-#charset = unset
-#insert_final_newline = unset
 
 # TODO: remove when .editorconfig is properly set up
-[mswindows/**]
+[mswindows/external/**]
 end_of_line = unset
 insert_final_newline = unset
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -103,6 +103,17 @@ end_of_line = unset
 charset = unset
 insert_final_newline = unset
 
+# TODO: remove when .editorconfig is properly set up
+[mswindows/*]
+trim_trailing_whitespace = unset
+end_of_line = unset
+charset = unset
+insert_final_newline = unset
+
+# TODO: remove when fixed:
+[.github/workflows/test_thorough.bat]
+insert_final_newline = unset
+
 # Binary files
 [**/PERMANENT/vector/*/{cidx,coor,sidx,topo}]
 trim_trailing_whitespace = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -98,10 +98,10 @@ insert_final_newline = unset
 trim_trailing_whitespace = false
 
 [mswindows/{generic.manifest,Installer-Files/*.url}]
-trim_trailing_whitespace = unset
+#trim_trailing_whitespace = unset
 end_of_line = unset
-charset = unset
-insert_final_newline = unset
+#charset = unset
+#insert_final_newline = unset
 
 # TODO: remove when .editorconfig is properly set up
 [mswindows/**]

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,7 +32,7 @@ indent_size = 4
 end_of_line = crlf
 
 # TODO: remove when fixed
-[mswindows/{osgeo4w,}/*.{bat}{.tmpl,}]
+[mswindows/{osgeo4w,*}/*.{bat}{.tmpl,}]
 end_of_line = unset
 insert_final_newline = unset
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -105,9 +105,8 @@ insert_final_newline = unset
 
 # TODO: remove when .editorconfig is properly set up
 [mswindows/**]
-trim_trailing_whitespace = unset
+# trim_trailing_whitespace = unset
 end_of_line = unset
-charset = unset
 insert_final_newline = unset
 
 # TODO: remove when fixed:

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,7 +32,12 @@ indent_size = 4
 end_of_line = crlf
 
 # TODO: remove when fixed
-[mswindows/{osgeo4w,*}/*.{bat}{.tmpl,}]
+[mswindows/osgeo4w/*.{bat}{.tmpl,}]
+end_of_line = unset
+insert_final_newline = unset
+
+# TODO: remove when fixed
+[mswindows/*.{bat}{.tmpl,}]
 end_of_line = unset
 insert_final_newline = unset
 

--- a/.github/workflows/.editorconfig
+++ b/.github/workflows/.editorconfig
@@ -1,3 +1,0 @@
-[*.sh]
-indent_style = space
-indent_size = 4

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -44,12 +44,6 @@ jobs:
               - '.yamllint'
               - 'pyproject.toml'
 
-      - name: Check for CRLF endings
-        uses: erclu/check-crlf@94acb86c2a41b0a46bd8087b63a06f0457dd0c6c # v1.2.0
-        with:
-          # Ignore all test data, Windows-specific directories and scripts.
-          exclude: mswindows .*\.bat .*/testsuite/data/.*
-
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -34,7 +34,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
+      - name: Install uv and restore its cache
+        uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
 
       - name: Check that files with the same content are the same
         run: |

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -72,4 +72,4 @@ jobs:
               ""
 
       - run: pip install pre-commit && pre-commit run -a
-        if: ${{ steps.changes.outputs.precommit == 'true' }}
+        # if: ${{ steps.changes.outputs.precommit == 'true' }}

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
 
       - name: Check that files with the same content are the same
         run: |
@@ -71,5 +72,13 @@ jobs:
               $(git rev-parse HEAD~30) \
               ""
 
-      - run: pip install pre-commit && pre-commit run -a
-        # if: ${{ steps.changes.outputs.precommit == 'true' }}
+      - name: "Run pre-commit"
+        run: |
+          echo '```console' > "$GITHUB_STEP_SUMMARY"
+          # Enable color output for pre-commit and remove it for the summary
+          # Use --hook-stage=manual to enable slower pre-commit hooks that are skipped by default
+          uvx pre-commit run --all-files --show-diff-on-failure --color=always --hook-stage=manual | \
+            tee >(sed -E 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGK]//g' >> "$GITHUB_STEP_SUMMARY") >&1
+          exit_code="${PIPESTATUS[0]}"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit "$exit_code"

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -71,6 +71,11 @@ jobs:
               ${{ github.ref_name }} \
               $(git rev-parse HEAD~30) \
               ""
+      - name: "Cache pre-commit"
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: "Run pre-commit"
         run: |

--- a/.github/workflows/additional_checks.yml
+++ b/.github/workflows/additional_checks.yml
@@ -30,20 +30,6 @@ jobs:
         with:
           fetch-depth: 31
 
-      - name: Check what files were changed
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes
-        with:
-          filters: |
-            precommit:
-              - '.clang-format'
-              - '.flake8'
-              - '.github/**'
-              - '.markdownlint.yml'
-              - '.pre-commit-config.yaml'
-              - '.yamllint'
-              - 'pyproject.toml'
-
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -51,6 +51,7 @@ jobs:
           VALIDATE_BASH_EXEC: true
           # VALIDATE_CSS: true
           # VALIDATE_DOCKER: true
+          VALIDATE_EDITORCONFIG: true
           VALIDATE_JAVASCRIPT_ES: true
           # VALIDATE_JAVASCRIPT_STANDARD: true
           VALIDATE_JSON: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,3 +74,7 @@ repos:
     rev: v1.37.1
     hooks:
       - id: yamllint
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker
+    rev: v3.3.0
+    hooks:
+      - id: editorconfig-checker


### PR DESCRIPTION
Simplified and adapted from  #4792.
Fixes https://github.com/OSGeo/grass/pull/6066#issuecomment-3075510813

The action that checks for CRLF has been failing since at least this weekend. I took a look this weekend, and since the action builds a docker image on the fly each time, we are affected if any of the services called during the image built are down.
Here, it was using an older Debian 10 (buster), and installed additional software. It seems that the package repository URLs are not available at the same location as before. Probably not removed, but some manual tweeking must be done to set the new URL. I couldn’t find an announcement or hints on when the change have been made. I didn’t see much other projects doing some changes to the install steps, but still found some.

Considering that that action has low chances of beeing fixed in a timely matter, I replaced the functionality with an .editorconfig file and editorconfig-checker. Compared to #4792, here I don’t attempt to make the line ending changes persist in the repo through .gitattributes, and ignore a bit more of non-ready config sections (since the functionality replaced was less detailed than what the .editorconfig I already had almost working).


I made the pre-commit run always, and made it faster in consequence to not add a big impact. With hot cache, it is taking 1min-1min10, which is about the same. I knew pre-commit could be faster in CI as I already saw how fast it was in ruff’s own CI when submitting one of my PRs there once. It can still be a bit faster, but it’s enough for today.