### PR TITLE
lib/parser: Use the first allowed in example

### DIFF
--- a/lib/gis/parser_md_cli.c
+++ b/lib/gis/parser_md_cli.c
@@ -194,12 +194,44 @@ void print_cli_example(FILE *file, const char *indent)
             if (opt->required || first_required_rule_option == opt) {
                 fprintf(file, " ");
                 fprintf(file, "%s=", opt->key);
+
+                char *value = NULL;
                 if (opt->answer) {
-                    fprintf(file, "%s", opt->answer);
+                    value = G_store(opt->answer);
+                }
+                else if (opt->options && opt->type == TYPE_STRING) {
+                    // Get example value from allowed values, but only for
+                    // strings because numbers may have ranges and we don't
+                    // want to print a range.
+                    // Get allowed values as tokens.
+                    char **tokens;
+                    char delm[2];
+                    delm[0] = ',';
+                    delm[1] = '\0';
+                    tokens = G_tokenize(opt->options, delm);
+                    // We are interested in the first allowed value.
+                    if (tokens[0]) {
+                        G_chop(tokens[0]);
+                        value = G_store(tokens[0]);
+                    }
+                    G_free_tokens(tokens);
+                }
+
+                if (value) {
+                    fprintf(file, "%s", value);
                 }
                 else {
-                    fprintf(file, "%s", type);
+                    if (opt->type == TYPE_INTEGER) {
+                        fprintf(file, "0");
+                    }
+                    else if (opt->type == TYPE_DOUBLE) {
+                        fprintf(file, "0.0");
+                    }
+                    else {
+                        fprintf(file, "%s", type);
+                    }
                 }
+                G_free(value);
             }
             opt = opt->next_opt;
         }

--- a/lib/gis/parser_md_python.c
+++ b/lib/gis/parser_md_python.c
@@ -287,15 +287,38 @@ void print_python_example(FILE *file, const char *python_function,
             if (opt->required || first_required_rule_option == opt ||
                 (strcmp(opt->key, "format") == 0 && output_format_default)) {
                 fprintf(file, ", %s=", opt->key);
+
+                char *value = NULL;
+                if (opt->answer) {
+                    value = G_store(opt->answer);
+                }
+                else if (opt->options && opt->type == TYPE_STRING) {
+                    // Get example value from allowed values, but only for
+                    // strings because numbers may have ranges and we don't
+                    // want to print a range.
+                    // Get allowed values as tokens.
+                    char **tokens;
+                    char delm[2];
+                    delm[0] = ',';
+                    delm[1] = '\0';
+                    tokens = G_tokenize(opt->options, delm);
+                    // We are interested in the first allowed value.
+                    if (tokens[0]) {
+                        G_chop(tokens[0]);
+                        value = G_store(tokens[0]);
+                    }
+                    G_free_tokens(tokens);
+                }
+
                 if (output_format_default && strcmp(opt->key, "format") == 0) {
                     fprintf(file, "\"%s\"", output_format_default);
                 }
-                else if (opt->answer) {
+                else if (value) {
                     if (opt->type == TYPE_INTEGER || opt->type == TYPE_DOUBLE) {
-                        fprintf(file, "%s", opt->answer);
+                        fprintf(file, "%s", value);
                     }
                     else {
-                        fprintf(file, "\"%s\"", opt->answer);
+                        fprintf(file, "\"%s\"", value);
                     }
                 }
                 else {
@@ -309,6 +332,7 @@ void print_python_example(FILE *file, const char *python_function,
                         fprintf(file, "\"%s\"", type);
                     }
                 }
+                G_free(value);
             }
             opt = opt->next_opt;
         }


### PR DESCRIPTION
In the generated example for each tool, use the first allowed value from the list of allowed values in the options field. This can be done for strings only because numbers may have ranges in the options field. Before, simply the type, i.e., string would be printed unless key_desc was defined. For r.series, this is replacing 'string' by 'average' as a value for method in the example.

Apply the same to Python and CLI and sync CLI to Python which adds the fallback number values to CLI example.
