### PR TITLE
r.mapcalc: remove static variables from mode and median to fix parallelization

### DIFF
--- a/lib/calc/xmedian.c
+++ b/lib/calc/xmedian.c
@@ -44,10 +44,10 @@ static int dcmp(const void *aa, const void *bb)
 
 int f_median(int argc, const int *argt, void **args)
 {
-    static void *array;
-    static int alloc;
     int size = argc * Rast_cell_size(argt[0]);
     int i, j;
+    const int threshold = 32;
+    bool use_heap = false;
 
     if (argc < 1)
         return E_ARG_LO;
@@ -56,16 +56,18 @@ int f_median(int argc, const int *argt, void **args)
         if (argt[i] != argt[0])
             return E_ARG_TYPE;
 
-    if (size > alloc) {
-        alloc = size;
-        array = G_realloc(array, size);
-    }
-
     switch (argt[0]) {
     case CELL_TYPE: {
+        CELL stack_array[threshold];
+        CELL *a = stack_array;
+
+        if (argc > threshold) {
+            a = G_malloc(size);
+            use_heap = true;
+        }
+
         CELL *res = args[0];
         CELL **argv = (CELL **)&args[1];
-        CELL *a = array;
         CELL *a1 = &a[(argc - 1) / 2];
         CELL *a2 = &a[argc / 2];
 
@@ -87,12 +89,22 @@ int f_median(int argc, const int *argt, void **args)
             }
         }
 
+        if (use_heap) {
+            G_free(a);
+        }
         return 0;
     }
     case FCELL_TYPE: {
+        FCELL stack_array[threshold];
+        FCELL *a = stack_array;
+
+        if (argc > threshold) {
+            a = G_malloc(size);
+            use_heap = true;
+        }
+
         FCELL *res = args[0];
         FCELL **argv = (FCELL **)&args[1];
-        FCELL *a = array;
         FCELL *a1 = &a[(argc - 1) / 2];
         FCELL *a2 = &a[argc / 2];
 
@@ -114,12 +126,22 @@ int f_median(int argc, const int *argt, void **args)
             }
         }
 
+        if (use_heap) {
+            G_free(a);
+        }
         return 0;
     }
     case DCELL_TYPE: {
+        DCELL stack_array[threshold];
+        DCELL *a = stack_array;
+
+        if (argc > threshold) {
+            a = G_malloc(size);
+            use_heap = true;
+        }
+
         DCELL *res = args[0];
         DCELL **argv = (DCELL **)&args[1];
-        DCELL *a = array;
         DCELL *a1 = &a[(argc - 1) / 2];
         DCELL *a2 = &a[argc / 2];
 
@@ -141,6 +163,9 @@ int f_median(int argc, const int *argt, void **args)
             }
         }
 
+        if (use_heap) {
+            G_free(a);
+        }
         return 0;
     }
     default:

--- a/lib/calc/xmedian.c
+++ b/lib/calc/xmedian.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include <grass/gis.h>
-#include <grass/raster.h>
 #include <grass/raster.h>
 #include <grass/calc.h>
 
@@ -9,6 +9,8 @@
 median(x1,x2,..,xn)
    return median of arguments
 **********************************************************************/
+
+#define SIZE_THRESHOLD 32
 
 static int icmp(const void *aa, const void *bb)
 {
@@ -46,7 +48,6 @@ int f_median(int argc, const int *argt, void **args)
 {
     int size = argc * Rast_cell_size(argt[0]);
     int i, j;
-    const int threshold = 32;
     bool use_heap = false;
 
     if (argc < 1)
@@ -58,10 +59,10 @@ int f_median(int argc, const int *argt, void **args)
 
     switch (argt[0]) {
     case CELL_TYPE: {
-        CELL stack_array[threshold];
+        CELL stack_array[SIZE_THRESHOLD];
         CELL *a = stack_array;
 
-        if (argc > threshold) {
+        if (argc > SIZE_THRESHOLD) {
             a = G_malloc(size);
             use_heap = true;
         }
@@ -95,10 +96,10 @@ int f_median(int argc, const int *argt, void **args)
         return 0;
     }
     case FCELL_TYPE: {
-        FCELL stack_array[threshold];
+        FCELL stack_array[SIZE_THRESHOLD];
         FCELL *a = stack_array;
 
-        if (argc > threshold) {
+        if (argc > SIZE_THRESHOLD) {
             a = G_malloc(size);
             use_heap = true;
         }
@@ -132,10 +133,10 @@ int f_median(int argc, const int *argt, void **args)
         return 0;
     }
     case DCELL_TYPE: {
-        DCELL stack_array[threshold];
+        DCELL stack_array[SIZE_THRESHOLD];
         DCELL *a = stack_array;
 
-        if (argc > threshold) {
+        if (argc > SIZE_THRESHOLD) {
             a = G_malloc(size);
             use_heap = true;
         }

--- a/lib/calc/xmode.c
+++ b/lib/calc/xmode.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include <grass/gis.h>
 #include <grass/raster.h>
@@ -8,6 +9,8 @@
 mode(x1,x2,..,xn)
    return mode of arguments
 **********************************************************************/
+
+#define SIZE_THRESHOLD 32
 
 static int dcmp(const void *aa, const void *bb)
 {
@@ -56,8 +59,7 @@ static double mode(double *value, int argc)
 
 int f_mode(int argc, const int *argt, void **args)
 {
-    const int threshold = 32;
-    double stack_value[threshold];
+    double stack_value[SIZE_THRESHOLD];
     double *value = stack_value;
     bool use_heap = false;
     int size = argc * sizeof(double);
@@ -70,7 +72,7 @@ int f_mode(int argc, const int *argt, void **args)
         if (argt[i] != argt[0])
             return E_ARG_TYPE;
 
-    if (argc > threshold) {
+    if (argc > SIZE_THRESHOLD) {
         value = G_malloc(size);
         use_heap = true;
     }

--- a/lib/calc/xnmedian.c
+++ b/lib/calc/xnmedian.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include <grass/gis.h>
 #include <grass/raster.h>
@@ -9,6 +10,8 @@
 median(x1,x2,..,xn)
    return median of arguments
 **********************************************************************/
+
+#define SIZE_THRESHOLD 32
 
 static int icmp(const void *aa, const void *bb)
 {
@@ -46,7 +49,6 @@ int f_nmedian(int argc, const int *argt, void **args)
 {
     int size = argc * Rast_cell_size(argt[0]);
     int i, j;
-    const int threshold = 32;
     bool use_heap = false;
 
     if (argc < 1)
@@ -58,10 +60,10 @@ int f_nmedian(int argc, const int *argt, void **args)
 
     switch (argt[0]) {
     case CELL_TYPE: {
-        CELL stack_array[threshold];
+        CELL stack_array[SIZE_THRESHOLD];
         CELL *a = stack_array;
 
-        if (argc > threshold) {
+        if (argc > SIZE_THRESHOLD) {
             a = G_malloc(size);
             use_heap = true;
         }
@@ -102,10 +104,10 @@ int f_nmedian(int argc, const int *argt, void **args)
     }
 
     case FCELL_TYPE: {
-        FCELL stack_array[threshold];
+        FCELL stack_array[SIZE_THRESHOLD];
         FCELL *a = stack_array;
 
-        if (argc > threshold) {
+        if (argc > SIZE_THRESHOLD) {
             a = G_malloc(size);
             use_heap = true;
         }
@@ -146,10 +148,10 @@ int f_nmedian(int argc, const int *argt, void **args)
     }
 
     case DCELL_TYPE: {
-        DCELL stack_array[threshold];
+        DCELL stack_array[SIZE_THRESHOLD];
         DCELL *a = stack_array;
 
-        if (argc > threshold) {
+        if (argc > SIZE_THRESHOLD) {
             a = G_malloc(size);
             use_heap = true;
         }

--- a/lib/calc/xnmedian.c
+++ b/lib/calc/xnmedian.c
@@ -44,10 +44,10 @@ static int dcmp(const void *aa, const void *bb)
 
 int f_nmedian(int argc, const int *argt, void **args)
 {
-    static void *array;
-    static int alloc;
     int size = argc * Rast_cell_size(argt[0]);
     int i, j;
+    const int threshold = 32;
+    bool use_heap = false;
 
     if (argc < 1)
         return E_ARG_LO;
@@ -56,16 +56,18 @@ int f_nmedian(int argc, const int *argt, void **args)
         if (argt[i] != argt[0])
             return E_ARG_TYPE;
 
-    if (size > alloc) {
-        alloc = size;
-        array = G_realloc(array, size);
-    }
-
     switch (argt[0]) {
     case CELL_TYPE: {
+        CELL stack_array[threshold];
+        CELL *a = stack_array;
+
+        if (argc > threshold) {
+            a = G_malloc(size);
+            use_heap = true;
+        }
+
         CELL *res = args[0];
         CELL **argv = (CELL **)&args[1];
-        CELL *a = array;
         CELL a1;
         CELL *resc;
 
@@ -93,12 +95,23 @@ int f_nmedian(int argc, const int *argt, void **args)
             }
         }
 
+        if (use_heap) {
+            G_free(a);
+        }
         return 0;
     }
+
     case FCELL_TYPE: {
+        FCELL stack_array[threshold];
+        FCELL *a = stack_array;
+
+        if (argc > threshold) {
+            a = G_malloc(size);
+            use_heap = true;
+        }
+
         FCELL *res = args[0];
         FCELL **argv = (FCELL **)&args[1];
-        FCELL *a = array;
         FCELL a1;
         FCELL *resc;
 
@@ -126,12 +139,23 @@ int f_nmedian(int argc, const int *argt, void **args)
             }
         }
 
+        if (use_heap) {
+            G_free(a);
+        }
         return 0;
     }
+
     case DCELL_TYPE: {
+        DCELL stack_array[threshold];
+        DCELL *a = stack_array;
+
+        if (argc > threshold) {
+            a = G_malloc(size);
+            use_heap = true;
+        }
+
         DCELL *res = args[0];
         DCELL **argv = (DCELL **)&args[1];
-        DCELL *a = array;
         DCELL a1;
         DCELL *resc;
 
@@ -159,8 +183,12 @@ int f_nmedian(int argc, const int *argt, void **args)
             }
         }
 
+        if (use_heap) {
+            G_free(a);
+        }
         return 0;
     }
+
     default:
         return E_INV_TYPE;
     }

--- a/lib/calc/xnmode.c
+++ b/lib/calc/xnmode.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include <grass/gis.h>
 #include <grass/raster.h>
@@ -8,6 +9,8 @@
 mode(x1,x2,..,xn)
    return mode of arguments
 **********************************************************************/
+
+#define SIZE_THRESHOLD 32
 
 static int dcmp(const void *aa, const void *bb)
 {
@@ -56,8 +59,7 @@ static double mode(double *value, int argc)
 
 int f_nmode(int argc, const int *argt, void **args)
 {
-    const int threshold = 32;
-    double stack_value[threshold];
+    double stack_value[SIZE_THRESHOLD];
     double *value = stack_value;
     bool use_heap = false;
     int size = argc * sizeof(double);
@@ -70,7 +72,7 @@ int f_nmode(int argc, const int *argt, void **args)
         if (argt[i] != argt[0])
             return E_ARG_TYPE;
 
-    if (argc > threshold) {
+    if (argc > SIZE_THRESHOLD) {
         value = G_malloc(size);
         use_heap = true;
     }

--- a/raster/r.mapcalc/testsuite/test_median_mode.py
+++ b/raster/r.mapcalc/testsuite/test_median_mode.py
@@ -26,12 +26,12 @@ class TestMedianMode(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        expression = "{o}=row()*col()".format(o=cls.input)
+        expression = f"{cls.input} = row()*col()"
         cls.use_temp_region()
         cls.runModule("g.region", n=3, s=0, e=3, w=0, res=1)
         cls.runModule("r.mapcalc", expression=expression, overwrite=True)
         cls.to_remove.append(cls.input)
-        expression = "{o}=null()".format(o=cls.input_null)
+        expression = f"{cls.input_null} = null()"
         cls.runModule("r.mapcalc", expression=expression, overwrite=True)
         cls.to_remove.append(cls.input_null)
 
@@ -46,9 +46,7 @@ class TestMedianMode(TestCase):
         )
 
     def test_median_cell(self):
-        expression = "{o} = median({i}, {i} + 1, {i} - 1, {i})".format(
-            o=self.output, i=self.input
-        )
+        expression = f"{self.output} = median({self.input}, {self.input} + 1, {self.input} - 1, {self.input})"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.to_remove.append(self.output)
@@ -57,9 +55,7 @@ class TestMedianMode(TestCase):
         )
 
     def test_median_dcell(self):
-        expression = "{o} = median(double({i}), double({i} + 1), double({i} - 1), double({i}))".format(
-            o=self.output, i=self.input
-        )
+        expression = f"{self.output} = median(double({self.input}), double({self.input} + 1), double({self.input} - 1), double({self.input}))"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.to_remove.append(self.output)
@@ -68,8 +64,8 @@ class TestMedianMode(TestCase):
         )
 
     def test_median_cell_many_numbers(self):
-        expression = "{o} = median({numbers})".format(
-            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        expression = (
+            f"{self.output} = median({','.join([str(n) for n in list(range(1, 50))])})"
         )
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
@@ -79,17 +75,13 @@ class TestMedianMode(TestCase):
         )
 
     def test_median_cell_many_numbers_null(self):
-        expression = "{o} = median({numbers}, null())".format(
-            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
-        )
+        expression = f"{self.output} = median({','.join([str(n) for n in list(range(1, 50))])}, null())"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.to_remove.append(self.output)
         self.assertRasterFitsUnivar(self.output, {"n": 0}, precision=1e-6)
 
-        expression = "{o} = nmedian({numbers}, null())".format(
-            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
-        )
+        expression = f"{self.output} = nmedian({','.join([str(n) for n in list(range(1, 50))])}, null())"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.assertRasterFitsUnivar(
@@ -97,9 +89,7 @@ class TestMedianMode(TestCase):
         )
 
     def test_mode_cell(self):
-        expression = "{o} = mode({i}, {i} + 1, {i} - 1, {i})".format(
-            o=self.output, i=self.input
-        )
+        expression = f"{self.output} = mode({self.input}, {self.input} + 1, {self.input} - 1, {self.input})"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.to_remove.append(self.output)
@@ -108,9 +98,7 @@ class TestMedianMode(TestCase):
         )
 
     def test_mode_dcell(self):
-        expression = "{o} = mode(double({i}), double({i} + 1), double({i} - 1), double({i}))".format(
-            o=self.output, i=self.input
-        )
+        expression = f"{self.output} = mode(double({self.input}), double({self.input} + 1), double({self.input} - 1), double({self.input}))"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.to_remove.append(self.output)
@@ -119,8 +107,8 @@ class TestMedianMode(TestCase):
         )
 
     def test_mode_cell_many_numbers(self):
-        expression = "{o} = mode(1, {numbers})".format(
-            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        expression = (
+            f"{self.output} = mode(1, {','.join([str(n) for n in list(range(1, 50))])})"
         )
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
@@ -130,17 +118,13 @@ class TestMedianMode(TestCase):
         )
 
     def test_mode_cell_many_numbers_null(self):
-        expression = "{o} = mode(1, {numbers}, null())".format(
-            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
-        )
+        expression = f"{self.output} = mode(1, {','.join([str(n) for n in list(range(1, 50))])}, null())"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.to_remove.append(self.output)
         self.assertRasterFitsUnivar(self.output, {"n": 0}, precision=1e-6)
 
-        expression = "{o} = nmode(1, {numbers}, null())".format(
-            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
-        )
+        expression = f"{self.output} = nmode(1, {','.join([str(n) for n in list(range(1, 50))])}, null())"
         self.assertModule("r.mapcalc", expression=expression, overwrite=True)
         self.assertRasterExists(self.output)
         self.assertRasterFitsUnivar(

--- a/raster/r.mapcalc/testsuite/test_median_mode.py
+++ b/raster/r.mapcalc/testsuite/test_median_mode.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+############################################################################
+#
+# MODULE:        test_median_mode.py
+# AUTHOR:        Anna Petrasova, based on Vaclav Petras test_row_above_below_bug.py
+# PURPOSE:       Test median, mode in r.mapcalc
+# COPYRIGHT:     (C) 2025 by Anna Petrasova and the GRASS Development Team
+#
+#                This program is free software under the GNU General Public
+#                License (>=v2). Read the file COPYING that comes with GRASS
+#                for details.
+#
+#############################################################################
+
+
+from grass.gunittest.case import TestCase
+from grass.gunittest.main import test
+
+
+class TestMedianMode(TestCase):
+    to_remove = []
+    input = "r_mapcalc_test_input"
+    input_null = "r_mapcalc_test_input_null"
+    output = "r_mapcalc_test_output"
+
+    @classmethod
+    def setUpClass(cls):
+        expression = "{o}=row()*col()".format(o=cls.input)
+        cls.use_temp_region()
+        cls.runModule("g.region", n=3, s=0, e=3, w=0, res=1)
+        cls.runModule("r.mapcalc", expression=expression, overwrite=True)
+        cls.to_remove.append(cls.input)
+        expression = "{o}=null()".format(o=cls.input_null)
+        cls.runModule("r.mapcalc", expression=expression, overwrite=True)
+        cls.to_remove.append(cls.input_null)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.del_temp_region()
+        cls.runModule(
+            "g.remove",
+            flags="f",
+            type="raster",
+            name=cls.to_remove,
+        )
+
+    def test_median_cell(self):
+        expression = "{o} = median({i}, {i} + 1, {i} - 1, {i})".format(
+            o=self.output, i=self.input
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRastersNoDifference(
+            actual=self.output, reference=self.input, precision=0
+        )
+
+    def test_median_dcell(self):
+        expression = "{o} = median(double({i}), double({i} + 1), double({i} - 1), double({i}))".format(
+            o=self.output, i=self.input
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRastersNoDifference(
+            actual=self.output, reference=self.input, precision=0
+        )
+
+    def test_median_cell_many_numbers(self):
+        expression = "{o} = median({numbers})".format(
+            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRasterFitsUnivar(
+            self.output, {"mean": 25, "range": 0}, precision=1e-6
+        )
+
+    def test_median_cell_many_numbers_null(self):
+        expression = "{o} = median({numbers}, null())".format(
+            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRasterFitsUnivar(self.output, {"n": 0}, precision=1e-6)
+
+        expression = "{o} = nmedian({numbers}, null())".format(
+            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.assertRasterFitsUnivar(
+            self.output, {"mean": 25, "range": 0}, precision=1e-6
+        )
+
+    def test_mode_cell(self):
+        expression = "{o} = mode({i}, {i} + 1, {i} - 1, {i})".format(
+            o=self.output, i=self.input
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRastersNoDifference(
+            actual=self.output, reference=self.input, precision=0
+        )
+
+    def test_mode_dcell(self):
+        expression = "{o} = mode(double({i}), double({i} + 1), double({i} - 1), double({i}))".format(
+            o=self.output, i=self.input
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRastersNoDifference(
+            actual=self.output, reference=self.input, precision=0
+        )
+
+    def test_mode_cell_many_numbers(self):
+        expression = "{o} = mode(1, {numbers})".format(
+            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRasterFitsUnivar(
+            self.output, {"mean": 1, "range": 0}, precision=1e-6
+        )
+
+    def test_mode_cell_many_numbers_null(self):
+        expression = "{o} = mode(1, {numbers}, null())".format(
+            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.to_remove.append(self.output)
+        self.assertRasterFitsUnivar(self.output, {"n": 0}, precision=1e-6)
+
+        expression = "{o} = nmode(1, {numbers}, null())".format(
+            o=self.output, numbers=",".join([str(n) for n in list(range(1, 50))])
+        )
+        self.assertModule("r.mapcalc", expression=expression, overwrite=True)
+        self.assertRasterExists(self.output)
+        self.assertRasterFitsUnivar(
+            self.output, {"mean": 1, "range": 0}, precision=1e-6
+        )
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
This is an attempt to get rid of static variables from the r.mapcalc functions for mode and median. The static variables were there I assume to not allocate for every row, but it complicates parallelization, see #5742. Since the size of the array is typically very small (the number of arguments of the median() or mode() function, can be raster or number), it will use array on stack and allocate only for larger sizes. 

I am not a C expert, but hopefully this makes sense.