### PR TITLE
chore: Update .gitignore to include some changes from grass-addons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.pyc
 OBJ.*
 locale/scriptstrings/*
+*.o
+*.tmp.html
 bin.*/*
 build
 /out/
@@ -46,7 +48,7 @@ daag*.s
 # notebook helper files
 .ipynb_checkpoints
 
-# python environment
+# Ignore Python virtual environment
 venv/
 env/
 .venv/


### PR DESCRIPTION
After comparing the .gitignore files from the main grass repo and the addons repo, I carried over some relevant exclusions here, notably the *.tmp.html exclusions, the whole point of this PR.

It is related to https://github.com/OSGeo/grass-addons/pull/1441, but in the other direction