### PR TITLE
CI(docs): Generate Programmer's Manual with Doxygen in CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Get dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y wget git gawk findutils doxygen graphviz gettext
+          sudo apt-get install -y wget git gawk findutils \
+            doxygen \
+            gettext \
+            graphviz \
+            libpq-dev
           xargs -a <(awk '! /^ *(#|$)/' "grass/.github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
 
@@ -112,6 +116,7 @@ jobs:
             --with-nls \
             --with-openmp \
             --with-pdal \
+            --with-postgres \
             --with-proj-share=/usr/share/proj \
             --with-pthread \
             --with-readline \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -120,7 +120,7 @@ jobs:
             --with-pdal \
             --with-postgres --with-postgres-includes=/usr/include/postgresql \
             --with-proj-share=/usr/share/proj \
-            --with-pthread \
+            --with-pthread=no \
             --with-readline \
             --with-sqlite \
             --with-tiff \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,8 @@ jobs:
             doxygen \
             gettext \
             graphviz \
-            libpq-dev
+            libpq-dev \
+            unixodbc-dev
           xargs -a <(awk '! /^ *(#|$)/' "grass/.github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
 
@@ -114,6 +115,7 @@ jobs:
             --with-libsvm \
             --with-netcdf \
             --with-nls \
+            --with-odbc \
             --with-openmp \
             --with-pdal \
             --with-postgres --with-postgres-includes=/usr/include/postgresql \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -95,7 +95,31 @@ jobs:
       - name: Build core
         run: |
           cd grass
-          ../grass/.github/workflows/build_ubuntu-22.04.sh "$HOME/install"
+          export INSTALL_PREFIX="$HOME/install"
+          ./configure \
+            --enable-largefile \
+            --prefix="$INSTALL_PREFIX/" \
+            --with-blas \
+            --with-bzlib \
+            --with-cxx \
+            --with-fftw \
+            --with-freetype \
+            --with-freetype-includes="/usr/include/freetype2/" \
+            --with-geos \
+            --with-lapack \
+            --with-libsvm \
+            --with-netcdf \
+            --with-nls \
+            --with-openmp \
+            --with-pdal \
+            --with-proj-share=/usr/share/proj \
+            --with-pthread \
+            --with-readline \
+            --with-sqlite \
+            --with-tiff \
+            --with-zstd
+          make
+          make install
 
       - name: Add the bin directory to PATH
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -131,13 +131,21 @@ jobs:
           cd grass
           make htmldocs
 
-      - name: Make the doxygen results available
+      - name: Make the doxygen results available (html)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: doxygen-site
           if-no-files-found: error
           path: |
             grass/html
+          retention-days: 3
+
+      - name: Make the doxygen results available (latex)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: doxygen-site-latex
+          if-no-files-found: error
+          path: |
             grass/latex
           retention-days: 3
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -121,7 +121,7 @@ jobs:
             --with-postgres --with-postgres-includes=/usr/include/postgresql \
             --with-proj-share=/usr/share/proj \
             --with-pthread=no \
-            --with-readline \
+            --with-readline=no \
             --with-sqlite \
             --with-tiff \
             --with-zstd

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -116,7 +116,7 @@ jobs:
             --with-nls \
             --with-openmp \
             --with-pdal \
-            --with-postgres \
+            --with-postgres --with-postgres-includes=/usr/include/postgresql \
             --with-proj-share=/usr/share/proj \
             --with-pthread \
             --with-readline \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -131,6 +131,16 @@ jobs:
           cd grass
           make htmldocs
 
+      - name: Make the doxygen results available
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: doxygen-site
+          if-no-files-found: error
+          path: |
+            grass/html
+            grass/latex
+          retention-days: 3
+
       - name: Build core
         run: |
           cd grass
@@ -148,16 +158,6 @@ jobs:
 
       - name: Test executing of the grass command
         run: ./grass/.github/workflows/test_simple.sh
-
-      - name: Make the doxygen results available
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: doxygen-site
-          if-no-files-found: error
-          path: |
-            grass/html
-            grass/latex
-          retention-days: 3
 
       - name: Compile addons
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -116,7 +116,7 @@ jobs:
             --with-netcdf \
             --with-nls \
             --with-odbc \
-            --with-openmp \
+            --with-openmp=no \
             --with-pdal \
             --with-postgres --with-postgres-includes=/usr/include/postgresql \
             --with-proj-share=/usr/share/proj \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "LD_LIBRARY_PATH=$HOME/install/lib" >> "$GITHUB_ENV"
 
-      - name: Build core
+      - name: Configure core
         run: |
           cd grass
           export INSTALL_PREFIX="$HOME/install"
@@ -123,6 +123,11 @@ jobs:
             --with-sqlite \
             --with-tiff \
             --with-zstd
+
+      - name: Build core
+        run: |
+          cd grass
+          export INSTALL_PREFIX="$HOME/install"
           make
           make install
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -105,7 +105,7 @@ jobs:
             --enable-largefile \
             --prefix="$INSTALL_PREFIX/" \
             --with-blas \
-            --with-bzlib \
+            --with-bzlib=no \
             --with-cxx \
             --with-fftw \
             --with-freetype \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           echo "LD_LIBRARY_PATH=$HOME/install/lib" >> "$GITHUB_ENV"
 
-      - name: Configure core
+      - name: Build core
         run: |
           cd grass
           export INSTALL_PREFIX="$HOME/install"
@@ -125,6 +125,19 @@ jobs:
             --with-sqlite \
             --with-tiff \
             --with-zstd
+          make
+          make install
+
+      - name: Add the bin directory to PATH
+        run: |
+          echo "$HOME/install/bin" >> "$GITHUB_PATH"
+
+      - name: Print installed versions
+        if: always()
+        run: ./grass/.github/workflows/print_versions.sh
+
+      - name: Test executing of the grass command
+        run: ./grass/.github/workflows/test_simple.sh
 
       - name: Build Programmer's Manual with doxygen
         run: |
@@ -148,25 +161,6 @@ jobs:
           path: |
             grass/latex
           retention-days: 3
-
-      - name: Build core
-        run: |
-          cd grass
-          export INSTALL_PREFIX="$HOME/install"
-          make
-          make install
-
-      - name: Add the bin directory to PATH
-        run: |
-          echo "$HOME/install/bin" >> "$GITHUB_PATH"
-
-      - name: Print installed versions
-        if: always()
-        run: ./grass/.github/workflows/print_versions.sh
-
-      - name: Test executing of the grass command
-        run: ./grass/.github/workflows/test_simple.sh
-
       - name: Compile addons
         run: |
           ./grass-addons/utils/cronjobs_osgeo_lxd/compile_addons_git.sh \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -124,6 +124,11 @@ jobs:
             --with-tiff \
             --with-zstd
 
+      - name: Build Programmer's Manual with doxygen
+        run: |
+          cd grass
+          make htmldocs
+
       - name: Build core
         run: |
           cd grass
@@ -141,11 +146,6 @@ jobs:
 
       - name: Test executing of the grass command
         run: ./grass/.github/workflows/test_simple.sh
-
-      - name: Build Programmer's Manual with doxygen
-        run: |
-          cd grass
-          make htmldocs
 
       - name: Make the doxygen results available
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -151,6 +151,8 @@ jobs:
           if-no-files-found: error
           path: |
             grass/html
+            !grass/html/**.map
+            !grass/html/**.md5
           retention-days: 3
 
       - name: Make the doxygen results available (latex)
@@ -160,6 +162,8 @@ jobs:
           if-no-files-found: error
           path: |
             grass/latex
+            !grass/latex/**.map
+            !grass/latex/**.md5
           retention-days: 3
       - name: Compile addons
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y wget git gawk findutils doxygen graphviz
+          sudo apt-get install -y wget git gawk findutils doxygen graphviz gettext
           xargs -a <(awk '! /^ *(#|$)/' "grass/.github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y wget git gawk findutils
+          sudo apt-get install -y wget git gawk findutils doxygen graphviz
           xargs -a <(awk '! /^ *(#|$)/' "grass/.github/workflows/apt.txt") -r -- \
               sudo apt-get install -y --no-install-recommends --no-install-suggests
 
@@ -107,6 +107,21 @@ jobs:
 
       - name: Test executing of the grass command
         run: ./grass/.github/workflows/test_simple.sh
+
+      - name: Build Programmer's Manual with doxygen
+        run: |
+          cd grass
+          make htmldocs
+
+      - name: Make the doxygen results available
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: doxygen-site
+          if-no-files-found: error
+          path: |
+            grass/html
+            grass/latex
+          retention-days: 3
 
       - name: Compile addons
         run: |


### PR DESCRIPTION
After having explored Doxygen a bit last week for potential improvements and upgrades, I asked @neteler last week to send me a snapshot of the doxygen-generated docs that are set up and published on the server. I wanted to have a true baseline of what the documentation workflow on the server was doing, in order to safely compare any improvements, such as upgrading the doxygen version to benefit from the numerous improvements in the past years, which aren't available in a distro's repos, especially an LTS version.

This PR does exactly this: Builds the doxygen docs in CI (previously never built in CI), and uploads an artifact that can be inspected and compared. The configure flags were changed to disable features with `--with-FEATURE=no` instead of `--without-FEATURE` or removing the line if not enabled by default. This is because these will be enabled back after this initial PR, but to keep the differences small with what is published on the server and what is built in CI with this PR.


The known and understood remaining differences with the snapshot of Monday Jul 14 2025:
- The bison/flex versions in CI is 3.8.2 instead of 3.7.5. The generated files for the sqlp SQL parser have some slight differences (like the source code copy).
- The changes in gjson made during the last week, like https://github.com/OSGeo/grass/pull/6053, that changes some line numbers
- The element order between uppercase and lowercase elements of the same string in the `globals_*.html` or `globals_defs_*.html`
- The files excluded from uploading in the artifact, `*.map` and `*.md5`, of the same base name of each image file made by DOT, as they are only used to avoid regenerating them, which isn't applicable in CI where a fresh copy is made (we wouldn't need to publish them anyways).
- Up to one pixel off plus slight different aliasing for most png graphs, due to a different compression, most probably different graphviz versions available on Ubuntu vs the Debian on the server.
- The commit hash present in every page's title:
  - With the `meld` tool, I'm using the following regex to ignore these lines: `8\.5\.0dev\(2025\)-[0-9|a-f]{10}`
- The build date+time of each specific page, shown in the footer:
  - With the `meld` tool, I'm using the following regex to ignore these lines: `\<li class="footer"\>Generated on \w\w\w \w\w\w \d\d? \d\d\d\d \d\d:\d\d:\d\d for GRASS GIS 8 Programmer&#39;s Manual by \<`
- The html map's area tags that have slightly different coordinates, because of some images have a 1px size difference:
  - With the `meld` tool, I'm using the following regex to ignore these lines: `^\<area shape=\"rect\" (?:href=\"(?:.*)\" )?(?:title=\"(?:.*)\" )?alt=\"(?:.*)\" coords=\"\d*,\d*,\d*,\d*\"/\>`
- The _formula.log file that is not present: No latex output yet, and was judged not important by Markus to have being built. The log on the server fails anyways, as shown by the formulas not rendered in html too like for G_meridional_radius_of_curvature() https://grass.osgeo.org/programming8/defs_2gis_8h.html#aed5d22663e0f04be62e0426c0ce827c3. To solve later, after having the baseline merged in.
  - <img height="300" alt="image" src="https://github.com/user-attachments/assets/a0cbc00c-0a84-49ef-a3d4-5dec31b51b0d" />
- Two generated search files not present anymore


The snapshot of the server cannot be uploaded here, as it is more than 25 MB (103 MB).


Once merged, the programmer's manual could be updated from the artifacts like the mkdocs site, as some upcoming changes probably won't be supported by the outdated Doxygen version previously used. Anyways, these programming docs should be distributed already built, and is not something that users need to build for compiling grass. There's way more benefits to having the best docs possible, instead of having every possible platform and setup being able to recreate our Doxygen docs website.

