### PR TITLE
chore: Add *.tmp.md to .gitignore to exclude temporary markdown files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,10 @@ grass.pc
 autom4te.cache/
 macos/cache/*
 
-# ignore specific file generated during make
+# Ignore temporary files used in htmldox, latexdox and pdfdox targets
+*.dox.org
+
+# Ignore specific files generated during make
 gui/wxpython/menustrings.py
 gui/wxpython/xml/menudata.xml
 gui/wxpython/xml/module_tree_menudata.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ OBJ.*
 locale/scriptstrings/*
 *.o
 *.tmp.html
+*.tmp.md
 bin.*/*
 build
 /out/


### PR DESCRIPTION
Follow-up from https://github.com/OSGeo/grass/pull/6090, analogous to https://github.com/OSGeo/grass-addons/pull/1442.

I noticed when building that there are now (since a couple of months) `*.tmp.md` files used when generating markdown docs, just like html docs were doing before.

This PR adds this pattern too to the .gitignore file.