### PR TITLE
CQ: Trim one trailing whitespace in python/grass/temporal/ply/lex.py

### DIFF
--- a/python/grass/temporal/ply/lex.py
+++ b/python/grass/temporal/ply/lex.py
@@ -714,7 +714,7 @@ class LexerReflect(object):
 #
 # Build all of the regular expression rules from definitions in the supplied module
 # -----------------------------------------------------------------------------
-def lex(*, module=None, object=None, debug=False, 
+def lex(*, module=None, object=None, debug=False,
         reflags=int(re.VERBOSE), debuglog=None, errorlog=None):
 
     global lexer


### PR DESCRIPTION
Since #5942 was last updated, we have changed the Additionnal Checks workflow, and the vendored copy of ply hadn't run with these new checks. There's one line with remaining trailing whitespace, so I'm just trimming it out here. So, this will clear the errors we see on main for all other PRs.