### PR TITLE
r3.info: Add test file

### DIFF
--- a/raster3d/r3.info/main.c
+++ b/raster3d/r3.info/main.c
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
         else
             G_fatal_error(_("Cannot allocate memory for string"));
 
-        if (G_asprintf(&line, "Location: %s", G_location()) > 0)
+        if (G_asprintf(&line, "Project: %s", G_location()) > 0)
             printline(line);
         else
             G_fatal_error(_("Cannot allocate memory for string"));

--- a/raster3d/r3.info/testsuite/test_r3_info.py
+++ b/raster3d/r3.info/testsuite/test_r3_info.py
@@ -36,7 +36,7 @@ class TestR3Info(TestCase):
             " +----------------------------------------------------------------------------+",
             " | Layer:    test_raster3d                  Date:                             |",
             " | Mapset:                                  Login of Creator:                 |",
-            " | Location:                                                                  |",
+            " | Project:                                                                  |",
             " | DataBase:                                                                  |",
             " | Title:    test_raster3d                                                    |",
             " | Units:    none                                                             |",
@@ -77,11 +77,11 @@ class TestR3Info(TestCase):
             " +----------------------------------------------------------------------------+",
             "",
         ]
-        # Skip exact match for lines containing "Location:", "Date:", "Login of Creator:",
+        # Skip exact match for lines containing "Project:", "Date:", "Login of Creator:",
         # "DataBase:" or "Mapset:" because their values vary
         for i, component in enumerate(result):
             if (
-                "Location:" in component
+                "Project:" in component
                 or "DataBase:" in component
                 or "Login of Creator:" in component
                 or "Date:" in component


### PR DESCRIPTION
ref: #5995 

This PR introduces a regression test suite for the `r3.info` module, ensuring that future changes—particularly the upcoming addition of JSON support—do not break existing behavior.

It also fixes a bug in flag handling: previously, combining `-r` and `-h` (`-rh`) produced range output in shell format but history output in plain format. Now, whenever the `-h` flag is used alongside `-g` or `-r`, the shell format will be applied otherwise, the plain format is used.
