### PR TITLE
grass.app: Use None as default value, hide os.environ

### DIFF
--- a/python/grass/app/runtime.py
+++ b/python/grass/app/runtime.py
@@ -31,7 +31,9 @@ class RuntimePaths:
     The resource paths are also set as environmental variables.
     """
 
-    def __init__(self, env=os.environ):
+    def __init__(self, env=None):
+        if env is None:
+            env = os.environ
         self.env = env
 
     @property


### PR DESCRIPTION
Use the same practice as elsewhere and hide os.environ inside the function using None as the default value in the function signature.

Fixes leaking of env vars into doc.

Fixes #6089
