### PR TITLE
i.oif: add test file

### DIFF
--- a/scripts/i.oif/testsuite/test_i_oif.py
+++ b/scripts/i.oif/testsuite/test_i_oif.py
@@ -1,8 +1,9 @@
+import os
+from pathlib import Path
+
 import grass.script as gs
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-import os
-from pathlib import Path
 
 
 class TestOIF(TestCase):


### PR DESCRIPTION
This PR introduces a regression test suite for the `i.oif` GRASS module. The tests are designed to validate the correctness, reproducibility, and formatting consistency of OIF calculations under synthetic, controlled input conditions.

### Tests Included:
- `test_oif_calculation_and_order`: Validates that OIF values are computed correctly and sorted in descending order for four synthetic input rasters with predictable spatial gradients. Serves as a stable regression benchmark for numerical outputs.
- `test_shell_script_style_output`: Checks that the `-g` flag produces correctly formatted shell-style output with compact comma-separated formatting. Ensures formatting logic does not regress.
- `test_serial_vs_parallel_consistency`: Verifies that running the module in serial mode (`-s`) yields the exact same results as the default parallel mode. Confirms deterministic computation regardless of execution strategy.
- `test_output_to_file`: Ensures that results are correctly written to a specified file using the `output` parameter. Confirms that the file format matches the default `stdout` output exactly.
- `test_constant_raster_yields_nan`: Confirms that any combination involving a constant raster yields `nan` (as expected due to zero variance), while all other combinations produce valid positive OIF values. Asserts numerical and formatting correctness.

Looking forward to feedback.