### PR TITLE
CQ: Trim newline between Doxygen docstring and function signature

### DIFF
--- a/db/drivers/odbc/table.c
+++ b/db/drivers/odbc/table.c
@@ -118,7 +118,6 @@
  * \param[in] name table name to drop
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_drop_table(dbString *name)
 {
     char cmd[200];

--- a/db/drivers/sqlite/create_table.c
+++ b/db/drivers/sqlite/create_table.c
@@ -25,7 +25,6 @@
  * \param[in] table
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_create_table(dbTable *table)
 {
     int col, ncols;

--- a/db/drivers/sqlite/describe.c
+++ b/db/drivers/sqlite/describe.c
@@ -34,7 +34,6 @@ static void get_column_info(sqlite3_stmt *statement, int col, int *litetype,
  * \param[in] table
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_describe_table(dbString *table_name, dbTable **table)
 {
     dbString sql;
@@ -110,7 +109,6 @@ int db__driver_describe_table(dbString *table_name, dbTable **table)
  * \param[in] c SQLite cursor. See NOTE.
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int describe_table(sqlite3_stmt *statement, dbTable **table, cursor *c)
 {
     int i, ncols, nkcols, ret;
@@ -295,7 +293,6 @@ static int dbmi_type(int litetype)
  * \param[in,out] litetype
  * \param[in,out] sqltype
  */
-
 static void get_column_info(sqlite3_stmt *statement, int col, int *litetype,
                             int *sqltype, int *length)
 {
@@ -339,7 +336,6 @@ static void get_column_info(sqlite3_stmt *statement, int col, int *litetype,
  *
  *   4. Otherwise, the affinity is NUMERIC.
  */
-
 static int affinity_type(const char *declared)
 {
     char *lc;

--- a/db/drivers/sqlite/execute.c
+++ b/db/drivers/sqlite/execute.c
@@ -28,7 +28,6 @@
  * \param[in] sql SQL statement
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_execute_immediate(dbString *sql)
 {
     char *s;
@@ -91,7 +90,6 @@ int db__driver_execute_immediate(dbString *sql)
  *
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_begin_transaction(void)
 {
     int ret;
@@ -117,7 +115,6 @@ int db__driver_begin_transaction(void)
  *
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_commit_transaction(void)
 {
     int ret;

--- a/db/drivers/sqlite/fetch.c
+++ b/db/drivers/sqlite/fetch.c
@@ -32,7 +32,6 @@
  * \param[in,out] more 1 = more data; 0 = no more data
  * \return int
  */
-
 int db__driver_fetch(dbCursor *cn, int position, int *more)
 {
     cursor *c;
@@ -238,7 +237,6 @@ int db__driver_fetch(dbCursor *cn, int position, int *more)
  * \param[in] cn open database cursor
  * \return int number of rows in table
  */
-
 int db__driver_get_num_rows(dbCursor *cn)
 {
     cursor *c;

--- a/db/drivers/sqlite/index.c
+++ b/db/drivers/sqlite/index.c
@@ -25,7 +25,6 @@
  * \param[in] index index to be created
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_create_index(dbIndex *index)
 {
     int i, ncols;

--- a/db/drivers/sqlite/listtab.c
+++ b/db/drivers/sqlite/listtab.c
@@ -29,7 +29,6 @@
  * \param[in] system
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_list_tables(dbString **tlist, int *tcount, int system)
 {
     int i, nrows;

--- a/db/drivers/sqlite/select.c
+++ b/db/drivers/sqlite/select.c
@@ -30,7 +30,6 @@
  * \param[in] mode
  * \return int DB_FAILED on error; DB_OK on success
  */
-
 int db__driver_open_select_cursor(dbString *sel, dbCursor *dbc, int mode)
 {
     cursor *c;

--- a/imagery/i.atcorr/computations.cpp
+++ b/imagery/i.atcorr/computations.cpp
@@ -168,8 +168,7 @@ double trunca()
   illustrate the way molecules and aerosols are mixed in a realistic atmosphere.
   For molecules, the scale height is 8km. For aerosols it is assumed to be 2km
   unless otherwise specified by the user (using aircraft measurements).
-*/
-
+ */
 double discre(const double ta, const double ha, const double tr,
               const double hr, const int it, const int ntd, const double yy,
               const double dd, const double ppp2, const double ppp1)

--- a/imagery/i.cluster/print3.c
+++ b/imagery/i.cluster/print3.c
@@ -6,7 +6,6 @@
 /*
  * safe to call only during checkpoint(1)
  */
-
 int print_seed_means(FILE *fd, struct Cluster *C)
 {
     int band;

--- a/imagery/i.ortho.photo/lib/error.c
+++ b/imagery/i.ortho.photo/lib/error.c
@@ -3,7 +3,6 @@
 /*
  * error: print error message and return 0
  */
-
 FILE *Bugs2;
 
 int error(char *s)

--- a/imagery/i.ortho.photo/lib/georef.c
+++ b/imagery/i.ortho.photo/lib/georef.c
@@ -35,7 +35,6 @@ static double determinant(double, double, double, double, double, double,
  *     | s2 s4 s5 |      | s2 s4 s5 |      | s2 s4 s5 |
  *
  */
-
 int I_compute_ref_equations(struct Ortho_Photo_Points *cp, double E12[3],
                             double N12[3], double E21[3], double N21[3])
 {

--- a/imagery/i.ortho.photo/lib/isnull.c
+++ b/imagery/i.ortho.photo/lib/isnull.c
@@ -8,7 +8,6 @@
 /*
  * isnull: returns 1 if matrix is null, else 0.
  */
-
 int isnull(MATRIX *a)
 {
     register int i, j, rows, cols;

--- a/imagery/i.ortho.photo/lib/m_add.c
+++ b/imagery/i.ortho.photo/lib/m_add.c
@@ -6,7 +6,6 @@
 /*
  * m_add: matrix addition (returns c = a + b)
  */
-
 int m_add(MATRIX *a, MATRIX *b, MATRIX *c)
 {
     register int nr, nc;

--- a/imagery/i.ortho.photo/lib/m_copy.c
+++ b/imagery/i.ortho.photo/lib/m_copy.c
@@ -4,7 +4,6 @@
 /*
  * m_copy: matrix equivalency (return a = b).
  */
-
 int m_copy(MATRIX *a, MATRIX *b)
 {
     register int r, c;

--- a/imagery/i.ortho.photo/lib/m_inverse.c
+++ b/imagery/i.ortho.photo/lib/m_inverse.c
@@ -12,7 +12,6 @@
  *  This routine is based on a routine found in Andrei Rogers, "Matrix
  *  Methods in Urban and Regional Analysis", (1971), pp. 143-153.
  */
-
 int inverse(MATRIX *a, MATRIX *b)
 {
     int i, j, k, l, ir = 0, ic = 0, nr, nc;

--- a/imagery/i.ortho.photo/lib/m_mult.c
+++ b/imagery/i.ortho.photo/lib/m_mult.c
@@ -6,7 +6,6 @@
 /*
  * m_mult: matrix multiplication (return c = a * b)
  */
-
 int m_mult(MATRIX *a, MATRIX *b, MATRIX *c)
 {
     register int i, j, k, nr, nc, ncols;

--- a/imagery/i.ortho.photo/lib/m_transpose.c
+++ b/imagery/i.ortho.photo/lib/m_transpose.c
@@ -5,7 +5,6 @@
 /*
  * transpose: returns arg2 as the transpose of arg1
  */
-
 int transpose(MATRIX *a, MATRIX *b)
 {
     register int i, j, nr, nc;

--- a/imagery/i.ortho.photo/lib/m_zero.c
+++ b/imagery/i.ortho.photo/lib/m_zero.c
@@ -3,7 +3,6 @@
 /*
  * zero: returns arg2 zero filled
  */
-
 int zero(MATRIX *a)
 {
     register int i, j;

--- a/imagery/i.smap/multialloc.c
+++ b/imagery/i.smap/multialloc.c
@@ -11,7 +11,6 @@
  * dimensions are stored in a list starting at d1. Each array element is
  * of size s.
  */
-
 char *multialloc(size_t s, /* individual array element size */
                  int d,    /* number of dimensions */
                  ...)

--- a/lib/bitmap/bitmap.c
+++ b/lib/bitmap/bitmap.c
@@ -54,7 +54,6 @@ static int Size = 1;
  *  \return pointer to struct BM
  *  \return NULL on error
  */
-
 struct BM *BM_create(int x, int y)
 {
     struct BM *map;
@@ -143,7 +142,6 @@ int BM_destroy(struct BM *map)
  *  \param size
  *  \return int
  */
-
 int BM_set_mode(int mode, int size)
 {
     int ret = 0;
@@ -181,7 +179,6 @@ int BM_set_mode(int mode, int size)
  *  \param val
  *  \return int
  */
-
 int BM_set(struct BM *map, int x, int y, int val)
 {
     unsigned char byte;
@@ -213,7 +210,6 @@ int BM_set(struct BM *map, int x, int y, int val)
  *  \param y
  *  \return int
  */
-
 int BM_get(struct BM *map, int x, int y)
 {
     unsigned char byte;
@@ -237,7 +233,6 @@ int BM_get(struct BM *map, int x, int y)
  *  \param map
  *  \return int
  */
-
 size_t BM_get_map_size(struct BM *map)
 {
     if (map->sparse)
@@ -260,7 +255,6 @@ size_t BM_get_map_size(struct BM *map)
  *  \param map
  *  \return int
  */
-
 int BM_file_write(FILE *fp, struct BM *map)
 {
     char c;
@@ -302,7 +296,6 @@ int BM_file_write(FILE *fp, struct BM *map)
  *  \param fp
  *  \return struct BM
  */
-
 struct BM *BM_file_read(FILE *fp)
 {
     struct BM *map;

--- a/lib/bitmap/sparse.c
+++ b/lib/bitmap/sparse.c
@@ -38,7 +38,6 @@ static int depth;
  *  \param y
  *  \return struct BM
  */
-
 struct BM *BM_create_sparse(int x, int y)
 {
     struct BM *map;
@@ -84,7 +83,6 @@ struct BM *BM_create_sparse(int x, int y)
  *  \param map
  *  \return int
  */
-
 int BM_destroy_sparse(struct BM *map)
 {
     int i;
@@ -121,7 +119,6 @@ int BM_destroy_sparse(struct BM *map)
  *  \param val
  *  \return int
  */
-
 int BM_set_sparse(struct BM *map, int x, int y, int val)
 {
     struct BMlink *p, *p2, *prev;
@@ -236,7 +233,6 @@ int BM_set_sparse(struct BM *map, int x, int y, int val)
  *  \param y
  *  \return int
  */
-
 int BM_get_sparse(struct BM *map, int x, int y)
 {
     struct BMlink *p;
@@ -261,7 +257,6 @@ int BM_get_sparse(struct BM *map, int x, int y)
  *  \param map
  *  \return int
  */
-
 size_t BM_get_map_size_sparse(struct BM *map)
 {
     int i;
@@ -290,7 +285,6 @@ size_t BM_get_map_size_sparse(struct BM *map)
  *  \param map
  *  \return int
  */
-
 int BM_dump_map_sparse(struct BM *map)
 {
     int i;
@@ -319,7 +313,6 @@ int BM_dump_map_sparse(struct BM *map)
  *  \param y
  *  \return int
  */
-
 int BM_dump_map_row_sparse(struct BM *map, int y)
 {
     int i;
@@ -350,7 +343,6 @@ int BM_dump_map_row_sparse(struct BM *map, int y)
  *  \param map
  *  \return int
  */
-
 int BM_file_write_sparse(FILE *fp, struct BM *map)
 {
     char c;

--- a/lib/cdhc/royston.c
+++ b/lib/cdhc/royston.c
@@ -8,7 +8,6 @@
  * W statistic to n=2000
  * needs as181.c as177.c as241.c Cdhc_dcmp.c as66.c
  */
-
 double *Cdhc_royston(double *x, int n)
 {
     static double y[2];

--- a/lib/datetime/between.c
+++ b/lib/datetime/between.c
@@ -4,7 +4,6 @@
  * This program is free software under the GPL (>=v2)
  * Read the file GPL.TXT coming with GRASS for details.
  */
-
 int datetime_is_between(int x, int a, int b)
 {
     if (a <= b)

--- a/lib/datetime/change.c
+++ b/lib/datetime/change.c
@@ -50,7 +50,6 @@ static void make_incr(DateTime *, int, int, DateTime *);
  *  \param round
  *  \return int
  */
-
 int datetime_change_from_to(DateTime *dt, int from, int to, int round)
 {
     DateTime dummy, incr;

--- a/lib/datetime/copy.c
+++ b/lib/datetime/copy.c
@@ -16,7 +16,6 @@
  *  \param src
  *  \return void
  */
-
 void datetime_copy(DateTime *dst, const DateTime *src)
 {
     memcpy(dst, src, sizeof(DateTime));

--- a/lib/datetime/diff.c
+++ b/lib/datetime/diff.c
@@ -75,7 +75,6 @@ static int _datetime_compare(const DateTime *, const DateTime *);
  *  \param result
  *  \return int
  */
-
 int datetime_difference(const DateTime *a, const DateTime *b, DateTime *result)
 {
     DateTime tb, ta, *early, *late;

--- a/lib/datetime/error.c
+++ b/lib/datetime/error.c
@@ -24,7 +24,6 @@ static char err_msg[1024];
  *  \param msg
  *  \return int
  */
-
 int datetime_error(int code, char *msg)
 {
     err_code = code;
@@ -42,7 +41,6 @@ int datetime_error(int code, char *msg)
  *
  *  \return int
  */
-
 int datetime_error_code(void)
 {
     return err_code;
@@ -55,7 +53,6 @@ int datetime_error_code(void)
  *
  *  \return char *
  */
-
 char *datetime_error_msg(void)
 {
     return err_msg;
@@ -68,7 +65,6 @@ char *datetime_error_msg(void)
  *
  *  \return void
  */
-
 void datetime_clear_error(void)
 {
     err_code = 0;

--- a/lib/datetime/format.c
+++ b/lib/datetime/format.c
@@ -22,7 +22,6 @@ static char *months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
  * \param buf
  * \return int
  */
-
 int datetime_format(const DateTime *dt, char *buf)
 {
     /* Format the DateTime structure as a human-readable string */

--- a/lib/datetime/incr1.c
+++ b/lib/datetime/incr1.c
@@ -64,7 +64,6 @@ static double _debug_decimal(DateTime * dt)
  *  \param incr
  *  \return int
  */
-
 int datetime_increment(DateTime *src, DateTime *incr)
 {
     int i, relfrom;
@@ -151,7 +150,6 @@ int datetime_increment(DateTime *src, DateTime *incr)
    already be minimized to allow borrowing from "lower" fields
 
  */
-
 static int _datetime_subtract_field(DateTime *src, DateTime *incr, int field)
 {
 

--- a/lib/datetime/incr2.c
+++ b/lib/datetime/incr2.c
@@ -16,7 +16,6 @@
  *  \param incr
  *  \return int
  */
-
 int datetime_is_valid_increment(const DateTime *src, const DateTime *incr)
 {
     return datetime_check_increment(src, incr) == 0;
@@ -54,7 +53,6 @@ int datetime_is_valid_increment(const DateTime *src, const DateTime *incr)
  *  \param incr
  *  \return int
  */
-
 int datetime_check_increment(const DateTime *src, const DateTime *incr)
 {
     if (!datetime_is_valid_type(src))

--- a/lib/datetime/incr3.c
+++ b/lib/datetime/incr3.c
@@ -37,7 +37,6 @@
  *  \param fracsec
  *  \return int
  */
-
 int datetime_get_increment_type(const DateTime *dt, int *mode, int *from,
                                 int *to, int *fracsec)
 {
@@ -80,7 +79,6 @@ int datetime_get_increment_type(const DateTime *dt, int *mode, int *from,
  *  \param incr
  *  \return int
  */
-
 int datetime_set_increment_type(const DateTime *src, DateTime *incr)
 {
     int mode, from, to, fracsec;

--- a/lib/datetime/local.c
+++ b/lib/datetime/local.c
@@ -25,7 +25,6 @@
  *  \param minutes
  *  \return int
  */
-
 int datetime_get_local_timezone(int *minutes)
 {
     struct tm *local, *gm;
@@ -78,7 +77,6 @@ int datetime_get_local_timezone(int *minutes)
  *  \param dt
  *  \return void
  */
-
 void datetime_get_local_time(DateTime *dt)
 {
     time_t clock;

--- a/lib/datetime/misc.c
+++ b/lib/datetime/misc.c
@@ -13,7 +13,6 @@
  *  \param ad
  *  \return int
  */
-
 int datetime_is_leap_year(int year, int ad)
 {
     if (year == 0)
@@ -35,7 +34,6 @@ int datetime_is_leap_year(int year, int ad)
  *  \param ad
  *  \return int
  */
-
 int datetime_days_in_year(int year, int ad)
 {
     if (year == 0)
@@ -57,7 +55,6 @@ int datetime_days_in_year(int year, int ad)
  *  \param ad
  *  \return int
  */
-
 int datetime_days_in_month(int year, int month, int ad)
 {
     static int days[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};

--- a/lib/datetime/same.c
+++ b/lib/datetime/same.c
@@ -18,7 +18,6 @@
  *  \param dst
  *  \return int
  */
-
 int datetime_is_same(const DateTime *src, const DateTime *dst)
 {
     /* WARNING: doesn't allow for padding */

--- a/lib/datetime/scan.c
+++ b/lib/datetime/scan.c
@@ -37,7 +37,6 @@ static int get_double(const char **, double *, int *, int *);
  *  \param buf
  *  \return int
  */
-
 int datetime_scan(DateTime *dt, const char *buf)
 {
     if (is_relative(buf)) {

--- a/lib/datetime/sign.c
+++ b/lib/datetime/sign.c
@@ -16,7 +16,6 @@
  *  \param dt
  *  \return int
  */
-
 int datetime_is_positive(const DateTime *dt)
 {
     return dt->positive != 0;
@@ -32,7 +31,6 @@ int datetime_is_positive(const DateTime *dt)
  *  \param dt
  *  \return int
  */
-
 int datetime_is_negative(const DateTime *dt)
 {
     return dt->positive == 0;
@@ -46,7 +44,6 @@ int datetime_is_negative(const DateTime *dt)
  *  \param dt
  *  \return void
  */
-
 void datetime_set_positive(DateTime *dt)
 {
     dt->positive = 1;
@@ -60,7 +57,6 @@ void datetime_set_positive(DateTime *dt)
  *  \param dt
  *  \return void
  */
-
 void datetime_set_negative(DateTime *dt)
 {
     dt->positive = 0;
@@ -72,7 +68,6 @@ void datetime_set_negative(DateTime *dt)
  *  \param dt
  *  \return void
  */
-
 void datetime_invert_sign(DateTime *dt)
 {
     dt->positive = !dt->positive;

--- a/lib/datetime/type.c
+++ b/lib/datetime/type.c
@@ -33,7 +33,6 @@
  *  \param fracsec
  *  \return int
  */
-
 int datetime_set_type(DateTime *dt, int mode, int from, int to, int fracsec)
 {
     dt->mode = mode;
@@ -74,7 +73,6 @@ int datetime_get_type(const DateTime *dt, int *mode, int *from, int *to,
  *  \param dt
  *  \return int
  */
-
 int datetime_is_valid_type(const DateTime *dt)
 {
     /* Returns 0 if DateTime structure is not valid. */
@@ -109,7 +107,6 @@ int datetime_is_valid_type(const DateTime *dt)
  *  \param dt
  *  \return int
  */
-
 int datetime_check_type(const DateTime *dt)
 {
     /* Returns 0 for a valid DateTime structure.
@@ -165,7 +162,6 @@ int datetime_in_interval_day_second(int x)
  *  \param dt
  *  \return int
  */
-
 int datetime_is_absolute(const DateTime *dt)
 {
     return (dt->mode == DATETIME_ABSOLUTE);
@@ -181,7 +177,6 @@ int datetime_is_absolute(const DateTime *dt)
  *  \param dt
  *  \return int
  */
-
 int datetime_is_relative(const DateTime *dt)
 {
     return (dt->mode == DATETIME_RELATIVE);

--- a/lib/datetime/tz1.c
+++ b/lib/datetime/tz1.c
@@ -20,7 +20,6 @@ static int have(int x, const DateTime *dt)
  *  \param minutes
  *  \return int
  */
-
 int datetime_check_timezone(const DateTime *dt, int minutes)
 {
     if (!datetime_is_absolute(dt))
@@ -42,7 +41,6 @@ int datetime_check_timezone(const DateTime *dt, int minutes)
  *  \param minutes
  *  \return int
  */
-
 int datetime_get_timezone(const DateTime *dt, int *minutes)
 {
     int stat;
@@ -63,7 +61,6 @@ int datetime_get_timezone(const DateTime *dt, int *minutes)
  *  \param minutes
  *  \return int
  */
-
 int datetime_set_timezone(DateTime *dt, int minutes)
 {
     int stat;
@@ -84,7 +81,6 @@ int datetime_set_timezone(DateTime *dt, int minutes)
  *  \param dt
  *  \return int
  */
-
 int datetime_unset_timezone(DateTime *dt)
 {
     dt->tz = -9999;
@@ -102,7 +98,6 @@ int datetime_unset_timezone(DateTime *dt)
  *  \param minutes
  *  \return int
  */
-
 int datetime_is_valid_timezone(int minutes)
 {
     return (minutes >= -720 && minutes <= 780);

--- a/lib/datetime/tz2.c
+++ b/lib/datetime/tz2.c
@@ -17,7 +17,6 @@
  *  \param minutes
  *  \return int
  */
-
 int datetime_change_timezone(DateTime *dt, int minutes)
 { /* new timezone in minutes */
     int stat;
@@ -55,7 +54,6 @@ int datetime_change_timezone(DateTime *dt, int minutes)
  *  \param dt
  *  \return int
  */
-
 int datetime_change_to_utc(DateTime *dt)
 {
     return datetime_change_timezone(dt, 0);
@@ -78,7 +76,6 @@ int datetime_change_to_utc(DateTime *dt)
  *  \param minutes
  *  \return void
  */
-
 void datetime_decompose_timezone(int tz, int *hours, int *minutes)
 {
     if (tz < 0)

--- a/lib/datetime/values.c
+++ b/lib/datetime/values.c
@@ -23,7 +23,6 @@ static int have(int x, const DateTime *dt)
  *  \param year
  *  \return int
  */
-
 int datetime_check_year(const DateTime *dt, int year)
 {
     if (!have(DATETIME_YEAR, dt))
@@ -48,7 +47,6 @@ int datetime_check_year(const DateTime *dt, int year)
  *  \param month
  *  \return int
  */
-
 int datetime_check_month(const DateTime *dt, int month)
 {
     if (!have(DATETIME_MONTH, dt))
@@ -83,7 +81,6 @@ int datetime_check_month(const DateTime *dt, int month)
  *  \param day
  *  \return int
  */
-
 int datetime_check_day(const DateTime *dt, int day)
 {
     int month, year, ad;
@@ -120,7 +117,6 @@ int datetime_check_day(const DateTime *dt, int day)
  *  \param hour
  *  \return int
  */
-
 int datetime_check_hour(const DateTime *dt, int hour)
 {
     if (!have(DATETIME_HOUR, dt))
@@ -145,7 +141,6 @@ int datetime_check_hour(const DateTime *dt, int hour)
  *  \param minute
  *  \return int
  */
-
 int datetime_check_minute(const DateTime *dt, int minute)
 {
     if (!have(DATETIME_MINUTE, dt))
@@ -170,7 +165,6 @@ int datetime_check_minute(const DateTime *dt, int minute)
  *  \param second
  *  \return int
  */
-
 int datetime_check_second(const DateTime *dt, double second)
 {
     if (!have(DATETIME_SECOND, dt))
@@ -195,7 +189,6 @@ int datetime_check_second(const DateTime *dt, double second)
  *  \param fracsec
  *  \return int
  */
-
 int datetime_check_fracsec(const DateTime *dt, int fracsec)
 {
     if (!have(DATETIME_SECOND, dt))
@@ -214,7 +207,6 @@ int datetime_check_fracsec(const DateTime *dt, int fracsec)
  *  \param year
  *  \return int
  */
-
 int datetime_get_year(const DateTime *dt, int *year)
 {
     int stat;
@@ -237,7 +229,6 @@ int datetime_get_year(const DateTime *dt, int *year)
  *  \param year
  *  \return int
  */
-
 int datetime_set_year(DateTime *dt, int year)
 {
     int stat;
@@ -261,7 +252,6 @@ int datetime_set_year(DateTime *dt, int year)
  *  \param month
  *  \return int
  */
-
 int datetime_get_month(const DateTime *dt, int *month)
 {
     int stat;
@@ -284,7 +274,6 @@ int datetime_get_month(const DateTime *dt, int *month)
  *  \param month
  *  \return int
  */
-
 int datetime_set_month(DateTime *dt, int month)
 {
     int stat;
@@ -308,7 +297,6 @@ int datetime_set_month(DateTime *dt, int month)
  *  \param day
  *  \return int
  */
-
 int datetime_get_day(const DateTime *dt, int *day)
 {
     int stat;
@@ -336,7 +324,6 @@ int datetime_get_day(const DateTime *dt, int *day)
  *  \param day
  *  \return int
  */
-
 int datetime_set_day(DateTime *dt, int day)
 {
     int stat;
@@ -357,7 +344,6 @@ int datetime_set_day(DateTime *dt, int day)
  *  \param hour
  *  \return int
  */
-
 int datetime_get_hour(const DateTime *dt, int *hour)
 {
     int stat;
@@ -378,7 +364,6 @@ int datetime_get_hour(const DateTime *dt, int *hour)
  *  \param hour
  *  \return int
  */
-
 int datetime_set_hour(DateTime *dt, int hour)
 {
     int stat;
@@ -399,7 +384,6 @@ int datetime_set_hour(DateTime *dt, int hour)
  *  \param minute
  *  \return int
  */
-
 int datetime_get_minute(const DateTime *dt, int *minute)
 {
     int stat;
@@ -420,7 +404,6 @@ int datetime_get_minute(const DateTime *dt, int *minute)
  *  \param minute
  *  \return int
  */
-
 int datetime_set_minute(DateTime *dt, int minute)
 {
     int stat;
@@ -441,7 +424,6 @@ int datetime_set_minute(DateTime *dt, int minute)
  *  \param second
  *  \return int
  */
-
 int datetime_get_second(const DateTime *dt, double *second)
 {
     int stat;
@@ -462,7 +444,6 @@ int datetime_get_second(const DateTime *dt, double *second)
  *  \param second
  *  \return int
  */
-
 int datetime_set_second(DateTime *dt, double second)
 {
     int stat;
@@ -483,7 +464,6 @@ int datetime_set_second(DateTime *dt, double second)
  *  \param fracsec
  *  \return int
  */
-
 int datetime_get_fracsec(const DateTime *dt, int *fracsec)
 {
     int stat;
@@ -504,7 +484,6 @@ int datetime_get_fracsec(const DateTime *dt, int *fracsec)
  *  \param fracsec
  *  \return int
  */
-
 int datetime_set_fracsec(DateTime *dt, int fracsec)
 {
     int stat;

--- a/lib/db/stubs/close_cursor.c
+++ b/lib/db/stubs/close_cursor.c
@@ -4,7 +4,6 @@
 /*!
    This function calls db_procedure_not_implemented().
  */
-
 int db__driver_close_cursor(dbCursor *cursor UNUSED)
 {
     db_procedure_not_implemented("db_close_cursor");

--- a/lib/display/cnversions.c
+++ b/lib/display/cnversions.c
@@ -383,7 +383,6 @@ void D_get_d(double x[2][2])
  *  \param D_row y
  *  \return double
  */
-
 double D_d_to_a_row(double D_row)
 {
     return A.north + (D_row - D.north) * D_to_A_conv.y;
@@ -398,7 +397,6 @@ double D_d_to_a_row(double D_row)
  *  \param D_col x
  *  \return double
  */
-
 double D_d_to_a_col(double D_col)
 {
     return A.west + (D_col - D.west) * D_to_A_conv.x;
@@ -413,7 +411,6 @@ double D_d_to_a_col(double D_col)
  *  \param D_row y
  *  \return double
  */
-
 double D_d_to_u_row(double D_row)
 {
     return U.north + (D_row - D.north) / U_to_D_conv.y;
@@ -428,7 +425,6 @@ double D_d_to_u_row(double D_row)
  *  \param D_col x
  *  \return double
  */
-
 double D_d_to_u_col(double D_col)
 {
     return U.west + (D_col - D.west) / U_to_D_conv.x;
@@ -443,7 +439,6 @@ double D_d_to_u_col(double D_col)
  *  \param A_row row
  *  \return double
  */
-
 double D_a_to_u_row(double A_row)
 {
     return U.north + (A_row - A.north) * A_to_U_conv.y;
@@ -459,7 +454,6 @@ double D_a_to_u_row(double A_row)
  *  \param A_col column
  *  \return double
  */
-
 double D_a_to_u_col(double A_col)
 {
     return U.west + (A_col - A.west) * A_to_U_conv.x;
@@ -474,7 +468,6 @@ double D_a_to_u_col(double A_col)
  *  \param A_row row
  *  \return double
  */
-
 double D_a_to_d_row(double A_row)
 {
     return D.north + (A_row - A.north) / D_to_A_conv.y;
@@ -490,7 +483,6 @@ double D_a_to_d_row(double A_row)
  *  \param A_col column
  *  \return double
  */
-
 double D_a_to_d_col(double A_col)
 {
     return D.west + (A_col - A.west) / D_to_A_conv.x;
@@ -505,7 +497,6 @@ double D_a_to_d_col(double A_col)
  *  \param U_row north
  *  \return double
  */
-
 double D_u_to_d_row(double U_row)
 {
     return D.north + (U_row - U.north) * U_to_D_conv.y;
@@ -520,7 +511,6 @@ double D_u_to_d_row(double U_row)
  *  \param U_col east
  *  \return double
  */
-
 double D_u_to_d_col(double U_col)
 {
     return D.west + (U_col - U.west) * U_to_D_conv.x;
@@ -535,7 +525,6 @@ double D_u_to_d_col(double U_col)
  *  \param U_row north
  *  \return double
  */
-
 double D_u_to_a_row(double U_row)
 {
     return A.north + (U_row - U.north) / A_to_U_conv.y;
@@ -550,7 +539,6 @@ double D_u_to_a_row(double U_row)
  *  \param U_col east
  *  \return double
  */
-
 double D_u_to_a_col(double U_col)
 {
     return A.west + (U_col - U.west) / A_to_U_conv.x;

--- a/lib/display/draw2.c
+++ b/lib/display/draw2.c
@@ -147,7 +147,6 @@ static void reduce_path(struct path *dst, const struct path *src, double eps)
  *  \param l left
  *  \param r right
  */
-
 void D_set_clip(double t, double b, double l, double r)
 {
     clip.left = min(l, r);
@@ -166,7 +165,6 @@ void D_set_clip(double t, double b, double l, double r)
  *
  *  \param ~
  */
-
 void D_clip_to_map(void)
 {
     double t, b, l, r;

--- a/lib/display/r_raster.c
+++ b/lib/display/r_raster.c
@@ -277,7 +277,6 @@ void D_font_info(char ***list, int *count)
  *  \param[out] r right edge of clip window
  *  \return ~
  */
-
 void D_get_clip_window(double *t, double *b, double *l, double *r)
 {
     COM_Get_window(t, b, l, r);
@@ -295,7 +294,6 @@ void D_get_clip_window(double *t, double *b, double *l, double *r)
  *  \param r right edge of clip window
  *  \return ~
  */
-
 void D_set_clip_window(double t, double b, double l, double r)
 {
     if (t < frame.t)
@@ -321,7 +319,6 @@ void D_set_clip_window(double t, double b, double l, double r)
  *  \param[out] r right edge of frame
  *  \return ~
  */
-
 void D_get_frame(double *t, double *b, double *l, double *r)
 {
     *t = frame.t;
@@ -341,7 +338,6 @@ void D_get_frame(double *t, double *b, double *l, double *r)
  *  \param[out] r right edge of screen
  *  \return ~
  */
-
 void D_get_screen(double *t, double *b, double *l, double *r)
 {
     *t = screen.t;
@@ -359,7 +355,6 @@ void D_get_screen(double *t, double *b, double *l, double *r)
  *  \param ~
  *  \return ~
  */
-
 void D_set_clip_window_to_map_window(void)
 {
     D_set_clip_window(D_get_d_north(), D_get_d_south(), D_get_d_west(),
@@ -375,7 +370,6 @@ void D_set_clip_window_to_map_window(void)
  *  \param ~
  *  \return ~
  */
-
 void D_set_clip_window_to_screen_window(void)
 {
     COM_Set_window(frame.t, frame.b, frame.l, frame.r);

--- a/lib/display/raster2.c
+++ b/lib/display/raster2.c
@@ -84,7 +84,6 @@ int D_c_color(CELL cat, struct Colors *colors)
  *  \param colors
  *  \return int
  */
-
 int D_d_color(DCELL val, struct Colors *colors)
 {
     return D_color_of_type(&val, colors, DCELL_TYPE);

--- a/lib/display/symbol.c
+++ b/lib/display/symbol.c
@@ -146,7 +146,6 @@ static void symbol(const SYMBOL *Symb, double x0, double y0,
  *  \param fill_color  Fill color
  *  \return void
  */
-
 void D_symbol(const SYMBOL *Symb, double x0, double y0,
               const RGBA_Color *line_color, const RGBA_Color *fill_color)
 {

--- a/lib/display/tran_colr.c
+++ b/lib/display/tran_colr.c
@@ -30,7 +30,6 @@ static int nalloc;
  *  \param suggested_color_index
  *  \return int
  */
-
 static int translate_or_add_color(const char *str)
 {
     int num_names = G_num_standard_color_names();
@@ -101,7 +100,6 @@ static int translate_or_add_color(const char *str)
  *  \param none_acceptable
  *  \return int Returns a color number usable by D_use_color.
  */
-
 int D_parse_color(const char *str, int none_acceptable)
 {
     int color;
@@ -125,7 +123,6 @@ int D_parse_color(const char *str, int none_acceptable)
  *  \param str Color name as an ASCII string
  *  \return int
  */
-
 int D_translate_color(const char *str)
 {
     return D_parse_color(str, 0);
@@ -141,7 +138,6 @@ int D_translate_color(const char *str)
  *  \param color
  *  \return int
  */
-
 int D_use_color(int color)
 {
     if (color <= 0)

--- a/lib/dspf/cube_io.c
+++ b/lib/dspf/cube_io.c
@@ -22,7 +22,6 @@ static unsigned char Buffer[10000]; /* buffer for outputting data to file */
  **   BUT, this code will simply place a 0 in 1st byte, and send it on to
  *       lower routine that writes out compressed data.
  */
-
 int write_cube(Cube_data *Cube, /* array of poly info  by threshold */
                int cur_x, file_info *headfax)
 {

--- a/lib/gis/alloc.c
+++ b/lib/gis/alloc.c
@@ -28,7 +28,6 @@
  * \param line line number
  * \param n number of elements
  */
-
 void *G__malloc(const char *file, int line, size_t n)
 {
     void *buf;
@@ -69,7 +68,6 @@ void *G__malloc(const char *file, int line, size_t n)
  * \param m element size
  * \param n number of elements
  */
-
 void *G__calloc(const char *file, int line, size_t m, size_t n)
 {
     void *buf;
@@ -146,7 +144,6 @@ void *G__realloc(const char *file, int line, void *buf, size_t n)
  *
  * \param[in,out] buf buffer holding original data
  */
-
 void G_free(void *buf)
 {
     free(buf);

--- a/lib/gis/area.c
+++ b/lib/gis/area.c
@@ -42,7 +42,6 @@ static struct state *st = &state;
  * \return 1 if the projection is planimetric (ie. UTM or SP)
  * \return 2 if the projection is non-planimetric (ie. latitude-longitude)
  */
-
 int G_begin_cell_area_calculations(void)
 {
     double a, e2;

--- a/lib/gis/area_poly1.c
+++ b/lib/gis/area_poly1.c
@@ -62,7 +62,6 @@ static double Qbar(double x)
  * \param a semi-major axis
  * \param e2 ellipsoid eccentricity squared
  */
-
 void G_begin_ellipsoid_polygon_area(double a, double e2)
 {
     double e4, e6;

--- a/lib/gis/area_sphere.c
+++ b/lib/gis/area_sphere.c
@@ -65,7 +65,6 @@ double G_darea0_on_sphere(double lat)
  * \param[in] south
  * \return double
  */
-
 double G_area_for_zone_on_sphere(double north, double south)
 {
     return (G_darea0_on_sphere(north) - G_darea0_on_sphere(south));

--- a/lib/gis/ascii_chk.c
+++ b/lib/gis/ascii_chk.c
@@ -27,7 +27,6 @@
  * \param[in,out] string buffer to have non-ascii characters removed
  * \return
  */
-
 void G_ascii_check(char *string)
 {
     char *ptr1, *ptr2;

--- a/lib/gis/asprintf.c
+++ b/lib/gis/asprintf.c
@@ -37,7 +37,6 @@
  * \param ap
  * \return number of bytes written
  */
-
 int G_vasprintf(char **out, const char *fmt, va_list ap)
 {
 #ifdef HAVE_ASPRINTF
@@ -96,7 +95,6 @@ int G_asprintf(char **out, const char *fmt, ...)
  * \param ap
  * \return number of bytes written
  */
-
 int G_rasprintf(char **out, size_t *size, const char *fmt, ...)
 {
     va_list ap;

--- a/lib/gis/commas.c
+++ b/lib/gis/commas.c
@@ -32,7 +32,6 @@
  * \return 1 if no commas inserted
  * \return 0 if commas inserted
  */
-
 int G_insert_commas(char *buf)
 {
     char number[100];
@@ -81,7 +80,6 @@ int G_insert_commas(char *buf)
  * \param[in,out] buf string
  * \return
  */
-
 void G_remove_commas(char *buf)
 {
     char *b;

--- a/lib/gis/copy_dir.c
+++ b/lib/gis/copy_dir.c
@@ -66,7 +66,6 @@
  *
  * \return 0 if successful, otherwise 1
  */
-
 int G_recursive_copy(const char *src, const char *dst)
 {
     DIR *dirp;

--- a/lib/gis/done_msg.c
+++ b/lib/gis/done_msg.c
@@ -24,7 +24,6 @@
  * \param[in] msg string.  Cannot be NULL.
  * \return
  */
-
 void G_done_msg(const char *msg, ...)
 {
     char buffer[2000];

--- a/lib/gis/geodist.c
+++ b/lib/gis/geodist.c
@@ -46,7 +46,6 @@ static struct state *st = &state;
  * \param a semi-major axis in meters
  * \param e2 ellipsoid eccentricity
  */
-
 void G_begin_geodesic_distance(double a, double e2)
 {
     st->al = a;
@@ -65,7 +64,6 @@ void G_begin_geodesic_distance(double a, double e2)
  * \param lat1 first latitude
  * \return
  */
-
 void G_set_geodesic_distance_lat1(double lat1)
 {
     st->t1r = atan(st->boa * tan(Radians(lat1)));

--- a/lib/gis/get_projinfo.c
+++ b/lib/gis/get_projinfo.c
@@ -123,7 +123,6 @@ struct Key_Value *G_get_projepsg(void)
    \return pointer to WKT string
    \return NULL when WKT is not available for the current location
  */
-
 char *G_get_projwkt(void)
 {
     char *wktstring = NULL;
@@ -233,7 +232,6 @@ char *G_get_projwkt(void)
    \return pointer to srid string
    \return NULL when srid is not available for the current location
  */
-
 char *G_get_projsrid(void)
 {
     char *sridstring = NULL;

--- a/lib/gis/is.c
+++ b/lib/gis/is.c
@@ -46,7 +46,6 @@ static int test_path_file(const char *path, const char *file)
  * \return 1 The directory is GISBASE
  * \return 0 The directory is not GISBASE
  */
-
 int G_is_gisbase(const char *path)
 {
     return test_path_file(path, "etc/element_list");
@@ -59,7 +58,6 @@ int G_is_gisbase(const char *path)
  * \return 1 The directory is location
  * \return 0 The directory is not location
  */
-
 int G_is_location(const char *path)
 {
     return test_path_file(path, "PERMANENT/DEFAULT_WIND");
@@ -72,7 +70,6 @@ int G_is_location(const char *path)
  * \return 1 The directory is mapset
  * \return 0 The directory is not mapset
  */
-
 int G_is_mapset(const char *path)
 {
     return test_path_file(path, "WIND");

--- a/lib/gis/locale.c
+++ b/lib/gis/locale.c
@@ -62,7 +62,6 @@ void G_init_locale(void)
  * \param[in] msgid
  * \retval char * Pointer to string
  */
-
 char *G_gettext(const char *package NO_NLS_UNUSED, const char *msgid)
 {
 #if defined(HAVE_LIBINTL_H) && defined(USE_NLS)
@@ -83,7 +82,6 @@ char *G_gettext(const char *package NO_NLS_UNUSED, const char *msgid)
  * \param[in] n The number
  * \retval char * Pointer to string
  */
-
 char *G_ngettext(const char *package NO_NLS_UNUSED, const char *msgids,
                  const char *msgidp, unsigned long int n)
 {

--- a/lib/gis/lrand48.c
+++ b/lib/gis/lrand48.c
@@ -49,7 +49,6 @@ static int seeded;
  *
  * \param[in] seedval 32-bit integer used to seed the PRNG
  */
-
 void G_srand48(long seedval)
 {
     uint32 x = (uint32) * (unsigned long *)&seedval;
@@ -68,7 +67,6 @@ void G_srand48(long seedval)
  *
  * \return generated seed value passed to G_srand48()
  */
-
 long G_srand48_auto(void)
 {
     unsigned long seed;
@@ -132,7 +130,6 @@ static void G__next(void)
  *
  * \return the generated value
  */
-
 long G_lrand48(void)
 {
     uint32 r;
@@ -147,7 +144,6 @@ long G_lrand48(void)
  *
  * \return the generated value
  */
-
 long G_mrand48(void)
 {
     uint32 r;
@@ -162,7 +158,6 @@ long G_mrand48(void)
  *
  * \return the generated value
  */
-
 double G_drand48(void)
 {
     double r = 0.0;

--- a/lib/gis/mach_name.c
+++ b/lib/gis/mach_name.c
@@ -13,7 +13,6 @@
  * array is returned.
  *
  */
-
 const char *G__machine_name(void)
 {
     static int initialized;

--- a/lib/gis/make_loc.c
+++ b/lib/gis/make_loc.c
@@ -508,7 +508,6 @@ int G_compare_projections(const struct Key_Value *proj_info1,
    \return 0 success
    \return -1 error writing
  */
-
 int G_write_projwkt(const char *location_name, const char *wktstring)
 {
     FILE *fp;
@@ -560,7 +559,6 @@ int G_write_projwkt(const char *location_name, const char *wktstring)
    \return 0 success
    \return -1 error writing
  */
-
 int G_write_projsrid(const char *location_name, const char *sridstring)
 {
     FILE *fp;

--- a/lib/gis/mapcase.c
+++ b/lib/gis/mapcase.c
@@ -14,7 +14,6 @@
  *  \param string
  *  \return char
  */
-
 char *G_tolcase(char *string)
 {
     char *p;
@@ -42,7 +41,6 @@ char *G_tolcase(char *string)
  *  \param string
  *  \return char
  */
-
 char *G_toucase(char *string)
 {
     char *p;

--- a/lib/gis/mkstemp.c
+++ b/lib/gis/mkstemp.c
@@ -124,7 +124,6 @@ char *G_mktemp(char *template)
  *
  * \return file descriptor
  */
-
 int G_mkstemp(char *template, int flags, int mode)
 {
 
@@ -159,7 +158,6 @@ int G_mkstemp(char *template, int flags, int mode)
  *
  * \return FILE*
  */
-
 FILE *G_mkstemp_fp(char *template, int flags, int mode)
 {
     const char *fmode = ((flags & O_ACCMODE) == O_RDWR)

--- a/lib/gis/myname.c
+++ b/lib/gis/myname.c
@@ -27,7 +27,6 @@
  *
  * \return pointer to a string
  */
-
 char *G_myname(void)
 {
     char name[GNAME_MAX];

--- a/lib/gis/omp_threads.c
+++ b/lib/gis/omp_threads.c
@@ -21,7 +21,6 @@
     \param opt A nprocs Option struct to specify the number of threads
     \return the number of threads set up for OpenMP parallel computing
 */
-
 int G_set_omp_num_threads(struct Option *opt)
 {
     /* make sure Option is not null */

--- a/lib/gis/open.c
+++ b/lib/gis/open.c
@@ -145,7 +145,6 @@ static int G__open(const char *element, const char *name, const char *mapset,
    \return open file descriptor (int)
    \return -1 could not open
  */
-
 int G_open_new(const char *element, const char *name)
 {
     return G__open(element, name, G_mapset(), 1);
@@ -187,7 +186,6 @@ int G_open_old(const char *element, const char *name, const char *mapset)
    \return open file descriptor (int)
    \return -1 could not open
  */
-
 int G_open_update(const char *element, const char *name)
 {
     int fd;
@@ -215,7 +213,6 @@ int G_open_update(const char *element, const char *name)
    \return open file descriptor (FILE *)
    \return NULL on error
  */
-
 FILE *G_fopen_new(const char *element, const char *name)
 {
     int fd;

--- a/lib/gis/open_misc.c
+++ b/lib/gis/open_misc.c
@@ -108,7 +108,6 @@ static int G__open_misc(const char *dir, const char *element, const char *name,
  *  \param name
  *  \return int
  */
-
 int G_open_new_misc(const char *dir, const char *element, const char *name)
 {
     return G__open_misc(dir, element, name, G_mapset(), 1);
@@ -130,7 +129,6 @@ int G_open_new_misc(const char *dir, const char *element, const char *name)
  *  \param mapset
  *  \return int
  */
-
 int G_open_old_misc(const char *dir, const char *element, const char *name,
                     const char *mapset)
 {
@@ -151,7 +149,6 @@ int G_open_old_misc(const char *dir, const char *element, const char *name,
  *  \param name
  *  \return int
  */
-
 int G_open_update_misc(const char *dir, const char *element, const char *name)
 {
     int fd;
@@ -178,7 +175,6 @@ int G_open_update_misc(const char *dir, const char *element, const char *name)
  *  \param name
  *  \return FILE *
  */
-
 FILE *G_fopen_new_misc(const char *dir, const char *element, const char *name)
 {
     int fd;
@@ -205,7 +201,6 @@ FILE *G_fopen_new_misc(const char *dir, const char *element, const char *name)
  *  \param mapset
  *  \return FILE *
  */
-
 FILE *G_fopen_old_misc(const char *dir, const char *element, const char *name,
                        const char *mapset)
 {

--- a/lib/gis/overwrite.c
+++ b/lib/gis/overwrite.c
@@ -30,7 +30,6 @@
  * \return 1 if overwrite
  * \return 0 if not overwrite
  */
-
 int G_check_overwrite(int argc, char **argv)
 {
     const char *overstr;

--- a/lib/gis/parser.c
+++ b/lib/gis/parser.c
@@ -136,7 +136,6 @@ static const char *get_renamed_option(const char *);
  * prompting.
  *
  */
-
 void G_disable_interactive(void)
 {
     st->no_interactive = 1;

--- a/lib/gis/plot.c
+++ b/lib/gis/plot.c
@@ -174,7 +174,6 @@ void G_plot_where_xy(double east, double north, int *x, int *y)
  * \param east easting
  * \param north northing
  */
-
 void G_plot_where_en(int x, int y, double *east, double *north)
 {
     *east = G_adjust_easting(EAST(x), &st->window);
@@ -240,7 +239,6 @@ static void fastline(double x1, double y1, double x2, double y2)
  *   the output window (left, right, top, bottom) should already
  *   be adjusted for this: left=-0.5; right = window.cols-0.5;
  */
-
 static void slowline(double x1, double y1, double x2, double y2)
 {
     double dx, dy;

--- a/lib/gis/remove.c
+++ b/lib/gis/remove.c
@@ -40,7 +40,6 @@ static int G__remove(int misc, const char *dir, const char *element,
  * \return 1 if successful
  * \return -1 on error
  */
-
 int G_remove(const char *element, const char *name)
 {
     return G__remove(0, NULL, element, name);

--- a/lib/gis/rhumbline.c
+++ b/lib/gis/rhumbline.c
@@ -54,7 +54,6 @@ static struct state *st = &state;
  * \return 1 on success
  * \return 0 on error
  */
-
 int G_begin_rhumbline_equation(double lon1, double lat1, double lon2,
                                double lat2)
 {
@@ -93,7 +92,6 @@ int G_begin_rhumbline_equation(double lon1, double lat1, double lon2,
  * \param[in] lon longitude
  * \return double latitude in degrees
  */
-
 double G_rhumbline_lat_from_lon(double lon)
 {
     if (st->parallel)

--- a/lib/gis/short_way.c
+++ b/lib/gis/short_way.c
@@ -24,7 +24,6 @@
  * \param[in,out] east1 east (x) coordinate of first point
  * \param[in,out] east2 east (x) coordinate of second point
  */
-
 void G_shortest_way(double *east1, double *east2)
 {
     if (G_projection() == PROJECTION_LL) {

--- a/lib/gis/snprintf.c
+++ b/lib/gis/snprintf.c
@@ -38,7 +38,6 @@
  * \param[in] fmt
  * \return number of chars written
  */
-
 int G_snprintf(char *str, size_t size, const char *fmt, ...)
 {
     va_list ap;

--- a/lib/gis/spawn.c
+++ b/lib/gis/spawn.c
@@ -896,7 +896,6 @@ int G_vspawn_ex(const char *command, const char **args)
  * \return -1 on error
  * \return process status on success
  */
-
 int G_spawn_ex(const char *command, ...)
 {
     struct spawn sp;
@@ -918,7 +917,6 @@ int G_spawn_ex(const char *command, ...)
  * \return -1 on error
  * \return process status on success
  */
-
 int G_spawn(const char *command, ...)
 {
     const char *args[MAX_ARGS];

--- a/lib/gis/token.c
+++ b/lib/gis/token.c
@@ -175,7 +175,6 @@ char **tokenize(const char *buf, const char *delim, const char *inchar)
 
    \return number of tokens
  */
-
 int G_number_of_tokens(char **tokens)
 {
     int n;

--- a/lib/gis/units.c
+++ b/lib/gis/units.c
@@ -130,7 +130,6 @@ double G_meters_to_units_factor_sq(int units)
 
   \return 1 if True, 0 otherwise
  */
-
 int G_is_units_type_spatial(int units)
 {
     switch (units) {
@@ -162,7 +161,6 @@ int G_is_units_type_spatial(int units)
 
   \return 1 if True, 0 otherwise
  */
-
 int G_is_units_type_temporal(int units)
 {
     switch (units) {

--- a/lib/gis/user_config.c
+++ b/lib/gis/user_config.c
@@ -285,7 +285,6 @@ static char *_make_sublevels(const char *elems)
  * \param[in] item
  * \return Pointer to string path
  */
-
 char *G_rc_path(const char *element, const char *item)
 {
     size_t len;

--- a/lib/gis/view.c
+++ b/lib/gis/view.c
@@ -41,7 +41,6 @@ static int Suppress_warn = 0;
  * \param[in] b
  * \return
  */
-
 void G_3dview_warning(int b)
 {
     Suppress_warn = b ? 0 : 1;
@@ -54,7 +53,6 @@ void G_3dview_warning(int b)
  * \param[in] w
  * \return always returns 1
  */
-
 int G_get_3dview_defaults(struct G_3dview *v, struct Cell_head *w)
 {
     if (!v || !w)
@@ -159,7 +157,6 @@ int G_get_3dview_defaults(struct G_3dview *v, struct Cell_head *w)
  * \return 1 on success
  * \return -1 on error
  */
-
 int G_put_3dview(const char *fname, const struct G_3dview *View,
                  const struct Cell_head *Win)
 {
@@ -239,7 +236,6 @@ int G_put_3dview(const char *fname, const struct G_3dview *View,
  * \return 2 if <b>fname</b> was written with this version of routine
  * \return 0 if is older format (through 4.0)
  */
-
 int G_get_3dview(const char *fname, const char *mapset, struct G_3dview *View)
 {
     struct Cell_head curwin;

--- a/lib/gis/wind_2_box.c
+++ b/lib/gis/wind_2_box.c
@@ -27,7 +27,6 @@
  * \param[in] cols number of columns in box
  * \return
  */
-
 void G_adjust_window_to_box(const struct Cell_head *src, struct Cell_head *dst,
                             int rows, int cols)
 {

--- a/lib/gis/wind_in.c
+++ b/lib/gis/wind_in.c
@@ -21,7 +21,6 @@
  * \return int
  *
  */
-
 int G_point_in_region(double easting, double northing)
 {
     struct Cell_head window;
@@ -44,7 +43,6 @@ int G_point_in_region(double easting, double northing)
  * \return int
  *
  */
-
 int G_point_in_window(double easting, double northing,
                       const struct Cell_head *window)
 {

--- a/lib/gis/wind_limits.c
+++ b/lib/gis/wind_limits.c
@@ -29,7 +29,6 @@
  * \return 1 no change
  * \return 0 changed
  */
-
 int G_limit_east(double *east UNUSED, int proj UNUSED)
 {
     return 1;
@@ -49,7 +48,6 @@ int G_limit_east(double *east UNUSED, int proj UNUSED)
  * \return 1 no change
  * \return 0 changed
  */
-
 int G_limit_west(double *west UNUSED, int proj UNUSED)
 {
     return 1;
@@ -67,7 +65,6 @@ int G_limit_west(double *west UNUSED, int proj UNUSED)
  * \return 1 no change
  * \return 0 changed
  */
-
 int G_limit_north(double *north, int proj)
 {
     if (proj == PROJECTION_LL) {
@@ -96,7 +93,6 @@ int G_limit_north(double *north, int proj)
  * \return 1 no change
  * \return 0 changed
  */
-
 int G_limit_south(double *south, int proj)
 {
     if (proj == PROJECTION_LL) {

--- a/lib/gis/wind_overlap.c
+++ b/lib/gis/wind_overlap.c
@@ -31,7 +31,6 @@
  * \return 1 if box overlaps window
  * \return 0 if box does not overlap window
  */
-
 int G_window_overlap(const struct Cell_head *window, double N, double S,
                      double E, double W)
 {
@@ -76,7 +75,6 @@ int G_window_overlap(const struct Cell_head *window, double N, double S,
  * \param[in] W west
  * \return percentage of overlap
  */
-
 double G_window_percentage_overlap(const struct Cell_head *window, double N,
                                    double S, double E, double W)
 {

--- a/lib/gis/wr_cellhd.c
+++ b/lib/gis/wr_cellhd.c
@@ -24,7 +24,6 @@
  * \param[in] is_cellhd 1 cell header; 0 window
  * \return
  */
-
 void G__write_Cell_head(FILE *fd, const struct Cell_head *cellhd, int is_cellhd)
 {
     char buf[1024];
@@ -70,7 +69,6 @@ void G__write_Cell_head(FILE *fd, const struct Cell_head *cellhd, int is_cellhd)
  * \param[in] is_cellhd 1 cell header; 0 window
  * \return
  */
-
 void G__write_Cell_head3(FILE *fd, const struct Cell_head *cellhd,
                          int is_cellhd)
 {

--- a/lib/gis/writ_zeros.c
+++ b/lib/gis/writ_zeros.c
@@ -26,7 +26,6 @@
  * \param[in] n number of bytes to write
  * \return
  */
-
 void G_write_zeros(int fd, size_t n)
 {
     char zeros[1024];

--- a/lib/gis/zone.c
+++ b/lib/gis/zone.c
@@ -20,7 +20,6 @@
  *
  * \return int cartographic zone
  */
-
 int G_zone(void)
 {
     struct Cell_head window;

--- a/lib/gmath/blas_level_2.c
+++ b/lib/gmath/blas_level_2.c
@@ -338,7 +338,6 @@ void G_math_f_aAx_by(float **A, float *x, float *y, float a, float b, float *z,
  * \param rows (int)
  * \return int
  */
-
 int G_math_d_A_T(double **A, int rows)
 {
     int i, j;
@@ -372,7 +371,6 @@ int G_math_d_A_T(double **A, int rows)
  * \param rows (int)
  * \return int
  */
-
 int G_math_f_A_T(float **A, int rows)
 {
     int i, j;

--- a/lib/gmath/dalloc.c
+++ b/lib/gmath/dalloc.c
@@ -35,7 +35,6 @@
  * \param[in] n size of vector to allocate
  * \return double *
  */
-
 double *G_alloc_vector(size_t n)
 {
     return (double *)G_calloc(n, sizeof(double));
@@ -53,7 +52,6 @@ double *G_alloc_vector(size_t n)
  * \param[in] cols number of columns in matrix
  * \return double **
  */
-
 double **G_alloc_matrix(int rows, int cols)
 {
     double **m;
@@ -77,7 +75,6 @@ double **G_alloc_matrix(int rows, int cols)
  * \param[in] n size of vector to allocate
  * \return float *
  */
-
 float *G_alloc_fvector(size_t n)
 {
     return (float *)G_calloc(n, sizeof(float));
@@ -95,7 +92,6 @@ float *G_alloc_fvector(size_t n)
  *  \param[in] cols number of columns in matrix
  *  \return float **
  */
-
 float **G_alloc_fmatrix(int rows, int cols)
 {
     float **m;
@@ -119,7 +115,6 @@ float **G_alloc_fmatrix(int rows, int cols)
  *  \param[in,out] v vector to free
  *  \return void
  */
-
 void G_free_vector(double *v)
 {
     G_free(v);
@@ -138,7 +133,6 @@ void G_free_vector(double *v)
  *  \param[in,out] v vector to free
  *  \return void
  */
-
 void G_free_fvector(float *v)
 {
     G_free(v);
@@ -157,7 +151,6 @@ void G_free_fvector(float *v)
  *  \param[in,out] m matrix to free
  *  \return void
  */
-
 void G_free_matrix(double **m)
 {
     G_free(m[0]);
@@ -177,7 +170,6 @@ void G_free_matrix(double **m)
  *  \param[in,out] m matrix to free
  *  \return void
  */
-
 void G_free_fmatrix(float **m)
 {
     G_free(m[0]);

--- a/lib/gmath/del2g.c
+++ b/lib/gmath/del2g.c
@@ -39,7 +39,6 @@
  * \param w
  * \return int
  */
-
 int del2g(double *img[2], int size, double w)
 {
     double *g[2]; /* the filter function */

--- a/lib/gmath/fft.c
+++ b/lib/gmath/fft.c
@@ -61,7 +61,6 @@
  * \param[in] dimr Value of image row dimension (max power of 2)
  * \return int always returns 0
  */
-
 int fft2(int i_sign, double (*data)[2], int NN, int dimc, int dimr)
 {
 #ifdef HAVE_FFTW3_H
@@ -118,7 +117,6 @@ int fft2(int i_sign, double (*data)[2], int NN, int dimc, int dimr)
  * \param[in] dimr Value of image row dimension (max power of 2)
  * \return int always returns 0
  */
-
 int fft(int i_sign, double *DATA[2], int NN, int dimc, int dimr)
 {
     fftw_complex *data;

--- a/lib/gmath/findzc.c
+++ b/lib/gmath/findzc.c
@@ -49,7 +49,6 @@
  * \param[in] num_orients
  * \return int always returns 0
  */
-
 int G_math_findzc(double conv[], int size, double zc[], double thresh,
                   int num_orients)
 {

--- a/lib/gmath/gauss.c
+++ b/lib/gmath/gauss.c
@@ -12,7 +12,6 @@
  & \param[in] sigma
  * \return double
  */
-
 double G_math_rand_gauss(double sigma)
 {
     double x, y, r2;

--- a/lib/gmath/la.c
+++ b/lib/gmath/la.c
@@ -63,7 +63,6 @@ static int egcmp(const void *pa, const void *pb);
  * \param ldim
  * \return mat_struct
  */
-
 mat_struct *G_matrix_init(int rows, int cols, int ldim)
 {
     mat_struct *tmp_arry;
@@ -94,7 +93,6 @@ mat_struct *G_matrix_init(int rows, int cols, int ldim)
  * \param A
  * \return 0 on error; 1 on success
  */
-
 int G_matrix_zero(mat_struct *A)
 {
     if (!A->vals)
@@ -119,7 +117,6 @@ int G_matrix_zero(mat_struct *A)
  * \param ldim
  * \return int
  */
-
 int G_matrix_set(mat_struct *A, int rows, int cols, int ldim)
 {
     if (rows < 1 || cols < 1 || ldim < 0) {
@@ -149,7 +146,6 @@ int G_matrix_set(mat_struct *A, int rows, int cols, int ldim)
  * \param A
  * \return mat_struct
  */
-
 mat_struct *G_matrix_copy(const mat_struct *A)
 {
     mat_struct *B;
@@ -182,7 +178,6 @@ mat_struct *G_matrix_copy(const mat_struct *A)
  * \param mt2
  * \return mat_struct
  */
-
 mat_struct *G_matrix_add(mat_struct *mt1, mat_struct *mt2)
 {
     return G__matrix_add(mt1, mt2, 1, 1);
@@ -200,7 +195,6 @@ mat_struct *G_matrix_add(mat_struct *mt1, mat_struct *mt2)
  * \param mt2
  * \return mat_struct
  */
-
 mat_struct *G_matrix_subtract(mat_struct *mt1, mat_struct *mt2)
 {
     return G__matrix_add(mt1, mt2, 1, -1);
@@ -218,7 +212,6 @@ mat_struct *G_matrix_subtract(mat_struct *mt1, mat_struct *mt2)
  * \param A
  * \return mat_struct
  */
-
 mat_struct *G_matrix_scalar_mul(double scalar, mat_struct *matrix,
                                 mat_struct *out)
 {
@@ -261,7 +254,6 @@ mat_struct *G_matrix_scalar_mul(double scalar, mat_struct *matrix,
  * \param c
  * \return mat_struct
  */
-
 mat_struct *G_matrix_scale(mat_struct *mt1, const double c)
 {
     return G__matrix_add(mt1, NULL, c, 0);
@@ -282,7 +274,6 @@ mat_struct *G_matrix_scale(mat_struct *mt1, const double c)
  * \param c2
  * \return mat_struct
  */
-
 mat_struct *G__matrix_add(mat_struct *mt1, mat_struct *mt2, const double c1,
                           const double c2)
 {
@@ -355,7 +346,6 @@ mat_struct *G__matrix_add(mat_struct *mt1, mat_struct *mt2, const double c1,
  * \param mt2
  * \return mat_struct
  */
-
 mat_struct *G_matrix_product(mat_struct *mt1, mat_struct *mt2)
 {
     mat_struct *mt3;
@@ -404,7 +394,6 @@ mat_struct *G_matrix_product(mat_struct *mt1, mat_struct *mt2)
  * \param mt
  * \return mat_struct
  */
-
 mat_struct *G_matrix_transpose(mat_struct *mt)
 {
     mat_struct *mt1;
@@ -591,7 +580,6 @@ int G_matrix_LU_solve(const mat_struct *mt1, mat_struct **xmat0,
  * \param mt
  * \return mat_struct
  */
-
 mat_struct *G_matrix_inverse(mat_struct *mt)
 {
     mat_struct *mt0, *res;
@@ -645,7 +633,6 @@ mat_struct *G_matrix_inverse(mat_struct *mt)
  * \param mt
  * \return void
  */
-
 void G_matrix_free(mat_struct *mt)
 {
     if (mt->is_init)
@@ -664,7 +651,6 @@ void G_matrix_free(mat_struct *mt)
  *  \param mt
  *  \return void
  */
-
 void G_matrix_print(mat_struct *mt)
 {
     int i, j;
@@ -703,7 +689,6 @@ void G_matrix_print(mat_struct *mt)
  *  \param val
  *  \return int
  */
-
 int G_matrix_set_element(mat_struct *mt, int rowval, int colval, double val)
 {
     if (!mt->is_init) {
@@ -735,7 +720,6 @@ int G_matrix_set_element(mat_struct *mt, int rowval, int colval, double val)
  *  \param colval
  *  \return double
  */
-
 double G_matrix_get_element(mat_struct *mt, int rowval, int colval)
 {
     double val;
@@ -757,7 +741,6 @@ double G_matrix_get_element(mat_struct *mt, int rowval, int colval)
  * \param col
  * \return vec_struct
  */
-
 vec_struct *G_matvect_get_column(mat_struct *mt, int col)
 {
     int i; /* loop */
@@ -797,7 +780,6 @@ vec_struct *G_matvect_get_column(mat_struct *mt, int col)
  * \param row
  * \return vec_struct
  */
-
 vec_struct *G_matvect_get_row(mat_struct *mt, int row)
 {
     int i; /* loop */
@@ -839,7 +821,6 @@ vec_struct *G_matvect_get_row(mat_struct *mt, int row)
  * \param indx
  * \return int
  */
-
 int G_matvect_extract_vector(mat_struct *mt, vtype vt, int indx)
 {
     if (vt == RVEC && indx >= mt->rows) {
@@ -885,7 +866,6 @@ int G_matvect_extract_vector(mat_struct *mt, vtype vt, int indx)
  *  \param vc
  *  \return int
  */
-
 int G_matvect_retrieve_matrix(vec_struct *vc)
 {
     /* We have to take the integrity of the vector structure
@@ -910,7 +890,6 @@ int G_matvect_retrieve_matrix(vec_struct *vc)
  * \param b
  * \return vec_struct
  */
-
 vec_struct *G_matvect_product(mat_struct *A, vec_struct *b, vec_struct *out)
 {
     unsigned int i, m, n, j;
@@ -964,7 +943,6 @@ vec_struct *G_matvect_product(mat_struct *A, vec_struct *b, vec_struct *out)
  * \param vt
  * \return vec_struct
  */
-
 vec_struct *G_vector_init(int cells, int ldim, vtype vt)
 {
     vec_struct *tmp_arry;
@@ -1009,7 +987,6 @@ vec_struct *G_vector_init(int cells, int ldim, vtype vt)
  * \param v
  * \return void
  */
-
 void G_vector_free(vec_struct *v)
 {
     if (v->is_init)
@@ -1032,7 +1009,6 @@ void G_vector_free(vec_struct *v)
  * \param out
  * \return vec_struct
  */
-
 vec_struct *G_vector_sub(vec_struct *v1, vec_struct *v2, vec_struct *out)
 {
     int idx1, idx2, idx0;
@@ -1107,7 +1083,6 @@ vec_struct *G_vector_sub(vec_struct *v1, vec_struct *v2, vec_struct *out)
  * \param vindx
  * \return int
  */
-
 int G_vector_set(vec_struct *A, int cells, int ldim, vtype vt, int vindx)
 {
     if ((cells < 1) || (vt == RVEC && ldim < 1) ||
@@ -1156,7 +1131,6 @@ int G_vector_set(vec_struct *A, int cells, int ldim, vtype vt, int vindx)
  * \param vc
  * \return double
  */
-
 double G_vector_norm_euclid(vec_struct *vc)
 {
     int incr, Nval;
@@ -1202,7 +1176,6 @@ double G_vector_norm_euclid(vec_struct *vc)
  * \param vflag
  * \return double
  */
-
 double G_vector_norm_maxval(vec_struct *vc, int vflag)
 {
     double xval, *startpt, *curpt;
@@ -1273,7 +1246,6 @@ double G_vector_norm_maxval(vec_struct *vc, int vflag)
  * \param vc
  * \return double
  */
-
 double G_vector_norm1(vec_struct *vc)
 {
     double result = 0.0;
@@ -1312,7 +1284,6 @@ double G_vector_norm1(vec_struct *vc)
  * \param out Output vector
  * \return vec_struct
  */
-
 vec_struct *G_vector_product(vec_struct *v1, vec_struct *v2, vec_struct *out)
 {
     int idx1, idx2, idx0;
@@ -1380,7 +1351,6 @@ vec_struct *G_vector_product(vec_struct *v1, vec_struct *v2, vec_struct *out)
  * \param comp_flag
  * \return vec_struct
  */
-
 vec_struct *G_vector_copy(const vec_struct *vc1, int comp_flag)
 {
     vec_struct *tmp_arry;
@@ -1492,7 +1462,6 @@ vec_struct *G_vector_copy(const vec_struct *vc1, int comp_flag)
  * \param out
  * \return int
  */
-
 int G_matrix_read(FILE *fp, mat_struct *out)
 {
     char buff[100];
@@ -1545,7 +1514,6 @@ int G_matrix_read(FILE *fp, mat_struct *out)
  * \param cols
  * \return mat_struct
  */
-
 mat_struct *G_matrix_resize(mat_struct *in, int rows, int cols)
 {
     mat_struct *matrix;
@@ -1580,7 +1548,6 @@ mat_struct *G_matrix_resize(mat_struct *in, int rows, int cols)
  * \param out
  * \return int
  */
-
 int G_matrix_stdin(mat_struct *out)
 {
     return G_matrix_read(stdin, out);
@@ -1597,7 +1564,6 @@ int G_matrix_stdin(mat_struct *out)
  * \param m
  * \return int
  */
-
 int G_matrix_eigen_sort(vec_struct *d, mat_struct *m)
 {
     mat_struct tmp;

--- a/lib/gmath/max_pow2.c
+++ b/lib/gmath/max_pow2.c
@@ -11,7 +11,6 @@
  * \param[in] n
  * \return long
  */
-
 long G_math_max_pow2(const long n)
 {
     long p2, n1;
@@ -38,7 +37,6 @@ long G_math_max_pow2(const long n)
  * \param[in] n
  * \return long
  */
-
 long G_math_min_pow2(const long n)
 {
     long p2, n1;

--- a/lib/gmath/mult.c
+++ b/lib/gmath/mult.c
@@ -19,7 +19,6 @@
  * \param size3
  * \return int
  */
-
 int G_math_complex_mult(double *v1[2], int size1, double *v2[2], int size2,
                         double *v3[2], int size3)
 {

--- a/lib/gmath/rand1.c
+++ b/lib/gmath/rand1.c
@@ -12,7 +12,6 @@
  * \param[in] seed
  * \return float
  */
-
 float G_math_rand(void)
 {
     return G_drand48();
@@ -23,7 +22,6 @@ float G_math_rand(void)
  *
  * \param[in] seed 32-bit integer used to seed the PRNG
  */
-
 void G_math_srand(int seed)
 {
     G_srand48(seed);
@@ -34,7 +32,6 @@ void G_math_srand(int seed)
  *
  * \return generated seed value passed to G_srand48()
  */
-
 int G_math_srand_auto(void)
 {
     return (int)G_srand48_auto();

--- a/lib/imagery/find.c
+++ b/lib/imagery/find.c
@@ -17,7 +17,6 @@
  *  \param group
  *  \return int 1 if group was found, 0 otherwise
  */
-
 int I_find_group(const char *group)
 {
     if (group == NULL || *group == 0)
@@ -36,7 +35,6 @@ int I_find_group(const char *group)
  *  \param mapset
  *  \return int 1 if group was found, 0 otherwise
  */
-
 int I_find_group2(const char *group, const char *mapset)
 {
     return G_find_file2("group", group, mapset) != NULL;

--- a/lib/imagery/group.c
+++ b/lib/imagery/group.c
@@ -108,7 +108,6 @@ int I_put_subgroup(const char *group, const char *subgroup)
  *  \param ref
  *  \return int
  */
-
 int I_get_group_ref(const char *group, struct Ref *ref)
 {
     return get_ref(group, "", NULL, ref);
@@ -126,7 +125,6 @@ int I_get_group_ref(const char *group, struct Ref *ref)
  *  \param ref
  *  \return int
  */
-
 int I_get_group_ref2(const char *group, const char *mapset, struct Ref *ref)
 {
     return get_ref(group, "", mapset, ref);
@@ -145,7 +143,6 @@ int I_get_group_ref2(const char *group, const char *mapset, struct Ref *ref)
  *  \param ref
  *  \return int
  */
-
 int I_get_subgroup_ref(const char *group, const char *subgroup, struct Ref *ref)
 {
     return get_ref(group, subgroup, NULL, ref);
@@ -306,7 +303,6 @@ int I_init_ref_color_nums(struct Ref *ref)
  *  \param ref
  *  \return int
  */
-
 int I_put_group_ref(const char *group, const struct Ref *ref)
 {
     return put_ref(group, "", ref);
@@ -327,7 +323,6 @@ int I_put_group_ref(const char *group, const struct Ref *ref)
  *  \param ref
  *  \return int
  */
-
 int I_put_subgroup_ref(const char *group, const char *subgroup,
                        const struct Ref *ref)
 {
@@ -382,7 +377,6 @@ static int put_ref(const char *group, const char *subgroup,
  *  \param ref
  *  \return int
  */
-
 int I_add_file_to_group_ref(const char *name, const char *mapset,
                             struct Ref *ref)
 {
@@ -430,7 +424,6 @@ int I_add_file_to_group_ref(const char *name, const char *mapset,
  *  \param dst
  *  \return int
  */
-
 int I_transfer_group_ref_file(const struct Ref *ref2, int n, struct Ref *ref1)
 {
     int k;
@@ -462,7 +455,6 @@ int I_transfer_group_ref_file(const struct Ref *ref2, int n, struct Ref *ref1)
  *  \param ref
  *  \return int
  */
-
 int I_init_group_ref(struct Ref *ref)
 {
     ref->nfiles = 0;
@@ -480,7 +472,6 @@ int I_init_group_ref(struct Ref *ref)
  *  \param ref
  *  \return int
  */
-
 int I_free_group_ref(struct Ref *ref)
 {
     if (ref->nfiles > 0)

--- a/lib/imagery/iscatt_core.c
+++ b/lib/imagery/iscatt_core.c
@@ -929,7 +929,6 @@ int I_apply_colormap(unsigned char *vals, unsigned char *vals_mask,
    \return 0 on success
    \return 1 on failure
  */
-
 int I_rasterize(double *polygon, int pol_n_pts, unsigned char val,
                 struct Cell_head *rast_region, unsigned char *rast)
 {

--- a/lib/imagery/list_subgp.c
+++ b/lib/imagery/list_subgp.c
@@ -48,7 +48,6 @@ char **list_subgroups(const char *group, const char *mapset, int *subgs_num)
  * \param[out] subgs_num number of subgroups which the group contains
  * \return array of subgroup names
  */
-
 char **I_list_subgroups(const char *group, int *subgs_num)
 {
 
@@ -63,7 +62,6 @@ char **I_list_subgroups(const char *group, int *subgs_num)
  * \param[out] subgs_num number of subgroups which the group contains
  * \return array of subgroup names
  */
-
 char **I_list_subgroups2(const char *group, const char *mapset, int *subgs_num)
 {
     return list_subgroups(group, mapset, subgs_num);

--- a/lib/imagery/points.c
+++ b/lib/imagery/points.c
@@ -52,7 +52,6 @@ static int I_read_control_points(FILE *fd, struct Control_Points *cp)
  *  \param status
  *  \return int
  */
-
 int I_new_control_point(struct Control_Points *cp, double e1, double n1,
                         double e2, double n2, int status)
 {
@@ -109,7 +108,6 @@ static int I_write_control_points(FILE *fd, const struct Control_Points *cp)
  *  \param cp
  *  \return int
  */
-
 int I_get_control_points(const char *group, struct Control_Points *cp)
 {
     FILE *fd;
@@ -144,7 +142,6 @@ int I_get_control_points(const char *group, struct Control_Points *cp)
  *  \param cp
  *  \return int
  */
-
 int I_put_control_points(const char *group, const struct Control_Points *cp)
 {
     FILE *fd;

--- a/lib/imagery/target.c
+++ b/lib/imagery/target.c
@@ -18,7 +18,6 @@
  *  \param mapset
  *  \return int
  */
-
 int I_get_target(const char *group, char *location, char *mapset)
 {
     FILE *fd;
@@ -57,7 +56,6 @@ int I_get_target(const char *group, char *location, char *mapset)
  *  \param mapset
  *  \return int
  */
-
 int I_put_target(const char *group, const char *location, const char *mapset)
 {
     FILE *fd;

--- a/lib/imagery/var.c
+++ b/lib/imagery/var.c
@@ -4,7 +4,6 @@
  * sum2: sum of x squared
  * n:    number of points
  */
-
 double I_variance(double sum, double sum2, int n)
 {
     if (n < 2)

--- a/lib/nviz/nviz.c
+++ b/lib/nviz/nviz.c
@@ -328,7 +328,6 @@ void Nviz_delete_arrow(nv_data *data)
    \return pointer to allocated scalebar_data structure
    \return NULL on error
  */
-
 struct scalebar_data *Nviz_new_scalebar(nv_data *data, int bar_id,
                                         float *coords, float size,
                                         unsigned int color)

--- a/lib/pngdriver/box.c
+++ b/lib/pngdriver/box.c
@@ -20,7 +20,6 @@
 
    \param fx1,fy1,fx2,fy2 rectangle coordinates
  */
-
 void PNG_Box(double fx1, double fy1, double fx2, double fy2)
 {
     int x1 = (int)floor(fx1 + 0.5);

--- a/lib/pngdriver/color.c
+++ b/lib/pngdriver/color.c
@@ -28,7 +28,6 @@
    \param g green color value
    \param b blue color value
  */
-
 void PNG_color_rgb(int r, int g, int b)
 {
     png.current_color = png_get_color(r, g, b, 0);

--- a/lib/pngdriver/draw_bitmap.c
+++ b/lib/pngdriver/draw_bitmap.c
@@ -29,7 +29,6 @@
    \param threshold threshold value
    \param buf data buffer
  */
-
 void PNG_draw_bitmap(int ncols, int nrows, int threshold,
                      const unsigned char *buf)
 {

--- a/lib/pngdriver/graph_set.c
+++ b/lib/pngdriver/graph_set.c
@@ -83,7 +83,6 @@ static void map_file(void)
    screen_left < screen_right
    screen_top  < screen_bottom
  */
-
 int PNG_Graph_set(void)
 {
     unsigned int red, grn, blu;

--- a/lib/proj/ellipse.c
+++ b/lib/proj/ellipse.c
@@ -156,7 +156,6 @@ int GPJ__get_ellipsoid_params(const struct Key_Value *proj_keys, double *a,
  * \return 1 on success
  * \return -1 if not found in table
  */
-
 int GPJ_get_ellipsoid_by_name(const char *name, struct gpj_ellps *estruct)
 {
     struct ellps_list *list, *listhead;

--- a/lib/raster/align_window.c
+++ b/lib/raster/align_window.c
@@ -37,7 +37,6 @@
  *
  * \return NULL on success
  */
-
 void Rast_align_window(struct Cell_head *window, const struct Cell_head *ref)
 {
     G_debug(1, "Rast_align_window()");

--- a/lib/raster/alloc_cell.c
+++ b/lib/raster/alloc_cell.c
@@ -34,7 +34,6 @@ static const int type_size[3] = {sizeof(CELL), sizeof(FCELL), sizeof(DCELL)};
  *
  * \return raster type size
  */
-
 size_t Rast_cell_size(RASTER_MAP_TYPE data_type)
 {
     return (type_size[F2I(data_type)]);

--- a/lib/raster/auto_mask.c
+++ b/lib/raster/auto_mask.c
@@ -84,7 +84,6 @@ int Rast__check_for_auto_masking(void)
  *
  * \return
  */
-
 void Rast_suppress_masking(void)
 {
     Rast__init();
@@ -102,7 +101,6 @@ void Rast_suppress_masking(void)
  *
  * \return
  */
-
 void Rast_unsuppress_masking(void)
 {
     Rast__init();

--- a/lib/raster/cats.c
+++ b/lib/raster/cats.c
@@ -912,7 +912,6 @@ int Rast_set_d_cat(const DCELL *rast1, const DCELL *rast2, const char *label,
  * \return 0 if null value detected
  * \return 1 on success
  */
-
 int Rast_set_cat(const void *rast1, const void *rast2, const char *label,
                  struct Categories *pcats, RASTER_MAP_TYPE data_type)
 {

--- a/lib/raster/cell_title.c
+++ b/lib/raster/cell_title.c
@@ -21,7 +21,6 @@
  *  \param mapset
  *  \return char *
  */
-
 char *Rast_get_cell_title(const char *name, const char *mapset)
 {
     FILE *fd;

--- a/lib/raster/color_rand.c
+++ b/lib/raster/color_rand.c
@@ -20,7 +20,6 @@
  *  \param max
  *  \return
  */
-
 void Rast_make_random_colors(struct Colors *colors, CELL min, CELL max)
 {
     unsigned char red, grn, blu;

--- a/lib/raster/color_xform.c
+++ b/lib/raster/color_xform.c
@@ -177,7 +177,6 @@ void Rast_histogram_eq_fp_colors(struct Colors *dst, struct Colors *src,
  * \param src struct containing original colors
  * \param samples number of samples
  */
-
 void Rast_log_colors(struct Colors *dst, struct Colors *src, int samples)
 {
     DCELL min, max;

--- a/lib/raster/histogram.c
+++ b/lib/raster/histogram.c
@@ -18,7 +18,6 @@ static int cmp_count(const void *, const void *);
  * \param  histogram
  * \return
  */
-
 void Rast_init_histogram(struct Histogram *histogram)
 {
     histogram->num = 0;
@@ -38,7 +37,6 @@ void Rast_init_histogram(struct Histogram *histogram)
  * \return 1  if successful,
  *         0  if no histogram file,
  */
-
 int Rast_read_histogram(const char *name, const char *mapset,
                         struct Histogram *histogram)
 {
@@ -83,7 +81,6 @@ int Rast_read_histogram(const char *name, const char *mapset,
  * \param histogram: struct for histogram
  * \return  void
  */
-
 void Rast_write_histogram(const char *name, const struct Histogram *histogram)
 {
     FILE *fp;
@@ -108,7 +105,6 @@ void Rast_write_histogram(const char *name, const struct Histogram *histogram)
  * \param statf: cell statistics
  * \return void
  */
-
 void Rast_write_histogram_cs(const char *name, struct Cell_stats *statf)
 {
     FILE *fp;
@@ -329,7 +325,6 @@ static FILE *fopen_histogram_new(const char *name)
  * \param name: name of map
  * \return
  */
-
 void Rast_remove_histogram(const char *name)
 {
     G_remove_misc("cell_misc", "histogram", name);

--- a/lib/raster/init.c
+++ b/lib/raster/init.c
@@ -39,7 +39,6 @@ static int init(void);
  * \return always returns 0 on success
  * \return exit() is called on error
  */
-
 void Rast_init(void)
 {
     Rast__init();
@@ -50,7 +49,6 @@ void Rast_init(void)
  *
  * \return
  */
-
 void Rast__check_init(void)
 {
     if (initialized)

--- a/lib/raster/open.c
+++ b/lib/raster/open.c
@@ -80,7 +80,6 @@ static int new_fileinfo(void)
  *
  * \return open file descriptor ( >= 0) if successful
  */
-
 static int open_raster_new(const char *name, int open_mode,
                            RASTER_MAP_TYPE map_type);
 

--- a/lib/raster/set_window.c
+++ b/lib/raster/set_window.c
@@ -94,7 +94,6 @@ void Rast_set_output_window(struct Cell_head *window)
  *
  * \param window window to become operative window
  */
-
 void Rast_set_input_window(struct Cell_head *window)
 {
     Rast__init();

--- a/lib/raster/window.c
+++ b/lib/raster/window.c
@@ -22,7 +22,6 @@
  *
  * \param window pointer to Cell_head
  */
-
 void Rast_get_window(struct Cell_head *window)
 {
     Rast__init_window();
@@ -41,7 +40,6 @@ void Rast_get_window(struct Cell_head *window)
  *
  * \param window pointer to Cell_head
  */
-
 void Rast_get_input_window(struct Cell_head *window)
 {
     Rast__init_window();
@@ -54,7 +52,6 @@ void Rast_get_input_window(struct Cell_head *window)
  *
  * \param window pointer to Cell_head
  */
-
 void Rast_get_output_window(struct Cell_head *window)
 {
     Rast__init_window();
@@ -203,7 +200,6 @@ int Rast_output_window_cols(void)
  *
  * \return row number
  */
-
 double Rast_northing_to_row(double north, const struct Cell_head *window)
 {
     return (window->north - north) / window->ns_res;
@@ -222,7 +218,6 @@ double Rast_northing_to_row(double north, const struct Cell_head *window)
  *
  * \return column number
  */
-
 double Rast_easting_to_col(double east, const struct Cell_head *window)
 {
     east = G_adjust_easting(east, window);

--- a/lib/raster3d/alloc.c
+++ b/lib/raster3d/alloc.c
@@ -17,7 +17,6 @@
  * NULL ... otherwise.
 
  */
-
 void *Rast3d_malloc(int nBytes)
 {
     void *buf;
@@ -42,7 +41,6 @@ void *Rast3d_malloc(int nBytes)
  *  \return void *: a pointer ... if successful,
  *         NULL ... otherwise.
  */
-
 void *Rast3d_realloc(void *ptr, int nBytes)
 {
     if (nBytes <= 0)
@@ -62,7 +60,6 @@ void *Rast3d_realloc(void *ptr, int nBytes)
  *  \param buf
  *  \return void
  */
-
 void Rast3d_free(void *buf)
 {
     free(buf);

--- a/lib/raster3d/cats.c
+++ b/lib/raster3d/cats.c
@@ -22,7 +22,6 @@
  *  \param cats
  *  \return int
  */
-
 int Rast3d_write_cats(const char *name, struct Categories *cats)
 /* adapted from Rast_write_cats */
 {
@@ -171,7 +170,6 @@ error:
  *  \param pcats
  *  \return int
  */
-
 int Rast3d_read_cats(const char *name, const char *mapset,
                      struct Categories *pcats)
 /* adapted from Rast_read_cats */

--- a/lib/raster3d/changeprecision.c
+++ b/lib/raster3d/changeprecision.c
@@ -18,7 +18,6 @@
  *  \param nameOut
  *  \return void
  */
-
 void Rast3d_change_precision(void *map, int precision, const char *nameOut)
 {
     void *map2;

--- a/lib/raster3d/changetype.c
+++ b/lib/raster3d/changetype.c
@@ -18,7 +18,6 @@
  *  \param nameOut
  *  \return void
  */
-
 void Rast3d_change_type(void *map, const char *nameOut)
 {
     void *map2;

--- a/lib/raster3d/defaults.c
+++ b/lib/raster3d/defaults.c
@@ -90,7 +90,6 @@ int g3d_vertical_unit_default = U_UNDEFINED;
  * \param doCompress specifies if a compression should be performed
  * \param precision a precision of compression
  */
-
 void Rast3d_set_compression_mode(int doCompress, int precision)
 {
     if ((doCompress != RASTER3D_NO_COMPRESSION) &&
@@ -123,7 +122,6 @@ void Rast3d_set_compression_mode(int doCompress, int precision)
  * \see Rast3d_set_compression_mode, RASTER3D_COMPRESSION_ENV_VAR_YES,
  RASTER3D_COMPRESSION_ENV_VAR_YES
  */
-
 void Rast3d_get_compression_mode(int *doCompress, int *precision)
 {
     if (doCompress != NULL)
@@ -140,7 +138,6 @@ void Rast3d_get_compression_mode(int *doCompress, int *precision)
  *  \param nTiles
  *  \return void
  */
-
 void Rast3d_set_cache_size(int nTiles)
 {
     if (nTiles < 0)
@@ -156,7 +153,6 @@ void Rast3d_set_cache_size(int nTiles)
  *
  *  \return int
  */
-
 int Rast3d_get_cache_size(void)
 {
     return g3d_cache_default;
@@ -170,7 +166,6 @@ int Rast3d_get_cache_size(void)
  *  \param nBytes
  *  \return void
  */
-
 void Rast3d_set_cache_limit(int nBytes)
 {
     if (nBytes <= 0)
@@ -186,7 +181,6 @@ void Rast3d_set_cache_limit(int nBytes)
  *
  *  \return int
  */
-
 int Rast3d_get_cache_limit(void)
 {
     return g3d_cache_max;
@@ -200,7 +194,6 @@ int Rast3d_get_cache_limit(void)
  *  \param type
  *  \return void
  */
-
 void Rast3d_set_file_type(int type)
 {
     if ((type != FCELL_TYPE) && (type != DCELL_TYPE))
@@ -216,7 +209,6 @@ void Rast3d_set_file_type(int type)
  *
  *  \return int
  */
-
 int Rast3d_get_file_type(void)
 {
     return g3d_file_type;
@@ -232,7 +224,6 @@ int Rast3d_get_file_type(void)
  *  \param tileZ
  *  \return void
  */
-
 void Rast3d_set_tile_dimension(int tileX, int tileY, int tileZ)
 {
     if ((g3d_tile_dimension[0] = tileX) <= 0)
@@ -258,7 +249,6 @@ void Rast3d_set_tile_dimension(int tileX, int tileY, int tileZ)
  *  \param tileZ
  *  \return void
  */
-
 void Rast3d_get_tile_dimension(int *tileX, int *tileY, int *tileZ)
 {
     *tileX = g3d_tile_dimension[0];
@@ -274,7 +264,6 @@ void Rast3d_get_tile_dimension(int *tileX, int *tileY, int *tileZ)
  *  \param fun
  *  \return void
  */
-
 void Rast3d_set_error_fun(void (*fun)(const char *))
 {
     g3d_error_fun = fun;
@@ -290,7 +279,6 @@ void Rast3d_set_error_fun(void (*fun)(const char *))
  *
  *  \return void
  */
-
 void Rast3d_init_defaults(void)
 {
     static int firstTime = 1;

--- a/lib/raster3d/error.c
+++ b/lib/raster3d/error.c
@@ -16,7 +16,6 @@
  *  \param msg
  *  \return void
  */
-
 void Rast3d_skip_error(const char *msg UNUSED)
 {
 }
@@ -30,7 +29,6 @@ void Rast3d_skip_error(const char *msg UNUSED)
  *  \param msg
  *  \return void
  */
-
 void Rast3d_print_error(const char *msg)
 {
     fprintf(stderr, "ERROR: ");
@@ -47,7 +45,6 @@ void Rast3d_print_error(const char *msg)
  *  \param msg
  *  \return void
  */
-
 void Rast3d_fatal_error(const char *msg, ...)
 {
     char buffer[2000]; /* No novels to the error logs, OK? */

--- a/lib/raster3d/filecompare.c
+++ b/lib/raster3d/filecompare.c
@@ -373,7 +373,6 @@ static void compareFilesNocache(void *map, void *map2)
  *  \param mapset2
  *  \return void
  */
-
 void Rast3d_compare_files(const char *f1, const char *mapset1, const char *f2,
                           const char *mapset2)
 {

--- a/lib/raster3d/getblock.c
+++ b/lib/raster3d/getblock.c
@@ -98,7 +98,6 @@ void Rast3d_get_block_nocache(RASTER3D_Map *map, int x0, int y0, int z0, int nx,
  *  \param type
  *  \return void
  */
-
 void Rast3d_get_block(RASTER3D_Map *map, int x0, int y0, int z0, int nx, int ny,
                       int nz, void *block, int type)
 {

--- a/lib/raster3d/getvalue.c
+++ b/lib/raster3d/getvalue.c
@@ -18,7 +18,6 @@
  *  \param type
  *  \return void
  */
-
 void Rast3d_get_value(RASTER3D_Map *map, int x, int y, int z, void *value,
                       int type)
 {
@@ -40,7 +39,6 @@ void Rast3d_get_value(RASTER3D_Map *map, int x, int y, int z, void *value,
  *  \param z
  *  \return float
  */
-
 float Rast3d_get_float(RASTER3D_Map *map, int x, int y, int z)
 {
     float value;
@@ -64,7 +62,6 @@ float Rast3d_get_float(RASTER3D_Map *map, int x, int y, int z)
  *  \param z
  *  \return double
  */
-
 double Rast3d_get_double(RASTER3D_Map *map, int x, int y, int z)
 {
     double value;
@@ -91,7 +88,6 @@ double Rast3d_get_double(RASTER3D_Map *map, int x, int y, int z)
  *  \param type
  *  \return void
  */
-
 void Rast3d_get_window_value(RASTER3D_Map *map, double north, double east,
                              double top, void *value, int type)
 {
@@ -127,7 +123,6 @@ void Rast3d_get_window_value(RASTER3D_Map *map, double north, double east,
  *  \param type
  *  \return void
  */
-
 void Rast3d_get_region_value(RASTER3D_Map *map, double north, double east,
                              double top, void *value, int type)
 {
@@ -161,7 +156,6 @@ void Rast3d_get_region_value(RASTER3D_Map *map, double north, double east,
  *  \param z
  *  \return float
  */
-
 float Rast3d_get_float_region(RASTER3D_Map *map, int x, int y, int z)
 {
     int tileIndex, offs;
@@ -204,7 +198,6 @@ float Rast3d_get_float_region(RASTER3D_Map *map, int x, int y, int z)
  *  \param z
  *  \return double
  */
-
 double Rast3d_get_double_region(RASTER3D_Map *map, int x, int y, int z)
 {
     int tileIndex, offs;
@@ -253,7 +246,6 @@ double Rast3d_get_double_region(RASTER3D_Map *map, int x, int y, int z)
  *  \param type
  *  \return void
  */
-
 void Rast3d_get_value_region(RASTER3D_Map *map, int x, int y, int z,
                              void *value, int type)
 {

--- a/lib/raster3d/header.c
+++ b/lib/raster3d/header.c
@@ -311,7 +311,6 @@ int Rast3d_rewrite_header(RASTER3D_Map *map)
  *  \param n
  *  \return int
  */
-
 int Rast3d_cache_size_encode(int cacheCode, int n)
 {
     if (cacheCode >= RASTER3D_NO_CACHE)

--- a/lib/raster3d/headerinfo.c
+++ b/lib/raster3d/headerinfo.c
@@ -14,7 +14,6 @@
  *  \param depths
  *  \return void
  */
-
 void Rast3d_get_coords_map(RASTER3D_Map *map, int *rows, int *cols, int *depths)
 {
     *rows = map->region.rows;
@@ -46,7 +45,6 @@ void Rast3d_get_coords_map_window(RASTER3D_Map *map, int *rows, int *cols,
  *  \param nz
  *  \return void
  */
-
 void Rast3d_get_nof_tiles_map(RASTER3D_Map *map, int *nx, int *ny, int *nz)
 {
     *nx = map->nx;
@@ -70,7 +68,6 @@ void Rast3d_get_nof_tiles_map(RASTER3D_Map *map, int *nx, int *ny, int *nz)
  *  \param bottom
  *  \return void
  */
-
 void Rast3d_get_region_map(RASTER3D_Map *map, double *north, double *south,
                            double *east, double *west, double *top,
                            double *bottom)
@@ -108,7 +105,6 @@ void Rast3d_get_window_map(RASTER3D_Map *map, double *north, double *south,
  *  \param region
  *  \return void
  */
-
 void Rast3d_get_region_struct_map(RASTER3D_Map *map, RASTER3D_Region *region)
 {
     Rast3d_region_copy(region, &(map->region));
@@ -134,7 +130,6 @@ void Rast3d_getWindowStructMap(RASTER3D_Map *map, RASTER3D_Region *window)
  *  \param z
  *  \return void
  */
-
 void Rast3d_get_tile_dimensions_map(RASTER3D_Map *map, int *x, int *y, int *z)
 {
     *x = map->tileX;
@@ -152,7 +147,6 @@ void Rast3d_get_tile_dimensions_map(RASTER3D_Map *map, int *x, int *y, int *z)
  *  \param map
  *  \return int
  */
-
 int Rast3d_tile_type_map(RASTER3D_Map *map)
 {
     return map->typeIntern;
@@ -169,7 +163,6 @@ int Rast3d_tile_type_map(RASTER3D_Map *map)
  *  \param unit
  *  \return void
  */
-
 void Rast3d_set_unit(RASTER3D_Map *map, const char *unit)
 {
     map->unit = G_store(unit);
@@ -186,7 +179,6 @@ void Rast3d_set_unit(RASTER3D_Map *map, const char *unit)
  *  \param vertical_unit
  *  \return void
  */
-
 void Rast3d_set_vertical_unit2(RASTER3D_Map *map, int vertical_unit)
 {
     map->vertical_unit = vertical_unit;
@@ -203,7 +195,6 @@ void Rast3d_set_vertical_unit2(RASTER3D_Map *map, int vertical_unit)
  *  \param vertical_unit
  *  \return void
  */
-
 void Rast3d_set_vertical_unit(RASTER3D_Map *map, const char *vertical_unit)
 {
     map->vertical_unit = G_units(vertical_unit);
@@ -219,7 +210,6 @@ void Rast3d_set_vertical_unit(RASTER3D_Map *map, const char *vertical_unit)
  *  \param map
  *  \return int
  */
-
 const char *Rast3d_get_unit(RASTER3D_Map *map)
 {
     return map->unit;
@@ -238,7 +228,6 @@ const char *Rast3d_get_unit(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 int Rast3d_get_vertical_unit2(RASTER3D_Map *map)
 {
     return map->vertical_unit;
@@ -256,7 +245,6 @@ int Rast3d_get_vertical_unit2(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 const char *Rast3d_get_vertical_unit(RASTER3D_Map *map)
 {
     return G_get_units_name(map->vertical_unit, 1, 0);
@@ -272,7 +260,6 @@ const char *Rast3d_get_vertical_unit(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 int Rast3d_file_type_map(RASTER3D_Map *map)
 {
     return map->type;
@@ -288,7 +275,6 @@ int Rast3d_file_type_map(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 int Rast3d_tile_precision_map(RASTER3D_Map *map)
 {
     return map->precision;
@@ -304,7 +290,6 @@ int Rast3d_tile_precision_map(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 int Rast3d_tile_use_cache_map(RASTER3D_Map *map)
 {
     return map->useCache;
@@ -318,7 +303,6 @@ int Rast3d_tile_use_cache_map(RASTER3D_Map *map)
  *  \param map
  *  \return void
  */
-
 void Rast3d_print_header(RASTER3D_Map *map)
 {
     double rangeMin, rangeMax;

--- a/lib/raster3d/history.c
+++ b/lib/raster3d/history.c
@@ -59,7 +59,6 @@ void SimpleErrorMessage(FILE *fd, const char *name, const char *mapset)
  *  \param history
  *  \return int
  */
-
 int Rast3d_read_history(const char *name, const char *mapset,
                         struct History *hist)
 {
@@ -93,7 +92,6 @@ int Rast3d_read_history(const char *name, const char *mapset,
  *  \param history
  *  \return int
  */
-
 int Rast3d_write_history(const char *name, struct History *hist)
 /* This function is adapted from Rast_write_history */
 {

--- a/lib/raster3d/mask.c
+++ b/lib/raster3d/mask.c
@@ -60,7 +60,6 @@ int Rast3d_mask_close(void)
  *
  *  \return int
  */
-
 int Rast3d_mask_file_exists(void)
 {
     return G_find_file_misc(RASTER3D_DIRECTORY, RASTER3D_CELL_ELEMENT,
@@ -133,7 +132,6 @@ static float Rast3d_getMaskFloat(RASTER3D_Map *map, int x, int y, int z)
  *  \return 1 ... if successful
  *          0 ... otherwise.
  */
-
 int Rast3d_mask_reopen(int cache)
 {
     int tmp;
@@ -171,7 +169,6 @@ int Rast3d_mask_reopen(int cache)
  *  \param z
  *  \return int
  */
-
 int Rast3d_is_masked(RASTER3D_Map *map, int x, int y, int z)
 {
     if (!Rast3d_maskMapExistsVar)
@@ -197,7 +194,6 @@ int Rast3d_is_masked(RASTER3D_Map *map, int x, int y, int z)
  *  \param type
  *  \return void
  */
-
 void Rast3d_mask_num(RASTER3D_Map *map, int x, int y, int z, void *value,
                      int type)
 {
@@ -220,7 +216,6 @@ void Rast3d_mask_num(RASTER3D_Map *map, int x, int y, int z, void *value,
  *  \param value
  *  \return void
  */
-
 void Rast3d_mask_float(RASTER3D_Map *map, int x, int y, int z, float *value)
 {
     if (!Rast3d_maskMapExistsVar)
@@ -241,7 +236,6 @@ void Rast3d_mask_float(RASTER3D_Map *map, int x, int y, int z, float *value)
  *  \param value
  *  \return void
  */
-
 void Rast3d_mask_double(RASTER3D_Map *map, int x, int y, int z, double *value)
 {
     if (!Rast3d_maskMapExistsVar)
@@ -267,7 +261,6 @@ void Rast3d_mask_double(RASTER3D_Map *map, int x, int y, int z, double *value)
  *  \param type
  *  \return void
  */
-
 void Rast3d_mask_tile(RASTER3D_Map *map, int tileIndex, void *tile, int type)
 {
     int nofNum, rows, cols, depths, xRedundant, yRedundant, zRedundant;
@@ -326,7 +319,6 @@ void Rast3d_mask_tile(RASTER3D_Map *map, int tileIndex, void *tile, int type)
  *  \param map
  *  \return void
  */
-
 void Rast3d_mask_on(RASTER3D_Map *map)
 {
     map->useMask = 1;
@@ -342,7 +334,6 @@ void Rast3d_mask_on(RASTER3D_Map *map)
  *  \param map
  *  \return void
  */
-
 void Rast3d_mask_off(RASTER3D_Map *map)
 {
     map->useMask = 0;
@@ -357,7 +348,6 @@ void Rast3d_mask_off(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 int Rast3d_mask_is_on(RASTER3D_Map *map)
 {
     return map->useMask;
@@ -371,7 +361,6 @@ int Rast3d_mask_is_on(RASTER3D_Map *map)
  *  \param map
  *  \return int
  */
-
 int Rast3d_mask_is_off(RASTER3D_Map *map)
 {
     return !map->useMask;
@@ -384,7 +373,6 @@ int Rast3d_mask_is_off(RASTER3D_Map *map)
  *
  *  \return char *
  */
-
 const char *Rast3d_mask_file(void)
 {
     return RASTER3D_MASK_MAP;
@@ -397,7 +385,6 @@ const char *Rast3d_mask_file(void)
  *
  *  \return int
  */
-
 int Rast3d_mask_map_exists(void)
 {
     return Rast3d_maskMapExistsVar;

--- a/lib/raster3d/null.c
+++ b/lib/raster3d/null.c
@@ -30,7 +30,6 @@ int Rast3d_is_null_value_num(const void *n, int type)
  *  \param type
  *  \return void
  */
-
 void Rast3d_set_null_value(void *c, int nofElts, int type)
 {
     if (type == FCELL_TYPE) {

--- a/lib/raster3d/open.c
+++ b/lib/raster3d/open.c
@@ -76,7 +76,6 @@ void *Rast3d_open_cell_old_no_header(const char *name, const char *mapset)
  *  \param cache
  *  \return void *
  */
-
 void *Rast3d_open_cell_old(const char *name, const char *mapset,
                            RASTER3D_Region *window, int typeIntern, int cache)
 {
@@ -205,7 +204,6 @@ void *Rast3d_open_cell_old(const char *name, const char *mapset,
  *  \param region
  *  \return void *
  */
-
 void *Rast3d_open_cell_new(const char *name, int typeIntern, int cache,
                            RASTER3D_Region *region)
 {

--- a/lib/raster3d/open2.c
+++ b/lib/raster3d/open2.c
@@ -37,7 +37,6 @@
  *  \param tileZ The number of cells in Z direction of a tile
  *  \return void *
  */
-
 void *Rast3d_open_new_param(const char *name, int typeIntern, int cache,
                             RASTER3D_Region *region, int type, int compression,
                             int precision, int tileX, int tileY, int tileZ)
@@ -92,7 +91,6 @@ void *Rast3d_open_new_param(const char *name, int typeIntern, int cache,
  *  \param maxSize The maximum size of a tile in kilo bytes
  *  \return void *
  */
-
 void *Rast3d_open_new_opt_tile_size(const char *name, int cache,
                                     RASTER3D_Region *region, int type,
                                     int maxSize)

--- a/lib/raster3d/param.c
+++ b/lib/raster3d/param.c
@@ -35,7 +35,6 @@ static Rast3d_paramType *param;
  *
  *  \return void
  */
-
 void Rast3d_set_standard3d_input_params(void)
 {
     param = Rast3d_malloc(sizeof(Rast3d_paramType));

--- a/lib/raster3d/putvalue.c
+++ b/lib/raster3d/putvalue.c
@@ -14,7 +14,6 @@
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_put_float(RASTER3D_Map *map, int x, int y, int z, float value)
 {
     int tileIndex, offs;
@@ -49,7 +48,6 @@ int Rast3d_put_float(RASTER3D_Map *map, int x, int y, int z, float value)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_put_double(RASTER3D_Map *map, int x, int y, int z, double value)
 {
     int tileIndex, offs;
@@ -88,7 +86,6 @@ int Rast3d_put_double(RASTER3D_Map *map, int x, int y, int z, double value)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_put_value(RASTER3D_Map *map, int x, int y, int z, const void *value,
                      int type)
 {

--- a/lib/raster3d/range.c
+++ b/lib/raster3d/range.c
@@ -105,7 +105,6 @@ int Rast3d_read_range(const char *name, const char *mapset,
  *  \return 1 ... if successful
  *          0 ... otherwise.
  */
-
 int Rast3d_range_load(RASTER3D_Map *map)
 {
     if (map->operation == RASTER3D_WRITE_DATA)
@@ -127,7 +126,6 @@ int Rast3d_range_load(RASTER3D_Map *map)
  *  \param min a pointer to a double to store minumim
  *  \param max a pointer to a double to store maximum
  */
-
 void Rast3d_range_min_max(RASTER3D_Map *map, double *min, double *max)
 {
     Rast_get_fp_range_min_max(&(map->range), min, max);

--- a/lib/raster3d/region.c
+++ b/lib/raster3d/region.c
@@ -15,7 +15,6 @@
  *  \param region2d
  *  \return void
  */
-
 void Rast3d_extract2d_region(RASTER3D_Region *region3d,
                              struct Cell_head *region2d)
 {
@@ -43,7 +42,6 @@ void Rast3d_extract2d_region(RASTER3D_Region *region3d,
  *  \param region2d
  *  \return void
  */
-
 void Rast3d_region_to_cell_head(RASTER3D_Region *region3d,
                                 struct Cell_head *region2d)
 {
@@ -82,7 +80,6 @@ void Rast3d_region_to_cell_head(RASTER3D_Region *region3d,
  *  \param region3d
  *  \return void
  */
-
 void Rast3d_incorporate2d_region(struct Cell_head *region2d,
                                  RASTER3D_Region *region3d)
 {
@@ -111,7 +108,6 @@ void Rast3d_incorporate2d_region(struct Cell_head *region2d,
  *  \param region3d
  *  \return void
  */
-
 void Rast3d_region_from_to_cell_head(struct Cell_head *region2d,
                                      RASTER3D_Region *region3d)
 {
@@ -145,7 +141,6 @@ void Rast3d_region_from_to_cell_head(struct Cell_head *region2d,
  *  \param region
  *  \return void
  */
-
 void Rast3d_adjust_region(RASTER3D_Region *region)
 {
     struct Cell_head region2d;
@@ -170,7 +165,6 @@ void Rast3d_adjust_region(RASTER3D_Region *region)
  *  \param region
  *  \return void
  */
-
 void Rast3d_adjust_region_res(RASTER3D_Region *region)
 {
     struct Cell_head region2d;
@@ -199,7 +193,6 @@ void Rast3d_adjust_region_res(RASTER3D_Region *region)
  *  \param regionSrc
  *  \return void
  */
-
 void Rast3d_region_copy(RASTER3D_Region *regionDest, RASTER3D_Region *regionSrc)
 {
     regionDest->proj = regionSrc->proj;
@@ -253,7 +246,6 @@ int Rast3d_read_region_map(const char *name, const char *mapset,
  *  \param top
  *  \return int
  */
-
 int Rast3d_is_valid_location(RASTER3D_Region *region, double north, double east,
                              double top)
 {
@@ -280,7 +272,6 @@ int Rast3d_is_valid_location(RASTER3D_Region *region, double north, double east,
  *  \param z
  *  \return void
  */
-
 void Rast3d_location2coord(RASTER3D_Region *region, double north, double east,
                            double top, int *x, int *y, int *z)
 {
@@ -311,7 +302,6 @@ void Rast3d_location2coord(RASTER3D_Region *region, double north, double east,
  *  \param z
  *  \return void
  */
-
 void Rast3d_location2coord_double(RASTER3D_Region *region, double north,
                                   double east, double top, double *x, double *y,
                                   double *z)
@@ -337,7 +327,6 @@ void Rast3d_location2coord_double(RASTER3D_Region *region, double north,
  *  \param z
  *  \return void
  */
-
 void Rast3d_location2coord2(RASTER3D_Region *region, double north, double east,
                             double top, int *x, int *y, int *z)
 {
@@ -382,7 +371,6 @@ void Rast3d_location2coord2(RASTER3D_Region *region, double north, double east,
  *  \param top
  *  \return void
  */
-
 void Rast3d_coord2location(RASTER3D_Region *region, double x, double y,
                            double z, double *north, double *east, double *top)
 {

--- a/lib/raster3d/resample.c
+++ b/lib/raster3d/resample.c
@@ -19,7 +19,6 @@
  *  \param type
  *  \return void
  */
-
 void Rast3d_nearest_neighbor(RASTER3D_Map *map, int x, int y, int z,
                              void *value, int type)
 {
@@ -86,7 +85,6 @@ void Rast3d_get_resampling_fun(RASTER3D_Map *map,
  *
  *  \return void
  */
-
 void Rast3d_get_nearest_neighbor_fun_ptr(void (**nnFunPtr)(RASTER3D_Map *, int,
                                                            int, int, void *,
                                                            int))

--- a/lib/raster3d/retile.c
+++ b/lib/raster3d/retile.c
@@ -74,7 +74,6 @@ static void retileNocache(void *map, const char *nameOut, int tileX, int tileY,
  *  \param tileZ
  *  \return void
  */
-
 void Rast3d_retile(void *map, const char *nameOut, int tileX, int tileY,
                    int tileZ)
 {

--- a/lib/raster3d/tilealloc.c
+++ b/lib/raster3d/tilealloc.c
@@ -19,7 +19,6 @@
  *  \return void * : a pointer to the vector ... if successful,
  *                   NULL ... otherwise.
  */
-
 void *Rast3d_alloc_tiles_type(RASTER3D_Map *map, int nofTiles, int type)
 {
     void *tiles;
@@ -45,7 +44,6 @@ void *Rast3d_alloc_tiles_type(RASTER3D_Map *map, int nofTiles, int type)
  *  \param nofTiles
  *  \return void *
  */
-
 void *Rast3d_alloc_tiles(RASTER3D_Map *map, int nofTiles)
 {
     void *tiles;
@@ -69,7 +67,6 @@ void *Rast3d_alloc_tiles(RASTER3D_Map *map, int nofTiles)
  *  \param tiles
  *  \return void
  */
-
 void Rast3d_free_tiles(void *tiles)
 {
     Rast3d_free(tiles);

--- a/lib/raster3d/tileio.c
+++ b/lib/raster3d/tileio.c
@@ -75,7 +75,6 @@
  *  \return void * a pointer to a buffer ... if successful,
  *                 NULL ... otherwise.
  */
-
 void *Rast3d_get_tile_ptr(RASTER3D_Map *map, int tileIndex)
 {
     void *ptr;
@@ -119,7 +118,6 @@ void *Rast3d_get_tile_ptr(RASTER3D_Map *map, int tileIndex)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_tile_load(RASTER3D_Map *map, int tileIndex)
 {
     if (Rast3d_get_tile_ptr(map, tileIndex) == NULL) {

--- a/lib/raster3d/tilemath.c
+++ b/lib/raster3d/tilemath.c
@@ -19,7 +19,6 @@
  *  \param zTile
  *  \return void
  */
-
 void Rast3d_tile_index2tile(RASTER3D_Map *map, int tileIndex, int *xTile,
                             int *yTile, int *zTile)
 {
@@ -45,7 +44,6 @@ void Rast3d_tile_index2tile(RASTER3D_Map *map, int tileIndex, int *xTile,
  *  \param zTile
  *  \return int
  */
-
 int Rast3d_tile2tile_index(RASTER3D_Map *map, int xTile, int yTile, int zTile)
 {
     return map->nxy * zTile + map->nx * yTile + xTile;
@@ -69,7 +67,6 @@ int Rast3d_tile2tile_index(RASTER3D_Map *map, int xTile, int yTile, int zTile)
  *  \param z
  *  \return void
  */
-
 void Rast3d_tile_coord_origin(RASTER3D_Map *map, int xTile, int yTile,
                               int zTile, int *x, int *y, int *z)
 {
@@ -93,7 +90,6 @@ void Rast3d_tile_coord_origin(RASTER3D_Map *map, int xTile, int yTile,
  *  \param z
  *  \return void
  */
-
 void Rast3d_tile_index_origin(RASTER3D_Map *map, int tileIndex, int *x, int *y,
                               int *z)
 {
@@ -125,7 +121,6 @@ void Rast3d_tile_index_origin(RASTER3D_Map *map, int tileIndex, int *x, int *y,
  *  \param zOffs
  *  \return void
  */
-
 void Rast3d_coord2tile_coord(RASTER3D_Map *map, int x, int y, int z, int *xTile,
                              int *yTile, int *zTile, int *xOffs, int *yOffs,
                              int *zOffs)
@@ -154,7 +149,6 @@ void Rast3d_coord2tile_coord(RASTER3D_Map *map, int x, int y, int z, int *xTile,
  *  \param offset
  *  \return void
  */
-
 void Rast3d_coord2tile_index(RASTER3D_Map *map, int x, int y, int z,
                              int *tileIndex, int *offset)
 {
@@ -181,7 +175,6 @@ void Rast3d_coord2tile_index(RASTER3D_Map *map, int x, int y, int z,
  *  \param z
  *  \return int
  */
-
 int Rast3d_coord_in_range(RASTER3D_Map *map, int x, int y, int z)
 {
     return (x >= 0) && (x < map->region.cols) && (y >= 0) &&
@@ -200,7 +193,6 @@ int Rast3d_coord_in_range(RASTER3D_Map *map, int x, int y, int z)
  *  \param tileIndex
  *  \return int
  */
-
 int Rast3d_tile_index_in_range(RASTER3D_Map *map, int tileIndex)
 {
     return (tileIndex < map->nTiles) && (tileIndex >= 0);
@@ -221,7 +213,6 @@ int Rast3d_tile_index_in_range(RASTER3D_Map *map, int tileIndex)
  *  \param z
  *  \return int
  */
-
 int Rast3d_tile_in_range(RASTER3D_Map *map, int x, int y, int z)
 {
     return (x >= 0) && (x < map->nx) && (y >= 0) && (y < map->ny) && (z >= 0) &&
@@ -249,7 +240,6 @@ int Rast3d_tile_in_range(RASTER3D_Map *map, int x, int y, int z)
  *  \param zRedundant
  *  \return int
  */
-
 int Rast3d_compute_clipped_tile_dimensions(RASTER3D_Map *map, int tileIndex,
                                            int *rows, int *cols, int *depths,
                                            int *xRedundant, int *yRedundant,
@@ -313,7 +303,6 @@ int Rast3d_compute_clipped_tile_dimensions(RASTER3D_Map *map, int tileIndex,
  *  \param maxSize The max size of the tile in kilo bytes
  *  \return void
  */
-
 void Rast3d_compute_optimal_tile_dimension(RASTER3D_Region *region, int type,
                                            int *tileX, int *tileY, int *tileZ,
                                            int maxSize)

--- a/lib/raster3d/tilenull.c
+++ b/lib/raster3d/tilenull.c
@@ -18,7 +18,6 @@
  *  \param type
  *  \return void
  */
-
 void Rast3d_set_null_tile_type(RASTER3D_Map *map, void *tile, int type)
 {
     Rast3d_set_null_value(tile, map->tileSize, type);
@@ -36,7 +35,6 @@ void Rast3d_set_null_tile_type(RASTER3D_Map *map, void *tile, int type)
  *  \param tile
  *  \return void
  */
-
 void Rast3d_set_null_tile(RASTER3D_Map *map, void *tile)
 {
     Rast3d_set_null_tile_type(map, tile, map->typeIntern);

--- a/lib/raster3d/tileread.c
+++ b/lib/raster3d/tileread.c
@@ -147,7 +147,6 @@ static int Rast3d_readTileCompressed(RASTER3D_Map *map, int tileIndex,
  *  \return 1 ... if successful,
  *          0 ... otherwise
  */
-
 int Rast3d_read_tile(RASTER3D_Map *map, int tileIndex, void *tile, int type)
 {
     int nofNum, rows, cols, depths, xRedundant, yRedundant, zRedundant;
@@ -206,7 +205,6 @@ int Rast3d_read_tile(RASTER3D_Map *map, int tileIndex, void *tile, int type)
  *  \param tile
  *  \return int
  */
-
 int Rast3d_read_tile_float(RASTER3D_Map *map, int tileIndex, void *tile)
 {
     if (!Rast3d_read_tile(map, tileIndex, tile, FCELL_TYPE)) {
@@ -229,7 +227,6 @@ int Rast3d_read_tile_float(RASTER3D_Map *map, int tileIndex, void *tile)
  *  \param tile
  *  \return int
  */
-
 int Rast3d_read_tile_double(RASTER3D_Map *map, int tileIndex, void *tile)
 {
     if (!Rast3d_read_tile(map, tileIndex, tile, DCELL_TYPE)) {
@@ -258,7 +255,6 @@ int Rast3d_read_tile_double(RASTER3D_Map *map, int tileIndex, void *tile)
  *          -1 ... if request is ignored,
  *          0 ... otherwise.
  */
-
 int Rast3d_lock_tile(RASTER3D_Map *map, int tileIndex)
 {
     if (!map->useCache)
@@ -285,7 +281,6 @@ int Rast3d_lock_tile(RASTER3D_Map *map, int tileIndex)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_unlock_tile(RASTER3D_Map *map, int tileIndex)
 {
     if (!map->useCache)
@@ -311,7 +306,6 @@ int Rast3d_unlock_tile(RASTER3D_Map *map, int tileIndex)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_unlock_all(RASTER3D_Map *map)
 {
     if (!map->useCache)
@@ -336,7 +330,6 @@ int Rast3d_unlock_all(RASTER3D_Map *map)
  *  \param map
  *  \return void
  */
-
 void Rast3d_autolock_on(RASTER3D_Map *map)
 {
     if (!map->useCache)
@@ -356,7 +349,6 @@ void Rast3d_autolock_on(RASTER3D_Map *map)
  *  \param map
  *  \return void
  */
-
 void Rast3d_autolock_off(RASTER3D_Map *map)
 {
     if (!map->useCache)
@@ -385,7 +377,6 @@ void Rast3d_autolock_off(RASTER3D_Map *map)
  *  \param minUnlocked
  *  \return void
  */
-
 void Rast3d_min_unlocked(RASTER3D_Map *map, int minUnlocked)
 {
     if (!map->useCache)
@@ -407,7 +398,6 @@ void Rast3d_min_unlocked(RASTER3D_Map *map, int minUnlocked)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_begin_cycle(RASTER3D_Map *map)
 {
     if (!Rast3d_unlock_all(map)) {
@@ -430,7 +420,6 @@ int Rast3d_begin_cycle(RASTER3D_Map *map)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_end_cycle(RASTER3D_Map *map)
 {
     Rast3d_autolock_off(map);

--- a/lib/raster3d/tilewrite.c
+++ b/lib/raster3d/tilewrite.c
@@ -122,7 +122,6 @@ static int Rast3d_writeTileCompressed(RASTER3D_Map *map, int nofNum)
  *          2 ... if write request was ignored,
  *          0 ... otherwise.
  */
-
 int Rast3d_write_tile(RASTER3D_Map *map, int tileIndex, const void *tile,
                       int type)
 {
@@ -191,7 +190,6 @@ int Rast3d_write_tile(RASTER3D_Map *map, int tileIndex, const void *tile,
  *  \param tile
  *  \return int
  */
-
 int Rast3d_write_tile_float(RASTER3D_Map *map, int tileIndex, const void *tile)
 {
     int status;
@@ -216,7 +214,6 @@ int Rast3d_write_tile_float(RASTER3D_Map *map, int tileIndex, const void *tile)
  *  \param tile
  *  \return int
  */
-
 int Rast3d_write_tile_double(RASTER3D_Map *map, int tileIndex, const void *tile)
 {
     int status;
@@ -249,7 +246,6 @@ int Rast3d_write_tile_double(RASTER3D_Map *map, int tileIndex, const void *tile)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_flush_tile(RASTER3D_Map *map, int tileIndex)
 {
     const void *tile;
@@ -294,7 +290,6 @@ int Rast3d_flush_tile(RASTER3D_Map *map, int tileIndex)
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_flush_tile_cube(RASTER3D_Map *map, int xMin, int yMin, int zMin,
                            int xMax, int yMax, int zMax)
 {
@@ -340,7 +335,6 @@ int Rast3d_flush_tile_cube(RASTER3D_Map *map, int xMin, int yMin, int zMin,
  *  \return 1 ... if successful,
  *          0 ... otherwise.
  */
-
 int Rast3d_flush_tiles_in_cube(RASTER3D_Map *map, int xMin, int yMin, int zMin,
                                int xMax, int yMax, int zMax)
 {

--- a/lib/raster3d/window.c
+++ b/lib/raster3d/window.c
@@ -19,7 +19,6 @@ RASTER3D_Region g3d_window;
  *  \param window
  *  \return void
  */
-
 void Rast3d_set_window_map(RASTER3D_Map *map, RASTER3D_Region *window)
 {
     Rast3d_region_copy(&(map->window), window);
@@ -37,7 +36,6 @@ void Rast3d_set_window_map(RASTER3D_Map *map, RASTER3D_Region *window)
  *  \param window
  *  \return void
  */
-
 void Rast3d_set_window(RASTER3D_Region *window)
 {
     Rast3d_region_copy(&g3d_window, window);
@@ -54,7 +52,6 @@ void Rast3d_set_window(RASTER3D_Region *window)
  *  \param window
  *  \return void
  */
-
 void Rast3d_get_window(RASTER3D_Region *window)
 {
     Rast3d_region_copy(window, &g3d_window);
@@ -81,7 +78,6 @@ RASTER3D_Region *Rast3d_window_ptr(void)
  *  \param top
  *  \return int
  */
-
 int Rast3d_isValidLocationWindow(RASTER3D_Map *map, double north, double east,
                                  double top)
 {

--- a/lib/raster3d/windowio.c
+++ b/lib/raster3d/windowio.c
@@ -129,7 +129,6 @@ static void Rast3d_getFullWindowPath(char *path, const char *windowName)
  *  \return 1 ... if successful
  *          0 ... otherwise.
  */
-
 int Rast3d_read_window(RASTER3D_Region *window, const char *windowName)
 {
     struct Cell_head win;

--- a/lib/raster3d/writeascii.c
+++ b/lib/raster3d/writeascii.c
@@ -15,7 +15,6 @@
  *  \param fname
  *  \return void
  */
-
 void Rast3d_write_ascii(void *map, const char *fname)
 {
     FILE *fp;

--- a/lib/rowio/put.c
+++ b/lib/rowio/put.c
@@ -37,7 +37,6 @@
  *
  * \return
  */
-
 int Rowio_put(ROWIO *R, const void *buf, int row)
 {
     int i;

--- a/lib/rowio/setup.c
+++ b/lib/rowio/setup.c
@@ -40,7 +40,6 @@
  * \return 1 on success
  * \return -1 no memory
  */
-
 int Rowio_setup(ROWIO *R, int fd, int nrows, int len,
                 int (*getrow)(int, void *, int, int),
                 int (*putrow)(int, const void *, int, int))

--- a/lib/rst/interp_float/func2d.c
+++ b/lib/rst/interp_float/func2d.c
@@ -102,7 +102,6 @@ double IL_crst(double r, /**< distance squared */
  *
  * Derivatives of radial basis function - regularized spline with tension(d=2)
  */
-
 int IL_crstg(double r, /**< distance squared */
 
              double fi, /**< tension */

--- a/lib/rst/interp_float/point2d.c
+++ b/lib/rst/interp_float/point2d.c
@@ -160,7 +160,6 @@ int IL_check_at_points_2d(struct interp_params *params,
  *
  * \return 1
  */
-
 int IL_write_point_2d(struct triple point, double err)
 {
 

--- a/lib/rst/interp_float/point2d_parallel.c
+++ b/lib/rst/interp_float/point2d_parallel.c
@@ -57,7 +57,6 @@
  * Alternative description:
  * ...calculate the maximum and RMS deviation caused by smoothing.
  */
-
 int IL_check_at_points_2d_cvdev(struct interp_params *params,
                                 struct quaddata *data, /*!< current region */
                                 double *b, /*!< solution of linear equations */

--- a/lib/segment/address.c
+++ b/lib/segment/address.c
@@ -104,7 +104,6 @@ int seg_address_slow(const SEGMENT *SEG, off_t row, off_t col, int *n,
  * \param[in,out] index
  * \return always returns 0
  */
-
 int seg_address(const SEGMENT *SEG, off_t row, off_t col, int *n, int *index)
 {
     /* old code

--- a/lib/segment/close.c
+++ b/lib/segment/close.c
@@ -29,7 +29,6 @@
  * \return 1 if successful
  * \return -1 if SEGMENT is not available (not open)
  */
-
 int Segment_close(SEGMENT *SEG)
 {
     if (SEG->open != 1)

--- a/lib/segment/flush.c
+++ b/lib/segment/flush.c
@@ -26,7 +26,6 @@
  * \param[in] SEG segment
  * \return always returns 0
  */
-
 int Segment_flush(SEGMENT *SEG)
 {
     int i;

--- a/lib/segment/format.c
+++ b/lib/segment/format.c
@@ -57,7 +57,6 @@ static int seek_only(int, off_t);
  * \return -1 if unable to seek or write <b>fd</b>
  * \return -3 if illegal parameters are passed
  */
-
 int Segment_format(int fd, off_t nrows, off_t ncols, int srows, int scols,
                    int len)
 {
@@ -95,7 +94,6 @@ int Segment_format(int fd, off_t nrows, off_t ncols, int srows, int scols,
  * \return -1 if unable to seek or write <b>fd</b>
  * \return -3 if illegal parameters are passed
  */
-
 int Segment_format_nofill(int fd, off_t nrows, off_t ncols, int srows,
                           int scols, int len)
 {

--- a/lib/segment/get.c
+++ b/lib/segment/get.c
@@ -33,7 +33,6 @@
  * \return 1 of successful
  * \return -1 if unable to seek or read segment file
  */
-
 int Segment_get(SEGMENT *SEG, void *buf, off_t row, off_t col)
 {
     int index, n, i;

--- a/lib/segment/get_row.c
+++ b/lib/segment/get_row.c
@@ -37,7 +37,6 @@
  * \return 1 if successful
  * \return -1 if unable to seek or read segment file
  */
-
 int Segment_get_row(const SEGMENT *SEG, void *buf, off_t row)
 {
     int size;

--- a/lib/segment/init.c
+++ b/lib/segment/init.c
@@ -52,7 +52,6 @@ static int read_off_t(int, off_t *);
  * \return -1 if unable to seek or read segment file
  * \return -2 if out of memory
  */
-
 int Segment_init(SEGMENT *SEG, int fd, int nseg)
 {
     SEG->open = 0;

--- a/lib/segment/open.c
+++ b/lib/segment/open.c
@@ -41,7 +41,6 @@
  * \return -5 if prepared file could not be read
  * \return -6 if out of memory
  */
-
 int Segment_open(SEGMENT *SEG, char *fname, off_t nrows, off_t ncols, int srows,
                  int scols, int len, int nseg)
 {

--- a/lib/segment/pagein.c
+++ b/lib/segment/pagein.c
@@ -31,7 +31,6 @@
  * \return 1 if successful
  * \return -1 if unable to seek or read segment file
  */
-
 int seg_pagein(SEGMENT *SEG, int n)
 {
     int cur;

--- a/lib/segment/pageout.c
+++ b/lib/segment/pageout.c
@@ -31,7 +31,6 @@
  * \return 1 if successful
  * \return -1 on error
  */
-
 int seg_pageout(SEGMENT *SEG, int i)
 {
     SEG->seek(SEG, SEG->scb[i].n, 0);

--- a/lib/segment/put.c
+++ b/lib/segment/put.c
@@ -39,7 +39,6 @@
  * \return 1 if successful
  * \return -1 if unable to seek or write segment file
  */
-
 int Segment_put(SEGMENT *SEG, const void *buf, off_t row, off_t col)
 {
     int index, n, i;

--- a/lib/segment/put_row.c
+++ b/lib/segment/put_row.c
@@ -37,7 +37,6 @@
  * \return 1 if successful
  * \return -1 if unable to seek or write segment file
  */
-
 int Segment_put_row(const SEGMENT *SEG, const void *buf, off_t row)
 {
     int size;

--- a/lib/segment/release.c
+++ b/lib/segment/release.c
@@ -30,7 +30,6 @@
  * \return 1 if successful
  * \return -1 if SEGMENT is not available (not open)
  */
-
 int Segment_release(SEGMENT *SEG)
 {
     int i;

--- a/lib/segment/setup.c
+++ b/lib/segment/setup.c
@@ -30,7 +30,6 @@
  * \return -1 if illegal parameters are passed in <b>SEG</b>
  * \return -2 if unable to allocate memory
  */
-
 int seg_setup(SEGMENT *SEG)
 {
     int i;

--- a/lib/vector/Vlib/area.c
+++ b/lib/vector/Vlib/area.c
@@ -286,7 +286,6 @@ int Vect_get_isle_area(struct Map_info *Map, int isle)
 
    \return perimeter of area with perimeters of isles in meters
  */
-
 double Vect_get_area_perimeter(struct Map_info *Map, int area)
 {
     const struct Plus_head *Plus;

--- a/lib/vector/Vlib/array.c
+++ b/lib/vector/Vlib/array.c
@@ -35,7 +35,6 @@ static int in_array(int *cats, size_t ncats, int cat);
    \return pointer to new struct varray
    \return NULL if failed
  */
-
 struct varray *Vect_new_varray(int size)
 {
     struct varray *p;

--- a/lib/vector/Vlib/break_lines.c
+++ b/lib/vector/Vlib/break_lines.c
@@ -59,7 +59,6 @@ void Vect_break_lines(struct Map_info *Map, int type, struct Map_info *Err)
 
    \return number of intersections
  */
-
 int Vect_break_lines_list(struct Map_info *Map, struct ilist *List_break,
                           struct ilist *List_ref, int type,
                           struct Map_info *Err)

--- a/lib/vector/Vlib/header.c
+++ b/lib/vector/Vlib/header.c
@@ -539,7 +539,6 @@ int Vect_get_proj(struct Map_info *Map)
    \return allocated string containing projection name
    \return NULL if <em>proj</em> is not a valid projection
  */
-
 const char *Vect_get_proj_name(struct Map_info *Map)
 {
     char name[256];

--- a/lib/vector/Vlib/legal_vname.c
+++ b/lib/vector/Vlib/legal_vname.c
@@ -28,7 +28,6 @@
    \return -1 if name does not start with letter A..Za..z or if name does not
    continue with A..Za..z0..9_
  */
-
 int Vect_legal_filename(const char *s)
 {
     /* full list of SQL keywords available at
@@ -89,7 +88,6 @@ int Vect_legal_filename(const char *s)
    \return 0 OK
    \return 1 error
  */
-
 int Vect_check_input_output_name(const char *input, const char *output,
                                  int error)
 {

--- a/lib/vector/Vlib/merge_lines.c
+++ b/lib/vector/Vlib/merge_lines.c
@@ -75,7 +75,6 @@ static int compare_cats(struct line_cats *ACats, struct line_cats *BCats)
 
    \return number of merged lines/boundaries
  */
-
 int Vect_merge_lines(struct Map_info *Map, int type, int *new_lines,
                      struct Map_info *Err)
 {

--- a/lib/vector/Vlib/net_analyze.c
+++ b/lib/vector/Vlib/net_analyze.c
@@ -256,7 +256,6 @@ static int find_shortest_path(struct Map_info *Map, int from, int to,
    return value, \return -1 : destination unreachable
 
  */
-
 int Vect_net_ttb_shortest_path(struct Map_info *Map, int from, int from_type,
                                int to, int to_type, int tucfield,
                                struct ilist *List, double *cost)

--- a/lib/vector/Vlib/net_build.c
+++ b/lib/vector/Vlib/net_build.c
@@ -45,7 +45,6 @@
 
    \return 0 on success, 1 on error
  */
-
 int Vect_net_ttb_build_graph(struct Map_info *Map, int ltype, int afield,
                              int nfield, int tfield, int tucfield,
                              const char *afcol, const char *abcol,

--- a/lib/vector/Vlib/remove_areas.c
+++ b/lib/vector/Vlib/remove_areas.c
@@ -37,7 +37,6 @@ int Vect_remove_small_areas_ext(struct Map_info *, double, struct Map_info *,
 
    \return number of removed areas
  */
-
 int Vect_remove_small_areas(struct Map_info *Map, double thresh,
                             struct Map_info *Err, double *removed_area)
 {

--- a/lib/vector/diglib/allocation.c
+++ b/lib/vector/diglib/allocation.c
@@ -29,7 +29,6 @@
  *   elements, size of chunks to allocate,  pointer to current array, sizeof
  *   an element.
  */
-
 void *dig_alloc_space(int n_wanted, int *n_elements, int chunk_size, void *ptr,
                       int element_size)
 {

--- a/lib/vector/diglib/plus_struct.c
+++ b/lib/vector/diglib/plus_struct.c
@@ -48,7 +48,6 @@
  *    store an int.  The mapdev code is not guaranteed to work if
  *    plus_t is changed to a type that is larger than an int.
  */
-
 int dig_Rd_P_node(struct Plus_head *Plus, int n, struct gvfile *fp)
 {
     int cnt, n_edges;

--- a/lib/vector/diglib/poly.c
+++ b/lib/vector/diglib/poly.c
@@ -31,7 +31,6 @@
  *
  * returns number of points or -1 on error
  */
-
 int dig_get_poly_points(int n_lines, struct line_pnts **LPoints,
                         int *direction, /* line direction: > 0 or < 0 */
                         struct line_pnts *BPoints)

--- a/lib/vector/diglib/spindex.c
+++ b/lib/vector/diglib/spindex.c
@@ -391,7 +391,6 @@ int dig_spidx_add_area(struct Plus_head *Plus, int area,
 
    \return 0
  */
-
 int dig_spidx_add_isle(struct Plus_head *Plus, int isle,
                        const struct bound_box *box)
 {

--- a/lib/vector/diglib/spindex_rw.c
+++ b/lib/vector/diglib/spindex_rw.c
@@ -686,7 +686,6 @@ int rtree_dump_node_file(FILE *fp, off_t pos, int with_z, struct RTree *t)
    \return -1 on error
    \return offset to root node on success
  */
-
 static off_t rtree_write_from_memory(struct gvfile *fp, off_t startpos,
                                      struct RTree *t, int off_t_size)
 {
@@ -793,7 +792,6 @@ static off_t rtree_write_from_memory(struct gvfile *fp, off_t startpos,
    \return -1 on error
    \return offset to root node on success
  */
-
 static off_t rtree_write_from_file(struct gvfile *fp, off_t startpos,
                                    struct RTree *t, int off_t_size)
 {
@@ -921,7 +919,6 @@ static off_t rtree_write_to_sidx(struct gvfile *fp, off_t startpos,
 
    \return pointer to root node on success
  */
-
 static void rtree_load_to_memory(struct gvfile *fp, off_t rootpos,
                                  struct RTree *t, int off_t_size)
 {
@@ -1045,7 +1042,6 @@ static void rtree_load_to_memory(struct gvfile *fp, off_t rootpos,
 
    \return offset to root node
  */
-
 static void rtree_load_to_file(struct gvfile *fp, off_t rootpos,
                                struct RTree *t, int off_t_size)
 {

--- a/lib/vector/rtree/index.c
+++ b/lib/vector/rtree/index.c
@@ -223,7 +223,6 @@ void RTreeSetOverflow(struct RTree *t, char overflow)
 
    \return nothing
  */
-
 void RTreeDestroyTree(struct RTree *t)
 {
     int i;

--- a/lib/vector/rtree/node.c
+++ b/lib/vector/rtree/node.c
@@ -173,7 +173,6 @@ void RTreeNodeCover(struct RTree_Node *n, struct RTree_Rect *r, struct RTree *t)
  * area to accommodate the new rectangle, then the smallest area before,
  * to get the best resolution when searching.
  */
-
 static int RTreePickLeafBranch(struct RTree_Rect *r, struct RTree_Node *n,
                                struct RTree *t)
 {
@@ -600,7 +599,6 @@ int RTreeAddBranch(struct RTree_Branch *b, struct RTree_Node *n,
 /*
  * for debugging only: print items to stdout
  */
-
 void RTreeTabIn(int depth)
 {
     int i;

--- a/ps/ps.map/catval.c
+++ b/ps/ps.map/catval.c
@@ -32,7 +32,6 @@
  *
  * \return number of records or -1 if it fails
  */
-
 int load_catval_array_rgb(struct Map_info *map, int vec,
                           dbCatValArray *cvarr_rgb)
 {
@@ -94,7 +93,6 @@ int load_catval_array_rgb(struct Map_info *map, int vec,
  *
  * \return number of records or -1 if it fails
  */
-
 int load_catval_array_size(struct Map_info *map, int vec,
                            dbCatValArray *cvarr_size)
 {
@@ -161,7 +159,6 @@ int load_catval_array_size(struct Map_info *map, int vec,
  *
  * \return number of records or -1 if it fails
  */
-
 int load_catval_array_rot(struct Map_info *map, int vec,
                           dbCatValArray *cvarr_rot)
 {

--- a/ps/ps.map/gprims.c
+++ b/ps/ps.map/gprims.c
@@ -19,7 +19,6 @@ int draw_line(double x1, double y1, double x2, double y2)
    by calling G_plot_where_xy() and therefore they are integers which need to
    be divided by 10. to get double with precision until first decimal place
  */
-
 int start_line(double east, double north)
 {
     int x, y;

--- a/raster/r.buffer/find_dist.c
+++ b/raster/r.buffer/find_dist.c
@@ -39,7 +39,6 @@ int begin_distance(int row)
  * Returns: first zone to occur (-1 if none)
  * Note: modifies distances structure (global)
  */
-
 int find_distances(int row)
 {
     int i;

--- a/raster/r.fill.stats/cell_funcs.c
+++ b/raster/r.fill.stats/cell_funcs.c
@@ -64,7 +64,6 @@ void write_cell_value_d(void *cell_output, void *cell_input)
 /*
  * Write a double value into a cell (truncates for CELL type output).
  */
-
 void write_double_value_c(void *cell, double val)
 {
     Rast_set_c_value(cell, (CELL)val, OUT_TYPE);

--- a/raster/r.flow/aspect.h
+++ b/raster/r.flow/aspect.h
@@ -4,5 +4,4 @@
  * aspect_fly: calculates aspect on the fly based on elevation map in z
  * globals r: region, parm
  */
-
 DCELL aspect_fly(DCELL *, DCELL *, DCELL *, double /* n, c, s, d */);

--- a/raster/r.flow/flow_io.h
+++ b/raster/r.flow/flow_io.h
@@ -8,7 +8,6 @@
  * globals rw: el, as
  * globals w:  density, string
  */
-
 void read_input_files(void);
 
 /*
@@ -16,19 +15,16 @@ void read_input_files(void);
  * globals r: parm, fl
  * globals w: string, el, as, ds, lgfd
  */
-
 void open_output_files(void);
 
 /*
  * close_files: closes continuously written/read files, outputs header info
  * globals r: parm, el, as, ds, lgfd, fl
  */
-
 void close_files(void);
 
 /*
  * write_density_file: dumps density matrix and colormap
  * globals r: density, parm, region, string
  */
-
 void write_density_file(void);

--- a/raster/r.flow/mem.h
+++ b/raster/r.flow/mem.h
@@ -15,14 +15,12 @@ extern CELL v;
  * globals r: parm, region
  * globals w: fl, density, ew_dist, el, as, ds
  */
-
 void allocate_heap(void);
 
 /*
  * deallocate_heap: frees space for other processes, closes cts output files
  * globals r: parm, bitbar, lgfd, el, as, ew_dist
  */
-
 void deallocate_heap(void);
 
 void put_row_seg(layer, int /* l, row */);

--- a/raster/r.flow/precomp.h
+++ b/raster/r.flow/precomp.h
@@ -1,5 +1,4 @@
 /*
  * precompute: fill lookup tables to prepare for calculation
  */
-
 void precompute(void);

--- a/raster/r.li/r.li.daemon/daemon.h
+++ b/raster/r.li/r.li.daemon/daemon.h
@@ -137,7 +137,6 @@ typedef int rli_func(int fd, char **par, struct area_entry *ad, double *result);
  * idiom for success/failure. The interface was designed to accommodate
  * common usage of this function in r.li modules.
  */
-
 int calculateIndex(char *file, rli_func *f, char **parameters, char *raster,
                    char *output);
 

--- a/raster/r.neighbors/bufs.c
+++ b/raster/r.neighbors/bufs.c
@@ -9,7 +9,6 @@
    last row read will be in the last i/o buf
 
  */
-
 int allocate_bufs(void)
 {
     int i, t;

--- a/raster/r.out.pov/main.c
+++ b/raster/r.out.pov/main.c
@@ -238,7 +238,6 @@ void writeHeader(FILE *outputF)
 /*
  * read profiles
  */
-
 void processProfiles(int inputFile, FILE *outputF)
 {
     CELL *cell;

--- a/raster/r.out.vrml/put_grid.c
+++ b/raster/r.out.vrml/put_grid.c
@@ -7,7 +7,6 @@
  * Currently, grid space is "unitized" so that the
  * largest dimension of the current region in GRASS == 1.0
  */
-
 void vrml_put_grid(FILE *vout, struct Cell_head *w, int elevfd, int colorfd,
                    struct Colors *colr, int color_ok, int rows, int cols,
                    int shh)

--- a/raster/r.out.vrml/vrml.c
+++ b/raster/r.out.vrml/vrml.c
@@ -28,7 +28,6 @@ void vrml_end(FILE *vout)
    decrease the level of indentation.  For better storage,
    just comment out the tab printing.
  */
-
 void vrml_putline(int indent, FILE *vout, char *str)
 {
     static int ind = 0;

--- a/raster/r.patch/do_patch.c
+++ b/raster/r.patch/do_patch.c
@@ -9,7 +9,6 @@
  * returns: 1 the result still contains nulls
  *          0 the result contains no zero nulls
  */
-
 int is_zero_value(void *rast, RASTER_MAP_TYPE data_type)
 {
 

--- a/raster/r.patch/support.c
+++ b/raster/r.patch/support.c
@@ -44,7 +44,6 @@ void merge_threads(struct Cell_stats **thread_statf, int nprocs, int nfiles)
  * final cats/colr only if these patching layers actually
  * contributed new categories to the final result
  */
-
 int support(char **names, struct Cell_stats *statf, int nfiles,
             struct Categories *cats, int *cats_ok, struct Colors *colr,
             int *colr_ok, RASTER_MAP_TYPE out_type)

--- a/raster/r.report/sums.c
+++ b/raster/r.report/sums.c
@@ -5,7 +5,6 @@
  (updated upon return to point to next stat)
  nl is the layer number (or level)
  */
-
 double area_sum(int *ns, int nl)
 {
     double area;

--- a/raster/r.viewshed/viewshed.cpp
+++ b/raster/r.viewshed/viewshed.cpp
@@ -433,7 +433,6 @@ MemoryVisibilityGrid *viewshed_in_memory(char *inputfname, GridHeader *hd,
    runs in external memory, i.e. the input grid and the outpt grid are
    stored as streams
  */
-
 IOVisibilityGrid *viewshed_external(char *inputfname, GridHeader *hd,
                                     Viewpoint *vp, ViewOptions viewOptions)
 {

--- a/raster3d/r3.out.v5d/main.c
+++ b/raster3d/r3.out.v5d/main.c
@@ -94,7 +94,6 @@ void getParams(char **input, char **output, int *decim UNUSED)
 /* Opens the output v5d file and writes the header.
  * Returns the file handle for the output file.
  */
-
 void convert(char *fileout, int rows, int cols, int depths, int trueCoords)
 {
 

--- a/raster3d/r3.showdspf/thresh_array.c
+++ b/raster3d/r3.showdspf/thresh_array.c
@@ -5,7 +5,6 @@
  **  return an array of struct cmndln_info of resulting
  **   thresholds based on  in_out flag
  */
-
 int build_thresh_arrays(D_spec, headp)
 struct dspec *D_spec;
 file_info *headp;

--- a/vector/v.clean/prune.c
+++ b/vector/v.clean/prune.c
@@ -30,7 +30,6 @@
  * 3) position of centroids on the left and right side is checked and pruning
  *    is not done if centroid would be attached to another area
  */
-
 int prune(struct Map_info *Out, int otype, double thresh, struct Map_info *Err)
 {
     int line, type, nlines;

--- a/vector/v.in.ascii/points.c
+++ b/vector/v.in.ascii/points.c
@@ -51,7 +51,6 @@ static int is_double(char *str)
  * If the who whole column is empty, column_sample will contain NULL
  * for that given column.
  */
-
 int points_analyse(FILE *ascii_in, FILE *ascii, char *fs, char *td,
                    int *rowlength, int *ncolumns, int *minncolumns, int *nrows,
                    int **column_type, char ***column_sample,

--- a/vector/v.net/turntable.c
+++ b/vector/v.net/turntable.c
@@ -43,7 +43,6 @@ static double compute_line_nodes_angle(struct line_pnts *points)
    \return lines angle
    \return -9.0 if line is defined by one point or has same start and end point
  */
-
 static double compute_lines_angle(struct line_pnts *line_pnts_from,
                                   int from_dir, struct line_pnts *line_pnts_to,
                                   int to_dir)

--- a/vector/v.perturb/zufallrs.c
+++ b/vector/v.perturb/zufallrs.c
@@ -7,7 +7,6 @@
  * in seed block. IMPORTANT: svblk must be dimensioned at least 608 in
  * driver. The entire contents of klotz0 must be restored.
  */
-
 int zufallrs(double *svblk)
 {
     int i;

--- a/vector/v.perturb/zufallsv.c
+++ b/vector/v.perturb/zufallsv.c
@@ -8,7 +8,6 @@
  * driver. The entire contents of klotz0 (pointer in buff, and buff) must
  * be saved.
  */
-
 int zufallsv(double *svblk)
 {
     int i;

--- a/vector/v.surf.idw/read_sites.c
+++ b/vector/v.surf.idw/read_sites.c
@@ -12,7 +12,6 @@
  * Only uses floating point attributes.
  * mccauley
  */
-
 void read_sites(const char *name, const char *field_name, const char *col,
                 int noindex)
 {

--- a/vector/v.to.db/lines.c
+++ b/vector/v.to.db/lines.c
@@ -56,7 +56,6 @@ void read_side_cats(struct line_cats *ACats, int *val, int *count)
  * Read: - points/centroids : cat,count,coor
  *       - lines/boundaries : cat,count,length,slope,sinuous
  */
-
 int read_lines(struct Map_info *Map)
 {
     int i, idx, nlines, type, found;

--- a/vector/v.vol.rst/user1.c
+++ b/vector/v.vol.rst/user1.c
@@ -59,7 +59,6 @@
    INPUT now reads site files using the new, multi-attribute format
    (mca 2/12/96)
  */
-
 int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
 {
     struct quadruple *point;
@@ -398,7 +397,6 @@ int INPUT(struct Map_info *In, char *column, char *scol, char *wheresql)
 /*
  * OUTGR now writes 3d raster maps (mca 2/15/96)
  */
-
 int OUTGR(void)
 {
     void *cf1, *cf2, *cf3, *cf4, *cf5, *cf6, *cf7;

--- a/vector/v.voronoi/vo_extend.c
+++ b/vector/v.voronoi/vo_extend.c
@@ -25,7 +25,6 @@
  *
  *    returns: 0 on error, 1 otherwise
  */
-
 int extend_line(double s, double n, double w, double e, double a, double b,
                 double c, double x, double y, double *c_x, double *c_y,
                 int knownPointAtLeft)


### PR DESCRIPTION
Even if the current version of Doxygen doesn't complain much, different parsers in an IDE, like VSCode, doesn't recognize the block comment above when there are extra newlines.

Used the following regex to find possible candidates:
```
\n\s(?:\*)\/\n\n((?:\w* [\*]*)+[\w]*\()
```

And replaced with:
```
\n */\n$1
```

I applied the replacements one file at a time, and manually checked each when staging the changes.