### PR TITLE
CI: Fix labeler permissions to create labels

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -21,6 +21,7 @@ jobs:
   labeler:
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I noticed when using my second fork of grass (through an organisation), that the labeler workflow doesn't work anymore.
The error shown in the CI logs is:
```
Error: HttpError: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
Error: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
```

The `pull-requests: write` permission doesn't seem to allow creating labels anymore, the `issues: write` is also needed.

As discussed in https://github.com/googleapis/release-please-action/issues/1105#issuecomment-2780292262 and https://github.com/googleapis/release-please-action/issues/1105#issuecomment-2850640688, there seems to be a change and GitHub support requested a documentation change too, as the docs doesn't represent reality.