### PR TITLE
tests: Enable tests for gunittest's test_assertions_vect.py

### DIFF
--- a/.github/workflows/macos_gunittest.cfg
+++ b/.github/workflows/macos_gunittest.cfg
@@ -6,7 +6,6 @@
 exclude =
     gui/wxpython/core/testsuite/test_gcmd.py
     gui/wxpython/core/testsuite/toolboxes.sh
-    python/grass/gunittest/testsuite/test_assertions_vect.py
     python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
     python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py
     python/grass/temporal/testsuite/unittests_temporal_raster_algebra_equal_ts.py

--- a/.gunittest.cfg
+++ b/.gunittest.cfg
@@ -5,7 +5,6 @@
 # but it includes mainly tests which can (and should) be fixed.
 exclude =
     gui/wxpython/core/testsuite/toolboxes.sh
-    python/grass/gunittest/testsuite/test_assertions_vect.py
     python/grass/gunittest/testsuite/test_gunitest_doctests.py
     python/grass/pygrass/raster/testsuite/test_pygrass_raster_doctests.py
     python/grass/pygrass/rpc/testsuite/test_pygrass_rpc_doctests.py

--- a/python/grass/gunittest/testsuite/test_assertions_vect.py
+++ b/python/grass/gunittest/testsuite/test_assertions_vect.py
@@ -2,10 +2,10 @@
 Tests assertion methods for vectors.
 """
 
+import unittest
 from grass.exceptions import CalledModuleError
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
-from grass.gunittest.utils import xfail_windows
 
 
 V_UNIVAR_SCHOOLS_WIDTH_SUBSET = """n=144
@@ -282,7 +282,7 @@ class TestVectorGeometryAssertions(TestCase):
         self.assertFileExists(self.simple_base_file)
         self.assertFileExists(self.simple_modified_file)
 
-    @xfail_windows
+    @unittest.expectedFailure
     def test_assertVectorEqualsAscii_by_import(self):
         amap = "simple_vector_map_imported_base"
         self.runModule(


### PR DESCRIPTION
I was preparing some changes in gunittest code, and noticed that a whole set of asserts were not tested, and there was a typo in one of them for more than a decade. Unfortunately, the tests here weren't checking for this particular assert.
The file was excluded because of one error that is unrelated to the problem I found.
By making it an expected failure, the 10 other tests in the file can be executed.