### PR TITLE
grass.gunittest: Fix typo in function `TestCase.assertVectorsNoAreaDifference()` for `_compute_vector_xor`

### DIFF
--- a/python/grass/gunittest/case.py
+++ b/python/grass/gunittest/case.py
@@ -1127,7 +1127,7 @@ class TestCase(unittest.TestCase):
 
         This method should not be used to test v.overlay or v.select.
         """
-        diff = self._compute_xor_vectors(
+        diff = self._compute_vector_xor(
             ainput=reference,
             binput=actual,
             alayer=layer,


### PR DESCRIPTION
Since the lines were introduced, it always had that unexistant function. I made a search in the git log, and there's only one commit where the count of `_compute_xor_vectors` occurences change. So I assume it was meant to be `_compute_vector_xor`, in the same file.

The function `assertVectorsNoAreaDifference()` has no tests, and its declaration is the only occurrence. It seems to be there to match the other types of `assert*No*Difference()` functions.