### PR TITLE
CI(pytest): Upload test results to Codecov for test analytics 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -98,6 +98,7 @@ jobs:
           pytest \
             @.github/workflows/pytest_args_ci.txt \
             @.github/workflows/pytest_args_parallel.txt \
+            --junitxml=pytest.xdist.junit.xml \
             -k 'not testsuite'
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
         shell: micromamba-shell {0}
@@ -107,6 +108,7 @@ jobs:
           pytest \
             @.github/workflows/pytest_args_ci.txt \
             @.github/workflows/pytest_args_not_parallel.txt \
+            --junitxml=pytest.needs_solo_run.junit.xml \
             -k 'not testsuite'
       - name: Run pytest with a single worker (for gunittest-based tests)
         shell: micromamba-shell {0}
@@ -114,7 +116,15 @@ jobs:
           export PYTHONPATH=$(grass --config python_path):$PYTHONPATH
           export LD_LIBRARY_PATH=$(grass --config path)/lib:$LD_LIBRARY_PATH
           pytest \
-            @.github/workflows/pytest_args_gunittest.txt
+            @.github/workflows/pytest_args_gunittest.txt \
+            --junitxml=pytest.gunittest.junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        with:
+          flags: macos-pytest-python
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Cache GRASS Sample Dataset
         id: cached-data

--- a/.github/workflows/osgeo4w.yml
+++ b/.github/workflows/osgeo4w.yml
@@ -135,6 +135,7 @@ jobs:
           path %GISBASE%\lib;%GISBASE%\bin;%PATH%
           pytest ^
             @.github/workflows/pytest_args_ci.txt ^
+            --junitxml=pytest.junit.xml ^
             -k "not testsuite"
         shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
       - name: Run pytest with a single worker (for gunittest-based tests)
@@ -145,8 +146,16 @@ jobs:
           pytest ^
             @.github/workflows/pytest_args_ci.txt ^
             @.github/workflows/pytest_args_deselect.txt ^
-            @.github/workflows/pytest_args_gunittest.txt
+            @.github/workflows/pytest_args_gunittest.txt ^
+            --junitxml=pytest.gunittest.junit.xml
         shell: cmd /D /E:ON /V:OFF /S /C "CALL C:/OSGeo4W/OSGeo4W.bat "{0}""
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        with:
+          flags: ${{ matrix.os }}-pytest-python
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run tests
         run: .github/workflows/test_thorough.bat '${{env.O4WROOT}}\opt\grass\grass85.bat' '${{env.O4WROOT}}\bin\python3'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -91,6 +91,7 @@ jobs:
             @.github/workflows/pytest_args_ci.txt \
             @.github/workflows/pytest_args_cov.txt \
             @.github/workflows/pytest_args_parallel.txt \
+            --junitxml=pytest.xdist.junit.xml \
             -k 'not testsuite'
 
       - name: Run pytest with a single worker (for tests marked with needs_solo_run)
@@ -103,6 +104,7 @@ jobs:
             @.github/workflows/pytest_args_ci.txt \
             @.github/workflows/pytest_args_cov.txt \
             @.github/workflows/pytest_args_not_parallel.txt \
+            --junitxml=pytest.needs_solo_run.junit.xml \
             -k 'not testsuite'
       - name: Run pytest with a single worker (for gunittest-based tests)
         run: |
@@ -112,7 +114,8 @@ jobs:
           export INITIAL_PWD="${PWD}"
           pytest \
             @.github/workflows/pytest_args_cov.txt \
-            @.github/workflows/pytest_args_gunittest.txt
+            @.github/workflows/pytest_args_gunittest.txt \
+            --junitxml=pytest.gunittest.junit.xml
       - name: Fix non-standard installed script paths in coverage data
         run: |
           export PYTHONPATH=`grass --config python_path`:$PYTHONPATH
@@ -123,6 +126,12 @@ jobs:
           coverage combine
           coverage html
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
+        with:
+          flags: pytest-python-${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:

--- a/.github/workflows/pytest_args_ci.txt
+++ b/.github/workflows/pytest_args_ci.txt
@@ -2,4 +2,6 @@
 --color=yes
 --durations=0
 --durations-min=0.5
+--junitxml=junit.xml
+-o junit_family=legacy
 -ra

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ python/grass/docs/src/pydispatch.rst
 python/grass/docs/src/pygrass.*rst
 python/grass/docs/src/script.rst
 python/grass/docs/src/temporal.rst
+
+# Test result files
+*junit.xml


### PR DESCRIPTION
Codecov had this feature announced and available for a while now, but they're pushing it a little more now. I think it can be useful a bit.

Basically, you can upload a junit-style xml test report, which basically is an xml file with the test names, the results, and the time taken. Pytest works out of the box. The goal is to upload even on test failures, so that we can analyze which tests are flaky, how many are failing often etc.

For unittest, there's a package that we could use that replaces unittest' test runner class, but gunittest already does the same thing, so it's not readily available yet to implement (it would be more useful to get a value on the i.smap failure rate for example).

I was waiting before working on this and submitting a PR as it wasn't clear if the pull request comments would be posted on failures. There has been some feedback since, and I didn't see one yet, even if I did a PR with purposely failing tests after merging in my main branch (adding/removing "not" in asserts).



The interface, for the main branch (of my fork), looks like:

<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/aa4eff65-2ead-45f1-bd92-641c2a2f6d90" />

I configured flags, so we can filter them:
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/fa5f2518-7881-46f4-bcdc-181ff672d240" />

It also analyzes what are the slow tests. For example, in our pytest tests, 28 tests take way more time than the others. (The time seems like for the last 30 days, but less since it's been on my main branch for only a couple commits, at the first commit it was like 4-5 minutes for a subset of 23 tests)

<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/291415dc-3c87-4b88-a911-36082c196644" />


Here's an example for a branch, and also showing where there's a flaky test (a new v.class test from https://github.com/OSGeo/grass/pull/6071, on sometimes fails on Windows, even in the main repo):
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/4fdf85b0-1fc2-49c4-b59c-fda67e3b341b" />



I didn't try on my second fork to see how it behaves without a codecov token. I strongly suppose it works the same as for code coverage upload, which still worked yesterday. Technically, they shouldn't have made a separate action, as it is pretty much the same as the code coverage upload action, it even uses the same cli binary uploader.

There was a beta feature in oct 2023 that looks still in beta that used a similar mechanism. You uploaded a list of tests collected before actually running them, and from the code coverage, the labels, the flags, and the changes, it would select the tests that must be ran, maybe a bit more, and you run these. I don't feel it was appropriate or ready to rely on, but it was an interesting idea. Having only the test results uploaded doesn't have any real impact if it stops working.



I also tried out using open id connect (oidc) with the `use_oidc: true` + adding workflow permissions instead of having the CODECOV_TOKEN, for both the test result upload and code coverage upload, and both worked fine multiple times. I simply kept it out fromm here, as it was not needed to work correctly.