### PR TITLE
CI(docs): Enable bzlib, openmp, pthread, and readline support in build for doxygen docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -105,7 +105,7 @@ jobs:
             --enable-largefile \
             --prefix="$INSTALL_PREFIX/" \
             --with-blas \
-            --with-bzlib=no \
+            --with-bzlib \
             --with-cxx \
             --with-fftw \
             --with-freetype \
@@ -116,12 +116,12 @@ jobs:
             --with-netcdf \
             --with-nls \
             --with-odbc \
-            --with-openmp=no \
+            --with-openmp \
             --with-pdal \
             --with-postgres --with-postgres-includes=/usr/include/postgresql \
             --with-proj-share=/usr/share/proj \
-            --with-pthread=no \
-            --with-readline=no \
+            --with-pthread \
+            --with-readline \
             --with-sqlite \
             --with-tiff \
             --with-zstd


### PR DESCRIPTION
Follow-up of #6092.
I thought I had created the PR, but no, it was only on my fork.

This enables extra features in the configure step, so more parts of the code can be documented. The goal is to have as much optional features enabled, so that the possible values for example, what db drivers are allowed, can represent the full set of features in the docs.

In #6092, the goal was to have a baseline that matched what was on the server.
If the packages are not installed on the server that independently generates the docs, only the artifact in CI will have these extra function blocks and extra text. Soon it'll be needed to publish the artifact so we can use newer doxygen versions, but now it is still kept at 1.9.1 as the server.