### PR TITLE
man: Ignore UNUSED attribute macros on parameters for doxygen docs

### DIFF
--- a/include/Make/Doxyfile_arch_html.in
+++ b/include/Make/Doxyfile_arch_html.in
@@ -2211,7 +2211,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2251,11 +2251,14 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = HAVE_OGR \
-                         HAVE_TIFFIO_H \
-                         HAVE_GEOS \
+PREDEFINED             = HAVE_GEOS \
+                         HAVE_LIBBLAS \
                          HAVE_LIBLAPACK \
-                         HAVE_LIBBLAS
+                         HAVE_OGR \
+                         HAVE_TIFFIO_H \
+                         NOPG_UNUSED= \
+                         NO_NLS_UNUSED= \
+                         UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/Make/Doxyfile_arch_latex.in
+++ b/include/Make/Doxyfile_arch_latex.in
@@ -2211,7 +2211,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2251,11 +2251,14 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = HAVE_OGR \
-                         HAVE_TIFFIO_H \
-                         HAVE_GEOS \
+PREDEFINED             = HAVE_GEOS \
+                         HAVE_LIBBLAS \
                          HAVE_LIBLAPACK \
-                         HAVE_LIBBLAS
+                         HAVE_OGR \
+                         HAVE_TIFFIO_H \
+                         NOPG_UNUSED= \
+                         NO_NLS_UNUSED= \
+                         UNUSED=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
Since the UNUSED macros are placed after the parameter names, Doxygen parses the attribute (UNUSED) like if it was the parameter name, and the parameter name as if it was part of the type. Doxygen then can't find the correct parameter in the docstring, and complains that there's a parameter 'UNUSED' not documented, and that an extra parameter is documented but is missing in the function signature.

This also applies to the NOPG_UNUSED and NO_NLS_UNUSED macros.

In the Doxygen config, we can predefine macros with another definition, essentially removing them. 
> [!NOTE]
> Note that this also means that permalinks built from a has of the signatures will change, but they were wrong before.



See https://stackoverflow.com/a/36306085 and the Doxygen docs for preprocessing https://www.doxygen.nl/manual/preprocessing.html