### PR TITLE
docs(lib/ogsf): Refactor, enhance and uniformize ogsf docstrings

### DIFF
--- a/include/grass/ogsf.h
+++ b/include/grass/ogsf.h
@@ -217,7 +217,8 @@ typedef struct {
 } typbuff;
 
 typedef struct { /* use hash table? */
-    int n_elem;  /* if n_elem == 256, index == NULL */
+    /** @brief if n_elem == 256, index == NULL */
+    int n_elem;
     char *index;
     int *value;
 } table256;
@@ -243,12 +244,21 @@ typedef struct {
 
 /* maybe add transformation matrix? */
 typedef struct {
-    IFLAG att_src;          /* NOTSET_ATT, MAP_ATT, CONST_ATT, FUNC_ATT */
-    IFLAG att_type;         /* ATTY_INT, ATTY_SHORT, ATTY_CHAR, or ATTY_FLOAT */
-    int hdata;              /* handle to dataset */
-    int (*user_func)(void); /* Not yet supported */
+    /** @brief NOTSET_ATT, MAP_ATT, CONST_ATT, FUNC_ATT */
+    IFLAG att_src;
+
+    /** @brief ATTY_INT, ATTY_SHORT, ATTY_CHAR, or ATTY_FLOAT */
+    IFLAG att_type;
+
+    /** @brief handle to dataset */
+    int hdata;
+
+    /** Not yet supported */
+    int (*user_func)(void);
     float constant;
-    int *lookup; /* TODO: use transform instead */
+
+    /** @todo: use transform instead */
+    int *lookup;
     float min_nz, max_nz, range_nz;
     float default_null;
 } gsurf_att;
@@ -256,19 +266,29 @@ typedef struct {
 typedef struct g_surf {
     int gsurf_id;
     int cols, rows;
-    gsurf_att att[MAX_ATTS]; /* mask, topo, color, etc. */
-    IFLAG draw_mode;         /* DM_GOURAUD | DM_FRINGE | DM_POLY,
-                              DM_WIRE, DM_WIRE_POLY */
-    long wire_color;         /* 0xBBGGRR or WC_COLOR_ATT */
-    double ox, oy;           /* real world origin (i.e., SW corner) */
+
+    /** @brief mask, topo, color, etc. */
+    gsurf_att att[MAX_ATTS];
+
+    /** @brief DM_GOURAUD | DM_FRINGE | DM_POLY, DM_WIRE, DM_WIRE_POLY */
+    IFLAG draw_mode;
+
+    /** @brief 0xBBGGRR or WC_COLOR_ATT */
+    long wire_color;
+
+    /** @brief real world origin (i.e., SW corner) */
+    double ox, oy;
     double xres, yres;
     float z_exag;
     float x_trans, y_trans, z_trans;
     float xmin, xmax, ymin, ymax, zmin, zmax, zminmasked;
     float xrange, yrange, zrange;
     float zmin_nz, zmax_nz, zrange_nz;
-    int x_mod, y_mod, x_modw, y_modw; /*cells per viewcell, per wire viewcell */
-    int nz_topo, nz_color;            /* no zero flags */
+    /** @brief cells per viewcell, per wire viewcell */
+    int x_mod, y_mod, x_modw, y_modw;
+
+    /** @brief no zero flags */
+    int nz_topo, nz_color;
     int mask_needupdate, norm_needupdate;
     unsigned long *norms;
     struct BM *curmask;
@@ -281,23 +301,43 @@ typedef struct g_surf {
    usually be stored as 2d, since they may be draped on multiple
    surfaces & Z will vary depending upon surface. */
 
-/* Struct for vector feature displaying attributes */
+/**
+ * @brief Struct for vector feature displaying attributes.
+ */
 typedef struct g_vect_style {
-    int color;  /* Line color */
-    int symbol; /* Point symbol/line type */
-    float size; /* Symbol size. Unset for lines. */
-    int width;  /* Line width. Also used for lines forming symbols i.e. X */
+    /** @brief Line color. */
+    int color;
+
+    /** @brief %Point symbol/line type. */
+    int symbol;
+
+    /** @brief Symbol size.
+     *
+     * Unset for lines.
+     */
+    float size;
+
+    /**
+     * @brief Line width.
+     *
+     * Also used for lines forming symbols i.e. X.
+     */
+    int width;
 
     /*TODO:fill;         Area fill pattern */
     /*TODO:falpha;       Area fill transparency */
     /*TODO:lalpha;       Line/boundary/point transparency */
     /*TODO:struct *orientation;  Symbol orientation */
-    struct g_vect_style *next; /* Point to next gvstyle struct if single point
-                                  has multiple styles. In such case feature with
-                                  next style should be shifted. */
+
+    /** @brief %Point to next \ref gvstyle struct if single point has multiple
+     * styles.
+     *
+     * In such case, the feature with next style should be shifted.
+     */
+    struct g_vect_style *next;
 } gvstyle;
 
-/* Struct for vector map (thematic mapping) */
+/** @brief Struct for vector map (thematic mapping) */
 typedef struct g_vect_style_thematic {
     int active;
     int layer;
@@ -308,7 +348,7 @@ typedef struct g_vect_style_thematic {
     char *width_column;
 } gvstyle_thematic;
 
-/* Line instance */
+/** @brief Line instance */
 typedef struct g_line {
     int type;
     float norm[3];
@@ -316,23 +356,31 @@ typedef struct g_line {
     Point3 *p3;
     Point2 *p2;
 
-    struct line_cats *
-        cats; /* Store information about all layers/cats for thematic display */
-    gvstyle *style;          /* Line instance look&feel */
-    signed char highlighted; /* >0 Feature is highlighted */
+    /** @brief Store information about all layers/cats for thematic display */
+    struct line_cats *cats;
+
+    /** @brief Line instance look&feel. */
+    gvstyle *style;
+
+    /** @brief >0 Feature is highlighted. */
+    signed char highlighted;
 
     struct g_line *next;
 } geoline;
 
-/* Vector map (lines) */
+/** @brief Vector map (lines) */
 typedef struct g_vect {
     int gvect_id;
     int use_mem, n_lines;
-    int drape_surf_id[MAX_SURFS]; /* if you want 'em flat, define the surface */
+
+    /** if you want 'em flat, define the surface */
+    int drape_surf_id[MAX_SURFS];
+
     int use_z;
     int n_surfs;
     char *filename;
     float x_trans, y_trans, z_trans;
+
     /* also maybe center & rotate? */
     geoline *lines;
     geoline *fastlines;
@@ -340,31 +388,38 @@ typedef struct g_vect {
     struct g_vect *next;
     void *clientdata;
 
-    gvstyle_thematic *tstyle; /* thematic mapping */
-    gvstyle *style;           /* Vector default look&feel */
-    gvstyle *hstyle;          /* IMHO highlight should be per layer basis. */
+    /** @brief thematic mapping */
+    gvstyle_thematic *tstyle;
+
+    /** @brief Vector default look&feel */
+    gvstyle *style;
+    gvstyle *hstyle; /* IMHO highlight should be per layer basis. */
 } geovect;
 
-/* Point instance */
+/** @brief Point instance */
 typedef struct g_point {
     int dims;
     Point3 p3;
 
-    struct line_cats *
-        cats; /* Store information about all layers/cats for thematic display */
+    /** @brief Store information about all layers/cats for thematic display */
+    struct line_cats *cats;
     gvstyle *style;
-    signed char highlighted; /* >0 Feature is highlighted */
+
+    /** @brief >0 Feature is highlighted */
+    signed char highlighted;
 
     struct g_point *next;
 } geopoint;
 
-/* Vector map (points) */
+/** @brief Vector map (points) */
 typedef struct g_site {
     int gsite_id;
     int drape_surf_id[MAX_SURFS]; /* ditto */
     int n_surfs, n_sites;
     int use_z, use_mem;
-    int has_z; /* set when file loaded */
+
+    /** set when file loaded */
+    int has_z;
 
     char *filename;
     transform attr_trans;
@@ -374,32 +429,51 @@ typedef struct g_site {
     struct g_site *next;
     void *clientdata;
 
-    gvstyle_thematic *tstyle; /* thematic mapping */
-    gvstyle *style;           /* points default look&feel */
-    gvstyle *hstyle;          /* IMHO highlight should be per layer basis */
+    /** @brief thematic mapping */
+    gvstyle_thematic *tstyle;
+
+    /** @brief points default look&feel */
+    gvstyle *style;
+    gvstyle *hstyle; /* IMHO highlight should be per layer basis */
 } geosite;
 
 typedef struct {
-    int data_id;        /* id */
-    IFLAG file_type;    /* file type */
-    unsigned int count; /* number of referencies to this file */
-    char *file_name;    /* file name */
+    /** @brief id */
+    int data_id;
+
+    /** @brief file type */
+    IFLAG file_type;
+
+    /** @brief number of referencies to this file */
+    unsigned int count;
+
+    /** @brief file name */
+    char *file_name;
 
     IFLAG data_type;
-    void *map;       /* pointer to volume file descriptor */
-    double min, max; /* minimum, maximum value in file */
 
-    IFLAG status; /* current status */
-    IFLAG mode;   /* current read mode */
+    /** @brief pointer to volume file descriptor */
+    void *map;
 
-    void *buff; /* data buffer */
+    /** @brief minimum, maximum value in file */
+    double min, max;
+
+    /** @brief current status */
+    IFLAG status;
+    /** @brief current read mode */
+    IFLAG mode;
+
+    /** @brief data buffer */
+    void *buff;
 } geovol_file;
 
 typedef struct {
     IFLAG att_src;
 
     int hfile;
-    int (*user_func)(void); /* unused */
+
+    /** unused */
+    int (*user_func)(void);
     float constant;
 
     void *att_data;
@@ -450,35 +524,62 @@ typedef struct g_vol {
 } geovol;
 
 struct lightdefs {
-    float position[4]; /* X, Y, Z, (1=local/0=inf) */
-    float color[3];    /* R, G, B */
-    float ambient[3];  /* R, G, B */
-    float emission[3]; /* R, G, B */
-    float shine;       /* 0. to 128. */
+    /** @brief X, Y, Z, (1=local/0=inf) */
+    float position[4];
+
+    /** @brief R, G, B */
+    float color[3];
+
+    /** @brief R, G, B */
+    float ambient[3];
+
+    /** @brief R, G, B */
+    float emission[3];
+
+    /** @brief 0. to 128. */
+    float shine;
 };
 
 struct georot {
-    int do_rot;             /* do rotation */
-    double rot_angle;       /* rotation angle */
-    double rot_axes[3];     /* rotation axis */
-    GLdouble rotMatrix[16]; /* rotation matrix */
+    /** @brief do rotation */
+    int do_rot;
+
+    /** @brief rotation angle */
+    double rot_angle;
+
+    /** @brief rotation axis */
+    double rot_axes[3];
+
+    /** @brief rotation matrix */
+    GLdouble rotMatrix[16];
 };
 
 typedef struct {
-    int coord_sys; /* latlon, equal area, etc */
-    int view_proj; /* perspective, ortho */
-    int infocus;   /* fixed center of view - true or false */
+    /** @brief latlon, equal area, etc */
+    int coord_sys;
+
+    /** @brief perspective, ortho */
+    int view_proj;
+
+    /** @brief fixed center of view - true or false */
+    int infocus;
     float from_to[2][4];
     struct georot rotate;
-    int twist, fov, incl, look;  /* 10ths of degrees */
-    float real_to[4], vert_exag; /* a global Z exag */
+
+    /** @brief 10ths of degrees */
+    int twist, fov, incl, look;
+
+    /** @brief a global Z exag */
+    float real_to[4], vert_exag;
     float scale;
     struct lightdefs lights[MAX_LIGHTS];
 } geoview;
 
 typedef struct { /* need to add elements here for off_screen drawing */
     float nearclip, farclip, aspect;
-    short left, right, bottom, top; /* Screen coordinates */
+
+    /** @brief Screen coordinates */
+    short left, right, bottom, top;
     int bgcol;
 } geodisplay;
 

--- a/lib/gis/distance.c
+++ b/lib/gis/distance.c
@@ -67,8 +67,8 @@ int G_begin_distance_calculations(void)
    latitude-longitude, this distance is measured along the
    geodesic. Two routines perform geodesic distance calculations.
 
-   \param e1,n1 east-north coordinates of first point
-   \param e2,n2 east-north coordinates of second point
+   \param[in] e1,n1 east-north coordinates of first point
+   \param[in] e2,n2 east-north coordinates of second point
 
    \return distance
  */

--- a/lib/gis/geodist.c
+++ b/lib/gis/geodist.c
@@ -61,7 +61,7 @@ void G_begin_geodesic_distance(double a, double e2)
  *
  * <b>Note:</b> Must be called first.
  *
- * \param lat1 first latitude
+ * \param[in] lat1 first latitude
  * \return
  */
 void G_set_geodesic_distance_lat1(double lat1)
@@ -76,7 +76,7 @@ void G_set_geodesic_distance_lat1(double lat1)
  *
  * <b>Note:</b> Must be called second.
  *
- * \param lat2 second latitidue
+ * \param[in] lat2 second latitude
  */
 void G_set_geodesic_distance_lat2(double lat2)
 {
@@ -111,8 +111,8 @@ void G_set_geodesic_distance_lat2(double lat2)
  * passed to G_set_geodesic_distance_latl() and <i>lat2</i> was the
  * latitude passed to G_set_geodesic_distance_lat2().
  *
- * \param lon1 first longitude
- * \param lon2 second longitude
+ * \param[in] lon1 first longitude
+ * \param[in] lon2 second longitude
  *
  * \return double distance in meters
  */
@@ -185,8 +185,8 @@ double G_geodesic_distance_lon_to_lon(double lon1, double lon2)
  * <b>Note:</b> The calculation of the geodesic distance is fairly
  * costly.
  *
- * \param lon1,lat1 longitude,latitude of first point
- * \param lon2,lat2 longitude,latitude of second point
+ * \param[in] lon1,lat1 longitude,latitude of first point
+ * \param[in] lon2,lat2 longitude,latitude of second point
  *
  * \return distance in meters
  */

--- a/lib/ogsf/gs.c
+++ b/lib/ogsf/gs.c
@@ -1306,7 +1306,7 @@ int gs_setall_norm_needupdate(void)
    \brief Check if point is masked
 
    \param gs pointer to geosurf struct
-   \param pt point coordinates (X,Y,Z)
+   \param[in] pt point coordinates (X,Y,Z)
 
    \return 1 masked
    \return 0 not masked

--- a/lib/ogsf/gs3.c
+++ b/lib/ogsf/gs3.c
@@ -71,8 +71,8 @@ typedef int FILEDESC;
 
    Uses G_distance().
 
-   \param from 'from' point (X, Y)
-   \param to 'to' point (X, Y)
+   \param[in] from 'from' point (X, Y)
+   \param[in] to 'to' point (X, Y)
 
    \return distance
  */

--- a/lib/ogsf/gs_util.c
+++ b/lib/ogsf/gs_util.c
@@ -46,9 +46,9 @@
 
    Default is meters.
 
-   \param from starting point
-   \param to ending point
-   \param units map units
+   \param[in] from starting point (X,Y)
+   \param[in] to ending point (X,Y)
+   \param[in] units map units
 
    \return distance between two geographic coordinates in current projection
  */
@@ -133,8 +133,8 @@ double GS_geodistance(double *from, double *to, const char *units)
 /*!
    \brief Calculate distance
 
-   \param from 'from' point (X,Y,Z)
-   \param to 'to' point (X,Y,Z)
+   \param[in] from 'from' point (X,Y,Z)
+   \param[in] to 'to' point (X,Y,Z)
 
    \return distance
  */
@@ -152,8 +152,8 @@ float GS_distance(float *from, float *to)
 /*!
    \brief Calculate distance in plane
 
-   \param from 'from' point (X,Y)
-   \param to 'to' point (X,Y)
+   \param[in] from 'from' point (X,Y)
+   \param[in] to 'to' point (X,Y)
 
    \return distance
  */
@@ -172,8 +172,8 @@ float GS_P2distance(float *from, float *to)
 
    v1 = v2
 
-   \param[out] v1 first vector
-   \param v2 second vector
+   \param[out] v1 first 3D vector (X,Y,Z)
+   \param[in] v2 second 3D vector (X,Y,Z)
  */
 void GS_v3eq(float *v1, float *v2)
 {
@@ -189,8 +189,8 @@ void GS_v3eq(float *v1, float *v2)
 
    v1 += v2
 
-   \param[in,out] v1 first vector
-   \param v2 second vector
+   \param[in,out] v1 first 3D vector (X,Y,Z)
+   \param[in] v2 second 3D vector (X,Y,Z)
  */
 void GS_v3add(float *v1, float *v2)
 {
@@ -206,8 +206,8 @@ void GS_v3add(float *v1, float *v2)
 
    v1 -= v2
 
-   \param[in,out] v1 first vector
-   \param v2 second vector
+   \param[in,out] v1 first 3D vector (X,Y,Z)
+   \param v2 second 3D vector (X,Y,Z)
  */
 void GS_v3sub(float *v1, float *v2)
 {
@@ -223,8 +223,8 @@ void GS_v3sub(float *v1, float *v2)
 
    v1 *= k
 
-   \param[in,out] v1 vector
-   \param k multiplicator
+   \param[in,out] v1 3D vector (X,Y,Z)
+   \param[in] k multiplicator
  */
 void GS_v3mult(float *v1, float k)
 {
@@ -236,9 +236,9 @@ void GS_v3mult(float *v1, float k)
 }
 
 /*!
-   \brief Change v1 so that it is a unit vector (2D)
+   \brief Change v1 so that it is a unit vector (3D)
 
-   \param[in,out] v1 vector
+   \param[in,out] v1 3D vector (X,Y,Z)
 
    \return 0 if magnitude of v1 is zero
    \return 1 if magnitude of v1 > 0
@@ -261,9 +261,9 @@ int GS_v3norm(float *v1)
 }
 
 /*!
-   \brief Change v1 so that it is a unit vector (3D)
+   \brief Change v1 so that it is a unit vector (2D)
 
-   \param[in,out] v1 vector
+   \param[in,out] v1 2D vector (X,Y)
 
    \return 0 if magnitude of v1 is zero
    \return 1 if magnitude of v1 > 0
@@ -287,7 +287,7 @@ int GS_v2norm(float *v1)
 /*!
    \brief Changes v1 so that it is a unit vector
 
-   \param dv1 vector
+   \param[in,out] dv1 3D vector (X,Y,Z)
 
    \return 0 if magnitude of dv1 is zero
    \return 1 if magnitude of dv1 > 0
@@ -312,8 +312,8 @@ int GS_dv3norm(double *dv1)
 /*!
    \brief Change v2 so that v1v2 is a unit vector
 
-   \param v1 first vector
-   \param v2[in,out] second vector
+   \param[in] v1 first 3D vector (X,Y,Z)
+   \param[in,out] v2 second 3D vector (X,Y,Z)
 
    \return 0 if magnitude of dx is zero
    \return 1 if magnitude of dx > 0
@@ -341,9 +341,9 @@ int GS_v3normalize(float *v1, float *v2)
 /*!
    \brief Get a normalized direction from v1 to v2, store in v3
 
-   \param v1 first vector
-   \param v2 second vector
-   \param[out] v3 output vector
+   \param[in] v1 first 3D vector (X,Y,Z)
+   \param[in] v2 second 3D vector (X,Y,Z)
+   \param[out] v3 output 3D vector (X,Y,Z)
 
    \return 0 if magnitude of dx is zero
    \return 1 if magnitude of dx > 0
@@ -372,9 +372,9 @@ int GS_v3dir(float *v1, float *v2, float *v3)
 /*!
    \brief Get a normalized direction from v1 to v2, store in v3 (2D)
 
-   \param v1 first vector
-   \param v2 second vector
-   \param[out] v3 output vector
+   \param[in] v1 first 2D vector (X,Y)
+   \param[in] v2 second 2D vector (X,Y)
+   \param[out] v3 output 2D vector (X,Y)
 
    \return 0 if magnitude of dx is zero
    \return 1 if magnitude of dx > 0
@@ -396,9 +396,9 @@ void GS_v2dir(float *v1, float *v2, float *v3)
 /*!
    \brief Get the cross product v3 = v1 cross v2
 
-   \param v1 first vector
-   \param v2 second vector
-   \param[out] v3 output vector
+   \param[in] v1 first 3D vector (X,Y,Z)
+   \param[in] v2 second 3D vector (X,Y,Z)
+   \param[out] v3 output 3D vector (X,Y,Z)
  */
 void GS_v3cross(float *v1, float *v2, float *v3)
 {
@@ -412,7 +412,7 @@ void GS_v3cross(float *v1, float *v2, float *v3)
 /*!
    \brief Magnitude of vector
 
-   \param v1 vector
+   \param[in] v1 3D vector (X,Y,Z)
    \param[out] mag magnitude value
  */
 void GS_v3mag(float *v1, float *mag)
@@ -428,9 +428,9 @@ void GS_v3mag(float *v1, float *mag)
    Initialize by calling with a number nhist to represent number of
    previous entries to check, then call with zero as nhist
 
-   \param p1 first point
-   \param p2 second point
-   \param nhist ?
+   \param[in] p1 first point
+   \param[in] p2 second point
+   \param[in] nhist ?
 
    \return -1 on error
    \return -2

--- a/lib/ogsf/gsd_objs.c
+++ b/lib/ogsf/gsd_objs.c
@@ -28,16 +28,16 @@
 
 static void init_stuff(void);
 
-/*!
-   \brief vertices for octahedron
+/**
+ * @brief vertices for octahedron
  */
 float Octo[6][3] = {{1.0, 0.0, 0.0},  {0.0, 1.0, 0.0},  {0.0, 0.0, 1.0},
                     {-1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}};
 
 #define ONORM .57445626
 
-/*!
-   \brief normals for flat-shaded octahedron
+/**
+ * @brief normals for flat-shaded octahedron
  */
 float OctoN[8][3] = {
     {ONORM, ONORM, ONORM},   {-ONORM, ONORM, ONORM},   {ONORM, -ONORM, ONORM},
@@ -69,13 +69,13 @@ float origin[3] = {0.0, 0.0, 0.0};
 #define DOWN_NORM Octo[5]
 #define ORIGIN    origin
 
-/*!
-   \brief vertices & normals for octagon in xy plane
+/**
+ * @brief vertices & normals for octagon in xy plane
  */
 float ogverts[8][3];
 
-/*!
-   \brief vertices for octagon in xy plane, z=1
+/**
+ * @brief vertices for octagon in xy plane, z=1
  */
 float ogvertsplus[8][3];
 
@@ -120,12 +120,16 @@ static void init_stuff(void)
     return;
 }
 
-/*!
-   \brief ADD
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a plus sign symbol at the specified center location.
+ *
+ * This function renders a plus sign ('+') symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_plus(float *center, int colr, float siz)
 {
@@ -155,14 +159,14 @@ void gsd_plus(float *center, int colr, float siz)
     return;
 }
 
-/*!
-   \brief Line on surface, fix z-values
-
-   \todo remove fudge, instead fudge the Z buffer
-
-   \param gs surface (geosurf)
-   \param v1 first point
-   \param v2 second point
+/**
+ * @brief Line on surface, fix z-values
+ *
+ * @todo remove fudge, instead fudge the Z buffer
+ *
+ * @param gs surface (geosurf)
+ * @param v1 first point (X,Y)
+ * @param v2 second point (X,Y)
  */
 void gsd_line_onsurf(geosurf *gs, float *v1, float *v2)
 {
@@ -193,22 +197,21 @@ void gsd_line_onsurf(geosurf *gs, float *v1, float *v2)
     return;
 }
 
-/*!
-   \brief Multiline on surface, fix z-values
-
-   \todo remove fudge, instead fudge the Z buffer
-
-   Like above, except only draws first n points of line, or np,
-   whichever is less.  Returns number of points used. Fills
-   pt with last pt drawn.
-
-   \param gs surface (geosurf)
-   \param v1 first point
-   \param v2 second point
-   \param pt
-   \param n number of segments
-
-   \param number of vertices
+/**
+ * @brief Multiline on surface, fix z-values
+ *
+ * @todo remove fudge, instead fudge the Z buffer
+ *
+ * Like above, except only draws first n points of line, or np,
+ * whichever is less.  Returns number of points used. Fills
+ * pt with last pt drawn.
+ *
+ * @param gs surface (geosurf)
+ * @param v1 Pointer to a float array representing the first point as a vector.
+ * @param v2 Pointer to a float array representing the second point as a vector.
+ * @param[out] pt
+ * @param[in] n number of segments
+ * @return int
  */
 int gsd_nline_onsurf(geosurf *gs, float *v1, float *v2, float *pt, int n)
 {
@@ -243,15 +246,19 @@ int gsd_nline_onsurf(geosurf *gs, float *v1, float *v2, float *pt, int n)
     return (0);
 }
 
-/*!
-   \brief Draw X symbol
-
-   Note gs: NULL if flat
-
-   \param gs surface (geosurf)
-   \param center
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a X symbol at the specified center location.
+ *
+ * This function renders a x ('X') symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * Note gs: NULL if flat
+ *
+ * @param gs surface (geosurf)
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_x(geosurf *gs, float *center, int colr, float siz)
 {
@@ -295,12 +302,16 @@ void gsd_x(geosurf *gs, float *center, int colr, float siz)
     return;
 }
 
-/*!
-   \brief Draw diamond symbol
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a diamond symbol at the specified center location.
+ *
+ * This function renders a diamond symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_diamond(float *center, unsigned long colr, float siz)
 {
@@ -395,14 +406,18 @@ void gsd_diamond(float *center, unsigned long colr, float siz)
     return;
 }
 
-/*!
-   \brief Draw cube
-
-   Added by Hamish Bowman Nov 2005
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a cube symbol at the specified center location.
+ *
+ * This function renders a cube symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * Added by Hamish Bowman Nov 2005
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_cube(float *center, unsigned long colr, float siz)
 {
@@ -471,14 +486,18 @@ void gsd_cube(float *center, unsigned long colr, float siz)
     return;
 }
 
-/*!
-   \brief Draw box
-
-   Added by Hamish Bowman Nov 2005
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a box symbol at the specified center location.
+ *
+ * This function renders a box symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * Added by Hamish Bowman Nov 2005
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_draw_box(float *center, unsigned long colr, float siz)
 {
@@ -532,12 +551,16 @@ void gsd_draw_box(float *center, unsigned long colr, float siz)
     return;
 }
 
-/*!
-   \brief Draw sphere
-
-   \param center center point
-   \param colr color value
-   \param size size value
+/**
+ * @brief Draws a sphere at the specified center location.
+ *
+ * This function renders a sphere at the given center
+ * coordinates with the specified color and size.
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the sphere.
+ * @param siz    Size of the sphere.
  */
 void gsd_drawsphere(float *center, unsigned long colr, float siz)
 {
@@ -571,12 +594,16 @@ void gsd_diamond_lines(void)
     return;
 }
 
-/*!
-   \brief Draw asterisk
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws an asterisk symbol at the specified center location.
+ *
+ * This function renders an asterisk symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_draw_asterisk(float *center, unsigned long colr, float siz)
 {
@@ -626,12 +653,16 @@ void gsd_draw_asterisk(float *center, unsigned long colr, float siz)
     return;
 }
 
-/*!
-   \brief Draw gyro
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a gyro symbol at the specified center location.
+ *
+ * This function renders a gyro symbol at the given center
+ * coordinates with the specified color and size.
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_draw_gyro(float *center, unsigned long colr, float siz)
 {
@@ -680,10 +711,10 @@ void gsd_draw_gyro(float *center, unsigned long colr, float siz)
     return;
 }
 
-/*!
-   \brief Draw 3d cursor
-
-   \param pt point
+/**
+ * @brief Draw 3d cursor
+ *
+ * @param[in] pt point
  */
 void gsd_3dcursor(float *pt)
 {
@@ -721,13 +752,26 @@ void gsd_3dcursor(float *pt)
     return;
 }
 
-/*!
-   \brief ADD
-
-   \param dir
-   \param slope
-   \param aspect
-   \param degrees
+/**
+ * @brief Converts a direction vector to slope and aspect angles.
+ *
+ * Given a 3D direction vector, this function computes the slope and aspect
+ * angles corresponding to the vector. The aspect is the compass direction
+ * (azimuth) of the projection of the vector onto the XY plane, and the slope
+ * is the angle between the vector and the vertical axis (Z).
+ *
+ * @param[in]  dir     Pointer to an array of 3 floats representing the
+ *                     direction vector [dx, dy, dz].
+ * @param[out] slope   Pointer to a float where the computed slope angle will be
+ *                     stored (in radians or degrees).
+ * @param[out] aspect  Pointer to a float where the computed aspect angle will
+ *                     be stored (in radians or degrees).
+ * @param[in]  degrees If non-zero, the output angles are converted to degrees;
+ *                     otherwise, they are in radians.
+ *
+ * The function handles edge cases where the direction vector is vertical or
+ * horizontal. Aspect is set to 0 if the vector has no horizontal component.
+ * Slope is negative for upward-pointing vectors, positive for downward.
  */
 void dir_to_slope_aspect(float *dir, float *slope, float *aspect, int degrees)
 {
@@ -787,19 +831,23 @@ void dir_to_slope_aspect(float *dir, float *slope, float *aspect, int degrees)
     return;
 }
 
-/*!
-   \brief Draw North Arrow takes OpenGL coords and size
-
-   \param pos2
-   \param len
-   \param fontbase
-   \param arw_clr north arrow color
-   \param text_clr text color
-
-   \return 1
+/**
+ * @brief Draw North Arrow
+ *
+ * Takes OpenGL coords and size
+ *
+ * @param pos2 Pointer to a float array representing the position as a
+ *             3D vector (X,Y,Z).
+ * @param len
+ * @param fontbase
+ * @param arw_clr north arrow color
+ * @param text_clr text color
+ *
+ * @return 1
+ *
+ * @todo Store arrow somewhere to enable it's removal/change.
+ * @todo Add option to specify north text and font.
  */
-/*TODO: Store arrow somewhere to enable it's removal/change.
-   Add option to specify north text and font. */
 int gsd_north_arrow(float *pos2, float len, GLuint fontbase,
                     unsigned long arw_clr, unsigned long text_clr)
 {
@@ -876,24 +924,26 @@ int gsd_north_arrow(float *pos2, float len, GLuint fontbase,
     return (1);
 }
 
-/*!
-   \brief ADD
-
-   siz is height, sz is global exag to correct for.
-
-   If onsurf in non-null, z component of dir is dropped and
-   line-on-suf is used, resulting in length of arrow being proportional
-   to slope
-
-   \param center center point
-   \param colr color value
-   \param siz size value
-   \param dir
-   \param sz
-   \param onsurf surface (geosurf)
-
-   \return 1 no surface given
-   \return 0 on surface
+/**
+ * @brief Draws an arrow
+ *
+ * siz is height, sz is global exag to correct for.
+ *
+ * If onsurf in non-null, z component of dir is dropped and
+ * line-on-suf is used, resulting in length of arrow being proportional
+ * to slope.
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr Integer representing the color to use for drawing the arrow.
+ * @param siz Size of the arrow.
+ * @param dir Direction of the arrow. Pointer to a float array representing the
+ *            3D vector (X,Y,Z).
+ * @param sz height, sz is global exag to correct for.
+ * @param onsurf surface (geosurf).
+ *
+ * @return 1 no surface given
+ * @return 0 on surface
  */
 int gsd_arrow(float *center, unsigned long colr, float siz, float *dir,
               float sz, geosurf *onsurf)
@@ -956,16 +1006,18 @@ int gsd_arrow(float *center, unsigned long colr, float siz, float *dir,
     return (1);
 }
 
-/*!
-   \brief Draw north arrow on surface
-
-   \param base
-   \param tip
-   \param colr
-   \param wid
-   \param gs surface (geosurf)
-
-   \return 0
+/**
+ * @brief Draw north arrow on surface
+ *
+ * @param base Pointer to a float array representing the base as a
+ *             2D vector (X,Y).
+ * @param tip Pointer to a float array representing the tip as a
+ *            2D vector (X,Y).
+ * @param colr Integer representing the color to use for drawing the arrow.
+ * @param wid Line width (see \ref gsd_linewidth)
+ * @param gs surface (geosurf)
+ *
+ * @return 0
  */
 int gsd_arrow_onsurf(float *base, float *tip, unsigned long colr, int wid,
                      geosurf *gs)
@@ -1044,15 +1096,17 @@ int gsd_arrow_onsurf(float *base, float *tip, unsigned long colr, int wid,
     return (0);
 }
 
-/*!
-   \brief Draw 3d north arrow
-
-   \param center center point
-   \param colr color value
-   \param siz1 height
-   \param siz2 is diameter
-   \param dir
-   \param sz
+/**
+ * @brief Draw 3d north arrow
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr Integer representing the color to use for drawing the arrow.
+ * @param siz1 size
+ * @param siz2 size
+ * @param dir Direction of the arrow. Pointer to a float array representing the
+ *            3D vector (X,Y,Z).
+ * @param sz height
  */
 void gsd_3darrow(float *center, unsigned long colr, float siz1, float siz2,
                  float *dir, float sz)
@@ -1121,18 +1175,20 @@ void gsd_3darrow(float *center, unsigned long colr, float siz1, float siz2,
     return;
 }
 
-/*!
-   \brief Draw Scalebar takes OpenGL coords and size
-
-   Adapted from gsd_north_arrow Hamish Bowman Dec 2006
-
-   \param pos2
-   \param len
-   \param fontbase font-base
-   \param bar_clr barscale color
-   \param text_clr text color
-
-   \return 1
+/**
+ * @brief Draw Scalebar takes OpenGL coords and size
+ *
+ * Adapted from gsd_north_arrow Hamish Bowman Dec 2006
+ *
+ * @param pos2 Pointer to a float array representing the scalebar position as a
+ *             3D vector (X,Y,Z).
+ * @param len
+ * @param fontbase font-base
+ * @param bar_clr barscale color.
+ *                Integer representing the color to use for the barscale.
+ * @param text_clr test color.
+ *                 Integer representing the color to use for the text.
+ * @return 1
  */
 int gsd_scalebar(float *pos2, float len, GLuint fontbase, unsigned long bar_clr,
                  unsigned long text_clr)
@@ -1208,18 +1264,20 @@ int gsd_scalebar(float *pos2, float len, GLuint fontbase, unsigned long bar_clr,
     return (1);
 }
 
-/*!
-   \brief Draw Scalebar (as lines)
-
-   Adapted from gsd_scalebar A.Kratochvilova 2011
-
-   \param pos scalebar position
-   \param len
-   \param fontbase font-base (unused)
-   \param bar_clr barscale color
-   \param text_clr text color (unused)
-
-   \return 1
+/**
+ * @brief Draw Scalebar (as lines)
+ *
+ * Adapted from gsd_scalebar A.Kratochvilova 2011
+ *
+ * @param pos Pointer to a float array representing the scalebar position as a
+ *            3D vector (X,Y,Z).
+ * @param len
+ * @param fontbase font-base (unused)
+ * @param bar_clr barscale color.
+ *                Integer representing the color to use for the barscale.
+ * @param text_clr Text color (unused).
+ *                 Integer representing the color to use for the text.
+ * @return 1
  */
 int gsd_scalebar_v2(float *pos, float len, GLuint fontbase UNUSED,
                     unsigned long bar_clr, unsigned long text_clr UNUSED)
@@ -1277,14 +1335,14 @@ int gsd_scalebar_v2(float *pos, float len, GLuint fontbase UNUSED,
     return 1;
 }
 
-/*!
-   \brief Primitives only called after transforms
-
-   Center is actually center at base of 8 sided cone
-
-   \param col color value
+/**
+ * @brief Primitives only called after transforms
+ *
+ * Center is actually center at base of 8 sided cone
+ *
+ * @param colr Integer representing the color to use for drawing the cone.
  */
-void primitive_cone(unsigned long col)
+void primitive_cone(unsigned long colr)
 {
     float tip[3];
     static int first = 1;
@@ -1298,30 +1356,30 @@ void primitive_cone(unsigned long col)
     tip[Z] = 1.0;
 
     gsd_bgntfan();
-    gsd_litvert_func2(UP_NORM, col, tip);
-    gsd_litvert_func2(ogverts[0], col, ogverts[0]);
-    gsd_litvert_func2(ogverts[1], col, ogverts[1]);
-    gsd_litvert_func2(ogverts[2], col, ogverts[2]);
-    gsd_litvert_func2(ogverts[3], col, ogverts[3]);
-    gsd_litvert_func2(ogverts[4], col, ogverts[4]);
-    gsd_litvert_func2(ogverts[5], col, ogverts[5]);
-    gsd_litvert_func2(ogverts[6], col, ogverts[6]);
-    gsd_litvert_func2(ogverts[7], col, ogverts[7]);
-    gsd_litvert_func2(ogverts[0], col, ogverts[0]);
+    gsd_litvert_func2(UP_NORM, colr, tip);
+    gsd_litvert_func2(ogverts[0], colr, ogverts[0]);
+    gsd_litvert_func2(ogverts[1], colr, ogverts[1]);
+    gsd_litvert_func2(ogverts[2], colr, ogverts[2]);
+    gsd_litvert_func2(ogverts[3], colr, ogverts[3]);
+    gsd_litvert_func2(ogverts[4], colr, ogverts[4]);
+    gsd_litvert_func2(ogverts[5], colr, ogverts[5]);
+    gsd_litvert_func2(ogverts[6], colr, ogverts[6]);
+    gsd_litvert_func2(ogverts[7], colr, ogverts[7]);
+    gsd_litvert_func2(ogverts[0], colr, ogverts[0]);
     gsd_endtfan();
 
     return;
 }
 
-/*!
-   \brief Primitives only called after transforms
-
-   Center is actually center at base of 8 sided cylinder
-
-   \param col color value
-   \param caps
+/**
+ * @brief Primitives only called after transforms
+ *
+ * Center is actually center at base of 8 sided cylinder
+ *
+ * @param colr Integer representing the color to use for drawing the cylinder.
+ * @param caps If non zero, draw caps at the bottom and top of the cylinder.
  */
-void primitive_cylinder(unsigned long col, int caps)
+void primitive_cylinder(unsigned long colr, int caps)
 {
     static int first = 1;
 
@@ -1331,53 +1389,53 @@ void primitive_cylinder(unsigned long col, int caps)
     }
 
     gsd_bgnqstrip();
-    gsd_litvert_func2(ogverts[0], col, ogvertsplus[0]);
-    gsd_litvert_func2(ogverts[0], col, ogverts[0]);
-    gsd_litvert_func2(ogverts[1], col, ogvertsplus[1]);
-    gsd_litvert_func2(ogverts[1], col, ogverts[1]);
-    gsd_litvert_func2(ogverts[2], col, ogvertsplus[2]);
-    gsd_litvert_func2(ogverts[2], col, ogverts[2]);
-    gsd_litvert_func2(ogverts[3], col, ogvertsplus[3]);
-    gsd_litvert_func2(ogverts[3], col, ogverts[3]);
-    gsd_litvert_func2(ogverts[4], col, ogvertsplus[4]);
-    gsd_litvert_func2(ogverts[4], col, ogverts[4]);
-    gsd_litvert_func2(ogverts[5], col, ogvertsplus[5]);
-    gsd_litvert_func2(ogverts[5], col, ogverts[5]);
-    gsd_litvert_func2(ogverts[6], col, ogvertsplus[6]);
-    gsd_litvert_func2(ogverts[6], col, ogverts[6]);
-    gsd_litvert_func2(ogverts[7], col, ogvertsplus[7]);
-    gsd_litvert_func2(ogverts[7], col, ogverts[7]);
-    gsd_litvert_func2(ogverts[0], col, ogvertsplus[0]);
-    gsd_litvert_func2(ogverts[0], col, ogverts[0]);
+    gsd_litvert_func2(ogverts[0], colr, ogvertsplus[0]);
+    gsd_litvert_func2(ogverts[0], colr, ogverts[0]);
+    gsd_litvert_func2(ogverts[1], colr, ogvertsplus[1]);
+    gsd_litvert_func2(ogverts[1], colr, ogverts[1]);
+    gsd_litvert_func2(ogverts[2], colr, ogvertsplus[2]);
+    gsd_litvert_func2(ogverts[2], colr, ogverts[2]);
+    gsd_litvert_func2(ogverts[3], colr, ogvertsplus[3]);
+    gsd_litvert_func2(ogverts[3], colr, ogverts[3]);
+    gsd_litvert_func2(ogverts[4], colr, ogvertsplus[4]);
+    gsd_litvert_func2(ogverts[4], colr, ogverts[4]);
+    gsd_litvert_func2(ogverts[5], colr, ogvertsplus[5]);
+    gsd_litvert_func2(ogverts[5], colr, ogverts[5]);
+    gsd_litvert_func2(ogverts[6], colr, ogvertsplus[6]);
+    gsd_litvert_func2(ogverts[6], colr, ogverts[6]);
+    gsd_litvert_func2(ogverts[7], colr, ogvertsplus[7]);
+    gsd_litvert_func2(ogverts[7], colr, ogverts[7]);
+    gsd_litvert_func2(ogverts[0], colr, ogvertsplus[0]);
+    gsd_litvert_func2(ogverts[0], colr, ogverts[0]);
     gsd_endqstrip();
 
     if (caps) {
         /* draw top */
         gsd_bgntfan();
-        gsd_litvert_func2(UP_NORM, col, UP_NORM);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[0]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[1]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[2]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[3]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[4]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[5]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[6]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[7]);
-        gsd_litvert_func2(UP_NORM, col, ogvertsplus[0]);
+        gsd_litvert_func2(UP_NORM, colr, UP_NORM);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[0]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[1]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[2]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[3]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[4]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[5]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[6]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[7]);
+        gsd_litvert_func2(UP_NORM, colr, ogvertsplus[0]);
         gsd_endtfan();
 
         /* draw bottom */
         gsd_bgntfan();
-        gsd_litvert_func2(DOWN_NORM, col, ORIGIN);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[0]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[1]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[2]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[3]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[4]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[5]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[6]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[7]);
-        gsd_litvert_func2(DOWN_NORM, col, ogverts[0]);
+        gsd_litvert_func2(DOWN_NORM, colr, ORIGIN);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[0]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[1]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[2]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[3]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[4]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[5]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[6]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[7]);
+        gsd_litvert_func2(DOWN_NORM, colr, ogverts[0]);
         gsd_endtfan();
     }
 
@@ -1387,12 +1445,12 @@ void primitive_cylinder(unsigned long col, int caps)
 /*** ACS_MODIFY_BEGIN - sites_attribute management
  * ********************************/
 /*
-   Draws boxes that are used for histograms by gpd_obj function in gpd.c
+   Draws boxes that are used for histograms by \ref gpd_obj function in gpd.c
    for site_attribute management
  */
 
-/*!
-   \brief Vertices for box
+/**
+ * @brief Vertices for box
  */
 float Box[8][3] = {{1.0, 1.0, -1.0},  {-1.0, 1.0, -1.0}, {-1.0, 1.0, 1.0},
                    {1.0, 1.0, 1.0},   {1.0, -1.0, -1.0}, {-1.0, -1.0, -1.0},
@@ -1401,14 +1459,18 @@ float Box[8][3] = {{1.0, 1.0, -1.0},  {-1.0, 1.0, -1.0}, {-1.0, 1.0, 1.0},
 float BoxN[6][3] = {{0, 0, -ONORM}, {0, 0, ONORM}, {0, ONORM, 0},
                     {0, -ONORM, 0}, {ONORM, 0, 0}, {-ONORM, 0, 0}};
 
-/*!
-   \brief Draw box
-
-   Warning siz is an array (we need it for scale only Z in histograms)
-
-   \param center center point
-   \param colr color value
-   \param siz size value
+/**
+ * @brief Draws a box at the specified center location.
+ *
+ * This function renders a box at the given center
+ * coordinates with the specified color and size.
+ *
+ * @warning siz is an array (we need it for scale only Z in histograms)
+ *
+ * @param center Pointer to a float array representing the (x, y, z) coordinates
+ *               of the center point.
+ * @param colr   Integer representing the color to use for drawing the symbol.
+ * @param siz    Size of the symbol.
  */
 void gsd_box(float *center, int colr, float *siz)
 {

--- a/lib/ogsf/gsdrape.c
+++ b/lib/ogsf/gsdrape.c
@@ -84,7 +84,7 @@ static typbuff *Ebuf; /* elevation buffer */
 static int Flat;
 
 /*!
-   \brief Initizalize
+   \brief Initialize
 
    \param[in] rows number of rows
    \param[in] cols number of columns

--- a/lib/ogsf/gsdrape.c
+++ b/lib/ogsf/gsdrape.c
@@ -86,8 +86,8 @@ static int Flat;
 /*!
    \brief Initizalize
 
-   \param rows number of rows
-   \param cols number of columns
+   \param[in] rows number of rows
+   \param[in] cols number of columns
 
    \return -1 on failure
    \return 1 on success
@@ -127,9 +127,9 @@ static int drape_line_init(int rows, int cols)
    \brief Get segments
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
-   \param num
+   \param[in] bgn begin point
+   \param[in] end end point
+   \param[out] num
 
    \return pointer to Point3 struct
  */
@@ -172,8 +172,8 @@ static Point3 *_gsdrape_get_segments(geosurf *gs, float *bgn, float *end,
 /*!
    \brief Calculate 2D distance
 
-   \param p1 first point
-   \param p2 second point
+   \param[in] p1 first point
+   \param[in] p2 second point
 
    \return distance
  */
@@ -223,11 +223,12 @@ int gsdrape_set_surface(geosurf *gs)
    - if seg intersects
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
+   \param[in,out] bgn begin point
+   \param[in,out] end end point
 
    \return 0 if segment doesn't intersect the viewregion, or intersects only at
-   corner \return otherwise returns 1
+           corner
+   \return otherwise returns 1
  */
 int seg_intersect_vregion(geosurf *gs, float *bgn, float *end)
 {
@@ -340,9 +341,9 @@ int seg_intersect_vregion(geosurf *gs, float *bgn, float *end)
    \brief ADD
 
    \param gs surface (geosurf)
-   \param bgn begin point (x,y)
-   \param end end point (x,y)
-   \param num
+   \param[in,out] bgn begin point (x,y)
+   \param[in,out] end end point (x,y)
+   \param[out] num
 
    \return pointer to Point3 struct
  */
@@ -390,9 +391,9 @@ Point3 *gsdrape_get_segments(geosurf *gs, float *bgn, float *end, int *num)
    \brief Get all segments
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
-   \param num
+   \param[in,out] bgn begin point
+   \param[in,out] end end point
+   \param[out] num
 
    \return pointer to Point3 struct
  */
@@ -430,10 +431,10 @@ Point3 *gsdrape_get_allsegments(geosurf *gs, float *bgn, float *end, int *num)
    \brief ADD
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
-   \param f first
-   \param l last
+   \param[in] bgn begin point
+   \param[in] end end point
+   \param[out] f first
+   \param[out] l last
  */
 void interp_first_last(geosurf *gs, float *bgn, float *end, Point3 f, Point3 l)
 {
@@ -458,7 +459,7 @@ void interp_first_last(geosurf *gs, float *bgn, float *end, Point3 f, Point3 l)
    \brief ADD
 
    \param gs surface (geosurf)
-   \param pt
+   \param[in,out] pt
  */
 int _viewcell_tri_interp(geosurf *gs, Point3 pt)
 {
@@ -496,6 +497,11 @@ int _viewcell_tri_interp(geosurf *gs, Point3 pt)
    pt has X & Y coordinates in it, we interpolate Z here
 
    This could probably be much shorter, but not much faster.
+
+   \param gs
+   \param buf
+   \param[in,out] pt
+   \param[in] check_mask
 
    \return 1 if point is in view region
    \return otherwise 0 (if masked)
@@ -684,7 +690,7 @@ int viewcell_tri_interp(geosurf *gs, typbuff *buf, Point3 pt, int check_mask)
    \brief ADD
 
    \param gs surface (geosurf)
-   \param pt
+   \param[in] pt
 
    \return 1
    \return 0
@@ -714,11 +720,11 @@ int in_vregion(geosurf *gs, float *pt)
    along the way and storing the result in I3d.
 
    \param gs surface (geosurf)
-   \param first first point
-   \param last last point
-   \param vi
-   \param hi
-   \param di
+   \param[in] first first point
+   \param[in] last last point
+   \param[in] vi
+   \param[in] hi
+   \param[in] di
 
    \return
  */
@@ -869,9 +875,9 @@ int order_intersects(geosurf *gs, Point3 first, Point3 last, int vi, int hi,
    Colinear already eliminated
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
-   \param dir direction
+   \param[in] bgn begin point
+   \param[in] end end point
+   \param[in] dir direction
 
    \return
  */
@@ -963,9 +969,9 @@ int get_vert_intersects(geosurf *gs, float *bgn, float *end, float *dir)
    \brief Get horizontal intersects
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
-   \param dir
+   \param[in] bgn begin point
+   \param[in] end end point
+   \param[in] dir
 
    \return number of intersects
  */
@@ -1058,8 +1064,8 @@ int get_horz_intersects(geosurf *gs, float *bgn, float *end, float *dir)
    Colinear already eliminated
 
    \param gs surface (geosurf)
-   \param bgn begin point
-   \param end end point
+   \param[in] bgn begin point
+   \param[in] end end point
    \param dir ? (unused)
 
    \return number of intersects
@@ -1192,8 +1198,8 @@ int get_diag_intersects(geosurf *gs, float *bgn, float *end, float *dir UNUSED)
    If the lines intersect, the output variables x, y are
    set to coordinates of the point of intersection.
 
-   \param x1,y1,x2,y2 coordinates of endpoints of one segment
-   \param x3,y3,x4,y4 coordinates of endpoints of other segment
+   \param[in] x1,y1,x2,y2 coordinates of endpoints of one segment
+   \param[in] x3,y3,x4,y4 coordinates of endpoints of other segment
    \param[out] x,y coordinates of intersection point
 
    \return 0 no intersection
@@ -1274,8 +1280,8 @@ int segs_intersect(float x1, float y1, float x2, float y2, float x3, float y3,
 
    Plane defined by three points here; user fills in unk[X] & unk[Y]
 
-   \param p1,p2,p3 points defining plane
-   \param unk point
+   \param[in,out] p1,p2,p3 points defining plane
+   \param[in,out] unk point
 
    \return 1 point on plane
    \return 0 point not on plane
@@ -1296,8 +1302,8 @@ int Point_on_plane(Point3 p1, Point3 p2, Point3 p3, Point3 unk)
 
    User fills in intersect[X] & intersect[Y]
 
-   \param[out] intersect intersect coordinates
-   \param plane plane definition
+   \param[in,out] intersect intersect coordinates
+   \param[in] plane plane definition
 
    \return 0 doesn't intersect
    \return 1 intesects
@@ -1320,7 +1326,7 @@ int XY_intersect_plane(float *intersect, float *plane)
 /*!
    \brief Define plane
 
-   \param p1,p2,p3 three point on plane
+   \param[in] p1,p2,p3 three point on plane
    \param[out] plane plane definition
 
    \return 1
@@ -1350,7 +1356,8 @@ int P3toPlane(Point3 p1, Point3 p2, Point3 p3, float *plane)
 /*!
    \brief Get cross product
 
-   \param a,b,c
+   \param[in] a,b
+   \param[out] c
 
    \return cross product c = a cross b
  */

--- a/lib/ogsf/gsget.c
+++ b/lib/ogsf/gsget.c
@@ -22,7 +22,7 @@
    \brief Get map attributes
 
    \param buff
-   \param offset
+   \param[in] offset
    \param[out] att
 
    \return 0 on failure


### PR DESCRIPTION
All of this started by my wanting to know what the "color value" int was, and if the color of gvstyle was referring to the same concept. So I dug a bit, and ended up making the information available rendered in doxygen, or injected new knowledge into the docstrings.

First, there's the file lib/ogsf/gsdrape.c and lib/ogsf/gs_util.c that I went and interpreted the code to add the parameter directions `[in]`, `[out]`, or `[in,out]`. Since it was like a sudoku, the related functions had to be annotated too, when known, in order to fill out more.

For lib/ogsf/gs_util.c, I also interpreted the code to indicate if the arrays were for 2D vectors or 3D vectors.


For lib/ogsf/gsd_objs.c, the main part of the work of this PR, I completely refactored the docs, making them uniform. I started out with AI to rewrite one single docstring, then completly overhauled it by the end when adapting it for each of the functions. I also asked Copilot for the docs of one function that wasn't documented and hard to understand, then I rewrote 80%+ of it to tune and enhance it. I was surprised by how close it got.

Finally, for include/grass/ogsf.h, I formatted the docstrings of the typedef's fields so that they:
1. appear in the Doxygen docs.
2. Short info shows up in the summary table before the longer docs below
3. Are correctly parsed even by IDEs, and less ambiguous.

That third goal is why, after many trials and errors, opted for using `/** @brief bla bla bla */` above the member to document, more standard and used by other tools, rather than a doxygen-specific advanced syntax that would allow attaching a documentation comment to a code preceding it, rather than following it. Being able to hover around when coding is almost as important and useful to me, as firing up the developper's documentation online to find the same info.


<details><summary><b>Lots of screenshots!</b></summary>
<p>

For example:
Before:
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/1ddb94a4-7a47-477a-977b-946da49efaff" />

After:
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/dbe254a3-ea96-4a7b-8806-85320eea550d" />


Before:
<img width="3840" height="2052" alt="image" src="https://github.com/user-attachments/assets/11c11826-0b03-4016-a5d3-13fb618ebec5" />
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/7e9518f6-7d5d-4a4c-958d-ef7e1bf0a33d" />

After:
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/455789d6-4d53-431f-9319-fc33a949f54e" />
<img width="3840" height="2064" alt="image" src="https://github.com/user-attachments/assets/68dc6f7c-cc36-42fe-801e-f4159c13f77a" />


Before & after:
<img width="3836" height="2060" alt="image" src="https://github.com/user-attachments/assets/f18dd000-d4ec-423e-a45f-c846ab40b55d" />
<img width="3831" height="2069" alt="image" src="https://github.com/user-attachments/assets/dc1ab1da-d25a-4784-98cf-d59676c5f09c" />
<img width="3838" height="2071" alt="image" src="https://github.com/user-attachments/assets/743301d2-a13f-443b-8f16-86144a808efc" />
<img width="3835" height="2065" alt="image" src="https://github.com/user-attachments/assets/bfbc05be-ed72-4f95-9c7e-f5910390a470" />





</p>
</details> 


