### PR TITLE
r.stats: add CSV support

### DIFF
--- a/raster/r.stats/global.h
+++ b/raster/r.stats/global.h
@@ -15,6 +15,7 @@ extern int ncols, no_nulls, no_nulls_all;
 extern int nsteps, cat_ranges, raw_output, as_int, averaged;
 extern int *is_fp;
 extern DCELL *DMAX, *DMIN;
+extern char **map_names; /* input map names */
 
 extern CELL NULL_CELL;
 

--- a/raster/r.stats/main.c
+++ b/raster/r.stats/main.c
@@ -40,6 +40,7 @@ CELL NULL_CELL;
 
 char *fs;
 struct Categories *labels;
+char **map_names; /* input map names */
 
 int main(int argc, char *argv[])
 {
@@ -325,8 +326,11 @@ int main(int argc, char *argv[])
         is_fp = (int *)G_realloc(is_fp, (nfiles + 1) * sizeof(int));
         DMAX = (DCELL *)G_realloc(DMAX, (nfiles + 1) * sizeof(DCELL));
         DMIN = (DCELL *)G_realloc(DMIN, (nfiles + 1) * sizeof(DCELL));
+        map_names =
+            (char **)G_realloc(map_names, (nfiles + 1) * sizeof(char *));
 
         fd[nfiles] = Rast_open_old(name, "");
+        map_names[nfiles] = G_store(name);
 
         if (!as_int)
             is_fp[nfiles] = Rast_map_is_fp(name, "");

--- a/raster/r.stats/raw_stats.c
+++ b/raster/r.stats/raw_stats.c
@@ -48,9 +48,9 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
             fprintf(stdout, "%s%s%s%s", "col", fs, "row", fs);
 
         for (i = 0; i < nfiles; i++) {
-            fprintf(stdout, "%s%s", i ? fs : "", "cat");
+            fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i], "cat");
             if (with_labels)
-                fprintf(stdout, "%s%s", fs, "label");
+                fprintf(stdout, "%s%s_%s", fs, map_names[i], "label");
         }
         fprintf(stdout, "\n");
     }

--- a/raster/r.stats/stats.c
+++ b/raster/r.stats/stats.c
@@ -276,7 +276,7 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
         if (format == CSV) {
             /* CSV Header */
             for (i = 0; i < nfiles; i++) {
-                fprintf(stdout, "%s%s", i ? fs : "", "cat");
+                fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i], "cat");
             }
             if (with_areas) {
                 fprintf(stdout, "%s%s", fs, "area");
@@ -318,14 +318,17 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
             /* CSV Header */
             for (i = 0; i < nfiles; i++) {
                 if (raw_output || !is_fp[i] || as_int)
-                    fprintf(stdout, "%s%s", i ? fs : "", "cat");
+                    fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i],
+                            "cat");
                 else if (averaged)
-                    fprintf(stdout, "%s%s", i ? fs : "", "average");
+                    fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i],
+                            "average");
                 else
-                    fprintf(stdout, "%s%s", i ? fs : "", "range");
+                    fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i],
+                            "range");
 
                 if (with_labels)
-                    fprintf(stdout, "%s%s", fs, "label");
+                    fprintf(stdout, "%s%s_%s", fs, map_names[i], "label");
             }
 
             if (with_areas) {

--- a/raster/r.stats/testsuite/test_r_stats.py
+++ b/raster/r.stats/testsuite/test_r_stats.py
@@ -818,7 +818,7 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,percent", "1,21.74%", "2,86.96%"]
+        expected_output = ["test_raster_1_cat,percent", "1,21.74%", "2,86.96%"]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -833,7 +833,14 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,cat,count", "1,1,5", "2,2,5", "2,3,5", "2,4,5", "2,*,5"]
+        expected_output = [
+            "test_raster_1_cat,test_raster_2_cat,count",
+            "1,1,5",
+            "2,2,5",
+            "2,3,5",
+            "2,4,5",
+            "2,*,5",
+        ]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -845,7 +852,7 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,area", "1,2000.000000", "2,8000.000000"]
+        expected_output = ["test_raster_1_cat,area", "1,2000.000000", "2,8000.000000"]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -858,7 +865,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "range,label",
+            "float_raster_range,float_raster_label",
             "0.5-0.515686,from 1 degrees to 1 degrees",
             "0.986275-1.001961,from 1 degrees to 2 degrees",
             "1.488235-1.503922,from 2 degrees to 3 degrees",
@@ -877,7 +884,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "east,north,cat",
+            "east,north,test_raster_1_cat",
             "10,90,1",
             "30,90,2",
             "50,90,2",
@@ -916,7 +923,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "col,row,cat",
+            "col,row,test_raster_1_cat",
             "1,1,1",
             "2,1,2",
             "3,1,2",
@@ -958,7 +965,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "average,area",
+            "float_raster_average,area",
             "0.507843,2000.000000",
             "0.994118,2000.000000",
             "1.496078,2000.000000",
@@ -977,7 +984,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "cat,area",
+            "float_raster_cat,area",
             "1,2000.000000",
             "32,2000.000000",
             "64,2000.000000",
@@ -999,7 +1006,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "range,label",
+            "float_raster_range,float_raster_label",
             "0.5-1,1 degrees",
             "1-1.5,2 degrees",
             "2-2.5,4 degrees",
@@ -1019,7 +1026,7 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,count", "1,10", "2,10", "5,5"]
+        expected_output = ["float_raster_cat,count", "1,10", "2,10", "5,5"]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -1035,7 +1042,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "cat,cat,area,count,percent",
+            "test_raster_1_cat,test_raster_2_cat,area,count,percent",
             "1,1,2000.000000,5,33.33%",
             "2,2,2000.000000,5,33.33%",
             "2,3,2000.000000,5,33.33%",
@@ -1056,7 +1063,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "cat,label,cat,label",
+            "test_raster_1_cat,test_raster_1_label,test_raster_2_cat,test_raster_2_label",
             "1,trees,1,trees",
             "2,water,2,buildings",
             "2,water,3,buildings",


### PR DESCRIPTION
Fixes: #5835 

Added CSV output support for `r.stats`, including headers. Note that the `cat`/`average`/`range` and `label` may appear multiple times when processing multiple rasters.
Let me know if this makes sense or if it needs to be updated?

I also attempted to add JSONL support but had some doubts. Even with JSONL, the schema would remain hierarchical since there can be more than one map, and we need arrays to represent their categories. So, the JSONL format would resemble the current JSON format but without the outer array.