### PR TITLE
r.volume: add csv column headers

### DIFF
--- a/raster/r.volume/main.c
+++ b/raster/r.volume/main.c
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
     unsigned long *n, *e;
     long int *count;
     int fd_data, fd_clump;
+    int skip_header = 0;
 
     const char *datamap, *clumpmap, *centroidsmap;
 
@@ -192,6 +193,9 @@ int main(int argc, char *argv[])
             G_fatal_error(_("The -f flag cannot be used with format=json. "
                             "Please select only one output format."));
         }
+        else if (format == PLAIN)
+            skip_header = 1; /* For backward compatibility */
+
         format = CSV;
     }
     // print = flag.print->answer;
@@ -355,7 +359,14 @@ int main(int argc, char *argv[])
     total_vol = 0.0;
 
     /* print output, write centroids */
-    if (fd_centroids || print)
+    if (fd_centroids || print) {
+        if (print && !skip_header && format == CSV) {
+            /* CSV Header */
+            fprintf(stdout, "%s%s%s%s%s%s%s%s%s%s%s%s%s\n", "cat", fs,
+                    "average", fs, "sum", fs, "cells", fs, "easting", fs,
+                    "northing", fs, "volume");
+        }
+
         for (i = 1; i <= max; i++) {
             if (count[i]) {
                 avg = sum[i] / (double)count[i];
@@ -414,6 +425,7 @@ int main(int argc, char *argv[])
                 }
             }
         }
+    }
 
     /* write centroid attributes and close the map */
     if (fd_centroids) {

--- a/raster/r.volume/testsuite/test_r_volume.py
+++ b/raster/r.volume/testsuite/test_r_volume.py
@@ -113,6 +113,7 @@ class TestRVolume(TestCase):
         )
         self.assertModule(module)
         expected_output = [
+            "cat,average,sum,cells,easting,northing,volume",
             "217,118.93,86288828,725562,635325.00,221535.00,8628882798.63",
             "262,108.97,21650560,198684,638935.00,222495.00,2165056037.02",
             "270,92.23,63578874,689373,642405.00,221485.00,6357887443.53",


### PR DESCRIPTION
Fixes: #6049 

This PR adds CSV headers to `r.volume`. I liked the method proposed by @wenzeslaus, where for backward compatibility - when the `-f` flag is used without `format=csv` - headers are not printed. Otherwise, CSV headers are always printed when the CSV format is specified. So, I used this method instead of adding an explicit flag for column headers, which I assume isn't that useful.