### PR TITLE
d.vect: Fix Copy into fixed buffer size issues

### DIFF
--- a/display/d.vect/legend.c
+++ b/display/d.vect/legend.c
@@ -1,4 +1,5 @@
 #include <grass/gis.h>
+#include <grass/glocale.h>
 #include <grass/vector.h>
 #include "local_proto.h"
 

--- a/display/d.vect/legend.c
+++ b/display/d.vect/legend.c
@@ -13,7 +13,9 @@ void write_into_legfile(struct Map_info *Map, int type, const char *leglab,
     char *leg_file;
     char map[GNAME_MAX];
     char *ptr;
-    strcpy(map, name_map);
+    if (G_strlcpy(map, name_map, sizeof(map)) >= sizeof(map)) {
+        G_fatal_error(_("Map name <%s> is too long"), name_map);
+    }
 #ifdef _MSC_VER
     strtok_s(map, "@", &ptr);
 #else

--- a/display/d.vect/main.c
+++ b/display/d.vect/main.c
@@ -362,7 +362,9 @@ int main(int argc, char **argv)
         }
     }
 
-    strcpy(map_name, map_opt->answer);
+    if (G_strlcpy(map_name, map_opt->answer, sizeof(map_name)) >= sizeof(map_name)) {
+        G_fatal_error(_("Map name <%s> is too long"), map_opt->answer);
+    }
 
     default_width = atoi(width_opt->answer);
     if (default_width < 0)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1208268, 1415697)
Used G_strlcpy() to fix this issue.