### PR TITLE
grass.tools: Rename tool name parameter

### DIFF
--- a/python/grass/tools/session_tools.py
+++ b/python/grass/tools/session_tools.py
@@ -147,7 +147,7 @@ class Tools:
 
         return env or self._original_env
 
-    def run(self, name: str, /, **kwargs):
+    def run(self, tool_name_: str, /, **kwargs):
         """Run a tool by specifying its name as a string and parameters.
 
         The parameters tool are tool name as a string and parameters as keyword
@@ -156,7 +156,7 @@ class Tools:
 
         The function may perform additional processing on the parameters.
 
-        :param name: name of a GRASS tool
+        :param tool_name_: name of a GRASS tool
         :param kwargs: tool parameters
         """
         # Object parameters are handled first before the conversion of the call to a
@@ -166,7 +166,7 @@ class Tools:
 
         # Get a fixed env parameter at at the beginning of each execution,
         # but repeat it every time in case the referenced environment is modified.
-        args, popen_options = gs.popen_args_command(name, **kwargs)
+        args, popen_options = gs.popen_args_command(tool_name_, **kwargs)
         # We approximate original kwargs with the possibly-modified kwargs.
         return self.run_cmd(
             args,
@@ -199,7 +199,7 @@ class Tools:
             **popen_options,
         )
 
-    def call(self, name: str, /, **kwargs):
+    def call(self, tool_name_: str, /, **kwargs):
         """Run a tool by specifying its name as a string and parameters.
 
         The parameters tool are tool name as a string and parameters as keyword
@@ -210,10 +210,10 @@ class Tools:
         the parameters, but numbers, lists, and tuples will still be translated to
         strings for execution.
 
-        :param name: name of a GRASS tool
+        :param tool_name_: name of a GRASS tool
         :param **kwargs: tool parameters
         """
-        args, popen_options = gs.popen_args_command(name, **kwargs)
+        args, popen_options = gs.popen_args_command(tool_name_, **kwargs)
         return self.call_cmd(args, **popen_options)
 
     def call_cmd(self, command, tool_kwargs=None, input=None, **popen_options):


### PR DESCRIPTION
This avoids conflict with name parameter passed in kwargs. Alternative name would be arg, but going with a more descriptive name.

I got a Pylint warning in #5878:

```text
python/grass/tools/session_tools.py:205:12: W1117: 'name' will be included in '**kwargs' since a positional-only parameter with this name already exists (kwarg-superseded-by-positional-arg)
```

It was triggered by:

```python
self.call(
                "g.remove",
                type="raster",
                name=object_parameter_handler.temporary_rasters,
                flags="f",
            )
```

I tried to recreate the issue I got with a test, but I was not able to.

```python

def test_json_with_tool_name_and_tool_name_parameter(xy_dataset_session):
    """Check that using a tool name and a tool name parameter works

    This tests for the case we decide to rename first parameter to *name*
    which would be the obvious choice. While the code works as expected
    in any case, a linter should trigger the warning if something is wrong.
    """
    tools = Tools(session=xy_dataset_session)
    assert tools.call("g.remove", type="raster", name="does_not_exit")
```

Anyway, it seems reasonable to simply change the name. The use will likely get tested enough by other code, so a specific test is not needed. On top of that, the test would be really to trigger a linter, because the runtime behavior is actually expected in our case.