### PR TITLE
Fix unchecked return value from library

### DIFF
--- a/raster/r.in.gridatb/file_io.c
+++ b/raster/r.in.gridatb/file_io.c
@@ -19,8 +19,10 @@ void rdwr_gridatb(void)
     buf[0] = 0;
     if (fscanf(fp, "%[^\n]", buf) != 1)
         G_fatal_error(_("Error reading data"));
-    if (!buf[0])
-        getc(fp);
+    if (!buf[0]) {
+        if (getc(fp) == EOF)
+            G_fatal_error(_("Unexpected end of file while reading %s"), file);
+    }
 
     if (fscanf(fp, "%d %d %lf\n", &cellhd.cols, &cellhd.rows, &cellhd.ns_res) !=
         3)


### PR DESCRIPTION
This pull request fixes issue identified by Coverity Scan (CID : 1415806)
added a check for getc()